### PR TITLE
Restore session transcript on TUI load and command execution

### DIFF
--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1221,7 +1221,40 @@ impl Tui {
         vec![]
     }
 
+    fn reconcile_transcript_after_command(
+        &mut self,
+        prev_session: Option<String>,
+        prev_agent: Option<String>,
+        command_was: &str,
+    ) {
+        let (curr_session, curr_agent) = {
+            let cfg = self.config.read();
+            let s = cfg.session.as_ref().map(|s| s.name().to_string());
+            let a = cfg.agent.as_ref().map(|a| a.name().to_string());
+            (s, a)
+        };
+
+        let needs_reconcile = curr_session != prev_session
+            || curr_agent != prev_agent
+            || command_was.starts_with(".empty session")
+            || command_was.starts_with(".reset session")
+            || command_was.starts_with(".reset repl")
+            || command_was.starts_with(".compact session")
+            || command_was.starts_with(".edit session");
+
+        if !needs_reconcile {
+            return;
+        }
+
+        self.app.transcript.clear();
+        self.app.streaming_assistant_idx = None;
+        self.app.transcript = Self::build_initial_transcript(&self.config);
+        self.pin_transcript_to_bottom();
+    }
+
     pub(super) async fn run_command(&mut self, line: &str) -> Result<()> {
+        let prev_session = self.config.read().session.as_ref().map(|s| s.name().to_string());
+        let prev_agent = self.config.read().agent.as_ref().map(|a| a.name().to_string());
         // Run the command inside a block that owns the lock guards so they are
         // dropped before we touch `self` again for transcript / UI updates.
         let (result, captured) = {
@@ -1266,6 +1299,7 @@ impl Tui {
                     llm_busy,
                     pending_message,
                 );
+                self.reconcile_transcript_after_command(prev_session, prev_agent, line);
             }
             Err(err) => {
                 self.app

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1253,8 +1253,18 @@ impl Tui {
     }
 
     pub(super) async fn run_command(&mut self, line: &str) -> Result<()> {
-        let prev_session = self.config.read().session.as_ref().map(|s| s.name().to_string());
-        let prev_agent = self.config.read().agent.as_ref().map(|a| a.name().to_string());
+        let prev_session = self
+            .config
+            .read()
+            .session
+            .as_ref()
+            .map(|s| s.name().to_string());
+        let prev_agent = self
+            .config
+            .read()
+            .agent
+            .as_ref()
+            .map(|a| a.name().to_string());
         // Run the command inside a block that owns the lock guards so they are
         // dropped before we touch `self` again for transcript / UI updates.
         let (result, captured) = {

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -12,6 +12,7 @@ use crossterm::event::{
 };
 use crossterm::terminal::{enable_raw_mode, supports_keyboard_enhancement, EnterAlternateScreen};
 use crossterm::ExecutableCommand;
+use harnx_core::message::Message;
 use harnx_hooks::{drain_async_results, AsyncHookManager, PersistentHookManager};
 use harnx_runtime::config::GlobalConfig;
 use harnx_runtime::utils::create_abort_signal;
@@ -102,7 +103,7 @@ impl Tui {
         })
     }
 
-    fn build_initial_transcript(config: &GlobalConfig) -> Vec<TranscriptItem> {
+    pub(crate) fn build_initial_transcript(config: &GlobalConfig) -> Vec<TranscriptItem> {
         let mut entries = vec![];
         let cfg = config.read();
         let state = cfg.state();
@@ -113,25 +114,30 @@ impl Tui {
             env!("CARGO_PKG_VERSION")
         )));
 
-        // Show agent banner and conversation starters if an agent is active
-        if state.contains(harnx_runtime::config::StateFlags::AGENT) {
-            if let Ok(banner) = cfg.agent_banner() {
-                if !banner.trim().is_empty() {
-                    entries.push(TranscriptItem::AssistantText(banner));
+        let history = session_history_transcript_items(config);
+        if !history.is_empty() {
+            entries.extend(history);
+        } else {
+            // Show agent banner and conversation starters if an agent is active
+            if state.contains(harnx_runtime::config::StateFlags::AGENT) {
+                if let Ok(banner) = cfg.agent_banner() {
+                    if !banner.trim().is_empty() {
+                        entries.push(TranscriptItem::AssistantText(banner));
+                    }
                 }
-            }
-            if let Some(agent) = &cfg.agent {
-                let starters = agent.conversation_staters();
-                if !starters.is_empty() {
-                    let list = starters
-                        .iter()
-                        .enumerate()
-                        .map(|(i, s)| format!("  {}. {s}", i + 1))
-                        .collect::<Vec<_>>()
-                        .join("\n");
-                    entries.push(TranscriptItem::SystemText(format!(
-                        "Conversation starters:\n{list}\n(type .starter <n> to use)"
-                    )));
+                if let Some(agent) = &cfg.agent {
+                    let starters = agent.conversation_staters();
+                    if !starters.is_empty() {
+                        let list = starters
+                            .iter()
+                            .enumerate()
+                            .map(|(i, s)| format!("  {}. {s}", i + 1))
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        entries.push(TranscriptItem::SystemText(format!(
+                            "Conversation starters:\n{list}\n(type .starter <n> to use)"
+                        )));
+                    }
                 }
             }
         }
@@ -271,4 +277,74 @@ impl Tui {
         })
         .await
     }
+}
+
+pub(crate) fn messages_to_transcript_items(messages: &[Message]) -> Vec<TranscriptItem> {
+    use harnx_core::message::{MessageContent, MessageRole};
+    use serde_json::Value;
+
+    let mut items = Vec::new();
+    for msg in messages {
+        match msg.role {
+            MessageRole::System => {}
+            MessageRole::User => {
+                let text = msg.content.to_text();
+                if !text.is_empty() {
+                    items.push(TranscriptItem::UserText(text));
+                }
+            }
+            MessageRole::Assistant => {
+                let text = msg.content.to_text();
+                if !text.is_empty() {
+                    items.push(TranscriptItem::AssistantText(text));
+                }
+            }
+            MessageRole::Tool => {
+                if let MessageContent::ToolCalls(ref tc) = msg.content {
+                    if !tc.thought.as_deref().unwrap_or("").trim().is_empty() {
+                        items.push(TranscriptItem::ThoughtText(
+                            tc.thought.as_deref().unwrap().trim().to_string(),
+                        ));
+                    }
+                    if !tc.text.trim().is_empty() {
+                        items.push(TranscriptItem::AssistantText(tc.text.clone()));
+                    }
+                    for r in &tc.tool_results {
+                        let input_yaml = if r.call.arguments == Value::Null {
+                            None
+                        } else {
+                            Some(harnx_runtime::utils::pretty_yaml_block(&r.call.arguments))
+                        };
+                        items.push(TranscriptItem::ToolCall {
+                            tool_name: r.call.name.clone(),
+                            input_yaml,
+                        });
+                        for line in crate::agent_event_sink::render_tool_result_text(&r.output, &[])
+                            .split('\n')
+                        {
+                            if !line.is_empty() {
+                                items.push(TranscriptItem::ToolResultText(line.to_string()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    items
+}
+
+pub(crate) fn session_history_transcript_items(config: &GlobalConfig) -> Vec<TranscriptItem> {
+    let cfg = config.read();
+    let session = match cfg.session.as_ref() {
+        Some(s) if !s.is_empty() => s,
+        _ => return vec![],
+    };
+    let mut items = Vec::new();
+    if !session.compressed_messages.is_empty() {
+        items.extend(messages_to_transcript_items(&session.compressed_messages));
+        items.push(TranscriptItem::SystemText("─── session compacted ───".to_string()));
+    }
+    items.extend(messages_to_transcript_items(&session.messages));
+    items
 }

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -343,7 +343,9 @@ pub(crate) fn session_history_transcript_items(config: &GlobalConfig) -> Vec<Tra
     let mut items = Vec::new();
     if !session.compressed_messages.is_empty() {
         items.extend(messages_to_transcript_items(&session.compressed_messages));
-        items.push(TranscriptItem::SystemText("─── session compacted ───".to_string()));
+        items.push(TranscriptItem::SystemText(
+            "─── session compacted ───".to_string(),
+        ));
     }
     items.extend(messages_to_transcript_items(&session.messages));
     items

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__info_session_with_session_in_tui.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__info_session_with_session_in_tui.snap
@@ -4,9 +4,9 @@ expression: rendered
 ---
 Welcome to harnx 0.30.0  •  Type .help for commands, Tab to
 complete.
+💬  info-session-with-session-test
 model               mock:mock-model
 save_session        true
-
 
 
 


### PR DESCRIPTION
Populates the TUI transcript with full conversation history when starting with an existing session. Reconciles and reloads the transcript after session-affecting commands (`.session`, `.agent`, `.exit session`, `.exit agent`, `.reset repl`, `.reset session`, `.empty session`, `.compact`, `.edit`) to ensure the display always matches the active session state.

Includes a mapping from session Message objects to TranscriptItem variants, supporting assistant thoughts, tool calls, and result rendering. Displays a separator for compacted sessions.