### PR TITLE
Fix TUI stripping anyhow cause chains

### DIFF
--- a/.changesets/fix-310-tui-error-chain.md
+++ b/.changesets/fix-310-tui-error-chain.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Fix missing error details in TUI: full `anyhow` error chain (including `Caused by:`) is now shown in the TUI transcript, matching the CLI output.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,6 +1755,7 @@ dependencies = [
  "futures-util",
  "harnx-client",
  "harnx-core",
+ "harnx-render",
  "parking_lot",
  "serde_json",
  "tokio",

--- a/crates/harnx-acp/src/manager.rs
+++ b/crates/harnx-acp/src/manager.rs
@@ -468,6 +468,39 @@ mod tests {
             .block_on(future)
     }
 
+    /// Mutex that serialises tests which install a global `AgentEventSink`.
+    /// The sink is process-global; concurrent tests would see each other's events.
+    /// Uses `tokio::sync::Mutex` so the guard can be held across `.await` points.
+    static SINK_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    fn assert_error_event(
+        event: &(
+            harnx_core::event::AgentEvent,
+            Option<harnx_core::event::AgentSource>,
+        ),
+        expected_fragments: &[&str],
+        expected_agent: &str,
+        expected_session_id: Option<&str>,
+    ) {
+        use harnx_core::event::{AgentEvent, AgentSource, ModelEvent};
+        match event {
+            (
+                AgentEvent::Model(ModelEvent::Error(msg)),
+                Some(AgentSource { agent, session_id }),
+            ) => {
+                for fragment in expected_fragments {
+                    assert!(
+                        msg.contains(fragment),
+                        "error message missing {fragment:?}, got: {msg}"
+                    );
+                }
+                assert_eq!(agent, expected_agent);
+                assert_eq!(session_id.as_deref(), expected_session_id);
+            }
+            other => panic!("expected ModelEvent::Error with source, got: {other:?}"),
+        }
+    }
+
     fn test_config(name: &str) -> AcpServerConfig {
         AcpServerConfig {
             name: name.to_string(),
@@ -676,6 +709,8 @@ enabled: false
         };
         use std::sync::Mutex;
 
+        let _guard = SINK_LOCK.lock().await;
+
         struct CollectingSink {
             events: Mutex<Vec<(AgentEvent, Option<AgentSource>)>>,
         }
@@ -732,6 +767,63 @@ enabled: false
             }
             other => panic!("unexpected second event: {other:?}"),
         }
+
+        drop(events);
+        harnx_core::sink::clear_agent_event_sink();
+    }
+
+    /// Test that error events from sub-agents pass through the forwarding layer intact.
+    /// When a sub-agent emits a ModelEvent::Error with a formatted cause chain,
+    /// the ACP forwarding layer should preserve the full error string without stripping
+    /// or mangling the "Caused by:" sections.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn forward_acp_chunks_preserves_error_event_content() {
+        use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource, ModelEvent};
+        use std::sync::Mutex;
+
+        let _guard = SINK_LOCK.lock().await;
+
+        struct CollectingSink {
+            events: Mutex<Vec<(AgentEvent, Option<AgentSource>)>>,
+        }
+        impl AgentEventSink for CollectingSink {
+            fn emit(&self, event: AgentEvent, source: Option<AgentSource>) {
+                self.events.lock().unwrap().push((event, source));
+            }
+        }
+
+        let sink = std::sync::Arc::new(CollectingSink {
+            events: Mutex::new(Vec::new()),
+        });
+        harnx_core::sink::clear_agent_event_sink();
+        harnx_core::sink::install_agent_event_sink(sink.clone());
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+        // Simulate a sub-agent emitting an error with a formatted cause chain
+        let formatted_error = "outer error message\n\nCaused by:\n    root cause detail";
+        let source = AgentSource {
+            agent: "pytheas".to_string(),
+            session_id: Some("sub-session-error".to_string()),
+        };
+
+        tx.send(NestedAcpEvent::Agent(
+            AgentEvent::Model(ModelEvent::Error(formatted_error.to_string())),
+            Some(source.clone()),
+        ))
+        .unwrap();
+        drop(tx);
+
+        forward_acp_chunks(rx, None, "test".to_string()).await;
+
+        let events = sink.events.lock().unwrap();
+        assert_eq!(events.len(), 1, "Should have exactly one event");
+        assert_error_event(
+            &events[0],
+            &["outer error message", "Caused by:", "root cause detail"],
+            "pytheas",
+            Some("sub-session-error"),
+        );
 
         drop(events);
         harnx_core::sink::clear_agent_event_sink();

