### PR TITLE
fix(tui): correct partial-bottom tall-item scroll direction

### DIFF
--- a/.changesets/fix-tall-item-scroll-direction.md
+++ b/.changesets/fix-tall-item-scroll-direction.md
@@ -1,0 +1,24 @@
+---
+harnx: patch
+---
+Fix TUI scroll direction through tall transcript items.
+
+When a transcript entry was taller than the viewport, scrolling up caused the
+visible window through the item to slide *forward* through its content (toward
+the last line) instead of backward (toward the first line).  At the maximum
+scroll-up position the rendered slice was identical to the pinned-to-bottom
+view, making the user feel they could not actually scroll past the bottom of a
+tall item.
+
+Root cause: the vendored `ratatui_widget_scrolling::PartialBottomItem` carries
+the number of lines of the item that are scrolled *above* the viewport, but the
+value being passed in was `scroll_offset` — the number of lines scrolled
+*below* the viewport.  These only happen to coincide at one specific scroll
+position; everywhere else the renderer skipped the wrong portion of the item's
+buffer.  The fix passes the correct quantity:
+`max(0, item_height - scroll_offset - viewport_height)`.
+
+Also adds a regression test in `harnx-tui` that asserts the exact set of lines
+visible at several scroll positions for a 20-line item in a 10-line viewport.
+The previous PR #264 test only asserted the presence of *some* line in a
+3-line range, which was satisfied by both the buggy and the correct output.

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -3938,3 +3938,80 @@ async fn test_tall_item_scroll_shows_correct_portion_and_no_dead_zone() {
         "position ({pos_after_clamp}) must be clamped to last_max_position ({max_after_render}) after render"
     );
 }
+
+/// Regression test: when an item is taller than the viewport and the user
+/// scrolls up, the visible window through that item must move *backwards*
+/// through the buffer (toward earlier lines), not forwards.
+///
+/// Symptom (from the user video): scrolling up makes the visible content
+/// "go in the wrong direction".  Concretely, when the scroll position is
+/// such that the first line of the chunk should be at the top of the
+/// viewport, the buggy code instead shows the *last* lines of the chunk
+/// (i.e. the same content that's visible when pinned to the bottom).
+///
+/// Math (V = transcript viewport height = 10, H = item height = 20):
+///
+/// | scroll_up count | scroll_offset | expected first/last visible buffer lines |
+/// |-----------------|---------------|------------------------------------------|
+/// |               0 | 0             | line-11 .. line-20                       |
+/// |               1 | 1             | line-10 .. line-19                       |
+/// |               5 | 5             | line-06 .. line-15                       |
+/// |              10 | 10            | line-01 .. line-10                       |
+#[tokio::test]
+async fn test_tall_item_scroll_window_moves_in_correct_direction() {
+    // size 40x13 → transcript area is 13 - 3 (input) = 10 rows.
+    let mut harness = TuiTestHarness::with_size(40, 13);
+
+    let lines: Vec<String> = (1..=20).map(|i| format!("line-{i:02}")).collect();
+    let tall_text = lines.join("\n");
+
+    harness.tui().clear_transcript();
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText(tall_text));
+    harness.tui().pin_transcript_to_bottom();
+
+    // Helper: assert the visible portion of the transcript shows exactly
+    // line-{first}..line-{last} (inclusive, zero-padded), and no others.
+    let assert_window = |harness: &mut TuiTestHarness, first: usize, last: usize, label: &str| {
+        let view = normalize_screen(&harness.screen_contents());
+        for n in 1..=20usize {
+            let needle = format!("line-{n:02}");
+            let in_window = n >= first && n <= last;
+            let present = view.contains(&needle);
+            assert_eq!(
+                    present, in_window,
+                    "{label}: expected {needle} present={in_window}, got present={present}\nview:\n{view}"
+                );
+        }
+    };
+
+    // 1. Pinned to bottom — should show the last 10 lines (line-11..line-20).
+    harness.render();
+    assert_window(&mut harness, 11, 20, "initial bottom view");
+
+    // 2. Scroll up by 1.  The window should slide backwards by 1 line:
+    //    line-10..line-19.  The buggy code instead shows line-02..line-11
+    //    (window jumps backwards by H-V-1 = 9 lines and slides forward).
+    harness.tui().app.scroll_state.scroll_up();
+    harness.render();
+    assert_window(&mut harness, 10, 19, "after scroll_up x1");
+
+    // 3. Scroll up by 4 more (total 5).
+    for _ in 0..4 {
+        harness.tui().app.scroll_state.scroll_up();
+    }
+    harness.render();
+    assert_window(&mut harness, 6, 15, "after scroll_up x5");
+
+    // 4. Scroll up by 5 more (total 10 = max).  We should now be at the
+    //    very top of the item: line-01..line-10.  The buggy code instead
+    //    shows line-11..line-20 (identical to the pinned-to-bottom view!).
+    for _ in 0..5 {
+        harness.tui().app.scroll_state.scroll_up();
+    }
+    harness.render();
+    assert_window(&mut harness, 1, 10, "after scroll_up x10 (top of item)");
+}

