### PR TITLE
fix(mcp-bash): set stdin to null to prevent command hangs

### DIFF
--- a/.changesets/fix-bash-stdin-hang.md
+++ b/.changesets/fix-bash-stdin-hang.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Fix MCP bash tool hanging by setting `stdin(Stdio::null())` on spawned commands. Without this, child processes inherited the MCP transport's stdin pipe, causing commands to block indefinitely waiting for input that would never arrive.

--- a/src/bin/harnx-mcp-bash/server.rs
+++ b/src/bin/harnx-mcp-bash/server.rs
@@ -143,6 +143,7 @@ impl BashServer {
         let mut child = Command::new("bash")
             .args(["-c", &params.command])
             .current_dir(&working_dir)
+            .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true)


### PR DESCRIPTION
## Problem

When the MCP bash tool runs commands, some commands hang indefinitely even though they complete instantly when run manually in a terminal.

**Example:** `rg -l -i "spinner" --type ts --type tsx ... 2>/dev/null || rg ...` hangs forever via the MCP bash tool but finishes immediately in a terminal.

## Root Cause

The `Command` spawn in `exec_command_impl` was not setting `stdin`, so child processes **inherited the parent's stdin** — which is the MCP JSON-RPC transport pipe (not a terminal). Commands or sub-processes that attempt to read stdin would block indefinitely waiting for input that would never arrive through the protocol pipe.

## Fix

Added `.stdin(Stdio::null())` to the `Command` builder, connecting the child's stdin to `/dev/null`. Any stdin read immediately gets EOF, which is the correct behavior for a non-interactive command execution server.

## Changes

- `src/bin/harnx-mcp-bash/server.rs`: Added `.stdin(Stdio::null())` to `Command::new("bash")` spawn
- `.changesets/fix-bash-stdin-hang.md`: Changeset for patch release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a critical issue where bash commands would hang indefinitely during execution. The bash tool now properly isolates input streams for spawned commands, ensuring reliable execution and preventing unexpected blocking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->