### PR TITLE
fix(acp): write response_text before forwarding to close prompt-task race

### DIFF
--- a/crates/harnx-acp/src/client.rs
+++ b/crates/harnx-acp/src/client.rs
@@ -308,8 +308,7 @@ impl acp::Client for AcpNotificationClient {
                 }
             }
 
-            self.forward_agent_event(event, resolved_source)
-                .await;
+            self.forward_agent_event(event, resolved_source).await;
         }
 
         Ok(())

--- a/crates/harnx-acp/src/client.rs
+++ b/crates/harnx-acp/src/client.rs
@@ -292,20 +292,24 @@ impl acp::Client for AcpNotificationClient {
         };
 
         if let Some(event) = event {
-            let chunk_for_response = if is_agent_message {
-                message_text.clone()
-            } else {
-                None
-            };
-
-            self.forward_agent_event(event, resolved_source.clone())
-                .await;
-
-            if let Some(chunk) = chunk_for_response {
-                let mut sessions = self.sessions.write().await;
-                let state = sessions.entry(session_id).or_default();
-                state.response_text.push_str(&chunk);
+            // Append to response_text BEFORE forwarding the event.
+            //
+            // `forward_agent_event` acquires `self.chunk_forwarder.write()`
+            // which can yield, allowing the `WorkerCommand::Prompt` task to
+            // run and snapshot `response_text` via `state.response_text.clone()`
+            // before this notification's text has been appended.  Writing first
+            // ensures the text is visible to the prompt-completion task regardless
+            // of scheduling order.
+            if is_agent_message {
+                if let Some(ref chunk) = message_text {
+                    let mut sessions = self.sessions.write().await;
+                    let state = sessions.entry(session_id).or_default();
+                    state.response_text.push_str(chunk);
+                }
             }
+
+            self.forward_agent_event(event, resolved_source)
+                .await;
         }
 
         Ok(())


### PR DESCRIPTION
## Problem

`nested_sub_agent_activity_no_duplicates` snapshot test intermittently dropped `"Researcher complete"` from the `response:` field in the sub-agent tool result.

## Root Cause

In `session_notification`, `AgentMessageChunk` text was appended to `response_text` AFTER calling `forward_agent_event(...).await`. That await yields on `self.chunk_forwarder.write().await`. On the same `LocalSet`, the `WorkerCommand::Prompt` task could resume during that yield, snapshot `response_text` via `state.response_text.clone()`, and return — before the notification's text was appended.

Race window:
```
Task A (session_notification for "Researcher complete"):
  1. message_text = Some("Researcher complete")
  2. forward_agent_event(...).await  ← YIELDS (chunk_forwarder.write())
       └─ Task B resumes
  3. [Task B: conn.prompt resolves, acquires sessions lock, clones response_text → missing chunk]
  4. Task A resumes → appends to response_text → too late
```

## Fix

Move `response_text.push_str` to **before** `forward_agent_event`, establishing a happens-before relationship so the text is always visible to the prompt-completion task regardless of scheduler ordering.

The `sessions` lock is released before the forwarding await, preserving existing lock sequencing (no deadlock risk).

Also removes a redundant `.clone()` on `resolved_source` at its terminal call site.

## Validation

- Confirmed by deep code analysis (zosimus): race anatomy verified, protocol ordering verified, no side-effects of reordering
- Aristarchus: APPROVE
- 21/21 `harnx-acp` unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of agent message response handling by ensuring response text is properly captured regardless of scheduling conditions.

* **Refactor**
  * Optimized control flow to reduce temporary variables and unnecessary cloning operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->