### PR TITLE
feat: model fallback and retry with exponential backoff

### DIFF
--- a/src/client/bedrock.rs
+++ b/src/client/bedrock.rs
@@ -181,10 +181,11 @@ impl Client for BedrockClient {
 async fn chat_completions(builder: RequestBuilder) -> Result<ChatCompletionsOutput> {
     let res = builder.send().await?;
     let status = res.status();
+    let retry_after = parse_retry_after(res.headers());
     let data: Value = res.json().await?;
 
     if !status.is_success() {
-        catch_error(&data, status.as_u16())?;
+        catch_error(&data, status.as_u16(), retry_after)?;
     }
 
     debug!("non-stream-data: {data}");
@@ -198,8 +199,9 @@ async fn chat_completions_streaming(
     let res = builder.send().await?;
     let status = res.status();
     if !status.is_success() {
+        let retry_after = parse_retry_after(res.headers());
         let data: Value = res.json().await?;
-        catch_error(&data, status.as_u16())?;
+        catch_error(&data, status.as_u16(), retry_after)?;
         bail!("Invalid response data: {data}");
     }
 
@@ -316,7 +318,7 @@ async fn embeddings(builder: RequestBuilder) -> Result<EmbeddingsOutput> {
     let data: Value = res.json().await?;
 
     if !status.is_success() {
-        catch_error(&data, status.as_u16())?;
+        catch_error(&data, status.as_u16(), None)?;
     }
 
     let res_body: EmbeddingsResBody =

--- a/src/client/claude.rs
+++ b/src/client/claude.rs
@@ -70,9 +70,10 @@ pub async fn claude_chat_completions(
 ) -> Result<ChatCompletionsOutput> {
     let res = builder.send().await?;
     let status = res.status();
+    let retry_after = parse_retry_after(res.headers());
     let data: Value = res.json().await?;
     if !status.is_success() {
-        catch_error(&data, status.as_u16())?;
+        catch_error(&data, status.as_u16(), retry_after)?;
     }
     debug!("non-stream-data: {data}");
     claude_extract_chat_completions(&data)

--- a/src/client/cohere.rs
+++ b/src/client/cohere.rs
@@ -113,9 +113,10 @@ async fn chat_completions(
 ) -> Result<ChatCompletionsOutput> {
     let res = builder.send().await?;
     let status = res.status();
+    let retry_after = parse_retry_after(res.headers());
     let data: Value = res.json().await?;
     if !status.is_success() {
-        catch_error(&data, status.as_u16())?;
+        catch_error(&data, status.as_u16(), retry_after)?;
     }
 
     debug!("non-stream-data: {data}");
@@ -196,7 +197,7 @@ async fn embeddings(builder: RequestBuilder, _model: &Model) -> Result<Embedding
     let status = res.status();
     let data: Value = res.json().await?;
     if !status.is_success() {
-        catch_error(&data, status.as_u16())?;
+        catch_error(&data, status.as_u16(), None)?;
     }
     let res_body: EmbeddingsResBody =
         serde_json::from_value(data).context("Invalid embeddings data")?;

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -65,10 +65,11 @@ pub fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duratio
     if let Some(val) = headers.get("retry-after").and_then(|v| v.to_str().ok()) {
         if let Ok(secs) = val.parse::<u64>() {
             consider(Duration::from_secs(secs));
-        } else if let Ok(secs) = val.parse::<f64>() {
-            consider(Duration::from_secs_f64(secs));
+        } else if let Some(d) = safe_duration_from_secs_f64(val.parse::<f64>().ok()) {
+            consider(d);
+        } else if let Some(d) = parse_http_date_retry_after(val) {
+            consider(d);
         }
-        // HTTP-date parsing omitted for simplicity; integer seconds covers most providers
     }
 
     // OpenAI-style rate limit reset headers (values in seconds or duration strings like "1s", "2m")
@@ -83,29 +84,62 @@ pub fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duratio
     max_duration
 }
 
+/// Convert an `Option<f64>` to a `Duration`, returning `None` for negative, NaN, or infinite values.
+fn safe_duration_from_secs_f64(val: Option<f64>) -> Option<Duration> {
+    let v = val?;
+    if v.is_finite() && v >= 0.0 {
+        Some(Duration::from_secs_f64(v))
+    } else {
+        None
+    }
+}
+
+/// Parse an RFC 2616 / RFC 7231 HTTP-date `Retry-After` value into a duration from now.
+fn parse_http_date_retry_after(val: &str) -> Option<Duration> {
+    use chrono::{DateTime, Utc};
+    // Try common HTTP date formats: RFC 2822, RFC 850, asctime
+    let target = DateTime::parse_from_rfc2822(val)
+        .map(|dt| dt.with_timezone(&Utc))
+        .or_else(|_| {
+            DateTime::parse_from_str(val, "%A, %d-%b-%y %T GMT").map(|dt| dt.with_timezone(&Utc))
+        })
+        .or_else(|_| {
+            chrono::NaiveDateTime::parse_from_str(val, "%a %b %e %T %Y").map(|ndt| ndt.and_utc())
+        })
+        .ok()?;
+    let now = Utc::now();
+    if target > now {
+        let diff = target - now;
+        diff.to_std().ok()
+    } else {
+        Some(Duration::ZERO)
+    }
+}
+
 /// Parse a duration value that may be seconds (integer/float) or a simple duration string like "1s", "2m", "500ms".
 fn parse_duration_value(val: &str) -> Option<Duration> {
     let val = val.trim();
-    if let Ok(secs) = val.parse::<f64>() {
-        return Some(Duration::from_secs_f64(secs));
+    if let Some(d) = safe_duration_from_secs_f64(val.parse::<f64>().ok()) {
+        return Some(d);
     }
     if let Some(s) = val.strip_suffix("ms") {
-        return s
-            .trim()
-            .parse::<f64>()
-            .ok()
-            .map(Duration::from_secs_f64)
-            .map(|d| d / 1000);
+        let ms = s.trim().parse::<f64>().ok()?;
+        return if ms.is_finite() && ms >= 0.0 {
+            Some(Duration::from_secs_f64(ms / 1000.0))
+        } else {
+            None
+        };
     }
     if let Some(s) = val.strip_suffix('s') {
-        return s.trim().parse::<f64>().ok().map(Duration::from_secs_f64);
+        return safe_duration_from_secs_f64(s.trim().parse::<f64>().ok());
     }
     if let Some(s) = val.strip_suffix('m') {
-        return s
-            .trim()
-            .parse::<f64>()
-            .ok()
-            .map(|v| Duration::from_secs_f64(v * 60.0));
+        let mins = s.trim().parse::<f64>().ok()?;
+        return if mins.is_finite() && mins >= 0.0 {
+            Some(Duration::from_secs_f64(mins * 60.0))
+        } else {
+            None
+        };
     }
     None
 }

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -72,10 +72,7 @@ pub fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duratio
     }
 
     // OpenAI-style rate limit reset headers (values in seconds or duration strings like "1s", "2m")
-    for header_name in [
-        "x-ratelimit-reset-requests",
-        "x-ratelimit-reset-tokens",
-    ] {
+    for header_name in ["x-ratelimit-reset-requests", "x-ratelimit-reset-tokens"] {
         if let Some(val) = headers.get(header_name).and_then(|v| v.to_str().ok()) {
             if let Some(d) = parse_duration_value(val) {
                 consider(d);
@@ -93,13 +90,22 @@ fn parse_duration_value(val: &str) -> Option<Duration> {
         return Some(Duration::from_secs_f64(secs));
     }
     if let Some(s) = val.strip_suffix("ms") {
-        return s.trim().parse::<f64>().ok().map(Duration::from_secs_f64).map(|d| d / 1000);
+        return s
+            .trim()
+            .parse::<f64>()
+            .ok()
+            .map(Duration::from_secs_f64)
+            .map(|d| d / 1000);
     }
     if let Some(s) = val.strip_suffix('s') {
         return s.trim().parse::<f64>().ok().map(Duration::from_secs_f64);
     }
     if let Some(s) = val.strip_suffix('m') {
-        return s.trim().parse::<f64>().ok().map(|v| Duration::from_secs_f64(v * 60.0));
+        return s
+            .trim()
+            .parse::<f64>()
+            .ok()
+            .map(|v| Duration::from_secs_f64(v * 60.0));
     }
     None
 }

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -18,6 +18,91 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use std::sync::LazyLock;
 use std::time::Duration;
+
+/// Structured error from LLM API calls, carrying HTTP status and retry-after info.
+#[derive(Debug)]
+pub struct LlmError {
+    pub status: u16,
+    pub message: String,
+    pub retry_after: Option<Duration>,
+}
+
+impl LlmError {
+    /// Returns true for transient/retryable HTTP status codes.
+    pub fn is_retryable(&self) -> bool {
+        matches!(self.status, 429 | 500 | 502 | 503 | 529)
+    }
+
+    /// Returns true for authentication/authorization errors (missing API key, etc).
+    pub fn is_auth_error(&self) -> bool {
+        matches!(self.status, 401 | 403)
+    }
+}
+
+impl std::fmt::Display for LlmError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} (status: {})", self.message, self.status)
+    }
+}
+
+impl std::error::Error for LlmError {}
+
+/// Parse retry/cooldown duration from HTTP response headers.
+///
+/// Checks `Retry-After` (seconds or HTTP-date), `x-ratelimit-reset-requests`,
+/// and `x-ratelimit-reset-tokens`, returning the maximum duration found.
+pub fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    let mut max_duration: Option<Duration> = None;
+
+    let mut consider = |d: Duration| {
+        max_duration = Some(match max_duration {
+            Some(current) => current.max(d),
+            None => d,
+        });
+    };
+
+    // Standard Retry-After header (seconds integer or HTTP-date)
+    if let Some(val) = headers.get("retry-after").and_then(|v| v.to_str().ok()) {
+        if let Ok(secs) = val.parse::<u64>() {
+            consider(Duration::from_secs(secs));
+        } else if let Ok(secs) = val.parse::<f64>() {
+            consider(Duration::from_secs_f64(secs));
+        }
+        // HTTP-date parsing omitted for simplicity; integer seconds covers most providers
+    }
+
+    // OpenAI-style rate limit reset headers (values in seconds or duration strings like "1s", "2m")
+    for header_name in [
+        "x-ratelimit-reset-requests",
+        "x-ratelimit-reset-tokens",
+    ] {
+        if let Some(val) = headers.get(header_name).and_then(|v| v.to_str().ok()) {
+            if let Some(d) = parse_duration_value(val) {
+                consider(d);
+            }
+        }
+    }
+
+    max_duration
+}
+
+/// Parse a duration value that may be seconds (integer/float) or a simple duration string like "1s", "2m", "500ms".
+fn parse_duration_value(val: &str) -> Option<Duration> {
+    let val = val.trim();
+    if let Ok(secs) = val.parse::<f64>() {
+        return Some(Duration::from_secs_f64(secs));
+    }
+    if let Some(s) = val.strip_suffix("ms") {
+        return s.trim().parse::<f64>().ok().map(Duration::from_secs_f64).map(|d| d / 1000);
+    }
+    if let Some(s) = val.strip_suffix('s') {
+        return s.trim().parse::<f64>().ok().map(Duration::from_secs_f64);
+    }
+    if let Some(s) = val.strip_suffix('m') {
+        return s.trim().parse::<f64>().ok().map(|v| Duration::from_secs_f64(v * 60.0));
+    }
+    None
+}
 use tokio::sync::mpsc::unbounded_channel;
 
 const MODELS_YAML: &str = include_str!("../../models.yaml");
@@ -693,46 +778,58 @@ pub async fn noop_rerank(_builder: RequestBuilder, _model: &Model) -> Result<Rer
     bail!("The client doesn't support rerank api")
 }
 
-pub fn catch_error(data: &Value, status: u16) -> Result<()> {
+pub fn catch_error(data: &Value, status: u16, retry_after: Option<Duration>) -> Result<()> {
     if (200..300).contains(&status) {
         return Ok(());
     }
     debug!("Invalid response, status: {status}, data: {data}");
-    if let Some(error) = data["error"].as_object() {
+    let message = if let Some(error) = data["error"].as_object() {
         if let (Some(typ), Some(message)) = (
             json_str_from_map(error, "type"),
             json_str_from_map(error, "message"),
         ) {
-            bail!("{message} (type: {typ})");
+            format!("{message} (type: {typ})")
         } else if let (Some(typ), Some(message)) = (
             json_str_from_map(error, "code"),
             json_str_from_map(error, "message"),
         ) {
-            bail!("{message} (code: {typ})");
+            format!("{message} (code: {typ})")
+        } else {
+            format!("Invalid response data: {data} (status: {status})")
         }
     } else if let Some(error) = data["errors"][0].as_object() {
         if let (Some(code), Some(message)) = (
             error.get("code").and_then(|v| v.as_u64()),
             json_str_from_map(error, "message"),
         ) {
-            bail!("{message} (status: {code})")
+            format!("{message} (status: {code})")
+        } else {
+            format!("Invalid response data: {data} (status: {status})")
         }
     } else if let Some(error) = data[0]["error"].as_object() {
-        if let (Some(status), Some(message)) = (
+        if let (Some(err_status), Some(message)) = (
             json_str_from_map(error, "status"),
             json_str_from_map(error, "message"),
         ) {
-            bail!("{message} (status: {status})")
+            format!("{message} (status: {err_status})")
+        } else {
+            format!("Invalid response data: {data} (status: {status})")
         }
-    } else if let (Some(detail), Some(status)) = (data["detail"].as_str(), data["status"].as_i64())
-    {
-        bail!("{detail} (status: {status})");
+    } else if let (Some(detail), Some(code)) = (data["detail"].as_str(), data["status"].as_i64()) {
+        format!("{detail} (status: {code})")
     } else if let Some(error) = data["error"].as_str() {
-        bail!("{error}");
+        error.to_string()
     } else if let Some(message) = data["message"].as_str() {
-        bail!("{message}");
+        message.to_string()
+    } else {
+        format!("Invalid response data: {data} (status: {status})")
+    };
+    Err(LlmError {
+        status,
+        message,
+        retry_after,
     }
-    bail!("Invalid response data: {data} (status: {status})");
+    .into())
 }
 
 pub fn json_str_from_map<'a>(

--- a/src/client/gemini.rs
+++ b/src/client/gemini.rs
@@ -125,7 +125,7 @@ async fn embeddings(builder: RequestBuilder, _model: &Model) -> Result<Embedding
     let status = res.status();
     let data: Value = res.json().await?;
     if !status.is_success() {
-        catch_error(&data, status.as_u16())?;
+        catch_error(&data, status.as_u16(), None)?;
     }
     let res_body: EmbeddingsResBody =
         serde_json::from_value(data).context("Invalid embeddings data")?;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -4,6 +4,7 @@ mod message;
 #[macro_use]
 mod macros;
 mod model;
+pub mod retry;
 mod stream;
 
 pub use crate::tool::ToolCall;

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -324,6 +324,9 @@ pub struct ModelData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt_prefix: Option<Vec<String>>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_cooldown_secs: Option<u64>,
+
     // embedding-only properties
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens_per_chunk: Option<usize>,

--- a/src/client/openai.rs
+++ b/src/client/openai.rs
@@ -90,9 +90,10 @@ pub async fn openai_chat_completions(
 ) -> Result<ChatCompletionsOutput> {
     let res = builder.send().await?;
     let status = res.status();
+    let retry_after = parse_retry_after(res.headers());
     let data: Value = res.json().await?;
     if !status.is_success() {
-        catch_error(&data, status.as_u16())?;
+        catch_error(&data, status.as_u16(), retry_after)?;
     }
 
     debug!("non-stream-data: {data}");
@@ -222,7 +223,7 @@ pub async fn openai_embeddings(
     let status = res.status();
     let data: Value = res.json().await?;
     if !status.is_success() {
-        catch_error(&data, status.as_u16())?;
+        catch_error(&data, status.as_u16(), None)?;
     }
     let res_body: EmbeddingsResBody =
         serde_json::from_value(data).context("Invalid embeddings data")?;

--- a/src/client/openai_compatible.rs
+++ b/src/client/openai_compatible.rs
@@ -122,9 +122,10 @@ fn get_api_base_ext(self_: &OpenAICompatibleClient) -> Result<String> {
 pub async fn generic_rerank(builder: RequestBuilder, _model: &Model) -> Result<RerankOutput> {
     let res = builder.send().await?;
     let status = res.status();
+    let retry_after = parse_retry_after(res.headers());
     let mut data: Value = res.json().await?;
     if !status.is_success() {
-        catch_error(&data, status.as_u16())?;
+        catch_error(&data, status.as_u16(), retry_after)?;
     }
     if data.get("results").is_none() && data.get("data").is_some() {
         if let Some(data_obj) = data.as_object_mut() {

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -26,7 +26,7 @@ impl ModelCooldownMap {
     pub fn is_on_cooldown(&self, model_id: &str) -> bool {
         self.cooldowns
             .get(model_id)
-            .map_or(false, |expires| Instant::now() < *expires)
+            .is_some_and(|expires| Instant::now() < *expires)
     }
 
     pub fn set_cooldown(&mut self, model_id: &str, duration: Duration) {
@@ -54,17 +54,19 @@ pub async fn call_with_retry_and_fallback(
     input: &Input,
     config: &GlobalConfig,
     abort_signal: AbortSignal,
-) -> Result<(String, Option<String>, Vec<ToolResult>, CompletionTokenUsage)> {
+) -> Result<(
+    String,
+    Option<String>,
+    Vec<ToolResult>,
+    CompletionTokenUsage,
+)> {
     let agent = input.agent();
     let retry_config = agent.retry_config();
 
     // Build model list: primary model + fallbacks
     let primary_model_id = {
         let cfg = config.read();
-        agent
-            .model_id()
-            .unwrap_or(&cfg.model_id)
-            .to_string()
+        agent.model_id().unwrap_or(&cfg.model_id).to_string()
     };
     let mut model_ids: Vec<String> = vec![primary_model_id];
     model_ids.extend(agent.model_fallbacks().iter().cloned());
@@ -137,7 +139,12 @@ async fn try_model_with_retries(
     client: &dyn Client,
     retry_config: &RetryConfig,
     abort_signal: AbortSignal,
-) -> Result<(String, Option<String>, Vec<ToolResult>, CompletionTokenUsage)> {
+) -> Result<(
+    String,
+    Option<String>,
+    Vec<ToolResult>,
+    CompletionTokenUsage,
+)> {
     let mut last_error: Option<anyhow::Error> = None;
 
     for attempt in 0..retry_config.attempts {
@@ -263,8 +270,10 @@ mod tests {
     fn test_cooldown_map_expired() {
         let mut map = ModelCooldownMap::default();
         // Set cooldown that has already expired (0 duration)
-        map.cooldowns
-            .insert("model-a".to_string(), Instant::now() - Duration::from_secs(1));
+        map.cooldowns.insert(
+            "model-a".to_string(),
+            Instant::now() - Duration::from_secs(1),
+        );
         assert!(!map.is_on_cooldown("model-a"));
     }
 
@@ -282,10 +291,22 @@ mod tests {
             initial_delay_ms: 1000,
             max_delay_ms: 60000,
         };
-        assert_eq!(compute_backoff_delay(&config, 0), Duration::from_millis(1000));
-        assert_eq!(compute_backoff_delay(&config, 1), Duration::from_millis(2000));
-        assert_eq!(compute_backoff_delay(&config, 2), Duration::from_millis(4000));
-        assert_eq!(compute_backoff_delay(&config, 10), Duration::from_millis(60000)); // clamped
+        assert_eq!(
+            compute_backoff_delay(&config, 0),
+            Duration::from_millis(1000)
+        );
+        assert_eq!(
+            compute_backoff_delay(&config, 1),
+            Duration::from_millis(2000)
+        );
+        assert_eq!(
+            compute_backoff_delay(&config, 2),
+            Duration::from_millis(4000)
+        );
+        assert_eq!(
+            compute_backoff_delay(&config, 10),
+            Duration::from_millis(60000)
+        ); // clamped
     }
 
     use crate::client::TestStateGuard;
@@ -296,8 +317,10 @@ mod tests {
     use std::sync::Arc;
 
     fn make_config() -> GlobalConfig {
-        let mut config = Config::default();
-        config.stream = false;
+        let config = Config {
+            stream: false,
+            ..Default::default()
+        };
         Arc::new(RwLock::new(config))
     }
 
@@ -331,8 +354,7 @@ mod tests {
             initial_delay_ms: 10,
             max_delay_ms: 100,
         };
-        let result =
-            try_model_with_retries(&input, client.as_ref(), &retry_config, abort).await;
+        let result = try_model_with_retries(&input, client.as_ref(), &retry_config, abort).await;
         assert!(
             result.is_ok(),
             "Expected success after retries, got: {:?}",
@@ -350,11 +372,7 @@ mod tests {
             retry_after: None,
         }
         .into();
-        let mock = Arc::new(
-            MockClient::builder()
-                .error_on_stream(auth_err)
-                .build(),
-        );
+        let mock = Arc::new(MockClient::builder().error_on_stream(auth_err).build());
         let _guard = TestStateGuard::new(Some(mock)).await;
 
         let config = make_config();
@@ -367,8 +385,7 @@ mod tests {
             initial_delay_ms: 10,
             max_delay_ms: 100,
         };
-        let result =
-            try_model_with_retries(&input, client.as_ref(), &retry_config, abort).await;
+        let result = try_model_with_retries(&input, client.as_ref(), &retry_config, abort).await;
         assert!(result.is_err());
 
         let err = result.unwrap_err();
@@ -381,9 +398,30 @@ mod tests {
     async fn test_all_retries_exhausted_returns_error() {
         let mock = Arc::new(
             MockClient::builder()
-                .error_on_stream(LlmError { status: 500, message: "err".into(), retry_after: None }.into())
-                .error_on_stream(LlmError { status: 500, message: "err".into(), retry_after: None }.into())
-                .error_on_stream(LlmError { status: 500, message: "err".into(), retry_after: None }.into())
+                .error_on_stream(
+                    LlmError {
+                        status: 500,
+                        message: "err".into(),
+                        retry_after: None,
+                    }
+                    .into(),
+                )
+                .error_on_stream(
+                    LlmError {
+                        status: 500,
+                        message: "err".into(),
+                        retry_after: None,
+                    }
+                    .into(),
+                )
+                .error_on_stream(
+                    LlmError {
+                        status: 500,
+                        message: "err".into(),
+                        retry_after: None,
+                    }
+                    .into(),
+                )
                 .build(),
         );
         let _guard = TestStateGuard::new(Some(mock)).await;
@@ -398,9 +436,11 @@ mod tests {
             initial_delay_ms: 10,
             max_delay_ms: 100,
         };
-        let result =
-            try_model_with_retries(&input, client.as_ref(), &retry_config, abort).await;
-        assert!(result.is_err(), "Expected error after all retries exhausted");
+        let result = try_model_with_retries(&input, client.as_ref(), &retry_config, abort).await;
+        assert!(
+            result.is_err(),
+            "Expected error after all retries exhausted"
+        );
 
         let err = result.unwrap_err();
         let llm_err = find_llm_error(&err);
@@ -433,8 +473,7 @@ mod tests {
             initial_delay_ms: 10,
             max_delay_ms: 100,
         };
-        let result =
-            try_model_with_retries(&input, client.as_ref(), &retry_config, abort).await;
+        let result = try_model_with_retries(&input, client.as_ref(), &retry_config, abort).await;
         assert!(result.is_err());
 
         let err = result.unwrap_err();

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::config::{GlobalConfig, Input, RetryConfig};
 use crate::tool::ToolResult;
-use crate::utils::AbortSignal;
+use crate::utils::{wait_abort_signal, AbortSignal};
 
 use anyhow::Result;
 use std::collections::HashMap;
@@ -75,7 +75,12 @@ pub async fn call_with_retry_and_fallback(
 
     for model_id in &model_ids {
         // Skip models on cooldown
-        if config.read().model_cooldowns.is_on_cooldown(model_id) {
+        if config
+            .read()
+            .model_cooldowns
+            .lock()
+            .is_on_cooldown(model_id)
+        {
             debug!("Skipping model '{}' (on cooldown)", model_id);
             continue;
         }
@@ -89,8 +94,9 @@ pub async fn call_with_retry_and_fallback(
                     model_id, err
                 );
                 config
-                    .write()
+                    .read()
                     .model_cooldowns
+                    .lock()
                     .set_infinite_cooldown(model_id);
                 last_error = Some(err);
                 continue;
@@ -102,16 +108,17 @@ pub async fn call_with_retry_and_fallback(
         {
             Ok(result) => return Ok(result),
             Err(err) => {
-                let cooldown = compute_cooldown(&err, config, model_id);
-                config
-                    .write()
-                    .model_cooldowns
-                    .set_cooldown(model_id, cooldown);
-
                 if is_non_retryable_non_auth(&err) {
-                    // Non-retryable errors (400, 404) should not try fallbacks
+                    // Non-retryable errors (400, 404) should not sideline the model
                     return Err(err);
                 }
+
+                let cooldown = compute_cooldown(&err, config, model_id);
+                config
+                    .read()
+                    .model_cooldowns
+                    .lock()
+                    .set_cooldown(model_id, cooldown);
 
                 warn!(
                     "Model '{}' exhausted retries, cooldown {}s. Trying next fallback.",
@@ -146,8 +153,10 @@ async fn try_model_with_retries(
     CompletionTokenUsage,
 )> {
     let mut last_error: Option<anyhow::Error> = None;
+    // Ensure at least one attempt even if configured as 0
+    let attempts = retry_config.attempts.max(1);
 
-    for attempt in 0..retry_config.attempts {
+    for attempt in 0..attempts {
         let result = if input.stream() {
             call_chat_completions_streaming(input, client, abort_signal.clone()).await
         } else {
@@ -168,29 +177,39 @@ async fn try_model_with_retries(
                         return Err(err);
                     }
                     // Retryable error
-                    if attempt + 1 < retry_config.attempts {
+                    if attempt + 1 < attempts {
                         let delay = compute_backoff_delay(retry_config, attempt);
                         warn!(
                             "Retryable error (status {}), attempt {}/{}. Retrying in {}ms...",
                             llm_err.status,
                             attempt + 1,
-                            retry_config.attempts,
+                            attempts,
                             delay.as_millis()
                         );
-                        tokio::time::sleep(delay).await;
+                        tokio::select! {
+                            () = tokio::time::sleep(delay) => {}
+                            () = wait_abort_signal(&abort_signal) => {
+                                return Err(err);
+                            }
+                        }
                     }
                 } else {
                     // Non-LlmError (network timeout, DNS, etc): treat as retryable
-                    if attempt + 1 < retry_config.attempts {
+                    if attempt + 1 < attempts {
                         let delay = compute_backoff_delay(retry_config, attempt);
                         warn!(
                             "Network error, attempt {}/{}. Retrying in {}ms: {}",
                             attempt + 1,
-                            retry_config.attempts,
+                            attempts,
                             delay.as_millis(),
                             err
                         );
-                        tokio::time::sleep(delay).await;
+                        tokio::select! {
+                            () = tokio::time::sleep(delay) => {}
+                            () = wait_abort_signal(&abort_signal) => {
+                                return Err(err);
+                            }
+                        }
                     }
                 }
                 last_error = Some(err);

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -1,0 +1,483 @@
+use super::{
+    call_chat_completions, call_chat_completions_streaming, init_client, Client, LlmError, Model,
+    ModelType,
+};
+use crate::config::{GlobalConfig, Input, RetryConfig};
+use crate::tool::ToolResult;
+use crate::utils::AbortSignal;
+
+use anyhow::Result;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+
+const DEFAULT_COOLDOWN_SECS: u64 = 60;
+
+/// A far-future instant used as "infinite" cooldown (~100 years from process start).
+static INFINITE_INSTANT: LazyLock<Instant> =
+    LazyLock::new(|| Instant::now() + Duration::from_secs(100 * 365 * 24 * 3600));
+
+#[derive(Debug, Clone, Default)]
+pub struct ModelCooldownMap {
+    cooldowns: HashMap<String, Instant>,
+}
+
+impl ModelCooldownMap {
+    pub fn is_on_cooldown(&self, model_id: &str) -> bool {
+        self.cooldowns
+            .get(model_id)
+            .map_or(false, |expires| Instant::now() < *expires)
+    }
+
+    pub fn set_cooldown(&mut self, model_id: &str, duration: Duration) {
+        let expires = Instant::now()
+            .checked_add(duration)
+            .unwrap_or(*INFINITE_INSTANT);
+        self.cooldowns.insert(model_id.to_string(), expires);
+    }
+
+    pub fn set_infinite_cooldown(&mut self, model_id: &str) {
+        self.cooldowns
+            .insert(model_id.to_string(), *INFINITE_INSTANT);
+    }
+}
+
+/// Token usage from a completion call.
+pub use super::CompletionTokenUsage;
+
+/// Attempt an LLM call with retry (exponential backoff) and model fallback.
+///
+/// Iterates through the primary model and any fallbacks configured on the agent.
+/// For each model, retries up to `retry_config.attempts` times on retryable errors.
+/// On exhaustion or auth errors, sets a cooldown on the model and moves to the next.
+pub async fn call_with_retry_and_fallback(
+    input: &Input,
+    config: &GlobalConfig,
+    abort_signal: AbortSignal,
+) -> Result<(String, Option<String>, Vec<ToolResult>, CompletionTokenUsage)> {
+    let agent = input.agent();
+    let retry_config = agent.retry_config();
+
+    // Build model list: primary model + fallbacks
+    let primary_model_id = {
+        let cfg = config.read();
+        agent
+            .model_id()
+            .unwrap_or(&cfg.model_id)
+            .to_string()
+    };
+    let mut model_ids: Vec<String> = vec![primary_model_id];
+    model_ids.extend(agent.model_fallbacks().iter().cloned());
+
+    let mut last_error: Option<anyhow::Error> = None;
+
+    for model_id in &model_ids {
+        // Skip models on cooldown
+        if config.read().model_cooldowns.is_on_cooldown(model_id) {
+            debug!("Skipping model '{}' (on cooldown)", model_id);
+            continue;
+        }
+
+        // Resolve model and create client
+        let client = match resolve_client(config, model_id) {
+            Ok(client) => client,
+            Err(err) => {
+                warn!(
+                    "Failed to initialize client for model '{}': {}. Setting infinite cooldown.",
+                    model_id, err
+                );
+                config
+                    .write()
+                    .model_cooldowns
+                    .set_infinite_cooldown(model_id);
+                last_error = Some(err);
+                continue;
+            }
+        };
+
+        match try_model_with_retries(input, client.as_ref(), &retry_config, abort_signal.clone())
+            .await
+        {
+            Ok(result) => return Ok(result),
+            Err(err) => {
+                let cooldown = compute_cooldown(&err, config, model_id);
+                config
+                    .write()
+                    .model_cooldowns
+                    .set_cooldown(model_id, cooldown);
+
+                if is_non_retryable_non_auth(&err) {
+                    // Non-retryable errors (400, 404) should not try fallbacks
+                    return Err(err);
+                }
+
+                warn!(
+                    "Model '{}' exhausted retries, cooldown {}s. Trying next fallback.",
+                    model_id,
+                    cooldown.as_secs()
+                );
+                last_error = Some(err);
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| anyhow::anyhow!("All models are on cooldown")))
+}
+
+fn resolve_client(config: &GlobalConfig, model_id: &str) -> Result<Box<dyn Client>> {
+    let model = {
+        let cfg = config.read();
+        Model::retrieve_model(&cfg, model_id, ModelType::Chat)?
+    };
+    init_client(config, Some(model))
+}
+
+async fn try_model_with_retries(
+    input: &Input,
+    client: &dyn Client,
+    retry_config: &RetryConfig,
+    abort_signal: AbortSignal,
+) -> Result<(String, Option<String>, Vec<ToolResult>, CompletionTokenUsage)> {
+    let mut last_error: Option<anyhow::Error> = None;
+
+    for attempt in 0..retry_config.attempts {
+        let result = if input.stream() {
+            call_chat_completions_streaming(input, client, abort_signal.clone()).await
+        } else {
+            call_chat_completions(input, true, false, client, abort_signal.clone()).await
+        };
+
+        match result {
+            Ok(result) => return Ok(result),
+            Err(err) => {
+                // Check if this is a retryable error
+                if let Some(llm_err) = find_llm_error(&err) {
+                    if llm_err.is_auth_error() {
+                        // Auth errors: don't retry, let caller set infinite cooldown
+                        return Err(err);
+                    }
+                    if !llm_err.is_retryable() {
+                        // Non-retryable (400, 404, etc): fail immediately
+                        return Err(err);
+                    }
+                    // Retryable error
+                    if attempt + 1 < retry_config.attempts {
+                        let delay = compute_backoff_delay(retry_config, attempt);
+                        warn!(
+                            "Retryable error (status {}), attempt {}/{}. Retrying in {}ms...",
+                            llm_err.status,
+                            attempt + 1,
+                            retry_config.attempts,
+                            delay.as_millis()
+                        );
+                        tokio::time::sleep(delay).await;
+                    }
+                } else {
+                    // Non-LlmError (network timeout, DNS, etc): treat as retryable
+                    if attempt + 1 < retry_config.attempts {
+                        let delay = compute_backoff_delay(retry_config, attempt);
+                        warn!(
+                            "Network error, attempt {}/{}. Retrying in {}ms: {}",
+                            attempt + 1,
+                            retry_config.attempts,
+                            delay.as_millis(),
+                            err
+                        );
+                        tokio::time::sleep(delay).await;
+                    }
+                }
+                last_error = Some(err);
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| anyhow::anyhow!("All retry attempts failed")))
+}
+
+fn compute_backoff_delay(config: &RetryConfig, attempt: u32) -> Duration {
+    let base = Duration::from_millis(config.initial_delay_ms);
+    let max = Duration::from_millis(config.max_delay_ms);
+    let delay = base.saturating_mul(2u32.saturating_pow(attempt));
+    delay.min(max)
+}
+
+fn compute_cooldown(err: &anyhow::Error, config: &GlobalConfig, model_id: &str) -> Duration {
+    // Check for LlmError with retry_after from 429 headers
+    if let Some(llm_err) = find_llm_error(err) {
+        if llm_err.is_auth_error() {
+            return Duration::from_secs(100 * 365 * 24 * 3600); // effectively infinite
+        }
+        if let Some(retry_after) = llm_err.retry_after {
+            return retry_after;
+        }
+    }
+
+    // Check model-specific error_cooldown_secs config
+    let cfg = config.read();
+    if let Ok(model) = Model::retrieve_model(&cfg, model_id, ModelType::Chat) {
+        if let Some(cooldown_secs) = model.data().error_cooldown_secs {
+            return Duration::from_secs(cooldown_secs);
+        }
+    }
+
+    Duration::from_secs(DEFAULT_COOLDOWN_SECS)
+}
+
+/// Search the anyhow error chain for an LlmError.
+/// The Client trait wraps errors with `.with_context()`, so the LlmError
+/// may be a root cause rather than the top-level error.
+fn find_llm_error(err: &anyhow::Error) -> Option<&LlmError> {
+    for cause in err.chain() {
+        if let Some(llm_err) = cause.downcast_ref::<LlmError>() {
+            return Some(llm_err);
+        }
+    }
+    None
+}
+
+/// Returns true if the error is non-retryable AND not an auth error.
+/// These errors (400, 404) should not trigger fallback to next model.
+fn is_non_retryable_non_auth(err: &anyhow::Error) -> bool {
+    if let Some(llm_err) = find_llm_error(err) {
+        !llm_err.is_retryable() && !llm_err.is_auth_error()
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cooldown_map_basic() {
+        let mut map = ModelCooldownMap::default();
+        assert!(!map.is_on_cooldown("model-a"));
+
+        map.set_cooldown("model-a", Duration::from_secs(60));
+        assert!(map.is_on_cooldown("model-a"));
+        assert!(!map.is_on_cooldown("model-b"));
+    }
+
+    #[test]
+    fn test_cooldown_map_expired() {
+        let mut map = ModelCooldownMap::default();
+        // Set cooldown that has already expired (0 duration)
+        map.cooldowns
+            .insert("model-a".to_string(), Instant::now() - Duration::from_secs(1));
+        assert!(!map.is_on_cooldown("model-a"));
+    }
+
+    #[test]
+    fn test_infinite_cooldown() {
+        let mut map = ModelCooldownMap::default();
+        map.set_infinite_cooldown("model-a");
+        assert!(map.is_on_cooldown("model-a"));
+    }
+
+    #[test]
+    fn test_backoff_delay() {
+        let config = RetryConfig {
+            attempts: 3,
+            initial_delay_ms: 1000,
+            max_delay_ms: 60000,
+        };
+        assert_eq!(compute_backoff_delay(&config, 0), Duration::from_millis(1000));
+        assert_eq!(compute_backoff_delay(&config, 1), Duration::from_millis(2000));
+        assert_eq!(compute_backoff_delay(&config, 2), Duration::from_millis(4000));
+        assert_eq!(compute_backoff_delay(&config, 10), Duration::from_millis(60000)); // clamped
+    }
+
+    use crate::client::TestStateGuard;
+    use crate::config::Config;
+    use crate::test_utils::{MockClient, MockTurnBuilder};
+    use crate::utils::create_abort_signal;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn make_config() -> GlobalConfig {
+        let mut config = Config::default();
+        config.stream = false;
+        Arc::new(RwLock::new(config))
+    }
+
+    fn make_input(config: &GlobalConfig) -> Input {
+        Input::from_str(config, "hello", None)
+    }
+
+    #[tokio::test]
+    async fn test_retry_on_rate_limit_then_success() {
+        let rate_limit_err: anyhow::Error = LlmError {
+            status: 429,
+            message: "Rate limit exceeded".to_string(),
+            retry_after: None,
+        }
+        .into();
+        let mock = Arc::new(
+            MockClient::builder()
+                .error_on_stream(rate_limit_err)
+                .add_turn(MockTurnBuilder::new().add_text_chunk("Hello back!").build())
+                .build(),
+        );
+        let _guard = TestStateGuard::new(Some(mock)).await;
+
+        let config = make_config();
+        let input = make_input(&config);
+        let abort = create_abort_signal();
+
+        let client = input.create_client().unwrap();
+        let retry_config = RetryConfig {
+            attempts: 3,
+            initial_delay_ms: 10,
+            max_delay_ms: 100,
+        };
+        let result =
+            try_model_with_retries(&input, client.as_ref(), &retry_config, abort).await;
+        assert!(
+            result.is_ok(),
+            "Expected success after retries, got: {:?}",
+            result.err()
+        );
+        let (output, _, _, _) = result.unwrap();
+        assert_eq!(output, "Hello back!");
+    }
+
+    #[tokio::test]
+    async fn test_auth_error_no_retry() {
+        let auth_err: anyhow::Error = LlmError {
+            status: 401,
+            message: "Invalid API key".to_string(),
+            retry_after: None,
+        }
+        .into();
+        let mock = Arc::new(
+            MockClient::builder()
+                .error_on_stream(auth_err)
+                .build(),
+        );
+        let _guard = TestStateGuard::new(Some(mock)).await;
+
+        let config = make_config();
+        let input = make_input(&config);
+        let abort = create_abort_signal();
+
+        let client = input.create_client().unwrap();
+        let retry_config = RetryConfig {
+            attempts: 3,
+            initial_delay_ms: 10,
+            max_delay_ms: 100,
+        };
+        let result =
+            try_model_with_retries(&input, client.as_ref(), &retry_config, abort).await;
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        let llm_err = find_llm_error(&err).unwrap();
+        assert!(llm_err.is_auth_error());
+        assert_eq!(llm_err.status, 401);
+    }
+
+    #[tokio::test]
+    async fn test_all_retries_exhausted_returns_error() {
+        let mock = Arc::new(
+            MockClient::builder()
+                .error_on_stream(LlmError { status: 500, message: "err".into(), retry_after: None }.into())
+                .error_on_stream(LlmError { status: 500, message: "err".into(), retry_after: None }.into())
+                .error_on_stream(LlmError { status: 500, message: "err".into(), retry_after: None }.into())
+                .build(),
+        );
+        let _guard = TestStateGuard::new(Some(mock)).await;
+
+        let config = make_config();
+        let input = make_input(&config);
+        let abort = create_abort_signal();
+
+        let client = input.create_client().unwrap();
+        let retry_config = RetryConfig {
+            attempts: 3,
+            initial_delay_ms: 10,
+            max_delay_ms: 100,
+        };
+        let result =
+            try_model_with_retries(&input, client.as_ref(), &retry_config, abort).await;
+        assert!(result.is_err(), "Expected error after all retries exhausted");
+
+        let err = result.unwrap_err();
+        let llm_err = find_llm_error(&err);
+        assert!(llm_err.is_some(), "Expected LlmError, got: {}", err);
+        assert_eq!(llm_err.unwrap().status, 500);
+    }
+
+    #[tokio::test]
+    async fn test_non_retryable_error_fails_immediately() {
+        let bad_request_err: anyhow::Error = LlmError {
+            status: 400,
+            message: "Invalid request".to_string(),
+            retry_after: None,
+        }
+        .into();
+        let mock = Arc::new(
+            MockClient::builder()
+                .error_on_stream(bad_request_err)
+                .build(),
+        );
+        let _guard = TestStateGuard::new(Some(mock)).await;
+
+        let config = make_config();
+        let input = make_input(&config);
+        let abort = create_abort_signal();
+
+        let client = input.create_client().unwrap();
+        let retry_config = RetryConfig {
+            attempts: 3,
+            initial_delay_ms: 10,
+            max_delay_ms: 100,
+        };
+        let result =
+            try_model_with_retries(&input, client.as_ref(), &retry_config, abort).await;
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        let llm_err = find_llm_error(&err).unwrap();
+        assert_eq!(llm_err.status, 400);
+    }
+
+    #[test]
+    fn test_compute_cooldown_with_retry_after() {
+        let err: anyhow::Error = LlmError {
+            status: 429,
+            message: "Rate limited".to_string(),
+            retry_after: Some(Duration::from_secs(30)),
+        }
+        .into();
+        let config = make_config();
+        let cooldown = compute_cooldown(&err, &config, "some-model");
+        assert_eq!(cooldown, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_compute_cooldown_auth_error() {
+        let err: anyhow::Error = LlmError {
+            status: 401,
+            message: "Unauthorized".to_string(),
+            retry_after: None,
+        }
+        .into();
+        let config = make_config();
+        let cooldown = compute_cooldown(&err, &config, "some-model");
+        assert!(cooldown > Duration::from_secs(365 * 24 * 3600));
+    }
+
+    #[test]
+    fn test_compute_cooldown_default() {
+        let err: anyhow::Error = LlmError {
+            status: 500,
+            message: "Server error".to_string(),
+            retry_after: None,
+        }
+        .into();
+        let config = make_config();
+        let cooldown = compute_cooldown(&err, &config, "unknown-model");
+        assert_eq!(cooldown, Duration::from_secs(DEFAULT_COOLDOWN_SECS));
+    }
+}

--- a/src/client/stream.rs
+++ b/src/client/stream.rs
@@ -1,4 +1,4 @@
-use super::{catch_error, CompletionTokenUsage, ToolCall};
+use super::{catch_error, parse_retry_after, CompletionTokenUsage, ToolCall};
 use crate::utils::AbortSignal;
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -183,6 +183,7 @@ where
                 match err {
                     EventSourceError::StreamEnded => {}
                     EventSourceError::InvalidStatusCode(status, res) => {
+                        let retry_after = parse_retry_after(res.headers());
                         let text = res.text().await?;
                         let data: Value = match text.parse() {
                             Ok(data) => data,
@@ -193,7 +194,7 @@ where
                                 );
                             }
                         };
-                        catch_error(&data, status.as_u16())?;
+                        catch_error(&data, status.as_u16(), retry_after)?;
                     }
                     EventSourceError::InvalidContentType(header_value, res) => {
                         let text = res.text().await?;

--- a/src/client/vertexai.rs
+++ b/src/client/vertexai.rs
@@ -188,9 +188,10 @@ pub async fn gemini_chat_completions(
 ) -> Result<ChatCompletionsOutput> {
     let res = builder.send().await?;
     let status = res.status();
+    let retry_after = parse_retry_after(res.headers());
     let data: Value = res.json().await?;
     if !status.is_success() {
-        catch_error(&data, status.as_u16())?;
+        catch_error(&data, status.as_u16(), retry_after)?;
     }
     debug!("non-stream-data: {data}");
     gemini_extract_chat_completions_text(&data)
@@ -204,8 +205,9 @@ pub async fn gemini_chat_completions_streaming(
     let res = builder.send().await?;
     let status = res.status();
     if !status.is_success() {
+        let retry_after = parse_retry_after(res.headers());
         let data: Value = res.json().await?;
-        catch_error(&data, status.as_u16())?;
+        catch_error(&data, status.as_u16(), retry_after)?;
     } else {
         let handle = |value: &str| -> Result<()> {
             let data: Value = serde_json::from_str(value)?;
@@ -259,7 +261,7 @@ async fn embeddings(builder: RequestBuilder, _model: &Model) -> Result<Embedding
     let status = res.status();
     let data: Value = res.json().await?;
     if !status.is_success() {
-        catch_error(&data, status.as_u16())?;
+        catch_error(&data, status.as_u16(), None)?;
     }
     let res_body: EmbeddingsResBody =
         serde_json::from_value(data).context("Invalid embeddings data")?;

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -143,6 +143,8 @@ impl Agent {
         Self {
             name: name.to_string(),
             model_id: frontmatter.model_id,
+            model_fallbacks: frontmatter.model_fallbacks,
+            retry: frontmatter.retry,
             temperature: frontmatter.temperature,
             top_p: frontmatter.top_p,
             use_tools: frontmatter.use_tools,
@@ -599,6 +601,10 @@ struct AgentFrontMatter {
         skip_serializing_if = "Option::is_none"
     )]
     model_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    model_fallbacks: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    retry: Option<RetryConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -631,6 +637,8 @@ impl AgentFrontMatter {
     fn from_agent(agent: &Agent) -> Self {
         Self {
             model_id: agent.model_id.clone(),
+            model_fallbacks: agent.model_fallbacks.clone(),
+            retry: agent.retry.clone(),
             temperature: agent.temperature,
             top_p: agent.top_p,
             use_tools: agent.use_tools.clone(),
@@ -647,6 +655,8 @@ impl AgentFrontMatter {
 
     fn is_empty(&self) -> bool {
         self.model_id.is_none()
+            && self.model_fallbacks.is_empty()
+            && self.retry.is_none()
             && self.temperature.is_none()
             && self.top_p.is_none()
             && self.use_tools.is_none()

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -17,6 +17,36 @@ use std::{
 
 pub const TEMP_AGENT_NAME: &str = "%%";
 
+fn default_retry_attempts() -> u32 {
+    3
+}
+fn default_initial_delay_ms() -> u64 {
+    1000
+}
+fn default_max_delay_ms() -> u64 {
+    60000
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RetryConfig {
+    #[serde(default = "default_retry_attempts")]
+    pub attempts: u32,
+    #[serde(default = "default_initial_delay_ms")]
+    pub initial_delay_ms: u64,
+    #[serde(default = "default_max_delay_ms")]
+    pub max_delay_ms: u64,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            attempts: default_retry_attempts(),
+            initial_delay_ms: default_initial_delay_ms(),
+            max_delay_ms: default_max_delay_ms(),
+        }
+    }
+}
+
 pub const CREATE_TITLE_AGENT: &str = "%create-title%";
 
 const CREATE_TITLE_PROMPT: &str = r#"Create a concise, 3-6 word title.
@@ -46,6 +76,10 @@ pub struct Agent {
         skip_serializing_if = "Option::is_none"
     )]
     model_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    model_fallbacks: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    retry: Option<RetryConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -378,6 +412,19 @@ impl Agent {
 
     pub fn model_id(&self) -> Option<&str> {
         self.model_id.as_deref()
+    }
+
+    pub fn model_fallbacks(&self) -> &[String] {
+        &self.model_fallbacks
+    }
+
+    pub fn retry_config(&self) -> RetryConfig {
+        self.retry.clone().unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    pub fn set_model_fallbacks(&mut self, fallbacks: Vec<String>) {
+        self.model_fallbacks = fallbacks;
     }
 
     pub fn use_tools(&self) -> Option<Vec<String>> {

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -283,6 +283,11 @@ impl Input {
         &self.agent
     }
 
+    #[cfg(test)]
+    pub fn agent_mut(&mut self) -> &mut Agent {
+        &mut self.agent
+    }
+
     pub fn set_agent(&mut self, agent: Agent) {
         self.with_agent = !agent.name().trim().is_empty();
         self.agent = agent;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -244,7 +244,7 @@ pub struct Config {
     pub hooks: Option<HooksConfig>,
 
     #[serde(skip)]
-    pub model_cooldowns: crate::client::retry::ModelCooldownMap,
+    pub model_cooldowns: std::sync::Arc<parking_lot::Mutex<crate::client::retry::ModelCooldownMap>>,
     #[serde(skip)]
     pub macro_flag: bool,
     #[serde(skip)]
@@ -453,7 +453,7 @@ impl Default for Config {
 
             hooks: None,
 
-            model_cooldowns: Default::default(),
+            model_cooldowns: std::sync::Arc::new(parking_lot::Mutex::new(Default::default())),
             macro_flag: false,
             info_flag: false,
             agent_variables: None,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,7 +2,7 @@ mod agent;
 mod input;
 pub mod session;
 
-pub use self::agent::{complete_agent_variables, list_agents, Agent, AgentVariables};
+pub use self::agent::{complete_agent_variables, list_agents, Agent, AgentVariables, RetryConfig};
 pub use self::agent::{CREATE_TITLE_AGENT, TEMP_AGENT_NAME};
 pub use self::input::Input;
 use self::session::Session;
@@ -244,6 +244,8 @@ pub struct Config {
     pub hooks: Option<HooksConfig>,
 
     #[serde(skip)]
+    pub model_cooldowns: crate::client::retry::ModelCooldownMap,
+    #[serde(skip)]
     pub macro_flag: bool,
     #[serde(skip)]
     pub info_flag: bool,
@@ -378,6 +380,7 @@ impl Clone for Config {
             mcp_servers: self.mcp_servers.clone(),
             acp_servers: self.acp_servers.clone(),
             hooks: self.hooks.clone(),
+            model_cooldowns: self.model_cooldowns.clone(),
             macro_flag: self.macro_flag,
             info_flag: self.info_flag,
             agent_variables: self.agent_variables.clone(),
@@ -450,6 +453,7 @@ impl Default for Config {
 
             hooks: None,
 
+            model_cooldowns: Default::default(),
             macro_flag: false,
             info_flag: false,
             agent_variables: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ pub mod test_utils;
 
 use crate::cli::Cli;
 use crate::client::{
-    call_chat_completions, call_chat_completions_streaming, list_models, ModelType,
+    list_models, retry::call_with_retry_and_fallback, ModelType,
 };
 use crate::config::{
     ensure_parent_exists, list_agents, load_env_file, macro_execute, Config, GlobalConfig, Input,
@@ -447,7 +447,6 @@ async fn start_directive_inner(
     }
     drain_async_results(async_manager, pending_async_context);
     inject_pending_async_context(&mut input, pending_async_context);
-    let client = input.create_client()?;
     config.write().before_chat_completion(&input)?;
     let (hooks, session_id, cwd) = hook_dispatch_context(config);
     let input_text = input.text();
@@ -469,10 +468,8 @@ async fn start_directive_inner(
         HookResultControl::Ask { .. } => {} // Ask is not applicable for UserPromptSubmit
         HookResultControl::Continue => {}
     }
-    let (output, thought, tool_results, usage) = if !input.stream() {
-        match call_chat_completions(&input, true, false, client.as_ref(), abort_signal.clone())
-            .await
-        {
+    let (output, thought, tool_results, usage) =
+        match call_with_retry_and_fallback(&input, config, abort_signal.clone()).await {
             Ok(result) => result,
             Err(err) => {
                 let event = HookEvent::StopFailure {
@@ -497,35 +494,7 @@ async fn start_directive_inner(
                 );
                 return Err(err);
             }
-        }
-    } else {
-        match call_chat_completions_streaming(&input, client.as_ref(), abort_signal.clone()).await {
-            Ok(result) => result,
-            Err(err) => {
-                let event = HookEvent::StopFailure {
-                    error: err.to_string(),
-                    error_type: "api_error".to_string(),
-                };
-                let _ = dispatch_hooks_with_managers(
-                    &event,
-                    &hooks.entries,
-                    &session_id,
-                    &cwd,
-                    Some(async_manager),
-                    Some(persistent_manager),
-                )
-                .await;
-                let _ = config.write().after_chat_completion(
-                    &input,
-                    "",
-                    None,
-                    &[],
-                    &Default::default(),
-                );
-                return Err(err);
-            }
-        }
-    };
+        };
     config.write().after_chat_completion(
         &input,
         &output,

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,9 +23,7 @@ extern crate log;
 pub mod test_utils;
 
 use crate::cli::Cli;
-use crate::client::{
-    list_models, retry::call_with_retry_and_fallback, ModelType,
-};
+use crate::client::{list_models, retry::call_with_retry_and_fallback, ModelType};
 use crate::config::{
     ensure_parent_exists, list_agents, load_env_file, macro_execute, Config, GlobalConfig, Input,
     WorkingMode, TEMP_SESSION_NAME,

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -10,7 +10,7 @@ use self::highlighter::ReplHighlighter;
 use self::prompt::ReplPrompt;
 use std::io::Write;
 
-use crate::client::{call_chat_completions, call_chat_completions_streaming};
+use crate::client::retry::call_with_retry_and_fallback;
 use crate::config::{
     macro_execute, AgentVariables, AssertState, Config, GlobalConfig, Input, LastMessage,
     StateFlags,
@@ -1134,7 +1134,6 @@ async fn ask_inner(
     drain_async_results(async_manager, pending_async_context);
     inject_pending_async_context(&mut input, pending_async_context);
 
-    let client = input.create_client()?;
     config.write().before_chat_completion(&input)?;
     let (hooks, session_id, cwd) = {
         let config = config.read();
@@ -1149,8 +1148,8 @@ async fn ask_inner(
             env::current_dir().unwrap_or_default(),
         )
     };
-    let (output, thought, tool_results, usage) = if input.stream() {
-        match call_chat_completions_streaming(&input, client.as_ref(), abort_signal.clone()).await {
+    let (output, thought, tool_results, usage) =
+        match call_with_retry_and_fallback(&input, &config, abort_signal.clone()).await {
             Ok(result) => result,
             Err(err) => {
                 let event = HookEvent::StopFailure {
@@ -1175,37 +1174,7 @@ async fn ask_inner(
                 );
                 return Err(err);
             }
-        }
-    } else {
-        match call_chat_completions(&input, true, false, client.as_ref(), abort_signal.clone())
-            .await
-        {
-            Ok(result) => result,
-            Err(err) => {
-                let event = HookEvent::StopFailure {
-                    error: err.to_string(),
-                    error_type: "api_error".to_string(),
-                };
-                let _ = dispatch_hooks_with_managers(
-                    &event,
-                    &hooks.entries,
-                    &session_id,
-                    &cwd,
-                    Some(async_manager),
-                    Some(persistent_manager),
-                )
-                .await;
-                let _ = config.write().after_chat_completion(
-                    &input,
-                    "",
-                    None,
-                    &[],
-                    &Default::default(),
-                );
-                return Err(err);
-            }
-        }
-    };
+        };
     config.write().after_chat_completion(
         &input,
         &output,

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1149,7 +1149,7 @@ async fn ask_inner(
         )
     };
     let (output, thought, tool_results, usage) =
-        match call_with_retry_and_fallback(&input, &config, abort_signal.clone()).await {
+        match call_with_retry_and_fallback(&input, config, abort_signal.clone()).await {
             Ok(result) => result,
             Err(err) => {
                 let event = HookEvent::StopFailure {

--- a/src/test_utils/mock_client.rs
+++ b/src/test_utils/mock_client.rs
@@ -78,9 +78,18 @@ impl MockResponseEvent {
                 output.tool_calls.push(tool_call.clone());
             }
             Self::Error(err) => {
-                // Return the error instead of continuing
-                // We need to convert Arc<Error> back to owned Error
-                // Since Error isn't Clone, we create a new error from the display
+                // Try to downcast to a concrete error type that implements Clone.
+                // For LlmError (the most common test case), reconstruct it to preserve
+                // the error type through the anyhow chain.
+                if let Some(llm_err) = err.downcast_ref::<crate::client::LlmError>() {
+                    return Err(crate::client::LlmError {
+                        status: llm_err.status,
+                        message: llm_err.message.clone(),
+                        retry_after: llm_err.retry_after,
+                    }
+                    .into());
+                }
+                // Fallback: create a new error from the display string
                 let msg = err.to_string();
                 return Err(anyhow::anyhow!("{}", msg));
             }
@@ -125,6 +134,14 @@ impl MockTurn {
                 MockResponseEvent::Text(text) => output.text.push_str(text),
                 MockResponseEvent::ToolCall(tool_call) => output.tool_calls.push(tool_call.clone()),
                 MockResponseEvent::Error(err) => {
+                    if let Some(llm_err) = err.downcast_ref::<crate::client::LlmError>() {
+                        return Err(crate::client::LlmError {
+                            status: llm_err.status,
+                            message: llm_err.message.clone(),
+                            retry_after: llm_err.retry_after,
+                        }
+                        .into());
+                    }
                     return Err(anyhow::anyhow!("{}", err));
                 }
             }

--- a/src/test_utils/mock_client.rs
+++ b/src/test_utils/mock_client.rs
@@ -81,13 +81,17 @@ impl MockResponseEvent {
                 // Try to downcast to a concrete error type that implements Clone.
                 // For LlmError (the most common test case), reconstruct it to preserve
                 // the error type through the anyhow chain.
-                if let Some(llm_err) = err.downcast_ref::<crate::client::LlmError>() {
-                    return Err(crate::client::LlmError {
-                        status: llm_err.status,
-                        message: llm_err.message.clone(),
-                        retry_after: llm_err.retry_after,
+                // Walk the error chain to find LlmError (it may be
+                // wrapped by .with_context() or other anyhow layers).
+                for cause in err.chain() {
+                    if let Some(llm_err) = cause.downcast_ref::<crate::client::LlmError>() {
+                        return Err(crate::client::LlmError {
+                            status: llm_err.status,
+                            message: llm_err.message.clone(),
+                            retry_after: llm_err.retry_after,
+                        }
+                        .into());
                     }
-                    .into());
                 }
                 // Fallback: create a new error from the display string
                 let msg = err.to_string();

--- a/src/test_utils/mock_openai_server.rs
+++ b/src/test_utils/mock_openai_server.rs
@@ -31,6 +31,21 @@ pub struct MockOpenAiTurn {
     pub text_chunks: Vec<String>,
     #[serde(default)]
     pub tool_calls: Vec<MockOpenAiToolCall>,
+    /// If set, return an HTTP error instead of a normal response.
+    #[serde(default)]
+    pub error: Option<MockOpenAiError>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MockOpenAiError {
+    pub status: u16,
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub error_type: String,
+    /// Extra headers to include in the error response (e.g., "Retry-After: 5").
+    #[serde(default)]
+    pub headers: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -64,7 +79,7 @@ impl ServerState {
             .cloned()
             .unwrap_or_else(|| MockOpenAiTurn {
                 text_chunks: vec![self.script.fallback_text.clone()],
-                tool_calls: vec![],
+                ..Default::default()
             })
     }
 
@@ -266,6 +281,38 @@ fn handle_chat_completions(request: Value, state: &ServerState, stream: &mut Tcp
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
     let turn = state.next_turn();
+
+    // Handle error responses
+    if let Some(error) = &turn.error {
+        let body = json!({
+            "error": {
+                "message": error.message,
+                "type": error.error_type,
+            }
+        });
+        let body_str = body.to_string();
+        let status_text = match error.status {
+            401 => "401 Unauthorized",
+            403 => "403 Forbidden",
+            429 => "429 Too Many Requests",
+            500 => "500 Internal Server Error",
+            502 => "502 Bad Gateway",
+            503 => "503 Service Unavailable",
+            _ => "400 Bad Request",
+        };
+        let mut extra_headers = String::new();
+        for (key, value) in &error.headers {
+            extra_headers.push_str(&format!("{key}: {value}\r\n"));
+        }
+        let response = format!(
+            "HTTP/1.1 {status_text}\r\nContent-Type: application/json\r\n{extra_headers}Content-Length: {}\r\nConnection: close\r\n\r\n{body_str}",
+            body_str.len()
+        );
+        let _ = stream.write_all(response.as_bytes());
+        let _ = stream.flush();
+        return;
+    }
+
     let tool_calls: Vec<Value> = turn
         .tool_calls
         .iter()

--- a/src/test_utils/mock_openai_server.rs
+++ b/src/test_utils/mock_openai_server.rs
@@ -292,13 +292,13 @@ fn handle_chat_completions(request: Value, state: &ServerState, stream: &mut Tcp
         });
         let body_str = body.to_string();
         let status_text = match error.status {
-            401 => "401 Unauthorized",
-            403 => "403 Forbidden",
-            429 => "429 Too Many Requests",
-            500 => "500 Internal Server Error",
-            502 => "502 Bad Gateway",
-            503 => "503 Service Unavailable",
-            _ => "400 Bad Request",
+            401 => format!("{} Unauthorized", error.status),
+            403 => format!("{} Forbidden", error.status),
+            429 => format!("{} Too Many Requests", error.status),
+            500 => format!("{} Internal Server Error", error.status),
+            502 => format!("{} Bad Gateway", error.status),
+            503 => format!("{} Service Unavailable", error.status),
+            other => format!("{other} Error"),
         };
         let mut extra_headers = String::new();
         for (key, value) in &error.headers {

--- a/src/test_utils/repro_249_tmux.rs
+++ b/src/test_utils/repro_249_tmux.rs
@@ -207,6 +207,7 @@ fn script() -> MockOpenAiScript {
                     }),
                     id: Some("call_delegate_1".to_string()),
                 }],
+                ..Default::default()
             },
             // Turn 1: sub-agent calls the MCP tool
             MockOpenAiTurn {
@@ -216,20 +217,21 @@ fn script() -> MockOpenAiScript {
                     arguments: json!({}),
                     id: Some("call_mcp_1".to_string()),
                 }],
+                ..Default::default()
             },
             // Turn 2: sub-agent summarizes after getting MCP tool result
             MockOpenAiTurn {
                 text_chunks: vec![format!(
                     "The tool returned: {REPRO_249_MCP_TOOL_RESPONSE}"
                 )],
-                tool_calls: vec![],
+                ..Default::default()
             },
             // Turn 3: parent summarizes after delegation returns
             MockOpenAiTurn {
                 text_chunks: vec![format!(
                     "The child used {REPRO_249_MCP_TOOL_NAME} and got: {REPRO_249_MCP_TOOL_RESPONSE}"
                 )],
-                tool_calls: vec![],
+                ..Default::default()
             },
         ],
         fallback_text: "No more scripted responses.".to_string(),


### PR DESCRIPTION
## Summary

- Adds per-agent model fallback chains (`model_fallbacks` config) and retry with exponential backoff (`retry` config with `attempts`, `initial_delay_ms`, `max_delay_ms`)
- Introduces structured `LlmError` type carrying HTTP status + `Retry-After` header info, replacing opaque `anyhow::bail!()` in `catch_error`
- Adds per-model cooldown tracking: 429 with `Retry-After` headers use the header value; auth errors (401/403) get infinite cooldown; misconfigured models (init failure) get infinite cooldown
- Extracts retry-after duration from `Retry-After`, `x-ratelimit-reset-requests`, and `x-ratelimit-reset-tokens` headers across all client implementations
- Wires `call_with_retry_and_fallback` into REPL and directive call sites

## Config example

```yaml
# Agent config
model: openai:gpt-4o
model_fallbacks:
  - claude:sonnet
  - openai:gpt-4o-mini
retry:
  attempts: 3
  initial_delay_ms: 1000
  max_delay_ms: 60000
```

```yaml
# Model config
error_cooldown_secs: 120
```

## Test plan

- [x] `cargo check` — zero errors, zero warnings
- [x] `cargo test` — 285 tests pass (11 new retry tests)
- [x] Unit tests: cooldown map, backoff computation, cooldown duration
- [x] Integration tests: retry on 429 then success, auth error no retry, all retries exhausted, non-retryable error immediate failure
- [ ] Manual: configure agent with fallbacks and invalid primary API key — verify fallback
- [ ] Manual: verify existing behavior preserved when no fallbacks/retry configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retries with exponential backoff and cross-model fallback
  * Per-model cooldown tracking to avoid repeated requests
  * Honor server rate-limit signals (Retry-After)
  * Configurable retry attempts and backoff in agent settings

* **Bug Fixes / Reliability**
  * Improved error reporting that surfaces optional retry/cooldown timing for rate-limited responses

* **Tests**
  * Added unit tests for cooldowns, backoff, retry and fallback behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->