### PR TITLE
feat(retry): honour server Retry-After hint in 429 responses

### DIFF
--- a/.changesets/429-retry-after-cooldown.md
+++ b/.changesets/429-retry-after-cooldown.md
@@ -1,0 +1,12 @@
+---
+harnx: minor
+---
+When a 429 response includes a `Retry-After` hint, the retry loop now compares
+it against the total remaining backoff budget for that model:
+
+- If `retry_after` is **shorter** than the remaining budget, the loop waits for
+  exactly `retry_after` before the next attempt (instead of the exponential
+  backoff delay).
+- If `retry_after` is **longer** than the remaining budget, the loop exits
+  immediately and lets the outer fallback logic place the model on cooldown for
+  the server-specified duration — no unnecessary retries are made.

--- a/crates/harnx-engine/src/retry.rs
+++ b/crates/harnx-engine/src/retry.rs
@@ -256,6 +256,96 @@ fn resolve_client(ctx: &TurnContext, model_id: &str) -> Result<Box<dyn Client>> 
     ctx.init_client(&model)
 }
 
+/// What the retry loop should do after an attempt fails.
+enum AttemptOutcome {
+    /// Sleep for the given duration then retry, logging the given message.
+    Sleep(Duration, String),
+    /// Return the error immediately (auth / non-retryable).
+    BailImmediately,
+    /// Store the error and exit the retry loop (e.g. retry-after exceeds budget).
+    ExitLoop,
+}
+
+/// Classify a failed attempt and decide what to do next.
+///
+/// Returns the outcome (including the delay and warning message for `Sleep`)
+/// so `try_model_with_retries_custom` stays a thin, low-complexity loop.
+fn handle_attempt_error(
+    err: &anyhow::Error,
+    retry_config: &RetryConfig,
+    attempt: u32,
+    attempts: u32,
+) -> AttemptOutcome {
+    if let Some(llm_err) = find_llm_error(err) {
+        if llm_err.is_auth_error() || !llm_err.is_retryable() {
+            return AttemptOutcome::BailImmediately;
+        }
+        if attempt + 1 >= attempts {
+            return AttemptOutcome::ExitLoop;
+        }
+        match retry_delay_for_llm_error(llm_err, retry_config, attempt, attempts) {
+            None => AttemptOutcome::ExitLoop,
+            Some(delay) => {
+                let hint = if llm_err.retry_after.is_some() {
+                    " (server retry-after)"
+                } else {
+                    ""
+                };
+                let msg = format!(
+                    "Retryable error (status {}, {}), attempt {}/{}. Retrying in {}ms{hint}...",
+                    llm_err.status,
+                    llm_err.message,
+                    attempt + 1,
+                    attempts,
+                    delay.as_millis()
+                );
+                AttemptOutcome::Sleep(delay, msg)
+            }
+        }
+    } else {
+        // Non-LlmError (network timeout, DNS, etc): treat as retryable.
+        if attempt + 1 < attempts {
+            let delay = compute_backoff_delay(retry_config, attempt);
+            let msg = format!(
+                "Network error, attempt {}/{}. Retrying in {}ms: {}",
+                attempt + 1,
+                attempts,
+                delay.as_millis(),
+                err
+            );
+            AttemptOutcome::Sleep(delay, msg)
+        } else {
+            AttemptOutcome::ExitLoop
+        }
+    }
+}
+
+/// Determine how long to wait before the next retry attempt, given an LLM error.
+///
+/// Returns `Some(delay)` if the loop should sleep then retry, or `None` if the
+/// server's `retry_after` hint exceeds the remaining backoff budget and the loop
+/// should bail immediately.
+fn retry_delay_for_llm_error(
+    llm_err: &LlmError,
+    retry_config: &RetryConfig,
+    attempt: u32,
+    attempts: u32,
+) -> Option<Duration> {
+    if let Some(retry_after) = llm_err.retry_after {
+        let remaining_budget: Duration = (attempt + 1..attempts)
+            .map(|a| compute_backoff_delay(retry_config, a))
+            .sum();
+        if retry_after > remaining_budget {
+            // Server wants us to wait longer than we'd spend retrying — bail.
+            return None;
+        }
+        // Honour the server hint instead of the backoff schedule.
+        Some(retry_after)
+    } else {
+        Some(compute_backoff_delay(retry_config, attempt))
+    }
+}
+
 /// Inner retry loop for a single model. Public for test-support use in
 /// harnx — harnx retains a thin test wrapper that builds a `TurnContext`
 /// from its `GlobalConfig` and calls this function.
