### PR TITLE
feat(tui): submit pending message after tool round

### DIFF
--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -31,6 +31,10 @@ pub struct Input {
     rag_name: Option<String>,
     with_session: bool,
     with_agent: bool,
+    /// User text injected after tool-call results (pending message consumed
+    /// mid-tool-loop).  Appended as a trailing User message in
+    /// `build_messages()`.
+    injected_user_text: Option<String>,
 }
 
 impl Input {
@@ -51,6 +55,7 @@ impl Input {
             rag_name: None,
             with_session,
             with_agent,
+            injected_user_text: None,
         }
     }
 
@@ -118,6 +123,7 @@ impl Input {
             rag_name: None,
             with_session,
             with_agent,
+            injected_user_text: None,
         })
     }
 
@@ -226,6 +232,14 @@ impl Input {
         self
     }
 
+    pub fn set_injected_user_text(&mut self, text: String) {
+        self.injected_user_text = Some(text);
+    }
+
+    pub fn injected_user_text(&self) -> Option<&str> {
+        self.injected_user_text.as_deref()
+    }
+
     pub fn create_client(&self) -> Result<Box<dyn Client>> {
         init_client(&self.config, Some(self.agent().model().clone()))
     }
@@ -266,6 +280,12 @@ impl Input {
             messages.push(Message::new(
                 MessageRole::Assistant,
                 MessageContent::ToolCalls(tool_calls.clone()),
+            ))
+        }
+        if let Some(text) = &self.injected_user_text {
+            messages.push(Message::new(
+                MessageRole::User,
+                MessageContent::Text(text.clone()),
             ))
         }
         Ok(messages)

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -807,6 +807,17 @@ impl Session {
                 });
                 self.messages.push(tool_msg);
             }
