### PR TITLE
fix(claude,bedrock): echo thinking blocks on streaming multi-turn tool calls (#347)

### DIFF
--- a/crates/harnx-client/src/bedrock.rs
+++ b/crates/harnx-client/src/bedrock.rs
@@ -185,7 +185,12 @@ struct BedrockStreamState {
     function_name: String,
     function_arguments: String,
     function_id: String,
-    reasoning_state: i32,
+    /// Accumulated signature from `reasoningContent.signature` deltas for
+    /// the current reasoning block. Passed to each toolUse emitted in the
+    /// same turn so the serialiser can echo it back verbatim on the next
+    /// request — Bedrock (and the underlying Anthropic API) rejects
+    /// reasoning round-trips whose signature is missing or modified.
+    thinking_signature: String,
 }
 
 fn bedrock_emit_pending_tool_call(
@@ -204,11 +209,16 @@ fn bedrock_emit_pending_tool_call(
             state.function_name, state.function_arguments
         )
     })?;
+    let thought_signature = if state.thinking_signature.is_empty() {
+        None
+    } else {
+        Some(state.thinking_signature.clone())
+    };
     handler.tool_call(ToolCall::new(
         state.function_name.clone(),
         arguments,
         Some(state.function_id.clone()),
-        None,
+        thought_signature,
     ))?;
     state.function_name.clear();
     state.function_arguments.clear();
