### PR TITLE
fix(acp): unify UI output events for local and remote flows

### DIFF
--- a/src/acp/client.rs
+++ b/src/acp/client.rs
@@ -960,51 +960,84 @@ fn agent_from_meta_value(value: &serde_json::Value) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+fn session_from_meta_value(value: &serde_json::Value) -> Option<String> {
+    value
+        .get("session")
+        .and_then(serde_json::Value::as_str)
+        .filter(|session| !session.is_empty())
+        .map(ToOwned::to_owned)
+}
+
 fn resolve_notification_source(
     fallback_agent: &str,
     notification: &acp::SessionNotification,
 ) -> UiOutputSource {
     let session_id = notification.session_id.0.to_string();
-    let update_agent = match &notification.update {
-        acp::SessionUpdate::AgentMessageChunk(chunk) => chunk
-            .meta
-            .as_ref()
-            .and_then(|meta| agent_from_meta_value(&json!(meta))),
-        acp::SessionUpdate::AgentThoughtChunk(chunk) => chunk
-            .meta
-            .as_ref()
-            .and_then(|meta| agent_from_meta_value(&json!(meta))),
-        acp::SessionUpdate::ToolCall(call) => call
-            .meta
-            .as_ref()
-            .and_then(|meta| agent_from_meta_value(&json!(meta))),
-        acp::SessionUpdate::ToolCallUpdate(update) => update
-            .meta
-            .as_ref()
-            .and_then(|meta| agent_from_meta_value(&json!(meta))),
-        acp::SessionUpdate::Plan(plan) => plan
-            .meta
-            .as_ref()
-            .and_then(|meta| agent_from_meta_value(&json!(meta))),
-        acp::SessionUpdate::SessionInfoUpdate(info) => info
-            .meta
-            .as_ref()
-            .and_then(|meta| meta.get("agent"))
-            .and_then(serde_json::Value::as_str)
-            .filter(|agent| !agent.is_empty())
-            .map(ToOwned::to_owned)
-            .or_else(|| {
-                info.meta
+    let (update_agent, update_session) = match &notification.update {
+        acp::SessionUpdate::AgentMessageChunk(chunk) => {
+            let meta = chunk.meta.as_ref().map(|meta| json!(meta));
+            (
+                meta.as_ref().and_then(agent_from_meta_value),
+                meta.as_ref().and_then(session_from_meta_value),
+            )
+        }
+        acp::SessionUpdate::AgentThoughtChunk(chunk) => {
+            let meta = chunk.meta.as_ref().map(|meta| json!(meta));
+            (
+                meta.as_ref().and_then(agent_from_meta_value),
+                meta.as_ref().and_then(session_from_meta_value),
+            )
+        }
+        acp::SessionUpdate::ToolCall(call) => {
+            let meta = call.meta.as_ref().map(|meta| json!(meta));
+            (
+                meta.as_ref().and_then(agent_from_meta_value),
+                meta.as_ref().and_then(session_from_meta_value),
+            )
+        }
+        acp::SessionUpdate::ToolCallUpdate(update) => {
+            let meta = update.meta.as_ref().map(|meta| json!(meta));
+            (
+                meta.as_ref().and_then(agent_from_meta_value),
+                meta.as_ref().and_then(session_from_meta_value),
+            )
+        }
+        acp::SessionUpdate::Plan(plan) => {
+            let meta = plan.meta.as_ref().map(|meta| json!(meta));
+            (
+                meta.as_ref().and_then(agent_from_meta_value),
+                meta.as_ref().and_then(session_from_meta_value),
+            )
+        }
+        acp::SessionUpdate::SessionInfoUpdate(info) => {
+            let direct_meta = info.meta.as_ref().map(|meta| json!(meta));
+            (
+                direct_meta
                     .as_ref()
-                    .and_then(|meta| meta.get("harnx:usage"))
                     .and_then(agent_from_meta_value)
-            }),
-        _ => None,
+                    .or_else(|| {
+                        info.meta
+                            .as_ref()
+                            .and_then(|meta| meta.get("harnx:usage"))
+                            .and_then(agent_from_meta_value)
+                    }),
+                direct_meta
+                    .as_ref()
+                    .and_then(session_from_meta_value)
+                    .or_else(|| {
+                        info.meta
+                            .as_ref()
+                            .and_then(|meta| meta.get("harnx:usage"))
+                            .and_then(session_from_meta_value)
+                    }),
+            )
+        }
+        _ => (None, None),
     };
 
     UiOutputSource {
         agent: update_agent.unwrap_or_else(|| fallback_agent.to_string()),
-        session_id: Some(session_id),
+        session_id: Some(update_session.unwrap_or(session_id)),
     }
 }
 
@@ -1097,6 +1130,23 @@ mod tests {
         let source = resolve_notification_source("argus", &notification);
         assert_eq!(source.agent, "argus");
         assert_eq!(source.session_id.as_deref(), Some("outer-session"));
+    }
+
+    #[test]
+    fn resolve_notification_source_uses_nested_session_when_present() {
+        let notification = acp::SessionNotification::new(
+            acp::SessionId::new("outer-session"),
+            acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new("hello".into()).meta(
+                serde_json::Map::from_iter([
+                    ("agent".to_string(), json!("aristarchus")),
+                    ("session".to_string(), json!("nested-session")),
+                ]),
+            )),
+        );
+
+        let source = resolve_notification_source("argus", &notification);
+        assert_eq!(source.agent, "aristarchus");
+        assert_eq!(source.session_id.as_deref(), Some("nested-session"));
     }
 
     #[test]

--- a/src/acp/client.rs
+++ b/src/acp/client.rs
@@ -7,6 +7,7 @@ use crate::ui_output::{
 };
 use agent_client_protocol::{self as acp, Agent as _};
 use anyhow::{anyhow, Context, Result};
