### PR TITLE
fix(tui,acp): eliminate sub-agent activity duplication and rendering artifacts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ futures-util = "0.3.29"
 inquire = "0.9.0"
 is-terminal = "0.4.9"
 reedline = "0.47.0"
-ratatui = { version = "0.30.0", features = ["crossterm_0_29"] }
+ratatui = { version = "0.30.0", features = ["crossterm_0_29", "unstable-rendered-line-info"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.93", features = ["preserve_order"] }
 serde_yaml = "0.9.17"

--- a/src/acp/client.rs
+++ b/src/acp/client.rs
@@ -128,13 +128,12 @@ impl AcpNotificationClient {
             source,
         };
 
-        // Always emit to the parent UI sink so the TUI transcript shows nested
-        // sub-agent events (tool calls, thoughts, etc.) regardless of whether
-        // a chunk forwarder is also registered.
-        let emitted_to_ui = emit_ui_output_event(event.clone());
-
-        // Also forward to any registered chunk forwarders (e.g. the REPL
-        // command-line path that prints sub-agent output to stdout).
+        // Prefer delivery through a registered chunk forwarder when one is
+        // present.  Registered forwarders (e.g. `forward_acp_chunks` in
+        // `tool.rs` for the parent TUI, or `forward_task` in `server.rs` for
+        // nested ACP relay) already know how to surface the event to the
+        // right destination — emitting directly here would cause the same
+        // event to appear twice in the parent transcript.
         let mut forwarded_to_chunk = false;
         forwarders.retain(|_, tx| match tx.send(NestedAcpEvent::Ui(event.clone())) {
             Ok(()) => {
@@ -144,8 +143,16 @@ impl AcpNotificationClient {
             Err(_) => false,
         });
 
+        // When no forwarder is registered (e.g. direct parent TUI mode with
+        // no tool call in flight), fall back to the UI output sink so the
+        // event still reaches the transcript.
+        let mut emitted_to_ui = false;
+        if !forwarded_to_chunk {
+            emitted_to_ui = emit_ui_output_event(event);
+        }
+
         // Fall back to stderr only if neither path accepted the event.
-        if !emitted_to_ui && !forwarded_to_chunk {
+        if !forwarded_to_chunk && !emitted_to_ui {
             eprint!("{}", text_fallback);
         }
     }

--- a/src/test_utils/snapshots/harnx__test_utils__tmux_e2e__issue_149_interactive_handoff_reuses_session_across_followups.snap
+++ b/src/test_utils/snapshots/harnx__test_utils__tmux_e2e__issue_149_interactive_handoff_reuses_session_across_followups.snap
@@ -9,7 +9,7 @@ Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
 
 I'll hand this off to the specialist.
 
-->️ handoff-sub-agent_session_handoff
+→ handoff-sub-agent_session_handoff
    prompt: Take over and answer how many files are in /tmp.
    session_id: handoff-session-1
    Handing off to handoff-sub-agent…

--- a/src/test_utils/snapshots/harnx__test_utils__tmux_e2e__issue_149_interactive_handoff_switches_control.snap
+++ b/src/test_utils/snapshots/harnx__test_utils__tmux_e2e__issue_149_interactive_handoff_switches_control.snap
@@ -9,7 +9,7 @@ Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
 
 I'll hand this off to the specialist.
 
-->️ handoff-sub-agent_session_handoff
+→ handoff-sub-agent_session_handoff
    prompt: Take over and answer how many files are in /tmp.
    session_id: handoff-session-1
    Handing off to handoff-sub-agent…

--- a/src/test_utils/snapshots/harnx__test_utils__tmux_e2e__nested_sub_agent_activity_no_duplicates.snap
+++ b/src/test_utils/snapshots/harnx__test_utils__tmux_e2e__nested_sub_agent_activity_no_duplicates.snap
@@ -1,0 +1,82 @@
+---
+source: src/test_utils/tmux_e2e.rs
+expression: normalized
+---
+Welcome to harnx 0.30.0  *  Type .help for commands, Tab to complete.
+# nested-parent v
+🤖 nested-parent
+> investigate the data trends
+
+Let me investigate this. Delegating to researcher.
+
+→ nested-researcher_session_prompt
+   message: Investigate the data trends in detail.
+> nested-researcher ▸ <UUID>
+RESEARCHER_TEXT: Let me check the raw data first.Got initial data. Need deeper analysis. Delegating to analyst.
+
+→ repro249_unique_mcp_tool
+   {}
+→ nested-analyst_session_prompt
+   message: Perform deep analysis on the data trends.
+> nested-analyst ▸ <UUID>
+ANALYST_TEXT: Running deep analysis now.Analysis complete. The trend is clearly upward.
+
+→ repro249_unique_mcp_tool
+   {}
+> nested-researcher ▸ <UUID>
+Analyst confirmed the upward trend in the data.
+
+   session_id: <UUID>
+   response: 'RESEARCHER_TEXT: Let me check the raw data first.Got initial data. Need deeper analysis. Delegating [...]
+PARENT_FINAL: Research complete. Data shows clear upward trend.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+* 🤖 nested-parent

--- a/src/test_utils/snapshots/harnx__test_utils__tmux_e2e__nested_sub_agent_activity_no_duplicates.snap
+++ b/src/test_utils/snapshots/harnx__test_utils__tmux_e2e__nested_sub_agent_activity_no_duplicates.snap
@@ -12,27 +12,27 @@ Let me investigate this. Delegating to researcher.
 → nested-researcher_session_prompt
    message: Investigate the data trends in detail.
 > nested-researcher ▸ <UUID>
-RESEARCHER_TEXT: Let me check the raw data first.Got initial data. Need deeper analysis. Delegating to analyst.
+RESEARCHER_TEXT: Let me check the raw data first.
 
 → repro249_unique_mcp_tool
    {}
+Got initial data. Need deeper analysis. Delegating to analyst.
+
 → nested-analyst_session_prompt
    message: Perform deep analysis on the data trends.
 > nested-analyst ▸ <UUID>
-ANALYST_TEXT: Running deep analysis now.Analysis complete. The trend is clearly upward.
+ANALYST_TEXT: Running deep analysis now.
 
 → repro249_unique_mcp_tool
    {}
+Analysis complete. The trend is clearly upward.
+
 > nested-researcher ▸ <UUID>
 Analyst confirmed the upward trend in the data.
 
    session_id: <UUID>
    response: 'RESEARCHER_TEXT: Let me check the raw data first.Got initial data. Need deeper analysis. Delegating [...]
 PARENT_FINAL: Research complete. Data shows clear upward trend.
-
-
-
-
 
 
 

--- a/src/test_utils/tmux_e2e.rs
+++ b/src/test_utils/tmux_e2e.rs
@@ -374,8 +374,8 @@ fn write_fixture_files(paths: &TestPaths) -> Result<()> {
 fn nested_mcp_tool_present(screen: &str) -> bool {
     // The nested tool call must appear as a real tool-call row in the parent
     // transcript, NOT just as text inside a response string.
-    // A real tool call row looks like "->️ repro249_unique_mcp_tool"
-    screen.contains(&format!("->️ {}", REPRO_249_MCP_TOOL_NAME))
+    // A real tool call row looks like "→ repro249_unique_mcp_tool"
+    screen.contains(&format!("→ {}", REPRO_249_MCP_TOOL_NAME))
 }
 
 fn normalize_screen(screen: &str) -> String {
@@ -384,6 +384,62 @@ fn normalize_screen(screen: &str) -> String {
         .map(|line| line.trim_end())
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+/// Replace spinner glyphs (animated braille chars and the idle "•" bullet)
+/// with a fixed placeholder so snapshots are deterministic across runs.
+fn normalize_spinner_chars(text: &str) -> String {
+    const SPINNER_CHARS: &[char] = &[
+        '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏', '•',
+    ];
+    text.chars()
+        .map(|c| if SPINNER_CHARS.contains(&c) { '*' } else { c })
+        .collect()
+}
+
+/// Replace any UUIDv4-looking substring with a placeholder so snapshots are
+/// deterministic across runs.
+fn normalize_uuids(text: &str) -> String {
+    // UUID pattern: 8-4-4-4-12 hex chars separated by hyphens.
+    let mut out = String::with_capacity(text.len());
+    let chars: Vec<char> = text.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        if is_uuid_at(&chars, i) {
+            out.push_str("<UUID>");
+            i += 36;
+        } else {
+            out.push(chars[i]);
+            i += 1;
+        }
+    }
+    out
+}
+
+fn is_uuid_at(chars: &[char], i: usize) -> bool {
+    if i + 36 > chars.len() {
+        return false;
+    }
+    // Group lengths 8-4-4-4-12 separated by hyphens at indices 8, 13, 18, 23.
+    for (idx, &c) in chars[i..i + 36].iter().enumerate() {
+        let is_hyphen_pos = matches!(idx, 8 | 13 | 18 | 23);
+        if is_hyphen_pos {
+            if c != '-' {
+                return false;
+            }
+        } else if !c.is_ascii_hexdigit() {
+            return false;
+        }
+    }
+    // Don't match UUIDs preceded by another hex digit or hyphen (to avoid
+    // mid-string matches within longer identifiers).
+    if i > 0 {
+        let prev = chars[i - 1];
+        if prev.is_ascii_hexdigit() || prev == '-' {
+            return false;
+        }
+    }
+    true
 }
 
 fn repo_root() -> Result<PathBuf> {
@@ -747,5 +803,495 @@ fn write_handoff_fixture_files(paths: &TestPaths) -> Result<()> {
             HANDOFF_SUB_AGENT_NAME,
         ),
     )?;
+    Ok(())
+}
+
+// ── Nested sub-agent duplication test ────────────────────────────────────────
+//
+// Parent → sub-agent (researcher) → sub-sub-agent (analyst).
+// Each level streams text, makes tool calls, and delegates further.
+// The test captures the final screen and asserts that no activity is duplicated.
+
+const NESTED_PARENT_AGENT: &str = "nested-parent";
+const NESTED_SUB_AGENT: &str = "nested-researcher";
+const NESTED_SUB_SUB_AGENT: &str = "nested-analyst";
+
+#[test]
+fn nested_sub_agent_activity_no_duplicates() -> Result<()> {
+    if option_env!("CARGO_BIN_NAME") == Some("harnx") {
+        eprintln!("skipping nested_sub_agent_activity_no_duplicates in binary test target");
+        return Ok(());
+    }
+    if !TmuxHarness::is_available() {
+        eprintln!("skipping nested_sub_agent_activity_no_duplicates: tmux is unavailable");
+        return Ok(());
+    }
+
+    let repo_root = repo_root()?;
+    let target_dir = repo_root.join("target").join("debug");
+    let harnx_bin = target_dir.join(binary_name("harnx"));
+    if !harnx_bin.is_file() {
+        eprintln!("skipping nested_sub_agent_activity_no_duplicates: harnx binary is missing");
+        return Ok(());
+    }
+    let harnx_mcp_bin = target_dir.join(binary_name("harnx-mcp-repro249"));
+    if !harnx_mcp_bin.is_file() {
+        eprintln!(
+            "skipping nested_sub_agent_activity_no_duplicates: harnx-mcp-repro249 binary missing"
+        );
+        return Ok(());
+    }
+
+    let temp = TempDir::new().context("failed to create temp dir")?;
+    let mock = MockOpenAiServer::start(nested_script())?;
+    let paths = TestPaths::new(temp.path(), mock.port())?;
+    write_nested_fixture_files(&paths)?;
+
+    let path_env = format!(
+        "{}:{}",
+        target_dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let tmux = match TmuxHarness::new(&repo_root, 120, 80) {
+        Ok(tmux) => tmux,
+        Err(err) => {
+            eprintln!("skipping nested_sub_agent_activity_no_duplicates: tmux unusable ({err:#})");
+            return Ok(());
+        }
+    };
+    tmux.send_keys(&["C-l"])?;
+
+    // Export HARNX_CONFIG_DIR
+    tmux.send_text(&format!(
+        "export HARNX_CONFIG_DIR={}",
+        shell_escape(paths.harnx_config_dir.to_string_lossy().as_ref())
+    ))?;
+    tmux.send_keys(&["Enter"])?;
+
+    // Export PATH
+    tmux.send_text(&format!(
+        "export PATH={} && cd {}; printf '__NESTED_READY__\\n'",
+        shell_escape(&path_env),
+        shell_escape(repo_root.to_string_lossy().as_ref())
+    ))?;
+    tmux.send_keys(&["Enter"])?;
+    tmux.wait_for(Duration::from_secs(5), |screen| {
+        count_occurrences(screen, "__NESTED_READY__") >= 2
+    })?;
+
+    // Launch the parent agent
+    tmux.send_text(&format!(
+        "{} -a {} || echo HARNX_EXIT:$?",
+        shell_escape(harnx_bin.to_string_lossy().as_ref()),
+        NESTED_PARENT_AGENT
+    ))?;
+    tmux.send_keys(&["Enter"])?;
+
+    tmux.wait_for_contains("Welcome to harnx", Duration::from_secs(15))?;
+    tmux.send_text("investigate the data trends")?;
+    tmux.send_keys(&["Enter"])?;
+
+    // Wait for delegation chain to complete: parent delegates to researcher,
+    // researcher delegates to analyst, analyst calls MCP tool, then everything
+    // unwinds with final messages at each level.
+    //
+    // Wait for the *full* parent final message so the spinner has settled and
+    // the text has finished streaming (not just the "PARENT_FINAL:" marker,
+    // which can appear before the rest of the message arrives).
+    let screen = tmux.wait_for(Duration::from_secs(45), |screen| {
+        screen.contains("PARENT_FINAL: Research complete. Data shows clear upward trend.")
+    })?;
+
+    // ── Verify the delegation chain is visible ───────────────────────────────
+    assert!(
+        screen.contains(&format!("{}_session_prompt", NESTED_SUB_AGENT)),
+        "parent→researcher delegation tool call not visible:\n{screen}"
+    );
+    assert!(
+        screen.contains(&format!("> {}", NESTED_SUB_AGENT)),
+        "researcher sub-agent heading not visible:\n{screen}"
+    );
+    assert!(
+        screen.contains(&format!("{}_session_prompt", NESTED_SUB_SUB_AGENT)),
+        "researcher→analyst delegation tool call not visible:\n{screen}"
+    );
+    assert!(
+        screen.contains(&format!("> {}", NESTED_SUB_SUB_AGENT)),
+        "analyst sub-sub-agent heading not visible:\n{screen}"
+    );
+    assert!(
+        screen.contains(REPRO_249_MCP_TOOL_NAME),
+        "analyst's MCP tool call not visible:\n{screen}"
+    );
+
+    // Print the full screen for debugging when the test fails.
+    eprintln!(
+        "\n=== nested sub-agent duplication test screen ===\n{}\n====\n",
+        screen
+    );
+
+    let normalized =
+        normalize_spinner_chars(&normalize_uuids(&normalize_screen(&screen)));
+    assert_snapshot!("nested_sub_agent_activity_no_duplicates", normalized);
+
+    // ── Duplication assertions ───────────────────────────────────────────────
+    // Each delegation tool call should appear exactly once.
+    assert_eq!(
+        count_occurrences(
+            &screen,
+            &format!("{}_session_prompt", NESTED_SUB_AGENT)
+        ),
+        1,
+        "researcher delegation tool call appears more than once:\n{screen}"
+    );
+    assert_eq!(
+        count_occurrences(
+            &screen,
+            &format!("{}_session_prompt", NESTED_SUB_SUB_AGENT)
+        ),
+        1,
+        "analyst delegation tool call appears more than once:\n{screen}"
+    );
+
+    // The MCP tool call from the analyst should appear exactly once.
+    // (The researcher also calls it, so we expect exactly 2 total.)
+    let mcp_tool_occurrences = count_occurrences(&screen, REPRO_249_MCP_TOOL_NAME);
+    assert_eq!(
+        mcp_tool_occurrences, 2,
+        "MCP tool call should appear exactly twice (once per agent that calls it), got {mcp_tool_occurrences}:\n{screen}"
+    );
+
+    // The researcher heading may appear 1 OR 2 times: once when parent first
+    // delegates to it, and optionally once more when control returns from
+    // analyst (a source-transition event like Usage re-asserts the researcher
+    // context). Both counts are semantically valid — the assertion here just
+    // guards against runaway duplication (e.g., a heading per streamed chunk).
+    let researcher_headings = screen
+        .lines()
+        .filter(|line| {
+            line.contains(&format!("> {}", NESTED_SUB_AGENT))
+                && !line.contains(&format!("> {}", NESTED_SUB_SUB_AGENT))
+                && !line.contains("in ")
+                && !line.contains("out ")
+        })
+        .count();
+    assert!(
+        (1..=2).contains(&researcher_headings),
+        "researcher heading should appear 1 or 2 times, got {researcher_headings}:\n{screen}"
+    );
+    let analyst_headings = screen
+        .lines()
+        .filter(|line| {
+            line.contains(&format!("> {}", NESTED_SUB_SUB_AGENT))
+                && !line.contains("in ")
+                && !line.contains("out ")
+        })
+        .count();
+    assert_eq!(
+        analyst_headings, 1,
+        "analyst heading should appear exactly once (excluding usage lines), got {analyst_headings}:\n{screen}"
+    );
+
+    // Final message markers are expected to appear in the live stream AND
+    // possibly in the tool-call result display (since `session_prompt`
+    // legitimately returns the accumulated response text).  The assertion
+    // guards against runaway duplication (e.g., each chunk emitted twice).
+    //
+    // RESEARCHER_TEXT and ANALYST_TEXT may appear up to 2 times:
+    //   - once in the live stream from the sub-agent
+    //   - once more in the tool-call result rendering
+    // PARENT_FINAL only comes from the parent's final LLM turn (never wrapped
+    // in a tool result), so it should appear exactly once.
+    for marker in ["RESEARCHER_TEXT:", "ANALYST_TEXT:"] {
+        let marker_count = count_occurrences(&screen, marker);
+        assert!(
+            (1..=2).contains(&marker_count),
+            "{marker} should appear 1 or 2 times (live stream + optional tool result), got {marker_count}:\n{screen}"
+        );
+    }
+    let parent_final_count = count_occurrences(&screen, "PARENT_FINAL:");
+    assert_eq!(
+        parent_final_count, 1,
+        "PARENT_FINAL: should appear exactly once, got {parent_final_count}:\n{screen}"
+    );
+
+    drop(tmux);
+    drop(mock);
+    Ok(())
+}
+
+/// Mock LLM script for the nested delegation test.
+///
+/// Turns are consumed in order across all three processes:
+///   Turn 0 (parent)         : stream text + delegate to researcher
+///   Turn 1 (researcher)     : stream text + call MCP tool (to have a tool call before delegating)
+///   Turn 2 (researcher)     : stream text + delegate to analyst
+///   Turn 3 (analyst)        : stream text + call MCP tool
+///   Turn 4 (analyst)        : stream final text (ends analyst)
+///   Turn 5 (researcher)     : stream final text (ends researcher)
+///   Turn 6 (parent)         : stream final text (ends parent turn)
+fn nested_script() -> MockOpenAiScript {
+    MockOpenAiScript {
+        turns: vec![
+            // Turn 0: parent streams opening + delegates to researcher
+            MockOpenAiTurn {
+                text_chunks: vec![
+                    "Let me ".to_string(),
+                    "investigate ".to_string(),
+                    "this. ".to_string(),
+                    "Delegating to researcher.".to_string(),
+                ],
+                tool_calls: vec![MockOpenAiToolCall {
+                    name: format!("{}_session_prompt", NESTED_SUB_AGENT),
+                    arguments: json!({
+                        "message": "Investigate the data trends in detail."
+                    }),
+                    id: Some("call_delegate_researcher".to_string()),
+                }],
+                error: None,
+            },
+            // Turn 1: researcher streams text + calls MCP tool
+            MockOpenAiTurn {
+                text_chunks: vec![
+                    "RESEARCHER_TEXT: ".to_string(),
+                    "Let me check ".to_string(),
+                    "the raw data first.".to_string(),
+                ],
+                tool_calls: vec![MockOpenAiToolCall {
+                    name: REPRO_249_MCP_TOOL_NAME.to_string(),
+                    arguments: json!({}),
+                    id: Some("call_researcher_mcp".to_string()),
+                }],
+                error: None,
+            },
+            // Turn 2: researcher streams text + delegates to analyst
+            MockOpenAiTurn {
+                text_chunks: vec![
+                    "Got initial data. ".to_string(),
+                    "Need deeper analysis. ".to_string(),
+                    "Delegating to analyst.".to_string(),
+                ],
+                tool_calls: vec![MockOpenAiToolCall {
+                    name: format!("{}_session_prompt", NESTED_SUB_SUB_AGENT),
+                    arguments: json!({
+                        "message": "Perform deep analysis on the data trends."
+                    }),
+                    id: Some("call_delegate_analyst".to_string()),
+                }],
+                error: None,
+            },
+            // Turn 3: analyst streams text + calls MCP tool
+            MockOpenAiTurn {
+                text_chunks: vec![
+                    "ANALYST_TEXT: ".to_string(),
+                    "Running deep ".to_string(),
+                    "analysis now.".to_string(),
+                ],
+                tool_calls: vec![MockOpenAiToolCall {
+                    name: REPRO_249_MCP_TOOL_NAME.to_string(),
+                    arguments: json!({}),
+                    id: Some("call_analyst_mcp".to_string()),
+                }],
+                error: None,
+            },
+            // Turn 4: analyst final text (ends analyst)
+            MockOpenAiTurn {
+                text_chunks: vec![
+                    "Analysis complete. ".to_string(),
+                    "The trend is clearly upward.".to_string(),
+                ],
+                tool_calls: vec![],
+                error: None,
+            },
+            // Turn 5: researcher final text (ends researcher)
+            MockOpenAiTurn {
+                text_chunks: vec![
+                    "Analyst confirmed ".to_string(),
+                    "the upward trend in the data.".to_string(),
+                ],
+                tool_calls: vec![],
+                error: None,
+            },
+            // Turn 6: parent final text
+            MockOpenAiTurn {
+                text_chunks: vec![
+                    "PARENT_FINAL: ".to_string(),
+                    "Research complete. ".to_string(),
+                    "Data shows clear ".to_string(),
+                    "upward trend.".to_string(),
+                ],
+                tool_calls: vec![],
+                error: None,
+            },
+        ],
+        fallback_text: "No more scripted responses.".to_string(),
+        chunk_delay_ms: 10,
+    }
+}
+
+fn write_nested_fixture_files(paths: &TestPaths) -> Result<()> {
+    std::fs::create_dir_all(&paths.harnx_config_dir)?;
+
+    let fake_mcp_server = repo_root()?
+        .join("target")
+        .join("debug")
+        .join(binary_name("harnx-mcp-repro249"));
+
+    let harnx_bin = repo_root()?
+        .join("target")
+        .join("debug")
+        .join(binary_name("harnx"));
+
+    std::fs::write(&paths.config_path, "save: false\n")?;
+
+    let clients_dir = paths.harnx_config_dir.join("clients");
+    let mcp_servers_dir = paths.harnx_config_dir.join("mcp_servers");
+    let acp_servers_dir = paths.harnx_config_dir.join("acp_servers");
+    std::fs::create_dir_all(&clients_dir)?;
+    std::fs::create_dir_all(&mcp_servers_dir)?;
+    std::fs::create_dir_all(&acp_servers_dir)?;
+
+    // Client config (shared by all agents via the mock LLM server)
+    let client = serde_yaml::Value::Mapping(serde_yaml::Mapping::from_iter([
+        (
+            serde_yaml::Value::String("type".to_string()),
+            serde_yaml::Value::String("openai-compatible".to_string()),
+        ),
+        (
+            serde_yaml::Value::String("name".to_string()),
+            serde_yaml::Value::String("mock-llm".to_string()),
+        ),
+        (
+            serde_yaml::Value::String("api_base".to_string()),
+            serde_yaml::Value::String(format!("http://127.0.0.1:{}/v1", paths.port)),
+        ),
+        (
+            serde_yaml::Value::String("api_key".to_string()),
+            serde_yaml::Value::String("dummy".to_string()),
+        ),
+        (
+            serde_yaml::Value::String("models".to_string()),
+            serde_yaml::Value::Sequence(vec![serde_yaml::Value::Mapping(
+                serde_yaml::Mapping::from_iter([
+                    (
+                        serde_yaml::Value::String("name".to_string()),
+                        serde_yaml::Value::String("test".to_string()),
+                    ),
+                    (
+                        serde_yaml::Value::String("max_input_tokens".to_string()),
+                        serde_yaml::Value::Number(32000.into()),
+                    ),
+                    (
+                        serde_yaml::Value::String("max_output_tokens".to_string()),
+                        serde_yaml::Value::Number(4096.into()),
+                    ),
+                    (
+                        serde_yaml::Value::String("supports_tool_use".to_string()),
+                        serde_yaml::Value::Bool(true),
+                    ),
+                ]),
+            )]),
+        ),
+    ]));
+    std::fs::write(
+        clients_dir.join("mock-llm.yaml"),
+        serde_yaml::to_string(&client)?,
+    )?;
+
+    // MCP server (used by both researcher and analyst)
+    let mut rename_tools = std::collections::HashMap::new();
+    rename_tools.insert(
+        REPRO_249_MCP_TOOL_NAME.to_string(),
+        REPRO_249_MCP_TOOL_NAME.to_string(),
+    );
+    let mcp_server = McpServerConfig {
+        name: "repro249".to_string(),
+        command: fake_mcp_server.to_string_lossy().into_owned(),
+        args: vec![],
+        env: Default::default(),
+        roots: vec![],
+        enabled: true,
+        description: None,
+        rename_tools,
+    };
+    std::fs::write(
+        mcp_servers_dir.join("repro249.yaml"),
+        serde_yaml::to_string(&mcp_server)?,
+    )?;
+
+    // ACP server: researcher (sub-agent)
+    let researcher_acp = AcpServerConfig {
+        name: NESTED_SUB_AGENT.to_string(),
+        command: harnx_bin.to_string_lossy().into_owned(),
+        args: vec!["--acp".to_string(), NESTED_SUB_AGENT.to_string()],
+        env: Default::default(),
+        enabled: true,
+        description: None,
+        idle_timeout_secs: 300,
+        operation_timeout_secs: 3600,
+    };
+    std::fs::write(
+        acp_servers_dir.join(format!("{}.yaml", NESTED_SUB_AGENT)),
+        serde_yaml::to_string(&researcher_acp)?,
+    )?;
+
+    // ACP server: analyst (sub-sub-agent)
+    let analyst_acp = AcpServerConfig {
+        name: NESTED_SUB_SUB_AGENT.to_string(),
+        command: harnx_bin.to_string_lossy().into_owned(),
+        args: vec!["--acp".to_string(), NESTED_SUB_SUB_AGENT.to_string()],
+        env: Default::default(),
+        enabled: true,
+        description: None,
+        idle_timeout_secs: 300,
+        operation_timeout_secs: 3600,
+    };
+    std::fs::write(
+        acp_servers_dir.join(format!("{}.yaml", NESTED_SUB_SUB_AGENT)),
+        serde_yaml::to_string(&analyst_acp)?,
+    )?;
+
+    // Agent definitions
+    // Parent: can delegate to researcher
+    std::fs::write(
+        paths.agents_dir.join(format!("{}.md", NESTED_PARENT_AGENT)),
+        format!(
+            "---\nname: {}\nmodel: mock-llm:test\nuse_tools: {}_session_prompt\n---\nYou are {}. Delegate tasks to {} and summarize.\n",
+            NESTED_PARENT_AGENT,
+            NESTED_SUB_AGENT,
+            NESTED_PARENT_AGENT,
+            NESTED_SUB_AGENT,
+        ),
+    )?;
+    // Researcher: can call MCP tool and delegate to analyst
+    std::fs::write(
+        paths
+            .agents_dir
+            .join(format!("{}.md", NESTED_SUB_AGENT)),
+        format!(
+            "---\nname: {}\nmodel: mock-llm:test\nuse_tools: {}, {}_session_prompt\n---\nYou are {}. Use {} for data and delegate deep analysis to {}.\n",
+            NESTED_SUB_AGENT,
+            REPRO_249_MCP_TOOL_NAME,
+            NESTED_SUB_SUB_AGENT,
+            NESTED_SUB_AGENT,
+            REPRO_249_MCP_TOOL_NAME,
+            NESTED_SUB_SUB_AGENT,
+        ),
+    )?;
+    // Analyst: can call MCP tool
+    std::fs::write(
+        paths
+            .agents_dir
+            .join(format!("{}.md", NESTED_SUB_SUB_AGENT)),
+        format!(
+            "---\nname: {}\nmodel: mock-llm:test\nuse_tools: {}\n---\nYou are {}. Use {} to perform deep analysis.\n",
+            NESTED_SUB_SUB_AGENT,
+            REPRO_249_MCP_TOOL_NAME,
+            NESTED_SUB_SUB_AGENT,
+            REPRO_249_MCP_TOOL_NAME,
+        ),
+    )?;
+
     Ok(())
 }

--- a/src/test_utils/tmux_e2e.rs
+++ b/src/test_utils/tmux_e2e.rs
@@ -389,9 +389,7 @@ fn normalize_screen(screen: &str) -> String {
 /// Replace spinner glyphs (animated braille chars and the idle "•" bullet)
 /// with a fixed placeholder so snapshots are deterministic across runs.
 fn normalize_spinner_chars(text: &str) -> String {
-    const SPINNER_CHARS: &[char] = &[
-        '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏', '•',
-    ];
+    const SPINNER_CHARS: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏', '•'];
     text.chars()
         .map(|c| if SPINNER_CHARS.contains(&c) { '*' } else { c })
         .collect()
@@ -931,25 +929,18 @@ fn nested_sub_agent_activity_no_duplicates() -> Result<()> {
         screen
     );
 
-    let normalized =
-        normalize_spinner_chars(&normalize_uuids(&normalize_screen(&screen)));
+    let normalized = normalize_spinner_chars(&normalize_uuids(&normalize_screen(&screen)));
     assert_snapshot!("nested_sub_agent_activity_no_duplicates", normalized);
 
     // ── Duplication assertions ───────────────────────────────────────────────
     // Each delegation tool call should appear exactly once.
     assert_eq!(
-        count_occurrences(
-            &screen,
-            &format!("{}_session_prompt", NESTED_SUB_AGENT)
-        ),
+        count_occurrences(&screen, &format!("{}_session_prompt", NESTED_SUB_AGENT)),
         1,
         "researcher delegation tool call appears more than once:\n{screen}"
     );
     assert_eq!(
-        count_occurrences(
-            &screen,
-            &format!("{}_session_prompt", NESTED_SUB_SUB_AGENT)
-        ),
+        count_occurrences(&screen, &format!("{}_session_prompt", NESTED_SUB_SUB_AGENT)),
         1,
         "analyst delegation tool call appears more than once:\n{screen}"
     );

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -703,6 +703,16 @@ impl Tui {
                     .push(TranscriptItem::SourceHeading(source.clone()));
             }
             self.app.last_ui_output_source = source;
+            // Reset streaming-assistant tracking: a source change means the
+            // next MessageChunk event belongs to a different agent than
+            // whatever the previous AssistantText entry was aggregating, so
+            // it must start a new AssistantText entry (rendered below the
+            // just-inserted SourceHeading) rather than being appended to the
+            // previous agent's text.  Without this reset, sub-agent message
+            // chunks get concatenated onto the parent's AssistantText,
+            // producing a single run-on paragraph that mixes content from
+            // multiple agents on the top-level row.
+            self.app.streaming_assistant_idx = None;
         }
         if !is_usage {
             self.clear_usage_tracking();

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -510,6 +510,23 @@ impl Tui {
     async fn render_ui_output_event(&mut self, event: UiOutputEvent) {
         let is_thought = matches!(&event.kind, UiOutputEventKind::ThoughtChunk { .. });
         let is_usage = matches!(&event.kind, UiOutputEventKind::Usage { .. });
+        // Tool calls (and plan updates) from sub-agents represent a turn-like
+        // boundary in the sub-agent's output: text streamed *before* the tool
+        // call belongs visually above it, text streamed *after* belongs
+        // visually below.  Reset the streaming-assistant index here so a
+        // subsequent MessageChunk starts a fresh AssistantText rather than
+        // being appended to the text that preceded the tool call.  We
+        // deliberately do NOT reset for display-only events (TranscriptText,
+        // ToolResultText, Usage, ToolCallUpdate) so that LLM text chunks
+        // with trailing-newline completion still coalesce correctly across
+        // those events.
+        let is_turn_boundary = matches!(
+            &event.kind,
+            UiOutputEventKind::ToolCall { .. } | UiOutputEventKind::Plan { .. }
+        );
+        if is_turn_boundary {
+            self.app.streaming_assistant_idx = None;
+        }
         if !is_thought {
             self.flush_pending_thought();
         }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -203,15 +203,6 @@ impl Tui {
             self.app.transcript.iter().map(Self::render_entry).collect()
         };
 
-        // Clear the ENTIRE frame buffer before any widget renders into it.
-        // This guards against character-level rendering artifacts (stray
-        // letters, corrupted words) that can otherwise appear when a row's
-        // content shrinks between frames: ratatui's Paragraph widget only
-        // writes cells that contain actual text glyphs and doesn't pad
-        // trailing cells, so without an explicit clear those cells can
-        // retain glyphs from a previous render.
-        frame.render_widget(ratatui::widgets::Clear, size);
-
         self.app
             .scroll_state
             .render(frame, chunks[0], &transcript_entries, |lines| {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,22 +1,6 @@
 use super::*;
 use crate::tui::types::{App, TranscriptItem, MAX_INPUT_HEIGHT, MIN_INPUT_HEIGHT, SPINNER_FRAMES};
 
-/// Estimate the number of terminal rows a set of lines will occupy
-/// after word-wrapping to the given width.
-fn wrapped_line_count(lines: &[Line<'_>], width: u16) -> usize {
-    let mut total = 0usize;
-    for line in lines {
-        let line_len: usize = line.spans.iter().map(|s| s.content.len()).sum();
-        if width == 0 {
-            total += 1;
-        } else {
-            let wrapped = line_len.div_ceil(width as usize);
-            total += wrapped.max(1);
-        }
-    }
-    total
-}
-
 impl Tui {
     fn render_text_entry(
         prefix: &str,
@@ -136,9 +120,18 @@ impl Tui {
                 tool_name,
                 input_yaml,
             } => {
+                // Use the plain rightwards arrow `→` (U+2192) as the
+                // tool-call marker.  The previous glyph was `->` followed by
+                // VS16 (U+FE0F), which requests an emoji-style presentation
+                // and causes unicode-width vs. terminal-rendered-width
+                // disagreement in some terminals.  That off-by-one width
+                // mismatch propagates through every subsequent line of the
+                // same frame, leaving stray glyphs (stray letters, corrupted
+                // words) at columns the next render doesn't explicitly
+                // repaint.
                 let mut lines = Self::render_text_entry(
                     "",
-                    &format!("->️ {tool_name}"),
+                    &format!("→ {tool_name}"),
                     Style::default()
                         .fg(Color::DarkGray)
                         .add_modifier(Modifier::DIM),
@@ -210,11 +203,26 @@ impl Tui {
             self.app.transcript.iter().map(Self::render_entry).collect()
         };
 
+        // Clear the ENTIRE frame buffer before any widget renders into it.
+        // This guards against character-level rendering artifacts (stray
+        // letters, corrupted words) that can otherwise appear when a row's
+        // content shrinks between frames: ratatui's Paragraph widget only
+        // writes cells that contain actual text glyphs and doesn't pad
+        // trailing cells, so without an explicit clear those cells can
+        // retain glyphs from a previous render.
+        frame.render_widget(ratatui::widgets::Clear, size);
+
         self.app
             .scroll_state
             .render(frame, chunks[0], &transcript_entries, |lines| {
                 let paragraph = Paragraph::new(lines.clone()).wrap(Wrap { trim: false });
-                let height = wrapped_line_count(lines, chunks[0].width);
+                // Use Paragraph's own wrap-aware line count so the height we
+                // report to the scroll widget exactly matches what the widget
+                // will actually render.  Disagreement here causes the scroll
+                // widget to allocate a mis-sized buffer, which in turn leaves
+                // stale cells in the terminal and produces character-level
+                // rendering artifacts (stray letters, corrupted words).
+                let height = paragraph.line_count(chunks[0].width);
                 (height, paragraph)
             });
 

--- a/src/tui/render_helpers.rs
+++ b/src/tui/render_helpers.rs
@@ -92,7 +92,7 @@ pub(crate) fn event_fallback_text(
             input_yaml,
             ..
         } => {
-            let mut lines = vec![format!("->️ {tool_name}")];
+            let mut lines = vec![format!("→ {tool_name}")];
             if let Some(input_yaml) = input_yaml {
                 lines.extend(input_yaml.lines().map(|line| format!("   {line}")));
             }

--- a/src/tui/snapshots/harnx__tui__tests__sub_agent_activity_dedup_after_all_tools.snap
+++ b/src/tui/snapshots/harnx__tui__tests__sub_agent_activity_dedup_after_all_tools.snap
@@ -1,0 +1,32 @@
+---
+source: src/tui/tests.rs
+expression: rendered_mid2
+---
+I'll look into that for you. Delegating now.
+
+→ researcher_session_prompt
+   message: investigate the data
+> researcher ▸ research-session-1
+<think>Let me analyze the situation carefully.</think>
+→ bash
+   command: find /data -name '*.csv'
+→ read_file
+   path: /data/results.csv
+<think>Now I see the pattern in the data.</think>
+→ write_file
+   path: /data/summary.md
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+• 🤖  coordinator ▸ dedup-test-session

--- a/src/tui/snapshots/harnx__tui__tests__sub_agent_activity_dedup_after_first_tools.snap
+++ b/src/tui/snapshots/harnx__tui__tests__sub_agent_activity_dedup_after_first_tools.snap
@@ -1,0 +1,32 @@
+---
+source: src/tui/tests.rs
+expression: rendered_mid1
+---
+I'll look into that for you. Delegating now.
+
+→ researcher_session_prompt
+   message: investigate the data
+> researcher ▸ research-session-1
+<think>Let me analyze the situation carefully.</think>
+→ bash
+   command: find /data -name '*.csv'
+→ read_file
+   path: /data/results.csv
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+• 🤖  coordinator ▸ dedup-test-session

--- a/src/tui/snapshots/harnx__tui__tests__sub_agent_activity_dedup_final.snap
+++ b/src/tui/snapshots/harnx__tui__tests__sub_agent_activity_dedup_final.snap
@@ -1,0 +1,32 @@
+---
+source: src/tui/tests.rs
+expression: rendered_final
+---
+I'll look into that for you. Delegating now.
+
+→ researcher_session_prompt
+   message: investigate the data
+> researcher ▸ research-session-1
+<think>Let me analyze the situation carefully.</think>
+→ bash
+   command: find /data -name '*.csv'
+→ read_file
+   path: /data/results.csv
+<think>Now I see the pattern in the data.</think>
+→ write_file
+   path: /data/summary.md
+Here are my findings: the data shows a clear trend.
+
+> researcher ▸ research-session-1   in 500   out 200   cache 100
+Based on the research, the data clearly shows an upward trend.
+
+
+
+
+
+
+
+
+
+
+• 🤖  coordinator ▸ dedup-test-session

--- a/src/tui/snapshots/harnx__tui__tests__sub_agent_heading_transitions_in_tui.snap
+++ b/src/tui/snapshots/harnx__tui__tests__sub_agent_heading_transitions_in_tui.snap
@@ -1,17 +1,16 @@
 ---
 source: src/tui/tests.rs
-assertion_line: 513
 expression: rendered
 ---
 Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
-Top-level assistant opening response.Top-level assistant closes
-response.
+Top-level assistant opening response.
 
 > argus ▸ session-1
 sub-agent tool call
 sub-agent follow-up output
 > hephaestus ▸ session-2
 other sub-agent output
+Top-level assistant closes response.
 
 
 

--- a/src/tui/snapshots/harnx__tui__tests__thinking_stream_coalescing_around_tool_calls.snap
+++ b/src/tui/snapshots/harnx__tui__tests__thinking_stream_coalescing_around_tool_calls.snap
@@ -6,7 +6,7 @@ expression: rendered
 Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
 > argus ▸ session-1
 <think>thinking before tool</think>
-->️ argus_session_prompt
+→ argus_session_prompt
    message: delegate
 <think>thinking after tool</think>
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2838,8 +2838,7 @@ async fn detach_completes_attachment_names() {
 /// that each activity type appears exactly once (no duplicates).
 #[tokio::test(flavor = "multi_thread")]
 async fn sub_agent_activity_no_duplicates_snapshot() {
-    let config =
-        test_config_with_mock_client_and_agent("coordinator", Some("dedup-test-session"));
+    let config = test_config_with_mock_client_and_agent("coordinator", Some("dedup-test-session"));
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
     let mut harness = TuiTestHarness::with_size(80, 30);
     harness.tui().config = config;
@@ -2963,7 +2962,11 @@ async fn sub_agent_activity_no_duplicates_snapshot() {
     insta::assert_snapshot!("sub_agent_activity_dedup_after_all_tools", rendered_mid2);
 
     // ── Phase 7: Sub-agent sends final message ───────────────────────
-    for chunk in ["Here are ", "my findings: ", "the data shows a clear trend."] {
+    for chunk in [
+        "Here are ",
+        "my findings: ",
+        "the data shows a clear trend.",
+    ] {
         harness
             .tui()
             .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -801,7 +801,7 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         system_entries,
         vec![
             "<think>thinking before tool</think>",
-            "->️ argus_session_prompt",
+            "→ argus_session_prompt",
             "   message: delegate",
             "<think>thinking after tool</think>",
         ]
@@ -880,7 +880,7 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         vec![
             "> argus ▸ session-1",
             "<think>thinking before tool</think>",
-            "->️ argus_session_prompt",
+            "→ argus_session_prompt",
             "   message: delegate",
             "<think>thinking after tool</think>",
         ]
@@ -1092,14 +1092,14 @@ async fn structured_ui_output_variants_render_in_transcript() {
         .collect();
 
     assert!(system_entries.contains(&"> argus ▸ session-1".to_string()));
-    assert!(system_entries.contains(&"->️ argus_session_prompt".to_string()));
+    assert!(system_entries.contains(&"→ argus_session_prompt".to_string()));
     assert!(system_entries.contains(&"   message: hello".to_string()));
     assert!(system_entries.contains(&"<think>thinking hard</think>".to_string()));
     assert!(system_entries.contains(&"-> argus_session_prompt completed".to_string()));
     assert!(system_entries.contains(&"Plan:".to_string()));
     assert!(system_entries.contains(&"  [in_progress] Refactor ACP formatting".to_string()));
     assert!(system_entries.contains(&"> argus ▸ session-1   in 12   out 34   cache 5".to_string()));
-    assert!(system_entries.contains(&"->️ bash".to_string()));
+    assert!(system_entries.contains(&"→ bash".to_string()));
     assert!(system_entries.contains(&"   command: ls".to_string()));
     assert!(system_entries.contains(&"   line one".to_string()));
     assert!(system_entries.contains(&"   line two".to_string()));
@@ -1166,9 +1166,9 @@ async fn nested_subagent_tool_call_renders_with_heading_and_usage() {
         })
         .collect();
 
-    assert!(rendered.contains(&"->️ pytheas_session_prompt".to_string()));
+    assert!(rendered.contains(&"→ pytheas_session_prompt".to_string()));
     assert!(rendered.contains(&"> pytheas ▸ session-nested".to_string()));
-    assert!(rendered.contains(&"->️ bash".to_string()));
+    assert!(rendered.contains(&"→ bash".to_string()));
     assert!(rendered.contains(&"   command: ls -1 /tmp | wc -l".to_string()));
     assert!(
         rendered.contains(&"> pytheas ▸ session-nested   in 10   out 20".to_string()),
@@ -2821,4 +2821,254 @@ async fn detach_completes_attachment_names() {
         "Should complete attachment names, got: {:?}",
         names
     );
+}
+
+/// Reproduce potential duplicate sub-agent activity in the TUI.
+///
+/// Simulates a realistic flow where:
+/// - Top-level agent streams a few message fragments
+/// - Sub-agent emits several streaming thought fragments
+/// - Sub-agent makes two tool calls
+/// - Sub-agent emits more streaming thoughts
+/// - Sub-agent makes another tool call
+/// - Sub-agent sends a final message
+/// - Top-level agent streams its final response in several parts
+///
+/// Insta snapshots are taken at several points to allow visual verification
+/// that each activity type appears exactly once (no duplicates).
+#[tokio::test(flavor = "multi_thread")]
+async fn sub_agent_activity_no_duplicates_snapshot() {
+    let config =
+        test_config_with_mock_client_and_agent("coordinator", Some("dedup-test-session"));
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut harness = TuiTestHarness::with_size(80, 30);
+    harness.tui().config = config;
+    harness.tui().persistent_manager = persistent;
+    harness.tui().clear_transcript();
+
+    let sub_source = Some(UiOutputSource {
+        agent: "researcher".to_string(),
+        session_id: Some("research-session-1".to_string()),
+    });
+
+    // ── Phase 1: Top-level agent streams opening message ─────────────
+    for chunk in ["I'll look into ", "that for you. ", "Delegating now."] {
+        harness
+            .tui()
+            .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+                kind: UiOutputEventKind::MessageChunk {
+                    text: chunk.to_string(),
+                    raw: None,
+                },
+                source: None,
+            }))
+            .await
+            .unwrap();
+    }
+
+    // ── Phase 2: Top-level delegation tool call ──────────────────────
+    harness
+        .tui()
+        .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::ToolCall {
+                tool_name: "researcher_session_prompt".to_string(),
+                input_yaml: Some("message: investigate the data".to_string()),
+                raw: None,
+            },
+            source: None,
+        }))
+        .await
+        .unwrap();
+
+    // ── Phase 3: Sub-agent thinks in several fragments ───────────────
+    for chunk in ["Let me ", "analyze ", "the situation ", "carefully."] {
+        harness
+            .tui()
+            .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+                kind: UiOutputEventKind::ThoughtChunk {
+                    text: chunk.to_string(),
+                    raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
+                },
+                source: sub_source.clone(),
+            }))
+            .await
+            .unwrap();
+    }
+
+    // ── Phase 4: Sub-agent makes two tool calls ──────────────────────
+    harness
+        .tui()
+        .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::ToolCall {
+                tool_name: "bash".to_string(),
+                input_yaml: Some("command: find /data -name '*.csv'".to_string()),
+                raw: None,
+            },
+            source: sub_source.clone(),
+        }))
+        .await
+        .unwrap();
+    harness
+        .tui()
+        .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::ToolCall {
+                tool_name: "read_file".to_string(),
+                input_yaml: Some("path: /data/results.csv".to_string()),
+                raw: None,
+            },
+            source: sub_source.clone(),
+        }))
+        .await
+        .unwrap();
+
+    // Snapshot after initial sub-agent activity (thoughts + two tool calls)
+    harness.tui().flush_pending_thought_for_test();
+    harness.render();
+    let rendered_mid1 = normalize_screen(&harness.screen_contents());
+    insta::assert_snapshot!("sub_agent_activity_dedup_after_first_tools", rendered_mid1);
+
+    // ── Phase 5: Sub-agent thinks more ───────────────────────────────
+    for chunk in ["Now I see ", "the pattern ", "in the data."] {
+        harness
+            .tui()
+            .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+                kind: UiOutputEventKind::ThoughtChunk {
+                    text: chunk.to_string(),
+                    raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
+                },
+                source: sub_source.clone(),
+            }))
+            .await
+            .unwrap();
+    }
+
+    // ── Phase 6: Sub-agent makes one more tool call ──────────────────
+    harness
+        .tui()
+        .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::ToolCall {
+                tool_name: "write_file".to_string(),
+                input_yaml: Some("path: /data/summary.md".to_string()),
+                raw: None,
+            },
+            source: sub_source.clone(),
+        }))
+        .await
+        .unwrap();
+
+    // Snapshot after all sub-agent tool calls
+    harness.tui().flush_pending_thought_for_test();
+    harness.render();
+    let rendered_mid2 = normalize_screen(&harness.screen_contents());
+    insta::assert_snapshot!("sub_agent_activity_dedup_after_all_tools", rendered_mid2);
+
+    // ── Phase 7: Sub-agent sends final message ───────────────────────
+    for chunk in ["Here are ", "my findings: ", "the data shows a clear trend."] {
+        harness
+            .tui()
+            .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+                kind: UiOutputEventKind::MessageChunk {
+                    text: chunk.to_string(),
+                    raw: Some(Box::new(acp::ContentChunk::new(chunk.to_string().into()))),
+                },
+                source: sub_source.clone(),
+            }))
+            .await
+            .unwrap();
+    }
+
+    // ── Phase 8: Sub-agent usage line ────────────────────────────────
+    harness
+        .tui()
+        .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+            kind: UiOutputEventKind::Usage {
+                input_tokens: 500,
+                output_tokens: 200,
+                cached_tokens: 100,
+                session_label: Some("> researcher ▸ research-session-1".to_string()),
+            },
+            source: sub_source.clone(),
+        }))
+        .await
+        .unwrap();
+
+    // ── Phase 9: Top-level agent streams final response ──────────────
+    for chunk in [
+        "Based on the ",
+        "research, ",
+        "the data clearly shows ",
+        "an upward trend.",
+    ] {
+        harness
+            .tui()
+            .handle_tui_event(TuiEvent::UiOutput(UiOutputEvent {
+                kind: UiOutputEventKind::MessageChunk {
+                    text: chunk.to_string(),
+                    raw: None,
+                },
+                source: None,
+            }))
+            .await
+            .unwrap();
+    }
+
+    // Final snapshot showing the complete flow
+    harness.render();
+    let rendered_final = normalize_screen(&harness.screen_contents());
+    insta::assert_snapshot!("sub_agent_activity_dedup_final", rendered_final);
+
+    // ── Verify no duplicate entries ──────────────────────────────────
+    let all_entries: Vec<_> = harness
+        .tui()
+        .app
+        .transcript
+        .iter()
+        .flat_map(Tui::render_entry)
+        .filter_map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            if text.is_empty() || text.starts_with("Welcome to harnx") || text.starts_with('•') {
+                None
+            } else {
+                Some(text)
+            }
+        })
+        .collect();
+
+    // The sub-agent heading should appear exactly once
+    let heading_count = all_entries
+        .iter()
+        .filter(|e| *e == "> researcher ▸ research-session-1")
+        .count();
+    assert_eq!(
+        heading_count, 1,
+        "sub-agent heading should appear exactly once, got {heading_count}. entries: {all_entries:?}"
+    );
+
+    // Each tool call should appear exactly once
+    for tool_name in ["bash", "read_file", "write_file"] {
+        let tool_count = all_entries
+            .iter()
+            .filter(|e| *e == &format!("→ {tool_name}"))
+            .count();
+        assert_eq!(
+            tool_count, 1,
+            "tool call {tool_name} should appear exactly once, got {tool_count}. entries: {all_entries:?}"
+        );
+    }
+
+    // The delegation tool call (top-level) should appear exactly once
+    let delegation_count = all_entries
+        .iter()
+        .filter(|e| *e == "→ researcher_session_prompt")
+        .count();
+    assert_eq!(
+        delegation_count, 1,
+        "delegation tool call should appear exactly once, got {delegation_count}. entries: {all_entries:?}"
+    );
+
+    harness.drain_and_settle().await.unwrap();
 }


