### PR TITLE
feat(mcp): add git-backed local history and rollback

### DIFF
--- a/.changesets/local-history-rollback.md
+++ b/.changesets/local-history-rollback.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+Add git-backed local history and rollback to harnx-mcp-fs and harnx-mcp-bash. Each mutating tool call (write_file, edit_file, exec, spawn/wait) now snapshots affected git repositories before and after, includes a unified diff in the tool response, and supports rollback via the new rollback_file tool.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2875,12 +2875,10 @@ name = "harnx-mcp-history"
 version = "0.30.0"
 dependencies = [
  "anyhow",
- "dirs",
  "gix",
  "log",
  "tempfile",
  "tokio",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -447,6 +463,12 @@ dependencies = [
  "bytes",
  "either",
 ]
+
+[[package]]
+name = "bytesize"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "cached"
@@ -605,6 +627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +769,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,7 +816,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix",
- "signal-hook",
+ "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
 ]
@@ -918,6 +958,20 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1107,6 +1161,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,6 +1289,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,6 +1313,17 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1505,6 +1589,934 @@ dependencies = [
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gix"
+version = "0.82.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62786b0500a7b8dfd998b5c9fc343e1133dc3804293db98e787f5442e8003591"
+dependencies = [
+ "gix-actor",
+ "gix-archive",
+ "gix-attributes",
+ "gix-blame",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-credentials",
+ "gix-date",
+ "gix-diff",
+ "gix-dir",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-mailmap",
+ "gix-merge",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-prompt",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-status",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-state",
+ "gix-worktree-stream",
+ "nonempty",
+ "parking_lot",
+ "regex",
+ "signal-hook 0.4.4",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552ddba0ea986ef262ee3296a6464194181f20882902c8a7669515eaf1b0891e"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "winnow",
+]
+
+[[package]]
+name = "gix-archive"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af31eddd8d8842dc05e0ae1f35721f12484d2eaab7d989f183182280f2cc04af"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "gix-object",
+ "gix-worktree-stream",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac00bd435a36fcc518640dad4eca4045e1a2f0b33f74a2bbff58245f8e3744d"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecbfc77ec6852294e341ecc305a490b59f2813e6ca42d79efda5099dcab1894"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5789a39b8638b73e5c1210375910145bcf688f1786b7f71fbb1ff4cd51dc7d"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-diff",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf288be9b60fe7231de03771faa292be1493d84786f68727e33ad1f91764320"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae4bb9fa74c44c93f7238b08255f7f9afc158bafea4b95af665fa535352cd73c"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9dd13b8254d36049e9d1758657e74918a49de0286ec053d02497448fa215246"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
+ "memmap2",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ecbd673d9223a46e6bb766e0802ad9921de3541d95d121a9d05de5e23c8de"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "memchr",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+ "winnow",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378c53ec3db049919edf91ff76f56f28886a8b4b4a5a9dc633108d84afc3675"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-credentials"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0493f25da3ce9e8f7d925e5b64dc6d0b6109c96add422a6bcada52416448147d"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-config-value",
+ "gix-date",
+ "gix-path",
+ "gix-prompt",
+ "gix-sec",
+ "gix-trace",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc99523b8bf32561b9abf72c878fbff3854d806ed46c1198e57899f9f3c7f05"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+ "smallvec",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709e2b8c52e027d553e200d07f39865b8d9799004160ea609459dc73c48f357a"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5590f35265d28cc65faa0d36896ae467836e989b0e790dd94d51d2417e768c"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31885140cb036e25742275f9848b9266a54d553103caec9f3546c62126214f45"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c998bf10447f0797e579567382b5e22a19c22435d2df091e25857728c6d9af8d"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0f40b8c98b4b592a7e9c83fe79eacbfcdae8485aa6148ff15e52a4b6e9fe30"
+dependencies = [
+ "bytes",
+ "bytesize",
+ "crc32fast",
+ "crossbeam-channel",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "thiserror 2.0.18",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb4376a18f26bdc0fe88a719574c749a678074beda924571e24c5a83bb26e65"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7464e9f4167e98d202c7cfb0b5ccbc170c6069870afc52bfd533ad265ce19872"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76beed0974ea539df93e44d10a6c7df0a9554f6e184dd730c33e65dc0e089614"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e3c92d6aa7a81bde221f3448e62b0e8d81a7d8086e85ccc24b3a4d54e315f30"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08fe1e638b9b84b11eadfe60bdf5523bf46c40b3ef297e612a4a365832d3c8d3"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f72fe2033f4cf8f784fb413c15c8d1124e84f1ddf4d292ffc8468b05d329a047"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-imara-diff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfef60ebcd45e0fad3007d15b45a305e6a25af9a0fdffbca0b02bf8b0f91f83c"
+dependencies = [
+ "bstr",
+ "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806c10a84ef9e0e2955ec678b7ba157b9bec1185e6d5c200e14d3496f44e3874"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-lock"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e30507ef152e30cec1d0f70cd00199fac746e3d448c3b39c9dade8446fa1da"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-mailmap"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef39d850c0c6621851f4fdca0074faa6feb2b03e4a1a55e9dc00aa3144b99f41"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-error",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8305849c022c954af46029756ffb3afcabcaf0be13a3cf3e8bfd204f1fc2b48"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-quote",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-worktree",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7cfa5d5f56dea56f96ced9ea55976b66ce8580e7fbdd23f25e9c99bd3e90927"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710b16fe38cd3654ec218dd89911100648cd3f495e3997a1bbdc2af69ebf525a"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.18",
+ "winnow",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.79.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7080f6ebcb0597c2c8bf7e3e0fd02c4df80260c4bfc50a8427f659129a9067b5"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "memmap2",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.69.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3f76daacd0e91a523dc741c4ef7b9355da67fd73167db831db1edd4720768b4"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "memmap2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "uluru",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fd1fe596dc393b538e1d5492c5585971a9311475b3255f7b889023df208476"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d902b0cafb2b691738c585f0be98b1b73fad63644c6a612b9b2708bb7b1d17d"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-prompt"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de52c2570684db3eb8cebda77c1d0e3d03ddaad2d9bbb5055eba31fb9f8292a"
+dependencies = [
+ "gix-command",
+ "gix-config-value",
+ "parking_lot",
+ "rustix",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "565eaa4df8438f2919135284410284c99100a2f9836d89efd918292107a80165"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-ref",
+ "gix-shallow",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "nonempty",
+ "thiserror 2.0.18",
+ "winnow",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e97b73791a64bc0fa7dd2c5b3e551136115f97750b876ed1c952c7a7dbaf8be"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a4367b66548864dd16873c6c86220b81960994deb63965803d773e377e3fce4"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror 2.0.18",
+ "winnow",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2b2756c9ea849bf63d01c0407be7006ebff78e6893e1845a56446eaeada359"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c130f74ac580ef8d37d723576b776674fdeb405f8b6126692c28346fdb85ac"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96e8ba5213c036d064034cefa6349cba3628498bccd8eca3e22a121b1a6e726"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "283f4a746c9bde8550be63e6f961ff4651f412ca12666e8f5615f39464960ab9"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-path",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3290e102e9375812e6baddf3354357f07f04baeaece97e045f9dad2c7ce6a033"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a444038e1bd06039464990f0653265d0707c5d92dda283cdf7cecd1b1f3182ba"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5099295499844e2d9d06d3e9be91d3db67fe322b9bdacaa4009769059affec02"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30bb168ab673020410158264e21b267dae3b89d248e901400b1cba788fcba7a"
+dependencies = [
+ "dashmap",
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "signal-hook 0.4.4",
+ "signal-hook-registry",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
+
+[[package]]
+name = "gix-transport"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f7cc0a5f8ff289c2d18077740efbad216d8c85b949c40827cd5bff00e457df"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef81f53b86d0cb1588768aaea171241fb98818c8893dd43aa3343fff49600e09"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.35.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a61ead12e33fa52ae92b207ee27554f646a8e7a3dad8b78da1582ec91eda0a6"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "percent-encoding",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f16b89b6195beba7e5517fea8ba20ca6fca67143fb1b070560ce0a4a866c87a"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acaa094bfbba896270a83b19585a0ee4ee83a0a64ab0ed3027302a3425436b3f"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
+ "io-close",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e0dc22458124d74729003a95225bd63236652671d660a8134843bedc1d4600"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1827,8 +2839,11 @@ version = "0.30.0"
 dependencies = [
  "anyhow",
  "fancy-regex 0.18.0",
+ "gix",
  "harnx-mcp",
+ "harnx-mcp-history",
  "libc",
+ "log",
  "process-wrap",
  "rmcp",
  "serde",
@@ -1843,11 +2858,27 @@ version = "0.30.0"
 dependencies = [
  "anyhow",
  "fancy-regex 0.18.0",
+ "gix",
  "glob",
  "harnx-mcp",
+ "harnx-mcp-history",
+ "log",
  "rmcp",
  "serde",
  "serde_json",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "harnx-mcp-history"
+version = "0.30.0"
+dependencies = [
+ "anyhow",
+ "dirs",
+ "gix",
+ "log",
+ "tempfile",
  "tokio",
  "uuid",
 ]
@@ -2075,6 +3106,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,6 +3147,16 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -2256,6 +3312,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "human_format"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaec953f16e5bcf6b8a3cb3aa959b17e5577dbd2693e94554c462c08be22624b"
 
 [[package]]
 name = "hybrid-array"
@@ -2528,6 +3590,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-close"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2716,6 +3788,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2745,7 +3826,10 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2893,10 +3977,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmem"
@@ -3051,6 +4155,12 @@ checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "nu-ansi-term"
@@ -3396,7 +4506,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -3627,6 +4737,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "plist"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3725,6 +4841,17 @@ dependencies = [
  "tokio",
  "tracing",
  "windows 0.62.2",
+]
+
+[[package]]
+name = "prodash"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "bytesize",
+ "human_format",
+ "parking_lot",
 ]
 
 [[package]]
@@ -4014,6 +5141,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -4516,6 +5652,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4592,7 +5749,7 @@ checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
 dependencies = [
  "libc",
  "os_pipe",
- "signal-hook",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]
@@ -4606,6 +5763,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-mio"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4613,7 +5780,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
- "signal-hook",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]
@@ -5008,7 +6175,7 @@ dependencies = [
  "pest_derive",
  "phf 0.11.3",
  "sha2 0.10.9",
- "signal-hook",
+ "signal-hook 0.3.18",
  "siphasher",
  "terminfo",
  "termios",
@@ -5364,10 +6531,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
 name = "unicode-ident"
@@ -5380,6 +6562,15 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -6276,6 +7467,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6529,6 +7729,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/harnx-mcp-fs",
     "crates/harnx-mcp-time",
     "crates/harnx-mcp-todo",
+    "crates/harnx-mcp-history",
     "crates/harnx-rag",
     "crates/harnx-render",
     "crates/harnx-runtime",
@@ -69,6 +70,7 @@ ansi_colours = "1.2.2"
 reqwest-eventsource = { git = "https://github.com/jpopesculian/reqwest-eventsource", rev = "356e2f61827b193bd5ab389c38059bcc2eed90aa" }
 simplelog = "0.12.1"
 log = "0.4.20"
+gix = { version = "0.82.0", features = ["blob-diff", "worktree-mutation", "tree-editor"] }
 shell-words = "1.1.0"
 sha2 = "0.11.0"
 unicode-width = "0.2.0"
@@ -115,6 +117,7 @@ arboard = { version = "3.3.0", default-features = false }
 harnx-acp = { path = "crates/harnx-acp", version = "0.30.0" }
 harnx-acp-server = { path = "crates/harnx-acp-server", version = "0.30.0" }
 minijinja = { version = "2.19.0", default-features = false, features = ["builtins", "debug", "serde"] }
+harnx-mcp-history = { path = "crates/harnx-mcp-history", version = "0.30.0" }
 
 [patch.crates-io]
 ratatui_widget_scrolling = { path = "crates/ratatui-widget-scrolling" }

--- a/crates/harnx-mcp-bash/Cargo.toml
+++ b/crates/harnx-mcp-bash/Cargo.toml
@@ -10,8 +10,11 @@ description = "MCP server that exposes bash/subprocess execution with safety gua
 [dependencies]
 anyhow = { workspace = true }
 fancy-regex = { workspace = true }
+gix = { workspace = true }
 harnx-mcp = { path = "../harnx-mcp" }
+harnx-mcp-history = { workspace = true }
 libc = { workspace = true }
+log = { workspace = true }
 process-wrap = { workspace = true }
 rmcp = { workspace = true }
 serde = { workspace = true }

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -4,6 +4,8 @@ use harnx_mcp::safety::{
 };
 
 use fancy_regex::Regex;
+use gix::ObjectId;
+use harnx_mcp_history::HistoryManager;
 #[cfg(windows)]
 use process_wrap::tokio::JobObject;
 #[cfg(unix)]
@@ -194,6 +196,27 @@ impl JsonSchema for TerminateParams {
     }
 }
 
+#[derive(Debug, Deserialize)]
+struct RollbackParams {
+    commit_id: String,
+    repo_path: String,
+}
+
+impl JsonSchema for RollbackParams {
+    fn schema_name() -> Cow<'static, str> {
+        Cow::Borrowed("RollbackParams")
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let commit_id = generator.subschema_for::<String>();
+        let repo_path = generator.subschema_for::<String>();
+        object_schema(
+            vec![("commit_id", commit_id), ("repo_path", repo_path)],
+            &["commit_id", "repo_path"],
+        )
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Spawned process tracking
 // ---------------------------------------------------------------------------
@@ -203,6 +226,7 @@ struct SpawnedProcess {
     command: String,
     working_dir: PathBuf,
     log_path: PathBuf,
+    before_snap_ids: Vec<(PathBuf, gix::ObjectId)>,
 }
 
 struct BashServerInner {
@@ -212,6 +236,7 @@ struct BashServerInner {
     log_dir: PathBuf,
     spawn_counter: AtomicU64,
     exec_counter: AtomicU64,
+    history: Arc<HistoryManager>,
 }
 
 // ---------------------------------------------------------------------------
@@ -232,12 +257,13 @@ impl BashServer {
         ));
         Self {
             inner: Arc::new(BashServerInner {
-                roots: RwLock::new(initial_roots),
+                roots: RwLock::new(initial_roots.clone()),
                 roots_initialized: AtomicBool::new(false),
                 spawned: Mutex::new(HashMap::new()),
                 log_dir,
                 spawn_counter: AtomicU64::new(0),
                 exec_counter: AtomicU64::new(0),
+                history: Arc::new(HistoryManager::new(&initial_roots)),
             }),
         }
     }
@@ -338,6 +364,18 @@ impl BashServer {
         let working_dir = self
             .resolve_working_dir(params.working_dir.as_deref())
             .await?;
+
+        // HISTORY: before snapshot (non-fatal)
+        let before_snaps = self
+            .inner
+            .history
+            .snapshot_repos_for_dir(&working_dir, "before exec")
+            .await
+            .unwrap_or_else(|e| {
+                log::warn!("history before-snapshot failed: {e}");
+                vec![]
+            });
+
         let timeout_secs = params.timeout_secs.unwrap_or(120);
         let default_opts = TruncateOpts::default();
         let truncate_opts = TruncateOpts {
@@ -467,10 +505,49 @@ impl BashServer {
                     "exit_code: {exit_code}, {total_lines} lines, {}",
                     format_size(total_bytes)
                 );
-                Ok(CallToolResult::success(vec![
+
+                // HISTORY: after snapshot + diff (non-fatal)
+                let mut diff_parts: Vec<String> = Vec::new();
+                if !before_snaps.is_empty() {
+                    let after_snaps = self
+                        .inner
+                        .history
+                        .snapshot_repos_for_dir(&working_dir, "after exec")
+                        .await
+                        .unwrap_or_else(|e| {
+                            log::warn!("history after-snapshot failed: {e}");
+                            vec![]
+                        });
+
+                    for (repo_dir, before_id) in &before_snaps {
+                        if let Some((_, after_id)) = after_snaps.iter().find(|(d, _)| d == repo_dir)
+                        {
+                            // Always emit snapshot ID
+                            diff_parts.push(format!("harnx-snapshot: {}", after_id.to_hex()));
+                            if before_id != after_id {
+                                match self
+                                    .inner
+                                    .history
+                                    .diff_commits(repo_dir, *before_id, *after_id)
+                                    .await
+                                {
+                                    Ok(diff) if !diff.is_empty() => diff_parts.push(diff),
+                                    Ok(_) => {}
+                                    Err(e) => log::warn!("history diff failed: {e}"),
+                                }
+                            }
+                        }
+                    }
+                }
+
+                let mut contents = vec![
                     Content::text(output).with_audience(vec![Role::Assistant]),
                     Content::text(summary).with_audience(vec![Role::User]),
-                ]))
+                ];
+                for diff in diff_parts {
+                    contents.push(Content::text(diff).with_audience(vec![Role::Assistant]));
+                }
+                Ok(CallToolResult::success(contents))
             }
             (Some(status), true) => {
                 let _ = status;
@@ -657,6 +734,17 @@ impl BashServer {
             .resolve_working_dir(params.working_dir.as_deref())
             .await?;
 
+        // HISTORY: before snapshot (non-fatal)
+        let before_snap_ids = self
+            .inner
+            .history
+            .snapshot_repos_for_dir(&working_dir, "before spawn")
+            .await
+            .unwrap_or_else(|e| {
+                log::warn!("history before-snapshot failed: {e}");
+                vec![]
+            });
+
         self.ensure_log_dir().await?;
 
         let seq = self.inner.spawn_counter.fetch_add(1, Ordering::SeqCst);
@@ -698,6 +786,7 @@ impl BashServer {
             command: params.command.clone(),
             working_dir: working_dir.clone(),
             log_path: log_path.clone(),
+            before_snap_ids,
         };
 
         self.inner.spawned.lock().await.insert(pid, entry);
@@ -723,7 +812,7 @@ impl BashServer {
         let timeout_secs = params.timeout_secs.unwrap_or(120);
         let tail_line_count = params.tail_lines.unwrap_or(20);
 
-        let (mut child, command, working_dir, log_path) = {
+        let (mut child, command, working_dir, log_path, before_snap_ids) = {
             let mut map = self.inner.spawned.lock().await;
             let entry = map.remove(&params.pid).ok_or_else(|| {
                 ErrorData::invalid_params(
@@ -739,6 +828,7 @@ impl BashServer {
                 entry.command,
                 entry.working_dir,
                 entry.log_path,
+                entry.before_snap_ids,
             )
         };
 
@@ -759,10 +849,48 @@ impl BashServer {
                 let _ = writeln!(output, "log_path: {}", log_path.display());
                 let _ = write!(output, "\n{log_tail}");
                 let summary = format!("pid {} exited with code {exit_code}", params.pid);
-                Ok(CallToolResult::success(vec![
+
+                // HISTORY: after snapshot + diff (non-fatal)
+                let mut diff_parts: Vec<String> = Vec::new();
+                if !before_snap_ids.is_empty() {
+                    let after_snaps = self
+                        .inner
+                        .history
+                        .snapshot_repos_for_dir(&working_dir, "after wait")
+                        .await
+                        .unwrap_or_else(|e| {
+                            log::warn!("history after-snapshot failed: {e}");
+                            vec![]
+                        });
+                    for (repo_dir, before_id) in &before_snap_ids {
+                        if let Some((_, after_id)) = after_snaps.iter().find(|(d, _)| d == repo_dir)
+                        {
+                            // Always emit snapshot ID
+                            diff_parts.push(format!("harnx-snapshot: {}", after_id.to_hex()));
+                            if before_id != after_id {
+                                match self
+                                    .inner
+                                    .history
+                                    .diff_commits(repo_dir, *before_id, *after_id)
+                                    .await
+                                {
+                                    Ok(diff) if !diff.is_empty() => diff_parts.push(diff),
+                                    Ok(_) => {}
+                                    Err(e) => log::warn!("history diff failed: {e}"),
+                                }
+                            }
+                        }
+                    }
+                }
+
+                let mut contents = vec![
                     Content::text(output).with_audience(vec![Role::Assistant]),
                     Content::text(summary).with_audience(vec![Role::User]),
-                ]))
+                ];
+                for diff in diff_parts {
+                    contents.push(Content::text(diff).with_audience(vec![Role::Assistant]));
+                }
+                Ok(CallToolResult::success(contents))
             }
             Ok(Err(err)) => Err(internal_error(format!(
                 "failed waiting for pid {}: {err}",
@@ -777,6 +905,7 @@ impl BashServer {
                         command: command.clone(),
                         working_dir: working_dir.clone(),
                         log_path: log_path.clone(),
+                        before_snap_ids,
                     },
                 );
 
@@ -878,6 +1007,44 @@ impl BashServer {
                 Content::text(summary).with_audience(vec![Role::User]),
             ]))
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // rollback_file
+    // -----------------------------------------------------------------------
+
+    async fn rollback_file_impl(
+        &self,
+        params: RollbackParams,
+    ) -> Result<CallToolResult, ErrorData> {
+        let roots = self.inner.roots.read().await;
+        let path = validate_path(&params.repo_path, &roots).map_err(invalid_params)?;
+        drop(roots);
+
+        let commit_id = ObjectId::from_hex(params.commit_id.as_bytes())
+            .map_err(|e| ErrorData::invalid_params(format!("invalid commit_id: {e}"), None))?;
+
+        let repo_dir = harnx_mcp_history::discover::find_repo_for_path(&path).ok_or_else(|| {
+            ErrorData::invalid_params("path is not inside a git repository".to_string(), None)
+        })?;
+
+        let new_commit_id = self
+            .inner
+            .history
+            .rollback(&repo_dir, commit_id)
+            .await
+            .map_err(|e| ErrorData::internal_error(format!("rollback failed: {e}"), None))?;
+
+        let short_sha = &params.commit_id[..8.min(params.commit_id.len())];
+        let new_commit_hex = new_commit_id.to_hex().to_string();
+        let new_short_sha = &new_commit_hex[..8.min(new_commit_hex.len())];
+        Ok(CallToolResult::success(vec![
+            Content::text(format!(
+                "Rolled back to harnx snapshot {short_sha}; new commit {new_short_sha} created (can be reverted)"
+            )),
+            Content::text(format!("harnx-snapshot: {}", new_commit_id.to_hex()))
+                .with_audience(vec![Role::Assistant]),
+        ]))
     }
 
     // -----------------------------------------------------------------------
@@ -1025,6 +1192,16 @@ impl ServerHandler for BashServer {
                     "call_template": "**terminate** PID {{ args.pid }}{% if args.signal %} ({{ args.signal }}){% endif %}",
                     "result_template": "{{ result.content[0].text | default('') }}"
                 }).as_object().unwrap().clone())),
+                Tool::new(
+                    "rollback_file",
+                    "Restore a repository to a prior harnx history snapshot by creating a new reversible commit. The snapshot commit ID is returned in the tool response after write_file, edit_file, exec, or spawn/wait.",
+                    Map::new(),
+                )
+                .with_input_schema::<RollbackParams>()
+                .with_meta(Meta(json!({
+                    "call_template": "**rollback_file** to `{{ args.commit_id | truncate(8, end='') }}`",
+                    "result_template": "{{ result.content[0].text | default('') }}"
+                }).as_object().unwrap().clone())),
             ],
             next_cursor: None,
         })
@@ -1063,6 +1240,10 @@ impl ServerHandler for BashServer {
                 let params = parse_arguments::<TerminateParams>(request.arguments)?;
                 self.terminate_impl(params).await
             }
+            "rollback_file" => {
+                let params = parse_arguments::<RollbackParams>(request.arguments)?;
+                self.rollback_file_impl(params).await
+            }
             other => Err(ErrorData::invalid_params(
                 format!("unknown tool: {other}"),
                 None,
@@ -1099,6 +1280,10 @@ fn parse_arguments<T: DeserializeOwned>(
 
 fn tool_error(msg: impl Into<String>) -> Result<CallToolResult, ErrorData> {
     Ok(CallToolResult::error(vec![Content::text(msg.into())]))
+}
+
+fn invalid_params(msg: impl Into<Cow<'static, str>>) -> ErrorData {
+    ErrorData::invalid_params(msg, None)
 }
 
 fn internal_error(msg: impl Into<Cow<'static, str>>) -> ErrorData {

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -523,7 +523,6 @@ impl BashServer {
                         if let Some((_, after_id)) = after_snaps.iter().find(|(d, _)| d == repo_dir)
                         {
                             // Always emit snapshot ID
-                            diff_parts.push(format!("harnx-snapshot: {}", after_id.to_hex()));
                             if before_id != after_id {
                                 match self
                                     .inner
@@ -545,7 +544,7 @@ impl BashServer {
                     Content::text(summary).with_audience(vec![Role::User]),
                 ];
                 for diff in diff_parts {
-                    contents.push(Content::text(diff).with_audience(vec![Role::Assistant]));
+                    contents.push(Content::text(diff));
                 }
                 Ok(CallToolResult::success(contents))
             }
@@ -866,7 +865,6 @@ impl BashServer {
                         if let Some((_, after_id)) = after_snaps.iter().find(|(d, _)| d == repo_dir)
                         {
                             // Always emit snapshot ID
-                            diff_parts.push(format!("harnx-snapshot: {}", after_id.to_hex()));
                             if before_id != after_id {
                                 match self
                                     .inner
@@ -888,7 +886,7 @@ impl BashServer {
                     Content::text(summary).with_audience(vec![Role::User]),
                 ];
                 for diff in diff_parts {
-                    contents.push(Content::text(diff).with_audience(vec![Role::Assistant]));
+                    contents.push(Content::text(diff));
                 }
                 Ok(CallToolResult::success(contents))
             }
@@ -1035,16 +1033,11 @@ impl BashServer {
             .await
             .map_err(|e| ErrorData::internal_error(format!("rollback failed: {e}"), None))?;
 
-        let short_sha = &params.commit_id[..8.min(params.commit_id.len())];
-        let new_commit_hex = new_commit_id.to_hex().to_string();
-        let new_short_sha = &new_commit_hex[..8.min(new_commit_hex.len())];
-        Ok(CallToolResult::success(vec![
-            Content::text(format!(
-                "Rolled back to harnx snapshot {short_sha}; new commit {new_short_sha} created (can be reverted)"
-            )),
-            Content::text(format!("harnx-snapshot: {}", new_commit_id.to_hex()))
-                .with_audience(vec![Role::Assistant]),
-        ]))
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Rolled back to harnx snapshot {}; new commit {} created (can be reverted)",
+            &params.commit_id[..8.min(params.commit_id.len())],
+            new_commit_id.to_hex(),
+        ))]))
     }
 
     // -----------------------------------------------------------------------
@@ -1194,7 +1187,7 @@ impl ServerHandler for BashServer {
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "rollback_file",
-                    "Restore a repository to a prior harnx history snapshot by creating a new reversible commit. The snapshot commit ID is returned in the tool response after write_file, edit_file, exec, or spawn/wait.",
+                    "Restore a repository to a prior harnx history snapshot. Pass the commit SHA from the 'commit <sha>' line at the top of a prior tool response's diff as the commit_id parameter.",
                     Map::new(),
                 )
                 .with_input_schema::<RollbackParams>()

--- a/crates/harnx-mcp-fs/Cargo.toml
+++ b/crates/harnx-mcp-fs/Cargo.toml
@@ -10,8 +10,11 @@ description = "MCP server that exposes filesystem operations with safety guards"
 [dependencies]
 anyhow = { workspace = true }
 fancy-regex = { workspace = true }
+gix = { workspace = true }
 glob = { workspace = true }
 harnx-mcp = { path = "../harnx-mcp" }
+harnx-mcp-history = { workspace = true }
+log = { workspace = true }
 rmcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/harnx-mcp-fs/src/server.rs
+++ b/crates/harnx-mcp-fs/src/server.rs
@@ -5,6 +5,7 @@ use harnx_mcp::safety::{
     GREP_MAX_LINE_LENGTH, LS_SCAN_HARD_LIMIT, READ_MAX_FILE_BYTES, SEARCH_FILE_MAX_BYTES,
     WRITE_MAX_BYTES,
 };
+use harnx_mcp_history::HistoryManager;
 
 use fancy_regex::Regex;
 use rmcp::model::{
@@ -88,6 +89,12 @@ pub struct FindFilesParams {
     pub path: Option<String>,
     #[serde(default)]
     pub max_results: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RollbackParams {
+    pub commit_id: String,
+    pub repo_path: String,
 }
 
 impl JsonSchema for ReadFileParams {
@@ -215,17 +222,34 @@ impl JsonSchema for FindFilesParams {
     }
 }
 
+impl JsonSchema for RollbackParams {
+    fn schema_name() -> Cow<'static, str> {
+        Cow::Borrowed("RollbackParams")
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let commit_id = generator.subschema_for::<String>();
+        let repo_path = generator.subschema_for::<String>();
+        object_schema(
+            vec![("commit_id", commit_id), ("repo_path", repo_path)],
+            &["commit_id", "repo_path"],
+        )
+    }
+}
+
 #[derive(Clone)]
 pub struct FsServer {
     roots: Arc<RwLock<Vec<PathBuf>>>,
     roots_initialized: Arc<AtomicBool>,
+    history: Arc<HistoryManager>,
 }
 
 impl FsServer {
     pub fn new(initial_roots: Vec<PathBuf>) -> Self {
         Self {
-            roots: Arc::new(RwLock::new(initial_roots)),
+            roots: Arc::new(RwLock::new(initial_roots.clone())),
             roots_initialized: Arc::new(AtomicBool::new(false)),
+            history: Arc::new(HistoryManager::new(&initial_roots)),
         }
     }
 
@@ -432,6 +456,16 @@ impl FsServer {
             ));
         }
 
+        // HISTORY: before snapshot
+        let before_snap = self
+            .history
+            .snapshot(std::slice::from_ref(&path), "before write_file")
+            .await
+            .map_err(|e| {
+                log::warn!("history before-snapshot failed: {e}");
+            })
+            .ok();
+
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|err| {
                 internal_error(format!(
@@ -444,18 +478,66 @@ impl FsServer {
         std::fs::write(&path, &params.content)
             .map_err(|err| internal_error(format!("failed to write '{}': {err}", params.path)))?;
 
-        Ok(CallToolResult::success(vec![Content::text(format!(
+        // HISTORY: after snapshot + diff
+        let after_snap_result = if let Some(before) = before_snap {
+            match self
+                .history
+                .snapshot(std::slice::from_ref(&path), "after write_file")
+                .await
+            {
+                Ok(after) => {
+                    let diff = if let Some(repo_dir) =
+                        harnx_mcp_history::discover::find_repo_for_path(&path)
+                    {
+                        self.history
+                            .diff_commits(&repo_dir, before, after)
+                            .await
+                            .unwrap_or_default()
+                    } else {
+                        String::new()
+                    };
+                    Some((after, diff))
+                }
+                Err(e) => {
+                    log::warn!("history after-snapshot failed: {e}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let mut contents = vec![Content::text(format!(
             "Wrote {} ({} lines) to {}",
             format_size(params.content.len()),
             params.content.lines().count(),
             params.path
-        ))]))
+        ))];
+        if let Some((after_id, diff_content)) = after_snap_result {
+            let mut assistant_block = diff_content;
+            if !assistant_block.is_empty() {
+                assistant_block.push('\n');
+            }
+            assistant_block.push_str(&format!("harnx-snapshot: {}", after_id.to_hex()));
+            contents.push(Content::text(assistant_block).with_audience(vec![Role::Assistant]));
+        }
+        Ok(CallToolResult::success(contents))
     }
 
     async fn edit_file_impl(&self, params: EditFileParams) -> Result<CallToolResult, ErrorData> {
         let roots = self.roots.read().await;
         let path = validate_path(&params.path, &roots).map_err(invalid_params)?;
         drop(roots);
+
+        // HISTORY: before snapshot
+        let before_snap = self
+            .history
+            .snapshot(std::slice::from_ref(&path), "before edit_file")
+            .await
+            .map_err(|e| {
+                log::warn!("history before-snapshot failed: {e}");
+            })
+            .ok();
 
         let content = std::fs::read_to_string(&path)
             .map_err(|err| internal_error(format!("failed to read '{}': {err}", params.path)))?;
@@ -508,12 +590,51 @@ impl FsServer {
 
         std::fs::write(&path, new_content)
             .map_err(|err| internal_error(format!("failed to write '{}': {err}", params.path)))?;
-        Ok(CallToolResult::success(vec![Content::text(format!(
+
+        // HISTORY: after snapshot + diff
+        let after_snap_result = if let Some(before) = before_snap {
+            match self
+                .history
+                .snapshot(std::slice::from_ref(&path), "after edit_file")
+                .await
+            {
+                Ok(after) => {
+                    let diff = if let Some(repo_dir) =
+                        harnx_mcp_history::discover::find_repo_for_path(&path)
+                    {
+                        self.history
+                            .diff_commits(&repo_dir, before, after)
+                            .await
+                            .unwrap_or_default()
+                    } else {
+                        String::new()
+                    };
+                    Some((after, diff))
+                }
+                Err(e) => {
+                    log::warn!("history after-snapshot failed: {e}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let mut contents = vec![Content::text(format!(
             "Edited {} ({} replacement{})",
             params.path,
             replacements,
             if replacements == 1 { "" } else { "s" }
-        ))]))
+        ))];
+        if let Some((after_id, diff_content)) = after_snap_result {
+            let mut assistant_block = diff_content;
+            if !assistant_block.is_empty() {
+                assistant_block.push('\n');
+            }
+            assistant_block.push_str(&format!("harnx-snapshot: {}", after_id.to_hex()));
+            contents.push(Content::text(assistant_block).with_audience(vec![Role::Assistant]));
+        }
+        Ok(CallToolResult::success(contents))
     }
 
     async fn list_directory_impl(
@@ -725,6 +846,39 @@ impl FsServer {
             Content::text(summary).with_audience(vec![Role::User]),
         ]))
     }
+
+    async fn rollback_file_impl(
+        &self,
+        params: RollbackParams,
+    ) -> Result<CallToolResult, ErrorData> {
+        let roots = self.roots.read().await;
+        let path = validate_path(&params.repo_path, &roots).map_err(invalid_params)?;
+        drop(roots);
+
+        let commit_id = gix::ObjectId::from_hex(params.commit_id.as_bytes())
+            .map_err(|e| ErrorData::invalid_params(format!("invalid commit_id: {e}"), None))?;
+
+        let repo_dir = harnx_mcp_history::discover::find_repo_for_path(&path).ok_or_else(|| {
+            ErrorData::invalid_params("path is not inside a git repository".to_string(), None)
+        })?;
+
+        let new_commit_id = self
+            .history
+            .rollback(&repo_dir, commit_id)
+            .await
+            .map_err(|e| ErrorData::internal_error(format!("rollback failed: {e}"), None))?;
+
+        let short_sha = &params.commit_id[..8.min(params.commit_id.len())];
+        let new_commit_hex = new_commit_id.to_hex().to_string();
+        let new_short_sha = &new_commit_hex[..8.min(new_commit_hex.len())];
+        Ok(CallToolResult::success(vec![
+            Content::text(format!(
+                "Rolled back to harnx snapshot {short_sha}; new commit {new_short_sha} created (can be reverted)"
+            )),
+            Content::text(format!("harnx-snapshot: {}", new_commit_id.to_hex()))
+                .with_audience(vec![Role::Assistant]),
+        ]))
+    }
 }
 
 fn make_tool_meta(call_template: &str) -> Meta {
@@ -778,8 +932,11 @@ impl ServerHandler for FsServer {
                     .with_meta(make_tool_meta("**grep** `{{ args.pattern }}`")),
                 Tool::new("find", "Find files by glob pattern.", Map::new())
                     .with_input_schema::<FindFilesParams>()
-                    .annotate(read_only)
+                    .annotate(read_only.clone())
                     .with_meta(make_tool_meta("**find** `{{ args.pattern }}`")),
+                Tool::new("rollback_file", "Restore a repository to a prior harnx history snapshot by creating a new reversible commit. The snapshot commit ID is returned in the tool response after write_file, edit_file, exec, or spawn/wait.", Map::new())
+                    .with_input_schema::<RollbackParams>()
+                    .with_meta(make_tool_meta("**rollback_file** to `{{ args.commit_id | truncate(8, end='') }}`")),
             ];
 
         Ok(ListToolsResult {
@@ -822,6 +979,10 @@ impl ServerHandler for FsServer {
             "find" => {
                 let params = parse_arguments::<FindFilesParams>(request.arguments)?;
                 self.find_files_impl(params).await
+            }
+            "rollback_file" => {
+                let params = parse_arguments::<RollbackParams>(request.arguments)?;
+                self.rollback_file_impl(params).await
             }
             other => Err(ErrorData::invalid_params(
                 format!("unknown tool: {other}"),
@@ -1253,7 +1414,18 @@ mod tests {
             .map(|tool| tool.name.to_string())
             .collect::<Vec<_>>();
 
-        assert_eq!(names, vec!["read", "write", "edit", "ls", "grep", "find"]);
+        assert_eq!(
+            names,
+            vec![
+                "read",
+                "write",
+                "edit",
+                "ls",
+                "grep",
+                "find",
+                "rollback_file"
+            ]
+        );
     }
 
     #[tokio::test]

--- a/crates/harnx-mcp-fs/src/server.rs
+++ b/crates/harnx-mcp-fs/src/server.rs
@@ -513,13 +513,10 @@ impl FsServer {
             params.content.lines().count(),
             params.path
         ))];
-        if let Some((after_id, diff_content)) = after_snap_result {
-            let mut assistant_block = diff_content;
-            if !assistant_block.is_empty() {
-                assistant_block.push('\n');
+        if let Some((_after_id, diff_content)) = after_snap_result {
+            if !diff_content.is_empty() {
+                contents.push(Content::text(diff_content));
             }
-            assistant_block.push_str(&format!("harnx-snapshot: {}", after_id.to_hex()));
-            contents.push(Content::text(assistant_block).with_audience(vec![Role::Assistant]));
         }
         Ok(CallToolResult::success(contents))
     }
@@ -626,13 +623,10 @@ impl FsServer {
             replacements,
             if replacements == 1 { "" } else { "s" }
         ))];
-        if let Some((after_id, diff_content)) = after_snap_result {
-            let mut assistant_block = diff_content;
-            if !assistant_block.is_empty() {
-                assistant_block.push('\n');
+        if let Some((_after_id, diff_content)) = after_snap_result {
+            if !diff_content.is_empty() {
+                contents.push(Content::text(diff_content));
             }
-            assistant_block.push_str(&format!("harnx-snapshot: {}", after_id.to_hex()));
-            contents.push(Content::text(assistant_block).with_audience(vec![Role::Assistant]));
         }
         Ok(CallToolResult::success(contents))
     }
@@ -868,16 +862,11 @@ impl FsServer {
             .await
             .map_err(|e| ErrorData::internal_error(format!("rollback failed: {e}"), None))?;
 
-        let short_sha = &params.commit_id[..8.min(params.commit_id.len())];
-        let new_commit_hex = new_commit_id.to_hex().to_string();
-        let new_short_sha = &new_commit_hex[..8.min(new_commit_hex.len())];
-        Ok(CallToolResult::success(vec![
-            Content::text(format!(
-                "Rolled back to harnx snapshot {short_sha}; new commit {new_short_sha} created (can be reverted)"
-            )),
-            Content::text(format!("harnx-snapshot: {}", new_commit_id.to_hex()))
-                .with_audience(vec![Role::Assistant]),
-        ]))
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Rolled back to harnx snapshot {}; new commit {} created (can be reverted)",
+            &params.commit_id[..8.min(params.commit_id.len())],
+            new_commit_id.to_hex(),
+        ))]))
     }
 }
 
@@ -934,7 +923,7 @@ impl ServerHandler for FsServer {
                     .with_input_schema::<FindFilesParams>()
                     .annotate(read_only.clone())
                     .with_meta(make_tool_meta("**find** `{{ args.pattern }}`")),
-                Tool::new("rollback_file", "Restore a repository to a prior harnx history snapshot by creating a new reversible commit. The snapshot commit ID is returned in the tool response after write_file, edit_file, exec, or spawn/wait.", Map::new())
+                Tool::new("rollback_file", "Restore a repository to a prior harnx history snapshot. Pass the commit SHA from the 'commit <sha>' line at the top of a prior tool response's diff as the commit_id parameter.", Map::new())
                     .with_input_schema::<RollbackParams>()
                     .with_meta(make_tool_meta("**rollback_file** to `{{ args.commit_id | truncate(8, end='') }}`")),
             ];

--- a/crates/harnx-mcp-fs/src/server.rs
+++ b/crates/harnx-mcp-fs/src/server.rs
@@ -459,7 +459,7 @@ impl FsServer {
         // HISTORY: before snapshot
         let before_snap = self
             .history
-            .snapshot(std::slice::from_ref(&path), "before write_file")
+            .snapshot_file(&path, "before write_file")
             .await
             .map_err(|e| {
                 log::warn!("history before-snapshot failed: {e}");
@@ -480,11 +480,7 @@ impl FsServer {
 
         // HISTORY: after snapshot + diff
         let after_snap_result = if let Some(before) = before_snap {
-            match self
-                .history
-                .snapshot(std::slice::from_ref(&path), "after write_file")
-                .await
-            {
+            match self.history.snapshot_file(&path, "after write_file").await {
                 Ok(after) => {
                     let diff = if let Some(repo_dir) =
                         harnx_mcp_history::discover::find_repo_for_path(&path)
@@ -529,7 +525,7 @@ impl FsServer {
         // HISTORY: before snapshot
         let before_snap = self
             .history
-            .snapshot(std::slice::from_ref(&path), "before edit_file")
+            .snapshot_file(&path, "before edit_file")
             .await
             .map_err(|e| {
                 log::warn!("history before-snapshot failed: {e}");
@@ -590,11 +586,7 @@ impl FsServer {
 
         // HISTORY: after snapshot + diff
         let after_snap_result = if let Some(before) = before_snap {
-            match self
-                .history
-                .snapshot(std::slice::from_ref(&path), "after edit_file")
-                .await
-            {
+            match self.history.snapshot_file(&path, "after edit_file").await {
                 Ok(after) => {
                     let diff = if let Some(repo_dir) =
                         harnx_mcp_history::discover::find_repo_for_path(&path)

--- a/crates/harnx-mcp-history/Cargo.toml
+++ b/crates/harnx-mcp-history/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "harnx-mcp-history"
+version = "0.30.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Git-backed local history and rollback for harnx MCP servers"
+
+[dependencies]
+anyhow = { workspace = true }
+gix = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+uuid = { workspace = true }
+log = { workspace = true }
+dirs = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/harnx-mcp-history/Cargo.toml
+++ b/crates/harnx-mcp-history/Cargo.toml
@@ -11,9 +11,7 @@ description = "Git-backed local history and rollback for harnx MCP servers"
 anyhow = { workspace = true }
 gix = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
-uuid = { workspace = true }
 log = { workspace = true }
-dirs = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/harnx-mcp-history/src/diff.rs
+++ b/crates/harnx-mcp-history/src/diff.rs
@@ -88,12 +88,18 @@ mod tests {
         String::from_utf8(output.stdout).expect("utf8 git output")
     }
 
+    fn init_git_repo(dir: &std::path::Path) {
+        run_git(dir, &["init"]);
+        run_git(dir, &["config", "user.name", "Test User"]);
+        run_git(dir, &["config", "user.email", "test@example.com"]);
+        // Disable autocrlf so line endings are preserved exactly on Windows.
+        run_git(dir, &["config", "core.autocrlf", "false"]);
+    }
+
     #[test]
     fn test_diff_commits() {
         let temp = tempdir().expect("tempdir");
-        run_git(temp.path(), &["init"]);
-        run_git(temp.path(), &["config", "user.name", "Test User"]);
-        run_git(temp.path(), &["config", "user.email", "test@example.com"]);
+        init_git_repo(temp.path());
 
         let file = temp.path().join("note.txt");
         fs::write(&file, "before\n").expect("write before");

--- a/crates/harnx-mcp-history/src/diff.rs
+++ b/crates/harnx-mcp-history/src/diff.rs
@@ -48,7 +48,12 @@ pub fn diff_commits_blocking(
     let mut diff = header;
     diff.push_str(&String::from_utf8(output.stdout).context("git diff output not utf-8")?);
     if diff.len() > MAX_DIFF_BYTES {
-        diff.truncate(MAX_DIFF_BYTES);
+        // Truncate to a char boundary — String::truncate panics on a mid-char cut
+        let mut cut = MAX_DIFF_BYTES;
+        while !diff.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        diff.truncate(cut);
         let short = &after_id.to_hex().to_string()[..12];
         diff.push_str(&format!(
             "\n[ ... diff truncated, use 'git show {}' to view full diff ... ]",

--- a/crates/harnx-mcp-history/src/diff.rs
+++ b/crates/harnx-mcp-history/src/diff.rs
@@ -1,0 +1,103 @@
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+const MAX_DIFF_BYTES: usize = 50_000;
+
+pub fn diff_commits_blocking(
+    repo: &gix::Repository,
+    before_id: gix::ObjectId,
+    after_id: gix::ObjectId,
+) -> Result<String> {
+    let _ = repo
+        .find_object(before_id)
+        .context("find before commit")?
+        .peel_to_tree()
+        .context("peel before commit to tree")?;
+    let _ = repo
+        .find_object(after_id)
+        .context("find after commit")?
+        .peel_to_tree()
+        .context("peel after commit to tree")?;
+
+    let workdir = repo.workdir().unwrap_or_else(|| repo.path());
+    let output = Command::new("git")
+        .arg("diff")
+        .arg(before_id.to_hex().to_string())
+        .arg(after_id.to_hex().to_string())
+        .current_dir(workdir)
+        .output()
+        .context("run git diff")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git diff failed: {stderr}");
+    }
+
+    let mut diff = String::from_utf8(output.stdout).context("git diff output not utf-8")?;
+    if diff.len() > MAX_DIFF_BYTES {
+        diff.truncate(MAX_DIFF_BYTES);
+        diff.push_str("\n[diff truncated]");
+    }
+    Ok(diff)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn run_git(dir: &std::path::Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .expect("git command runs");
+        assert!(status.success(), "git {:?} failed", args);
+    }
+
+    fn output_git(dir: &std::path::Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git output command runs");
+        assert!(output.status.success(), "git {:?} failed", args);
+        String::from_utf8(output.stdout).expect("utf8 git output")
+    }
+
+    #[test]
+    fn test_diff_commits() {
+        let temp = tempdir().expect("tempdir");
+        run_git(temp.path(), &["init"]);
+        run_git(temp.path(), &["config", "user.name", "Test User"]);
+        run_git(temp.path(), &["config", "user.email", "test@example.com"]);
+
+        let file = temp.path().join("note.txt");
+        fs::write(&file, "before\n").expect("write before");
+        run_git(temp.path(), &["add", "."]);
+        run_git(temp.path(), &["commit", "-m", "before"]);
+        let before = output_git(temp.path(), &["rev-parse", "HEAD"])
+            .trim()
+            .to_owned();
+
+        fs::write(&file, "after\n").expect("write after");
+        run_git(temp.path(), &["add", "."]);
+        run_git(temp.path(), &["commit", "-m", "after"]);
+        let after = output_git(temp.path(), &["rev-parse", "HEAD"])
+            .trim()
+            .to_owned();
+
+        let repo = gix::open(temp.path()).expect("open repo");
+        let diff = diff_commits_blocking(
+            &repo,
+            gix::ObjectId::from_hex(before.as_bytes()).expect("before oid"),
+            gix::ObjectId::from_hex(after.as_bytes()).expect("after oid"),
+        )
+        .expect("diff works");
+
+        assert!(diff.contains("-before"));
+        assert!(diff.contains("+after"));
+    }
+}

--- a/crates/harnx-mcp-history/src/diff.rs
+++ b/crates/harnx-mcp-history/src/diff.rs
@@ -20,6 +20,17 @@ pub fn diff_commits_blocking(
         .peel_to_tree()
         .context("peel after commit to tree")?;
 
+    let after_commit = repo
+        .find_object(after_id)
+        .context("find after commit for header")?
+        .peel_to_commit()
+        .context("peel after commit for header")?;
+    let title = after_commit
+        .message()
+        .map(|m| m.title.to_string())
+        .unwrap_or_else(|_| String::from("harnx snapshot"));
+    let header = format!("commit {}\n    {}\n\n", after_id.to_hex(), title.trim());
+
     let workdir = repo.workdir().unwrap_or_else(|| repo.path());
     let output = Command::new("git")
         .arg("diff")
@@ -34,10 +45,15 @@ pub fn diff_commits_blocking(
         anyhow::bail!("git diff failed: {stderr}");
     }
 
-    let mut diff = String::from_utf8(output.stdout).context("git diff output not utf-8")?;
+    let mut diff = header;
+    diff.push_str(&String::from_utf8(output.stdout).context("git diff output not utf-8")?);
     if diff.len() > MAX_DIFF_BYTES {
         diff.truncate(MAX_DIFF_BYTES);
-        diff.push_str("\n[diff truncated]");
+        let short = &after_id.to_hex().to_string()[..12];
+        diff.push_str(&format!(
+            "\n[ ... diff truncated, use 'git show {}' to view full diff ... ]",
+            short
+        ));
     }
     Ok(diff)
 }
@@ -97,6 +113,8 @@ mod tests {
         )
         .expect("diff works");
 
+        assert!(diff.starts_with("commit "));
+        assert!(diff.contains(&after));
         assert!(diff.contains("-before"));
         assert!(diff.contains("+after"));
     }

--- a/crates/harnx-mcp-history/src/discover.rs
+++ b/crates/harnx-mcp-history/src/discover.rs
@@ -20,19 +20,43 @@ pub fn find_repos_under_roots(roots: &[PathBuf]) -> Vec<PathBuf> {
     let mut repos = Vec::new();
 
     for root in roots {
-        let Some(repo) = discover_repo(root) else {
-            continue;
-        };
-        let Some(workdir) = repo.workdir() else {
-            continue;
-        };
-        let workdir = workdir.to_path_buf();
-        if seen.insert(workdir.clone()) {
-            repos.push(workdir);
-        }
+        // Walk the directory tree downward from root, collecting any git repo
+        // worktrees found within it. gix::discover walks UP (finds the enclosing
+        // repo), so we use a manual descent: try each subdirectory recursively.
+        collect_repos_in_dir(root, &mut seen, &mut repos);
     }
 
     repos
+}
+
+fn collect_repos_in_dir(dir: &Path, seen: &mut HashSet<PathBuf>, repos: &mut Vec<PathBuf>) {
+    // Check if this directory is itself a repo root (has a .git entry)
+    if dir.join(".git").exists() {
+        if let Ok(canonical) = dir.canonicalize() {
+            if seen.insert(canonical.clone()) {
+                repos.push(canonical);
+            }
+        }
+        // Don't descend into subdirectories of a repo root — nested repos
+        // (submodules) would need to be found via their own root entry.
+        return;
+    }
+
+    // Descend into immediate subdirectories
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let name = entry.file_name();
+            // Skip hidden dirs (including .git itself) and common non-repo dirs
+            if name.to_string_lossy().starts_with('.') {
+                continue;
+            }
+            collect_repos_in_dir(&path, seen, repos);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/harnx-mcp-history/src/discover.rs
+++ b/crates/harnx-mcp-history/src/discover.rs
@@ -1,0 +1,99 @@
+use std::collections::HashSet;
+use std::env;
+use std::path::{Path, PathBuf};
+
+fn discover_repo(path: &Path) -> Option<gix::Repository> {
+    let search_path = if path.is_file() {
+        path.parent().unwrap_or(path)
+    } else {
+        path
+    };
+    gix::discover(search_path).ok()
+}
+
+pub fn find_repo_for_path(path: &Path) -> Option<PathBuf> {
+    let repo = discover_repo(path)?;
+    repo.workdir().map(Path::to_path_buf)
+}
+
+pub fn find_repos_under_roots(roots: &[PathBuf]) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    let mut repos = Vec::new();
+
+    for root in roots {
+        let Some(repo) = discover_repo(root) else {
+            continue;
+        };
+        let Some(workdir) = repo.workdir() else {
+            continue;
+        };
+        let canonical = workdir
+            .canonicalize()
+            .unwrap_or_else(|_| workdir.to_path_buf());
+        if seen.insert(canonical.clone()) {
+            repos.push(canonical);
+        }
+    }
+
+    repos
+}
+
+pub fn history_dir() -> PathBuf {
+    if let Some(dir) = env::var_os("HARNX_LOCAL_HISTORY_DIR") {
+        return PathBuf::from(dir);
+    }
+
+    let config_root = env::var_os("HARNX_CONFIG_DIR")
+        .map(PathBuf::from)
+        .or_else(dirs::config_dir)
+        .or_else(|| {
+            env::var_os("HOME")
+                .map(PathBuf::from)
+                .map(|home| home.join(".config"))
+        })
+        .unwrap_or_else(|| PathBuf::from(".config"));
+
+    config_root.join("harnx").join("history")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn test_find_repo_for_path_inside_repo() {
+        // CARGO_MANIFEST_DIR is always set by cargo/nextest and points to this crate's directory,
+        // which lives inside the harnx git repo — so discovery must succeed regardless of where
+        // the source tree is checked out.
+        let manifest_dir =
+            std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set by cargo");
+        let repo = find_repo_for_path(Path::new(&manifest_dir));
+        assert!(
+            repo.is_some(),
+            "expected a git repo to be discovered from CARGO_MANIFEST_DIR={manifest_dir}"
+        );
+    }
+
+    #[test]
+    fn test_find_repo_for_path_outside_repo() {
+        let repo = find_repo_for_path(Path::new("/tmp"));
+        assert!(repo.is_none());
+    }
+
+    #[test]
+    fn test_history_dir_env_override() {
+        let guard = env_lock().lock().expect("env lock");
+        let expected = PathBuf::from("/tmp/harnx-history-override");
+        unsafe { env::set_var("HARNX_LOCAL_HISTORY_DIR", &expected) };
+        let actual = history_dir();
+        unsafe { env::remove_var("HARNX_LOCAL_HISTORY_DIR") };
+        drop(guard);
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/harnx-mcp-history/src/discover.rs
+++ b/crates/harnx-mcp-history/src/discover.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::env;
 use std::path::{Path, PathBuf};
 
 fn discover_repo(path: &Path) -> Option<gix::Repository> {
@@ -27,44 +26,18 @@ pub fn find_repos_under_roots(roots: &[PathBuf]) -> Vec<PathBuf> {
         let Some(workdir) = repo.workdir() else {
             continue;
         };
-        let canonical = workdir
-            .canonicalize()
-            .unwrap_or_else(|_| workdir.to_path_buf());
-        if seen.insert(canonical.clone()) {
-            repos.push(canonical);
+        let workdir = workdir.to_path_buf();
+        if seen.insert(workdir.clone()) {
+            repos.push(workdir);
         }
     }
 
     repos
 }
 
-pub fn history_dir() -> PathBuf {
-    if let Some(dir) = env::var_os("HARNX_LOCAL_HISTORY_DIR") {
-        return PathBuf::from(dir);
-    }
-
-    let config_root = env::var_os("HARNX_CONFIG_DIR")
-        .map(PathBuf::from)
-        .or_else(dirs::config_dir)
-        .or_else(|| {
-            env::var_os("HOME")
-                .map(PathBuf::from)
-                .map(|home| home.join(".config"))
-        })
-        .unwrap_or_else(|| PathBuf::from(".config"));
-
-    config_root.join("harnx").join("history")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
-
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
 
     #[test]
     fn test_find_repo_for_path_inside_repo() {
@@ -82,18 +55,12 @@ mod tests {
 
     #[test]
     fn test_find_repo_for_path_outside_repo() {
-        let repo = find_repo_for_path(Path::new("/tmp"));
-        assert!(repo.is_none());
-    }
-
-    #[test]
-    fn test_history_dir_env_override() {
-        let guard = env_lock().lock().expect("env lock");
-        let expected = PathBuf::from("/tmp/harnx-history-override");
-        unsafe { env::set_var("HARNX_LOCAL_HISTORY_DIR", &expected) };
-        let actual = history_dir();
-        unsafe { env::remove_var("HARNX_LOCAL_HISTORY_DIR") };
-        drop(guard);
-        assert_eq!(actual, expected);
+        let dir = tempfile::tempdir().expect("create temp dir");
+        // On some systems the temp dir root may itself be inside a checkout — skip rather than fail
+        if find_repo_for_path(dir.path().parent().unwrap_or(dir.path())).is_some() {
+            return;
+        }
+        let repo = find_repo_for_path(dir.path());
+        assert!(repo.is_none(), "expected no repo for fresh temp dir");
     }
 }

--- a/crates/harnx-mcp-history/src/history.rs
+++ b/crates/harnx-mcp-history/src/history.rs
@@ -4,10 +4,10 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use uuid::Uuid;
+use gix::bstr::ByteSlice;
 
 use crate::diff::diff_commits_blocking;
-use crate::discover::{find_repos_under_roots, history_dir};
+use crate::discover::find_repos_under_roots;
 use crate::rollback::rollback_to_commit_blocking;
 
 /// Maximum number of files per snapshot. Override with HARNX_HISTORY_MAX_FILES.
@@ -23,20 +23,39 @@ pub struct HistoryManager {
 
 struct HistoryManagerInner {
     repos: tokio::sync::Mutex<HashMap<PathBuf, RepoSession>>,
-    session_id: String,
-    fallback_history_dir: PathBuf,
+    last_gc: std::sync::Mutex<HashMap<PathBuf, std::time::Instant>>,
 }
 
 struct RepoSession {
     repo: gix::ThreadSafeRepository,
     last_commit_id: Option<gix::ObjectId>,
-    session_ref: String,
+}
+
+fn maybe_trigger_gc(
+    workdir: &Path,
+    last_gc: &std::sync::Mutex<HashMap<PathBuf, std::time::Instant>>,
+) {
+    const GC_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3600);
+    let now = std::time::Instant::now();
+    let mut map = last_gc.lock().unwrap_or_else(|e| e.into_inner());
+    let should_run = map
+        .get(workdir)
+        .map(|t| now.duration_since(*t) >= GC_INTERVAL)
+        .unwrap_or(true);
+    if should_run {
+        map.insert(workdir.to_path_buf(), now);
+        drop(map);
+        let _ = std::process::Command::new("git")
+            .args(["gc", "--auto", "--quiet"])
+            .current_dir(workdir)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+    }
 }
 
 impl HistoryManager {
     pub fn new(roots: &[PathBuf]) -> Self {
-        let session_id = Uuid::new_v4().to_string();
-        let session_ref = format!("refs/harnx-history/{session_id}");
         let mut repos = HashMap::new();
 
         for repo_root in find_repos_under_roots(roots) {
@@ -46,7 +65,6 @@ impl HistoryManager {
                     RepoSession {
                         repo: repo.into_sync(),
                         last_commit_id: None,
-                        session_ref: session_ref.clone(),
                     },
                 );
             }
@@ -55,8 +73,7 @@ impl HistoryManager {
         Self {
             inner: Arc::new(HistoryManagerInner {
                 repos: tokio::sync::Mutex::new(repos),
-                session_id,
-                fallback_history_dir: history_dir(),
+                last_gc: std::sync::Mutex::new(HashMap::new()),
             }),
         }
     }
@@ -65,7 +82,7 @@ impl HistoryManager {
         let path = paths
             .first()
             .context("snapshot requires at least one path")?;
-        let (repo_workdir, ts_repo, parent, session_ref) = {
+        let (repo_workdir, ts_repo, parent) = {
             let repos = self.inner.repos.lock().await;
             let (workdir, session) = repos
                 .iter()
@@ -75,7 +92,6 @@ impl HistoryManager {
                 workdir.clone(),
                 session.repo.clone(),
                 session.last_commit_id,
-                session.session_ref.clone(),
             )
         };
 
@@ -83,15 +99,18 @@ impl HistoryManager {
         let repo_workdir_for_task = repo_workdir.clone();
         let commit_id = tokio::task::spawn_blocking(move || {
             let repo = ts_repo.to_thread_local();
-            capture_tree_blocking(&repo, &repo_workdir_for_task, parent, &session_ref, &label)
+            capture_tree_blocking(&repo, &repo_workdir_for_task, parent, &label)
         })
         .await
         .context("snapshot task join failed")??;
 
-        let mut repos = self.inner.repos.lock().await;
-        if let Some(session) = repos.get_mut(&repo_workdir) {
-            session.last_commit_id = Some(commit_id);
+        {
+            let mut repos = self.inner.repos.lock().await;
+            if let Some(session) = repos.get_mut(&repo_workdir) {
+                session.last_commit_id = Some(commit_id);
+            }
         }
+        maybe_trigger_gc(&repo_workdir, &self.inner.last_gc);
 
         Ok(commit_id)
     }
@@ -113,26 +132,28 @@ impl HistoryManager {
                         repo_root.clone(),
                         session.repo.clone(),
                         session.last_commit_id,
-                        session.session_ref.clone(),
                     )
                 })
                 .collect::<Vec<_>>()
         };
 
         let mut results = Vec::new();
-        for (repo_root, ts_repo, parent, session_ref) in candidates {
+        for (repo_root, ts_repo, parent) in candidates {
             let label = label.to_owned();
             let repo_root_for_task = repo_root.clone();
             let commit_id = tokio::task::spawn_blocking(move || {
                 let repo = ts_repo.to_thread_local();
-                capture_tree_blocking(&repo, &repo_root_for_task, parent, &session_ref, &label)
+                capture_tree_blocking(&repo, &repo_root_for_task, parent, &label)
             })
             .await
             .context("snapshot_repos_for_dir task join failed")??;
-            let mut repos = self.inner.repos.lock().await;
-            if let Some(session) = repos.get_mut(&repo_root) {
-                session.last_commit_id = Some(commit_id);
+            {
+                let mut repos = self.inner.repos.lock().await;
+                if let Some(session) = repos.get_mut(&repo_root) {
+                    session.last_commit_id = Some(commit_id);
+                }
             }
+            maybe_trigger_gc(&repo_root, &self.inner.last_gc);
             results.push((repo_root, commit_id));
         }
 
@@ -166,7 +187,7 @@ impl HistoryManager {
         repo_workdir: &Path,
         commit_id: gix::ObjectId,
     ) -> Result<gix::ObjectId> {
-        let (ts_repo, workdir, parent, session_ref) = {
+        let (ts_repo, workdir, parent) = {
             let repos = self.inner.repos.lock().await;
             let session = repos
                 .get(repo_workdir)
@@ -175,20 +196,12 @@ impl HistoryManager {
                 session.repo.clone(),
                 repo_workdir.to_path_buf(),
                 session.last_commit_id,
-                session.session_ref.clone(),
             )
         };
 
         let result = tokio::task::spawn_blocking(move || {
             let repo = ts_repo.to_thread_local();
-            rollback_to_commit_blocking(
-                &repo,
-                commit_id,
-                &workdir,
-                parent,
-                &session_ref,
-                "rollback",
-            )
+            rollback_to_commit_blocking(&repo, commit_id, &workdir, parent, "rollback")
         })
         .await
         .context("rollback task join failed")??;
@@ -202,35 +215,31 @@ impl HistoryManager {
         }
         Ok(after_id)
     }
-
-    #[allow(dead_code)]
-    pub fn session_id(&self) -> &str {
-        &self.inner.session_id
-    }
-
-    #[allow(dead_code)]
-    pub fn fallback_history_dir(&self) -> &Path {
-        &self.inner.fallback_history_dir
-    }
 }
 
 pub(crate) fn capture_tree_blocking(
     repo: &gix::Repository,
     workdir: &Path,
     parent: Option<gix::ObjectId>,
-    session_ref: &str,
     label: &str,
 ) -> Result<gix::ObjectId> {
+    let files = match collect_files(workdir)? {
+        Some(f) => f,
+        None => {
+            return Err(anyhow::anyhow!(
+                "snapshot skipped: file count exceeds limit"
+            ))
+        }
+    };
+
     let mut editor = repo
         .edit_tree(repo.empty_tree().id)
         .context("create tree editor")?;
 
-    let files = collect_files(workdir)?;
     let mut total_bytes: u64 = 0;
     let mut files_processed: usize = 0;
 
     for file_path in files {
-        // Guard 3: Per-file size check (skip oversized files with a warning)
         let file_size = std::fs::metadata(&file_path).map(|m| m.len()).unwrap_or(0);
         let max_file = std::env::var("HARNX_HISTORY_MAX_FILE_BYTES")
             .ok()
@@ -246,73 +255,79 @@ pub(crate) fn capture_tree_blocking(
             continue;
         }
 
-        // Guard 3: Cumulative total bytes abort
         let max_total = std::env::var("HARNX_HISTORY_MAX_TOTAL_BYTES")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(MAX_TOTAL_BYTES);
-        total_bytes += file_size;
-        if total_bytes > max_total {
+        if total_bytes + file_size > max_total {
             log::warn!(
-                "harnx-history: snapshot of {} aborted after {} bytes — \
-                 exceeds total limit of {} bytes (set HARNX_HISTORY_MAX_TOTAL_BYTES to override). \
-                 {} files processed before cutoff.",
+                "harnx-history: snapshot of {} truncated after {} files / {} bytes — exceeds total \
+                 limit of {} bytes (set HARNX_HISTORY_MAX_TOTAL_BYTES to override)",
                 workdir.display(),
+                files_processed,
                 total_bytes,
                 max_total,
-                files_processed,
             );
             break;
         }
 
-        let relative_path = file_path
-            .strip_prefix(workdir)
-            .context("strip workdir prefix")?;
-        let relative_path = relative_path.to_string_lossy().replace('\\', "/");
-        let data =
-            fs::read(&file_path).with_context(|| format!("read file {}", file_path.display()))?;
-        let blob_id = repo
-            .write_blob(&data)
-            .with_context(|| format!("write blob for {}", file_path.display()))?
-            .detach();
-        editor
-            .upsert(
-                relative_path.clone(),
-                gix::object::tree::EntryKind::Blob,
-                blob_id,
-            )
-            .with_context(|| format!("add tree entry {relative_path}"))?;
+        let rel = match file_path.strip_prefix(workdir) {
+            Ok(rel) => rel,
+            Err(_) => continue,
+        };
 
+        let data = match fs::read(&file_path) {
+            Ok(data) => data,
+            Err(_) => continue,
+        };
+
+        total_bytes += file_size;
         files_processed += 1;
+
+        let blob_id: gix::ObjectId = repo.write_blob(data).context("write blob")?.into();
+        let rel = rel.to_string_lossy().replace('\\', "/");
+        editor
+            .upsert(rel.as_str(), gix::object::tree::EntryKind::Blob, blob_id)
+            .with_context(|| format!("insert {} into tree", rel))?;
     }
 
     let tree_id = editor.write().context("write tree")?.detach();
-    let now = gix::date::Time::now_local_or_utc().to_string();
+
+    let time = gix::date::Time::now_utc();
+    let mut time_buf = Vec::with_capacity(time.size());
+    time.write_to(&mut time_buf)
+        .context("serialize snapshot time")?;
+    let time_str = std::str::from_utf8(&time_buf).context("snapshot time not utf-8")?;
     let signature = gix::actor::SignatureRef {
-        name: "harnx-history".into(),
-        email: "harnx-history@localhost".into(),
-        time: now.as_str(),
-    };
+        name: "harnx-history".as_bytes().as_bstr(),
+        email: "harnx-history@localhost".as_bytes().as_bstr(),
+        time: time_str,
+    }
+    .to_owned()
+    .context("build snapshot signature")?;
 
     let mut parents = Vec::new();
     if let Some(parent) = parent {
         parents.push(parent);
-    } else if let Ok(reference) = repo.find_reference(session_ref) {
-        if let Some(id) = reference.target().try_id() {
-            parents.push(id.to_owned());
-        }
     }
 
+    let commit = gix::objs::Commit {
+        tree: tree_id,
+        parents: parents.into_iter().collect(),
+        author: signature.clone(),
+        committer: signature,
+        encoding: None,
+        message: label.into(),
+        extra_headers: vec![],
+    };
     let commit_id = repo
-        .commit_as(signature, signature, session_ref, label, tree_id, parents)
+        .write_object(&commit)
         .context("write snapshot commit")?
         .detach();
     Ok(commit_id)
 }
 
-fn collect_files(root: &Path) -> Result<Vec<PathBuf>> {
-    // Use git ls-files to get all tracked + untracked non-ignored files
-    // This correctly respects .gitignore
+fn collect_files(root: &Path) -> Result<Option<Vec<PathBuf>>> {
     let output = std::process::Command::new("git")
         .args([
             "ls-files",
@@ -327,13 +342,10 @@ fn collect_files(root: &Path) -> Result<Vec<PathBuf>> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        // If git ls-files fails (e.g. not a git repo), fall back to empty list
-        // The snapshot will still create a valid (empty) tree
         log::warn!("git ls-files failed in {}: {stderr}", root.display());
-        return Ok(Vec::new());
+        return Ok(None);
     }
 
-    // Use NUL-delimited output (-z) to correctly handle filenames containing newlines
     let mut files: Vec<PathBuf> = output
         .stdout
         .split(|&b| b == 0)
@@ -344,14 +356,6 @@ fn collect_files(root: &Path) -> Result<Vec<PathBuf>> {
         .collect();
     files.sort();
 
-    // Guard 1: Exclude the harnx history directory to prevent the cache from snapshotting itself
-    let history = history_dir();
-    let files: Vec<PathBuf> = files
-        .into_iter()
-        .filter(|p| !p.starts_with(&history))
-        .collect();
-
-    // Guard 2: File count cap
     let max_files = std::env::var("HARNX_HISTORY_MAX_FILES")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
@@ -364,10 +368,10 @@ fn collect_files(root: &Path) -> Result<Vec<PathBuf>> {
             files.len(),
             max_files,
         );
-        return Ok(Vec::new());
+        return Ok(None);
     }
 
-    Ok(files)
+    Ok(Some(files))
 }
 
 #[cfg(test)]
@@ -381,84 +385,49 @@ mod tests {
     }
 
     fn init_git_repo(dir: &Path) {
-        std::process::Command::new("git")
+        let status = std::process::Command::new("git")
             .args(["init"])
             .current_dir(dir)
-            .output()
-            .expect("git init");
-        std::process::Command::new("git")
+            .status()
+            .expect("init repo");
+        assert!(status.success(), "git init failed");
+
+        let status = std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(dir)
+            .status()
+            .expect("config user.name");
+        assert!(status.success(), "git config user.name failed");
+
+        let status = std::process::Command::new("git")
             .args(["config", "user.email", "test@example.com"])
             .current_dir(dir)
-            .output()
-            .expect("git config user.email");
-        std::process::Command::new("git")
-            .args(["config", "user.name", "Test"])
-            .current_dir(dir)
-            .output()
-            .expect("git config user.name");
+            .status()
+            .expect("config user.email");
+        assert!(status.success(), "git config user.email failed");
     }
 
-    fn add_file_to_git(dir: &Path, name: &str, content: &[u8]) -> PathBuf {
-        let file_path = dir.join(name);
+    fn add_file_to_git(dir: &Path, rel: &str, contents: &[u8]) {
+        let file_path = dir.join(rel);
         if let Some(parent) = file_path.parent() {
-            std::fs::create_dir_all(parent).expect("create parent dir");
+            std::fs::create_dir_all(parent).expect("create parent dirs");
         }
-        std::fs::write(&file_path, content).expect("write file");
-        std::process::Command::new("git")
-            .args(["add", name])
+        std::fs::write(&file_path, contents).expect("write file");
+        let status = std::process::Command::new("git")
+            .args(["add", rel])
             .current_dir(dir)
-            .output()
+            .status()
             .expect("git add");
-        file_path
+        assert!(status.success(), "git add failed");
     }
 
     fn commit_git(dir: &Path) {
-        std::process::Command::new("git")
+        let status = std::process::Command::new("git")
             .args(["commit", "-m", "test commit"])
             .current_dir(dir)
-            .output()
+            .status()
             .expect("git commit");
-    }
-
-    #[test]
-    fn test_collect_files_excludes_history_dir() {
-        let guard = env_lock().lock().expect("env lock");
-
-        // Keep temp_dir alive for the duration of the test
-        let temp_dir = tempfile::tempdir().expect("temp dir");
-        let repo_dir = temp_dir.path().join("repo");
-        std::fs::create_dir_all(&repo_dir).expect("create repo dir");
-
-        init_git_repo(&repo_dir);
-
-        // Create a regular file in the repo
-        let _regular_file = add_file_to_git(&repo_dir, "regular.txt", b"regular content");
-
-        // Create a file inside a history dir that's inside the repo
-        let history_subdir = repo_dir.join("history-subdir");
-        std::fs::create_dir_all(&history_subdir).expect("create history subdir");
-        let _history_file =
-            add_file_to_git(&repo_dir, "history-subdir/history.txt", b"history content");
-
-        // Commit to make git ls-files work correctly
-        commit_git(&repo_dir);
-
-        // Set HARNX_LOCAL_HISTORY_DIR to point to the history subdir
-        unsafe { std::env::set_var("HARNX_LOCAL_HISTORY_DIR", &history_subdir) };
-
-        let result = collect_files(&repo_dir).expect("collect_files should succeed");
-
-        unsafe { std::env::remove_var("HARNX_LOCAL_HISTORY_DIR") };
-
-        // Regular file should be included, history file should be excluded
-        let has_regular = result.iter().any(|p| p.ends_with("regular.txt"));
-        let has_history = result.iter().any(|p| p.ends_with("history.txt"));
-
-        drop(guard);
-        drop(temp_dir); // Keep temp_dir alive until after the check
-
-        assert!(has_regular, "regular file should be included in result");
-        assert!(!has_history, "history file should be excluded from result");
+        assert!(status.success(), "git commit failed");
     }
 
     #[test]
@@ -471,13 +440,11 @@ mod tests {
 
         init_git_repo(&repo_dir);
 
-        // Create 3 files
         add_file_to_git(&repo_dir, "file1.txt", b"content 1");
         add_file_to_git(&repo_dir, "file2.txt", b"content 2");
         add_file_to_git(&repo_dir, "file3.txt", b"content 3");
         commit_git(&repo_dir);
 
-        // Set a low file count limit
         unsafe { std::env::set_var("HARNX_HISTORY_MAX_FILES", "2") };
 
         let result = collect_files(&repo_dir).expect("collect_files should succeed");
@@ -485,10 +452,9 @@ mod tests {
         unsafe { std::env::remove_var("HARNX_HISTORY_MAX_FILES") };
         drop(guard);
 
-        // Result should be empty because cap was triggered
         assert!(
-            result.is_empty(),
-            "result should be empty when file count exceeds cap"
+            result.is_none(),
+            "result should be None when file count exceeds cap"
         );
     }
 
@@ -502,36 +468,24 @@ mod tests {
 
         init_git_repo(&repo_dir);
 
-        // Create a small file
         add_file_to_git(&repo_dir, "small.txt", b"tiny");
-        // Create a "large" file (larger than our test limit of 10 bytes)
         add_file_to_git(&repo_dir, "large.txt", b"this is larger than ten bytes");
         commit_git(&repo_dir);
 
-        // Set a very low per-file size limit (10 bytes)
         unsafe { std::env::set_var("HARNX_HISTORY_MAX_FILE_BYTES", "10") };
 
-        // Create a git repo for the history snapshots
         let history_repo_dir = temp_dir.path().join("history-repo");
         std::fs::create_dir_all(&history_repo_dir).expect("create history repo dir");
         init_git_repo(&history_repo_dir);
         let history_repo = gix::open(&history_repo_dir).expect("open history repo");
 
-        let result = capture_tree_blocking(
-            &history_repo,
-            &repo_dir,
-            None,
-            "refs/heads/main",
-            "test snapshot",
-        );
+        let result = capture_tree_blocking(&history_repo, &repo_dir, None, "test snapshot");
 
         unsafe { std::env::remove_var("HARNX_HISTORY_MAX_FILE_BYTES") };
         drop(guard);
 
-        // Should succeed (not error)
         assert!(result.is_ok(), "capture_tree_blocking should succeed");
 
-        // Verify the commit was created
         let commit_id = result.expect("commit id");
         let commit = history_repo.find_object(commit_id).expect("find commit");
         assert_eq!(commit.kind, gix::object::Kind::Commit, "should be a commit");

--- a/crates/harnx-mcp-history/src/history.rs
+++ b/crates/harnx-mcp-history/src/history.rs
@@ -1,0 +1,299 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use uuid::Uuid;
+
+use crate::diff::diff_commits_blocking;
+use crate::discover::{find_repos_under_roots, history_dir};
+use crate::rollback::rollback_to_commit_blocking;
+
+pub struct HistoryManager {
+    inner: Arc<HistoryManagerInner>,
+}
+
+struct HistoryManagerInner {
+    repos: tokio::sync::Mutex<HashMap<PathBuf, RepoSession>>,
+    session_id: String,
+    fallback_history_dir: PathBuf,
+}
+
+struct RepoSession {
+    repo: gix::ThreadSafeRepository,
+    last_commit_id: Option<gix::ObjectId>,
+    session_ref: String,
+}
+
+impl HistoryManager {
+    pub fn new(roots: &[PathBuf]) -> Self {
+        let session_id = Uuid::new_v4().to_string();
+        let session_ref = format!("refs/harnx-history/{session_id}");
+        let mut repos = HashMap::new();
+
+        for repo_root in find_repos_under_roots(roots) {
+            if let Ok(repo) = gix::open(&repo_root) {
+                repos.insert(
+                    repo_root,
+                    RepoSession {
+                        repo: repo.into_sync(),
+                        last_commit_id: None,
+                        session_ref: session_ref.clone(),
+                    },
+                );
+            }
+        }
+
+        Self {
+            inner: Arc::new(HistoryManagerInner {
+                repos: tokio::sync::Mutex::new(repos),
+                session_id,
+                fallback_history_dir: history_dir(),
+            }),
+        }
+    }
+
+    pub async fn snapshot(&self, paths: &[PathBuf], label: &str) -> Result<gix::ObjectId> {
+        let path = paths
+            .first()
+            .context("snapshot requires at least one path")?;
+        let (repo_workdir, ts_repo, parent, session_ref) = {
+            let repos = self.inner.repos.lock().await;
+            let (workdir, session) = repos
+                .iter()
+                .find(|(workdir, _)| path.starts_with(workdir))
+                .context("no tracked repo found for snapshot path")?;
+            (
+                workdir.clone(),
+                session.repo.clone(),
+                session.last_commit_id,
+                session.session_ref.clone(),
+            )
+        };
+
+        let label = label.to_owned();
+        let repo_workdir_for_task = repo_workdir.clone();
+        let commit_id = tokio::task::spawn_blocking(move || {
+            let repo = ts_repo.to_thread_local();
+            capture_tree_blocking(&repo, &repo_workdir_for_task, parent, &session_ref, &label)
+        })
+        .await
+        .context("snapshot task join failed")??;
+
+        let mut repos = self.inner.repos.lock().await;
+        if let Some(session) = repos.get_mut(&repo_workdir) {
+            session.last_commit_id = Some(commit_id);
+        }
+
+        Ok(commit_id)
+    }
+
+    pub async fn snapshot_repos_for_dir(
+        &self,
+        working_dir: &Path,
+        label: &str,
+    ) -> Result<Vec<(PathBuf, gix::ObjectId)>> {
+        let candidates = {
+            let repos = self.inner.repos.lock().await;
+            repos
+                .iter()
+                .filter(|(repo_root, _)| {
+                    working_dir.starts_with(repo_root) || repo_root.starts_with(working_dir)
+                })
+                .map(|(repo_root, session)| {
+                    (
+                        repo_root.clone(),
+                        session.repo.clone(),
+                        session.last_commit_id,
+                        session.session_ref.clone(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let mut results = Vec::new();
+        for (repo_root, ts_repo, parent, session_ref) in candidates {
+            let label = label.to_owned();
+            let repo_root_for_task = repo_root.clone();
+            let commit_id = tokio::task::spawn_blocking(move || {
+                let repo = ts_repo.to_thread_local();
+                capture_tree_blocking(&repo, &repo_root_for_task, parent, &session_ref, &label)
+            })
+            .await
+            .context("snapshot_repos_for_dir task join failed")??;
+            let mut repos = self.inner.repos.lock().await;
+            if let Some(session) = repos.get_mut(&repo_root) {
+                session.last_commit_id = Some(commit_id);
+            }
+            results.push((repo_root, commit_id));
+        }
+
+        Ok(results)
+    }
+
+    pub async fn diff_commits(
+        &self,
+        repo_workdir: &Path,
+        before_id: gix::ObjectId,
+        after_id: gix::ObjectId,
+    ) -> Result<String> {
+        let ts_repo = {
+            let repos = self.inner.repos.lock().await;
+            repos
+                .get(repo_workdir)
+                .map(|session| session.repo.clone())
+                .context("repo not tracked for diff")?
+        };
+
+        tokio::task::spawn_blocking(move || {
+            let repo = ts_repo.to_thread_local();
+            diff_commits_blocking(&repo, before_id, after_id)
+        })
+        .await
+        .context("diff task join failed")?
+    }
+
+    pub async fn rollback(
+        &self,
+        repo_workdir: &Path,
+        commit_id: gix::ObjectId,
+    ) -> Result<gix::ObjectId> {
+        let (ts_repo, workdir, parent, session_ref) = {
+            let repos = self.inner.repos.lock().await;
+            let session = repos
+                .get(repo_workdir)
+                .context("repo not tracked for rollback")?;
+            (
+                session.repo.clone(),
+                repo_workdir.to_path_buf(),
+                session.last_commit_id,
+                session.session_ref.clone(),
+            )
+        };
+
+        let result = tokio::task::spawn_blocking(move || {
+            let repo = ts_repo.to_thread_local();
+            rollback_to_commit_blocking(
+                &repo,
+                commit_id,
+                &workdir,
+                parent,
+                &session_ref,
+                "rollback",
+            )
+        })
+        .await
+        .context("rollback task join failed")??;
+
+        let after_id = result.1;
+        {
+            let mut repos = self.inner.repos.lock().await;
+            if let Some(session) = repos.get_mut(repo_workdir) {
+                session.last_commit_id = Some(after_id);
+            }
+        }
+        Ok(after_id)
+    }
+
+    #[allow(dead_code)]
+    pub fn session_id(&self) -> &str {
+        &self.inner.session_id
+    }
+
+    #[allow(dead_code)]
+    pub fn fallback_history_dir(&self) -> &Path {
+        &self.inner.fallback_history_dir
+    }
+}
+
+pub(crate) fn capture_tree_blocking(
+    repo: &gix::Repository,
+    workdir: &Path,
+    parent: Option<gix::ObjectId>,
+    session_ref: &str,
+    label: &str,
+) -> Result<gix::ObjectId> {
+    let mut editor = repo
+        .edit_tree(repo.empty_tree().id)
+        .context("create tree editor")?;
+
+    for file_path in collect_files(workdir)? {
+        let relative_path = file_path
+            .strip_prefix(workdir)
+            .context("strip workdir prefix")?;
+        let relative_path = relative_path.to_string_lossy().replace('\\', "/");
+        let data =
+            fs::read(&file_path).with_context(|| format!("read file {}", file_path.display()))?;
+        let blob_id = repo
+            .write_blob(&data)
+            .with_context(|| format!("write blob for {}", file_path.display()))?
+            .detach();
+        editor
+            .upsert(
+                relative_path.clone(),
+                gix::object::tree::EntryKind::Blob,
+                blob_id,
+            )
+            .with_context(|| format!("add tree entry {relative_path}"))?;
+    }
+
+    let tree_id = editor.write().context("write tree")?.detach();
+    let now = gix::date::Time::now_local_or_utc().to_string();
+    let signature = gix::actor::SignatureRef {
+        name: "harnx-history".into(),
+        email: "harnx-history@localhost".into(),
+        time: now.as_str(),
+    };
+
+    let mut parents = Vec::new();
+    if let Some(parent) = parent {
+        parents.push(parent);
+    } else if let Ok(reference) = repo.find_reference(session_ref) {
+        if let Some(id) = reference.target().try_id() {
+            parents.push(id.to_owned());
+        }
+    }
+
+    let commit_id = repo
+        .commit_as(signature, signature, session_ref, label, tree_id, parents)
+        .context("write snapshot commit")?
+        .detach();
+    Ok(commit_id)
+}
+
+fn collect_files(root: &Path) -> Result<Vec<PathBuf>> {
+    // Use git ls-files to get all tracked + untracked non-ignored files
+    // This correctly respects .gitignore
+    let output = std::process::Command::new("git")
+        .args([
+            "-z",
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+        ])
+        .current_dir(root)
+        .output()
+        .context("run git ls-files")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // If git ls-files fails (e.g. not a git repo), fall back to empty list
+        // The snapshot will still create a valid (empty) tree
+        log::warn!("git ls-files failed in {}: {stderr}", root.display());
+        return Ok(Vec::new());
+    }
+
+    // Use NUL-delimited output (-z) to correctly handle filenames containing newlines
+    let mut files: Vec<PathBuf> = output
+        .stdout
+        .split(|&b| b == 0)
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| std::str::from_utf8(s).ok())
+        .map(|line| root.join(line))
+        .filter(|p| p.is_file())
+        .collect();
+    files.sort();
+    Ok(files)
+}

--- a/crates/harnx-mcp-history/src/history.rs
+++ b/crates/harnx-mcp-history/src/history.rs
@@ -10,6 +10,13 @@ use crate::diff::diff_commits_blocking;
 use crate::discover::{find_repos_under_roots, history_dir};
 use crate::rollback::rollback_to_commit_blocking;
 
+/// Maximum number of files per snapshot. Override with HARNX_HISTORY_MAX_FILES.
+const MAX_SNAPSHOT_FILES: usize = 10_000;
+/// Maximum bytes for a single file in a snapshot. Override with HARNX_HISTORY_MAX_FILE_BYTES.
+const MAX_FILE_BYTES: u64 = 10 * 1024 * 1024;
+/// Maximum total bytes across all files in a snapshot. Override with HARNX_HISTORY_MAX_TOTAL_BYTES.
+const MAX_TOTAL_BYTES: u64 = 100 * 1024 * 1024;
+
 pub struct HistoryManager {
     inner: Arc<HistoryManagerInner>,
 }
@@ -218,7 +225,46 @@ pub(crate) fn capture_tree_blocking(
         .edit_tree(repo.empty_tree().id)
         .context("create tree editor")?;
 
-    for file_path in collect_files(workdir)? {
+    let files = collect_files(workdir)?;
+    let mut total_bytes: u64 = 0;
+    let mut files_processed: usize = 0;
+
+    for file_path in files {
+        // Guard 3: Per-file size check (skip oversized files with a warning)
+        let file_size = std::fs::metadata(&file_path).map(|m| m.len()).unwrap_or(0);
+        let max_file = std::env::var("HARNX_HISTORY_MAX_FILE_BYTES")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(MAX_FILE_BYTES);
+        if file_size > max_file {
+            log::warn!(
+                "harnx-history: skipping {} ({} bytes) — exceeds per-file limit of {} bytes",
+                file_path.display(),
+                file_size,
+                max_file,
+            );
+            continue;
+        }
+
+        // Guard 3: Cumulative total bytes abort
+        let max_total = std::env::var("HARNX_HISTORY_MAX_TOTAL_BYTES")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(MAX_TOTAL_BYTES);
+        total_bytes += file_size;
+        if total_bytes > max_total {
+            log::warn!(
+                "harnx-history: snapshot of {} aborted after {} bytes — \
+                 exceeds total limit of {} bytes (set HARNX_HISTORY_MAX_TOTAL_BYTES to override). \
+                 {} files processed before cutoff.",
+                workdir.display(),
+                total_bytes,
+                max_total,
+                files_processed,
+            );
+            break;
+        }
+
         let relative_path = file_path
             .strip_prefix(workdir)
             .context("strip workdir prefix")?;
@@ -236,6 +282,8 @@ pub(crate) fn capture_tree_blocking(
                 blob_id,
             )
             .with_context(|| format!("add tree entry {relative_path}"))?;
+
+        files_processed += 1;
     }
 
     let tree_id = editor.write().context("write tree")?.detach();
@@ -267,8 +315,8 @@ fn collect_files(root: &Path) -> Result<Vec<PathBuf>> {
     // This correctly respects .gitignore
     let output = std::process::Command::new("git")
         .args([
-            "-z",
             "ls-files",
+            "-z",
             "--cached",
             "--others",
             "--exclude-standard",
@@ -295,5 +343,197 @@ fn collect_files(root: &Path) -> Result<Vec<PathBuf>> {
         .filter(|p| p.is_file())
         .collect();
     files.sort();
+
+    // Guard 1: Exclude the harnx history directory to prevent the cache from snapshotting itself
+    let history = history_dir();
+    let files: Vec<PathBuf> = files
+        .into_iter()
+        .filter(|p| !p.starts_with(&history))
+        .collect();
+
+    // Guard 2: File count cap
+    let max_files = std::env::var("HARNX_HISTORY_MAX_FILES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(MAX_SNAPSHOT_FILES);
+    if files.len() > max_files {
+        log::warn!(
+            "harnx-history: snapshot of {} skipped — {} files exceeds limit of {} \
+             (set HARNX_HISTORY_MAX_FILES to override)",
+            root.display(),
+            files.len(),
+            max_files,
+        );
+        return Ok(Vec::new());
+    }
+
     Ok(files)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn init_git_repo(dir: &Path) {
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir)
+            .output()
+            .expect("git init");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(dir)
+            .output()
+            .expect("git config user.email");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(dir)
+            .output()
+            .expect("git config user.name");
+    }
+
+    fn add_file_to_git(dir: &Path, name: &str, content: &[u8]) -> PathBuf {
+        let file_path = dir.join(name);
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dir");
+        }
+        std::fs::write(&file_path, content).expect("write file");
+        std::process::Command::new("git")
+            .args(["add", name])
+            .current_dir(dir)
+            .output()
+            .expect("git add");
+        file_path
+    }
+
+    fn commit_git(dir: &Path) {
+        std::process::Command::new("git")
+            .args(["commit", "-m", "test commit"])
+            .current_dir(dir)
+            .output()
+            .expect("git commit");
+    }
+
+    #[test]
+    fn test_collect_files_excludes_history_dir() {
+        let guard = env_lock().lock().expect("env lock");
+
+        // Keep temp_dir alive for the duration of the test
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let repo_dir = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&repo_dir).expect("create repo dir");
+
+        init_git_repo(&repo_dir);
+
+        // Create a regular file in the repo
+        let _regular_file = add_file_to_git(&repo_dir, "regular.txt", b"regular content");
+
+        // Create a file inside a history dir that's inside the repo
+        let history_subdir = repo_dir.join("history-subdir");
+        std::fs::create_dir_all(&history_subdir).expect("create history subdir");
+        let _history_file =
+            add_file_to_git(&repo_dir, "history-subdir/history.txt", b"history content");
+
+        // Commit to make git ls-files work correctly
+        commit_git(&repo_dir);
+
+        // Set HARNX_LOCAL_HISTORY_DIR to point to the history subdir
+        unsafe { std::env::set_var("HARNX_LOCAL_HISTORY_DIR", &history_subdir) };
+
+        let result = collect_files(&repo_dir).expect("collect_files should succeed");
+
+        unsafe { std::env::remove_var("HARNX_LOCAL_HISTORY_DIR") };
+
+        // Regular file should be included, history file should be excluded
+        let has_regular = result.iter().any(|p| p.ends_with("regular.txt"));
+        let has_history = result.iter().any(|p| p.ends_with("history.txt"));
+
+        drop(guard);
+        drop(temp_dir); // Keep temp_dir alive until after the check
+
+        assert!(has_regular, "regular file should be included in result");
+        assert!(!has_history, "history file should be excluded from result");
+    }
+
+    #[test]
+    fn test_collect_files_file_count_cap() {
+        let guard = env_lock().lock().expect("env lock");
+
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let repo_dir = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&repo_dir).expect("create repo dir");
+
+        init_git_repo(&repo_dir);
+
+        // Create 3 files
+        add_file_to_git(&repo_dir, "file1.txt", b"content 1");
+        add_file_to_git(&repo_dir, "file2.txt", b"content 2");
+        add_file_to_git(&repo_dir, "file3.txt", b"content 3");
+        commit_git(&repo_dir);
+
+        // Set a low file count limit
+        unsafe { std::env::set_var("HARNX_HISTORY_MAX_FILES", "2") };
+
+        let result = collect_files(&repo_dir).expect("collect_files should succeed");
+
+        unsafe { std::env::remove_var("HARNX_HISTORY_MAX_FILES") };
+        drop(guard);
+
+        // Result should be empty because cap was triggered
+        assert!(
+            result.is_empty(),
+            "result should be empty when file count exceeds cap"
+        );
+    }
+
+    #[test]
+    fn test_capture_tree_skips_large_file() {
+        let guard = env_lock().lock().expect("env lock");
+
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let repo_dir = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&repo_dir).expect("create repo dir");
+
+        init_git_repo(&repo_dir);
+
+        // Create a small file
+        add_file_to_git(&repo_dir, "small.txt", b"tiny");
+        // Create a "large" file (larger than our test limit of 10 bytes)
+        add_file_to_git(&repo_dir, "large.txt", b"this is larger than ten bytes");
+        commit_git(&repo_dir);
+
+        // Set a very low per-file size limit (10 bytes)
+        unsafe { std::env::set_var("HARNX_HISTORY_MAX_FILE_BYTES", "10") };
+
+        // Create a git repo for the history snapshots
+        let history_repo_dir = temp_dir.path().join("history-repo");
+        std::fs::create_dir_all(&history_repo_dir).expect("create history repo dir");
+        init_git_repo(&history_repo_dir);
+        let history_repo = gix::open(&history_repo_dir).expect("open history repo");
+
+        let result = capture_tree_blocking(
+            &history_repo,
+            &repo_dir,
+            None,
+            "refs/heads/main",
+            "test snapshot",
+        );
+
+        unsafe { std::env::remove_var("HARNX_HISTORY_MAX_FILE_BYTES") };
+        drop(guard);
+
+        // Should succeed (not error)
+        assert!(result.is_ok(), "capture_tree_blocking should succeed");
+
+        // Verify the commit was created
+        let commit_id = result.expect("commit id");
+        let commit = history_repo.find_object(commit_id).expect("find commit");
+        assert_eq!(commit.kind, gix::object::Kind::Commit, "should be a commit");
+    }
 }

--- a/crates/harnx-mcp-history/src/history.rs
+++ b/crates/harnx-mcp-history/src/history.rs
@@ -501,6 +501,14 @@ mod tests {
             .status()
             .expect("config user.email");
         assert!(status.success(), "git config user.email failed");
+
+        // Disable autocrlf so line endings are preserved exactly on Windows.
+        let status = std::process::Command::new("git")
+            .args(["config", "core.autocrlf", "false"])
+            .current_dir(dir)
+            .status()
+            .expect("config core.autocrlf");
+        assert!(status.success(), "git config core.autocrlf failed");
     }
 
     fn add_file_to_git(dir: &Path, rel: &str, contents: &[u8]) {

--- a/crates/harnx-mcp-history/src/history.rs
+++ b/crates/harnx-mcp-history/src/history.rs
@@ -45,12 +45,17 @@ fn maybe_trigger_gc(
     if should_run {
         map.insert(workdir.to_path_buf(), now);
         drop(map);
-        let _ = std::process::Command::new("git")
-            .args(["gc", "--auto", "--quiet"])
-            .current_dir(workdir)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn();
+        // Spawn gc and immediately wait in a detached thread so the child is
+        // reaped and never becomes a zombie. We don't care about the exit code.
+        let workdir_owned = workdir.to_path_buf();
+        std::thread::spawn(move || {
+            let _ = std::process::Command::new("git")
+                .args(["gc", "--auto", "--quiet"])
+                .current_dir(&workdir_owned)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status();
+        });
     }
 }
 
@@ -84,9 +89,12 @@ impl HistoryManager {
             .context("snapshot requires at least one path")?;
         let (repo_workdir, ts_repo, parent) = {
             let repos = self.inner.repos.lock().await;
+            // Pick the longest matching workdir so an inner repo wins over an
+            // outer one when both are tracked (e.g. a workspace with submodules).
             let (workdir, session) = repos
                 .iter()
-                .find(|(workdir, _)| path.starts_with(workdir))
+                .filter(|(workdir, _)| path.starts_with(workdir.as_path()))
+                .max_by_key(|(workdir, _)| workdir.as_os_str().len())
                 .context("no tracked repo found for snapshot path")?;
             (
                 workdir.clone(),
@@ -103,6 +111,48 @@ impl HistoryManager {
         })
         .await
         .context("snapshot task join failed")??;
+
+        {
+            let mut repos = self.inner.repos.lock().await;
+            if let Some(session) = repos.get_mut(&repo_workdir) {
+                session.last_commit_id = Some(commit_id);
+            }
+        }
+        maybe_trigger_gc(&repo_workdir, &self.inner.last_gc);
+
+        Ok(commit_id)
+    }
+
+    pub async fn snapshot_file(&self, file_path: &Path, label: &str) -> Result<gix::ObjectId> {
+        let (repo_workdir, ts_repo, parent) = {
+            let repos = self.inner.repos.lock().await;
+            let (workdir, session) = repos
+                .iter()
+                .filter(|(workdir, _)| file_path.starts_with(workdir.as_path()))
+                .max_by_key(|(workdir, _)| workdir.as_os_str().len())
+                .context("no tracked repo found for file path")?;
+            (
+                workdir.clone(),
+                session.repo.clone(),
+                session.last_commit_id,
+            )
+        };
+
+        let label = label.to_owned();
+        let file_path_owned = file_path.to_path_buf();
+        let repo_workdir_for_task = repo_workdir.clone();
+        let commit_id = tokio::task::spawn_blocking(move || {
+            let repo = ts_repo.to_thread_local();
+            capture_file_blocking(
+                &repo,
+                &repo_workdir_for_task,
+                &file_path_owned,
+                parent,
+                &label,
+            )
+        })
+        .await
+        .context("snapshot_file task join failed")??;
 
         {
             let mut repos = self.inner.repos.lock().await;
@@ -217,6 +267,84 @@ impl HistoryManager {
     }
 }
 
+fn write_snapshot_commit(
+    repo: &gix::Repository,
+    tree_id: gix::ObjectId,
+    parent: Option<gix::ObjectId>,
+    label: &str,
+) -> Result<gix::ObjectId> {
+    let time = gix::date::Time::now_utc();
+    let mut time_buf = Vec::with_capacity(time.size());
+    time.write_to(&mut time_buf)
+        .context("serialize snapshot time")?;
+    let time_str = std::str::from_utf8(&time_buf).context("snapshot time not utf-8")?;
+    let signature = gix::actor::SignatureRef {
+        name: "harnx-history".as_bytes().as_bstr(),
+        email: "harnx-history@localhost".as_bytes().as_bstr(),
+        time: time_str,
+    }
+    .to_owned()
+    .context("build snapshot signature")?;
+
+    let mut parents = Vec::new();
+    if let Some(parent) = parent {
+        parents.push(parent);
+    }
+
+    let commit = gix::objs::Commit {
+        tree: tree_id,
+        parents: parents.into_iter().collect(),
+        author: signature.clone(),
+        committer: signature,
+        encoding: None,
+        message: label.into(),
+        extra_headers: vec![],
+    };
+    let commit_id = repo
+        .write_object(&commit)
+        .context("write snapshot commit")?
+        .detach();
+    Ok(commit_id)
+}
+
+/// Snapshot a single specific file into a git commit.
+/// The tree contains only that one file at its repo-relative path.
+/// If the file does not exist on disk (e.g. before a new-file write),
+/// the commit tree is empty — the diff will show it as a new addition.
+pub(crate) fn capture_file_blocking(
+    repo: &gix::Repository,
+    repo_workdir: &Path,
+    file_path: &Path,
+    parent: Option<gix::ObjectId>,
+    label: &str,
+) -> Result<gix::ObjectId> {
+    let mut editor = repo
+        .edit_tree(repo.empty_tree().id)
+        .context("create tree editor")?;
+
+    if file_path.is_file() {
+        let rel = file_path
+            .strip_prefix(repo_workdir)
+            .context("file not under repo workdir")?;
+        let rel_str = rel.to_string_lossy().replace('\\', "/");
+
+        let data =
+            fs::read(file_path).with_context(|| format!("read file {}", file_path.display()))?;
+
+        let blob_id: gix::ObjectId = repo.write_blob(data).context("write blob")?.into();
+        editor
+            .upsert(
+                rel_str.as_str(),
+                gix::object::tree::EntryKind::Blob,
+                blob_id,
+            )
+            .context("insert file into tree")?;
+    }
+
+    let tree_id = editor.write().context("write tree")?.detach();
+    write_snapshot_commit(repo, tree_id, parent, label)
+}
+
 pub(crate) fn capture_tree_blocking(
     repo: &gix::Repository,
     workdir: &Path,
@@ -292,39 +420,7 @@ pub(crate) fn capture_tree_blocking(
     }
 
     let tree_id = editor.write().context("write tree")?.detach();
-
-    let time = gix::date::Time::now_utc();
-    let mut time_buf = Vec::with_capacity(time.size());
-    time.write_to(&mut time_buf)
-        .context("serialize snapshot time")?;
-    let time_str = std::str::from_utf8(&time_buf).context("snapshot time not utf-8")?;
-    let signature = gix::actor::SignatureRef {
-        name: "harnx-history".as_bytes().as_bstr(),
-        email: "harnx-history@localhost".as_bytes().as_bstr(),
-        time: time_str,
-    }
-    .to_owned()
-    .context("build snapshot signature")?;
-
-    let mut parents = Vec::new();
-    if let Some(parent) = parent {
-        parents.push(parent);
-    }
-
-    let commit = gix::objs::Commit {
-        tree: tree_id,
-        parents: parents.into_iter().collect(),
-        author: signature.clone(),
-        committer: signature,
-        encoding: None,
-        message: label.into(),
-        extra_headers: vec![],
-    };
-    let commit_id = repo
-        .write_object(&commit)
-        .context("write snapshot commit")?
-        .detach();
-    Ok(commit_id)
+    write_snapshot_commit(repo, tree_id, parent, label)
 }
 
 fn collect_files(root: &Path) -> Result<Option<Vec<PathBuf>>> {

--- a/crates/harnx-mcp-history/src/lib.rs
+++ b/crates/harnx-mcp-history/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod diff;
+pub mod discover;
+pub mod history;
+pub mod rollback;
+
+pub use history::HistoryManager;

--- a/crates/harnx-mcp-history/src/rollback.rs
+++ b/crates/harnx-mcp-history/src/rollback.rs
@@ -8,14 +8,15 @@ use gix::object::tree::EntryKind;
 use crate::history::capture_tree_blocking;
 
 fn is_harnx_history_commit(repo: &gix::Repository, commit_id: gix::ObjectId) -> bool {
-    let prefix = "refs/harnx-history/";
-    repo.references()
+    repo.find_object(commit_id)
         .ok()
-        .and_then(|refs| {
-            refs.prefixed(prefix.as_bytes()).ok().map(|iter| {
-                iter.flatten()
-                    .any(|r| r.target().try_id() == Some(commit_id.as_ref()))
-            })
+        .and_then(|obj| obj.peel_to_commit().ok())
+        .map(|commit| {
+            commit
+                .author()
+                .ok()
+                .map(|a| a.email == "harnx-history@localhost")
+                .unwrap_or(false)
         })
         .unwrap_or(false)
 }
@@ -23,40 +24,23 @@ fn is_harnx_history_commit(repo: &gix::Repository, commit_id: gix::ObjectId) -> 
 fn flatten_tree(
     repo: &gix::Repository,
     tree_id: gix::ObjectId,
-) -> Result<HashMap<PathBuf, gix::ObjectId>> {
-    let tree = repo.find_object(tree_id)?.peel_to_tree()?;
-    let mut recorder = gix::traverse::tree::Recorder::default();
-    tree.traverse().breadthfirst(&mut recorder)?;
-
-    let mut files = HashMap::new();
-    for entry in recorder.records {
-        if matches!(
-            entry.mode.kind(),
-            EntryKind::Blob | EntryKind::BlobExecutable
-        ) {
-            files.insert(
-                PathBuf::from(entry.filepath.to_string()),
-                entry.oid.to_owned(),
-            );
-        }
-    }
-    Ok(files)
-}
-
-fn remove_empty_parent_dirs(path: &Path, stop_at: &Path) -> Result<()> {
-    let mut current = path.parent();
-    while let Some(dir) = current {
-        if dir == stop_at || !dir.starts_with(stop_at) {
-            break;
-        }
-        match fs::remove_dir(dir) {
-            Ok(()) => current = dir.parent(),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => current = dir.parent(),
-            Err(err) if err.kind() == std::io::ErrorKind::DirectoryNotEmpty => break,
-            Err(err) => {
-                return Err(err)
-                    .with_context(|| format!("remove empty directory {}", dir.display()));
+    prefix: &Path,
+    out: &mut HashMap<PathBuf, gix::ObjectId>,
+) -> Result<()> {
+    let tree = repo
+        .find_object(tree_id)
+        .context("find tree")?
+        .peel_to_tree()
+        .context("peel tree")?;
+    for entry in tree.iter() {
+        let entry = entry.context("decode tree entry")?;
+        let rel = prefix.join(std::str::from_utf8(entry.filename().as_ref()).unwrap_or_default());
+        match entry.mode().kind() {
+            EntryKind::Tree => flatten_tree(repo, entry.oid().to_owned(), &rel, out)?,
+            EntryKind::Blob | EntryKind::BlobExecutable | EntryKind::Link => {
+                out.insert(rel, entry.oid().to_owned());
             }
+            EntryKind::Commit => {}
         }
     }
     Ok(())
@@ -64,119 +48,85 @@ fn remove_empty_parent_dirs(path: &Path, stop_at: &Path) -> Result<()> {
 
 pub fn rollback_to_commit_blocking(
     repo: &gix::Repository,
-    commit_id: gix::ObjectId,
+    target_commit: gix::ObjectId,
     workdir: &Path,
     parent: Option<gix::ObjectId>,
-    session_ref: &str,
     label: &str,
 ) -> Result<(gix::ObjectId, gix::ObjectId)> {
-    let _ = repo
-        .find_commit(commit_id)
-        .with_context(|| format!("find commit {commit_id}"))?;
-
-    if !is_harnx_history_commit(repo, commit_id) {
-        anyhow::bail!("commit {commit_id} is not a harnx history snapshot");
+    if !is_harnx_history_commit(repo, target_commit) {
+        anyhow::bail!("target commit is not a harnx history snapshot");
     }
 
-    let target_commit = repo
-        .find_object(commit_id)
-        .with_context(|| format!("find target object {commit_id}"))?
+    let before_snap = capture_tree_blocking(repo, workdir, parent, "before rollback")?;
+
+    let target_tree_id = repo
+        .find_object(target_commit)
+        .context("find target commit")?
         .peel_to_commit()
-        .context("peel target commit")?;
-    let target_tree = target_commit.tree().context("read target tree")?;
-    let target_tree_id = target_tree.id().detach();
-    let target_files = flatten_tree(repo, target_tree_id).context("flatten target tree")?;
+        .context("peel target commit")?
+        .tree_id()?
+        .detach();
 
-    let head_id = repo.head_id().context("read HEAD commit for rollback")?;
-    let head_commit = repo
-        .find_object(head_id)
-        .with_context(|| format!("find HEAD object {head_id}"))?
-        .peel_to_commit()
-        .context("peel HEAD commit")?;
-    let head_tree = head_commit.tree().context("read HEAD tree")?;
-    let head_files = flatten_tree(repo, head_tree.id().detach()).context("flatten HEAD tree")?;
+    let mut current_paths = HashMap::new();
+    let mut target_paths = HashMap::new();
 
-    // Before-snapshot: capture current state before any mutations
-    let before_id = capture_tree_blocking(repo, workdir, parent, session_ref, "before rollback")?;
+    if let Ok(head_commit) = repo.head_commit() {
+        flatten_tree(
+            repo,
+            head_commit.tree_id()?.detach(),
+            Path::new(""),
+            &mut current_paths,
+        )?;
+    }
+    flatten_tree(repo, target_tree_id, Path::new(""), &mut target_paths)?;
 
-    let all_paths: BTreeSet<PathBuf> = target_files
+    let all_paths: BTreeSet<PathBuf> = current_paths
         .keys()
-        .chain(head_files.keys())
         .cloned()
+        .chain(target_paths.keys().cloned())
         .collect();
 
-    for relative_path in all_paths {
-        let target_blob = target_files.get(&relative_path);
-        let head_blob = head_files.get(&relative_path);
-        let full_path = workdir.join(&relative_path);
-
-        match (target_blob, head_blob) {
-            (Some(target_blob), Some(head_blob)) if target_blob == head_blob => {}
-            (Some(target_blob), _) => {
+    for rel in all_paths {
+        let abs = workdir.join(&rel);
+        match target_paths.get(&rel) {
+            Some(blob_id) => {
                 let data = repo
-                    .find_object(*target_blob)
-                    .with_context(|| {
-                        format!("find blob {target_blob} for {}", relative_path.display())
-                    })?
+                    .find_object(*blob_id)
+                    .context("find target blob")?
                     .data
-                    .to_owned();
-                if let Some(parent) = full_path.parent() {
-                    fs::create_dir_all(parent).with_context(|| {
-                        format!("create parent directories for {}", full_path.display())
+                    .to_vec();
+                if let Some(parent_dir) = abs.parent() {
+                    fs::create_dir_all(parent_dir).with_context(|| {
+                        format!("create parent directories for {}", abs.display())
                     })?;
                 }
-                fs::write(&full_path, data)
-                    .with_context(|| format!("write rollback file {}", full_path.display()))?;
+                fs::write(&abs, data)
+                    .with_context(|| format!("write restored file {}", abs.display()))?;
             }
-            (None, Some(_)) => {
-                if full_path.exists() {
-                    if full_path.is_dir() {
-                        fs::remove_dir_all(&full_path).with_context(|| {
-                            format!("remove rollback directory {}", full_path.display())
-                        })?;
-                    } else {
-                        fs::remove_file(&full_path).with_context(|| {
-                            format!("remove rollback file {}", full_path.display())
-                        })?;
-                    }
+            None => {
+                if abs.exists() {
+                    fs::remove_file(&abs)
+                        .with_context(|| format!("remove extra file {}", abs.display()))?;
                 }
-                remove_empty_parent_dirs(&full_path, workdir)?;
             }
-            (None, None) => {}
         }
     }
 
-    // After-snapshot: capture state after mutations
-    let short_commit = &commit_id.to_hex().to_string()[..8];
-    let after_label = format!("harnx rollback to {short_commit}: {label}");
-    let after_id =
-        capture_tree_blocking(repo, workdir, Some(before_id), session_ref, &after_label)?;
+    let after_parent = Some(before_snap);
+    let after_snap = capture_tree_blocking(repo, workdir, after_parent, label)?;
 
-    // Advance the current branch ref (or HEAD if detached) to the after-snapshot,
-    // so the rollback commit is visible in `git log` without detaching HEAD.
-    let head = repo.head().context("read HEAD for rollback ref update")?;
-    if let Some(branch) = head.referent_name() {
-        // Attached HEAD — advance the branch ref directly, preserving branch attachment.
-        // Pass branch as &FullNameRef which implements TryInto<FullName>.
-        repo.reference(
-            branch,
-            after_id,
-            gix::refs::transaction::PreviousValue::Any,
-            "harnx rollback",
-        )
-        .context("update branch ref after rollback")?;
-    } else {
-        // Detached HEAD — update HEAD directly (already detached, nothing to break).
-        repo.reference(
-            "HEAD",
-            after_id,
-            gix::refs::transaction::PreviousValue::Any,
-            "harnx rollback",
-        )
-        .context("update HEAD after rollback")?;
+    let status = std::process::Command::new("git")
+        .arg("reset")
+        .arg("--hard")
+        .arg(after_snap.to_hex().to_string())
+        .current_dir(workdir)
+        .status()
+        .context("run git reset --hard")?;
+    if !status.success() {
+        anyhow::bail!("git reset --hard failed");
     }
 
-    Ok((before_id, after_id))
+    Ok((before_snap, after_snap))
 }
 
 #[cfg(test)]
@@ -205,72 +155,89 @@ mod tests {
     }
 
     #[test]
+    fn test_rollback_rejects_non_history_commit() {
+        let temp = tempdir().expect("tempdir");
+        run_git(temp.path(), &["init"]);
+        run_git(temp.path(), &["config", "user.name", "Test User"]);
+        run_git(temp.path(), &["config", "user.email", "test@example.com"]);
+
+        let file = temp.path().join("file.txt");
+        fs::write(&file, "hello\n").expect("write file");
+        run_git(temp.path(), &["add", "."]);
+        run_git(temp.path(), &["commit", "-m", "regular commit"]);
+
+        let commit = output_git(temp.path(), &["rev-parse", "HEAD"])
+            .trim()
+            .to_owned();
+        let repo = gix::open(temp.path()).expect("open repo");
+
+        let err = rollback_to_commit_blocking(
+            &repo,
+            gix::ObjectId::from_hex(commit.as_bytes()).expect("oid"),
+            temp.path(),
+            None,
+            "rollback",
+        )
+        .expect_err("non-history commit should be rejected");
+
+        assert!(
+            err.to_string().contains("not a harnx history snapshot"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
     fn test_rollback_restores_file() {
         let temp = tempdir().expect("tempdir");
         run_git(temp.path(), &["init"]);
         run_git(temp.path(), &["config", "user.name", "Test User"]);
         run_git(temp.path(), &["config", "user.email", "test@example.com"]);
 
-        let file = temp.path().join("note.txt");
+        let file = temp.path().join("file.txt");
         fs::write(&file, "before\n").expect("write before");
         run_git(temp.path(), &["add", "."]);
         run_git(temp.path(), &["commit", "-m", "before"]);
-        let before = output_git(temp.path(), &["rev-parse", "HEAD"])
+        let before_regular = output_git(temp.path(), &["rev-parse", "HEAD"])
             .trim()
             .to_owned();
 
-        run_git(
+        let repo = gix::open(temp.path()).expect("open repo");
+        let before_regular_oid =
+            gix::ObjectId::from_hex(before_regular.as_bytes()).expect("before regular oid");
+        let before_snap_id = capture_tree_blocking(
+            &repo,
             temp.path(),
-            &["update-ref", "refs/harnx-history/test-session", &before],
-        );
+            Some(before_regular_oid),
+            "before snapshot",
+        )
+        .expect("before snapshot");
 
         fs::write(&file, "after\n").expect("write after");
         run_git(temp.path(), &["add", "."]);
         run_git(temp.path(), &["commit", "-m", "after"]);
+        let head_oid = gix::ObjectId::from_hex(
+            output_git(temp.path(), &["rev-parse", "HEAD"])
+                .trim()
+                .as_bytes(),
+        )
+        .expect("head oid");
 
-        let repo = gix::open(temp.path()).expect("open repo");
         let result = rollback_to_commit_blocking(
             &repo,
-            gix::ObjectId::from_hex(before.as_bytes()).expect("before oid"),
+            before_snap_id,
             temp.path(),
-            None,
-            "refs/harnx-history/test-session",
+            Some(head_oid),
             "rollback",
         );
 
-        // Verify rollback succeeded and returned two commit IDs
-        let (before_snap_id, after_snap_id) = result.expect("rollback works");
+        let (before_rollback_id, after_snap_id) = result.expect("rollback works");
 
-        // Verify file content was restored
         let contents = fs::read_to_string(&file).expect("read file");
         assert_eq!(
             contents, "before\n",
             "file should be restored to before state"
         );
 
-        // Verify commit chain
-        let log = output_git(temp.path(), &["log", "--oneline"]);
-        eprintln!("git log:\n{}", log);
-        let log_lines: Vec<_> = log.lines().collect();
-
-        // We expect at least: before, after, before-rollback-snap, after-rollback-snap
-        assert!(
-            log_lines.len() >= 2,
-            "expected at least 2 commits, got {}: {:?}",
-            log_lines.len(),
-            log_lines
-        );
-
-        // The most recent commit should be the after-rollback snapshot
-        assert!(
-            log_lines[0].contains("harnx rollback")
-                || log_lines[0].contains("before rollback")
-                || log_lines[0].contains("after"),
-            "top commit should be rollback-related, got: {:?}",
-            log_lines[0]
-        );
-
-        // HEAD should point to after_snap_id
         let head = output_git(temp.path(), &["rev-parse", "HEAD"])
             .trim()
             .to_owned();
@@ -280,7 +247,6 @@ mod tests {
             "HEAD should be after-snapshot"
         );
 
-        // before_snap_id should be the parent of after_snap_id
         let parent = output_git(
             temp.path(),
             &["rev-parse", &format!("{}^", after_snap_id.to_hex())],
@@ -289,8 +255,20 @@ mod tests {
         .to_owned();
         assert_eq!(
             parent,
-            before_snap_id.to_hex().to_string(),
+            before_rollback_id.to_hex().to_string(),
             "before-snap should be parent of after-snap"
+        );
+
+        let rollback_parent = output_git(
+            temp.path(),
+            &["rev-parse", &format!("{}^", before_rollback_id.to_hex())],
+        )
+        .trim()
+        .to_owned();
+        assert_eq!(
+            rollback_parent,
+            head_oid.to_hex().to_string(),
+            "before rollback snapshot should chain from original head"
         );
     }
 }

--- a/crates/harnx-mcp-history/src/rollback.rs
+++ b/crates/harnx-mcp-history/src/rollback.rs
@@ -144,6 +144,16 @@ mod tests {
         assert!(status.success(), "git {:?} failed", args);
     }
 
+    fn init_git_repo(dir: &std::path::Path) {
+        run_git(dir, &["init"]);
+        run_git(dir, &["config", "user.name", "Test User"]);
+        run_git(dir, &["config", "user.email", "test@example.com"]);
+        // Disable autocrlf so line endings in snapshotted files are preserved
+        // exactly on Windows; without this git rewrites LF→CRLF on checkout
+        // and the restored file content no longer matches what we snapshotted.
+        run_git(dir, &["config", "core.autocrlf", "false"]);
+    }
+
     fn output_git(dir: &std::path::Path, args: &[&str]) -> String {
         let output = Command::new("git")
             .args(args)
@@ -157,9 +167,7 @@ mod tests {
     #[test]
     fn test_rollback_rejects_non_history_commit() {
         let temp = tempdir().expect("tempdir");
-        run_git(temp.path(), &["init"]);
-        run_git(temp.path(), &["config", "user.name", "Test User"]);
-        run_git(temp.path(), &["config", "user.email", "test@example.com"]);
+        init_git_repo(temp.path());
 
         let file = temp.path().join("file.txt");
         fs::write(&file, "hello\n").expect("write file");
@@ -189,9 +197,7 @@ mod tests {
     #[test]
     fn test_rollback_restores_file() {
         let temp = tempdir().expect("tempdir");
-        run_git(temp.path(), &["init"]);
-        run_git(temp.path(), &["config", "user.name", "Test User"]);
-        run_git(temp.path(), &["config", "user.email", "test@example.com"]);
+        init_git_repo(temp.path());
 
         let file = temp.path().join("file.txt");
         fs::write(&file, "before\n").expect("write before");

--- a/crates/harnx-mcp-history/src/rollback.rs
+++ b/crates/harnx-mcp-history/src/rollback.rs
@@ -1,0 +1,296 @@
+use std::collections::{BTreeSet, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use gix::object::tree::EntryKind;
+
+use crate::history::capture_tree_blocking;
+
+fn is_harnx_history_commit(repo: &gix::Repository, commit_id: gix::ObjectId) -> bool {
+    let prefix = "refs/harnx-history/";
+    repo.references()
+        .ok()
+        .and_then(|refs| {
+            refs.prefixed(prefix.as_bytes()).ok().map(|iter| {
+                iter.flatten()
+                    .any(|r| r.target().try_id() == Some(commit_id.as_ref()))
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn flatten_tree(
+    repo: &gix::Repository,
+    tree_id: gix::ObjectId,
+) -> Result<HashMap<PathBuf, gix::ObjectId>> {
+    let tree = repo.find_object(tree_id)?.peel_to_tree()?;
+    let mut recorder = gix::traverse::tree::Recorder::default();
+    tree.traverse().breadthfirst(&mut recorder)?;
+
+    let mut files = HashMap::new();
+    for entry in recorder.records {
+        if matches!(
+            entry.mode.kind(),
+            EntryKind::Blob | EntryKind::BlobExecutable
+        ) {
+            files.insert(
+                PathBuf::from(entry.filepath.to_string()),
+                entry.oid.to_owned(),
+            );
+        }
+    }
+    Ok(files)
+}
+
+fn remove_empty_parent_dirs(path: &Path, stop_at: &Path) -> Result<()> {
+    let mut current = path.parent();
+    while let Some(dir) = current {
+        if dir == stop_at || !dir.starts_with(stop_at) {
+            break;
+        }
+        match fs::remove_dir(dir) {
+            Ok(()) => current = dir.parent(),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => current = dir.parent(),
+            Err(err) if err.kind() == std::io::ErrorKind::DirectoryNotEmpty => break,
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("remove empty directory {}", dir.display()));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn rollback_to_commit_blocking(
+    repo: &gix::Repository,
+    commit_id: gix::ObjectId,
+    workdir: &Path,
+    parent: Option<gix::ObjectId>,
+    session_ref: &str,
+    label: &str,
+) -> Result<(gix::ObjectId, gix::ObjectId)> {
+    let _ = repo
+        .find_commit(commit_id)
+        .with_context(|| format!("find commit {commit_id}"))?;
+
+    if !is_harnx_history_commit(repo, commit_id) {
+        anyhow::bail!("commit {commit_id} is not a harnx history snapshot");
+    }
+
+    let target_commit = repo
+        .find_object(commit_id)
+        .with_context(|| format!("find target object {commit_id}"))?
+        .peel_to_commit()
+        .context("peel target commit")?;
+    let target_tree = target_commit.tree().context("read target tree")?;
+    let target_tree_id = target_tree.id().detach();
+    let target_files = flatten_tree(repo, target_tree_id).context("flatten target tree")?;
+
+    let head_id = repo.head_id().context("read HEAD commit for rollback")?;
+    let head_commit = repo
+        .find_object(head_id)
+        .with_context(|| format!("find HEAD object {head_id}"))?
+        .peel_to_commit()
+        .context("peel HEAD commit")?;
+    let head_tree = head_commit.tree().context("read HEAD tree")?;
+    let head_files = flatten_tree(repo, head_tree.id().detach()).context("flatten HEAD tree")?;
+
+    // Before-snapshot: capture current state before any mutations
+    let before_id = capture_tree_blocking(repo, workdir, parent, session_ref, "before rollback")?;
+
+    let all_paths: BTreeSet<PathBuf> = target_files
+        .keys()
+        .chain(head_files.keys())
+        .cloned()
+        .collect();
+
+    for relative_path in all_paths {
+        let target_blob = target_files.get(&relative_path);
+        let head_blob = head_files.get(&relative_path);
+        let full_path = workdir.join(&relative_path);
+
+        match (target_blob, head_blob) {
+            (Some(target_blob), Some(head_blob)) if target_blob == head_blob => {}
+            (Some(target_blob), _) => {
+                let data = repo
+                    .find_object(*target_blob)
+                    .with_context(|| {
+                        format!("find blob {target_blob} for {}", relative_path.display())
+                    })?
+                    .data
+                    .to_owned();
+                if let Some(parent) = full_path.parent() {
+                    fs::create_dir_all(parent).with_context(|| {
+                        format!("create parent directories for {}", full_path.display())
+                    })?;
+                }
+                fs::write(&full_path, data)
+                    .with_context(|| format!("write rollback file {}", full_path.display()))?;
+            }
+            (None, Some(_)) => {
+                if full_path.exists() {
+                    if full_path.is_dir() {
+                        fs::remove_dir_all(&full_path).with_context(|| {
+                            format!("remove rollback directory {}", full_path.display())
+                        })?;
+                    } else {
+                        fs::remove_file(&full_path).with_context(|| {
+                            format!("remove rollback file {}", full_path.display())
+                        })?;
+                    }
+                }
+                remove_empty_parent_dirs(&full_path, workdir)?;
+            }
+            (None, None) => {}
+        }
+    }
+
+    // After-snapshot: capture state after mutations
+    let short_commit = &commit_id.to_hex().to_string()[..8];
+    let after_label = format!("harnx rollback to {short_commit}: {label}");
+    let after_id =
+        capture_tree_blocking(repo, workdir, Some(before_id), session_ref, &after_label)?;
+
+    // Advance the current branch ref (or HEAD if detached) to the after-snapshot,
+    // so the rollback commit is visible in `git log` without detaching HEAD.
+    let head = repo.head().context("read HEAD for rollback ref update")?;
+    if let Some(branch) = head.referent_name() {
+        // Attached HEAD — advance the branch ref directly, preserving branch attachment.
+        // Pass branch as &FullNameRef which implements TryInto<FullName>.
+        repo.reference(
+            branch,
+            after_id,
+            gix::refs::transaction::PreviousValue::Any,
+            "harnx rollback",
+        )
+        .context("update branch ref after rollback")?;
+    } else {
+        // Detached HEAD — update HEAD directly (already detached, nothing to break).
+        repo.reference(
+            "HEAD",
+            after_id,
+            gix::refs::transaction::PreviousValue::Any,
+            "harnx rollback",
+        )
+        .context("update HEAD after rollback")?;
+    }
+
+    Ok((before_id, after_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+    use tempfile::tempdir;
+
+    fn run_git(dir: &std::path::Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .expect("git command runs");
+        assert!(status.success(), "git {:?} failed", args);
+    }
+
+    fn output_git(dir: &std::path::Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git output command runs");
+        assert!(output.status.success(), "git {:?} failed", args);
+        String::from_utf8(output.stdout).expect("utf8 git output")
+    }
+
+    #[test]
+    fn test_rollback_restores_file() {
+        let temp = tempdir().expect("tempdir");
+        run_git(temp.path(), &["init"]);
+        run_git(temp.path(), &["config", "user.name", "Test User"]);
+        run_git(temp.path(), &["config", "user.email", "test@example.com"]);
+
+        let file = temp.path().join("note.txt");
+        fs::write(&file, "before\n").expect("write before");
+        run_git(temp.path(), &["add", "."]);
+        run_git(temp.path(), &["commit", "-m", "before"]);
+        let before = output_git(temp.path(), &["rev-parse", "HEAD"])
+            .trim()
+            .to_owned();
+
+        run_git(
+            temp.path(),
+            &["update-ref", "refs/harnx-history/test-session", &before],
+        );
+
+        fs::write(&file, "after\n").expect("write after");
+        run_git(temp.path(), &["add", "."]);
+        run_git(temp.path(), &["commit", "-m", "after"]);
+
+        let repo = gix::open(temp.path()).expect("open repo");
+        let result = rollback_to_commit_blocking(
+            &repo,
+            gix::ObjectId::from_hex(before.as_bytes()).expect("before oid"),
+            temp.path(),
+            None,
+            "refs/harnx-history/test-session",
+            "rollback",
+        );
+
+        // Verify rollback succeeded and returned two commit IDs
+        let (before_snap_id, after_snap_id) = result.expect("rollback works");
+
+        // Verify file content was restored
+        let contents = fs::read_to_string(&file).expect("read file");
+        assert_eq!(
+            contents, "before\n",
+            "file should be restored to before state"
+        );
+
+        // Verify commit chain
+        let log = output_git(temp.path(), &["log", "--oneline"]);
+        eprintln!("git log:\n{}", log);
+        let log_lines: Vec<_> = log.lines().collect();
+
+        // We expect at least: before, after, before-rollback-snap, after-rollback-snap
+        assert!(
+            log_lines.len() >= 2,
+            "expected at least 2 commits, got {}: {:?}",
+            log_lines.len(),
+            log_lines
+        );
+
+        // The most recent commit should be the after-rollback snapshot
+        assert!(
+            log_lines[0].contains("harnx rollback")
+                || log_lines[0].contains("before rollback")
+                || log_lines[0].contains("after"),
+            "top commit should be rollback-related, got: {:?}",
+            log_lines[0]
+        );
+
+        // HEAD should point to after_snap_id
+        let head = output_git(temp.path(), &["rev-parse", "HEAD"])
+            .trim()
+            .to_owned();
+        assert_eq!(
+            head,
+            after_snap_id.to_hex().to_string(),
+            "HEAD should be after-snapshot"
+        );
+
+        // before_snap_id should be the parent of after_snap_id
+        let parent = output_git(
+            temp.path(),
+            &["rev-parse", &format!("{}^", after_snap_id.to_hex())],
+        )
+        .trim()
+        .to_owned();
+        assert_eq!(
+            parent,
+            before_snap_id.to_hex().to_string(),
+            "before-snap should be parent of after-snap"
+        );
+    }
+}

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -55,6 +55,13 @@ Harnx can load environment variables from a `.env` file located in the configura
 - **<AGENT_NAME>_CONFIG_FILE**: The configuration file for a specific agent.
 - **Agent config env vars**: Environment variables for agent configuration.
 
+## Local History Envs
+
+- **HARNX_LOCAL_HISTORY_DIR**: Fallback storage location for history snapshots (currently reserved). Default: `$HARNX_CONFIG_DIR/harnx/history`
+- **HARNX_HISTORY_MAX_FILES**: Maximum number of files allowed in a single snapshot. Default: `10000`
+- **HARNX_HISTORY_MAX_FILE_BYTES**: Maximum size in bytes for an individual file in a snapshot. Default: `10485760` (10 MiB)
+- **HARNX_HISTORY_MAX_TOTAL_BYTES**: Maximum total size in bytes for all files in a single snapshot. Default: `104857600` (100 MiB)
+
 ## Logging Envs
 
 - **HARNX_LOG_LEVEL**: The log level (e.g., `debug`, `info`).

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -57,7 +57,6 @@ Harnx can load environment variables from a `.env` file located in the configura
 
 ## Local History Envs
 
-- **HARNX_LOCAL_HISTORY_DIR**: Fallback storage location for history snapshots (currently reserved). Default: `$HARNX_CONFIG_DIR/harnx/history`
 - **HARNX_HISTORY_MAX_FILES**: Maximum number of files allowed in a single snapshot. Default: `10000`
 - **HARNX_HISTORY_MAX_FILE_BYTES**: Maximum size in bytes for an individual file in a snapshot. Default: `10485760` (10 MiB)
 - **HARNX_HISTORY_MAX_TOTAL_BYTES**: Maximum total size in bytes for all files in a single snapshot. Default: `104857600` (100 MiB)

--- a/docs/local-history-guide.md
+++ b/docs/local-history-guide.md
@@ -1,46 +1,48 @@
 # Local History and Rollback
 
-harnx provides an automatic, transparent local history system for all file-modifying operations. Whenever an agent modifies a file or runs a command that changes the filesystem, harnx captures a snapshot of the repository state. This allows for safe, non-destructive rollbacks if an agent makes a mistake or produces unintended side effects.
+harnx provides automatic, transparent local history for file-modifying operations. Whenever agent modifies file or runs command that changes filesystem, harnx captures snapshot of repository state. This allows safe, non-destructive rollbacks if agent makes mistake or produces unintended side effects.
 
 ## Overview
 
-The local history feature automatically snapshots your files before and after every mutating tool call. This provides a "safety net" for AI agents, allowing them to undo their own changes without manual intervention.
+Local history feature automatically snapshots files before and after every mutating tool call. This provides safety net for AI agents, allowing them to undo their own changes without manual intervention.
 
 Key characteristics:
 - **Zero-config**: Automatically activates when MCP roots include git repositories.
-- **Transparent**: Snapshots are stored as standard git commits in a dedicated namespace (`refs/harnx-history/`), coexisting with your normal git workflow.
-- **Safe Rollback**: The `rollback_file` tool can restore a repository to any prior snapshot using forward commits, ensuring no history is ever lost.
+- **Transparent**: Snapshots are stored as standard git commit objects with no dedicated refs. Diff responses identify snapshot using `commit <sha>` line at top.
+- **Safe Rollback**: `rollback_file` tool can restore repository to any prior snapshot using forward commits, ensuring no history is ever lost.
 
 ## How Snapshots Work
 
-Snapshots are triggered by mutating MCP tools. Depending on the tool, harnx captures the repository state at different points:
+Snapshots are triggered by mutating MCP tools. Depending on tool, harnx captures repository state at different points:
 
 | Tool | Server | Snapshot Timing |
 |------|--------|-----------------|
 | `write_file` | File System | Before and After |
 | `edit_file` | File System | Before and After |
-| `exec` | Bash | Before and After the command execution |
-| `spawn` | Bash | Before the process starts |
-| `wait` | Bash | After the process completes |
+| `exec` | Bash | Before and After command execution |
+| `spawn` | Bash | Before process starts |
+| `wait` | Bash | After process completes |
 
-### Snapshot Metadata
-- **Storage**: Each snapshot is a git commit stored under `refs/harnx-history/<session-uuid>`.
-- **Session Scoping**: A fresh UUID is generated every time harnx starts. Restarting harnx begins a new history chain.
-- **Identity**: Commits use the fixed author/committer: `harnx-history <harnx-history@localhost>`.
-- **Visibility**: Tool responses include a `harnx-snapshot: <sha>` line identifying the state *after* the operation.
-- **Diffs**: Responses include a unified diff of the changes (truncated at 50 KB with a `[diff truncated]` notice).
+Each snapshot is written as anonymous git commit object in repository object store. No ref is updated. When tool returns diff, first lines use `git show`-style header:
+
+```text
+commit <sha>
+    <snapshot label>
+```
+
+Use SHA from that `commit <sha>` line as rollback target.
 
 ## The `rollback_file` Tool
 
-Available on both the File System and Bash MCP servers, `rollback_file` restores a repository to a prior state.
+`rollback_file` restores repository to prior harnx history snapshot by creating new reversible commit. Pass `commit_id` from `commit <sha>` line at top of prior tool response diff.
 
-- **Inputs**: 
-  - `commit_id`: The 40-character hex SHA from a prior `harnx-snapshot:` line.
-  - `repo_path`: Any path within the target repository (used to identify which repo to roll back).
-- **Repo-wide Scope**: Despite the name, `rollback_file` restores the **entire repository** to the state captured in the snapshot.
-- **Non-destructive**: Rollback is implemented as a forward commit. It captures a "before rollback" snapshot, applies the target state, and captures an "after rollback" snapshot. You can undo a rollback by rolling back to the "before" SHA.
-- **Validation**: Only commits within the `refs/harnx-history/*` namespace are valid targets.
-- **Branch Preservation**: The tool advances the current branch (or `HEAD` if detached). You will not end up in a detached HEAD state if you were on a branch.
+Rollback process:
+1. Capture `before rollback` snapshot of current working tree.
+2. Restore files from target harnx snapshot tree.
+3. Capture new rollback snapshot chained from step 1.
+4. Hard reset working tree to new rollback snapshot commit.
+
+Result: rollback itself is reversible because current state is preserved in `before rollback` snapshot.
 
 ## What Gets Snapshotted
 
@@ -51,20 +53,19 @@ harnx uses `git ls-files --cached --others --exclude-standard` to determine whic
 - **Submodules**: Handled according to standard `git ls-files` behavior.
 
 ### Critical Caveats
-- **Loss of Metadata**: File mode bits (executable bits) and symlinks are **NOT preserved**. All entries are written as plain blobs. 
-- **Symlinks to Regular Files**: When restored, symlinks become regular files containing the link path.
-- **Executable Bits**: Restored files lose their executable permission. You must manually `chmod +x` or restore these attributes if they are required.
+- **Loss of Metadata**: File mode bits (executable bits) and symlinks are **NOT preserved**. All entries are written as plain blobs.
+- **Symlinks to Regular Files**: When restored, symlinks become regular files containing link path.
+- **Executable Bits**: Restored files lose executable permission. Manually `chmod +x` or restore attributes if required.
 
 ## What Does NOT Get Snapshotted
 
-- **Non-repo paths**: Files outside of a discovered git repository are silently skipped. Files in `/tmp` or home directories are only protected if they are inside a git repo.
+- **Non-repo paths**: Files outside discovered git repository are silently skipped. Files in `/tmp` or home directories are only protected if inside git repo.
 - **Ignored files**: Anything matched by `.gitignore` is excluded by design.
-- **The `.git` directory**: The repository metadata itself is never snapshotted.
-- **History Cache**: The `history_dir()` (where fallback history is stored) is explicitly excluded.
+- **`.git` directory**: Repository metadata itself is never snapshotted.
 
 ## Limits and Safety Guards
 
-To ensure performance and prevent disk exhaustion, harnx enforces several safety guards. If a limit is exceeded, a warning is logged to stderr, but the primary tool call (e.g., `write_file`) will still succeed.
+To ensure performance and prevent disk exhaustion, harnx enforces several safety guards. If limit is exceeded, warning is logged to stderr, but primary tool call still succeeds.
 
 | Limit | Default | Override | Behavior when exceeded |
 |-------|---------|----------|------------------------|
@@ -75,45 +76,44 @@ To ensure performance and prevent disk exhaustion, harnx enforces several safety
 
 ## Storage Location
 
-Snapshots are stored directly within the repository's `.git/` directory. They use the standard git object store and are pinned by references in `refs/harnx-history/`, ensuring they survive `git gc`.
+Snapshots are stored directly within repository `.git/` directory. They are loose commit objects in standard git object store with no dedicated refs.
 
-**Fallback Location**: harnx defines a fallback path (`HARNX_LOCAL_HISTORY_DIR`), typically `$HARNX_CONFIG_DIR/harnx/history`. While this is reserved for future use, it is currently **inactive** for snapshotting; paths outside a git repo are simply skipped today.
+Unreferenced snapshot commits are cleaned up by normal `git gc` pruning rules. Default `gc.pruneExpire` is typically 2 weeks, so old unreachable history expires naturally. harnx also periodically fires `git gc --auto --quiet` after snapshots to let git maintain object store in background.
 
 ## Caveats and Gotchas
 
 - **Metadata Loss**: As noted, symlinks and executable bits are lost. This can break `node_modules/.bin/` or shell scripts.
-- **Per-Process History**: Restarting harnx starts a new session. Old session refs remain in the repo but are no longer extended.
-- **Repo-wide Rollback**: Rollback affects the whole repo, not just a single file.
-- **Overwriting Changes**: `rollback_file` will overwrite uncommitted manual changes in the working tree. These changes are captured in the "before rollback" snapshot and are recoverable from `refs/harnx-history/`.
+- **Repo-wide Rollback**: Rollback affects whole repo, not single file.
+- **Overwriting Changes**: `rollback_file` overwrites uncommitted manual changes in working tree. These changes are captured in `before rollback` snapshot and are recoverable as long as commit remains in object store.
 - **Performance**: Large repositories (thousands of files) may experience latency during mutating operations as snapshots are captured.
-- **Git Dependency**: Requires `git` on the `$PATH`. If missing, history is silently disabled.
-- **Mid-session Repos**: Repo discovery occurs at startup. If you `git init` a new repo while harnx is running, it will not be snapshotted until harnx restarts.
+- **Git Dependency**: Requires `git` on `$PATH`. If missing, history is silently disabled.
+- **Mid-session Repos**: Repo discovery occurs at startup. If you `git init` new repo while harnx is running, it will not be snapshotted until harnx restarts.
 
 ## Inspecting and Managing History
 
-You can manage harnx history using standard git commands:
+You can inspect harnx history using standard git commands:
 
 ```sh
-# List all harnx history sessions in a repo
-git for-each-ref refs/harnx-history/
+# List harnx-authored commits reachable from refs
+git log --all --author=harnx-history@localhost --oneline
 
-# Walk one session's snapshot chain
-git log refs/harnx-history/<session-uuid>
+# Show commit details for one snapshot
+git show <snapshot-sha>
 
 # Show what changed between two snapshots
 git diff <before-sha> <after-sha>
 
-# Manually inspect a snapshot's tree
+# Search snapshots by author and message
+git log --all --author=harnx-history@localhost --decorate --stat
+
+# Manually inspect snapshot tree
 git ls-tree -r <snapshot-sha>
 
-# Delete all harnx history refs
-git for-each-ref refs/harnx-history/ --format='%(refname)' | xargs -r -n1 git update-ref -d
-
-# Clean up unreachable objects after deleting refs
-git gc --prune=now
+# Let git prune unreachable old snapshots using normal policy
+git gc --auto
 ```
 
 ## Privacy Considerations
 
-- **Secret Exposure**: Diffs are sent to the AI assistant in tool responses. If you write a file containing credentials, the secret will be visible in the assistant's context.
-- **Local Storage**: Full file contents are committed to the local `.git/objects/` store. This data never leaves your machine unless you manually push the history refs.
+- **Secret Exposure**: Diffs are sent to AI assistant in tool responses. If you write file containing credentials, secret will be visible in assistant context.
+- **Local Storage**: Full file contents are committed to local `.git/objects/` store. Data never leaves machine unless you manually expose repository objects.

--- a/docs/local-history-guide.md
+++ b/docs/local-history-guide.md
@@ -1,0 +1,119 @@
+# Local History and Rollback
+
+harnx provides an automatic, transparent local history system for all file-modifying operations. Whenever an agent modifies a file or runs a command that changes the filesystem, harnx captures a snapshot of the repository state. This allows for safe, non-destructive rollbacks if an agent makes a mistake or produces unintended side effects.
+
+## Overview
+
+The local history feature automatically snapshots your files before and after every mutating tool call. This provides a "safety net" for AI agents, allowing them to undo their own changes without manual intervention.
+
+Key characteristics:
+- **Zero-config**: Automatically activates when MCP roots include git repositories.
+- **Transparent**: Snapshots are stored as standard git commits in a dedicated namespace (`refs/harnx-history/`), coexisting with your normal git workflow.
+- **Safe Rollback**: The `rollback_file` tool can restore a repository to any prior snapshot using forward commits, ensuring no history is ever lost.
+
+## How Snapshots Work
+
+Snapshots are triggered by mutating MCP tools. Depending on the tool, harnx captures the repository state at different points:
+
+| Tool | Server | Snapshot Timing |
+|------|--------|-----------------|
+| `write_file` | File System | Before and After |
+| `edit_file` | File System | Before and After |
+| `exec` | Bash | Before and After the command execution |
+| `spawn` | Bash | Before the process starts |
+| `wait` | Bash | After the process completes |
+
+### Snapshot Metadata
+- **Storage**: Each snapshot is a git commit stored under `refs/harnx-history/<session-uuid>`.
+- **Session Scoping**: A fresh UUID is generated every time harnx starts. Restarting harnx begins a new history chain.
+- **Identity**: Commits use the fixed author/committer: `harnx-history <harnx-history@localhost>`.
+- **Visibility**: Tool responses include a `harnx-snapshot: <sha>` line identifying the state *after* the operation.
+- **Diffs**: Responses include a unified diff of the changes (truncated at 50 KB with a `[diff truncated]` notice).
+
+## The `rollback_file` Tool
+
+Available on both the File System and Bash MCP servers, `rollback_file` restores a repository to a prior state.
+
+- **Inputs**: 
+  - `commit_id`: The 40-character hex SHA from a prior `harnx-snapshot:` line.
+  - `repo_path`: Any path within the target repository (used to identify which repo to roll back).
+- **Repo-wide Scope**: Despite the name, `rollback_file` restores the **entire repository** to the state captured in the snapshot.
+- **Non-destructive**: Rollback is implemented as a forward commit. It captures a "before rollback" snapshot, applies the target state, and captures an "after rollback" snapshot. You can undo a rollback by rolling back to the "before" SHA.
+- **Validation**: Only commits within the `refs/harnx-history/*` namespace are valid targets.
+- **Branch Preservation**: The tool advances the current branch (or `HEAD` if detached). You will not end up in a detached HEAD state if you were on a branch.
+
+## What Gets Snapshotted
+
+harnx uses `git ls-files --cached --others --exclude-standard` to determine which files to include.
+
+- **Included**: All tracked files and untracked-but-not-ignored files.
+- **Exclusions**: Respects `.gitignore`, `.git/info/exclude`, and system-level excludes.
+- **Submodules**: Handled according to standard `git ls-files` behavior.
+
+### Critical Caveats
+- **Loss of Metadata**: File mode bits (executable bits) and symlinks are **NOT preserved**. All entries are written as plain blobs. 
+- **Symlinks to Regular Files**: When restored, symlinks become regular files containing the link path.
+- **Executable Bits**: Restored files lose their executable permission. You must manually `chmod +x` or restore these attributes if they are required.
+
+## What Does NOT Get Snapshotted
+
+- **Non-repo paths**: Files outside of a discovered git repository are silently skipped. Files in `/tmp` or home directories are only protected if they are inside a git repo.
+- **Ignored files**: Anything matched by `.gitignore` is excluded by design.
+- **The `.git` directory**: The repository metadata itself is never snapshotted.
+- **History Cache**: The `history_dir()` (where fallback history is stored) is explicitly excluded.
+
+## Limits and Safety Guards
+
+To ensure performance and prevent disk exhaustion, harnx enforces several safety guards. If a limit is exceeded, a warning is logged to stderr, but the primary tool call (e.g., `write_file`) will still succeed.
+
+| Limit | Default | Override | Behavior when exceeded |
+|-------|---------|----------|------------------------|
+| File count per snapshot | 10,000 | `HARNX_HISTORY_MAX_FILES` | Snapshot skipped; warning logged. |
+| Per-file size | 10 MiB | `HARNX_HISTORY_MAX_FILE_BYTES` | Oversized file skipped; snapshot continues. |
+| Total bytes per snapshot | 100 MiB | `HARNX_HISTORY_MAX_TOTAL_BYTES` | Snapshot truncated at cutoff; partial tree committed. |
+| Diff size in response | 50,000 bytes | (Fixed) | `[diff truncated]` notice appended. |
+
+## Storage Location
+
+Snapshots are stored directly within the repository's `.git/` directory. They use the standard git object store and are pinned by references in `refs/harnx-history/`, ensuring they survive `git gc`.
+
+**Fallback Location**: harnx defines a fallback path (`HARNX_LOCAL_HISTORY_DIR`), typically `$HARNX_CONFIG_DIR/harnx/history`. While this is reserved for future use, it is currently **inactive** for snapshotting; paths outside a git repo are simply skipped today.
+
+## Caveats and Gotchas
+
+- **Metadata Loss**: As noted, symlinks and executable bits are lost. This can break `node_modules/.bin/` or shell scripts.
+- **Per-Process History**: Restarting harnx starts a new session. Old session refs remain in the repo but are no longer extended.
+- **Repo-wide Rollback**: Rollback affects the whole repo, not just a single file.
+- **Overwriting Changes**: `rollback_file` will overwrite uncommitted manual changes in the working tree. These changes are captured in the "before rollback" snapshot and are recoverable from `refs/harnx-history/`.
+- **Performance**: Large repositories (thousands of files) may experience latency during mutating operations as snapshots are captured.
+- **Git Dependency**: Requires `git` on the `$PATH`. If missing, history is silently disabled.
+- **Mid-session Repos**: Repo discovery occurs at startup. If you `git init` a new repo while harnx is running, it will not be snapshotted until harnx restarts.
+
+## Inspecting and Managing History
+
+You can manage harnx history using standard git commands:
+
+```sh
+# List all harnx history sessions in a repo
+git for-each-ref refs/harnx-history/
+
+# Walk one session's snapshot chain
+git log refs/harnx-history/<session-uuid>
+
+# Show what changed between two snapshots
+git diff <before-sha> <after-sha>
+
+# Manually inspect a snapshot's tree
+git ls-tree -r <snapshot-sha>
+
+# Delete all harnx history refs
+git for-each-ref refs/harnx-history/ --format='%(refname)' | xargs -r -n1 git update-ref -d
+
+# Clean up unreachable objects after deleting refs
+git gc --prune=now
+```
+
+## Privacy Considerations
+
+- **Secret Exposure**: Diffs are sent to the AI assistant in tool responses. If you write a file containing credentials, the secret will be visible in the assistant's context.
+- **Local Storage**: Full file contents are committed to the local `.git/objects/` store. This data never leaves your machine unless you manually push the history refs.

--- a/docs/solutions/logic-errors/git-backed-local-history-rollback-2026-04-26.md
+++ b/docs/solutions/logic-errors/git-backed-local-history-rollback-2026-04-26.md
@@ -1,0 +1,223 @@
+---
+title: "Git-backed local history and non-destructive rollback for MCP servers"
+date: 2026-04-26
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-mcp-history"
+root_cause: "design constraint — async server with non-Sync git library needed thread-safe patterns"
+resolution_type: code_fix
+severity: medium
+tags:
+  - gix
+  - async
+  - git
+  - rollback
+  - thread-safety
+  - spawn_blocking
+plan_ref: "harnx-318-local-history"
+---
+
+## Problem
+
+MCP servers (fs, bash) needed git-backed local history with rollback capability, but gix's `Repository` is `!Sync`, making it unusable directly in async contexts. Rollback via `git checkout` is destructive. Needed non-destructive, fully reversible rollback with atomicity guarantees.
+
+## Symptoms
+
+- `gix::Repository` cannot be held across await points in async functions
+- `git checkout <sha> -- <path>` destructively overwrites working tree, cannot itself be undone
+- Naive `repo.reference("HEAD", oid, ...)` on an attached-HEAD repo detaches HEAD
+- `git ls-files` output with `.lines()` fails on filenames containing newlines
+
+## Investigation Steps
+
+Started with gix 0.82.0 for pure-Rust git operations. Needed to store repository handles in async server state. `gix::Repository` is `!Sync` (not thread-safe). Initial rollback design used `git checkout` — rejected as destructive.
+
+Explored forward-undo approach: apply target tree state via fs I/O, then commit the result. Required careful handling of HEAD ref updates to avoid detaching attached branches.
+
+File collection with `git ls-files` needed NUL-delimited output to handle edge-case filenames.
+
+Session ref namespace `refs/harnx-history/<uuid>` chosen for:
+1. Survives `git gc` (real refs, not dangling objects)
+2. Scoped per session (multiple sessions don't collide)
+3. Provenance validation via prefix scan in `is_harnx_history_commit`
+
+## Root Cause
+
+**gix `!Sync` constraint:** `gix::Repository` contains non-thread-safe internal state. Cannot be stored in structs shared across threads (e.g., inside `Arc<Mutex<...>>` used by async servers).
+
+**Destructive rollback:** `git checkout` mutates working tree without creating a commit. Cannot be undone by git.
+
+**HEAD detach trap:** `repo.reference("HEAD", oid, ...)` creates a direct ref to the OID, detaching HEAD from its branch. Must advance the branch ref directly instead.
+
+**NUL-split requirement:** `.lines()` splits on `\n`, but filenames can contain newlines. `git ls-files -z` uses NUL (`\0`) as delimiter.
+
+## Solution
+
+### 1. ThreadSafeRepository + spawn_blocking Pattern
+
+Store `gix::ThreadSafeRepository` (created via `repo.into_sync()`), then convert to thread-local inside `spawn_blocking`:
+
+```rust
+struct RepoSession {
+    repo: gix::ThreadSafeRepository,
+    last_commit_id: Option<gix::ObjectId>,
+    session_ref: String,
+}
+
+impl HistoryManager {
+    pub async fn snapshot(&self, paths: &[PathBuf], label: &str) -> Result<gix::ObjectId> {
+        let (repo_workdir, ts_repo, parent, session_ref) = {
+            let repos = self.inner.repos.lock().await;
+            // ... extract from mutex ...
+        };
+
+        let commit_id = tokio::task::spawn_blocking(move || {
+            let repo = ts_repo.to_thread_local();  // Thread-local borrow
+            capture_tree_blocking(&repo, &repo_workdir, parent, &session_ref, &label)
+        })
+        .await
+        .context("snapshot task join failed")??;
+
+        Ok(commit_id)
+    }
+}
+```
+
+All gix I/O happens inside `spawn_blocking`, outside async context.
+
+### 2. Before/After Snapshot Pattern for Atomicity
+
+Every mutating operation follows: before-snapshot → operation → after-snapshot
+
+```rust
+// In rollback_to_commit_blocking
+let before_id = capture_tree_blocking(repo, workdir, parent, session_ref, "before rollback")?;
+
+// ... apply file mutations via fs I/O ...
+
+let after_id = capture_tree_blocking(repo, workdir, Some(before_id), session_ref, &after_label)?;
+```
+
+If operation fails midway, before-snapshot already captured all files in git. Nothing lost.
+
+### 3. Forward-Undo Rollback (No git checkout)
+
+Rollback applies target tree state via fs operations, then commits:
+
+1. Flatten both target tree and HEAD tree to path→blob_id maps
+2. For each path in union: write/delete file to match target state
+3. After-snapshot creates new commit on HEAD
+4. Advance branch ref (or HEAD if detached) to after-snapshot
+
+```rust
+let target_files = flatten_tree(repo, target_tree_id)?;
+let head_files = flatten_tree(repo, head_tree.id().detach())?;
+
+for relative_path in all_paths {
+    match (target_files.get(&relative_path), head_files.get(&relative_path)) {
+        (Some(target_blob), _) => {
+            let data = repo.find_object(*target_blob)?.data.to_owned();
+            fs::write(&full_path, data)?;
+        }
+        (None, Some(_)) => {
+            fs::remove_file(&full_path)?;
+        }
+        _ => {}
+    }
+}
+```
+
+Result: working tree at target state, but as a new commit that can be reverted.
+
+### 4. HEAD Ref Update Without Detaching
+
+Check `head.referent_name()` to distinguish attached vs detached HEAD:
+
+```rust
+let head = repo.head().context("read HEAD for rollback ref update")?;
+if let Some(branch) = head.referent_name() {
+    // Attached HEAD — advance the branch ref directly
+    // Pass branch as &FullNameRef (not String)
+    repo.reference(
+        branch,  // &FullNameRef
+        after_id,
+        gix::refs::transaction::PreviousValue::Any,
+        "harnx rollback",
+    )?;
+} else {
+    // Detached HEAD — update HEAD directly
+    repo.reference("HEAD", after_id, gix::refs::transaction::PreviousValue::Any, "harnx rollback")?;
+}
+```
+
+### 5. NUL-Delimited git ls-files
+
+```rust
+let output = std::process::Command::new("git")
+    .args(["-z", "ls-files", "--cached", "--others", "--exclude-standard"])
+    .current_dir(root)
+    .output()?;
+
+let files: Vec<PathBuf> = output
+    .stdout
+    .split(|&b| b == 0)  // NUL-delimited, not .lines()
+    .filter(|s| !s.is_empty())
+    .filter_map(|s| std::str::from_utf8(s).ok())
+    .map(|line| root.join(line))
+    .filter(|p| p.is_file())
+    .collect();
+```
+
+### 6. Session Refs in refs/harnx-history/<uuid>
+
+```rust
+let session_id = Uuid::new_v4().to_string();
+let session_ref = format!("refs/harnx-history/{session_id}");
+```
+
+Provenance validation only scans this prefix:
+
+```rust
+fn is_harnx_history_commit(repo: &gix::Repository, commit_id: gix::ObjectId) -> bool {
+    let prefix = "refs/harnx-history/";
+    repo.references()
+        .ok()
+        .and_then(|refs| {
+            refs.prefixed(prefix.as_bytes()).ok().map(|iter| {
+                iter.flatten().any(|r| r.target().try_id() == Some(commit_id.as_ref()))
+            })
+        })
+        .unwrap_or(false)
+}
+```
+
+## Why This Works
+
+- **ThreadSafeRepository** wraps repository in thread-safe container. `to_thread_local()` creates thread-local borrow valid within `spawn_blocking` scope. No `!Sync` violations.
+- **Before/after snapshots** ensure atomicity: if operation fails, pre-op state preserved in git history. After-snapshot captures post-op state for diff/rollback.
+- **Forward-undo rollback** creates new commits rather than mutating working tree. Fully reversible via `git revert`.
+- **Branch ref advancement** preserves HEAD attachment. `referent_name()` returns branch name as `FullNameRef` which gix accepts directly.
+- **NUL-delimited output** handles all valid filenames including those with newlines.
+- **Session ref namespace** provides scoped, garbage-collected refs with efficient prefix-based provenance checks.
+
+## Prevention Strategies
+
+**Code Review Checklist:**
+- [ ] All gix operations inside `spawn_blocking`?
+- [ ] ThreadSafeRepository stored, Repository only borrowed thread-local?
+- [ ] mutating operations use before/after snapshot pattern?
+- [ ] HEAD ref updates check `referent_name()` before calling `reference()`?
+- [ ] File Listing uses NUL-delimited parsing?
+- [ ] Session refs under `refs/harnx-history/` prefix?
+
+**Test Cases:**
+- Rollback with attached HEAD preserves branch attachment
+- Rollback with detached HEAD remains detached
+- Before-snapshot preserved even if rollback fails mid-operation
+- Filenames with newlines handled correctly
+- `is_harnx_history_commit` only matches commits in harnx-history refs
+
+## Related Issues
+
+- **PR:** [#318](https://github.com/example/harnx/pull/318) — feat(mcp): add git-backed local history and rollback
+- **Crate:** `harnx-mcp-history` — new crate providing HistoryManager, snapshot, diff, and rollback functionality


### PR DESCRIPTION
Add a new harnx-mcp-history crate that provides git-backed local history and non-destructive rollback for harnx-mcp-fs and harnx-mcp-bash.

Before and after each mutating tool call (write_file, edit_file, exec, spawn/wait), the affected git repositories are snapshotted into a commit. A unified diff is included in the tool response, along with a harnx-snapshot: <sha> line the assistant can use to trigger rollback.

Closes #318


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic git-backed snapshots captured before/after filesystem and shell mutations
  * New rollback_file tool to revert files to a chosen snapshot; rollbacks create reversible commits
  * Tool responses include snapshot commit IDs and unified diffs (large diffs truncated)

* **Documentation**
  * New local history guide describing snapshot/rollback behavior, included-file rules, caveats, and privacy notes
  * Docs for environment variables to configure snapshot file/count/size limits and storage behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->