### PR TITLE
fix: update shell completion scripts for current CLI

### DIFF
--- a/scripts/completions/harnx.bash
+++ b/scripts/completions/harnx.bash
@@ -17,7 +17,7 @@ _harnx() {
 
     case "${cmd}" in
         harnx)
-            opts="-m -r -s -a -e -c -f -S -h -V --model --prompt --role --session --empty-session --save-session --agent --agent-variable --rag --rebuild-rag --macro --serve --execute --code --file --no-stream --dry-run --info --sync-models --list-models --list-roles --list-sessions --list-agents --list-rags --list-macros --help --version"
+            opts="-m -s -a -f -S -t -h -V --model --prompt --session --empty-session --save-session --agent --agent-variable --rag --rebuild-rag --macro --serve --acp --file --no-stream --dry-run --info --sync-models --list-models --list-sessions --list-agents --list-rags --list-macros --mcp-root --tool --help --version"
             if [[ ${cur} == -* || ${cword} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -33,11 +33,6 @@ _harnx() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                -r|--role)
-                    COMPREPLY=($(compgen -W "$("$1" --list-roles)" -- "${cur}"))
-                    __ltrim_colon_completions "$cur"
-                    return 0
-                    ;;
                 -s|--session)
                     COMPREPLY=($(compgen -W "$("$1" --list-sessions)" -- "${cur}"))
                     __ltrim_colon_completions "$cur"
@@ -48,13 +43,22 @@ _harnx() {
                     __ltrim_colon_completions "$cur"
                     return 0
                     ;;
-                -R|--rag)
+                --rag)
                     COMPREPLY=($(compgen -W "$("$1" --list-rags)" -- "${cur}"))
                     __ltrim_colon_completions "$cur"
                     return 0
                     ;;
                 --macro)
                     COMPREPLY=($(compgen -W "$("$1" --list-macros)" -- "${cur}"))
+                    __ltrim_colon_completions "$cur"
+                    return 0
+                    ;;
+                --serve)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --acp)
+                    COMPREPLY=($(compgen -W "$("$1" --list-agents)" -- "${cur}"))
                     __ltrim_colon_completions "$cur"
                     return 0
                     ;;
@@ -71,6 +75,26 @@ _harnx() {
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
                         compopt -o filenames
                     fi
+                    return 0
+                    ;;
+                --mcp-root)
+                    local oldifs
+                    if [[ -v IFS ]]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -d "${cur}"))
+                    if [[ -v oldifs ]]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                -t|--tool)
+                    # Tools can be tool names or toolset names - no dynamic completion available
+                    COMPREPLY=()
                     return 0
                     ;;
                 *)

--- a/scripts/completions/harnx.fish
+++ b/scripts/completions/harnx.fish
@@ -1,6 +1,5 @@
 complete -c harnx -s m -l model -x -a "(harnx --list-models)" -d 'Select a LLM model' -r
 complete -c harnx -l prompt -d 'Use the system prompt'
-complete -c harnx -s r -l role -x -a "(harnx --list-roles)" -d 'Select a role' -r
 complete -c harnx -s s -l session -x  -a "(harnx --list-sessions)" -d 'Start or join a session' -r
 complete -c harnx -l empty-session -d 'Ensure the session is empty'
 complete -c harnx -l save-session -d 'Ensure the new conversation is saved to the session'
@@ -9,19 +8,19 @@ complete -c harnx -l agent-variable -d 'Set agent variables'
 complete -c harnx -l rag -x  -a"(harnx --list-rags)" -d 'Start a RAG' -r
 complete -c harnx -l rebuild-rag -d 'Rebuild the RAG to sync document changes'
 complete -c harnx -l macro -x  -a"(harnx --list-macros)" -d 'Execute a macro' -r