@@ -248,11 +258,20 @@ fn bedrock_handle_content_block_delta(
     if let Some(text) = data["delta"]["text"].as_str() {
         handler.text(text)?;
     } else if let Some(text) = data["delta"]["reasoningContent"]["text"].as_str() {
-        if state.reasoning_state == 0 {
-            handler.text("<think>\n")?;
-            state.reasoning_state = 1;
-        }
-        handler.text(text)?;
+        // Route reasoning text to the dedicated thought buffer so the
+        // serialiser can echo a `reasoningContent` block on the next
+        // request. Routing to `handler.text()` instead folds reasoning
+        // into the text buffer wrapped in `<think>...</think>` and
+        // returns `thought = None`, which makes the next turn omit the
+        // reasoningContent block entirely — the model then sees its own
+        // tool calls as orphaned and produces "previous session"
+        // hallucinations.
+        handler.thought(text)?;
+    } else if let Some(sig) = data["delta"]["reasoningContent"]["signature"].as_str() {
+        // Bedrock Converse Stream delivers the reasoning-block signature
+        // via a `reasoningContent.signature` delta after the text deltas.
+        // Accumulate so it can be attached to every toolUse in the turn.
+        state.thinking_signature.push_str(sig);
     } else if let Some(input) = data["delta"]["toolUse"]["input"].as_str() {
         state.function_arguments.push_str(input);
     }
@@ -263,15 +282,16 @@ fn bedrock_handle_content_block_stop(
     state: &mut BedrockStreamState,
     handler: &mut SseHandler,
 ) -> Result<()> {
-    if state.reasoning_state == 1 {
-        handler.text("\n</think>\n\n")?;
-        state.reasoning_state = 0;
-    }
     // Emit if a toolUse block is pending, and reset accumulators so the
     // fallback emit path in contentBlockStart doesn't re-fire this same
     // call when the next toolUse block begins. Same bug that affected
     // the Claude streaming parser (both follow Anthropic's content-block
     // protocol).
+    //
+    // Reasoning-block close brackets are no longer emitted here — the
+    // SseHandler's `thought()` / `text()` / `tool_call()` / `done()`
+    // methods manage `<think>...</think>` display framing themselves now
+    // that reasoning text flows through `thought_buffer`.
     bedrock_emit_pending_tool_call(state, handler)
 }
 
@@ -431,10 +451,37 @@ fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Resu
                     })]
                 }
                 MessageContent::ToolCalls(MessageContentToolCalls {
-                    tool_results, text, ..
+                    tool_results,
+                    text,
+                    thought,
+                    ..
                 }) => {
                     let mut assistant_parts = vec![];
                     let mut user_parts = vec![];
+                    if let Some(thought_text) = thought {
+                        // Echo the reasoningContent block verbatim so
+                        // Bedrock knows this assistant turn included
+                        // extended thinking. The signature is stored on
+                        // each tool call in the turn — omitting it
+                        // causes the model to treat its own tool calls
+                        // as coming from a "previous session" and
+                        // produce replay-confusion hallucinations.
+                        let signature = tool_results
+                            .first()
+                            .and_then(|r| r.call.thought_signature.as_deref())
+                            .unwrap_or("");
+                        let mut reasoning_text = json!({ "text": thought_text });
+                        if !signature.is_empty() {
+                            if let Some(obj) = reasoning_text.as_object_mut() {
+                                obj.insert("signature".to_string(), signature.into());
+                            }
+                        }
+                        assistant_parts.push(json!({
+                            "reasoningContent": {
+                                "reasoningText": reasoning_text,
+                            }
+                        }));
+                    }
                     if !text.is_empty() {
                         assistant_parts.push(json!({
                             "text": text,
@@ -526,7 +573,8 @@ fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Resu
 
 fn extract_chat_completions(data: &Value) -> Result<ChatCompletionsOutput> {
     let mut text = String::new();
-    let mut reasoning = None;
+    let mut reasoning: Option<String> = None;
+    let mut reasoning_signature: Option<String> = None;
     let mut tool_calls = vec![];
     if let Some(array) = data["output"]["message"]["content"].as_array() {
         for item in array {
@@ -538,8 +586,11 @@ fn extract_chat_completions(data: &Value) -> Result<ChatCompletionsOutput> {
             } else if let Some(reasoning_text) =
                 item["reasoningContent"]["reasoningText"].as_object()
             {
-                if let Some(text) = json_str_from_map(reasoning_text, "text") {
-                    reasoning = Some(text.to_string());
+                if let Some(t) = json_str_from_map(reasoning_text, "text") {
+                    reasoning = Some(t.to_string());
+                }
+                if let Some(s) = json_str_from_map(reasoning_text, "signature") {
+                    reasoning_signature = Some(s.to_string());
                 }
             } else if let Some(tool_use) = item["toolUse"].as_object() {
                 if let (Some(id), Some(name), Some(input)) = (
@@ -551,25 +602,43 @@ fn extract_chat_completions(data: &Value) -> Result<ChatCompletionsOutput> {
                         name.to_string(),
                         input.clone(),
                         Some(id.to_string()),
-                        None,
+                        None, // signature attached below
                     ));
                 }
             }
         }
     }
 
-    if let Some(reasoning) = reasoning {
-        text = format!("<think>\n{reasoning}\n</think>\n\n{text}")
+    // Attach the reasoning signature to every tool call in this turn.
+    // Bedrock requires the signature echoed back verbatim alongside the
+    // reasoningContent block.
+    if let Some(sig) = &reasoning_signature {
+        for call in &mut tool_calls {
+            call.thought_signature = Some(sig.clone());
+        }
     }
 
-    if text.is_empty() && tool_calls.is_empty() {
-        bail!("Invalid response data: {data}");
+    // When there are tool calls, carry the thought on its dedicated field
+    // so the serialiser can echo back the reasoningContent block on the
+    // next request. When there are no tool calls, fold it into text for
+    // display (existing behaviour for plain-text reasoning responses).
+    if !tool_calls.is_empty() {
+        if text.is_empty() && reasoning.is_none() {
+            bail!("Invalid response data: {data}");
+        }
+    } else {
+        if let Some(r) = &reasoning {
+            text = format!("<think>\n{r}\n</think>\n\n{text}");
+        }
+        if text.is_empty() {
+            bail!("Invalid response data: {data}");
+        }
     }
 
     let output = ChatCompletionsOutput {
         text,
         tool_calls,
-        thought: None,
+        thought: reasoning,
         id: None,
         input_tokens: data["usage"]["inputTokens"].as_u64(),
         output_tokens: data["usage"]["outputTokens"].as_u64(),
@@ -744,6 +813,296 @@ mod tests {
             ids,
             vec![Some("toolu_A"), Some("toolu_B")],
             "each toolUse block should be emitted exactly once"
+        );
+    }
+
+    /// End-to-end reasoning round-trip on the Bedrock STREAMING path.
+    ///
+    /// When Bedrock Converse Stream delivers a reasoningContent block
+    /// (text deltas + trailing signature delta) followed by toolUse, the
+    /// streaming parser must:
+    ///   1. route reasoning text to `handler.thought()` (not
+    ///      `handler.text()`, which would fold reasoning into the text
+    ///      buffer wrapped in `<think>...</think>` and lose the thought),
+    ///   2. capture the `reasoningContent.signature` delta and attach it
+    ///      to every toolUse in the turn, and
+    ///   3. surface the thought via `SseHandler::take()` so the
+    ///      serialiser can echo a `reasoningContent` block on the next
+    ///      request.
+    ///
+    /// If any of those break, the next turn's request has no
+    /// reasoningContent block, the model sees its own tool calls as
+    /// orphaned, and it produces "previous session" hallucinations.
+    /// This test drives the full state machine and verifies the next
+    /// request body is well-formed.
+    #[test]
+    fn bedrock_streaming_thought_roundtrips_into_next_request_body() {
+        use harnx_core::api_types::ChatCompletionsData;
+        use harnx_core::message::{Message, MessageContent, MessageContentToolCalls, MessageRole};
+        use harnx_core::model::Model;
+        use harnx_core::tool::ToolResult;
+
+        let (tx, _rx) = unbounded_channel();
+        let mut handler = SseHandler::new(tx, create_abort_signal());
+        let mut state = BedrockStreamState::default();
+
+        // Realistic Bedrock Converse Stream sequence: reasoning block
+        // (multi-chunk text + trailing signature delta) then a toolUse.
+        let events: Vec<(&str, Value)> = vec![
+            ("contentBlockStart", json!({"start": {}})),
+            (
+                "contentBlockDelta",
+                json!({"delta": {"reasoningContent": {"text": "Let me think "}}}),
+            ),
+            (
+                "contentBlockDelta",
+                json!({"delta": {"reasoningContent": {"text": "about this."}}}),
+            ),
+            (
+                "contentBlockDelta",
+                json!({"delta": {"reasoningContent": {"signature": "sig_bedrock_xyz"}}}),
+            ),
+            ("contentBlockStop", json!({})),
+            (
+                "contentBlockStart",
+                json!({"start": {"toolUse": {"toolUseId": "toolu_S", "name": "Bash"}}}),
+            ),
+            (
+                "contentBlockDelta",
+                json!({"delta": {"toolUse": {"input": "{\"command\":\"ls\"}"}}}),
+            ),
+            ("contentBlockStop", json!({})),
+        ];
+        for (smithy_type, data) in &events {
+            bedrock_handle_stream_event(&mut state, &mut handler, smithy_type, data)
+                .expect("stream event should process");
+        }
+
+        let (text, thought, tool_calls, _usage) = handler.take();
+
+        assert_eq!(
+            thought.as_deref(),
+            Some("Let me think about this."),
+            "Bedrock streaming reasoning text must reach the dedicated thought \
+             field, not the text buffer wrapped in <think>"
+        );
+        assert!(
+            !text.contains("<think>"),
+            "text buffer must not be polluted with <think> wrappers when \
+             tool calls are present. Got: {text:?}"
+        );
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(
+            tool_calls[0].thought_signature.as_deref(),
+            Some("sig_bedrock_xyz"),
+            "Bedrock streaming reasoningContent.signature must reach \
+             ToolCall.thought_signature"
+        );
+
+        // Now simulate what the agent loop does: build a ToolCalls message
+        // from (text, thought, tool_calls), then build the next request body.
+        let tool_result = ToolResult::new(tool_calls.into_iter().next().unwrap(), json!("ok"));
+        let messages = vec![
+            Message::new(
+                MessageRole::User,
+                MessageContent::Text("Run a command".to_string()),
+            ),
+            Message::new(
+                MessageRole::Tool,
+                MessageContent::ToolCalls(MessageContentToolCalls::new(
+                    vec![tool_result],
+                    text,
+                    thought,
+                )),
+            ),
+        ];
+        let mut model = Model::new("bedrock", "us.anthropic.claude-sonnet-4-6");
+        model.set_max_tokens(Some(4096), true);
+        let body = build_chat_completions_body(
+            ChatCompletionsData {
+                messages,
+                temperature: None,
+                top_p: None,
+                functions: None,
+                stream: true,
+            },
+            &model,
+        )
+        .unwrap();
+
+        let assistant_msg = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["role"] == "assistant")
+            .expect("must have an assistant turn");
+        let content = assistant_msg["content"]
+            .as_array()
+            .expect("assistant content array");
+
+        // Find the reasoningContent block — it must exist and precede the
+        // toolUse so Bedrock can verify the reasoning matches the request.
+        let reasoning_idx = content
+            .iter()
+            .position(|b| b["reasoningContent"].is_object())
+            .expect(
+                "next request body must include a reasoningContent block for the \
+                 streamed assistant turn: otherwise the model receives tool \
+                 results with no record of its prior reasoning",
+            );
+        let tool_use_idx = content
+            .iter()
+            .position(|b| b["toolUse"].is_object())
+            .expect("must have a toolUse block");
+        assert!(
+            reasoning_idx < tool_use_idx,
+            "reasoningContent must precede toolUse"
+        );
+
+        let reasoning_text = &content[reasoning_idx]["reasoningContent"]["reasoningText"];
+        assert_eq!(reasoning_text["text"], "Let me think about this.");
+        assert_eq!(
+            reasoning_text["signature"], "sig_bedrock_xyz",
+            "reasoning signature must be echoed verbatim from the streamed \
+             reasoningContent.signature delta"
+        );
+    }
+
+    /// Multiple toolUse blocks in one streamed Bedrock turn must all carry
+    /// the same reasoning signature. Bedrock rejects requests where any
+    /// toolUse sibling of a reasoningContent block lacks the signature
+    /// when echoed back.
+    #[test]
+    fn bedrock_streaming_multiple_tool_calls_share_thought_signature() {
+        let (tx, _rx) = unbounded_channel();
+        let mut handler = SseHandler::new(tx, create_abort_signal());
+        let mut state = BedrockStreamState::default();
+
+        let events: Vec<(&str, Value)> = vec![
+            ("contentBlockStart", json!({"start": {}})),
+            (
+                "contentBlockDelta",
+                json!({"delta": {"reasoningContent": {"text": "Plan two calls."}}}),
+            ),
+            (
+                "contentBlockDelta",
+                json!({"delta": {"reasoningContent": {"signature": "sig_multi"}}}),
+            ),
+            ("contentBlockStop", json!({})),
+            (
+                "contentBlockStart",
+                json!({"start": {"toolUse": {"toolUseId": "toolu_A", "name": "Bash"}}}),
+            ),
+            (
+                "contentBlockDelta",
+                json!({"delta": {"toolUse": {"input": "{\"command\":\"pwd\"}"}}}),
+            ),
+            ("contentBlockStop", json!({})),
+            (
+                "contentBlockStart",
+                json!({"start": {"toolUse": {"toolUseId": "toolu_B", "name": "Bash"}}}),
+            ),
+            (
+                "contentBlockDelta",
+                json!({"delta": {"toolUse": {"input": "{\"command\":\"ls\"}"}}}),
+            ),
+            ("contentBlockStop", json!({})),
+        ];
+        for (smithy_type, data) in &events {
+            bedrock_handle_stream_event(&mut state, &mut handler, smithy_type, data)
+                .expect("stream event should process");
+        }
+
+        let (_text, thought, tool_calls, _usage) = handler.take();
+        assert_eq!(thought.as_deref(), Some("Plan two calls."));
+        assert_eq!(tool_calls.len(), 2);
+        for call in &tool_calls {
+            assert_eq!(
+                call.thought_signature.as_deref(),
+                Some("sig_multi"),
+                "every streamed toolUse sibling of a reasoningContent block \
+                 must carry its signature so the next request body is well-formed"
+            );
+        }
+    }
+
+    /// Non-streaming counterpart: `extract_chat_completions` must capture
+    /// the reasoningContent signature and attach it to every parsed
+    /// toolUse so a multi-call thinking turn echoes correctly.
+    #[test]
+    fn bedrock_extract_attaches_signature_to_every_tool_call() {
+        let response = json!({
+            "output": {"message": {"role": "assistant", "content": [
+                {
+                    "reasoningContent": {
+                        "reasoningText": {
+                            "text": "two calls",
+                            "signature": "sig_multi"
+                        }
+                    }
+                },
+                {"toolUse": {"toolUseId": "toolu_A", "name": "Bash", "input": {"command": "pwd"}}},
+                {"toolUse": {"toolUseId": "toolu_B", "name": "Bash", "input": {"command": "ls"}}}
+            ]}},
+            "usage": {"inputTokens": 1, "outputTokens": 1}
+        });
+
+        let output = extract_chat_completions(&response).unwrap();
+        assert_eq!(
+            output.thought.as_deref(),
+            Some("two calls"),
+            "thought must be stored in ChatCompletionsOutput.thought, not folded \
+             into text when tool calls are present"
+        );
+        assert_eq!(output.tool_calls.len(), 2);
+        for call in &output.tool_calls {
+            assert_eq!(
+                call.thought_signature.as_deref(),
+                Some("sig_multi"),
+                "every parsed toolUse sibling of a reasoningContent block must \
+                 carry its signature (non-streaming multi-call)"
+            );
+        }
+    }
+
+    /// Bedrock streaming text-only response with reasoning must populate
+    /// `thought` cleanly without polluting `text`. Pins the no-tool path
+    /// so a future refactor can't re-introduce `<think>` wrappers in text.
+    #[test]
+    fn bedrock_streaming_text_only_with_thinking_separates_buffers() {
+        let (tx, _rx) = unbounded_channel();
+        let mut handler = SseHandler::new(tx, create_abort_signal());
+        let mut state = BedrockStreamState::default();
+
+        let events: Vec<(&str, Value)> = vec![
+            ("contentBlockStart", json!({"start": {}})),
+            (
+                "contentBlockDelta",
+                json!({"delta": {"reasoningContent": {"text": "Considering."}}}),
+            ),
+            (
+                "contentBlockDelta",
+                json!({"delta": {"reasoningContent": {"signature": "sig_text"}}}),
+            ),
+            ("contentBlockStop", json!({})),
+            ("contentBlockStart", json!({"start": {}})),
+            (
+                "contentBlockDelta",
+                json!({"delta": {"text": "Final answer."}}),
+            ),
+            ("contentBlockStop", json!({})),
+        ];
+        for (smithy_type, data) in &events {
+            bedrock_handle_stream_event(&mut state, &mut handler, smithy_type, data)
+                .expect("stream event should process");
+        }
+
+        let (text, thought, tool_calls, _usage) = handler.take();
+        assert_eq!(text, "Final answer.", "text buffer carries only the prose");
+        assert_eq!(thought.as_deref(), Some("Considering."));
+        assert!(
+            tool_calls.is_empty(),
+            "no toolUse blocks were sent; tool_calls must stay empty"
         );
     }
 }

--- a/crates/harnx-client/src/claude.rs
+++ b/crates/harnx-client/src/claude.rs
@@ -165,8 +165,15 @@ fn claude_handle_content_block_delta(
     if let Some(text) = delta["text"].as_str() {
         handler.text(text)?;
     } else if let Some(text) = delta["thinking"].as_str() {
-        claude_transition_reasoning(state, handler, true)?;
-        handler.text(text)?;
+        // Route thinking deltas to the dedicated thought buffer so the
+        // serialiser can echo a `{"type":"thinking",...}` block on the next
+        // request (issue #347 / #328 streaming side). Routing to
+        // `handler.text()` instead would fold thinking into the text buffer
+        // wrapped in `<think>...</think>` and leave `thought` = None, which
+        // makes the next turn omit the thinking block entirely — the model
+        // then sees its own tool calls as orphaned and produces "previous
+        // session" hallucinations.
+        handler.thought(text)?;
     } else if let Some(sig) = delta["signature"].as_str() {
         // signature_delta: accumulate the thinking-block signature so it can
         // be echoed back verbatim on the next API request (issue #328).
@@ -695,6 +702,335 @@ system_prompt_prefix:
             output.tool_calls[0].thought_signature,
             Some("sig_abc123".to_string()),
             "thinking signature must be stored in ToolCall.thought_signature (issue #328: currently always None)"
+        );
+    }
+
+    /// End-to-end roundtrip for issue #347 / #328 on the STREAMING path.
+    ///
+    /// The non-streaming roundtrip is already covered above
+    /// (`claude_extract_preserves_thought_and_signature` +
+    /// `claude_body_includes_thinking_block_when_thought_present`), but issue
+    /// #328's "previous session" symptom can also surface on the streaming path
+    /// when the thinking text is delivered as `content_block_delta` events with
+    /// a trailing `signature_delta`.
+    ///
+    /// This test drives `claude_handle_stream_event` with a realistic event
+    /// sequence (thinking deltas → signature_delta → tool_use), takes the
+    /// `SseHandler` output the same way `run_chat_completion_streaming` does,
+    /// then feeds it back into `claude_build_chat_completions_body` to verify
+    /// the next request includes the thinking block + signature. If the
+    /// streaming side drops the thought (e.g. because thinking deltas were
+    /// routed to the text buffer instead of the thought buffer), the
+    /// serialiser produces an assistant turn with no thinking block and the
+    /// model sees its tool calls as orphaned — exactly the bug we keep
+    /// reopening.
+    #[test]
+    fn claude_streaming_thought_roundtrips_into_next_request_body() {
+        use harnx_core::abort::create_abort_signal;
+        use harnx_core::message::{Message, MessageContent, MessageContentToolCalls, MessageRole};
+        use harnx_core::tool::ToolResult;
+        use tokio::sync::mpsc::unbounded_channel;
+
+        let (tx, _rx) = unbounded_channel();
+        let mut handler = SseHandler::new(tx, create_abort_signal());
+        let mut state = ClaudeStreamState::default();
+
+        // Realistic Anthropic streaming sequence: thinking block (with
+        // multi-chunk text and a signature_delta), then a tool_use block.
+        let events = [
+            json!({
+                "type": "message_start",
+                "message": {"usage": {"input_tokens": 100, "cache_read_input_tokens": 0}}
+            }),
+            json!({
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "thinking", "thinking": ""}
+            }),
+            json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "thinking_delta", "thinking": "Let me think "}
+            }),
+            json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "thinking_delta", "thinking": "about this."}
+            }),
+            json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "signature_delta", "signature": "sig_stream_xyz"}
+            }),
+            json!({"type": "content_block_stop", "index": 0}),
+            json!({
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {"type": "tool_use", "name": "Bash", "id": "toolu_S"}
+            }),
+            json!({
+                "type": "content_block_delta",
+                "index": 1,
+                "delta": {"type": "input_json_delta", "partial_json": "{\"command\":\"ls\"}"}
+            }),
+            json!({"type": "content_block_stop", "index": 1}),
+            json!({
+                "type": "message_delta",
+                "delta": {"stop_reason": "tool_use"},
+                "usage": {"output_tokens": 42}
+            }),
+        ];
+
+        for event in &events {
+            claude_handle_stream_event(&mut state, &mut handler, event)
+                .expect("stream event should process");
+        }
+
+        // Drain the handler the same way run_chat_completion_streaming does.
+        let (text, thought, tool_calls, _usage) = handler.take();
+
+        // The thinking content must end up on the dedicated `thought` field,
+        // NOT folded into the text buffer with <think>...</think> wrappers.
+        // If it lands in `text`, the next turn's request body will have no
+        // thinking block to echo back (issue #328 streaming-side regression).
+        assert_eq!(
+            thought.as_deref(),
+            Some("Let me think about this."),
+            "streaming thought must be captured in the dedicated thought field, \
+             not the text buffer (issue #347: streaming path regresses #328)"
+        );
+        assert!(
+            !text.contains("<think>"),
+            "streaming text must not be polluted with <think> wrappers when \
+             tool calls are present — the wrapper is meant for plain-text \
+             reasoning responses; tool-call turns echo the raw thinking block. \
+             Got text: {text:?}"
+        );
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(
+            tool_calls[0].thought_signature.as_deref(),
+            Some("sig_stream_xyz"),
+            "streaming signature must reach the tool_call (PR #330 streaming side)"
+        );
+
+        // Now simulate what the agent loop does: build a ToolCalls message
+        // from (text, thought, tool_calls), then build the next request body.
+        let tool_result = ToolResult::new(tool_calls.into_iter().next().unwrap(), json!("ok"));
+        let messages = vec![
+            Message::new(
+                MessageRole::User,
+                MessageContent::Text("Run a command".to_string()),
+            ),
+            Message::new(
+                MessageRole::Tool,
+                MessageContent::ToolCalls(MessageContentToolCalls::new(
+                    vec![tool_result],
+                    text,
+                    thought,
+                )),
+            ),
+        ];
+
+        let mut model = Model::new("claude", "claude-3-5-sonnet");
+        model.set_max_tokens(Some(4096), true);
+
+        let body = claude_build_chat_completions_body(
+            ChatCompletionsData {
+                messages,
+                temperature: None,
+                top_p: None,
+                functions: None,
+                stream: true,
+            },
+            &model,
+        )
+        .unwrap();
+
+        let assistant_msg = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["role"] == "assistant")
+            .expect("must have an assistant turn");
+        let content = assistant_msg["content"]
+            .as_array()
+            .expect("assistant content array");
+
+        let thinking_block = content
+            .iter()
+            .find(|b| b["type"] == "thinking")
+            .expect(
+                "next request body must include a thinking block for the \
+                 streamed assistant turn (issue #328/#347): otherwise the \
+                 model receives tool results with no record of its prior \
+                 reasoning and infers a session boundary",
+            );
+        assert_eq!(thinking_block["thinking"], "Let me think about this.");
+        assert_eq!(
+            thinking_block["signature"], "sig_stream_xyz",
+            "thinking block signature must be echoed verbatim from the \
+             streamed signature_delta"
+        );
+    }
+
+    /// Multiple tool_use blocks in one streamed turn must all carry the same
+    /// thought signature. The Anthropic API rejects requests where any
+    /// tool_use sibling of a thinking block lacks its signature when echoed
+    /// back, and the signature is shared across all tool calls in the turn.
+    /// Without this, a 2-tool turn would round-trip with one valid call and
+    /// one orphan call on the next request.
+    #[test]
+    fn claude_streaming_multiple_tool_calls_share_thought_signature() {
+        use harnx_core::abort::create_abort_signal;
+        use tokio::sync::mpsc::unbounded_channel;
+
+        let (tx, _rx) = unbounded_channel();
+        let mut handler = SseHandler::new(tx, create_abort_signal());
+        let mut state = ClaudeStreamState::default();
+
+        let events = [
+            json!({
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "thinking", "thinking": ""}
+            }),
+            json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "thinking_delta", "thinking": "Plan two calls."}
+            }),
+            json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "signature_delta", "signature": "sig_multi"}
+            }),
+            json!({"type": "content_block_stop", "index": 0}),
+            json!({
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {"type": "tool_use", "name": "Bash", "id": "toolu_A"}
+            }),
+            json!({
+                "type": "content_block_delta",
+                "index": 1,
+                "delta": {"type": "input_json_delta", "partial_json": "{\"command\":\"pwd\"}"}
+            }),
+            json!({"type": "content_block_stop", "index": 1}),
+            json!({
+                "type": "content_block_start",
+                "index": 2,
+                "content_block": {"type": "tool_use", "name": "Bash", "id": "toolu_B"}
+            }),
+            json!({
+                "type": "content_block_delta",
+                "index": 2,
+                "delta": {"type": "input_json_delta", "partial_json": "{\"command\":\"ls\"}"}
+            }),
+            json!({"type": "content_block_stop", "index": 2}),
+        ];
+        for event in &events {
+            claude_handle_stream_event(&mut state, &mut handler, event)
+                .expect("stream event should process");
+        }
+
+        let (_text, thought, tool_calls, _usage) = handler.take();
+        assert_eq!(thought.as_deref(), Some("Plan two calls."));
+        assert_eq!(tool_calls.len(), 2);
+        for call in &tool_calls {
+            assert_eq!(
+                call.thought_signature.as_deref(),
+                Some("sig_multi"),
+                "every streamed tool_use sibling of a thinking block must carry \
+                 its signature so the next request body is well-formed (issue #328 \
+                 multi-call generalization)"
+            );
+        }
+    }
+
+    /// Mirror of `claude_streaming_multiple_tool_calls_share_thought_signature`
+    /// for the non-streaming path. `claude_extract_chat_completions` already
+    /// loops over all tool_calls and assigns the captured signature to each;
+    /// this test pins that behavior so a future refactor can't drop the loop
+    /// and silently break multi-call thinking turns.
+    #[test]
+    fn claude_extract_attaches_signature_to_every_tool_call() {
+        let response = json!({
+            "id": "msg_multi",
+            "content": [
+                {"type": "thinking", "thinking": "two calls", "signature": "sig_multi"},
+                {"type": "tool_use", "id": "toolu_A", "name": "Bash", "input": {"command": "pwd"}},
+                {"type": "tool_use", "id": "toolu_B", "name": "Bash", "input": {"command": "ls"}}
+            ],
+            "usage": {"input_tokens": 1, "output_tokens": 1}
+        });
+
+        let output = claude_extract_chat_completions(&response).unwrap();
+        assert_eq!(output.tool_calls.len(), 2);
+        for call in &output.tool_calls {
+            assert_eq!(
+                call.thought_signature.as_deref(),
+                Some("sig_multi"),
+                "every parsed tool_use sibling of a thinking block must carry \
+                 its signature (non-streaming multi-call)"
+            );
+        }
+    }
+
+    /// Streaming text-only response with extended thinking must populate
+    /// `thought` cleanly without polluting `text`. This is the dual of the
+    /// thinking+tool_use roundtrip — it pins the behavior the streaming-side
+    /// fix relies on for the no-tool-calls path so a future refactor of
+    /// `handler.thought()` can't silently re-introduce `<think>` wrappers
+    /// into the text buffer.
+    #[test]
+    fn claude_streaming_text_only_with_thinking_separates_buffers() {
+        use harnx_core::abort::create_abort_signal;
+        use tokio::sync::mpsc::unbounded_channel;
+
+        let (tx, _rx) = unbounded_channel();
+        let mut handler = SseHandler::new(tx, create_abort_signal());
+        let mut state = ClaudeStreamState::default();
+
+        let events = [
+            json!({
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "thinking", "thinking": ""}
+            }),
+            json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "thinking_delta", "thinking": "Considering."}
+            }),
+            json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "signature_delta", "signature": "sig_text"}
+            }),
+            json!({"type": "content_block_stop", "index": 0}),
+            json!({
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {"type": "text", "text": ""}
+            }),
+            json!({
+                "type": "content_block_delta",
+                "index": 1,
+                "delta": {"type": "text_delta", "text": "Final answer."}
+            }),
+            json!({"type": "content_block_stop", "index": 1}),
+        ];
+        for event in &events {
+            claude_handle_stream_event(&mut state, &mut handler, event)
+                .expect("stream event should process");
+        }
+
+        let (text, thought, tool_calls, _usage) = handler.take();
+        assert_eq!(text, "Final answer.", "text buffer carries only the prose");
+        assert_eq!(thought.as_deref(), Some("Considering."));
+        assert!(
+            tool_calls.is_empty(),
+            "no tool_use blocks were sent; tool_calls must stay empty"
         );
     }
 

