### PR TITLE
repetitive output subagent name session fixup

### DIFF
--- a/src/acp/client.rs
+++ b/src/acp/client.rs
@@ -960,51 +960,84 @@ fn agent_from_meta_value(value: &serde_json::Value) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+fn session_from_meta_value(value: &serde_json::Value) -> Option<String> {
+    value
+        .get("session")
+        .and_then(serde_json::Value::as_str)
+        .filter(|session| !session.is_empty())
+        .map(ToOwned::to_owned)
+}
+
 fn resolve_notification_source(
     fallback_agent: &str,
     notification: &acp::SessionNotification,
 ) -> UiOutputSource {
     let session_id = notification.session_id.0.to_string();
-    let update_agent = match &notification.update {
-        acp::SessionUpdate::AgentMessageChunk(chunk) => chunk
-            .meta
-            .as_ref()
-            .and_then(|meta| agent_from_meta_value(&json!(meta))),
-        acp::SessionUpdate::AgentThoughtChunk(chunk) => chunk
-            .meta
-            .as_ref()
-            .and_then(|meta| agent_from_meta_value(&json!(meta))),
-        acp::SessionUpdate::ToolCall(call) => call
-            .meta
-            .as_ref()
-            .and_then(|meta| agent_from_meta_value(&json!(meta))),
-        acp::SessionUpdate::ToolCallUpdate(update) => update
-            .meta
-            .as_ref()
-            .and_then(|meta| agent_from_meta_value(&json!(meta))),
-        acp::SessionUpdate::Plan(plan) => plan
-            .meta
-            .as_ref()
-            .and_then(|meta| agent_from_meta_value(&json!(meta))),
-        acp::SessionUpdate::SessionInfoUpdate(info) => info
-            .meta
-            .as_ref()
-            .and_then(|meta| meta.get("agent"))
-            .and_then(serde_json::Value::as_str)
-            .filter(|agent| !agent.is_empty())
-            .map(ToOwned::to_owned)
-            .or_else(|| {
-                info.meta
+    let (update_agent, update_session) = match &notification.update {
+        acp::SessionUpdate::AgentMessageChunk(chunk) => {
+            let meta = chunk.meta.as_ref().map(|meta| json!(meta));
+            (
+                meta.as_ref().and_then(agent_from_meta_value),
+                meta.as_ref().and_then(session_from_meta_value),
+            )
+        }
+        acp::SessionUpdate::AgentThoughtChunk(chunk) => {
+            let meta = chunk.meta.as_ref().map(|meta| json!(meta));
+            (
+                meta.as_ref().and_then(agent_from_meta_value),
+                meta.as_ref().and_then(session_from_meta_value),
+            )
+        }
+        acp::SessionUpdate::ToolCall(call) => {
+            let meta = call.meta.as_ref().map(|meta| json!(meta));
+            (
+                meta.as_ref().and_then(agent_from_meta_value),
+                meta.as_ref().and_then(session_from_meta_value),
+            )
+        }
+        acp::SessionUpdate::ToolCallUpdate(update) => {
+            let meta = update.meta.as_ref().map(|meta| json!(meta));
+            (
+                meta.as_ref().and_then(agent_from_meta_value),
+                meta.as_ref().and_then(session_from_meta_value),
+            )
+        }
+        acp::SessionUpdate::Plan(plan) => {
+            let meta = plan.meta.as_ref().map(|meta| json!(meta));
+            (
+                meta.as_ref().and_then(agent_from_meta_value),
+                meta.as_ref().and_then(session_from_meta_value),
+            )
+        }
+        acp::SessionUpdate::SessionInfoUpdate(info) => {
+            let direct_meta = info.meta.as_ref().map(|meta| json!(meta));
+            (
+                direct_meta
                     .as_ref()
-                    .and_then(|meta| meta.get("harnx:usage"))
                     .and_then(agent_from_meta_value)
-            }),
-        _ => None,
+                    .or_else(|| {
+                        info.meta
+                            .as_ref()
+                            .and_then(|meta| meta.get("harnx:usage"))
+                            .and_then(agent_from_meta_value)
+                    }),
+                direct_meta
+                    .as_ref()
+                    .and_then(session_from_meta_value)
+                    .or_else(|| {
+                        info.meta
+                            .as_ref()
+                            .and_then(|meta| meta.get("harnx:usage"))
+                            .and_then(session_from_meta_value)
+                    }),
+            )
+        }
+        _ => (None, None),
     };
 
     UiOutputSource {
         agent: update_agent.unwrap_or_else(|| fallback_agent.to_string()),
-        session_id: Some(session_id),
+        session_id: Some(update_session.unwrap_or(session_id)),
     }
 }
 
@@ -1097,6 +1130,23 @@ mod tests {
         let source = resolve_notification_source("argus", &notification);
         assert_eq!(source.agent, "argus");
         assert_eq!(source.session_id.as_deref(), Some("outer-session"));
+    }
+
+    #[test]
+    fn resolve_notification_source_uses_nested_session_when_present() {
+        let notification = acp::SessionNotification::new(
+            acp::SessionId::new("outer-session"),
+            acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new("hello".into()).meta(
+                serde_json::Map::from_iter([
+                    ("agent".to_string(), json!("aristarchus")),
+                    ("session".to_string(), json!("nested-session")),
+                ]),
+            )),
+        );
+
+        let source = resolve_notification_source("argus", &notification);
+        assert_eq!(source.agent, "aristarchus");
+        assert_eq!(source.session_id.as_deref(), Some("nested-session"));
     }
 
     #[test]

--- a/src/acp/client.rs
+++ b/src/acp/client.rs
@@ -7,6 +7,7 @@ use crate::ui_output::{
 };
 use agent_client_protocol::{self as acp, Agent as _};
 use anyhow::{anyhow, Context, Result};
