### PR TITLE
fix: anchor front-matter regex and propagate YAML parse errors (#56)

### DIFF
--- a/crates/harnx-core/src/agent_config.rs
+++ b/crates/harnx-core/src/agent_config.rs
@@ -36,7 +36,7 @@ pub const CREATE_TITLE_AGENT_NAME: &str = "%create-title%";
 pub type AgentVariables = IndexMap<String, String>;
 
 static RE_METADATA: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?s)-{3,}\s*(.*?)\s*-{3,}\s*(.*)").unwrap());
+    LazyLock::new(|| Regex::new(r"(?s)\A-{3,}\s*(.*?)\s*-{3,}\s*(.*)").unwrap());
 
 // --- Toolset-value serde helpers ---------------------------------------------
 //
@@ -153,7 +153,7 @@ pub struct AgentConfig {
 }
 
 impl AgentConfig {
-    pub fn from_markdown(name: &str, content: &str) -> Self {
+    pub fn from_markdown(name: &str, content: &str) -> Result<Self> {
         let mut metadata = "";
         let mut prompt = content.trim();
         if let Ok(Some(caps)) = RE_METADATA.captures(content) {
@@ -167,9 +167,10 @@ impl AgentConfig {
         let frontmatter = if metadata.is_empty() {
             AgentFrontMatter::default()
         } else {
-            serde_yaml::from_str::<AgentFrontMatter>(metadata).unwrap_or_default()
+            serde_yaml::from_str::<AgentFrontMatter>(metadata)
+                .map_err(|e| anyhow::anyhow!("Invalid front-matter in agent '{}': {}", name, e))?
         };
-        Self {
+        Ok(Self {
             name: name.to_string(),
             model_id: frontmatter.model_id,
             model_fallbacks: frontmatter.model_fallbacks,
@@ -188,13 +189,17 @@ impl AgentConfig {
             compaction_agent: frontmatter.compaction_agent,
             prompt,
             ..Default::default()
-        }
+        })
     }
 
     pub fn from_prompt(prompt: &str) -> Self {
-        let mut agent = Self::from_markdown(TEMP_AGENT_NAME, prompt);
-        agent.name = TEMP_AGENT_NAME.to_string();
-        agent
+        let mut prompt = prompt.to_string();
+        interpolate_variables(&mut prompt);
+        Self {
+            name: TEMP_AGENT_NAME.to_string(),
+            prompt,
+            ..Default::default()
+        }
     }
 
     /// Markdown body for the built-in `%create-title%` agent, or `None`
@@ -585,6 +590,48 @@ fn serialize_frontmatter(frontmatter: &AgentFrontMatter) -> Result<String> {
 }
 
 // --- AgentVariable -----------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_frontmatter_only_at_start_of_file() {
+        // A `--- ... ---` block that is NOT at the very start of the file must
+        // be treated as plain prompt text, not parsed as front-matter.
+        let content = "Some preamble text.\n---\nmodel: openai:gpt-4o\n---\nMore text.";
+        let agent = AgentConfig::from_markdown("test", content).unwrap();
+        // No model should have been parsed from the mid-file block.
+        assert!(agent.model_id().is_none());
+        // The entire content (trimmed) should appear as the prompt.
+        let instructions = agent.interpolated_instructions();
+        assert!(
+            instructions.contains("Some preamble text."),
+            "expected preamble in prompt, got: {instructions:?}"
+        );
+        assert!(
+            instructions.contains("model: openai:gpt-4o"),
+            "expected mid-file --- block to be part of prompt, got: {instructions:?}"
+        );
+    }
+
+    #[test]
+    fn test_malformed_frontmatter_returns_error() {
+        // A file whose leading front-matter contains invalid YAML must return
+        // Err rather than silently producing a default config.
+        let content = "---\nmodel: [unclosed bracket\n---\nYou are an agent.";
+        let result = AgentConfig::from_markdown("bad-agent", content);
+        assert!(
+            result.is_err(),
+            "expected Err for malformed YAML front-matter, got Ok"
+        );
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            msg.contains("Invalid front-matter"),
+            "expected error message to mention 'Invalid front-matter', got: {msg:?}"
+        );
+    }
+}
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct AgentVariable {

--- a/crates/harnx-core/src/session.rs
+++ b/crates/harnx-core/src/session.rs
@@ -397,14 +397,14 @@ impl Session {
 }
 
 impl Session {
-    pub fn to_agent_config(&self) -> AgentConfig {
+    pub fn to_agent_config(&self) -> Result<AgentConfig> {
         let agent_name = self.agent_name.as_deref().unwrap_or(TEMP_AGENT_NAME);
         let prompt = if self.agent_prompt.is_empty() {
             self.agent_instructions.as_str()
         } else {
             self.agent_prompt.as_str()
         };
-        let mut config = AgentConfig::from_markdown(agent_name, prompt);
+        let mut config = AgentConfig::from_markdown(agent_name, prompt)?;
         config.set_model(self.model.clone());
         config.set_temperature(self.temperature);
         config.set_top_p(self.top_p);
@@ -412,7 +412,7 @@ impl Session {
         config.set_model_fallbacks(self.model_fallbacks.clone());
         config.set_compaction_agent(self.compaction_agent.clone());
         config.set_shared_variables(self.agent_variables.clone());
-        config
+        Ok(config)
     }
 
     pub fn model(&self) -> &Model {

--- a/crates/harnx-runtime/src/config/agent.rs
+++ b/crates/harnx-runtime/src/config/agent.rs
@@ -55,7 +55,7 @@ impl Agent {
 pub fn builtin(name: &str) -> Result<Agent> {
     let content = AgentConfig::builtin_markdown(name)
         .ok_or_else(|| anyhow::anyhow!("Unknown built-in agent `{name}`"))?;
-    Ok(Agent::new(AgentConfig::from_markdown(name, content)))
+    Ok(Agent::new(AgentConfig::from_markdown(name, content)?))
 }
 
 pub fn load(path: &Path) -> Result<Agent> {
@@ -65,7 +65,7 @@ pub fn load(path: &Path) -> Result<Agent> {
         .file_stem()
         .and_then(|value| value.to_str())
         .ok_or_else(|| anyhow!("Invalid agent file name: '{}'", path.display()))?;
-    Ok(Agent::new(AgentConfig::from_markdown(name, &contents)))
+    Ok(Agent::new(AgentConfig::from_markdown(name, &contents)?))
 }
 
 /// Load file-backed defaults for variables that have a `path:` field.
@@ -430,7 +430,7 @@ mod tests {
     }
 
     fn make_agent_with_tools(prompt: &str, tools: Vec<crate::tool::ToolDeclaration>) -> Agent {
-        let mut agent = Agent::new(AgentConfig::from_markdown("test", prompt));
+        let mut agent = Agent::new(AgentConfig::from_markdown("test", prompt).unwrap());
         agent
             .config
             .set_tools(crate::tool::Tools::init_from_mcp(if tools.is_empty() {
@@ -444,7 +444,7 @@ mod tests {
     #[test]
     fn test_agent_from_markdown_full() {
         let content = "---\nmodel: openai:gpt-4o\ntemperature: 0.7\ntop_p: 0.9\nuse_tools: fs,web_search\ndescription: A test agent\nversion: '1.0'\n---\nYou are a helpful test agent.";
-        let agent = AgentConfig::from_markdown("test-agent", content);
+        let agent = AgentConfig::from_markdown("test-agent", content).unwrap();
         assert_eq!(agent.name(), "test-agent");
         assert_eq!(agent.model_id(), Some("openai:gpt-4o"));
         assert_eq!(agent.temperature(), Some(0.7));
@@ -461,7 +461,7 @@ mod tests {
     #[test]
     fn test_agent_from_markdown_minimal() {
         let content = "Just instructions, no front-matter.";
-        let agent = AgentConfig::from_markdown("minimal", content);
+        let agent = AgentConfig::from_markdown("minimal", content).unwrap();
         assert_eq!(agent.name(), "minimal");
         assert!(agent.model_id().is_none());
         assert!(agent.temperature().is_none());
@@ -474,7 +474,7 @@ mod tests {
     #[test]
     fn test_agent_from_markdown_empty_body() {
         let content = "---\nmodel: openai:gpt-4o\ntemperature: 0.5\n---\n";
-        let agent = AgentConfig::from_markdown("empty-body", content);
+        let agent = AgentConfig::from_markdown("empty-body", content).unwrap();
         assert_eq!(agent.name(), "empty-body");
         assert_eq!(agent.model_id(), Some("openai:gpt-4o"));
         assert!(agent.interpolated_instructions().is_empty());
@@ -516,7 +516,7 @@ mod tests {
     #[test]
     fn test_agent_from_markdown_with_use_tools() {
         let content = "---\nuse_tools: fs_*,bash_exec\n---\nHelp with files.";
-        let agent = AgentConfig::from_markdown("tools-agent", content);
+        let agent = AgentConfig::from_markdown("tools-agent", content).unwrap();
         assert_eq!(
             agent.use_tools(),
             Some(vec!["fs_*".to_string(), "bash_exec".to_string()])
@@ -526,14 +526,14 @@ mod tests {
     #[test]
     fn test_agent_compaction_agent_set() {
         let content = "---\ncompaction_agent: my-compactor\n---\nYou are a test agent.";
-        let agent = AgentConfig::from_markdown("test-agent", content);
+        let agent = AgentConfig::from_markdown("test-agent", content).unwrap();
         assert_eq!(agent.compaction_agent(), Some("my-compactor"));
     }
 
     #[test]
     fn test_agent_compaction_agent_unset() {
         let content = "---\nmodel: openai:gpt-4o\n---\nYou are a test agent.";
-        let agent = AgentConfig::from_markdown("test-agent", content);
+        let agent = AgentConfig::from_markdown("test-agent", content).unwrap();
         assert!(agent.compaction_agent().is_none());
     }
 
@@ -541,11 +541,11 @@ mod tests {
     fn test_agent_compaction_agent_roundtrip() {
         let content =
             "---\ncompaction_agent: my-compactor\nmodel: openai:gpt-4o\n---\nYou are a test agent.";
-        let agent = AgentConfig::from_markdown("test-agent", content);
+        let agent = AgentConfig::from_markdown("test-agent", content).unwrap();
 
         // Export and re-parse
         let exported = agent.export().unwrap();
-        let reparsed = AgentConfig::from_markdown("test-agent", &exported);
+        let reparsed = AgentConfig::from_markdown("test-agent", &exported).unwrap();
 
         assert_eq!(reparsed.compaction_agent(), Some("my-compactor"));
         assert_eq!(reparsed.model_id(), Some("openai:gpt-4o"));

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -3440,7 +3440,7 @@ mod tests {
         let mut main_agent = Agent::new(AgentConfig::from_markdown(
             "main",
             "---\nmodel: gemini:gemini-3.1-flash-lite-preview\ncompaction_agent: my-compactor\n---\nYou are the main agent.",
-        ));
+        ).unwrap());
         main_agent.set_model(crate::client::Model::new(
             "gemini",
             "gemini-3.1-flash-lite-preview",

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -655,7 +655,11 @@ pub fn save(
 }
 
 pub fn to_agent(session: &Session) -> Agent {
-    Agent::new(session.to_agent_config())
+    Agent::new(
+        session
+            .to_agent_config()
+            .expect("session agent config should always be valid"),
+    )
 }
 
 pub fn compress(session: &mut Session, mut prompt: String) {
@@ -991,7 +995,7 @@ mod tests {
         let agent = Agent::new(AgentConfig::from_markdown(
             "test",
             "---\nmodel: openai:gpt-4o\nmodel_fallbacks:\n  - anthropic:claude\n  - google:gemini\n---\nYou are a test agent.",
-        ));
+        ).unwrap());
         let mut session = test_session();
 
         session.set_agent(&agent);


### PR DESCRIPTION
Two bugs in AgentConfig::from_markdown:

1. RE_METADATA matched any '--- ... ---' block anywhere in the file, not just at the start. A mid-file --- block would silently consume all preceding text as "metadata" and discard it from the prompt. Fix: anchor the regex with \A so only a leading block matches.

2. serde_yaml::from_str(...).unwrap_or_default() silently discarded YAML parse errors, producing a default AgentConfig instead of surfacing the problem. Fix: propagate the error with map_err + ?.

from_markdown now returns Result<Self>. All callers updated:
- builtin() and load() in harnx-runtime propagate with ?
- Session::to_agent_config() updated to Result<AgentConfig>
- to_agent() updated with .expect()
- All test call sites updated with .unwrap()

from_prompt() is inlined (no regex) since plain prompts never carry front-matter.

Two regression tests added to harnx-core:
- test_frontmatter_only_at_start_of_file
- test_malformed_frontmatter_returns_error

Fixes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent configuration validation with stricter front-matter detection that requires metadata blocks at the start of configuration files.
  * Configuration parsing now explicitly reports errors for malformed YAML instead of silently falling back to defaults, providing clearer feedback when configuration files are invalid.

* **Refactor**
  * Enhanced error handling throughout configuration loading to propagate validation failures to callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->