### PR TITLE
fix(acp): resolve file-backed agent variables before ACP session start

### DIFF
--- a/.changesets/fix-acp-file-backed-variables.md
+++ b/.changesets/fix-acp-file-backed-variables.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+fix(acp): resolve file-backed agent variable defaults before starting an ACP session. After the ACP-session-path fix in #323, `use_agent_by_name` ran before `use_session`, which in turn ran `init_agent_session_variables` and bailed with "agent variables are required" for any agent declaring `path:`-backed variables — because the synchronous `retrieve_agent` (unlike async `agent::init`) never loaded the file content into the variable's `default`. `use_agent_by_name` now performs that file-loading step itself, mirroring the async flow.

--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -222,10 +222,10 @@ impl acp::Agent for HarnxAgent {
             }
         }
 
-        // Load and resolve the agent (expands system prompt variables like
-        // {{__os__}}). In non-ACP flows this happens via
-        // init_agent_session_variables; in ACP mode we do it here since the
-        // agent is not stored on the config.
+        // Build a fresh agent for the input.  The agent is also stored on
+        // the config (via `use_agent_by_name` above) which is what carries
+        // session/shared variables; this local copy is used to expand system
+        // prompt variables like {{__os__}} via `set_agent`.
         let mut agent = self
             .config
             .read()

--- a/crates/harnx-runtime/src/config/agent.rs
+++ b/crates/harnx-runtime/src/config/agent.rs
@@ -102,6 +102,21 @@ fn resolve_file_backed_variables(variables: &mut [AgentVariable], agent_dir: &Pa
     Ok(())
 }
 
+/// Load file-backed variable defaults onto the agent's variables.
+///
+/// For each variable with a `path:` field, reads the file and stores its
+/// content as the variable's `default`.  This is the subset of init that
+/// must run before `init_agent_session_variables` so that user-provided
+/// `agent_variables` can still override file defaults.
+pub fn resolve_file_defaults(agent: &mut Agent) -> Result<()> {
+    let agent_file_path = Config::agent_file(agent.name());
+    let agent_dir = agent_file_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(Config::agents_data_dir);
+    resolve_file_backed_variables(agent.config.variables_mut(), &agent_dir)
+}
+
 /// Resolve file-backed variable defaults and populate `shared_variables`.
 ///
 /// This performs the synchronous subset of `init()` that loads variable