--- a/crates/ratatui-widget-scrolling/src/lib.rs
+++ b/crates/ratatui-widget-scrolling/src/lib.rs
@@ -14,6 +14,19 @@ pub type FullItems = Option<(std::ops::Range<IndexInHeightLog>, Rect)>;
 /// `lines_above_viewport` is the number of lines of this item that are
 /// scrolled above the top of the viewport.  The renderer must skip that
 /// many lines before copying content into the frame.
+/// `(item_index, screen_area, lines_above_viewport)`
+///
+/// `lines_above_viewport` is the number of lines of this item that have been
+/// scrolled past the *top* edge of the viewport (not the bottom).  The
+/// renderer must skip exactly that many lines from the start of the item
+/// buffer before copying content into the frame.
+///
+/// For a tall item that is anchored at the bottom of the viewport (the most
+/// recent transcript entry), this is `max(0, item_height - scroll_offset -
+/// viewport_height)` — the portion of the item that overflows above the
+/// visible area.  When the item does not overflow above the viewport
+/// (i.e. it fits between the bottom of the viewport and somewhere inside it),
+/// this is `0`.
 pub type PartialBottomItem = Option<(IndexInHeightLog, Rect, usize)>;
 
 pub struct ScrollState {
@@ -420,10 +433,19 @@ pub fn get_areas_to_render_from_scroll_position(
                 remaining_item_bottom_height_after_scrolling
             };
 
-        // Store the return value.
-        // The third field is `scroll_offset`: the number of lines of this item
-        // that are scrolled above the top of the viewport.  The renderer must
-        // skip exactly that many lines before copying content to the frame.
+        // Lines of this item that are above the *top* of the viewport — the
+        // portion that overflows upward beyond what the viewport can show.
+        // Equals `(height - scroll_offset) - viewport_height` when the item
+        // overflows the top of the viewport, otherwise `0`.
+        //
+        // The renderer skips this many lines from the start of the item's
+        // buffer before copying.  Passing `scroll_offset` here (which counts
+        // lines below the viewport, not above) makes the visible window
+        // through a tall item slide in the wrong direction as the user
+        // scrolls — the bug fixed here.
+        let lines_above_viewport =
+            remaining_item_bottom_height_after_scrolling.saturating_sub(viewable_space);
+
         area_for_partial_draw_bottom = Some((
             index,
             Rect {
@@ -435,7 +457,7 @@ pub fn get_areas_to_render_from_scroll_position(
                 height: partial_item_bottom_height.try_into().unwrap_or(u16::MAX),
                 ..area
             },
-            scroll_offset,
+            lines_above_viewport,
         ));
     }
 
@@ -932,5 +954,43 @@ mod tests {
                 width: 5,
             }
         );
