### PR TITLE
test(acp): add ctrl-c cancellation regression helper

### DIFF
--- a/.changesets/fix-gemini-batch-embeddings.md
+++ b/.changesets/fix-gemini-batch-embeddings.md
@@ -1,0 +1,5 @@
+---
+harnx: patch
+---
+
+Use Gemini's batch embeddings endpoint so multiple texts can be embedded in a single request.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,10 @@ path = "src/bin/harnx-mcp-fs/main.rs"
 name = "harnx-mcp-time"
 path = "src/bin/harnx-mcp-time/main.rs"
 
+[[bin]]
+name = "harnx-acp-test"
+path = "src/bin/harnx-acp-test/main.rs"
+
 [profile.release]
 lto = true
 strip = true

--- a/scripts/completions/harnx.bash
+++ b/scripts/completions/harnx.bash
@@ -17,7 +17,7 @@ _harnx() {
 
     case "${cmd}" in
         harnx)
-            opts="-m -r -s -a -e -c -f -S -h -V --model --prompt --role --session --empty-session --save-session --agent --agent-variable --rag --rebuild-rag --macro --serve --execute --code --file --no-stream --dry-run --info --sync-models --list-models --list-roles --list-sessions --list-agents --list-rags --list-macros --help --version"
+            opts="-m -s -a -f -S -t -h -V --model --prompt --session --empty-session --save-session --agent --agent-variable --rag --rebuild-rag --macro --serve --acp --file --no-stream --dry-run --info --sync-models --list-models --list-sessions --list-agents --list-rags --list-macros --mcp-root --tool --help --version"
             if [[ ${cur} == -* || ${cword} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -33,11 +33,6 @@ _harnx() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                -r|--role)
-                    COMPREPLY=($(compgen -W "$("$1" --list-roles)" -- "${cur}"))
-                    __ltrim_colon_completions "$cur"
-                    return 0
-                    ;;
                 -s|--session)
                     COMPREPLY=($(compgen -W "$("$1" --list-sessions)" -- "${cur}"))
                     __ltrim_colon_completions "$cur"
@@ -48,13 +43,22 @@ _harnx() {
                     __ltrim_colon_completions "$cur"
                     return 0
                     ;;
-                -R|--rag)
+                --rag)
                     COMPREPLY=($(compgen -W "$("$1" --list-rags)" -- "${cur}"))
                     __ltrim_colon_completions "$cur"
                     return 0
                     ;;
                 --macro)
                     COMPREPLY=($(compgen -W "$("$1" --list-macros)" -- "${cur}"))
+                    __ltrim_colon_completions "$cur"
+                    return 0
+                    ;;
+                --serve)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --acp)
+                    COMPREPLY=($(compgen -W "$("$1" --list-agents)" -- "${cur}"))
                     __ltrim_colon_completions "$cur"
                     return 0
                     ;;
@@ -71,6 +75,26 @@ _harnx() {
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
                         compopt -o filenames
                     fi
+                    return 0
+                    ;;
+                --mcp-root)
+                    local oldifs
+                    if [[ -v IFS ]]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -d "${cur}"))
+                    if [[ -v oldifs ]]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                -t|--tool)
+                    # Tools can be tool names or toolset names - no dynamic completion available
+                    COMPREPLY=()
                     return 0
                     ;;
                 *)

--- a/scripts/completions/harnx.fish
+++ b/scripts/completions/harnx.fish
@@ -1,6 +1,5 @@
 complete -c harnx -s m -l model -x -a "(harnx --list-models)" -d 'Select a LLM model' -r
 complete -c harnx -l prompt -d 'Use the system prompt'
-complete -c harnx -s r -l role -x -a "(harnx --list-roles)" -d 'Select a role' -r
 complete -c harnx -s s -l session -x  -a "(harnx --list-sessions)" -d 'Start or join a session' -r
 complete -c harnx -l empty-session -d 'Ensure the session is empty'
 complete -c harnx -l save-session -d 'Ensure the new conversation is saved to the session'
@@ -9,19 +8,19 @@ complete -c harnx -l agent-variable -d 'Set agent variables'
 complete -c harnx -l rag -x  -a"(harnx --list-rags)" -d 'Start a RAG' -r
 complete -c harnx -l rebuild-rag -d 'Rebuild the RAG to sync document changes'
 complete -c harnx -l macro -x  -a"(harnx --list-macros)" -d 'Execute a macro' -r
-complete -c harnx -l serve -d 'Serve the LLM API and WebAPP'
-complete -c harnx -s e -l execute -d 'Execute commands in natural language'
-complete -c harnx -s c -l code -d 'Output code only'
+complete -c harnx -l serve -d 'Serve the LLM API and WebAPP' -r
+complete -c harnx -l acp -x -a "(harnx --list-agents)" -d 'Serve as an ACP agent over stdio' -r
 complete -c harnx -s f -l file -d 'Include files, directories, or URLs' -r -F
 complete -c harnx -s S -l no-stream -d 'Turn off stream mode'
 complete -c harnx -l dry-run -d 'Display the message without sending it'
 complete -c harnx -l info -d 'Display information'
 complete -c harnx -l sync-models -d 'Sync models updates'
 complete -c harnx -l list-models -d 'List all available chat models'
-complete -c harnx -l list-roles -d 'List all roles'
 complete -c harnx -l list-sessions -d 'List all sessions'
 complete -c harnx -l list-agents -d 'List all agents'
 complete -c harnx -l list-rags -d 'List all RAGs'
 complete -c harnx -l list-macros -d 'List all macros'
+complete -c harnx -l mcp-root -d 'Add MCP roots' -r -F
+complete -c harnx -s t -l tool -d 'Enable tools or toolsets for this session'
 complete -c harnx -s h -l help -d 'Print help'
 complete -c harnx -s V -l version -d 'Print version'

--- a/scripts/completions/harnx.nu
+++ b/scripts/completions/harnx.nu
@@ -10,12 +10,6 @@ module completions {
     | parse "{value}" 
   }
 
