### PR TITLE
fix(acp): persist sub-agent sessions to disk

### DIFF
--- a/.changesets/fix-acp-subagent-session-persistence.md
+++ b/.changesets/fix-acp-subagent-session-persistence.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Fix ACP sub-agent sessions so they persist to disk like other operating modes.

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -299,12 +299,21 @@ impl acp::Agent for HarnxAgent {
                     .await?
             };
 
-            {
-                let mut config = self.config.write();
-                config
-                    .save_message(&input, &output, thought.as_deref())
-                    .map_err(|e| acp::Error::new(-32603, format!("Failed to save message: {e}")))?;
-            }
+            let config = self.config.clone();
+            let input_for_save = input.clone();
+            let output_for_save = output.clone();
+            let thought_for_save = thought.clone();
+            tokio::task::spawn_blocking(move || {
+                let mut config = config.write();
+                config.save_message(
+                    &input_for_save,
+                    &output_for_save,
+                    thought_for_save.as_deref(),
+                )
+            })
+            .await
+            .map_err(|e| acp::Error::new(-32603, format!("Failed to join save task: {e}")))?
+            .map_err(|e| acp::Error::new(-32603, format!("Failed to save message: {e}")))?;
 
             if tool_calls.is_empty() {
                 return Ok(acp::PromptResponse::new(acp::StopReason::EndTurn));
@@ -921,10 +930,11 @@ mod tests {
             .expect("prompt should succeed");
 
             assert_eq!(response.stop_reason, acp::StopReason::EndTurn);
+            let chunks = chunks.borrow();
             assert!(
-                !chunks.borrow().is_empty(),
-                "expected prompt roundtrip output chunks, got {:?}",
-                chunks.borrow()
+                chunks.iter().any(|chunk| !chunk.trim().is_empty()),
+                "expected prompt roundtrip output to include at least one non-empty chunk, got {:?}",
+                *chunks
             );
 
             let session_path = config.read().session_file(&session.session_id.to_string());

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -553,14 +553,16 @@ async fn eval_mcp_async(
 mod tests {
     use super::*;
     use crate::{
-        client::{ClientConfig, Model, ModelType},
+        client::{ClientConfig, Model, ModelType, TestStateGuard},
         config::{Config, CREATE_TITLE_AGENT},
+        test_utils::{MockClient, MockTurnBuilder},
     };
     use agent_client_protocol::Agent;
     use std::{
         cell::RefCell,
         pin::Pin,
         rc::Rc,
+        sync::Arc,
         task::{Context as TaskContext, Poll},
     };
     use tokio::io::{AsyncRead as TokioAsyncRead, AsyncWrite as TokioAsyncWrite, ReadBuf};
@@ -866,6 +868,17 @@ mod tests {
         let config = test_config();
 
         run_local(async move {
+            let _guard = TestStateGuard::new(Some(Arc::new(
+                MockClient::builder()
+                    .add_turn(
+                        MockTurnBuilder::new()
+                            .add_text_chunk("mock roundtrip response")
+                            .build(),
+                    )
+                    .build(),
+            )))
+            .await;
+
             let (client_conn, chunks, server_handle, client_handle) =
                 setup_roundtrip(CREATE_TITLE_AGENT, config.clone());
 

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -279,7 +279,8 @@ impl acp::Agent for HarnxAgent {
             .retrieve_agent(&self.agent_name)
             .map_err(|e| acp::Error::new(-32603, format!("Failed to retrieve agent: {e}")))?;
 
-        let mut input = Input::from_str(&self.config, &prompt_text, Some(agent));
+        let mut input = Input::from_str(&self.config, &prompt_text, None);
+        input.set_agent(agent);
         let client = input
             .create_client()
             .map_err(|e| acp::Error::new(-32603, format!("Failed to create client: {e}")))?;
@@ -297,6 +298,13 @@ impl acp::Agent for HarnxAgent {
                 self.execute_llm_non_streaming(&session_key, &input, client.as_ref(), &abort_signal)
                     .await?
             };
+
+            {
+                let mut config = self.config.write();
+                config
+                    .save_message(&input, &output, thought.as_deref())
+                    .map_err(|e| acp::Error::new(-32603, format!("Failed to save message: {e}")))?;
+            }
 
             if tool_calls.is_empty() {
                 return Ok(acp::PromptResponse::new(acp::StopReason::EndTurn));
@@ -665,7 +673,7 @@ mod tests {
         config.clients = clients;
         config.model = Model::retrieve_model(&config, "openai:gpt-4o", ModelType::Chat)
             .expect("load test model");
-        config.dry_run = true;
+        config.save_session = Some(true);
 
         Arc::new(RwLock::new(config))
     }
@@ -901,8 +909,8 @@ mod tests {
 
             assert_eq!(response.stop_reason, acp::StopReason::EndTurn);
             assert!(
-                chunks.borrow().join("").contains("hello from client"),
-                "expected prompt roundtrip output, got {:?}",
+                !chunks.borrow().is_empty(),
+                "expected prompt roundtrip output chunks, got {:?}",
                 chunks.borrow()
             );
 
@@ -910,6 +918,11 @@ mod tests {
             assert!(
                 !session_path.display().to_string().contains("/sessions/_/"),
                 "session file should not be written under '_' temp directory: {}",
+                session_path.display()
+            );
+            assert!(
+                session_path.exists(),
+                "ACP prompt should persist the session to disk at {}",
                 session_path.display()
             );
 

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -284,6 +284,7 @@ impl Input {
     }
 
     pub fn set_agent(&mut self, agent: Agent) {
+        self.with_agent = !agent.name().trim().is_empty();
         self.agent = agent;
     }
 

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -283,6 +283,10 @@ impl Input {
         &self.agent
     }
 
+    pub fn set_agent(&mut self, agent: Agent) {
+        self.agent = agent;
+    }
+
     pub fn session<'a>(&self, session: &'a Option<Session>) -> Option<&'a Session> {
         if self.with_session {
             session.as_ref()
@@ -291,12 +295,8 @@ impl Input {
         }
     }
 
-    pub fn session_mut<'a>(&self, session: &'a mut Option<Session>) -> Option<&'a mut Session> {
-        if self.with_session {
-            session.as_mut()
-        } else {
-            None
-        }
+    pub fn with_session(&self) -> bool {
+        self.with_session
     }
 
     pub fn with_agent(&self) -> bool {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2431,12 +2431,21 @@ impl Config {
         }
     }
 
-    fn save_message(&mut self, input: &Input, output: &str, thought: Option<&str>) -> Result<()> {
+    pub(crate) fn save_message(
+        &mut self,
+        input: &Input,
+        output: &str,
+        thought: Option<&str>,
+    ) -> Result<()> {
         let mut input = input.clone();
         input.clear_patch();
-        if let Some(session) = input.session_mut(&mut self.session) {
-            session.add_message(&input, output, thought)?;
-            return Ok(());
+        let sessions_dir = self.sessions_dir();
+        if input.with_session() {
+            if let Some(session) = self.session.as_mut() {
+                session.set_sessions_dir(sessions_dir);
+                session.add_message(&input, output, thought)?;
+                return Ok(());
+            }
         }
 
         if !self.save {


### PR DESCRIPTION
## Summary
- persist ACP sub-agent prompts into the active session log
- preserve session-backed saving when ACP constructs prompt input
- add a regression test ensuring ACP roundtrips write a session file to disk

## Testing
- cargo fmt
- cargo build
- cargo clippy --all --all-targets -- -D warnings
- cargo nextest run --all

## Related
- Closes #232
- Relates to #154
- Relates to #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ACP sub-agent sessions now persist to disk, preserving session state between interactions and matching other agent modes.
  * ACP flows enable session persistence by default; each completed exchange is saved so subsequent requests can resume prior context.
  * Improved reliability: interactions are written to session files after each round, and session files are created as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->