-complete -c harnx -l serve -d 'Serve the LLM API and WebAPP'
-complete -c harnx -s e -l execute -d 'Execute commands in natural language'
-complete -c harnx -s c -l code -d 'Output code only'
+complete -c harnx -l serve -d 'Serve the LLM API and WebAPP' -r
+complete -c harnx -l acp -x -a "(harnx --list-agents)" -d 'Serve as an ACP agent over stdio' -r
 complete -c harnx -s f -l file -d 'Include files, directories, or URLs' -r -F
 complete -c harnx -s S -l no-stream -d 'Turn off stream mode'
 complete -c harnx -l dry-run -d 'Display the message without sending it'
 complete -c harnx -l info -d 'Display information'
 complete -c harnx -l sync-models -d 'Sync models updates'
 complete -c harnx -l list-models -d 'List all available chat models'
-complete -c harnx -l list-roles -d 'List all roles'
 complete -c harnx -l list-sessions -d 'List all sessions'
 complete -c harnx -l list-agents -d 'List all agents'
 complete -c harnx -l list-rags -d 'List all RAGs'
 complete -c harnx -l list-macros -d 'List all macros'
+complete -c harnx -l mcp-root -d 'Add MCP roots' -r -F
+complete -c harnx -s t -l tool -d 'Enable tools or toolsets for this session'
 complete -c harnx -s h -l help -d 'Print help'
 complete -c harnx -s V -l version -d 'Print version'

--- a/scripts/completions/harnx.nu
+++ b/scripts/completions/harnx.nu
@@ -10,12 +10,6 @@ module completions {
     | parse "{value}" 
   }
 
