### PR TITLE
docs: replace wiki references with local documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,16 +150,16 @@ Harnx supports custom dark and light themes, which highlight response text and c
 
 ## Documentation
 
-- [Chat-REPL Guide](https://github.com/dobesv/harnx/wiki/Chat-REPL-Guide)
-- [Command-Line Guide](https://github.com/dobesv/harnx/wiki/Command-Line-Guide)
-- [Role Guide](https://github.com/dobesv/harnx/wiki/Role-Guide)
-- [Macro Guide](https://github.com/dobesv/harnx/wiki/Macro-Guide)
-- [RAG Guide](https://github.com/dobesv/harnx/wiki/RAG-Guide)
-- [Environment Variables](https://github.com/dobesv/harnx/wiki/Environment-Variables)
-- [Configuration Guide](https://github.com/dobesv/harnx/wiki/Configuration-Guide)
-- [Custom Theme](https://github.com/dobesv/harnx/wiki/Custom-Theme)
-- [Custom REPL Prompt](https://github.com/dobesv/harnx/wiki/Custom-REPL-Prompt)
-- [FAQ](https://github.com/dobesv/harnx/wiki/FAQ)
+- [Chat-REPL Guide](docs/chat-repl-guide.md)
+- [Command-Line Guide](docs/command-line-guide.md)
+- [Role Guide](docs/role-guide.md)
+- [Macro Guide](docs/macro-guide.md)
+- [RAG Guide](docs/rag-guide.md)
+- [Environment Variables](docs/environment-variables.md)
+- [Configuration Guide](docs/configuration-guide.md)
+- [Custom Theme](docs/custom-theme.md)
+- [Custom REPL Prompt](docs/custom-repl-prompt.md)
+- [FAQ](docs/faq.md)
 
 ## Contributing
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -71,7 +71,7 @@ summarize_prompt: 'Summarize the discussion briefly in 200 words or less to use 
 summary_prompt: 'This is a summary of the chat history as a recap: '
 
 # ---- RAG ----
-# See [RAG-Guide](https://github.com/dobesv/harnx/wiki/RAG-Guide) for more details.
+# See docs/rag-guide.md for more details.
 rag_embedding_model: null        # Specifies the embedding model used for context retrieval
 rag_reranker_model: null         # Specifies the reranker model used for sorting retrieved documents
 rag_top_k: 5                     # Specifies the number of documents to retrieve for answering queries
@@ -109,7 +109,7 @@ document_loaders:
 # ---- apperence ----
 highlight: true                  # Controls syntax highlighting
 light_theme: false               # Activates a light color theme when true. env: HARNX_LIGHT_THEME
-# Custom REPL left/right prompts, see https://github.com/dobesv/harnx/wiki/Custom-REPL-Prompt for more details
+# Custom REPL left/right prompts, see docs/custom-repl-prompt.md for more details
 left_prompt:
   '{color.green}{?session {?agent {agent}>}{session}{?role /}}{!session {?agent {agent}>}}{role}{?rag @{rag}}{color.cyan}{?session )}{!session >}{color.reset} '
 right_prompt:

--- a/docs/chat-repl-guide.md
+++ b/docs/chat-repl-guide.md
@@ -1,0 +1,168 @@
+# Chat REPL Guide
+
+The core of Harnx is Chat-REPL.
+
+## REPL Features
+
+- **Tab Autocompletion:** All REPL commands have completions.
+  - `.<tab>` to complete REPL commands.
+  - `.model <tab>` to complete chat models.
+  - `.set <tab>` to complete config keys.
+  - `.set key <tab>` to complete config values.
+- **Multi-line Support:** Input multi-line text in the following ways:
+  - Press `ctrl+o` to edit buffer with an external editor (recommend).
+  - Paste multi-line text (requires terminal support for bracketed paste).
+  - Type `:::` to start multi-line editing, type `:::` to finish it.
+  - Use hotkey `{ctrl,shift,alt}+enter` or `ctrl+j` to insert a newline directly.
+- **History Search:** Press `ctrl+r` to search the history. Use `↑↓` to navigate through the history.
+- **Configurable Keybinding:** Emacs-style bindings and basic VI-style.
+- **[Custom REPL Prompt](custom-repl-prompt.md):** Display information about the current context in the prompt.
+
+## REPL Commands
+
+### `.model` - change the current LLM
+
+```
+openai:gpt-4o     128000 /     4096  |       5 /     15    👁 ⚒
+|                 |            |             |       |     |  └─ support function callings
+|                 |            |             |       |     └─ support vision
+|                 |            |             |       └─ output price ($/1M)
+|                 |            |             └─ input price ($/1M)
+|                 |            |
+|                 |            └─ max output tokens
+|                 └─ max input tokens
+└─ model id
+```
+
+### `.role` - role management
+
+```
+.role                    Create or switch to a role
+.info role               Show role info
+.edit role               Modify current role
+.save role               Save current role to file
+.exit role               Exit active role
+```
+
+### `.prompt` - set a temporary role using a prompt
+
+Compared to `.role`, `.prompt` does not persist to a file; it creates and switches to a temporary role.
+
+### `.session` - session management
+
+```
+.session                 Start or switch to a session
+.empty session           Clear session messages
+.compress session        Compress session messages
+.info session            Show session info
+.edit session            Modify current session
+.save session            Save current session to file
+.exit session            Exit active session
+```
+
+### `.agent` - chat with AI agent
+
+```
+.agent                   Use an agent
+.starter                 Use a conversation starter
+.edit agent-config       Modify agent configuration file
+.info agent              Show agent info
+.exit agent              Leave agent
+```
+
+### `.rag` - chat with documents
+
+```
+.rag                     Initialize or access RAG
+.edit rag-docs           Add or remove documents from an existing RAG
+.rebuild rag             Rebuild RAG for document changes
+.sources rag             Show citation sources used in last query
+.info rag                Show RAG info
+.exit rag                Leave RAG
+```
+
+### `.macro` - execute a macro
+
+```
+.macro test-function-calling
+.macro within-agent todo list all my todos
+```
+
+### `.file` - read files and use them as input
+
+```
+Usage: .file <file|dir|url|%%|cmd>... [-- <text>...]
+
+.file data.txt
+.file %% -- translate last reply to english
+.file `git diff` -- generate git commit message
+.file config.yaml -- convert to toml
+.file screenshot.png -- design a web app based on the image
+.file https://ibb.co/a.png https://ibb.co/b.png -- what is the difference?
+.file https://github.com/dobesv/harnx/blob/main/README.md -- what are the features of Harnx?
+```
+
+> NOTE: `%%` and `cmd` are supported starting from V0.27.0.
+
+### `.continue` - continue previous response
+
+This command is often used to resume generation that was interrupted due to the response exceeding the length limit.
+
+### `.regenerate` - regenerate the response
+
+If the response is interrupted or unsatisfactory, you can regenerate it with `.regenerate`.
+
+### `.copy` - copy last response
+
+### `.set` - adjust runtime settings
+
+```
+.set <tab>
+.set max_output_tokens 4096
+.set temperature 1.2
+.set top_p 0.8
+.set dry_run true
+.set stream false
+.set save true
+.set function_calling true
+.set use_tools <tab>
+.set save_session true
+.set compress_threshold 1000
+.set rag_reranker_model <tab>
+.set rag_top_k 4
+.set highlight true
+```
+
+### `.edit` - modify config/role/session/agent-config/rag-docs
+
+```
+.edit config             Modify configuration file
+.edit role               Modify current role
+.edit session            Modify current session
+.edit agent-config       Modify agent configuration file
+.edit rag-docs           Add or remove documents from an existing RAG
+```
+
+### `.delete` - delete roles/sessions/RAGs/agents
+
+### `.info` - display system/role/session/agent/RAG info
+
+```
+.info                    Show system info
+.info role               Show role info
+.info session            Show session info
+.info agent              Show agent info
+.info rag                Show RAG info
+```
+
+### `.exit` - exit role/session/RAG/agent/REPL
+
+```
+.exit role               Exit active role
+.exit session            Exit active session
+.exit agent              Leave agent
+.exit rag                Leave RAG
+.exit                    Exit REPL
+```
+
+### `.help` - show help guide

--- a/docs/command-line-guide.md
+++ b/docs/command-line-guide.md
@@ -1,0 +1,135 @@
+# Command Line Guide
+
+## Usage
+
+```
+Usage: harnx [OPTIONS] [TEXT]...
+
+Arguments:
+  [TEXT]...  Input text
+
+Options:
+  -m, --model <MODEL>                  Select a LLM model
+      --prompt <PROMPT>                Use the system prompt
+  -r, --role <ROLE>                    Select a role
+  -s, --session [<SESSION>]            Start or join a session
+      --empty-session                  Ensure the session is empty
+      --save-session                   Ensure the new conversation is saved to the session
+  -a, --agent <AGENT>                  Start a agent
+      --agent-variable <NAME> <VALUE>  Set agent variables
+      --rag <RAG>                      Start a RAG
+      --rebuild-rag                    Rebuild the RAG to sync document changes
+      --macro <MACRO>                  Execute a macro
+      --serve [<ADDRESS>]              Serve the LLM API and WebAPP
+  -e, --execute                        Execute commands in natural language
+  -c, --code                           Output code only
+  -f, --file <FILE>                    Include files, directories, or URLs
+  -S, --no-stream                      Turn off stream mode
+      --dry-run                        Display the message without sending it
+      --info                           Display information
+      --sync-models                    Sync models updates
+      --list-models                    List all available chat models
+      --list-roles                     List all roles
+      --list-sessions                  List all sessions
+      --list-agents                    List all agents
+      --list-rags                      List all RAGs
+      --list-macros                    List all macros
+  -h, --help                           Print help
+  -V, --version                        Print version
+```
+
+## Examples
+
+```
+harnx                                          # Enter REPL
+harnx Tell a joke                              # Generate response
+
+harnx -e install nvim                          # Execute command
+harnx -c fibonacci in js                       # Generate code
+
+harnx --serve                                  # Run server
+harnx --serve 0.0.0.0:8080                     # Run server with addr
+
+harnx -m openai:gpt-4o                         # Select LLM
+
+harnx -r role1                                 # Use role 'role1'
+harnx -s                                       # Begin a temp session
+harnx -s session1                              # Use session 'session1'
+harnx -a agent1                                # Use agent 'agent1'
+harnx --rag rag1                               # Use RAG 'rag1'
+
+harnx --info                                   # View system info
+harnx -r role1 --info                          # View role info
+harnx -s session1 --info                       # View session info
+harnx -a agent1 --info                         # View agent info
+harnx --rag rag1 --info                        # View RAG info
+
+harnx --macro macro1                           # Execute macro 'macro1'
+harnx --macro macro2 arg1 arg2                 # Execute macro 'macro2' with args
+
+cat data.toml | harnx -c to json > data.json   # Pipe Input/Output
+output=$(harnx -S $input)                      # Run in the script
+
+harnx -f a.png -f b.png diff images            # Use files
+```
+
+## Shell Assistant
+
+Simply input what you want to do in natural language, and harnx will prompt and run the command that achieves your intent.
+
+**Harnx is aware of the OS and shell you're using, so it provides shell commands for your specific system.**
+
+## Shell Integration
+
+Simply type `alt+e` to let `harnx` provide intelligent completions directly in your terminal.
+
+Harnx offers shell integration scripts for bash, zsh, PowerShell, fish, and nushell. You can find them on GitHub at [https://github.com/dobesv/harnx/tree/main/scripts/shell-integration](https://github.com/dobesv/harnx/tree/main/scripts/shell-integration).
+
+## Shell Autocompletion
+
+The shell autocompletion suggests commands, options, and filenames as you type, enabling you to type less, work faster, and avoid typos.
+
+Harnx offers shell completion scripts for bash, zsh, PowerShell, fish, and nushell. You can find them on GitHub at [https://github.com/dobesv/harnx/tree/main/scripts/completions](https://github.com/dobesv/harnx/tree/main/scripts/completions).
+
+## Generate Code
+
+By using the `--code` or `-c` parameter, you can specifically request pure code output.
+
+**The `-c/--code` with pipe ensures the extraction of code from Markdown.**
+
+## Use Files & URLs
+
+The `-f/--file` flag can be used to send files to LLMs.
+
+```
+# Use local file
+harnx -f data.txt
+# Use image file
+harnx -f image.png ocr
+# Use multiple files
+harnx -f file1 -f file2 explain
+# Use local dirs
+harnx -f dir/ summarize
+# Use remote URLs
+harnx -f https://example.com/page summarize
+```
+
+## Run Server
+
+Harnx comes with a built-in lightweight HTTP server.
+
+```
+$ harnx --serve
+Chat Completions API: http://127.0.0.1:8000/v1/chat/completions
+Embeddings API:       http://127.0.0.1:8000/v1/embeddings
+LLM Playground:       http://127.0.0.1:8000/playground
+LLM Arena:            http://127.0.0.1:8000/arena?num=2
+```
+
+Change the listening address:
+
+```
+$ harnx --serve 0.0.0.0
+$ harnx --serve 8080
+$ harnx --serve 0.0.0.0:8080
+```

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -1,0 +1,232 @@
+# Configuration Guide
+
+## Configuration File
+
+On first run, Harnx creates a configuration file automatically.
+
+The config file path is `<user-config-dir>/harnx/config.yaml`. The exact location depends on your operating system:
+
+| OS      | Path                                                    |
+| ------- | ------------------------------------------------------- |
+| Windows | `C:\Users\Alice\AppData\Roaming\harnx\config.yaml`     |
+| macOS   | `/Users/Alice/Library/Application Support/harnx/config.yaml` |
+| Linux   | `/home/alice/.config/harnx/config.yaml`                 |
+
+To find the config file path on your system:
+
+```sh
+harnx --info | grep config_file
+```
+
+In REPL mode, you can open the config file for editing with:
+
+```
+.edit config
+```
+
+## LLM
+
+- **model**: The LLM model to use. Can be set to a specific model or a client name.
+- **temperature**: Controls randomness. Lower values make output more focused and deterministic.
+- **top_p**: Controls diversity via nucleus sampling.
+
+Setting `model` to a client name (e.g., `openai`) uses that client's default model.
+
+## Behavior
+
+- **stream**: Whether to stream responses. (`true`/`false`)
+- **save**: Whether to save messages. (`true`/`false`)
+- **keybindings**: Keybinding style for REPL mode. (`emacs`/`vi`)
+- **editor**: External editor command for the `.edit` REPL command.
+- **wrap**: Wrap text at a specified number of characters, or `no` to disable.
+- **wrap_code**: Whether to wrap code blocks. (`true`/`false`)
+
+## Tool Use
+
+Harnx supports tool use (renamed from "Function calling").
+
+- **tool_use**: Enable or disable tool use globally. (`true`/`false`)
+- **mapping_tools**: Map specific tools to specific models or roles.
+- **use_tools**: Specify which tools to make available.
+
+Visit [https://github.com/sigoden/llm-functions](https://github.com/sigoden/llm-functions) for setup instructions and available tools.
+
+## Prelude
+
+Prelude commands run automatically when entering a mode.
+
+- **repl_prelude**: Commands to run when entering REPL mode.
+- **cmd_prelude**: Commands to run when entering CMD mode.
+- **agent_prelude**: Commands to run when entering an agent session.
+
+## Session
+
+- **save_session**: Whether to save session history. (`true`/`false`)
+- **compress_threshold**: Token count threshold that triggers conversation compression.
+- **summarize_prompt**: Prompt used when summarizing conversation for compression.
+- **summary_prompt**: Prompt used when generating a session summary.
+
+## RAG
+
+- **rag_embedding_model**: Model used for generating embeddings.
+- **rag_reranker_model**: Model used for reranking retrieved documents.
+- **rag_top_k**: Number of top results to retrieve.
+- **rag_chunk_size**: Size of text chunks for document splitting.
+- **rag_chunk_overlap**: Overlap between consecutive chunks.
+- **rag_template**: Template for formatting RAG context in prompts.
+- **document_loaders**: Configuration for loading different document types.
+
+See the [RAG Guide](rag-guide.md) for detailed setup instructions.
+
+## Appearance
+
+- **highlight**: Whether to enable syntax highlighting. (`true`/`false`)
+- **light_theme**: Whether to use the light theme. (`true`/`false`). Note: this is `light_theme`, not `theme`.
+- **left_prompt**: Custom left prompt for REPL mode.
+- **right_prompt**: Custom right prompt for REPL mode.
+
+See [Custom REPL Prompt](custom-repl-prompt.md) for prompt customization details.
+
+## Misc
+
+- **serve_addr**: Address and port for the built-in HTTP server.
+- **user_agent**: Custom User-Agent header for HTTP requests.
+- **save_shell_history**: Whether to save shell command history. (`true`/`false`)
+- **sync_models_url**: URL to sync available models from.
+
+## Agent-Specific Configuration
+
+Each agent can have its own configuration file at:
+
+```
+<harnx-config-dir>/agents/<agent-name>/config.yaml
+```
+
+Agent config files support the following properties:
+
+- **model**: Override the default model for this agent.
+- **temperature**: Override the default temperature for this agent.
+- **top_p**: Override the default top_p for this agent.
+- **use_tools**: Specify which tools this agent can use.
+- **agent_prelude**: Commands to run when entering this agent's session.
+- **instructions**: System prompt / instructions for the agent.
+- **variables**: Variables that can be interpolated into the agent's prompts.
+
+## Clients
+
+Harnx supports many LLM providers. Each client is configured in the `clients` section of the config file.
+
+### General Client Configuration
+
+Every client supports these common options:
+
+```yaml
+clients:
+  - type: <provider>        # Provider type (e.g., openai, claude, gemini)
+    api_key: <key>           # API key (can also use env vars)
+    models:
+      - name: <model-name>
+        max_input_tokens: 128000
+        max_output_tokens: 8192
+```
+
+You can add chat models, embedding models, and reranker models to any client:
+
+```yaml
+clients:
+  - type: openai
+    api_key: <key>
+    models:
+      - name: gpt-4o
+        type: chat
+        max_input_tokens: 128000
+        max_output_tokens: 16384
+      - name: text-embedding-3-large
+        type: embedding
+        max_input_tokens: 8191
+        default_chunk_size: 3000
+      - name: custom-reranker
+        type: reranker
+        max_input_tokens: 8191
+```
+
+### Proxy
+
+Set a proxy for a specific client:
+
+```yaml
+clients:
+  - type: openai
+    api_key: <key>
+    proxy: socks5://127.0.0.1:1080
+```
+
+### Patching API Requests
+
+You can patch the URL, headers, and body of API requests sent to any client. This is useful for custom endpoints, authentication schemes, or provider-specific parameters.
+
+```yaml
+clients:
+  - type: openai
+    patch:
+      chat_completions:
+        url: https://custom-endpoint.example.com/v1/chat/completions
+        headers:
+          X-Custom-Header: custom-value
+        body:
+          custom_param: custom_value
+```
+
+### Provider Examples
+
+#### Gemini Safety Settings
+Gemini safety settings example using patch:
+
+```yaml
+clients:
+  - type: gemini
+    api_key: xxxxxxxxxxxxxxxxxxxxxxxx
+    patch:
+      chat_completions:
+        body:
+          safetySettings:
+            - category: HARM_CATEGORY_HARASSMENT
+              threshold: BLOCK_NONE
+            - category: HARM_CATEGORY_HATE_SPEECH
+              threshold: BLOCK_NONE
+            - category: HARM_CATEGORY_SEXUALLY_EXPLICIT
+              threshold: BLOCK_NONE
+            - category: HARM_CATEGORY_DANGEROUS_CONTENT
+              threshold: BLOCK_NONE
+```
+
+#### DeepSeek Beta API
+Deepseek beta API example using patch:
+
+```yaml
+clients:
+  - type: openai-compatible
+    name: deepseek
+    api_base: https://api.deepseek.com
+    api_key: sk-xxxxxxxxxxxxxxxxxxxxxxxx
+    patch:
+      chat_completions:
+        headers:
+          X-Beta: "true"
+```
+
+#### OpenAI-Compatible Providers
+
+Any provider that implements the OpenAI API format can be configured:
+
+```yaml
+clients:
+  - type: openai-compatible
+    name: my-provider
+    api_base: https://api.my-provider.com/v1
+    api_key: <key>
+    models:
+      - name: my-model
+        max_input_tokens: 32000
+        max_output_tokens: 4096
+```

--- a/docs/custom-repl-prompt.md
+++ b/docs/custom-repl-prompt.md
@@ -1,0 +1,83 @@
+# Custom REPL Prompt
+
+The REPL prompt displays context information about the active role, session, RAG, and agent.
+
+## Prompt States
+
+The prompt adapts to show relevant context depending on what's active:
+
+- none
+- role
+- session
+- agent
+- rag
+- session + role
+- session + rag
+- session + role + rag
+- agent + session
+- agent + rag
+- agent + session + rag
+
+## Configuration
+
+Edit `left_prompt` and `right_prompt` in your config file to customize the REPL prompt.
+
+### Default left_prompt
+
+```
+'{color.green}{?session {?agent {agent}>}{session}{?role /}}{!session {?agent {agent}>}}{role}{?rag @{rag}}{color.cyan}{?session )}{!session >}{color.reset} '
+```
+
+### Default right_prompt
+
+```
+'{color.purple}{?session {?consume_tokens {consume_tokens}({consume_percent}%)}{!consume_tokens {consume_tokens}}}{color.reset}'
+```
+
+## Syntax
+
+| Syntax | Description |
+|---|---|
+| `{var}` | Replace with the value of `var` |
+| `{?var template}` | Evaluate `template` when `var` is truthy |
+| `{!var template}` | Evaluate `template` when `var` is falsy |
+
+## Variables
+
+| Variable | Description |
+|---|---|
+| `model` | Current model |
+| `client_name` | Client name |
+| `model_name` | Model name |
+| `max_input_tokens` | Max input tokens |
+| `temperature` | Temperature |
+| `top_p` | Top P |
+| `dry_run` | Dry run mode |
+| `stream` | Stream mode |
+| `save` | Save mode |
+| `wrap` | Wrap mode |
+| `role` | Active role |
+| `session` | Active session |
+| `dirty` | Session dirty flag |
+| `consume_tokens` | Consumed tokens |
+| `consume_percent` | Consumed token percentage |
+| `user_messages_len` | Number of user messages |
+| `rag` | Active RAG |
+| `agent` | Active agent |
+
+## Color Variables
+
+All `color.*` variables map to ANSI color codes:
+
+| Variable | Variable |
+|---|---|
+| `color.reset` | `color.black` |
+| `color.dark_gray` | `color.red` |
+| `color.light_red` | `color.green` |
+| `color.light_green` | `color.yellow` |
+| `color.light_yellow` | `color.blue` |
+| `color.light_blue` | `color.purple` |
+| `color.light_purple` | `color.magenta` |
+| `color.light_magenta` | `color.cyan` |
+| `color.light_cyan` | `color.white` |
+| `color.light_gray` | |

--- a/docs/custom-theme.md
+++ b/docs/custom-theme.md
@@ -1,0 +1,128 @@
+# Custom Theme
+
+Harnx supports custom themes via `.tmTheme` files. You can use a custom dark theme and a custom light theme to highlight response text and code blocks.
+
+## Setup
+
+1. Download a `.tmTheme` file.
+2. Place it in the Harnx config directory.
+3. Name it `dark.tmTheme` for the dark theme or `light.tmTheme` for the light theme.
+4. Harnx will automatically load the theme on startup.
+
+Navigate to the config directory:
+
+```sh
+cd "$(dirname "$(harnx --info | grep config_file | awk '{print $2}')")"
+```
+
+Download a dark theme:
+
+```sh
+wget -O dark.tmTheme <theme-url>
+```
+
+Download a light theme:
+
+```sh
+wget -O light.tmTheme <theme-url>
+```
+
+## Available Themes
+
+### 1337-Scheme
+
+```sh
+wget -O dark.tmTheme https://raw.githubusercontent.com/MarkMichos/1337-Scheme/master/1337-Scheme.tmTheme
+```
+
+### Coldark
+
+Dark:
+
+```sh
+wget -O dark.tmTheme https://raw.githubusercontent.com/ArmandPhilworthy/coldark-tmTheme/master/Coldark-Dark.tmTheme
+```
+
+Light:
+
+```sh
+wget -O light.tmTheme https://raw.githubusercontent.com/ArmandPhilworthy/coldark-tmTheme/master/Coldark-Cold.tmTheme
+```
+
+### Dracula
+
+```sh
+wget -O dark.tmTheme https://raw.githubusercontent.com/dracula/sublime/master/Dracula.tmTheme
+```
+
+### Github
+
+```sh
+wget -O light.tmTheme https://raw.githubusercontent.com/primer/github-textmate-theme/main/GitHub.tmTheme
+```
+
+### gruvbox
+
+Dark:
+
+```sh
+wget -O dark.tmTheme https://raw.githubusercontent.com/peaceant/gruvbox/master/gruvbox%20(Dark)%20(Hard).tmTheme
+```
+
+Light:
+
+```sh
+wget -O light.tmTheme https://raw.githubusercontent.com/peaceant/gruvbox/master/gruvbox%20(Light)%20(Hard).tmTheme
+```
+
+### OneHalf
+
+Dark:
+
+```sh
+wget -O dark.tmTheme https://raw.githubusercontent.com/sonph/onehalf/master/sublimetext/OneHalfDark.tmTheme
+```
+
+Light:
+
+```sh
+wget -O light.tmTheme https://raw.githubusercontent.com/sonph/onehalf/master/sublimetext/OneHalfLight.tmTheme
+```
+
+### Solarized
+
+Dark:
+
+```sh
+wget -O dark.tmTheme https://raw.githubusercontent.com/braver/Solarized/master/Solarized%20(dark).tmTheme
+```
+
+Light:
+
+```sh
+wget -O light.tmTheme https://raw.githubusercontent.com/braver/Solarized/master/Solarized%20(light).tmTheme
+```
+
+### Sublime Snazzy
+
+```sh
+wget -O dark.tmTheme https://raw.githubusercontent.com/greggb/sublime-snazzy/master/Sublime%20Snazzy.tmTheme
+```
+
+### TwoDark
+
+```sh
+wget -O dark.tmTheme https://raw.githubusercontent.com/nicklayb/TwoDark/master/TwoDark.tmTheme
+```
+
+### Visual Studio Dark+
+
+```sh
+wget -O dark.tmTheme https://raw.githubusercontent.com/nicklayb/VSDarkPlus-tmTheme/master/VSDarkPlus.tmTheme
+```
+
+### Zenburn
+
+```sh
+wget -O dark.tmTheme https://raw.githubusercontent.com/colinta/zenburn/master/zenburn.tmTheme
+```

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,69 @@
+# Environment Variables
+
+## Env file
+
+Harnx can load environment variables from a `.env` file located in the configuration directory: `<harnx-config-dir>/.env`.
+
+## Config-Related Envs
+
+- **HARNX_MODEL**: The default model to use.
+- **HARNX_TEMPERATURE**: The temperature setting for the model.
+- **HARNX_TOP_P**: The top_p setting for the model.
+- **HARNX_STREAM**: Whether to stream the output (boolean).
+- **HARNX_SAVE**: Whether to save the conversation history (boolean).
+- **HARNX_EDITOR**: The editor to use for editing messages or configuration.
+- **HARNX_WRAP**: Whether to wrap the output text (boolean).
+- **HARNX_WRAP_CODE**: Whether to wrap code blocks (boolean).
+- **HARNX_SAVE_SESSION**: Whether to save the session (boolean).
+- **HARNX_COMPRESS_THRESHOLD**: The threshold for compressing the session history.
+- **HARNX_TOOL_USE**: Enable or disable tool use (boolean). Note: renamed from `AICHAT_FUNCTION_CALLING`.
+- **HARNX_USE_TOOLS**: Specify which tools to use.
+- **HARNX_RAG_EMBEDDING_MODEL**: The model used for embeddings in RAG.
+- **HARNX_RAG_RERANKER_MODEL**: The model used for reranking in RAG.
+- **HARNX_RAG_TOP_K**: The number of top results to retrieve.
+- **HARNX_RAG_CHUNK_SIZE**: The size of chunks for document processing.
+- **HARNX_RAG_CHUNK_OVERLAP**: The overlap between chunks.
+- **HARNX_RAG_TEMPLATE**: The template for RAG prompts.
+- **HARNX_HIGHLIGHT**: Whether to highlight the output (boolean).
+- **HARNX_LIGHT_THEME**: Whether to use a light theme (boolean).
+- **HARNX_SERVE_ADDR**: The address to serve the API on.
+- **HARNX_USER_AGENT**: The user agent string for API requests.
+- **HARNX_SAVE_SHELL_HISTORY**: Whether to save shell history (boolean).
+- **HARNX_SYNC_MODELS_URL**: The URL to sync models from.
+
+## Client-Related Envs
+
+- **{client}_API_KEY**: API key for a specific client (e.g., `OPENAI_API_KEY`, `CLAUDE_API_KEY`).
+- **HARNX_PLATFORM**: The platform to use.
+- **HARNX_PATCH_{client}_CHAT_COMPLETIONS**: Patch for chat completions for a specific client.
+- **HARNX_SHELL**: The shell to use for executing commands.
+
+## Files/Dirs Envs
+
+- **HARNX_CONFIG_DIR**: The directory for configuration files.
+- **HARNX_ENV_FILE**: The path to the environment file.
+- **HARNX_CONFIG_FILE**: The path to the configuration file.
+- **HARNX_ROLES_DIR**: The directory for roles.
+- **HARNX_SESSIONS_DIR**: The directory for sessions.
+- **HARNX_RAGS_DIR**: The directory for RAG data.
+- **HARNX_FUNCTIONS_DIR**: The directory for functions.
+- **HARNX_MESSAGES_FILE**: The path to the messages file.
+
+## Agent-Related Envs
+
+- **<AGENT_NAME>_FUNCTIONS_DIR**: The functions directory for a specific agent.
+- **<AGENT_NAME>_DATA_DIR**: The data directory for a specific agent.
+- **<AGENT_NAME>_CONFIG_FILE**: The configuration file for a specific agent.
+- **Agent config env vars**: Environment variables for agent configuration.
+
+## Logging Envs
+
+- **HARNX_LOG_LEVEL**: The log level (e.g., `debug`, `info`).
+- **HARNX_LOG_FILE**: The path to the log file.
+
+## Generic Envs
+
+- **HTTPS_PROXY / ALL_PROXY**: Proxy settings for network requests.
+- **NO_COLOR**: Disable colored output.
+- **EDITOR**: The default editor.
+- **XDG_CONFIG_HOME**: The base directory for configuration files on Linux.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,55 @@
+# FAQ
+
+## How to log or debug?
+
+Set the `HARNX_LOG_LEVEL` environment variable to `debug`:
+
+```sh
+HARNX_LOG_LEVEL=debug harnx
+```
+
+Then check the log file at `<harnx-config-dir>/harnx.log`.
+
+## How to enable web search?
+
+There are two ways to enable web search:
+
+### 1. Models with built-in web search
+
+Some models have built-in web search capabilities (e.g., Perplexity, OpenRouter online models). Enable this via a model patch in your config.
+
+### 2. Web search tool use
+
+Use the `web_search` tool to give your LLM web search capabilities through tool use.
+
+## Why compress sessions?
+
+The Chat API is stateless, so the full conversation history is sent with every request. This means history grows rapidly, causing two problems:
+
+1. **Increased latency and cost.** Larger payloads take longer to process and consume more tokens.
+2. **May exceed LLM capacity.** Models have a maximum context window. Long conversations can hit that limit.
+
+Harnx addresses this with automatic session compression. When consumed tokens exceed the `compress_threshold`, Harnx compresses the conversation history automatically.
+
+## Why don't LLMs call tools even though they support tool use?
+
+Several things can prevent tool calls from working:
+
+1. **The LLM may only support non-streaming tool use.** Some models can't handle tool calls in streaming mode. Try using `-S` or `.set stream false` to disable streaming.
+
+2. **Missing `functions.json`.** The tool definitions file may not exist. Rebuild your tools in the `llm-functions` directory.
+
+3. **Input not related to available tools.** The LLM won't call tools if your prompt doesn't relate to any of the registered tool functions.
+
+## What is the difference between agents and roles?
+
+**Roles** are a prompt library. A role consists of instructions (a system prompt) and optional model configuration.
+
+**Agents** are like OpenAI GPTs. An agent is a superset of a role. In fact, a role is just an agent that only has instructions.
+
+Agents add these capabilities on top of roles:
+
+- **Variables** for dynamic prompt templates
+- **Conversation starters** for guided interactions
+- **Documents** for RAG (retrieval-augmented generation)
+- **AI tools** for function calling

--- a/docs/macro-guide.md
+++ b/docs/macro-guide.md
@@ -1,0 +1,59 @@
+# Macro Guide
+
+Macros are predefined sequences of REPL commands that automate repetitive tasks or workflows, enabling efficient execution of a series of commands with customizable variables and isolated execution contexts.
+
+## Macro Definition
+
+Macros are defined using YAML files stored in the `<harnx-config-dir>/macros/` directory. Each YAML file represents a single macro, and the filename (excluding the `.yaml` extension) serves as the macro's name.
+
+The YAML file for a macro consists of two main sections:
+
+- **`steps`** (Required):
+   An array of strings, where each string represents a single REPL command to be executed in sequence. These commands must be valid REPL commands.
+
+- **`variables`** (Optional):
+   An array of variable definitions that can be used within the macro. Each variable has the following properties:
+   - **`name`** (Required): The name of the variable, which can be referenced in the macro steps using the `{{name}}` syntax.
+   - **`default`** (Optional): A default value for the variable. If no value is provided during execution, the default will be used. If no default is specified and no value is provided, an error will occur.
+   - **`rest`** (Optional, Boolean): When set to `true`, this variable will collect all remaining arguments into a single variable. This is only applicable to the last variable in the list. The default value is `false`.
+
+## Macro Examples
+
+```yaml
+# <harnx-config-dir>/macros/generate-commit-message.yaml
+steps:
+  - .file `git diff` -- generate git commit message
+```
+
+```yaml
+# <harnx-config-dir>/macros/within-agent.yaml
+variables:
+  - name: agent
+  - name: args
+    rest: true
+    default: What can your do?
+steps:
+  - .agent {{agent}}
+  - '{{args}}'
+```
+
+```yaml
+# <harnx-config-dir>/macros/multi-agents.yaml
+variables:
+  - name: args
+    rest: true
+steps:
+  - .agent design-tui
+  - '{{args}}'
+  - .agent build-tui
+  - .file %%
+  - .agent fixing-bugs
+  - .file %%
+```
+
+## Macro Execution
+
+When a Macro is executed, it runs in an **isolated context**:
+
+- It does **not** inherit any pre-existing role, session, RAG, or agent state.
+- Executing a Macro will **not** affect your current context. This ensures that your workflow remains clean and unaffected by Macro operations.

--- a/docs/rag-guide.md
+++ b/docs/rag-guide.md
@@ -1,0 +1,60 @@
+# RAG Guide
+
+RAG can improve the efficacy of large language model (LLM) applications by leveraging custom data.
+
+Harnx has a built-in vector database and full-text search engine, eliminating reliance on third-party services and providing ready-to-use RAG functionality.
+
+## Document Sources
+
+Harnx can build RAG knowledge bases from a variety of document sources.
+
+| Source                  | Example                                              |
+| ----------------------- | ---------------------------------------------------- |
+| Files                   | `/tmp/dir1/file1;/tmp/dir1/file2`                    |
+| Directory               | `/tmp/dir1/`                                         |
+| Directory (extensions)  | `/tmp/dir2/**/*.{md,txt}`                            |
+| Url                     | `https://sigoden.github.io/mynotes/tools/linux.html` |
+| RecursiveUrl (websites) | `https://sigoden.github.io/mynotes/tools/**`         |
+| Document Loader         | `jina:https://example.com/no-static-page`            |
+
+> `**` is used to distinguish between Url and RecursiveUrl
+
+## Custom Document Loaders
+
+By default, Harnx can only process text files. We need to configure the `document_loaders` so Harnx can handle binary files such as PDFs and DOCXs.
+
+```yaml
+# Define document loaders to control how RAG and `.file`/`--file` load files of specific formats.
+document_loaders:
+  # You can add custom loaders using the following syntax:
+  #   <file-extension>: <command-to-load-the-file>
+  # Note: Use `$1` for input file and `$2` for output file. If `$2` is omitted, use stdout as output.
+  pdf: 'pdftotext $1 -'                         # Load .pdf file, see https://poppler.freedesktop.org to set up pdftotext
+  docx: 'pandoc --to plain $1'                  # Load .docx file, see https://pandoc.org to set up pandoc
+  jina: 'curl -fsSL https://r.jina.ai/$1 -H "Authorization: Bearer <jina_api_key>"'
+  # Load a git repo with https://github.com/bodo-run/yek
+  git: >
+    sh -c "yek $1 --json | jq '[.[] | { path: .filename, contents: .content }]'"
+```
+
+The `document_loaders` configuration item is a map where the key represents the file extension and the value specifies the corresponding loader command.
+
+To ensure the loaders function correctly, please verify that the required tools are installed.
+
+## Use Reranker
+
+Harnx RAG defaults to the `reciprocal_rank_fusion` algorithm for merging vector and keyword search results.
+
+However, using a reranker to combine these results is a more established method that can yield greater relevance and accuracy.
+
+You can add the following configuration to specify the default reranker.
+
+```yaml
+rag_reranker_model: null                    # Specifies the rerank model to use
+```
+
+You can also dynamically adjust the reranker using the `.set` command.
+
+```
+.set rag_reranker_model <tab>
+```

--- a/docs/role-guide.md
+++ b/docs/role-guide.md
@@ -1,0 +1,112 @@
+# Role Guide
+
+## Role Definition
+
+Roles are instrumental in customizing Large Language Model (LLM) behaviors, thereby enhancing user interactions and boosting overall productivity.
+
+A role primarily consists of a name and a prompt, alongside several optional configurations:
+
+- **`model`:** The preferred LLM (e.g. `openai:gpt-4o`).
+- **`temperature`:** Controls the creativity and randomness of the LLM's response.
+- **`top_p`:** Alternative way to control LLM's output diversity, affecting the probability distribution of tokens.
+- **`use_tools`:** Tools attached to this role.
+
+Below is an example of the `grammar-genie` role located at `<harnx-config-dir>/roles/grammar-genie.md`:
+
+```
+---
+model: openai:gpt-4o
+temperature: 0
+top_p: 0
+
+---
+Your task is to take the text provided and rewrite it into a clear, grammatically correct version while preserving the original meaning as closely as possible. Correct any spelling mistakes, punctuation errors, verb tense issues, word choice problems, and other grammatical mistakes.
+```
+
+Just like `%functions%`, we can also create a role with only `use_tools` configuration that specify the functions to include when chatting.
+
+```
+---
+use_tools: web_search,execute_command
+---
+```
+
+## Types of Prompts
+
+There are three types of prompts in Harnx:
+
+### Embedded Prompt
+
+- Contains `__INPUT__` placeholder, which gets replaced with your input.
+- Ideal for concise, input-driven replies.
+
+```yaml
+- name: emoji
+  prompt: convert __INPUT__ to emoji
+```
+
+Running `harnx -r emoji angry` would generate messages:
+```json
+[
+  {"role": "user", "content": "convert angry to emoji"}
+]
+```
+
+### System Prompt
+
+- Does not include `__INPUT__`.
+- Sets a general context for the LLM's behavior.
+
+```yaml
+- name: emoji
+  prompt: convert my words to emoji
+```
+
+Running `harnx -r emoji angry` would generate messages:
+
+```json
+[
+  {"role": "system", "content": "convert my words to emoji"},
+  {"role": "user", "content": "angry"}
+]
+```
+
+### Few-shot Prompt
+
+- An extension of the system prompt, offering more precise instructions.
+- Uses `### INPUT:` and `### OUTPUT:` to denote user and assistant messages.
+
+```yaml
+- name: code
+  prompt: |-
+    Provide only code without comments or explanations.
+    ### INPUT:
+    async sleep in js
+    ### OUTPUT:
+    ```javascript
+    async function timeout(ms) {
+      return new Promise(resolve => setTimeout(resolve, ms));
+    }
+```
+
+Running `harnx -r code echo server in node.js` would generate messages:
+
+```json
+[
+  {"role": "system", "content": "Provide only code without comments or explanations."},
+  {"role": "user", "content": "async sleep in js"},
+  {"role": "assistant", "content": "```javascript\nasync function timeout(ms) {\n  return new Promise(resolve => setTimeout(resolve, ms));\n}\n```"},
+  {"role": "user", "content": "echo server in node.js"}
+]
+```
+
+## Built-in Roles
+
+Harnx includes these built-in roles:
+
+- `%shell%`: Generates shell commands (used by `harnx -e`)
+- `%explain-shell%`: Explains shell commands (used by `harnx -e` > `explain`)
+- `%code%`: Generates code (used by `harnx -c`)
+- `%functions%`: Attach function declarations of all tools (`use_tools: all`).
+
+Built-in role names are always enclosed in `%...%`. You can override them by creating a role with the same name.


### PR DESCRIPTION
## Summary

- Removed all references to the inherited aichat wiki from README.md and config.example.yaml
- Created 10 local documentation files in `docs/` covering all topics previously in the wiki
- All content adapted for Harnx (renamed binary, env vars, config paths, repo URLs)

## New Documentation Files

| File | Content |
|------|---------|
| `docs/chat-repl-guide.md` | REPL features and all 14 REPL commands |
| `docs/command-line-guide.md` | CLI usage, options, shell integration |
| `docs/configuration-guide.md` | Full config file reference with client examples |
| `docs/role-guide.md` | Role definition, prompt types, built-in roles |
| `docs/macro-guide.md` | Macro YAML structure and execution |
| `docs/rag-guide.md` | Document sources, loaders, reranker |
| `docs/environment-variables.md` | All env vars (config, client, files, agent, logging) |
| `docs/custom-theme.md` | Theme setup with available tmTheme options |
| `docs/custom-repl-prompt.md` | Prompt syntax, variables, state showcases |
| `docs/faq.md` | Debugging, web search, sessions, tools FAQ |

## Updated Files

- **README.md** — Documentation section links now point to `docs/*.md`
- **config.example.yaml** — Two comment references updated to local doc paths