+use serde_json::json;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::pin::Pin;
@@ -105,26 +106,23 @@ impl AcpNotificationClient {
     /// Forward a display-only chunk (e.g. usage banner) to subscribers or
     /// stderr.  Unlike the main chunk path this never touches
     /// `state.response_text`.
-    async fn forward_display_chunk(&self, text: &str, session_id: &str) {
+    async fn forward_display_chunk(&self, text: &str, source: UiOutputSource) {
         self.forward_ui_output_event(
             UiOutputEvent {
                 kind: UiOutputEventKind::TranscriptText {
                     text: text.to_string(),
                 },
-                source: None,
+                source: Some(source.clone()),
             },
-            session_id,
+            source,
         )
         .await;
     }
 
-    async fn forward_ui_output_event(&self, event: UiOutputEvent, session_id: &str) {
+    async fn forward_ui_output_event(&self, event: UiOutputEvent, source: UiOutputSource) {
         let mut delivered = false;
         let mut forwarders = self.chunk_forwarder.write().await;
-        let source = Some(UiOutputSource {
-            agent: self.agent_name.clone(),
-            session_id: Some(session_id.to_string()),
-        });
+        let source = event.source.clone().or(Some(source));
         let text_fallback = format_ui_event_for_terminal(&event.kind, source.as_ref());
         let event = UiOutputEvent {
             kind: event.kind,
@@ -201,6 +199,7 @@ impl acp::Client for AcpNotificationClient {
     async fn session_notification(&self, args: acp::SessionNotification) -> acp::Result<()> {
         let session_id = args.session_id.0.to_string();
         let _ = self.activity_tx.send(session_id.clone());
+        let resolved_source = resolve_notification_source(&self.agent_name, &args);
 
         // Handle SessionInfoUpdate separately: its display output is
         // display-only metadata (e.g. usage banners) that must never be
@@ -210,42 +209,50 @@ impl acp::Client for AcpNotificationClient {
         // SessionInfoUpdate with an early return we keep it out of the
         // shared chunk → response_text path entirely.
         if let acp::SessionUpdate::SessionInfoUpdate(ref info) = args.update {
-            if let Some(event) = session_info_update_event(info) {
-                self.forward_ui_output_event(event, &session_id).await;
+            if let Some(event) = session_info_update_event(info, resolved_source.clone()) {
+                self.forward_ui_output_event(event, resolved_source.clone())
+                    .await;
             }
             return Ok(());
         }
 
         let is_agent_message = matches!(args.update, acp::SessionUpdate::AgentMessageChunk(_));
         let event = match args.update {
-            acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk { content, .. }) => {
-                let text = content_block_to_text(&content);
+            acp::SessionUpdate::AgentMessageChunk(chunk) => {
+                let text = chunk_text(&chunk.content);
                 if text.trim().is_empty() {
                     None
                 } else {
                     Some(UiOutputEvent {
-                        kind: UiOutputEventKind::LlmText(text),
-                        source: None,
+                        kind: UiOutputEventKind::MessageChunk {
+                            text,
+                            raw: Some(Box::new(chunk)),
+                        },
+                        source: Some(resolved_source.clone()),
                     })
                 }
             }
-            acp::SessionUpdate::AgentThoughtChunk(acp::ContentChunk { content, .. }) => {
-                let text = content_block_to_text(&content);
-                if text.is_empty() {
+            acp::SessionUpdate::AgentThoughtChunk(chunk) => {
+                let text = chunk_text(&chunk.content);
+                if text.trim().is_empty() {
                     None
                 } else {
                     Some(UiOutputEvent {
-                        kind: UiOutputEventKind::AcpThought { text },
-                        source: None,
+                        kind: UiOutputEventKind::ThoughtChunk {
+                            text,
+                            raw: Some(Box::new(chunk)),
+                        },
+                        source: Some(resolved_source.clone()),
                     })
                 }
             }
             acp::SessionUpdate::ToolCall(tc) => Some(UiOutputEvent {
-                kind: UiOutputEventKind::StructuredBlock {
-                    title: tc.title,
-                    body: tc.raw_input.as_ref().map(pretty_yaml_block),
+                kind: UiOutputEventKind::ToolCall {
+                    tool_name: tc.title.clone(),
+                    input_yaml: tc.raw_input.as_ref().map(pretty_yaml_block),
+                    raw: Some(Box::new(tc)),
                 },
-                source: None,
+                source: Some(resolved_source.clone()),
             }),
             acp::SessionUpdate::ToolCallUpdate(tcu) => {
                 let title = tcu.fields.title.clone();
@@ -259,14 +266,12 @@ impl acp::Client for AcpNotificationClient {
                     None
                 } else {
                     Some(UiOutputEvent {
-                        kind: UiOutputEventKind::StatusLine {
-                            text: crate::tui::render_helpers::render_status_line(
-                                title.as_deref(),
-                                status.as_deref(),
-                            )
-                            .unwrap_or_default(),
+                        kind: UiOutputEventKind::ToolCallUpdate {
+                            title,
+                            status,
+                            raw: Some(Box::new(tcu)),
                         },
-                        source: None,
+                        source: Some(resolved_source.clone()),
                     })
                 }
             }
@@ -287,7 +292,7 @@ impl acp::Client for AcpNotificationClient {
                 } else {
                     Some(UiOutputEvent {
                         kind: UiOutputEventKind::Plan { entries },
-                        source: None,
+                        source: Some(resolved_source.clone()),
                     })
                 }
             }
@@ -311,7 +316,7 @@ impl acp::Client for AcpNotificationClient {
         if let Some(event) = event {
             let chunk_for_response = if is_agent_message {
                 match &event.kind {
-                    UiOutputEventKind::LlmText(text)
+                    UiOutputEventKind::MessageChunk { text, .. }
                     | UiOutputEventKind::TranscriptText { text } => Some(text.clone()),
                     _ => None,
                 }
@@ -319,7 +324,8 @@ impl acp::Client for AcpNotificationClient {
                 None
             };
 
-            self.forward_ui_output_event(event, &session_id).await;
+            self.forward_ui_output_event(event, resolved_source.clone())
+                .await;
 
             if let Some(chunk) = chunk_for_response {
                 let mut sessions = self.sessions.write().await;
@@ -946,34 +952,76 @@ fn wrap_display_text(text: &str, initial_indent: &str, subsequent_indent: &str) 
     wrap(text, options).join("\n")
 }
 
-fn session_info_update_event(info: &acp::SessionInfoUpdate) -> Option<UiOutputEvent> {
+fn agent_from_meta_value(value: &serde_json::Value) -> Option<String> {
+    value
+        .get("agent")
+        .and_then(serde_json::Value::as_str)
+        .filter(|agent| !agent.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn resolve_notification_source(
+    fallback_agent: &str,
+    notification: &acp::SessionNotification,
+) -> UiOutputSource {
+    let session_id = notification.session_id.0.to_string();
+    let update_agent = match &notification.update {
+        acp::SessionUpdate::AgentMessageChunk(chunk) => chunk
+            .meta
+            .as_ref()
+            .and_then(|meta| agent_from_meta_value(&json!(meta))),
+        acp::SessionUpdate::AgentThoughtChunk(chunk) => chunk
+            .meta
+            .as_ref()
+            .and_then(|meta| agent_from_meta_value(&json!(meta))),
+        acp::SessionUpdate::ToolCall(call) => call
+            .meta
+            .as_ref()
+            .and_then(|meta| agent_from_meta_value(&json!(meta))),
+        acp::SessionUpdate::ToolCallUpdate(update) => update
+            .meta
+            .as_ref()
+            .and_then(|meta| agent_from_meta_value(&json!(meta))),
+        acp::SessionUpdate::Plan(plan) => plan
+            .meta
+            .as_ref()
+            .and_then(|meta| agent_from_meta_value(&json!(meta))),
+        acp::SessionUpdate::SessionInfoUpdate(info) => info
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.get("agent"))
+            .and_then(serde_json::Value::as_str)
+            .filter(|agent| !agent.is_empty())
+            .map(ToOwned::to_owned)
+            .or_else(|| {
+                info.meta
+                    .as_ref()
+                    .and_then(|meta| meta.get("harnx:usage"))
+                    .and_then(agent_from_meta_value)
+            }),
+        _ => None,
+    };
+
+    UiOutputSource {
+        agent: update_agent.unwrap_or_else(|| fallback_agent.to_string()),
+        session_id: Some(session_id),
+    }
+}
+
+fn session_info_update_event(
+    info: &acp::SessionInfoUpdate,
+    source: UiOutputSource,
+) -> Option<UiOutputEvent> {
     let meta = info.meta.as_ref()?;
     let usage = meta.get("harnx:usage")?;
     let input_tokens = usage["input_tokens"].as_u64().unwrap_or(0);
     let output_tokens = usage["output_tokens"].as_u64().unwrap_or(0);
     let cached_tokens = usage["cached_tokens"].as_u64().unwrap_or(0);
-    let agent = usage["agent"].as_str().unwrap_or("");
-    let session = usage["session"].as_str().unwrap_or("");
-    if input_tokens == 0 && output_tokens == 0 {
+    if input_tokens == 0 && output_tokens == 0 && cached_tokens == 0 {
         return None;
     }
 
-    let session_label = match (agent.is_empty(), session.is_empty()) {
-        (false, false) => Some(crate::tui::render_helpers::source_heading(
-            &UiOutputSource {
-                agent: agent.to_string(),
-                session_id: Some(session.to_string()),
-            },
-        )),
-        (false, true) => Some(crate::tui::render_helpers::source_heading(
-            &UiOutputSource {
-                agent: agent.to_string(),
-                session_id: None,
-            },
-        )),
-        (true, false) => Some(format!("💬 {}", session)),
-        (true, true) => None,
-    };
+    let session_label = Some(crate::tui::render_helpers::source_heading(&source));
 
     Some(UiOutputEvent {
         kind: UiOutputEventKind::Usage {
@@ -982,18 +1030,11 @@ fn session_info_update_event(info: &acp::SessionInfoUpdate) -> Option<UiOutputEv
             cached_tokens,
             session_label,
         },
-        source: None,
+        source: Some(source),
     })
 }
 
-fn format_ui_event_for_terminal(
-    kind: &UiOutputEventKind,
-    source: Option<&UiOutputSource>,
-) -> String {
-    event_fallback_text(kind, source)
-}
-
-fn content_block_to_text(content: &acp::ContentBlock) -> String {
+fn chunk_text(content: &acp::ContentBlock) -> String {
     match content {
         acp::ContentBlock::Text(text) => text.text.clone(),
         acp::ContentBlock::ResourceLink(link) => link.uri.to_string(),
@@ -1004,20 +1045,70 @@ fn content_block_to_text(content: &acp::ContentBlock) -> String {
     }
 }
 
+fn format_ui_event_for_terminal(
+    kind: &UiOutputEventKind,
+    source: Option<&UiOutputSource>,
+) -> String {
+    event_fallback_text(kind, source)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
 
     #[test]
+    fn session_info_update_event_preserves_outer_source() {
+        let info = acp::SessionInfoUpdate::new().meta(serde_json::Map::from_iter([(
+            "harnx:usage".to_string(),
+            json!({
+                "agent": "aristarchus",
+                "session": "nested-session-1",
+                "input_tokens": 10,
+                "output_tokens": 2,
+                "cached_tokens": 5,
+            }),
+        )]));
+
+        let event = session_info_update_event(
+            &info,
+            UiOutputSource {
+                agent: "fallback-agent".to_string(),
+                session_id: Some("outer-session-1".to_string()),
+            },
+        )
+        .expect("usage event");
+        assert!(matches!(
+            event.source,
+            Some(UiOutputSource {
+                agent,
+                session_id: Some(session_id)
+            }) if agent == "fallback-agent" && session_id == "outer-session-1"
+        ));
+    }
+
+    #[test]
+    fn resolve_notification_source_falls_back_to_client_name() {
+        let notification = acp::SessionNotification::new(
+            acp::SessionId::new("outer-session"),
+            acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new("hello".into())),
+        );
+
+        let source = resolve_notification_source("argus", &notification);
+        assert_eq!(source.agent, "argus");
+        assert_eq!(source.session_id.as_deref(), Some("outer-session"));
+    }
+
+    #[test]
     fn terminal_fallback_renders_structured_tool_call_and_plan() {
         let tool_rendered = format_ui_event_for_terminal(
-            &UiOutputEventKind::StructuredBlock {
-                title: "argus_session_prompt".to_string(),
-                body: Some(pretty_yaml_block(&json!({
+            &UiOutputEventKind::ToolCall {
+                tool_name: "argus_session_prompt".to_string(),
+                input_yaml: Some(pretty_yaml_block(&json!({
                     "message": "Goal — Something long that should remain visible\nAcceptance criteria — Multiline preserved",
                     "session_id": "abc123"
                 }))),
+                raw: None,
             },
             None,
         );
@@ -1049,9 +1140,11 @@ mod tests {
     #[test]
     fn agent_message_chunks_stay_verbatim_in_terminal_fallback() {
         let rendered = format_ui_event_for_terminal(
-            &UiOutputEventKind::LlmText(
-                "Line one from sub-agent\nLine two from sub-agent with extra detail".to_string(),
-            ),
+            &UiOutputEventKind::MessageChunk {
+                text: "Line one from sub-agent\nLine two from sub-agent with extra detail"
+                    .to_string(),
+                raw: None,
+            },
             None,
         );
 

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -436,9 +436,13 @@ async fn nested_ui_event_to_session_update(
         });
 
     match event.kind {
-        UiOutputEventKind::TranscriptText { text } => Some(acp::SessionUpdate::AgentMessageChunk(
-            acp::ContentChunk::new(text.into()),
-        )),
+        UiOutputEventKind::TranscriptText { text } => {
+            let mut chunk = acp::ContentChunk::new(text.into());
+            if let Some(meta) = source_meta.clone() {
+                chunk = chunk.meta(meta);
+            }
+            Some(acp::SessionUpdate::AgentMessageChunk(chunk))
+        }
         UiOutputEventKind::MessageChunk { text, raw } => {
             let mut chunk = raw
                 .map(|chunk| *chunk)

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -427,20 +427,60 @@ fn content_block_to_text(content: &acp::ContentBlock) -> String {
 async fn nested_ui_event_to_session_update(
     event: crate::ui_output::UiOutputEvent,
 ) -> Option<acp::SessionUpdate> {
+    let source_meta: Option<serde_json::Map<String, serde_json::Value>> =
+        event.source.as_ref().map(|source| {
+            serde_json::Map::from_iter([
+                ("agent".to_string(), json!(source.agent)),
+                ("session".to_string(), json!(source.session_id)),
+            ])
+        });
+
     match event.kind {
-        UiOutputEventKind::LlmText(text) | UiOutputEventKind::TranscriptText { text } => Some(
-            acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(text.into())),
-        ),
-        UiOutputEventKind::ToolResultText { .. } => None,
-        UiOutputEventKind::AcpThought { text } => Some(acp::SessionUpdate::AgentThoughtChunk(
+        UiOutputEventKind::TranscriptText { text } => Some(acp::SessionUpdate::AgentMessageChunk(
             acp::ContentChunk::new(text.into()),
         )),
-        UiOutputEventKind::StructuredBlock { title, body } => Some(acp::SessionUpdate::ToolCall(
-            acp::ToolCall::new(title, body.unwrap_or_default()),
-        )),
-        UiOutputEventKind::StatusLine { text } => Some(acp::SessionUpdate::ToolCallUpdate(
-            acp::ToolCallUpdate::new("status", acp::ToolCallUpdateFields::new().title(text)),
-        )),
+        UiOutputEventKind::MessageChunk { text, raw } => {
+            let mut chunk = raw
+                .map(|chunk| *chunk)
+                .unwrap_or_else(|| acp::ContentChunk::new(text.into()));
+            if let Some(meta) = source_meta.clone() {
+                chunk = chunk.meta(meta);
+            }
+            Some(acp::SessionUpdate::AgentMessageChunk(chunk))
+        }
+        UiOutputEventKind::ToolResultText { .. } => None,
+        UiOutputEventKind::ThoughtChunk { text, raw } => {
+            let mut chunk = raw
+                .map(|chunk| *chunk)
+                .unwrap_or_else(|| acp::ContentChunk::new(text.into()));
+            if let Some(meta) = source_meta.clone() {
+                chunk = chunk.meta(meta);
+            }
+            Some(acp::SessionUpdate::AgentThoughtChunk(chunk))
+        }
+        UiOutputEventKind::ToolCallUpdate { title, status, raw } => {
+            let mut update = if let Some(update) = raw {
+                *update
+            } else {
+                let mut fields = acp::ToolCallUpdateFields::new();
+                if let Some(title) = title {
+                    fields = fields.title(title);
+                }
+                if let Some(status) = status {
+                    let status = match status.as_str() {
+                        "completed" => acp::ToolCallStatus::Completed,
+                        "in_progress" => acp::ToolCallStatus::InProgress,
+                        _ => acp::ToolCallStatus::Pending,
+                    };
+                    fields = fields.status(status);
+                }
+                acp::ToolCallUpdate::new("status", fields)
+            };
+            if let Some(meta) = source_meta.clone() {
+                update = update.meta(meta);
+            }
+            Some(acp::SessionUpdate::ToolCallUpdate(update))
+        }
         UiOutputEventKind::Plan { entries } => {
             let mapped_entries = entries
                 .into_iter()
@@ -453,21 +493,39 @@ async fn nested_ui_event_to_session_update(
                     acp::PlanEntry::new(entry.content, acp::PlanEntryPriority::Medium, status)
                 })
                 .collect();
-            Some(acp::SessionUpdate::Plan(acp::Plan::new(mapped_entries)))
+            let mut plan = acp::Plan::new(mapped_entries);
+            if let Some(meta) = source_meta.clone() {
+                plan = plan.meta(meta);
+            }
+            Some(acp::SessionUpdate::Plan(plan))
         }
-        UiOutputEventKind::McpToolInvocation {
+        UiOutputEventKind::ToolCall {
             tool_name,
             input_yaml,
-        } => Some(acp::SessionUpdate::ToolCall(acp::ToolCall::new(
-            tool_name,
-            input_yaml.unwrap_or_default(),
-        ))),
-        UiOutputEventKind::LlmFinal { output, .. } => Some(acp::SessionUpdate::AgentMessageChunk(
-            acp::ContentChunk::new(output.into()),
-        )),
-        UiOutputEventKind::LlmError(err) => Some(acp::SessionUpdate::AgentMessageChunk(
-            acp::ContentChunk::new(format!("[error] {err}").into()),
-        )),
+            raw,
+        } => {
+            let mut call = raw
+                .map(|call| *call)
+                .unwrap_or_else(|| acp::ToolCall::new(tool_name, input_yaml.unwrap_or_default()));
+            if let Some(meta) = source_meta.clone() {
+                call = call.meta(meta);
+            }
+            Some(acp::SessionUpdate::ToolCall(call))
+        }
+        UiOutputEventKind::LlmFinal { output, .. } => {
+            let mut chunk = acp::ContentChunk::new(output.into());
+            if let Some(meta) = source_meta.clone() {
+                chunk = chunk.meta(meta);
+            }
+            Some(acp::SessionUpdate::AgentMessageChunk(chunk))
+        }
+        UiOutputEventKind::LlmError(err) => {
+            let mut chunk = acp::ContentChunk::new(format!("[error] {err}").into());
+            if let Some(meta) = source_meta.clone() {
+                chunk = chunk.meta(meta);
+            }
+            Some(acp::SessionUpdate::AgentMessageChunk(chunk))
+        }
         UiOutputEventKind::Usage { .. } => None,
     }
 }
@@ -825,12 +883,17 @@ mod tests {
     #[test]
     fn nested_ui_event_maps_to_structured_session_updates() {
         run_local(async {
+            let nested_source = crate::ui_output::UiOutputSource {
+                agent: "argus".to_string(),
+                session_id: Some("nested-123".to_string()),
+            };
             let tool_update = nested_ui_event_to_session_update(crate::ui_output::UiOutputEvent {
-                kind: UiOutputEventKind::McpToolInvocation {
+                kind: UiOutputEventKind::ToolCall {
                     tool_name: "argus_session_prompt".to_string(),
                     input_yaml: Some("message: hello".to_string()),
+                    raw: None,
                 },
-                source: None,
+                source: Some(nested_source.clone()),
             })
             .await
             .expect("tool update");
@@ -839,23 +902,29 @@ mod tests {
                 acp::SessionUpdate::ToolCall(call) => {
                     assert!(format!("{:?}", call).contains("argus_session_prompt"));
                     assert!(format!("{:?}", call).contains("message: hello"));
+                    assert!(format!("{:?}", call).contains("argus"));
+                    assert!(format!("{:?}", call).contains("nested-123"));
                 }
                 other => panic!("unexpected tool update: {other:?}"),
             }
 
             let thought_update =
                 nested_ui_event_to_session_update(crate::ui_output::UiOutputEvent {
-                    kind: UiOutputEventKind::AcpThought {
+                    kind: UiOutputEventKind::ThoughtChunk {
                         text: "thinking".to_string(),
+                        raw: Some(Box::new(acp::ContentChunk::new("thinking".into()))),
                     },
-                    source: None,
+                    source: Some(nested_source.clone()),
                 })
                 .await
                 .expect("thought update");
-            assert!(matches!(
-                thought_update,
-                acp::SessionUpdate::AgentThoughtChunk(_)
-            ));
+            match thought_update {
+                acp::SessionUpdate::AgentThoughtChunk(chunk) => {
+                    assert!(format!("{:?}", chunk).contains("argus"));
+                    assert!(format!("{:?}", chunk).contains("nested-123"));
+                }
+                other => panic!("unexpected thought update: {other:?}"),
+            }
 
             let plan_update = nested_ui_event_to_session_update(crate::ui_output::UiOutputEvent {
                 kind: UiOutputEventKind::Plan {
@@ -864,7 +933,7 @@ mod tests {
                         content: "delegate to argus".to_string(),
                     }],
                 },
-                source: None,
+                source: Some(nested_source),
             })
             .await
             .expect("plan update");

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -354,12 +354,13 @@ impl ToolCall {
 
         // Emit tool call info to TUI or terminal
         let event = UiOutputEvent {
-            kind: UiOutputEventKind::McpToolInvocation {
+            kind: UiOutputEventKind::ToolCall {
                 tool_name: self.name.clone(),
                 input_yaml: match json_data {
                     Value::Null => None,
                     _ => Some(pretty_yaml_block(&json_data)),
                 },
+                raw: None,
             },
             source: None,
         };
@@ -568,12 +569,13 @@ mod tests {
     #[test]
     fn test_mcp_tool_invocation_terminal_fallback_multiline_yaml() {
         let rendered = event_fallback_text(
-            &UiOutputEventKind::McpToolInvocation {
+            &UiOutputEventKind::ToolCall {
                 tool_name: "argus_session_prompt".to_string(),
                 input_yaml: Some(pretty_yaml_block(&json!({
                     "message": "Goal — Improve display\nAcceptance criteria — Wrap nicely",
                     "session_id": "session-1"
                 }))),
+                raw: None,
             },
             None,
         );
@@ -801,9 +803,10 @@ mod tests {
         let forward = tokio::spawn(forward_acp_chunks(rx, None, "working".to_string(), false));
 
         tx.send(NestedAcpEvent::Ui(UiOutputEvent {
-            kind: UiOutputEventKind::McpToolInvocation {
+            kind: UiOutputEventKind::ToolCall {
                 tool_name: "argus_session_prompt".to_string(),
                 input_yaml: Some("message: hi".to_string()),
+                raw: None,
             },
             source: Some(crate::ui_output::UiOutputSource {
                 agent: "argus".to_string(),
@@ -817,9 +820,10 @@ mod tests {
 
         let event = ui_rx.recv().await.expect("forwarded UI event");
         match event.kind {
-            UiOutputEventKind::McpToolInvocation {
+            UiOutputEventKind::ToolCall {
                 tool_name,
                 input_yaml,
+                ..
             } => {
                 assert_eq!(tool_name, "argus_session_prompt");
                 assert_eq!(input_yaml.as_deref(), Some("message: hi"));

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::tui::render_helpers::{
-    render_plan_entries, render_structured_block, render_usage_line, source_heading,
+    render_plan_entries, render_status_line, render_usage_line, source_heading,
 };
 use crate::tui::types::{TranscriptEntry, TuiEvent};
 use crate::ui_output::{UiOutputEvent, UiOutputEventKind, UiOutputSource};
@@ -478,7 +478,7 @@ impl Tui {
     }
 
     async fn render_ui_output_event(&mut self, event: UiOutputEvent) {
-        let is_thought = matches!(&event.kind, UiOutputEventKind::AcpThought { .. });
+        let is_thought = matches!(&event.kind, UiOutputEventKind::ThoughtChunk { .. });
         let is_usage = matches!(&event.kind, UiOutputEventKind::Usage { .. });
         if !is_thought {
             self.flush_pending_thought();
@@ -505,12 +505,16 @@ impl Tui {
                         .collect()
                 }
             }
-            UiOutputEventKind::LlmText(text) => {
-                self.app.last_ui_output_source = None;
-                self.app.pending_thought_source = None;
-                self.append_streaming_assistant_chunk(&text);
-                self.pin_transcript_to_bottom();
-                vec![]
+            UiOutputEventKind::MessageChunk { text, .. } => {
+                if text.trim().is_empty() {
+                    vec![]
+                } else {
+                    self.app.last_ui_output_source = None;
+                    self.app.pending_thought_source = None;
+                    self.append_streaming_assistant_chunk(&text);
+                    self.pin_transcript_to_bottom();
+                    vec![]
+                }
             }
             UiOutputEventKind::LlmFinal { output, usage } => {
                 self.flush_pending_thought();
@@ -574,8 +578,18 @@ impl Tui {
                 }
                 vec![]
             }
-            UiOutputEventKind::AcpThought { text } => {
-                let clean = strip_ansi(&text);
+            UiOutputEventKind::ThoughtChunk { text, raw } => {
+                let text = crate::tui::render_helpers::event_fallback_text(
+                    &UiOutputEventKind::ThoughtChunk {
+                        text: text.clone(),
+                        raw: raw.clone(),
+                    },
+                    event.source.as_ref(),
+                );
+                let clean = strip_ansi(&text)
+                    .trim_start_matches("<think>")
+                    .trim_end_matches("</think>")
+                    .to_string();
                 if clean.trim().is_empty() {
                     vec![]
                 } else {
@@ -587,14 +601,12 @@ impl Tui {
                     vec![]
                 }
             }
-            UiOutputEventKind::StructuredBlock { title, body } => {
-                render_structured_block(&title, body.as_deref())
-            }
-            UiOutputEventKind::StatusLine { text } => {
-                if text.is_empty() {
-                    vec![]
-                } else {
+
+            UiOutputEventKind::ToolCallUpdate { title, status, .. } => {
+                if let Some(text) = render_status_line(title.as_deref(), status.as_deref()) {
                     vec![TranscriptEntry::System(text)]
+                } else {
+                    vec![]
                 }
             }
             UiOutputEventKind::Plan { entries } => render_plan_entries(&entries),
@@ -621,10 +633,20 @@ impl Tui {
                     vec![]
                 }
             }
-            UiOutputEventKind::McpToolInvocation {
+            UiOutputEventKind::ToolCall {
                 tool_name,
                 input_yaml,
-            } => render_structured_block(&format!("->️ {tool_name}"), input_yaml.as_deref()),
+                ..
+            } => {
+                let mut entries = vec![TranscriptEntry::System(format!("->️ {tool_name}"))];
+                if let Some(yaml) = &input_yaml {
+                    entries.extend(
+                        yaml.lines()
+                            .map(|line| TranscriptEntry::System(format!("   {line}"))),
+                    );
+                }
+                entries
+            }
         };
 
         if !rendered_entries.is_empty() {

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1,8 +1,6 @@
 use super::*;
-use crate::tui::render_helpers::{
-    render_plan_entries, render_status_line, render_usage_line, source_heading,
-};
-use crate::tui::types::{TranscriptEntry, TuiEvent};
+use crate::tui::render_helpers::{render_status_line, render_usage_line};
+use crate::tui::types::{TranscriptItem, TuiEvent};
 use crate::ui_output::{UiOutputEvent, UiOutputEventKind, UiOutputSource};
 use std::path::Path;
 
@@ -82,7 +80,7 @@ impl Tui {
             (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
                 // Abort current operation; reset signal so next submit works (fix #3)
                 self.abort_signal.set_ctrlc();
-                self.app.transcript.push(TranscriptEntry::System(
+                self.app.transcript.push(TranscriptItem::SystemText(
                     "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
                 ));
                 self.app.llm_busy = false;
@@ -150,14 +148,14 @@ impl Tui {
                         // Dot-command: route through repl command handler
                         self.app
                             .transcript
-                            .push(TranscriptEntry::User(text.clone()));
+                            .push(TranscriptItem::UserText(text.clone()));
                         self.app.input = Self::new_input();
                         self.run_repl_command(&text).await?;
                         self.refresh_input_chrome();
                     } else {
                         self.app
                             .transcript
-                            .push(TranscriptEntry::User(text.clone()));
+                            .push(TranscriptItem::UserText(text.clone()));
                         self.app.input = Self::new_input();
                         let msg = crate::tui::types::PendingMessage {
                             text,
@@ -249,7 +247,7 @@ impl Tui {
                             unique_attachment_display_name(&self.app.attachments, &original_name);
                         let dest = unique_attachment_storage_path(&dir, &original_name);
                         if let Err(err) = tokio::fs::copy(&src, &dest).await {
-                            self.app.transcript.push(TranscriptEntry::Error(format!(
+                            self.app.transcript.push(TranscriptItem::ErrorText(format!(
                                 "Failed to copy attachment: {err}"
                             )));
                         } else {
@@ -260,13 +258,13 @@ impl Tui {
                         }
                     }
                     Err(err) => {
-                        self.app.transcript.push(TranscriptEntry::Error(format!(
+                        self.app.transcript.push(TranscriptItem::ErrorText(format!(
                             "Failed to create attachment directory: {err}"
                         )));
                     }
                 }
             } else {
-                self.app.transcript.push(TranscriptEntry::Error(format!(
+                self.app.transcript.push(TranscriptItem::ErrorText(format!(
                     "File not found: {path_str}"
                 )));
             }
@@ -285,7 +283,7 @@ impl Tui {
                 .filter(|a| a.display_name == name)
             {
                 if let Err(err) = std::fs::remove_file(&attachment.path) {
-                    self.app.transcript.push(TranscriptEntry::Error(format!(
+                    self.app.transcript.push(TranscriptItem::ErrorText(format!(
                         "Failed to remove detached attachment file {}: {err}",
                         attachment.display_name
                     )));
@@ -329,7 +327,7 @@ impl Tui {
                     self.app.attachments.push(attachment);
                 }
                 Err(err) => {
-                    self.app.transcript.push(TranscriptEntry::Error(format!(
+                    self.app.transcript.push(TranscriptItem::ErrorText(format!(
                         "Failed to save pasted text: {err}"
                     )));
                 }
@@ -419,7 +417,7 @@ impl Tui {
         self.app.input = Self::new_input();
         self.app
             .transcript
-            .push(TranscriptEntry::User(pending.text.clone()));
+            .push(TranscriptItem::UserText(pending.text.clone()));
         self.render_submitted_attachments(&pending.attachments);
         self.pin_transcript_to_bottom();
         if pending.text.trim_start().starts_with('.') {
@@ -439,22 +437,23 @@ impl Tui {
             return;
         }
 
-        self.app.transcript.push(TranscriptEntry::System(format!(
-            "Attachments ({}):",
-            attachments.len()
-        )));
+        self.app
+            .transcript
+            .push(TranscriptItem::AttachmentHeader(format!(
+                "Attachments ({})",
+                attachments.len()
+            )));
 
         for attachment in attachments {
-            self.app.transcript.push(TranscriptEntry::System(format!(
-                "  - {}",
-                attachment.display_name
-            )));
+            self.app.transcript.push(TranscriptItem::AttachmentItem(
+                attachment.display_name.clone(),
+            ));
 
             if let Some(preview) = render_attachment_preview(&attachment.path) {
                 for line in preview.lines() {
                     self.app
                         .transcript
-                        .push(TranscriptEntry::System(format!("      {line}")));
+                        .push(TranscriptItem::AttachmentPreviewLine(line.to_string()));
                 }
             }
         }
@@ -466,10 +465,9 @@ impl Tui {
         }
         let text = std::mem::take(&mut self.app.pending_thought_text);
         self.app.pending_thought_source = None;
-        self.app.transcript.push(TranscriptEntry::System(format!(
-            "<think>{}</think>",
-            text.trim()
-        )));
+        self.app
+            .transcript
+            .push(TranscriptItem::ThoughtText(text.trim().to_string()));
     }
 
     #[cfg(test)]
@@ -491,7 +489,7 @@ impl Tui {
                 if clean.is_empty() {
                     vec![]
                 } else {
-                    vec![TranscriptEntry::System(clean)]
+                    vec![TranscriptItem::SystemText(clean)]
                 }
             }
             UiOutputEventKind::ToolResultText { text } => {
@@ -501,7 +499,7 @@ impl Tui {
                 } else {
                     clean
                         .lines()
-                        .map(|line| TranscriptEntry::System(format!("   {line}")))
+                        .map(|line| TranscriptItem::ToolResultText(line.to_string()))
                         .collect()
                 }
             }
@@ -521,19 +519,25 @@ impl Tui {
                 if !output.is_empty() {
                     if let Some(idx) = self.app.streaming_assistant_idx {
                         match self.app.transcript.get_mut(idx) {
-                            Some(TranscriptEntry::Assistant(existing)) if !existing.is_empty() => {
+                            Some(TranscriptItem::AssistantText(existing))
+                                if !existing.is_empty() =>
+                            {
                                 if existing != &output {
                                     *existing = output;
                                 }
                             }
                             _ => {
-                                self.app.transcript.push(TranscriptEntry::Assistant(output));
+                                self.app
+                                    .transcript
+                                    .push(TranscriptItem::AssistantText(output));
                                 self.app.streaming_assistant_idx =
                                     Some(self.app.transcript.len() - 1);
                             }
                         }
                     } else {
-                        self.app.transcript.push(TranscriptEntry::Assistant(output));
+                        self.app
+                            .transcript
+                            .push(TranscriptItem::AssistantText(output));
                         self.app.streaming_assistant_idx = Some(self.app.transcript.len() - 1);
                     }
                     self.pin_transcript_to_bottom();
@@ -542,7 +546,7 @@ impl Tui {
                 if !usage.is_empty() {
                     self.app
                         .transcript
-                        .push(TranscriptEntry::System(format!("Usage: {usage}")));
+                        .push(TranscriptItem::SystemText(format!("Usage: {usage}")));
                     self.pin_transcript_to_bottom();
                 }
                 self.refresh_input_chrome();
@@ -551,7 +555,7 @@ impl Tui {
                     if let Err(err) = self.submit_pending_message(pending).await {
                         self.app
                             .transcript
-                            .push(TranscriptEntry::Error(err.to_string()));
+                            .push(TranscriptItem::ErrorText(err.to_string()));
                         self.pin_transcript_to_bottom();
                     }
                 }
@@ -562,7 +566,7 @@ impl Tui {
                 self.app.llm_busy = false;
                 self.app.streaming_assistant_idx = None;
                 self.app.last_ui_output_source = None;
-                self.app.transcript.push(TranscriptEntry::Error(err));
+                self.app.transcript.push(TranscriptItem::ErrorText(err));
                 self.pin_transcript_to_bottom();
                 self.refresh_input_chrome();
 
@@ -570,7 +574,7 @@ impl Tui {
                     if let Err(err) = self.submit_pending_message(pending).await {
                         self.app
                             .transcript
-                            .push(TranscriptEntry::Error(err.to_string()));
+                            .push(TranscriptItem::ErrorText(err.to_string()));
                         self.pin_transcript_to_bottom();
                     }
                 }
@@ -602,12 +606,12 @@ impl Tui {
 
             UiOutputEventKind::ToolCallUpdate { title, status, .. } => {
                 if let Some(text) = render_status_line(title.as_deref(), status.as_deref()) {
-                    vec![TranscriptEntry::System(text)]
+                    vec![TranscriptItem::StatusLine(text)]
                 } else {
                     vec![]
                 }
             }
-            UiOutputEventKind::Plan { entries } => render_plan_entries(&entries),
+            UiOutputEventKind::Plan { entries } => vec![TranscriptItem::Plan(entries)],
             UiOutputEventKind::Usage {
                 input_tokens,
                 output_tokens,
@@ -625,7 +629,7 @@ impl Tui {
                     if self.update_existing_usage_line(event.source.as_ref(), &line) {
                         vec![]
                     } else {
-                        vec![TranscriptEntry::System(line)]
+                        vec![TranscriptItem::UsageLine(line)]
                     }
                 } else {
                     vec![]
@@ -636,14 +640,10 @@ impl Tui {
                 input_yaml,
                 ..
             } => {
-                let mut entries = vec![TranscriptEntry::System(format!("->️ {tool_name}"))];
-                if let Some(yaml) = &input_yaml {
-                    entries.extend(
-                        yaml.lines()
-                            .map(|line| TranscriptEntry::System(format!("   {line}"))),
-                    );
-                }
-                entries
+                vec![TranscriptItem::ToolCall {
+                    tool_name,
+                    input_yaml,
+                }]
             }
         };
 
@@ -666,8 +666,9 @@ impl Tui {
         let source = source.cloned();
         if source != self.app.last_ui_output_source {
             if let Some(source) = &source {
-                let heading = source_heading(source);
-                self.app.transcript.push(TranscriptEntry::System(heading));
+                self.app
+                    .transcript
+                    .push(TranscriptItem::SourceHeading(source.clone()));
             }
             self.app.last_ui_output_source = source;
         }
@@ -693,7 +694,7 @@ impl Tui {
             return false;
         };
         match entry {
-            TranscriptEntry::System(existing) => {
+            TranscriptItem::UsageLine(existing) => {
                 *existing = line.to_string();
                 true
             }
@@ -1014,7 +1015,7 @@ impl Tui {
 
         let clean = strip_ansi(&captured).trim_end_matches('\n').to_string();
         if !clean.is_empty() {
-            self.app.transcript.push(TranscriptEntry::System(clean));
+            self.app.transcript.push(TranscriptItem::SystemText(clean));
             self.pin_transcript_to_bottom();
         }
 
@@ -1035,7 +1036,7 @@ impl Tui {
             Err(err) => {
                 self.app
                     .transcript
-                    .push(TranscriptEntry::Error(err.to_string()));
+                    .push(TranscriptItem::ErrorText(err.to_string()));
             }
         }
         Ok(())

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -509,8 +509,6 @@ impl Tui {
                 if text.trim().is_empty() {
                     vec![]
                 } else {
-                    self.app.last_ui_output_source = None;
-                    self.app.pending_thought_source = None;
                     self.append_streaming_assistant_chunk(&text);
                     self.pin_transcript_to_bottom();
                     vec![]

--- a/src/tui/lifecycle.rs
+++ b/src/tui/lifecycle.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::tui::event_source::{CrosstermEventSource, EventSource};
 use crate::tui::terminal::{cleanup_terminal_state, PanicTerminalHookGuard};
-use crate::tui::types::{App, TranscriptEntry, TuiEvent, SPINNER_FRAMES, TICK_RATE};
+use crate::tui::types::{App, TranscriptItem, TuiEvent, SPINNER_FRAMES, TICK_RATE};
 
 impl Tui {
     #[cfg(test)]
@@ -82,13 +82,13 @@ impl Tui {
         })
     }
 
-    fn build_initial_transcript(config: &GlobalConfig) -> Vec<TranscriptEntry> {
+    fn build_initial_transcript(config: &GlobalConfig) -> Vec<TranscriptItem> {
         let mut entries = vec![];
         let cfg = config.read();
         let state = cfg.state();
 
         // Show welcome only when not already in an agent/RAG session (matches old REPL behaviour)
-        entries.push(TranscriptEntry::System(format!(
+        entries.push(TranscriptItem::SystemText(format!(
             "Welcome to {} {}  •  Type .help for commands, Tab to complete.",
             env!("CARGO_CRATE_NAME"),
             env!("CARGO_PKG_VERSION")
@@ -98,7 +98,7 @@ impl Tui {
         if state.contains(crate::config::StateFlags::AGENT) {
             if let Ok(banner) = cfg.agent_banner() {
                 if !banner.trim().is_empty() {
-                    entries.push(TranscriptEntry::Assistant(banner));
+                    entries.push(TranscriptItem::AssistantText(banner));
                 }
             }
             if let Some(agent) = &cfg.agent {
@@ -110,7 +110,7 @@ impl Tui {
                         .map(|(i, s)| format!("  {}. {s}", i + 1))
                         .collect::<Vec<_>>()
                         .join("\n");
-                    entries.push(TranscriptEntry::System(format!(
+                    entries.push(TranscriptItem::SystemText(format!(
                         "Conversation starters:\n{list}\n(type .starter <n> to use)"
                     )));
                 }
@@ -120,7 +120,7 @@ impl Tui {
         // Show status line if set (session / model info)
         let status = cfg.render_status_line(true);
         if !status.is_empty() {
-            entries.push(TranscriptEntry::System(status));
+            entries.push(TranscriptItem::SystemText(status));
         }
 
         entries
@@ -239,7 +239,7 @@ impl Tui {
                 .unwrap_or_else(|| "Continue working on pending tasks.".to_string())
         };
         let _ = max_resume; // used inside run_prompt_inner
-        self.app.transcript.push(TranscriptEntry::System(format!(
+        self.app.transcript.push(TranscriptItem::SystemText(format!(
             "↩ Async resume: {context}"
         )));
         self.pin_transcript_to_bottom();

--- a/src/tui/prompt.rs
+++ b/src/tui/prompt.rs
@@ -256,7 +256,10 @@ impl Tui {
                     crate::client::SseEvent::Text(text) => {
                         let _ =
                             event_tx.send(TuiEvent::UiOutput(crate::ui_output::UiOutputEvent {
-                                kind: crate::ui_output::UiOutputEventKind::LlmText(text),
+                                kind: crate::ui_output::UiOutputEventKind::MessageChunk {
+                                    text,
+                                    raw: None,
+                                },
                                 source: None,
                             }));
                     }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::tui::types::{App, TranscriptEntry, MAX_INPUT_HEIGHT, MIN_INPUT_HEIGHT, SPINNER_FRAMES};
+use crate::tui::types::{App, TranscriptItem, MAX_INPUT_HEIGHT, MIN_INPUT_HEIGHT, SPINNER_FRAMES};
 
 /// Estimate the number of terminal rows a set of lines will occupy
 /// after word-wrapping to the given width.
@@ -18,30 +18,12 @@ fn wrapped_line_count(lines: &[Line<'_>], width: u16) -> usize {
 }
 
 impl Tui {
-    pub(super) fn render_entry(entry: &TranscriptEntry) -> Vec<Line<'static>> {
-        let (prefix, text, style) = match entry {
-            TranscriptEntry::System(text) => (
-                "",
-                text.clone(),
-                Style::default()
-                    .fg(Color::DarkGray)
-                    .add_modifier(Modifier::DIM),
-            ),
-            TranscriptEntry::User(text) => (
-                "> ",
-                text.clone(),
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            TranscriptEntry::Assistant(text) => ("", text.clone(), Style::default()),
-            TranscriptEntry::Error(text) => (
-                "error: ",
-                text.clone(),
-                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-            ),
-        };
-
+    fn render_text_entry(
+        prefix: &str,
+        text: &str,
+        style: Style,
+        add_trailing_spacing: bool,
+    ) -> Vec<Line<'static>> {
         let mut lines = vec![];
         for (index, line) in text.lines().enumerate() {
             if index == 0 {
@@ -56,15 +38,151 @@ impl Tui {
         if lines.is_empty() {
             lines.push(Line::from(Span::styled(prefix.to_string(), style)));
         }
-        let add_trailing_spacing = match entry {
-            TranscriptEntry::System(_) => false,
-            TranscriptEntry::Assistant(text) => !text.contains('\n'),
-            _ => true,
-        };
         if add_trailing_spacing {
             lines.push(Line::from(""));
         }
         lines
+    }
+
+    pub(super) fn render_entry(entry: &TranscriptItem) -> Vec<Line<'static>> {
+        match entry {
+            TranscriptItem::SourceHeading(source) => Self::render_text_entry(
+                "",
+                &crate::tui::render_helpers::source_heading(source),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
+                false,
+            ),
+            TranscriptItem::SystemText(text) => Self::render_text_entry(
+                "",
+                text,
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
+                false,
+            ),
+            TranscriptItem::UserText(text) => Self::render_text_entry(
+                "> ",
+                text,
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+                true,
+            ),
+            TranscriptItem::AssistantText(text) => {
+                Self::render_text_entry("", text, Style::default(), !text.contains('\n'))
+            }
+            TranscriptItem::ErrorText(text) => Self::render_text_entry(
+                "error: ",
+                text,
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                true,
+            ),
+            TranscriptItem::ThoughtText(text) => Self::render_text_entry(
+                "",
+                &format!("<think>{text}</think>"),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
+                false,
+            ),
+            TranscriptItem::ToolResultText(text) => Self::render_text_entry(
+                "   ",
+                text,
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
+                false,
+            ),
+            TranscriptItem::StatusLine(text) => Self::render_text_entry(
+                "",
+                text,
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
+                false,
+            ),
+            TranscriptItem::Plan(entries) => {
+                let mut lines = Self::render_text_entry(
+                    "",
+                    "Plan:",
+                    Style::default()
+                        .fg(Color::DarkGray)
+                        .add_modifier(Modifier::DIM),
+                    false,
+                );
+                for entry in entries {
+                    lines.extend(Self::render_text_entry(
+                        "",
+                        &format!("  [{}] {}", entry.status, entry.content),
+                        Style::default()
+                            .fg(Color::DarkGray)
+                            .add_modifier(Modifier::DIM),
+                        false,
+                    ));
+                }
+                lines
+            }
+            TranscriptItem::UsageLine(text) => Self::render_text_entry(
+                "",
+                text,
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
+                false,
+            ),
+            TranscriptItem::ToolCall {
+                tool_name,
+                input_yaml,
+            } => {
+                let mut lines = Self::render_text_entry(
+                    "",
+                    &format!("->️ {tool_name}"),
+                    Style::default()
+                        .fg(Color::DarkGray)
+                        .add_modifier(Modifier::DIM),
+                    false,
+                );
+                if let Some(yaml) = input_yaml {
+                    for line in yaml.lines() {
+                        lines.extend(Self::render_text_entry(
+                            "   ",
+                            line,
+                            Style::default()
+                                .fg(Color::DarkGray)
+                                .add_modifier(Modifier::DIM),
+                            false,
+                        ));
+                    }
+                }
+                lines
+            }
+            TranscriptItem::AttachmentHeader(text) => Self::render_text_entry(
+                "",
+                &format!("{text}:"),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
+                false,
+            ),
+            TranscriptItem::AttachmentItem(text) => Self::render_text_entry(
+                "  - ",
+                text,
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
+                false,
+            ),
+            TranscriptItem::AttachmentPreviewLine(text) => Self::render_text_entry(
+                "      ",
+                text,
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
+                false,
+            ),
+        }
     }
 
     pub(crate) fn draw(&mut self, frame: &mut Frame<'_>) {
@@ -240,7 +358,7 @@ impl Tui {
         while !remainder.is_empty() {
             if let Some(idx) = self.app.streaming_assistant_idx {
                 match self.app.transcript.get_mut(idx) {
-                    Some(TranscriptEntry::Assistant(existing)) => {
+                    Some(TranscriptItem::AssistantText(existing)) => {
                         if existing.is_empty() {
                             if let Some(split_at) = remainder.find('\n') {
                                 let (segment, rest) = remainder.split_at(split_at + 1);
@@ -279,7 +397,7 @@ impl Tui {
             } else {
                 self.app
                     .transcript
-                    .push(TranscriptEntry::Assistant(String::new()));
+                    .push(TranscriptItem::AssistantText(String::new()));
                 self.app.streaming_assistant_idx = Some(self.app.transcript.len() - 1);
             }
         }

--- a/src/tui/render_helpers.rs
+++ b/src/tui/render_helpers.rs
@@ -1,5 +1,4 @@
-use crate::tui::types::TranscriptEntry;
-use crate::ui_output::{UiOutputEventKind, UiOutputPlanEntry, UiOutputSource};
+use crate::ui_output::{UiOutputEventKind, UiOutputSource};
 
 pub(crate) fn render_status_line(title: Option<&str>, status: Option<&str>) -> Option<String> {
     let line = [title, status]
@@ -17,20 +16,6 @@ pub(crate) fn source_heading(source: &UiOutputSource) -> String {
         }
         _ => format!("> {}", source.agent),
     }
-}
-
-pub(super) fn render_plan_entries(entries: &[UiOutputPlanEntry]) -> Vec<TranscriptEntry> {
-    if entries.is_empty() {
-        return vec![];
-    }
-
-    let mut rendered = vec![TranscriptEntry::System("Plan: ".trim_end().to_string())];
-    rendered.extend(
-        entries.iter().map(|entry| {
-            TranscriptEntry::System(format!("  [{}] {}", entry.status, entry.content))
-        }),
-    );
-    rendered
 }
 
 pub(crate) fn render_usage_line(

--- a/src/tui/render_helpers.rs
+++ b/src/tui/render_helpers.rs
@@ -19,17 +19,6 @@ pub(crate) fn source_heading(source: &UiOutputSource) -> String {
     }
 }
 
-pub(super) fn render_structured_block(title: &str, body: Option<&str>) -> Vec<TranscriptEntry> {
-    let mut entries = vec![TranscriptEntry::System(title.to_string())];
-    if let Some(body) = body {
-        entries.extend(
-            body.lines()
-                .map(|line| TranscriptEntry::System(format!("   {line}"))),
-        );
-    }
-    entries
-}
-
 pub(super) fn render_plan_entries(entries: &[UiOutputPlanEntry]) -> Vec<TranscriptEntry> {
     if entries.is_empty() {
         return vec![];
@@ -74,25 +63,18 @@ pub(crate) fn event_fallback_text(
     source: Option<&UiOutputSource>,
 ) -> String {
     match kind {
-        UiOutputEventKind::LlmText(text)
+        UiOutputEventKind::MessageChunk { text, .. }
         | UiOutputEventKind::TranscriptText { text }
         | UiOutputEventKind::ToolResultText { text } => text.clone(),
         UiOutputEventKind::LlmFinal { output, usage: _ } => output.clone(),
         UiOutputEventKind::LlmError(err) => err.clone(),
-        UiOutputEventKind::AcpThought { text } => format!("<think>{text}</think>"),
-        UiOutputEventKind::StructuredBlock { title, body } => {
-            let mut lines = vec![title.clone()];
-            if let Some(body) = body {
-                lines.extend(body.lines().map(|line| format!("   {line}")));
-            }
-            format!("\n{}\n", lines.join("\n"))
+        UiOutputEventKind::ThoughtChunk { text, .. } => {
+            format!("<think>{text}</think>")
         }
-        UiOutputEventKind::StatusLine { text } => {
-            if text.is_empty() {
-                String::new()
-            } else {
-                format!("\n{text}\n")
-            }
+        UiOutputEventKind::ToolCallUpdate { title, status, .. } => {
+            render_status_line(title.as_deref(), status.as_deref())
+                .map(|text| format!("\n{text}\n"))
+                .unwrap_or_default()
         }
         UiOutputEventKind::Plan { entries } => {
             if entries.is_empty() {
@@ -120,9 +102,10 @@ pub(crate) fn event_fallback_text(
         )
         .map(|line| format!("\n{line}\n"))
         .unwrap_or_default(),
-        UiOutputEventKind::McpToolInvocation {
+        UiOutputEventKind::ToolCall {
             tool_name,
             input_yaml,
+            ..
         } => {
             let mut lines = vec![format!("->️ {tool_name}")];
             if let Some(input_yaml) = input_yaml {

--- a/src/tui/snapshots/harnx__tui__tests__thinking_stream_coalescing_around_tool_calls.snap
+++ b/src/tui/snapshots/harnx__tui__tests__thinking_stream_coalescing_around_tool_calls.snap
@@ -1,12 +1,12 @@
 ---
 source: src/tui/tests.rs
-assertion_line: 776
+assertion_line: 807
 expression: rendered
 ---
 Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
 > argus ▸ session-1
 <think>thinking before tool</think>
-argus_session_prompt
+->️ argus_session_prompt
    message: delegate
 <think>thinking after tool</think>
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -6,6 +6,7 @@ use crate::tui::render_helpers::event_fallback_text;
 use crate::tui::types::{TranscriptEntry, TuiEvent};
 use crate::ui_output::{UiOutputEvent, UiOutputEventKind, UiOutputSource};
 use crate::utils::dimmed_text;
+use agent_client_protocol as acp;
 use parking_lot::RwLock;
 use std::sync::Arc;
 use std::time::Duration;
@@ -206,7 +207,10 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
     let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
 
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::LlmText("Hello\nworld".to_string()),
+        kind: UiOutputEventKind::MessageChunk {
+            text: "Hello\nworld".to_string(),
+            raw: None,
+        },
         source: None,
     }))
     .await
@@ -220,7 +224,10 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
     .await
     .unwrap();
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::LlmText("\nAgain".to_string()),
+        kind: UiOutputEventKind::MessageChunk {
+            text: "\nAgain".to_string(),
+            raw: None,
+        },
         source: None,
     }))
     .await
@@ -455,7 +462,10 @@ async fn sub_agent_heading_transitions_render_in_tui_snapshot() {
     harness
         .tui()
         .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::LlmText("Top-level assistant opening response.".to_string()),
+            kind: UiOutputEventKind::MessageChunk {
+                text: "Top-level assistant opening response.".to_string(),
+                raw: None,
+            },
             source: None,
         }))
         .await
@@ -502,7 +512,10 @@ async fn sub_agent_heading_transitions_render_in_tui_snapshot() {
     harness
         .tui()
         .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::LlmText("Top-level assistant closes response.".to_string()),
+            kind: UiOutputEventKind::MessageChunk {
+                text: "Top-level assistant closes response.".to_string(),
+                raw: None,
+            },
             source: None,
         }))
         .await
@@ -526,9 +539,10 @@ async fn structured_system_entries_do_not_insert_blank_lines_between_each_line()
     harness
         .tui()
         .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::StructuredBlock {
-                title: "argus_session_prompt".to_string(),
-                body: Some("message: hello\nsession_id: abc123".to_string()),
+            kind: UiOutputEventKind::ToolCall {
+                tool_name: "argus_session_prompt".to_string(),
+                input_yaml: Some("message: hello\nsession_id: abc123".to_string()),
+                raw: None,
             },
             source: Some(UiOutputSource {
                 agent: "argus".to_string(),
@@ -540,8 +554,11 @@ async fn structured_system_entries_do_not_insert_blank_lines_between_each_line()
     harness
         .tui()
         .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::AcpThought {
+            kind: UiOutputEventKind::ThoughtChunk {
                 text: "thinking hard\nstep two".to_string(),
+                raw: Some(Box::new(acp::ContentChunk::new(
+                    "thinking hard\nstep two".into(),
+                ))),
             },
             source: Some(UiOutputSource {
                 agent: "argus".to_string(),
@@ -565,8 +582,9 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
 
     for chunk in ["thinking ", "before ", "tool"] {
         tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::AcpThought {
+            kind: UiOutputEventKind::ThoughtChunk {
                 text: chunk.to_string(),
+                raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
             },
             source: None,
         }))
@@ -575,9 +593,10 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
     }
 
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::StructuredBlock {
-            title: "argus_session_prompt".to_string(),
-            body: Some("message: delegate".to_string()),
+        kind: UiOutputEventKind::ToolCall {
+            tool_name: "argus_session_prompt".to_string(),
+            input_yaml: Some("message: delegate".to_string()),
+            raw: None,
         },
         source: None,
     }))
@@ -586,8 +605,9 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
 
     for chunk in ["thinking ", "after ", "tool"] {
         tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::AcpThought {
+            kind: UiOutputEventKind::ThoughtChunk {
                 text: chunk.to_string(),
+                raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
             },
             source: None,
         }))
@@ -615,7 +635,7 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         system_entries,
         vec![
             "<think>thinking before tool</think>",
-            "argus_session_prompt",
+            "->️ argus_session_prompt",
             "   message: delegate",
             "<think>thinking after tool</think>",
         ]
@@ -635,8 +655,9 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
 
     for chunk in ["thinking ", "before ", "tool"] {
         tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::AcpThought {
+            kind: UiOutputEventKind::ThoughtChunk {
                 text: chunk.to_string(),
+                raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
             },
             source: source.clone(),
         }))
@@ -645,9 +666,10 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
     }
 
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::StructuredBlock {
-            title: "argus_session_prompt".to_string(),
-            body: Some("message: delegate".to_string()),
+        kind: UiOutputEventKind::ToolCall {
+            tool_name: "argus_session_prompt".to_string(),
+            input_yaml: Some("message: delegate".to_string()),
+            raw: None,
         },
         source: source.clone(),
     }))
@@ -656,8 +678,9 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
 
     for chunk in ["thinking ", "after ", "tool"] {
         tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::AcpThought {
+            kind: UiOutputEventKind::ThoughtChunk {
                 text: chunk.to_string(),
+                raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
             },
             source: source.clone(),
         }))
@@ -686,7 +709,7 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         vec![
             "> argus ▸ session-1",
             "<think>thinking before tool</think>",
-            "argus_session_prompt",
+            "->️ argus_session_prompt",
             "   message: delegate",
             "<think>thinking after tool</think>",
         ]
@@ -704,7 +727,10 @@ async fn llm_multiline_text_renders_without_extra_blank_lines() {
     harness
         .tui()
         .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::LlmText("line one\nline two\nline three".to_string()),
+            kind: UiOutputEventKind::MessageChunk {
+                text: "line one\nline two\nline three".to_string(),
+                raw: None,
+            },
             source: None,
         }))
         .await
@@ -731,8 +757,9 @@ async fn thinking_stream_coalescing_around_tool_calls_snapshot() {
         harness
             .tui()
             .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-                kind: UiOutputEventKind::AcpThought {
+                kind: UiOutputEventKind::ThoughtChunk {
                     text: chunk.to_string(),
+                    raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
                 },
                 source: Some(UiOutputSource {
                     agent: "argus".to_string(),
@@ -745,9 +772,10 @@ async fn thinking_stream_coalescing_around_tool_calls_snapshot() {
     harness
         .tui()
         .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-            kind: UiOutputEventKind::StructuredBlock {
-                title: "argus_session_prompt".to_string(),
-                body: Some("message: delegate".to_string()),
+            kind: UiOutputEventKind::ToolCall {
+                tool_name: "argus_session_prompt".to_string(),
+                input_yaml: Some("message: delegate".to_string()),
+                raw: None,
             },
             source: Some(UiOutputSource {
                 agent: "argus".to_string(),
@@ -760,8 +788,9 @@ async fn thinking_stream_coalescing_around_tool_calls_snapshot() {
         harness
             .tui()
             .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-                kind: UiOutputEventKind::AcpThought {
+                kind: UiOutputEventKind::ThoughtChunk {
                     text: chunk.to_string(),
+                    raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
                 },
                 source: Some(UiOutputSource {
                     agent: "argus".to_string(),
@@ -785,9 +814,10 @@ async fn structured_ui_output_variants_render_in_transcript() {
     let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
 
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::StructuredBlock {
-            title: "argus_session_prompt".to_string(),
-            body: Some("message: hello\nsession_id: abc123".to_string()),
+        kind: UiOutputEventKind::ToolCall {
+            tool_name: "argus_session_prompt".to_string(),
+            input_yaml: Some("message: hello\nsession_id: abc123".to_string()),
+            raw: None,
         },
         source: Some(UiOutputSource {
             agent: "argus".to_string(),
@@ -797,8 +827,9 @@ async fn structured_ui_output_variants_render_in_transcript() {
     .await
     .unwrap();
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::AcpThought {
+        kind: UiOutputEventKind::ThoughtChunk {
             text: "thinking hard".to_string(),
+            raw: Some(Box::new(acp::ContentChunk::new("thinking hard".into()))),
         },
         source: Some(UiOutputSource {
             agent: "argus".to_string(),
@@ -808,8 +839,10 @@ async fn structured_ui_output_variants_render_in_transcript() {
     .await
     .unwrap();
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::StatusLine {
-            text: "-> argus_session_prompt completed".to_string(),
+        kind: UiOutputEventKind::ToolCallUpdate {
+            title: Some("argus_session_prompt".to_string()),
+            status: Some("completed".to_string()),
+            raw: None,
         },
         source: Some(UiOutputSource {
             agent: "argus".to_string(),
@@ -853,9 +886,10 @@ async fn structured_ui_output_variants_render_in_transcript() {
     .await
     .unwrap();
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
-        kind: UiOutputEventKind::McpToolInvocation {
+        kind: UiOutputEventKind::ToolCall {
             tool_name: "bash".to_string(),
             input_yaml: Some("command: ls".to_string()),
+            raw: None,
         },
         source: None,
     }))
@@ -881,7 +915,7 @@ async fn structured_ui_output_variants_render_in_transcript() {
         .collect();
 
     assert!(system_entries.contains(&"> argus ▸ session-1"));
-    assert!(system_entries.contains(&"argus_session_prompt"));
+    assert!(system_entries.contains(&"->️ argus_session_prompt"));
     assert!(system_entries.contains(&"   message: hello"));
     assert!(system_entries.contains(&"<think>thinking hard</think>"));
     assert!(system_entries.contains(&"-> argus_session_prompt completed"));
@@ -958,6 +992,51 @@ async fn consecutive_usage_updates_replace_previous_usage_row_for_same_source() 
             .filter(|line| **line == "> pytheas ▸ session-1   in 20   out 2")
             .count(),
         1
+    );
+}
+
+#[tokio::test]
+async fn acp_message_chunks_coalesce_like_direct_llm_streaming() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    let source = UiOutputSource {
+        agent: "aristarchus".to_string(),
+        session_id: Some("session-1".to_string()),
+    };
+
+    for chunk in [
+        "Now I have ",
+        "enough ",
+        "information to ",
+        "complete my review.",
+    ] {
+        tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::MessageChunk {
+                text: chunk.to_string(),
+                raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
+            },
+            source: Some(source.clone()),
+        }))
+        .await
+        .unwrap();
+    }
+
+    let assistant_entries: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|entry| match entry {
+            TranscriptEntry::Assistant(text) => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(assistant_entries.len(), 1);
+    assert_eq!(
+        assistant_entries[0],
+        "Now I have enough information to complete my review."
     );
 }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -3,7 +3,7 @@ use crate::client::{Client, ClientConfig, TestStateGuard};
 use crate::config::Config;
 use crate::test_utils::{MockClient, MockTurnBuilder, TuiTestHarness};
 use crate::tui::render_helpers::event_fallback_text;
-use crate::tui::types::{TranscriptEntry, TuiEvent};
+use crate::tui::types::{TranscriptItem, TuiEvent};
 use crate::ui_output::{UiOutputEvent, UiOutputEventKind, UiOutputSource};
 use crate::utils::dimmed_text;
 use agent_client_protocol as acp;
@@ -127,7 +127,7 @@ async fn shift_enter_inserts_newline_without_submitting() {
         .app
         .transcript
         .iter()
-        .all(|entry| !matches!(entry, TranscriptEntry::User(_))));
+        .all(|entry| !matches!(entry, TranscriptItem::UserText(_))));
 }
 
 #[tokio::test]
@@ -154,7 +154,7 @@ async fn pending_message_is_auto_sent_after_finish() {
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptEntry::User(text) if text == "follow up"));
+        .any(|entry| matches!(entry, TranscriptItem::UserText(text) if text == "follow up"));
     assert!(has_user_entry);
 }
 
@@ -238,7 +238,7 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
         .transcript
         .iter()
         .filter_map(|entry| match entry {
-            TranscriptEntry::Assistant(text) => Some(text.as_str()),
+            TranscriptItem::AssistantText(text) => Some(text.as_str()),
             _ => None,
         })
         .collect();
@@ -247,7 +247,7 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptEntry::System(text) if text == "tool output")));
+        .any(|entry| matches!(entry, TranscriptItem::SystemText(text) if text == "tool output")));
 }
 
 #[tokio::test]
@@ -293,17 +293,22 @@ async fn ui_output_inserts_heading_when_source_changes() {
         .app
         .transcript
         .iter()
-        .filter_map(|entry| match entry {
-            TranscriptEntry::System(text) => Some(text.as_str()),
-            _ => None,
+        .flat_map(Tui::render_entry)
+        .filter_map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            (!text.is_empty()).then_some(text)
         })
         .collect();
 
-    assert!(system_entries.contains(&"> argus ▸ session-1"));
-    assert!(system_entries.contains(&"first chunk"));
-    assert!(system_entries.contains(&"second chunk"));
-    assert!(system_entries.contains(&"> hephaestus ▸ session-2"));
-    assert!(system_entries.contains(&"other chunk"));
+    assert!(system_entries.contains(&"> argus ▸ session-1".to_string()));
+    assert!(system_entries.contains(&"first chunk".to_string()));
+    assert!(system_entries.contains(&"second chunk".to_string()));
+    assert!(system_entries.contains(&"> hephaestus ▸ session-2".to_string()));
+    assert!(system_entries.contains(&"other chunk".to_string()));
 
     let argus_heading_count = system_entries
         .iter()
@@ -367,7 +372,7 @@ async fn info_commands_render_into_tui_transcript() {
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptEntry::System(text) if !text.is_empty()));
+        .any(|entry| matches!(entry, TranscriptItem::SystemText(text) if !text.is_empty()));
     assert!(has_session_output);
 }
 
@@ -387,7 +392,7 @@ async fn info_session_does_not_print_raw_output_in_tui_mode() {
         .transcript
         .iter()
         .filter_map(|entry| match entry {
-            TranscriptEntry::System(text) => Some(text.as_str()),
+            TranscriptItem::SystemText(text) => Some(text.as_str()),
             _ => None,
         })
         .collect::<Vec<_>>()
@@ -621,13 +626,18 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         .app
         .transcript
         .iter()
-        .filter_map(|entry| match entry {
-            TranscriptEntry::System(text)
-                if !text.starts_with("Welcome to harnx") && !text.starts_with('•') =>
-            {
-                Some(text.as_str())
+        .flat_map(Tui::render_entry)
+        .filter_map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            if text.is_empty() || text.starts_with("Welcome to harnx") || text.starts_with('•') {
+                None
+            } else {
+                Some(text)
             }
-            _ => None,
         })
         .collect();
 
@@ -694,13 +704,18 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         .app
         .transcript
         .iter()
-        .filter_map(|entry| match entry {
-            TranscriptEntry::System(text)
-                if !text.starts_with("Welcome to harnx") && !text.starts_with('•') =>
-            {
-                Some(text.as_str())
+        .flat_map(Tui::render_entry)
+        .filter_map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            if text.is_empty() || text.starts_with("Welcome to harnx") || text.starts_with('•') {
+                None
+            } else {
+                Some(text)
             }
-            _ => None,
         })
         .collect();
 
@@ -908,24 +923,29 @@ async fn structured_ui_output_variants_render_in_transcript() {
         .app
         .transcript
         .iter()
-        .filter_map(|entry| match entry {
-            TranscriptEntry::System(text) => Some(text.as_str()),
-            _ => None,
+        .flat_map(Tui::render_entry)
+        .filter_map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            (!text.is_empty()).then_some(text)
         })
         .collect();
 
-    assert!(system_entries.contains(&"> argus ▸ session-1"));
-    assert!(system_entries.contains(&"->️ argus_session_prompt"));
-    assert!(system_entries.contains(&"   message: hello"));
-    assert!(system_entries.contains(&"<think>thinking hard</think>"));
-    assert!(system_entries.contains(&"-> argus_session_prompt completed"));
-    assert!(system_entries.contains(&"Plan:"));
-    assert!(system_entries.contains(&"  [in_progress] Refactor ACP formatting"));
-    assert!(system_entries.contains(&"> argus ▸ session-1   in 12   out 34   cache 5"));
-    assert!(system_entries.contains(&"->️ bash"));
-    assert!(system_entries.contains(&"   command: ls"));
-    assert!(system_entries.contains(&"   line one"));
-    assert!(system_entries.contains(&"   line two"));
+    assert!(system_entries.contains(&"> argus ▸ session-1".to_string()));
+    assert!(system_entries.contains(&"->️ argus_session_prompt".to_string()));
+    assert!(system_entries.contains(&"   message: hello".to_string()));
+    assert!(system_entries.contains(&"<think>thinking hard</think>".to_string()));
+    assert!(system_entries.contains(&"-> argus_session_prompt completed".to_string()));
+    assert!(system_entries.contains(&"Plan:".to_string()));
+    assert!(system_entries.contains(&"  [in_progress] Refactor ACP formatting".to_string()));
+    assert!(system_entries.contains(&"> argus ▸ session-1   in 12   out 34   cache 5".to_string()));
+    assert!(system_entries.contains(&"->️ bash".to_string()));
+    assert!(system_entries.contains(&"   command: ls".to_string()));
+    assert!(system_entries.contains(&"   line one".to_string()));
+    assert!(system_entries.contains(&"   line two".to_string()));
 }
 
 #[tokio::test]
@@ -966,9 +986,14 @@ async fn consecutive_usage_updates_replace_previous_usage_row_for_same_source() 
         .app
         .transcript
         .iter()
-        .filter_map(|entry| match entry {
-            TranscriptEntry::System(text) => Some(text.as_str()),
-            _ => None,
+        .flat_map(Tui::render_entry)
+        .filter_map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            (!text.is_empty()).then_some(text)
         })
         .collect();
 
@@ -1028,7 +1053,7 @@ async fn acp_message_chunks_coalesce_like_direct_llm_streaming() {
         .transcript
         .iter()
         .filter_map(|entry| match entry {
-            TranscriptEntry::Assistant(text) => Some(text.as_str()),
+            TranscriptItem::AssistantText(text) => Some(text.as_str()),
             _ => None,
         })
         .collect();
@@ -1068,20 +1093,25 @@ async fn submitting_message_with_attachments_renders_attachment_list_and_preview
         .app
         .transcript
         .iter()
-        .filter_map(|entry| match entry {
-            TranscriptEntry::System(text) => Some(text.as_str()),
-            _ => None,
+        .flat_map(Tui::render_entry)
+        .filter_map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            (!text.is_empty()).then_some(text)
         })
         .collect();
 
     assert!(matches!(
-        tui.app.transcript.iter().find(|entry| matches!(entry, TranscriptEntry::User(_))),
-        Some(TranscriptEntry::User(text)) if text == "hello with files"
+        tui.app.transcript.iter().find(|entry| matches!(entry, TranscriptItem::UserText(_))),
+        Some(TranscriptItem::UserText(text)) if text == "hello with files"
     ));
-    assert!(system_entries.contains(&"Attachments (1):"));
-    assert!(system_entries.contains(&"  - notes.txt"));
-    assert!(system_entries.contains(&"      first line"));
-    assert!(system_entries.contains(&"      second line"));
+    assert!(system_entries.contains(&"Attachments (1):".to_string()));
+    assert!(system_entries.contains(&"  - notes.txt".to_string()));
+    assert!(system_entries.contains(&"      first line".to_string()));
+    assert!(system_entries.contains(&"      second line".to_string()));
 }
 
 #[test]
@@ -1133,7 +1163,7 @@ async fn representative_repl_commands_render_into_tui_transcript() {
             .transcript
             .iter()
             .filter_map(|entry| match entry {
-                TranscriptEntry::System(text) => Some(text.as_str()),
+                TranscriptItem::SystemText(text) => Some(text.as_str()),
                 _ => None,
             })
             .collect::<Vec<_>>()
@@ -1179,7 +1209,7 @@ async fn test_basic_message_and_streaming_response() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("Test message".to_string()));
+        .push(TranscriptItem::UserText("Test message".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1226,7 +1256,7 @@ async fn test_basic_message_and_streaming_response() {
         .transcript
         .iter()
         .filter_map(|entry| match entry {
-            TranscriptEntry::Assistant(text) => Some(text.clone()),
+            TranscriptItem::AssistantText(text) => Some(text.clone()),
             _ => None,
         })
         .collect();
@@ -1236,7 +1266,7 @@ async fn test_basic_message_and_streaming_response() {
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptEntry::User(text) if text == "Test message")));
+        .any(|entry| matches!(entry, TranscriptItem::UserText(text) if text == "Test message")));
 
     let rendered = normalize_screen(&harness.screen_contents());
     insta::assert_snapshot!("basic_message_and_streaming_response", rendered);
@@ -1276,7 +1306,7 @@ async fn test_streaming_with_tool_calls() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("What is the answer?".to_string()));
+        .push(TranscriptItem::UserText("What is the answer?".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1365,7 +1395,7 @@ async fn test_sub_agent_delegation_tool_appears() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("Help me".to_string()));
+        .push(TranscriptItem::UserText("Help me".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1472,7 +1502,7 @@ async fn test_screen_overflow_and_word_wrap() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User(user_message.to_string()));
+        .push(TranscriptItem::UserText(user_message.to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1626,7 +1656,7 @@ async fn test_ctrl_c_cancels_streaming() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("Long request".to_string()));
+        .push(TranscriptItem::UserText("Long request".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1662,9 +1692,13 @@ async fn test_ctrl_c_cancels_streaming() {
     harness.tui().abort_signal.set_ctrlc();
 
     // Manually trigger the Ctrl+C handling (same as handle_key for Ctrl+C)
-    harness.tui().app.transcript.push(TranscriptEntry::System(
-        "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
-    ));
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::SystemText(
+            "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
+        ));
     harness.tui().app.llm_busy = false;
     harness.tui().abort_signal.reset();
 
@@ -1705,7 +1739,7 @@ async fn test_streaming_error_shows_in_transcript() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("Error test".to_string()));
+        .push(TranscriptItem::UserText("Error test".to_string()));
 
     // The error should propagate through start_prompt
     let result = harness
@@ -1731,7 +1765,7 @@ async fn test_streaming_error_shows_in_transcript() {
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptEntry::Error(_)));
+        .any(|entry| matches!(entry, TranscriptItem::ErrorText(_)));
     assert!(has_error, "Transcript should contain an error entry");
 
     harness.drain_and_settle().await.unwrap();
@@ -1770,7 +1804,7 @@ async fn test_cancel_during_tool_execution() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("Search test".to_string()));
+        .push(TranscriptItem::UserText("Search test".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1805,9 +1839,13 @@ async fn test_cancel_during_tool_execution() {
     harness.tui().abort_signal.set_ctrlc();
 
     // Manually trigger the Ctrl+C handling (same as handle_key for Ctrl+C)
-    harness.tui().app.transcript.push(TranscriptEntry::System(
-        "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
-    ));
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::SystemText(
+            "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
+        ));
     harness.tui().app.llm_busy = false;
     harness.tui().abort_signal.reset();
 
@@ -1859,7 +1897,7 @@ async fn paste_multiline_creates_temp_attachment() {
         .app
         .transcript
         .iter()
-        .filter(|entry| matches!(entry, TranscriptEntry::User(_)))
+        .filter(|entry| matches!(entry, TranscriptItem::UserText(_)))
         .collect();
     assert!(
         user_entries.is_empty(),
@@ -2042,7 +2080,7 @@ async fn attach_command_adds_attachment() {
         .app
         .transcript
         .iter()
-        .filter(|e| matches!(e, TranscriptEntry::User(_)))
+        .filter(|e| matches!(e, TranscriptItem::UserText(_)))
         .collect();
     assert!(user_entries.is_empty());
 
@@ -2069,7 +2107,7 @@ async fn attach_command_preserves_draft_text() {
         .app
         .transcript
         .iter()
-        .filter(|e| matches!(e, TranscriptEntry::User(_)))
+        .filter(|e| matches!(e, TranscriptItem::UserText(_)))
         .collect();
     assert!(user_entries.is_empty());
 
@@ -2092,7 +2130,7 @@ async fn attach_nonexistent_file_shows_error() {
         .app
         .transcript
         .iter()
-        .any(|e| matches!(e, TranscriptEntry::Error(msg) if msg.contains("not found")));
+        .any(|e| matches!(e, TranscriptItem::ErrorText(msg) if msg.contains("not found")));
     assert!(has_error, "Should show error for nonexistent file");
 }
 
@@ -2318,7 +2356,7 @@ async fn test_recovery_after_cancellation() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("First request".to_string()));
+        .push(TranscriptItem::UserText("First request".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -2347,9 +2385,13 @@ async fn test_recovery_after_cancellation() {
     harness.drain_and_settle().await.unwrap();
 
     // Simulate cancellation
-    harness.tui().app.transcript.push(TranscriptEntry::System(
-        "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
-    ));
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::SystemText(
+            "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
+        ));
     harness.tui().app.llm_busy = false;
     harness.tui().abort_signal.reset();
     harness.render();
@@ -2379,7 +2421,7 @@ async fn test_recovery_after_cancellation() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("Second request".to_string()));
+        .push(TranscriptItem::UserText("Second request".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {

--- a/src/tui/types.rs
+++ b/src/tui/types.rs
@@ -51,7 +51,7 @@ pub(crate) struct PendingMessage {
 }
 
 pub(super) struct App {
-    pub(super) transcript: Vec<TranscriptEntry>,
+    pub(super) transcript: Vec<TranscriptItem>,
     pub(super) input: TextArea<'static>,
     pub(super) spinner_index: usize,
     pub(super) should_quit: bool,
@@ -100,21 +100,25 @@ pub(super) fn cleanup_attachment_dir(dir: &std::path::Path) {
     let _ = std::fs::remove_dir_all(dir);
 }
 
-#[derive(Clone)]
-#[cfg(test)]
-pub(crate) enum TranscriptEntry {
-    System(String),
-    User(String),
-    Assistant(String),
-    Error(String),
-}
-
-#[cfg(not(test))]
-pub(super) enum TranscriptEntry {
-    System(String),
-    User(String),
-    Assistant(String),
-    Error(String),
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum TranscriptItem {
+    SourceHeading(UiOutputSource),
+    SystemText(String),
+    UserText(String),
+    AssistantText(String),
+    ErrorText(String),
+    ThoughtText(String),
+    ToolResultText(String),
+    StatusLine(String),
+    Plan(Vec<crate::ui_output::UiOutputPlanEntry>),
+    UsageLine(String),
+    ToolCall {
+        tool_name: String,
+        input_yaml: Option<String>,
+    },
+    AttachmentHeader(String),
+    AttachmentItem(String),
+    AttachmentPreviewLine(String),
 }
 
 #[cfg(test)]

--- a/src/ui_output.rs
+++ b/src/ui_output.rs
@@ -1,3 +1,4 @@
+use agent_client_protocol as acp;
 #[cfg(test)]
 use std::sync::Mutex;
 #[cfg(not(test))]
@@ -15,24 +16,31 @@ pub enum UiOutputEventKind {
     ToolResultText {
         text: String,
     },
-    LlmText(String),
+    MessageChunk {
+        text: String,
+        raw: Option<Box<acp::ContentChunk>>,
+    },
     LlmFinal {
         output: String,
         usage: crate::client::CompletionTokenUsage,
     },
     LlmError(String),
-    AcpThought {
+    ThoughtChunk {
         text: String,
+        raw: Option<Box<acp::ContentChunk>>,
     },
-    StatusLine {
-        text: String,
+    ToolCall {
+        tool_name: String,
+        input_yaml: Option<String>,
+        raw: Option<Box<acp::ToolCall>>,
+    },
+    ToolCallUpdate {
+        title: Option<String>,
+        status: Option<String>,
+        raw: Option<Box<acp::ToolCallUpdate>>,
     },
     TranscriptText {
         text: String,
-    },
-    StructuredBlock {
-        title: String,
-        body: Option<String>,
     },
     Plan {
         entries: Vec<UiOutputPlanEntry>,
@@ -42,10 +50,6 @@ pub enum UiOutputEventKind {
         output_tokens: u64,
         cached_tokens: u64,
         session_label: Option<String>,
-    },
-    McpToolInvocation {
-        tool_name: String,
-        input_yaml: Option<String>,
     },
 }
 


### PR DESCRIPTION
- **fix(acp): unify UI output events for local and remote flows**
- **fixes**
- **refactor(tui): preserve semantic transcript items until render**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured message and thought event representation to use a chunk-based model for improved streaming support.
  * Enhanced transcript item types with expanded variants for better content categorization (thoughts, tool calls, attachments, etc.).
  * Improved event source tracking and preservation throughout the message processing pipeline.
  * Refactored tool invocation and update event handling for clearer separation and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->