### PR TITLE
docs: add automatic prompt caching example for Claude client

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -257,7 +257,7 @@ clients:
   # See https://docs.anthropic.com/claude/reference/getting-started-with-the-api
   - type: claude
     api_base: https://api.anthropic.com/v1            # Optional
-    api_key: xxx
+    # api_key:    # $CLAUDE_API_KEY from environment or .env file will be used
     # Enable automatic prompt caching for Claude models.
     # This adds "cache_control": {"type": "ephemeral"} at the top level of every
     # Messages API request, which tells the API to automatically cache the prompt


### PR DESCRIPTION
## Summary

Adds a documented example to `config.example.yaml` showing how to enable Anthropic's automatic prompt caching via the `patch` mechanism.

## What this does

The config adds `cache_control: {type: ephemeral}` at the top level of every Claude Messages API request body. This tells the Anthropic API to automatically cache the prompt prefix up to the last cacheable block.

### Benefits
- **90% cost reduction** on cached input tokens (read at 10% of normal price)
- **Reduced latency** — cached prefixes skip re-processing
- **Zero code changes** — uses the existing `patch` mechanism to inject the field
- **Automatic breakpoint management** — the API moves the cache breakpoint forward as conversations grow

### How it works
- First turn: system prompt + tools + messages are written to cache (`cache_creation_input_tokens`)
- Subsequent turns (within 5-min TTL): cached prefix is read (`cache_read_input_tokens`), only new content is processed

### Reference
- [Anthropic Prompt Caching Docs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled automatic prompt caching for Claude API requests

* **Chores**
  * Updated configuration example to read API keys from environment variables instead of hardcoded placeholders

<!-- end of auto-generated comment: release notes by coderabbit.ai -->