### PR TITLE
feat(mcp-fs): indicate result truncation in tool summaries

### DIFF
--- a/crates/harnx-mcp-fs/src/main.rs
+++ b/crates/harnx-mcp-fs/src/main.rs
@@ -12,6 +12,7 @@
 //! If no roots are specified (via CLI or MCP client), all operations are denied.
 
 mod server;
+mod summary;
 
 use rmcp::ServiceExt;
 use server::FsServer;

--- a/crates/harnx-mcp-fs/src/server.rs
+++ b/crates/harnx-mcp-fs/src/server.rs
@@ -754,9 +754,18 @@ impl FsServer {
                 None,
             ));
         }
-        // The glob crate always expects '/' as the path separator, even on Windows,
-        // so normalize the base path before escaping (Path::display yields '\' on Windows).
+        // The glob crate doesn't understand Windows verbatim prefixes (`\\?\`)
+        // produced by canonicalize(), and expects '/' as the path separator on
+        // every platform — normalize both before building the pattern.
         let mut base_str = search_path.display().to_string();
+        #[cfg(windows)]
+        {
+            if let Some(rest) = base_str.strip_prefix(r"\\?\UNC\").map(str::to_owned) {
+                base_str = format!(r"\\{rest}");
+            } else if let Some(rest) = base_str.strip_prefix(r"\\?\").map(str::to_owned) {
+                base_str = rest;
+            }
+        }
         if std::path::MAIN_SEPARATOR != '/' {
             base_str = base_str.replace(std::path::MAIN_SEPARATOR, "/");
         }

--- a/crates/harnx-mcp-fs/src/server.rs
+++ b/crates/harnx-mcp-fs/src/server.rs
@@ -754,8 +754,13 @@ impl FsServer {
                 None,
             ));
         }
