### PR TITLE
refactor: Rename 'function' terminology to 'tool' for LLM-callable tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ Integrate external documents into your LLM conversations for more accurate and c
 
 ![harnx-rag](https://github.com/user-attachments/assets/359f0cb8-ee37-432f-a89f-96a2ebab01f6)
 
-### Function Calling
+### Tool Use
 
-Function calling supercharges LLMs by connecting them to external tools and data sources. This unlocks a world of possibilities, enabling LLMs to go beyond their core capabilities and tackle a wider range of tasks.
+Tool use supercharges LLMs by connecting them to external tools and data sources. This unlocks a world of possibilities, enabling LLMs to go beyond their core capabilities and tackle a wider range of tasks.
 
 We have created a new repository [https://github.com/sigoden/llm-functions](https://github.com/sigoden/llm-functions) to help you make the most of this feature.
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -11,16 +11,16 @@ editor: null                     # Specifies the command used to edit input buff
 wrap: no                         # Controls text wrapping (no, auto, <max-width>)
 wrap_code: false                 # Enables or disables wrapping of code blocks
 
-# ---- function-calling ----
+# ---- tool-use ----
 # Visit https://github.com/sigoden/llm-functions for setup instructions
-function_calling: true           # Enables or disables function calling (Globally).
+tool_use: true                   # Enables or disables tool use (Globally).
 mapping_tools:                   # Alias for a tool or toolset
   fs: 'fs_cat,fs_ls,fs_mkdir,fs_rm,fs_write'
 use_tools: null                  # Which tools to use by default. (e.g. 'fs,web_search')
 
 # ---- mcp servers ----
 # MCP (Model Context Protocol) servers provide external tools.
-# function_calling must be true for MCP tools to work.
+# tool_use must be true for MCP tools to work.
 # mcp_servers:
 #   - name: filesystem                 # Unique server name
 #     command: npx                     # Command to start the server
@@ -131,7 +131,7 @@ clients:
   #     - name: xxxx                                  # Chat model
   #       max_input_tokens: 100000
   #       supports_vision: true
-  #       supports_function_calling: true
+  #       supports_tool_use: true
   #     - name: xxxx                                  # Embedding model
   #       type: embedding
   #       default_chunk_size: 1500                        
@@ -175,7 +175,7 @@ clients:
         max_input_tokens: 131072
       - name: llama3.1
         max_input_tokens: 128000
-        supports_function_calling: true
+        supports_tool_use: true
       - name: llama3.2-vision
         max_input_tokens: 131072
         supports_vision: true
@@ -270,7 +270,7 @@ clients:
       - name: gpt-4o                                  # Model deployment name
         max_input_tokens: 128000
         supports_vision: true
-        supports_function_calling: true
+        supports_tool_use: true
 
   # See https://cloud.google.com/vertex-ai
   - type: vertexai

--- a/docs/plans/2026-03-31-001-refactor-rename-function-to-tool-plan.md
+++ b/docs/plans/2026-03-31-001-refactor-rename-function-to-tool-plan.md
@@ -1,0 +1,191 @@
+---
+title: "refactor: Rename 'function' terminology to 'tool' for LLM-callable tools"
+type: refactor
+status: active
+date: 2026-03-31
+---
+
+# Rename "function" to "tool" for LLM-callable tools
+
+## Overview
+
+The codebase uses "function" to refer to LLM-callable tools (a holdover from OpenAI's original "function calling" API naming). The industry has standardized on "tool" / "tool use." This refactor aligns the codebase terminology — code identifiers, config keys, env vars, directory names, and docs — with the modern convention.
+
+## Problem Frame
+
+Users configuring harnx encounter `function_calling`, `functions_dir`, `FunctionDeclaration`, etc. when the feature is universally known as "tool use" today. This creates confusion and makes the project feel dated.
+
+## Requirements Trace
+
+- R1. Rename all LLM-callable-tool references from "function" to "tool" in Rust source code
+- R2. Rename config YAML keys: `function_calling` → `tool_use`, `functions_dir` constant → `tools`
+- R3. Rename `supports_function_calling` → `supports_tool_use` in models.yaml
+- R4. Rename env vars: `HARNX_FUNCTION_CALLING` → `HARNX_TOOL_USE`, `HARNX_FUNCTIONS_DIR` → `HARNX_TOOLS_DIR`
+- R5. Update example configs and docs
+- R6. Keep `use_tools` and `mapping_tools` names unchanged (already correct)
+- R7. Clean break — no backward compatibility shims
+
+## Scope Boundaries
+
+- DO rename: `FunctionDeclaration`, `Functions` struct, `function_calling` config key, `functions` field, `functions_dir`/`functions_file`/`functions_bin_dir` paths, `supports_function_calling` in models.yaml, `select_functions`, `load_functions`, `function.rs` filename, env vars with "function" in name
+- DO NOT rename: `use_tools`, `mapping_tools` (already say "tools"), Rust language `fn` keyword usage, unrelated uses of "function" in comments that refer to programming functions (not LLM tools)
+- DO NOT rename: `ToolCall`, `ToolResult`, `eval_tool_calls` (already correct)
+
+## Key Technical Decisions
+
+- **Clean break**: No serde aliases or backward compat — users update configs once
+- **File rename**: `src/function.rs` → `src/tool.rs`
+- **Directory constant**: `FUNCTIONS_DIR_NAME` ("functions") → `TOOLS_DIR_NAME` ("tools")
+- **On-disk**: The config directory `functions/` becomes `tools/`, `functions.json` becomes `tools.json`
+- **models.yaml field**: `supports_function_calling` → `supports_tool_use`
+- **Config key**: `function_calling: true` → `tool_use: true`
+
+## Rename Map
+
+| Old identifier | New identifier | Files |
+|---|---|---|
+| `src/function.rs` | `src/tool.rs` | filesystem |
+| `FunctionDeclaration` | `ToolDeclaration` | function.rs, client/common.rs, mcp/convert.rs, mcp/client.rs, serve.rs, config/mod.rs |
+| `Functions` (struct) | `Tools` | function.rs, config/mod.rs, config/agent.rs, serve.rs |
+| `function_calling` (config field) | `tool_use` | config/mod.rs, config.example.yaml, config/role.rs |
+| `select_functions` | `select_tools` | config/mod.rs, config/input.rs |
+| `load_functions` | `load_tools` | config/mod.rs |
+| `function_declarations_for_use_tools` | `tool_declarations_for_use_tools` | config/mod.rs |
+| `functions` (Config field) | `tools` | config/mod.rs |
+| `FUNCTIONS_DIR_NAME` | `TOOLS_DIR_NAME` | config/mod.rs |
+| `FUNCTIONS_FILE_NAME` | `TOOLS_FILE_NAME` | config/mod.rs |
+| `FUNCTIONS_BIN_DIR_NAME` | `TOOLS_BIN_DIR_NAME` | config/mod.rs |
+| `functions_dir()` | `tools_dir()` | config/mod.rs |
+| `functions_file()` | `tools_file()` | config/mod.rs |
+| `functions_bin_dir()` | `tools_bin_dir()` | config/mod.rs |
+| `agents_functions_dir()` | `agents_tools_dir()` | config/mod.rs |
+| `agent_functions_dir()` | `agent_tools_dir()` | config/mod.rs, config/agent.rs |
+| `HARNX_FUNCTION_CALLING` | `HARNX_TOOL_USE` | config/mod.rs (load_envs) |
+| `HARNX_FUNCTIONS_DIR` | `HARNX_TOOLS_DIR` | config/mod.rs |
+| `<AGENT>_FUNCTIONS_DIR` | `<AGENT>_TOOLS_DIR` | config/mod.rs, config/agent.rs |
+| `supports_function_calling` | `supports_tool_use` | client/model.rs, models.yaml, config.example.yaml |
+| `run_llm_function` | `run_llm_tool` | function.rs, config/agent.rs |
+| `eval_tool_calls` | keep as-is | already correct |
+| `parse_tools` | keep as-is | already correct |
+| `init_from_mcp` | keep as-is | already correct |
+
+## Implementation Units
+
+- [ ] **Unit 1: Rename `src/function.rs` → `src/tool.rs` and update `mod` declaration**
+
+  **Goal:** Move the file and fix the module reference in `main.rs` or `lib.rs`.
+
+  **Files:**
+  - Rename: `src/function.rs` → `src/tool.rs`
+  - Modify: `src/main.rs` (mod declaration)
+  - Modify: every file that does `use crate::function::` → `use crate::tool::`
+
+  **Approach:** `git mv` the file, then fix all `mod function` and `use crate::function` references.
+
+  **Patterns to follow:** Standard Rust module rename.
+
+  **Verification:** `cargo check` passes.
+
+- [ ] **Unit 2: Rename core types in `src/tool.rs`**
+
+  **Goal:** Rename `FunctionDeclaration` → `ToolDeclaration`, `Functions` → `Tools`, `run_llm_function` → `run_llm_tool`.
+
+  **Files:**
+  - Modify: `src/tool.rs`
+  - Modify: all importers (client/common.rs, mcp/convert.rs, mcp/client.rs, serve.rs, config/mod.rs, config/agent.rs, config/input.rs)
+
+  **Approach:** LSP rename for each symbol, or global find-replace with verification.
+
+  **Verification:** `cargo check` passes.
+
+- [ ] **Unit 3: Rename config constants and path helpers in `config/mod.rs`**
+
+  **Goal:** Rename `FUNCTIONS_DIR_NAME` → `TOOLS_DIR_NAME`, `FUNCTIONS_FILE_NAME` → `TOOLS_FILE_NAME`, `FUNCTIONS_BIN_DIR_NAME` → `TOOLS_BIN_DIR_NAME`, and all associated methods (`functions_dir` → `tools_dir`, etc.).
+
+  **Files:**
+  - Modify: `src/config/mod.rs`
+  - Modify: `src/config/agent.rs` (calls `Config::agent_functions_dir`, etc.)
+  - Modify: `src/function.rs` / `src/tool.rs` (calls `Config::functions_bin_dir`)
+
+  **Approach:** Rename constants and methods, fix all call sites.
+
+  **Verification:** `cargo check` passes.
+
+- [ ] **Unit 4: Rename `function_calling` config field → `tool_use`**
+
+  **Goal:** Rename the `function_calling` bool field in `Config` struct to `tool_use`, update serde, env var loading (`HARNX_FUNCTION_CALLING` → `HARNX_TOOL_USE`), and all references.
+
+  **Files:**
+  - Modify: `src/config/mod.rs` (struct field, `Default`, `load_envs`, `select_functions` → `select_tools`, info display, completion)
+  - Modify: `src/config/role.rs` (if referenced)
+  - Modify: `src/config/agent.rs` (if referenced)
+
+  **Approach:** Rename field, fix all usages, update the env var name string.
+
+  **Verification:** `cargo check` passes.
+
+- [ ] **Unit 5: Rename `functions` field on Config → `tools`**
+
+  **Goal:** Rename the `pub functions: Functions` field to `pub tools: Tools`.
+
+  **Files:**
+  - Modify: `src/config/mod.rs`
+  - Modify: `src/serve.rs`
+  - Modify: `src/config/agent.rs`
+
+  **Verification:** `cargo check` passes.
+
+- [ ] **Unit 6: Rename `supports_function_calling` → `supports_tool_use` in model code and models.yaml**
+
+  **Goal:** Rename the field in `ModelData` and update all ~160 occurrences in `models.yaml`.
+
+  **Files:**
+  - Modify: `src/client/model.rs`
+  - Modify: `models.yaml` (global replace)
+  - Modify: `config.example.yaml`
+
+  **Approach:** Rename struct field in model.rs, then global replace in YAML files.
+
+  **Verification:** `cargo check` passes, `cargo test` passes.
+
+- [ ] **Unit 7: Update example configs and docs**
+
+  **Goal:** Update `config.example.yaml`, `config.agent.example.yaml`, `README.md`, and any role/asset markdown that mentions "function calling" in the LLM-tool sense.
+
+  **Files:**
+  - Modify: `config.example.yaml`
+  - Modify: `config.agent.example.yaml`
+  - Modify: `README.md`
+  - Modify: `assets/roles/%code%.md` (if applicable)
+
+  **Approach:** Replace "function calling" → "tool use", "function_calling" → "tool_use", "functions" → "tools" in prose/comments. Be careful not to rename references to programming functions.
+
+  **Verification:** Read through changes for correctness.
+
+- [ ] **Unit 8: Final verification**
+
+  **Goal:** Full test suite, clippy, and format check pass.
+
+  **Verification:**
+  - `cargo test --all` passes
+  - `cargo clippy --all --all-targets -- -D warnings` passes
+  - `cargo fmt --all --check` passes
+
+## System-Wide Impact
+
+- **Config files:** Users must update `function_calling` → `tool_use` in their `config.yaml`
+- **Env vars:** `HARNX_FUNCTION_CALLING` → `HARNX_TOOL_USE`, `HARNX_FUNCTIONS_DIR` → `HARNX_TOOLS_DIR`
+- **On-disk directories:** `<config_dir>/functions/` → `<config_dir>/tools/`, `functions.json` → `tools.json`
+- **Agent dirs:** `<config_dir>/functions/agents/` → `<config_dir>/tools/agents/`
+- **models.yaml:** `supports_function_calling` → `supports_tool_use` (fetched from remote sync URL too)
+
+## Risks & Dependencies
+
+- Users with existing configs will need to update field names (clean break decision)
+- The `models.yaml` sync URL serves the old field name until the rename is merged and deployed
+- Agent function directories on disk won't auto-migrate; users move them manually
+
+## Sources & References
+
+- Related code: `src/function.rs`, `src/config/mod.rs`, `src/client/model.rs`
+- Config: `config.example.yaml`, `models.yaml`

--- a/models.yaml
+++ b/models.yaml
@@ -9,55 +9,55 @@
       input_price: 1.75
       output_price: 14
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gpt-5
       max_input_tokens: 400000
       max_output_tokens: 128000
       input_price: 1.25
       output_price: 10
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gpt-5-mini
       max_input_tokens: 400000
       max_output_tokens: 128000
       input_price: 0.25
       output_price: 2
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gpt-5-nano
       max_input_tokens: 400000
       max_output_tokens: 128000
       input_price: 0.05
       output_price: 0.4
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gpt-4.1
       max_input_tokens: 1047576
       max_output_tokens: 32768
       input_price: 2
       output_price: 8
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gpt-4o
       max_input_tokens: 128000
       max_output_tokens: 16384
       input_price: 2.5
       output_price: 10
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gpt-4-turbo
       max_input_tokens: 128000
       max_output_tokens: 4096
       input_price: 10
       output_price: 30
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gpt-3.5-turbo
       max_input_tokens: 16385
       max_output_tokens: 4096
       input_price: 0.5
       output_price: 1.5
-      supports_function_calling: true
+      supports_tool_use: true
     - name: text-embedding-3-large
       type: embedding
       input_price: 0.13
@@ -83,43 +83,43 @@
       input_price: 0
       output_price: 0
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gemini-2.5-pro
       max_input_tokens: 1048576
       max_output_tokens: 65536
       input_price: 0
       output_price: 0
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gemini-2.5-flash-lite
       max_input_tokens: 1000000
       max_output_tokens: 64000
       input_price: 0
       output_price: 0
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gemini-3-pro-preview
       max_input_tokens: 1048576
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gemini-3-flash-preview
       max_input_tokens: 1048576
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gemini-2.0-flash
       max_input_tokens: 1048576
       max_output_tokens: 8192
       input_price: 0
       output_price: 0
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gemini-2.0-flash-lite
       max_input_tokens: 1048576
       max_output_tokens: 8192
       input_price: 0
       output_price: 0
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gemma-3-27b-it
       max_input_tokens: 131072
       max_output_tokens: 8192
@@ -144,7 +144,7 @@
       input_price: 5
       output_price: 25
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: claude-opus-4-6:thinking
       real_name: claude-opus-4-6
       max_input_tokens: 200000
@@ -153,7 +153,7 @@
       input_price: 5
       output_price: 25
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
       patch:
         body:
           temperature: null
@@ -168,7 +168,7 @@
       input_price: 3
       output_price: 15
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: claude-sonnet-4-6:thinking
       real_name: claude-sonnet-4-6
       max_input_tokens: 200000
@@ -177,7 +177,7 @@
       input_price: 3
       output_price: 15
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
       patch:
         body:
           temperature: null
@@ -192,7 +192,7 @@
       input_price: 5
       output_price: 25
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: claude-opus-4-5-20251101:thinking
       real_name: claude-opus-4-5-20251101
       max_input_tokens: 200000
@@ -201,7 +201,7 @@
       input_price: 5
       output_price: 25
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
       patch:
         body:
           temperature: null
@@ -216,7 +216,7 @@
       input_price: 3
       output_price: 15
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: claude-sonnet-4-5-20250929:thinking
       real_name: claude-sonnet-4-5-20250929
       max_input_tokens: 200000
@@ -225,7 +225,7 @@
       input_price: 3
       output_price: 15
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
       patch:
         body:
           temperature: null
@@ -240,7 +240,7 @@
       input_price: 1
       output_price: 5
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: claude-haiku-4-5-20251001:thinking
       real_name: claude-haiku-4-5-20251001
       max_input_tokens: 200000
@@ -249,7 +249,7 @@
       input_price: 1
       output_price: 5
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
       patch:
         body:
           temperature: null
@@ -268,19 +268,19 @@
       max_output_tokens: 262144
       input_price: 0.5
       output_price: 1.5
-      supports_function_calling: true
+      supports_tool_use: true
       supports_vision: true
     - name: mistral-medium-latest
       max_input_tokens: 131072
       input_price: 0.4
       output_price: 2
-      supports_function_calling: true
+      supports_tool_use: true
       supports_vision: true
     - name: mistral-small-latest
       max_input_tokens: 32768
       input_price: 0.1
       output_price: 0.3
-      supports_function_calling: true
+      supports_tool_use: true
       supports_vision: true
     - name: magistral-medium-latest
       max_input_tokens: 131072
@@ -294,22 +294,22 @@
       max_input_tokens: 262144
       input_price: 0.4
       output_price: 2
-      supports_function_calling: true
+      supports_tool_use: true
     - name: devstral-small-latest
       max_input_tokens: 262144
       input_price: 0.1
       output_price: 0.3
-      supports_function_calling: true
+      supports_tool_use: true
     - name: codestral-latest
       max_input_tokens: 262144
       input_price: 0.3
       output_price: 0.9
-      supports_function_calling: true
+      supports_tool_use: true
     - name: ministral-14b-latest
       max_input_tokens: 262144
       input_price: 0.2
       output_price: 0.2
-      supports_function_calling: true
+      supports_tool_use: true
     - name: mistral-embed
       type: embedding
       max_input_tokens: 8092
@@ -327,12 +327,12 @@
       max_input_tokens: 256000
       input_price: 2
       output_price: 8
-      supports_function_calling: true
+      supports_tool_use: true
     - name: jamba-mini
       max_input_tokens: 256000
       input_price: 0.2
       output_price: 0.4
-      supports_function_calling: true
+      supports_tool_use: true
 
 # Links:
 #  - https://docs.cohere.com/docs/models
@@ -345,7 +345,7 @@
       max_output_tokens: 8192
       input_price: 2.5
       output_price: 10
-      supports_function_calling: true
+      supports_tool_use: true
     - name: command-a-reasoning-08-2025
       max_input_tokens: 262144
       max_output_tokens: 32768
@@ -399,17 +399,17 @@
       max_input_tokens: 2000000
       input_price: 0.2
       output_price: 0.5
-      supports_function_calling: true
+      supports_tool_use: true
     - name: grok-4-1-fast-reasoning
       max_input_tokens: 2000000
       input_price: 0.2
       output_price: 0.5
-      supports_function_calling: true
+      supports_tool_use: true
     - name: grok-code-fast-1
       max_input_tokens: 256000
       input_price: 0.2
       output_price: 1.5
-      supports_function_calling: true
+      supports_tool_use: true
 
 # Links:
 #  - https://docs.perplexity.ai/getting-started/models
@@ -442,34 +442,34 @@
       max_input_tokens: 131072
       input_price: 0
       output_price: 0
-      supports_function_calling: true
+      supports_tool_use: true
     - name: openai/gpt-oss-20b
       max_input_tokens: 131072
       input_price: 0
       output_price: 0
-      supports_function_calling: true
+      supports_tool_use: true
     - name: meta-llama/llama-4-maverick-17b-128e-instruct
       max_input_tokens: 131072
       input_price: 0
       output_price: 0
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: meta-llama/llama-4-scout-17b-16e-instruct
       max_input_tokens: 131072
       input_price: 0
       output_price: 0
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: llama-3.3-70b-versatile
       max_input_tokens: 131072
       input_price: 0
       output_price: 0
-      supports_function_calling: true
+      supports_tool_use: true
     - name: moonshotai/kimi-k2-instruct-0905
       max_input_tokens: 262144
       input_price: 0
       output_price: 0
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen/qwen3-32b
       max_input_tokens: 131072
       input_price: 0
@@ -495,43 +495,43 @@
       input_price: 0.3
       output_price: 2.5
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gemini-2.5-pro
       max_input_tokens: 1048576
       max_output_tokens: 65536
       input_price: 1.25
       output_price: 10
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gemini-2.5-flash-lite
       max_input_tokens: 1048576
       max_output_tokens: 65536
       input_price: 0.3
       output_price: 0.4
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gemini-3-pro-preview
       max_input_tokens: 1048576
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gemini-3-flash-preview
       max_input_tokens: 1048576
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gemini-2.0-flash-001
       max_input_tokens: 1048576
       max_output_tokens: 8192
       input_price: 0.15
       output_price: 0.6
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gemini-2.0-flash-lite-001
       max_input_tokens: 1048576
       max_output_tokens: 8192
       input_price: 0.075
       output_price: 0.3
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: claude-opus-4-6
       max_input_tokens: 200000
       max_output_tokens: 8192
@@ -539,7 +539,7 @@
       input_price: 5
       output_price: 25
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: claude-opus-4-6:thinking
       real_name: claude-opus-4-6
       max_input_tokens: 200000
@@ -562,7 +562,7 @@
       input_price: 3
       output_price: 15
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: claude-sonnet-4-6:thinking
       real_name: claude-sonnet-4-6
       max_input_tokens: 200000
@@ -585,7 +585,7 @@
       input_price: 5
       output_price: 25
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: claude-opus-4-5@20251101:thinking
       real_name: claude-opus-4-5@20251101
       max_input_tokens: 200000
@@ -608,7 +608,7 @@
       input_price: 3
       output_price: 15
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: claude-sonnet-4-5@20250929:thinking
       real_name: claude-sonnet-4-5@20250929
       max_input_tokens: 200000
@@ -631,7 +631,7 @@
       input_price: 1
       output_price: 5
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: claude-haiku-4-5@20251001:thinking
       real_name: claude-haiku-4-5@20251001
       max_input_tokens: 200000
@@ -676,7 +676,7 @@
       input_price: 5
       output_price: 25
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: us.anthropic.claude-opus-4-6-v1:thinking
       real_name: us.anthropic.claude-opus-4-6-v1
       max_input_tokens: 200000
@@ -701,7 +701,7 @@
       input_price: 3
       output_price: 15
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: us.anthropic.claude-sonnet-4-6:thinking
       real_name: us.anthropic.claude-sonnet-4-6
       max_input_tokens: 200000
@@ -726,7 +726,7 @@
       input_price: 5
       output_price: 25
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: us.anthropic.claude-opus-4-5-20251101-v1:0:thinking
       real_name: us.anthropic.claude-opus-4-5-20251101-v1:0
       max_input_tokens: 200000
@@ -751,7 +751,7 @@
       input_price: 3
       output_price: 15
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: us.anthropic.claude-sonnet-4-5-20250929-v1:0:thinking
       real_name: us.anthropic.claude-sonnet-4-5-20250929-v1:0
       max_input_tokens: 200000
@@ -776,7 +776,7 @@
       input_price: 1
       output_price: 5
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: us.anthropic.claude-haiku-4-5-20251001-v1:0:thinking
       real_name: us.anthropic.claude-haiku-4-5-20251001-v1:0
       max_input_tokens: 200000
@@ -800,7 +800,7 @@
       require_max_tokens: true
       input_price: 0.24
       output_price: 0.97
-      supports_function_calling: true
+      supports_tool_use: true
       supports_vision: true
     - name: us.meta.llama4-scout-17b-instruct-v1:0
       max_input_tokens: 131072
@@ -808,7 +808,7 @@
       require_max_tokens: true
       input_price: 0.17
       output_price: 0.66
-      supports_function_calling: true
+      supports_tool_use: true
       supports_vision: true
     - name: us.meta.llama3-3-70b-instruct-v1:0
       max_input_tokens: 131072
@@ -816,7 +816,7 @@
       require_max_tokens: true
       input_price: 0.72
       output_price: 0.72
-      supports_function_calling: true
+      supports_tool_use: true
     - name: us.amazon.nova-premier-v1:0
       max_input_tokens: 300000
       max_output_tokens: 5120
@@ -957,21 +957,21 @@
   models:
     - name: qwen3.5-plus
       max_input_tokens: 262144
-      supports_function_calling: true
+      supports_tool_use: true
       patch:
         body:
           enable_thinking: false
     - name: qwen3.5-plus:thinking
       real_name: qwen3.5-plus
       max_input_tokens: 262144
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen3-max
       max_input_tokens: 262144
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen3-max:thinking
       real_name: qwen3-max
       max_input_tokens: 262144
-      supports_function_calling: true
+      supports_tool_use: true
       patch:
         body:
           enable_thinking: true
@@ -987,19 +987,19 @@
       max_input_tokens: 1000000
     - name: qwen3.5-397b-a17b
       max_input_tokens: 262144
-      supports_function_calling: true
+      supports_tool_use: true
       patch:
         body:
           enable_thinking: false
     - name: qwen3.5-397b-a17b:thinking
       real_name: qwen3.5-397b-a17b
       max_input_tokens: 262144
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen3-next-80b-a3b-instruct
       max_input_tokens: 131072
       input_price: 0.14
       output_price: 0.56
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen3-next-80b-a3b-thinking
       max_input_tokens: 131072
       input_price: 0.14
@@ -1008,7 +1008,7 @@
       max_input_tokens: 131072
       input_price: 0.28
       output_price: 1.12
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen3-235b-a22b-thinking-2507
       max_input_tokens: 131072
       input_price: 0.28
@@ -1017,7 +1017,7 @@
       max_input_tokens: 131072
       input_price: 0.105
       output_price: 0.42
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen3-30b-a3b-thinking-2507
       max_input_tokens: 131072
       input_price: 0.105
@@ -1061,12 +1061,12 @@
       max_input_tokens: 131072
       input_price: 0.112
       output_price: 0.28
-      supports_function_calling: true
+      supports_tool_use: true
     - name: hunyuan-2.0-thinking-20251109
       max_input_tokens: 131072
       input_price: 0.14
       output_price: 0.56
-      supports_function_calling: true
+      supports_tool_use: true
     - name: hunyuan-vision-1.5-instruct
       max_input_tokens: 24576
       input_price: 0.42
@@ -1089,19 +1089,19 @@
       input_price: 0.56
       output_price: 2.94
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: kimi-k2-turbo-preview
       max_input_tokens: 262144
       input_price: 1.12
       output_price: 8.12
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: kimi-k2-0905-preview
       max_input_tokens: 262144
       input_price: 0.56
       output_price: 2.24
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: kimi-k2-thinking-turbo
       max_input_tokens: 262144
       input_price: 1.12
@@ -1123,7 +1123,7 @@
       max_output_tokens: 8192
       input_price: 0.56
       output_price: 1.68
-      supports_function_calling: true
+      supports_tool_use: true
     - name: deepseek-reasoner
       max_input_tokens: 64000
       max_output_tokens: 32768
@@ -1137,22 +1137,22 @@
   models:
     - name: glm-5
       max_input_tokens: 202752
-      supports_function_calling: true
+      supports_tool_use: true
     - name: glm-5:instruct
       real_name: glm-5
       max_input_tokens: 202752
-      supports_function_calling: true
+      supports_tool_use: true
       patch:
         body:
           thinking:
             type: disabled
     - name: glm-4.7
       max_input_tokens: 202752
-      supports_function_calling: true
+      supports_tool_use: true
     - name: glm-4.7:instruct
       real_name: glm-4.7
       max_input_tokens: 202752
-      supports_function_calling: true
+      supports_tool_use: true
       patch:
         body:
           thinking:
@@ -1161,7 +1161,7 @@
       max_input_tokens: 202752
       input_price: 0
       output_price: 0
-      supports_function_calling: true
+      supports_tool_use: true
     - name: glm-4.6v
       max_input_tokens: 65536
       supports_vision: true
@@ -1190,22 +1190,22 @@
       max_input_tokens: 204800
       input_price: 0.294
       output_price: 1.176
-      supports_function_calling: true
+      supports_tool_use: true
     - name: minimax-m2.5-highspeed
       max_input_tokens: 204800
       input_price: 0.588
       output_price: 2.352
-      supports_function_calling: true
+      supports_tool_use: true
     - name: minimax-m2.1
       max_input_tokens: 204800
       input_price: 0.294
       output_price: 1.176
-      supports_function_calling: true
+      supports_tool_use: true
     - name: minimax-m2.1-highspeed
       max_input_tokens: 204800
       input_price: 0.588
       output_price: 2.352
-      supports_function_calling: true
+      supports_tool_use: true
 
 # Links:
 #  - https://openrouter.ai/models
@@ -1218,63 +1218,63 @@
       input_price: 1.75
       output_price: 14
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: openai/gpt-5
       max_input_tokens: 400000
       max_output_tokens: 128000
       input_price: 1.25
       output_price: 10
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: openai/gpt-5-mini
       max_input_tokens: 400000
       max_output_tokens: 128000
       input_price: 0.25
       output_price: 2
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: openai/gpt-5-nano
       max_input_tokens: 400000
       max_output_tokens: 128000
       input_price: 0.05
       output_price: 0.4
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: openai/gpt-4.1
       max_input_tokens: 1047576
       max_output_tokens: 32768
       input_price: 2
       output_price: 8
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: openai/gpt-4o
       max_input_tokens: 128000
       input_price: 2.5
       output_price: 10
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: openai/gpt-oss-120b
       max_input_tokens: 131072
       input_price: 0.09
       output_price: 0.45
-      supports_function_calling: true
+      supports_tool_use: true
     - name: openai/gpt-oss-20b
       max_input_tokens: 131072
       input_price: 0.04
       output_price: 0.16
-      supports_function_calling: true
+      supports_tool_use: true
     - name: google/gemini-2.5-flash
       max_input_tokens: 1048576
       input_price: 0.3
       output_price: 2.5
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: google/gemini-2.5-pro
       max_input_tokens: 1048576
       input_price: 1.25
       output_price: 10
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: google/gemini-2.5-flash-lite
       max_input_tokens: 1048576
       input_price: 0.3
@@ -1285,13 +1285,13 @@
       input_price: 0.15
       output_price: 0.6
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: google/gemini-2.0-flash-lite-001
       max_input_tokens: 1048576
       input_price: 0.075
       output_price: 0.3
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: google/gemma-3-27b-it
       max_input_tokens: 131072
       input_price: 0.1
@@ -1303,7 +1303,7 @@
       input_price: 5
       output_price: 25
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: anthropic/claude-sonnet-4.6
       max_input_tokens: 200000
       max_output_tokens: 8192
@@ -1311,7 +1311,7 @@
       input_price: 3
       output_price: 15
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: anthropic/claude-opus-4.5
       max_input_tokens: 200000
       max_output_tokens: 8192
@@ -1319,7 +1319,7 @@
       input_price: 5
       output_price: 25
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: anthropic/claude-sonnet-4.5
       max_input_tokens: 200000
       max_output_tokens: 8192
@@ -1327,7 +1327,7 @@
       input_price: 3
       output_price: 15
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: anthropic/claude-haiku-4.5
       max_input_tokens: 200000
       max_output_tokens: 8192
@@ -1335,19 +1335,19 @@
       input_price: 1
       output_price: 5
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: meta-llama/llama-4-maverick
       max_input_tokens: 1048576
       input_price: 0.18
       output_price: 0.6
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: meta-llama/llama-4-scout
       max_input_tokens: 327680
       input_price: 0.08
       output_price: 0.3
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: meta-llama/llama-3.3-70b-instruct
       max_input_tokens: 131072
       input_price: 0.12
@@ -1356,12 +1356,12 @@
       max_input_tokens: 262144
       input_price: 0.5
       output_price: 1.5
-      supports_function_calling: true
+      supports_tool_use: true
     - name: mistralai/mistral-medium-3.1
       max_input_tokens: 131072
       input_price: 0.4
       output_price: 2
-      supports_function_calling: true
+      supports_tool_use: true
       supports_vision: true
     - name: mistralai/mistral-small-3.2-24b-instruct
       max_input_tokens: 131072
@@ -1372,32 +1372,32 @@
       max_input_tokens: 262144
       input_price: 0.5
       output_price: 0.22
-      supports_function_calling: true
+      supports_tool_use: true
     - name: mistralai/devstral-small
       max_input_tokens: 131072
       input_price: 0.07
       output_price: 0.28
-      supports_function_calling: true
+      supports_tool_use: true
     - name: mistralai/codestral-2508
       max_input_tokens: 256000
       input_price: 0.3
       output_price: 0.9
-      supports_function_calling: true
+      supports_tool_use: true
     - name: mistralai/ministral-14b-2512
       max_input_tokens: 262144
       input_price: 0.2
       output_price: 0.2
-      supports_function_calling: true
+      supports_tool_use: true
     - name: ai21/jamba-large-1.7
       max_input_tokens: 256000
       input_price: 2
       output_price: 8
-      supports_function_calling: true
+      supports_tool_use: true
     - name: cohere/command-a
       max_input_tokens: 256000
       input_price: 2.5
       output_price: 10
-      supports_function_calling: true
+      supports_tool_use: true
     - name: cohere/command-r7b-12-2024
       max_input_tokens: 128000
       max_output_tokens: 4096
@@ -1411,29 +1411,29 @@
       max_input_tokens: 262144
       input_price: 1.2
       output_price: 6
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen/qwen3-max-thinking
       max_input_tokens: 262144
       input_price: 1.2
       output_price: 6
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen/qwen3.5-plus-02-15
       max_input_tokens: 1000000
       max_output_tokens: 8192
       input_price: 0.4
       output_price: 2.4
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen/qwen3.5-397b-a17b
       max_input_tokens: 262144
       max_output_tokens: 8192
       input_price: 0.15
       output_price: 1
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen/qwen3-next-80b-a3b-instruct
       max_input_tokens: 262144
       input_price: 0.1
       output_price: 0.8
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen/qwen3-next-80b-a3b-thinking
       max_input_tokens: 262144
       input_price: 0.1
@@ -1442,7 +1442,7 @@
       max_input_tokens: 262144
       input_price: 0.12
       output_price: 0.59
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen/qwen3-235b-a22b-thinking-2507
       max_input_tokens: 262144
       input_price: 0.118
@@ -1469,54 +1469,54 @@
       max_input_tokens: 262144
       input_price: 0.12
       output_price: 0.75
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen/qwen3-coder-plus
       max_input_tokens: 128000
       input_price: 1
       output_price: 5
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen/qwen3-coder-flash
       max_input_tokens: 128000
       input_price: 0.3
       output_price: 1.5
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen/qwen3-coder  # Qwen3 Coder 480B A35B
       max_input_tokens: 262144
       input_price: 0.22
       output_price: 0.95
-      supports_function_calling: true
+      supports_tool_use: true
     - name: qwen/qwen3-coder-30b-a3b-instruct
       max_input_tokens: 262144
       input_price: 0.052
       output_price: 0.207
-      supports_function_calling: true
+      supports_tool_use: true
     - name: moonshotai/kimi-k2.5
       max_input_tokens: 262144
       input_price: 0.57
       output_price: 2.85
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: moonshotai/kimi-k2-0905
       max_input_tokens: 262144
       input_price: 0.296
       output_price: 1.185
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: moonshotai/kimi-k2-thinking
       max_input_tokens: 262144
       input_price: 0.45
       output_price: 2.35
-      supports_function_calling: true
+      supports_tool_use: true
     - name: x-ai/grok-4.1-fast
       max_input_tokens: 2000000
       input_price: 0.2
       output_price: 0.5
-      supports_function_calling: true
+      supports_tool_use: true
     - name: x-ai/grok-code-fast-1
       max_input_tokens: 256000
       input_price: 0.2
       output_price: 1.5
-      supports_function_calling: true
+      supports_tool_use: true
     - name: amazon/nova-premier-v1
       max_input_tokens: 1000000
       input_price: 2.5
@@ -1565,27 +1565,27 @@
       max_input_tokens: 196608
       input_price: 0.3
       output_price: 1.1
-      supports_function_calling: true
+      supports_tool_use: true
     - name: minimax/minimax-m2.1
       max_input_tokens: 196608
       input_price: 0.12
       output_price: 0.48
-      supports_function_calling: true
+      supports_tool_use: true
     - name: z-ai/glm-5
       max_input_tokens: 204800
       input_price: 0.95
       output_price: 2.55
-      supports_function_calling: true
+      supports_tool_use: true
     - name: z-ai/glm-4.7
       max_input_tokens: 202752
       input_price: 0.16
       output_price: 0.80
-      supports_function_calling: true
+      supports_tool_use: true
     - name: z-ai/glm-4.7-flash
       max_input_tokens: 202752
       input_price: 0.07
       output_price: 0.40
-      supports_function_calling: true
+      supports_tool_use: true
     - name: z-ai/glm-4.6v
       max_input_tokens: 131072
       input_price: 0.3
@@ -1600,26 +1600,26 @@
       max_input_tokens: 400000
       max_output_tokens: 128000
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gpt-5-mini
       max_input_tokens: 400000
       max_output_tokens: 128000
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gpt-5-nano
       max_input_tokens: 400000
       max_output_tokens: 128000
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gpt-4.1
       max_input_tokens: 1047576
       max_output_tokens: 32768
       supports_vision: true
-      supports_function_calling: true
+      supports_tool_use: true
     - name: gpt-4o
       max_input_tokens: 128000
       max_output_tokens: 16384
-      supports_function_calling: true
+      supports_tool_use: true
     - name: text-embedding-3-large
       type: embedding
       max_tokens_per_chunk: 8191
@@ -1640,13 +1640,13 @@
       max_input_tokens: 131072
     - name: mistral-medium-2505
       max_input_tokens: 131072
-      supports_function_calling: true
+      supports_tool_use: true
     - name: mistral-small-2503
       max_input_tokens: 131072
-      supports_function_calling: true
+      supports_tool_use: true
     - name: codestral-2501
       max_input_tokens: 256000
-      supports_function_calling: true
+      supports_tool_use: true
     - name: cohere-embed-v3-english
       type: embedding
       max_tokens_per_chunk: 512
@@ -1685,12 +1685,12 @@
       max_input_tokens: 131072
       input_price: 0.09
       output_price: 0.45
-      supports_function_calling: true
+      supports_tool_use: true
     - name: openai/gpt-oss-20b
       max_input_tokens: 131072
       input_price: 0.04
       output_price: 0.16
-      supports_function_calling: true
+      supports_tool_use: true
     - name: meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8
       max_input_tokens: 1048576
       input_price: 0.18
@@ -1705,17 +1705,17 @@
       max_input_tokens: 262144
       input_price: 1.2
       output_price: 6
-      supports_function_calling: true
+      supports_tool_use: true
     - name: Qwen/Qwen3-Max-Thinking
       max_input_tokens: 262144
       input_price: 1.2
       output_price: 6
-      supports_function_calling: true
+      supports_tool_use: true
     - name: Qwen/Qwen3-Next-80B-A3B-Instruct
       max_input_tokens: 262144
       input_price: 0.14
       output_price: 1.4
-      supports_function_calling: true
+      supports_tool_use: true
     - name: Qwen/Qwen3-Next-80B-A3B-Thinking
       max_input_tokens: 262144
       input_price: 0.14
@@ -1724,7 +1724,7 @@
       max_input_tokens: 131072
       input_price: 0.13
       output_price: 0.6
-      supports_function_calling: true
+      supports_tool_use: true
     - name: Qwen/Qwen3-235B-A22B-Thinking-2507
       max_input_tokens: 131072
       input_price: 0.13
@@ -1733,12 +1733,12 @@
       max_input_tokens: 131072
       input_price: 0.4
       output_price: 1.6
-      supports_function_calling: true
+      supports_tool_use: true
     - name: Qwen/Qwen3-Coder-30B-A3B-Instruct
       max_input_tokens: 262144
       input_price: 0.07
       output_price: 0.27
-      supports_function_calling: true
+      supports_tool_use: true
     - name: Qwen/Qwen3-30B-A3B
       max_input_tokens: 40960
       input_price: 0.1
@@ -1752,7 +1752,7 @@
       max_input_tokens: 163840
       input_price: 0.26
       output_price: 0.39
-      supports_function_calling: true
+      supports_tool_use: true
     - name: google/gemma-3-27b-it
       max_input_tokens: 131072
       input_price: 0.1
@@ -1765,42 +1765,42 @@
       max_input_tokens: 262144
       input_price: 0.5
       output_price: 2.8
-      supports_function_calling: true
+      supports_tool_use: true
     - name: moonshotai/Kimi-K2-Instruct-0905
       max_input_tokens: 262144
       input_price: 0.5
       output_price: 2.0
-      supports_function_calling: true
+      supports_tool_use: true
     - name: moonshotai/Kimi-K2-Thinking
       max_input_tokens: 262144
       input_price: 0.55
       output_price: 2.5
-      supports_function_calling: true
+      supports_tool_use: true
     - name: MiniMaxAI/MiniMax-M2.5
       max_input_tokens: 196608
       input_price: 0.27
       output_price: 0.95
-      supports_function_calling: true
+      supports_tool_use: true
     - name: MiniMaxAI/MiniMax-M2.1
       max_input_tokens: 196608
       input_price: 0.27
       output_price: 0.95
-      supports_function_calling: true
+      supports_tool_use: true
     - name: zai-org/GLM-5
       max_input_tokens: 202752
       input_price: 0.8
       output_price: 2.56
-      supports_function_calling: true
+      supports_tool_use: true
     - name: zai-org/GLM-4.7
       max_input_tokens: 202752
       input_price: 0.43
       output_price: 1.75
-      supports_function_calling: true
+      supports_tool_use: true
     - name: zai-org/GLM-4.7-Flash
       max_input_tokens: 202752
       input_price: 0.06
       output_price: 0.4
-      supports_function_calling: true
+      supports_tool_use: true
     - name: zai-org/GLM-4.6V
       max_input_tokens: 131072
       input_price: 0.3

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -2,8 +2,8 @@ use super::*;
 
 use crate::{
     config::{Config, GlobalConfig, Input},
-    function::{eval_tool_calls, FunctionDeclaration, ToolCall, ToolResult},
     render::render_stream,
+    tool::{eval_tool_calls, ToolCall, ToolDeclaration, ToolResult},
     utils::*,
 };
 
@@ -371,7 +371,7 @@ pub struct ChatCompletionsData {
     pub messages: Vec<Message>,
     pub temperature: Option<f64>,
     pub top_p: Option<f64>,
-    pub functions: Option<Vec<FunctionDeclaration>>,
+    pub functions: Option<Vec<ToolDeclaration>>,
     pub stream: bool,
 }
 

--- a/src/client/message.rs
+++ b/src/client/message.rs
@@ -1,6 +1,6 @@
 use super::Model;
 
-use crate::{function::ToolResult, multiline_text, utils::dimmed_text};
+use crate::{multiline_text, tool::ToolResult, utils::dimmed_text};
 
 use serde::{Deserialize, Serialize};
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -6,7 +6,7 @@ mod macros;
 mod model;
 mod stream;
 
-pub use crate::function::ToolCall;
+pub use crate::tool::ToolCall;
 pub use common::*;
 pub use message::*;
 pub use model::*;

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -135,7 +135,7 @@ impl Model {
                     input_price,
                     output_price,
                     supports_vision,
-                    supports_function_calling,
+                    supports_tool_use,
                     ..
                 } = &self.data;
                 let max_input_tokens = stringify_option_value(max_input_tokens);
@@ -146,7 +146,7 @@ impl Model {
                 if *supports_vision {
                     capabilities.push('👁');
                 };
-                if *supports_function_calling {
+                if *supports_tool_use {
                     capabilities.push('⚒');
                 };
                 let capabilities: String = capabilities
@@ -316,7 +316,7 @@ pub struct ModelData {
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub supports_vision: bool,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub supports_function_calling: bool,
+    pub supports_tool_use: bool,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     no_stream: bool,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use crate::{
     client::Model,
-    function::{run_llm_function, Functions},
+    tool::{run_llm_tool, Tools},
 };
 
 use anyhow::{Context, Result};
@@ -24,7 +24,7 @@ pub struct Agent {
     session_variables: Option<AgentVariables>,
     shared_dynamic_instructions: Option<String>,
     session_dynamic_instructions: Option<String>,
-    functions: Functions,
+    tools: Tools,
     rag: Option<Arc<Rag>>,
     model: Model,
 }
@@ -35,12 +35,12 @@ impl Agent {
         name: &str,
         abort_signal: AbortSignal,
     ) -> Result<Self> {
-        let functions_dir = Config::agent_functions_dir(name);
+        let functions_dir = Config::agent_tools_dir(name);
         let definition_file_path = functions_dir.join("index.yaml");
         if !definition_file_path.exists() {
             bail!("Unknown agent `{name}`");
         }
-        let functions_file_path = functions_dir.join("functions.json");
+        let functions_file_path = functions_dir.join("tools.json");
         let rag_path = Config::agent_rag_file(name, DEFAULT_AGENT_NAME);
         let config_path = Config::agent_config_file(name);
         let mut agent_config = if config_path.exists() {
@@ -59,9 +59,9 @@ impl Agent {
             None
         };
         let functions = if functions_file_path.exists() {
-            Functions::init(&functions_file_path, mcp_tools)?
+            Tools::init(&functions_file_path, mcp_tools)?
         } else {
-            Functions::init_from_mcp(mcp_tools)
+            Tools::init_from_mcp(mcp_tools)
         };
         definition.replace_tools_placeholder(&functions);
 
@@ -121,7 +121,7 @@ impl Agent {
             session_variables: None,
             shared_dynamic_instructions: None,
             session_dynamic_instructions: None,
-            functions,
+            tools: functions,
             rag,
             model,
         })
@@ -200,7 +200,7 @@ impl Agent {
         let mut definition = self.definition.clone();
         definition.instructions = self.interpolated_instructions();
         value["definition"] = json!(definition);
-        value["functions_dir"] = Config::agent_functions_dir(&self.name)
+        value["tools_dir"] = Config::agent_tools_dir(&self.name)
             .display()
             .to_string()
             .into();
@@ -228,8 +228,8 @@ impl Agent {
         &self.config
     }
 
-    pub fn functions(&self) -> &Functions {
-        &self.functions
+    pub fn tools(&self) -> &Tools {
+        &self.tools
     }
 
     pub fn rag(&self) -> Option<Arc<Rag>> {
@@ -325,7 +325,7 @@ impl Agent {
     }
 
     fn run_instructions_fn(&self) -> Result<String> {
-        let value = run_llm_function(
+        let value = run_llm_tool(
             self.name().to_string(),
             vec!["_instructions".into(), "{}".into()],
             self.variable_envs(),
@@ -503,7 +503,7 @@ impl AgentDefinition {
         )
     }
 
-    fn replace_tools_placeholder(&mut self, functions: &Functions) {
+    fn replace_tools_placeholder(&mut self, functions: &Tools) {
         let tools_placeholder: &str = "{{__tools__}}";
         if self.instructions.contains(tools_placeholder) {
             let tools = functions
@@ -535,7 +535,7 @@ pub struct AgentVariable {
 }
 
 pub fn list_agents() -> Vec<String> {
-    let agents_file = Config::functions_dir().join("agents.txt");
+    let agents_file = Config::tools_dir().join("agents.txt");
     let contents = match read_to_string(agents_file) {
         Ok(v) => v,
         Err(_) => return vec![],
@@ -554,7 +554,7 @@ pub fn list_agents() -> Vec<String> {
 }
 
 pub fn complete_agent_variables(agent_name: &str) -> Vec<(String, Option<String>)> {
-    let index_path = Config::agent_functions_dir(agent_name).join("index.yaml");
+    let index_path = Config::agent_tools_dir(agent_name).join("index.yaml");
     if !index_path.exists() {
         return vec![];
     }

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -4,7 +4,7 @@ use crate::client::{
     init_client, patch_messages, ChatCompletionsData, Client, ImageUrl, Message, MessageContent,
     MessageContentPart, MessageContentToolCalls, MessageRole, Model,
 };
-use crate::function::ToolResult;
+use crate::tool::ToolResult;
 use crate::utils::{base64_encode, is_loader_protocol, sha256, AbortSignal};
 
 use anyhow::{bail, Context, Result};
@@ -239,7 +239,7 @@ impl Input {
         patch_messages(&mut messages, model);
         model.guard_max_input_tokens(&messages)?;
         let (temperature, top_p) = (self.role().temperature(), self.role().top_p());
-        let functions = self.config.read().select_functions(self.role());
+        let functions = self.config.read().select_tools(self.role());
         Ok(ChatCompletionsData {
             messages,
             temperature,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,12 +14,12 @@ use crate::client::{
     create_client_config, list_client_types, list_models, ClientConfig, MessageContentToolCalls,
     Model, ModelType, ProviderModels, OPENAI_COMPATIBLE_PROVIDERS,
 };
-use crate::function::{FunctionDeclaration, Functions, ToolResult};
 use crate::hooks::{AsyncHookManager, HooksConfig};
 use crate::mcp::{McpManager, McpServerConfig};
 use crate::rag::Rag;
 use crate::render::{MarkdownRender, RenderOptions};
 use crate::repl::{run_repl_command, split_args_text};
+use crate::tool::{ToolDeclaration, ToolResult, Tools};
 use crate::utils::*;
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -58,9 +58,9 @@ const ENV_FILE_NAME: &str = ".env";
 const MESSAGES_FILE_NAME: &str = "messages.md";
 const SESSIONS_DIR_NAME: &str = "sessions";
 const RAGS_DIR_NAME: &str = "rags";
-const FUNCTIONS_DIR_NAME: &str = "functions";
-const FUNCTIONS_FILE_NAME: &str = "functions.json";
-const FUNCTIONS_BIN_DIR_NAME: &str = "bin";
+const TOOLS_DIR_NAME: &str = "tools";
+const TOOLS_FILE_NAME: &str = "tools.json";
+const TOOLS_BIN_DIR_NAME: &str = "bin";
 const AGENTS_DIR_NAME: &str = "agents";
 
 const CLIENTS_FIELD: &str = "clients";
@@ -115,7 +115,7 @@ pub struct Config {
     pub wrap: Option<String>,
     pub wrap_code: bool,
 
-    pub function_calling: bool,
+    pub tool_use: bool,
     pub mapping_tools: IndexMap<String, String>,
     pub use_tools: Option<String>,
 
@@ -167,7 +167,7 @@ pub struct Config {
     #[serde(skip)]
     pub model: Model,
     #[serde(skip)]
-    pub functions: Functions,
+    pub tools: Tools,
     #[serde(skip)]
     pub mcp_manager: Option<Arc<McpManager>>,
     #[serde(skip)]
@@ -200,7 +200,7 @@ impl Default for Config {
             wrap: None,
             wrap_code: false,
 
-            function_calling: true,
+            tool_use: true,
             mapping_tools: Default::default(),
             use_tools: None,
 
@@ -242,7 +242,7 @@ impl Default for Config {
             agent_variables: None,
 
             model: Default::default(),
-            functions: Default::default(),
+            tools: Default::default(),
             mcp_manager: None,
             working_mode: WorkingMode::Cmd,
             last_message: None,
@@ -288,7 +288,7 @@ impl Config {
             }
 
             config.init_mcp_manager();
-            config.load_functions()?;
+            config.load_tools()?;
 
             config.setup_model()?;
             config.setup_document_loaders();
@@ -380,19 +380,19 @@ impl Config {
         }
     }
 
-    pub fn functions_dir() -> PathBuf {
-        match env::var(get_env_name("functions_dir")) {
+    pub fn tools_dir() -> PathBuf {
+        match env::var(get_env_name("tools_dir")) {
             Ok(value) => PathBuf::from(value),
-            Err(_) => Self::local_path(FUNCTIONS_DIR_NAME),
+            Err(_) => Self::local_path(TOOLS_DIR_NAME),
         }
     }
 
-    pub fn functions_file() -> PathBuf {
-        Self::functions_dir().join(FUNCTIONS_FILE_NAME)
+    pub fn tools_file() -> PathBuf {
+        Self::tools_dir().join(TOOLS_FILE_NAME)
     }
 
-    pub fn functions_bin_dir() -> PathBuf {
-        Self::functions_dir().join(FUNCTIONS_BIN_DIR_NAME)
+    pub fn tools_bin_dir() -> PathBuf {
+        Self::tools_dir().join(TOOLS_BIN_DIR_NAME)
     }
 
     pub fn session_file(&self, name: &str) -> PathBuf {
@@ -431,14 +431,14 @@ impl Config {
         Self::agent_data_dir(agent_name).join(format!("{rag_name}.yaml"))
     }
 
-    pub fn agents_functions_dir() -> PathBuf {
-        Self::functions_dir().join(AGENTS_DIR_NAME)
+    pub fn agents_tools_dir() -> PathBuf {
+        Self::tools_dir().join(AGENTS_DIR_NAME)
     }
 
-    pub fn agent_functions_dir(name: &str) -> PathBuf {
-        match env::var(format!("{}_FUNCTIONS_DIR", normalize_env_name(name))) {
+    pub fn agent_tools_dir(name: &str) -> PathBuf {
+        match env::var(format!("{}_TOOLS_DIR", normalize_env_name(name))) {
             Ok(value) => PathBuf::from(value),
-            Err(_) => Self::agents_functions_dir().join(name),
+            Err(_) => Self::agents_tools_dir().join(name),
         }
     }
 
@@ -624,7 +624,7 @@ impl Config {
             ),
             ("rag_top_k", rag_top_k.to_string()),
             ("dry_run", self.dry_run.to_string()),
-            ("function_calling", self.function_calling.to_string()),
+            ("tool_use", self.tool_use.to_string()),
             ("stream", self.stream.to_string()),
             ("save", self.save.to_string()),
             ("keybindings", self.keybindings.clone()),
@@ -638,7 +638,7 @@ impl Config {
             ("sessions_dir", display_path(&self.sessions_dir())),
             ("rags_dir", display_path(&Self::rags_dir())),
             ("macros_dir", display_path(&Self::macros_dir())),
-            ("functions_dir", display_path(&Self::functions_dir())),
+            ("tools_dir", display_path(&Self::tools_dir())),
             ("messages_file", display_path(&self.messages_file())),
         ];
         if let Some(hooks) = &self.hooks {
@@ -699,12 +699,12 @@ impl Config {
                 let value = value.parse().with_context(|| "Invalid value")?;
                 config.write().dry_run = value;
             }
-            "function_calling" => {
+            "tool_use" => {
                 let value = value.parse().with_context(|| "Invalid value")?;
-                if value && config.write().functions.is_empty() {
-                    bail!("Function calling cannot be enabled because no functions are installed.")
+                if value && config.write().tools.is_empty() {
+                    bail!("Tool use cannot be enabled because no tools are installed.")
                 }
-                config.write().function_calling = value;
+                config.write().tool_use = value;
             }
             "stream" => {
                 let value = value.parse().with_context(|| "Invalid value")?;
@@ -1161,7 +1161,7 @@ impl Config {
             let mut markdown_render = MarkdownRender::init(render_options)?;
             let agent_info: Option<(String, Vec<String>)> = self.agent.as_ref().map(|agent| {
                 let functions = agent
-                    .functions()
+                    .tools()
                     .declarations()
                     .iter()
                     .filter_map(|v| if v.agent { Some(v.name.clone()) } else { None })
@@ -1520,8 +1520,8 @@ impl Config {
         session_name: Option<&str>,
         abort_signal: AbortSignal,
     ) -> Result<()> {
-        if !config.read().function_calling {
-            bail!("Please enable function calling before using the agent.");
+        if !config.read().tool_use {
+            bail!("Please enable tool use before using the agent.");
         }
         if config.read().agent.is_some() {
             bail!("Already in a agent, please run '.exit agent' first to exit the current agent.");
@@ -1678,11 +1678,11 @@ impl Config {
         Ok(())
     }
 
-    pub fn select_functions(&self, role: &Role) -> Option<Vec<FunctionDeclaration>> {
+    pub fn select_tools(&self, role: &Role) -> Option<Vec<ToolDeclaration>> {
         let mut functions = vec![];
-        if self.function_calling {
+        if self.tool_use {
             if let Some(use_tools) = role.use_tools() {
-                let declarations = self.function_declarations_for_use_tools(Some(&use_tools));
+                let declarations = self.tool_declarations_for_use_tools(Some(&use_tools));
                 let mut tool_names: HashSet<String> = Default::default();
                 let declaration_names: HashSet<String> =
                     declarations.iter().map(|v| v.name.to_string()).collect();
@@ -1716,7 +1716,7 @@ impl Config {
             }
 
             if let Some(agent) = &self.agent {
-                let mut agent_functions = agent.functions().declarations();
+                let mut agent_functions = agent.tools().declarations();
                 let tool_names: HashSet<String> = agent_functions
                     .iter()
                     .filter_map(|v| {
@@ -1811,7 +1811,7 @@ impl Config {
                         "rag_top_k",
                         "max_output_tokens",
                         "dry_run",
-                        "function_calling",
+                        "tool_use",
                         "stream",
                         "save",
                         "highlight",
@@ -1836,7 +1836,7 @@ impl Config {
                 "dry_run" => complete_bool(self.dry_run),
                 "stream" => complete_bool(self.stream),
                 "save" => complete_bool(self.save),
-                "function_calling" => complete_bool(self.function_calling),
+                "tool_use" => complete_bool(self.tool_use),
                 "use_tools" => {
                     let mut prefix = String::new();
                     let mut ignores = HashSet::new();
@@ -1849,7 +1849,7 @@ impl Config {
                         values.push("all".to_string());
                     }
                     values.extend(
-                        self.function_declarations_for_use_tools(Some("all"))
+                        self.tool_declarations_for_use_tools(Some("all"))
                             .iter()
                             .map(|v| v.name.clone()),
                     );
@@ -2315,8 +2315,8 @@ impl Config {
             self.wrap_code = v;
         }
 
-        if let Some(Some(v)) = read_env_bool(&get_env_name("function_calling")) {
-            self.function_calling = v;
+        if let Some(Some(v)) = read_env_bool(&get_env_name("tool_use")) {
+            self.tool_use = v;
         }
         if let Ok(v) = env::var(get_env_name("mapping_tools")) {
             if let Ok(v) = serde_json::from_str(&v) {
@@ -2415,8 +2415,8 @@ impl Config {
         }
     }
 
-    fn load_functions(&mut self) -> Result<()> {
-        self.functions = Functions::init(&Self::functions_file(), None)?;
+    fn load_tools(&mut self) -> Result<()> {
+        self.tools = Tools::init(&Self::tools_file(), None)?;
         Ok(())
     }
 
@@ -2443,11 +2443,8 @@ impl Config {
         })
     }
 
-    fn function_declarations_for_use_tools(
-        &self,
-        use_tools: Option<&str>,
-    ) -> Vec<FunctionDeclaration> {
-        let mut declarations = self.functions.declarations();
+    fn tool_declarations_for_use_tools(&self, use_tools: Option<&str>) -> Vec<ToolDeclaration> {
+        let mut declarations = self.tools.declarations();
         if let Some(use_tools) = use_tools {
             if self.needs_mcp_tools(use_tools) {
                 if let Some(manager) = &self.mcp_manager {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
 mod cli;
 mod client;
 mod config;
-mod function;
 mod hooks;
 mod mcp;
 mod rag;
 mod render;
 mod repl;
 mod serve;
+mod tool;
 #[macro_use]
 mod utils;
 

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -1,5 +1,5 @@
-use super::{mcp_tool_to_function, McpServerConfig};
-use crate::function::FunctionDeclaration;
+use super::{mcp_tool_to_declaration, McpServerConfig};
+use crate::tool::ToolDeclaration;
 
 use anyhow::{anyhow, bail, Context, Result};
 use parking_lot::RwLock;
@@ -14,7 +14,7 @@ use tokio::runtime::{Builder, Handle};
 pub struct McpClient {
     name: String,
     config: McpServerConfig,
-    tools: Arc<RwLock<Vec<FunctionDeclaration>>>,
+    tools: Arc<RwLock<Vec<ToolDeclaration>>>,
     connected: Arc<RwLock<bool>>,
     service: Arc<RwLock<Option<RunningService<RoleClient, ()>>>>,
 }
@@ -79,7 +79,7 @@ impl McpClient {
             .into_iter()
             .map(|tool| {
                 let input_schema = Value::Object((*tool.input_schema).clone());
-                mcp_tool_to_function(
+                mcp_tool_to_declaration(
                     &self.name,
                     tool.name.as_ref(),
                     tool.description.as_deref().unwrap_or_default(),
@@ -111,7 +111,7 @@ impl McpClient {
         Ok(())
     }
 
-    pub fn get_tools(&self) -> Vec<FunctionDeclaration> {
+    pub fn get_tools(&self) -> Vec<ToolDeclaration> {
         self.tools.read().clone()
     }
 
@@ -191,7 +191,7 @@ impl McpManager {
         client.disconnect().await
     }
 
-    pub async fn get_all_tools(&self) -> Vec<FunctionDeclaration> {
+    pub async fn get_all_tools(&self) -> Vec<ToolDeclaration> {
         let clients: Vec<_> = self.clients.read().values().cloned().collect();
         for client in &clients {
             if !client.is_connected() {
@@ -213,7 +213,7 @@ impl McpManager {
         tools
     }
 
-    pub fn get_all_tools_blocking(&self) -> Vec<FunctionDeclaration> {
+    pub fn get_all_tools_blocking(&self) -> Vec<ToolDeclaration> {
         if let Ok(handle) = Handle::try_current() {
             tokio::task::block_in_place(|| handle.block_on(self.get_all_tools()))
         } else {
@@ -227,7 +227,7 @@ impl McpManager {
         }
     }
 
-    pub async fn get_server_tools(&self, server_name: &str) -> Result<Vec<FunctionDeclaration>> {
+    pub async fn get_server_tools(&self, server_name: &str) -> Result<Vec<ToolDeclaration>> {
         let client = self
             .clients
             .read()

--- a/src/mcp/convert.rs
+++ b/src/mcp/convert.rs
@@ -1,16 +1,16 @@
-use crate::function::{FunctionDeclaration, JsonSchema};
+use crate::tool::{JsonSchema, ToolDeclaration};
 
 use anyhow::{anyhow, Result};
 use indexmap::IndexMap;
 use serde_json::Value;
 
-pub fn mcp_tool_to_function(
+pub fn mcp_tool_to_declaration(
     server_name: &str,
     tool_name: &str,
     tool_description: &str,
     input_schema: &Value,
-) -> Result<FunctionDeclaration> {
-    Ok(FunctionDeclaration {
+) -> Result<ToolDeclaration> {
+    Ok(ToolDeclaration {
         name: format!("mcp__{server_name}__{tool_name}"),
         description: tool_description.to_string(),
         parameters: convert_json_schema(input_schema)?,
@@ -100,7 +100,7 @@ fn convert_json_schema(schema: &Value) -> Result<JsonSchema> {
 
 #[cfg(test)]
 mod tests {
-    use super::{convert_json_schema, mcp_tool_to_function};
+    use super::{convert_json_schema, mcp_tool_to_declaration};
     use serde_json::json;
 
     #[test]
@@ -182,7 +182,7 @@ mod tests {
         });
 
         let function =
-            mcp_tool_to_function("filesystem", "read_file", "Read a file from disk", &schema)
+            mcp_tool_to_declaration("filesystem", "read_file", "Read a file from disk", &schema)
                 .expect("convert tool");
 
         assert_eq!(function.name, "mcp__filesystem__read_file");

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -8,7 +8,7 @@ pub use client::McpManager;
 pub use config::McpServerConfig;
 
 #[allow(unused_imports)]
-use convert::mcp_tool_to_function;
+use convert::mcp_tool_to_declaration;
 
 pub fn is_mcp_tool(name: &str) -> bool {
     name.starts_with("mcp__")

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,4 +1,4 @@
-use crate::{client::*, config::*, function::*, rag::*, utils::*};
+use crate::{client::*, config::*, rag::*, tool::*, utils::*};
 
 use anyhow::{anyhow, bail, Result};
 use bytes::Bytes;
@@ -74,7 +74,7 @@ struct Server {
 impl Server {
     fn new(config: &GlobalConfig) -> Self {
         let mut config = config.read().clone();
-        config.functions = Functions::default();
+        config.tools = Tools::default();
         let mut models = list_all_models(&config);
         let mut default_model = config.model.clone();
         default_model.data_mut().name = DEFAULT_MODEL_NAME.into();
@@ -913,7 +913,7 @@ fn parse_messages(message: Vec<Value>) -> Result<Vec<Message>> {
     Ok(output)
 }
 
-fn parse_tools(tools: Option<Vec<Value>>) -> Result<Option<Vec<FunctionDeclaration>>> {
+fn parse_tools(tools: Option<Vec<Value>>) -> Result<Option<Vec<ToolDeclaration>>> {
     let tools = match tools {
         Some(v) => v,
         None => return Ok(None),

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -141,17 +141,14 @@ impl ToolResult {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct Functions {
-    declarations: Vec<FunctionDeclaration>,
-    mcp_declarations: Vec<FunctionDeclaration>,
+pub struct Tools {
+    declarations: Vec<ToolDeclaration>,
+    mcp_declarations: Vec<ToolDeclaration>,
 }
 
-impl Functions {
-    pub fn init(
-        declarations_path: &Path,
-        mcp_tools: Option<Vec<FunctionDeclaration>>,
-    ) -> Result<Self> {
-        let declarations: Vec<FunctionDeclaration> = if declarations_path.exists() {
+impl Tools {
+    pub fn init(declarations_path: &Path, mcp_tools: Option<Vec<ToolDeclaration>>) -> Result<Self> {
+        let declarations: Vec<ToolDeclaration> = if declarations_path.exists() {
             let ctx = || {
                 format!(
                     "Failed to load functions at {}",
@@ -170,14 +167,14 @@ impl Functions {
         })
     }
 
-    pub fn init_from_mcp(mcp_tools: Option<Vec<FunctionDeclaration>>) -> Self {
+    pub fn init_from_mcp(mcp_tools: Option<Vec<ToolDeclaration>>) -> Self {
         Self {
             declarations: vec![],
             mcp_declarations: mcp_tools.unwrap_or_default(),
         }
     }
 
-    pub fn find(&self, name: &str) -> Option<&FunctionDeclaration> {
+    pub fn find(&self, name: &str) -> Option<&ToolDeclaration> {
         self.declarations
             .iter()
             .chain(self.mcp_declarations.iter())
@@ -189,7 +186,7 @@ impl Functions {
             || self.mcp_declarations.iter().any(|v| v.name == name)
     }
 
-    pub fn declarations(&self) -> Vec<FunctionDeclaration> {
+    pub fn declarations(&self) -> Vec<ToolDeclaration> {
         self.declarations
             .iter()
             .chain(self.mcp_declarations.iter())
@@ -203,7 +200,7 @@ impl Functions {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FunctionDeclaration {
+pub struct ToolDeclaration {
     pub name: String,
     pub description: String,
     pub parameters: JsonSchema,
@@ -299,7 +296,7 @@ impl ToolCall {
 
         cmd_args.push(json_data.to_string());
 
-        let output = match run_llm_function(cmd_name, cmd_args, envs)? {
+        let output = match run_llm_tool(cmd_name, cmd_args, envs)? {
             Some(contents) => serde_json::from_str(&contents)
                 .ok()
                 .unwrap_or_else(|| json!({"output": contents})),
@@ -359,7 +356,7 @@ impl ToolCall {
         agent: &Agent,
     ) -> Result<CallConfig> {
         let function_name = self.name.clone();
-        match agent.functions().find(&function_name) {
+        match agent.tools().find(&function_name) {
             Some(function) => {
                 let agent_name = agent.name().to_string();
                 if function.agent {
@@ -384,7 +381,7 @@ impl ToolCall {
 
     fn extract_call_config_from_config(&self, config: &GlobalConfig) -> Result<CallConfig> {
         let function_name = self.name.clone();
-        match config.read().functions.contains(&function_name) {
+        match config.read().tools.contains(&function_name) {
             true => Ok((
                 function_name.clone(),
                 function_name,
@@ -396,7 +393,7 @@ impl ToolCall {
     }
 }
 
-pub fn run_llm_function(
+pub fn run_llm_tool(
     cmd_name: String,
     cmd_args: Vec<String>,
     mut envs: HashMap<String, String>,
@@ -405,12 +402,12 @@ pub fn run_llm_function(
 
     let mut bin_dirs: Vec<PathBuf> = vec![];
     if cmd_args.len() > 1 {
-        let dir = Config::agent_functions_dir(&cmd_name).join("bin");
+        let dir = Config::agent_tools_dir(&cmd_name).join("bin");
         if dir.exists() {
             bin_dirs.push(dir);
         }
     }
-    bin_dirs.push(Config::functions_bin_dir());
+    bin_dirs.push(Config::tools_bin_dir());
     let current_path = std::env::var("PATH").context("No PATH environment variable")?;
     let prepend_path = bin_dirs
         .iter()


### PR DESCRIPTION
## Summary

- Renames all LLM-callable-tool references from "function" to "tool" across code, config, env vars, and docs
- Aligns terminology with modern industry convention ("tool use" instead of "function calling")
- Clean break — no backward compatibility shims

## Changes

**Code (16 files, ~540 lines changed):**
- `src/function.rs` → `src/tool.rs`
- `FunctionDeclaration` → `ToolDeclaration`, `Functions` → `Tools`
- `function_calling` config field → `tool_use`
- `functions_dir`/`functions_file` → `tools_dir`/`tools_file`
- `select_functions` → `select_tools`
- `supports_function_calling` → `supports_tool_use` (~160 occurrences in models.yaml)

**Config/env (clean break):**
- `HARNX_FUNCTION_CALLING` → `HARNX_TOOL_USE`
- `HARNX_FUNCTIONS_DIR` → `HARNX_TOOLS_DIR`
- On-disk: `functions/` → `tools/`, `functions.json` → `tools.json`

**Unchanged** (already correct): `use_tools`, `mapping_tools`, `ToolCall`, `ToolResult`

## Breaking Changes

Users must update their `config.yaml`:
- `function_calling: true` → `tool_use: true`
- Any `HARNX_FUNCTION_CALLING` env vars → `HARNX_TOOL_USE`
- On-disk `functions/` directories → `tools/`

## Testing

- `cargo test --all` — 79 passed
- `cargo clippy --all --all-targets -- -D warnings` — no issues
- `cargo fmt --all --check` — clean