+    }
+
+    /// `lines_above_viewport` (the third tuple field of `PartialBottomItem`)
+    /// must equal the number of item lines scrolled past the *top* of the
+    /// viewport, not the number scrolled past the bottom.  These two values
+    /// only coincide at one specific scroll position; everywhere else,
+    /// passing the wrong one makes the visible window through a tall item
+    /// slide in the wrong direction.
+    ///
+    /// For a single item with H = 20 in a viewport with V = 10:
+    ///
+    /// | scroll_offset (S) | expected lines_above = max(0, H - S - V) |
+    /// |-------------------|------------------------------------------|
+    /// |                 1 |                                        9 |
+    /// |                 5 |                                        5 |
+    /// |                10 |                                        0 |
+    /// |                15 |                                        0 (item no longer overflows top) |
+    #[test]
+    fn partial_bottom_lines_above_is_overflow_above_not_offset_below() {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            height: 10,
+            width: 5,
+        };
+        let height_log = [20];
+
+        for (scroll_offset, expected_lines_above) in [(1, 9), (5, 5), (10, 0), (15, 0)] {
+            let (_, _, partial_bottom) =
+                get_areas_to_render_from_scroll_position(area, scroll_offset, &height_log);
+            let (_, _, lines_above) = partial_bottom.unwrap_or_else(|| {
+                panic!("expected partial_bottom for scroll_offset={scroll_offset}")
+            });
+            assert_eq!(
+                lines_above, expected_lines_above,
+                "scroll_offset={scroll_offset}: lines_above must be max(0, H-S-V), not S"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #325: when a transcript entry was taller than the viewport, scrolling up made the visible window through the item slide *forward* through its buffer (toward the last line) instead of backward (toward the first line). At maximum scroll-up the rendered slice was identical to the pinned-to-bottom view — so it looked like you couldn't scroll past the bottom of a tall item, and the content sometimes appeared to "go in the wrong direction" or "slide down onto itself" as the user scrolled up.

## Root cause

`PartialBottomItem`'s third tuple field is documented as *"lines of this item scrolled above the top of the viewport"* and the renderer (`copy_partial_bottom_widget_to_frame`) skips that many lines from the start of the item buffer.

PR #325 wired in `scroll_offset` there, but `scroll_offset` counts lines scrolled *below* the viewport. These two values only coincide at one specific scroll position. For a 20-line item in a 10-line viewport:

| `scroll_offset` (S) | Should show | Buggy code shows |
|---|---|---|
| 1  | line-10..line-19 | line-02..line-11 |
| 5  | line-06..line-15 | line-06..line-15 (lucky coincidence) |
| 10 | line-01..line-10 (top of item at top) | line-11..line-20 (last line at bottom!) |

## Fix

Pass `(item_height - scroll_offset).saturating_sub(viewport_height)` instead of `scroll_offset` in `crates/ratatui-widget-scrolling/src/lib.rs`. This is the actual portion of the item that overflows above the viewport — `0` when the item doesn't overflow upward, `H - S - V` when it does.

## Why the PR #325 regression test missed this

The existing test asserted *"view contains line-08 OR line-09 OR line-10"* in a 7-row range that both the buggy and the correct outputs satisfied. This PR adds a stricter end-to-end test that pins the exact set of visible lines at four scroll positions through a 20-line item in a 10-line viewport, plus a function-level unit test in `ratatui_widget_scrolling` that locks in the boundary cases.

## Test plan

- [x] `cargo nextest run --workspace` — 453 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New regression test fails on the buggy code, passes on the fix
- [ ] Manual: scroll through a long transcript entry in the TUI and verify the visible window moves in the correct direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scrolling behavior in tall transcript items where scroll-up operations were moving in the wrong direction. The visible content now correctly shifts toward earlier lines instead of remaining pinned at the bottom.

* **Tests**
  * Added regression test to verify correct scrolling behavior for tall items across multiple scroll positions throughout the viewport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->