### PR TITLE
test(tui): mirror session initialization in helper

### DIFF
--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -16,7 +16,7 @@ fn test_config_with_mock_client() -> GlobalConfig {
     test_config_with_mock_client_and_agent("test-agent", "test-session")
 }
 
-fn test_config_with_mock_client_and_agent(agent_name: &str, _session_name: &str) -> GlobalConfig {
+fn test_config_with_mock_client_and_agent(agent_name: &str, session_name: &str) -> GlobalConfig {
     let config = test_config();
     {
         let mut guard = config.write();
@@ -33,8 +33,9 @@ fn test_config_with_mock_client_and_agent(agent_name: &str, _session_name: &str)
         // Build deterministic in-memory session state for tests instead of
         // relying on use_session(), which resolves models through configured
         // clients and can fail with the mock test model.
-        let mut session = crate::config::session::Session::new(&guard, "test-session");
+        let mut session = crate::config::session::Session::new(&guard, session_name);
         session.set_model(model);
+        session.set_sessions_dir(guard.sessions_dir());
         guard.session = Some(session);
     }
     config


### PR DESCRIPTION
## Summary\n- make the TUI test helper use the provided session name\n- mirror  by setting  on the in-memory test session\n- keep the deterministic in-memory session setup used by the streaming snapshot test\n\n## Testing\n- cargo test tui::tests::test_basic_message_and_streaming_response -- --nocapture\n- cargo fmt --all\n- cargo build\n- cargo clippy --all --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test infrastructure to improve test reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->