### PR TITLE
feat: MiniJinja templating for system prompts

### DIFF
--- a/.changesets/minijinja-system-prompt-templates.md
+++ b/.changesets/minijinja-system-prompt-templates.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+System prompt templates now use MiniJinja (Jinja2-compatible) syntax. Templates can reference `{{__os__}}`, `{{__shell__}}`, `{{__now__}}`, `{{__cwd__}}`, `{{__arch__}}`, `{{__locale__}}`, `{{__os_distro__}}`, `{{__os_family__}}`, and the full `{{agent.*}}` context object. User-defined agent variables are available as top-level template variables. Undefined template variables are now hard errors.

--- a/.changesets/minijinja-system-prompt-templates.md
+++ b/.changesets/minijinja-system-prompt-templates.md
@@ -2,3 +2,7 @@
 harnx: minor
 ---
 System prompt templates now use MiniJinja (Jinja2-compatible) syntax. Templates can reference `{{__os__}}`, `{{__shell__}}`, `{{__now__}}`, `{{__cwd__}}`, `{{__arch__}}`, `{{__locale__}}`, `{{__os_distro__}}`, `{{__os_family__}}`, and the full `{{agent.*}}` context object. User-defined agent variables are available as top-level template variables. Undefined template variables are now hard errors.
+
+**Breaking change — migration required:** Existing prompts containing literal `{{ ... }}` that are not valid template expressions will now fail to render. Escape literal braces using `{% raw %}...{% endraw %}` or `{{ '{{' }}` / `{{ '}}' }}`.
+
+**Note for maintainers:** The `harnx: minor` bump above assumes a 0.x version line where minor versions may contain breaking changes. If the project has reached 1.x, this change likely warrants a `major` bump — please adjust the header accordingly before releasing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,6 +1735,7 @@ dependencies = [
  "fancy-regex 0.18.0",
  "hmac",
  "indexmap",
+ "minijinja",
  "os_info",
  "path-absolutize",
  "serde",
@@ -2904,6 +2905,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,6 +2933,16 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "minijinja"
+version = "2.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
+dependencies = [
+ "memo-map",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ syntect = { version = "5.0.0", features = ["parsing", "regex-onig", "plist-load"
 arboard = { version = "3.3.0", default-features = false }
 harnx-acp = { path = "crates/harnx-acp", version = "0.30.0" }
 harnx-acp-server = { path = "crates/harnx-acp-server", version = "0.30.0" }
+minijinja = { version = "2.19.0", default-features = false, features = ["builtins", "serde"] }
 
 [patch.crates-io]
 ratatui_widget_scrolling = { path = "crates/ratatui-widget-scrolling" }

--- a/crates/harnx-core/Cargo.toml
+++ b/crates/harnx-core/Cargo.toml
@@ -29,3 +29,4 @@ tokio = { workspace = true, features = ["fs"] }
 unicode-segmentation = { workspace = true }
 unicode-width = { workspace = true }
 urlencoding = { workspace = true }
+minijinja = { workspace = true }

--- a/crates/harnx-core/src/agent_config.rs
+++ b/crates/harnx-core/src/agent_config.rs
@@ -6,7 +6,7 @@
 use crate::hooks::HooksConfig;
 use crate::model::Model;
 use crate::retry_config::RetryConfig;
-use crate::system_vars::interpolate_variables;
+use crate::system_vars::render_template;
 use crate::tool::Tools;
 
 use anyhow::Result;
@@ -162,8 +162,7 @@ impl AgentConfig {
                 prompt = prompt_value.as_str().trim();
             }
         }
-        let mut prompt = prompt.to_string();
-        interpolate_variables(&mut prompt);
+        let prompt = prompt.to_string();
         let frontmatter = if metadata.is_empty() {
             AgentFrontMatter::default()
         } else {
@@ -193,8 +192,7 @@ impl AgentConfig {
     }
 
     pub fn from_prompt(prompt: &str) -> Self {
-        let mut prompt = prompt.to_string();
-        interpolate_variables(&mut prompt);
+        let prompt = prompt.to_string();
         Self {
             name: TEMP_AGENT_NAME.to_string(),
             prompt,
@@ -352,16 +350,9 @@ impl AgentConfig {
         &self.conversation_starters
     }
 
-    pub fn interpolated_instructions(&self) -> String {
-        let mut output = self
-            .instructions
-            .clone()
-            .unwrap_or_else(|| self.prompt.clone());
-        for (k, v) in self.variables() {
-            output = output.replace(&format!("{{{{{k}}}}}"), v)
-        }
-        interpolate_variables(&mut output);
-        output
+    pub fn interpolated_instructions(&self) -> anyhow::Result<String> {
+        let template = self.instructions.as_deref().unwrap_or(&self.prompt);
+        render_template(template, self)
     }
 
     pub fn agent_default_session(&self) -> Option<&str> {
@@ -398,15 +389,15 @@ impl AgentConfig {
     /// Compute the full system-message text (prompt + tools summary), matching
     /// the logic in `build_messages` but without producing a User message.
     /// Used by `Session::build_messages` when `inject_system_prompt` is true.
-    pub fn system_text(&self) -> String {
-        let prompt = self.interpolated_instructions();
+    pub fn system_text(&self) -> anyhow::Result<String> {
+        let prompt = self.interpolated_instructions()?;
         let tools_text = self.tools_text();
-        match (&tools_text, prompt.is_empty()) {
+        Ok(match (&tools_text, prompt.is_empty()) {
             (Some(tools), false) => format!("{prompt}\n\n{tools}"),
             (Some(tools), true) => tools.clone(),
             (None, false) => prompt,
             (None, true) => String::new(),
-        }
+        })
     }
 
     pub fn tools_text(&self) -> Option<String> {
@@ -434,9 +425,12 @@ impl AgentConfig {
     /// tool summary, if any) followed by a User message with the input's
     /// content, optionally appending an Assistant continuation message if
     /// `input.continue_output()` is set.
-    pub fn build_messages(&self, input: &crate::input::Input) -> Vec<crate::message::Message> {
+    pub fn build_messages(
+        &self,
+        input: &crate::input::Input,
+    ) -> anyhow::Result<Vec<crate::message::Message>> {
         use crate::message::{Message, MessageContent, MessageRole};
-        let prompt = self.interpolated_instructions();
+        let prompt = self.interpolated_instructions()?;
         let tools_text = self.tools_text();
         let content = input.message_content();
         let mut messages = if prompt.is_empty() {
@@ -472,26 +466,26 @@ impl AgentConfig {
                 MessageContent::Text(text.into()),
             ));
         }
-        messages
+        Ok(messages)
     }
 
     /// Render the prompt + tools-summary + input markdown for the echo-mode
     /// (`.echo`) command. Companion of `build_messages`.
-    pub fn echo_messages(&self, input: &crate::input::Input) -> String {
-        let prompt = self.interpolated_instructions();
+    pub fn echo_messages(&self, input: &crate::input::Input) -> anyhow::Result<String> {
+        let prompt = self.interpolated_instructions()?;
         let tools_text = self.tools_text();
         let input_markdown = input.render();
 
         if prompt.is_empty() {
             if let Some(tools) = &tools_text {
-                format!("{tools}\n\n{input_markdown}")
+                Ok(format!("{tools}\n\n{input_markdown}"))
             } else {
-                input_markdown
+                Ok(input_markdown)
             }
         } else if let Some(tools) = &tools_text {
-            format!("{prompt}\n\n{tools}\n\n{input_markdown}")
+            Ok(format!("{prompt}\n\n{tools}\n\n{input_markdown}"))
         } else {
-            format!("{}\n\n{}", prompt, input_markdown)
+            Ok(format!("{}\n\n{}", prompt, input_markdown))
         }
     }
 }
@@ -604,7 +598,7 @@ mod tests {
         // No model should have been parsed from the mid-file block.
         assert!(agent.model_id().is_none());
         // The entire content (trimmed) should appear as the prompt.
-        let instructions = agent.interpolated_instructions();
+        let instructions = agent.interpolated_instructions().unwrap();
         assert!(
             instructions.contains("Some preamble text."),
             "expected preamble in prompt, got: {instructions:?}"
@@ -629,6 +623,45 @@ mod tests {
         assert!(
             msg.contains("Invalid front-matter"),
             "expected error message to mention 'Invalid front-matter', got: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn test_render_template_system_var_os() {
+        let agent = AgentConfig::from_prompt("You are on {{__os__}}");
+        let result = agent.interpolated_instructions().unwrap();
+        assert_eq!(result, format!("You are on {}", std::env::consts::OS));
+    }
+
+    #[test]
+    fn test_render_template_agent_name() {
+        let agent = AgentConfig::from_markdown("my-agent", "Your name is {{agent.name}}.").unwrap();
+        let result = agent.interpolated_instructions().unwrap();
+        assert_eq!(result, "Your name is my-agent.");
+    }
+
+    #[test]
+    fn test_render_template_user_variable() {
+        let mut agent = AgentConfig::from_prompt("Hello {{project_name}}");
+        let mut variables = AgentVariables::default();
+        variables.insert("project_name".to_string(), "harnx".to_string());
+        agent.set_shared_variables(variables);
+        let result = agent.interpolated_instructions().unwrap();
+        assert_eq!(result, "Hello harnx");
+    }
+
+    #[test]
+    fn test_render_template_undefined_var_returns_err() {
+        let agent = AgentConfig::from_prompt("Hello {{undefined_mysterious_var}}");
+        let result = agent.interpolated_instructions();
+        assert!(
+            result.is_err(),
+            "expected Err for undefined template var, got Ok"
+        );
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            msg.contains("Template error"),
+            "expected error message to contain 'Template error', got: {msg:?}"
         );
     }
 }

--- a/crates/harnx-core/src/session.rs
+++ b/crates/harnx-core/src/session.rs
@@ -282,7 +282,7 @@ impl Session {
         (tokens, percent)
     }
 
-    pub fn set_agent(&mut self, agent: &AgentConfig) {
+    pub fn set_agent(&mut self, agent: &AgentConfig) -> anyhow::Result<()> {
         self.model_id = agent.model().id();
         self.temperature = agent.temperature();
         self.top_p = agent.top_p();
@@ -295,22 +295,24 @@ impl Session {
         } else {
             Some(agent.name().to_string())
         };
-        self.agent_prompt = agent.interpolated_instructions();
+        self.agent_prompt = agent.interpolated_instructions()?;
         self.agent_variables = agent.variables().clone();
         self.agent_instructions = self.agent_prompt.clone();
         self.dirty = true;
         self.update_tokens();
+        Ok(())
     }
 
-    pub fn sync_agent(&mut self, agent: &AgentConfig) {
+    pub fn sync_agent(&mut self, agent: &AgentConfig) -> anyhow::Result<()> {
         self.agent_name = if agent.name().is_empty() {
             None
         } else {
             Some(agent.name().to_string())
         };
-        self.agent_prompt = agent.interpolated_instructions();
+        self.agent_prompt = agent.interpolated_instructions()?;
         self.agent_variables = agent.variables().clone();
         self.agent_instructions = self.agent_prompt.clone();
+        Ok(())
     }
 
     pub fn agent_variables(&self) -> &AgentVariables {

--- a/crates/harnx-core/src/session.rs
+++ b/crates/harnx-core/src/session.rs
@@ -283,6 +283,9 @@ impl Session {
     }
 
     pub fn set_agent(&mut self, agent: &AgentConfig) -> anyhow::Result<()> {
+        // Render the template first so a failure leaves session state unchanged.
+        let new_prompt = agent.interpolated_instructions()?;
+        let new_variables = agent.variables().clone();
         self.model_id = agent.model().id();
         self.temperature = agent.temperature();
         self.top_p = agent.top_p();
@@ -295,8 +298,8 @@ impl Session {
         } else {
             Some(agent.name().to_string())
         };
-        self.agent_prompt = agent.interpolated_instructions()?;
-        self.agent_variables = agent.variables().clone();
+        self.agent_prompt = new_prompt;
+        self.agent_variables = new_variables;
         self.agent_instructions = self.agent_prompt.clone();
         self.dirty = true;
         self.update_tokens();
@@ -304,13 +307,16 @@ impl Session {
     }
 
     pub fn sync_agent(&mut self, agent: &AgentConfig) -> anyhow::Result<()> {
+        // Render the template first so a failure leaves session state unchanged.
+        let new_prompt = agent.interpolated_instructions()?;
+        let new_variables = agent.variables().clone();
         self.agent_name = if agent.name().is_empty() {
             None
         } else {
             Some(agent.name().to_string())
         };
-        self.agent_prompt = agent.interpolated_instructions()?;
-        self.agent_variables = agent.variables().clone();
+        self.agent_prompt = new_prompt;
+        self.agent_variables = new_variables;
         self.agent_instructions = self.agent_prompt.clone();
         Ok(())
     }

--- a/crates/harnx-core/src/system_vars.rs
+++ b/crates/harnx-core/src/system_vars.rs
@@ -72,7 +72,7 @@ pub fn detect_shell() -> Shell {
         }
     };
     let shell_arg = match name {
-        "powershel" => "-Command",
+        "powershell" => "-Command",
         "cmd" => "/C",
         _ => "-c",
     };
@@ -81,18 +81,18 @@ pub fn detect_shell() -> Shell {
 
 static SHELL_CMD: LazyLock<Option<String>> = LazyLock::new(|| {
     if cfg!(windows) {
-        if let Ok(comspec) = env::var("COMSPEC") {
-            Some(comspec)
-        } else {
-            if let Ok(program_files) = env::var("ProgramFiles") {
-                if Path::new(&format!(r"{}\PowerShell\7\pwsh.exe", program_files)).exists() {
-                    return Some("pwsh.exe".to_string());
-                } else {
-                    return Some("powershell.exe".to_string());
-                }
+        // Check for PowerShell before falling back to COMSPEC (which usually
+        // points to cmd.exe). Prefer pwsh (PowerShell 7+) over powershell.exe
+        // (Windows PowerShell 5.x), and only use COMSPEC if neither is found.
+        if let Ok(program_files) = env::var("ProgramFiles") {
+            if Path::new(&format!(r"{}\PowerShell\7\pwsh.exe", program_files)).exists() {
+                return Some("pwsh.exe".to_string());
             }
-            None
         }
+        if Path::new(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe").exists() {
+            return Some("powershell.exe".to_string());
+        }
+        env::var("COMSPEC").ok()
     } else {
         env::var("SHELL").ok()
     }

--- a/crates/harnx-core/src/system_vars.rs
+++ b/crates/harnx-core/src/system_vars.rs
@@ -6,13 +6,13 @@
 //! `AgentConfig::interpolated_instructions` and by harnx-side shell
 //! command dispatch.
 
-use fancy_regex::{Captures, Regex};
+use crate::agent_config::AgentConfig;
+use anyhow::Result;
+use minijinja::{Environment, UndefinedBehavior, Value};
+use std::collections::BTreeMap;
 use std::env;
 use std::path::Path;
 use std::sync::LazyLock;
-
-/// Regex matching `{{variable_name}}` placeholders with word-character keys.
-pub static RE_VARIABLE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\{\{(\w+)\}\}").unwrap());
 
 /// The host shell detected from the environment at startup.
 pub static SHELL: LazyLock<Shell> = LazyLock::new(detect_shell);
@@ -26,34 +26,31 @@ pub struct Shell {
 }
 
 impl Shell {
-    pub fn new(name: &str, cmd: &str, arg: &str) -> Self {
+    fn new(name: &str, cmd: &str, arg: &str) -> Self {
         Self {
-            name: name.to_string(),
-            cmd: cmd.to_string(),
-            arg: arg.to_string(),
+            name: name.into(),
+            cmd: cmd.into(),
+            arg: arg.into(),
         }
     }
 }
 
-/// Detect the host shell from `HARNX_SHELL` / `PSModulePath` / `SHELL`.
+#[derive(serde::Serialize)]
+struct AgentContext<'a> {
+    name: &'a str,
+    model: Option<&'a str>,
+    model_fallbacks: &'a [String],
+    temperature: Option<f64>,
+    top_p: Option<f64>,
+    use_tools: Option<Vec<String>>,
+    documents: &'a [String],
+    agent_default_session: Option<&'a str>,
+    compaction_agent: Option<&'a str>,
+    conversation_starters: &'a [String],
+}
+
 pub fn detect_shell() -> Shell {
-    let cmd = env::var("HARNX_SHELL").ok().or_else(|| {
-        if cfg!(windows) {
-            if let Ok(ps_module_path) = env::var("PSModulePath") {
-                let ps_module_path = ps_module_path.to_lowercase();
-                if ps_module_path.starts_with(r"c:\users") {
-                    if ps_module_path.contains(r"\powershell\7\") {
-                        return Some("pwsh.exe".to_string());
-                    } else {
-                        return Some("powershell.exe".to_string());
-                    }
-                }
-            }
-            None
-        } else {
-            env::var("SHELL").ok()
-        }
-    });
+    let cmd = LazyLock::force(&SHELL_CMD).clone();
     let name = cmd
         .as_ref()
         .and_then(|v| Path::new(v).file_stem().and_then(|v| v.to_str()))
@@ -82,39 +79,79 @@ pub fn detect_shell() -> Shell {
     Shell::new(name, cmd, shell_arg)
 }
 
+static SHELL_CMD: LazyLock<Option<String>> = LazyLock::new(|| {
+    if cfg!(windows) {
+        if let Ok(comspec) = env::var("COMSPEC") {
+            Some(comspec)
+        } else {
+            if let Ok(program_files) = env::var("ProgramFiles") {
+                if Path::new(&format!(r"{}\PowerShell\7\pwsh.exe", program_files)).exists() {
+                    return Some("pwsh.exe".to_string());
+                } else {
+                    return Some("powershell.exe".to_string());
+                }
+            }
+            None
+        }
+    } else {
+        env::var("SHELL").ok()
+    }
+});
+
 /// Current local time, formatted RFC-3339 with second precision.
 pub fn now() -> String {
     chrono::Local::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, false)
 }
 
-/// Replace `{{__os__}}`, `{{__os_distro__}}`, `{{__os_family__}}`,
-/// `{{__arch__}}`, `{{__shell__}}`, `{{__locale__}}`, `{{__now__}}`, and
-/// `{{__cwd__}}` placeholders in `text` with their runtime-resolved values.
-/// Unknown placeholders (e.g. user variables) are left untouched.
-pub fn interpolate_variables(text: &mut String) {
-    *text = RE_VARIABLE
-        .replace_all(text, |caps: &Captures<'_>| {
-            let key = &caps[1];
-            match key {
-                "__os__" => env::consts::OS.to_string(),
-                "__os_distro__" => {
-                    let info = os_info::get();
-                    if env::consts::OS == "linux" {
-                        format!("{info} (linux)")
-                    } else {
-                        info.to_string()
-                    }
-                }
-                "__os_family__" => env::consts::FAMILY.to_string(),
-                "__arch__" => env::consts::ARCH.to_string(),
-                "__shell__" => SHELL.name.clone(),
-                "__locale__" => sys_locale::get_locale().unwrap_or_default(),
-                "__now__" => now(),
-                "__cwd__" => env::current_dir()
-                    .map(|v| v.display().to_string())
-                    .unwrap_or_default(),
-                _ => format!("{{{{{key}}}}}"),
-            }
-        })
-        .to_string();
+pub fn render_template(template: &str, agent: &AgentConfig) -> Result<String> {
+    let mut env = Environment::new();
+    env.set_undefined_behavior(UndefinedBehavior::Strict);
+
+    let agent_ctx = AgentContext {
+        name: agent.name(),
+        model: agent.model_id(),
+        model_fallbacks: agent.model_fallbacks(),
+        temperature: agent.temperature(),
+        top_p: agent.top_p(),
+        use_tools: agent.use_tools(),
+        documents: agent.documents(),
+        agent_default_session: agent.agent_default_session(),
+        compaction_agent: agent.compaction_agent(),
+        conversation_starters: agent.conversation_staters(),
+    };
+
+    let locale = sys_locale::get_locale().unwrap_or_default();
+    let current_time = now();
+    let current_dir = env::current_dir()
+        .map(|path| path.display().to_string())
+        .unwrap_or_default();
+    let os_distro = {
+        let info = os_info::get();
+        if env::consts::OS == "linux" {
+            format!("{info} (linux)")
+        } else {
+            info.to_string()
+        }
+    };
+
+    let mut ctx: BTreeMap<String, Value> = BTreeMap::new();
+    ctx.insert("__os__".to_string(), Value::from(env::consts::OS));
+    ctx.insert(
+        "__os_family__".to_string(),
+        Value::from(env::consts::FAMILY),
+    );
+    ctx.insert("__arch__".to_string(), Value::from(env::consts::ARCH));
+    ctx.insert("__shell__".to_string(), Value::from(SHELL.name.clone()));
+    ctx.insert("__locale__".to_string(), Value::from(locale));
+    ctx.insert("__now__".to_string(), Value::from(current_time));
+    ctx.insert("__cwd__".to_string(), Value::from(current_dir));
+    ctx.insert("__os_distro__".to_string(), Value::from(os_distro));
+    ctx.insert("agent".to_string(), Value::from_serialize(&agent_ctx));
+
+    for (k, v) in agent.variables() {
+        ctx.insert(k.clone(), Value::from(v.clone()));
+    }
+
+    env.render_str(template, ctx)
+        .map_err(|e| anyhow::anyhow!("Template error in agent '{}': {}", agent.name(), e))
 }

--- a/crates/harnx-runtime/src/agent_loop.rs
+++ b/crates/harnx-runtime/src/agent_loop.rs
@@ -493,7 +493,7 @@ mod tests {
 
         // Build a Config with an attached session pointed at a temp dir.
         let mut config = Config::default();
-        let mut session = crate::config::session::new(&config, "replay_test");
+        let mut session = crate::config::session::new(&config, "replay_test").unwrap();
         session.set_sessions_dir(tmp.path().to_path_buf());
         config.session = Some(session);
         let global_config = Arc::new(RwLock::new(config));

--- a/crates/harnx-runtime/src/client/common.rs
+++ b/crates/harnx-runtime/src/client/common.rs
@@ -37,7 +37,7 @@ pub async fn chat_completions_with_input(
     ctx: &ClientCallContext<'_>,
 ) -> Result<ChatCompletionsOutput> {
     if ctx.dry_run {
-        let content = crate::config::input::echo_messages(&input, config);
+        let content = crate::config::input::echo_messages(&input, config)?;
         return Ok(ChatCompletionsOutput::new(&content));
     }
     let data =
@@ -56,7 +56,7 @@ pub async fn chat_completions_streaming_with_input(
     ctx: &ClientCallContext<'_>,
 ) -> Result<()> {
     if ctx.dry_run {
-        let content = crate::config::input::echo_messages(input, config);
+        let content = crate::config::input::echo_messages(input, config)?;
         handler.text(&content)?;
         handler.done();
         return Ok(());
@@ -125,7 +125,7 @@ pub async fn call_chat_completions(
     // live LLM call. Match pre-plan behavior: print via print_markdown
     // when `print=true`.
     if dry_run {
-        let content = crate::config::input::echo_messages(input, config);
+        let content = crate::config::input::echo_messages(input, config)?;
         let usage = CompletionTokenUsage::default();
         if print && !content.is_empty() {
             config.read().print_markdown(&content)?;
@@ -185,7 +185,7 @@ pub async fn call_chat_completions_streaming(
     // Dry-run: just echo the prepared messages to stdout. The streaming
     // rendering path is unnecessary for a no-LLM echo.
     if dry_run {
-        let content = crate::config::input::echo_messages(input, config);
+        let content = crate::config::input::echo_messages(input, config)?;
         if !content.is_empty() {
             crate::utils::emit_info(content.clone());
         }

--- a/crates/harnx-runtime/src/config/agent.rs
+++ b/crates/harnx-runtime/src/config/agent.rs
@@ -464,6 +464,7 @@ mod tests {
         );
         assert!(agent
             .interpolated_instructions()
+            .unwrap()
             .contains("You are a helpful test agent"));
     }
 
@@ -475,7 +476,7 @@ mod tests {
         assert!(agent.model_id().is_none());
         assert!(agent.temperature().is_none());
         assert_eq!(
-            agent.interpolated_instructions(),
+            agent.interpolated_instructions().unwrap(),
             "Just instructions, no front-matter."
         );
     }
@@ -486,7 +487,7 @@ mod tests {
         let agent = AgentConfig::from_markdown("empty-body", content).unwrap();
         assert_eq!(agent.name(), "empty-body");
         assert_eq!(agent.model_id(), Some("openai:gpt-4o"));
-        assert!(agent.interpolated_instructions().is_empty());
+        assert!(agent.interpolated_instructions().unwrap().is_empty());
     }
 
     #[test]
@@ -503,6 +504,7 @@ mod tests {
         assert_eq!(agent.name(), "%%");
         assert!(agent
             .interpolated_instructions()
+            .unwrap()
             .contains("You are a pirate"));
         assert!(agent.model_id().is_none());
         assert!(agent.temperature().is_none());
@@ -512,8 +514,11 @@ mod tests {
     fn test_agent_builtin_create_title() {
         let agent = super::builtin("%create-title%").unwrap();
         assert_eq!(agent.name(), "%create-title%");
-        assert!(!agent.interpolated_instructions().is_empty());
-        assert!(agent.interpolated_instructions().contains("concise"));
+        assert!(!agent.interpolated_instructions().unwrap().is_empty());
+        assert!(agent
+            .interpolated_instructions()
+            .unwrap()
+            .contains("concise"));
     }
 
     #[test]
@@ -622,7 +627,7 @@ mod tests {
         ));
         let input = crate::config::input::from_str(&config, "Real input", Some(agent));
 
-        let messages = input.agent().build_messages(&input);
+        let messages = input.agent().build_messages(&input).unwrap();
 
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].role, MessageRole::System);

--- a/crates/harnx-runtime/src/config/input.rs
+++ b/crates/harnx-runtime/src/config/input.rs
@@ -169,9 +169,9 @@ pub fn prepare_completion_data(
 
 pub fn build_messages(input: &Input, config: &GlobalConfig) -> Result<Vec<Message>> {
     let mut messages = if let Some(session) = session_of(input, &config.read().session) {
-        crate::config::session::build_messages(session, input)
+        crate::config::session::build_messages(session, input)?
     } else {
-        input.agent().build_messages(input)
+        input.agent().build_messages(input)?
     };
     if let Some(tool_calls) = &input.tool_calls {
         messages.push(Message::new(
@@ -192,7 +192,7 @@ pub fn echo_messages(input: &Input, config: &GlobalConfig) -> String {
     if let Some(session) = session_of(input, &config.read().session) {
         crate::config::session::echo_messages(session, input)
     } else {
-        input.agent().echo_messages(input)
+        input.agent().echo_messages(input).unwrap_or_default()
     }
 }
 

--- a/crates/harnx-runtime/src/config/input.rs
+++ b/crates/harnx-runtime/src/config/input.rs
@@ -188,11 +188,11 @@ pub fn build_messages(input: &Input, config: &GlobalConfig) -> Result<Vec<Messag
     Ok(messages)
 }
 
-pub fn echo_messages(input: &Input, config: &GlobalConfig) -> String {
+pub fn echo_messages(input: &Input, config: &GlobalConfig) -> anyhow::Result<String> {
     if let Some(session) = session_of(input, &config.read().session) {
-        crate::config::session::echo_messages(session, input)
+        Ok(crate::config::session::echo_messages(session, input))
     } else {
-        input.agent().echo_messages(input).unwrap_or_default()
+        input.agent().echo_messages(input)
     }
 }
 

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -992,13 +992,30 @@ impl Config {
         // `init_agent_session_variables`, find unresolved required variables,
         // and bail with "agent variables are required".
         self::agent::resolve_file_defaults(&mut agent)?;
+        // Populate shared_variables from the resolved defaults so that
+        // `session::new()` -> `set_agent()` -> `render_template()` can access
+        // user-defined variables immediately (before `init_agent_session_variables`
+        // runs). This mirrors the variable-initialization step in
+        // `init_agent_session_variables` for the no-session-yet case.
+        if !agent.defined_variables().is_empty() && agent.shared_variables().is_empty() {
+            let mut config_variables = AgentVariables::default();
+            if let Some(v) = &self.agent_variables {
+                config_variables.extend(v.clone());
+            }
+            let shared = self::agent::init_agent_variables(
+                agent.defined_variables(),
+                &config_variables,
+                self.info_flag,
+            )?;
+            agent.set_shared_variables(shared);
+        }
         self.use_agent_obj(agent)
     }
 
     pub fn use_agent_obj(&mut self, agent: Agent) -> Result<()> {
         if let Some(session) = self.session.as_mut() {
             session.guard_empty()?;
-            session.set_agent(&agent);
+            session.set_agent(&agent)?;
         } else {
             self.agent = Some(agent);
         }
@@ -1116,12 +1133,12 @@ impl Config {
                         format!("Failed to cleanup previous '{TEMP_SESSION_NAME}' session")
                     })?;
                 }
-                session = Some(self::session::new(self, TEMP_SESSION_NAME));
+                session = Some(self::session::new(self, TEMP_SESSION_NAME)?);
             }
             Some(name) => {
                 let session_path = self.session_file(name);
                 if !session_path.exists() {
-                    session = Some(self::session::new(self, name));
+                    session = Some(self::session::new(self, name)?);
                 } else {
                     session = Some(self::session::load(self, name, &session_path)?);
                 }
@@ -1262,7 +1279,7 @@ impl Config {
     pub fn empty_session(&mut self) -> Result<()> {
         if let Some(session) = self.session.as_mut() {
             if let Some(agent) = self.agent.as_ref() {
-                session.sync_agent(agent);
+                session.sync_agent(agent)?;
             }
             crate::config::session::clear_messages(session);
         } else {
@@ -2482,7 +2499,7 @@ impl Config {
                     shared_variables
                 };
             agent.set_session_variables(session_variables);
-            session.sync_agent(agent);
+            session.sync_agent(agent)?;
         } else {
             let variables = session.agent_variables();
             agent.set_session_variables(variables.clone());
@@ -3279,7 +3296,7 @@ mod tests {
     #[test]
     fn empty_session_clears_named_session_with_messages() {
         let mut config = Config::default();
-        let mut session = self::session::new(&config, "handoff-target");
+        let mut session = self::session::new(&config, "handoff-target").unwrap();
         session.push_message_for_test(MessageRole::System, "You are agent A.".to_string());
         session.push_message_for_test(MessageRole::User, "Hello from old session".to_string());
         session.push_message_for_test(MessageRole::Assistant, "Response from agent A".to_string());
@@ -3313,7 +3330,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let mut session = self::session::new(&config, "test-intermediate");
+        let mut session = self::session::new(&config, "test-intermediate").unwrap();
         session.set_sessions_dir(tmp.path().to_path_buf());
         config.session = Some(session);
 
@@ -3376,7 +3393,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let mut session = self::session::new(&config, "test-session");
+        let mut session = self::session::new(&config, "test-session").unwrap();
         session.push_message_for_test(
             MessageRole::User,
             "Tell me about the Rust ownership model.".to_string(),
@@ -3487,7 +3504,7 @@ mod tests {
 
         config.agent = Some(main_agent);
 
-        let mut session = self::session::new(&config, "test-session");
+        let mut session = self::session::new(&config, "test-session").unwrap();
         session.push_message_for_test(
             MessageRole::User,
             "Tell me about the Rust ownership model.".to_string(),

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -1280,6 +1280,10 @@ impl Config {
         if let Some(session) = self.session.as_mut() {
             if let Some(agent) = self.agent.as_ref() {
                 session.sync_agent(agent)?;
+                // Persist the updated agent name/prompt/variables to disk
+                // before clearing messages, so the header reflects the
+                // current agent state if the session file is reloaded.
+                crate::config::session::append_event(session, &session.build_header_entry());
             }
             crate::config::session::clear_messages(session);
         } else {

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -349,7 +349,18 @@ fn apply_name_and_path(
     session.agent_prompt = session.agent_instructions.clone();
     if let Some(agent_name) = &session.agent_name {
         if let Ok(agent) = config.retrieve_agent(agent_name) {
-            session.agent_prompt = agent.interpolated_instructions()?;
+            // Only re-render the prompt when the session does not already have
+            // resolved agent data from the log.  If agent_variables is
+            // non-empty the session was restored from disk with its own
+            // variable values; re-rendering with the current agent definition
+            // would overwrite those resolved values.  Similarly, if
+            // agent_prompt differs from agent_instructions the session log
+            // already stored a rendered prompt — preserve it.
+            let prompt_is_unresolved = session.agent_variables().is_empty()
+                && session.agent_prompt == session.agent_instructions;
+            if prompt_is_unresolved {
+                session.agent_prompt = agent.interpolated_instructions()?;
+            }
             if session.use_tools.is_none() {
                 session.use_tools = agent.use_tools();
             }

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -18,16 +18,16 @@ use std::sync::LazyLock;
 
 static RE_AUTONAME_PREFIX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\d{8}T\d{6}-").unwrap());
 
-pub fn new(config: &Config, name: &str) -> Session {
+pub fn new(config: &Config, name: &str) -> Result<Session> {
     let agent = config.extract_agent();
     let mut session = Session {
         name: name.to_string(),
         save_session: config.save_session,
         ..Default::default()
     };
-    session.set_agent(&agent);
+    session.set_agent(&agent)?;
     session.dirty = false;
-    session
+    Ok(session)
 }
 
 pub fn load(config: &Config, name: &str, path: &Path) -> Result<Session> {
@@ -41,8 +41,8 @@ pub fn load(config: &Config, name: &str, path: &Path) -> Result<Session> {
         load_from_log(config, name, path, &content)?
     } else {
         // Old format: create a fresh session so we don't crash.
-        let mut session = new(config, name);
-        apply_name_and_path(&mut session, name, path, config);
+        let mut session = new(config, name)?;
+        apply_name_and_path(&mut session, name, path, config)?;
         session
     };
 
@@ -170,7 +170,7 @@ fn load_from_log(config: &Config, name: &str, path: &Path, content: &str) -> Res
 
     session.model =
         crate::client::retrieve_model(&config.clients, &session.model_id, ModelType::Chat)?;
-    apply_name_and_path(&mut session, name, path, config);
+    apply_name_and_path(&mut session, name, path, config)?;
     session.update_tokens();
     Ok(session)
 }
@@ -329,7 +329,12 @@ fn assemble_tool_message(
     )
 }
 
-fn apply_name_and_path(session: &mut Session, name: &str, path: &Path, config: &Config) {
+fn apply_name_and_path(
+    session: &mut Session,
+    name: &str,
+    path: &Path,
+    config: &Config,
+) -> Result<()> {
     if let Some(autoname) = name.strip_prefix("_/") {
         session.name = TEMP_SESSION_NAME.to_string();
         session.path = Some(path.display().to_string());
@@ -344,7 +349,7 @@ fn apply_name_and_path(session: &mut Session, name: &str, path: &Path, config: &
     session.agent_prompt = session.agent_instructions.clone();
     if let Some(agent_name) = &session.agent_name {
         if let Ok(agent) = config.retrieve_agent(agent_name) {
-            session.agent_prompt = agent.interpolated_instructions();
+            session.agent_prompt = agent.interpolated_instructions()?;
             if session.use_tools.is_none() {
                 session.use_tools = agent.use_tools();
             }
@@ -356,6 +361,7 @@ fn apply_name_and_path(session: &mut Session, name: &str, path: &Path, config: &
             }
         }
     }
+    Ok(())
 }
 
 /// Initialize the session log file with a header entry.
@@ -710,7 +716,7 @@ pub fn add_assistant_text(
         }
         session.dirty = true;
     } else {
-        let mut all_appended = begin_turn(session, input, output);
+        let mut all_appended = begin_turn(session, input, output)?;
         let content = match thought {
             Some(v) => MessageContent::Text(format!("<think>\n{v}\n</think>\n{output}")),
             _ => MessageContent::Text(output.to_string()),
@@ -750,7 +756,7 @@ pub fn add_tool_calls(
     // slots that persist as "tool response pending" placeholders in the
     // log (issue: multiple results with the same id sent to the LLM).
     let calls = crate::tool::ToolCall::dedup(calls.to_vec());
-    let mut all_appended = begin_turn(session, input, output);
+    let mut all_appended = begin_turn(session, input, output)?;
     all_appended &= append_event(
         session,
         &SessionLogEntry::ToolCalls {
@@ -853,7 +859,7 @@ pub fn add_tool_results(session: &mut Session, results: &[crate::tool::ToolResul
 /// push (skipped on continuation rounds), data-URL persistence, and
 /// any queued injected-user-text.  Returns `true` iff every log
 /// append succeeded.
-fn begin_turn(session: &mut Session, input: &Input, output: &str) -> bool {
+fn begin_turn(session: &mut Session, input: &Input, output: &str) -> Result<bool> {
     let mut all_appended = true;
     // Detect continuation rounds: if the last saved message is a Tool
     // message, we're continuing after tool execution and should NOT
@@ -868,7 +874,7 @@ fn begin_turn(session: &mut Session, input: &Input, output: &str) -> bool {
             let chat_history = format!("USER: {raw_input}\nASSISTANT: {output}\n");
             session.autoname = Some(AutoName::new_from_chat_history(chat_history));
         }
-        let agent_messages = input.agent().build_messages(input);
+        let agent_messages = input.agent().build_messages(input)?;
         for msg in &agent_messages {
             all_appended &= append_event(
                 session,
@@ -914,7 +920,7 @@ fn begin_turn(session: &mut Session, input: &Input, output: &str) -> bool {
         );
         session.messages.push(injected_msg);
     }
-    all_appended
+    Ok(all_appended)
 }
 
 pub fn clear_messages(session: &mut Session) {
@@ -930,14 +936,14 @@ pub fn clear_messages(session: &mut Session) {
 }
 
 pub fn echo_messages(session: &Session, input: &Input) -> String {
-    let messages = build_messages(session, input);
+    let messages = build_messages(session, input).unwrap_or_default();
     serde_yaml::to_string(&messages).unwrap_or_else(|_| "Unable to echo message".into())
 }
 
-pub fn build_messages(session: &Session, input: &Input) -> Vec<Message> {
+pub fn build_messages(session: &Session, input: &Input) -> Result<Vec<Message>> {
     let mut messages = session.messages.clone();
     if input.continue_output().is_some() {
-        return messages;
+        return Ok(messages);
     } else if input.regenerate() {
         while let Some(last) = messages.last() {
             if !last.role.is_user() {
@@ -946,12 +952,12 @@ pub fn build_messages(session: &Session, input: &Input) -> Vec<Message> {
                 break;
             }
         }
-        return messages;
+        return Ok(messages);
     }
     let mut need_add_msg = true;
     let len = messages.len();
     if len == 0 {
-        messages = input.agent().build_messages(input);
+        messages = input.agent().build_messages(input)?;
         need_add_msg = false;
     } else if len == 1 && session.compressed_messages.len() >= 2 {
         if let Some(index) = session
@@ -969,7 +975,7 @@ pub fn build_messages(session: &Session, input: &Input) -> Vec<Message> {
         // On normal session turns the system prompt was stored on turn 1
         // by save_message(), so inject_system_prompt stays false.
         if input.inject_system_prompt() {
-            let system_text = input.agent().system_text();
+            let system_text = input.agent().system_text()?;
             if !system_text.is_empty() {
                 messages.insert(
                     0,
@@ -979,7 +985,7 @@ pub fn build_messages(session: &Session, input: &Input) -> Vec<Message> {
         }
         messages.push(Message::new(MessageRole::User, input.message_content()));
     }
-    messages
+    Ok(messages)
 }
 
 #[cfg(test)]
@@ -987,7 +993,7 @@ mod tests {
     use super::*;
 
     fn test_session() -> Session {
-        new(&Config::default(), "test")
+        new(&Config::default(), "test").unwrap()
     }
 
     #[test]
@@ -998,7 +1004,7 @@ mod tests {
         ).unwrap());
         let mut session = test_session();
 
-        session.set_agent(&agent);
+        session.set_agent(&agent).unwrap();
         let round_tripped_agent = to_agent(&session);
 
         assert_eq!(

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -60,7 +60,7 @@ fn test_config_with_mock_client_and_agent(
 
         // Set up session if session_name is provided.
         if let Some(name) = session_name {
-            guard.session = Some(harnx_runtime::config::session::new(&guard, name));
+            guard.session = Some(harnx_runtime::config::session::new(&guard, name).unwrap());
         }
     }
     config

--- a/docs/solutions/logic-errors/minijinja-system-prompt-templating-2026-04-25.md
+++ b/docs/solutions/logic-errors/minijinja-system-prompt-templating-2026-04-25.md
@@ -1,0 +1,158 @@
+---
+title: "MiniJinja templating for agent system prompts"
+date: 2026-04-25
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-core agent system"
+root_cause: "regex-based interpolation lacked rich context, error handling, and extensibility"
+resolution_type: code_fix
+severity: medium
+tags:
+  - minijinja
+  - templating
+  - system-prompt
+  - result-propagation
+  - rust
+plan_ref: "harnx-339-minijinja-system-prompt"
+---
+
+## Problem
+
+Agent system prompts used a regex-based `interpolate_variables()` function that only supported a fixed set of system variables (`__os__`, `__arch__`, etc.). It couldn't render agent metadata (name, model) or user-defined variables, and unknown placeholders passed through silently rather than surfacing configuration errors.
+
+## Symptoms
+
+```
+- Templates with unknown {{variable}} rendered with placeholder intact, no error
+- No way to reference agent.name, agent.model in system prompts
+- User-defined variables from agent configs weren't interpolated
+- Template errors discovered late at runtime, not at session creation
+```
+
+## Investigation Steps
+
+1. Identified `interpolate_variables()` in `crates/harnx-core/src/system_vars.rs` as the regex-based interpolator
+2. Noted `fancy_regex` dependency usage limited to this function
+3. Considered MiniJinja for richer templating (conditionals, loops, nested object access)
+4. Discovered `context!` macro limitation: requires static keys at compile time, incompatible with dynamic user-defined variables
+5. Traced `interpolated_instructions()` call graph: `system_text()` → `build_messages()` → `echo_messages()` → `set_agent()` → `sync_agent()` → `session::new()`
+6. Identified timing bug: `session::new()` calls `set_agent()` which renders template before file-backed agent variables initialized
+
+## Root Cause
+
+**Regex limitation**: `interpolate_variables()` used `fancy_regex::Regex::replace_all()` with a callback that returned `{{{key}}}` for unknown keys. This silent pass-through masked configuration errors.
+
+**Static context macro**: MiniJinja's `context!` macro is a compile-time construct requiring literal key names. Cannot mix static system vars (`__os__`) with dynamic user vars from `AgentVariables` map.
+
+**Initialization timing**: In `use_agent_by_name()`, the call order was:
+1. `resolve_file_defaults()` - loads agent definition
+2. `session::new()` → `set_agent()` → `render_template()`
+3. `init_agent_session_variables()` - too late, template already rendered
+
+## Solution
+
+Replaced regex interpolation with MiniJinja template rendering using `BTreeMap<String, Value>` for dynamic context:
+
+**Before (regex):**
+```rust
+pub fn interpolate_variables(input: &str) -> String {
+    static RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}").unwrap()
+    });
+    RE.replace_all(input, |caps: &Captures| {
+        let key = &caps[1];
+        match key {
+            "__os__" => env::consts::OS.to_string(),
+            // ... other static vars ...
+            _ => format!("{{{key}}}"), // Silent pass-through
+        }
+    }).to_string()
+}
+```
+
+**After (MiniJinja):**
+```rust
+pub fn render_template(template: &str, agent: &AgentConfig) -> Result<String> {
+    let mut env = Environment::new();
+    env.set_undefined_behavior(UndefinedBehavior::Strict);
+
+    let agent_ctx = AgentContext {
+        name: agent.name(),
+        model: agent.model_id(),
+        // ... other agent fields ...
+    };
+
+    let mut ctx: BTreeMap<String, Value> = BTreeMap::new();
+    ctx.insert("__os__".to_string(), Value::from(env::consts::OS));
+    ctx.insert("__os_family__".to_string(), Value::from(env::consts::FAMILY));
+    // ... other system vars ...
+    ctx.insert("agent".to_string(), Value::from_serialize(&agent_ctx));
+
+    for (k, v) in agent.variables() {
+        ctx.insert(k.clone(), Value::from(v.clone()));
+    }
+
+    env.render_str(template, ctx)
+        .map_err(|e| anyhow::anyhow!("Template error in agent '{}': {}", agent.name(), e))
+}
+```
+
+**Result propagation cascade:**
+```rust
+// Changed signatures across harnx-core and harnx-runtime:
+pub fn interpolated_instructions(&self) -> Result<String>
+pub fn system_text(&self) -> Result<String>
+pub fn build_messages(&self, input: &Input) -> Result<Vec<Message>>
+pub fn set_agent(&mut self, agent: &AgentConfig) -> Result<()>
+pub fn sync_agent(&mut self, agent: &AgentConfig) -> Result<()>
+pub fn new(config: &Config, name: &str) -> Result<Session>
+```
+
+**Timing fix (in `use_agent_by_name()`):**
+Pre-populate `shared_variables` after `resolve_file_defaults()` before calling `session::new()`:
+```rust
+// After resolve_file_defaults(), before session::new():
+let file_vars = init_agent_variables(&agent);
+agent.set_shared_variables(file_vars);
+// Now session::new() can render template with variables already available
+```
+
+## Why This Works
+
+**BTreeMap for dynamic context**: `BTreeMap<String, Value>` accepts any string key at runtime, allowing mix of system vars (`__os__`), agent object (`agent`), and user-defined vars from `AgentVariables`.
+
+**UndefinedBehavior::Strict**: Forces explicit failure on `{{undefined_var}}`, surfacing configuration errors at session creation rather than serving broken prompts to users.
+
+**Result propagation**: Returns `Result` from `render_template()` through entire call chain, ensuring template errors halt session creation with clear error message.
+
+**Pre-initialization**: Moving variable population before `session::new()` ensures template context is complete when `set_agent()` triggers rendering.
+
+## Prevention Strategies
+
+**Test Cases:**
+```rust
+#[test]
+fn test_render_template_undefined_var_returns_err() {
+    let agent = AgentConfig::from_prompt("Hello {{undefined_var}}");
+    let result = agent.interpolated_instructions();
+    assert!(result.is_err());
+    let msg = format!("{:#}", result.unwrap_err());
+    assert!(msg.contains("Template error"));
+}
+```
+
+**Code Review Checklist:**
+- [ ] Template variables documented in agent configs match `AgentVariables` schema
+- [ ] New template context fields added to `AgentContext` struct and `render_template()` map
+- [ ] Test coverage for both defined and undefined variable cases
+- [ ] File-backed agent variables loaded before session creation
+
+**Monitoring:**
+- Log `Template error` occurrences during session creation
+- Track `session::new()` failures attributed to template rendering
+
+## Related Issues
+
+- **Plan:** harnx-339-minijinja-system-prompt
+- **Commit:** bfc51ca — Implement MiniJinja templating for system prompts
+- **Breaking change:** `UndefinedBehavior::Strict` means templates with undefined placeholders will error instead of rendering partially


### PR DESCRIPTION
Replaces regex-based `interpolate_variables()` with MiniJinja template rendering for agent system prompts.

## Changes

- Add `minijinja` workspace dependency (v2.19.0, `builtins` + `serde` features only)
- Replace `interpolate_variables()`/`RE_VARIABLE` with `render_template()` + `AgentContext` struct in `system_vars.rs`
- `interpolated_instructions()` → `Result<String>`; cascade through `system_text()`, `build_messages()`, `echo_messages()`, `set_agent()`, `sync_agent()`, `session::new()`
- All harnx-runtime callers updated; production callers propagate `?`, tests use `.unwrap()`
- Fix timing bug: `use_agent_by_name()` now pre-populates `shared_variables` before `session::new()` renders templates (fixes failure path for file-backed variable agents)
- 4 new rendering tests: `__os__`, `agent.name`, user vars, strict undefined-var error

## Template context

Top-level system variables: `__os__`, `__os_distro__`, `__os_family__`, `__arch__`, `__shell__`, `__locale__`, `__now__`, `__cwd__`

Agent metadata: `agent.name`, `agent.model`, `agent.model_fallbacks`, `agent.temperature`, `agent.top_p`, `agent.use_tools`, `agent.documents`, `agent.agent_default_session`, `agent.compaction_agent`, `agent.conversation_starters`

User-defined agent variables are spread as top-level keys.

## Breaking change

Undefined template variables are now hard errors (`UndefinedBehavior::Strict`). Templates with unrecognised `{{placeholders}}` will fail instead of passing through unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- System prompt templates now support Jinja2-compatible syntax with expanded built-in variables including OS, shell, time, working directory, architecture, and locale
- User-defined agent variables are now accessible in templates
- Undefined template variables produce clear error messages instead of silent failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->