### PR TITLE
sub agent event propagation fixups

### DIFF
--- a/src/acp/client.rs
+++ b/src/acp/client.rs
@@ -1,4 +1,4 @@
-use super::AcpServerConfig;
+use super::{AcpServerConfig, NestedAcpEvent};
 
 use crate::tui::render_helpers::event_fallback_text;
 use crate::ui_output::{
@@ -38,7 +38,7 @@ pub struct AcpClient {
     initialize_response: Arc<RwLock<Option<acp::InitializeResponse>>>,
     sessions: Arc<RwLock<HashMap<String, SessionState>>>,
     worker: Arc<Mutex<Option<AcpWorkerHandle>>>,
-    chunk_forwarder: Arc<RwLock<HashMap<u64, mpsc::UnboundedSender<String>>>>,
+    chunk_forwarder: Arc<RwLock<HashMap<u64, mpsc::UnboundedSender<NestedAcpEvent>>>>,
     activity_tx: broadcast::Sender<String>,
 }
 
@@ -79,7 +79,7 @@ enum WorkerCommand {
 struct AcpNotificationClient {
     agent_name: String,
     sessions: Arc<RwLock<HashMap<String, SessionState>>>,
-    chunk_forwarder: Arc<RwLock<HashMap<u64, mpsc::UnboundedSender<String>>>>,
+    chunk_forwarder: Arc<RwLock<HashMap<u64, mpsc::UnboundedSender<NestedAcpEvent>>>>,
     activity_tx: broadcast::Sender<String>,
 }
 
@@ -91,7 +91,7 @@ impl AcpNotificationClient {
     fn new(
         agent_name: String,
         sessions: Arc<RwLock<HashMap<String, SessionState>>>,
-        chunk_forwarder: Arc<RwLock<HashMap<u64, mpsc::UnboundedSender<String>>>>,
+        chunk_forwarder: Arc<RwLock<HashMap<u64, mpsc::UnboundedSender<NestedAcpEvent>>>>,
         activity_tx: broadcast::Sender<String>,
     ) -> Self {
         Self {
@@ -136,7 +136,7 @@ impl AcpNotificationClient {
                 eprint!("{}", text_fallback);
             }
         } else {
-            forwarders.retain(|_, tx| match tx.send(text_fallback.clone()) {
+            forwarders.retain(|_, tx| match tx.send(NestedAcpEvent::Ui(event.clone())) {
                 Ok(()) => {
                     delivered = true;
                     true
@@ -596,7 +596,7 @@ impl AcpClient {
             })?
     }
 
-    pub async fn set_chunk_forwarder(&self, id: u64, tx: mpsc::UnboundedSender<String>) {
+    pub async fn set_chunk_forwarder(&self, id: u64, tx: mpsc::UnboundedSender<NestedAcpEvent>) {
         self.chunk_forwarder.write().await.insert(id, tx);
     }
 
@@ -626,7 +626,7 @@ fn spawn_worker(
     config: AcpServerConfig,
     sessions: Arc<RwLock<HashMap<String, SessionState>>>,
     initialize_response: Arc<RwLock<Option<acp::InitializeResponse>>>,
-    chunk_forwarder: Arc<RwLock<HashMap<u64, mpsc::UnboundedSender<String>>>>,
+    chunk_forwarder: Arc<RwLock<HashMap<u64, mpsc::UnboundedSender<NestedAcpEvent>>>>,
     activity_tx: broadcast::Sender<String>,
 ) -> Result<(AcpWorkerHandle, oneshot::Receiver<Result<()>>)> {
     let (tx, rx) = mpsc::unbounded_channel();
@@ -682,7 +682,7 @@ async fn worker_main(
     initialize_response: Arc<RwLock<Option<acp::InitializeResponse>>>,
     mut rx: mpsc::UnboundedReceiver<WorkerCommand>,
     ready_tx: oneshot::Sender<Result<()>>,
-    chunk_forwarder: Arc<RwLock<HashMap<u64, mpsc::UnboundedSender<String>>>>,
+    chunk_forwarder: Arc<RwLock<HashMap<u64, mpsc::UnboundedSender<NestedAcpEvent>>>>,
     mut abort_rx: oneshot::Receiver<()>,
     activity_tx: broadcast::Sender<String>,
 ) -> Result<()> {

--- a/src/acp/client.rs
+++ b/src/acp/client.rs
@@ -1,7 +1,10 @@
 use super::AcpServerConfig;
 
-use crate::ui_output::emit_ui_output;
-use crate::utils::dimmed_text;
+use crate::tui::render_helpers::event_fallback_text;
+use crate::ui_output::{
+    emit_ui_output_event, pretty_yaml_block, UiOutputEvent, UiOutputEventKind, UiOutputPlanEntry,
+    UiOutputSource,
+};
 use agent_client_protocol::{self as acp, Agent as _};
 use anyhow::{anyhow, Context, Result};
 use std::cell::RefCell;
@@ -74,6 +77,7 @@ enum WorkerCommand {
 }
 
 struct AcpNotificationClient {
+    agent_name: String,
     sessions: Arc<RwLock<HashMap<String, SessionState>>>,
     chunk_forwarder: Arc<RwLock<HashMap<u64, mpsc::UnboundedSender<String>>>>,
     activity_tx: broadcast::Sender<String>,
@@ -85,11 +89,13 @@ struct TokioCompat<T> {
 
 impl AcpNotificationClient {
     fn new(
+        agent_name: String,
         sessions: Arc<RwLock<HashMap<String, SessionState>>>,
         chunk_forwarder: Arc<RwLock<HashMap<u64, mpsc::UnboundedSender<String>>>>,
         activity_tx: broadcast::Sender<String>,
     ) -> Self {
         Self {
+            agent_name,
             sessions,
             chunk_forwarder,
             activity_tx,
@@ -99,24 +105,46 @@ impl AcpNotificationClient {
     /// Forward a display-only chunk (e.g. usage banner) to subscribers or
     /// stderr.  Unlike the main chunk path this never touches
     /// `state.response_text`.
-    async fn forward_display_chunk(&self, text: &str) {
+    async fn forward_display_chunk(&self, text: &str, session_id: &str) {
+        self.forward_ui_output_event(
+            UiOutputEvent {
+                kind: UiOutputEventKind::TranscriptText {
+                    text: text.to_string(),
+                },
+                source: None,
+            },
+            session_id,
+        )
+        .await;
+    }
+
+    async fn forward_ui_output_event(&self, event: UiOutputEvent, session_id: &str) {
         let mut delivered = false;
         let mut forwarders = self.chunk_forwarder.write().await;
+        let source = Some(UiOutputSource {
+            agent: self.agent_name.clone(),
+            session_id: Some(session_id.to_string()),
+        });
+        let text_fallback = format_ui_event_for_terminal(&event.kind, source.as_ref());
+        let event = UiOutputEvent {
+            kind: event.kind,
+            source,
+        };
+
         if forwarders.is_empty() {
-            if !emit_ui_output(text.to_string()) {
-                eprint!("{}", text);
+            if !emit_ui_output_event(event) {
+                eprint!("{}", text_fallback);
             }
         } else {
-            let owned = text.to_string();
-            forwarders.retain(|_, tx| match tx.send(owned.clone()) {
+            forwarders.retain(|_, tx| match tx.send(text_fallback.clone()) {
                 Ok(()) => {
                     delivered = true;
                     true
                 }
                 Err(_) => false,
             });
-            if !delivered && !emit_ui_output(text.to_string()) {
-                eprint!("{}", text);
+            if !delivered && !emit_ui_output_event(event) {
+                eprint!("{}", text_fallback);
             }
         }
     }
@@ -182,67 +210,85 @@ impl acp::Client for AcpNotificationClient {
         // SessionInfoUpdate with an early return we keep it out of the
         // shared chunk → response_text path entirely.
         if let acp::SessionUpdate::SessionInfoUpdate(ref info) = args.update {
-            let display = format_session_info_update(info);
-            if !display.is_empty() {
-                self.forward_display_chunk(&display).await;
+            if let Some(event) = session_info_update_event(info) {
+                self.forward_ui_output_event(event, &session_id).await;
             }
             return Ok(());
         }
 
         let is_agent_message = matches!(args.update, acp::SessionUpdate::AgentMessageChunk(_));
-        let chunk = match args.update {
+        let event = match args.update {
             acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk { content, .. }) => {
-                format_agent_message_display(&content_block_to_text(&content))
+                let text = content_block_to_text(&content);
+                if text.trim().is_empty() {
+                    None
+                } else {
+                    Some(UiOutputEvent {
+                        kind: UiOutputEventKind::LlmText(text),
+                        source: None,
+                    })
+                }
             }
             acp::SessionUpdate::AgentThoughtChunk(acp::ContentChunk { content, .. }) => {
                 let text = content_block_to_text(&content);
                 if text.is_empty() {
-                    String::new()
+                    None
                 } else {
-                    format!("<think>{text}</think>")
+                    Some(UiOutputEvent {
+                        kind: UiOutputEventKind::AcpThought { text },
+                        source: None,
+                    })
                 }
             }
-            acp::SessionUpdate::ToolCall(tc) => {
-                format_tool_call_display(&tc.title, tc.raw_input.as_ref())
-            }
+            acp::SessionUpdate::ToolCall(tc) => Some(UiOutputEvent {
+                kind: UiOutputEventKind::StructuredBlock {
+                    title: tc.title,
+                    body: tc.raw_input.as_ref().map(pretty_yaml_block),
+                },
+                source: None,
+            }),
             acp::SessionUpdate::ToolCallUpdate(tcu) => {
-                let mut parts = vec![];
-                if let Some(title) = &tcu.fields.title {
-                    parts.push(title.clone());
-                }
-                if let Some(status) = &tcu.fields.status {
-                    parts.push(
-                        serde_json::to_value(status)
-                            .ok()
-                            .and_then(|v| v.as_str().map(String::from))
-                            .unwrap_or_else(|| format!("{:?}", status)),
-                    );
-                }
-                if parts.is_empty() {
-                    String::new()
+                let title = tcu.fields.title.clone();
+                let status = tcu.fields.status.as_ref().map(|status| {
+                    serde_json::to_value(status)
+                        .ok()
+                        .and_then(|v| v.as_str().map(String::from))
+                        .unwrap_or_else(|| format!("{:?}", status))
+                });
+                if title.is_none() && status.is_none() {
+                    None
                 } else {
-                    format!("\n{}\n", dimmed_text(&parts.join(" ")))
+                    Some(UiOutputEvent {
+                        kind: UiOutputEventKind::StatusLine {
+                            text: crate::tui::render_helpers::render_status_line(
+                                title.as_deref(),
+                                status.as_deref(),
+                            )
+                            .unwrap_or_default(),
+                        },
+                        source: None,
+                    })
                 }
             }
             acp::SessionUpdate::Plan(p) => {
-                let entries: Vec<String> = p
+                let entries: Vec<UiOutputPlanEntry> = p
                     .entries
                     .iter()
-                    .map(|e| {
-                        let status_str = serde_json::to_value(&e.status)
+                    .map(|e| UiOutputPlanEntry {
+                        status: serde_json::to_value(&e.status)
                             .ok()
                             .and_then(|v| v.as_str().map(String::from))
-                            .unwrap_or_else(|| format!("{:?}", e.status));
-                        format!("  [{}] {}", status_str, e.content)
+                            .unwrap_or_else(|| format!("{:?}", e.status)),
+                        content: e.content.clone(),
                     })
                     .collect();
                 if entries.is_empty() {
-                    String::new()
+                    None
                 } else {
-                    format!(
-                        "\n{}\n",
-                        dimmed_text(&format!("Plan:\n{}", entries.join("\n")))
-                    )
+                    Some(UiOutputEvent {
+                        kind: UiOutputEventKind::Plan { entries },
+                        source: None,
+                    })
                 }
             }
             // SessionInfoUpdate is handled above via early return.
@@ -253,37 +299,29 @@ impl acp::Client for AcpNotificationClient {
             acp::SessionUpdate::UserMessageChunk(_)
             | acp::SessionUpdate::AvailableCommandsUpdate(_)
             | acp::SessionUpdate::CurrentModeUpdate(_)
-            | acp::SessionUpdate::ConfigOptionUpdate(_) => String::new(),
+            | acp::SessionUpdate::ConfigOptionUpdate(_) => None,
             // Required catch-all: SessionUpdate is #[non_exhaustive].
             // Log so future variants aren't silently swallowed.
             other => {
                 log::debug!("Unhandled ACP SessionUpdate variant: {:?}", other);
-                String::new()
+                None
             }
         };
 
-        if !chunk.is_empty() {
-            let mut delivered = false;
-            let mut forwarders = self.chunk_forwarder.write().await;
-            if forwarders.is_empty() {
-                if !emit_ui_output(chunk.clone()) {
-                    eprint!("{}", chunk);
+        if let Some(event) = event {
+            let chunk_for_response = if is_agent_message {
+                match &event.kind {
+                    UiOutputEventKind::LlmText(text)
+                    | UiOutputEventKind::TranscriptText { text } => Some(text.clone()),
+                    _ => None,
                 }
             } else {
-                forwarders.retain(|_, tx| match tx.send(chunk.clone()) {
-                    Ok(()) => {
-                        delivered = true;
-                        true
-                    }
-                    Err(_) => false,
-                });
-                if !delivered && !emit_ui_output(chunk.clone()) {
-                    eprint!("{}", chunk);
-                }
-            }
-            drop(forwarders);
+                None
+            };
 
-            if is_agent_message {
+            self.forward_ui_output_event(event, &session_id).await;
+
+            if let Some(chunk) = chunk_for_response {
                 let mut sessions = self.sessions.write().await;
                 let state = sessions.entry(session_id).or_default();
                 state.response_text.push_str(&chunk);
@@ -682,7 +720,8 @@ async fn worker_main(
         });
     }
 
-    let client = AcpNotificationClient::new(sessions.clone(), chunk_forwarder, activity_tx);
+    let client =
+        AcpNotificationClient::new(name.clone(), sessions.clone(), chunk_forwarder, activity_tx);
     let (conn, handle_io) = acp::ClientSideConnection::new(
         client,
         TokioCompat::new(stdin),
@@ -907,80 +946,51 @@ fn wrap_display_text(text: &str, initial_indent: &str, subsequent_indent: &str) 
     wrap(text, options).join("\n")
 }
 
-fn pretty_yaml_block(value: &serde_json::Value) -> String {
-    serde_yaml::to_string(value)
-        .map(|s| s.trim_end().to_string())
-        .unwrap_or_else(|_| value.to_string())
-}
-
-fn format_tool_call_display(title: &str, raw_input: Option<&serde_json::Value>) -> String {
-    let header = wrap_display_text(&format!("🛠️  {title}"), "", "   ");
-    match raw_input {
-        Some(input) => {
-            let body = pretty_yaml_block(input)
-                .lines()
-                .map(|line| format!("   {line}"))
-                .collect::<Vec<_>>()
-                .join("\n");
-            format!("\n{}\n{}\n", dimmed_text(&header), dimmed_text(&body))
-        }
-        None => format!("\n{}\n", dimmed_text(&header)),
-    }
-}
-
-fn format_agent_message_display(text: &str) -> String {
-    if text.trim().is_empty() {
-        String::new()
-    } else {
-        wrap_display_text(text, "", "")
-    }
-}
-
-fn format_session_info_update(info: &acp::SessionInfoUpdate) -> String {
-    let Some(meta) = &info.meta else {
-        return String::new();
-    };
-    let Some(usage) = meta.get("harnx:usage") else {
-        return String::new();
-    };
-    let input = usage["input_tokens"].as_u64().unwrap_or(0);
-    let output = usage["output_tokens"].as_u64().unwrap_or(0);
-    let cached = usage["cached_tokens"].as_u64().unwrap_or(0);
+fn session_info_update_event(info: &acp::SessionInfoUpdate) -> Option<UiOutputEvent> {
+    let meta = info.meta.as_ref()?;
+    let usage = meta.get("harnx:usage")?;
+    let input_tokens = usage["input_tokens"].as_u64().unwrap_or(0);
+    let output_tokens = usage["output_tokens"].as_u64().unwrap_or(0);
+    let cached_tokens = usage["cached_tokens"].as_u64().unwrap_or(0);
     let agent = usage["agent"].as_str().unwrap_or("");
     let session = usage["session"].as_str().unwrap_or("");
-    if input == 0 && output == 0 {
-        return String::new();
+    if input_tokens == 0 && output_tokens == 0 {
+        return None;
     }
-    // Format like the main REPL status line:
-    //   🤖 agent ▸ session   📥 N  📤 N  💾 N
-    let status = match (agent.is_empty(), session.is_empty()) {
-        (false, false) => format!("🤖 {} ▸ {}", agent, session),
-        (false, true) => format!("🤖 {}", agent),
-        (true, false) => format!("💬 {}", session),
-        (true, true) => String::new(),
+
+    let session_label = match (agent.is_empty(), session.is_empty()) {
+        (false, false) => Some(crate::tui::render_helpers::source_heading(
+            &UiOutputSource {
+                agent: agent.to_string(),
+                session_id: Some(session.to_string()),
+            },
+        )),
+        (false, true) => Some(crate::tui::render_helpers::source_heading(
+            &UiOutputSource {
+                agent: agent.to_string(),
+                session_id: None,
+            },
+        )),
+        (true, false) => Some(format!("💬 {}", session)),
+        (true, true) => None,
     };
-    let mut line_parts = vec![];
-    if !status.is_empty() {
-        line_parts.push(status);
-    }
-    let mut usage_parts = vec![];
-    if input > 0 {
-        usage_parts.push(format!("📥 {input}"));
-    }
-    if output > 0 {
-        usage_parts.push(format!("📤 {output}"));
-    }
-    if cached > 0 {
-        usage_parts.push(format!("💾 {cached}"));
-    }
-    if !usage_parts.is_empty() {
-        line_parts.push(format!("   {}", usage_parts.join("  ")));
-    }
-    if line_parts.is_empty() {
-        String::new()
-    } else {
-        format!("\n{}\n", dimmed_text(&line_parts.join("")))
-    }
+
+    Some(UiOutputEvent {
+        kind: UiOutputEventKind::Usage {
+            input_tokens,
+            output_tokens,
+            cached_tokens,
+            session_label,
+        },
+        source: None,
+    })
+}
+
+fn format_ui_event_for_terminal(
+    kind: &UiOutputEventKind,
+    source: Option<&UiOutputSource>,
+) -> String {
+    event_fallback_text(kind, source)
 }
 
 fn content_block_to_text(content: &acp::ContentBlock) -> String {
@@ -1000,25 +1010,49 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn test_format_tool_call_display_multiline_yaml() {
-        let rendered = format_tool_call_display(
-            "argus_session_prompt",
-            Some(&json!({
-                "message": "Goal — Something long that should remain visible\nAcceptance criteria — Multiline preserved",
-                "session_id": "abc123"
-            })),
+    fn terminal_fallback_renders_structured_tool_call_and_plan() {
+        let tool_rendered = format_ui_event_for_terminal(
+            &UiOutputEventKind::StructuredBlock {
+                title: "argus_session_prompt".to_string(),
+                body: Some(pretty_yaml_block(&json!({
+                    "message": "Goal — Something long that should remain visible\nAcceptance criteria — Multiline preserved",
+                    "session_id": "abc123"
+                }))),
+            },
+            None,
         );
+        assert!(tool_rendered.contains("argus_session_prompt"));
+        assert!(tool_rendered.contains("message:"));
+        assert!(tool_rendered.contains("Acceptance criteria"));
+        assert!(tool_rendered.contains("session_id:"));
 
-        assert!(rendered.contains("argus_session_prompt"));
-        assert!(rendered.contains("message:"));
-        assert!(rendered.contains("Acceptance criteria"));
-        assert!(rendered.contains("session_id:"));
+        let plan_rendered = format_ui_event_for_terminal(
+            &UiOutputEventKind::Plan {
+                entries: vec![
+                    UiOutputPlanEntry {
+                        status: "in_progress".to_string(),
+                        content: "Migrate remaining ACP formatting".to_string(),
+                    },
+                    UiOutputPlanEntry {
+                        status: "pending".to_string(),
+                        content: "Update snapshots".to_string(),
+                    },
+                ],
+            },
+            None,
+        );
+        assert!(plan_rendered.contains("Plan:"));
+        assert!(plan_rendered.contains("[in_progress] Migrate remaining ACP formatting"));
+        assert!(plan_rendered.contains("[pending] Update snapshots"));
     }
 
     #[test]
-    fn test_format_agent_message_display_preserves_multiline_content() {
-        let rendered = format_agent_message_display(
-            "Line one from sub-agent\nLine two from sub-agent with extra detail",
+    fn agent_message_chunks_stay_verbatim_in_terminal_fallback() {
+        let rendered = format_ui_event_for_terminal(
+            &UiOutputEventKind::LlmText(
+                "Line one from sub-agent\nLine two from sub-agent with extra detail".to_string(),
+            ),
+            None,
         );
 
         assert!(rendered.contains("Line one from sub-agent"));

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -5,6 +5,7 @@ mod config;
 mod server;
 
 use crate::tool::{JsonSchema, ToolDeclaration};
+use crate::ui_output::UiOutputEvent;
 
 use anyhow::{anyhow, Result};
 use indexmap::IndexMap;
@@ -15,6 +16,12 @@ use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::mpsc;
+
+#[derive(Clone, Debug)]
+pub enum NestedAcpEvent {
+    Text(String),
+    Ui(UiOutputEvent),
+}
 
 pub struct AcpManager {
     clients: Arc<RwLock<HashMap<String, Arc<AcpClient>>>>,
@@ -59,7 +66,7 @@ impl AcpManager {
         tools
     }
 
-    pub async fn subscribe_chunks(&self) -> (mpsc::UnboundedReceiver<String>, u64) {
+    pub async fn subscribe_chunks(&self) -> (mpsc::UnboundedReceiver<NestedAcpEvent>, u64) {
         let (tx, rx) = mpsc::unbounded_channel();
         let subscription_id = self.next_subscription_id.fetch_add(1, Ordering::Relaxed);
         let clients: Vec<_> = self.clients.read().values().cloned().collect();

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -1,10 +1,9 @@
 use agent_client_protocol::{self as acp, Client as _};
-use std::{cell::RefCell, collections::HashMap, path::PathBuf, rc::Rc};
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
 use uuid::Uuid;
 
 use crate::client::{Client, SseEvent, SseHandler};
-use crate::config::session::SessionLogEntry;
-use crate::config::{ensure_parent_exists, Config, GlobalConfig, Input};
+use crate::config::{GlobalConfig, Input};
 use crate::tool::{ToolCall, ToolResult};
 use crate::utils::{wait_abort_signal, AbortSignal, AbortSignalInner};
 
@@ -26,32 +25,6 @@ pub struct HarnxAgent {
 struct HarnxSession {
     id: String,
     abort_signal: AbortSignal,
-    log_path: Option<PathBuf>,
-}
-
-impl HarnxSession {
-    /// Append a session log entry to this session's log file.
-    /// Uses async-compatible I/O (tokio::fs) to avoid blocking the Tokio runtime.
-    /// Best-effort: errors are logged but don't interrupt the session.
-    async fn append_log(&self, entry: &SessionLogEntry) {
-        let Some(path) = &self.log_path else { return };
-        let Ok(yaml) = serde_yaml::to_string(entry) else {
-            return;
-        };
-        let mut data = String::from("---\n");
-        data.push_str(&yaml);
-        use tokio::io::AsyncWriteExt;
-        match tokio::fs::OpenOptions::new().append(true).open(path).await {
-            Ok(mut file) => {
-                if let Err(e) = file.write_all(data.as_bytes()).await {
-                    warn!("Failed to write session log: {e}");
-                }
-            }
-            Err(e) => {
-                warn!("Failed to open session log for append: {e}");
-            }
-        }
-    }
 }
 
 impl HarnxAgent {
@@ -66,43 +39,6 @@ impl HarnxAgent {
 
     pub fn set_connection(&self, conn: Rc<acp::AgentSideConnection>) {
         self.connection.replace(Some(conn));
-    }
-
-    /// Create a session log file for an ACP session and write the header.
-    /// Returns the log file path, or None if creation failed.
-    async fn create_session_log(&self, session_id: &str) -> Option<PathBuf> {
-        let config = self.config.read();
-        let sessions_dir = Config::agent_data_dir(&self.agent_name)
-            .join("sessions")
-            .join("_");
-        drop(config);
-
-        let now = chrono::Local::now();
-        let name = now.format("%Y%m%dT%H%M%S").to_string();
-        let short_id = session_id.get(..8).unwrap_or(session_id);
-        let filename = format!("{name}-{short_id}.yaml");
-        let path = sessions_dir.join(&filename);
-        if ensure_parent_exists(&path).is_err() {
-            return None;
-        }
-
-        let agent = self.config.read().retrieve_agent(&self.agent_name).ok()?;
-        let header = SessionLogEntry::Header {
-            model_id: agent.model().id(),
-            temperature: agent.temperature(),
-            top_p: agent.top_p(),
-            use_tools: agent.use_tools(),
-            save_session: Some(true),
-            compress_threshold: None,
-            agent_name: Some(self.agent_name.clone()),
-            agent_variables: Default::default(),
-            agent_instructions: String::new(),
-        };
-        let content = serde_yaml::to_string(&header).ok()?;
-        if tokio::fs::write(&path, &content).await.is_err() {
-            return None;
-        }
-        Some(path)
     }
 
     async fn send_text_chunk(&self, session_id: &str, text: &str) -> acp::Result<()> {
@@ -279,11 +215,20 @@ impl acp::Agent for HarnxAgent {
         _args: acp::NewSessionRequest,
     ) -> acp::Result<acp::NewSessionResponse> {
         let session_id = Uuid::new_v4().to_string();
-        let log_path = self.create_session_log(&session_id).await;
+        {
+            let mut config = self.config.write();
+            if config.session.is_some() {
+                config
+                    .exit_session()
+                    .map_err(|e| acp::Error::new(-32603, format!("Failed to exit session: {e}")))?;
+            }
+            config
+                .use_session(Some(&session_id))
+                .map_err(|e| acp::Error::new(-32603, format!("Failed to create session: {e}")))?;
+        }
         let session = HarnxSession {
             id: session_id.clone(),
             abort_signal: AbortSignalInner::new(),
-            log_path,
         };
         self.sessions
             .borrow_mut()
@@ -311,6 +256,21 @@ impl acp::Agent for HarnxAgent {
             session.abort_signal.clone()
         };
 
+        {
+            let mut config = self.config.write();
+            let active_session_name = config.session.as_ref().map(|s| s.name().to_string());
+            if active_session_name.as_deref() != Some(session_key.as_str()) {
+                if config.session.is_some() {
+                    config.exit_session().map_err(|e| {
+                        acp::Error::new(-32603, format!("Failed to exit session: {e}"))
+                    })?;
+                }
+                config
+                    .use_session(Some(&session_key))
+                    .map_err(|e| acp::Error::new(-32603, format!("Failed to load session: {e}")))?;
+            }
+        }
+
         let agent = self
             .config
             .read()
@@ -321,17 +281,6 @@ impl acp::Agent for HarnxAgent {
         let client = input
             .create_client()
             .map_err(|e| acp::Error::new(-32603, format!("Failed to create client: {e}")))?;
-
-        // Log user prompt to session file (async, best-effort).
-        let session_for_user_log = {
-            let sessions = self.sessions.borrow();
-            sessions.get(session_key.as_str()).cloned()
-        };
-        if let Some(session) = session_for_user_log {
-            session
-                .append_log(&SessionLogEntry::message_user(prompt_text.clone()))
-                .await;
-        }
 
         let mut round = 0u32;
         loop {
@@ -348,20 +297,6 @@ impl acp::Agent for HarnxAgent {
             };
 
             if tool_calls.is_empty() {
-                // Log final assistant response.
-                let session_for_assistant_log = {
-                    let sessions = self.sessions.borrow();
-                    sessions.get(session_key.as_str()).cloned()
-                };
-                if let Some(session) = session_for_assistant_log {
-                    let content = match &thought {
-                        Some(t) => format!("<think>\n{t}\n</think>\n{output}"),
-                        None => output.clone(),
-                    };
-                    session
-                        .append_log(&SessionLogEntry::message_assistant(content))
-                        .await;
-                }
                 return Ok(acp::PromptResponse::new(acp::StopReason::EndTurn));
             }
 
@@ -813,7 +748,7 @@ mod tests {
 
         run_local(async move {
             let (client_conn, chunks, server_handle, client_handle) =
-                setup_roundtrip(CREATE_TITLE_AGENT, config);
+                setup_roundtrip(CREATE_TITLE_AGENT, config.clone());
 
             timeout(
                 Duration::from_secs(5),
@@ -837,6 +772,11 @@ mod tests {
             .expect("new_session should not hang")
             .expect("new_session should succeed");
 
+            assert_eq!(
+                config.read().session.as_ref().map(|s| s.name().to_string()),
+                Some(session.session_id.to_string())
+            );
+
             let response = timeout(
                 Duration::from_secs(5),
                 client_conn.prompt(acp::PromptRequest::new(
@@ -853,6 +793,13 @@ mod tests {
                 chunks.borrow().join("").contains("hello from client"),
                 "expected prompt roundtrip output, got {:?}",
                 chunks.borrow()
+            );
+
+            let session_path = config.read().session_file(&session.session_id.to_string());
+            assert!(
+                !session_path.display().to_string().contains("/sessions/_/"),
+                "session file should not be written under '_' temp directory: {}",
+                session_path.display()
             );
 
             server_handle.abort();

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -411,11 +411,10 @@ async fn nested_ui_event_to_session_update(
     event: crate::ui_output::UiOutputEvent,
 ) -> Option<acp::SessionUpdate> {
     match event.kind {
-        UiOutputEventKind::LlmText(text)
-        | UiOutputEventKind::TranscriptText { text }
-        | UiOutputEventKind::ToolResultText { text } => Some(
+        UiOutputEventKind::LlmText(text) | UiOutputEventKind::TranscriptText { text } => Some(
             acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(text.into())),
         ),
+        UiOutputEventKind::ToolResultText { .. } => None,
         UiOutputEventKind::AcpThought { text } => Some(acp::SessionUpdate::AgentThoughtChunk(
             acp::ContentChunk::new(text.into()),
         )),

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -1,3 +1,4 @@
+use super::NestedAcpEvent;
 use agent_client_protocol::{self as acp, Client as _};
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 use uuid::Uuid;
@@ -5,6 +6,7 @@ use uuid::Uuid;
 use crate::client::{Client, SseEvent, SseHandler};
 use crate::config::{GlobalConfig, Input};
 use crate::tool::{ToolCall, ToolResult};
+use crate::ui_output::UiOutputEventKind;
 use crate::utils::{wait_abort_signal, AbortSignal, AbortSignalInner};
 
 use anyhow::bail;
@@ -330,14 +332,25 @@ impl acp::Agent for HarnxAgent {
                     let forward_task = tokio::task::spawn_local(async move {
                         while let Some(chunk) = chunk_rx.recv().await {
                             if let Some(ref conn) = connection {
-                                let notification = acp::SessionNotification::new(
-                                    acp::SessionId::new(sid.clone()),
-                                    acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
-                                        chunk.into(),
-                                    )),
-                                );
-                                if let Err(e) = conn.session_notification(notification).await {
-                                    warn!("ACP nested streaming notification failed: {e}");
+                                let update = match chunk {
+                                    NestedAcpEvent::Ui(event) => {
+                                        nested_ui_event_to_session_update(event).await
+                                    }
+                                    NestedAcpEvent::Text(text) => {
+                                        Some(acp::SessionUpdate::AgentMessageChunk(
+                                            acp::ContentChunk::new(text.into()),
+                                        ))
+                                    }
+                                };
+
+                                if let Some(update) = update {
+                                    let notification = acp::SessionNotification::new(
+                                        acp::SessionId::new(sid.clone()),
+                                        update,
+                                    );
+                                    if let Err(e) = conn.session_notification(notification).await {
+                                        warn!("ACP nested streaming notification failed: {e}");
+                                    }
                                 }
                             }
                         }
@@ -394,6 +407,55 @@ fn content_block_to_text(content: &acp::ContentBlock) -> String {
 // single-threaded runtimes (the sync version uses `block_in_place` which
 // panics on `current_thread`). Skips CLI hooks since they are designed
 // for interactive terminal use.
+async fn nested_ui_event_to_session_update(
+    event: crate::ui_output::UiOutputEvent,
+) -> Option<acp::SessionUpdate> {
+    match event.kind {
+        UiOutputEventKind::LlmText(text)
+        | UiOutputEventKind::TranscriptText { text }
+        | UiOutputEventKind::ToolResultText { text } => Some(
+            acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(text.into())),
+        ),
+        UiOutputEventKind::AcpThought { text } => Some(acp::SessionUpdate::AgentThoughtChunk(
+            acp::ContentChunk::new(text.into()),
+        )),
+        UiOutputEventKind::StructuredBlock { title, body } => Some(acp::SessionUpdate::ToolCall(
+            acp::ToolCall::new(title, body.unwrap_or_default()),
+        )),
+        UiOutputEventKind::StatusLine { text } => Some(acp::SessionUpdate::ToolCallUpdate(
+            acp::ToolCallUpdate::new("status", acp::ToolCallUpdateFields::new().title(text)),
+        )),
+        UiOutputEventKind::Plan { entries } => {
+            let mapped_entries = entries
+                .into_iter()
+                .map(|entry| {
+                    let status = match entry.status.as_str() {
+                        "completed" => acp::PlanEntryStatus::Completed,
+                        "in_progress" => acp::PlanEntryStatus::InProgress,
+                        _ => acp::PlanEntryStatus::Pending,
+                    };
+                    acp::PlanEntry::new(entry.content, acp::PlanEntryPriority::Medium, status)
+                })
+                .collect();
+            Some(acp::SessionUpdate::Plan(acp::Plan::new(mapped_entries)))
+        }
+        UiOutputEventKind::McpToolInvocation {
+            tool_name,
+            input_yaml,
+        } => Some(acp::SessionUpdate::ToolCall(acp::ToolCall::new(
+            tool_name,
+            input_yaml.unwrap_or_default(),
+        ))),
+        UiOutputEventKind::LlmFinal { output, .. } => Some(acp::SessionUpdate::AgentMessageChunk(
+            acp::ContentChunk::new(output.into()),
+        )),
+        UiOutputEventKind::LlmError(err) => Some(acp::SessionUpdate::AgentMessageChunk(
+            acp::ContentChunk::new(format!("[error] {err}").into()),
+        )),
+        UiOutputEventKind::Usage { .. } => None,
+    }
+}
+
 async fn eval_tool_calls_async(
     config: &GlobalConfig,
     mut calls: Vec<ToolCall>,
@@ -739,6 +801,56 @@ mod tests {
 
             server_handle.abort();
             client_handle.abort();
+        });
+    }
+
+    #[test]
+    fn nested_ui_event_maps_to_structured_session_updates() {
+        run_local(async {
+            let tool_update = nested_ui_event_to_session_update(crate::ui_output::UiOutputEvent {
+                kind: UiOutputEventKind::McpToolInvocation {
+                    tool_name: "argus_session_prompt".to_string(),
+                    input_yaml: Some("message: hello".to_string()),
+                },
+                source: None,
+            })
+            .await
+            .expect("tool update");
+
+            match tool_update {
+                acp::SessionUpdate::ToolCall(call) => {
+                    assert!(format!("{:?}", call).contains("argus_session_prompt"));
+                    assert!(format!("{:?}", call).contains("message: hello"));
+                }
+                other => panic!("unexpected tool update: {other:?}"),
+            }
+
+            let thought_update =
+                nested_ui_event_to_session_update(crate::ui_output::UiOutputEvent {
+                    kind: UiOutputEventKind::AcpThought {
+                        text: "thinking".to_string(),
+                    },
+                    source: None,
+                })
+                .await
+                .expect("thought update");
+            assert!(matches!(
+                thought_update,
+                acp::SessionUpdate::AgentThoughtChunk(_)
+            ));
+
+            let plan_update = nested_ui_event_to_session_update(crate::ui_output::UiOutputEvent {
+                kind: UiOutputEventKind::Plan {
+                    entries: vec![crate::ui_output::UiOutputPlanEntry {
+                        status: "in_progress".to_string(),
+                        content: "delegate to argus".to_string(),
+                    }],
+                },
+                source: None,
+            })
+            .await
+            .expect("plan update");
+            assert!(matches!(plan_update, acp::SessionUpdate::Plan(_)));
         });
     }
 

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -57,22 +57,6 @@ pub enum SessionLogEntry {
     Clear,
 }
 
-impl SessionLogEntry {
-    pub fn message_user(text: String) -> Self {
-        Self::Message {
-            role: MessageRole::User,
-            content: MessageContent::Text(text),
-        }
-    }
-
-    pub fn message_assistant(text: String) -> Self {
-        Self::Message {
-            role: MessageRole::Assistant,
-            content: MessageContent::Text(text),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct Session {
     #[serde(rename(serialize = "model", deserialize = "model"))]

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1,4 +1,5 @@
 use crate::{
+    acp::NestedAcpEvent,
     config::GlobalConfig,
     hooks::{dispatch::dispatch_hooks, HookEvent, HookResultControl},
     mcp_safety::{truncate_output, TruncateOpts},
@@ -478,7 +479,7 @@ impl ToolCall {
 /// then restores the spinner.  This gives the user live visibility into
 /// sub-agent (and sub-sub-agent) tool calls, thoughts, and plan updates.
 async fn forward_acp_chunks(
-    mut chunk_rx: UnboundedReceiver<String>,
+    mut chunk_rx: UnboundedReceiver<NestedAcpEvent>,
     spinner: Option<Spinner>,
     spinner_msg: String,
 ) {
@@ -488,15 +489,24 @@ async fn forward_acp_chunks(
         if let Some(ref s) = spinner {
             s.pause();
         }
-        let event = UiOutputEvent {
-            kind: UiOutputEventKind::TranscriptText {
-                text: chunk.clone(),
-            },
-            source: None,
-        };
-        if !emit_ui_output_event(event) {
-            print!("{chunk}");
-            let _ = std::io::stdout().flush();
+        match chunk {
+            NestedAcpEvent::Ui(event) => {
+                let fallback = event_fallback_text(&event.kind, event.source.as_ref());
+                if !emit_ui_output_event(event) {
+                    print!("{fallback}");
+                    let _ = std::io::stdout().flush();
+                }
+            }
+            NestedAcpEvent::Text(text) => {
+                let event = UiOutputEvent {
+                    kind: UiOutputEventKind::TranscriptText { text: text.clone() },
+                    source: None,
+                };
+                if !emit_ui_output_event(event) {
+                    print!("{text}");
+                    let _ = std::io::stdout().flush();
+                }
+            }
         }
         // Re-enable the spinner after printing.
         if let Some(ref s) = spinner {
@@ -545,8 +555,10 @@ fn extract_user_display_text(result: &Value) -> Option<String> {
 mod tests {
     use super::*;
     use crate::config::Config;
+    use crate::ui_output::{clear_ui_output_sender, install_ui_output_sender};
     use parking_lot::RwLock;
     use std::sync::Arc;
+    use tokio::sync::mpsc::unbounded_channel;
 
     #[test]
     fn test_mcp_tool_invocation_terminal_fallback_multiline_yaml() {
@@ -773,5 +785,43 @@ mod tests {
         let event = UiOutputEventKind::ToolResultText { text: text.clone() };
 
         assert_eq!(event_fallback_text(&event, None), text);
+    }
+
+    #[tokio::test]
+    async fn forward_acp_chunks_preserves_structured_nested_events() {
+        let (ui_tx, mut ui_rx) = unbounded_channel();
+        install_ui_output_sender(ui_tx);
+
+        let (tx, rx) = unbounded_channel();
+        let forward = tokio::spawn(forward_acp_chunks(rx, None, "working".to_string()));
+
+        tx.send(NestedAcpEvent::Ui(UiOutputEvent {
+            kind: UiOutputEventKind::McpToolInvocation {
+                tool_name: "argus_session_prompt".to_string(),
+                input_yaml: Some("message: hi".to_string()),
+            },
+            source: Some(crate::ui_output::UiOutputSource {
+                agent: "argus".to_string(),
+                session_id: Some("sess-1".to_string()),
+            }),
+        }))
+        .unwrap();
+        drop(tx);
+
+        forward.await.unwrap();
+
+        let event = ui_rx.recv().await.expect("forwarded UI event");
+        match event.kind {
+            UiOutputEventKind::McpToolInvocation {
+                tool_name,
+                input_yaml,
+            } => {
+                assert_eq!(tool_name, "argus_session_prompt");
+                assert_eq!(input_yaml.as_deref(), Some("message: hi"));
+            }
+            other => panic!("unexpected event kind: {other:?}"),
+        }
+
+        clear_ui_output_sender();
     }
 }

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -2,7 +2,11 @@ use crate::{
     config::GlobalConfig,
     hooks::{dispatch::dispatch_hooks, HookEvent, HookResultControl},
     mcp_safety::{truncate_output, TruncateOpts},
-    ui_output::emit_ui_output,
+    tui::render_helpers::event_fallback_text,
+    ui_output::{
+        emit_ui_output_event, has_ui_output_sink, pretty_yaml_block, UiOutputEvent,
+        UiOutputEventKind,
+    },
     utils::*,
 };
 
@@ -12,7 +16,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashSet;
 use std::io::Write as _;
-use textwrap::{wrap, Options};
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::UnboundedReceiver;
 
@@ -105,7 +108,11 @@ pub fn eval_tool_calls(config: &GlobalConfig, mut calls: Vec<ToolCall>) -> Resul
                     });
                 let truncated = truncate_output(&output_str, &opts);
                 let text = format!("{}\n", dimmed_text(&truncated));
-                if !emit_ui_output(text.clone()) && *IS_STDOUT_TERMINAL {
+                let event = UiOutputEvent {
+                    kind: UiOutputEventKind::ToolResultText { text: text.clone() },
+                    source: None,
+                };
+                if !emit_ui_output_event(event) && *IS_STDOUT_TERMINAL {
                     print!("{text}");
                 }
 
@@ -290,47 +297,6 @@ pub struct ToolCall {
     pub thought_signature: Option<String>,
 }
 
-fn display_wrap_width() -> usize {
-    std::env::var("COLUMNS")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .filter(|&w| w >= 40)
-        .unwrap_or(88)
-}
-
-fn wrap_display_text(text: &str, initial_indent: &str, subsequent_indent: &str) -> String {
-    if text.trim().is_empty() {
-        return String::new();
-    }
-    let options = Options::new(display_wrap_width())
-        .initial_indent(initial_indent)
-        .subsequent_indent(subsequent_indent)
-        .break_words(false)
-        .word_splitter(textwrap::WordSplitter::NoHyphenation);
-    wrap(text, options).join("\n")
-}
-
-fn pretty_yaml_block(value: &Value) -> String {
-    serde_yaml::to_string(value)
-        .map(|s| s.trim_end().to_string())
-        .unwrap_or_else(|_| value.to_string())
-}
-
-fn format_tool_invocation_display(tool_name: &str, json_data: &Value) -> String {
-    let header = wrap_display_text(&format!("🛠️  {tool_name}"), "", "   ");
-    match json_data {
-        Value::Null => format!("{}\n", dimmed_text(&header)),
-        _ => {
-            let body = pretty_yaml_block(json_data)
-                .lines()
-                .map(|line| format!("   {line}"))
-                .collect::<Vec<_>>()
-                .join("\n");
-            format!("{}\n{}\n", dimmed_text(&header), dimmed_text(&body))
-        }
-    }
-}
-
 impl ToolCall {
     pub fn dedup(calls: Vec<Self>) -> Vec<Self> {
         let mut new_calls = vec![];
@@ -386,8 +352,18 @@ impl ToolCall {
         };
 
         // Emit tool call info to TUI or terminal
-        let text = format_tool_invocation_display(&self.name, &json_data);
-        if !emit_ui_output(text.clone()) && *IS_STDOUT_TERMINAL {
+        let event = UiOutputEvent {
+            kind: UiOutputEventKind::McpToolInvocation {
+                tool_name: self.name.clone(),
+                input_yaml: match json_data {
+                    Value::Null => None,
+                    _ => Some(pretty_yaml_block(&json_data)),
+                },
+            },
+            source: None,
+        };
+        let text = event_fallback_text(&event.kind, event.source.as_ref());
+        if !emit_ui_output_event(event) && *IS_STDOUT_TERMINAL {
             print!("{text}");
         }
 
@@ -422,7 +398,7 @@ impl ToolCall {
                 // stdout in real-time instead of being silently swallowed.
                 let result = tokio::task::block_in_place(|| {
                     tokio::runtime::Handle::current().block_on(async {
-                        let has_ui_output = emit_ui_output("");
+                        let has_ui_output = has_ui_output_sink();
                         let is_terminal = *IS_STDOUT_TERMINAL && !has_ui_output;
                         let (chunk_rx, subscription_id) = manager.subscribe_chunks().await;
 
@@ -512,7 +488,13 @@ async fn forward_acp_chunks(
         if let Some(ref s) = spinner {
             s.pause();
         }
-        if !emit_ui_output(chunk.clone()) {
+        let event = UiOutputEvent {
+            kind: UiOutputEventKind::TranscriptText {
+                text: chunk.clone(),
+            },
+            source: None,
+        };
+        if !emit_ui_output_event(event) {
             print!("{chunk}");
             let _ = std::io::stdout().flush();
         }
@@ -567,13 +549,16 @@ mod tests {
     use std::sync::Arc;
 
     #[test]
-    fn test_format_tool_invocation_display_multiline_yaml() {
-        let rendered = format_tool_invocation_display(
-            "argus_session_prompt",
-            &json!({
-                "message": "Goal — Improve display\nAcceptance criteria — Wrap nicely",
-                "session_id": "session-1"
-            }),
+    fn test_mcp_tool_invocation_terminal_fallback_multiline_yaml() {
+        let rendered = event_fallback_text(
+            &UiOutputEventKind::McpToolInvocation {
+                tool_name: "argus_session_prompt".to_string(),
+                input_yaml: Some(pretty_yaml_block(&json!({
+                    "message": "Goal — Improve display\nAcceptance criteria — Wrap nicely",
+                    "session_id": "session-1"
+                }))),
+            },
+            None,
         );
 
         assert!(rendered.contains("argus_session_prompt"));
@@ -780,5 +765,13 @@ mod tests {
             extract_user_display_text(&result),
             Some("has annotations but no audience".to_string())
         );
+    }
+
+    #[test]
+    fn test_tool_result_event_fallback_text_matches_terminal_output() {
+        let text = "\u{1b}[2mtool output\u{1b}[0m\n".to_string();
+        let event = UiOutputEventKind::ToolResultText { text: text.clone() };
+
+        assert_eq!(event_fallback_text(&event, None), text);
     }
 }

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -413,8 +413,12 @@ impl ToolCall {
                         // Forward chunks either to TUI output sink or stdout.
                         let spinner_clone = spinner.clone();
                         let spinner_msg = format!("  {} working…", tool_name);
-                        let forward_handle =
-                            tokio::spawn(forward_acp_chunks(chunk_rx, spinner_clone, spinner_msg));
+                        let forward_handle = tokio::spawn(forward_acp_chunks(
+                            chunk_rx,
+                            spinner_clone,
+                            spinner_msg,
+                            is_terminal,
+                        ));
 
                         let call_result = manager.call_tool(&tool_name, json_data).await;
 
@@ -482,6 +486,7 @@ async fn forward_acp_chunks(
     mut chunk_rx: UnboundedReceiver<NestedAcpEvent>,
     spinner: Option<Spinner>,
     spinner_msg: String,
+    allow_fallback_print: bool,
 ) {
     while let Some(chunk) = chunk_rx.recv().await {
         // Pause the spinner (clear display but keep task alive) before
@@ -492,7 +497,7 @@ async fn forward_acp_chunks(
         match chunk {
             NestedAcpEvent::Ui(event) => {
                 let fallback = event_fallback_text(&event.kind, event.source.as_ref());
-                if !emit_ui_output_event(event) {
+                if !emit_ui_output_event(event) && allow_fallback_print {
                     print!("{fallback}");
                     let _ = std::io::stdout().flush();
                 }
@@ -502,7 +507,7 @@ async fn forward_acp_chunks(
                     kind: UiOutputEventKind::TranscriptText { text: text.clone() },
                     source: None,
                 };
-                if !emit_ui_output_event(event) {
+                if !emit_ui_output_event(event) && allow_fallback_print {
                     print!("{text}");
                     let _ = std::io::stdout().flush();
                 }
@@ -793,7 +798,7 @@ mod tests {
         install_ui_output_sender(ui_tx);
 
         let (tx, rx) = unbounded_channel();
-        let forward = tokio::spawn(forward_acp_chunks(rx, None, "working".to_string()));
+        let forward = tokio::spawn(forward_acp_chunks(rx, None, "working".to_string(), false));
 
         tx.send(NestedAcpEvent::Ui(UiOutputEvent {
             kind: UiOutputEventKind::McpToolInvocation {

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1,5 +1,9 @@
 use super::*;
+use crate::tui::render_helpers::{
+    render_plan_entries, render_structured_block, render_usage_line, source_heading,
+};
 use crate::tui::types::{TranscriptEntry, TuiEvent};
+use crate::ui_output::{UiOutputEvent, UiOutputEventKind, UiOutputSource};
 
 fn unique_attachment_display_name(
     attachments: &[crate::tui::types::Attachment],
@@ -347,18 +351,8 @@ impl Tui {
 
     async fn handle_tui_event_inner(&mut self, event: TuiEvent) -> Result<()> {
         match event {
-            TuiEvent::UiOutput(text) => {
-                // Strip ANSI escape codes so raw terminal output doesn't corrupt the TUI (fix #6)
-                let clean = strip_ansi(&text);
-                let clean = clean.trim_end_matches('\n').to_string();
-                if !clean.is_empty() {
-                    self.app.transcript.push(TranscriptEntry::System(clean));
-                    self.pin_transcript_to_bottom();
-                }
-            }
-            TuiEvent::Chunk(chunk) => {
-                self.append_streaming_assistant_chunk(&chunk);
-                self.pin_transcript_to_bottom();
+            TuiEvent::UiOutput(event) => {
+                self.render_ui_output_event(event).await;
             }
             TuiEvent::ToolRoundComplete => {
                 // Intermediate tool round — prompt loop continues, don't clear llm_busy.
@@ -366,8 +360,63 @@ impl Tui {
                 // continue without inserting a blank separator or synthetic status line.
                 self.pin_transcript_to_bottom();
             }
-            TuiEvent::Finished { output, usage } => {
+        }
+        Ok(())
+    }
+
+    async fn submit_pending_message(
+        &mut self,
+        pending: crate::tui::types::PendingMessage,
+    ) -> Result<()> {
+        self.app.input = Self::new_input();
+        self.app
+            .transcript
+            .push(TranscriptEntry::User(pending.text.clone()));
+        self.pin_transcript_to_bottom();
+        if pending.text.trim_start().starts_with('.') {
+            self.app.attachments = pending.attachments;
+            self.app.attachment_dir = pending.attachment_dir;
+            self.app.paste_count = pending.paste_count;
+            self.run_repl_command(&pending.text).await?;
+            self.refresh_input_chrome();
+        } else {
+            self.start_prompt(pending).await?;
+        }
+        Ok(())
+    }
+
+    async fn render_ui_output_event(&mut self, event: UiOutputEvent) {
+        self.render_ui_output_heading(event.source.as_ref());
+
+        let rendered_entries = match event.kind {
+            UiOutputEventKind::TranscriptText { text } => {
+                let clean = strip_ansi(&text).trim_end_matches('\n').to_string();
+                if clean.is_empty() {
+                    vec![]
+                } else {
+                    vec![TranscriptEntry::System(clean)]
+                }
+            }
+            UiOutputEventKind::ToolResultText { text } => {
+                let clean = strip_ansi(&text).trim_end_matches('\n').to_string();
+                if clean.is_empty() {
+                    vec![]
+                } else {
+                    clean
+                        .lines()
+                        .map(|line| TranscriptEntry::System(format!("   {line}")))
+                        .collect()
+                }
+            }
+            UiOutputEventKind::LlmText(text) => {
+                self.app.last_ui_output_source = None;
+                self.append_streaming_assistant_chunk(&text);
+                self.pin_transcript_to_bottom();
+                vec![]
+            }
+            UiOutputEventKind::LlmFinal { output, usage } => {
                 self.app.llm_busy = false;
+                self.app.last_ui_output_source = None;
                 if !output.is_empty() {
                     if let Some(idx) = self.app.streaming_assistant_idx {
                         match self.app.transcript.get_mut(idx) {
@@ -398,43 +447,87 @@ impl Tui {
                 self.refresh_input_chrome();
 
                 if let Some(pending) = self.app.pending_message.take() {
-                    self.submit_pending_message(pending).await?;
+                    if let Err(err) = self.submit_pending_message(pending).await {
+                        self.app
+                            .transcript
+                            .push(TranscriptEntry::Error(err.to_string()));
+                        self.pin_transcript_to_bottom();
+                    }
                 }
+                vec![]
             }
-            TuiEvent::Errored(err) => {
+            UiOutputEventKind::LlmError(err) => {
                 self.app.llm_busy = false;
                 self.app.streaming_assistant_idx = None;
+                self.app.last_ui_output_source = None;
                 self.app.transcript.push(TranscriptEntry::Error(err));
                 self.pin_transcript_to_bottom();
                 self.refresh_input_chrome();
 
                 if let Some(pending) = self.app.pending_message.take() {
-                    self.submit_pending_message(pending).await?;
+                    if let Err(err) = self.submit_pending_message(pending).await {
+                        self.app
+                            .transcript
+                            .push(TranscriptEntry::Error(err.to_string()));
+                        self.pin_transcript_to_bottom();
+                    }
+                }
+                vec![]
+            }
+            UiOutputEventKind::AcpThought { text } => {
+                let clean = strip_ansi(&text).trim().to_string();
+                if clean.is_empty() {
+                    vec![]
+                } else {
+                    vec![TranscriptEntry::System(format!("<think>{clean}</think>"))]
                 }
             }
+            UiOutputEventKind::StructuredBlock { title, body } => {
+                render_structured_block(&title, body.as_deref())
+            }
+            UiOutputEventKind::StatusLine { text } => {
+                if text.is_empty() {
+                    vec![]
+                } else {
+                    vec![TranscriptEntry::System(text)]
+                }
+            }
+            UiOutputEventKind::Plan { entries } => render_plan_entries(&entries),
+            UiOutputEventKind::Usage {
+                input_tokens,
+                output_tokens,
+                cached_tokens,
+                session_label,
+            } => render_usage_line(
+                input_tokens,
+                output_tokens,
+                cached_tokens,
+                session_label.as_deref(),
+                event.source.as_ref(),
+            )
+            .map(|line| vec![TranscriptEntry::System(line)])
+            .unwrap_or_default(),
+            UiOutputEventKind::McpToolInvocation {
+                tool_name,
+                input_yaml,
+            } => render_structured_block(&format!("->️ {tool_name}"), input_yaml.as_deref()),
+        };
+
+        if !rendered_entries.is_empty() {
+            self.app.transcript.extend(rendered_entries);
+            self.pin_transcript_to_bottom();
         }
-        Ok(())
     }
 
-    async fn submit_pending_message(
-        &mut self,
-        pending: crate::tui::types::PendingMessage,
-    ) -> Result<()> {
-        self.app.input = Self::new_input();
-        self.app
-            .transcript
-            .push(TranscriptEntry::User(pending.text.clone()));
-        self.pin_transcript_to_bottom();
-        if pending.text.trim_start().starts_with('.') {
-            self.app.attachments = pending.attachments;
-            self.app.attachment_dir = pending.attachment_dir;
-            self.app.paste_count = pending.paste_count;
-            self.run_repl_command(&pending.text).await?;
-            self.refresh_input_chrome();
-        } else {
-            self.start_prompt(pending).await?;
+    fn render_ui_output_heading(&mut self, source: Option<&UiOutputSource>) {
+        let source = source.cloned();
+        if source != self.app.last_ui_output_source {
+            if let Some(source) = &source {
+                let heading = source_heading(source);
+                self.app.transcript.push(TranscriptEntry::System(heading));
+            }
+            self.app.last_ui_output_source = source;
         }
-        Ok(())
     }
 
     pub(super) async fn start_prompt(
@@ -462,7 +555,10 @@ impl Tui {
             )
             .await;
             if let Err(err) = result {
-                let _ = event_tx.send(TuiEvent::Errored(err.to_string()));
+                let _ = event_tx.send(TuiEvent::UiOutput(UiOutputEvent {
+                    kind: UiOutputEventKind::LlmError(err.to_string()),
+                    source: None,
+                }));
             }
         });
 

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -385,7 +385,28 @@ impl Tui {
         Ok(())
     }
 
+    fn flush_pending_thought(&mut self) {
+        if self.app.pending_thought_text.is_empty() {
+            return;
+        }
+        let text = std::mem::take(&mut self.app.pending_thought_text);
+        self.app.pending_thought_source = None;
+        self.app.transcript.push(TranscriptEntry::System(format!(
+            "<think>{}</think>",
+            text.trim()
+        )));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn flush_pending_thought_for_test(&mut self) {
+        self.flush_pending_thought();
+    }
+
     async fn render_ui_output_event(&mut self, event: UiOutputEvent) {
+        let is_thought = matches!(&event.kind, UiOutputEventKind::AcpThought { .. });
+        if !is_thought {
+            self.flush_pending_thought();
+        }
         self.render_ui_output_heading(event.source.as_ref());
 
         let rendered_entries = match event.kind {
@@ -410,11 +431,13 @@ impl Tui {
             }
             UiOutputEventKind::LlmText(text) => {
                 self.app.last_ui_output_source = None;
+                self.app.pending_thought_source = None;
                 self.append_streaming_assistant_chunk(&text);
                 self.pin_transcript_to_bottom();
                 vec![]
             }
             UiOutputEventKind::LlmFinal { output, usage } => {
+                self.flush_pending_thought();
                 self.app.llm_busy = false;
                 self.app.last_ui_output_source = None;
                 if !output.is_empty() {
@@ -457,6 +480,7 @@ impl Tui {
                 vec![]
             }
             UiOutputEventKind::LlmError(err) => {
+                self.flush_pending_thought();
                 self.app.llm_busy = false;
                 self.app.streaming_assistant_idx = None;
                 self.app.last_ui_output_source = None;
@@ -475,11 +499,16 @@ impl Tui {
                 vec![]
             }
             UiOutputEventKind::AcpThought { text } => {
-                let clean = strip_ansi(&text).trim().to_string();
-                if clean.is_empty() {
+                let clean = strip_ansi(&text);
+                if clean.trim().is_empty() {
                     vec![]
                 } else {
-                    vec![TranscriptEntry::System(format!("<think>{clean}</think>"))]
+                    if self.app.pending_thought_source != event.source {
+                        self.flush_pending_thought();
+                        self.app.pending_thought_source = event.source.clone();
+                    }
+                    self.app.pending_thought_text.push_str(&clean);
+                    vec![]
                 }
             }
             UiOutputEventKind::StructuredBlock { title, body } => {
@@ -515,6 +544,8 @@ impl Tui {
 
         if !rendered_entries.is_empty() {
             self.app.transcript.extend(rendered_entries);
+            self.pin_transcript_to_bottom();
+        } else if is_thought {
             self.pin_transcript_to_bottom();
         }
     }

--- a/src/tui/lifecycle.rs
+++ b/src/tui/lifecycle.rs
@@ -34,11 +34,11 @@ impl Tui {
     ) -> Result<Self> {
         let (event_tx, event_rx) = mpsc::unbounded_channel();
         let ui_output_tx = event_tx.clone();
-        let (bridge_tx, mut bridge_rx) = mpsc::unbounded_channel::<String>();
+        let (bridge_tx, mut bridge_rx) = mpsc::unbounded_channel();
         install_ui_output_sender(bridge_tx);
         tokio::spawn(async move {
-            while let Some(text) = bridge_rx.recv().await {
-                let _ = ui_output_tx.send(TuiEvent::UiOutput(text));
+            while let Some(event) = bridge_rx.recv().await {
+                let _ = ui_output_tx.send(TuiEvent::UiOutput(event));
             }
         });
 
@@ -59,6 +59,7 @@ impl Tui {
                 llm_busy: false,
                 scroll_state: ratatui_widget_scrolling::ScrollState::new(),
                 streaming_assistant_idx: None,
+                last_ui_output_source: None,
                 pending_message: None,
                 completions: vec![],
                 completion_index: 0,

--- a/src/tui/lifecycle.rs
+++ b/src/tui/lifecycle.rs
@@ -60,6 +60,8 @@ impl Tui {
                 scroll_state: ratatui_widget_scrolling::ScrollState::new(),
                 streaming_assistant_idx: None,
                 last_ui_output_source: None,
+                pending_thought_source: None,
+                pending_thought_text: String::new(),
                 pending_message: None,
                 completions: vec![],
                 completion_index: 0,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -37,6 +37,7 @@ mod input;
 mod lifecycle;
 mod prompt;
 mod render;
+pub(crate) mod render_helpers;
 mod terminal;
 #[cfg(test)]
 mod tests;

--- a/src/tui/prompt.rs
+++ b/src/tui/prompt.rs
@@ -96,10 +96,15 @@ impl Tui {
                 )
                 .await;
                 if matches!(outcome.control, HookResultControl::Block { .. }) {
-                    let _ = ctx.event_tx.send(TuiEvent::Finished {
-                        output: String::new(),
-                        usage: Default::default(),
-                    });
+                    let _ =
+                        ctx.event_tx
+                            .send(TuiEvent::UiOutput(crate::ui_output::UiOutputEvent {
+                                kind: crate::ui_output::UiOutputEventKind::LlmFinal {
+                                    output: String::new(),
+                                    usage: Default::default(),
+                                },
+                                source: None,
+                            }));
                     break;
                 }
             }
@@ -170,10 +175,15 @@ impl Tui {
                 with_embeddings = false;
                 continue;
             } else {
-                let _ = ctx.event_tx.send(TuiEvent::Finished {
-                    output: output.clone(),
-                    usage: usage.clone(),
-                });
+                let _ = ctx
+                    .event_tx
+                    .send(TuiEvent::UiOutput(crate::ui_output::UiOutputEvent {
+                        kind: crate::ui_output::UiOutputEventKind::LlmFinal {
+                            output: output.clone(),
+                            usage: usage.clone(),
+                        },
+                        source: None,
+                    }));
             }
 
             let max_resume = hooks.max_resume.unwrap_or(5);
@@ -244,7 +254,11 @@ impl Tui {
             while let Some(evt) = rx.recv().await {
                 match evt {
                     crate::client::SseEvent::Text(text) => {
-                        let _ = event_tx.send(TuiEvent::Chunk(text));
+                        let _ =
+                            event_tx.send(TuiEvent::UiOutput(crate::ui_output::UiOutputEvent {
+                                kind: crate::ui_output::UiOutputEventKind::LlmText(text),
+                                source: None,
+                            }));
                     }
                     crate::client::SseEvent::Done => break,
                 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -56,7 +56,14 @@ impl Tui {
         if lines.is_empty() {
             lines.push(Line::from(Span::styled(prefix.to_string(), style)));
         }
-        lines.push(Line::from(""));
+        let add_trailing_spacing = match entry {
+            TranscriptEntry::System(_) => false,
+            TranscriptEntry::Assistant(text) => !text.contains('\n'),
+            _ => true,
+        };
+        if add_trailing_spacing {
+            lines.push(Line::from(""));
+        }
         lines
     }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -320,9 +320,9 @@ impl Tui {
             let (tokens, percent) = session.tokens_usage();
             if tokens > 0 {
                 if percent > 0.0 {
-                    parts.push(format!("💬 {}({:.0}%)", tokens, percent));
+                    parts.push(format!("Context: {}({:.0}%)", tokens, percent));
                 } else {
-                    parts.push(format!("💬 {}", tokens));
+                    parts.push(format!("Context: {}", tokens));
                 }
             }
         }
@@ -369,9 +369,9 @@ impl Tui {
         let cursor_style = if pending_message {
             Style::default()
                 .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD)
+                .add_modifier(Modifier::BOLD | Modifier::REVERSED)
         } else {
-            Style::default()
+            Style::default().add_modifier(Modifier::REVERSED)
         };
         app.input.set_cursor_style(cursor_style);
     }

--- a/src/tui/render_helpers.rs
+++ b/src/tui/render_helpers.rs
@@ -1,0 +1,134 @@
+use crate::tui::types::TranscriptEntry;
+use crate::ui_output::{UiOutputEventKind, UiOutputPlanEntry, UiOutputSource};
+
+pub(crate) fn render_status_line(title: Option<&str>, status: Option<&str>) -> Option<String> {
+    let line = [title, status]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!line.is_empty()).then_some(format!("-> {line}"))
+}
+
+pub(crate) fn source_heading(source: &UiOutputSource) -> String {
+    match &source.session_id {
+        Some(session_id) if !session_id.is_empty() => {
+            format!("🤖 {} ▸ {}", source.agent, session_id)
+        }
+        _ => format!("🤖 {}", source.agent),
+    }
+}
+
+pub(super) fn render_structured_block(title: &str, body: Option<&str>) -> Vec<TranscriptEntry> {
+    let mut entries = vec![TranscriptEntry::System(title.to_string())];
+    if let Some(body) = body {
+        entries.extend(
+            body.lines()
+                .map(|line| TranscriptEntry::System(format!("   {line}"))),
+        );
+    }
+    entries
+}
+
+pub(super) fn render_plan_entries(entries: &[UiOutputPlanEntry]) -> Vec<TranscriptEntry> {
+    if entries.is_empty() {
+        return vec![];
+    }
+
+    let mut rendered = vec![TranscriptEntry::System("Plan: ".trim_end().to_string())];
+    rendered.extend(
+        entries.iter().map(|entry| {
+            TranscriptEntry::System(format!("  [{}] {}", entry.status, entry.content))
+        }),
+    );
+    rendered
+}
+
+pub(crate) fn render_usage_line(
+    input_tokens: u64,
+    output_tokens: u64,
+    cached_tokens: u64,
+    session_label: Option<&str>,
+    source: Option<&UiOutputSource>,
+) -> Option<String> {
+    let mut parts = vec![];
+    if let Some(label) = session_label {
+        parts.push(label.to_string());
+    } else if let Some(source) = source {
+        parts.push(source_heading(source));
+    }
+    if input_tokens > 0 {
+        parts.push(format!("📥 {input_tokens}"));
+    }
+    if output_tokens > 0 {
+        parts.push(format!("📤 {output_tokens}"));
+    }
+    if cached_tokens > 0 {
+        parts.push(format!("💾 {cached_tokens}"));
+    }
+    (!parts.is_empty()).then(|| parts.join("   "))
+}
+
+pub(crate) fn event_fallback_text(
+    kind: &UiOutputEventKind,
+    source: Option<&UiOutputSource>,
+) -> String {
+    match kind {
+        UiOutputEventKind::LlmText(text)
+        | UiOutputEventKind::TranscriptText { text }
+        | UiOutputEventKind::ToolResultText { text } => text.clone(),
+        UiOutputEventKind::LlmFinal { output, usage: _ } => output.clone(),
+        UiOutputEventKind::LlmError(err) => err.clone(),
+        UiOutputEventKind::AcpThought { text } => format!("<think>{text}</think>"),
+        UiOutputEventKind::StructuredBlock { title, body } => {
+            let mut lines = vec![title.clone()];
+            if let Some(body) = body {
+                lines.extend(body.lines().map(|line| format!("   {line}")));
+            }
+            format!("\n{}\n", lines.join("\n"))
+        }
+        UiOutputEventKind::StatusLine { text } => {
+            if text.is_empty() {
+                String::new()
+            } else {
+                format!("\n{text}\n")
+            }
+        }
+        UiOutputEventKind::Plan { entries } => {
+            if entries.is_empty() {
+                String::new()
+            } else {
+                let body = entries
+                    .iter()
+                    .map(|entry| format!("  [{}] {}", entry.status, entry.content))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                format!("\nPlan:\n{body}\n")
+            }
+        }
+        UiOutputEventKind::Usage {
+            input_tokens,
+            output_tokens,
+            cached_tokens,
+            session_label,
+        } => render_usage_line(
+            *input_tokens,
+            *output_tokens,
+            *cached_tokens,
+            session_label.as_deref(),
+            source,
+        )
+        .map(|line| format!("\n{line}\n"))
+        .unwrap_or_default(),
+        UiOutputEventKind::McpToolInvocation {
+            tool_name,
+            input_yaml,
+        } => {
+            let mut lines = vec![format!("->️ {tool_name}")];
+            if let Some(input_yaml) = input_yaml {
+                lines.extend(input_yaml.lines().map(|line| format!("   {line}")));
+            }
+            format!("\n{}\n", lines.join("\n"))
+        }
+    }
+}

--- a/src/tui/snapshots/harnx__tui__tests__help_in_tui.snap
+++ b/src/tui/snapshots/harnx__tui__tests__help_in_tui.snap
@@ -1,8 +1,9 @@
 ---
 source: src/tui/tests.rs
-assertion_line: 364
+assertion_line: 690
 expression: rendered
 ---
+.rag                     Initialize or access RAG
 .edit rag-docs           Add or remove documents from an existing RAG
 .rebuild rag             Rebuild RAG for document changes
 .sources rag             Show citation sources used in last query
@@ -23,5 +24,4 @@ expression: rendered
 Type ::: to start multi-line editing, type ::: to finish it.
 Press Ctrl+O to open an editor for editing the input buffer.
 Press Ctrl+C to cancel the response, Ctrl+D to exit the REPL.
-
 • Input

--- a/src/tui/snapshots/harnx__tui__tests__info_session_with_session_in_tui.snap
+++ b/src/tui/snapshots/harnx__tui__tests__info_session_with_session_in_tui.snap
@@ -1,12 +1,13 @@
 ---
 source: src/tui/tests.rs
+assertion_line: 442
 expression: rendered
 ---
 Welcome to harnx 0.30.0  •  Type .help for commands, Tab to
 complete.
-
 model               mock:mock-model
 save_session        true
+
 
 
 

--- a/src/tui/snapshots/harnx__tui__tests__info_session_without_session_in_tui.snap
+++ b/src/tui/snapshots/harnx__tui__tests__info_session_without_session_in_tui.snap
@@ -1,12 +1,12 @@
 ---
 source: src/tui/tests.rs
-assertion_line: 306
+assertion_line: 410
 expression: rendered
 ---
 Welcome to harnx 0.30.0  •  Type .help for commands, Tab to
 complete.
-
 error: No session
+
 
 
 

--- a/src/tui/snapshots/harnx__tui__tests__sub_agent_heading_transitions_in_tui.snap
+++ b/src/tui/snapshots/harnx__tui__tests__sub_agent_heading_transitions_in_tui.snap
@@ -1,0 +1,21 @@
+---
+source: src/tui/tests.rs
+assertion_line: 469
+expression: rendered
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
+
+Top-level assistant opening response.Top-level assistant closes
+response.
+
+🤖  argus ▸ session-1
+
+sub-agent tool call
+
+sub-agent follow-up output
+
+🤖  hephaestus ▸ session-2
+
+other sub-agent output
+
+• 🤖  main-agent ▸ main-session

--- a/src/tui/snapshots/harnx__tui__tests__sub_agent_heading_transitions_in_tui.snap
+++ b/src/tui/snapshots/harnx__tui__tests__sub_agent_heading_transitions_in_tui.snap
@@ -1,21 +1,21 @@
 ---
 source: src/tui/tests.rs
-assertion_line: 469
+assertion_line: 513
 expression: rendered
 ---
 Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
-
 Top-level assistant opening response.Top-level assistant closes
 response.
 
 🤖  argus ▸ session-1
-
 sub-agent tool call
-
 sub-agent follow-up output
-
 🤖  hephaestus ▸ session-2
-
 other sub-agent output
+
+
+
+
+
 
 • 🤖  main-agent ▸ main-session

--- a/src/tui/snapshots/harnx__tui__tests__thinking_stream_coalescing_around_tool_calls.snap
+++ b/src/tui/snapshots/harnx__tui__tests__thinking_stream_coalescing_around_tool_calls.snap
@@ -1,0 +1,21 @@
+---
+source: src/tui/tests.rs
+assertion_line: 750
+expression: rendered
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
+🤖  argus ▸ session-1
+<think>thinking before tool</think>
+argus_session_prompt
+   message: delegate
+<think>thinking after tool</think>
+
+
+
+
+
+
+
+
+
+• 🤖  coordinator ▸ coalescing-test

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -3,6 +3,7 @@ use crate::client::{Client, ClientConfig, TestStateGuard};
 use crate::config::Config;
 use crate::test_utils::{MockClient, MockTurnBuilder, TuiTestHarness};
 use crate::tui::types::{TranscriptEntry, TuiEvent};
+use crate::ui_output::{UiOutputEvent, UiOutputEventKind, UiOutputSource};
 use parking_lot::RwLock;
 use std::sync::Arc;
 use std::time::Duration;
@@ -57,6 +58,22 @@ fn normalize_screen(contents: &str) -> String {
         .map(|line| line.trim_end())
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+#[tokio::test]
+async fn input_cursor_style_remains_visible_in_normal_and_pending_states() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    Tui::refresh_input_chrome_from_state(&config, &mut tui.app, false, false);
+    let normal_style = tui.app.input.cursor_style();
+    assert!(normal_style.add_modifier.contains(Modifier::REVERSED));
+
+    Tui::refresh_input_chrome_from_state(&config, &mut tui.app, false, true);
+    let pending_style = tui.app.input.cursor_style();
+    assert!(pending_style.add_modifier.contains(Modifier::REVERSED));
+    assert!(pending_style.add_modifier.contains(Modifier::BOLD));
 }
 
 #[tokio::test]
@@ -118,10 +135,13 @@ async fn pending_message_is_auto_sent_after_finish() {
     tui.app.llm_busy = true;
     tui.queue_pending_message("follow up".to_string());
 
-    tui.handle_tui_event(TuiEvent::Finished {
-        output: "done".to_string(),
-        usage: Default::default(),
-    })
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::LlmFinal {
+            output: "done".to_string(),
+            usage: Default::default(),
+        },
+        source: None,
+    }))
     .await
     .unwrap();
 
@@ -161,10 +181,13 @@ async fn pending_dot_command_restores_attachments_before_running() {
     });
     tui.set_input_text(".info attachments");
 
-    tui.handle_tui_event(TuiEvent::Finished {
-        output: "done".to_string(),
-        usage: Default::default(),
-    })
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::LlmFinal {
+            output: "done".to_string(),
+            usage: Default::default(),
+        },
+        source: None,
+    }))
     .await
     .unwrap();
 
@@ -180,15 +203,26 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
     let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
 
-    tui.handle_tui_event(TuiEvent::Chunk("Hello\nworld".to_string()))
-        .await
-        .unwrap();
-    tui.handle_tui_event(TuiEvent::UiOutput("tool output".to_string()))
-        .await
-        .unwrap();
-    tui.handle_tui_event(TuiEvent::Chunk("\nAgain".to_string()))
-        .await
-        .unwrap();
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::LlmText("Hello\nworld".to_string()),
+        source: None,
+    }))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::TranscriptText {
+            text: "tool output".to_string(),
+        },
+        source: None,
+    }))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::LlmText("\nAgain".to_string()),
+        source: None,
+    }))
+    .await
+    .unwrap();
 
     let assistant_entries: Vec<_> = tui
         .app
@@ -205,6 +239,68 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
         .transcript
         .iter()
         .any(|entry| matches!(entry, TranscriptEntry::System(text) if text == "tool output")));
+}
+
+#[tokio::test]
+async fn ui_output_inserts_heading_when_source_changes() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    let source = crate::ui_output::UiOutputSource {
+        agent: "argus".to_string(),
+        session_id: Some("session-1".to_string()),
+    };
+
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::TranscriptText {
+            text: "first chunk".to_string(),
+        },
+        source: Some(source.clone()),
+    }))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::TranscriptText {
+            text: "second chunk".to_string(),
+        },
+        source: Some(source),
+    }))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::TranscriptText {
+            text: "other chunk".to_string(),
+        },
+        source: Some(crate::ui_output::UiOutputSource {
+            agent: "hephaestus".to_string(),
+            session_id: Some("session-2".to_string()),
+        }),
+    }))
+    .await
+    .unwrap();
+
+    let system_entries: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|entry| match entry {
+            TranscriptEntry::System(text) => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(system_entries.contains(&"🤖 argus ▸ session-1"));
+    assert!(system_entries.contains(&"first chunk"));
+    assert!(system_entries.contains(&"second chunk"));
+    assert!(system_entries.contains(&"🤖 hephaestus ▸ session-2"));
+    assert!(system_entries.contains(&"other chunk"));
+
+    let argus_heading_count = system_entries
+        .iter()
+        .filter(|text| **text == "🤖 argus ▸ session-1")
+        .count();
+    assert_eq!(argus_heading_count, 1);
 }
 
 #[tokio::test]
@@ -344,6 +440,193 @@ async fn info_session_with_session_renders_in_tui_snapshot() {
     let rendered = normalize_screen(&harness.screen_contents());
     assert!(rendered.contains("info-session-with-session-test"));
     insta::assert_snapshot!("info_session_with_session_in_tui", rendered);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sub_agent_heading_transitions_render_in_tui_snapshot() {
+    let config = test_config_with_mock_client_and_agent("main-agent", Some("main-session"));
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut harness = TuiTestHarness::with_size(72, 18);
+    harness.tui().config = config;
+    harness.tui().persistent_manager = persistent;
+
+    harness
+        .tui()
+        .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::LlmText("Top-level assistant opening response.".to_string()),
+            source: None,
+        }))
+        .await
+        .unwrap();
+    harness
+        .tui()
+        .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::TranscriptText {
+                text: "sub-agent tool call".to_string(),
+            },
+            source: Some(UiOutputSource {
+                agent: "argus".to_string(),
+                session_id: Some("session-1".to_string()),
+            }),
+        }))
+        .await
+        .unwrap();
+    harness
+        .tui()
+        .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::TranscriptText {
+                text: "sub-agent follow-up output".to_string(),
+            },
+            source: Some(UiOutputSource {
+                agent: "argus".to_string(),
+                session_id: Some("session-1".to_string()),
+            }),
+        }))
+        .await
+        .unwrap();
+    harness
+        .tui()
+        .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::TranscriptText {
+                text: "other sub-agent output".to_string(),
+            },
+            source: Some(UiOutputSource {
+                agent: "hephaestus".to_string(),
+                session_id: Some("session-2".to_string()),
+            }),
+        }))
+        .await
+        .unwrap();
+    harness
+        .tui()
+        .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::LlmText("Top-level assistant closes response.".to_string()),
+            source: None,
+        }))
+        .await
+        .unwrap();
+
+    harness.render();
+    let rendered = normalize_screen(&harness.screen_contents());
+    assert!(rendered.contains("argus ▸ session-1"));
+    assert!(rendered.contains("hephaestus ▸ session-2"));
+    insta::assert_snapshot!("sub_agent_heading_transitions_in_tui", rendered);
+}
+
+#[tokio::test]
+async fn structured_ui_output_variants_render_in_transcript() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::StructuredBlock {
+            title: "argus_session_prompt".to_string(),
+            body: Some("message: hello\nsession_id: abc123".to_string()),
+        },
+        source: Some(UiOutputSource {
+            agent: "argus".to_string(),
+            session_id: Some("session-1".to_string()),
+        }),
+    }))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::AcpThought {
+            text: "thinking hard".to_string(),
+        },
+        source: Some(UiOutputSource {
+            agent: "argus".to_string(),
+            session_id: Some("session-1".to_string()),
+        }),
+    }))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::StatusLine {
+            text: "-> argus_session_prompt completed".to_string(),
+        },
+        source: Some(UiOutputSource {
+            agent: "argus".to_string(),
+            session_id: Some("session-1".to_string()),
+        }),
+    }))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::Plan {
+            entries: vec![
+                crate::ui_output::UiOutputPlanEntry {
+                    status: "in_progress".to_string(),
+                    content: "Refactor ACP formatting".to_string(),
+                },
+                crate::ui_output::UiOutputPlanEntry {
+                    status: "pending".to_string(),
+                    content: "Update snapshots".to_string(),
+                },
+            ],
+        },
+        source: Some(UiOutputSource {
+            agent: "argus".to_string(),
+            session_id: Some("session-1".to_string()),
+        }),
+    }))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::Usage {
+            input_tokens: 12,
+            output_tokens: 34,
+            cached_tokens: 5,
+            session_label: Some("🤖 argus ▸ session-1".to_string()),
+        },
+        source: Some(UiOutputSource {
+            agent: "argus".to_string(),
+            session_id: Some("session-1".to_string()),
+        }),
+    }))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::McpToolInvocation {
+            tool_name: "bash".to_string(),
+            input_yaml: Some("command: ls".to_string()),
+        },
+        source: None,
+    }))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::ToolResultText {
+            text: "\u{1b}[2mline one\nline two\u{1b}[0m\n".to_string(),
+        },
+        source: None,
+    }))
+    .await
+    .unwrap();
+
+    let system_entries: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|entry| match entry {
+            TranscriptEntry::System(text) => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(system_entries.contains(&"🤖 argus ▸ session-1"));
+    assert!(system_entries.contains(&"argus_session_prompt"));
+    assert!(system_entries.contains(&"   message: hello"));
+    assert!(system_entries.contains(&"<think>thinking hard</think>"));
+    assert!(system_entries.contains(&"-> argus_session_prompt completed"));
+    assert!(system_entries.contains(&"Plan:"));
+    assert!(system_entries.contains(&"  [in_progress] Refactor ACP formatting"));
+    assert!(system_entries.contains(&"🤖 argus ▸ session-1   📥 12   📤 34   💾 5"));
+    assert!(system_entries.contains(&"->️ bash"));
+    assert!(system_entries.contains(&"   command: ls"));
+    assert!(system_entries.contains(&"   line one"));
+    assert!(system_entries.contains(&"   line two"));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -514,6 +514,269 @@ async fn sub_agent_heading_transitions_render_in_tui_snapshot() {
 }
 
 #[tokio::test]
+async fn structured_system_entries_do_not_insert_blank_lines_between_each_line() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut harness = TuiTestHarness::with_size(72, 16);
+    harness.tui().config = config;
+    harness.tui().persistent_manager = persistent;
+
+    harness
+        .tui()
+        .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::StructuredBlock {
+                title: "argus_session_prompt".to_string(),
+                body: Some("message: hello\nsession_id: abc123".to_string()),
+            },
+            source: Some(UiOutputSource {
+                agent: "argus".to_string(),
+                session_id: Some("session-1".to_string()),
+            }),
+        }))
+        .await
+        .unwrap();
+    harness
+        .tui()
+        .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::AcpThought {
+                text: "thinking hard\nstep two".to_string(),
+            },
+            source: Some(UiOutputSource {
+                agent: "argus".to_string(),
+                session_id: Some("session-1".to_string()),
+            }),
+        }))
+        .await
+        .unwrap();
+
+    harness.render();
+    let rendered = normalize_screen(&harness.screen_contents());
+    assert!(!rendered.contains("argus_session_prompt\n\n   message: hello"));
+    assert!(!rendered.contains("💭 thinking hard\n\nstep two 💬"));
+}
+
+#[tokio::test]
+async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    for chunk in ["thinking ", "before ", "tool"] {
+        tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::AcpThought {
+                text: chunk.to_string(),
+            },
+            source: None,
+        }))
+        .await
+        .unwrap();
+    }
+
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::StructuredBlock {
+            title: "argus_session_prompt".to_string(),
+            body: Some("message: delegate".to_string()),
+        },
+        source: None,
+    }))
+    .await
+    .unwrap();
+
+    for chunk in ["thinking ", "after ", "tool"] {
+        tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::AcpThought {
+                text: chunk.to_string(),
+            },
+            source: None,
+        }))
+        .await
+        .unwrap();
+    }
+
+    tui.flush_pending_thought_for_test();
+
+    let system_entries: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|entry| match entry {
+            TranscriptEntry::System(text)
+                if !text.starts_with("Welcome to harnx") && !text.starts_with('•') =>
+            {
+                Some(text.as_str())
+            }
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        system_entries,
+        vec![
+            "<think>thinking before tool</think>",
+            "argus_session_prompt",
+            "   message: delegate",
+            "<think>thinking after tool</think>",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    let source = Some(UiOutputSource {
+        agent: "argus".to_string(),
+        session_id: Some("session-1".to_string()),
+    });
+
+    for chunk in ["thinking ", "before ", "tool"] {
+        tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::AcpThought {
+                text: chunk.to_string(),
+            },
+            source: source.clone(),
+        }))
+        .await
+        .unwrap();
+    }
+
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::StructuredBlock {
+            title: "argus_session_prompt".to_string(),
+            body: Some("message: delegate".to_string()),
+        },
+        source: source.clone(),
+    }))
+    .await
+    .unwrap();
+
+    for chunk in ["thinking ", "after ", "tool"] {
+        tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::AcpThought {
+                text: chunk.to_string(),
+            },
+            source: source.clone(),
+        }))
+        .await
+        .unwrap();
+    }
+
+    tui.flush_pending_thought_for_test();
+
+    let system_entries: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|entry| match entry {
+            TranscriptEntry::System(text)
+                if !text.starts_with("Welcome to harnx") && !text.starts_with('•') =>
+            {
+                Some(text.as_str())
+            }
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        system_entries,
+        vec![
+            "🤖 argus ▸ session-1",
+            "<think>thinking before tool</think>",
+            "argus_session_prompt",
+            "   message: delegate",
+            "<think>thinking after tool</think>",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn llm_multiline_text_renders_without_extra_blank_lines() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut harness = TuiTestHarness::with_size(60, 12);
+    harness.tui().config = config;
+    harness.tui().persistent_manager = persistent;
+
+    harness
+        .tui()
+        .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::LlmText("line one\nline two\nline three".to_string()),
+            source: None,
+        }))
+        .await
+        .unwrap();
+
+    harness.render();
+    let rendered = normalize_screen(&harness.screen_contents());
+    assert!(rendered.contains("line one"));
+    assert!(rendered.contains("line two"));
+    assert!(rendered.contains("line three"));
+    assert!(!rendered.contains("line one\n\nline two"));
+    assert!(!rendered.contains("line two\n\nline three"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn thinking_stream_coalescing_around_tool_calls_snapshot() {
+    let config = test_config_with_mock_client_and_agent("coordinator", Some("coalescing-test"));
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut harness = TuiTestHarness::with_size(72, 18);
+    harness.tui().config = config;
+    harness.tui().persistent_manager = persistent;
+
+    for chunk in ["thinking ", "before ", "tool"] {
+        harness
+            .tui()
+            .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+                kind: UiOutputEventKind::AcpThought {
+                    text: chunk.to_string(),
+                },
+                source: Some(UiOutputSource {
+                    agent: "argus".to_string(),
+                    session_id: Some("session-1".to_string()),
+                }),
+            }))
+            .await
+            .unwrap();
+    }
+    harness
+        .tui()
+        .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::StructuredBlock {
+                title: "argus_session_prompt".to_string(),
+                body: Some("message: delegate".to_string()),
+            },
+            source: Some(UiOutputSource {
+                agent: "argus".to_string(),
+                session_id: Some("session-1".to_string()),
+            }),
+        }))
+        .await
+        .unwrap();
+    for chunk in ["thinking ", "after ", "tool"] {
+        harness
+            .tui()
+            .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+                kind: UiOutputEventKind::AcpThought {
+                    text: chunk.to_string(),
+                },
+                source: Some(UiOutputSource {
+                    agent: "argus".to_string(),
+                    session_id: Some("session-1".to_string()),
+                }),
+            }))
+            .await
+            .unwrap();
+    }
+    harness.tui().flush_pending_thought_for_test();
+
+    harness.render();
+    let rendered = normalize_screen(&harness.screen_contents());
+    insta::assert_snapshot!("thinking_stream_coalescing_around_tool_calls", rendered);
+}
+
+#[tokio::test]
 async fn structured_ui_output_variants_render_in_transcript() {
     let config = test_config();
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));

--- a/src/tui/types.rs
+++ b/src/tui/types.rs
@@ -1,6 +1,6 @@
-use crate::client::CompletionTokenUsage;
 use crate::config::GlobalConfig;
 use crate::hooks::{AsyncHookManager, PersistentHookManager};
+use crate::ui_output::{UiOutputEvent, UiOutputSource};
 use crate::utils::AbortSignal;
 
 use ratatui_textarea::TextArea;
@@ -58,6 +58,7 @@ pub(super) struct App {
     pub(super) llm_busy: bool,
     pub(super) scroll_state: ratatui_widget_scrolling::ScrollState,
     pub(super) streaming_assistant_idx: Option<usize>,
+    pub(super) last_ui_output_source: Option<UiOutputSource>,
     pub(super) pending_message: Option<PendingMessage>,
     pub(super) completions: Vec<(String, Option<String>)>,
     pub(super) completion_index: usize,
@@ -114,28 +115,14 @@ pub(super) enum TranscriptEntry {
 
 #[cfg(test)]
 pub(crate) enum TuiEvent {
-    UiOutput(String),
-    Chunk(String),
+    UiOutput(UiOutputEvent),
     /// Intermediate tool round completed; the prompt loop continues.
     ToolRoundComplete,
-    /// Final completion — no more turns.
-    Finished {
-        output: String,
-        usage: CompletionTokenUsage,
-    },
-    Errored(String),
 }
 
 #[cfg(not(test))]
 pub(super) enum TuiEvent {
-    UiOutput(String),
-    Chunk(String),
+    UiOutput(UiOutputEvent),
     /// Intermediate tool round completed; the prompt loop continues.
     ToolRoundComplete,
-    /// Final completion — no more turns.
-    Finished {
-        output: String,
-        usage: CompletionTokenUsage,
-    },
-    Errored(String),
 }

--- a/src/tui/types.rs
+++ b/src/tui/types.rs
@@ -59,6 +59,8 @@ pub(super) struct App {
     pub(super) scroll_state: ratatui_widget_scrolling::ScrollState,
     pub(super) streaming_assistant_idx: Option<usize>,
     pub(super) last_ui_output_source: Option<UiOutputSource>,
+    pub(super) pending_thought_source: Option<UiOutputSource>,
+    pub(super) pending_thought_text: String,
     pub(super) pending_message: Option<PendingMessage>,
     pub(super) completions: Vec<(String, Option<String>)>,
     pub(super) completion_index: usize,

--- a/src/ui_output.rs
+++ b/src/ui_output.rs
@@ -4,19 +4,82 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 use tokio::sync::mpsc::UnboundedSender;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UiOutputSource {
+    pub agent: String,
+    pub session_id: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub enum UiOutputEventKind {
+    ToolResultText {
+        text: String,
+    },
+    LlmText(String),
+    LlmFinal {
+        output: String,
+        usage: crate::client::CompletionTokenUsage,
+    },
+    LlmError(String),
+    AcpThought {
+        text: String,
+    },
+    StatusLine {
+        text: String,
+    },
+    TranscriptText {
+        text: String,
+    },
+    StructuredBlock {
+        title: String,
+        body: Option<String>,
+    },
+    Plan {
+        entries: Vec<UiOutputPlanEntry>,
+    },
+    Usage {
+        input_tokens: u64,
+        output_tokens: u64,
+        cached_tokens: u64,
+        session_label: Option<String>,
+    },
+    McpToolInvocation {
+        tool_name: String,
+        input_yaml: Option<String>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UiOutputPlanEntry {
+    pub status: String,
+    pub content: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct UiOutputEvent {
+    pub kind: UiOutputEventKind,
+    pub source: Option<UiOutputSource>,
+}
+
+pub fn pretty_yaml_block(value: &serde_json::Value) -> String {
+    serde_yaml::to_string(value)
+        .map(|s| s.trim_end().to_string())
+        .unwrap_or_else(|_| value.to_string())
+}
+
 #[cfg(test)]
-static UI_OUTPUT_SENDER: Mutex<Option<UnboundedSender<String>>> = Mutex::new(None);
+static UI_OUTPUT_SENDER: Mutex<Option<UnboundedSender<UiOutputEvent>>> = Mutex::new(None);
 
 #[cfg(not(test))]
-static UI_OUTPUT_SENDER: OnceLock<UnboundedSender<String>> = OnceLock::new();
+static UI_OUTPUT_SENDER: OnceLock<UnboundedSender<UiOutputEvent>> = OnceLock::new();
 
 #[cfg(not(test))]
-pub fn install_ui_output_sender(sender: UnboundedSender<String>) {
+pub fn install_ui_output_sender(sender: UnboundedSender<UiOutputEvent>) {
     let _ = UI_OUTPUT_SENDER.set(sender);
 }
 
 #[cfg(test)]
-pub fn install_ui_output_sender(sender: UnboundedSender<String>) {
+pub fn install_ui_output_sender(sender: UnboundedSender<UiOutputEvent>) {
     let mut guard = UI_OUTPUT_SENDER
         .lock()
         .expect("UI_OUTPUT_SENDER mutex poisoned");
@@ -24,20 +87,33 @@ pub fn install_ui_output_sender(sender: UnboundedSender<String>) {
 }
 
 #[cfg(not(test))]
-pub fn emit_ui_output(text: impl Into<String>) -> bool {
+pub fn has_ui_output_sink() -> bool {
+    UI_OUTPUT_SENDER.get().is_some()
+}
+
+#[cfg(test)]
+pub fn has_ui_output_sink() -> bool {
+    let guard = UI_OUTPUT_SENDER
+        .lock()
+        .expect("UI_OUTPUT_SENDER mutex poisoned");
+    guard.is_some()
+}
+
+#[cfg(not(test))]
+pub fn emit_ui_output_event(event: UiOutputEvent) -> bool {
     match UI_OUTPUT_SENDER.get() {
-        Some(sender) => sender.send(text.into()).is_ok(),
+        Some(sender) => sender.send(event).is_ok(),
         None => false,
     }
 }
 
 #[cfg(test)]
-pub fn emit_ui_output(text: impl Into<String>) -> bool {
+pub fn emit_ui_output_event(event: UiOutputEvent) -> bool {
     let guard = UI_OUTPUT_SENDER
         .lock()
         .expect("UI_OUTPUT_SENDER mutex poisoned");
     match guard.as_ref() {
-        Some(sender) => sender.send(text.into()).is_ok(),
+        Some(sender) => sender.send(event).is_ok(),
         None => false,
     }
 }


### PR DESCRIPTION
- **refactor(tui): unify structured UI event rendering**
- **refactor(acp): preserve structured nested agent activity**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured UI output with distinct rendering for thoughts, tool results, plans, usage lines, and agent/session headings; events now carry source info.

* **Improvements**
  * Better terminal fallback rendering for structured blocks, plans and multiline assistant text.
  * Deferred “thought” rendering coalesces streaming thoughts into coherent blocks.
  * Input cursor and context display refinements for clearer composition feedback.

* **Chores**
  * Removed per-session log file management; sessions use unified configuration.

* **Tests**
  * Added/updated UI rendering and streaming tests covering headings, structured output, and fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->