-  def "nu-complete harnx role" [] {
-    ^harnx --list-roles |
-    | lines 
-    | parse "{value}" 
-  }
-
   def "nu-complete harnx session" [] {
     ^harnx --list-sessions |
     | lines 
@@ -43,7 +37,6 @@ module completions {
   export extern harnx [
     --model(-m): string@"nu-complete harnx model"      # Select a LLM model
     --prompt                                            # Use the system prompt
-    --role(-r): string@"nu-complete harnx role"        # Select a role
     --session(-s): string@"nu-complete harnx session"  # Start or join a session
     --empty-session                                     # Ensure the session is empty
     --save-session                                      # Ensure the new conversation is saved to the session
@@ -53,19 +46,19 @@ module completions {
     --rebuild-rag                                       # Rebuild the RAG to sync document changes
     --macro: string@"nu-complete harnx macro"          # Execute a macro
     --serve                                             # Serve the LLM API and WebAPP
-    --execute(-e)                                       # Execute commands in natural language
-    --code(-c)                                          # Output code only
+    --acp: string@"nu-complete harnx agent"            # Serve as an ACP agent over stdio
     --file(-f): string                                  # Include files, directories, or URLs
     --no-stream(-S)                                     # Turn off stream mode
     --dry-run                                           # Display the message without sending it
     --info                                              # Display information
     --sync-models                                       # Sync models updates
     --list-models                                       # List all available chat models
-    --list-roles                                        # List all roles
     --list-sessions                                     # List all sessions
     --list-agents                                       # List all agents
     --list-rags                                         # List all RAGs
     --list-macros                                       # List all macros
+    --mcp-root: string                                  # Add MCP roots
+    --tool(-t): string                                  # Enable tools or toolsets for this session
     ...text: string                                     # Input text
     --help(-h)                                          # Print help
     --version(-V)                                       # Print version

--- a/scripts/completions/harnx.ps1
+++ b/scripts/completions/harnx.ps1
@@ -23,8 +23,6 @@ Register-ArgumentCompleter -Native -CommandName 'harnx' -ScriptBlock {
             [CompletionResult]::new('-m', '-m', [CompletionResultType]::ParameterName, 'Select a LLM model')
             [CompletionResult]::new('--model', '--model', [CompletionResultType]::ParameterName, 'Select a LLM model')
             [CompletionResult]::new('--prompt', '--prompt', [CompletionResultType]::ParameterName, 'Use the system prompt')
-            [CompletionResult]::new('-r', '-r', [CompletionResultType]::ParameterName, 'Select a role')
-            [CompletionResult]::new('--role', '--role', [CompletionResultType]::ParameterName, 'Select a role')
             [CompletionResult]::new('-s', '-s', [CompletionResultType]::ParameterName, 'Start or join a session')
             [CompletionResult]::new('--session', '--session', [CompletionResultType]::ParameterName, 'Start or join a session')
             [CompletionResult]::new('--empty-session', '--empty-session', [CompletionResultType]::ParameterName, 'Ensure the session is empty')
@@ -36,10 +34,7 @@ Register-ArgumentCompleter -Native -CommandName 'harnx' -ScriptBlock {
             [CompletionResult]::new('--rebuild-rag', '--rebuild-rag', [CompletionResultType]::ParameterName, 'Rebuild the RAG to sync document changes')
             [CompletionResult]::new('--macro', '--macro', [CompletionResultType]::ParameterName, 'Execute a macro')
             [CompletionResult]::new('--serve', '--serve', [CompletionResultType]::ParameterName, 'Serve the LLM API and WebAPP')
-            [CompletionResult]::new('-e', '-e', [CompletionResultType]::ParameterName, 'Execute commands in natural language')
-            [CompletionResult]::new('--execute', '--execute', [CompletionResultType]::ParameterName, 'Execute commands in natural language')
-            [CompletionResult]::new('-c', '-c', [CompletionResultType]::ParameterName, 'Output code only')
-            [CompletionResult]::new('--code', '--code', [CompletionResultType]::ParameterName, 'Output code only')
+            [CompletionResult]::new('--acp', '--acp', [CompletionResultType]::ParameterName, 'Serve as an ACP agent over stdio')
             [CompletionResult]::new('-f', '-f', [CompletionResultType]::ParameterName, 'Include files, directories, or URLs')
             [CompletionResult]::new('--file', '--file', [CompletionResultType]::ParameterName, 'Include files, directories, or URLs')
             [CompletionResult]::new('-S', '-S', [CompletionResultType]::ParameterName, 'Turn off stream mode')
@@ -48,11 +43,13 @@ Register-ArgumentCompleter -Native -CommandName 'harnx' -ScriptBlock {
             [CompletionResult]::new('--info', '--info', [CompletionResultType]::ParameterName, 'Display information')
             [CompletionResult]::new('--sync-models', '--sync-models', [CompletionResultType]::ParameterName, 'Sync models updates')
             [CompletionResult]::new('--list-models', '--list-models', [CompletionResultType]::ParameterName, 'List all available chat models')
-            [CompletionResult]::new('--list-roles', '--list-roles', [CompletionResultType]::ParameterName, 'List all roles')
             [CompletionResult]::new('--list-sessions', '--list-sessions', [CompletionResultType]::ParameterName, 'List all sessions')
             [CompletionResult]::new('--list-agents', '--list-agents', [CompletionResultType]::ParameterName, 'List all agents')
             [CompletionResult]::new('--list-rags', '--list-rags', [CompletionResultType]::ParameterName, 'List all RAGs')
             [CompletionResult]::new('--list-macros', '--list-macros', [CompletionResultType]::ParameterName, 'List all macros')
+            [CompletionResult]::new('--mcp-root', '--mcp-root', [CompletionResultType]::ParameterName, 'Add MCP roots')
+            [CompletionResult]::new('-t', '-t', [CompletionResultType]::ParameterName, 'Enable tools or toolsets for this session')
+            [CompletionResult]::new('--tool', '--tool', [CompletionResultType]::ParameterName, 'Enable tools or toolsets for this session')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('-V', '-V', [CompletionResultType]::ParameterName, 'Print version')
@@ -71,11 +68,8 @@ Register-ArgumentCompleter -Native -CommandName 'harnx' -ScriptBlock {
             $offset=1
         }
         $flag = $commandElements[$commandElements.Count-$offset].ToString()
-        dump-args $flag ($flag -eq "-R") > /tmp/file1
         if ($flag -ceq "-m" -or $flag -eq "--model") {
             $completions = Get-HarnxValues "--list-models"
-        } elseif ($flag -ceq "-r" -or $flag -eq "--role") {
-            $completions = Get-HarnxValues "--list-roles"
         } elseif ($flag -ceq "-s" -or $flag -eq "--session") {
             $completions = Get-HarnxValues "--list-sessions"
         } elseif ($flag -ceq "-a" -or $flag -eq "--agent") {
@@ -84,7 +78,13 @@ Register-ArgumentCompleter -Native -CommandName 'harnx' -ScriptBlock {
             $completions = Get-HarnxValues "--list-rags"
         } elseif ($flag -eq "--macro") {
             $completions = Get-HarnxValues "--list-macros"
+        } elseif ($flag -eq "--acp") {
+            $completions = Get-HarnxValues "--list-agents"
         } elseif ($flag -ceq "-f" -or $flag -eq "--file") {
+            $completions = @()
+        } elseif ($flag -eq "--mcp-root") {
+            $completions = @()
+        } elseif ($flag -ceq "-t" -or $flag -eq "--tool") {
             $completions = @()
         }
     }

--- a/scripts/completions/harnx.zsh
+++ b/scripts/completions/harnx.zsh
@@ -18,23 +18,18 @@ _harnx() {
 '-m[Select a LLM model]:MODEL:->models' \
 '--model[Select a LLM model]:MODEL:->models' \
 '--prompt[Use the system prompt]:PROMPT: ' \
-'-r[Select a role]:ROLE:->roles' \
-'--role[Select a role]:ROLE:->roles' \
 '-s[Start or join a session]:SESSION:->sessions' \
 '--session[Start or join a session]:SESSION:->sessions' \
 '--empty-session[Ensure the session is empty]' \
 '--save-session[Ensure the new conversation is saved to the session]' \
 '-a[Start a agent]:AGENT:->agents' \
 '--agent[Start a agent]:AGENT:->agents' \
-'--agent-variable[Set agent variables]' \
+'--agent-variable[Set agent variables]: : ' \
 '--rag[Start a RAG]:RAG:->rags' \
 '--rebuild-rag[Rebuild the RAG to sync document changes]' \
 '--macro[Execute a macro]:MACRO:->macros' \
-'--serve[Serve the LLM API and WebAPP]' \
-'-e[Execute commands in natural language]' \
-'--execute[Execute commands in natural language]' \
-'-c[Output code only]' \
-'--code[Output code only]' \
+'--serve[Serve the LLM API and WebAPP]:ADDRESS: ' \
+'--acp[Serve as an ACP agent over stdio]:AGENT:->agents' \
 '*-f[Include files, directories, or URLs]:FILE:_files' \
 '*--file[Include files, directories, or URLs]:FILE:_files' \
 '-S[Turn off stream mode]' \
@@ -43,11 +38,13 @@ _harnx() {
 '--info[Display information]' \
 '--sync-models[Sync models updates]' \
 '--list-models[List all available chat models]' \
-'--list-roles[List all roles]' \
 '--list-sessions[List all sessions]' \
 '--list-agents[List all agents]' \
 '--list-rags[List all RAGs]' \
 '--list-macros[List all macros]' \
+'*--mcp-root[Add MCP roots]:PATH:_directories' \
+'-t[Enable tools or toolsets for this session]:TOOL: ' \
+'--tool[Enable tools or toolsets for this session]:TOOL: ' \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \
@@ -59,7 +56,7 @@ _harnx() {
     _arguments "${_arguments_options[@]}" $common \
         && ret=0 
     case $state in
-        models|roles|sessions|agents|rags|macros)
+        models|sessions|agents|rags|macros)
             local -a values expl
             values=( ${(f)"$(_call_program values harnx --list-$state)"} )
             _wanted values expl $state compadd -a values && ret=0


### PR DESCRIPTION
## Summary
- sync bundled shell completion scripts with the current `src/cli.rs` options
- remove stale completion entries for deleted flags like `--role`, `--execute`, `--code`, and `--list-roles`
- add current options including `--acp`, `--mcp-root`, and `--tool`/`-t`

## Testing
- cargo fmt --all
- cargo build
- cargo clippy --all --all-targets -- -D warnings
- cargo nextest run --all

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shell completion support for `--tool`, `--mcp-root`, and `--acp` options across bash, fish, nushell, PowerShell, and zsh
  * Enabled dynamic agent name completion for the `--acp` option

* **Changes**
  * Removed completion support for `--role`, `--execute`, and `--code` options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->