### PR TITLE
fix: update in-memory agent name after save

### DIFF
--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -334,6 +334,10 @@ impl Agent {
         &self.name
     }
 
+    pub fn set_name(&mut self, name: &str) {
+        self.name = name.to_string();
+    }
+
     pub fn model(&self) -> &Model {
         &self.model
     }
@@ -771,6 +775,14 @@ Input 1
         assert_eq!(agent.name(), "empty-body");
         assert_eq!(agent.model_id(), Some("openai:gpt-4o"));
         assert!(agent.interpolated_instructions().is_empty());
+    }
+
+    #[test]
+    fn test_agent_set_name() {
+        let mut agent = Agent::from_prompt("You are a test agent.");
+        assert_eq!(agent.name(), "%%");
+        agent.set_name("new-name");
+        assert_eq!(agent.name(), "new-name");
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1068,6 +1068,7 @@ impl Config {
                     agent_path.display()
                 )
             })?;
+            agent.set_name(&agent_name);
             if self.working_mode.is_repl() {
                 println!("✓ Saved the agent to '{}'.", agent_path.display());
             }


### PR DESCRIPTION
## Summary

Fixes #51 — After `.save agent <new-name>`, the in-memory agent name now updates to match the saved file name.

## Changes

- Added `Agent::set_name()` method to allow updating the agent's private `name` field
- Called `set_name` in `Config::save_agent()` after successfully writing the agent to disk
- Added `test_agent_set_name` test to verify the behavior

## Root Cause

`Config::save_agent()` wrote the agent to the new path but never mutated the in-memory `agent.name`. This meant follow-up REPL operations (`.info agent`, subsequent saves) still referenced the stale name (`%%` for temp agents, or the prior name).

The analogous `Session::save()` already handled this correctly — this fix follows the same pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent name synchronization when saving to ensure the stored agent name matches the internal representation, preventing inconsistencies between saved configurations and runtime state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->