### PR TITLE
Update MCP roots calculation to support environment expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,7 +1064,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1394,6 +1394,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "shell-words",
+ "shellexpand",
  "simplelog",
  "syntect",
  "sys-locale",
@@ -2794,7 +2795,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3139,7 +3140,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3152,7 +3153,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3490,6 +3491,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3776,7 +3786,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4582,7 +4592,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ rmcp = { version = "0.8.1", features = ["client", "server", "transport-child-pro
 process-wrap = { version = "8", features = ["tokio1"] }
 agent-client-protocol = { git = "https://github.com/agentclientprotocol/rust-sdk" }
 glob = "0.3"
+shellexpand = "3.1.0"
 schemars = "0.8"
 
 [dependencies.reqwest]

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -104,9 +104,19 @@ impl fmt::Debug for McpClient {
 }
 
 impl McpClient {
+    fn expand_path(path: &str) -> String {
+        shellexpand::full(path)
+            .map(|p| p.to_string())
+            .unwrap_or_else(|_| path.to_string())
+    }
+
     pub fn new(config: McpServerConfig) -> Self {
         let name = config.name.clone();
-        let roots = config.roots.clone();
+        let roots = config
+            .roots
+            .iter()
+            .map(|r| Self::expand_path(r))
+            .collect::<Vec<_>>();
         Self {
             name,
             config,
@@ -251,10 +261,11 @@ impl McpClient {
     }
 
     pub async fn add_root(&self, root: &str) -> Result<()> {
+        let root = Self::expand_path(root);
         let changed = {
             let mut roots = self.roots.write();
-            if !roots.contains(&root.to_string()) {
-                roots.push(root.to_string());
+            if !roots.contains(&root) {
+                roots.push(root);
                 true
             } else {
                 false
@@ -567,6 +578,33 @@ mod tests {
         let expected_path = std::env::current_dir().unwrap().canonicalize().unwrap();
         let expected_uri = path_to_file_uri(&expected_path);
         assert_eq!(uri, expected_uri);
+    }
+
+    #[test]
+    fn test_mcp_roots_expansion() {
+        let mut config = test_mcp_config("test");
+        std::env::set_var("TEST_ROOT", "/tmp/test");
+        config.roots = vec!["$TEST_ROOT/a".to_string(), "~/b".to_string()];
+
+        let client = McpClient::new(config);
+        let roots = client.get_roots();
+
+        assert_eq!(roots.len(), 2);
+        assert_eq!(roots[0], "/tmp/test/a");
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(roots[1], format!("{}/b", home.to_string_lossy()));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_roots_add_expansion() {
+        let config = test_mcp_config("test");
+        std::env::set_var("ADD_TEST_ROOT", "/tmp/add_test");
+        let client = McpClient::new(config);
+
+        client.add_root("$ADD_TEST_ROOT/c").await.unwrap();
+        let roots = client.get_roots();
+
+        assert!(roots.contains(&"/tmp/add_test/c".to_string()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR adds support for environment variable expansion (e.g., $HOME, ~) in MCP roots configuration.

### Changes
- Added `shellexpand` dependency.
- Implemented `expand_path` helper in `McpClient`.
- Updated `McpClient::new` and `add_root` to expand paths.
- Added unit tests for expansion logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic expansion of environment variables and home directory (~) notation in configured root paths, enabling more flexible path configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->