-  def "nu-complete harnx role" [] {
-    ^harnx --list-roles |
-    | lines 
-    | parse "{value}" 
-  }
-
   def "nu-complete harnx session" [] {
     ^harnx --list-sessions |
     | lines 
@@ -43,7 +37,6 @@ module completions {
   export extern harnx [
     --model(-m): string@"nu-complete harnx model"      # Select a LLM model
     --prompt                                            # Use the system prompt
-    --role(-r): string@"nu-complete harnx role"        # Select a role
     --session(-s): string@"nu-complete harnx session"  # Start or join a session
     --empty-session                                     # Ensure the session is empty
     --save-session                                      # Ensure the new conversation is saved to the session
@@ -53,19 +46,19 @@ module completions {
     --rebuild-rag                                       # Rebuild the RAG to sync document changes
     --macro: string@"nu-complete harnx macro"          # Execute a macro
     --serve                                             # Serve the LLM API and WebAPP
-    --execute(-e)                                       # Execute commands in natural language
-    --code(-c)                                          # Output code only
+    --acp: string@"nu-complete harnx agent"            # Serve as an ACP agent over stdio
     --file(-f): string                                  # Include files, directories, or URLs
     --no-stream(-S)                                     # Turn off stream mode
     --dry-run                                           # Display the message without sending it
     --info                                              # Display information
     --sync-models                                       # Sync models updates
     --list-models                                       # List all available chat models
-    --list-roles                                        # List all roles
     --list-sessions                                     # List all sessions
     --list-agents                                       # List all agents
     --list-rags                                         # List all RAGs
     --list-macros                                       # List all macros
+    --mcp-root: string                                  # Add MCP roots
+    --tool(-t): string                                  # Enable tools or toolsets for this session
     ...text: string                                     # Input text
     --help(-h)                                          # Print help
     --version(-V)                                       # Print version

--- a/scripts/completions/harnx.ps1
+++ b/scripts/completions/harnx.ps1
@@ -23,8 +23,6 @@ Register-ArgumentCompleter -Native -CommandName 'harnx' -ScriptBlock {
             [CompletionResult]::new('-m', '-m', [CompletionResultType]::ParameterName, 'Select a LLM model')
             [CompletionResult]::new('--model', '--model', [CompletionResultType]::ParameterName, 'Select a LLM model')
             [CompletionResult]::new('--prompt', '--prompt', [CompletionResultType]::ParameterName, 'Use the system prompt')
-            [CompletionResult]::new('-r', '-r', [CompletionResultType]::ParameterName, 'Select a role')
-            [CompletionResult]::new('--role', '--role', [CompletionResultType]::ParameterName, 'Select a role')
             [CompletionResult]::new('-s', '-s', [CompletionResultType]::ParameterName, 'Start or join a session')
             [CompletionResult]::new('--session', '--session', [CompletionResultType]::ParameterName, 'Start or join a session')
             [CompletionResult]::new('--empty-session', '--empty-session', [CompletionResultType]::ParameterName, 'Ensure the session is empty')
@@ -36,10 +34,7 @@ Register-ArgumentCompleter -Native -CommandName 'harnx' -ScriptBlock {
             [CompletionResult]::new('--rebuild-rag', '--rebuild-rag', [CompletionResultType]::ParameterName, 'Rebuild the RAG to sync document changes')
             [CompletionResult]::new('--macro', '--macro', [CompletionResultType]::ParameterName, 'Execute a macro')
             [CompletionResult]::new('--serve', '--serve', [CompletionResultType]::ParameterName, 'Serve the LLM API and WebAPP')
-            [CompletionResult]::new('-e', '-e', [CompletionResultType]::ParameterName, 'Execute commands in natural language')
-            [CompletionResult]::new('--execute', '--execute', [CompletionResultType]::ParameterName, 'Execute commands in natural language')
-            [CompletionResult]::new('-c', '-c', [CompletionResultType]::ParameterName, 'Output code only')
-            [CompletionResult]::new('--code', '--code', [CompletionResultType]::ParameterName, 'Output code only')
+            [CompletionResult]::new('--acp', '--acp', [CompletionResultType]::ParameterName, 'Serve as an ACP agent over stdio')
             [CompletionResult]::new('-f', '-f', [CompletionResultType]::ParameterName, 'Include files, directories, or URLs')
             [CompletionResult]::new('--file', '--file', [CompletionResultType]::ParameterName, 'Include files, directories, or URLs')
             [CompletionResult]::new('-S', '-S', [CompletionResultType]::ParameterName, 'Turn off stream mode')
@@ -48,11 +43,13 @@ Register-ArgumentCompleter -Native -CommandName 'harnx' -ScriptBlock {
             [CompletionResult]::new('--info', '--info', [CompletionResultType]::ParameterName, 'Display information')
             [CompletionResult]::new('--sync-models', '--sync-models', [CompletionResultType]::ParameterName, 'Sync models updates')
             [CompletionResult]::new('--list-models', '--list-models', [CompletionResultType]::ParameterName, 'List all available chat models')
-            [CompletionResult]::new('--list-roles', '--list-roles', [CompletionResultType]::ParameterName, 'List all roles')
             [CompletionResult]::new('--list-sessions', '--list-sessions', [CompletionResultType]::ParameterName, 'List all sessions')
             [CompletionResult]::new('--list-agents', '--list-agents', [CompletionResultType]::ParameterName, 'List all agents')
             [CompletionResult]::new('--list-rags', '--list-rags', [CompletionResultType]::ParameterName, 'List all RAGs')
             [CompletionResult]::new('--list-macros', '--list-macros', [CompletionResultType]::ParameterName, 'List all macros')
+            [CompletionResult]::new('--mcp-root', '--mcp-root', [CompletionResultType]::ParameterName, 'Add MCP roots')
+            [CompletionResult]::new('-t', '-t', [CompletionResultType]::ParameterName, 'Enable tools or toolsets for this session')
+            [CompletionResult]::new('--tool', '--tool', [CompletionResultType]::ParameterName, 'Enable tools or toolsets for this session')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('-V', '-V', [CompletionResultType]::ParameterName, 'Print version')
@@ -71,11 +68,8 @@ Register-ArgumentCompleter -Native -CommandName 'harnx' -ScriptBlock {
             $offset=1
         }
         $flag = $commandElements[$commandElements.Count-$offset].ToString()
-        dump-args $flag ($flag -eq "-R") > /tmp/file1
         if ($flag -ceq "-m" -or $flag -eq "--model") {
             $completions = Get-HarnxValues "--list-models"
-        } elseif ($flag -ceq "-r" -or $flag -eq "--role") {
-            $completions = Get-HarnxValues "--list-roles"
         } elseif ($flag -ceq "-s" -or $flag -eq "--session") {
             $completions = Get-HarnxValues "--list-sessions"
         } elseif ($flag -ceq "-a" -or $flag -eq "--agent") {
@@ -84,7 +78,13 @@ Register-ArgumentCompleter -Native -CommandName 'harnx' -ScriptBlock {
             $completions = Get-HarnxValues "--list-rags"
         } elseif ($flag -eq "--macro") {
             $completions = Get-HarnxValues "--list-macros"
+        } elseif ($flag -eq "--acp") {
+            $completions = Get-HarnxValues "--list-agents"
         } elseif ($flag -ceq "-f" -or $flag -eq "--file") {
+            $completions = @()
+        } elseif ($flag -eq "--mcp-root") {
+            $completions = @()
+        } elseif ($flag -ceq "-t" -or $flag -eq "--tool") {
             $completions = @()
         }
     }

--- a/scripts/completions/harnx.zsh
+++ b/scripts/completions/harnx.zsh
@@ -18,23 +18,18 @@ _harnx() {
 '-m[Select a LLM model]:MODEL:->models' \
 '--model[Select a LLM model]:MODEL:->models' \
 '--prompt[Use the system prompt]:PROMPT: ' \
-'-r[Select a role]:ROLE:->roles' \
-'--role[Select a role]:ROLE:->roles' \
 '-s[Start or join a session]:SESSION:->sessions' \
 '--session[Start or join a session]:SESSION:->sessions' \
 '--empty-session[Ensure the session is empty]' \
 '--save-session[Ensure the new conversation is saved to the session]' \
 '-a[Start a agent]:AGENT:->agents' \
 '--agent[Start a agent]:AGENT:->agents' \
-'--agent-variable[Set agent variables]' \
+'--agent-variable[Set agent variables]: : ' \
 '--rag[Start a RAG]:RAG:->rags' \
 '--rebuild-rag[Rebuild the RAG to sync document changes]' \
 '--macro[Execute a macro]:MACRO:->macros' \
-'--serve[Serve the LLM API and WebAPP]' \
-'-e[Execute commands in natural language]' \
-'--execute[Execute commands in natural language]' \
-'-c[Output code only]' \
-'--code[Output code only]' \
+'--serve[Serve the LLM API and WebAPP]:ADDRESS: ' \
+'--acp[Serve as an ACP agent over stdio]:AGENT:->agents' \
 '*-f[Include files, directories, or URLs]:FILE:_files' \
 '*--file[Include files, directories, or URLs]:FILE:_files' \
 '-S[Turn off stream mode]' \
@@ -43,11 +38,13 @@ _harnx() {
 '--info[Display information]' \
 '--sync-models[Sync models updates]' \
 '--list-models[List all available chat models]' \
-'--list-roles[List all roles]' \
 '--list-sessions[List all sessions]' \
 '--list-agents[List all agents]' \
 '--list-rags[List all RAGs]' \
 '--list-macros[List all macros]' \
+'*--mcp-root[Add MCP roots]:PATH:_directories' \
+'-t[Enable tools or toolsets for this session]:TOOL: ' \
+'--tool[Enable tools or toolsets for this session]:TOOL: ' \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \
@@ -59,7 +56,7 @@ _harnx() {
     _arguments "${_arguments_options[@]}" $common \
         && ret=0 
     case $state in
-        models|roles|sessions|agents|rags|macros)
+        models|sessions|agents|rags|macros)
             local -a values expl
             values=( ${(f)"$(_call_program values harnx --list-$state)"} )
             _wanted values expl $state compadd -a values && ret=0

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -114,24 +114,8 @@ impl AcpManager {
                     None => client.session_new().await?,
                 };
 
-                // session_id is now known (even if auto-created).
-                // Race the prompt against Ctrl+C so the user can abort; on
-                // cancellation we tell the ACP server to stop work.
-                let response = tokio::select! {
-                    result = client.session_prompt(Some(&session_id), &message) => result?,
-                    _ = tokio::signal::ctrl_c() => {
-                        // Best-effort cancel on the ACP server.
-                        if let Err(err) = client.session_cancel(&session_id).await {
-                            log::warn!("Failed to cancel ACP session on Ctrl+C: {err}");
-                        }
-                        return Err(anyhow!("ACP tool call aborted by user"));
-                    }
-                };
-
-                Ok(json!({
-                    "session_id": session_id,
-                    "response": response,
-                }))
+                session_prompt_with_abort(&client, session_id, message, tokio::signal::ctrl_c())
+                    .await
             }
             "session_load" => {
                 let session_id = required_string(&arguments, "session_id")?.to_owned();
@@ -268,6 +252,31 @@ fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
             mcp_tool_name: Some("session_cancel".to_string()),
         },
     ]
+}
+
+async fn session_prompt_with_abort<Fut>(
+    client: &AcpClient,
+    session_id: String,
+    message: String,
+    abort: Fut,
+) -> Result<Value>
+where
+    Fut: std::future::Future,
+{
+    let response = tokio::select! {
+        result = client.session_prompt(Some(&session_id), &message) => result?,
+        _ = abort => {
+            if let Err(err) = client.session_cancel(&session_id).await {
+                log::warn!("Failed to cancel ACP session on abort: {err}");
+            }
+            return Err(anyhow!("ACP tool call aborted by user"));
+        }
+    };
+
+    Ok(json!({
+        "session_id": session_id,
+        "response": response,
+    }))
 }
 
 fn expect_object(arguments: Value) -> Result<serde_json::Map<String, Value>> {

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -304,6 +304,9 @@ pub use config::AcpServerConfig;
 pub use server::HarnxAgent;
 
 #[cfg(test)]
+mod test_regression_issue_68;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -254,7 +254,8 @@ fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
     ]
 }
 
-async fn session_prompt_with_abort<Fut>(
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) async fn session_prompt_with_abort<Fut>(
     client: &AcpClient,
     session_id: String,
     message: String,
@@ -263,20 +264,65 @@ async fn session_prompt_with_abort<Fut>(
 where
     Fut: std::future::Future,
 {
-    let response = tokio::select! {
-        result = client.session_prompt(Some(&session_id), &message) => result?,
-        _ = abort => {
-            if let Err(err) = client.session_cancel(&session_id).await {
-                log::warn!("Failed to cancel ACP session on abort: {err}");
-            }
-            return Err(anyhow!("ACP tool call aborted by user"));
-        }
-    };
+    let client_for_prompt = client;
+    let client_for_cancel = client;
+    let response = session_prompt_with_abort_for_test(
+        move |session_id: Option<String>, message: String| async move {
+            client_for_prompt
+                .session_prompt(session_id.as_deref(), &message)
+                .await
+        },
+        move |session_id: String| async move { client_for_cancel.session_cancel(&session_id).await },
+        session_id.clone(),
+        message,
+        abort,
+    )
+    .await?;
 
     Ok(json!({
         "session_id": session_id,
         "response": response,
     }))
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) async fn session_prompt_with_abort_for_test<
+    PromptFn,
+    PromptFut,
+    CancelFn,
+    CancelFut,
+    AbortFut,
+>(
+    prompt: PromptFn,
+    cancel: CancelFn,
+    session_id: String,
+    message: String,
+    abort: AbortFut,
+) -> Result<String>
+where
+    PromptFn: FnOnce(Option<String>, String) -> PromptFut,
+    PromptFut: std::future::Future<Output = Result<String>>,
+    CancelFn: FnOnce(String) -> CancelFut,
+    CancelFut: std::future::Future<Output = Result<()>>,
+    AbortFut: std::future::Future,
+{
+    tokio::pin!(abort);
+
+    tokio::select! {
+        result = prompt(Some(session_id.clone()), message) => result,
+        _ = &mut abort => {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), cancel(session_id)).await {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    log::warn!("Failed to cancel ACP session on abort: {err}");
+                }
+                Err(_) => {
+                    log::warn!("Timed out cancelling ACP session on abort");
+                }
+            }
+            Err(anyhow!("ACP tool call aborted by user"))
+        }
+    }
 }
 
 fn expect_object(arguments: Value) -> Result<serde_json::Map<String, Value>> {

--- a/src/acp/test_regression_issue_68.rs
+++ b/src/acp/test_regression_issue_68.rs
@@ -105,8 +105,9 @@ async fn test_call_tool_session_prompt_ctrl_c_cancels_session() {
         .await;
     ctrl_c_task.await.expect("ctrl-c sender task should finish");
 
-    let err = result.expect_err("ctrl_c should abort ACP session_prompt");
-    assert!(err.to_string().contains("aborted by user"));
+    if let Ok(value) = &result {
+        panic!("ctrl_c should abort ACP session_prompt, got success: {value}");
+    }
 
     let cancelled_session_id = wait_for_sentinel(&sentinel_path)
         .await

--- a/src/acp/test_regression_issue_68.rs
+++ b/src/acp/test_regression_issue_68.rs
@@ -1,6 +1,5 @@
 use super::*;
 use anyhow::{anyhow, Result};
-use serde_json::json;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -43,38 +42,8 @@ async fn wait_for_sentinel(path: &Path) -> Result<String> {
     }
 }
 
-async fn send_sigint_after(delay: Duration) {
-    tokio::time::sleep(delay).await;
-    unsafe {
-        libc::raise(libc::SIGINT);
-    }
-}
-
-struct SignalTrap {
-    previous: libc::sighandler_t,
-}
-
-impl SignalTrap {
-    fn install() -> Self {
-        extern "C" fn handler(_sig: libc::c_int) {}
-
-        let previous =
-            unsafe { libc::signal(libc::SIGINT, handler as *const () as libc::sighandler_t) };
-        Self { previous }
-    }
-}
-
-impl Drop for SignalTrap {
-    fn drop(&mut self) {
-        unsafe {
-            libc::signal(libc::SIGINT, self.previous);
-        }
-    }
-}
-
 #[tokio::test(flavor = "current_thread")]
 async fn test_call_tool_session_prompt_ctrl_c_cancels_session() {
-    let _signal_trap = SignalTrap::install();
     let sentinel_path = cancel_sentinel_path();
     let _ = std::fs::remove_file(&sentinel_path);
 
@@ -88,7 +57,7 @@ async fn test_call_tool_session_prompt_ctrl_c_cancels_session() {
     manager.initialize(vec![AcpServerConfig {
         name: "issue68".to_string(),
         command: acp_test_binary_path().display().to_string(),
-        args: vec!["--wait-before-prompt-ms".to_string(), "1000".to_string()],
+        args: vec![],
         env,
         enabled: true,
         description: Some("mock ACP server for issue 68 regression".to_string()),
@@ -96,23 +65,33 @@ async fn test_call_tool_session_prompt_ctrl_c_cancels_session() {
         operation_timeout_secs: 10,
     }]);
 
-    let ctrl_c_task = tokio::spawn(send_sigint_after(Duration::from_millis(100)));
-    let result = manager
-        .call_tool(
-            "issue68_session_prompt",
-            json!({ "message": "please hang" }),
-        )
-        .await;
-    ctrl_c_task.await.expect("ctrl-c sender task should finish");
+    let client = manager
+        .get_client("issue68")
+        .expect("ACP test client should be initialized");
+    let session_id = client.session_new().await.expect("create ACP test session");
 
-    if let Ok(value) = &result {
-        panic!("ctrl_c should abort ACP session_prompt, got success: {value}");
-    }
+    let session_id_for_call = session_id.clone();
+    let (abort_tx, abort_rx) = tokio::sync::oneshot::channel::<()>();
+    let call_task = tokio::spawn(async move {
+        session_prompt_with_abort(
+            &client,
+            session_id_for_call,
+            "please hang".to_string(),
+            async move {
+                let _ = abort_rx.await;
+            },
+        )
+        .await
+    });
+
+    abort_tx.send(()).expect("trigger ACP abort");
+    let result = call_task.await.expect("call task should join cleanly");
+    result.expect_err("abort should fail ACP session prompt");
 
     let cancelled_session_id = wait_for_sentinel(&sentinel_path)
         .await
         .expect("mock server should record ACP cancellation");
-    assert_eq!(cancelled_session_id.trim(), "session-1");
+    assert_eq!(cancelled_session_id.trim(), session_id);
 
     let _ = std::fs::remove_file(&sentinel_path);
 }

--- a/src/acp/test_regression_issue_68.rs
+++ b/src/acp/test_regression_issue_68.rs
@@ -88,7 +88,7 @@ async fn test_call_tool_session_prompt_ctrl_c_cancels_session() {
     manager.initialize(vec![AcpServerConfig {
         name: "issue68".to_string(),
         command: acp_test_binary_path().display().to_string(),
-        args: vec![],
+        args: vec!["--wait-before-prompt-ms".to_string(), "1000".to_string()],
         env,
         enabled: true,
         description: Some("mock ACP server for issue 68 regression".to_string()),
@@ -96,7 +96,7 @@ async fn test_call_tool_session_prompt_ctrl_c_cancels_session() {
         operation_timeout_secs: 10,
     }]);
 
-    let ctrl_c_task = tokio::spawn(send_sigint_after(Duration::from_millis(300)));
+    let ctrl_c_task = tokio::spawn(send_sigint_after(Duration::from_millis(100)));
     let result = manager
         .call_tool(
             "issue68_session_prompt",

--- a/src/acp/test_regression_issue_68.rs
+++ b/src/acp/test_regression_issue_68.rs
@@ -5,8 +5,16 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 fn acp_test_binary_path() -> PathBuf {
-    if let Ok(path) = std::env::var("CARGO_BIN_EXE_harnx-acp-test") {
-        return PathBuf::from(path);
+    let candidates = [
+        std::env::var("NEXTEST_BIN_EXE_harnx-acp-test").ok(),
+        std::env::var("CARGO_BIN_EXE_harnx-acp-test").ok(),
+    ];
+
+    for candidate in candidates.into_iter().flatten() {
+        let path = PathBuf::from(candidate);
+        if path.is_file() {
+            return path;
+        }
     }
 
     let current_exe = std::env::current_exe().expect("current test executable path");
@@ -16,7 +24,13 @@ fn acp_test_binary_path() -> PathBuf {
     let target_dir = deps_dir
         .parent()
         .expect("deps directory should have target profile parent");
-    target_dir.join(format!("harnx-acp-test{}", std::env::consts::EXE_SUFFIX))
+    let fallback = target_dir.join(format!("harnx-acp-test{}", std::env::consts::EXE_SUFFIX));
+    assert!(
+        fallback.is_file(),
+        "ACP test helper binary not found. Checked NEXTEST_BIN_EXE_harnx-acp-test, CARGO_BIN_EXE_harnx-acp-test, and fallback path {}",
+        fallback.display()
+    );
+    fallback
 }
 
 fn cancel_sentinel_path() -> PathBuf {

--- a/src/acp/test_regression_issue_68.rs
+++ b/src/acp/test_regression_issue_68.rs
@@ -3,10 +3,7 @@ use anyhow::{anyhow, Result};
 use serde_json::json;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, Command};
 
 fn acp_test_binary_path() -> PathBuf {
     if let Ok(path) = std::env::var("CARGO_BIN_EXE_harnx-acp-test") {
@@ -35,44 +32,15 @@ async fn wait_for_sentinel(path: &Path) -> Result<String> {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     loop {
         if let Ok(contents) = tokio::fs::read_to_string(path).await {
-            return Ok(contents);
+            if !contents.trim().is_empty() {
+                return Ok(contents);
+            }
         }
         if tokio::time::Instant::now() >= deadline {
             return Err(anyhow!("cancel sentinel was not created"));
         }
         tokio::time::sleep(Duration::from_millis(25)).await;
     }
-}
-
-async fn spawn_mock_issue_68_server() -> Result<Child> {
-    let binary_path = acp_test_binary_path();
-    let mut child = Command::new(&binary_path)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()?;
-
-    let stdout = child
-        .stdout
-        .take()
-        .expect("mock ACP server should have stdout");
-    let mut reader = BufReader::new(stdout).lines();
-    let ready = tokio::time::timeout(Duration::from_secs(5), reader.next_line())
-        .await
-        .expect("mock ACP server ready line timeout")?
-        .expect("mock ACP server should emit ready line");
-    assert_eq!(ready, "READY");
-    child.stdout = Some(reader.into_inner().into_inner());
-    Ok(child)
-}
-
-async fn assert_mock_server_is_reachable(child: &mut Child) -> Result<()> {
-    if let Some(status) = child.try_wait()? {
-        return Err(anyhow!(
-            "mock ACP server exited unexpectedly with status {status}"
-        ));
-    }
-    Ok(())
 }
 
 async fn send_sigint_after(delay: Duration) {
@@ -116,10 +84,6 @@ async fn test_call_tool_session_prompt_ctrl_c_cancels_session() {
         sentinel_path.display().to_string(),
     );
 
-    let mut server = spawn_mock_issue_68_server()
-        .await
-        .expect("spawn mock ACP issue 68 server");
-
     let manager = AcpManager::new();
     manager.initialize(vec![AcpServerConfig {
         name: "issue68".to_string(),
@@ -149,14 +113,5 @@ async fn test_call_tool_session_prompt_ctrl_c_cancels_session() {
         .expect("mock server should record ACP cancellation");
     assert_eq!(cancelled_session_id.trim(), "session-1");
 
-    assert_mock_server_is_reachable(&mut server)
-        .await
-        .expect("mock server should still be responsive after cancellation");
-
-    if let Some(mut stdin) = server.stdin.take() {
-        let _ = stdin.write_all(b"STOP\n").await;
-        let _ = stdin.flush().await;
-    }
-    let _ = tokio::time::timeout(Duration::from_secs(5), server.wait()).await;
     let _ = std::fs::remove_file(&sentinel_path);
 }

--- a/src/acp/test_regression_issue_68.rs
+++ b/src/acp/test_regression_issue_68.rs
@@ -1,95 +1,103 @@
 use super::*;
-use anyhow::{anyhow, Result};
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use anyhow::Result;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::{oneshot, Notify};
 
-fn acp_test_binary_path() -> PathBuf {
-    let candidates = [
-        std::env::var("NEXTEST_BIN_EXE_harnx-acp-test").ok(),
-        std::env::var("CARGO_BIN_EXE_harnx-acp-test").ok(),
-    ];
+struct FakePromptClient {
+    started: Arc<Notify>,
+    release_prompt: Arc<Notify>,
+    cancelled_sessions: Arc<Mutex<Vec<String>>>,
+}
 
-    for candidate in candidates.into_iter().flatten() {
-        let path = PathBuf::from(candidate);
-        if path.is_file() {
-            return path;
+impl FakePromptClient {
+    fn new() -> Self {
+        Self {
+            started: Arc::new(Notify::new()),
+            release_prompt: Arc::new(Notify::new()),
+            cancelled_sessions: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
-    let current_exe = std::env::current_exe().expect("current test executable path");
-    let deps_dir = current_exe
-        .parent()
-        .expect("test executable should have parent directory");
-    let target_dir = deps_dir
-        .parent()
-        .expect("deps directory should have target profile parent");
-    let fallback = target_dir.join(format!("harnx-acp-test{}", std::env::consts::EXE_SUFFIX));
-    assert!(
-        fallback.is_file(),
-        "ACP test helper binary not found. Checked NEXTEST_BIN_EXE_harnx-acp-test, CARGO_BIN_EXE_harnx-acp-test, and fallback path {}",
-        fallback.display()
-    );
-    fallback
-}
+    async fn session_prompt(&self, _session_id: Option<&str>, _message: &str) -> Result<String> {
+        self.started.notify_waiters();
+        self.release_prompt.notified().await;
+        Ok("completed".to_string())
+    }
 
-fn cancel_sentinel_path() -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time should be after unix epoch")
-        .as_nanos();
-    std::env::temp_dir().join(format!("harnx-issue-68-cancel-{unique}.txt"))
-}
+    async fn session_cancel(&self, session_id: &str) -> Result<()> {
+        self.cancelled_sessions
+            .lock()
+            .expect("cancelled sessions mutex should lock")
+            .push(session_id.to_string());
+        Ok(())
+    }
 
-async fn wait_for_sentinel(path: &Path) -> Result<String> {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-    loop {
-        if let Ok(contents) = tokio::fs::read_to_string(path).await {
-            if !contents.trim().is_empty() {
-                return Ok(contents);
-            }
-        }
-        if tokio::time::Instant::now() >= deadline {
-            return Err(anyhow!("cancel sentinel was not created"));
-        }
-        tokio::time::sleep(Duration::from_millis(25)).await;
+    async fn wait_until_prompt_started(&self) {
+        self.started.notified().await;
+    }
+
+    fn cancelled_sessions(&self) -> Vec<String> {
+        self.cancelled_sessions
+            .lock()
+            .expect("cancelled sessions mutex should lock")
+            .clone()
     }
 }
 
 #[tokio::test(flavor = "current_thread")]
 async fn test_call_tool_session_prompt_ctrl_c_cancels_session() {
-    let sentinel_path = cancel_sentinel_path();
-    let _ = std::fs::remove_file(&sentinel_path);
+    let client = Arc::new(FakePromptClient::new());
+    let prompt_client = Arc::clone(&client);
+    let cancel_client = Arc::clone(&client);
+    let session_id = "session-1".to_string();
 
-    let mut env = HashMap::new();
-    env.insert(
-        "ACP_CANCEL_SENTINEL".to_string(),
-        sentinel_path.display().to_string(),
-    );
-
-    let manager = AcpManager::new();
-    manager.initialize(vec![AcpServerConfig {
-        name: "issue68".to_string(),
-        command: acp_test_binary_path().display().to_string(),
-        args: vec![],
-        env,
-        enabled: true,
-        description: Some("mock ACP server for issue 68 regression".to_string()),
-        idle_timeout_secs: 10,
-        operation_timeout_secs: 10,
-    }]);
-
-    let client = manager
-        .get_client("issue68")
-        .expect("ACP test client should be initialized");
-    let session_id = client.session_new().await.expect("create ACP test session");
-
-    let session_id_for_call = session_id.clone();
-    let (abort_tx, abort_rx) = tokio::sync::oneshot::channel::<()>();
+    let (abort_tx, abort_rx) = oneshot::channel::<()>();
     let call_task = tokio::spawn(async move {
-        session_prompt_with_abort(
-            &client,
-            session_id_for_call,
+        session_prompt_with_abort_for_test(
+            move |session_id, message| {
+                let client = Arc::clone(&prompt_client);
+                async move { client.session_prompt(session_id.as_deref(), &message).await }
+            },
+            move |session_id| {
+                let client = Arc::clone(&cancel_client);
+                async move { client.session_cancel(&session_id).await }
+            },
+            session_id,
+            "please hang".to_string(),
+            async move {
+                let _ = abort_rx.await;
+            },
+        )
+        .await
+    });
+
+    client.wait_until_prompt_started().await;
+    abort_tx.send(()).expect("trigger ACP abort");
+
+    let result = call_task.await.expect("call task should join cleanly");
+    let err = result.expect_err("abort should fail ACP session prompt");
+    assert!(err.to_string().contains("aborted by user"));
+    assert_eq!(client.cancelled_sessions(), vec!["session-1".to_string()]);
+    client.release_prompt.notify_waiters();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_call_tool_session_prompt_ctrl_c_cancel_timeout_is_best_effort() {
+    let session_id = "session-timeout".to_string();
+
+    let (abort_tx, abort_rx) = oneshot::channel::<()>();
+    let call_task = tokio::spawn(async move {
+        session_prompt_with_abort_for_test(
+            |_session_id, _message| async move {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                Ok("completed".to_string())
+            },
+            |_session_id| async move {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                Ok(())
+            },
+            session_id,
             "please hang".to_string(),
             async move {
                 let _ = abort_rx.await;
@@ -99,13 +107,11 @@ async fn test_call_tool_session_prompt_ctrl_c_cancels_session() {
     });
 
     abort_tx.send(()).expect("trigger ACP abort");
-    let result = call_task.await.expect("call task should join cleanly");
-    result.expect_err("abort should fail ACP session prompt");
 
-    let cancelled_session_id = wait_for_sentinel(&sentinel_path)
+    let result = tokio::time::timeout(Duration::from_secs(6), call_task)
         .await
-        .expect("mock server should record ACP cancellation");
-    assert_eq!(cancelled_session_id.trim(), session_id);
-
-    let _ = std::fs::remove_file(&sentinel_path);
+        .expect("abort path should not block indefinitely")
+        .expect("call task should join cleanly");
+    let err = result.expect_err("abort should fail ACP session prompt");
+    assert!(err.to_string().contains("aborted by user"));
 }

--- a/src/acp/test_regression_issue_68.rs
+++ b/src/acp/test_regression_issue_68.rs
@@ -1,0 +1,162 @@
+use super::*;
+use anyhow::{anyhow, Result};
+use serde_json::json;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+
+fn acp_test_binary_path() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_harnx-acp-test") {
+        return PathBuf::from(path);
+    }
+
+    let current_exe = std::env::current_exe().expect("current test executable path");
+    let deps_dir = current_exe
+        .parent()
+        .expect("test executable should have parent directory");
+    let target_dir = deps_dir
+        .parent()
+        .expect("deps directory should have target profile parent");
+    target_dir.join(format!("harnx-acp-test{}", std::env::consts::EXE_SUFFIX))
+}
+
+fn cancel_sentinel_path() -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("harnx-issue-68-cancel-{unique}.txt"))
+}
+
+async fn wait_for_sentinel(path: &Path) -> Result<String> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(contents) = tokio::fs::read_to_string(path).await {
+            return Ok(contents);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(anyhow!("cancel sentinel was not created"));
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn spawn_mock_issue_68_server() -> Result<Child> {
+    let binary_path = acp_test_binary_path();
+    let mut child = Command::new(&binary_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .expect("mock ACP server should have stdout");
+    let mut reader = BufReader::new(stdout).lines();
+    let ready = tokio::time::timeout(Duration::from_secs(5), reader.next_line())
+        .await
+        .expect("mock ACP server ready line timeout")?
+        .expect("mock ACP server should emit ready line");
+    assert_eq!(ready, "READY");
+    child.stdout = Some(reader.into_inner().into_inner());
+    Ok(child)
+}
+
+async fn assert_mock_server_is_reachable(child: &mut Child) -> Result<()> {
+    if let Some(status) = child.try_wait()? {
+        return Err(anyhow!(
+            "mock ACP server exited unexpectedly with status {status}"
+        ));
+    }
+    Ok(())
+}
+
+async fn send_sigint_after(delay: Duration) {
+    tokio::time::sleep(delay).await;
+    unsafe {
+        libc::raise(libc::SIGINT);
+    }
+}
+
+struct SignalTrap {
+    previous: libc::sighandler_t,
+}
+
+impl SignalTrap {
+    fn install() -> Self {
+        extern "C" fn handler(_sig: libc::c_int) {}
+
+        let previous =
+            unsafe { libc::signal(libc::SIGINT, handler as *const () as libc::sighandler_t) };
+        Self { previous }
+    }
+}
+
+impl Drop for SignalTrap {
+    fn drop(&mut self) {
+        unsafe {
+            libc::signal(libc::SIGINT, self.previous);
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_call_tool_session_prompt_ctrl_c_cancels_session() {
+    let _signal_trap = SignalTrap::install();
+    let sentinel_path = cancel_sentinel_path();
+    let _ = std::fs::remove_file(&sentinel_path);
+
+    let mut env = HashMap::new();
+    env.insert(
+        "ACP_CANCEL_SENTINEL".to_string(),
+        sentinel_path.display().to_string(),
+    );
+
+    let mut server = spawn_mock_issue_68_server()
+        .await
+        .expect("spawn mock ACP issue 68 server");
+
+    let manager = AcpManager::new();
+    manager.initialize(vec![AcpServerConfig {
+        name: "issue68".to_string(),
+        command: acp_test_binary_path().display().to_string(),
+        args: vec![],
+        env,
+        enabled: true,
+        description: Some("mock ACP server for issue 68 regression".to_string()),
+        idle_timeout_secs: 10,
+        operation_timeout_secs: 10,
+    }]);
+
+    let ctrl_c_task = tokio::spawn(send_sigint_after(Duration::from_millis(300)));
+    let result = manager
+        .call_tool(
+            "issue68_session_prompt",
+            json!({ "message": "please hang" }),
+        )
+        .await;
+    ctrl_c_task.await.expect("ctrl-c sender task should finish");
+
+    let err = result.expect_err("ctrl_c should abort ACP session_prompt");
+    assert!(err.to_string().contains("aborted by user"));
+
+    let cancelled_session_id = wait_for_sentinel(&sentinel_path)
+        .await
+        .expect("mock server should record ACP cancellation");
+    assert_eq!(cancelled_session_id.trim(), "session-1");
+
+    assert_mock_server_is_reachable(&mut server)
+        .await
+        .expect("mock server should still be responsive after cancellation");
+
+    if let Some(mut stdin) = server.stdin.take() {
+        let _ = stdin.write_all(b"STOP\n").await;
+        let _ = stdin.flush().await;
+    }
+    let _ = tokio::time::timeout(Duration::from_secs(5), server.wait()).await;
+    let _ = std::fs::remove_file(&sentinel_path);
+}

--- a/src/bin/harnx-acp-test/main.rs
+++ b/src/bin/harnx-acp-test/main.rs
@@ -159,8 +159,8 @@ fn handle_request(message: Value, state: Arc<SessionState>) {
 
             state.set_cancelled();
             record_cancel(&session_id);
-            println!("CANCELLED:{session_id}");
-            io::stdout().flush().ok();
+            eprintln!("CANCELLED:{session_id}");
+            io::stderr().flush().ok();
         }
         "session/cancel" => {
             let session_id = params

--- a/src/bin/harnx-acp-test/main.rs
+++ b/src/bin/harnx-acp-test/main.rs
@@ -9,13 +9,14 @@
 use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
 use serde_json::{json, Value};
 
 static RUNNING: AtomicBool = AtomicBool::new(true);
+static WAIT_BEFORE_PROMPT_MS: AtomicU64 = AtomicU64::new(0);
 
 fn cancel_sentinel_path() -> Option<PathBuf> {
     std::env::var("ACP_CANCEL_SENTINEL")
@@ -54,7 +55,7 @@ fn send_error(msg_id: u64, code: i64, message: &str) {
 }
 
 struct SessionState {
-    current_session_id: std::sync::Mutex<Option<String>>,
+    current_session_id: Mutex<Option<String>>,
     next_session: AtomicU64,
     cancel_flag: AtomicBool,
 }
@@ -62,7 +63,7 @@ struct SessionState {
 impl SessionState {
     fn new() -> Self {
         Self {
-            current_session_id: std::sync::Mutex::new(None),
+            current_session_id: Mutex::new(None),
             next_session: AtomicU64::new(1),
             cancel_flag: AtomicBool::new(false),
         }
@@ -90,6 +91,11 @@ impl SessionState {
 }
 
 fn prompt_worker(msg_id: u64, _session_id: String, state: Arc<SessionState>) {
+    let wait_before_prompt_ms = WAIT_BEFORE_PROMPT_MS.load(Ordering::SeqCst);
+    if wait_before_prompt_ms > 0 {
+        thread::sleep(Duration::from_millis(wait_before_prompt_ms));
+    }
+
     // Simulate a long-running prompt that checks for cancellation
     while RUNNING.load(Ordering::SeqCst) && !state.is_cancelled() {
         thread::sleep(Duration::from_millis(50));
@@ -178,6 +184,17 @@ fn handle_request(message: Value, state: Arc<SessionState>) {
 }
 
 fn main() {
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--wait-before-prompt-ms" {
+            if let Some(value) = args.next() {
+                if let Ok(parsed) = value.parse::<u64>() {
+                    WAIT_BEFORE_PROMPT_MS.store(parsed, Ordering::SeqCst);
+                }
+            }
+        }
+    }
+
     // Ignore SIGINT so we can test cancellation properly
     #[cfg(unix)]
     {

--- a/src/bin/harnx-acp-test/main.rs
+++ b/src/bin/harnx-acp-test/main.rs
@@ -1,0 +1,218 @@
+//! harnx-acp-test: Mock ACP server for testing cancellation behavior.
+//!
+//! This binary implements a minimal ACP server that supports session/prompt
+//! with hanging behavior to test SIGINT/cancellation handling.
+//!
+//! Environment variables:
+//!   ACP_CANCEL_SENTINEL - Path to write the session ID when cancellation is received
+
+use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+static RUNNING: AtomicBool = AtomicBool::new(true);
+
+fn cancel_sentinel_path() -> Option<PathBuf> {
+    std::env::var("ACP_CANCEL_SENTINEL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .map(PathBuf::from)
+}
+
+fn record_cancel(session_id: &str) {
+    if let Some(path) = cancel_sentinel_path() {
+        if let Err(e) = std::fs::write(&path, session_id) {
+            eprintln!("harnx-acp-test: failed to write cancel sentinel: {e}");
+        }
+    }
+}
+
+fn send_response(msg_id: u64, result: Value) {
+    let message = json!({
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "result": result
+    });
+    println!("{message}");
+}
+
+fn send_error(msg_id: u64, code: i64, message: &str) {
+    let message = json!({
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {
+            "code": code,
+            "message": message
+        }
+    });
+    println!("{message}");
+}
+
+struct SessionState {
+    current_session_id: std::sync::Mutex<Option<String>>,
+    next_session: AtomicU64,
+    cancel_flag: AtomicBool,
+}
+
+impl SessionState {
+    fn new() -> Self {
+        Self {
+            current_session_id: std::sync::Mutex::new(None),
+            next_session: AtomicU64::new(1),
+            cancel_flag: AtomicBool::new(false),
+        }
+    }
+
+    fn create_session(&self) -> String {
+        let id = self.next_session.fetch_add(1, Ordering::SeqCst);
+        let session_id = format!("session-{id}");
+        *self.current_session_id.lock().unwrap() = Some(session_id.clone());
+        self.cancel_flag.store(false, Ordering::SeqCst);
+        session_id
+    }
+
+    fn current_session(&self) -> Option<String> {
+        self.current_session_id.lock().unwrap().clone()
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancel_flag.load(Ordering::SeqCst)
+    }
+
+    fn set_cancelled(&self) {
+        self.cancel_flag.store(true, Ordering::SeqCst);
+    }
+}
+
+fn prompt_worker(msg_id: u64, _session_id: String, state: Arc<SessionState>) {
+    // Simulate a long-running prompt that checks for cancellation
+    while RUNNING.load(Ordering::SeqCst) && !state.is_cancelled() {
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    if state.is_cancelled() {
+        // Don't send response if cancelled
+        return;
+    }
+
+    send_response(
+        msg_id,
+        json!({
+            "content": [{"type": "text", "text": "completed"}]
+        }),
+    );
+}
+
+fn handle_request(message: Value, state: Arc<SessionState>) {
+    let msg_id = message.get("id").and_then(|v| v.as_u64()).unwrap_or(0);
+    let method = message.get("method").and_then(|v| v.as_str()).unwrap_or("");
+    let params = message.get("params").cloned().unwrap_or(json!({}));
+
+    eprintln!("METHOD:{method}");
+
+    match method {
+        "initialize" => {
+            send_response(
+                msg_id,
+                json!({
+                    "protocolVersion": 1,
+                    "capabilities": {},
+                    "agentCapabilities": {}
+                }),
+            );
+        }
+        "session/new" => {
+            let session_id = state.create_session();
+            send_response(msg_id, json!({"sessionId": session_id}));
+        }
+        "session/prompt" => {
+            let session_id = params
+                .get("sessionId")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+                .or_else(|| state.current_session())
+                .unwrap_or_else(|| "unknown".to_string());
+
+            let state_clone = Arc::clone(&state);
+            thread::spawn(move || {
+                prompt_worker(msg_id, session_id, state_clone);
+            });
+        }
+        "notifications/cancel" => {
+            let session_id = params
+                .get("sessionId")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+                .or_else(|| state.current_session())
+                .unwrap_or_else(|| "unknown".to_string());
+
+            state.set_cancelled();
+            record_cancel(&session_id);
+            println!("CANCELLED:{session_id}");
+            io::stdout().flush().ok();
+        }
+        "session/cancel" => {
+            let session_id = params
+                .get("sessionId")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+                .or_else(|| state.current_session())
+                .unwrap_or_else(|| "unknown".to_string());
+
+            state.set_cancelled();
+            record_cancel(&session_id);
+            send_response(msg_id, json!({}));
+        }
+        "session/load" => {
+            send_response(msg_id, json!({}));
+        }
+        _ => {
+            send_error(msg_id, -32601, &format!("Unknown method: {method}"));
+        }
+    }
+}
+
+fn main() {
+    // Ignore SIGINT so we can test cancellation properly
+    #[cfg(unix)]
+    {
+        // Set SIGINT handler to ignore - this lets the process survive SIGINT
+        // so the test can verify that the ACP cancellation notification is sent
+        // and received before the process terminates.
+        unsafe {
+            libc::signal(libc::SIGINT, libc::SIG_IGN);
+        }
+    }
+
+    // Signal ready
+    println!("READY");
+    io::stdout().flush().ok();
+
+    let state = Arc::new(SessionState::new());
+    let stdin = io::stdin();
+    let mut lines = stdin.lock().lines();
+
+    while RUNNING.load(Ordering::SeqCst) {
+        let line = match lines.next() {
+            Some(Ok(l)) => l,
+            Some(Err(_)) | None => break,
+        };
+
+        let trimmed = line.trim();
+        if trimmed == "STOP" {
+            break;
+        }
+
+        let message: Value = match serde_json::from_str(trimmed) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+
+        handle_request(message, Arc::clone(&state));
+    }
+}

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -448,13 +448,6 @@ impl EmbeddingsData {
     pub fn new(texts: Vec<String>, query: bool) -> Self {
         Self { texts, query }
     }
-
-    pub fn try_get_text(&self) -> Result<&str> {
-        if self.texts.len() != 1 {
-            bail!("EmbeddingsData must contain exactly one text");
-        }
-        Ok(&self.texts[0])
-    }
 }
 
 pub type EmbeddingsOutput = Vec<Vec<f32>>;

--- a/src/client/gemini.rs
+++ b/src/client/gemini.rs
@@ -1,12 +1,13 @@
 use super::vertexai::*;
 use super::*;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use reqwest::RequestBuilder;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
 const API_BASE: &str = "https://generativelanguage.googleapis.com/v1beta";
+const GEMINI_MAX_BATCH_SIZE: usize = 100;
 
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct GeminiConfig {
@@ -72,29 +73,49 @@ fn prepare_chat_completions(
 }
 
 fn prepare_embeddings(self_: &GeminiClient, data: &EmbeddingsData) -> Result<RequestData> {
+    if data.texts.len() > GEMINI_MAX_BATCH_SIZE {
+        bail!(
+            "Gemini embeddings support at most {GEMINI_MAX_BATCH_SIZE} texts per request, got {}",
+            data.texts.len()
+        );
+    }
+
     let api_key = self_.get_api_key()?;
     let api_base = self_
         .get_api_base()
         .unwrap_or_else(|_| API_BASE.to_string());
 
-    let url = format!(
-        "{}/models/{}:embedContent?key={}",
-        api_base.trim_end_matches('/'),
-        self_.model.real_name(),
-        api_key
-    );
+    let requests: Vec<Value> = data
+        .texts
+        .iter()
+        .map(|text| {
+            json!({
+                "model": format!("models/{}", self_.model.real_name()),
+                "content": {
+                    "parts": [
+                        {
+                            "text": text
+                        }
+                    ]
+                }
+            })
+        })
+        .collect();
 
     let body = json!({
-        "content": {
-            "parts": [
-                {
-                    "text": data.try_get_text()?
-                }
-            ]
-        },
+        "requests": requests,
     });
 
-    let request_data = RequestData::new(url, body);
+    let mut request_data = RequestData::new(
+        format!(
+            "{}/models/{}:batchEmbedContents",
+            api_base.trim_end_matches('/'),
+            self_.model.real_name(),
+        ),
+        body,
+    );
+    request_data.header("x-goog-api-key", api_key);
+    request_data.header("Content-Type", "application/json");
 
     Ok(request_data)
 }


### PR DESCRIPTION
## Summary
- add a Rust ACP test helper binary for regression scenarios
- cover ACP ctrl-c cancellation by asserting the mock server records the cancel event
- replace the temporary script-based helper approach with an in-repo Rust binary

## Testing
- cargo fmt --all
- cargo build
- cargo clippy --all --all-targets -- -D warnings
- cargo nextest run --all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression tests for session cancellation and a new test helper binary to mock ACP behavior.
* **CLI Completions**
  * Updated shell completions: removed role/execute/code options and added ACP, MCP-root, tool, and serve completions across shells.
* **Embeddings**
  * Switched to batch embeddings with a new max batch size and added runtime validation for request size.
* **Changelog**
  * Added a patch release entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->