--- a/crates/harnx-engine/Cargo.toml
+++ b/crates/harnx-engine/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = { workspace = true }
 futures-util = { workspace = true }
 harnx-client = { path = "../harnx-client" }
 harnx-core = { path = "../harnx-core" }
+harnx-render = { path = "../harnx-render" }
 parking_lot = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/harnx-engine/src/chat_completions.rs
+++ b/crates/harnx-engine/src/chat_completions.rs
@@ -12,6 +12,7 @@ use harnx_core::event::{AgentEvent, ModelEvent};
 use harnx_core::sink::emit_agent_event;
 use harnx_core::text::{extract_code_block, strip_think_tag};
 use harnx_core::tool::ToolCall;
+use harnx_render::pretty_error_string;
 
 /// Non-streaming LLM call. Builds the `reqwest::Client`, invokes
 /// `Client::chat_completions_inner`, and wraps the error with a useful
@@ -130,7 +131,9 @@ pub async fn run_chat_completion(
             Ok((text, thought, tool_calls, usage))
         }
         Err(err) => {
-            emit_agent_event(AgentEvent::Model(ModelEvent::Error(err.to_string())));
+            emit_agent_event(AgentEvent::Model(ModelEvent::Error(pretty_error_string(
+                &err,
+            ))));
             Err(err)
         }
     }
@@ -187,7 +190,9 @@ pub async fn run_chat_completion_streaming(
             Ok((text, thought, tool_calls, usage, false))
         }
         Err(err) => {
-            emit_agent_event(AgentEvent::Model(ModelEvent::Error(err.to_string())));
+            emit_agent_event(AgentEvent::Model(ModelEvent::Error(pretty_error_string(
+                &err,
+            ))));
             if text.is_empty() {
                 Err(err)
             } else {

--- a/crates/harnx-render/src/lib.rs
+++ b/crates/harnx-render/src/lib.rs
@@ -7,7 +7,8 @@ mod markdown;
 pub use self::markdown::{MarkdownRender, RenderOptions};
 
 pub fn render_error(err: anyhow::Error) {
-    eprintln!("{}", error_text(&pretty_error(&err)));
+    let body = pretty_error_string(&err);
+    eprintln!("{}", error_text(&format!("Error: {body}")));
 }
 
 /// Built-in Monokai Extended theme bytes — bincode-legacy-encoded
@@ -63,12 +64,15 @@ fn no_color() -> bool {
     })
 }
 