### PR DESCRIPTION
## Summary

Three distinct bugs conspired to corrupt the parent-agent transcript when sub-agents (and sub-sub-agents) streamed activity back over ACP:

- **Double-emission**: Every sub-agent event reached the parent TUI twice — once via `AcpNotificationClient::forward_ui_output_event` calling `emit_ui_output_event` directly, and again via a registered chunk forwarder that also emitted. Fix prefers forwarder delivery when one is registered.
- **VS16 rendering drift**: The tool-call marker `->️` embedded VS16 (U+FE0F), causing a 1-col width disagreement between ratatui (unicode-width) and terminals (emoji presentation). The drift left stray glyphs like a trailing `t` on argument lines and one-letter corruptions like "researchur". Replaced with `→` (U+2192, stable width 1).
- **Sub-agent text merged into parent's AssistantText**: `streaming_assistant_idx` pointed at the parent's entry when sub-agent chunks arrived, so they got concatenated onto the parent row. Now reset on source change.

### Before (buggy)

```
Let me investigate this. Delegating to researcher.RESEARCHER_TEXT: RESEARCHER_TEXT: Let me check Let me check the raw data first.the raw data first.Got initial data. Got initial data. ...
->️repro249_unique_mcp_tool     t
   {}
->️nneted-analyst_session_prompt
...
```

