### PR TITLE
fix: show full error chain in delegation and tool errors

### DIFF
--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -422,7 +422,7 @@ impl acp::Agent for HarnxAgent {
                 match result {
                     Ok(results) => results,
                     Err(e) => {
-                        self.send_text_chunk(&session_key, &format!("\n[Tool error: {e}]"))
+                        self.send_text_chunk(&session_key, &format!("\n[Tool error: {e:#}]"))
                             .await?;
                         return Ok(acp::PromptResponse::new(acp::StopReason::EndTurn));
                     }

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -131,11 +131,12 @@ pub fn eval_tool_calls(config: &GlobalConfig, mut calls: Vec<ToolCall>) -> Resul
                 output.push(result_obj);
             }
             Err(ToolError::Recoverable(err)) => {
+                let error_display = format!("{err:#}");
                 let fail_event = HookEvent::PostToolUseFailure {
                     tool_name: call.name.clone(),
                     tool_input: tool_input.clone(),
                     tool_use_id: tool_use_id.clone(),
-                    error: err.to_string(),
+                    error: error_display.clone(),
                 };
                 let _ = tokio::task::block_in_place(|| {
                     Handle::current().block_on(dispatch_hooks(
@@ -149,7 +150,7 @@ pub fn eval_tool_calls(config: &GlobalConfig, mut calls: Vec<ToolCall>) -> Resul
                 is_all_null = false;
                 let error_result = json!({
                     "is_error": true,
-                    "error": err.to_string(),
+                    "error": error_display,
                 });
                 output.push(ToolResult::new(call, error_result));
             }


### PR DESCRIPTION
## Summary
- Use anyhow's alternate Display (`{:#}`) instead of plain Display (`{}`) when formatting tool errors, so the full error chain (root cause included) is shown instead of just the outermost context message
- Fixes both the ACP server tool error response (`src/acp/server.rs`) and the local tool evaluation error result (`src/tool.rs`)

## Test plan
- [x] `cargo check` passes
- [x] All 523 tests pass (`cargo nextest run --all`)
- [ ] Manually trigger an ACP delegation failure and verify the error now includes the root cause (e.g. "Failed to send ACP prompt to session '...' on '...': connection refused")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated error message formatting to display more detailed error information, enhancing clarity in error reporting and feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->