### PR TITLE
fix(tui): show attachments in transcript on direct submit and dot-command

### DIFF
--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -231,6 +231,13 @@ where
                     err,
                     cooldown.as_secs()
                 ));
+                // Yield so the TUI event loop has a chance to process the
+                // warning message (sent via emit_ui_output_event) before the
+                // final error event arrives through a separate channel.
+                // Without this yield, the LlmError can race ahead of the last
+                // "exhausted retries" TranscriptText event and appear in the
+                // wrong order in the transcript.
+                tokio::task::yield_now().await;
                 last_error = Some(err);
             }
         }

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -151,16 +151,22 @@ impl Tui {
                         self.refresh_input_chrome();
                     } else if text.trim_start().starts_with('.') {
                         // Dot-command: route through repl command handler
+                        let attachments_snapshot = self.app.attachments.clone();
                         self.app
                             .transcript
                             .push(TranscriptItem::UserText(text.clone()));
+                        self.render_submitted_attachments(&attachments_snapshot);
+                        self.pin_transcript_to_bottom();
                         self.app.input = Self::new_input();
                         self.run_repl_command(&text).await?;
                         self.refresh_input_chrome();
                     } else {
+                        let attachments_snapshot = self.app.attachments.clone();
                         self.app
                             .transcript
                             .push(TranscriptItem::UserText(text.clone()));
+                        self.render_submitted_attachments(&attachments_snapshot);
+                        self.pin_transcript_to_bottom();
                         self.app.input = Self::new_input();
                         let msg = crate::tui::types::PendingMessage {
                             text,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2439,6 +2439,82 @@ async fn attach_command_preserves_draft_text() {
 }
 
 #[tokio::test]
+async fn direct_submit_with_attachments_renders_attachment_entries_in_transcript() {
+    use crate::tui::types::Attachment;
+    use std::path::PathBuf;
+
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.app.attachments = vec![Attachment {
+        path: PathBuf::from("/tmp/example.txt"),
+        display_name: "example.txt".to_string(),
+    }];
+    tui.set_input_text("check attachment");
+
+    tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    let user_index = tui
+        .app
+        .transcript
+        .iter()
+        .position(
+            |item| matches!(item, TranscriptItem::UserText(text) if text == "check attachment"),
+        )
+        .expect("expected submitted user text in transcript");
+
+    assert!(matches!(
+        tui.app.transcript.get(user_index + 1),
+        Some(TranscriptItem::AttachmentHeader(text)) if text == "Attachments (1)"
+    ));
+    assert!(matches!(
+        tui.app.transcript.get(user_index + 2),
+        Some(TranscriptItem::AttachmentItem(text)) if text == "example.txt"
+    ));
+}
+
+#[tokio::test]
+async fn dot_command_with_attachments_renders_attachment_entries_in_transcript() {
+    use crate::tui::types::Attachment;
+    use std::path::PathBuf;
+
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.app.attachments = vec![Attachment {
+        path: PathBuf::from("/tmp/example.txt"),
+        display_name: "example.txt".to_string(),
+    }];
+    tui.set_input_text(".info attachments");
+
+    tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    let user_index = tui
+        .app
+        .transcript
+        .iter()
+        .position(
+            |item| matches!(item, TranscriptItem::UserText(text) if text == ".info attachments"),
+        )
+        .expect("expected dot-command user text in transcript");
+
+    assert!(matches!(
+        tui.app.transcript.get(user_index + 1),
+        Some(TranscriptItem::AttachmentHeader(text)) if text == "Attachments (1)"
+    ));
+    assert!(matches!(
+        tui.app.transcript.get(user_index + 2),
+        Some(TranscriptItem::AttachmentItem(text)) if text == "example.txt"
+    ));
+}
+
+#[tokio::test]
 async fn attach_nonexistent_file_shows_error() {
     let config = test_config();
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));

--- a/tests/snapshots/tmux_e2e__retry_all_fail_shows_warnings_in_tui.snap
+++ b/tests/snapshots/tmux_e2e__retry_all_fail_shows_warnings_in_tui.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/tmux_e2e.rs
-assertion_line: 1469
+assertion_line: 1427
 expression: normalized
 ---
 Welcome to harnx 0.30.0  *  Type .help for commands, Tab to complete.

--- a/tests/tmux_e2e.rs
+++ b/tests/tmux_e2e.rs
@@ -851,7 +851,7 @@ fn nested_sub_agent_activity_no_duplicates() -> Result<()> {
     // Wait for the *full* parent final message so the spinner has settled and
     // the text has finished streaming (not just the "PARENT_FINAL:" marker,
     // which can appear before the rest of the message arrives).
-    let screen = tmux.wait_for(Duration::from_secs(45), |screen| {
+    let screen = tmux.wait_for(Duration::from_secs(90), |screen| {
         screen.contains("PARENT_FINAL: Research complete. Data shows clear upward trend.")
     })?;
 


### PR DESCRIPTION
In handle_key(), two direct-submit paths (dot-command path and direct LLM submit path) now call render_submitted_attachments() + pin_transcript_to_bottom() after pushing UserText to the transcript, matching the existing behavior in submit_pending_message_inner().

Tests were added in src/tui/tests.rs covering both paths.

Issue: #237 (https://github.com/dobesv/harnx/issues/237)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Attachments now display in the transcript immediately when submitting messages via Enter input; the transcript auto-scrolls to show submitted content.
  * Reduced likelihood of out-of-order transcript events when a model exhausts retries, improving message ordering reliability.

* **Tests**
  * Added tests verifying attachments render after direct message and dot-command submissions.
  * Extended an end-to-end wait in a test to ensure complete message streaming before assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->