### PR TITLE
Interrupt in-flight agent streaming on Ctrl-C

### DIFF
--- a/.changesets/fix-ctrl-c-abort.md
+++ b/.changesets/fix-ctrl-c-abort.md
@@ -1,0 +1,10 @@
+---
+harnx: patch
+---
+Fix Ctrl-C not actually interrupting the agent (#292).
+
+`SseHandler::text()` and `thought()` now check the abort signal before
+forwarding chunks, so content arriving after Ctrl-C is silently dropped.
+The Ctrl-C key handler no longer immediately resets the abort signal — the
+reset is deferred to the next prompt submission, giving the background task
+time to observe the cancellation.

--- a/crates/harnx-client/src/bedrock.rs
+++ b/crates/harnx-client/src/bedrock.rs
@@ -316,6 +316,9 @@ async fn chat_completions_streaming(
     let mut buffer = BytesMut::new();
     let mut decoder = MessageFrameDecoder::new();
     while let Some(chunk) = stream.next().await {
+        if handler.aborted() {
+            break;
+        }
         let chunk = chunk?;
         buffer.extend_from_slice(&chunk);
         while let DecodedFrame::Complete(message) = decoder.decode_frame(&mut buffer)? {

--- a/crates/harnx-client/src/claude.rs
+++ b/crates/harnx-client/src/claude.rs
@@ -218,6 +218,9 @@ pub async fn claude_chat_completions_streaming(
 ) -> Result<()> {
     let mut state = ClaudeStreamState::default();
     let handle = |message: SseMmessage| -> Result<bool> {
+        if handler.aborted() {
+            return Ok(true);
+        }
         let data: Value = serde_json::from_str(&message.data)?;
         debug!("stream-data: {data}");
         claude_handle_stream_event(&mut state, handler, &data)?;

--- a/crates/harnx-client/src/cohere.rs
+++ b/crates/harnx-client/src/cohere.rs
@@ -196,6 +196,9 @@ async fn chat_completions_streaming(
 ) -> Result<()> {
     let mut state = CohereStreamState::default();
     let handle = |message: SseMmessage| -> Result<bool> {
+        if handler.aborted() {
+            return Ok(true);
+        }
         if message.data == "[DONE]" {
             return Ok(true);
         }

--- a/crates/harnx-client/src/openai.rs
+++ b/crates/harnx-client/src/openai.rs
@@ -243,6 +243,9 @@ pub async fn openai_chat_completions_streaming(
 ) -> Result<()> {
     let mut state = OpenAiStreamState::default();
     let handle = |message: SseMmessage| -> Result<bool> {
+        if handler.aborted() {
+            return Ok(true);
+        }
         if message.data == "[DONE]" {
             openai_emit_pending_tool_call(&mut state, handler)?;
             return Ok(true);

--- a/crates/harnx-client/src/stream.rs
+++ b/crates/harnx-client/src/stream.rs
@@ -40,6 +40,9 @@ impl SseHandler {
         if text.is_empty() {
             return Ok(());
         }
+        if self.abort_signal.aborted() {
+            return Ok(());
+        }
         let prefix = if !self.thought_buffer.is_empty() && !self.thought_closed {
             self.thought_closed = true;
             "\n</think>\n\n"
@@ -73,6 +76,9 @@ impl SseHandler {
 
     pub fn thought(&mut self, thought: &str) -> Result<()> {
         if thought.is_empty() {
+            return Ok(());
+        }
+        if self.abort_signal.aborted() {
             return Ok(());
         }
         let prefix = if self.thought_buffer.is_empty() {
@@ -124,6 +130,9 @@ impl SseHandler {
 
     pub fn tool_call(&mut self, call: ToolCall) -> Result<()> {
         // debug!("HandleCall: {:?}", call);
+        if self.abort_signal.aborted() {
+            return Ok(());
+        }
         if !self.thought_buffer.is_empty() && !self.thought_closed {
             self.thought_closed = true;
             let _ = self
@@ -138,6 +147,10 @@ impl SseHandler {
         self.abort_signal.clone()
     }
 
+    pub fn aborted(&self) -> bool {
+        self.abort_signal.aborted()
+    }
+
     pub fn tool_calls(&self) -> &[ToolCall] {
         &self.tool_calls
     }
@@ -148,6 +161,9 @@ impl SseHandler {
         output_tokens: Option<u64>,
         cached_tokens: Option<u64>,
     ) {
+        if self.abort_signal.aborted() {
+            return;
+        }
         if input_tokens.is_some() {
             self.input_tokens = input_tokens;
         }
@@ -239,7 +255,7 @@ where
 pub async fn json_stream<S, F, E>(mut stream: S, mut handle: F) -> Result<()>
 where
     S: Stream<Item = Result<bytes::Bytes, E>> + Unpin,
-    F: FnMut(&str) -> Result<()>,
+    F: FnMut(&str) -> Result<bool>,
     E: std::error::Error,
 {
     let mut parser = JsonStreamParser::default();
@@ -250,7 +266,9 @@ where
         unparsed_bytes.extend(chunk_bytes);
         match std::str::from_utf8(&unparsed_bytes) {
             Ok(text) => {
-                parser.process(text, &mut handle)?;
+                if parser.process(text, &mut handle)? {
+                    break;
+                }
                 unparsed_bytes.clear();
             }
             Err(_) => {
@@ -277,9 +295,9 @@ struct JsonStreamParser {
 }
 
 impl JsonStreamParser {
-    fn process<F>(&mut self, text: &str, handle: &mut F) -> Result<()>
+    fn process<F>(&mut self, text: &str, handle: &mut F) -> Result<bool>
     where
-        F: FnMut(&str) -> Result<()>,
+        F: FnMut(&str) -> Result<bool>,
     {
         self.buffer.extend(text.chars());
 
@@ -315,7 +333,10 @@ impl JsonStreamParser {
                     if self.balances.is_empty() {
                         if let Some(start) = self.start.take() {
                             let value: String = self.buffer[start..=i].iter().collect();
-                            handle(&value)?;
+                            if handle(&value)? {
+                                self.cursor = self.buffer.len();
+                                return Ok(true);
+                            }
                         }
                     }
                 }
@@ -326,7 +347,7 @@ impl JsonStreamParser {
             }
         }
         self.cursor = self.buffer.len();
-        Ok(())
+        Ok(false)
     }
 }
 
@@ -359,7 +380,7 @@ mod tests {
             let mut output = vec![];
             let ret = json_stream(stream, |data| {
                 output.push(data.to_string());
-                Ok(())
+                Ok(false)
             })
             .await;
             assert!(ret.is_ok());

--- a/crates/harnx-client/src/vertexai.rs
+++ b/crates/harnx-client/src/vertexai.rs
@@ -245,10 +245,14 @@ pub async fn gemini_chat_completions_streaming(
         let data: Value = res.json().await?;
         catch_error(&data, status.as_u16(), retry_after)?;
     } else {
-        let handle = |value: &str| -> Result<()> {
+        let handle = |value: &str| -> Result<bool> {
+            if handler.aborted() {
+                return Ok(true);
+            }
             let data: Value = serde_json::from_str(value)?;
             debug!("stream-data: {data}");
-            gemini_handle_stream_chunk(handler, &data)
+            gemini_handle_stream_chunk(handler, &data)?;
+            Ok(false)
         };
         json_stream(res.bytes_stream(), handle).await?;
     }

--- a/crates/harnx-runtime/src/test_utils/mock_client.rs
+++ b/crates/harnx-runtime/src/test_utils/mock_client.rs
@@ -53,6 +53,7 @@ use reqwest::Client as ReqwestClient;
 use serde_json::Value;
 use std::collections::VecDeque;
 use std::sync::Arc;
+use tokio::sync::Notify;
 
 #[derive(Debug, Clone)]
 pub enum MockResponseEvent {
@@ -60,13 +61,22 @@ pub enum MockResponseEvent {
     Text(String),
     /// A tool call to include in the response.
     ToolCall(ToolCall),
+    /// Block streaming until test releases gate.
+    Gate {
+        reached: Arc<Notify>,
+        release: Arc<Notify>,
+    },
     /// Return an error during streaming (for testing error scenarios).
     /// Uses `Arc<Error>` since `anyhow::Error` is not `Clone`.
     Error(Arc<anyhow::Error>),
 }
 
 impl MockResponseEvent {
-    fn apply(&self, handler: &mut SseHandler, output: &mut ChatCompletionsOutput) -> Result<()> {
+    async fn apply(
+        &self,
+        handler: &mut SseHandler,
+        output: &mut ChatCompletionsOutput,
+    ) -> Result<()> {
         match self {
             Self::Text(text) => {
                 handler.text(text)?;
@@ -75,6 +85,10 @@ impl MockResponseEvent {
             Self::ToolCall(tool_call) => {
                 handler.tool_call(tool_call.clone())?;
                 output.tool_calls.push(tool_call.clone());
+            }
+            Self::Gate { reached, release } => {
+                reached.notify_one();
+                release.notified().await;
             }
             Self::Error(err) => {
                 // Try to downcast to a concrete error type that implements Clone.
@@ -136,6 +150,7 @@ impl MockTurn {
             match event {
                 MockResponseEvent::Text(text) => output.text.push_str(text),
                 MockResponseEvent::ToolCall(tool_call) => output.tool_calls.push(tool_call.clone()),
+                MockResponseEvent::Gate { .. } => {}
                 MockResponseEvent::Error(err) => {
                     if let Some(llm_err) = err.downcast_ref::<crate::client::LlmError>() {
                         return Err(crate::client::LlmError {
@@ -212,6 +227,14 @@ impl MockTurnBuilder {
                 Some(id.into()),
                 None,
             )));
+        self
+    }
+
+    /// Add blocking gate to pause streaming until test releases it.
+    pub fn add_gate(mut self, reached: Arc<Notify>, release: Arc<Notify>) -> Self {
+        self.turn
+            .events
+            .push(MockResponseEvent::Gate { reached, release });
         self
     }
 
@@ -335,7 +358,13 @@ impl Client for MockClient {
         let turn = self.next_turn(data)?;
         let mut result = Ok(());
         for event in turn.events() {
-            if let Err(e) = event.apply(handler, &mut ChatCompletionsOutput::default()) {
+            if handler.abort().aborted() {
+                break;
+            }
+            if let Err(e) = event
+                .apply(handler, &mut ChatCompletionsOutput::default())
+                .await
+            {
                 result = Err(e);
                 break;
             }

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -83,13 +83,14 @@ impl Tui {
                 self.app.should_quit = true;
             }
             (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
-                // Abort current operation; reset signal so next submit works (fix #3)
+                // Abort current operation; the signal is reset before the next submit (see below).
                 self.abort_signal.set_ctrlc();
                 self.app.transcript.push(TranscriptItem::SystemText(
                     "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
                 ));
                 self.app.llm_busy = false;
-                self.abort_signal.reset();
+                self.app.pending_message = None;
+                *self.shared_pending_message.lock().await = None;
             }
             (KeyCode::Up, KeyModifiers::NONE) => {
                 self.handle_up_key(key);

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -15,7 +15,7 @@ use ratatui::style::Modifier;
 use ratatui::text::Line;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 fn yaml_to_json(yaml: &str) -> serde_json::Value {
     serde_yaml::from_str::<serde_json::Value>(yaml)
@@ -3376,4 +3376,101 @@ async fn history_preview_cursor_style() {
         preview_style.add_modifier.contains(Modifier::REVERSED),
         "preview cursor should still have REVERSED modifier for visibility"
     );
+}
+
+/// Regression test for #292: Ctrl-C during in-flight streaming must actually
+/// abort background task, not only update UI state.
+///
+/// FAILS before fix (abort_signal.reset() in Ctrl-C handler clears signal before
+/// background task can observe it).
+/// PASSES after fix (reset() removed from Ctrl-C handler).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ctrl_c_interrupts_in_flight_streaming() {
+    let config =
+        test_config_with_mock_client_and_agent("test-agent", Some("ctrl-c-in-flight-session"));
+    let gate_reached = Arc::new(Notify::new());
+    let gate_release = Arc::new(Notify::new());
+    let mock_client = Arc::new(
+        MockClient::builder()
+            .global_config(config.clone())
+            .add_turn(
+                MockTurnBuilder::new()
+                    .add_text_chunk("before-gate")
+                    .add_gate(gate_reached.clone(), gate_release.clone())
+                    .add_text_chunk("after-gate — should not appear")
+                    .build(),
+            )
+            .build(),
+    );
+
+    let _guard = TestStateGuard::new(Some(mock_client)).await;
+
+    let mut harness = TuiTestHarness::with_config(config.clone());
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::UserText("Long request".to_string()));
+    harness
+        .tui()
+        .start_prompt(crate::types::PendingMessage {
+            text: "Long request".to_string(),
+            attachments: vec![],
+            attachment_dir: None,
+            paste_count: 0,
+        })
+        .await
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), gate_reached.notified())
+        .await
+        .expect("mock stream should reach gate before Ctrl+C");
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL))
+        .await
+        .unwrap();
+
+    gate_release.notify_one();
+
+    if harness
+        .wait_until_screen_contains("aborted", Duration::from_secs(5))
+        .await
+        .is_err()
+    {
+        harness
+            .wait_until_screen_contains("Ctrl+C", Duration::from_secs(5))
+            .await
+            .unwrap();
+    }
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while harness.tui().app.llm_busy {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for llm_busy to clear"
+        );
+        while let Ok(event) = harness.tui().event_rx.try_recv() {
+            harness.tui().handle_tui_event(event).await.unwrap();
+        }
+        harness.render();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let screen = harness.screen_contents();
+    assert!(
+        !screen.contains("after-gate — should not appear"),
+        "stream should be interrupted before gate release chunk appears: {screen}"
+    );
+    assert!(
+        screen.contains("aborted") || screen.contains("Ctrl+C"),
+        "screen should show abort message, got: {screen}"
+    );
+    assert!(
+        !harness.tui().app.llm_busy,
+        "Ctrl+C should clear llm_busy for in-flight streaming"
+    );
+
+    harness.drain_and_settle().await.unwrap();
 }


### PR DESCRIPTION
The Ctrl-C handler was calling abort_signal.reset() immediately after set_ctrlc(), clearing the abort flag before the background run_prompt_task could observe it. Streaming and tool calls continued as if nothing happened.

Three-part fix:
- Remove abort_signal.reset() from the Ctrl-C handler; reset is already deferred to the next prompt submission
- Also discard any queued pending_message on abort
- SseHandler::text() and thought() now check abort before forwarding chunks, so content arriving after Ctrl-C is dropped at the source
- SseHandler::tool_call() and set_usage() get the same early abort guard
- All SSE provider closures (openai, claude, cohere) return Ok(true) on abort to break out of the network read loop promptly
- json_stream upgraded to FnMut(&str) -> Result<bool> so vertexai can signal early exit; bedrock's custom loop gets an abort check at the top
- MockResponseEvent::Gate added to block mock streaming mid-turn for deterministic concurrency testing
- New regression test test_ctrl_c_interrupts_in_flight_streaming confirms the fix end-to-end

[#292]

Plan: fix-292-ctrl-c-abort

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Ctrl-C now properly interrupts active streaming and prevents stale content from rendering after cancellation.
  * Improved abort signal handling across all LLM provider integrations to ensure clean operation cancellation.
  * Deferred abort signal reset to the next prompt submission, allowing background tasks adequate time to observe cancellation.

* **Tests**
  * Added regression test for Ctrl-C behavior during active streaming operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->