### PR TITLE
feat(repl): show agent name and session ID in spinner, usage line, and initial prompt

### DIFF
--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -545,13 +545,22 @@ pub async fn create_openai_compatible_client_config(
 
 fn spinner_label(config: &GlobalConfig) -> String {
     let config = config.read();
+    // Icons omitted — the spinner braille frame serves as the leading character
+    let status = config.render_status_line(false);
     if let Some(session) = &config.session {
         let su = session.completion_usage();
         if !su.is_empty() {
-            return format!("Generating [{}]", su);
+            if status.is_empty() {
+                return su.to_string();
+            }
+            return format!("{}    {}", status, su);
         }
     }
-    "Generating".to_string()
+    if status.is_empty() {
+        "Generating".to_string()
+    } else {
+        status
+    }
 }
 
 pub async fn call_chat_completions(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -86,8 +86,8 @@ __CONTEXT__
 __INPUT__
 </user_query>"#;
 
-const LEFT_PROMPT: &str = "{color.green}{?session {?agent {agent}>}{session}{?agent /}}{!session {?agent {agent}>}}{agent}{?rag @{rag}}{color.cyan}{?session )}{!session >}{color.reset} ";
-const RIGHT_PROMPT: &str = "{color.purple}{?session {?consume_tokens {consume_tokens}({consume_percent}%)}{!consume_tokens {consume_tokens}}}{color.reset}";
+const LEFT_PROMPT: &str = "{color.cyan}>{color.reset} ";
+const RIGHT_PROMPT: &str = "";
 
 static EDITOR: OnceLock<Option<String>> = OnceLock::new();
 
@@ -2082,6 +2082,37 @@ impl Config {
         let variables = self.generate_prompt_context();
         let right_prompt = self.right_prompt.as_deref().unwrap_or(RIGHT_PROMPT);
         render_prompt(right_prompt, &variables)
+    }
+
+    /// Render a status line showing agent name and session ID.
+    ///
+    /// When `use_icons` is true, an appropriate icon leads the line:
+    /// - `🤖 <agent> ▸ <session>` when an agent is active
+    /// - `💬 <session>` when only a session is active (no robot icon)
+    ///
+    /// When `use_icons` is false, icons are omitted (used for spinner where
+    /// the braille animation frame serves as the leading character).
+    pub fn render_status_line(&self, use_icons: bool) -> String {
+        let agent_name = if let Some(agent) = &self.agent {
+            Some(agent.name().to_string())
+        } else {
+            let agent = self.extract_agent();
+            if agent.name() != TEMP_AGENT_NAME {
+                Some(agent.name().to_string())
+            } else {
+                None
+            }
+        };
+        let session_name = self.session.as_ref().map(|s| s.name().to_string());
+        match (agent_name, session_name, use_icons) {
+            (Some(agent), Some(session), true) => format!("🤖 {} ▸ {}", agent, session),
+            (Some(agent), Some(session), false) => format!("{} ▸ {}", agent, session),
+            (Some(agent), None, true) => format!("🤖 {}", agent),
+            (Some(agent), None, false) => agent,
+            (None, Some(session), true) => format!("💬 {}", session),
+            (None, Some(session), false) => session,
+            (None, None, _) => String::new(),
+        }
     }
 
     pub fn print_markdown(&self, text: &str) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -515,15 +515,39 @@ async fn start_directive_inner(
         .write()
         .after_chat_completion(&input, &output, &tool_results, &usage)?;
     if tool_results.is_empty() {
-        let session_usage = config
-            .read()
+        let config_read = config.read();
+        let status = config_read.render_status_line(true);
+        let session_usage = config_read
             .session
             .as_ref()
             .map(|s| s.completion_usage().clone());
         let display_usage = session_usage.as_ref().unwrap_or(&usage);
-        if !display_usage.is_empty() {
-            eprintln!("{}", dimmed_text(&format!("[{}]", display_usage)));
+        let context_stats = config_read
+            .session
+            .as_ref()
+            .map(|s| {
+                let (tokens, percent) = s.tokens_usage();
+                if percent > 0.0 {
+                    format!("💬 {}({:.0}%)", tokens, percent)
+                } else {
+                    format!("💬 {}", tokens)
+                }
+            })
+            .unwrap_or_default();
+        let mut line_parts = vec![];
+        if !status.is_empty() {
+            line_parts.push(status);
         }
+        if !display_usage.is_empty() {
+            line_parts.push(format!("   {}", display_usage));
+        }
+        if !context_stats.is_empty() {
+            line_parts.push(format!("  {}", context_stats));
+        }
+        if !line_parts.is_empty() {
+            eprintln!("{}", dimmed_text(&line_parts.join("")));
+        }
+        drop(config_read);
     }
     let stop_outcome = if tool_results.is_empty() {
         let event = HookEvent::Stop {

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -245,6 +245,14 @@ Type ".help" for additional help.
             )
         }
 
+        // Print initial session/agent status line
+        {
+            let status = self.config.read().render_status_line(true);
+            if !status.is_empty() {
+                eprintln!("{}", dimmed_text(&status));
+            }
+        }
+
         loop {
             if self.abort_signal.aborted_ctrld() {
                 break;
@@ -1029,10 +1037,6 @@ Commands:
         }
     }
 
-    if !config.read().macro_flag {
-        println!();
-    }
-
     Ok(false)
 }
 
@@ -1156,15 +1160,42 @@ async fn ask_inner(
         .write()
         .after_chat_completion(&input, &output, &tool_results, &usage)?;
     if tool_results.is_empty() {
-        let session_usage = config
-            .read()
+        if !config.read().macro_flag {
+            eprintln!();
+        }
+        let config_read = config.read();
+        let status = config_read.render_status_line(true);
+        let session_usage = config_read
             .session
             .as_ref()
             .map(|s| s.completion_usage().clone());
         let display_usage = session_usage.as_ref().unwrap_or(&usage);
-        if !display_usage.is_empty() {
-            eprintln!("{}", dimmed_text(&format!("[{}]", display_usage)));
+        let context_stats = config_read
+            .session
+            .as_ref()
+            .map(|s| {
+                let (tokens, percent) = s.tokens_usage();
+                if percent > 0.0 {
+                    format!("💬 {}({:.0}%)", tokens, percent)
+                } else {
+                    format!("💬 {}", tokens)
+                }
+            })
+            .unwrap_or_default();
+        let mut line_parts = vec![];
+        if !status.is_empty() {
+            line_parts.push(status);
         }
+        if !display_usage.is_empty() {
+            line_parts.push(format!("   {}", display_usage));
+        }
+        if !context_stats.is_empty() {
+            line_parts.push(format!("  {}", context_stats));
+        }
+        if !line_parts.is_empty() {
+            eprintln!("{}", dimmed_text(&line_parts.join("")));
+        }
+        drop(config_read);
     }
     let stop_outcome = if tool_results.is_empty() {
         let event = HookEvent::Stop {

--- a/src/repl/prompt.rs
+++ b/src/repl/prompt.rs
@@ -30,7 +30,7 @@ impl Prompt for ReplPrompt {
     }
 
     fn render_prompt_multiline_indicator(&self) -> Cow<'_, str> {
-        Cow::Borrowed("... ")
+        Cow::Borrowed("")
     }
 
     fn render_prompt_history_search_indicator(

--- a/src/utils/spinner.rs
+++ b/src/utils/spinner.rs
@@ -30,8 +30,7 @@ impl SpinnerInner {
         }
         let mut writer = stdout();
         let frame = Self::DATA[self.index % Self::DATA.len()];
-        let dots = ".".repeat((self.index / 5) % 4);
-        let line = format!("{frame}{}{:<3}", self.message, dots);
+        let line = format!("{frame}{}", self.message);
         queue!(writer, cursor::MoveToColumn(0), style::Print(line),)?;
         if self.index == 0 {
             queue!(writer, cursor::Hide)?;


### PR DESCRIPTION
## Summary

Improves REPL status visibility by showing the agent name and session ID prominently in the spinner, usage line, and at session start — instead of burying them in the input prompt.

## Changes

### Spinner during generation
**Before:** `⠋ Generating [📥 39  📤 12248  💾 246516]...`
**After:** `⠋ my-agent ▸ my-session    📥 39  📤 12248  💾 246516`

- Spinner braille animation replaces the 🤖 icon
- Removed trailing animated dots
- Removed square brackets around usage stats
- Extra spacing between agent/session info and stats

### Usage line after LLM response
**Before:** `[📥 39  📤 12248  💾 246516]`
**After:** `🤖 my-agent ▸ my-session   📥 39  📤 12248  💾 246516  💬 5432(12%)`

- Shows agent name and session ID with 🤖 prefix
- Includes context window usage (💬 tokens(percent%)) previously only in right prompt
- No square brackets, better spacing

### Input prompt
**Before:** `agent>session/agent) ` with right-side token stats
**After:** `> ` (clean cyan arrow)

Agent/session info moved to status lines above; right prompt emptied to avoid interfering with input.

### Multiline indicator
**Before:** `... ` on continuation lines
**After:** (empty) — makes copy/pasting multi-line inputs much easier

### Session start
**Before:** (nothing)
**After:** `🤖 my-agent ▸ my-session` printed before first prompt

## Files Changed
- `src/config/mod.rs` — Simplified LEFT/RIGHT_PROMPT, added `render_status_line(prefix)`
- `src/client/common.rs` — Updated `spinner_label()` to use status line
- `src/repl/mod.rs` — Updated usage display, added initial status line
- `src/main.rs` — Updated usage display for CMD mode
- `src/repl/prompt.rs` — Removed multiline `...` indicator
- `src/utils/spinner.rs` — Removed trailing animated dots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Simplified spinner output (removed animated trailing dots and extra padding)
  * Removed multiline prompt indicator
  * Show agent/session status alongside completion usage in prompts and on startup
  * Display completion token usage with optional percentage
  * Consolidated status/usage/context into a single dimmed line for cleaner stderr output
<!-- end of auto-generated comment: release notes by coderabbit.ai -->