### PR TITLE
feat: support Anthropic OAuth tokens with Bearer auth for Claude client

### DIFF
--- a/src/client/claude.rs
+++ b/src/client/claude.rs
@@ -55,7 +55,11 @@ fn prepare_chat_completions(
     let mut request_data = RequestData::new(url, body);
 
     request_data.header("anthropic-version", "2023-06-01");
-    request_data.header("x-api-key", api_key);
+    if api_key.starts_with("sk-ant-oat") {
+        request_data.bearer_auth(api_key);
+    } else {
+        request_data.header("x-api-key", api_key);
+    }
 
     Ok(request_data)
 }


### PR DESCRIPTION
## Summary

- Detects Anthropic OAuth access tokens (`sk-ant-oat*`) and sends them via `Authorization: Bearer` header instead of `x-api-key`
- Regular API keys (`sk-ant-api03-*` etc.) continue to use `x-api-key` as before

**Problem:** Setting `CLAUDE_API_KEY` to an OAuth access token (e.g. from a Claude Pro/Max subscription) results in `invalid x-api-key (type: authentication_error)` because the token is sent as `x-api-key` when Anthropic's API expects `Authorization: Bearer` for OAuth tokens.

**Per [Anthropic docs](https://code.claude.com/docs/en/iam#authentication-precedence):**
- `ANTHROPIC_API_KEY` → `X-Api-Key` header (direct API keys)
- `ANTHROPIC_AUTH_TOKEN` → `Authorization: Bearer` header (OAuth tokens)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key handling to ensure all supported key formats work correctly with appropriate authentication methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->