-/// Inlined from `harnx::utils::pretty_error`. Formats an
-/// `anyhow::Error` with its cause chain in the same layout the
-/// original harnx helper used.
-fn pretty_error(err: &anyhow::Error) -> String {
+/// Format an `anyhow::Error` cause chain as a plain-text string.
+///
+/// Produces a multi-line string with the top-level message on the first line
+/// and a `Caused by:` block for any nested causes.  The output does **not**
+/// include an `"Error: "` prefix — the TUI renderer (`render.rs`) adds its own
+/// `"error: "` label, and [`render_error`] prepends `"Error: "` for the CLI path.
+pub fn pretty_error_string(err: &anyhow::Error) -> String {
     let mut output = vec![];
-    output.push(format!("Error: {err}"));
+    output.push(format!("{err}"));
     let causes: Vec<_> = err.chain().skip(1).collect();
     let causes_len = causes.len();
     if causes_len > 0 {
@@ -84,7 +88,7 @@ fn pretty_error(err: &anyhow::Error) -> String {
     output.join("\n")
 }
 
-/// Helper for `pretty_error`. Also inlined from `harnx::utils::indent_text`.
+/// Helper for [`pretty_error_string`]. Inlined from `harnx::utils::indent_text`.
 fn indent_text<T: ToString>(s: T, size: usize) -> String {
     let indent_str = " ".repeat(size);
     s.to_string()
@@ -92,4 +96,44 @@ fn indent_text<T: ToString>(s: T, size: usize) -> String {
         .map(|line| format!("{indent_str}{line}"))
         .collect::<Vec<String>>()
         .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pretty_error_string;
+
+    #[test]
+    fn no_causes() {
+        let err = anyhow::anyhow!("something went wrong");
+        assert_eq!(pretty_error_string(&err), "something went wrong");
+    }
+
+    #[test]
+    fn single_cause() {
+        let err = anyhow::anyhow!("root cause").context("outer context");
+        let s = pretty_error_string(&err);
+        assert_eq!(s, "outer context\n\nCaused by:\n    root cause");
+    }
+
+    #[test]
+    fn multiple_causes() {
+        let err = anyhow::anyhow!("innermost")
+            .context("middle")
+            .context("outermost");
+        let s = pretty_error_string(&err);
+        assert_eq!(
+            s,
+            "outermost\n\nCaused by:\n    0: middle\n    1: innermost"
+        );
+    }
+
+    #[test]
+    fn render_error_prepends_error_prefix() {
+        // Verify the string shape render_error would produce (without ANSI/color).
+        let err = anyhow::anyhow!("root cause").context("outer");
+        let body = pretty_error_string(&err);
+        let cli_output = format!("Error: {body}");
+        assert!(cli_output.starts_with("Error: outer"));
+        assert!(cli_output.contains("Caused by:"));
+    }
 }

--- a/crates/harnx-runtime/src/test_utils/mock_client.rs
+++ b/crates/harnx-runtime/src/test_utils/mock_client.rs
@@ -55,6 +55,66 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use tokio::sync::Notify;
 
+/// Rebuild an `anyhow::Error` chain from an `Arc<anyhow::Error>`.
+///
+/// Since `anyhow::Error` is not `Clone`, the mock stores errors in `Arc`. When
+/// the mock needs to *return* the error (which consumes it), it reconstructs
+/// the full chain by collecting each cause's display string and re-wrapping
+/// them from innermost to outermost. This preserves `Caused by:` output.
+///
+/// `LlmError` is a special case: it is reconstructed as the concrete type so
+/// that retry logic can downcast it even after the chain is rebuilt. Any outer
+/// context messages that wrapped the `LlmError` in the original chain are
+/// re-applied on top of the reconstructed error, preserving the full chain for
+/// `pretty_error_string`.
+fn rebuild_anyhow_chain(err: &Arc<anyhow::Error>) -> anyhow::Error {
+    // Collect chain entries (outermost first) as display strings, and note the
+    // index of the LlmError entry so we can reconstruct it as a concrete type
+    // (required for retry logic to downcast it) while still re-wrapping any
+    // outer context messages that sat above it in the original chain.
+    let chain: Vec<&dyn std::error::Error> = err.chain().collect();
+
+    // Find the LlmError position in the chain.
+    let llm_pos = chain
+        .iter()
+        .position(|e| e.downcast_ref::<crate::client::LlmError>().is_some());
+
+    if let Some(pos) = llm_pos {
+        let llm_err = chain[pos]
+            .downcast_ref::<crate::client::LlmError>()
+            .unwrap();
+
+        // Reconstruct the concrete LlmError as the innermost anyhow error so
+        // that retry logic can still downcast it.
+        let mut rebuilt: anyhow::Error = crate::client::LlmError {
+            status: llm_err.status,
+            message: llm_err.message.clone(),
+            retry_after: llm_err.retry_after,
+        }
+        .into();
+
+        // Re-apply outer context messages (those above LlmError in the chain)
+        // from innermost-outer to outermost so the final chain matches the
+        // original: outermost_ctx → ... → LlmError.
+        for outer in chain[..pos].iter().rev() {
+            rebuilt = rebuilt.context(outer.to_string());
+        }
+        return rebuilt;
+    }
+
+    // Generic case: no LlmError found — collect display strings and rebuild
+    // from innermost to outermost so the resulting error has the same chain.
+    let messages: Vec<String> = chain.iter().map(|e| e.to_string()).collect();
+    if messages.is_empty() {
+        return anyhow::anyhow!("{}", err);
+    }
+    let mut rebuilt = anyhow::anyhow!("{}", messages[messages.len() - 1]);
+    for msg in messages[..messages.len() - 1].iter().rev() {
+        rebuilt = rebuilt.context(msg.clone());
+    }
+    rebuilt
+}
+
 #[derive(Debug, Clone)]
 pub enum MockResponseEvent {
     /// A text chunk to stream to the client.
@@ -91,24 +151,7 @@ impl MockResponseEvent {
                 release.notified().await;
             }
             Self::Error(err) => {
-                // Try to downcast to a concrete error type that implements Clone.
-                // For LlmError (the most common test case), reconstruct it to preserve
-                // the error type through the anyhow chain.
-                // Walk the error chain to find LlmError (it may be
-                // wrapped by .with_context() or other anyhow layers).
-                for cause in err.chain() {
-                    if let Some(llm_err) = cause.downcast_ref::<crate::client::LlmError>() {
-                        return Err(crate::client::LlmError {
-                            status: llm_err.status,
-                            message: llm_err.message.clone(),
-                            retry_after: llm_err.retry_after,
-                        }
-                        .into());
-                    }
-                }
-                // Fallback: create a new error from the display string
-                let msg = err.to_string();
-                return Err(anyhow::anyhow!("{}", msg));
+                return Err(rebuild_anyhow_chain(err));
             }
         }
         Ok(())
@@ -152,15 +195,7 @@ impl MockTurn {
                 MockResponseEvent::ToolCall(tool_call) => output.tool_calls.push(tool_call.clone()),
                 MockResponseEvent::Gate { .. } => {}
                 MockResponseEvent::Error(err) => {
-                    if let Some(llm_err) = err.downcast_ref::<crate::client::LlmError>() {
-                        return Err(crate::client::LlmError {
-                            status: llm_err.status,
-                            message: llm_err.message.clone(),
-                            retry_after: llm_err.retry_after,
-                        }
-                        .into());
-                    }
-                    return Err(anyhow::anyhow!("{}", err));
+                    return Err(rebuild_anyhow_chain(err));
                 }
             }
         }

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -5,6 +5,7 @@ use crate::types::{TranscriptItem, TuiEvent};
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use harnx_core::event::{AgentEvent, AgentSource};
+use harnx_render::pretty_error_string;
 use harnx_runtime::utils::pretty_yaml_block;
 use ratatui_textarea::{Input as TextInput, Key};
 use std::path::Path;
@@ -654,7 +655,7 @@ impl Tui {
                     if let Err(err) = self.submit_pending_message(pending).await {
                         self.app
                             .transcript
-                            .push(TranscriptItem::ErrorText(err.to_string()));
+                            .push(TranscriptItem::ErrorText(pretty_error_string(&err)));
                         self.pin_transcript_to_bottom();
                     }
                 }
@@ -673,7 +674,7 @@ impl Tui {
                     if let Err(err) = self.submit_pending_message(pending).await {
                         self.app
                             .transcript
-                            .push(TranscriptItem::ErrorText(err.to_string()));
+                            .push(TranscriptItem::ErrorText(pretty_error_string(&err)));
                         self.pin_transcript_to_bottom();
                     }
                 }
@@ -830,7 +831,7 @@ impl Tui {
             if let Err(err) = result {
                 use harnx_core::event::{AgentEvent, ModelEvent};
                 let _ = event_tx.send(TuiEvent::Agent(
-                    AgentEvent::Model(ModelEvent::Error(err.to_string())),
+                    AgentEvent::Model(ModelEvent::Error(pretty_error_string(&err))),
                     None,
                 ));
             }
@@ -1171,7 +1172,7 @@ impl Tui {
             Err(err) => {
                 self.app
                     .transcript
-                    .push(TranscriptItem::ErrorText(err.to_string()));
+                    .push(TranscriptItem::ErrorText(pretty_error_string(&err)));
             }
         }
         Ok(())

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -2094,6 +2094,89 @@ async fn test_streaming_error_shows_in_transcript() {
     harness.drain_and_settle().await.unwrap();
 }
 
+/// Test that a chained error shows the full cause chain in the TUI transcript.
+///
+/// This test verifies that when a `ModelEvent::Error` carrying a `pretty_error_string`-
+/// formatted chain arrives at the TUI, the full text (including "Caused by:") is
+/// stored in `TranscriptItem::ErrorText` and rendered on screen.
+///
+/// We inject the event directly into the TUI's event channel rather than going
+/// through `start_prompt` / the LLM retry pipeline — that avoids backoff delays
+/// and keeps the test focused on the TUI's own error-display behaviour.
+#[tokio::test]
+async fn test_streaming_error_shows_full_cause_chain_in_transcript() {
+    use harnx_render::pretty_error_string;
+
+    // Build the chained error and format it the same way the engine does.
+    let chained_error = anyhow::anyhow!("root cause detail").context("outer error message");
+    let formatted = pretty_error_string(&chained_error);
+
+    // Verify the formatted string has the expected structure before injecting.
+    assert!(
+        formatted.contains("outer error message"),
+        "pretty_error_string should contain outer message, got: {formatted}"
+    );
+    assert!(
+        formatted.contains("Caused by:"),
+        "pretty_error_string should contain 'Caused by:', got: {formatted}"
+    );
+    assert!(
+        formatted.contains("root cause detail"),
+        "pretty_error_string should contain root cause, got: {formatted}"
+    );
+
+    let config =
+        test_config_with_mock_client_and_agent("test-agent", Some("error-chain-display-session"));
+    let mut harness = TuiTestHarness::with_config(config.clone());
+    harness.tui().clear_transcript();
+
+    // Inject the already-formatted error directly into the TUI event channel,
+    // bypassing the LLM call / retry pipeline entirely.
+    harness
+        .tui()
+        .event_tx
+        .send(TuiEvent::Agent(
+            AgentEvent::Model(ModelEvent::Error(formatted.clone())),
+            None,
+        ))
+        .unwrap();
+
+    // Drain the single queued event into the transcript.
+    harness.drain_and_settle().await.unwrap();
+
+    // The transcript must have an ErrorText entry containing the full chain.
+    let error_text = harness
+        .tui()
+        .app
+        .transcript
+        .iter()
+        .find_map(|entry| match entry {
+            TranscriptItem::ErrorText(text) => Some(text.clone()),
+            _ => None,
+        })
+        .expect("Transcript should contain an ErrorText entry after ModelEvent::Error");
+
+    assert!(
+        error_text.contains("outer error message"),
+        "ErrorText should contain outer error message, got: {error_text}"
+    );
+    assert!(
+        error_text.contains("Caused by:"),
+        "ErrorText should contain 'Caused by:', got: {error_text}"
+    );
+    assert!(
+        error_text.contains("root cause detail"),
+        "ErrorText should contain root cause detail, got: {error_text}"
+    );
+
+    // Also verify the rendered screen shows "error:" prefix.
+    harness.render();
+    assert!(
+        harness.screen_contents().contains("error:"),
+        "Rendered screen should show 'error:' prefix for ErrorText"
+    );
+}
+
 /// Test cancellation during tool call execution.
 /// When user presses Ctrl+C while a tool is executing, the tool should be aborted.
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/harnx/tests/snapshots/tmux_e2e__retry_all_fail_shows_warnings_in_tui.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__retry_all_fail_shows_warnings_in_tui.snap
@@ -1,6 +1,5 @@
 ---
-source: tests/tmux_e2e.rs
-assertion_line: 1427
+source: crates/harnx/tests/tmux_e2e.rs
 expression: normalized
 ---
 Welcome to harnx 0.30.0  *  Type .help for commands, Tab to complete.
@@ -18,8 +17,8 @@ mock-llm:primary)), cooldown 60s. Trying next fallback.
 mock-llm:fallback)), cooldown 60s. Trying next fallback.
 error: Failed to call chat-completions api (client: mock-llm, model: mock-llm:fallback)
 
