### PR TITLE
fix(tui): fix shift key and key repeat in kitty terminal

### DIFF
--- a/src/tui/lifecycle.rs
+++ b/src/tui/lifecycle.rs
@@ -164,7 +164,9 @@ impl Tui {
             let timeout = TICK_RATE.saturating_sub(last_tick.elapsed());
             if event_source.poll(timeout)? {
                 match event_source.read()? {
-                    Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    Event::Key(key)
+                        if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+                    {
                         self.handle_key(key).await?
                     }
                     Event::Mouse(mouse) => {
@@ -206,8 +208,7 @@ impl Tui {
                 if supports_keyboard_enhancement().unwrap_or(false) {
                     let _ = stdout.execute(PushKeyboardEnhancementFlags(
                         KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                            | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
-                            | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES,
+                            | KeyboardEnhancementFlags::REPORT_EVENT_TYPES,
                     ));
                 }
                 let _ = stdout.execute(EnableMouseCapture);

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -65,8 +65,7 @@ impl Tui {
         if supports_keyboard_enhancement()? {
             stdout.execute(PushKeyboardEnhancementFlags(
                 KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                    | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
-                    | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES,
+                    | KeyboardEnhancementFlags::REPORT_EVENT_TYPES,
             ))?;
         }
         stdout.execute(EnableMouseCapture)?;


### PR DESCRIPTION
## Summary

Closes #251

- Remove `REPORT_ALL_KEYS_AS_ESCAPE_CODES` keyboard enhancement flag — kitty's enhanced protocol sends base key codes with a shift modifier instead of the shifted character (e.g. `'a'` + SHIFT instead of `'A'`), so capital letters and shifted symbols like `!@#` were broken
- Accept `KeyEventKind::Repeat` events alongside `Press` in the event loop — with `REPORT_EVENT_TYPES` enabled, kitty sends held keys as `Repeat` rather than `Press`, so key repeat (e.g. holding backspace) was silently dropped

## Test plan

- [x] All 274 unit tests pass
- [x] Builds and installs successfully
- [ ] Manual test in kitty: capital letters, shifted symbols (`!@#$`), holding backspace, holding arrow keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved keyboard event handling in the terminal interface to process repeat events
  * Adjusted keyboard enhancement configuration settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->