@@ -111,13 +126,7 @@ fn resolve_file_backed_variables(variables: &mut [AgentVariable], agent_dir: &Pa
 /// model and this method for variables when you need a lightweight agent
 /// suitable for non-interactive use (e.g. compaction).
 pub fn resolve_variables(agent: &mut Agent) -> Result<()> {
-    let agent_file_path = Config::agent_file(agent.name());
-    let agent_dir = agent_file_path
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(Config::agents_data_dir);
-
-    resolve_file_backed_variables(agent.config.variables_mut(), &agent_dir)?;
+    resolve_file_defaults(agent)?;
 
     let new_variables = init_agent_variables(
         agent.config.defined_variables(),

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -985,7 +985,13 @@ impl Config {
     }
 
     pub fn use_agent_by_name(&mut self, name: &str) -> Result<()> {
-        let agent = self.retrieve_agent(name)?;
+        let mut agent = self.retrieve_agent(name)?;
+        // Mirror the async `use_agent` flow: `init()` resolves file-backed
+        // variable defaults (the `path:` field) before the agent becomes
+        // active.  Without this, a follow-up `use_session` would call
+        // `init_agent_session_variables`, find unresolved required variables,
+        // and bail with "agent variables are required".
+        self::agent::resolve_file_defaults(&mut agent)?;
         self.use_agent_obj(agent)
     }
 
@@ -3532,6 +3538,77 @@ mod tests {
         assert!(
             has_system,
             "compaction agent's system prompt must be in the messages; messages: {messages:?}"
+        );
+    }
+
+    /// Regression test for the ACP-server failure where `use_agent_by_name`
+    /// followed by `use_session` bailed with "agent variables are required"
+    /// for an agent whose variables use `path:` (file-backed defaults).  The
+    /// async `agent::init` resolves these defaults, but the synchronous
+    /// `retrieve_agent` does not — `use_agent_by_name` must do so itself,
+    /// otherwise `init_agent_session_variables` (called from `use_session`)
+    /// finds no defaults and bails in non-interactive contexts like ACP.
+    #[tokio::test]
+    async fn test_use_agent_by_name_resolves_file_backed_variable_defaults() {
+        use crate::client::TestStateGuard;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let agents_dir = temp.path().join("agents");
+        std::fs::create_dir_all(agents_dir.join("shared")).unwrap();
+        std::fs::write(
+            agents_dir.join("file-backed-vars.md"),
+            "---\nvariables:\n  - name: prompt_body\n    description: Shared prompt\n    path: shared/prompt.md\n---\n{{prompt_body}}\n",
+        )
+        .unwrap();
+        std::fs::write(agents_dir.join("shared/prompt.md"), "Loaded body").unwrap();
+
+        struct EnvGuard {
+            key: &'static str,
+            prev: Option<std::ffi::OsString>,
+        }
+        impl EnvGuard {
+            fn new(key: &'static str, value: &std::path::Path) -> Self {
+                let prev = std::env::var_os(key);
+                unsafe { std::env::set_var(key, value) };
+                Self { key, prev }
+            }
+        }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.prev {
+                    Some(v) => unsafe { std::env::set_var(self.key, v) },
+                    None => unsafe { std::env::remove_var(self.key) },
+                }
+            }
+        }
+
+        // Hold the global test lock so concurrent tests can't race on the
+        // shared HARNX_CONFIG_DIR env var.
+        let _guard = TestStateGuard::new(None).await;
+        let _env = EnvGuard::new("HARNX_CONFIG_DIR", temp.path());
+
+        // Drive use_session in non-interactive mode so the inquire prompt
+        // that would otherwise hang in CI is suppressed.  The fix must still
+        // produce populated shared_variables under no_interaction.
+        let mut config = Config {
+            info_flag: true,
+            ..Default::default()
+        };
+        config
+            .use_agent_by_name("file-backed-vars")
+            .expect("use_agent_by_name must resolve path-backed variable defaults");
+        config
+            .use_session(Some("file-backed-vars-session"))
+            .expect("use_session must succeed once defaults are resolved");
+
+        let agent = config.agent.as_ref().expect("agent should be set");
+        assert_eq!(
+            agent
+                .shared_variables()
+                .get("prompt_body")
+                .map(String::as_str),
+            Some("Loaded body"),
+            "shared_variables should be populated from the file-backed default"
         );
     }
 }


### PR DESCRIPTION
## Problem

`harnx --acp <agent>` returned `Failed to create session: The following agent variables are required: …` for every agent declaring `path:`-backed variables (`zosimus`, `aristarchus`, `clio`, `hephaestus`, etc.). Errors are visible in `~/.config/harnx/agents/sisyphus/sessions/continue-weirdness-fix-2.yaml`. Reproducible by piping a synthetic ACP `session/new` request to `harnx --acp zosimus`.

## Root cause

#323 fixed ACP session persistence by calling `use_agent_by_name` before `use_session`. As a side effect, `init_agent_session_variables` (called at the tail of `use_session`) stopped short-circuiting on `agent: None` and started running `init_agent_variables`. The async `agent::init` populates `variable.default` from `path:` files, but the synchronous `retrieve_agent` used by `use_agent_by_name` never did. With no defaults, no user-provided values, and no terminal in the ACP process, `init_agent_variables` bailed.

## Fix

Sync `use_agent_by_name` now resolves file-backed defaults itself (extracted as `resolve_file_defaults` from the existing `resolve_variables`), mirroring the async `agent::init` flow. The file load happens before the agent is stored on `Config`, so by the time `use_session` calls `init_agent_session_variables`, the defaults are in place. User-provided `agent_variables` still override file defaults because `init_agent_variables` is what merges them — only its bail condition is removed.

The stale comment in the ACP server's `prompt` handler claiming "the agent is not stored on the config" is also corrected.

## Test plan

- `test_use_agent_by_name_resolves_file_backed_variable_defaults` exercises the exact `use_agent_by_name` → `use_session` sequence with a `path:`-backed variable. Verified it fails on the previous behavior and passes with the fix.
- Manual ACP repro: `printf 'initialize\nsession/new\n' | harnx --acp zosimus` returns a `sessionId` instead of the variables error.
- Full workspace: `cargo build`, `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` (446/446 pass).

---

[![Compound Engineering v2.62.1](https://img.shields.io/badge/Compound_Engineering-v2.62.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file-backed agent variable resolution to occur before ACP session initialization, preventing failures for agents with file-based variables.

* **Tests**
  * Added regression test to verify file-backed agent variables are properly resolved during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->