-
-
+Caused by:
+    Internal Server Error (type: server_error) (status: 500)
 
 
 

--- a/crates/harnx/tests/tmux_e2e.rs
+++ b/crates/harnx/tests/tmux_e2e.rs
@@ -1152,9 +1152,11 @@ fn nested_sub_agent_activity_no_duplicates() -> Result<()> {
     tmux.send_text("do nested delegation")?;
     tmux.send_keys(&["Enter"])?;
 
-    let screen = tmux.wait_for(Duration::from_secs(30), |screen| {
-        screen.contains("Nested task complete")
-    })?;
+    let screen = tmux.wait_for_stable(
+        Duration::from_secs(30),
+        Duration::from_millis(300),
+        |screen| screen.contains("Nested task complete"),
+    )?;
 
     let delegate_tool_name = format!("{}_session_prompt", NESTED_SUB_AGENT);
     let nested_delegate_tool_name = format!("{}_session_prompt", NESTED_SUB_SUB_AGENT);


### PR DESCRIPTION
Introduced pretty_error_string in harnx-render to format the full anyhow
cause chain with a "Caused by:" block. Error emission sites previously
called .to_string(), which collapsed the chain to only the outermost
message.

All ModelEvent::Error emission sites in harnx-engine and harnx-tui now
use the new formatting. Restored the "Error: " prefix in the CLI
rendering path for parity. Includes unit tests for the formatter and
integration tests verifying chain preservation through the engine, TUI,
and ACP forwarding.

[#310]

Plan: fix-310-tui-error-chain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Error messages in TUI transcripts now display complete error chains, including nested cause details, aligning TUI error display with CLI behavior.

## Tests
* Added comprehensive tests to validate end-to-end display of chained errors in transcripts and error propagation layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->