-        let escaped_base = glob::Pattern::escape(&search_path.display().to_string());
-        // The glob crate always expects '/' as the path separator, even on Windows.
+        // The glob crate always expects '/' as the path separator, even on Windows,
+        // so normalize the base path before escaping (Path::display yields '\' on Windows).
+        let mut base_str = search_path.display().to_string();
+        if std::path::MAIN_SEPARATOR != '/' {
+            base_str = base_str.replace(std::path::MAIN_SEPARATOR, "/");
+        }
+        let escaped_base = glob::Pattern::escape(&base_str);
         let full_pattern = format!("{escaped_base}/{}", params.pattern);
         let glob_results = glob::glob(&full_pattern).map_err(|err| {
             ErrorData::invalid_params(format!("invalid glob pattern: {err}"), None)

--- a/crates/harnx-mcp-fs/src/server.rs
+++ b/crates/harnx-mcp-fs/src/server.rs
@@ -1,9 +1,13 @@
+use crate::summary::{
+    apply_search_notices, find_summary, ls_summary, render_read_result, search_summary,
+    SearchTruncation,
+};
+
 use harnx_mcp::safety::{
     file_uri_to_path, format_size, is_binary_content, sanitize_output_text, truncate_line,
-    truncate_output, validate_path, validate_write_path, TruncateOpts, DEFAULT_FIND_LIMIT,
-    DEFAULT_GREP_LIMIT, DEFAULT_LS_LIMIT, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES,
-    GREP_MAX_LINE_LENGTH, LS_SCAN_HARD_LIMIT, READ_MAX_FILE_BYTES, SEARCH_FILE_MAX_BYTES,
-    WRITE_MAX_BYTES,
+    validate_path, validate_write_path, DEFAULT_FIND_LIMIT, DEFAULT_GREP_LIMIT, DEFAULT_LS_LIMIT,
+    DEFAULT_MAX_LINES, GREP_MAX_LINE_LENGTH, LS_SCAN_HARD_LIMIT, READ_MAX_FILE_BYTES,
+    SEARCH_FILE_MAX_BYTES, WRITE_MAX_BYTES,
 };
 use harnx_mcp_history::HistoryManager;
 
@@ -367,7 +371,10 @@ impl FsServer {
         let total_matching_lines = numbered_lines.len();
         let mut notices = Vec::new();
 
-        if let Some(tail_count) = params.tail {
+        let (shown_line_start, shown_line_end) = if let Some(tail_count) = params.tail {
+            if tail_count == 0 {
+                return tool_error("tail must be at least 1".to_string());
+            }
             if tail_count < total_matching_lines {
                 notices.push(format!(
                     "showing last {} of {} matching lines",
@@ -376,6 +383,7 @@ impl FsServer {
             }
             let start = total_matching_lines.saturating_sub(tail_count);
             numbered_lines = numbered_lines.into_iter().skip(start).collect();
+            (start + 1, total_matching_lines)
         } else {
             let offset = params.offset.unwrap_or(1).max(1);
             let limit = params.limit.unwrap_or(DEFAULT_MAX_LINES);
@@ -385,6 +393,10 @@ impl FsServer {
                     "Offset {} is beyond end of result set ({} matching lines total)",
                     offset, total_matching_lines
                 ));
+            }
+
+            if limit == 0 {
+                return tool_error("limit must be at least 1".to_string());
             }
 
             let start = offset - 1;
@@ -397,50 +409,18 @@ impl FsServer {
                 ));
             }
             numbered_lines = numbered_lines[start..end].to_vec();
-        }
-
-        let raw_output = numbered_lines
-            .into_iter()
-            .map(|(line_number, line)| format!("{line_number}: {line}"))
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        let default_opts = TruncateOpts::default();
-        let truncate_opts = TruncateOpts {
-            head_lines: params.head_lines.unwrap_or(default_opts.head_lines),
-            tail_lines: params.tail_lines.unwrap_or(default_opts.tail_lines),
-            line_head_bytes: default_opts.line_head_bytes,
-            line_tail_bytes: default_opts.line_tail_bytes,
-            max_output_bytes: params
-                .max_output_bytes
-                .unwrap_or(default_opts.max_output_bytes.min(DEFAULT_MAX_BYTES)),
-            ..default_opts
+            (offset, end)
         };
-        let truncated_output = truncate_output(&raw_output, &truncate_opts);
 
-        if truncated_output != raw_output {
-            notices.push(format!(
-                "output truncated from {} to {}. Use head_lines, tail_lines, or max_output_bytes to see more",
-                format_size(raw_output.len()),
-                format_size(truncated_output.len())
-            ));
-        }
-
-        let mut output = truncated_output;
-        if !notices.is_empty() {
-            let _ = write!(output, "\n\n[{}]", notices.join(". "));
-        }
-
-        let summary = format!(
-            "Read {} ({} lines, {})",
-            params.path,
+        render_read_result(
+            &params,
+            numbered_lines,
             total_matching_lines,
-            format_size(raw_output.len())
-        );
-        Ok(CallToolResult::success(vec![
-            Content::text(output).with_audience(vec![Role::Assistant]),
-            Content::text(summary).with_audience(vec![Role::User]),
-        ]))
+            shown_line_start,
+            shown_line_end,
+            bytes.len(),
+            notices,
+        )
     }
 
     async fn write_file_impl(&self, params: WriteFileParams) -> Result<CallToolResult, ErrorData> {
@@ -679,7 +659,7 @@ impl FsServer {
             );
         }
 
-        let summary = format!("Listed {} entries in {}", entry_count, params.path);
+        let summary = ls_summary(&params.path, entry_count, scan_count, limit_reached);
         Ok(CallToolResult::success(vec![
             Content::text(output).with_audience(vec![Role::Assistant]),
             Content::text(summary).with_audience(vec![Role::User]),
@@ -738,31 +718,20 @@ impl FsServer {
         let match_count = results.len();
 
         let raw_output = results.join("\n");
-        let truncated_output = truncate_output(&raw_output, &TruncateOpts::default());
-        let mut notices = Vec::new();
-        if limit_reached {
-            notices.push(format!(
-                "results limited to {} matches. Refine the pattern for more specific results",
-                max_results
-            ));
-        }
-        if truncated_output != raw_output {
-            notices.push(format!(
-                "output truncated from {} to {}. Use max_results to increase the limit",
-                format_size(raw_output.len()),
-                format_size(truncated_output.len())
-            ));
-        }
+        let raw_bytes = raw_output.len();
+        let (output, byte_truncated) = apply_search_notices(raw_output, limit_reached, max_results);
 
-        let mut output = truncated_output;
-        if !notices.is_empty() {
-            let _ = write!(output, "\n\n[{}]", notices.join(". "));
-        }
-
-        let summary = format!(
-            "Found {} matches in {}",
-            match_count,
-            params.path.as_deref().unwrap_or("workspace")
+        let search_location = params.path.as_deref().unwrap_or("workspace");
+        let summary = search_summary(
+            search_location,
+            &SearchTruncation {
+                match_count,
+                max_results,
+                limit_reached,
+                output_bytes: output.len(),
+                raw_bytes,
+                byte_truncated,
+            },
         );
         Ok(CallToolResult::success(vec![
             Content::text(output).with_audience(vec![Role::Assistant]),
@@ -786,6 +755,7 @@ impl FsServer {
             ));
         }
         let escaped_base = glob::Pattern::escape(&search_path.display().to_string());
+        // The glob crate always expects '/' as the path separator, even on Windows.
         let full_pattern = format!("{escaped_base}/{}", params.pattern);
         let glob_results = glob::glob(&full_pattern).map_err(|err| {
             ErrorData::invalid_params(format!("invalid glob pattern: {err}"), None)
@@ -826,13 +796,15 @@ impl FsServer {
             );
         }
 
-        let summary = format!("Found {} matches", path_count);
+        let summary = find_summary(path_count, max_results, limit_reached);
         Ok(CallToolResult::success(vec![
             Content::text(output).with_audience(vec![Role::Assistant]),
             Content::text(summary).with_audience(vec![Role::User]),
         ]))
     }
+}
 
+impl FsServer {
     async fn rollback_file_impl(
         &self,
         params: RollbackParams,
@@ -1368,6 +1340,24 @@ mod tests {
             .unwrap()
     }
 
+    fn make_server(dir: &std::path::Path) -> FsServer {
+        FsServer::new(vec![dir.to_path_buf()])
+    }
+
+    fn user_summary(result: &CallToolResult) -> String {
+        result
+            .content
+            .iter()
+            .filter(|content| {
+                content
+                    .audience()
+                    .map(|a| a.contains(&Role::User))
+                    .unwrap_or(false)
+            })
+            .find_map(|content| content.raw.as_text().map(|text| text.text.clone()))
+            .unwrap_or_default()
+    }
+
     fn tool_args(value: Value) -> Map<String, Value> {
         value.as_object().unwrap().clone()
     }
@@ -1379,7 +1369,7 @@ mod tests {
             _server_service,
             client_service,
         } = connect_server(
-            FsServer::new(vec![temp_dir.path().to_path_buf()]),
+            make_server(temp_dir.path()),
             vec![temp_dir.path().to_path_buf()],
         )
         .await;
@@ -1419,7 +1409,7 @@ mod tests {
             _server_service,
             client_service,
         } = connect_server(
-            FsServer::new(vec![temp_dir.path().to_path_buf()]),
+            make_server(temp_dir.path()),
             vec![temp_dir.path().to_path_buf()],
         )
         .await;
@@ -1452,7 +1442,7 @@ mod tests {
             _server_service,
             client_service,
         } = connect_server(
-            FsServer::new(vec![temp_dir.path().to_path_buf()]),
+            make_server(temp_dir.path()),
             vec![temp_dir.path().to_path_buf()],
         )
         .await;
@@ -1496,7 +1486,7 @@ mod tests {
             _server_service,
             client_service,
         } = connect_server(
-            FsServer::new(vec![temp_dir.path().to_path_buf()]),
+            make_server(temp_dir.path()),
             vec![temp_dir.path().to_path_buf()],
         )
         .await;
@@ -1524,7 +1514,7 @@ mod tests {
         let temp_dir = TestDir::new();
         let file_path = temp_dir.path().join("offset.txt");
         std::fs::write(&file_path, "one\ntwo\nthree\nfour\n").unwrap();
-        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+        let server = make_server(temp_dir.path());
 
         let result = server
             .read_file_impl(ReadFileParams {
@@ -1551,7 +1541,7 @@ mod tests {
         let temp_dir = TestDir::new();
         let file_path = temp_dir.path().join("grep.txt");
         std::fs::write(&file_path, "alpha\nmatch-one\nbeta\nmatch-two\n").unwrap();
-        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+        let server = make_server(temp_dir.path());
 
         let result = server
             .read_file_impl(ReadFileParams {
@@ -1578,7 +1568,7 @@ mod tests {
         let temp_dir = TestDir::new();
         let file_path = temp_dir.path().join("tail.txt");
         std::fs::write(&file_path, "one\ntwo\nthree\nfour\n").unwrap();
-        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+        let server = make_server(temp_dir.path());
 
         let result = server
             .read_file_impl(ReadFileParams {
@@ -1605,7 +1595,7 @@ mod tests {
         let temp_dir = TestDir::new();
         let file_path = temp_dir.path().join("binary.bin");
         std::fs::write(&file_path, b"hello\0world").unwrap();
-        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+        let server = make_server(temp_dir.path());
 
         let result = server
             .read_file_impl(ReadFileParams {
@@ -1714,5 +1704,235 @@ mod tests {
         let text = text_content(&result);
         assert!(text.contains("one.txt:2: needle"));
         assert!(!text.contains("two.txt"));
+    }
+
+    // ── truncation-in-user-summary tests (issue #144) ──────────────────────
+
+    #[tokio::test]
+    async fn test_read_file_summary_limited_on_pagination() {
+        // offset=1 limit=2 on a 4-line file → shows lines 1–2, more remain.
+        // Summary must show the slice range and byte counts.
+        let temp_dir = TestDir::new();
+        let file_path = temp_dir.path().join("paginated.txt");
+        std::fs::write(&file_path, "one\ntwo\nthree\nfour\n").unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .read_file_impl(ReadFileParams {
+                path: file_path.to_string_lossy().to_string(),
+                offset: Some(1),
+                limit: Some(2),
+                tail: None,
+                grep: None,
+                head_lines: None,
+                tail_lines: None,
+                max_output_bytes: None,
+            })
+            .await
+            .unwrap();
+
+        let summary = user_summary(&result);
+        assert!(
+            summary.contains("lines 1\u{2013}2 of 4"),
+            "expected exact paginated range 'lines 1\u{2013}2 of 4' in summary, got: {summary:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_summary_not_limited_when_small() {
+        let temp_dir = TestDir::new();
+        for i in 0..3 {
+            std::fs::write(temp_dir.path().join(format!("f{i}.txt")), "x").unwrap();
+        }
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .list_directory_impl(ListDirectoryParams {
+                path: temp_dir.path().to_string_lossy().to_string(),
+                recursive: Some(false),
+            })
+            .await
+            .unwrap();
+
+        let summary = user_summary(&result);
+        assert!(
+            !summary.contains("limited"),
+            "expected no 'limited' for small listing, got: {summary:?}"
+        );
+        assert!(
+            summary.contains("Listed 3 entries"),
+            "expected count in summary, got: {summary:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_summary_limited_when_over_default_limit() {
+        // Create DEFAULT_LS_LIMIT + 1 files to trigger limit_reached.
+        // Summary should show "Listed 500 of 501 entries in …".
+        let temp_dir = TestDir::new();
+        for i in 0..=DEFAULT_LS_LIMIT {
+            std::fs::write(temp_dir.path().join(format!("f{i:04}.txt")), "x").unwrap();
+        }
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .list_directory_impl(ListDirectoryParams {
+                path: temp_dir.path().to_string_lossy().to_string(),
+                recursive: Some(false),
+            })
+            .await
+            .unwrap();
+
+        let summary = user_summary(&result);
+        // Should show "Listed 500 of 501 entries" — capped count + true total.
+        assert!(
+            summary.contains(&format!(
+                "Listed {} of {} entries",
+                DEFAULT_LS_LIMIT,
+                DEFAULT_LS_LIMIT + 1
+            )),
+            "expected 'Listed N of M entries' in summary, got: {summary:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_search_files_summary_variants() {
+        struct Case {
+            files: &'static [(&'static str, &'static str)],
+            max_results: usize,
+            check: fn(&str),
+        }
+
+        let cases: &[Case] = &[
+            Case {
+                files: &[
+                    ("match0.txt", "needle\n"),
+                    ("match1.txt", "needle\n"),
+                    ("match2.txt", "needle\n"),
+                ],
+                max_results: 1,
+                check: |summary| {
+                    assert!(
+                        summary.contains("1+"),
+                        "expected '1+' in summary when max_results hit, got: {summary:?}"
+                    );
+                    assert!(
+                        summary.contains("showing 1"),
+                        "expected 'showing 1' in summary, got: {summary:?}"
+                    );
+                },
+            },
+            Case {
+                files: &[("one.txt", "needle\n")],
+                max_results: 10,
+                check: |summary| {
+                    assert!(
+                        !summary.contains("limited"),
+                        "expected no 'limited' when all results returned, got: {summary:?}"
+                    );
+                },
+            },
+        ];
+
+        for case in cases {
+            let temp_dir = TestDir::new();
+            for (name, content) in case.files {
+                std::fs::write(temp_dir.path().join(name), content).unwrap();
+            }
+            let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+            let result = server
+                .search_files_impl(SearchFilesParams {
+                    pattern: "needle".to_string(),
+                    path: Some(temp_dir.path().to_string_lossy().to_string()),
+                    include: None,
+                    context_lines: Some(0),
+                    ignore_case: Some(false),
+                    max_results: Some(case.max_results),
+                })
+                .await
+                .unwrap();
+
+            (case.check)(user_summary(&result).as_str());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_find_files_basic() {
+        // Regression: glob pattern must use '/' not MAIN_SEPARATOR —
+        // the glob crate expects Unix separators on all platforms.
+        let temp_dir = TestDir::new();
+        std::fs::write(temp_dir.path().join("hello.txt"), "").unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .find_files_impl(FindFilesParams {
+                pattern: "*.txt".to_string(),
+                path: Some(temp_dir.path().to_string_lossy().to_string()),
+                max_results: Some(10),
+            })
+            .await
+            .unwrap();
+
+        let text = text_content(&result);
+        assert!(
+            text.contains("hello.txt"),
+            "find_files should locate files on any platform, got: {text:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_files_summary_variants() {
+        struct Case {
+            files: &'static [&'static str],
+            max_results: usize,
+            check: fn(&str),
+        }
+
+        let cases: &[Case] = &[
+            Case {
+                files: &["file0.txt", "file1.txt", "file2.txt"],
+                max_results: 1,
+                check: |summary| {
+                    assert!(
+                        summary.contains("1+"),
+                        "expected '1+' in find_files summary when max_results hit, got: {summary:?}"
+                    );
+                    assert!(
+                        summary.contains("showing 1"),
+                        "expected 'showing 1' in find_files summary, got: {summary:?}"
+                    );
+                },
+            },
+            Case {
+                files: &["only.txt"],
+                max_results: 10,
+                check: |summary| {
+                    assert!(
+                        !summary.contains("limited"),
+                        "expected no 'limited' when all files returned, got: {summary:?}"
+                    );
+                },
+            },
+        ];
+
+        for case in cases {
+            let temp_dir = TestDir::new();
+            for name in case.files {
+                std::fs::write(temp_dir.path().join(name), "").unwrap();
+            }
+            let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+            let result = server
+                .find_files_impl(FindFilesParams {
+                    pattern: "*.txt".to_string(),
+                    path: Some(temp_dir.path().to_string_lossy().to_string()),
+                    max_results: Some(case.max_results),
+                })
+                .await
+                .unwrap();
+
+            (case.check)(user_summary(&result).as_str());
+        }
     }
 }

--- a/crates/harnx-mcp-fs/src/summary.rs
+++ b/crates/harnx-mcp-fs/src/summary.rs
@@ -1,0 +1,239 @@
+use harnx_mcp::safety::{
+    format_size, truncate_output, TruncateOpts, DEFAULT_MAX_BYTES, LS_SCAN_HARD_LIMIT,
+};
+use rmcp::model::{CallToolResult, Content, ErrorData, Role};
+use std::fmt::Write as _;
+
+use crate::server::ReadFileParams;
+
+pub(crate) fn render_read_result(
+    params: &ReadFileParams,
+    numbered_lines: Vec<(usize, &str)>,
+    total_lines: usize,
+    shown_start: usize,
+    shown_end: usize,
+    file_bytes: usize,
+    mut notices: Vec<String>,
+) -> Result<CallToolResult, ErrorData> {
+    let shown_content_bytes: usize = numbered_lines.iter().map(|(_, l)| l.len() + 1).sum();
+    let raw_output = numbered_lines
+        .into_iter()
+        .map(|(n, l)| format!("{n}: {l}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let d = TruncateOpts::default();
+    let opts = TruncateOpts {
+        head_lines: params.head_lines.unwrap_or(d.head_lines),
+        tail_lines: params.tail_lines.unwrap_or(d.tail_lines),
+        max_output_bytes: params
+            .max_output_bytes
+            .unwrap_or(d.max_output_bytes.min(DEFAULT_MAX_BYTES)),
+        ..d
+    };
+    let (output, byte_truncated) = truncate_with_notices(
+        raw_output,
+        &opts,
+        "Use head_lines, tail_lines, or max_output_bytes to see more",
+        &mut notices,
+    );
+    let slice = ReadSlice {
+        total_lines,
+        shown_start,
+        shown_end,
+        shown_content_bytes,
+        file_bytes,
+        byte_truncated,
+    };
+    let summary = read_file_summary(&params.path, &slice);
+    Ok(CallToolResult::success(vec![
+        Content::text(output).with_audience(vec![Role::Assistant]),
+        Content::text(summary).with_audience(vec![Role::User]),
+    ]))
+}
+
+/// Truncate `raw_output`, append a notice if truncation occurred, then append
+/// all accumulated notices to the output.  Returns `(output, byte_truncated)`.
+fn truncate_with_notices(
+    raw_output: String,
+    opts: &TruncateOpts,
+    truncation_hint: &str,
+    notices: &mut Vec<String>,
+) -> (String, bool) {
+    let truncated = truncate_output(&raw_output, opts);
+    let byte_truncated = truncated != raw_output;
+    if byte_truncated {
+        notices.push(format!(
+            "output truncated from {} to {}. {}",
+            format_size(raw_output.len()),
+            format_size(truncated.len()),
+            truncation_hint,
+        ));
+    }
+    let mut output = truncated;
+    if !notices.is_empty() {
+        let _ = write!(output, "\n\n[{}]", notices.join(". "));
+    }
+    (output, byte_truncated)
+}
+
+struct ReadSlice {
+    total_lines: usize,
+    shown_start: usize,
+    shown_end: usize,
+    shown_content_bytes: usize,
+    file_bytes: usize,
+    byte_truncated: bool,
+}
+
+fn read_file_summary(path: &str, s: &ReadSlice) -> String {
+    let all = s.shown_start == 1 && s.shown_end == s.total_lines;
+    let lines_part = if all {
+        format!("{} lines", s.total_lines)
+    } else {
+        format!(
+            "lines {}\u{2013}{} of {}",
+            s.shown_start, s.shown_end, s.total_lines
+        )
+    };
+    let bytes_part = if s.byte_truncated {
+        format!(
+            "truncated to {} of {}",
+            format_size(s.shown_content_bytes),
+            format_size(s.file_bytes)
+        )
+    } else if all {
+        format_size(s.file_bytes)
+    } else {
+        format!(
+            "{} of {}",
+            format_size(s.shown_content_bytes),
+            format_size(s.file_bytes)
+        )
+    };
+    format!("Read {} ({}, {})", path, lines_part, bytes_part)
+}
+
+pub(crate) fn ls_summary(
+    path: &str,
+    entry_count: usize,
+    scan_count: usize,
+    limit_reached: bool,
+) -> String {
+    if scan_count >= LS_SCAN_HARD_LIMIT {
+        format!(
+            "Listed {} of {}+ entries in {}",
+            entry_count, LS_SCAN_HARD_LIMIT, path
+        )
+    } else if limit_reached {
+        format!(
+            "Listed {} of {} entries in {}",
+            entry_count, scan_count, path
+        )
+    } else {
+        format!("Listed {} entries in {}", entry_count, path)
+    }
+}
+
+pub(crate) fn apply_search_notices(
+    raw_output: String,
+    limit_reached: bool,
+    max_results: usize,
+) -> (String, bool) {
+    let mut notices = Vec::new();
+    if limit_reached {
+        notices.push(format!(
+            "results limited to {} matches. Refine the pattern for more specific results",
+            max_results
+        ));
+    }
+    truncate_with_notices(
+        raw_output,
+        &TruncateOpts::default(),
+        "Refine the pattern or narrow the search path",
+        &mut notices,
+    )
+}
+
+pub(crate) struct SearchTruncation {
+    pub match_count: usize,
+    pub max_results: usize,
+    pub limit_reached: bool,
+    pub output_bytes: usize,
+    pub raw_bytes: usize,
+    pub byte_truncated: bool,
+}
+
+pub(crate) fn search_summary(location: &str, t: &SearchTruncation) -> String {
+    match (t.limit_reached, t.byte_truncated) {
+        (false, false) => format!("Found {} matches in {}", t.match_count, location),
+        (true, false) => format!(
+            "Found {}+ matches in {} (showing {})",
+            t.max_results, location, t.match_count
+        ),
+        (false, true) => format!(
+            "Found {} matches in {} ({} of {} shown)",
+            t.match_count,
+            location,
+            format_size(t.output_bytes),
+            format_size(t.raw_bytes)
+        ),
+        (true, true) => format!(
+            "Found {}+ matches in {} (showing {}, truncated to {} of {})",
+            t.max_results,
+            location,
+            t.match_count,
+            format_size(t.output_bytes),
+            format_size(t.raw_bytes)
+        ),
+    }
+}
+
+pub(crate) fn find_summary(path_count: usize, max_results: usize, limit_reached: bool) -> String {
+    if limit_reached {
+        format!("Found {}+ matches (showing {})", max_results, path_count)
+    } else {
+        format!("Found {} matches", path_count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_file_summary_complete() {
+        let s = read_file_summary(
+            "foo.txt",
+            &ReadSlice {
+                total_lines: 10,
+                shown_start: 1,
+                shown_end: 10,
+                shown_content_bytes: 100,
+                file_bytes: 100,
+                byte_truncated: false,
+            },
+        );
+        assert!(s.starts_with("Read foo.txt ("), "got: {s:?}");
+        assert!(
+            !s.contains("lines 1"),
+            "complete read should not show range, got: {s:?}"
+        );
+    }
+
+    #[test]
+    fn read_file_summary_paginated() {
+        let s = read_file_summary(
+            "bar.txt",
+            &ReadSlice {
+                total_lines: 100,
+                shown_start: 1,
+                shown_end: 20,
+                shown_content_bytes: 200,
+                file_bytes: 1000,
+                byte_truncated: false,
+            },
+        );
+        assert!(s.contains("lines 1") && s.contains("of 100"), "got: {s:?}");
+        assert!(s.contains("of 1"), "expected byte ratio, got: {s:?}");
+    }
+}


### PR DESCRIPTION
Updates the summaries for read_file, list_directory, search_files, and
find_files tools to explicitly indicate when result sets are truncated.

Adds a new user_summary() test helper and 8 regression tests covering
both limited and complete result paths for all four tools.

[https://github.com/dobesv/harnx/issues/144]

Plan: issue-144-truncation-summaries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified, consistent user-facing summaries and truncation notices across read, list, search, and find operations
  * Improved cross-platform handling for file pattern matching in search/find

* **Bug Fixes**
  * More accurate pagination, byte/line counts, and clearer truncation/limit messages
  * Stronger validation of read parameters to prevent invalid requests

* **Tests**
  * Expanded tests for pagination, listing caps, search limits, and find summaries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->