### PR TITLE
fix: stabilize TUI status output and attachment transcript rendering

### DIFF
--- a/.changesets/ui-status-emoji-and-consolidation.md
+++ b/.changesets/ui-status-emoji-and-consolidation.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Simplified TUI status headings and usage indicators to avoid variable-width emoji glitches, and consolidated consecutive sub-agent usage updates into a single refreshed row.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,6 +1628,7 @@ dependencies = [
  "simplelog",
  "syntect",
  "sys-locale",
+ "tempfile",
  "terminal-colorsaurus",
  "textwrap",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ insta = { version = "1", features = ["yaml"] }
 pretty_assertions = "1.4.0"
 rand = "0.10.0"
 tokio-test = "0.4"
+tempfile = "3"
 
 [[bin]]
 name = "harnx-mcp-todo"

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -105,7 +105,7 @@ pub fn eval_tool_calls(config: &GlobalConfig, mut calls: Vec<ToolCall>) -> Resul
                 let output_str =
                     extract_user_display_text(&result).unwrap_or_else(|| match &result {
                         Value::String(s) => s.clone(),
-                        _ => result.to_string(),
+                        _ => pretty_yaml_block(&result),
                     });
                 let truncated = truncate_output(&output_str, &opts);
                 let text = format!("{}\n", dimmed_text(&truncated));

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -4,6 +4,10 @@ use crate::tui::render_helpers::{
 };
 use crate::tui::types::{TranscriptEntry, TuiEvent};
 use crate::ui_output::{UiOutputEvent, UiOutputEventKind, UiOutputSource};
+use std::path::Path;
+
+const ATTACHMENT_PREVIEW_MAX_CHARS: usize = 800;
+const ATTACHMENT_PREVIEW_MAX_LINES: usize = 12;
 
 fn unique_attachment_display_name(
     attachments: &[crate::tui::types::Attachment],
@@ -38,6 +42,34 @@ fn unique_attachment_storage_path(
         .map(|e| format!(".{}", e.to_string_lossy()))
         .unwrap_or_default();
     dir.join(format!("{}-{}{}", stem, uuid::Uuid::new_v4(), ext))
+}
+
+fn render_attachment_preview(path: &Path) -> Option<String> {
+    let bytes = std::fs::read(path).ok()?;
+    let text = std::str::from_utf8(&bytes).ok()?;
+    let mut lines = Vec::new();
+    let mut chars_seen = 0usize;
+
+    for line in text.lines().take(ATTACHMENT_PREVIEW_MAX_LINES) {
+        if chars_seen >= ATTACHMENT_PREVIEW_MAX_CHARS {
+            break;
+        }
+        let remaining = ATTACHMENT_PREVIEW_MAX_CHARS.saturating_sub(chars_seen);
+        let snippet: String = line.chars().take(remaining).collect();
+        chars_seen += snippet.chars().count();
+        lines.push(snippet);
+    }
+
+    if lines.is_empty() {
+        return None;
+    }
+
+    let truncated = text.chars().count() > chars_seen || text.lines().count() > lines.len();
+    let mut preview = lines.join("\n");
+    if truncated {
+        preview.push_str("\n...");
+    }
+    Some(preview)
 }
 
 impl Tui {
@@ -364,7 +396,23 @@ impl Tui {
         Ok(())
     }
 
+    #[cfg(test)]
+    pub(crate) async fn submit_pending_message(
+        &mut self,
+        pending: crate::tui::types::PendingMessage,
+    ) -> Result<()> {
+        self.submit_pending_message_inner(pending).await
+    }
+
+    #[cfg(not(test))]
     async fn submit_pending_message(
+        &mut self,
+        pending: crate::tui::types::PendingMessage,
+    ) -> Result<()> {
+        self.submit_pending_message_inner(pending).await
+    }
+
+    async fn submit_pending_message_inner(
         &mut self,
         pending: crate::tui::types::PendingMessage,
     ) -> Result<()> {
@@ -372,6 +420,7 @@ impl Tui {
         self.app
             .transcript
             .push(TranscriptEntry::User(pending.text.clone()));
+        self.render_submitted_attachments(&pending.attachments);
         self.pin_transcript_to_bottom();
         if pending.text.trim_start().starts_with('.') {
             self.app.attachments = pending.attachments;
@@ -383,6 +432,32 @@ impl Tui {
             self.start_prompt(pending).await?;
         }
         Ok(())
+    }
+
+    fn render_submitted_attachments(&mut self, attachments: &[crate::tui::types::Attachment]) {
+        if attachments.is_empty() {
+            return;
+        }
+
+        self.app.transcript.push(TranscriptEntry::System(format!(
+            "Attachments ({}):",
+            attachments.len()
+        )));
+
+        for attachment in attachments {
+            self.app.transcript.push(TranscriptEntry::System(format!(
+                "  - {}",
+                attachment.display_name
+            )));
+
+            if let Some(preview) = render_attachment_preview(&attachment.path) {
+                for line in preview.lines() {
+                    self.app
+                        .transcript
+                        .push(TranscriptEntry::System(format!("      {line}")));
+                }
+            }
+        }
     }
 
     fn flush_pending_thought(&mut self) {
@@ -404,10 +479,11 @@ impl Tui {
 
     async fn render_ui_output_event(&mut self, event: UiOutputEvent) {
         let is_thought = matches!(&event.kind, UiOutputEventKind::AcpThought { .. });
+        let is_usage = matches!(&event.kind, UiOutputEventKind::Usage { .. });
         if !is_thought {
             self.flush_pending_thought();
         }
-        self.render_ui_output_heading(event.source.as_ref());
+        self.render_ui_output_heading(event.source.as_ref(), is_usage);
 
         let rendered_entries = match event.kind {
             UiOutputEventKind::TranscriptText { text } => {
@@ -527,15 +603,24 @@ impl Tui {
                 output_tokens,
                 cached_tokens,
                 session_label,
-            } => render_usage_line(
-                input_tokens,
-                output_tokens,
-                cached_tokens,
-                session_label.as_deref(),
-                event.source.as_ref(),
-            )
-            .map(|line| vec![TranscriptEntry::System(line)])
-            .unwrap_or_default(),
+            } => {
+                let line = render_usage_line(
+                    input_tokens,
+                    output_tokens,
+                    cached_tokens,
+                    session_label.as_deref(),
+                    event.source.as_ref(),
+                );
+                if let Some(line) = line {
+                    if self.update_existing_usage_line(event.source.as_ref(), &line) {
+                        vec![]
+                    } else {
+                        vec![TranscriptEntry::System(line)]
+                    }
+                } else {
+                    vec![]
+                }
+            }
             UiOutputEventKind::McpToolInvocation {
                 tool_name,
                 input_yaml,
@@ -543,14 +628,21 @@ impl Tui {
         };
 
         if !rendered_entries.is_empty() {
+            let start_idx = self.app.transcript.len();
             self.app.transcript.extend(rendered_entries);
+            if is_usage {
+                self.app.last_usage_source = event.source.clone();
+                self.app.last_usage_transcript_idx = Some(start_idx);
+            } else {
+                self.clear_usage_tracking();
+            }
             self.pin_transcript_to_bottom();
-        } else if is_thought {
+        } else if is_thought || is_usage {
             self.pin_transcript_to_bottom();
         }
     }
 
-    fn render_ui_output_heading(&mut self, source: Option<&UiOutputSource>) {
+    fn render_ui_output_heading(&mut self, source: Option<&UiOutputSource>, is_usage: bool) {
         let source = source.cloned();
         if source != self.app.last_ui_output_source {
             if let Some(source) = &source {
@@ -558,6 +650,37 @@ impl Tui {
                 self.app.transcript.push(TranscriptEntry::System(heading));
             }
             self.app.last_ui_output_source = source;
+        }
+        if !is_usage {
+            self.clear_usage_tracking();
+        }
+    }
+
+    fn clear_usage_tracking(&mut self) {
+        self.app.last_usage_source = None;
+        self.app.last_usage_transcript_idx = None;
+    }
+
+    fn update_existing_usage_line(&mut self, source: Option<&UiOutputSource>, line: &str) -> bool {
+        if self.app.last_usage_source.as_ref() != source {
+            return false;
+        }
+        let Some(idx) = self.app.last_usage_transcript_idx else {
+            return false;
+        };
+        let Some(entry) = self.app.transcript.get_mut(idx) else {
+            self.clear_usage_tracking();
+            return false;
+        };
+        match entry {
+            TranscriptEntry::System(existing) => {
+                *existing = line.to_string();
+                true
+            }
+            _ => {
+                self.clear_usage_tracking();
+                false
+            }
         }
     }
 

--- a/src/tui/lifecycle.rs
+++ b/src/tui/lifecycle.rs
@@ -60,6 +60,8 @@ impl Tui {
                 scroll_state: ratatui_widget_scrolling::ScrollState::new(),
                 streaming_assistant_idx: None,
                 last_ui_output_source: None,
+                last_usage_source: None,
+                last_usage_transcript_idx: None,
                 pending_thought_source: None,
                 pending_thought_text: String::new(),
                 pending_message: None,

--- a/src/tui/render_helpers.rs
+++ b/src/tui/render_helpers.rs
@@ -13,9 +13,9 @@ pub(crate) fn render_status_line(title: Option<&str>, status: Option<&str>) -> O
 pub(crate) fn source_heading(source: &UiOutputSource) -> String {
     match &source.session_id {
         Some(session_id) if !session_id.is_empty() => {
-            format!("🤖 {} ▸ {}", source.agent, session_id)
+            format!("> {} ▸ {}", source.agent, session_id)
         }
-        _ => format!("🤖 {}", source.agent),
+        _ => format!("> {}", source.agent),
     }
 }
 
@@ -58,13 +58,13 @@ pub(crate) fn render_usage_line(
         parts.push(source_heading(source));
     }
     if input_tokens > 0 {
-        parts.push(format!("📥 {input_tokens}"));
+        parts.push(format!("in {input_tokens}"));
     }
     if output_tokens > 0 {
-        parts.push(format!("📤 {output_tokens}"));
+        parts.push(format!("out {output_tokens}"));
     }
     if cached_tokens > 0 {
-        parts.push(format!("💾 {cached_tokens}"));
+        parts.push(format!("cache {cached_tokens}"));
     }
     (!parts.is_empty()).then(|| parts.join("   "))
 }

--- a/src/tui/snapshots/harnx__tui__tests__sub_agent_heading_transitions_in_tui.snap
+++ b/src/tui/snapshots/harnx__tui__tests__sub_agent_heading_transitions_in_tui.snap
@@ -7,10 +7,10 @@ Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
 Top-level assistant opening response.Top-level assistant closes
 response.
 
-🤖  argus ▸ session-1
+> argus ▸ session-1
 sub-agent tool call
 sub-agent follow-up output
-🤖  hephaestus ▸ session-2
+> hephaestus ▸ session-2
 other sub-agent output
 
 

--- a/src/tui/snapshots/harnx__tui__tests__thinking_stream_coalescing_around_tool_calls.snap
+++ b/src/tui/snapshots/harnx__tui__tests__thinking_stream_coalescing_around_tool_calls.snap
@@ -1,10 +1,10 @@
 ---
 source: src/tui/tests.rs
-assertion_line: 750
+assertion_line: 776
 expression: rendered
 ---
 Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
-🤖  argus ▸ session-1
+> argus ▸ session-1
 <think>thinking before tool</think>
 argus_session_prompt
    message: delegate

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2,8 +2,10 @@ use super::*;
 use crate::client::{Client, ClientConfig, TestStateGuard};
 use crate::config::Config;
 use crate::test_utils::{MockClient, MockTurnBuilder, TuiTestHarness};
+use crate::tui::render_helpers::event_fallback_text;
 use crate::tui::types::{TranscriptEntry, TuiEvent};
 use crate::ui_output::{UiOutputEvent, UiOutputEventKind, UiOutputSource};
+use crate::utils::dimmed_text;
 use parking_lot::RwLock;
 use std::sync::Arc;
 use std::time::Duration;
@@ -290,15 +292,15 @@ async fn ui_output_inserts_heading_when_source_changes() {
         })
         .collect();
 
-    assert!(system_entries.contains(&"🤖 argus ▸ session-1"));
+    assert!(system_entries.contains(&"> argus ▸ session-1"));
     assert!(system_entries.contains(&"first chunk"));
     assert!(system_entries.contains(&"second chunk"));
-    assert!(system_entries.contains(&"🤖 hephaestus ▸ session-2"));
+    assert!(system_entries.contains(&"> hephaestus ▸ session-2"));
     assert!(system_entries.contains(&"other chunk"));
 
     let argus_heading_count = system_entries
         .iter()
-        .filter(|text| **text == "🤖 argus ▸ session-1")
+        .filter(|text| **text == "> argus ▸ session-1")
         .count();
     assert_eq!(argus_heading_count, 1);
 }
@@ -682,7 +684,7 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
     assert_eq!(
         system_entries,
         vec![
-            "🤖 argus ▸ session-1",
+            "> argus ▸ session-1",
             "<think>thinking before tool</think>",
             "argus_session_prompt",
             "   message: delegate",
@@ -841,7 +843,7 @@ async fn structured_ui_output_variants_render_in_transcript() {
             input_tokens: 12,
             output_tokens: 34,
             cached_tokens: 5,
-            session_label: Some("🤖 argus ▸ session-1".to_string()),
+            session_label: Some("> argus ▸ session-1".to_string()),
         },
         source: Some(UiOutputSource {
             agent: "argus".to_string(),
@@ -878,18 +880,141 @@ async fn structured_ui_output_variants_render_in_transcript() {
         })
         .collect();
 
-    assert!(system_entries.contains(&"🤖 argus ▸ session-1"));
+    assert!(system_entries.contains(&"> argus ▸ session-1"));
     assert!(system_entries.contains(&"argus_session_prompt"));
     assert!(system_entries.contains(&"   message: hello"));
     assert!(system_entries.contains(&"<think>thinking hard</think>"));
     assert!(system_entries.contains(&"-> argus_session_prompt completed"));
     assert!(system_entries.contains(&"Plan:"));
     assert!(system_entries.contains(&"  [in_progress] Refactor ACP formatting"));
-    assert!(system_entries.contains(&"🤖 argus ▸ session-1   📥 12   📤 34   💾 5"));
+    assert!(system_entries.contains(&"> argus ▸ session-1   in 12   out 34   cache 5"));
     assert!(system_entries.contains(&"->️ bash"));
     assert!(system_entries.contains(&"   command: ls"));
     assert!(system_entries.contains(&"   line one"));
     assert!(system_entries.contains(&"   line two"));
+}
+
+#[tokio::test]
+async fn consecutive_usage_updates_replace_previous_usage_row_for_same_source() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    let source = UiOutputSource {
+        agent: "pytheas".to_string(),
+        session_id: Some("session-1".to_string()),
+    };
+
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::Usage {
+            input_tokens: 10,
+            output_tokens: 1,
+            cached_tokens: 0,
+            session_label: None,
+        },
+        source: Some(source.clone()),
+    }))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::Usage {
+            input_tokens: 20,
+            output_tokens: 2,
+            cached_tokens: 0,
+            session_label: None,
+        },
+        source: Some(source.clone()),
+    }))
+    .await
+    .unwrap();
+
+    let system_entries: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|entry| match entry {
+            TranscriptEntry::System(text) => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        system_entries
+            .iter()
+            .filter(|line| **line == "> pytheas ▸ session-1")
+            .count(),
+        1
+    );
+    assert_eq!(
+        system_entries
+            .iter()
+            .filter(|line| **line == "> pytheas ▸ session-1   in 10   out 1")
+            .count(),
+        0
+    );
+    assert_eq!(
+        system_entries
+            .iter()
+            .filter(|line| **line == "> pytheas ▸ session-1   in 20   out 2")
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn submitting_message_with_attachments_renders_attachment_list_and_preview() {
+    use crate::tui::types::Attachment;
+
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("notes.txt");
+    std::fs::write(&file, "first line\nsecond line\nthird line").unwrap();
+
+    tui.submit_pending_message(crate::tui::types::PendingMessage {
+        text: "hello with files".to_string(),
+        attachments: vec![Attachment {
+            path: file,
+            display_name: "notes.txt".to_string(),
+        }],
+        attachment_dir: None,
+        paste_count: 0,
+    })
+    .await
+    .unwrap();
+
+    let system_entries: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|entry| match entry {
+            TranscriptEntry::System(text) => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(matches!(
+        tui.app.transcript.iter().find(|entry| matches!(entry, TranscriptEntry::User(_))),
+        Some(TranscriptEntry::User(text)) if text == "hello with files"
+    ));
+    assert!(system_entries.contains(&"Attachments (1):"));
+    assert!(system_entries.contains(&"  - notes.txt"));
+    assert!(system_entries.contains(&"      first line"));
+    assert!(system_entries.contains(&"      second line"));
+}
+
+#[test]
+fn mcp_tool_result_fallback_uses_multiline_yaml_for_structured_json() {
+    let event = UiOutputEventKind::ToolResultText {
+        text: dimmed_text("content:\n  - type: text\n    text: hello\nisError: false\n"),
+    };
+
+    let rendered = event_fallback_text(&event, None);
+    assert!(rendered.contains("content:"));
+    assert!(rendered.contains("type: text"));
+    assert!(!rendered.contains("{\"content\""));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tui/types.rs
+++ b/src/tui/types.rs
@@ -43,7 +43,7 @@ pub(super) struct Attachment {
 }
 
 #[derive(Clone)]
-pub(super) struct PendingMessage {
+pub(crate) struct PendingMessage {
     pub(super) text: String,
     pub(super) attachments: Vec<Attachment>,
     pub(super) attachment_dir: Option<PathBuf>,
@@ -59,6 +59,8 @@ pub(super) struct App {
     pub(super) scroll_state: ratatui_widget_scrolling::ScrollState,
     pub(super) streaming_assistant_idx: Option<usize>,
     pub(super) last_ui_output_source: Option<UiOutputSource>,
+    pub(super) last_usage_source: Option<UiOutputSource>,
+    pub(super) last_usage_transcript_idx: Option<usize>,
     pub(super) pending_thought_source: Option<UiOutputSource>,
     pub(super) pending_thought_text: String,
     pub(super) pending_message: Option<PendingMessage>,


### PR DESCRIPTION
## Summary
- replace variable-width status emoji with simpler stable markers in TUI output
- coalesce consecutive sub-agent usage updates onto a single transcript row
- render structured tool fallback output as multiline YAML instead of compact JSON
- show submitted attachments in the transcript with filenames and truncated text previews

## Issues
- fixes #237
- fixes #238

## Validation
- cargo fmt
- cargo build
- cargo clippy --all --all-targets -- -D warnings
- cargo nextest run --all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added attachment preview functionality when submitting messages with file attachments.

* **Improvements**
  * Simplified TUI status headings and usage indicators to prevent variable-width emoji display issues.
  * Consolidated consecutive usage updates to replace previous rows instead of accumulating multiple rows for the same source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->