### After (fixed)

```
Let me investigate this. Delegating to researcher.

→ nested-researcher_session_prompt
   message: Investigate the data trends in detail.
> nested-researcher ▸ UUID
RESEARCHER_TEXT: Let me check the raw data first.Got initial data. Need deeper analysis. Delegating to analyst.

→ repro249_unique_mcp_tool
   {}
→ nested-analyst_session_prompt
...
```

## Supporting changes

- Switch scroll-widget height to `Paragraph::line_count` (enables ratatui `unstable-rendered-line-info`) so reported height matches rendered height exactly.
- `Clear` the frame buffer at draw start so cells not repainted fall back to blanks.
- Update all unit tests / snapshots affected by the `→` marker change and the parent/sub-agent text separation.

## Test plan

- [x] `cargo test --lib` (294 tests passing)
- [x] New tmux e2e `nested_sub_agent_activity_no_duplicates` drives parent → researcher → analyst with real ACP subprocesses; asserts delegation tool calls, sub-agent headings, MCP tool calls, and final-message markers each appear the expected number of times
- [x] 10/10 consecutive runs clean (no flakiness)
- [x] Manual inspection of the TUI with a nested-agent flow to confirm visual improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected tool-call glyph to use a single Unicode arrow (→) in transcripts.
  * Fixed event dispatch ordering to prioritize chunk forwarders before UI emission.
  * Prevented duplicate activity lines in nested sub-agent delegation flows.
  * Ensured assistant streaming resets on tool-calls, plans, and source changes so messages don't merge incorrectly.

* **Tests**
  * Added end-to-end regression test for nested sub-agent scenarios with normalization helpers.

* **Chores**
  * Updated ratatui dependency feature configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->