### PR TITLE
feat: add compaction_agent for customizable context compression

### DIFF
--- a/.changesets/compaction-agent.md
+++ b/.changesets/compaction-agent.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+Add `compaction_agent` field to agent config. When set, context compression uses that agent's model, system prompt, and parameters instead of the global defaults.

--- a/example_config/agents/example-agent.md
+++ b/example_config/agents/example-agent.md
@@ -15,6 +15,7 @@ use_tools:                       # Which MCP tools to allow
 description: ""                  # Short description of the agent
 version: ""                      # Agent version string
 agent_default_session: null      # Set a session to use when starting the agent
+# compaction_agent: null          # Agent to use for context compression (uses its model/system prompt)
 instructions: null               # Override the instructions below
 
 variables:                       # Agent variables (prompted on first use)

--- a/src/client/stream.rs
+++ b/src/client/stream.rs
@@ -285,10 +285,8 @@ impl JsonStreamParser {
                     }
                     self.balances.push(ch);
                 }
-                '[' => {
-                    if self.start.is_some() {
-                        self.balances.push(ch);
-                    }
+                '[' if self.start.is_some() => {
+                    self.balances.push(ch);
                 }
                 '}' => {
                     self.balances.pop();

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -106,6 +106,8 @@ pub struct Agent {
     instructions: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     hooks: Option<HooksConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    compaction_agent: Option<String>,
     #[serde(default)]
     prompt: String,
 
@@ -156,6 +158,7 @@ impl Agent {
             agent_default_session: frontmatter.agent_default_session,
             instructions: frontmatter.instructions,
             hooks: frontmatter.hooks,
+            compaction_agent: frontmatter.compaction_agent,
             prompt,
             ..Default::default()
         }
@@ -183,6 +186,69 @@ impl Agent {
             .and_then(|value| value.to_str())
             .ok_or_else(|| anyhow!("Invalid agent file name: '{}'", path.display()))?;
         Ok(Self::from_markdown(name, &contents))
+    }
+
+    /// Resolve file-backed variable defaults and populate `shared_variables`.
+    ///
+    /// This performs the synchronous subset of `init()` that loads variable
+    /// values from files (the `path:` field on agent variables) and then
+    /// runs `init_agent_variables` with `no_interaction: true`.  It does NOT
+    /// touch MCP, RAG, or model resolution — call `retrieve_agent` for the
+    /// model and this method for variables when you need a lightweight agent
+    /// suitable for non-interactive use (e.g. compaction).
+    pub fn resolve_variables(&mut self) -> Result<()> {
+        let agent_file_path = Config::agent_file(self.name());
+        let agent_dir = agent_file_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(Config::agents_data_dir);
+
+        Self::resolve_file_backed_variables(&mut self.variables, &agent_dir)?;
+
+        let new_variables = Self::init_agent_variables(
+            &self.variables,
+            &self.shared_variables,
+            true, // no_interaction
+        )?;
+        self.set_shared_variables(new_variables);
+        Ok(())
+    }
+
+    /// Load file-backed defaults for variables that have a `path:` field.
+    fn resolve_file_backed_variables(
+        variables: &mut [AgentVariable],
+        agent_dir: &Path,
+    ) -> Result<()> {
+        for variable in variables.iter_mut() {
+            if let Some(path_str) = &variable.path {
+                if variable.default.is_some() {
+                    log::warn!(
+                        "Variable '{}': both 'path' and 'default' set, using 'path'",
+                        variable.name
+                    );
+                }
+
+                let resolved_path = safe_join_path(agent_dir, path_str).ok_or_else(|| {
+                    anyhow!(
+                        "Variable '{}': path '{}' is not allowed (must be relative, no '..' traversal)",
+                        variable.name,
+                        path_str
+                    )
+                })?;
+
+                let content = std::fs::read_to_string(&resolved_path).with_context(|| {
+                    format!(
+                        "Failed to load file '{}' (resolved to '{}') for variable '{}'",
+                        path_str,
+                        resolved_path.display(),
+                        variable.name
+                    )
+                })?;
+
+                variable.default = Some(content);
+            }
+        }
+        Ok(())
     }
 
     pub async fn init(
@@ -229,35 +295,7 @@ impl Agent {
             .map(Path::to_path_buf)
             .unwrap_or_else(Config::agents_data_dir);
 
-        for variable in &mut agent.variables {
-            if let Some(path_str) = &variable.path {
-                if variable.default.is_some() {
-                    log::warn!(
-                        "Variable '{}': both 'path' and 'default' set, using 'path'",
-                        variable.name
-                    );
-                }
-
-                let resolved_path = safe_join_path(&agent_dir, path_str).ok_or_else(|| {
-                    anyhow!(
-                        "Variable '{}': path '{}' is not allowed (must be relative, no '..' traversal)",
-                        variable.name,
-                        path_str
-                    )
-                })?;
-
-                let content = std::fs::read_to_string(&resolved_path).with_context(|| {
-                    format!(
-                        "Failed to load file '{}' (resolved to '{}') for variable '{}'",
-                        path_str,
-                        resolved_path.display(),
-                        variable.name
-                    )
-                })?;
-
-                variable.default = Some(content);
-            }
-        }
+        Self::resolve_file_backed_variables(&mut agent.variables, &agent_dir)?;
 
         agent.rag = if rag_path.exists() {
             Some(Arc::new(Rag::load(config, DEFAULT_AGENT_NAME, &rag_path)?))
@@ -428,12 +466,20 @@ impl Agent {
         self.model_fallbacks = fallbacks;
     }
 
+    pub fn set_compaction_agent(&mut self, value: Option<String>) {
+        self.compaction_agent = value;
+    }
+
     pub fn use_tools(&self) -> Option<Vec<String>> {
         self.use_tools.clone()
     }
 
     pub fn hooks(&self) -> Option<&HooksConfig> {
         self.hooks.as_ref()
+    }
+
+    pub fn compaction_agent(&self) -> Option<&str> {
+        self.compaction_agent.as_deref()
     }
 
     pub fn has_args(&self) -> bool {
@@ -571,6 +617,20 @@ impl Agent {
         self.session_variables = None;
     }
 
+    /// Compute the full system-message text (prompt + tools summary), matching
+    /// the logic in `build_messages` but without producing a User message.
+    /// Used by `Session::build_messages` when `inject_system_prompt` is true.
+    pub fn system_text(&self) -> String {
+        let prompt = self.interpolated_instructions();
+        let tools_text = self.tools_text();
+        match (&tools_text, prompt.is_empty()) {
+            (Some(tools), false) => format!("{prompt}\n\n{tools}"),
+            (Some(tools), true) => tools.clone(),
+            (None, false) => prompt,
+            (None, true) => String::new(),
+        }
+    }
+
     fn tools_text(&self) -> Option<String> {
         let declarations = self.tools.declarations();
         if declarations.is_empty() {
@@ -630,6 +690,8 @@ struct AgentFrontMatter {
     instructions: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     hooks: Option<HooksConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    compaction_agent: Option<String>,
 }
 
 impl AgentFrontMatter {
@@ -649,6 +711,7 @@ impl AgentFrontMatter {
             agent_default_session: agent.agent_default_session.clone(),
             instructions: agent.instructions.clone(),
             hooks: agent.hooks.clone(),
+            compaction_agent: agent.compaction_agent.clone(),
         }
     }
 
@@ -667,6 +730,7 @@ impl AgentFrontMatter {
             && self.agent_default_session.is_none()
             && self.instructions.is_none()
             && self.hooks.is_none()
+            && self.compaction_agent.is_none()
     }
 }
 
@@ -901,6 +965,34 @@ mod tests {
             agent.use_tools(),
             Some(vec!["fs_*".to_string(), "bash_exec".to_string()])
         );
+    }
+
+    #[test]
+    fn test_agent_compaction_agent_set() {
+        let content = "---\ncompaction_agent: my-compactor\n---\nYou are a test agent.";
+        let agent = Agent::from_markdown("test-agent", content);
+        assert_eq!(agent.compaction_agent(), Some("my-compactor"));
+    }
+
+    #[test]
+    fn test_agent_compaction_agent_unset() {
+        let content = "---\nmodel: openai:gpt-4o\n---\nYou are a test agent.";
+        let agent = Agent::from_markdown("test-agent", content);
+        assert!(agent.compaction_agent().is_none());
+    }
+
+    #[test]
+    fn test_agent_compaction_agent_roundtrip() {
+        let content =
+            "---\ncompaction_agent: my-compactor\nmodel: openai:gpt-4o\n---\nYou are a test agent.";
+        let agent = Agent::from_markdown("test-agent", content);
+
+        // Export and re-parse
+        let exported = agent.export().unwrap();
+        let reparsed = Agent::from_markdown("test-agent", &exported);
+
+        assert_eq!(reparsed.compaction_agent(), Some("my-compactor"));
+        assert_eq!(reparsed.model_id(), Some("openai:gpt-4o"));
     }
 
     #[test]

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -5,7 +5,7 @@ use crate::client::{
     MessageContentPart, MessageContentToolCalls, MessageRole, Model,
 };
 use crate::tool::ToolResult;
-use crate::utils::{base64_encode, is_loader_protocol, sha256, AbortSignal};
+use crate::utils::{base64_encode, create_abort_signal, is_loader_protocol, sha256, AbortSignal};
 
 use anyhow::{bail, Context, Result};
 use indexmap::IndexSet;
@@ -31,6 +31,11 @@ pub struct Input {
     rag_name: Option<String>,
     with_session: bool,
     with_agent: bool,
+    /// When true, `Session::build_messages` will prepend the agent's system
+    /// prompt even though the session already has messages.  Set by
+    /// `set_agent()` — the only path that swaps agents after construction
+    /// (e.g. compaction).
+    inject_system_prompt: bool,
     /// User text injected after tool-call results (pending message consumed
     /// mid-tool-loop).  Appended as a trailing User message in
     /// `build_messages()`.
@@ -55,6 +60,7 @@ impl Input {
             rag_name: None,
             with_session,
             with_agent,
+            inject_system_prompt: false,
             injected_user_text: None,
         }
     }
@@ -123,6 +129,7 @@ impl Input {
             rag_name: None,
             with_session,
             with_agent,
+            inject_system_prompt: false,
             injected_user_text: None,
         })
     }
@@ -244,9 +251,13 @@ impl Input {
         init_client(&self.config, Some(self.agent().model().clone()))
     }
 
+    /// Fetch chat text with retry and model fallback support.
+    /// Uses the agent's configured fallback models if the primary model fails.
     pub async fn fetch_chat_text(&self) -> Result<String> {
-        let client = self.create_client()?;
-        let text = client.chat_completions(self.clone()).await?.text;
+        let abort_signal = create_abort_signal();
+        let (text, _, _, _) =
+            crate::client::retry::call_with_retry_and_fallback(self, &self.config, abort_signal)
+                .await?;
         let text = strip_think_tag(&text).to_string();
         Ok(text)
     }
@@ -310,6 +321,8 @@ impl Input {
 
     pub fn set_agent(&mut self, agent: Agent) {
         self.with_agent = !agent.name().trim().is_empty();
+        self.with_session = self.with_session || self.config.read().session.is_some();
+        self.inject_system_prompt = true;
         self.agent = agent;
     }
 
@@ -327,6 +340,10 @@ impl Input {
 
     pub fn with_agent(&self) -> bool {
         self.with_agent
+    }
+
+    pub fn inject_system_prompt(&self) -> bool {
+        self.inject_system_prompt
     }
 
     pub fn summary(&self) -> String {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -65,9 +65,8 @@ const SERVE_ADDR: &str = "127.0.0.1:8000";
 const SYNC_MODELS_URL: &str =
     "https://raw.githubusercontent.com/dobesv/harnx/refs/heads/main/models.yaml";
 
-const SUMMARIZE_PROMPT: &str =
+const DEFAULT_COMPACT_PROMPT: &str =
     "Summarize the discussion briefly in 200 words or less to use as a prompt for future context.";
-const SUMMARY_PROMPT: &str = "This is a summary of the chat history as a recap: ";
 
 const RAG_TEMPLATE: &str = r#"Answer the query based on the context while respecting the rules. (user query, some textual context and rules, all inside xml tags)
 
@@ -246,8 +245,6 @@ pub struct Config {
 
     pub save_session: Option<bool>,
     pub compress_threshold: usize,
-    pub summarize_prompt: Option<String>,
-    pub summary_prompt: Option<String>,
 
     pub rag_embedding_model: Option<String>,
     pub rag_reranker_model: Option<String>,
@@ -339,8 +336,6 @@ impl std::fmt::Debug for Config {
             .field("agent_default_session", &self.agent_default_session)
             .field("save_session", &self.save_session)
             .field("compress_threshold", &self.compress_threshold)
-            .field("summarize_prompt", &self.summarize_prompt)
-            .field("summary_prompt", &self.summary_prompt)
             .field("rag_embedding_model", &self.rag_embedding_model)
             .field("rag_reranker_model", &self.rag_reranker_model)
             .field("rag_top_k", &self.rag_top_k)
@@ -398,8 +393,6 @@ impl Clone for Config {
             agent_default_session: self.agent_default_session.clone(),
             save_session: self.save_session,
             compress_threshold: self.compress_threshold,
-            summarize_prompt: self.summarize_prompt.clone(),
-            summary_prompt: self.summary_prompt.clone(),
             rag_embedding_model: self.rag_embedding_model.clone(),
             rag_reranker_model: self.rag_reranker_model.clone(),
             rag_top_k: self.rag_top_k,
@@ -464,8 +457,6 @@ impl Default for Config {
 
             save_session: Some(true),
             compress_threshold: 180000,
-            summarize_prompt: None,
-            summary_prompt: None,
 
             rag_embedding_model: None,
             rag_reranker_model: None,
@@ -942,6 +933,10 @@ impl Config {
                 };
                 config.write().set_model_fallbacks(value);
             }
+            "compaction_agent" => {
+                let value = parse_value(value)?;
+                config.write().set_compaction_agent(value);
+            }
             "max_output_tokens" => {
                 let value = parse_value(value)?;
                 config.write().set_max_output_tokens(value);
@@ -1099,6 +1094,14 @@ impl Config {
             session.set_model_fallbacks(value);
         } else if let Some(agent) = self.agent.as_mut() {
             agent.set_model_fallbacks(value);
+        }
+    }
+
+    pub fn set_compaction_agent(&mut self, value: Option<String>) {
+        if let Some(session) = self.session.as_mut() {
+            session.set_compaction_agent(value);
+        } else if let Some(agent) = self.agent.as_mut() {
+            agent.set_compaction_agent(value);
         }
     }
 
@@ -1602,19 +1605,19 @@ impl Config {
         list_file_names(self.sessions_dir().join("_"), ".yaml")
     }
 
-    pub fn maybe_compress_session(config: GlobalConfig) {
-        let mut need_compress = false;
+    pub fn maybe_compact_session(config: GlobalConfig) {
+        let mut need_compact = false;
         {
             let mut config = config.write();
             let compress_threshold = config.compress_threshold;
             if let Some(session) = config.session.as_mut() {
                 if session.need_compress(compress_threshold) {
                     session.set_compressing(true);
-                    need_compress = true;
+                    need_compact = true;
                 }
             }
         };
-        if !need_compress {
+        if !need_compact {
             return;
         }
         let color = if config.read().light_theme() {
@@ -1622,13 +1625,10 @@ impl Config {
         } else {
             nu_ansi_term::Color::DarkGray
         };
-        print!(
-            "\n📢 {}\n",
-            color.italic().paint("Compressing the session."),
-        );
+        print!("\n📢 {}\n", color.italic().paint("Compacting the session."),);
         tokio::spawn(async move {
-            if let Err(err) = Config::compress_session(&config).await {
-                warn!("Failed to compress the session: {err}");
+            if let Err(err) = Config::compact_session(&config).await {
+                warn!("Failed to compact the session: {err}");
             }
             if let Some(session) = config.write().session.as_mut() {
                 session.set_compressing(false);
@@ -1636,36 +1636,62 @@ impl Config {
         });
     }
 
-    pub async fn compress_session(config: &GlobalConfig) -> Result<()> {
+    pub async fn compact_session(config: &GlobalConfig) -> Result<()> {
         match config.read().session.as_ref() {
             Some(session) => {
                 if !session.has_user_messages() {
-                    bail!("No need to compress since there are no messages in the session")
+                    bail!("No need to compact since there are no messages in the session")
                 }
             }
             None => bail!("No session"),
         }
 
-        let prompt = config
+        // Check if the current agent has a compaction_agent configured
+        let compaction_agent_name = config
             .read()
-            .summarize_prompt
-            .clone()
-            .unwrap_or_else(|| SUMMARIZE_PROMPT.into());
-        let input = Input::from_str(config, &prompt, None);
+            .extract_agent()
+            .compaction_agent()
+            .map(str::to_owned);
+
+        let (prompt, agent_override) = if let Some(name) = compaction_agent_name {
+            match config.read().retrieve_agent(&name) {
+                Ok(mut compaction_agent) => {
+                    if let Err(e) = compaction_agent.resolve_variables() {
+                        warn!("Failed to resolve variables for compaction_agent '{name}': {e}");
+                    }
+                    // Keep the normal compaction prompt text so session-aware
+                    // message building still has non-empty user content, while
+                    // the agent override provides the specialized system prompt.
+                    (DEFAULT_COMPACT_PROMPT.to_string(), Some(compaction_agent))
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to load compaction_agent '{name}': {e}; falling back to default compaction"
+                    );
+                    (DEFAULT_COMPACT_PROMPT.to_string(), None)
+                }
+            }
+        } else {
+            (DEFAULT_COMPACT_PROMPT.to_string(), None)
+        };
+
+        // Build the Input without an agent override so that with_session=true is
+        // preserved — the compaction LLM must see the full session history to
+        // summarise it.  Then swap the agent (model/params/prompt) in place
+        // without disturbing the with_session flag.
+        let mut input = Input::from_str(config, &prompt, None);
+        if let Some(compaction_agent) = agent_override {
+            input.set_agent(compaction_agent);
+        }
         let summary = input.fetch_chat_text().await?;
-        let summary_prompt = config
-            .read()
-            .summary_prompt
-            .clone()
-            .unwrap_or_else(|| SUMMARY_PROMPT.into());
         if let Some(session) = config.write().session.as_mut() {
-            session.compress(format!("{summary_prompt}{summary}"));
+            session.compress(summary);
         }
         config.write().discontinuous_last_message();
         Ok(())
     }
 
-    pub fn is_compressing_session(&self) -> bool {
+    pub fn is_compacting_session(&self) -> bool {
         self.session
             .as_ref()
             .map(|v| v.compressing())
@@ -2156,6 +2182,8 @@ impl Config {
                         "use_tools",
                         "save_session",
                         "compress_threshold",
+                        "compaction_agent",
+                        "model_fallbacks",
                         "rag_reranker_model",
                         "rag_top_k",
                         "max_output_tokens",
@@ -2879,12 +2907,6 @@ impl Config {
         if let Some(Some(v)) = read_env_value::<usize>(&get_env_name("compress_threshold")) {
             self.compress_threshold = v;
         }
-        if let Some(v) = read_env_value::<String>(&get_env_name("summarize_prompt")) {
-            self.summarize_prompt = v;
-        }
-        if let Some(v) = read_env_value::<String>(&get_env_name("summary_prompt")) {
-            self.summary_prompt = v;
-        }
 
         if let Some(v) = read_env_value::<String>(&get_env_name("rag_embedding_model")) {
             self.rag_embedding_model = v;
@@ -3572,5 +3594,175 @@ mod tests {
         assert_eq!(roots[0], cwd);
         assert_eq!(roots[1], "/extra");
         assert_eq!(roots[2], "/existing");
+    }
+
+    // ── compact_session tests ────────────────────────────────────────────────
+
+    use crate::client::{MessageContent, MessageRole};
+
+    /// Helper: create a GlobalConfig with a session that already has one user
+    /// message in it, suitable for compaction tests.
+    fn make_config_with_session() -> GlobalConfig {
+        let mut config = Config {
+            stream: false,
+            ..Default::default()
+        };
+        let mut session = Session::new(&config, "test-session");
+        session.push_message_for_test(
+            MessageRole::User,
+            "Tell me about the Rust ownership model.".to_string(),
+        );
+        config.session = Some(session);
+        Arc::new(RwLock::new(config))
+    }
+
+    /// compact_session (no compaction_agent) must send the session history to
+    /// the LLM — i.e. the user message from the conversation must appear in
+    /// the ChatCompletionsData that the mock receives.
+    #[tokio::test]
+    async fn test_compact_session_default_includes_session_history() {
+        use crate::client::TestStateGuard;
+        use crate::test_utils::{MockClient, MockTurnBuilder};
+
+        let mock = Arc::new(
+            MockClient::builder()
+                .add_turn(MockTurnBuilder::new().add_text_chunk("Summary.").build())
+                .build(),
+        );
+        let _guard = TestStateGuard::new(Some(mock.clone())).await;
+        let config = make_config_with_session();
+
+        Config::compact_session(&config).await.unwrap();
+
+        let history = mock.conversation_history();
+        assert_eq!(
+            history.conversation_history.len(),
+            1,
+            "expected exactly one LLM call"
+        );
+        let messages = &history.conversation_history[0].messages;
+        let has_history = messages.iter().any(|m| {
+            if let MessageContent::Text(t) = &m.content {
+                t.contains("Rust ownership model")
+            } else {
+                false
+            }
+        });
+        assert!(
+            has_history,
+            "session history must be forwarded to the compaction LLM; messages: {messages:?}"
+        );
+    }
+
+    /// compact_session with a compaction_agent must also send the session
+    /// history — `set_agent` must not drop `with_session`.
+    #[tokio::test]
+    async fn test_compact_session_with_compaction_agent_includes_session_history() {
+        use crate::client::TestStateGuard;
+        use crate::test_utils::{MockClient, MockTurnBuilder};
+        use std::io::Write as _;
+
+        // Write a minimal compaction agent file to a temp dir and point the
+        // config's agents directory at it via HARNX_CONFIG_DIR.
+        let temp = tempfile::TempDir::new().unwrap();
+        let agents_dir = temp.path().join("agents");
+        std::fs::create_dir_all(&agents_dir).unwrap();
+
+        let agent_content = "---\nmodel: gemini:gemini-3.1-flash-lite-preview\n---\nYou are a specialized compaction agent. Produce a concise summary.\n";
+        let mut f = std::fs::File::create(agents_dir.join("my-compactor.md")).unwrap();
+        f.write_all(agent_content.as_bytes()).unwrap();
+
+        // Build a config where the current (non-session) agent has
+        // compaction_agent = "my-compactor".
+        let mut main_agent = Agent::from_markdown(
+            "main",
+            "---\nmodel: gemini:gemini-3.1-flash-lite-preview\ncompaction_agent: my-compactor\n---\nYou are the main agent.",
+        );
+        main_agent.set_model(crate::client::Model::new(
+            "gemini",
+            "gemini-3.1-flash-lite-preview",
+        ));
+
+        let mut config = Config {
+            stream: false,
+            ..Default::default()
+        };
+        // Point Config::agent_file() at the temp dir via HARNX_CONFIG_DIR.
+        // Use an RAII guard so the env var is restored even on panic.
+        struct EnvGuard {
+            key: &'static str,
+            prev: Option<std::ffi::OsString>,
+        }
+        impl EnvGuard {
+            fn new(key: &'static str, value: &std::path::Path) -> Self {
+                let prev = std::env::var_os(key);
+                // SAFETY: test-only; concurrent env mutation is accepted.
+                unsafe { std::env::set_var(key, value) };
+                Self { key, prev }
+            }
+        }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.prev {
+                    Some(v) => unsafe { std::env::set_var(self.key, v) },
+                    None => unsafe { std::env::remove_var(self.key) },
+                }
+            }
+        }
+        let _env = EnvGuard::new("HARNX_CONFIG_DIR", temp.path());
+
+        config.agent = Some(main_agent);
+
+        let mut session = Session::new(&config, "test-session");
+        session.push_message_for_test(
+            MessageRole::User,
+            "Tell me about the Rust ownership model.".to_string(),
+        );
+        config.session = Some(session);
+        let config = Arc::new(RwLock::new(config));
+
+        let mock = Arc::new(
+            MockClient::builder()
+                .add_turn(MockTurnBuilder::new().add_text_chunk("Compacted.").build())
+                .build(),
+        );
+        let _guard = TestStateGuard::new(Some(mock.clone())).await;
+
+        Config::compact_session(&config).await.unwrap();
+
+        let history = mock.conversation_history();
+        assert_eq!(
+            history.conversation_history.len(),
+            1,
+            "expected exactly one LLM call"
+        );
+        let messages = &history.conversation_history[0].messages;
+
+        // The session history must be present.
+        let has_history = messages.iter().any(|m| {
+            if let MessageContent::Text(t) = &m.content {
+                t.contains("Rust ownership model")
+            } else {
+                false
+            }
+        });
+        assert!(
+            has_history,
+            "session history must be forwarded even when a compaction_agent is configured; messages: {messages:?}"
+        );
+
+        // The compaction agent's system prompt must also be present.
+        let has_system = messages.iter().any(|m| {
+            m.role == MessageRole::System
+                && if let MessageContent::Text(t) = &m.content {
+                    t.contains("specialized compaction agent")
+                } else {
+                    false
+                }
+        });
+        assert!(
+            has_system,
+            "compaction agent's system prompt must be in the messages; messages: {messages:?}"
+        );
     }
 }

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -45,6 +45,8 @@ pub enum SessionLogEntry {
         agent_instructions: String,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         model_fallbacks: Vec<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        compaction_agent: Option<String>,
     },
     #[serde(rename = "message")]
     Message {
@@ -86,6 +88,8 @@ pub struct Session {
     agent_instructions: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     model_fallbacks: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    compaction_agent: Option<String>,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     compressed_messages: Vec<Message>,
@@ -180,6 +184,7 @@ impl Session {
                     agent_variables,
                     agent_instructions,
                     model_fallbacks,
+                    compaction_agent,
                 } => {
                     session.model_id = model_id;
                     session.temperature = temperature;
@@ -191,6 +196,7 @@ impl Session {
                     session.agent_variables = agent_variables;
                     session.agent_instructions = agent_instructions;
                     session.model_fallbacks = model_fallbacks;
+                    session.compaction_agent = compaction_agent;
                 }
                 SessionLogEntry::Message { role, content } => {
                     session.messages.push(Message::new(role, content));
@@ -240,6 +246,9 @@ impl Session {
                 }
                 if session.model_fallbacks.is_empty() {
                     session.model_fallbacks = agent.model_fallbacks().to_vec();
+                }
+                if session.compaction_agent.is_none() {
+                    session.compaction_agent = agent.compaction_agent().map(str::to_string);
                 }
             }
         }
@@ -311,6 +320,7 @@ impl Session {
             agent_variables: self.agent_variables.clone(),
             agent_instructions: self.agent_instructions.clone(),
             model_fallbacks: self.model_fallbacks.clone(),
+            compaction_agent: self.compaction_agent.clone(),
         }
     }
 
@@ -533,6 +543,7 @@ impl Session {
         self.top_p = agent.top_p();
         self.use_tools = agent.use_tools();
         self.model_fallbacks = agent.model_fallbacks().to_vec();
+        self.compaction_agent = agent.compaction_agent().map(str::to_string);
         self.model = agent.model().clone();
         self.agent_name = convert_option_string(agent.name());
         self.agent_prompt = agent.interpolated_instructions();
@@ -562,6 +573,17 @@ impl Session {
 
     pub fn set_save_session_this_time(&mut self) {
         self.save_session_this_time = true;
+    }
+
+    /// Test-only helper: directly inject a message into the session without
+    /// going through the full save/log machinery.  Used to set up compaction
+    /// test scenarios.
+    #[cfg(test)]
+    pub(crate) fn push_message_for_test(&mut self, role: crate::client::MessageRole, text: String) {
+        self.messages.push(crate::client::Message::new(
+            role,
+            crate::client::MessageContent::Text(text),
+        ));
     }
 
     pub fn set_compress_threshold(&mut self, value: Option<usize>) {
@@ -906,6 +928,20 @@ impl Session {
             }
         }
         if need_add_msg {
+            // When the agent was swapped after construction (e.g. compaction),
+            // inject_system_prompt is true and we must prepend the agent's
+            // system prompt — session messages won't already contain it.
+            // On normal session turns the system prompt was stored on turn 1
+            // by save_message(), so inject_system_prompt stays false.
+            if input.inject_system_prompt() {
+                let system_text = input.agent().system_text();
+                if !system_text.is_empty() {
+                    messages.insert(
+                        0,
+                        Message::new(MessageRole::System, MessageContent::Text(system_text)),
+                    );
+                }
+            }
             messages.push(Message::new(MessageRole::User, input.message_content()));
         }
         messages
@@ -926,6 +962,7 @@ impl Session {
         agent.set_top_p(self.top_p);
         agent.set_use_tools(self.use_tools.clone());
         agent.set_model_fallbacks(self.model_fallbacks.clone());
+        agent.set_compaction_agent(self.compaction_agent.clone());
         agent.set_shared_variables(self.agent_variables.clone());
         agent
     }
@@ -984,6 +1021,13 @@ impl Session {
     pub fn set_model_fallbacks(&mut self, value: Vec<String>) {
         if self.model_fallbacks != value {
             self.model_fallbacks = value;
+            self.dirty = true;
+        }
+    }
+
+    pub fn set_compaction_agent(&mut self, value: Option<String>) {
+        if self.compaction_agent != value {
+            self.compaction_agent = value;
             self.dirty = true;
         }
     }

--- a/src/rag/mod.rs
+++ b/src/rag/mod.rs
@@ -994,10 +994,7 @@ fn reciprocal_rank_fusion(
 ) -> Vec<DocumentId> {
     let rrf_k = top_k * 2;
     let mut map: IndexMap<DocumentId, f32> = IndexMap::new();
-    for (document_ids, weight) in list_of_document_ids
-        .into_iter()
-        .zip(list_of_weights.into_iter())
-    {
+    for (document_ids, weight) in list_of_document_ids.into_iter().zip(list_of_weights) {
         for (index, &item) in document_ids.iter().enumerate() {
             *map.entry(item).or_default() += (1.0 / ((rrf_k + index + 1) as f32)) * weight;
         }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -112,8 +112,8 @@ pub static REPL_COMMANDS: LazyLock<[ReplCommand; 39]> = LazyLock::new(|| {
             AssertState::True(StateFlags::SESSION_EMPTY | StateFlags::SESSION),
         ),
         ReplCommand::new(
-            ".compress session",
-            "Compress session messages",
+            ".compact session",
+            "Compact session messages using configured compaction agent",
             AssertState::True(StateFlags::SESSION),
         ),
         ReplCommand::new(
@@ -674,17 +674,17 @@ pub async fn run_repl_command_with_output(
                     _ => writeln!(output, r#"Usage: .edit <config|agent|session|rag-docs>"#)?,
                 }
             }
-            ".compress" => match args {
+            ".compact" => match args {
                 Some("session") => {
                     abortable_run_with_spinner(
-                        Config::compress_session(config),
-                        "Compressing",
+                        Config::compact_session(config),
+                        "Compacting",
                         abort_signal.clone(),
                     )
                     .await?;
-                    writeln!(output, "✓ Successfully compressed the session.")?;
+                    writeln!(output, "✓ Successfully compacted the session.")?;
                 }
-                _ => writeln!(output, r#"Usage: .compress session"#)?,
+                _ => writeln!(output, r#"Usage: .compact session"#)?,
             },
             ".empty" => match args {
                 Some("session") => {
@@ -1127,7 +1127,7 @@ async fn ask_inner(
     if with_embeddings {
         input.use_embeddings(abort_signal.clone()).await?;
     }
-    while config.read().is_compressing_session() {
+    while config.read().is_compacting_session() {
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 
@@ -1343,7 +1343,7 @@ async fn ask_inner(
         }
 
         Config::maybe_autoname_session(config.clone());
-        Config::maybe_compress_session(config.clone());
+        Config::maybe_compact_session(config.clone());
         Ok(())
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -885,7 +885,7 @@ fn parse_messages(message: Vec<Value>) -> Result<Vec<Message>> {
                     if tool_calls.len() == tool_values.len() {
                         let mut list = vec![];
                         for ((id, name, arguments, thought_signature), (value, tool_call_id)) in
-                            tool_calls.into_iter().zip(tool_values.into_iter())
+                            tool_calls.into_iter().zip(tool_values)
                         {
                             if id != tool_call_id {
                                 return Err(err());

--- a/src/tui/prompt.rs
+++ b/src/tui/prompt.rs
@@ -271,7 +271,7 @@ impl Tui {
         }
 
         Config::maybe_autoname_session(ctx.config.clone());
-        Config::maybe_compress_session(ctx.config.clone());
+        Config::maybe_compact_session(ctx.config.clone());
         Ok(())
     }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -115,7 +115,7 @@ where
             Some((v, score))
         })
         .collect();
-    list.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    list.sort_unstable_by_key(|b| std::cmp::Reverse(b.1));
     list.into_iter().map(|(v, _)| v).collect()
 }
 


### PR DESCRIPTION
## Summary

Add `compaction_agent` field to agent config. When context compaction triggers (auto or manual via `.compact session`), if the current agent has `compaction_agent` set, the referenced agent's model, system prompt, and inference parameters are used for the compaction LLM call instead of the hardcoded default.

Closes #216

## Changes

### New: `compaction_agent` field on agent config
- `compaction_agent: my-compactor` in agent YAML frontmatter
- References another agent by name
- That agent's model, prompt, fallback models, retry config, temperature, etc. are all used for compaction
- If the referenced agent can't be loaded → warning logged, falls back to default behavior
- If not set → existing default compaction behavior unchanged

### Renamed: `.compress session` → `.compact session`
- REPL command renamed (no backwards compat alias — breaking change)
- Internal functions renamed: `compress_session` → `compact_session`, `maybe_compress_session` → `maybe_compact_session`, `is_compressing_session` → `is_compacting_session`

### Removed: `summarize_prompt` and `summary_prompt` config fields
- `summarize_prompt` (the instruction sent to LLM) — replaced by compaction agent's prompt
- `summary_prompt` (prefix prepended to stored result) — removed entirely, the LLM response is stored as-is
- Environment variable overrides for these fields also removed

### Improved: `fetch_chat_text` now uses retry + fallback
- Changed from direct `client.chat_completions()` to `call_with_retry_and_fallback()`
- Compaction (and autoname) now honor the agent's `model_fallbacks` and `retry` config
- This is a behavior improvement for all `fetch_chat_text` callers

## Testing
- 3 unit tests for `compaction_agent` field (parse, unset, round-trip)
- `cargo fmt && cargo build && cargo clippy -- -D warnings` — clean
- 301/301 unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a compaction_agent option so context compaction can use an agent’s model, system prompt, and parameters.

* **Refactor**
  * Renamed commands and UI wording from "compress" to "compact" across the app.
  * Compaction now preserves session history and can be driven by the configured compaction agent instead of global defaults.
  * Session logs now record compaction agent selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->