+use serde_json::json;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::pin::Pin;
@@ -105,26 +106,23 @@ impl AcpNotificationClient {
     /// Forward a display-only chunk (e.g. usage banner) to subscribers or
     /// stderr.  Unlike the main chunk path this never touches
     /// `state.response_text`.
-    async fn forward_display_chunk(&self, text: &str, session_id: &str) {
+    async fn forward_display_chunk(&self, text: &str, source: UiOutputSource) {
         self.forward_ui_output_event(
             UiOutputEvent {
                 kind: UiOutputEventKind::TranscriptText {
                     text: text.to_string(),
                 },
-                source: None,
+                source: Some(source.clone()),
             },
-            session_id,
+            source,
         )
         .await;
     }
 
-    async fn forward_ui_output_event(&self, event: UiOutputEvent, session_id: &str) {
+    async fn forward_ui_output_event(&self, event: UiOutputEvent, source: UiOutputSource) {
         let mut delivered = false;
         let mut forwarders = self.chunk_forwarder.write().await;
-        let source = Some(UiOutputSource {
-            agent: self.agent_name.clone(),
-            session_id: Some(session_id.to_string()),
-        });
+        let source = event.source.clone().or(Some(source));
         let text_fallback = format_ui_event_for_terminal(&event.kind, source.as_ref());
         let event = UiOutputEvent {
             kind: event.kind,
@@ -201,6 +199,7 @@ impl acp::Client for AcpNotificationClient {
     async fn session_notification(&self, args: acp::SessionNotification) -> acp::Result<()> {
         let session_id = args.session_id.0.to_string();
         let _ = self.activity_tx.send(session_id.clone());
+        let resolved_source = resolve_notification_source(&self.agent_name, &args);
 
         // Handle SessionInfoUpdate separately: its display output is
         // display-only metadata (e.g. usage banners) that must never be
@@ -210,42 +209,50 @@ impl acp::Client for AcpNotificationClient {
         // SessionInfoUpdate with an early return we keep it out of the
         // shared chunk → response_text path entirely.
         if let acp::SessionUpdate::SessionInfoUpdate(ref info) = args.update {
-            if let Some(event) = session_info_update_event(info) {
-                self.forward_ui_output_event(event, &session_id).await;
+            if let Some(event) = session_info_update_event(info, resolved_source.clone()) {
+                self.forward_ui_output_event(event, resolved_source.clone())
+                    .await;
             }
             return Ok(());
         }
 
         let is_agent_message = matches!(args.update, acp::SessionUpdate::AgentMessageChunk(_));
         let event = match args.update {
-            acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk { content, .. }) => {
-                let text = content_block_to_text(&content);
+            acp::SessionUpdate::AgentMessageChunk(chunk) => {
+                let text = chunk_text(&chunk.content);
                 if text.trim().is_empty() {
                     None
                 } else {
                     Some(UiOutputEvent {
-                        kind: UiOutputEventKind::LlmText(text),
-                        source: None,
+                        kind: UiOutputEventKind::MessageChunk {
+                            text,
+                            raw: Some(Box::new(chunk)),
+                        },
+                        source: Some(resolved_source.clone()),
                     })
                 }
             }
-            acp::SessionUpdate::AgentThoughtChunk(acp::ContentChunk { content, .. }) => {
-                let text = content_block_to_text(&content);
-                if text.is_empty() {
+            acp::SessionUpdate::AgentThoughtChunk(chunk) => {
+                let text = chunk_text(&chunk.content);
+                if text.trim().is_empty() {
                     None
                 } else {
                     Some(UiOutputEvent {
-                        kind: UiOutputEventKind::AcpThought { text },
-                        source: None,
+                        kind: UiOutputEventKind::ThoughtChunk {
+                            text,
+                            raw: Some(Box::new(chunk)),
+                        },
+                        source: Some(resolved_source.clone()),
                     })
                 }
             }
             acp::SessionUpdate::ToolCall(tc) => Some(UiOutputEvent {
-                kind: UiOutputEventKind::StructuredBlock {
-                    title: tc.title,
-                    body: tc.raw_input.as_ref().map(pretty_yaml_block),
+                kind: UiOutputEventKind::ToolCall {
+                    tool_name: tc.title.clone(),
+                    input_yaml: tc.raw_input.as_ref().map(pretty_yaml_block),
+                    raw: Some(Box::new(tc)),
                 },
-                source: None,
+                source: Some(resolved_source.clone()),
             }),
             acp::SessionUpdate::ToolCallUpdate(tcu) => {
                 let title = tcu.fields.title.clone();
@@ -259,14 +266,12 @@ impl acp::Client for AcpNotificationClient {
                     None
                 } else {
                     Some(UiOutputEvent {
-                        kind: UiOutputEventKind::StatusLine {
-                            text: crate::tui::render_helpers::render_status_line(
-                                title.as_deref(),
-                                status.as_deref(),
-                            )
-                            .unwrap_or_default(),
+                        kind: UiOutputEventKind::ToolCallUpdate {
+                            title,
+                            status,
+                            raw: Some(Box::new(tcu)),
                         },
-                        source: None,
+                        source: Some(resolved_source.clone()),
                     })
                 }
             }
@@ -287,7 +292,7 @@ impl acp::Client for AcpNotificationClient {
                 } else {
                     Some(UiOutputEvent {
                         kind: UiOutputEventKind::Plan { entries },
-                        source: None,
+                        source: Some(resolved_source.clone()),
                     })
                 }
             }
@@ -311,7 +316,7 @@ impl acp::Client for AcpNotificationClient {
         if let Some(event) = event {
             let chunk_for_response = if is_agent_message {
                 match &event.kind {
-                    UiOutputEventKind::LlmText(text)
+                    UiOutputEventKind::MessageChunk { text, .. }
                     | UiOutputEventKind::TranscriptText { text } => Some(text.clone()),
                     _ => None,
                 }
@@ -319,7 +324,8 @@ impl acp::Client for AcpNotificationClient {
                 None
             };
 
-            self.forward_ui_output_event(event, &session_id).await;
+            self.forward_ui_output_event(event, resolved_source.clone())
+                .await;
 
             if let Some(chunk) = chunk_for_response {
                 let mut sessions = self.sessions.write().await;
@@ -946,34 +952,76 @@ fn wrap_display_text(text: &str, initial_indent: &str, subsequent_indent: &str) 
     wrap(text, options).join("\n")
 }
 
-fn session_info_update_event(info: &acp::SessionInfoUpdate) -> Option<UiOutputEvent> {
+fn agent_from_meta_value(value: &serde_json::Value) -> Option<String> {
+    value
+        .get("agent")
+        .and_then(serde_json::Value::as_str)
+        .filter(|agent| !agent.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn resolve_notification_source(
+    fallback_agent: &str,
+    notification: &acp::SessionNotification,
+) -> UiOutputSource {
+    let session_id = notification.session_id.0.to_string();
+    let update_agent = match &notification.update {
+        acp::SessionUpdate::AgentMessageChunk(chunk) => chunk
+            .meta
+            .as_ref()
+            .and_then(|meta| agent_from_meta_value(&json!(meta))),
+        acp::SessionUpdate::AgentThoughtChunk(chunk) => chunk
+            .meta
+            .as_ref()
+            .and_then(|meta| agent_from_meta_value(&json!(meta))),
+        acp::SessionUpdate::ToolCall(call) => call
+            .meta
+            .as_ref()
+            .and_then(|meta| agent_from_meta_value(&json!(meta))),
+        acp::SessionUpdate::ToolCallUpdate(update) => update
+            .meta
+            .as_ref()
+            .and_then(|meta| agent_from_meta_value(&json!(meta))),
+        acp::SessionUpdate::Plan(plan) => plan
+            .meta
+            .as_ref()
+            .and_then(|meta| agent_from_meta_value(&json!(meta))),
+        acp::SessionUpdate::SessionInfoUpdate(info) => info
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.get("agent"))
+            .and_then(serde_json::Value::as_str)
+            .filter(|agent| !agent.is_empty())
+            .map(ToOwned::to_owned)
+            .or_else(|| {
+                info.meta
+                    .as_ref()
+                    .and_then(|meta| meta.get("harnx:usage"))
+                    .and_then(agent_from_meta_value)
+            }),
+        _ => None,
+    };
+
+    UiOutputSource {
+        agent: update_agent.unwrap_or_else(|| fallback_agent.to_string()),
+        session_id: Some(session_id),
+    }
+}
+
+fn session_info_update_event(
+    info: &acp::SessionInfoUpdate,
+    source: UiOutputSource,
+) -> Option<UiOutputEvent> {
     let meta = info.meta.as_ref()?;
     let usage = meta.get("harnx:usage")?;
     let input_tokens = usage["input_tokens"].as_u64().unwrap_or(0);
     let output_tokens = usage["output_tokens"].as_u64().unwrap_or(0);
     let cached_tokens = usage["cached_tokens"].as_u64().unwrap_or(0);
-    let agent = usage["agent"].as_str().unwrap_or("");
-    let session = usage["session"].as_str().unwrap_or("");
-    if input_tokens == 0 && output_tokens == 0 {
+    if input_tokens == 0 && output_tokens == 0 && cached_tokens == 0 {
         return None;
     }
 
-    let session_label = match (agent.is_empty(), session.is_empty()) {
-        (false, false) => Some(crate::tui::render_helpers::source_heading(
-            &UiOutputSource {
-                agent: agent.to_string(),
-                session_id: Some(session.to_string()),
-            },
-        )),
-        (false, true) => Some(crate::tui::render_helpers::source_heading(
-            &UiOutputSource {
-                agent: agent.to_string(),
-                session_id: None,
-            },
-        )),
-        (true, false) => Some(format!("💬 {}", session)),
-        (true, true) => None,
-    };
+    let session_label = Some(crate::tui::render_helpers::source_heading(&source));
 
     Some(UiOutputEvent {
         kind: UiOutputEventKind::Usage {
@@ -982,18 +1030,11 @@ fn session_info_update_event(info: &acp::SessionInfoUpdate) -> Option<UiOutputEv
             cached_tokens,
             session_label,
         },
-        source: None,
+        source: Some(source),
     })
 }
 
-fn format_ui_event_for_terminal(
-    kind: &UiOutputEventKind,
-    source: Option<&UiOutputSource>,
-) -> String {
-    event_fallback_text(kind, source)
-}
-
-fn content_block_to_text(content: &acp::ContentBlock) -> String {
+fn chunk_text(content: &acp::ContentBlock) -> String {
     match content {
         acp::ContentBlock::Text(text) => text.text.clone(),
         acp::ContentBlock::ResourceLink(link) => link.uri.to_string(),
@@ -1004,20 +1045,70 @@ fn content_block_to_text(content: &acp::ContentBlock) -> String {
     }
 }
 
+fn format_ui_event_for_terminal(
+    kind: &UiOutputEventKind,
+    source: Option<&UiOutputSource>,
+) -> String {
+    event_fallback_text(kind, source)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
 
     #[test]
+    fn session_info_update_event_preserves_outer_source() {
+        let info = acp::SessionInfoUpdate::new().meta(serde_json::Map::from_iter([(
+            "harnx:usage".to_string(),
+            json!({
+                "agent": "aristarchus",
+                "session": "nested-session-1",
+                "input_tokens": 10,
+                "output_tokens": 2,
+                "cached_tokens": 5,
+            }),
+        )]));
+
+        let event = session_info_update_event(
+            &info,
+            UiOutputSource {
+                agent: "fallback-agent".to_string(),
+                session_id: Some("outer-session-1".to_string()),
+            },
+        )
+        .expect("usage event");
+        assert!(matches!(
+            event.source,
+            Some(UiOutputSource {
+                agent,
+                session_id: Some(session_id)
+            }) if agent == "fallback-agent" && session_id == "outer-session-1"
+        ));
+    }
+
+    #[test]
+    fn resolve_notification_source_falls_back_to_client_name() {
+        let notification = acp::SessionNotification::new(
+            acp::SessionId::new("outer-session"),
+            acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new("hello".into())),
+        );
+
+        let source = resolve_notification_source("argus", &notification);
+        assert_eq!(source.agent, "argus");
+        assert_eq!(source.session_id.as_deref(), Some("outer-session"));
+    }
+
+    #[test]
     fn terminal_fallback_renders_structured_tool_call_and_plan() {
         let tool_rendered = format_ui_event_for_terminal(
-            &UiOutputEventKind::StructuredBlock {
-                title: "argus_session_prompt".to_string(),
-                body: Some(pretty_yaml_block(&json!({
+            &UiOutputEventKind::ToolCall {
+                tool_name: "argus_session_prompt".to_string(),
+                input_yaml: Some(pretty_yaml_block(&json!({
                     "message": "Goal — Something long that should remain visible\nAcceptance criteria — Multiline preserved",
                     "session_id": "abc123"
                 }))),
+                raw: None,
             },
             None,
         );
@@ -1049,9 +1140,11 @@ mod tests {
     #[test]
     fn agent_message_chunks_stay_verbatim_in_terminal_fallback() {
         let rendered = format_ui_event_for_terminal(
-            &UiOutputEventKind::LlmText(
-                "Line one from sub-agent\nLine two from sub-agent with extra detail".to_string(),
-            ),
+            &UiOutputEventKind::MessageChunk {
+                text: "Line one from sub-agent\nLine two from sub-agent with extra detail"
+                    .to_string(),
+                raw: None,
+            },
             None,
         );
 

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -436,9 +436,13 @@ async fn nested_ui_event_to_session_update(
         });
 
     match event.kind {
-        UiOutputEventKind::TranscriptText { text } => Some(acp::SessionUpdate::AgentMessageChunk(
-            acp::ContentChunk::new(text.into()),
-        )),
+        UiOutputEventKind::TranscriptText { text } => {
+            let mut chunk = acp::ContentChunk::new(text.into());
+            if let Some(meta) = source_meta.clone() {
+                chunk = chunk.meta(meta);
+            }
+            Some(acp::SessionUpdate::AgentMessageChunk(chunk))
+        }
         UiOutputEventKind::MessageChunk { text, raw } => {
             let mut chunk = raw
                 .map(|chunk| *chunk)

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -427,20 +427,60 @@ fn content_block_to_text(content: &acp::ContentBlock) -> String {
 async fn nested_ui_event_to_session_update(
     event: crate::ui_output::UiOutputEvent,
 ) -> Option<acp::SessionUpdate> {
+    let source_meta: Option<serde_json::Map<String, serde_json::Value>> =
+        event.source.as_ref().map(|source| {
+            serde_json::Map::from_iter([
+                ("agent".to_string(), json!(source.agent)),
+                ("session".to_string(), json!(source.session_id)),
+            ])
+        });
+
     match event.kind {
-        UiOutputEventKind::LlmText(text) | UiOutputEventKind::TranscriptText { text } => Some(
-            acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(text.into())),
-        ),
-        UiOutputEventKind::ToolResultText { .. } => None,
-        UiOutputEventKind::AcpThought { text } => Some(acp::SessionUpdate::AgentThoughtChunk(
+        UiOutputEventKind::TranscriptText { text } => Some(acp::SessionUpdate::AgentMessageChunk(
             acp::ContentChunk::new(text.into()),
         )),
-        UiOutputEventKind::StructuredBlock { title, body } => Some(acp::SessionUpdate::ToolCall(
-            acp::ToolCall::new(title, body.unwrap_or_default()),
-        )),
-        UiOutputEventKind::StatusLine { text } => Some(acp::SessionUpdate::ToolCallUpdate(
-            acp::ToolCallUpdate::new("status", acp::ToolCallUpdateFields::new().title(text)),
-        )),
+        UiOutputEventKind::MessageChunk { text, raw } => {
+            let mut chunk = raw
+                .map(|chunk| *chunk)
+                .unwrap_or_else(|| acp::ContentChunk::new(text.into()));
+            if let Some(meta) = source_meta.clone() {
+                chunk = chunk.meta(meta);
+            }
+            Some(acp::SessionUpdate::AgentMessageChunk(chunk))
+        }
+        UiOutputEventKind::ToolResultText { .. } => None,
+        UiOutputEventKind::ThoughtChunk { text, raw } => {
+            let mut chunk = raw
+                .map(|chunk| *chunk)
+                .unwrap_or_else(|| acp::ContentChunk::new(text.into()));
+            if let Some(meta) = source_meta.clone() {
+                chunk = chunk.meta(meta);
+            }
+            Some(acp::SessionUpdate::AgentThoughtChunk(chunk))
+        }
+        UiOutputEventKind::ToolCallUpdate { title, status, raw } => {
+            let mut update = if let Some(update) = raw {
+                *update
+            } else {
+                let mut fields = acp::ToolCallUpdateFields::new();
+                if let Some(title) = title {
+                    fields = fields.title(title);
+                }
+                if let Some(status) = status {
+                    let status = match status.as_str() {
+                        "completed" => acp::ToolCallStatus::Completed,
+                        "in_progress" => acp::ToolCallStatus::InProgress,
+                        _ => acp::ToolCallStatus::Pending,
+                    };
+                    fields = fields.status(status);
+                }
+                acp::ToolCallUpdate::new("status", fields)
+            };
+            if let Some(meta) = source_meta.clone() {
+                update = update.meta(meta);
+            }
+            Some(acp::SessionUpdate::ToolCallUpdate(update))
+        }
         UiOutputEventKind::Plan { entries } => {
             let mapped_entries = entries
                 .into_iter()
@@ -453,21 +493,39 @@ async fn nested_ui_event_to_session_update(
                     acp::PlanEntry::new(entry.content, acp::PlanEntryPriority::Medium, status)
                 })
                 .collect();
-            Some(acp::SessionUpdate::Plan(acp::Plan::new(mapped_entries)))
+            let mut plan = acp::Plan::new(mapped_entries);
+            if let Some(meta) = source_meta.clone() {
+                plan = plan.meta(meta);
+            }
+            Some(acp::SessionUpdate::Plan(plan))
         }
-        UiOutputEventKind::McpToolInvocation {
+        UiOutputEventKind::ToolCall {
             tool_name,
             input_yaml,
-        } => Some(acp::SessionUpdate::ToolCall(acp::ToolCall::new(
-            tool_name,
-            input_yaml.unwrap_or_default(),
-        ))),
-        UiOutputEventKind::LlmFinal { output, .. } => Some(acp::SessionUpdate::AgentMessageChunk(
-            acp::ContentChunk::new(output.into()),
-        )),
-        UiOutputEventKind::LlmError(err) => Some(acp::SessionUpdate::AgentMessageChunk(
-            acp::ContentChunk::new(format!("[error] {err}").into()),
-        )),
+            raw,
+        } => {
+            let mut call = raw
+                .map(|call| *call)
+                .unwrap_or_else(|| acp::ToolCall::new(tool_name, input_yaml.unwrap_or_default()));
+            if let Some(meta) = source_meta.clone() {
+                call = call.meta(meta);
+            }
+            Some(acp::SessionUpdate::ToolCall(call))
+        }
+        UiOutputEventKind::LlmFinal { output, .. } => {
+            let mut chunk = acp::ContentChunk::new(output.into());
+            if let Some(meta) = source_meta.clone() {
+                chunk = chunk.meta(meta);
+            }
+            Some(acp::SessionUpdate::AgentMessageChunk(chunk))
+        }
+        UiOutputEventKind::LlmError(err) => {
+            let mut chunk = acp::ContentChunk::new(format!("[error] {err}").into());
+            if let Some(meta) = source_meta.clone() {
+                chunk = chunk.meta(meta);
+            }
+            Some(acp::SessionUpdate::AgentMessageChunk(chunk))
+        }
         UiOutputEventKind::Usage { .. } => None,
     }
 }
@@ -825,12 +883,17 @@ mod tests {
     #[test]
     fn nested_ui_event_maps_to_structured_session_updates() {
         run_local(async {
+            let nested_source = crate::ui_output::UiOutputSource {
+                agent: "argus".to_string(),
+                session_id: Some("nested-123".to_string()),
+            };
             let tool_update = nested_ui_event_to_session_update(crate::ui_output::UiOutputEvent {
-                kind: UiOutputEventKind::McpToolInvocation {
+                kind: UiOutputEventKind::ToolCall {
                     tool_name: "argus_session_prompt".to_string(),
                     input_yaml: Some("message: hello".to_string()),
+                    raw: None,
                 },
-                source: None,
+                source: Some(nested_source.clone()),
             })
             .await
             .expect("tool update");
@@ -839,23 +902,29 @@ mod tests {
                 acp::SessionUpdate::ToolCall(call) => {
                     assert!(format!("{:?}", call).contains("argus_session_prompt"));
                     assert!(format!("{:?}", call).contains("message: hello"));
+                    assert!(format!("{:?}", call).contains("argus"));
+                    assert!(format!("{:?}", call).contains("nested-123"));
                 }
                 other => panic!("unexpected tool update: {other:?}"),
             }
 
             let thought_update =
                 nested_ui_event_to_session_update(crate::ui_output::UiOutputEvent {
-                    kind: UiOutputEventKind::AcpThought {
+                    kind: UiOutputEventKind::ThoughtChunk {
                         text: "thinking".to_string(),
+                        raw: Some(Box::new(acp::ContentChunk::new("thinking".into()))),
                     },
-                    source: None,
+                    source: Some(nested_source.clone()),
                 })
                 .await
                 .expect("thought update");
-            assert!(matches!(
-                thought_update,
-                acp::SessionUpdate::AgentThoughtChunk(_)
-            ));
+            match thought_update {
+                acp::SessionUpdate::AgentThoughtChunk(chunk) => {
+                    assert!(format!("{:?}", chunk).contains("argus"));
+                    assert!(format!("{:?}", chunk).contains("nested-123"));
+                }
+                other => panic!("unexpected thought update: {other:?}"),
+            }
 
             let plan_update = nested_ui_event_to_session_update(crate::ui_output::UiOutputEvent {
                 kind: UiOutputEventKind::Plan {
@@ -864,7 +933,7 @@ mod tests {
                         content: "delegate to argus".to_string(),
                     }],
                 },
-                source: None,
+                source: Some(nested_source),
             })
             .await
             .expect("plan update");

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -354,12 +354,13 @@ impl ToolCall {
 
         // Emit tool call info to TUI or terminal
         let event = UiOutputEvent {
-            kind: UiOutputEventKind::McpToolInvocation {
+            kind: UiOutputEventKind::ToolCall {
                 tool_name: self.name.clone(),
                 input_yaml: match json_data {
                     Value::Null => None,
                     _ => Some(pretty_yaml_block(&json_data)),
                 },
+                raw: None,
             },
             source: None,
         };
@@ -568,12 +569,13 @@ mod tests {
     #[test]
     fn test_mcp_tool_invocation_terminal_fallback_multiline_yaml() {
         let rendered = event_fallback_text(
-            &UiOutputEventKind::McpToolInvocation {
+            &UiOutputEventKind::ToolCall {
                 tool_name: "argus_session_prompt".to_string(),
                 input_yaml: Some(pretty_yaml_block(&json!({
                     "message": "Goal — Improve display\nAcceptance criteria — Wrap nicely",
                     "session_id": "session-1"
                 }))),
+                raw: None,
             },
             None,
         );
@@ -801,9 +803,10 @@ mod tests {
         let forward = tokio::spawn(forward_acp_chunks(rx, None, "working".to_string(), false));
 
         tx.send(NestedAcpEvent::Ui(UiOutputEvent {
-            kind: UiOutputEventKind::McpToolInvocation {
+            kind: UiOutputEventKind::ToolCall {
                 tool_name: "argus_session_prompt".to_string(),
                 input_yaml: Some("message: hi".to_string()),
+                raw: None,
             },
             source: Some(crate::ui_output::UiOutputSource {
                 agent: "argus".to_string(),
@@ -817,9 +820,10 @@ mod tests {
 
         let event = ui_rx.recv().await.expect("forwarded UI event");
         match event.kind {
-            UiOutputEventKind::McpToolInvocation {
+            UiOutputEventKind::ToolCall {
                 tool_name,
                 input_yaml,
+                ..
             } => {
                 assert_eq!(tool_name, "argus_session_prompt");
                 assert_eq!(input_yaml.as_deref(), Some("message: hi"));

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::tui::render_helpers::{
-    render_plan_entries, render_structured_block, render_usage_line, source_heading,
+    render_plan_entries, render_status_line, render_usage_line, source_heading,
 };
 use crate::tui::types::{TranscriptEntry, TuiEvent};
 use crate::ui_output::{UiOutputEvent, UiOutputEventKind, UiOutputSource};
@@ -478,7 +478,7 @@ impl Tui {
     }
 
     async fn render_ui_output_event(&mut self, event: UiOutputEvent) {
-        let is_thought = matches!(&event.kind, UiOutputEventKind::AcpThought { .. });
+        let is_thought = matches!(&event.kind, UiOutputEventKind::ThoughtChunk { .. });
         let is_usage = matches!(&event.kind, UiOutputEventKind::Usage { .. });
         if !is_thought {
             self.flush_pending_thought();
@@ -505,12 +505,16 @@ impl Tui {
                         .collect()
                 }
             }
-            UiOutputEventKind::LlmText(text) => {
-                self.app.last_ui_output_source = None;
-                self.app.pending_thought_source = None;
-                self.append_streaming_assistant_chunk(&text);
-                self.pin_transcript_to_bottom();
-                vec![]
+            UiOutputEventKind::MessageChunk { text, .. } => {
+                if text.trim().is_empty() {
+                    vec![]
+                } else {
+                    self.app.last_ui_output_source = None;
+                    self.app.pending_thought_source = None;
+                    self.append_streaming_assistant_chunk(&text);
+                    self.pin_transcript_to_bottom();
+                    vec![]
+                }
             }
             UiOutputEventKind::LlmFinal { output, usage } => {
                 self.flush_pending_thought();
@@ -574,8 +578,18 @@ impl Tui {
                 }
                 vec![]
             }
-            UiOutputEventKind::AcpThought { text } => {
-                let clean = strip_ansi(&text);
+            UiOutputEventKind::ThoughtChunk { text, raw } => {
+                let text = crate::tui::render_helpers::event_fallback_text(
+                    &UiOutputEventKind::ThoughtChunk {
+                        text: text.clone(),
+                        raw: raw.clone(),
+                    },
+                    event.source.as_ref(),
+                );
+                let clean = strip_ansi(&text)
+                    .trim_start_matches("<think>")
+                    .trim_end_matches("</think>")
+                    .to_string();
                 if clean.trim().is_empty() {
                     vec![]
                 } else {
@@ -587,14 +601,12 @@ impl Tui {
                     vec![]
                 }
             }
-            UiOutputEventKind::StructuredBlock { title, body } => {
-                render_structured_block(&title, body.as_deref())
-            }
-            UiOutputEventKind::StatusLine { text } => {
-                if text.is_empty() {
-                    vec![]
-                } else {
+
+            UiOutputEventKind::ToolCallUpdate { title, status, .. } => {
+                if let Some(text) = render_status_line(title.as_deref(), status.as_deref()) {
                     vec![TranscriptEntry::System(text)]
+                } else {
+                    vec![]
                 }
             }
             UiOutputEventKind::Plan { entries } => render_plan_entries(&entries),
@@ -621,10 +633,20 @@ impl Tui {
                     vec![]
                 }
             }
-            UiOutputEventKind::McpToolInvocation {
+            UiOutputEventKind::ToolCall {
                 tool_name,
                 input_yaml,
-            } => render_structured_block(&format!("->️ {tool_name}"), input_yaml.as_deref()),
+                ..
+            } => {
+                let mut entries = vec![TranscriptEntry::System(format!("->️ {tool_name}"))];
+                if let Some(yaml) = &input_yaml {
+                    entries.extend(
+                        yaml.lines()
+                            .map(|line| TranscriptEntry::System(format!("   {line}"))),
+                    );
+                }
+                entries
+            }
         };
 
         if !rendered_entries.is_empty() {

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -509,8 +509,6 @@ impl Tui {
                 if text.trim().is_empty() {
                     vec![]
                 } else {
-                    self.app.last_ui_output_source = None;
-                    self.app.pending_thought_source = None;
                     self.append_streaming_assistant_chunk(&text);
                     self.pin_transcript_to_bottom();
                     vec![]

--- a/src/tui/prompt.rs
+++ b/src/tui/prompt.rs
@@ -256,7 +256,10 @@ impl Tui {
                     crate::client::SseEvent::Text(text) => {
                         let _ =
                             event_tx.send(TuiEvent::UiOutput(crate::ui_output::UiOutputEvent {
-                                kind: crate::ui_output::UiOutputEventKind::LlmText(text),
+                                kind: crate::ui_output::UiOutputEventKind::MessageChunk {
+                                    text,
+                                    raw: None,
+                                },
                                 source: None,
                             }));
                     }

--- a/src/tui/render_helpers.rs
+++ b/src/tui/render_helpers.rs
@@ -19,17 +19,6 @@ pub(crate) fn source_heading(source: &UiOutputSource) -> String {
     }
 }
 
-pub(super) fn render_structured_block(title: &str, body: Option<&str>) -> Vec<TranscriptEntry> {
-    let mut entries = vec![TranscriptEntry::System(title.to_string())];
-    if let Some(body) = body {
-        entries.extend(
-            body.lines()
-                .map(|line| TranscriptEntry::System(format!("   {line}"))),
-        );
-    }
-    entries
-}
-
 pub(super) fn render_plan_entries(entries: &[UiOutputPlanEntry]) -> Vec<TranscriptEntry> {
     if entries.is_empty() {
         return vec![];
@@ -74,25 +63,18 @@ pub(crate) fn event_fallback_text(
     source: Option<&UiOutputSource>,
 ) -> String {
     match kind {
-        UiOutputEventKind::LlmText(text)
+        UiOutputEventKind::MessageChunk { text, .. }
         | UiOutputEventKind::TranscriptText { text }
         | UiOutputEventKind::ToolResultText { text } => text.clone(),
         UiOutputEventKind::LlmFinal { output, usage: _ } => output.clone(),
         UiOutputEventKind::LlmError(err) => err.clone(),
-        UiOutputEventKind::AcpThought { text } => format!("<think>{text}</think>"),
-        UiOutputEventKind::StructuredBlock { title, body } => {
-            let mut lines = vec![title.clone()];
-            if let Some(body) = body {
-                lines.extend(body.lines().map(|line| format!("   {line}")));
-            }
-            format!("\n{}\n", lines.join("\n"))
+        UiOutputEventKind::ThoughtChunk { text, .. } => {
+            format!("<think>{text}</think>")
         }
-        UiOutputEventKind::StatusLine { text } => {
-            if text.is_empty() {
-                String::new()
-            } else {
-                format!("\n{text}\n")
-            }
+        UiOutputEventKind::ToolCallUpdate { title, status, .. } => {
+            render_status_line(title.as_deref(), status.as_deref())
+                .map(|text| format!("\n{text}\n"))
+                .unwrap_or_default()
         }
         UiOutputEventKind::Plan { entries } => {
             if entries.is_empty() {
@@ -120,9 +102,10 @@ pub(crate) fn event_fallback_text(
         )
         .map(|line| format!("\n{line}\n"))
         .unwrap_or_default(),
-        UiOutputEventKind::McpToolInvocation {
+        UiOutputEventKind::ToolCall {
             tool_name,
             input_yaml,
+            ..
         } => {
             let mut lines = vec![format!("->️ {tool_name}")];
             if let Some(input_yaml) = input_yaml {

--- a/src/tui/snapshots/harnx__tui__tests__thinking_stream_coalescing_around_tool_calls.snap
+++ b/src/tui/snapshots/harnx__tui__tests__thinking_stream_coalescing_around_tool_calls.snap
@@ -1,12 +1,12 @@
 ---
 source: src/tui/tests.rs
-assertion_line: 776
+assertion_line: 807
 expression: rendered
 ---
 Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
 > argus ▸ session-1
 <think>thinking before tool</think>
-argus_session_prompt
+->️ argus_session_prompt
    message: delegate
 <think>thinking after tool</think>
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -6,6 +6,7 @@ use crate::tui::render_helpers::event_fallback_text;
 use crate::tui::types::{TranscriptEntry, TuiEvent};
 use crate::ui_output::{UiOutputEvent, UiOutputEventKind, UiOutputSource};
 use crate::utils::dimmed_text;
+use agent_client_protocol as acp;
 use parking_lot::RwLock;
 use std::sync::Arc;
 use std::time::Duration;
@@ -206,7 +207,10 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
     let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
 
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::LlmText("Hello\nworld".to_string()),
+        kind: UiOutputEventKind::MessageChunk {
+            text: "Hello\nworld".to_string(),
+            raw: None,
+        },
         source: None,
     }))
     .await
@@ -220,7 +224,10 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
     .await
     .unwrap();
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::LlmText("\nAgain".to_string()),
+        kind: UiOutputEventKind::MessageChunk {
+            text: "\nAgain".to_string(),
+            raw: None,
+        },
         source: None,
     }))
     .await
@@ -455,7 +462,10 @@ async fn sub_agent_heading_transitions_render_in_tui_snapshot() {
     harness
         .tui()
         .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::LlmText("Top-level assistant opening response.".to_string()),
+            kind: UiOutputEventKind::MessageChunk {
+                text: "Top-level assistant opening response.".to_string(),
+                raw: None,
+            },
             source: None,
         }))
         .await
@@ -502,7 +512,10 @@ async fn sub_agent_heading_transitions_render_in_tui_snapshot() {
     harness
         .tui()
         .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::LlmText("Top-level assistant closes response.".to_string()),
+            kind: UiOutputEventKind::MessageChunk {
+                text: "Top-level assistant closes response.".to_string(),
+                raw: None,
+            },
             source: None,
         }))
         .await
@@ -526,9 +539,10 @@ async fn structured_system_entries_do_not_insert_blank_lines_between_each_line()
     harness
         .tui()
         .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::StructuredBlock {
-                title: "argus_session_prompt".to_string(),
-                body: Some("message: hello\nsession_id: abc123".to_string()),
+            kind: UiOutputEventKind::ToolCall {
+                tool_name: "argus_session_prompt".to_string(),
+                input_yaml: Some("message: hello\nsession_id: abc123".to_string()),
+                raw: None,
             },
             source: Some(UiOutputSource {
                 agent: "argus".to_string(),
@@ -540,8 +554,11 @@ async fn structured_system_entries_do_not_insert_blank_lines_between_each_line()
     harness
         .tui()
         .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::AcpThought {
+            kind: UiOutputEventKind::ThoughtChunk {
                 text: "thinking hard\nstep two".to_string(),
+                raw: Some(Box::new(acp::ContentChunk::new(
+                    "thinking hard\nstep two".into(),
+                ))),
             },
             source: Some(UiOutputSource {
                 agent: "argus".to_string(),
@@ -565,8 +582,9 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
 
     for chunk in ["thinking ", "before ", "tool"] {
         tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::AcpThought {
+            kind: UiOutputEventKind::ThoughtChunk {
                 text: chunk.to_string(),
+                raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
             },
             source: None,
         }))
@@ -575,9 +593,10 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
     }
 
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::StructuredBlock {
-            title: "argus_session_prompt".to_string(),
-            body: Some("message: delegate".to_string()),
+        kind: UiOutputEventKind::ToolCall {
+            tool_name: "argus_session_prompt".to_string(),
+            input_yaml: Some("message: delegate".to_string()),
+            raw: None,
         },
         source: None,
     }))
@@ -586,8 +605,9 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
 
     for chunk in ["thinking ", "after ", "tool"] {
         tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::AcpThought {
+            kind: UiOutputEventKind::ThoughtChunk {
                 text: chunk.to_string(),
+                raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
             },
             source: None,
         }))
@@ -615,7 +635,7 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         system_entries,
         vec![
             "<think>thinking before tool</think>",
-            "argus_session_prompt",
+            "->️ argus_session_prompt",
             "   message: delegate",
             "<think>thinking after tool</think>",
         ]
@@ -635,8 +655,9 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
 
     for chunk in ["thinking ", "before ", "tool"] {
         tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::AcpThought {
+            kind: UiOutputEventKind::ThoughtChunk {
                 text: chunk.to_string(),
+                raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
             },
             source: source.clone(),
         }))
@@ -645,9 +666,10 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
     }
 
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::StructuredBlock {
-            title: "argus_session_prompt".to_string(),
-            body: Some("message: delegate".to_string()),
+        kind: UiOutputEventKind::ToolCall {
+            tool_name: "argus_session_prompt".to_string(),
+            input_yaml: Some("message: delegate".to_string()),
+            raw: None,
         },
         source: source.clone(),
     }))
@@ -656,8 +678,9 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
 
     for chunk in ["thinking ", "after ", "tool"] {
         tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::AcpThought {
+            kind: UiOutputEventKind::ThoughtChunk {
                 text: chunk.to_string(),
+                raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
             },
             source: source.clone(),
         }))
@@ -686,7 +709,7 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         vec![
             "> argus ▸ session-1",
             "<think>thinking before tool</think>",
-            "argus_session_prompt",
+            "->️ argus_session_prompt",
             "   message: delegate",
             "<think>thinking after tool</think>",
         ]
@@ -704,7 +727,10 @@ async fn llm_multiline_text_renders_without_extra_blank_lines() {
     harness
         .tui()
         .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::LlmText("line one\nline two\nline three".to_string()),
+            kind: UiOutputEventKind::MessageChunk {
+                text: "line one\nline two\nline three".to_string(),
+                raw: None,
+            },
             source: None,
         }))
         .await
@@ -731,8 +757,9 @@ async fn thinking_stream_coalescing_around_tool_calls_snapshot() {
         harness
             .tui()
             .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-                kind: UiOutputEventKind::AcpThought {
+                kind: UiOutputEventKind::ThoughtChunk {
                     text: chunk.to_string(),
+                    raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
                 },
                 source: Some(UiOutputSource {
                     agent: "argus".to_string(),
@@ -745,9 +772,10 @@ async fn thinking_stream_coalescing_around_tool_calls_snapshot() {
     harness
         .tui()
         .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::StructuredBlock {
-                title: "argus_session_prompt".to_string(),
-                body: Some("message: delegate".to_string()),
+            kind: UiOutputEventKind::ToolCall {
+                tool_name: "argus_session_prompt".to_string(),
+                input_yaml: Some("message: delegate".to_string()),
+                raw: None,
             },
             source: Some(UiOutputSource {
                 agent: "argus".to_string(),
@@ -760,8 +788,9 @@ async fn thinking_stream_coalescing_around_tool_calls_snapshot() {
         harness
             .tui()
             .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-                kind: UiOutputEventKind::AcpThought {
+                kind: UiOutputEventKind::ThoughtChunk {
                     text: chunk.to_string(),
+                    raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
                 },
                 source: Some(UiOutputSource {
                     agent: "argus".to_string(),
@@ -785,9 +814,10 @@ async fn structured_ui_output_variants_render_in_transcript() {
     let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
 
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::StructuredBlock {
-            title: "argus_session_prompt".to_string(),
-            body: Some("message: hello\nsession_id: abc123".to_string()),
+        kind: UiOutputEventKind::ToolCall {
+            tool_name: "argus_session_prompt".to_string(),
+            input_yaml: Some("message: hello\nsession_id: abc123".to_string()),
+            raw: None,
         },
         source: Some(UiOutputSource {
             agent: "argus".to_string(),
@@ -797,8 +827,9 @@ async fn structured_ui_output_variants_render_in_transcript() {
     .await
     .unwrap();
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::AcpThought {
+        kind: UiOutputEventKind::ThoughtChunk {
             text: "thinking hard".to_string(),
+            raw: Some(Box::new(acp::ContentChunk::new("thinking hard".into()))),
         },
         source: Some(UiOutputSource {
             agent: "argus".to_string(),
@@ -808,8 +839,10 @@ async fn structured_ui_output_variants_render_in_transcript() {
     .await
     .unwrap();
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::StatusLine {
-            text: "-> argus_session_prompt completed".to_string(),
+        kind: UiOutputEventKind::ToolCallUpdate {
+            title: Some("argus_session_prompt".to_string()),
+            status: Some("completed".to_string()),
+            raw: None,
         },
         source: Some(UiOutputSource {
             agent: "argus".to_string(),
@@ -853,9 +886,10 @@ async fn structured_ui_output_variants_render_in_transcript() {
     .await
     .unwrap();
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::McpToolInvocation {
+        kind: UiOutputEventKind::ToolCall {
             tool_name: "bash".to_string(),
             input_yaml: Some("command: ls".to_string()),
+            raw: None,
         },
         source: None,
     }))
@@ -881,7 +915,7 @@ async fn structured_ui_output_variants_render_in_transcript() {
         .collect();
 
     assert!(system_entries.contains(&"> argus ▸ session-1"));
-    assert!(system_entries.contains(&"argus_session_prompt"));
+    assert!(system_entries.contains(&"->️ argus_session_prompt"));
     assert!(system_entries.contains(&"   message: hello"));
     assert!(system_entries.contains(&"<think>thinking hard</think>"));
     assert!(system_entries.contains(&"-> argus_session_prompt completed"));
@@ -958,6 +992,51 @@ async fn consecutive_usage_updates_replace_previous_usage_row_for_same_source() 
             .filter(|line| **line == "> pytheas ▸ session-1   in 20   out 2")
             .count(),
         1
+    );
+}
+
+#[tokio::test]
+async fn acp_message_chunks_coalesce_like_direct_llm_streaming() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    let source = UiOutputSource {
+        agent: "aristarchus".to_string(),
+        session_id: Some("session-1".to_string()),
+    };
+
+    for chunk in [
+        "Now I have ",
+        "enough ",
+        "information to ",
+        "complete my review.",
+    ] {
+        tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::MessageChunk {
+                text: chunk.to_string(),
+                raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
+            },
+            source: Some(source.clone()),
+        }))
+        .await
+        .unwrap();
+    }
+
+    let assistant_entries: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|entry| match entry {
+            TranscriptEntry::Assistant(text) => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(assistant_entries.len(), 1);
+    assert_eq!(
+        assistant_entries[0],
+        "Now I have enough information to complete my review."
     );
 }
 

--- a/src/ui_output.rs
+++ b/src/ui_output.rs
@@ -1,3 +1,4 @@
+use agent_client_protocol as acp;
 #[cfg(test)]
 use std::sync::Mutex;
 #[cfg(not(test))]
@@ -15,24 +16,31 @@ pub enum UiOutputEventKind {
     ToolResultText {
         text: String,
     },
-    LlmText(String),
+    MessageChunk {
+        text: String,
+        raw: Option<Box<acp::ContentChunk>>,
+    },
     LlmFinal {
         output: String,
         usage: crate::client::CompletionTokenUsage,
     },
     LlmError(String),
-    AcpThought {
+    ThoughtChunk {
         text: String,
+        raw: Option<Box<acp::ContentChunk>>,
     },
-    StatusLine {
-        text: String,
+    ToolCall {
+        tool_name: String,
+        input_yaml: Option<String>,
+        raw: Option<Box<acp::ToolCall>>,
+    },
+    ToolCallUpdate {
+        title: Option<String>,
+        status: Option<String>,
+        raw: Option<Box<acp::ToolCallUpdate>>,
     },
     TranscriptText {
         text: String,
-    },
-    StructuredBlock {
-        title: String,
-        body: Option<String>,
     },
     Plan {
         entries: Vec<UiOutputPlanEntry>,
@@ -42,10 +50,6 @@ pub enum UiOutputEventKind {
         output_tokens: u64,
         cached_tokens: u64,
         session_label: Option<String>,
-    },
-    McpToolInvocation {
-        tool_name: String,
-        input_yaml: Option<String>,
     },
 }
 


### PR DESCRIPTION
## Summary
- unify `UiOutputEventKind` across local and ACP-derived flows using semantic event variants with `source` carrying origin
- preserve ACP raw payloads for message/thought/tool events so nested ACP forwarding can remain high fidelity
- route ACP assistant chunks through the same TUI streaming/coalescing path as direct LLM output and update related tests/snapshot

## Testing
- cargo fmt
- cargo build
- cargo clippy --all --all-targets -- -D warnings
- cargo nextest run --all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal UI event model updated to use richer chunk-based events for messages, thoughts, and tool activity.

* **New Features**
  * Streaming message/thought chunks now coalesce into smoother assistant transcripts.
  * Terminal/tool outputs render as explicit tool-call entries with clearer headers and status updates.

* **Bug Fixes**
  * Improved session/agent attribution so events reliably preserve and display their source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->