--- a/crates/harnx-client/src/claude.rs
+++ b/crates/harnx-client/src/claude.rs
@@ -167,12 +167,11 @@ fn claude_handle_content_block_delta(
     } else if let Some(text) = delta["thinking"].as_str() {
         // Route thinking deltas to the dedicated thought buffer so the
         // serialiser can echo a `{"type":"thinking",...}` block on the next
-        // request (issue #347 / #328 streaming side). Routing to
-        // `handler.text()` instead would fold thinking into the text buffer
-        // wrapped in `<think>...</think>` and leave `thought` = None, which
-        // makes the next turn omit the thinking block entirely — the model
-        // then sees its own tool calls as orphaned and produces "previous
-        // session" hallucinations.
+        // request. Routing to `handler.text()` instead folds thinking into
+        // the text buffer wrapped in `<think>...</think>` and returns
+        // `thought = None`, which makes the next turn omit the thinking
+        // block entirely — the model then sees its own tool calls as
+        // orphaned and produces "previous session" hallucinations.
         handler.thought(text)?;
     } else if let Some(sig) = delta["signature"].as_str() {
         // signature_delta: accumulate the thinking-block signature so it can
@@ -705,25 +704,24 @@ system_prompt_prefix:
         );
     }
 
-    /// End-to-end roundtrip for issue #347 / #328 on the STREAMING path.
+    /// End-to-end thinking + signature round-trip on the STREAMING path.
     ///