+            if let Some(injected) = input.injected_user_text() {
+                let injected_msg = Message::new(
+                    MessageRole::User,
+                    MessageContent::Text(injected.to_string()),
+                );
+                all_appended &= self.append_event(&SessionLogEntry::Message {
+                    role: injected_msg.role,
+                    content: injected_msg.content.clone(),
+                });
+                self.messages.push(injected_msg);
+            }
             let content = match thought {
                 Some(v) => MessageContent::Text(format!("<think>\n{v}\n</think>\n{output}")),
                 _ => MessageContent::Text(output.to_string()),

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -147,12 +147,7 @@ impl Tui {
                         self.app.pending_message = Some(pending.clone());
                         // Publish to shared state so the prompt task can
                         // pick it up between tool rounds.
-                        {
-                            let shared = self.shared_pending_message.clone();
-                            tokio::spawn(async move {
-                                *shared.lock().await = Some(pending);
-                            });
-                        }
+                        *self.shared_pending_message.lock().await = Some(pending);
                         self.refresh_input_chrome();
                     } else if text.trim_start().starts_with('.') {
                         // Dot-command: route through repl command handler
@@ -183,7 +178,7 @@ impl Tui {
                     self.app.attachments = pending.attachments;
                     self.app.attachment_dir = pending.attachment_dir;
                     self.app.paste_count = pending.paste_count;
-                    self.clear_shared_pending_message();
+                    self.clear_shared_pending_message().await;
                     self.refresh_input_chrome();
                 }
                 self.app.input.input(TextInput {
@@ -197,7 +192,7 @@ impl Tui {
                     self.app.attachments = pending.attachments;
                     self.app.attachment_dir = pending.attachment_dir;
                     self.app.paste_count = pending.paste_count;
-                    self.clear_shared_pending_message();
+                    self.clear_shared_pending_message().await;
                     self.refresh_input_chrome();
                 }
                 // Clear completions on any non-tab key
@@ -407,13 +402,17 @@ impl Tui {
                 self.app.streaming_assistant_idx = None;
                 self.pin_transcript_to_bottom();
             }
-            TuiEvent::PendingMessageConsumed(text) => {
+            TuiEvent::PendingMessageConsumed(pending) => {
                 // The prompt task consumed our pending message during a tool
                 // round.  Clear the local pending state, reset the input field,
-                // and show the consumed text in the transcript.
+                // and show the consumed text (and any attachments) in the
+                // transcript.
                 self.app.pending_message = None;
                 self.app.input = Self::new_input();
-                self.app.transcript.push(TranscriptItem::UserText(text));
+                self.app
+                    .transcript
+                    .push(TranscriptItem::UserText(pending.text.clone()));
+                self.render_submitted_attachments(&pending.attachments);
                 self.pin_transcript_to_bottom();
                 self.refresh_input_chrome();
             }
@@ -461,11 +460,8 @@ impl Tui {
 
     /// Clear the shared pending message so the prompt task does not consume a
     /// stale value after the user cancels or edits the pending draft.
-    fn clear_shared_pending_message(&self) {
-        let shared = self.shared_pending_message.clone();
-        tokio::spawn(async move {
-            *shared.lock().await = None;
-        });
+    async fn clear_shared_pending_message(&self) {
+        *self.shared_pending_message.lock().await = None;
     }
 
     fn render_submitted_attachments(&mut self, attachments: &[crate::tui::types::Attachment]) {

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -133,16 +133,26 @@ impl Tui {
                     // Add to history (fix #4)
                     self.push_history(text.clone());
                     if self.app.llm_busy {
-                        // Queue the message to send when LLM finishes
-                        // Keep the text in input so user can see/edit it
+                        // Queue the message to send when LLM finishes or
+                        // after the next tool round completes.
+                        // Keep the text in input so user can see/edit it.
                         let pending_attachments = self.app.attachments.clone();
                         let pending_attachment_dir = self.app.attachment_dir.clone();
-                        self.app.pending_message = Some(crate::tui::types::PendingMessage {
+                        let pending = crate::tui::types::PendingMessage {
                             text,
                             attachments: pending_attachments,
                             attachment_dir: pending_attachment_dir,
                             paste_count: self.app.paste_count,
-                        });
+                        };
+                        self.app.pending_message = Some(pending.clone());
+                        // Publish to shared state so the prompt task can
+                        // pick it up between tool rounds.
+                        {
+                            let shared = self.shared_pending_message.clone();
+                            tokio::spawn(async move {
+                                *shared.lock().await = Some(pending);
+                            });
+                        }
                         self.refresh_input_chrome();
                     } else if text.trim_start().starts_with('.') {
                         // Dot-command: route through repl command handler
@@ -173,6 +183,7 @@ impl Tui {
                     self.app.attachments = pending.attachments;
                     self.app.attachment_dir = pending.attachment_dir;
                     self.app.paste_count = pending.paste_count;
+                    self.clear_shared_pending_message();
                     self.refresh_input_chrome();
                 }
                 self.app.input.input(TextInput {
@@ -186,6 +197,7 @@ impl Tui {
                     self.app.attachments = pending.attachments;
                     self.app.attachment_dir = pending.attachment_dir;
                     self.app.paste_count = pending.paste_count;
+                    self.clear_shared_pending_message();
                     self.refresh_input_chrome();
                 }
                 // Clear completions on any non-tab key
@@ -395,6 +407,16 @@ impl Tui {
                 self.app.streaming_assistant_idx = None;
                 self.pin_transcript_to_bottom();
             }
+            TuiEvent::PendingMessageConsumed(text) => {
+                // The prompt task consumed our pending message during a tool
+                // round.  Clear the local pending state, reset the input field,
+                // and show the consumed text in the transcript.
+                self.app.pending_message = None;
+                self.app.input = Self::new_input();
+                self.app.transcript.push(TranscriptItem::UserText(text));
+                self.pin_transcript_to_bottom();
+                self.refresh_input_chrome();
+            }
         }
         Ok(())
     }
@@ -435,6 +457,15 @@ impl Tui {
             self.start_prompt(pending).await?;
         }
         Ok(())
+    }
+
+    /// Clear the shared pending message so the prompt task does not consume a
+    /// stale value after the user cancels or edits the pending draft.
+    fn clear_shared_pending_message(&self) {
+        let shared = self.shared_pending_message.clone();
+        tokio::spawn(async move {
+            *shared.lock().await = None;
+        });
     }
 
     fn render_submitted_attachments(&mut self, attachments: &[crate::tui::types::Attachment]) {
@@ -716,24 +747,19 @@ impl Tui {
     ) -> Result<()> {
         self.app.llm_busy = true;
 
-        let config = self.config.clone();
-        let abort_signal = self.abort_signal.clone();
-        let async_manager = self.async_manager.clone();
-        let persistent_manager = self.persistent_manager.clone();
-        let pending_async_context = self.pending_async_context.clone();
         let event_tx = self.event_tx.clone();
+        let ctx = crate::tui::prompt::PromptTaskContext {
+            config: self.config.clone(),
+            abort_signal: self.abort_signal.clone(),
+            async_manager: self.async_manager.clone(),
+            persistent_manager: self.persistent_manager.clone(),
+            pending_async_context: self.pending_async_context.clone(),
+            shared_pending_message: self.shared_pending_message.clone(),
+            event_tx: event_tx.clone(),
+        };
 
         tokio::spawn(async move {
-            let result: Result<()> = Self::run_prompt_task(
-                msg,
-                config,
-                abort_signal,
-                async_manager,
-                persistent_manager,
-                pending_async_context,
-                event_tx.clone(),
-            )
-            .await;
+            let result: Result<()> = Self::run_prompt_task(msg, ctx).await;
             if let Err(err) = result {
                 let _ = event_tx.send(TuiEvent::UiOutput(UiOutputEvent {
                     kind: UiOutputEventKind::LlmError(err.to_string()),

--- a/src/tui/lifecycle.rs
+++ b/src/tui/lifecycle.rs
@@ -5,7 +5,7 @@ use crate::tui::types::{App, TranscriptItem, TuiEvent, SPINNER_FRAMES, TICK_RATE
 
 impl Tui {
     #[cfg(test)]
-    pub(super) fn queue_pending_message(&mut self, text: String) {
+    pub(super) async fn queue_pending_message(&mut self, text: String) {
         let pending = crate::tui::types::PendingMessage {
             text: text.clone(),
             attachments: vec![],
@@ -14,10 +14,7 @@ impl Tui {
         };
         self.app.pending_message = Some(pending.clone());
         // Also publish to the shared state so the prompt task can consume it.
-        let shared = self.shared_pending_message.clone();
-        tokio::spawn(async move {
-            *shared.lock().await = Some(pending);
-        });
+        *self.shared_pending_message.lock().await = Some(pending);
         // Also set the input text so it remains visible (new behavior)
         self.set_input_text(&text);
         self.refresh_input_chrome();

--- a/src/tui/lifecycle.rs
+++ b/src/tui/lifecycle.rs
@@ -6,11 +6,17 @@ use crate::tui::types::{App, TranscriptItem, TuiEvent, SPINNER_FRAMES, TICK_RATE
 impl Tui {
     #[cfg(test)]
     pub(super) fn queue_pending_message(&mut self, text: String) {
-        self.app.pending_message = Some(crate::tui::types::PendingMessage {
+        let pending = crate::tui::types::PendingMessage {
             text: text.clone(),
             attachments: vec![],
             attachment_dir: None,
             paste_count: self.app.paste_count,
+        };
+        self.app.pending_message = Some(pending.clone());
+        // Also publish to the shared state so the prompt task can consume it.
+        let shared = self.shared_pending_message.clone();
+        tokio::spawn(async move {
+            *shared.lock().await = Some(pending);
         });
         // Also set the input text so it remains visible (new behavior)
         self.set_input_text(&text);
@@ -51,6 +57,7 @@ impl Tui {
             async_manager: Arc::new(Mutex::new(async_manager)),
             persistent_manager,
             pending_async_context: Arc::new(Mutex::new(None)),
+            shared_pending_message: Arc::new(Mutex::new(None)),
             app: App {
                 transcript: initial_transcript,
                 input: Self::new_input(),

--- a/src/tui/prompt.rs
+++ b/src/tui/prompt.rs
@@ -173,11 +173,21 @@ impl Tui {
                 // Check if the user queued a message while tools were running.
                 // If so, inject it as a trailing user message so the LLM sees
                 // it right after the tool results.
-                if let Some(pending) = ctx.shared_pending_message.lock().await.take() {
-                    merged_input.set_injected_user_text(pending.text.clone());
-                    let _ = ctx
-                        .event_tx
-                        .send(TuiEvent::PendingMessageConsumed(pending.text));
+                //
+                // Skip dot-commands and messages with attachments — those need
+                // the full submit_pending_message_inner() flow which runs on
+                // the TUI side after LlmFinal.
+                {
+                    let mut guard = ctx.shared_pending_message.lock().await;
+                    if let Some(pending) = guard.as_ref() {
+                        let is_dot_command = pending.text.trim_start().starts_with('.');
+                        let has_attachments = !pending.attachments.is_empty();
+                        if !is_dot_command && !has_attachments {
+                            let pending = guard.take().unwrap();
+                            merged_input.set_injected_user_text(pending.text.clone());
+                            let _ = ctx.event_tx.send(TuiEvent::PendingMessageConsumed(pending));
+                        }
+                    }
                 }
 
                 input = merged_input;

--- a/src/tui/prompt.rs
+++ b/src/tui/prompt.rs
@@ -8,29 +8,25 @@ pub(super) struct PromptTaskContext {
     pub(super) async_manager: Arc<Mutex<AsyncHookManager>>,
     pub(super) persistent_manager: Arc<Mutex<PersistentHookManager>>,
     pub(super) pending_async_context: Arc<Mutex<Option<String>>>,
+    pub(super) shared_pending_message: Arc<Mutex<Option<crate::tui::types::PendingMessage>>>,
     pub(super) event_tx: mpsc::UnboundedSender<TuiEvent>,
 }
 
 impl Tui {
     pub(super) async fn run_prompt_task(
         msg: crate::tui::types::PendingMessage,
-        config: GlobalConfig,
-        abort_signal: AbortSignal,
-        async_manager: Arc<Mutex<AsyncHookManager>>,
-        persistent_manager: Arc<Mutex<PersistentHookManager>>,
-        pending_async_context: Arc<Mutex<Option<String>>>,
-        event_tx: mpsc::UnboundedSender<TuiEvent>,
+        ctx: PromptTaskContext,
     ) -> Result<()> {
         let attachment_dir = msg.attachment_dir.clone();
         let input_res = if msg.attachments.is_empty() {
-            Ok(Input::from_str(&config, &msg.text, None))
+            Ok(Input::from_str(&ctx.config, &msg.text, None))
         } else {
             let paths: Vec<String> = msg
                 .attachments
                 .iter()
                 .map(|a| a.path.to_string_lossy().to_string())
                 .collect();
-            Input::from_files(&config, &msg.text, paths, None).await
+            Input::from_files(&ctx.config, &msg.text, paths, None).await
         };
         if let Some(dir) = attachment_dir {
             let cleanup_dir = dir.clone();
@@ -40,20 +36,7 @@ impl Tui {
             .await;
         }
         let input = input_res?;
-        Self::run_prompt_inner(
-            PromptTaskContext {
-                config,
-                abort_signal,
-                async_manager,
-                persistent_manager,
-                pending_async_context,
-                event_tx,
-            },
-            input,
-            0,
-            true,
-        )
-        .await
+        Self::run_prompt_inner(ctx, input, 0, true).await
     }
 
     async fn run_prompt_inner(
@@ -179,12 +162,24 @@ impl Tui {
             };
 
             if !tool_results.is_empty() {
-                let merged_input = input.merge_tool_results(output, thought, tool_results.clone());
+                let mut merged_input =
+                    input.merge_tool_results(output, thought, tool_results.clone());
                 let _ = ctx.event_tx.send(TuiEvent::ToolRoundComplete);
                 // Defer agent switch to the top of the next iteration so the
                 // TUI has a chance to render the tool-call row before the new
                 // agent's streaming output begins.
                 pending_switch = tool_results.iter().find_map(|v| v.switch_agent.clone());
+
+                // Check if the user queued a message while tools were running.
+                // If so, inject it as a trailing user message so the LLM sees
+                // it right after the tool results.
+                if let Some(pending) = ctx.shared_pending_message.lock().await.take() {
+                    merged_input.set_injected_user_text(pending.text.clone());
+                    let _ = ctx
+                        .event_tx
+                        .send(TuiEvent::PendingMessageConsumed(pending.text));
+                }
+
                 input = merged_input;
                 with_embeddings = pending_switch.is_some();
                 continue;

--- a/src/tui/snapshots/harnx__tui__tests__submitted_message_with_text_attachment.snap
+++ b/src/tui/snapshots/harnx__tui__tests__submitted_message_with_text_attachment.snap
@@ -1,0 +1,21 @@
+---
+source: src/tui/tests.rs
+assertion_line: 1923
+expression: rendered
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to
+complete.
+> check this file
+
+Attachments (1):
+  - notes.txt
+      Line 1 of notes
+      Line 2 of notes
+Got it, thanks!
+
+
+
+
+
+
+• Input

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -201,6 +201,70 @@ async fn pending_dot_command_restores_attachments_before_running() {
 }
 
 #[tokio::test]
+async fn pending_message_consumed_clears_pending_and_shows_in_transcript() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+    tui.app.llm_busy = true;
+    tui.queue_pending_message("interject here".to_string());
+    assert!(tui.app.pending_message.is_some());
+
+    // Simulate the prompt task consuming the pending message during a tool round.
+    tui.handle_tui_event(TuiEvent::PendingMessageConsumed(
+        "interject here".to_string(),
+    ))
+    .await
+    .unwrap();
+
+    // Pending message should be cleared.
+    assert!(tui.app.pending_message.is_none());
+    // Input field should be cleared.
+    assert!(tui.app.input.lines().join("").is_empty());
+    // The consumed text should appear in the transcript as a UserText entry.
+    let has_user_entry =
+        tui.app.transcript.iter().any(
+            |entry| matches!(entry, TranscriptItem::UserText(text) if text == "interject here"),
+        );
+    assert!(has_user_entry);
+}
+
+#[tokio::test]
+async fn pending_message_not_double_submitted_after_consumed() {
+    // When the prompt task consumes a pending message mid-tool-loop,
+    // the subsequent LlmFinal should NOT re-submit it.
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+    tui.app.llm_busy = true;
+    tui.queue_pending_message("once only".to_string());
+
+    // Prompt task consumed it.
+    tui.handle_tui_event(TuiEvent::PendingMessageConsumed("once only".to_string()))
+        .await
+        .unwrap();
+
+    // Now LlmFinal arrives.
+    tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+        kind: UiOutputEventKind::LlmFinal {
+            output: "final answer".to_string(),
+            usage: Default::default(),
+        },
+        source: None,
+    }))
+    .await
+    .unwrap();
+
+    // The user text should appear exactly once in the transcript.
+    let user_text_count = tui
+        .app
+        .transcript
+        .iter()
+        .filter(|entry| matches!(entry, TranscriptItem::UserText(text) if text == "once only"))
+        .count();
+    assert_eq!(user_text_count, 1);
+}
+
+#[tokio::test]
 async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
     let config = test_config();
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1870,6 +1870,64 @@ async fn test_pending_message_busy_state_snapshot() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_submitted_message_with_text_attachment_snapshot() {
+    use std::io::Write;
+
+    // Create a real temp file so render_attachment_preview can read it.
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("notes.txt");
+    {
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        writeln!(f, "Line 1 of notes").unwrap();
+        writeln!(f, "Line 2 of notes").unwrap();
+    }
+
+    let mut harness = TuiTestHarness::with_size(60, 18);
+
+    // Directly push transcript items that submit_pending_message_inner
+    // would create: UserText, then AttachmentHeader + AttachmentItem +
+    // AttachmentPreviewLines.
+    let tui = harness.tui();
+    tui.app
+        .transcript
+        .push(TranscriptItem::UserText("check this file".to_string()));
+    tui.app.transcript.push(TranscriptItem::AttachmentHeader(
+        "Attachments (1)".to_string(),
+    ));
+    tui.app
+        .transcript
+        .push(TranscriptItem::AttachmentItem("notes.txt".to_string()));
+    tui.app
+        .transcript
+        .push(TranscriptItem::AttachmentPreviewLine(
+            "Line 1 of notes".to_string(),
+        ));
+    tui.app
+        .transcript
+        .push(TranscriptItem::AttachmentPreviewLine(
+            "Line 2 of notes".to_string(),
+        ));
+    tui.app
+        .transcript
+        .push(TranscriptItem::AssistantText("Got it, thanks!".to_string()));
+
+    harness.render();
+    let rendered = normalize_screen(&harness.screen_contents());
+
+    // The attachment info should be visible in the rendered output.
+    assert!(
+        rendered.contains("notes.txt"),
+        "expected attachment name visible: {rendered}"
+    );
+    assert!(
+        rendered.contains("Line 1 of notes"),
+        "expected attachment preview visible: {rendered}"
+    );
+
+    insta::assert_snapshot!("submitted_message_with_text_attachment", rendered);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_input_word_wraps_long_line() {
     // Use a narrow viewport (30 cols) so a long single-line input must wrap
     let mut harness = TuiTestHarness::with_size(30, 10);

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -85,7 +85,8 @@ async fn pending_message_is_rendered_with_input_highlight_and_no_status_text() {
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
     let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
     tui.app.llm_busy = true;
-    tui.queue_pending_message("queued message".to_string());
+    tui.queue_pending_message("queued message".to_string())
+        .await;
 
     let title = line_to_plain(&tui.build_input_title());
     assert!(!title.contains("Pending message queued"));
@@ -100,7 +101,8 @@ async fn pending_message_is_cleared_when_user_edits_again() {
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
     let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
     tui.app.llm_busy = true;
-    tui.queue_pending_message("queued message".to_string());
+    tui.queue_pending_message("queued message".to_string())
+        .await;
 
     // Input should still contain the pending message text (new behavior)
     assert_eq!(tui.app.input.lines().join("\n"), "queued message");
@@ -136,7 +138,7 @@ async fn pending_message_is_auto_sent_after_finish() {
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
     let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
     tui.app.llm_busy = true;
-    tui.queue_pending_message("follow up".to_string());
+    tui.queue_pending_message("follow up".to_string()).await;
 
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
         kind: UiOutputEventKind::LlmFinal {
@@ -206,12 +208,18 @@ async fn pending_message_consumed_clears_pending_and_shows_in_transcript() {
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
     let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
     tui.app.llm_busy = true;
-    tui.queue_pending_message("interject here".to_string());
+    tui.queue_pending_message("interject here".to_string())
+        .await;
     assert!(tui.app.pending_message.is_some());
 
     // Simulate the prompt task consuming the pending message during a tool round.
     tui.handle_tui_event(TuiEvent::PendingMessageConsumed(
-        "interject here".to_string(),
+        crate::tui::types::PendingMessage {
+            text: "interject here".to_string(),
+            attachments: vec![],
+            attachment_dir: None,
+            paste_count: 0,
+        },
     ))
     .await
     .unwrap();
@@ -236,12 +244,19 @@ async fn pending_message_not_double_submitted_after_consumed() {
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
     let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
     tui.app.llm_busy = true;
-    tui.queue_pending_message("once only".to_string());
+    tui.queue_pending_message("once only".to_string()).await;
 
     // Prompt task consumed it.
-    tui.handle_tui_event(TuiEvent::PendingMessageConsumed("once only".to_string()))
-        .await
-        .unwrap();
+    tui.handle_tui_event(TuiEvent::PendingMessageConsumed(
+        crate::tui::types::PendingMessage {
+            text: "once only".to_string(),
+            attachments: vec![],
+            attachment_dir: None,
+            paste_count: 0,
+        },
+    ))
+    .await
+    .unwrap();
 
     // Now LlmFinal arrives.
     tui.handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
@@ -262,6 +277,73 @@ async fn pending_message_not_double_submitted_after_consumed() {
         .filter(|entry| matches!(entry, TranscriptItem::UserText(text) if text == "once only"))
         .count();
     assert_eq!(user_text_count, 1);
+}
+
+#[tokio::test]
+async fn pending_dot_command_not_consumed_mid_tool_loop() {
+    // Dot-commands should NOT be consumed mid-tool-loop; they must wait
+    // for LlmFinal where submit_pending_message_inner handles them.
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+    tui.app.llm_busy = true;
+
+    // Queue a dot-command as pending.
+    let pending = crate::tui::types::PendingMessage {
+        text: ".info model".to_string(),
+        attachments: vec![],
+        attachment_dir: None,
+        paste_count: 0,
+    };
+    tui.app.pending_message = Some(pending.clone());
+    *tui.shared_pending_message.lock().await = Some(pending);
+
+    // Verify the shared state still holds the dot-command (the prompt
+    // task would skip it because it starts with '.').
+    let guard = tui.shared_pending_message.lock().await;
+    assert!(guard.is_some());
+    assert!(guard.as_ref().unwrap().text.starts_with('.'));
+    drop(guard);
+
+    // The app-side pending message should still be present so LlmFinal
+    // can pick it up.
+    assert!(tui.app.pending_message.is_some());
+}
+
+#[tokio::test]
+async fn pending_message_with_attachments_not_consumed_mid_tool_loop() {
+    // Messages with attachments should NOT be consumed mid-tool-loop;
+    // they must wait for LlmFinal where submit_pending_message_inner
+    // handles them with full attachment processing.
+    use crate::tui::types::Attachment;
+    use std::path::PathBuf;
+
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+    tui.app.llm_busy = true;
+
+    let pending = crate::tui::types::PendingMessage {
+        text: "check this file".to_string(),
+        attachments: vec![Attachment {
+            path: PathBuf::from("/tmp/test.txt"),
+            display_name: "test.txt".to_string(),
+        }],
+        attachment_dir: None,
+        paste_count: 0,
+    };
+    tui.app.pending_message = Some(pending.clone());
+    *tui.shared_pending_message.lock().await = Some(pending);
+
+    // Verify the shared state still holds it (prompt task would skip
+    // because it has attachments).
+    let guard = tui.shared_pending_message.lock().await;
+    assert!(guard.is_some());
+    assert!(!guard.as_ref().unwrap().attachments.is_empty());
+    drop(guard);
+
+    // The app-side pending message should still be present.
+    assert!(tui.app.pending_message.is_some());
 }
 
 #[tokio::test]
@@ -1776,7 +1858,8 @@ async fn test_pending_message_busy_state_snapshot() {
     harness.tui().app.llm_busy = true;
     harness
         .tui()
-        .queue_pending_message("queued follow-up message".to_string());
+        .queue_pending_message("queued follow-up message".to_string())
+        .await;
     harness.render();
 
     let rendered = normalize_screen(&harness.screen_contents());

--- a/src/tui/types.rs
+++ b/src/tui/types.rs
@@ -129,7 +129,7 @@ pub(crate) enum TuiEvent {
     /// Intermediate tool round completed; the prompt loop continues.
     ToolRoundComplete,
     /// The prompt task consumed the pending message during a tool round.
-    PendingMessageConsumed(String),
+    PendingMessageConsumed(PendingMessage),
 }
 
 #[cfg(not(test))]
@@ -138,5 +138,5 @@ pub(super) enum TuiEvent {
     /// Intermediate tool round completed; the prompt loop continues.
     ToolRoundComplete,
     /// The prompt task consumed the pending message during a tool round.
-    PendingMessageConsumed(String),
+    PendingMessageConsumed(PendingMessage),
 }

--- a/src/tui/types.rs
+++ b/src/tui/types.rs
@@ -20,6 +20,8 @@ pub struct Tui {
     pub(super) async_manager: Arc<Mutex<AsyncHookManager>>,
     pub(super) persistent_manager: Arc<Mutex<PersistentHookManager>>,
     pub(super) pending_async_context: Arc<Mutex<Option<String>>>,
+    /// Shared state so the prompt task can consume a pending message mid-tool-loop.
+    pub(super) shared_pending_message: Arc<Mutex<Option<PendingMessage>>>,
     #[cfg(test)]
     #[allow(private_interfaces)]
     pub(crate) app: App,
@@ -126,6 +128,8 @@ pub(crate) enum TuiEvent {
     UiOutput(UiOutputEvent),
     /// Intermediate tool round completed; the prompt loop continues.
     ToolRoundComplete,
+    /// The prompt task consumed the pending message during a tool round.
+    PendingMessageConsumed(String),
 }
 
 #[cfg(not(test))]
@@ -133,4 +137,6 @@ pub(super) enum TuiEvent {
     UiOutput(UiOutputEvent),
     /// Intermediate tool round completed; the prompt loop continues.
     ToolRoundComplete,
+    /// The prompt task consumed the pending message during a tool round.
+    PendingMessageConsumed(String),
 }


### PR DESCRIPTION
## Summary
- When the user queues a message while the LLM is busy executing tool calls, inject it as a user message after tool results instead of waiting for all LLM activity to finish
- Adds shared `Arc<Mutex<Option<PendingMessage>>>` between the TUI and prompt task so the prompt loop can consume pending messages mid-tool-loop
- Adds `injected_user_text` field to `Input` so `build_messages()` appends the user's text after tool call results
- Session saving correctly persists the injected user message between tool results and assistant response

## Test plan
- [x] New test: `pending_message_consumed_clears_pending_and_shows_in_transcript`
- [x] New test: `pending_message_not_double_submitted_after_consumed`
- [x] All 289 existing tests pass
- [x] `cargo fmt`, `cargo clippy` clean

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow temporarily injected user text to be appended during intermediate tool rounds.
  * Introduce a shared pending-message state so prompts submitted while busy can be consumed across tasks; consumed pending messages clear the shared state and restore the input/transcript.

* **Bug Fixes**
  * Prevent duplicate submission of a consumed pending message; skip consuming dot-commands or messages with attachments mid-tool-loop.

* **Tests**
  * Added tests covering pending-message consumption, ordering, non-consumption cases, and rendering of submitted text-with-attachment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->