### PR TITLE
test(tui): fix flaky test_streaming_error_shows_in_transcript

### DIFF
--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -2090,19 +2090,46 @@ async fn test_streaming_error_shows_in_transcript() {
 
     let _ = result; // start_prompt always returns Ok (spawns a task)
 
-    // Wait for the error to appear in the transcript
-    harness
-        .wait_until_screen_contains("error:", Duration::from_secs(5))
-        .await
-        .unwrap();
-
-    let has_error = harness
-        .tui()
-        .app
-        .transcript
-        .iter()
-        .any(|entry| matches!(entry, TranscriptItem::ErrorText(_)));
-    assert!(has_error, "Transcript should contain an error entry");
+    // Wait for the ErrorText entry to appear in the transcript.
+    //
+    // Polling the rendered screen for the substring "error:" is ambiguous:
+    // the retry loop emits a `NoticeEvent::Warning` along the lines of
+    // "Model '...' exhausted retries (error: <cause>) ..." which renders as
+    // `SystemText` and *also* contains "error:".  On a slow runner the
+    // warning event arrives before the spawned prompt task's
+    // `ModelEvent::Error` has been processed into `ErrorText`, so the screen
+    // check would succeed while the transcript still lacks the entry the
+    // test cares about — producing the exact flake observed in CI on
+    // macos-latest.  Polling the transcript directly removes the ambiguity.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        while let Ok(event) = harness.tui().event_rx.try_recv() {
+            harness.tui().handle_tui_event(event).await.unwrap();
+        }
+        let has_error = harness
+            .tui()
+            .app
+            .transcript
+            .iter()
+            .any(|entry| matches!(entry, TranscriptItem::ErrorText(_)));
+        if has_error {
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            let summary: Vec<String> = harness
+                .tui()
+                .app
+                .transcript
+                .iter()
+                .map(|e| format!("{e:?}"))
+                .collect();
+            panic!(
+                "Transcript did not gain an ErrorText entry within 5s; transcript was:\n{}",
+                summary.join("\n")
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
 
     harness.drain_and_settle().await.unwrap();
 }


### PR DESCRIPTION
## Summary

`test_streaming_error_shows_in_transcript` has been flaking deterministically on macos-latest in CI (failures observed on commit \`d2acf5a\` on \`main\` and on every attempt of #333). Every failure was at the same line, in <5s — not a timeout.

## Root cause

The test polled the rendered screen for the substring `"error:"` and then asserted the transcript had a `TranscriptItem::ErrorText` entry. **Two events emit "error:" content** in this scenario:

1. The retry loop in `harnx-engine/src/retry.rs:234` emits `ctx.warn("Model '...' exhausted retries (error: <cause>) ...")` → `NoticeEvent::Warning` → rendered as `SystemText` containing `"(error: ..."`. Matches `"error:"`.
2. The spawned prompt task's terminal error becomes `ModelEvent::Error` → `TranscriptItem::ErrorText` (the entry the test actually wants).

These travel through different paths (warning via the global `AgentEventSink`, terminal error via the prompt task's `event_tx` fallback). On macos-latest the warning consistently arrives first, so `wait_until_screen_contains("error:")` returns success while the transcript still has no `ErrorText` — and the immediate `assert!` fires.

The screen substring was just an ambiguous proxy.

## Fix

Poll the transcript directly for `TranscriptItem::ErrorText` — that's the actual post-condition the test cares about, and it's not racy against the warning event. On timeout, dump the transcript so future debugging has context.

## Test plan

- [x] `cargo nextest run -p harnx-tui --stress-count=10 test_streaming_error_shows_in_transcript` — 10/10 pass
- [x] `cargo nextest run -p harnx-tui` — 85/85 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)