### PR TITLE
fix(template): populate shared_variables before session render; report undefined var

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ syntect = { version = "5.0.0", features = ["parsing", "regex-onig", "plist-load"
 arboard = { version = "3.3.0", default-features = false }
 harnx-acp = { path = "crates/harnx-acp", version = "0.30.0" }
 harnx-acp-server = { path = "crates/harnx-acp-server", version = "0.30.0" }
-minijinja = { version = "2.19.0", default-features = false, features = ["builtins", "serde"] }
+minijinja = { version = "2.19.0", default-features = false, features = ["builtins", "debug", "serde"] }
 
 [patch.crates-io]
 ratatui_widget_scrolling = { path = "crates/ratatui-widget-scrolling" }

--- a/crates/harnx-core/src/system_vars.rs
+++ b/crates/harnx-core/src/system_vars.rs
@@ -106,6 +106,7 @@ pub fn now() -> String {
 pub fn render_template(template: &str, agent: &AgentConfig) -> Result<String> {
     let mut env = Environment::new();
     env.set_undefined_behavior(UndefinedBehavior::Strict);
+    env.set_debug(true);
 
     let agent_ctx = AgentContext {
         name: agent.name(),
@@ -152,6 +153,21 @@ pub fn render_template(template: &str, agent: &AgentConfig) -> Result<String> {
         ctx.insert(k.clone(), Value::from(v.clone()));
     }
 
-    env.render_str(template, ctx)
-        .map_err(|e| anyhow::anyhow!("Template error in agent '{}': {}", agent.name(), e))
+    env.render_str(template, ctx).map_err(|e| {
+        let expr = e
+            .range()
+            .and_then(|range| template.get(range))
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty());
+        match expr {
+            Some(expr) => anyhow::anyhow!(
+                "Template error in agent '{}' at line {}: {} `{}`",
+                agent.name(),
+                e.line().unwrap_or(0),
+                e.kind(),
+                expr,
+            ),
+            None => anyhow::anyhow!("Template error in agent '{}': {}", agent.name(), e),
+        }
+    })
 }

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -1819,13 +1819,16 @@ impl Config {
         });
         config.write().rag = agent.rag();
         config.write().agent = Some(agent);
+        // Populate shared_variables from resolved file-backed defaults and
+        // any --agent-variable overrides before any code path that renders
+        // the template. session::new() -> set_agent() runs the template
+        // immediately, so this must happen before use_session().
+        config.write().init_agent_shared_variables()?;
         if let Some(session) = session {
             // Exit any existing session (e.g. from tui_default_session) before
             // switching to the agent's session.
             config.write().exit_session()?;
             config.write().use_session(Some(&session))?;
-        } else {
-            config.write().init_agent_shared_variables()?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

- `harnx -a <agent>` failed with `Error: Template error in agent 'X': undefined value (in <string>:1)` whenever a default session was in play (e.g. global `agent_default_session: $GIT_BRANCH-$GIT_PATH`). Root cause: `use_agent` only called `init_agent_shared_variables()` in the no-session branch, so `use_session → session::new → set_agent` rendered the MiniJinja template before file-backed variable defaults were copied from `defined_variables` into `shared_variables`. With #344's strict undefined behavior, the first `{{var}}` in the prompt errored out. Pre-#344 the old `replace`-based interpolation silently left placeholders in the prompt, so the bug existed but was invisible.
- The error itself was useless because MiniJinja's `UndefinedError` carries no detail and the `debug` feature wasn't enabled.

## Changes

- `crates/harnx-runtime/src/config/mod.rs` — call `init_agent_shared_variables()` unconditionally before either branch in `use_agent`, so `shared_variables` is populated before any session creates a render of the prompt.
- `Cargo.toml` — enable minijinja's `debug` feature so error spans/source are populated.
- `crates/harnx-core/src/system_vars.rs` — `env.set_debug(true)`, then in the error mapper extract the offending source via `Error::range()` against the template string and include the line number. Falls back to the original message if no range is available.

## Result

Before:

```
Error: Template error in agent 'daedalus': undefined value (in <string>:1)
```

After (when the bug is hit, e.g. via a typo):

```
Template error in agent 'daedalus' at line 1: undefined value `daedalus_core`
```

And `harnx -a daedalus` now starts successfully.

## Test plan

- [x] `cargo test -p harnx-core --lib` (64 passed)
- [x] `cargo test -p harnx-runtime --lib` (98 passed)
- [x] Verified `harnx -a daedalus` (which previously failed) renders the full system prompt via `echo hello | harnx -a daedalus --dry-run`.
- [x] Verified improved error message via a one-off example with an unknown variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)