@@ -275,60 +365,25 @@ where
     let attempts = retry_config.attempts.max(1);
 
     for attempt in 0..attempts {
-        let result = call_fn(input, client, abort_signal.clone()).await;
-
-        match result {
+        match call_fn(input, client, abort_signal.clone()).await {
             Ok(result) => return Ok(result),
-            Err(err) => {
-                // Check if this is a retryable error
-                if let Some(llm_err) = find_llm_error(&err) {
-                    if llm_err.is_auth_error() {
-                        // Auth errors: don't retry, let caller set infinite cooldown
-                        return Err(err);
-                    }
-                    if !llm_err.is_retryable() {
-                        // Non-retryable (400, 404, etc): fail immediately
-                        return Err(err);
-                    }
-                    // Retryable error
-                    if attempt + 1 < attempts {
-                        let delay = compute_backoff_delay(retry_config, attempt);
-                        ctx.warn(&format!(
-                            "Retryable error (status {}, {}), attempt {}/{}. Retrying in {}ms...",
-                            llm_err.status,
-                            llm_err.message,
-                            attempt + 1,
-                            attempts,
-                            delay.as_millis()
-                        ));
-                        tokio::select! {
-                            () = tokio::time::sleep(delay) => {}
-                            () = wait_abort_signal(&abort_signal) => {
-                                return Err(err);
-                            }
-                        }
-                    }
-                } else {
-                    // Non-LlmError (network timeout, DNS, etc): treat as retryable
-                    if attempt + 1 < attempts {
-                        let delay = compute_backoff_delay(retry_config, attempt);
-                        ctx.warn(&format!(
-                            "Network error, attempt {}/{}. Retrying in {}ms: {}",
-                            attempt + 1,
-                            attempts,
-                            delay.as_millis(),
-                            err
-                        ));
-                        tokio::select! {
-                            () = tokio::time::sleep(delay) => {}
-                            () = wait_abort_signal(&abort_signal) => {
-                                return Err(err);
-                            }
-                        }
-                    }
+            Err(err) => match handle_attempt_error(&err, retry_config, attempt, attempts) {
+                AttemptOutcome::BailImmediately => return Err(err),
+                AttemptOutcome::ExitLoop => {
+                    last_error = Some(err);
+                    break;
                 }
-                last_error = Some(err);
-            }
+                AttemptOutcome::Sleep(delay, msg) => {
+                    ctx.warn(&msg);
+                    tokio::select! {
+                        () = tokio::time::sleep(delay) => {}
+                        () = wait_abort_signal(&abort_signal) => {
+                            return Err(err);
+                        }
+                    }
+                    last_error = Some(err);
+                }
+            },
         }
     }
 

--- a/crates/harnx-runtime/src/client/retry.rs
+++ b/crates/harnx-runtime/src/client/retry.rs
@@ -389,6 +389,106 @@ mod tests {
         );
     }
 
+    /// Shared retry config for retry-after tests: 3 attempts, small budget
+    /// (20ms + 40ms = 60ms total) so tests run fast.
+    fn retry_after_test_config() -> RetryConfig {
+        RetryConfig {
+            attempts: 3,
+            initial_delay_ms: 20,
+            max_delay_ms: 100,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_retry_after_short_waits_server_hint_instead_of_backoff() {
+        // retry_after (5ms) < remaining budget (60ms) — should retry and succeed.
+        let rate_limit_err: anyhow::Error = LlmError {
+            status: 429,
+            message: "Rate limited".to_string(),
+            retry_after: Some(Duration::from_millis(5)),
+        }
+        .into();
+        let mock = Arc::new(
+            MockClient::builder()
+                .error_on_stream(rate_limit_err)
+                .add_turn(MockTurnBuilder::new().add_text_chunk("ok").build())
+                .build(),
+        );
+        let _guard = TestStateGuard::new(Some(mock)).await;
+
+        let config = make_config();
+        let input = make_input(&config);
+        let abort = create_abort_signal();
+        let client = crate::config::input::create_client(&input, &config).unwrap();
+
+        let result = try_model_with_retries(
+            &input,
+            client.as_ref(),
+            &config,
+            &retry_after_test_config(),
+            abort,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "Expected success after retrying with server retry-after hint: {:?}",
+            result.err()
+        );
+        let (output, _, _, _) = result.unwrap();
+        assert_eq!(output, "ok");
+    }
+
+    #[tokio::test]
+    async fn test_retry_after_long_exits_early_without_extra_attempts() {
+        // retry_after (10s) > remaining budget (60ms) — should bail after 1 attempt.
+        let rate_limit_err: anyhow::Error = LlmError {
+            status: 429,
+            message: "Rate limited".to_string(),
+            retry_after: Some(Duration::from_millis(10_000)),
+        }
+        .into();
+        let mock = Arc::new(
+            MockClient::builder()
+                .error_on_stream(rate_limit_err)
+                .add_turn(
+                    MockTurnBuilder::new()
+                        .add_text_chunk("should not reach")
+                        .build(),
+                )
+                .build(),
+        );
+        let _guard = TestStateGuard::new(Some(mock.clone())).await;
+
+        let config = make_config();
+        let input = make_input(&config);
+        let abort = create_abort_signal();
+        let client = crate::config::input::create_client(&input, &config).unwrap();
+
+        let result = try_model_with_retries(
+            &input,
+            client.as_ref(),
+            &config,
+            &retry_after_test_config(),
+            abort,
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "Expected error when retry-after exceeds budget"
+        );
+
+        let err = result.unwrap_err();
+        let llm_err = find_llm_error(&err).expect("Expected LlmError");
+        assert_eq!(llm_err.status, 429);
+
+        // Only 1 call should have been made — no spurious retries before the bail.
+        assert_eq!(
+            mock.conversation_history().conversation_history.len(),
+            1,
+            "Expected exactly 1 attempt before bailing on long retry-after"
+        );
+    }
+
     #[tokio::test]
     async fn test_invalid_fallback_model_reports_warning_and_skips() {
         // Primary model fails with a retryable error; the only fallback is an


### PR DESCRIPTION
When a 429 error includes a retry_after duration, compare it to the total remaining backoff budget for the current model:

- retry_after <= budget: sleep for retry_after instead of the exponential backoff delay, then retry as normal.
- retry_after > budget: bail out of the inner retry loop immediately (no sleep, no warn) so the outer fallback loop can set the correct cooldown via compute_cooldown (which already returns retry_after for 429s) and move on to a fallback model without wasting time on pointless retries.

Closes #306