### PR TITLE
fix(tui,acp): preserve semantic transcript events and surface nested delegated tool calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,14 @@ path = "src/bin/harnx-mcp-time/main.rs"
 name = "harnx-acp-test"
 path = "src/bin/harnx-acp-test/main.rs"
 
+[[bin]]
+name = "harnx-mock-llm"
+path = "src/bin/harnx-mock-llm/main.rs"
+
+[[bin]]
+name = "harnx-mcp-repro249"
+path = "src/bin/harnx-mcp-repro249/main.rs"
+
 [profile.release]
 lto = true
 strip = true

--- a/src/acp/client.rs
+++ b/src/acp/client.rs
@@ -120,7 +120,6 @@ impl AcpNotificationClient {
     }
 
     async fn forward_ui_output_event(&self, event: UiOutputEvent, source: UiOutputSource) {
-        let mut delivered = false;
         let mut forwarders = self.chunk_forwarder.write().await;
         let source = event.source.clone().or(Some(source));
         let text_fallback = format_ui_event_for_terminal(&event.kind, source.as_ref());
@@ -129,21 +128,28 @@ impl AcpNotificationClient {
             source,
         };
 
-        if forwarders.is_empty() {
-            if !emit_ui_output_event(event) {
-                eprint!("{}", text_fallback);
+        // Always emit to the parent UI sink so the TUI transcript shows nested
+        // sub-agent events (tool calls, thoughts, etc.) regardless of whether
+        // a chunk forwarder is also registered.  This fixes issue #249 where
+        // delegated sub-agent internal MCP tool calls were invisible in the
+        // parent transcript because the forwarder was treated as an exclusive
+        // destination.
+        let emitted_to_ui = emit_ui_output_event(event.clone());
+
+        // Also forward to any registered chunk forwarders (e.g. the REPL
+        // command-line path that prints sub-agent output to stdout).
+        let mut forwarded_to_chunk = false;
+        forwarders.retain(|_, tx| match tx.send(NestedAcpEvent::Ui(event.clone())) {
+            Ok(()) => {
+                forwarded_to_chunk = true;
+                true
             }
-        } else {
-            forwarders.retain(|_, tx| match tx.send(NestedAcpEvent::Ui(event.clone())) {
-                Ok(()) => {
-                    delivered = true;
-                    true
-                }
-                Err(_) => false,
-            });
-            if !delivered && !emit_ui_output_event(event) {
-                eprint!("{}", text_fallback);
-            }
+            Err(_) => false,
+        });
+
+        // Fall back to stderr only if neither path accepted the event.
+        if !emitted_to_ui && !forwarded_to_chunk {
+            eprint!("{}", text_fallback);
         }
     }
 }

--- a/src/acp/client.rs
+++ b/src/acp/client.rs
@@ -1235,6 +1235,14 @@ mod tests {
     async fn nested_tool_call_notification_preserves_structured_event_for_tui_pipeline() {
         let (ui_tx, _ui_rx) = tokio::sync::mpsc::unbounded_channel();
         crate::ui_output::install_ui_output_sender(ui_tx);
+        // Ensure we clean up the global sender when this test finishes.
+        struct ClearOnDrop;
+        impl Drop for ClearOnDrop {
+            fn drop(&mut self) {
+                crate::ui_output::clear_ui_output_sender();
+            }
+        }
+        let _guard = ClearOnDrop;
 
         let sessions = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
         let chunk_forwarder = Arc::new(tokio::sync::RwLock::new(HashMap::new()));

--- a/src/acp/client.rs
+++ b/src/acp/client.rs
@@ -267,6 +267,7 @@ impl acp::Client for AcpNotificationClient {
                 } else {
                     Some(UiOutputEvent {
                         kind: UiOutputEventKind::ToolCallUpdate {
+                            tool_call_id: Some(tcu.tool_call_id.to_string()),
                             title,
                             status,
                             raw: Some(Box::new(tcu)),

--- a/src/acp/client.rs
+++ b/src/acp/client.rs
@@ -960,84 +960,51 @@ fn agent_from_meta_value(value: &serde_json::Value) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-fn session_from_meta_value(value: &serde_json::Value) -> Option<String> {
-    value
-        .get("session")
-        .and_then(serde_json::Value::as_str)
-        .filter(|session| !session.is_empty())
-        .map(ToOwned::to_owned)
-}
-
 fn resolve_notification_source(
     fallback_agent: &str,
     notification: &acp::SessionNotification,
 ) -> UiOutputSource {
     let session_id = notification.session_id.0.to_string();
-    let (update_agent, update_session) = match &notification.update {
-        acp::SessionUpdate::AgentMessageChunk(chunk) => {
-            let meta = chunk.meta.as_ref().map(|meta| json!(meta));
-            (
-                meta.as_ref().and_then(agent_from_meta_value),
-                meta.as_ref().and_then(session_from_meta_value),
-            )
-        }
-        acp::SessionUpdate::AgentThoughtChunk(chunk) => {
-            let meta = chunk.meta.as_ref().map(|meta| json!(meta));
-            (
-                meta.as_ref().and_then(agent_from_meta_value),
-                meta.as_ref().and_then(session_from_meta_value),
-            )
-        }
-        acp::SessionUpdate::ToolCall(call) => {
-            let meta = call.meta.as_ref().map(|meta| json!(meta));
-            (
-                meta.as_ref().and_then(agent_from_meta_value),
-                meta.as_ref().and_then(session_from_meta_value),
-            )
-        }
-        acp::SessionUpdate::ToolCallUpdate(update) => {
-            let meta = update.meta.as_ref().map(|meta| json!(meta));
-            (
-                meta.as_ref().and_then(agent_from_meta_value),
-                meta.as_ref().and_then(session_from_meta_value),
-            )
-        }
-        acp::SessionUpdate::Plan(plan) => {
-            let meta = plan.meta.as_ref().map(|meta| json!(meta));
-            (
-                meta.as_ref().and_then(agent_from_meta_value),
-                meta.as_ref().and_then(session_from_meta_value),
-            )
-        }
-        acp::SessionUpdate::SessionInfoUpdate(info) => {
-            let direct_meta = info.meta.as_ref().map(|meta| json!(meta));
-            (
-                direct_meta
+    let update_agent = match &notification.update {
+        acp::SessionUpdate::AgentMessageChunk(chunk) => chunk
+            .meta
+            .as_ref()
+            .and_then(|meta| agent_from_meta_value(&json!(meta))),
+        acp::SessionUpdate::AgentThoughtChunk(chunk) => chunk
+            .meta
+            .as_ref()
+            .and_then(|meta| agent_from_meta_value(&json!(meta))),
+        acp::SessionUpdate::ToolCall(call) => call
+            .meta
+            .as_ref()
+            .and_then(|meta| agent_from_meta_value(&json!(meta))),
+        acp::SessionUpdate::ToolCallUpdate(update) => update
+            .meta
+            .as_ref()
+            .and_then(|meta| agent_from_meta_value(&json!(meta))),
+        acp::SessionUpdate::Plan(plan) => plan
+            .meta
+            .as_ref()
+            .and_then(|meta| agent_from_meta_value(&json!(meta))),
+        acp::SessionUpdate::SessionInfoUpdate(info) => info
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.get("agent"))
+            .and_then(serde_json::Value::as_str)
+            .filter(|agent| !agent.is_empty())
+            .map(ToOwned::to_owned)
+            .or_else(|| {
+                info.meta
                     .as_ref()
+                    .and_then(|meta| meta.get("harnx:usage"))
                     .and_then(agent_from_meta_value)
-                    .or_else(|| {
-                        info.meta
-                            .as_ref()
-                            .and_then(|meta| meta.get("harnx:usage"))
-                            .and_then(agent_from_meta_value)
-                    }),
-                direct_meta
-                    .as_ref()
-                    .and_then(session_from_meta_value)
-                    .or_else(|| {
-                        info.meta
-                            .as_ref()
-                            .and_then(|meta| meta.get("harnx:usage"))
-                            .and_then(session_from_meta_value)
-                    }),
-            )
-        }
-        _ => (None, None),
+            }),
+        _ => None,
     };
 
     UiOutputSource {
         agent: update_agent.unwrap_or_else(|| fallback_agent.to_string()),
-        session_id: Some(update_session.unwrap_or(session_id)),
+        session_id: Some(session_id),
     }
 }
 
@@ -1130,23 +1097,6 @@ mod tests {
         let source = resolve_notification_source("argus", &notification);
         assert_eq!(source.agent, "argus");
         assert_eq!(source.session_id.as_deref(), Some("outer-session"));
-    }
-
-    #[test]
-    fn resolve_notification_source_uses_nested_session_when_present() {
-        let notification = acp::SessionNotification::new(
-            acp::SessionId::new("outer-session"),
-            acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new("hello".into()).meta(
-                serde_json::Map::from_iter([
-                    ("agent".to_string(), json!("aristarchus")),
-                    ("session".to_string(), json!("nested-session")),
-                ]),
-            )),
-        );
-
-        let source = resolve_notification_source("argus", &notification);
-        assert_eq!(source.agent, "aristarchus");
-        assert_eq!(source.session_id.as_deref(), Some("nested-session"));
     }
 
     #[test]

--- a/src/acp/client.rs
+++ b/src/acp/client.rs
@@ -960,51 +960,84 @@ fn agent_from_meta_value(value: &serde_json::Value) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+fn session_from_meta_value(value: &serde_json::Value) -> Option<String> {
+    value
+        .get("session")
+        .and_then(serde_json::Value::as_str)
+        .filter(|session| !session.is_empty())
+        .map(ToOwned::to_owned)
+}
+
 fn resolve_notification_source(
     fallback_agent: &str,
     notification: &acp::SessionNotification,
 ) -> UiOutputSource {
     let session_id = notification.session_id.0.to_string();
-    let update_agent = match &notification.update {
-        acp::SessionUpdate::AgentMessageChunk(chunk) => chunk
-            .meta
-            .as_ref()
-            .and_then(|meta| agent_from_meta_value(&json!(meta))),
-        acp::SessionUpdate::AgentThoughtChunk(chunk) => chunk
-            .meta
-            .as_ref()
-            .and_then(|meta| agent_from_meta_value(&json!(meta))),
-        acp::SessionUpdate::ToolCall(call) => call
-            .meta
-            .as_ref()
-            .and_then(|meta| agent_from_meta_value(&json!(meta))),
-        acp::SessionUpdate::ToolCallUpdate(update) => update
-            .meta
-            .as_ref()
-            .and_then(|meta| agent_from_meta_value(&json!(meta))),
-        acp::SessionUpdate::Plan(plan) => plan
-            .meta
-            .as_ref()
-            .and_then(|meta| agent_from_meta_value(&json!(meta))),
-        acp::SessionUpdate::SessionInfoUpdate(info) => info
-            .meta
-            .as_ref()
-            .and_then(|meta| meta.get("agent"))
-            .and_then(serde_json::Value::as_str)
-            .filter(|agent| !agent.is_empty())
-            .map(ToOwned::to_owned)
-            .or_else(|| {
-                info.meta
+    let (update_agent, update_session) = match &notification.update {
+        acp::SessionUpdate::AgentMessageChunk(chunk) => {
+            let meta = chunk.meta.as_ref().map(|meta| json!(meta));
+            (
+                meta.as_ref().and_then(agent_from_meta_value),
+                meta.as_ref().and_then(session_from_meta_value),
+            )
+        }
+        acp::SessionUpdate::AgentThoughtChunk(chunk) => {
+            let meta = chunk.meta.as_ref().map(|meta| json!(meta));
+            (
+                meta.as_ref().and_then(agent_from_meta_value),
+                meta.as_ref().and_then(session_from_meta_value),
+            )
+        }
+        acp::SessionUpdate::ToolCall(call) => {
+            let meta = call.meta.as_ref().map(|meta| json!(meta));
+            (
+                meta.as_ref().and_then(agent_from_meta_value),
+                meta.as_ref().and_then(session_from_meta_value),
+            )
+        }
+        acp::SessionUpdate::ToolCallUpdate(update) => {
+            let meta = update.meta.as_ref().map(|meta| json!(meta));
+            (
+                meta.as_ref().and_then(agent_from_meta_value),
+                meta.as_ref().and_then(session_from_meta_value),
+            )
+        }
+        acp::SessionUpdate::Plan(plan) => {
+            let meta = plan.meta.as_ref().map(|meta| json!(meta));
+            (
+                meta.as_ref().and_then(agent_from_meta_value),
+                meta.as_ref().and_then(session_from_meta_value),
+            )
+        }
+        acp::SessionUpdate::SessionInfoUpdate(info) => {
+            let direct_meta = info.meta.as_ref().map(|meta| json!(meta));
+            (
+                direct_meta
                     .as_ref()
-                    .and_then(|meta| meta.get("harnx:usage"))
                     .and_then(agent_from_meta_value)
-            }),
-        _ => None,
+                    .or_else(|| {
+                        info.meta
+                            .as_ref()
+                            .and_then(|meta| meta.get("harnx:usage"))
+                            .and_then(agent_from_meta_value)
+                    }),
+                direct_meta
+                    .as_ref()
+                    .and_then(session_from_meta_value)
+                    .or_else(|| {
+                        info.meta
+                            .as_ref()
+                            .and_then(|meta| meta.get("harnx:usage"))
+                            .and_then(session_from_meta_value)
+                    }),
+            )
+        }
+        _ => (None, None),
     };
 
     UiOutputSource {
         agent: update_agent.unwrap_or_else(|| fallback_agent.to_string()),
-        session_id: Some(session_id),
+        session_id: Some(update_session.unwrap_or(session_id)),
     }
 }
 
@@ -1097,6 +1130,23 @@ mod tests {
         let source = resolve_notification_source("argus", &notification);
         assert_eq!(source.agent, "argus");
         assert_eq!(source.session_id.as_deref(), Some("outer-session"));
+    }
+
+    #[test]
+    fn resolve_notification_source_uses_nested_session_when_present() {
+        let notification = acp::SessionNotification::new(
+            acp::SessionId::new("outer-session"),
+            acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new("hello".into()).meta(
+                serde_json::Map::from_iter([
+                    ("agent".to_string(), json!("aristarchus")),
+                    ("session".to_string(), json!("nested-session")),
+                ]),
+            )),
+        );
+
+        let source = resolve_notification_source("argus", &notification);
+        assert_eq!(source.agent, "aristarchus");
+        assert_eq!(source.session_id.as_deref(), Some("nested-session"));
     }
 
     #[test]

--- a/src/acp/client.rs
+++ b/src/acp/client.rs
@@ -130,10 +130,7 @@ impl AcpNotificationClient {
 
         // Always emit to the parent UI sink so the TUI transcript shows nested
         // sub-agent events (tool calls, thoughts, etc.) regardless of whether
-        // a chunk forwarder is also registered.  This fixes issue #249 where
-        // delegated sub-agent internal MCP tool calls were invisible in the
-        // parent transcript because the forwarder was treated as an exclusive
-        // destination.
+        // a chunk forwarder is also registered.
         let emitted_to_ui = emit_ui_output_event(event.clone());
 
         // Also forward to any registered chunk forwarders (e.g. the REPL

--- a/src/acp/client.rs
+++ b/src/acp/client.rs
@@ -1089,6 +1089,7 @@ fn format_ui_event_for_terminal(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agent_client_protocol::Client as _;
     use serde_json::json;
 
     #[test]
@@ -1202,5 +1203,100 @@ mod tests {
         assert!(rendered.contains("Line one from sub-agent"));
         assert!(rendered.contains("Line two from sub-agent"));
         assert!(rendered.contains('\n'));
+    }
+
+    #[test]
+    fn resolve_notification_source_uses_nested_tool_call_metadata() {
+        let notification = acp::SessionNotification::new(
+            acp::SessionId::new("outer-session"),
+            acp::SessionUpdate::ToolCall(acp::ToolCall::new("ls", "path: /tmp").meta(
+                serde_json::Map::from_iter([
+                    ("agent".to_string(), json!("pytheas")),
+                    (
+                        "session".to_string(),
+                        json!("608e48b6-c880-4168-b028-1bda3469be07"),
+                    ),
+                ]),
+            )),
+        );
+
+        let source = resolve_notification_source("working", &notification);
+        assert_eq!(source.agent, "pytheas");
+        assert_eq!(
+            source.session_id.as_deref(),
+            Some("608e48b6-c880-4168-b028-1bda3469be07")
+        );
+    }
+
+    #[tokio::test]
+    async fn nested_tool_call_notification_preserves_structured_event_for_tui_pipeline() {
+        let (ui_tx, _ui_rx) = tokio::sync::mpsc::unbounded_channel();
+        crate::ui_output::install_ui_output_sender(ui_tx);
+
+        let sessions = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let chunk_forwarder = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel();
+        chunk_forwarder.write().await.insert(1, chunk_tx);
+        let (activity_tx, _) = tokio::sync::broadcast::channel(8);
+        let client = AcpNotificationClient::new(
+            "working".to_string(),
+            sessions,
+            chunk_forwarder,
+            activity_tx,
+        );
+
+        let notification = acp::SessionNotification::new(
+            acp::SessionId::new("outer-session"),
+            acp::SessionUpdate::ToolCall(
+                acp::ToolCall::new("call-1", "pytheas_session_prompt")
+                    .raw_input(json!({
+                        "message": "Count files in /tmp using ls first.",
+                        "session_id": "608e48b6-c880-4168-b028-1bda3469be07",
+                    }))
+                    .meta(serde_json::Map::from_iter([
+                        ("agent".to_string(), json!("pytheas")),
+                        (
+                            "session".to_string(),
+                            json!("608e48b6-c880-4168-b028-1bda3469be07"),
+                        ),
+                    ])),
+            ),
+        );
+
+        client.session_notification(notification).await.unwrap();
+
+        let forwarded = chunk_rx.recv().await.expect("forwarded nested ACP event");
+        let forwarded_event = match forwarded {
+            NestedAcpEvent::Ui(event) => event,
+            other => panic!("unexpected nested ACP event: {other:?}"),
+        };
+
+        match &forwarded_event.kind {
+            UiOutputEventKind::ToolCall {
+                tool_name,
+                input_yaml,
+                ..
+            } => {
+                assert_eq!(tool_name, "pytheas_session_prompt");
+                assert_eq!(
+                    input_yaml.as_deref(),
+                    Some(
+                        "message: Count files in /tmp using ls first.\nsession_id: 608e48b6-c880-4168-b028-1bda3469be07"
+                    )
+                );
+            }
+            other => panic!("unexpected forwarded event kind: {other:?}"),
+        }
+        assert_eq!(
+            forwarded_event.source.as_ref().map(|s| s.agent.as_str()),
+            Some("pytheas")
+        );
+        assert_eq!(
+            forwarded_event
+                .source
+                .as_ref()
+                .and_then(|s| s.session_id.as_deref()),
+            Some("608e48b6-c880-4168-b028-1bda3469be07")
+        );
     }
 }

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use crate::client::{Client, SseEvent, SseHandler};
 use crate::config::{GlobalConfig, Input};
 use crate::tool::{ToolCall, ToolResult};
-use crate::ui_output::{emit_ui_output_event, UiOutputEvent, UiOutputEventKind};
+use crate::ui_output::{emit_ui_output_event, UiOutputEvent, UiOutputEventKind, UiOutputSource};
 use crate::utils::{wait_abort_signal, AbortSignal, AbortSignalInner};
 
 use anyhow::bail;
@@ -340,6 +340,10 @@ impl acp::Agent for HarnxAgent {
                     })
                     .collect()
             } else {
+                let source = Some(UiOutputSource {
+                    agent: self.agent_name.clone(),
+                    session_id: Some(session_key.clone()),
+                });
                 let acp_manager = self.config.read().acp_manager.clone();
                 let result = if let Some(ref manager) = acp_manager {
                     let (mut chunk_rx, subscription_id) = manager.subscribe_chunks().await;
@@ -374,14 +378,14 @@ impl acp::Agent for HarnxAgent {
                     });
 
                     let result =
-                        eval_tool_calls_async(&self.config, tool_calls, &abort_signal).await;
+                        eval_tool_calls_async(&self.config, tool_calls, &abort_signal, source.clone()).await;
 
                     manager.unsubscribe_chunks(subscription_id).await;
                     let _ = forward_task.await;
 
                     result
                 } else {
-                    eval_tool_calls_async(&self.config, tool_calls, &abort_signal).await
+                    eval_tool_calls_async(&self.config, tool_calls, &abort_signal, source).await
                 };
 
                 match result {
@@ -544,6 +548,7 @@ async fn eval_tool_calls_async(
     config: &GlobalConfig,
     mut calls: Vec<ToolCall>,
     abort_signal: &AbortSignal,
+    source: Option<UiOutputSource>,
 ) -> anyhow::Result<Vec<ToolResult>> {
     let mut output = vec![];
     if calls.is_empty() {
@@ -559,7 +564,7 @@ async fn eval_tool_calls_async(
         if abort_signal.aborted() {
             bail!("Tool execution cancelled");
         }
-        let result = eval_mcp_async(config, &call, abort_signal).await;
+        let result = eval_mcp_async(config, &call, abort_signal, source.clone()).await;
         match result {
             Ok(mut value) => {
                 if value.is_null() {
@@ -584,6 +589,7 @@ async fn eval_mcp_async(
     config: &GlobalConfig,
     call: &ToolCall,
     abort_signal: &AbortSignal,
+    source: Option<UiOutputSource>,
 ) -> anyhow::Result<Value> {
     let json_data = if call.arguments.is_null() {
         Value::Null
@@ -626,7 +632,7 @@ async fn eval_mcp_async(
             input_yaml: None,
             raw: None,
         },
-        source: None,
+        source,
     });
 
     tokio::select! {

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -436,13 +436,9 @@ async fn nested_ui_event_to_session_update(
         });
 
     match event.kind {
-        UiOutputEventKind::TranscriptText { text } => {
-            let mut chunk = acp::ContentChunk::new(text.into());
-            if let Some(meta) = source_meta.clone() {
-                chunk = chunk.meta(meta);
-            }
-            Some(acp::SessionUpdate::AgentMessageChunk(chunk))
-        }
+        UiOutputEventKind::TranscriptText { text } => Some(acp::SessionUpdate::AgentMessageChunk(
+            acp::ContentChunk::new(text.into()),
+        )),
         UiOutputEventKind::MessageChunk { text, raw } => {
             let mut chunk = raw
                 .map(|chunk| *chunk)

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -436,9 +436,13 @@ async fn nested_ui_event_to_session_update(
         });
 
     match event.kind {
-        UiOutputEventKind::TranscriptText { text } => Some(acp::SessionUpdate::AgentMessageChunk(
-            acp::ContentChunk::new(text.into()),
-        )),
+        UiOutputEventKind::TranscriptText { text } => {
+            let mut chunk = acp::ContentChunk::new(text.into());
+            if let Some(meta) = source_meta.clone() {
+                chunk = chunk.meta(meta);
+            }
+            Some(acp::SessionUpdate::AgentMessageChunk(chunk))
+        }
         UiOutputEventKind::MessageChunk { text, raw } => {
             let mut chunk = raw
                 .map(|chunk| *chunk)

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use crate::client::{Client, SseEvent, SseHandler};
 use crate::config::{GlobalConfig, Input};
 use crate::tool::{ToolCall, ToolResult};
-use crate::ui_output::UiOutputEventKind;
+use crate::ui_output::{emit_ui_output_event, UiOutputEvent, UiOutputEventKind};
 use crate::utils::{wait_abort_signal, AbortSignal, AbortSignalInner};
 
 use anyhow::bail;
@@ -619,6 +619,15 @@ async fn eval_mcp_async(
         Some(m) => m,
         None => bail!("No tool provider configured for '{}'", call.name),
     };
+
+    emit_ui_output_event(UiOutputEvent {
+        kind: UiOutputEventKind::ToolCall {
+            tool_name: call.name.clone(),
+            input_yaml: None,
+            raw: None,
+        },
+        source: None,
+    });
 
     tokio::select! {
         result = manager.call_tool(&call.name, json_data) => result,

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -344,6 +344,27 @@ impl acp::Agent for HarnxAgent {
                     agent: self.agent_name.clone(),
                     session_id: Some(session_key.clone()),
                 });
+
+                // Notify the parent about each tool call so it appears in the
+                // parent transcript.  The `emit_ui_output_event` inside
+                // `eval_mcp_async` only works when a UI sink is installed
+                // (i.e. in the TUI process).  In ACP-server mode there is no
+                // UI sink, so we send the notification directly over the ACP
+                // connection.
+                let conn = self.connection.borrow().clone();
+                if let Some(conn) = conn {
+                    for call in &tool_calls {
+                        let tool_call_id = call.id.clone().unwrap_or_else(|| call.name.clone());
+                        let tc = acp::ToolCall::new(tool_call_id, call.name.clone())
+                            .raw_input(call.arguments.clone());
+                        let notification = acp::SessionNotification::new(
+                            acp::SessionId::new(session_key.clone()),
+                            acp::SessionUpdate::ToolCall(tc),
+                        );
+                        let _ = conn.session_notification(notification).await;
+                    }
+                }
+
                 let acp_manager = self.config.read().acp_manager.clone();
                 let result = if let Some(ref manager) = acp_manager {
                     let (mut chunk_rx, subscription_id) = manager.subscribe_chunks().await;
@@ -377,8 +398,13 @@ impl acp::Agent for HarnxAgent {
                         }
                     });
 
-                    let result =
-                        eval_tool_calls_async(&self.config, tool_calls, &abort_signal, source.clone()).await;
+                    let result = eval_tool_calls_async(
+                        &self.config,
+                        tool_calls,
+                        &abort_signal,
+                        source.clone(),
+                    )
+                    .await;
 
                     manager.unsubscribe_chunks(subscription_id).await;
                     let _ = forward_task.await;

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -462,7 +462,12 @@ async fn nested_ui_event_to_session_update(
             }
             Some(acp::SessionUpdate::AgentThoughtChunk(chunk))
         }
-        UiOutputEventKind::ToolCallUpdate { title, status, raw } => {
+        UiOutputEventKind::ToolCallUpdate {
+            tool_call_id,
+            title,
+            status,
+            raw,
+        } => {
             let mut update = if let Some(update) = raw {
                 *update
             } else {
@@ -478,7 +483,8 @@ async fn nested_ui_event_to_session_update(
                     };
                     fields = fields.status(status);
                 }
-                acp::ToolCallUpdate::new("status", fields)
+                let stable_tool_call_id = tool_call_id.unwrap_or_else(|| "status".to_string());
+                acp::ToolCallUpdate::new(stable_tool_call_id, fields)
             };
             if let Some(meta) = source_meta.clone() {
                 update = update.meta(meta);

--- a/src/bin/harnx-mcp-repro249/main.rs
+++ b/src/bin/harnx-mcp-repro249/main.rs
@@ -1,0 +1,13 @@
+mod server;
+
+use rmcp::ServiceExt;
+use server::Repro249Server;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let server = Repro249Server;
+    let transport = rmcp::transport::stdio();
+    let service = server.serve(transport).await?;
+    service.waiting().await?;
+    Ok(())
+}

--- a/src/bin/harnx-mcp-repro249/server.rs
+++ b/src/bin/harnx-mcp-repro249/server.rs
@@ -1,0 +1,60 @@
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, Content, ErrorData, Implementation, ListToolsResult,
+    PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+};
+use rmcp::service::{RequestContext, RoleServer};
+use rmcp::ServerHandler;
+use serde_json::{Map, Value};
+
+const TOOL_NAME: &str = "repro249_unique_mcp_tool";
+const TOOL_RESPONSE: &str = "repro249 fixed tool response";
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Repro249Server;
+
+impl ServerHandler for Repro249Server {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new(
+                "harnx-mcp-repro249",
+                env!("CARGO_PKG_VERSION"),
+            ))
+            .with_instructions("Deterministic fake MCP server for the repro_249 tmux test.")
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        let input_schema = Map::from_iter([
+            ("type".to_string(), Value::String("object".to_string())),
+            ("properties".to_string(), Value::Object(Map::new())),
+            ("additionalProperties".to_string(), Value::Bool(false)),
+        ]);
+
+        Ok(ListToolsResult {
+            meta: None,
+            tools: vec![Tool::new(
+                TOOL_NAME,
+                "Deterministic fake MCP tool for the repro_249 tmux test.",
+                input_schema,
+            )],
+            next_cursor: None,
+        })
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match request.name.as_ref() {
+            TOOL_NAME => Ok(CallToolResult::success(vec![Content::text(TOOL_RESPONSE)])),
+            other => Err(ErrorData::invalid_params(
+                format!("unknown tool: {other}"),
+                None,
+            )),
+        }
+    }
+}

--- a/src/bin/harnx-mock-llm/main.rs
+++ b/src/bin/harnx-mock-llm/main.rs
@@ -37,6 +37,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -325,9 +326,6 @@ fn handle_chat_completions(request: Value, state: &ServerState, stream: &mut std
         },
     };
 
-    // Combine text chunks
-    let full_text = turn.text_chunks.join("");
-
     // Build tool calls array
     let tool_calls: Vec<Value> = turn
         .tool_calls
@@ -346,8 +344,14 @@ fn handle_chat_completions(request: Value, state: &ServerState, stream: &mut std
         .collect();
 
     if is_stream {
-        write_streaming_response(stream, &full_text, &tool_calls);
+        write_streaming_response(
+            stream,
+            &turn.text_chunks,
+            state.script.chunk_delay_ms,
+            &tool_calls,
+        );
     } else {
+        let full_text = turn.text_chunks.join("");
         let response = build_non_streaming_response(&full_text, tool_calls);
         let response_str = response.to_string();
         let http_response = format!(
@@ -360,11 +364,28 @@ fn handle_chat_completions(request: Value, state: &ServerState, stream: &mut std
     }
 }
 
-fn write_streaming_response(stream: &mut std::net::TcpStream, text: &str, tool_calls: &[Value]) {
-    let mut body = String::new();
+fn write_streaming_response(
+    stream: &mut std::net::TcpStream,
+    text_chunks: &[String],
+    chunk_delay_ms: u64,
+    tool_calls: &[Value],
+) {
+    // Write HTTP headers for SSE (no Content-Length so we can flush per-event).
+    let header = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n";
+    let _ = stream.write_all(header.as_bytes());
+    let _ = stream.flush();
 
-    if !text.is_empty() {
-        body.push_str(&format!(
+    let delay = Duration::from_millis(chunk_delay_ms);
+
+    // Emit one SSE event per text chunk, preserving ordering.
+    for (i, chunk) in text_chunks.iter().enumerate() {
+        if chunk.is_empty() {
+            continue;
+        }
+        if i > 0 && chunk_delay_ms > 0 {
+            thread::sleep(delay);
+        }
+        let event = format!(
             "data: {}\n\n",
             json!({
                 "id": "chatcmpl-mock",
@@ -373,15 +394,21 @@ fn write_streaming_response(stream: &mut std::net::TcpStream, text: &str, tool_c
                 "model": "mock-llm",
                 "choices": [{
                     "index": 0,
-                    "delta": {"role": "assistant", "content": text},
+                    "delta": {"role": "assistant", "content": chunk},
                     "finish_reason": serde_json::Value::Null
                 }]
             })
-        ));
+        );
+        let _ = stream.write_all(event.as_bytes());
+        let _ = stream.flush();
     }
 
+    // Emit tool_calls or stop event.
     if !tool_calls.is_empty() {
-        body.push_str(&format!(
+        if chunk_delay_ms > 0 && !text_chunks.is_empty() {
+            thread::sleep(delay);
+        }
+        let event = format!(
             "data: {}\n\n",
             json!({
                 "id": "chatcmpl-mock",
@@ -394,9 +421,11 @@ fn write_streaming_response(stream: &mut std::net::TcpStream, text: &str, tool_c
                     "finish_reason": "tool_calls"
                 }]
             })
-        ));
+        );
+        let _ = stream.write_all(event.as_bytes());
+        let _ = stream.flush();
     } else {
-        body.push_str(&format!(
+        let event = format!(
             "data: {}\n\n",
             json!({
                 "id": "chatcmpl-mock",
@@ -409,17 +438,12 @@ fn write_streaming_response(stream: &mut std::net::TcpStream, text: &str, tool_c
                     "finish_reason": "stop"
                 }]
             })
-        ));
+        );
+        let _ = stream.write_all(event.as_bytes());
+        let _ = stream.flush();
     }
 
-    body.push_str("data: [DONE]\n\n");
-
-    let http_response = format!(
-        "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
-        body.len(),
-        body
-    );
-    let _ = stream.write_all(http_response.as_bytes());
+    let _ = stream.write_all(b"data: [DONE]\n\n");
     let _ = stream.flush();
 }
 

--- a/src/bin/harnx-mock-llm/main.rs
+++ b/src/bin/harnx-mock-llm/main.rs
@@ -1,0 +1,460 @@
+//! harnx-mock-llm: A standalone mock LLM server for local TUI repro workflows.
+//!
+//! This binary provides an HTTP server that mimics an OpenAI-compatible API
+//! with deterministic, scriptable responses. It's designed for local debugging
+//! and TUI reproduction workflows outside of `cargo test`.
+//!
+//! # Usage
+//!
+//! ```bash
+//! # Start server with default responses
+//! harnx-mock-llm --port 3829
+//!
+//! # Start with a script file
+//! harnx-mock-llm --port 3829 --script /path/to/script.yaml
+//! ```
+//!
+//! # Script Format
+//!
+//! The script file is YAML with the following structure:
+//!
+//! ```yaml
+//! turns:
+//!   - text_chunks:
+//!       - "Hello"
+//!       - " world"
+//!     tool_calls:
+//!       - name: "Bash"
+//!         arguments: { "command": "echo test" }
+//!   - text_chunks:
+//!       - "Second response"
+//! ```
+//!
+//! Each turn is consumed sequentially as requests arrive.
+
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// Script describing mock responses for each turn.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct MockScript {
+    /// List of turns. Each turn is consumed by one chat completion request.
+    #[serde(default)]
+    pub turns: Vec<MockTurn>,
+
+    /// Default response when no more turns are available.
+    #[serde(default = "default_fallback_text")]
+    pub fallback_text: String,
+
+    /// Delay in milliseconds between chunks.
+    #[serde(default)]
+    pub chunk_delay_ms: u64,
+}
+
+fn default_fallback_text() -> String {
+    "No more scripted responses.".to_string()
+}
+
+/// A single turn in the mock conversation.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MockTurn {
+    /// Text chunks to stream back.
+    #[serde(default)]
+    pub text_chunks: Vec<String>,
+
+    /// Tool calls to include in the response.
+    #[serde(default)]
+    pub tool_calls: Vec<MockToolCallDef>,
+}
+
+/// A tool call definition in the script.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MockToolCallDef {
+    pub name: String,
+    pub arguments: Value,
+
+    /// Optional: ID for the tool call (auto-generated if not provided).
+    #[serde(default)]
+    pub id: Option<String>,
+}
+
+/// Global state for the mock server.
+struct ServerState {
+    script: MockScript,
+    turn_index: AtomicUsize,
+    request_log: Mutex<Vec<Value>>,
+}
+
+impl ServerState {
+    fn new(script: MockScript) -> Self {
+        Self {
+            script,
+            turn_index: AtomicUsize::new(0),
+            request_log: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn current_turn(&self) -> Option<MockTurn> {
+        let idx = self.turn_index.load(Ordering::SeqCst);
+        self.script.turns.get(idx).cloned()
+    }
+
+    fn advance_turn(&self) {
+        self.turn_index.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn log_request(&self, request: Value) {
+        if let Ok(mut log) = self.request_log.lock() {
+            log.push(request);
+        }
+    }
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut port: u16 = 3829;
+    let mut script_path: Option<PathBuf> = None;
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--port" | "-p" => {
+                if let Some(value) = args.next() {
+                    if let Ok(p) = value.parse::<u16>() {
+                        port = p;
+                    }
+                }
+            }
+            "--script" | "-s" => {
+                if let Some(value) = args.next() {
+                    script_path = Some(PathBuf::from(value));
+                }
+            }
+            "--help" | "-h" => {
+                println!("harnx-mock-llm - Standalone mock LLM server for TUI repro workflows");
+                println!();
+                println!("Usage: harnx-mock-llm [OPTIONS]");
+                println!();
+                println!("Options:");
+                println!("  --port, -p <PORT>      Port to listen on (default: 3829)");
+                println!("  --script, -s <FILE>    YAML script file defining responses");
+                println!("  --help, -h             Show this help message");
+                println!();
+                println!("The server provides an OpenAI-compatible API at http://localhost:<PORT>");
+                println!();
+                println!("Script format (YAML):");
+                println!("  turns:");
+                println!("    - text_chunks: [\"Hello\", \" world\"]");
+                println!("      tool_calls:");
+                println!("        - name: Bash");
+                println!("          arguments: {{command: \"echo test\"}}");
+                return;
+            }
+            _ => {
+                eprintln!("Unknown argument: {}", arg);
+                eprintln!("Use --help for usage information");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    let script = if let Some(path) = script_path {
+        match std::fs::read_to_string(&path) {
+            Ok(content) => match serde_yaml::from_str::<MockScript>(&content) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("Failed to parse script file: {}", e);
+                    std::process::exit(1);
+                }
+            },
+            Err(e) => {
+                eprintln!("Failed to read script file: {}", e);
+                std::process::exit(1);
+            }
+        }
+    } else {
+        // Default script with a simple response
+        MockScript {
+            turns: vec![
+                MockTurn {
+                    text_chunks: vec!["Hello! ".to_string(), "I'm a mock LLM.".to_string()],
+                    tool_calls: vec![],
+                },
+                MockTurn {
+                    text_chunks: vec!["Second response.".to_string()],
+                    tool_calls: vec![],
+                },
+            ],
+            fallback_text: "No more scripted responses.".to_string(),
+            chunk_delay_ms: 50,
+        }
+    };
+
+    let state = Arc::new(ServerState::new(script));
+
+    // Run a simple HTTP server using std::net
+    let addr = format!("127.0.0.1:{}", port);
+    let listener = match std::net::TcpListener::bind(&addr) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("Failed to bind to {}: {}", addr, e);
+            std::process::exit(1);
+        }
+    };
+
+    // Signal ready
+    println!("READY listening on {}", addr);
+    io::stdout().flush().ok();
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                let state = Arc::clone(&state);
+                thread::spawn(move || {
+                    handle_connection(stream, state);
+                });
+            }
+            Err(e) => {
+                eprintln!("Connection failed: {}", e);
+            }
+        }
+    }
+}
+
+fn handle_connection(mut stream: std::net::TcpStream, state: Arc<ServerState>) {
+    use std::io::Read;
+
+    let mut buffer = [0; 65536];
+    let bytes_read = match stream.read(&mut buffer) {
+        Ok(n) if n > 0 => n,
+        _ => return,
+    };
+
+    let request_str = String::from_utf8_lossy(&buffer[..bytes_read]);
+
+    // Parse HTTP request
+    let mut lines = request_str.lines();
+    let request_line = match lines.next() {
+        Some(l) => l,
+        None => return,
+    };
+
+    let parts: Vec<&str> = request_line.split_whitespace().collect();
+    if parts.len() < 2 {
+        return;
+    }
+
+    let method = parts[0];
+    let path = parts[1];
+
+    // Find body (after double newline)
+    let body_start = request_str.find("\r\n\r\n").map(|i| i + 4);
+    let body = body_start.map(|start| &request_str[start..]).unwrap_or("");
+
+    // Route the request
+    match (method, path) {
+        ("GET", "/v1/models") => {
+            let response = handle_list_models();
+            let response_str = response.to_string();
+            let http_response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                response_str.len(),
+                response_str
+            );
+            let _ = stream.write_all(http_response.as_bytes());
+            let _ = stream.flush();
+        }
+        ("POST", "/v1/chat/completions") => {
+            let body_json: Value = match serde_json::from_str(body) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("Failed to parse request body: {}", e);
+                    json!({"error": "Invalid JSON"})
+                }
+            };
+            state.log_request(body_json.clone());
+            handle_chat_completions(body_json, &state, &mut stream);
+        }
+        _ => {
+            let response = json!({"error": "Not found"});
+            let response_str = response.to_string();
+            let http_response = format!(
+                "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                response_str.len(),
+                response_str
+            );
+            let _ = stream.write_all(http_response.as_bytes());
+            let _ = stream.flush();
+        }
+    }
+}
+
+fn handle_list_models() -> Value {
+    json!({
+        "object": "list",
+        "data": [
+            {
+                "id": "mock-llm",
+                "object": "model",
+                "created": 0,
+                "owned_by": "mock"
+            }
+        ]
+    })
+}
+
+fn handle_chat_completions(request: Value, state: &ServerState, stream: &mut std::net::TcpStream) {
+    let is_stream = request
+        .get("stream")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let turn = state.current_turn();
+    state.advance_turn();
+
+    let turn = match turn {
+        Some(t) => t,
+        None => MockTurn {
+            text_chunks: vec![state.script.fallback_text.clone()],
+            tool_calls: vec![],
+        },
+    };
+
+    // Combine text chunks
+    let full_text = turn.text_chunks.join("");
+
+    // Build tool calls array
+    let tool_calls: Vec<Value> = turn
+        .tool_calls
+        .iter()
+        .enumerate()
+        .map(|(i, tc)| {
+            json!({
+                "id": tc.id.clone().unwrap_or_else(|| format!("call_{}", i)),
+                "type": "function",
+                "function": {
+                    "name": tc.name,
+                    "arguments": tc.arguments.to_string()
+                }
+            })
+        })
+        .collect();
+
+    if is_stream {
+        write_streaming_response(stream, &full_text, &tool_calls);
+    } else {
+        let response = build_non_streaming_response(&full_text, tool_calls);
+        let response_str = response.to_string();
+        let http_response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            response_str.len(),
+            response_str
+        );
+        let _ = stream.write_all(http_response.as_bytes());
+        let _ = stream.flush();
+    }
+}
+
+fn write_streaming_response(stream: &mut std::net::TcpStream, text: &str, tool_calls: &[Value]) {
+    let mut body = String::new();
+
+    if !text.is_empty() {
+        body.push_str(&format!(
+            "data: {}\n\n",
+            json!({
+                "id": "chatcmpl-mock",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": "mock-llm",
+                "choices": [{
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": text},
+                    "finish_reason": serde_json::Value::Null
+                }]
+            })
+        ));
+    }
+
+    if !tool_calls.is_empty() {
+        body.push_str(&format!(
+            "data: {}\n\n",
+            json!({
+                "id": "chatcmpl-mock",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": "mock-llm",
+                "choices": [{
+                    "index": 0,
+                    "delta": {"tool_calls": tool_calls},
+                    "finish_reason": "tool_calls"
+                }]
+            })
+        ));
+    } else {
+        body.push_str(&format!(
+            "data: {}\n\n",
+            json!({
+                "id": "chatcmpl-mock",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": "mock-llm",
+                "choices": [{
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": "stop"
+                }]
+            })
+        ));
+    }
+
+    body.push_str("data: [DONE]\n\n");
+
+    let http_response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    let _ = stream.write_all(http_response.as_bytes());
+    let _ = stream.flush();
+}
+
+fn build_non_streaming_response(text: &str, tool_calls: Vec<Value>) -> Value {
+    let has_tool_calls = !tool_calls.is_empty();
+
+    let message = if has_tool_calls {
+        json!({
+            "role": "assistant",
+            "content": text,
+            "tool_calls": tool_calls
+        })
+    } else {
+        json!({
+            "role": "assistant",
+            "content": text
+        })
+    };
+
+    json!({
+        "id": "chatcmpl-mock",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "mock-llm",
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": if has_tool_calls { "tool_calls" } else { "stop" }
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0
+        }
+    })
+}

--- a/src/test_utils/mock_openai_server.rs
+++ b/src/test_utils/mock_openai_server.rs
@@ -1,0 +1,346 @@
+#![cfg(test)]
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+/// Script describing mock responses for each turn.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct MockOpenAiScript {
+    #[serde(default)]
+    pub turns: Vec<MockOpenAiTurn>,
+    #[serde(default = "default_fallback_text")]
+    pub fallback_text: String,
+    #[serde(default)]
+    pub chunk_delay_ms: u64,
+}
+
+fn default_fallback_text() -> String {
+    "No more scripted responses.".to_string()
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct MockOpenAiTurn {
+    #[serde(default)]
+    pub text_chunks: Vec<String>,
+    #[serde(default)]
+    pub tool_calls: Vec<MockOpenAiToolCall>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MockOpenAiToolCall {
+    pub name: String,
+    pub arguments: Value,
+    #[serde(default)]
+    pub id: Option<String>,
+}
+
+struct ServerState {
+    script: MockOpenAiScript,
+    turn_index: AtomicUsize,
+    request_log: Mutex<Vec<Value>>,
+}
+
+impl ServerState {
+    fn new(script: MockOpenAiScript) -> Self {
+        Self {
+            script,
+            turn_index: AtomicUsize::new(0),
+            request_log: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn next_turn(&self) -> MockOpenAiTurn {
+        let idx = self.turn_index.fetch_add(1, Ordering::SeqCst);
+        self.script
+            .turns
+            .get(idx)
+            .cloned()
+            .unwrap_or_else(|| MockOpenAiTurn {
+                text_chunks: vec![self.script.fallback_text.clone()],
+                tool_calls: vec![],
+            })
+    }
+
+    fn log_request(&self, request: Value) {
+        if let Ok(mut log) = self.request_log.lock() {
+            log.push(request);
+        }
+    }
+}
+
+pub struct MockOpenAiServer {
+    port: u16,
+    shutdown: Option<TcpStream>,
+    accept_thread: Option<JoinHandle<()>>,
+}
+
+impl MockOpenAiServer {
+    pub fn start(script: MockOpenAiScript) -> Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0").context("failed to bind mock server")?;
+        listener
+            .set_nonblocking(false)
+            .context("failed to configure mock server listener")?;
+        let port = listener
+            .local_addr()
+            .context("failed to get mock server address")?
+            .port();
+
+        let shutdown_listener =
+            TcpListener::bind("127.0.0.1:0").context("failed to bind shutdown listener")?;
+        let shutdown_addr = shutdown_listener
+            .local_addr()
+            .context("failed to get shutdown listener address")?;
+        let shutdown =
+            TcpStream::connect(shutdown_addr).context("failed to connect shutdown channel")?;
+        let (shutdown_server, _) = shutdown_listener
+            .accept()
+            .context("failed to accept shutdown channel")?;
+
+        let state = Arc::new(ServerState::new(script));
+        let accept_thread =
+            thread::spawn(move || run_accept_loop(listener, shutdown_server, state));
+
+        Ok(Self {
+            port,
+            shutdown: Some(shutdown),
+            accept_thread: Some(accept_thread),
+        })
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+impl Drop for MockOpenAiServer {
+    fn drop(&mut self) {
+        if let Some(mut shutdown) = self.shutdown.take() {
+            let _ = shutdown.write_all(b"shutdown");
+            let _ = shutdown.flush();
+            let _ = shutdown.shutdown(Shutdown::Both);
+        }
+        if let Some(handle) = self.accept_thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn run_accept_loop(listener: TcpListener, mut shutdown: TcpStream, state: Arc<ServerState>) {
+    let _ = listener.set_nonblocking(true);
+    let _ = shutdown.set_nonblocking(true);
+
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                let state = Arc::clone(&state);
+                thread::spawn(move || handle_connection(stream, state));
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(_) => break,
+        }
+
+        let mut buf = [0; 16];
+        match shutdown.read(&mut buf) {
+            Ok(0) => {}
+            Ok(_) => break,
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(_) => break,
+        }
+
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn handle_connection(mut stream: TcpStream, state: Arc<ServerState>) {
+    let mut buffer = vec![0_u8; 65536];
+    let bytes_read = match stream.read(&mut buffer) {
+        Ok(n) if n > 0 => n,
+        _ => return,
+    };
+
+    let request_str = String::from_utf8_lossy(&buffer[..bytes_read]);
+    let mut lines = request_str.lines();
+    let request_line = match lines.next() {
+        Some(line) => line,
+        None => return,
+    };
+    let parts: Vec<&str> = request_line.split_whitespace().collect();
+    if parts.len() < 2 {
+        return;
+    }
+
+    let method = parts[0];
+    let path = parts[1];
+    let body_start = request_str.find("\r\n\r\n").map(|i| i + 4);
+    let body = body_start.map(|start| &request_str[start..]).unwrap_or("");
+
+    match (method, path) {
+        ("GET", "/v1/models") => write_json_response(&mut stream, &handle_list_models()),
+        ("POST", "/v1/chat/completions") => {
+            let body_json: Value =
+                serde_json::from_str(body).unwrap_or_else(|_| json!({"error": "Invalid JSON"}));
+            state.log_request(body_json.clone());
+            handle_chat_completions(body_json, &state, &mut stream);
+        }
+        _ => write_http_response(
+            &mut stream,
+            "404 Not Found",
+            "application/json",
+            &json!({"error": "Not found"}).to_string(),
+        ),
+    }
+}
+
+fn handle_list_models() -> Value {
+    json!({
+        "object": "list",
+        "data": [{
+            "id": "mock-llm",
+            "object": "model",
+            "created": 0,
+            "owned_by": "mock"
+        }]
+    })
+}
+
+fn handle_chat_completions(request: Value, state: &ServerState, stream: &mut TcpStream) {
+    let is_stream = request
+        .get("stream")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let turn = state.next_turn();
+    let full_text = turn.text_chunks.join("");
+    let tool_calls: Vec<Value> = turn
+        .tool_calls
+        .iter()
+        .enumerate()
+        .map(|(i, tc)| {
+            json!({
+                "id": tc.id.clone().unwrap_or_else(|| format!("call_{i}")),
+                "type": "function",
+                "function": {
+                    "name": tc.name,
+                    "arguments": tc.arguments.to_string()
+                }
+            })
+        })
+        .collect();
+
+    if is_stream {
+        write_streaming_response(stream, &full_text, &tool_calls);
+    } else {
+        write_json_response(
+            stream,
+            &build_non_streaming_response(&full_text, tool_calls),
+        );
+    }
+}
+
+fn write_streaming_response(stream: &mut TcpStream, text: &str, tool_calls: &[Value]) {
+    let mut body = String::new();
+
+    if !text.is_empty() {
+        body.push_str(&format!(
+            "data: {}\n\n",
+            json!({
+                "id": "chatcmpl-mock",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": "mock-llm",
+                "choices": [{
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": text},
+                    "finish_reason": Value::Null
+                }]
+            })
+        ));
+    }
+
+    if !tool_calls.is_empty() {
+        body.push_str(&format!(
+            "data: {}\n\n",
+            json!({
+                "id": "chatcmpl-mock",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": "mock-llm",
+                "choices": [{
+                    "index": 0,
+                    "delta": {"tool_calls": tool_calls},
+                    "finish_reason": "tool_calls"
+                }]
+            })
+        ));
+    } else {
+        body.push_str(&format!(
+            "data: {}\n\n",
+            json!({
+                "id": "chatcmpl-mock",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": "mock-llm",
+                "choices": [{
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": "stop"
+                }]
+            })
+        ));
+    }
+
+    body.push_str("data: [DONE]\n\n");
+    write_http_response(stream, "200 OK", "text/event-stream", &body);
+}
+
+fn build_non_streaming_response(text: &str, tool_calls: Vec<Value>) -> Value {
+    let has_tool_calls = !tool_calls.is_empty();
+    let message = if has_tool_calls {
+        json!({
+            "role": "assistant",
+            "content": text,
+            "tool_calls": tool_calls
+        })
+    } else {
+        json!({
+            "role": "assistant",
+            "content": text
+        })
+    };
+
+    json!({
+        "id": "chatcmpl-mock",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "mock-llm",
+        "choices": [{
+            "index": 0,
+            "message": message,
+            "finish_reason": if has_tool_calls { "tool_calls" } else { "stop" }
+        }],
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0
+        }
+    })
+}
+
+fn write_json_response(stream: &mut TcpStream, response: &Value) {
+    write_http_response(stream, "200 OK", "application/json", &response.to_string());
+}
+
+fn write_http_response(stream: &mut TcpStream, status: &str, content_type: &str, body: &str) {
+    let http_response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(http_response.as_bytes());
+    let _ = stream.flush();
+}

--- a/src/test_utils/mock_openai_server.rs
+++ b/src/test_utils/mock_openai_server.rs
@@ -159,13 +159,63 @@ fn run_accept_loop(listener: TcpListener, mut shutdown: TcpStream, state: Arc<Se
 }
 
 fn handle_connection(mut stream: TcpStream, state: Arc<ServerState>) {
-    let mut buffer = vec![0_u8; 65536];
-    let bytes_read = match stream.read(&mut buffer) {
-        Ok(n) if n > 0 => n,
-        _ => return,
+    // Read the request in a loop until we have the complete headers
+    let mut buffer = Vec::new();
+    let mut temp_buf = [0u8; 1024];
+    let headers_end_pos = loop {
+        match stream.read(&mut temp_buf) {
+            Ok(0) => return, // EOF
+            Ok(n) => {
+                buffer.extend_from_slice(&temp_buf[..n]);
+                // Check if we have the full headers (ending with \r\n\r\n)
+                if let Some(pos) = buffer
+                    .windows(4)
+                    .position(|window| window == b"\r\n\r\n")
+                {
+                    break pos + 4;
+                }
+                // Prevent unbounded growth while waiting for headers
+                if buffer.len() > 1_048_576 {
+                    // 1MB limit for headers
+                    return;
+                }
+            }
+            Err(_) => return,
+        }
     };
 
-    let request_str = String::from_utf8_lossy(&buffer[..bytes_read]);
+    // Parse headers to extract Content-Length
+    let headers_str = match String::from_utf8(buffer[..headers_end_pos].to_vec()) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    let mut content_length = 0usize;
+    for line in headers_str.lines() {
+        if let Some(value) = line.strip_prefix("Content-Length:") {
+            content_length = value.trim().parse().unwrap_or(0);
+            break;
+        }
+    }
+
+    // Read the body based on Content-Length
+    let body_bytes_read = buffer.len() - headers_end_pos;
+    if body_bytes_read < content_length {
+        let remaining = content_length - body_bytes_read;
+        let current_len = buffer.len();
+        buffer.resize(current_len + remaining, 0);
+        let mut total_read = 0;
+        while total_read < remaining {
+            match stream.read(&mut buffer[current_len + total_read..]) {
+                Ok(0) => return, // EOF before complete body
+                Ok(n) => total_read += n,
+                Err(_) => return,
+            }
+        }
+    }
+
+    // Now parse the complete request
+    let request_str = String::from_utf8_lossy(&buffer);
     let mut lines = request_str.lines();
     let request_line = match lines.next() {
         Some(line) => line,
@@ -178,14 +228,17 @@ fn handle_connection(mut stream: TcpStream, state: Arc<ServerState>) {
 
     let method = parts[0];
     let path = parts[1];
-    let body_start = request_str.find("\r\n\r\n").map(|i| i + 4);
-    let body = body_start.map(|start| &request_str[start..]).unwrap_or("");
+    let body = if content_length > 0 && headers_end_pos < buffer.len() {
+        String::from_utf8_lossy(&buffer[headers_end_pos..headers_end_pos + content_length])
+    } else {
+        "".into()
+    };
 
     match (method, path) {
         ("GET", "/v1/models") => write_json_response(&mut stream, &handle_list_models()),
         ("POST", "/v1/chat/completions") => {
             let body_json: Value =
-                serde_json::from_str(body).unwrap_or_else(|_| json!({"error": "Invalid JSON"}));
+                serde_json::from_str(&body).unwrap_or_else(|_| json!({"error": "Invalid JSON"}));
             state.log_request(body_json.clone());
             handle_chat_completions(body_json, &state, &mut stream);
         }

--- a/src/test_utils/mock_openai_server.rs
+++ b/src/test_utils/mock_openai_server.rs
@@ -168,10 +168,7 @@ fn handle_connection(mut stream: TcpStream, state: Arc<ServerState>) {
             Ok(n) => {
                 buffer.extend_from_slice(&temp_buf[..n]);
                 // Check if we have the full headers (ending with \r\n\r\n)
-                if let Some(pos) = buffer
-                    .windows(4)
-                    .position(|window| window == b"\r\n\r\n")
-                {
+                if let Some(pos) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
                     break pos + 4;
                 }
                 // Prevent unbounded growth while waiting for headers
@@ -192,7 +189,7 @@ fn handle_connection(mut stream: TcpStream, state: Arc<ServerState>) {
 
     let mut content_length = 0usize;
     for line in headers_str.lines() {
-        if let Some(value) = line.strip_prefix("Content-Length:") {
+        if let Some(value) = line.to_ascii_lowercase().strip_prefix("content-length:") {
             content_length = value.trim().parse().unwrap_or(0);
             break;
         }
@@ -269,7 +266,6 @@ fn handle_chat_completions(request: Value, state: &ServerState, stream: &mut Tcp
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
     let turn = state.next_turn();
-    let full_text = turn.text_chunks.join("");
     let tool_calls: Vec<Value> = turn
         .tool_calls
         .iter()
@@ -287,8 +283,14 @@ fn handle_chat_completions(request: Value, state: &ServerState, stream: &mut Tcp
         .collect();
 
     if is_stream {
-        write_streaming_response(stream, &full_text, &tool_calls);
+        write_streaming_response(
+            stream,
+            &turn.text_chunks,
+            state.script.chunk_delay_ms,
+            &tool_calls,
+        );
     } else {
+        let full_text = turn.text_chunks.join("");
         write_json_response(
             stream,
             &build_non_streaming_response(&full_text, tool_calls),
@@ -296,11 +298,28 @@ fn handle_chat_completions(request: Value, state: &ServerState, stream: &mut Tcp
     }
 }
 
-fn write_streaming_response(stream: &mut TcpStream, text: &str, tool_calls: &[Value]) {
-    let mut body = String::new();
+fn write_streaming_response(
+    stream: &mut TcpStream,
+    text_chunks: &[String],
+    chunk_delay_ms: u64,
+    tool_calls: &[Value],
+) {
+    // Write HTTP headers for SSE (no Content-Length so we can flush per-event).
+    let header = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n";
+    let _ = stream.write_all(header.as_bytes());
+    let _ = stream.flush();
 
-    if !text.is_empty() {
-        body.push_str(&format!(
+    let delay = Duration::from_millis(chunk_delay_ms);
+
+    // Emit one SSE event per text chunk, preserving ordering.
+    for (i, chunk) in text_chunks.iter().enumerate() {
+        if chunk.is_empty() {
+            continue;
+        }
+        if i > 0 && chunk_delay_ms > 0 {
+            thread::sleep(delay);
+        }
+        let event = format!(
             "data: {}\n\n",
             json!({
                 "id": "chatcmpl-mock",
@@ -309,15 +328,21 @@ fn write_streaming_response(stream: &mut TcpStream, text: &str, tool_calls: &[Va
                 "model": "mock-llm",
                 "choices": [{
                     "index": 0,
-                    "delta": {"role": "assistant", "content": text},
+                    "delta": {"role": "assistant", "content": chunk},
                     "finish_reason": Value::Null
                 }]
             })
-        ));
+        );
+        let _ = stream.write_all(event.as_bytes());
+        let _ = stream.flush();
     }
 
+    // Emit tool_calls or stop event.
     if !tool_calls.is_empty() {
-        body.push_str(&format!(
+        if chunk_delay_ms > 0 && !text_chunks.is_empty() {
+            thread::sleep(delay);
+        }
+        let event = format!(
             "data: {}\n\n",
             json!({
                 "id": "chatcmpl-mock",
@@ -330,9 +355,11 @@ fn write_streaming_response(stream: &mut TcpStream, text: &str, tool_calls: &[Va
                     "finish_reason": "tool_calls"
                 }]
             })
-        ));
+        );
+        let _ = stream.write_all(event.as_bytes());
+        let _ = stream.flush();
     } else {
-        body.push_str(&format!(
+        let event = format!(
             "data: {}\n\n",
             json!({
                 "id": "chatcmpl-mock",
@@ -345,11 +372,13 @@ fn write_streaming_response(stream: &mut TcpStream, text: &str, tool_calls: &[Va
                     "finish_reason": "stop"
                 }]
             })
-        ));
+        );
+        let _ = stream.write_all(event.as_bytes());
+        let _ = stream.flush();
     }
 
-    body.push_str("data: [DONE]\n\n");
-    write_http_response(stream, "200 OK", "text/event-stream", &body);
+    let _ = stream.write_all(b"data: [DONE]\n\n");
+    let _ = stream.flush();
 }
 
 fn build_non_streaming_response(text: &str, tool_calls: Vec<Value>) -> Value {

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -9,6 +9,7 @@
 //!
 //! - [`mock_client`] - Mock LLM client for simulating streaming responses and tool calls
 //! - [`tui_harness`] - Test harness for TUI rendering tests without a real terminal
+//! - [`tmux_harness`] - Minimal tmux-backed harness for driving the real TUI locally
 //! - [`sync`] - Synchronization primitives for async test coordination
 //! - [`mock_acp`] - Mock ACP server for testing sub-agent delegation
 //!
@@ -58,10 +59,15 @@
 
 pub mod mock_acp;
 pub mod mock_client;
+pub mod mock_openai_server;
+mod repro_249_tmux;
 pub mod sync;
+pub mod tmux_harness;
 pub mod tui_harness;
 
 pub use mock_acp::*;
 pub use mock_client::*;
+pub use mock_openai_server::*;
 pub use sync::*;
+pub use tmux_harness::*;
 pub use tui_harness::*;

--- a/src/test_utils/repro_249_tmux.rs
+++ b/src/test_utils/repro_249_tmux.rs
@@ -69,28 +69,34 @@ fn repro_249_top_level_delegation_markers() -> Result<()> {
 
     // Step 2: Export PATH and cd to repo root for subsequent commands
     tmux.send_text(&format!(
-        "export PATH={} && cd {}",
+        "export PATH={} && cd {}; printf '__READY__\\n'",
         shell_escape(&path_env),
         shell_escape(repo_root.to_string_lossy().as_ref())
     ))?;
     tmux.send_keys(&["Enter"])?;
-    tmux.wait_for(Duration::from_secs(5), |screen| screen.contains("$"))?;
+    tmux.wait_for(Duration::from_secs(5), |screen| screen.contains("__READY__"))?;
 
     // Step 3: Run diagnostics - list agents
     tmux.send_text(&format!(
-        "{} --list-agents",
-        shell_escape(harnx_bin.to_string_lossy().as_ref())
+        "{}; printf '__READY__\\n'",
+        format!(
+            "{} --list-agents",
+            shell_escape(harnx_bin.to_string_lossy().as_ref())
+        )
     ))?;
     tmux.send_keys(&["Enter"])?;
-    tmux.wait_for(Duration::from_secs(5), |screen| screen.contains("$"))?;
+    tmux.wait_for(Duration::from_secs(5), |screen| screen.contains("__READY__"))?;
 
     // Step 4: Run diagnostics - list models
     tmux.send_text(&format!(
-        "{} --list-models",
-        shell_escape(harnx_bin.to_string_lossy().as_ref())
+        "{}; printf '__READY__\\n'",
+        format!(
+            "{} --list-models",
+            shell_escape(harnx_bin.to_string_lossy().as_ref())
+        )
     ))?;
     tmux.send_keys(&["Enter"])?;
-    tmux.wait_for(Duration::from_secs(5), |screen| screen.contains("$"))?;
+    tmux.wait_for(Duration::from_secs(5), |screen| screen.contains("__READY__"))?;
 
     // Step 5: Launch the test agent
     tmux.send_text(&format!(
@@ -210,12 +216,12 @@ fn write_fixture_files(paths: &TestPaths) -> Result<()> {
     let config = format!(
         "save: false\nclients:\n  - type: openai-compatible\n    name: mock-llm\n    api_base: http://127.0.0.1:{}/v1\n    api_key: dummy\n    models:\n      - name: test\n        max_input_tokens: 32000\n        max_output_tokens: 4096\n        supports_tool_use: true\nmcp_servers:\n  - name: repro249\n    command: {}\n    enabled: true\n    rename_tools:\n      {}: {}\nacp_servers:\n  - name: {}\n    command: {}\n    args: [\"--acp\", {}]\n    enabled: true\n",
         paths.port,
-        shell_escape(fake_mcp_server.to_string_lossy().as_ref()),
+        yaml_escape(fake_mcp_server.to_string_lossy().as_ref()),
         REPRO_249_MCP_TOOL_NAME,
         REPRO_249_MCP_TOOL_NAME,
         TEST_SUB_AGENT_NAME,
-        shell_escape(harnx_bin.to_string_lossy().as_ref()),
-        shell_escape(TEST_SUB_AGENT_NAME),
+        yaml_escape(harnx_bin.to_string_lossy().as_ref()),
+        yaml_escape(TEST_SUB_AGENT_NAME),
     );
     std::fs::write(&paths.config_path, config)?;
     std::fs::write(
@@ -279,5 +285,16 @@ fn shell_escape(input: &str) -> String {
     if input.is_empty() {
         return "''".to_string();
     }
-    format!("'{}'", input.replace('"', "'\"'\"'"))
+    // Escape single quotes for shell by replacing ' with '"'"'
+    format!("'{}'", input.replace('\'', "'\"'\"'"))
+}
+
+fn yaml_escape(input: &str) -> String {
+    // For YAML string values, wrap in double quotes and escape internal double quotes and backslashes
+    if input.is_empty() {
+        return "\"\"".to_string();
+    }
+    // Simple escaping: escape backslashes first, then double quotes
+    let escaped = input.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{}\"", escaped)
 }

--- a/src/test_utils/repro_249_tmux.rs
+++ b/src/test_utils/repro_249_tmux.rs
@@ -17,6 +17,13 @@ const TEST_SUB_AGENT_NAME: &str = "test-sub-agent";
 
 #[test]
 fn repro_249_top_level_delegation_markers() -> Result<()> {
+    if option_env!("CARGO_BIN_NAME") == Some("harnx") {
+        eprintln!(
+            "skipping repro_249_top_level_delegation_markers in binary test target to avoid duplicate tmux sessions"
+        );
+        return Ok(());
+    }
+
     if !TmuxHarness::is_available() {
         eprintln!("skipping repro_249_top_level_delegation_markers: tmux is unavailable");
         return Ok(());
@@ -113,17 +120,15 @@ fn repro_249_top_level_delegation_markers() -> Result<()> {
         "child sub-agent heading not visible:\n{screen}"
     );
 
-    // ── Issue #249 assertion ──────────────────────────────────────────────────
+    // ── Issue #249 regression assertion ───────────────────────────────────────
     // The child sub-agent internally called `repro249_unique_mcp_tool` via MCP.
-    // That internal tool call SHOULD be visible in the parent transcript, but is
-    // currently missing. This assertion documents the bug: if it ever starts
-    // passing, issue #249 is fixed.
+    // That internal tool call should remain visible in the parent transcript.
     let nested_visible = nested_mcp_tool_present(&screen);
     eprintln!(
         "\n=== Issue #249 tmux repro result ===\n\
          delegation visible    : {}\n\
          child heading visible : {}\n\
-         nested tool visible   : {} (expected: true — MISSING = bug reproduced)\n\
+         nested tool visible   : {} (expected: true — visible = fix confirmed)\n\
          === last screen ===\n{}\n====\n",
         screen.contains(&format!("{}_session_prompt", TEST_SUB_AGENT_NAME)),
         screen.contains(&format!("> {}", TEST_SUB_AGENT_NAME)),
@@ -131,8 +136,8 @@ fn repro_249_top_level_delegation_markers() -> Result<()> {
         screen,
     );
     assert!(
-        !nested_visible,
-        "nested internal MCP tool call IS now visible — issue #249 appears to be fixed!\n{screen}"
+        nested_visible,
+        "nested internal MCP tool call is not visible in the parent transcript; issue #249 regressed\n{screen}"
     );
 
     drop(tmux);

--- a/src/test_utils/repro_249_tmux.rs
+++ b/src/test_utils/repro_249_tmux.rs
@@ -68,35 +68,39 @@ fn repro_249_top_level_delegation_markers() -> Result<()> {
     tmux.send_keys(&["Enter"])?;
 
     // Step 2: Export PATH and cd to repo root for subsequent commands
+    //
+    // Each step uses a unique marker. The wait_for predicate requires the
+    // marker to appear at least twice in the pane: once in the echoed command
+    // line and once as actual output, ensuring the command has finished.
     tmux.send_text(&format!(
-        "export PATH={} && cd {}; printf '__READY__\\n'",
+        "export PATH={} && cd {}; printf '__READY_2__\\n'",
         shell_escape(&path_env),
         shell_escape(repo_root.to_string_lossy().as_ref())
     ))?;
     tmux.send_keys(&["Enter"])?;
-    tmux.wait_for(Duration::from_secs(5), |screen| screen.contains("__READY__"))?;
+    tmux.wait_for(Duration::from_secs(5), |screen| {
+        count_occurrences(screen, "__READY_2__") >= 2
+    })?;
 
     // Step 3: Run diagnostics - list agents
     tmux.send_text(&format!(
-        "{}; printf '__READY__\\n'",
-        format!(
-            "{} --list-agents",
-            shell_escape(harnx_bin.to_string_lossy().as_ref())
-        )
+        "{} --list-agents; printf '__READY_3__\\n'",
+        shell_escape(harnx_bin.to_string_lossy().as_ref())
     ))?;
     tmux.send_keys(&["Enter"])?;
-    tmux.wait_for(Duration::from_secs(5), |screen| screen.contains("__READY__"))?;
+    tmux.wait_for(Duration::from_secs(5), |screen| {
+        count_occurrences(screen, "__READY_3__") >= 2
+    })?;
 
     // Step 4: Run diagnostics - list models
     tmux.send_text(&format!(
-        "{}; printf '__READY__\\n'",
-        format!(
-            "{} --list-models",
-            shell_escape(harnx_bin.to_string_lossy().as_ref())
-        )
+        "{} --list-models; printf '__READY_4__\\n'",
+        shell_escape(harnx_bin.to_string_lossy().as_ref())
     ))?;
     tmux.send_keys(&["Enter"])?;
-    tmux.wait_for(Duration::from_secs(5), |screen| screen.contains("__READY__"))?;
+    tmux.wait_for(Duration::from_secs(5), |screen| {
+        count_occurrences(screen, "__READY_4__") >= 2
+    })?;
 
     // Step 5: Launch the test agent
     tmux.send_text(&format!(
@@ -174,10 +178,17 @@ impl TestPaths {
 }
 
 fn script() -> MockOpenAiScript {
+    // The mock LLM is shared between the parent and sub-agent processes.
+    // Turns are consumed in order across both processes:
+    //   Turn 0 (parent)    : delegate to the sub-agent via ACP tool call
+    //   Turn 1 (sub-agent) : call the MCP tool repro249_unique_mcp_tool
+    //   Turn 2 (sub-agent) : summarize the MCP tool result (ends the sub-agent)
+    //   Turn 3 (parent)    : final summary after delegation returns
     MockOpenAiScript {
         turns: vec![
+            // Turn 0: parent delegates to sub-agent
             MockOpenAiTurn {
-                text_chunks: vec!["I'll delegate this to pytheas.".to_string()],
+                text_chunks: vec!["I'll delegate this to the sub-agent.".to_string()],
                 tool_calls: vec![MockOpenAiToolCall {
                     name: format!("{}_session_prompt", TEST_SUB_AGENT_NAME),
                     arguments: json!({
@@ -188,6 +199,23 @@ fn script() -> MockOpenAiScript {
                     id: Some("call_delegate_1".to_string()),
                 }],
             },
+            // Turn 1: sub-agent calls the MCP tool
+            MockOpenAiTurn {
+                text_chunks: vec!["Let me call the tool.".to_string()],
+                tool_calls: vec![MockOpenAiToolCall {
+                    name: REPRO_249_MCP_TOOL_NAME.to_string(),
+                    arguments: json!({}),
+                    id: Some("call_mcp_1".to_string()),
+                }],
+            },
+            // Turn 2: sub-agent summarizes after getting MCP tool result
+            MockOpenAiTurn {
+                text_chunks: vec![format!(
+                    "The tool returned: {REPRO_249_MCP_TOOL_RESPONSE}"
+                )],
+                tool_calls: vec![],
+            },
+            // Turn 3: parent summarizes after delegation returns
             MockOpenAiTurn {
                 text_chunks: vec![format!(
                     "The child used {REPRO_249_MCP_TOOL_NAME} and got: {REPRO_249_MCP_TOOL_RESPONSE}"
@@ -227,8 +255,9 @@ fn write_fixture_files(paths: &TestPaths) -> Result<()> {
     std::fs::write(
         paths.agents_dir.join(format!("{}.md", TEST_AGENT_NAME)),
         format!(
-            "---\nname: {}\nmodel: mock-llm:test\n---\nYou are {}. Delegate the task to {} and then summarize the result.\n",
+            "---\nname: {}\nmodel: mock-llm:test\nuse_tools: {}_session_prompt\n---\nYou are {}. Delegate the task to {} and then summarize the result.\n",
             TEST_AGENT_NAME,
+            TEST_SUB_AGENT_NAME,
             TEST_AGENT_NAME,
             TEST_SUB_AGENT_NAME,
         ),
@@ -236,8 +265,9 @@ fn write_fixture_files(paths: &TestPaths) -> Result<()> {
     std::fs::write(
         paths.agents_dir.join(format!("{}.md", TEST_SUB_AGENT_NAME)),
         format!(
-            "---\nname: {}\nmodel: mock-llm:test\n---\nYou are {}. Always call the MCP tool named {REPRO_249_MCP_TOOL_NAME} before replying.\n",
+            "---\nname: {}\nmodel: mock-llm:test\nuse_tools: {}\n---\nYou are {}. Always call the MCP tool named {REPRO_249_MCP_TOOL_NAME} before replying.\n",
             TEST_SUB_AGENT_NAME,
+            REPRO_249_MCP_TOOL_NAME,
             TEST_SUB_AGENT_NAME,
         ),
     )?;
@@ -261,10 +291,8 @@ fn usage_line_present(screen: &str) -> bool {
 fn nested_mcp_tool_present(screen: &str) -> bool {
     // The nested tool call must appear as a real tool-call row in the parent
     // transcript, NOT just as text inside a response string.
-    // A real tool call row looks like "->️ repro249_unique_mcp_tool" or
-    // "-> repro249_unique_mcp_tool" (with the arrow prefix).
+    // A real tool call row looks like "->️ repro249_unique_mcp_tool"
     screen.contains(&format!("->️ {}", REPRO_249_MCP_TOOL_NAME))
-        || screen.contains(&format!("-> {}", REPRO_249_MCP_TOOL_NAME))
 }
 
 fn repo_root() -> Result<PathBuf> {
@@ -287,6 +315,10 @@ fn shell_escape(input: &str) -> String {
     }
     // Escape single quotes for shell by replacing ' with '"'"'
     format!("'{}'", input.replace('\'', "'\"'\"'"))
+}
+
+fn count_occurrences(haystack: &str, needle: &str) -> usize {
+    haystack.matches(needle).count()
 }
 
 fn yaml_escape(input: &str) -> String {

--- a/src/test_utils/repro_249_tmux.rs
+++ b/src/test_utils/repro_249_tmux.rs
@@ -1,0 +1,278 @@
+#![cfg(test)]
+
+use crate::test_utils::{
+    MockOpenAiScript, MockOpenAiServer, MockOpenAiToolCall, MockOpenAiTurn, TmuxHarness,
+};
+
+use anyhow::{Context, Result};
+use serde_json::json;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tempfile::TempDir;
+
+const REPRO_249_MCP_TOOL_NAME: &str = "repro249_unique_mcp_tool";
+const REPRO_249_MCP_TOOL_RESPONSE: &str = "repro249 fixed tool response";
+const TEST_AGENT_NAME: &str = "test-agent";
+const TEST_SUB_AGENT_NAME: &str = "test-sub-agent";
+
+#[test]
+fn repro_249_top_level_delegation_markers() -> Result<()> {
+    if !TmuxHarness::is_available() {
+        eprintln!("skipping repro_249_top_level_delegation_markers: tmux is unavailable");
+        return Ok(());
+    }
+
+    let repo_root = repo_root()?;
+    let target_dir = repo_root.join("target").join("debug");
+    let harnx_bin = target_dir.join(binary_name("harnx"));
+
+    if !harnx_bin.is_file() {
+        eprintln!("skipping repro_249_top_level_delegation_markers: harnx binary is missing");
+        return Ok(());
+    }
+
+    let temp = TempDir::new().context("failed to create temp dir")?;
+    let mock = MockOpenAiServer::start(script())?;
+    let paths = TestPaths::new(temp.path(), mock.port())?;
+    write_fixture_files(&paths)?;
+
+    let path_env = format!(
+        "{}:{}",
+        target_dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let tmux = match TmuxHarness::new(&repo_root, 120, 35) {
+        Ok(tmux) => tmux,
+        Err(err) => {
+            eprintln!(
+                "skipping repro_249_top_level_delegation_markers: tmux is unavailable or unusable ({err:#})"
+            );
+            return Ok(());
+        }
+    };
+    tmux.send_keys(&["C-l"])?;
+
+    // Step 1: Export HARNX_CONFIG_DIR
+    tmux.send_text(&format!(
+        "export HARNX_CONFIG_DIR={}",
+        shell_escape(paths.harnx_config_dir.to_string_lossy().as_ref())
+    ))?;
+    tmux.send_keys(&["Enter"])?;
+
+    // Step 2: Export PATH and cd to repo root for subsequent commands
+    tmux.send_text(&format!(
+        "export PATH={} && cd {}",
+        shell_escape(&path_env),
+        shell_escape(repo_root.to_string_lossy().as_ref())
+    ))?;
+    tmux.send_keys(&["Enter"])?;
+    tmux.wait_for(Duration::from_secs(5), |screen| screen.contains("$"))?;
+
+    // Step 3: Run diagnostics - list agents
+    tmux.send_text(&format!(
+        "{} --list-agents",
+        shell_escape(harnx_bin.to_string_lossy().as_ref())
+    ))?;
+    tmux.send_keys(&["Enter"])?;
+    tmux.wait_for(Duration::from_secs(5), |screen| screen.contains("$"))?;
+
+    // Step 4: Run diagnostics - list models
+    tmux.send_text(&format!(
+        "{} --list-models",
+        shell_escape(harnx_bin.to_string_lossy().as_ref())
+    ))?;
+    tmux.send_keys(&["Enter"])?;
+    tmux.wait_for(Duration::from_secs(5), |screen| screen.contains("$"))?;
+
+    // Step 5: Launch the test agent
+    tmux.send_text(&format!(
+        "{} -a {} || echo HARNX_EXIT:$?",
+        shell_escape(harnx_bin.to_string_lossy().as_ref()),
+        TEST_AGENT_NAME
+    ))?;
+    tmux.send_keys(&["Enter"])?;
+
+    tmux.wait_for_contains("Welcome to harnx", Duration::from_secs(15))?;
+    tmux.send_text("tell me how many files are in /tmp")?;
+    tmux.send_keys(&["Enter"])?;
+
+    // Wait for the delegation to complete: top-level tool call and child heading must appear.
+    let screen = tmux.wait_for(Duration::from_secs(30), |screen| {
+        screen.contains(&format!("{}_session_prompt", TEST_SUB_AGENT_NAME))
+            && screen.contains(&format!("> {}", TEST_SUB_AGENT_NAME))
+    })?;
+
+    // ── Known-good markers: delegation happened ──────────────────────────────
+    assert!(
+        screen.contains(&format!("{}_session_prompt", TEST_SUB_AGENT_NAME)),
+        "delegation tool call not visible:\n{screen}"
+    );
+    assert!(
+        screen.contains(&format!("> {}", TEST_SUB_AGENT_NAME)),
+        "child sub-agent heading not visible:\n{screen}"
+    );
+
+    // ── Issue #249 assertion ──────────────────────────────────────────────────
+    // The child sub-agent internally called `repro249_unique_mcp_tool` via MCP.
+    // That internal tool call SHOULD be visible in the parent transcript, but is
+    // currently missing. This assertion documents the bug: if it ever starts
+    // passing, issue #249 is fixed.
+    let nested_visible = nested_mcp_tool_present(&screen);
+    eprintln!(
+        "\n=== Issue #249 tmux repro result ===\n\
+         delegation visible    : {}\n\
+         child heading visible : {}\n\
+         nested tool visible   : {} (expected: true — MISSING = bug reproduced)\n\
+         === last screen ===\n{}\n====\n",
+        screen.contains(&format!("{}_session_prompt", TEST_SUB_AGENT_NAME)),
+        screen.contains(&format!("> {}", TEST_SUB_AGENT_NAME)),
+        nested_visible,
+        screen,
+    );
+    assert!(
+        !nested_visible,
+        "nested internal MCP tool call IS now visible — issue #249 appears to be fixed!\n{screen}"
+    );
+
+    drop(tmux);
+    drop(mock);
+    Ok(())
+}
+
+struct TestPaths {
+    harnx_config_dir: PathBuf,
+    config_path: PathBuf,
+    agents_dir: PathBuf,
+    port: u16,
+}
+
+impl TestPaths {
+    fn new(temp_root: &Path, port: u16) -> Result<Self> {
+        let harnx_config_dir = temp_root.join("harnx");
+        let config_path = harnx_config_dir.join("config.yaml");
+        let agents_dir = harnx_config_dir.join("agents");
+        std::fs::create_dir_all(&agents_dir)?;
+        Ok(Self {
+            harnx_config_dir,
+            config_path,
+            agents_dir,
+            port,
+        })
+    }
+}
+
+fn script() -> MockOpenAiScript {
+    MockOpenAiScript {
+        turns: vec![
+            MockOpenAiTurn {
+                text_chunks: vec!["I'll delegate this to pytheas.".to_string()],
+                tool_calls: vec![MockOpenAiToolCall {
+                    name: format!("{}_session_prompt", TEST_SUB_AGENT_NAME),
+                    arguments: json!({
+                        "message": format!(
+                            "Call the MCP tool named {REPRO_249_MCP_TOOL_NAME} and report its result."
+                        )
+                    }),
+                    id: Some("call_delegate_1".to_string()),
+                }],
+            },
+            MockOpenAiTurn {
+                text_chunks: vec![format!(
+                    "The child used {REPRO_249_MCP_TOOL_NAME} and got: {REPRO_249_MCP_TOOL_RESPONSE}"
+                )],
+                tool_calls: vec![],
+            },
+        ],
+        fallback_text: "No more scripted responses.".to_string(),
+        chunk_delay_ms: 0,
+    }
+}
+
+fn write_fixture_files(paths: &TestPaths) -> Result<()> {
+    std::fs::create_dir_all(&paths.harnx_config_dir)?;
+
+    let fake_mcp_server = repo_root()?
+        .join("target")
+        .join("debug")
+        .join(binary_name("harnx-mcp-repro249"));
+
+    let harnx_bin = repo_root()?
+        .join("target")
+        .join("debug")
+        .join(binary_name("harnx"));
+
+    let config = format!(
+        "save: false\nclients:\n  - type: openai-compatible\n    name: mock-llm\n    api_base: http://127.0.0.1:{}/v1\n    api_key: dummy\n    models:\n      - name: test\n        max_input_tokens: 32000\n        max_output_tokens: 4096\n        supports_tool_use: true\nmcp_servers:\n  - name: repro249\n    command: {}\n    enabled: true\n    rename_tools:\n      {}: {}\nacp_servers:\n  - name: {}\n    command: {}\n    args: [\"--acp\", {}]\n    enabled: true\n",
+        paths.port,
+        shell_escape(fake_mcp_server.to_string_lossy().as_ref()),
+        REPRO_249_MCP_TOOL_NAME,
+        REPRO_249_MCP_TOOL_NAME,
+        TEST_SUB_AGENT_NAME,
+        shell_escape(harnx_bin.to_string_lossy().as_ref()),
+        shell_escape(TEST_SUB_AGENT_NAME),
+    );
+    std::fs::write(&paths.config_path, config)?;
+    std::fs::write(
+        paths.agents_dir.join(format!("{}.md", TEST_AGENT_NAME)),
+        format!(
+            "---\nname: {}\nmodel: mock-llm:test\n---\nYou are {}. Delegate the task to {} and then summarize the result.\n",
+            TEST_AGENT_NAME,
+            TEST_AGENT_NAME,
+            TEST_SUB_AGENT_NAME,
+        ),
+    )?;
+    std::fs::write(
+        paths.agents_dir.join(format!("{}.md", TEST_SUB_AGENT_NAME)),
+        format!(
+            "---\nname: {}\nmodel: mock-llm:test\n---\nYou are {}. Always call the MCP tool named {REPRO_249_MCP_TOOL_NAME} before replying.\n",
+            TEST_SUB_AGENT_NAME,
+            TEST_SUB_AGENT_NAME,
+        ),
+    )?;
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn usage_line_present(screen: &str) -> bool {
+    let compact = screen.replace('\n', " ");
+    let Some(in_pos) = compact.find(" in ") else {
+        return false;
+    };
+    let Some(out_pos) = compact[in_pos..].find(" out ") else {
+        return false;
+    };
+    compact[in_pos + out_pos + 5..]
+        .chars()
+        .any(|c| c.is_ascii_digit())
+}
+
+fn nested_mcp_tool_present(screen: &str) -> bool {
+    // The nested tool call must appear as a real tool-call row in the parent
+    // transcript, NOT just as text inside a response string.
+    // A real tool call row looks like "->️ repro249_unique_mcp_tool" or
+    // "-> repro249_unique_mcp_tool" (with the arrow prefix).
+    screen.contains(&format!("->️ {}", REPRO_249_MCP_TOOL_NAME))
+        || screen.contains(&format!("-> {}", REPRO_249_MCP_TOOL_NAME))
+}
+
+fn repo_root() -> Result<PathBuf> {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .canonicalize()
+        .context("failed to resolve repo root")
+}
+
+fn binary_name(stem: &str) -> String {
+    if cfg!(windows) {
+        format!("{stem}.exe")
+    } else {
+        stem.to_string()
+    }
+}
+
+fn shell_escape(input: &str) -> String {
+    if input.is_empty() {
+        return "''".to_string();
+    }
+    format!("'{}'", input.replace('"', "'\"'\"'"))
+}

--- a/src/test_utils/repro_249_tmux.rs
+++ b/src/test_utils/repro_249_tmux.rs
@@ -38,6 +38,14 @@ fn repro_249_top_level_delegation_markers() -> Result<()> {
         return Ok(());
     }
 
+    let harnx_mcp_bin = target_dir.join(binary_name("harnx-mcp-repro249"));
+    if !harnx_mcp_bin.is_file() {
+        eprintln!(
+            "skipping repro_249_top_level_delegation_markers: harnx-mcp-repro249 binary is missing"
+        );
+        return Ok(());
+    }
+
     let temp = TempDir::new().context("failed to create temp dir")?;
     let mock = MockOpenAiServer::start(script())?;
     let paths = TestPaths::new(temp.path(), mock.port())?;
@@ -114,10 +122,11 @@ fn repro_249_top_level_delegation_markers() -> Result<()> {
     tmux.send_text("tell me how many files are in /tmp")?;
     tmux.send_keys(&["Enter"])?;
 
-    // Wait for the delegation to complete: top-level tool call and child heading must appear.
+    // Wait for delegation, child heading, and nested MCP tool call to all appear.
     let screen = tmux.wait_for(Duration::from_secs(30), |screen| {
         screen.contains(&format!("{}_session_prompt", TEST_SUB_AGENT_NAME))
             && screen.contains(&format!("> {}", TEST_SUB_AGENT_NAME))
+            && nested_mcp_tool_present(screen)
     })?;
 
     // ── Known-good markers: delegation happened ──────────────────────────────

--- a/src/test_utils/tmux_harness.rs
+++ b/src/test_utils/tmux_harness.rs
@@ -1,0 +1,215 @@
+//! Minimal tmux-backed harness for local-only end-to-end TUI tests.
+//!
+//! This helper intentionally uses the tmux CLI via `std::process` so tests can
+//! drive the real terminal UI without introducing additional heavy dependencies.
+//! Tests should gate themselves with [`TmuxHarness::is_available`] and skip when
+//! tmux is not installed in the local environment.
+
+use anyhow::{anyhow, bail, Context, Result};
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::{Command, Output};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+/// Small wrapper around an isolated tmux session used for local-only UI tests.
+pub struct TmuxHarness {
+    session_name: String,
+    socket_path: std::path::PathBuf,
+    pane_target: String,
+}
+
+impl TmuxHarness {
+    /// Returns true when tmux appears to be installed and runnable.
+    pub fn is_available() -> bool {
+        Command::new("tmux")
+            .arg("-V")
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    }
+
+    /// Creates a new detached tmux session with an isolated socket.
+    ///
+    /// The session is created under the ambient environment. Tests should apply
+    /// any custom environment variables when launching their test subject inside
+    /// the pane (e.g., via `send_text` with `env VAR=val ...`).
+    pub fn new(cwd: impl AsRef<Path>, cols: u16, rows: u16) -> Result<Self> {
+        let session_name = unique_name("harnx-test");
+        let socket_path = std::env::temp_dir().join(format!("{}.sock", unique_name("tmux")));
+
+        let mut command = Command::new("tmux");
+        command
+            .arg("-S")
+            .arg(&socket_path)
+            .arg("new-session")
+            .arg("-d")
+            .arg("-s")
+            .arg(&session_name)
+            .arg("-x")
+            .arg(cols.to_string())
+            .arg("-y")
+            .arg(rows.to_string())
+            // `bash -i` stays alive in detached mode and accepts `send-keys` input.
+            .arg("bash")
+            .arg("-i")
+            .current_dir(cwd.as_ref());
+
+        run_command(command).context("failed to create tmux session")?;
+
+        Ok(Self {
+            pane_target: format!("{}:0.0", session_name),
+            session_name,
+            socket_path,
+        })
+    }
+
+    /// Sends literal text to the tmux pane.
+    pub fn send_text(&self, text: &str) -> Result<()> {
+        self.tmux(["send-keys", "-t", &self.pane_target, "-l", text])
+            .context("failed to send tmux text")?;
+        Ok(())
+    }
+
+    /// Sends one or more tmux key names, such as `Enter` or `C-l`.
+    pub fn send_keys(&self, keys: &[&str]) -> Result<()> {
+        let mut args = vec!["send-keys", "-t", &self.pane_target];
+        args.extend(keys.iter().copied());
+        self.tmux(args).context("failed to send tmux keys")?;
+        Ok(())
+    }
+
+    /// Captures the pane contents, including scrollback.
+    pub fn capture_pane(&self) -> Result<String> {
+        let output = self
+            .tmux_output([
+                "capture-pane",
+                "-p",
+                "-J",
+                "-S",
+                "-",
+                "-E",
+                "-",
+                "-t",
+                &self.pane_target,
+            ])
+            .context("failed to capture tmux pane")?;
+        String::from_utf8(output.stdout).context("tmux output was not valid UTF-8")
+    }
+
+    /// Polls until the pane contains `expected` or times out.
+    pub fn wait_for_contains(&self, expected: &str, timeout: Duration) -> Result<String> {
+        let deadline = Instant::now() + timeout;
+
+        loop {
+            let last_capture = self.capture_pane()?;
+            if last_capture.contains(expected) {
+                return Ok(last_capture);
+            }
+            if Instant::now() >= deadline {
+                bail!(
+                    "timed out waiting for tmux pane to contain {:?}. Last capture:\n{}",
+                    expected,
+                    last_capture
+                );
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    /// Polls until the provided predicate matches the captured pane.
+    pub fn wait_for<F>(&self, timeout: Duration, predicate: F) -> Result<String>
+    where
+        F: Fn(&str) -> bool,
+    {
+        let deadline = Instant::now() + timeout;
+
+        loop {
+            let last_capture = self.capture_pane()?;
+            if predicate(&last_capture) {
+                return Ok(last_capture);
+            }
+            if Instant::now() >= deadline {
+                bail!(
+                    "timed out waiting for tmux predicate. Last capture:\n{}",
+                    last_capture
+                );
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    fn tmux<I, S>(&self, args: I) -> Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        run_command(self.base_command(args))?;
+        Ok(())
+    }
+
+    fn tmux_output<I, S>(&self, args: I) -> Result<Output>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let output = self
+            .base_command(args)
+            .output()
+            .context("failed to run tmux")?;
+        if output.status.success() {
+            Ok(output)
+        } else {
+            Err(anyhow!(format_command_error("tmux", &output)))
+        }
+    }
+
+    fn base_command<I, S>(&self, args: I) -> Command
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let mut command = Command::new("tmux");
+        command.arg("-S").arg(&self.socket_path);
+        for arg in args {
+            command.arg(arg.as_ref());
+        }
+        command
+    }
+}
+
+impl Drop for TmuxHarness {
+    fn drop(&mut self) {
+        let _ = self.tmux(["kill-session", "-t", &self.session_name]);
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+fn run_command(mut command: Command) -> Result<Output> {
+    let program = command.get_program().to_string_lossy().into_owned();
+    let output = command
+        .output()
+        .with_context(|| format!("failed to run {program}"))?;
+    if output.status.success() {
+        Ok(output)
+    } else {
+        Err(anyhow!(format_command_error(&program, &output)))
+    }
+}
+
+fn format_command_error(program: &str, output: &Output) -> String {
+    format!(
+        "{program} exited with status {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn unique_name(prefix: &str) -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{prefix}-{now}")
+}

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -504,7 +504,7 @@ impl Tui {
                 }
             }
             UiOutputEventKind::MessageChunk { text, .. } => {
-                if text.trim().is_empty() {
+                if text.is_empty() {
                     vec![]
                 } else {
                     self.append_streaming_assistant_chunk(&text);

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1,6 +1,8 @@
 use super::*;
-use crate::tui::render_helpers::{render_status_line, render_usage_line};
-use crate::tui::types::{TranscriptItem, TuiEvent};
+use crate::tui::render_helpers::{
+    render_plan_entries, render_status_line, render_usage_line, source_heading,
+};
+use crate::tui::types::{TranscriptEntry, TuiEvent};
 use crate::ui_output::{UiOutputEvent, UiOutputEventKind, UiOutputSource};
 use std::path::Path;
 
@@ -80,7 +82,7 @@ impl Tui {
             (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
                 // Abort current operation; reset signal so next submit works (fix #3)
                 self.abort_signal.set_ctrlc();
-                self.app.transcript.push(TranscriptItem::SystemText(
+                self.app.transcript.push(TranscriptEntry::System(
                     "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
                 ));
                 self.app.llm_busy = false;
@@ -148,14 +150,14 @@ impl Tui {
                         // Dot-command: route through repl command handler
                         self.app
                             .transcript
-                            .push(TranscriptItem::UserText(text.clone()));
+                            .push(TranscriptEntry::User(text.clone()));
                         self.app.input = Self::new_input();
                         self.run_repl_command(&text).await?;
                         self.refresh_input_chrome();
                     } else {
                         self.app
                             .transcript
-                            .push(TranscriptItem::UserText(text.clone()));
+                            .push(TranscriptEntry::User(text.clone()));
                         self.app.input = Self::new_input();
                         let msg = crate::tui::types::PendingMessage {
                             text,
@@ -247,7 +249,7 @@ impl Tui {
                             unique_attachment_display_name(&self.app.attachments, &original_name);
                         let dest = unique_attachment_storage_path(&dir, &original_name);
                         if let Err(err) = tokio::fs::copy(&src, &dest).await {
-                            self.app.transcript.push(TranscriptItem::ErrorText(format!(
+                            self.app.transcript.push(TranscriptEntry::Error(format!(
                                 "Failed to copy attachment: {err}"
                             )));
                         } else {
@@ -258,13 +260,13 @@ impl Tui {
                         }
                     }
                     Err(err) => {
-                        self.app.transcript.push(TranscriptItem::ErrorText(format!(
+                        self.app.transcript.push(TranscriptEntry::Error(format!(
                             "Failed to create attachment directory: {err}"
                         )));
                     }
                 }
             } else {
-                self.app.transcript.push(TranscriptItem::ErrorText(format!(
+                self.app.transcript.push(TranscriptEntry::Error(format!(
                     "File not found: {path_str}"
                 )));
             }
@@ -283,7 +285,7 @@ impl Tui {
                 .filter(|a| a.display_name == name)
             {
                 if let Err(err) = std::fs::remove_file(&attachment.path) {
-                    self.app.transcript.push(TranscriptItem::ErrorText(format!(
+                    self.app.transcript.push(TranscriptEntry::Error(format!(
                         "Failed to remove detached attachment file {}: {err}",
                         attachment.display_name
                     )));
@@ -327,7 +329,7 @@ impl Tui {
                     self.app.attachments.push(attachment);
                 }
                 Err(err) => {
-                    self.app.transcript.push(TranscriptItem::ErrorText(format!(
+                    self.app.transcript.push(TranscriptEntry::Error(format!(
                         "Failed to save pasted text: {err}"
                     )));
                 }
@@ -417,7 +419,7 @@ impl Tui {
         self.app.input = Self::new_input();
         self.app
             .transcript
-            .push(TranscriptItem::UserText(pending.text.clone()));
+            .push(TranscriptEntry::User(pending.text.clone()));
         self.render_submitted_attachments(&pending.attachments);
         self.pin_transcript_to_bottom();
         if pending.text.trim_start().starts_with('.') {
@@ -437,23 +439,22 @@ impl Tui {
             return;
         }
 
-        self.app
-            .transcript
-            .push(TranscriptItem::AttachmentHeader(format!(
-                "Attachments ({})",
-                attachments.len()
-            )));
+        self.app.transcript.push(TranscriptEntry::System(format!(
+            "Attachments ({}):",
+            attachments.len()
+        )));
 
         for attachment in attachments {
-            self.app.transcript.push(TranscriptItem::AttachmentItem(
-                attachment.display_name.clone(),
-            ));
+            self.app.transcript.push(TranscriptEntry::System(format!(
+                "  - {}",
+                attachment.display_name
+            )));
 
             if let Some(preview) = render_attachment_preview(&attachment.path) {
                 for line in preview.lines() {
                     self.app
                         .transcript
-                        .push(TranscriptItem::AttachmentPreviewLine(line.to_string()));
+                        .push(TranscriptEntry::System(format!("      {line}")));
                 }
             }
         }
@@ -465,9 +466,10 @@ impl Tui {
         }
         let text = std::mem::take(&mut self.app.pending_thought_text);
         self.app.pending_thought_source = None;
-        self.app
-            .transcript
-            .push(TranscriptItem::ThoughtText(text.trim().to_string()));
+        self.app.transcript.push(TranscriptEntry::System(format!(
+            "<think>{}</think>",
+            text.trim()
+        )));
     }
 
     #[cfg(test)]
@@ -489,7 +491,7 @@ impl Tui {
                 if clean.is_empty() {
                     vec![]
                 } else {
-                    vec![TranscriptItem::SystemText(clean)]
+                    vec![TranscriptEntry::System(clean)]
                 }
             }
             UiOutputEventKind::ToolResultText { text } => {
@@ -499,7 +501,7 @@ impl Tui {
                 } else {
                     clean
                         .lines()
-                        .map(|line| TranscriptItem::ToolResultText(line.to_string()))
+                        .map(|line| TranscriptEntry::System(format!("   {line}")))
                         .collect()
                 }
             }
@@ -507,6 +509,8 @@ impl Tui {
                 if text.trim().is_empty() {
                     vec![]
                 } else {
+                    self.app.last_ui_output_source = None;
+                    self.app.pending_thought_source = None;
                     self.append_streaming_assistant_chunk(&text);
                     self.pin_transcript_to_bottom();
                     vec![]
@@ -519,25 +523,19 @@ impl Tui {
                 if !output.is_empty() {
                     if let Some(idx) = self.app.streaming_assistant_idx {
                         match self.app.transcript.get_mut(idx) {
-                            Some(TranscriptItem::AssistantText(existing))
-                                if !existing.is_empty() =>
-                            {
+                            Some(TranscriptEntry::Assistant(existing)) if !existing.is_empty() => {
                                 if existing != &output {
                                     *existing = output;
                                 }
                             }
                             _ => {
-                                self.app
-                                    .transcript
-                                    .push(TranscriptItem::AssistantText(output));
+                                self.app.transcript.push(TranscriptEntry::Assistant(output));
                                 self.app.streaming_assistant_idx =
                                     Some(self.app.transcript.len() - 1);
                             }
                         }
                     } else {
-                        self.app
-                            .transcript
-                            .push(TranscriptItem::AssistantText(output));
+                        self.app.transcript.push(TranscriptEntry::Assistant(output));
                         self.app.streaming_assistant_idx = Some(self.app.transcript.len() - 1);
                     }
                     self.pin_transcript_to_bottom();
@@ -546,7 +544,7 @@ impl Tui {
                 if !usage.is_empty() {
                     self.app
                         .transcript
-                        .push(TranscriptItem::SystemText(format!("Usage: {usage}")));
+                        .push(TranscriptEntry::System(format!("Usage: {usage}")));
                     self.pin_transcript_to_bottom();
                 }
                 self.refresh_input_chrome();
@@ -555,7 +553,7 @@ impl Tui {
                     if let Err(err) = self.submit_pending_message(pending).await {
                         self.app
                             .transcript
-                            .push(TranscriptItem::ErrorText(err.to_string()));
+                            .push(TranscriptEntry::Error(err.to_string()));
                         self.pin_transcript_to_bottom();
                     }
                 }
@@ -566,7 +564,7 @@ impl Tui {
                 self.app.llm_busy = false;
                 self.app.streaming_assistant_idx = None;
                 self.app.last_ui_output_source = None;
-                self.app.transcript.push(TranscriptItem::ErrorText(err));
+                self.app.transcript.push(TranscriptEntry::Error(err));
                 self.pin_transcript_to_bottom();
                 self.refresh_input_chrome();
 
@@ -574,7 +572,7 @@ impl Tui {
                     if let Err(err) = self.submit_pending_message(pending).await {
                         self.app
                             .transcript
-                            .push(TranscriptItem::ErrorText(err.to_string()));
+                            .push(TranscriptEntry::Error(err.to_string()));
                         self.pin_transcript_to_bottom();
                     }
                 }
@@ -606,12 +604,12 @@ impl Tui {
 
             UiOutputEventKind::ToolCallUpdate { title, status, .. } => {
                 if let Some(text) = render_status_line(title.as_deref(), status.as_deref()) {
-                    vec![TranscriptItem::StatusLine(text)]
+                    vec![TranscriptEntry::System(text)]
                 } else {
                     vec![]
                 }
             }
-            UiOutputEventKind::Plan { entries } => vec![TranscriptItem::Plan(entries)],
+            UiOutputEventKind::Plan { entries } => render_plan_entries(&entries),
             UiOutputEventKind::Usage {
                 input_tokens,
                 output_tokens,
@@ -629,7 +627,7 @@ impl Tui {
                     if self.update_existing_usage_line(event.source.as_ref(), &line) {
                         vec![]
                     } else {
-                        vec![TranscriptItem::UsageLine(line)]
+                        vec![TranscriptEntry::System(line)]
                     }
                 } else {
                     vec![]
@@ -640,10 +638,14 @@ impl Tui {
                 input_yaml,
                 ..
             } => {
-                vec![TranscriptItem::ToolCall {
-                    tool_name,
-                    input_yaml,
-                }]
+                let mut entries = vec![TranscriptEntry::System(format!("->️ {tool_name}"))];
+                if let Some(yaml) = &input_yaml {
+                    entries.extend(
+                        yaml.lines()
+                            .map(|line| TranscriptEntry::System(format!("   {line}"))),
+                    );
+                }
+                entries
             }
         };
 
@@ -666,9 +668,8 @@ impl Tui {
         let source = source.cloned();
         if source != self.app.last_ui_output_source {
             if let Some(source) = &source {
-                self.app
-                    .transcript
-                    .push(TranscriptItem::SourceHeading(source.clone()));
+                let heading = source_heading(source);
+                self.app.transcript.push(TranscriptEntry::System(heading));
             }
             self.app.last_ui_output_source = source;
         }
@@ -694,7 +695,7 @@ impl Tui {
             return false;
         };
         match entry {
-            TranscriptItem::UsageLine(existing) => {
+            TranscriptEntry::System(existing) => {
                 *existing = line.to_string();
                 true
             }
@@ -1015,7 +1016,7 @@ impl Tui {
 
         let clean = strip_ansi(&captured).trim_end_matches('\n').to_string();
         if !clean.is_empty() {
-            self.app.transcript.push(TranscriptItem::SystemText(clean));
+            self.app.transcript.push(TranscriptEntry::System(clean));
             self.pin_transcript_to_bottom();
         }
 
@@ -1036,7 +1037,7 @@ impl Tui {
             Err(err) => {
                 self.app
                     .transcript
-                    .push(TranscriptItem::ErrorText(err.to_string()));
+                    .push(TranscriptEntry::Error(err.to_string()));
             }
         }
         Ok(())

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -386,8 +386,9 @@ impl Tui {
             }
             TuiEvent::ToolRoundComplete => {
                 // Intermediate tool round — prompt loop continues, don't clear llm_busy.
-                // Keep the current assistant streaming entry so follow-up text can
-                // continue without inserting a blank separator or synthetic status line.
+                // Flush any pending thought so follow-up thought after tool results
+                // starts a fresh block instead of appending to the earlier one.
+                self.flush_pending_thought();
                 self.pin_transcript_to_bottom();
             }
         }

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1,8 +1,6 @@
 use super::*;
-use crate::tui::render_helpers::{
-    render_plan_entries, render_status_line, render_usage_line, source_heading,
-};
-use crate::tui::types::{TranscriptEntry, TuiEvent};
+use crate::tui::render_helpers::{render_status_line, render_usage_line};
+use crate::tui::types::{TranscriptItem, TuiEvent};
 use crate::ui_output::{UiOutputEvent, UiOutputEventKind, UiOutputSource};
 use std::path::Path;
 
@@ -82,7 +80,7 @@ impl Tui {
             (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
                 // Abort current operation; reset signal so next submit works (fix #3)
                 self.abort_signal.set_ctrlc();
-                self.app.transcript.push(TranscriptEntry::System(
+                self.app.transcript.push(TranscriptItem::SystemText(
                     "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
                 ));
                 self.app.llm_busy = false;
@@ -150,14 +148,14 @@ impl Tui {
                         // Dot-command: route through repl command handler
                         self.app
                             .transcript
-                            .push(TranscriptEntry::User(text.clone()));
+                            .push(TranscriptItem::UserText(text.clone()));
                         self.app.input = Self::new_input();
                         self.run_repl_command(&text).await?;
                         self.refresh_input_chrome();
                     } else {
                         self.app
                             .transcript
-                            .push(TranscriptEntry::User(text.clone()));
+                            .push(TranscriptItem::UserText(text.clone()));
                         self.app.input = Self::new_input();
                         let msg = crate::tui::types::PendingMessage {
                             text,
@@ -249,7 +247,7 @@ impl Tui {
                             unique_attachment_display_name(&self.app.attachments, &original_name);
                         let dest = unique_attachment_storage_path(&dir, &original_name);
                         if let Err(err) = tokio::fs::copy(&src, &dest).await {
-                            self.app.transcript.push(TranscriptEntry::Error(format!(
+                            self.app.transcript.push(TranscriptItem::ErrorText(format!(
                                 "Failed to copy attachment: {err}"
                             )));
                         } else {
@@ -260,13 +258,13 @@ impl Tui {
                         }
                     }
                     Err(err) => {
-                        self.app.transcript.push(TranscriptEntry::Error(format!(
+                        self.app.transcript.push(TranscriptItem::ErrorText(format!(
                             "Failed to create attachment directory: {err}"
                         )));
                     }
                 }
             } else {
-                self.app.transcript.push(TranscriptEntry::Error(format!(
+                self.app.transcript.push(TranscriptItem::ErrorText(format!(
                     "File not found: {path_str}"
                 )));
             }
@@ -285,7 +283,7 @@ impl Tui {
                 .filter(|a| a.display_name == name)
             {
                 if let Err(err) = std::fs::remove_file(&attachment.path) {
-                    self.app.transcript.push(TranscriptEntry::Error(format!(
+                    self.app.transcript.push(TranscriptItem::ErrorText(format!(
                         "Failed to remove detached attachment file {}: {err}",
                         attachment.display_name
                     )));
@@ -329,7 +327,7 @@ impl Tui {
                     self.app.attachments.push(attachment);
                 }
                 Err(err) => {
-                    self.app.transcript.push(TranscriptEntry::Error(format!(
+                    self.app.transcript.push(TranscriptItem::ErrorText(format!(
                         "Failed to save pasted text: {err}"
                     )));
                 }
@@ -419,7 +417,7 @@ impl Tui {
         self.app.input = Self::new_input();
         self.app
             .transcript
-            .push(TranscriptEntry::User(pending.text.clone()));
+            .push(TranscriptItem::UserText(pending.text.clone()));
         self.render_submitted_attachments(&pending.attachments);
         self.pin_transcript_to_bottom();
         if pending.text.trim_start().starts_with('.') {
@@ -439,22 +437,23 @@ impl Tui {
             return;
         }
 
-        self.app.transcript.push(TranscriptEntry::System(format!(
-            "Attachments ({}):",
-            attachments.len()
-        )));
+        self.app
+            .transcript
+            .push(TranscriptItem::AttachmentHeader(format!(
+                "Attachments ({})",
+                attachments.len()
+            )));
 
         for attachment in attachments {
-            self.app.transcript.push(TranscriptEntry::System(format!(
-                "  - {}",
-                attachment.display_name
-            )));
+            self.app.transcript.push(TranscriptItem::AttachmentItem(
+                attachment.display_name.clone(),
+            ));
 
             if let Some(preview) = render_attachment_preview(&attachment.path) {
                 for line in preview.lines() {
                     self.app
                         .transcript
-                        .push(TranscriptEntry::System(format!("      {line}")));
+                        .push(TranscriptItem::AttachmentPreviewLine(line.to_string()));
                 }
             }
         }
@@ -466,10 +465,9 @@ impl Tui {
         }
         let text = std::mem::take(&mut self.app.pending_thought_text);
         self.app.pending_thought_source = None;
-        self.app.transcript.push(TranscriptEntry::System(format!(
-            "<think>{}</think>",
-            text.trim()
-        )));
+        self.app
+            .transcript
+            .push(TranscriptItem::ThoughtText(text.trim().to_string()));
     }
 
     #[cfg(test)]
@@ -491,7 +489,7 @@ impl Tui {
                 if clean.is_empty() {
                     vec![]
                 } else {
-                    vec![TranscriptEntry::System(clean)]
+                    vec![TranscriptItem::SystemText(clean)]
                 }
             }
             UiOutputEventKind::ToolResultText { text } => {
@@ -501,7 +499,7 @@ impl Tui {
                 } else {
                     clean
                         .lines()
-                        .map(|line| TranscriptEntry::System(format!("   {line}")))
+                        .map(|line| TranscriptItem::ToolResultText(line.to_string()))
                         .collect()
                 }
             }
@@ -521,19 +519,25 @@ impl Tui {
                 if !output.is_empty() {
                     if let Some(idx) = self.app.streaming_assistant_idx {
                         match self.app.transcript.get_mut(idx) {
-                            Some(TranscriptEntry::Assistant(existing)) if !existing.is_empty() => {
+                            Some(TranscriptItem::AssistantText(existing))
+                                if !existing.is_empty() =>
+                            {
                                 if existing != &output {
                                     *existing = output;
                                 }
                             }
                             _ => {
-                                self.app.transcript.push(TranscriptEntry::Assistant(output));
+                                self.app
+                                    .transcript
+                                    .push(TranscriptItem::AssistantText(output));
                                 self.app.streaming_assistant_idx =
                                     Some(self.app.transcript.len() - 1);
                             }
                         }
                     } else {
-                        self.app.transcript.push(TranscriptEntry::Assistant(output));
+                        self.app
+                            .transcript
+                            .push(TranscriptItem::AssistantText(output));
                         self.app.streaming_assistant_idx = Some(self.app.transcript.len() - 1);
                     }
                     self.pin_transcript_to_bottom();
@@ -542,7 +546,7 @@ impl Tui {
                 if !usage.is_empty() {
                     self.app
                         .transcript
-                        .push(TranscriptEntry::System(format!("Usage: {usage}")));
+                        .push(TranscriptItem::SystemText(format!("Usage: {usage}")));
                     self.pin_transcript_to_bottom();
                 }
                 self.refresh_input_chrome();
@@ -551,7 +555,7 @@ impl Tui {
                     if let Err(err) = self.submit_pending_message(pending).await {
                         self.app
                             .transcript
-                            .push(TranscriptEntry::Error(err.to_string()));
+                            .push(TranscriptItem::ErrorText(err.to_string()));
                         self.pin_transcript_to_bottom();
                     }
                 }
@@ -562,7 +566,7 @@ impl Tui {
                 self.app.llm_busy = false;
                 self.app.streaming_assistant_idx = None;
                 self.app.last_ui_output_source = None;
-                self.app.transcript.push(TranscriptEntry::Error(err));
+                self.app.transcript.push(TranscriptItem::ErrorText(err));
                 self.pin_transcript_to_bottom();
                 self.refresh_input_chrome();
 
@@ -570,7 +574,7 @@ impl Tui {
                     if let Err(err) = self.submit_pending_message(pending).await {
                         self.app
                             .transcript
-                            .push(TranscriptEntry::Error(err.to_string()));
+                            .push(TranscriptItem::ErrorText(err.to_string()));
                         self.pin_transcript_to_bottom();
                     }
                 }
@@ -602,12 +606,12 @@ impl Tui {
 
             UiOutputEventKind::ToolCallUpdate { title, status, .. } => {
                 if let Some(text) = render_status_line(title.as_deref(), status.as_deref()) {
-                    vec![TranscriptEntry::System(text)]
+                    vec![TranscriptItem::StatusLine(text)]
                 } else {
                     vec![]
                 }
             }
-            UiOutputEventKind::Plan { entries } => render_plan_entries(&entries),
+            UiOutputEventKind::Plan { entries } => vec![TranscriptItem::Plan(entries)],
             UiOutputEventKind::Usage {
                 input_tokens,
                 output_tokens,
@@ -625,7 +629,7 @@ impl Tui {
                     if self.update_existing_usage_line(event.source.as_ref(), &line) {
                         vec![]
                     } else {
-                        vec![TranscriptEntry::System(line)]
+                        vec![TranscriptItem::UsageLine(line)]
                     }
                 } else {
                     vec![]
@@ -636,14 +640,10 @@ impl Tui {
                 input_yaml,
                 ..
             } => {
-                let mut entries = vec![TranscriptEntry::System(format!("->️ {tool_name}"))];
-                if let Some(yaml) = &input_yaml {
-                    entries.extend(
-                        yaml.lines()
-                            .map(|line| TranscriptEntry::System(format!("   {line}"))),
-                    );
-                }
-                entries
+                vec![TranscriptItem::ToolCall {
+                    tool_name,
+                    input_yaml,
+                }]
             }
         };
 
@@ -666,8 +666,9 @@ impl Tui {
         let source = source.cloned();
         if source != self.app.last_ui_output_source {
             if let Some(source) = &source {
-                let heading = source_heading(source);
-                self.app.transcript.push(TranscriptEntry::System(heading));
+                self.app
+                    .transcript
+                    .push(TranscriptItem::SourceHeading(source.clone()));
             }
             self.app.last_ui_output_source = source;
         }
@@ -693,7 +694,7 @@ impl Tui {
             return false;
         };
         match entry {
-            TranscriptEntry::System(existing) => {
+            TranscriptItem::UsageLine(existing) => {
                 *existing = line.to_string();
                 true
             }
@@ -1014,7 +1015,7 @@ impl Tui {
 
         let clean = strip_ansi(&captured).trim_end_matches('\n').to_string();
         if !clean.is_empty() {
-            self.app.transcript.push(TranscriptEntry::System(clean));
+            self.app.transcript.push(TranscriptItem::SystemText(clean));
             self.pin_transcript_to_bottom();
         }
 
@@ -1035,7 +1036,7 @@ impl Tui {
             Err(err) => {
                 self.app
                     .transcript
-                    .push(TranscriptEntry::Error(err.to_string()));
+                    .push(TranscriptItem::ErrorText(err.to_string()));
             }
         }
         Ok(())

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -509,8 +509,6 @@ impl Tui {
                 if text.trim().is_empty() {
                     vec![]
                 } else {
-                    self.app.last_ui_output_source = None;
-                    self.app.pending_thought_source = None;
                     self.append_streaming_assistant_chunk(&text);
                     self.pin_transcript_to_bottom();
                     vec![]

--- a/src/tui/lifecycle.rs
+++ b/src/tui/lifecycle.rs
@@ -42,7 +42,7 @@ impl Tui {
             }
         });
 
-        // Build the initial transcript: welcome (if not in agent/RAG) + banner (if agent)
+        // Build the initial transcript: welcome + banner (if agent)
         let initial_transcript = Self::build_initial_transcript(config);
 
         Ok(Self {
@@ -87,7 +87,7 @@ impl Tui {
         let cfg = config.read();
         let state = cfg.state();
 
-        // Show welcome only when not already in an agent/RAG session (matches old REPL behaviour)
+        // Show the welcome banner on startup, even when an agent/session status line is also present.
         entries.push(TranscriptItem::SystemText(format!(
             "Welcome to {} {}  •  Type .help for commands, Tab to complete.",
             env!("CARGO_CRATE_NAME"),

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -3,7 +3,7 @@ use crate::client::{Client, ClientConfig, TestStateGuard};
 use crate::config::Config;
 use crate::test_utils::{MockClient, MockTurnBuilder, TuiTestHarness};
 use crate::tui::render_helpers::event_fallback_text;
-use crate::tui::types::{TranscriptItem, TuiEvent};
+use crate::tui::types::{TranscriptEntry, TuiEvent};
 use crate::ui_output::{UiOutputEvent, UiOutputEventKind, UiOutputSource};
 use crate::utils::dimmed_text;
 use agent_client_protocol as acp;
@@ -127,7 +127,7 @@ async fn shift_enter_inserts_newline_without_submitting() {
         .app
         .transcript
         .iter()
-        .all(|entry| !matches!(entry, TranscriptItem::UserText(_))));
+        .all(|entry| !matches!(entry, TranscriptEntry::User(_))));
 }
 
 #[tokio::test]
@@ -154,7 +154,7 @@ async fn pending_message_is_auto_sent_after_finish() {
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptItem::UserText(text) if text == "follow up"));
+        .any(|entry| matches!(entry, TranscriptEntry::User(text) if text == "follow up"));
     assert!(has_user_entry);
 }
 
@@ -238,7 +238,7 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
         .transcript
         .iter()
         .filter_map(|entry| match entry {
-            TranscriptItem::AssistantText(text) => Some(text.as_str()),
+            TranscriptEntry::Assistant(text) => Some(text.as_str()),
             _ => None,
         })
         .collect();
@@ -247,7 +247,7 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptItem::SystemText(text) if text == "tool output")));
+        .any(|entry| matches!(entry, TranscriptEntry::System(text) if text == "tool output")));
 }
 
 #[tokio::test]
@@ -293,22 +293,17 @@ async fn ui_output_inserts_heading_when_source_changes() {
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
-        .filter_map(|line| {
-            let text = line
-                .spans
-                .iter()
-                .map(|span| span.content.as_ref())
-                .collect::<String>();
-            (!text.is_empty()).then_some(text)
+        .filter_map(|entry| match entry {
+            TranscriptEntry::System(text) => Some(text.as_str()),
+            _ => None,
         })
         .collect();
 
-    assert!(system_entries.contains(&"> argus ▸ session-1".to_string()));
-    assert!(system_entries.contains(&"first chunk".to_string()));
-    assert!(system_entries.contains(&"second chunk".to_string()));
-    assert!(system_entries.contains(&"> hephaestus ▸ session-2".to_string()));
-    assert!(system_entries.contains(&"other chunk".to_string()));
+    assert!(system_entries.contains(&"> argus ▸ session-1"));
+    assert!(system_entries.contains(&"first chunk"));
+    assert!(system_entries.contains(&"second chunk"));
+    assert!(system_entries.contains(&"> hephaestus ▸ session-2"));
+    assert!(system_entries.contains(&"other chunk"));
 
     let argus_heading_count = system_entries
         .iter()
@@ -372,7 +367,7 @@ async fn info_commands_render_into_tui_transcript() {
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptItem::SystemText(text) if !text.is_empty()));
+        .any(|entry| matches!(entry, TranscriptEntry::System(text) if !text.is_empty()));
     assert!(has_session_output);
 }
 
@@ -392,7 +387,7 @@ async fn info_session_does_not_print_raw_output_in_tui_mode() {
         .transcript
         .iter()
         .filter_map(|entry| match entry {
-            TranscriptItem::SystemText(text) => Some(text.as_str()),
+            TranscriptEntry::System(text) => Some(text.as_str()),
             _ => None,
         })
         .collect::<Vec<_>>()
@@ -626,18 +621,13 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
-        .filter_map(|line| {
-            let text = line
-                .spans
-                .iter()
-                .map(|span| span.content.as_ref())
-                .collect::<String>();
-            if text.is_empty() || text.starts_with("Welcome to harnx") || text.starts_with('•') {
-                None
-            } else {
-                Some(text)
+        .filter_map(|entry| match entry {
+            TranscriptEntry::System(text)
+                if !text.starts_with("Welcome to harnx") && !text.starts_with('•') =>
+            {
+                Some(text.as_str())
             }
+            _ => None,
         })
         .collect();
 
@@ -704,18 +694,13 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
-        .filter_map(|line| {
-            let text = line
-                .spans
-                .iter()
-                .map(|span| span.content.as_ref())
-                .collect::<String>();
-            if text.is_empty() || text.starts_with("Welcome to harnx") || text.starts_with('•') {
-                None
-            } else {
-                Some(text)
+        .filter_map(|entry| match entry {
+            TranscriptEntry::System(text)
+                if !text.starts_with("Welcome to harnx") && !text.starts_with('•') =>
+            {
+                Some(text.as_str())
             }
+            _ => None,
         })
         .collect();
 
@@ -923,29 +908,24 @@ async fn structured_ui_output_variants_render_in_transcript() {
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
-        .filter_map(|line| {
-            let text = line
-                .spans
-                .iter()
-                .map(|span| span.content.as_ref())
-                .collect::<String>();
-            (!text.is_empty()).then_some(text)
+        .filter_map(|entry| match entry {
+            TranscriptEntry::System(text) => Some(text.as_str()),
+            _ => None,
         })
         .collect();
 
-    assert!(system_entries.contains(&"> argus ▸ session-1".to_string()));
-    assert!(system_entries.contains(&"->️ argus_session_prompt".to_string()));
-    assert!(system_entries.contains(&"   message: hello".to_string()));
-    assert!(system_entries.contains(&"<think>thinking hard</think>".to_string()));
-    assert!(system_entries.contains(&"-> argus_session_prompt completed".to_string()));
-    assert!(system_entries.contains(&"Plan:".to_string()));
-    assert!(system_entries.contains(&"  [in_progress] Refactor ACP formatting".to_string()));
-    assert!(system_entries.contains(&"> argus ▸ session-1   in 12   out 34   cache 5".to_string()));
-    assert!(system_entries.contains(&"->️ bash".to_string()));
-    assert!(system_entries.contains(&"   command: ls".to_string()));
-    assert!(system_entries.contains(&"   line one".to_string()));
-    assert!(system_entries.contains(&"   line two".to_string()));
+    assert!(system_entries.contains(&"> argus ▸ session-1"));
+    assert!(system_entries.contains(&"->️ argus_session_prompt"));
+    assert!(system_entries.contains(&"   message: hello"));
+    assert!(system_entries.contains(&"<think>thinking hard</think>"));
+    assert!(system_entries.contains(&"-> argus_session_prompt completed"));
+    assert!(system_entries.contains(&"Plan:"));
+    assert!(system_entries.contains(&"  [in_progress] Refactor ACP formatting"));
+    assert!(system_entries.contains(&"> argus ▸ session-1   in 12   out 34   cache 5"));
+    assert!(system_entries.contains(&"->️ bash"));
+    assert!(system_entries.contains(&"   command: ls"));
+    assert!(system_entries.contains(&"   line one"));
+    assert!(system_entries.contains(&"   line two"));
 }
 
 #[tokio::test]
@@ -986,14 +966,9 @@ async fn consecutive_usage_updates_replace_previous_usage_row_for_same_source() 
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
-        .filter_map(|line| {
-            let text = line
-                .spans
-                .iter()
-                .map(|span| span.content.as_ref())
-                .collect::<String>();
-            (!text.is_empty()).then_some(text)
+        .filter_map(|entry| match entry {
+            TranscriptEntry::System(text) => Some(text.as_str()),
+            _ => None,
         })
         .collect();
 
@@ -1053,7 +1028,7 @@ async fn acp_message_chunks_coalesce_like_direct_llm_streaming() {
         .transcript
         .iter()
         .filter_map(|entry| match entry {
-            TranscriptItem::AssistantText(text) => Some(text.as_str()),
+            TranscriptEntry::Assistant(text) => Some(text.as_str()),
             _ => None,
         })
         .collect();
@@ -1093,25 +1068,20 @@ async fn submitting_message_with_attachments_renders_attachment_list_and_preview
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
-        .filter_map(|line| {
-            let text = line
-                .spans
-                .iter()
-                .map(|span| span.content.as_ref())
-                .collect::<String>();
-            (!text.is_empty()).then_some(text)
+        .filter_map(|entry| match entry {
+            TranscriptEntry::System(text) => Some(text.as_str()),
+            _ => None,
         })
         .collect();
 
     assert!(matches!(
-        tui.app.transcript.iter().find(|entry| matches!(entry, TranscriptItem::UserText(_))),
-        Some(TranscriptItem::UserText(text)) if text == "hello with files"
+        tui.app.transcript.iter().find(|entry| matches!(entry, TranscriptEntry::User(_))),
+        Some(TranscriptEntry::User(text)) if text == "hello with files"
     ));
-    assert!(system_entries.contains(&"Attachments (1):".to_string()));
-    assert!(system_entries.contains(&"  - notes.txt".to_string()));
-    assert!(system_entries.contains(&"      first line".to_string()));
-    assert!(system_entries.contains(&"      second line".to_string()));
+    assert!(system_entries.contains(&"Attachments (1):"));
+    assert!(system_entries.contains(&"  - notes.txt"));
+    assert!(system_entries.contains(&"      first line"));
+    assert!(system_entries.contains(&"      second line"));
 }
 
 #[test]
@@ -1163,7 +1133,7 @@ async fn representative_repl_commands_render_into_tui_transcript() {
             .transcript
             .iter()
             .filter_map(|entry| match entry {
-                TranscriptItem::SystemText(text) => Some(text.as_str()),
+                TranscriptEntry::System(text) => Some(text.as_str()),
                 _ => None,
             })
             .collect::<Vec<_>>()
@@ -1209,7 +1179,7 @@ async fn test_basic_message_and_streaming_response() {
         .tui()
         .app
         .transcript
-        .push(TranscriptItem::UserText("Test message".to_string()));
+        .push(TranscriptEntry::User("Test message".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1256,7 +1226,7 @@ async fn test_basic_message_and_streaming_response() {
         .transcript
         .iter()
         .filter_map(|entry| match entry {
-            TranscriptItem::AssistantText(text) => Some(text.clone()),
+            TranscriptEntry::Assistant(text) => Some(text.clone()),
             _ => None,
         })
         .collect();
@@ -1266,7 +1236,7 @@ async fn test_basic_message_and_streaming_response() {
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptItem::UserText(text) if text == "Test message")));
+        .any(|entry| matches!(entry, TranscriptEntry::User(text) if text == "Test message")));
 
     let rendered = normalize_screen(&harness.screen_contents());
     insta::assert_snapshot!("basic_message_and_streaming_response", rendered);
@@ -1306,7 +1276,7 @@ async fn test_streaming_with_tool_calls() {
         .tui()
         .app
         .transcript
-        .push(TranscriptItem::UserText("What is the answer?".to_string()));
+        .push(TranscriptEntry::User("What is the answer?".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1395,7 +1365,7 @@ async fn test_sub_agent_delegation_tool_appears() {
         .tui()
         .app
         .transcript
-        .push(TranscriptItem::UserText("Help me".to_string()));
+        .push(TranscriptEntry::User("Help me".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1502,7 +1472,7 @@ async fn test_screen_overflow_and_word_wrap() {
         .tui()
         .app
         .transcript
-        .push(TranscriptItem::UserText(user_message.to_string()));
+        .push(TranscriptEntry::User(user_message.to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1656,7 +1626,7 @@ async fn test_ctrl_c_cancels_streaming() {
         .tui()
         .app
         .transcript
-        .push(TranscriptItem::UserText("Long request".to_string()));
+        .push(TranscriptEntry::User("Long request".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1692,13 +1662,9 @@ async fn test_ctrl_c_cancels_streaming() {
     harness.tui().abort_signal.set_ctrlc();
 
     // Manually trigger the Ctrl+C handling (same as handle_key for Ctrl+C)
-    harness
-        .tui()
-        .app
-        .transcript
-        .push(TranscriptItem::SystemText(
-            "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
-        ));
+    harness.tui().app.transcript.push(TranscriptEntry::System(
+        "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
+    ));
     harness.tui().app.llm_busy = false;
     harness.tui().abort_signal.reset();
 
@@ -1739,7 +1705,7 @@ async fn test_streaming_error_shows_in_transcript() {
         .tui()
         .app
         .transcript
-        .push(TranscriptItem::UserText("Error test".to_string()));
+        .push(TranscriptEntry::User("Error test".to_string()));
 
     // The error should propagate through start_prompt
     let result = harness
@@ -1765,7 +1731,7 @@ async fn test_streaming_error_shows_in_transcript() {
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptItem::ErrorText(_)));
+        .any(|entry| matches!(entry, TranscriptEntry::Error(_)));
     assert!(has_error, "Transcript should contain an error entry");
 
     harness.drain_and_settle().await.unwrap();
@@ -1804,7 +1770,7 @@ async fn test_cancel_during_tool_execution() {
         .tui()
         .app
         .transcript
-        .push(TranscriptItem::UserText("Search test".to_string()));
+        .push(TranscriptEntry::User("Search test".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1839,13 +1805,9 @@ async fn test_cancel_during_tool_execution() {
     harness.tui().abort_signal.set_ctrlc();
 
     // Manually trigger the Ctrl+C handling (same as handle_key for Ctrl+C)
-    harness
-        .tui()
-        .app
-        .transcript
-        .push(TranscriptItem::SystemText(
-            "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
-        ));
+    harness.tui().app.transcript.push(TranscriptEntry::System(
+        "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
+    ));
     harness.tui().app.llm_busy = false;
     harness.tui().abort_signal.reset();
 
@@ -1897,7 +1859,7 @@ async fn paste_multiline_creates_temp_attachment() {
         .app
         .transcript
         .iter()
-        .filter(|entry| matches!(entry, TranscriptItem::UserText(_)))
+        .filter(|entry| matches!(entry, TranscriptEntry::User(_)))
         .collect();
     assert!(
         user_entries.is_empty(),
@@ -2080,7 +2042,7 @@ async fn attach_command_adds_attachment() {
         .app
         .transcript
         .iter()
-        .filter(|e| matches!(e, TranscriptItem::UserText(_)))
+        .filter(|e| matches!(e, TranscriptEntry::User(_)))
         .collect();
     assert!(user_entries.is_empty());
 
@@ -2107,7 +2069,7 @@ async fn attach_command_preserves_draft_text() {
         .app
         .transcript
         .iter()
-        .filter(|e| matches!(e, TranscriptItem::UserText(_)))
+        .filter(|e| matches!(e, TranscriptEntry::User(_)))
         .collect();
     assert!(user_entries.is_empty());
 
@@ -2130,7 +2092,7 @@ async fn attach_nonexistent_file_shows_error() {
         .app
         .transcript
         .iter()
-        .any(|e| matches!(e, TranscriptItem::ErrorText(msg) if msg.contains("not found")));
+        .any(|e| matches!(e, TranscriptEntry::Error(msg) if msg.contains("not found")));
     assert!(has_error, "Should show error for nonexistent file");
 }
 
@@ -2356,7 +2318,7 @@ async fn test_recovery_after_cancellation() {
         .tui()
         .app
         .transcript
-        .push(TranscriptItem::UserText("First request".to_string()));
+        .push(TranscriptEntry::User("First request".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -2385,13 +2347,9 @@ async fn test_recovery_after_cancellation() {
     harness.drain_and_settle().await.unwrap();
 
     // Simulate cancellation
-    harness
-        .tui()
-        .app
-        .transcript
-        .push(TranscriptItem::SystemText(
-            "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
-        ));
+    harness.tui().app.transcript.push(TranscriptEntry::System(
+        "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
+    ));
     harness.tui().app.llm_busy = false;
     harness.tui().abort_signal.reset();
     harness.render();
@@ -2421,7 +2379,7 @@ async fn test_recovery_after_cancellation() {
         .tui()
         .app
         .transcript
-        .push(TranscriptItem::UserText("Second request".to_string()));
+        .push(TranscriptEntry::User("Second request".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -368,12 +368,22 @@ async fn info_commands_render_into_tui_transcript() {
         tui.handle_tui_event(event).await.unwrap();
     }
 
-    let has_session_output = tui
+    let rendered = tui
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptItem::SystemText(text) if !text.is_empty()));
-    assert!(has_session_output);
+        .flat_map(Tui::render_entry)
+        .filter_map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            (!text.is_empty()).then_some(text)
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(!rendered.trim().is_empty());
 }
 
 #[tokio::test]
@@ -855,6 +865,7 @@ async fn structured_ui_output_variants_render_in_transcript() {
     .unwrap();
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
         kind: UiOutputEventKind::ToolCallUpdate {
+            tool_call_id: Some("call-1".to_string()),
             title: Some("argus_session_prompt".to_string()),
             status: Some("completed".to_string()),
             raw: None,
@@ -1687,29 +1698,23 @@ async fn test_ctrl_c_cancels_streaming() {
     }
     harness.render();
 
-    // Now simulate Ctrl+C after streaming is done
-    // This tests the Ctrl+C handling when llm_busy is true
-    harness.tui().abort_signal.set_ctrlc();
-
-    // Manually trigger the Ctrl+C handling (same as handle_key for Ctrl+C)
+    // Now simulate Ctrl+C after streaming is done.
+    // Exercise the same cancellation path used in production key handling.
     harness
         .tui()
-        .app
-        .transcript
-        .push(TranscriptItem::SystemText(
-            "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
-        ));
-    harness.tui().app.llm_busy = false;
-    harness.tui().abort_signal.reset();
+        .handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL))
+        .await
+        .unwrap();
 
     harness.render();
     let screen = harness.screen_contents();
 
-    // The transcript should show the abort message
+    // The transcript should show the abort message and busy state should be cleared.
     assert!(
         screen.contains("aborted") || screen.contains("Ctrl+C"),
         "Screen should show abort message, got: {screen}"
     );
+    assert!(!harness.tui().app.llm_busy, "Ctrl+C should clear llm_busy");
 
     harness.drain_and_settle().await.unwrap();
 }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -960,6 +960,77 @@ async fn structured_ui_output_variants_render_in_transcript() {
 }
 
 #[tokio::test]
+async fn nested_subagent_tool_call_renders_with_heading_and_usage() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::ToolCall {
+            tool_name: "pytheas_session_prompt".to_string(),
+            input_yaml: Some("message: Count files in /tmp".to_string()),
+            raw: None,
+        },
+        source: None,
+    }))
+    .await
+    .unwrap();
+
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::ToolCall {
+            tool_name: "bash".to_string(),
+            input_yaml: Some("command: ls -1 /tmp | wc -l".to_string()),
+            raw: None,
+        },
+        source: Some(UiOutputSource {
+            agent: "pytheas".to_string(),
+            session_id: Some("session-nested".to_string()),
+        }),
+    }))
+    .await
+    .unwrap();
+
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::Usage {
+            input_tokens: 10,
+            output_tokens: 20,
+            cached_tokens: 0,
+            session_label: Some("> pytheas ▸ session-nested".to_string()),
+        },
+        source: Some(UiOutputSource {
+            agent: "pytheas".to_string(),
+            session_id: Some("session-nested".to_string()),
+        }),
+    }))
+    .await
+    .unwrap();
+
+    let rendered: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .flat_map(Tui::render_entry)
+        .filter_map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            (!text.is_empty()).then_some(text)
+        })
+        .collect();
+
+    assert!(rendered.contains(&"->️ pytheas_session_prompt".to_string()));
+    assert!(rendered.contains(&"> pytheas ▸ session-nested".to_string()));
+    assert!(rendered.contains(&"->️ bash".to_string()));
+    assert!(rendered.contains(&"   command: ls -1 /tmp | wc -l".to_string()));
+    assert!(
+        rendered.contains(&"> pytheas ▸ session-nested   in 10   out 20".to_string()),
+        "rendered transcript missing nested usage line: {rendered:?}"
+    );
+}
+
+#[tokio::test]
 async fn consecutive_usage_updates_replace_previous_usage_row_for_same_source() {
     let config = test_config();
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -3,7 +3,7 @@ use crate::client::{Client, ClientConfig, TestStateGuard};
 use crate::config::Config;
 use crate::test_utils::{MockClient, MockTurnBuilder, TuiTestHarness};
 use crate::tui::render_helpers::event_fallback_text;
-use crate::tui::types::{TranscriptEntry, TuiEvent};
+use crate::tui::types::{TranscriptItem, TuiEvent};
 use crate::ui_output::{UiOutputEvent, UiOutputEventKind, UiOutputSource};
 use crate::utils::dimmed_text;
 use agent_client_protocol as acp;
@@ -127,7 +127,7 @@ async fn shift_enter_inserts_newline_without_submitting() {
         .app
         .transcript
         .iter()
-        .all(|entry| !matches!(entry, TranscriptEntry::User(_))));
+        .all(|entry| !matches!(entry, TranscriptItem::UserText(_))));
 }
 
 #[tokio::test]
@@ -154,7 +154,7 @@ async fn pending_message_is_auto_sent_after_finish() {
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptEntry::User(text) if text == "follow up"));
+        .any(|entry| matches!(entry, TranscriptItem::UserText(text) if text == "follow up"));
     assert!(has_user_entry);
 }
 
@@ -238,7 +238,7 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
         .transcript
         .iter()
         .filter_map(|entry| match entry {
-            TranscriptEntry::Assistant(text) => Some(text.as_str()),
+            TranscriptItem::AssistantText(text) => Some(text.as_str()),
             _ => None,
         })
         .collect();
@@ -247,7 +247,7 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptEntry::System(text) if text == "tool output")));
+        .any(|entry| matches!(entry, TranscriptItem::SystemText(text) if text == "tool output")));
 }
 
 #[tokio::test]
@@ -293,17 +293,22 @@ async fn ui_output_inserts_heading_when_source_changes() {
         .app
         .transcript
         .iter()
-        .filter_map(|entry| match entry {
-            TranscriptEntry::System(text) => Some(text.as_str()),
-            _ => None,
+        .flat_map(Tui::render_entry)
+        .filter_map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            (!text.is_empty()).then_some(text)
         })
         .collect();
 
-    assert!(system_entries.contains(&"> argus ▸ session-1"));
-    assert!(system_entries.contains(&"first chunk"));
-    assert!(system_entries.contains(&"second chunk"));
-    assert!(system_entries.contains(&"> hephaestus ▸ session-2"));
-    assert!(system_entries.contains(&"other chunk"));
+    assert!(system_entries.contains(&"> argus ▸ session-1".to_string()));
+    assert!(system_entries.contains(&"first chunk".to_string()));
+    assert!(system_entries.contains(&"second chunk".to_string()));
+    assert!(system_entries.contains(&"> hephaestus ▸ session-2".to_string()));
+    assert!(system_entries.contains(&"other chunk".to_string()));
 
     let argus_heading_count = system_entries
         .iter()
@@ -367,7 +372,7 @@ async fn info_commands_render_into_tui_transcript() {
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptEntry::System(text) if !text.is_empty()));
+        .any(|entry| matches!(entry, TranscriptItem::SystemText(text) if !text.is_empty()));
     assert!(has_session_output);
 }
 
@@ -387,7 +392,7 @@ async fn info_session_does_not_print_raw_output_in_tui_mode() {
         .transcript
         .iter()
         .filter_map(|entry| match entry {
-            TranscriptEntry::System(text) => Some(text.as_str()),
+            TranscriptItem::SystemText(text) => Some(text.as_str()),
             _ => None,
         })
         .collect::<Vec<_>>()
@@ -621,13 +626,18 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         .app
         .transcript
         .iter()
-        .filter_map(|entry| match entry {
-            TranscriptEntry::System(text)
-                if !text.starts_with("Welcome to harnx") && !text.starts_with('•') =>
-            {
-                Some(text.as_str())
+        .flat_map(Tui::render_entry)
+        .filter_map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            if text.is_empty() || text.starts_with("Welcome to harnx") || text.starts_with('•') {
+                None
+            } else {
+                Some(text)
             }
-            _ => None,
         })
         .collect();
 
@@ -694,13 +704,18 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         .app
         .transcript
         .iter()
-        .filter_map(|entry| match entry {
-            TranscriptEntry::System(text)
-                if !text.starts_with("Welcome to harnx") && !text.starts_with('•') =>
-            {
-                Some(text.as_str())
+        .flat_map(Tui::render_entry)
+        .filter_map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            if text.is_empty() || text.starts_with("Welcome to harnx") || text.starts_with('•') {
+                None
+            } else {
+                Some(text)
             }
-            _ => None,
         })
         .collect();
 
@@ -908,24 +923,29 @@ async fn structured_ui_output_variants_render_in_transcript() {
         .app
         .transcript
         .iter()
-        .filter_map(|entry| match entry {
-            TranscriptEntry::System(text) => Some(text.as_str()),
-            _ => None,
+        .flat_map(Tui::render_entry)
+        .filter_map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            (!text.is_empty()).then_some(text)
         })
         .collect();
 
-    assert!(system_entries.contains(&"> argus ▸ session-1"));
-    assert!(system_entries.contains(&"->️ argus_session_prompt"));
-    assert!(system_entries.contains(&"   message: hello"));
-    assert!(system_entries.contains(&"<think>thinking hard</think>"));
-    assert!(system_entries.contains(&"-> argus_session_prompt completed"));
-    assert!(system_entries.contains(&"Plan:"));
-    assert!(system_entries.contains(&"  [in_progress] Refactor ACP formatting"));
-    assert!(system_entries.contains(&"> argus ▸ session-1   in 12   out 34   cache 5"));
-    assert!(system_entries.contains(&"->️ bash"));
-    assert!(system_entries.contains(&"   command: ls"));
-    assert!(system_entries.contains(&"   line one"));
-    assert!(system_entries.contains(&"   line two"));
+    assert!(system_entries.contains(&"> argus ▸ session-1".to_string()));
+    assert!(system_entries.contains(&"->️ argus_session_prompt".to_string()));
+    assert!(system_entries.contains(&"   message: hello".to_string()));
+    assert!(system_entries.contains(&"<think>thinking hard</think>".to_string()));
+    assert!(system_entries.contains(&"-> argus_session_prompt completed".to_string()));
+    assert!(system_entries.contains(&"Plan:".to_string()));
+    assert!(system_entries.contains(&"  [in_progress] Refactor ACP formatting".to_string()));
+    assert!(system_entries.contains(&"> argus ▸ session-1   in 12   out 34   cache 5".to_string()));
+    assert!(system_entries.contains(&"->️ bash".to_string()));
+    assert!(system_entries.contains(&"   command: ls".to_string()));
+    assert!(system_entries.contains(&"   line one".to_string()));
+    assert!(system_entries.contains(&"   line two".to_string()));
 }
 
 #[tokio::test]
@@ -966,9 +986,14 @@ async fn consecutive_usage_updates_replace_previous_usage_row_for_same_source() 
         .app
         .transcript
         .iter()
-        .filter_map(|entry| match entry {
-            TranscriptEntry::System(text) => Some(text.as_str()),
-            _ => None,
+        .flat_map(Tui::render_entry)
+        .filter_map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            (!text.is_empty()).then_some(text)
         })
         .collect();
 
@@ -1028,7 +1053,7 @@ async fn acp_message_chunks_coalesce_like_direct_llm_streaming() {
         .transcript
         .iter()
         .filter_map(|entry| match entry {
-            TranscriptEntry::Assistant(text) => Some(text.as_str()),
+            TranscriptItem::AssistantText(text) => Some(text.as_str()),
             _ => None,
         })
         .collect();
@@ -1068,20 +1093,25 @@ async fn submitting_message_with_attachments_renders_attachment_list_and_preview
         .app
         .transcript
         .iter()
-        .filter_map(|entry| match entry {
-            TranscriptEntry::System(text) => Some(text.as_str()),
-            _ => None,
+        .flat_map(Tui::render_entry)
+        .filter_map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            (!text.is_empty()).then_some(text)
         })
         .collect();
 
     assert!(matches!(
-        tui.app.transcript.iter().find(|entry| matches!(entry, TranscriptEntry::User(_))),
-        Some(TranscriptEntry::User(text)) if text == "hello with files"
+        tui.app.transcript.iter().find(|entry| matches!(entry, TranscriptItem::UserText(_))),
+        Some(TranscriptItem::UserText(text)) if text == "hello with files"
     ));
-    assert!(system_entries.contains(&"Attachments (1):"));
-    assert!(system_entries.contains(&"  - notes.txt"));
-    assert!(system_entries.contains(&"      first line"));
-    assert!(system_entries.contains(&"      second line"));
+    assert!(system_entries.contains(&"Attachments (1):".to_string()));
+    assert!(system_entries.contains(&"  - notes.txt".to_string()));
+    assert!(system_entries.contains(&"      first line".to_string()));
+    assert!(system_entries.contains(&"      second line".to_string()));
 }
 
 #[test]
@@ -1133,7 +1163,7 @@ async fn representative_repl_commands_render_into_tui_transcript() {
             .transcript
             .iter()
             .filter_map(|entry| match entry {
-                TranscriptEntry::System(text) => Some(text.as_str()),
+                TranscriptItem::SystemText(text) => Some(text.as_str()),
                 _ => None,
             })
             .collect::<Vec<_>>()
@@ -1179,7 +1209,7 @@ async fn test_basic_message_and_streaming_response() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("Test message".to_string()));
+        .push(TranscriptItem::UserText("Test message".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1226,7 +1256,7 @@ async fn test_basic_message_and_streaming_response() {
         .transcript
         .iter()
         .filter_map(|entry| match entry {
-            TranscriptEntry::Assistant(text) => Some(text.clone()),
+            TranscriptItem::AssistantText(text) => Some(text.clone()),
             _ => None,
         })
         .collect();
@@ -1236,7 +1266,7 @@ async fn test_basic_message_and_streaming_response() {
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptEntry::User(text) if text == "Test message")));
+        .any(|entry| matches!(entry, TranscriptItem::UserText(text) if text == "Test message")));
 
     let rendered = normalize_screen(&harness.screen_contents());
     insta::assert_snapshot!("basic_message_and_streaming_response", rendered);
@@ -1276,7 +1306,7 @@ async fn test_streaming_with_tool_calls() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("What is the answer?".to_string()));
+        .push(TranscriptItem::UserText("What is the answer?".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1365,7 +1395,7 @@ async fn test_sub_agent_delegation_tool_appears() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("Help me".to_string()));
+        .push(TranscriptItem::UserText("Help me".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1472,7 +1502,7 @@ async fn test_screen_overflow_and_word_wrap() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User(user_message.to_string()));
+        .push(TranscriptItem::UserText(user_message.to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1626,7 +1656,7 @@ async fn test_ctrl_c_cancels_streaming() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("Long request".to_string()));
+        .push(TranscriptItem::UserText("Long request".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1662,9 +1692,13 @@ async fn test_ctrl_c_cancels_streaming() {
     harness.tui().abort_signal.set_ctrlc();
 
     // Manually trigger the Ctrl+C handling (same as handle_key for Ctrl+C)
-    harness.tui().app.transcript.push(TranscriptEntry::System(
-        "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
-    ));
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::SystemText(
+            "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
+        ));
     harness.tui().app.llm_busy = false;
     harness.tui().abort_signal.reset();
 
@@ -1705,7 +1739,7 @@ async fn test_streaming_error_shows_in_transcript() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("Error test".to_string()));
+        .push(TranscriptItem::UserText("Error test".to_string()));
 
     // The error should propagate through start_prompt
     let result = harness
@@ -1731,7 +1765,7 @@ async fn test_streaming_error_shows_in_transcript() {
         .app
         .transcript
         .iter()
-        .any(|entry| matches!(entry, TranscriptEntry::Error(_)));
+        .any(|entry| matches!(entry, TranscriptItem::ErrorText(_)));
     assert!(has_error, "Transcript should contain an error entry");
 
     harness.drain_and_settle().await.unwrap();
@@ -1770,7 +1804,7 @@ async fn test_cancel_during_tool_execution() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("Search test".to_string()));
+        .push(TranscriptItem::UserText("Search test".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -1805,9 +1839,13 @@ async fn test_cancel_during_tool_execution() {
     harness.tui().abort_signal.set_ctrlc();
 
     // Manually trigger the Ctrl+C handling (same as handle_key for Ctrl+C)
-    harness.tui().app.transcript.push(TranscriptEntry::System(
-        "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
-    ));
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::SystemText(
+            "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
+        ));
     harness.tui().app.llm_busy = false;
     harness.tui().abort_signal.reset();
 
@@ -1859,7 +1897,7 @@ async fn paste_multiline_creates_temp_attachment() {
         .app
         .transcript
         .iter()
-        .filter(|entry| matches!(entry, TranscriptEntry::User(_)))
+        .filter(|entry| matches!(entry, TranscriptItem::UserText(_)))
         .collect();
     assert!(
         user_entries.is_empty(),
@@ -2042,7 +2080,7 @@ async fn attach_command_adds_attachment() {
         .app
         .transcript
         .iter()
-        .filter(|e| matches!(e, TranscriptEntry::User(_)))
+        .filter(|e| matches!(e, TranscriptItem::UserText(_)))
         .collect();
     assert!(user_entries.is_empty());
 
@@ -2069,7 +2107,7 @@ async fn attach_command_preserves_draft_text() {
         .app
         .transcript
         .iter()
-        .filter(|e| matches!(e, TranscriptEntry::User(_)))
+        .filter(|e| matches!(e, TranscriptItem::UserText(_)))
         .collect();
     assert!(user_entries.is_empty());
 
@@ -2092,7 +2130,7 @@ async fn attach_nonexistent_file_shows_error() {
         .app
         .transcript
         .iter()
-        .any(|e| matches!(e, TranscriptEntry::Error(msg) if msg.contains("not found")));
+        .any(|e| matches!(e, TranscriptItem::ErrorText(msg) if msg.contains("not found")));
     assert!(has_error, "Should show error for nonexistent file");
 }
 
@@ -2318,7 +2356,7 @@ async fn test_recovery_after_cancellation() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("First request".to_string()));
+        .push(TranscriptItem::UserText("First request".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {
@@ -2347,9 +2385,13 @@ async fn test_recovery_after_cancellation() {
     harness.drain_and_settle().await.unwrap();
 
     // Simulate cancellation
-    harness.tui().app.transcript.push(TranscriptEntry::System(
-        "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
-    ));
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::SystemText(
+            "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
+        ));
     harness.tui().app.llm_busy = false;
     harness.tui().abort_signal.reset();
     harness.render();
@@ -2379,7 +2421,7 @@ async fn test_recovery_after_cancellation() {
         .tui()
         .app
         .transcript
-        .push(TranscriptEntry::User("Second request".to_string()));
+        .push(TranscriptItem::UserText("Second request".to_string()));
     harness
         .tui()
         .start_prompt(crate::tui::types::PendingMessage {

--- a/src/ui_output.rs
+++ b/src/ui_output.rs
@@ -35,6 +35,7 @@ pub enum UiOutputEventKind {
         raw: Option<Box<acp::ToolCall>>,
     },
     ToolCallUpdate {
+        tool_call_id: Option<String>,
         title: Option<String>,
         status: Option<String>,
         raw: Option<Box<acp::ToolCallUpdate>>,


### PR DESCRIPTION
## Summary

This PR improves ACP/TUI event handling so delegated agent activity is represented and rendered more faithfully. It preserves semantic transcript items through TUI state, unifies UI output events across local and remote flows, fixes metadata/source handling for delegated sessions, and ensures nested delegated MCP tool calls are surfaced in the parent transcript.

## Key changes

- unify UI output events into shared semantic variants for local and remote flows
- preserve semantic transcript items in TUI state and render them lazily at draw time
- fix ACP notification source resolution and forwarding so delegated session metadata is retained
- stop repeated/redundant sub-agent heading behavior caused by premature flattening and source loss
- make message chunks coalesce like direct LLM streaming instead of rendering as separate system lines
- fix thought/tool boundary handling so post-tool thought does not merge into pre-tool thought
- add Rust-native tmux end-to-end repro coverage for issue #249
- surface nested delegated MCP tool calls in the parent transcript

## Testing

- `cargo fmt`
- `cargo build`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo nextest run --all`
- targeted tmux repro coverage for issue #249

## Notes / risks

- This PR does **not** include the untracked `docs/debug/` directory currently in the working tree.
- The main architectural change is that transcript rendering now happens from semantic items at draw time, which improves correctness and reflow behavior but touches core TUI rendering paths.
- ACP/TUI behavior around nested delegation is better covered now, but future follow-up may still further refine transcript rendering and debugging workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two local CLI servers: a mock OpenAI-compatible LLM server and a deterministic MCP repro server; test mock server for scripted OpenAI scenarios.

* **Bug Fixes**
  * Preserve whitespace-only streaming chunks.
  * Flush pending thought text before pinning transcript.
  * Improved Ctrl+C cancellation handling.

* **Improvements**
  * Tool-call updates now include stable identifiers and UI source context.
  * Welcome banner consistently shown on startup in agent mode.

* **Tests**
  * New integration/e2e tmux-based tests and test harnesses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->