-    /// The non-streaming roundtrip is already covered above
-    /// (`claude_extract_preserves_thought_and_signature` +
-    /// `claude_body_includes_thinking_block_when_thought_present`), but issue
-    /// #328's "previous session" symptom can also surface on the streaming path
-    /// when the thinking text is delivered as `content_block_delta` events with
-    /// a trailing `signature_delta`.
+    /// The non-streaming round-trip is covered by
+    /// `claude_extract_preserves_thought_and_signature` plus
+    /// `claude_body_includes_thinking_block_when_thought_present`. The
+    /// streaming path can regress the same "previous session" symptom
+    /// independently when thinking text is delivered as
+    /// `content_block_delta` events with a trailing `signature_delta`.
     ///
-    /// This test drives `claude_handle_stream_event` with a realistic event
-    /// sequence (thinking deltas → signature_delta → tool_use), takes the
-    /// `SseHandler` output the same way `run_chat_completion_streaming` does,
-    /// then feeds it back into `claude_build_chat_completions_body` to verify
-    /// the next request includes the thinking block + signature. If the
-    /// streaming side drops the thought (e.g. because thinking deltas were
-    /// routed to the text buffer instead of the thought buffer), the
-    /// serialiser produces an assistant turn with no thinking block and the
-    /// model sees its tool calls as orphaned — exactly the bug we keep
-    /// reopening.
+    /// This test drives `claude_handle_stream_event` with a realistic
+    /// event sequence (thinking deltas → signature_delta → tool_use),
+    /// takes the `SseHandler` output the same way
+    /// `run_chat_completion_streaming` does, then feeds it back into
+    /// `claude_build_chat_completions_body` to verify the next request
+    /// includes the thinking block + signature. If thinking deltas land
+    /// in the text buffer instead of the thought buffer the serialiser
+    /// emits an assistant turn with no thinking block and the model sees
+    /// its tool calls as orphaned.
     #[test]
     fn claude_streaming_thought_roundtrips_into_next_request_body() {
         use harnx_core::abort::create_abort_signal;
@@ -791,13 +789,14 @@ system_prompt_prefix:
 
         // The thinking content must end up on the dedicated `thought` field,
         // NOT folded into the text buffer with <think>...</think> wrappers.
-        // If it lands in `text`, the next turn's request body will have no
-        // thinking block to echo back (issue #328 streaming-side regression).
+        // If it lands in `text`, the next turn's request body has no thinking
+        // block to echo back and the model treats the tool results as
+        // orphaned.
         assert_eq!(
             thought.as_deref(),
             Some("Let me think about this."),
             "streaming thought must be captured in the dedicated thought field, \
-             not the text buffer (issue #347: streaming path regresses #328)"
+             not the text buffer"
         );
         assert!(
             !text.contains("<think>"),
@@ -810,7 +809,7 @@ system_prompt_prefix:
         assert_eq!(
             tool_calls[0].thought_signature.as_deref(),
             Some("sig_stream_xyz"),
-            "streaming signature must reach the tool_call (PR #330 streaming side)"
+            "streaming signature must reach the tool_call"
         );
 
         // Now simulate what the agent loop does: build a ToolCalls message
@@ -861,9 +860,9 @@ system_prompt_prefix:
             .find(|b| b["type"] == "thinking")
             .expect(
                 "next request body must include a thinking block for the \
-                 streamed assistant turn (issue #328/#347): otherwise the \
-                 model receives tool results with no record of its prior \
-                 reasoning and infers a session boundary",
+                 streamed assistant turn: otherwise the model receives tool \
+                 results with no record of its prior reasoning and infers a \
+                 session boundary",
             );
         assert_eq!(thinking_block["thinking"], "Let me think about this.");
         assert_eq!(
@@ -941,8 +940,7 @@ system_prompt_prefix:
                 call.thought_signature.as_deref(),
                 Some("sig_multi"),
                 "every streamed tool_use sibling of a thinking block must carry \
-                 its signature so the next request body is well-formed (issue #328 \
-                 multi-call generalization)"
+                 its signature so the next request body is well-formed"
             );
         }
     }

