### PR TITLE
feat(acp): wire --acp server to real agent execution

### DIFF
--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 use crate::client::{Client, SseEvent, SseHandler};
 use crate::config::{GlobalConfig, Input};
 use crate::tool::{ToolCall, ToolResult};
-use crate::utils::{AbortSignal, AbortSignalInner, wait_abort_signal};
+use crate::utils::{wait_abort_signal, AbortSignal, AbortSignalInner};
 
 use anyhow::bail;
 use serde_json::{json, Value};
@@ -40,11 +40,7 @@ impl HarnxAgent {
         self.connection.replace(Some(conn));
     }
 
-    async fn send_text_chunk(
-        &self,
-        session_id: &str,
-        text: &str,
-    ) -> acp::Result<()> {
+    async fn send_text_chunk(&self, session_id: &str, text: &str) -> acp::Result<()> {
         let connection = self.connection.borrow().clone();
         if let Some(connection) = connection {
             let notification = acp::SessionNotification::new(
@@ -80,9 +76,9 @@ impl HarnxAgent {
                             if let Some(ref conn) = connection {
                                 let notification = acp::SessionNotification::new(
                                     acp::SessionId::new(sid.clone()),
-                                    acp::SessionUpdate::AgentMessageChunk(
-                                        acp::ContentChunk::new(chunk.into()),
-                                    ),
+                                    acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+                                        chunk.into(),
+                                    )),
                                 );
                                 if let Err(e) = conn.session_notification(notification).await {
                                     warn!("ACP streaming notification failed: {e}");
@@ -212,25 +208,20 @@ impl acp::Agent for HarnxAgent {
 
             round += 1;
             if round > MAX_TOOL_CALL_ROUNDS {
-                self.send_text_chunk(
-                    &session_key,
-                    "\n[Error: maximum tool call rounds exceeded]",
-                )
-                .await?;
+                self.send_text_chunk(&session_key, "\n[Error: maximum tool call rounds exceeded]")
+                    .await?;
                 return Ok(acp::PromptResponse::new(acp::StopReason::EndTurn));
             }
 
-            let tool_results = match eval_tool_calls_async(&self.config, tool_calls, &abort_signal).await {
-                Ok(results) => results,
-                Err(e) => {
-                    self.send_text_chunk(
-                        &session_key,
-                        &format!("\n[Tool error: {e}]"),
-                    )
-                    .await?;
-                    return Ok(acp::PromptResponse::new(acp::StopReason::EndTurn));
-                }
-            };
+            let tool_results =
+                match eval_tool_calls_async(&self.config, tool_calls, &abort_signal).await {
+                    Ok(results) => results,
+                    Err(e) => {
+                        self.send_text_chunk(&session_key, &format!("\n[Tool error: {e}]"))
+                            .await?;
+                        return Ok(acp::PromptResponse::new(acp::StopReason::EndTurn));
+                    }
+                };
 
             input = input.merge_tool_results(output, tool_results);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,8 +285,9 @@ async fn run_acp_server(config: GlobalConfig, agent_name: String) -> Result<()> 
             };
 
             let local_set = LocalSet::new();
-            let result = local_set
-                .block_on(&runtime, async move { acp_server_main(config, agent_name).await });
+            let result = local_set.block_on(&runtime, async move {
+                acp_server_main(config, agent_name).await
+            });
             let _ = result_tx.send(result);
         })
         .context("Failed to start ACP server thread")?;


### PR DESCRIPTION
## Summary

- Wire `GlobalConfig` through `run_acp_server` → `acp_server_main` → `HarnxAgent`, replacing the ignored `_config` parameter
- Replace `PLACEHOLDER_RESPONSE` in `HarnxAgent::prompt()` with real LLM execution: agent lookup, streaming/non-streaming chat completions, tool call loop, and per-session cancellation
- Add `eval_tool_calls_async` / `eval_mcp_async` as async alternatives to the sync tool evaluation that work on the ACP server's single-threaded `current_thread` runtime

## Changes

### `src/main.rs`
- `run_acp_server` now passes `config` (was `_config`) into `acp_server_main`
- `acp_server_main` receives `GlobalConfig` and passes it to `HarnxAgent::new`

### `src/acp/server.rs`
- **`HarnxAgent`** stores `GlobalConfig`; sessions carry a per-session `AbortSignal` instead of a `cancelled` bool
- **`prompt()`** resolves the named agent via `retrieve_agent`, builds an `Input`, creates an LLM client, then enters an agent loop (LLM call → tool eval → merge results → repeat, up to 32 rounds)
- **Streaming**: `chat_completions_streaming` chunks forwarded as `AgentMessageChunk` ACP notifications via `tokio::join!`
- **Non-streaming**: `chat_completions` result sent as single chunk, wrapped in `tokio::select!` for cancellation
- **Tool calls**: `eval_tool_calls_async` avoids `block_in_place` (which panics on `current_thread` runtimes) and wraps each `call_tool` in `tokio::select!` against the session's abort signal
- **Cancellation**: `cancel()` sets the session's `AbortSignal`, which interrupts in-flight LLM streaming, non-streaming calls, and tool execution
- **Error handling**: streaming notification errors logged via `warn!` instead of silently discarded

## Testing

All 153 existing tests pass. The 3 server tests (`test_new_session_returns_unique_ids`, `test_cancel_marks_session`, `test_cancel_unknown_session_errors`) updated for the new `HarnxAgent(name, config)` constructor.

Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time streaming of LLM output with incremental notifications.
  * Iterative agent execution that runs tool calls until completion or configured limits.
  * Agents now initialize with persistent configuration for consistent behavior.

* **Improvements**
  * Immediate, reliable session abort signaling and cancellation handling.
  * Safer tool evaluation: argument validation, duplicate suppression, null-result detection, and clearer error reporting.
  * Better handling of cancelled and failed tool executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->