### PR TITLE
fix(gemini): support batch embeddings

### DIFF
--- a/.changesets/fix-gemini-batch-embeddings.md
+++ b/.changesets/fix-gemini-batch-embeddings.md
@@ -1,0 +1,5 @@
+---
+harnx: patch
+---
+
+Use Gemini's batch embeddings endpoint so multiple texts can be embedded in a single request.

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -448,13 +448,6 @@ impl EmbeddingsData {
     pub fn new(texts: Vec<String>, query: bool) -> Self {
         Self { texts, query }
     }
-
-    pub fn try_get_text(&self) -> Result<&str> {
-        if self.texts.len() != 1 {
-            bail!("EmbeddingsData must contain exactly one text");
-        }
-        Ok(&self.texts[0])
-    }
 }
 
 pub type EmbeddingsOutput = Vec<Vec<f32>>;

--- a/src/client/gemini.rs
+++ b/src/client/gemini.rs
@@ -90,7 +90,7 @@ fn prepare_embeddings(self_: &GeminiClient, data: &EmbeddingsData) -> Result<Req
         .iter()
         .map(|text| {
             json!({
-                "model": self_.model.real_name(),
+                "model": format!("models/{}", self_.model.real_name()),
                 "content": {
                     "parts": [
                         {

--- a/src/client/gemini.rs
+++ b/src/client/gemini.rs
@@ -1,12 +1,13 @@
 use super::vertexai::*;
 use super::*;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use reqwest::RequestBuilder;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
 const API_BASE: &str = "https://generativelanguage.googleapis.com/v1beta";
+const GEMINI_MAX_BATCH_SIZE: usize = 100;
 
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct GeminiConfig {
@@ -72,29 +73,49 @@ fn prepare_chat_completions(
 }
 
 fn prepare_embeddings(self_: &GeminiClient, data: &EmbeddingsData) -> Result<RequestData> {
+    if data.texts.len() > GEMINI_MAX_BATCH_SIZE {
+        bail!(
+            "Gemini embeddings support at most {GEMINI_MAX_BATCH_SIZE} texts per request, got {}",
+            data.texts.len()
+        );
+    }
+
     let api_key = self_.get_api_key()?;
     let api_base = self_
         .get_api_base()
         .unwrap_or_else(|_| API_BASE.to_string());
 
-    let url = format!(
-        "{}/models/{}:embedContent?key={}",
-        api_base.trim_end_matches('/'),
-        self_.model.real_name(),
-        api_key
-    );
+    let requests: Vec<Value> = data
+        .texts
+        .iter()
+        .map(|text| {
+            json!({
+                "model": self_.model.real_name(),
+                "content": {
+                    "parts": [
+                        {
+                            "text": text
+                        }
+                    ]
+                }
+            })
+        })
+        .collect();
 
     let body = json!({
-        "content": {
-            "parts": [
-                {
-                    "text": data.try_get_text()?
-                }
-            ]
-        },
+        "requests": requests,
     });
 
-    let request_data = RequestData::new(url, body);
+    let mut request_data = RequestData::new(
+        format!(
+            "{}/models/{}:batchEmbedContents",
+            api_base.trim_end_matches('/'),
+            self_.model.real_name(),
+        ),
+        body,
+    );
+    request_data.header("x-goog-api-key", api_key);
+    request_data.header("Content-Type", "application/json");
 
     Ok(request_data)
 }


### PR DESCRIPTION
Fixes #35

## Summary
- switch Gemini embeddings to the  endpoint
- remove the single-text restriction in 
- fail fast when a Gemini embeddings request exceeds the 100-text API limit
- use  header for Gemini embeddings auth
- add a changeset for release notes

## Validation
- cargo fmt
- cargo build
- cargo clippy --all --all-targets -- -D warnings
- cargo nextest run --all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gemini embeddings now process multiple texts in a single batch request (up to 100 items per batch).
  * Requests that exceed the 100-item batch limit will fail early with a clear error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->