--- a/crates/harnx-client/src/vertexai.rs
+++ b/crates/harnx-client/src/vertexai.rs
@@ -672,4 +672,112 @@ mod tests {
         assert_eq!(calls[0].arguments, json!({"cmd": "pwd"}));
         assert_eq!(calls[1].arguments, json!({"cmd": "ls"}));
     }
+
+    /// End-to-end thought + thoughtSignature roundtrip for Gemini/Vertex AI
+    /// (issue #347 cross-provider audit).
+    ///
+    /// Gemini's protocol carries `thought: <text>` parts and a
+    /// `thoughtSignature` on functionCall parts. Like Claude, dropping these
+    /// on the round-trip leaves the model's tool calls orphaned on the next
+    /// turn. The streaming code currently routes `part["thought"]` to
+    /// `handler.thought()` and captures `thoughtSignature` on tool_call
+    /// emission; this test pins both behaviors AND verifies the serialiser
+    /// echoes them back.
+    #[test]
+    fn gemini_streaming_thought_roundtrips_into_next_request_body() {
+        use harnx_core::api_types::ChatCompletionsData;
+        use harnx_core::message::{Message, MessageContent, MessageContentToolCalls, MessageRole};
+        use harnx_core::model::Model;
+        use harnx_core::tool::ToolResult;
+
+        let (tx, _rx) = unbounded_channel();
+        let mut handler = SseHandler::new(tx, create_abort_signal());
+
+        // Realistic Gemini chunk: a thought part, a text part, and a
+        // functionCall part with thoughtSignature, all in one candidate.
+        let chunk = json!({
+            "candidates": [{"content": {"parts": [
+                {"thought": "Plan the call."},
+                {"text": "Running ls."},
+                {
+                    "functionCall": {"name": "Bash", "args": {"cmd": "ls"}},
+                    "thoughtSignature": "sig_gemini_xyz"
+                }
+            ]}}]
+        });
+        gemini_handle_stream_chunk(&mut handler, &chunk).expect("stream chunk should process");
+
+        let (text, thought, tool_calls, _usage) = handler.take();
+        // Gemini prepends "\n\n" for non-first parts (gemini_handle_part).
+        assert!(
+            text.contains("Running ls."),
+            "text part flows to text buffer; got {text:?}"
+        );
+        assert_eq!(
+            thought.as_deref(),
+            Some("Plan the call."),
+            "thought part must reach the dedicated thought buffer (not text)"
+        );
+        assert!(
+            !text.contains("Plan the call."),
+            "thought must not leak into text buffer; got {text:?}"
+        );
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(
+            tool_calls[0].thought_signature.as_deref(),
+            Some("sig_gemini_xyz"),
+            "thoughtSignature on functionCall must reach ToolCall.thought_signature"
+        );
+
+        // Now feed it back through the serialiser and confirm the next
+        // request body carries thought + thoughtSignature on the model turn.
+        let tool_result = ToolResult::new(tool_calls.into_iter().next().unwrap(), json!("ok"));
+        let messages = vec![
+            Message::new(
+                MessageRole::User,
+                MessageContent::Text("Run a command".to_string()),
+            ),
+            Message::new(
+                MessageRole::Tool,
+                MessageContent::ToolCalls(MessageContentToolCalls::new(
+                    vec![tool_result],
+                    text,
+                    thought,
+                )),
+            ),
+        ];
+        let mut model = Model::new("gemini", "gemini-2.5-pro");
+        model.set_max_tokens(Some(4096), true);
+        let body = gemini_build_chat_completions_body(
+            ChatCompletionsData {
+                messages,
+                temperature: None,
+                top_p: None,
+                functions: None,
+                stream: true,
+            },
+            &model,
+        )
+        .unwrap();
+
+        let contents = body["contents"].as_array().unwrap();
+        let model_turn = contents
+            .iter()
+            .find(|c| c["role"] == "model")
+            .expect("must have a model role turn after the user message");
+        let parts = model_turn["parts"].as_array().unwrap();
+        let thought_part = parts
+            .iter()
+            .find(|p| p["thought"].is_string())
+            .expect("model turn must include a thought part on the round-trip");
+        assert_eq!(thought_part["thought"], "Plan the call.");
+        let fcall_part = parts
+            .iter()
+            .find(|p| p["functionCall"].is_object())
+            .expect("model turn must include a functionCall part");
+        assert_eq!(
+            fcall_part["thoughtSignature"], "sig_gemini_xyz",
+            "thoughtSignature must be echoed verbatim alongside the functionCall"
+        );
+    }
 }

--- a/crates/harnx-client/src/vertexai.rs
+++ b/crates/harnx-client/src/vertexai.rs
@@ -673,16 +673,14 @@ mod tests {
         assert_eq!(calls[1].arguments, json!({"cmd": "ls"}));
     }
 
-    /// End-to-end thought + thoughtSignature roundtrip for Gemini/Vertex AI
-    /// (issue #347 cross-provider audit).
+    /// End-to-end thought + thoughtSignature round-trip for Gemini/Vertex AI.
     ///
     /// Gemini's protocol carries `thought: <text>` parts and a
-    /// `thoughtSignature` on functionCall parts. Like Claude, dropping these
-    /// on the round-trip leaves the model's tool calls orphaned on the next
-    /// turn. The streaming code currently routes `part["thought"]` to
-    /// `handler.thought()` and captures `thoughtSignature` on tool_call
-    /// emission; this test pins both behaviors AND verifies the serialiser
-    /// echoes them back.
+    /// `thoughtSignature` on functionCall parts. Dropping either on the
+    /// round-trip leaves the model's tool calls orphaned on the next turn.
+    /// The streaming code routes `part["thought"]` to `handler.thought()`
+    /// and captures `thoughtSignature` on tool_call emission; this test
+    /// pins both behaviours AND verifies the serialiser echoes them back.
     #[test]
     fn gemini_streaming_thought_roundtrips_into_next_request_body() {
         use harnx_core::api_types::ChatCompletionsData;


### PR DESCRIPTION
## Summary

- Fixes #347 (streaming-side regression of #328): Claude direct streaming dropped the `thought` before the next request, recreating the "previous session" hallucination. Same wire-format bug on **Bedrock** thinking models, fixed in the same PR.
- One-line behavior change on each provider's content-block delta handler (route reasoning text to `handler.thought()`, not `handler.text()`); the rest is signature plumbing + serializer wiring + end-to-end tests.

## Provider scoreboard after this PR

| Provider | Before | After |
|---|---|---|
| Claude (direct) | Streaming dropped thought, parser/serializer correct (PR #330) | **Fixed** + roundtrip test pinning the streaming path |
| Bedrock (Claude via AWS) | Same structural bug as #328 — parser hard-coded `thought: None`, serializer ignored `thought`, signature delta never read (PR #330 explicitly punted) | **Fixed** end-to-end: parser, streaming, serializer, signature attachment, tests |
| Vertex / Gemini | Code correct, no regression test | Added round-trip test |
| OpenAI | Opaque reasoning, no round-trip required | No gap |

## What changed (claude.rs)

- `claude_handle_content_block_delta` — thinking deltas now go to `handler.thought()`. The handler already separates `text` / `thought` buffers and emits `<think>` / `</think>` display brackets over the SSE channel without polluting the text buffer.

## What changed (bedrock.rs)

- `bedrock_handle_content_block_delta` — route `reasoningContent.text` to `handler.thought()` (was `handler.text()` with `<think>...</think>` framing). New branch for `reasoningContent.signature` that accumulates into a `BedrockStreamState::thinking_signature` field. Drop the obsolete `reasoning_state` bracket tracking.
- `bedrock_emit_pending_tool_call` — attach the accumulated signature as `thought_signature` on every emitted `ToolCall` (was hardcoded `None`).
- `extract_chat_completions` (non-streaming) — capture both `reasoningText.text` and `reasoningText.signature`. Attach signature to every parsed `toolUse`. Surface the thought on `ChatCompletionsOutput.thought` (was hardcoded `None`).
- `build_chat_completions_body` (serializer) — stop ignoring `thought` on `MessageContent::ToolCalls`. When present, prepend a `reasoningContent.reasoningText` block (with signature) to the assistant content array.

## Tests added

**Claude:**
- `claude_streaming_thought_roundtrips_into_next_request_body` — full streaming roundtrip; **fails before the fix**, passes after.
- `claude_streaming_multiple_tool_calls_share_thought_signature`
- `claude_extract_attaches_signature_to_every_tool_call`
- `claude_streaming_text_only_with_thinking_separates_buffers`

**Bedrock:**
- `bedrock_streaming_thought_roundtrips_into_next_request_body`
- `bedrock_streaming_multiple_tool_calls_share_thought_signature`
- `bedrock_extract_attaches_signature_to_every_tool_call`
- `bedrock_streaming_text_only_with_thinking_separates_buffers`

**Vertex/Gemini:**
- `gemini_streaming_thought_roundtrips_into_next_request_body` — code was already correct; this just pins the contract.

## Test plan

- [x] `cargo test -p harnx-client` — 35 passed
- [x] `cargo build --workspace` — clean
- [x] New roundtrip tests fail before each one-line fix and pass after (verified manually by reverting `handler.thought()` → `handler.text()`)

## Caveat on the original issue trace

The captured session in #347 ran on plain `claude-sonnet-4-6` (no `:thinking`), so the exact bug wouldn't fire on that trace. The "previous turn" language in the captured log appears to be model confusion from increasing `exec-N` numbers in bash log paths combined with empty-output results after sed had already done the work. But the streaming-thinking bug is the closest match to the title and the symptom #328 was originally about, and it would produce identical output for any user on a `:thinking` variant — including on Bedrock, which the user reports they use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)