### PR TITLE
Bash tool inconsistencies fixups

### DIFF
--- a/.changesets/bash-mcp-exec-id.md
+++ b/.changesets/bash-mcp-exec-id.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+Replace PID-based identifiers in the bash MCP server with stable per-execution IDs. `spawn` now returns an `execution_id`; `wait`, `terminate`, and `read_exec_log` all accept `execution_id`. Stdout and stderr are kept in separate log files for both `exec` and `spawn`. `wait` now accepts the same output-filtering parameters as `exec` and returns the same response format. Output blocks now show stdout and stderr in clearly demarcated separate sections (`===== stdout =====` / `===== /stdout =====`), each truncated independently, so neither stream's content is lost to the other during truncation.

--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -5,23 +5,36 @@ set -e
 # @env DRY_RUN Dry run mode
 
 # @cmd Install all harnx binaries (harnx, harnx-serve, harnx-acp-server, harnx-mcp-*) from the local workspace
-# Release profile by default. Pass --debug for a faster build with slower runtime.
+# Single workspace build then copy into $CARGO_HOME/bin -- avoids the per-crate scratch
+# rebuilds that `cargo install --path` does. Release profile by default; pass --debug for
+# a faster build with slower runtime.
 # @flag --debug Install debug build instead of the default release build
-# @flag --force Overwrite an existing installed binary of the same name
-# @flag --locked Use the committed Cargo.lock (recommended for reproducible installs)
-# @arg pkgs*[harnx|harnx-serve|harnx-acp-server] Restrict the install to one or more bins (default: all three)
+# @arg bins*[harnx|harnx-serve|harnx-acp-server|harnx-mcp-bash|harnx-mcp-fs|harnx-mcp-time|harnx-mcp-todo] Restrict the install to one or more bins (default: all)
 install() {
-    args=()
-    [[ -n "$argc_debug" ]] && args+=(--debug)
-    [[ -n "$argc_force" ]] && args+=(--force)
-    [[ -n "$argc_locked" ]] && args+=(--locked)
-    pkgs=("${argc_pkgs[@]}")
-    if [[ ${#pkgs[@]} -eq 0 ]]; then
-        pkgs=(harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-fs harnx-mcp-time harnx-mcp-todo)
+    bins=("${argc_bins[@]}")
+    if [[ ${#bins[@]} -eq 0 ]]; then
+        bins=(harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-fs harnx-mcp-time harnx-mcp-todo)
     fi
-    for pkg in "${pkgs[@]}"; do
-        echo "==> Installing $pkg"
-        cargo install "${args[@]}" --path "crates/$pkg"
+
+    build_args=(--locked)
+    profile_dir="release"
+    if [[ -n "$argc_debug" ]]; then
+        profile_dir="debug"
+    else
+        build_args+=(--release)
+    fi
+    for bin in "${bins[@]}"; do
+        build_args+=(--bin "$bin")
+    done
+
+    cargo build "${build_args[@]}"
+
+    target_dir="${CARGO_TARGET_DIR:-target}"
+    install_dir="${CARGO_INSTALL_ROOT:-${CARGO_HOME:-$HOME/.cargo}}/bin"
+    mkdir -p "$install_dir"
+    for bin in "${bins[@]}"; do
+        echo "==> Installing $bin -> $install_dir/$bin"
+        cp -f "$target_dir/$profile_dir/$bin" "$install_dir/$bin"
     done
 }
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,6 +2848,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "uuid",
 ]

--- a/crates/harnx-client/src/bedrock.rs
+++ b/crates/harnx-client/src/bedrock.rs
@@ -175,6 +175,7 @@ async fn chat_completions(builder: RequestBuilder) -> Result<ChatCompletionsOutp
     }
 
     debug!("non-stream-data: {data}");
+    harnx_core::llm_trace::response("bedrock", &data);
     extract_chat_completions(&data)
 }
 
@@ -349,6 +350,12 @@ async fn chat_completions_streaming(
                 ("event", _) => {
                     let data: Value = serde_json::from_slice(message.payload())?;
                     debug!("stream-data: {smithy_type} {data}");
+                    if harnx_core::llm_trace::is_enabled() {
+                        harnx_core::llm_trace::stream_event(
+                            "bedrock",
+                            &serde_json::json!({"smithy_type": smithy_type, "event": data}),
+                        );
+                    }
                     bedrock_handle_stream_event(&mut state, handler, smithy_type, &data)?;
                 }
                 ("exception", _) => {
@@ -744,6 +751,7 @@ fn aws_fetch(
     headers.insert("authorization".into(), authorization_header);
 
     debug!("Request {endpoint} {body}");
+    harnx_core::llm_trace::request_raw(&endpoint, &body);
 
     let mut request_builder = client.request(method, endpoint).body(body);
 

--- a/crates/harnx-client/src/claude.rs
+++ b/crates/harnx-client/src/claude.rs
@@ -62,6 +62,7 @@ pub async fn claude_chat_completions(
         catch_error(&data, status.as_u16(), retry_after)?;
     }
     debug!("non-stream-data: {data}");
+    harnx_core::llm_trace::response("claude", &data);
     claude_extract_chat_completions(&data)
 }
 
@@ -262,6 +263,7 @@ pub async fn claude_chat_completions_streaming(
         }
         let data: Value = serde_json::from_str(&message.data)?;
         debug!("stream-data: {data}");
+        harnx_core::llm_trace::stream_event("claude", &data);
         claude_handle_stream_event(&mut state, handler, &data)?;
         Ok(false)
     };

--- a/crates/harnx-client/src/client.rs
+++ b/crates/harnx-client/src/client.rs
@@ -422,6 +422,7 @@ impl RequestData {
     pub fn into_builder(self, client: &ReqwestClient) -> RequestBuilder {
         let RequestData { url, headers, body } = self;
         debug!("Request {url} {body}");
+        harnx_core::llm_trace::request(&url, &body);
 
         let mut builder = client.post(url);
         for (key, value) in headers {

--- a/crates/harnx-client/src/cohere.rs
+++ b/crates/harnx-client/src/cohere.rs
@@ -107,6 +107,7 @@ async fn chat_completions(
     }
 
     debug!("non-stream-data: {data}");
+    harnx_core::llm_trace::response("cohere", &data);
     extract_chat_completions(&data)
 }
 
@@ -204,6 +205,7 @@ async fn chat_completions_streaming(
         }
         let data: Value = serde_json::from_str(&message.data)?;
         debug!("stream-data: {data}");
+        harnx_core::llm_trace::stream_event("cohere", &data);
         cohere_handle_stream_event(&mut state, handler, &data)?;
         Ok(false)
     };

--- a/crates/harnx-client/src/openai.rs
+++ b/crates/harnx-client/src/openai.rs
@@ -83,6 +83,7 @@ pub async fn openai_chat_completions(
     }
 
     debug!("non-stream-data: {data}");
+    harnx_core::llm_trace::response("openai", &data);
     openai_extract_chat_completions(&data)
 }
 
@@ -252,6 +253,7 @@ pub async fn openai_chat_completions_streaming(
         }
         let data: Value = serde_json::from_str(&message.data)?;
         debug!("stream-data: {data}");
+        harnx_core::llm_trace::stream_event("openai", &data);
         openai_handle_stream_event(&mut state, handler, &data)?;
         Ok(false)
     };

--- a/crates/harnx-client/src/vertexai.rs
+++ b/crates/harnx-client/src/vertexai.rs
@@ -180,6 +180,7 @@ pub async fn gemini_chat_completions(
         catch_error(&data, status.as_u16(), retry_after)?;
     }
     debug!("non-stream-data: {data}");
+    harnx_core::llm_trace::response("vertexai", &data);
     gemini_extract_chat_completions_text(&data)
 }
 
@@ -251,6 +252,7 @@ pub async fn gemini_chat_completions_streaming(
             }
             let data: Value = serde_json::from_str(value)?;
             debug!("stream-data: {data}");
+            harnx_core::llm_trace::stream_event("vertexai", &data);
             gemini_handle_stream_chunk(handler, &data)?;
             Ok(false)
         };

--- a/crates/harnx-core/src/lib.rs
+++ b/crates/harnx-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod event;
 pub mod hooks;
 pub mod input;
 pub mod last_message;
+pub mod llm_trace;
 pub mod macros;
 pub mod message;
 pub mod model;

--- a/crates/harnx-core/src/llm_trace.rs
+++ b/crates/harnx-core/src/llm_trace.rs
@@ -1,0 +1,230 @@
+//! Optional file-based trace of every LLM API call and its response.
+//!
+//! When the `HARNX_LLM_TRACE` env var is set to a path, harnx writes one
+//! JSON line per event to that file:
+//!
+//! - `kind: "request"` — the URL and body of an outgoing chat-completions
+//!   call, captured at the lowest layer where the request body is fully
+//!   built (after patches and header interpolation).
+//! - `kind: "response"` — the parsed JSON body of a non-streaming response.
+//! - `kind: "stream-event"` — one entry per parsed streaming event (one SSE
+//!   message, or one Bedrock event-stream frame).
+//!
+//! This is independent of the standard `simplelog` log filter so the trace
+//! file contains only LLM I/O and nothing else, even with debug logging
+//! disabled. When the env var is unset, every entry point is a cheap
+//! `OnceLock::get().is_none()` check, so call sites can invoke unconditionally.
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+use serde_json::{json, Value};
+
+const ENV_VAR: &str = "HARNX_LLM_TRACE";
+
+static TRACE_FILE: OnceLock<Mutex<File>> = OnceLock::new();
+
+/// Open the trace file if `HARNX_LLM_TRACE` is set. The first successful
+/// init wins; subsequent calls are no-ops. Open failures are reported on
+/// stderr — we never fail the process for trace failures.
+pub fn init_from_env() {
+    if TRACE_FILE.get().is_some() {
+        return;
+    }
+    let Ok(path) = std::env::var(ENV_VAR) else {
+        return;
+    };
+    if path.is_empty() {
+        return;
+    }
+    let path = PathBuf::from(path);
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+    }
+    match OpenOptions::new().create(true).append(true).open(&path) {
+        Ok(file) => {
+            let _ = TRACE_FILE.set(Mutex::new(file));
+        }
+        Err(err) => {
+            eprintln!(
+                "harnx: failed to open LLM trace file {}: {err}",
+                path.display()
+            );
+        }
+    }
+}
+
+pub fn is_enabled() -> bool {
+    TRACE_FILE.get().is_some()
+}
+
+fn timestamp() -> String {
+    chrono::Utc::now()
+        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+        .to_string()
+}
+
+fn write_entry(value: Value) {
+    let Some(lock) = TRACE_FILE.get() else {
+        return;
+    };
+    let line = match serde_json::to_string(&value) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    if let Ok(mut file) = lock.lock() {
+        let _ = writeln!(file, "{line}");
+        let _ = file.flush();
+    }
+}
+
+/// Trace an outgoing LLM HTTP request with a JSON body.
+pub fn request(url: &str, body: &Value) {
+    if !is_enabled() {
+        return;
+    }
+    write_entry(json!({
+        "ts": timestamp(),
+        "kind": "request",
+        "url": url,
+        "body": body,
+    }));
+}
+
+/// Trace an outgoing LLM HTTP request whose body is a raw byte string
+/// (e.g. an AWS SigV4-signed Bedrock body that's already serialized by the
+/// time we have access to it).
+pub fn request_raw(url: &str, body: &str) {
+    if !is_enabled() {
+        return;
+    }
+    match serde_json::from_str::<Value>(body) {
+        Ok(parsed) => write_entry(json!({
+            "ts": timestamp(),
+            "kind": "request",
+            "url": url,
+            "body": parsed,
+        })),
+        Err(_) => write_entry(json!({
+            "ts": timestamp(),
+            "kind": "request",
+            "url": url,
+            "body_raw": body,
+        })),
+    }
+}
+
+/// Trace a non-streaming LLM HTTP response body (parsed JSON).
+pub fn response(provider: &str, body: &Value) {
+    if !is_enabled() {
+        return;
+    }
+    write_entry(json!({
+        "ts": timestamp(),
+        "kind": "response",
+        "provider": provider,
+        "body": body,
+    }));
+}
+
+/// Trace one streaming event (one SSE message or one event-stream frame).
+pub fn stream_event(provider: &str, body: &Value) {
+    if !is_enabled() {
+        return;
+    }
+    write_entry(json!({
+        "ts": timestamp(),
+        "kind": "stream-event",
+        "provider": provider,
+        "body": body,
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader};
+    use std::sync::Mutex;
+
+    /// `init_from_env` writes to a process-wide `OnceLock`, so direct tests
+    /// of the public path conflict across the suite. Exercise the same
+    /// write path against a private file handle so the helpers'
+    /// serialization is still covered.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn read_lines(path: &std::path::Path) -> Vec<Value> {
+        let f = std::fs::File::open(path).unwrap();
+        BufReader::new(f)
+            .lines()
+            .map_while(Result::ok)
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str::<Value>(&l).expect("trace line is valid JSON"))
+            .collect()
+    }
+
+    fn write_via_handle(file: &Mutex<File>, value: Value) {
+        let line = serde_json::to_string(&value).unwrap();
+        let mut f = file.lock().unwrap();
+        writeln!(f, "{line}").unwrap();
+    }
+
+    #[test]
+    fn write_entry_serializes_request_response_and_stream_event() {
+        let _g = TEST_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!("harnx-llm-trace-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("trace.jsonl");
+        let _ = std::fs::remove_file(&path);
+        let file = Mutex::new(
+            OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .unwrap(),
+        );
+
+        write_via_handle(
+            &file,
+            json!({
+                "ts": "test",
+                "kind": "request",
+                "url": "https://api.example.com/v1/messages",
+                "body": {"model": "claude-3-7-sonnet", "messages": []},
+            }),
+        );
+        write_via_handle(
+            &file,
+            json!({
+                "ts": "test",
+                "kind": "response",
+                "provider": "claude",
+                "body": {"id": "msg_abc"},
+            }),
+        );
+        write_via_handle(
+            &file,
+            json!({
+                "ts": "test",
+                "kind": "stream-event",
+                "provider": "claude",
+                "body": {"type": "message_start"},
+            }),
+        );
+
+        let lines = read_lines(&path);
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0]["kind"], "request");
+        assert_eq!(lines[0]["url"], "https://api.example.com/v1/messages");
+        assert_eq!(lines[1]["kind"], "response");
+        assert_eq!(lines[1]["provider"], "claude");
+        assert_eq!(lines[2]["kind"], "stream-event");
+        assert_eq!(lines[2]["body"]["type"], "message_start");
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+}

--- a/crates/harnx-mcp-bash/Cargo.toml
+++ b/crates/harnx-mcp-bash/Cargo.toml
@@ -19,6 +19,7 @@ process-wrap = { workspace = true }
 rmcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tempfile = "3"
 tokio = { workspace = true, features = ["fs"] }
 uuid = { workspace = true }
 

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -28,7 +28,7 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{
-    atomic::{AtomicBool, AtomicU64, Ordering},
+    atomic::{AtomicBool, Ordering},
     Arc,
 };
 use std::time::Duration;
@@ -79,7 +79,8 @@ impl JsonSchema for ExecCommandParams {
 
 #[derive(Debug, Deserialize)]
 struct ReadExecLogParams {
-    path: String,
+    execution_id: String,
+    stream: String,
     #[serde(default)]
     offset: Option<usize>,
     #[serde(default)]
@@ -102,7 +103,8 @@ impl JsonSchema for ReadExecLogParams {
     }
 
     fn json_schema(generator: &mut SchemaGenerator) -> Schema {
-        let path = generator.subschema_for::<String>();
+        let execution_id = generator.subschema_for::<String>();
+        let stream = generator.subschema_for::<String>();
         let offset = generator.subschema_for::<Option<usize>>();
         let limit = generator.subschema_for::<Option<usize>>();
         let tail = generator.subschema_for::<Option<usize>>();
@@ -112,7 +114,8 @@ impl JsonSchema for ReadExecLogParams {
         let max_output_bytes = generator.subschema_for::<Option<usize>>();
         object_schema(
             vec![
-                ("path", path),
+                ("execution_id", execution_id),
+                ("stream", stream),
                 ("offset", offset),
                 ("limit", limit),
                 ("tail", tail),
@@ -121,7 +124,7 @@ impl JsonSchema for ReadExecLogParams {
                 ("tail_lines", tail_lines),
                 ("max_output_bytes", max_output_bytes),
             ],
-            &["path"],
+            &["execution_id", "stream"],
         )
     }
 }
@@ -150,11 +153,17 @@ impl JsonSchema for SpawnCommandParams {
 
 #[derive(Debug, Deserialize)]
 struct WaitParams {
-    pid: u32,
+    execution_id: String,
     #[serde(default)]
     timeout_secs: Option<u64>,
     #[serde(default)]
+    head_lines: Option<usize>,
+    #[serde(default)]
     tail_lines: Option<usize>,
+    #[serde(default)]
+    max_output_bytes: Option<usize>,
+    #[serde(default)]
+    grep: Option<String>,
 }
 
 impl JsonSchema for WaitParams {
@@ -163,23 +172,29 @@ impl JsonSchema for WaitParams {
     }
 
     fn json_schema(generator: &mut SchemaGenerator) -> Schema {
-        let pid = generator.subschema_for::<u32>();
+        let execution_id = generator.subschema_for::<String>();
         let timeout_secs = generator.subschema_for::<Option<u64>>();
+        let head_lines = generator.subschema_for::<Option<usize>>();
         let tail_lines = generator.subschema_for::<Option<usize>>();
+        let max_output_bytes = generator.subschema_for::<Option<usize>>();
+        let grep = generator.subschema_for::<Option<String>>();
         object_schema(
             vec![
-                ("pid", pid),
+                ("execution_id", execution_id),
                 ("timeout_secs", timeout_secs),
+                ("head_lines", head_lines),
                 ("tail_lines", tail_lines),
+                ("max_output_bytes", max_output_bytes),
+                ("grep", grep),
             ],
-            &["pid"],
+            &["execution_id"],
         )
     }
 }
 
 #[derive(Debug, Deserialize)]
 struct TerminateParams {
-    pid: u32,
+    execution_id: String,
     #[serde(default)]
     signal: Option<String>,
 }
@@ -190,9 +205,12 @@ impl JsonSchema for TerminateParams {
     }
 
     fn json_schema(generator: &mut SchemaGenerator) -> Schema {
-        let pid = generator.subschema_for::<u32>();
+        let execution_id = generator.subschema_for::<String>();
         let signal = generator.subschema_for::<Option<String>>();
-        object_schema(vec![("pid", pid), ("signal", signal)], &["pid"])
+        object_schema(
+            vec![("execution_id", execution_id), ("signal", signal)],
+            &["execution_id"],
+        )
     }
 }
 
@@ -225,17 +243,16 @@ struct SpawnedProcess {
     child: Box<dyn ChildWrapper>,
     command: String,
     working_dir: PathBuf,
-    log_path: PathBuf,
+    stdout_log_path: PathBuf,
+    stderr_log_path: PathBuf,
     before_snap_ids: Vec<(PathBuf, gix::ObjectId)>,
 }
 
 struct BashServerInner {
     roots: RwLock<Vec<PathBuf>>,
     roots_initialized: AtomicBool,
-    spawned: Mutex<HashMap<u32, SpawnedProcess>>,
+    spawned: Mutex<HashMap<String, SpawnedProcess>>,
     log_dir: PathBuf,
-    spawn_counter: AtomicU64,
-    exec_counter: AtomicU64,
     history: Arc<HistoryManager>,
 }
 
@@ -261,8 +278,6 @@ impl BashServer {
                 roots_initialized: AtomicBool::new(false),
                 spawned: Mutex::new(HashMap::new()),
                 log_dir,
-                spawn_counter: AtomicU64::new(0),
-                exec_counter: AtomicU64::new(0),
                 history: Arc::new(HistoryManager::new(&initial_roots)),
             }),
         }
@@ -325,28 +340,11 @@ impl BashServer {
             })
     }
 
-    fn next_exec_log_paths(&self) -> (PathBuf, PathBuf) {
-        let seq = self.inner.exec_counter.fetch_add(1, Ordering::SeqCst);
-        (
-            self.inner.log_dir.join(format!("exec-{seq}.stdout.log")),
-            self.inner.log_dir.join(format!("exec-{seq}.stderr.log")),
-        )
-    }
-
-    fn validate_log_path(&self, requested: &str) -> Result<PathBuf, ErrorData> {
-        validate_path(requested, std::slice::from_ref(&self.inner.log_dir)).map_err(|err| {
-            if err.starts_with("Cannot resolve path") {
-                ErrorData::invalid_params(
-                    format!("cannot resolve log path '{requested}': {err}"),
-                    None,
-                )
-            } else {
-                ErrorData::invalid_params(
-                    format!("log path '{requested}' is outside the bash server temp log directory"),
-                    None,
-                )
-            }
-        })
+    fn next_exec_dir(&self) -> Result<tempfile::TempDir, ErrorData> {
+        tempfile::Builder::new()
+            .prefix("exec-")
+            .tempdir_in(&self.inner.log_dir)
+            .map_err(|err| internal_error(format!("failed to create exec directory: {err}")))
     }
 
     // -----------------------------------------------------------------------
@@ -390,7 +388,11 @@ impl BashServer {
         };
 
         self.ensure_log_dir().await?;
-        let (stdout_log_path, stderr_log_path) = self.next_exec_log_paths();
+
+        let exec_dir = self.next_exec_dir()?.keep();
+        let stdout_log_path = exec_dir.join("stdout.log");
+        let stderr_log_path = exec_dir.join("stderr.log");
+        let execution_id = exec_dir.file_name().unwrap().to_string_lossy().into_owned();
 
         let stdout_file = tokio::fs::File::create(&stdout_log_path)
             .await
@@ -471,17 +473,27 @@ impl BashServer {
             let _ = f.sync_all().await;
         }
 
-        let output_bytes = merge_output(&stdout_bytes, &stderr_bytes);
-        let total_bytes = output_bytes.len();
-        let sanitized_output = sanitize_output_text(&String::from_utf8_lossy(&output_bytes));
-        let total_lines = count_lines(&sanitized_output);
-        let truncated_output = truncate_output(&sanitized_output, &truncate_opts);
-        let output_truncated = truncated_output != sanitized_output;
+        let stdout_str = String::from_utf8_lossy(&stdout_bytes).into_owned();
+        let stderr_str = String::from_utf8_lossy(&stderr_bytes).into_owned();
+        // exec does not expose a grep param; pass None
+        let (streams_block, stdout_lines, stderr_lines, stdout_bytes_len, stderr_bytes_len) =
+            render_streams_block(
+                &stdout_str,
+                &stderr_str,
+                &truncate_opts,
+                None,
+                &execution_id,
+                &stdout_log_path,
+                &stderr_log_path,
+            );
+        let total_lines = stdout_lines + stderr_lines;
+        let total_bytes = stdout_bytes_len + stderr_bytes_len;
 
         match (status, timed_out) {
             (Some(status), false) => {
                 let exit_code = status.code().unwrap_or(-1);
                 let mut output = String::new();
+                let _ = writeln!(output, "execution_id: {execution_id}");
                 let _ = writeln!(output, "exit_code: {exit_code}");
                 let _ = writeln!(output, "working_dir: {}", working_dir.display());
                 let _ = writeln!(output, "stdout_log_path: {}", stdout_log_path.display());
@@ -492,15 +504,7 @@ impl BashServer {
                     "total_bytes: {total_bytes} ({})",
                     format_size(total_bytes)
                 );
-                let _ = write!(
-                    output,
-                    "\n{}",
-                    render_output_block(
-                        &sanitized_output,
-                        &truncated_output,
-                        Some((&stdout_log_path, &stderr_log_path)),
-                    )
-                );
+                let _ = write!(output, "\n{streams_block}");
                 let summary = format!(
                     "exit_code: {exit_code}, {total_lines} lines, {}",
                     format_size(total_bytes)
@@ -552,14 +556,15 @@ impl BashServer {
                 let _ = status;
                 tool_error(render_timeout_message(TimeoutRenderContext {
                     working_dir: &working_dir,
+                    execution_id: &execution_id,
                     timeout_secs,
                     total_lines,
                     total_bytes,
-                    original: &sanitized_output,
-                    truncated: &truncated_output,
+                    stdout: &stdout_str,
+                    stderr: &stderr_str,
+                    truncate_opts: &truncate_opts,
                     stdout_log_path: &stdout_log_path,
                     stderr_log_path: &stderr_log_path,
-                    output_truncated,
                 }))
             }
             (None, _) => tool_error("process exited without status".to_string()),
@@ -581,7 +586,48 @@ impl BashServer {
             ));
         }
 
-        let path = self.validate_log_path(&params.path)?;
+        // Validate stream parameter
+        if params.stream != "stdout" && params.stream != "stderr" {
+            return Err(ErrorData::invalid_params(
+                format!(
+                    "stream must be 'stdout' or 'stderr', got '{}'",
+                    params.stream
+                ),
+                None,
+            ));
+        }
+
+        // Construct absolute path: log_dir/execution_id/stream.log
+        // We pass the absolute path string so validate_path uses canonicalize() correctly
+        // (passing a relative string would resolve against cwd, not log_dir).
+        let abs = self
+            .inner
+            .log_dir
+            .join(&params.execution_id)
+            .join(format!("{}.log", params.stream));
+        let path = validate_path(
+            abs.to_string_lossy().as_ref(),
+            std::slice::from_ref(&self.inner.log_dir),
+        )
+        .map_err(|err| {
+            if err.starts_with("Cannot resolve path") {
+                ErrorData::invalid_params(
+                    format!(
+                        "cannot resolve execution_id '{}': {}",
+                        params.execution_id, err
+                    ),
+                    None,
+                )
+            } else {
+                ErrorData::invalid_params(
+                    format!(
+                        "execution_id '{}' is outside the bash server temp log directory",
+                        params.execution_id
+                    ),
+                    None,
+                )
+            }
+        })?;
         let metadata = tokio::fs::metadata(&path)
             .await
             .map_err(|err| internal_error(format!("cannot access '{}': {err}", path.display())))?;
@@ -590,9 +636,12 @@ impl BashServer {
             return tool_error(format!("'{}' is not a regular log file.", path.display()));
         }
 
-        let content = tokio::fs::read_to_string(&path)
+        let raw_content = tokio::fs::read_to_string(&path)
             .await
             .map_err(|err| internal_error(format!("failed to read '{}': {err}", path.display())))?;
+        // Apply same sanitization as exec/wait output rendering so control characters
+        // don't leak through the log-read path.
+        let content = sanitize_output_text(&raw_content);
 
         let grep_regex = match params.grep.as_deref() {
             Some(pattern) => Some(Regex::new(pattern).map_err(|err| {
@@ -709,8 +758,9 @@ impl BashServer {
         }
 
         let summary = format!(
-            "Read {} ({} lines, {})",
-            path.display(),
+            "Read {}/{} ({} lines, {})",
+            params.execution_id,
+            params.stream,
             total_matching_lines,
             format_size(raw_output.len())
         );
@@ -746,26 +796,31 @@ impl BashServer {
 
         self.ensure_log_dir().await?;
 
-        let seq = self.inner.spawn_counter.fetch_add(1, Ordering::SeqCst);
-        let log_path = self.inner.log_dir.join(format!("bg-{seq}.log"));
+        let exec_dir = self.next_exec_dir()?.keep();
+        let stdout_log_path = exec_dir.join("stdout.log");
+        let stderr_log_path = exec_dir.join("stderr.log");
+        let execution_id = exec_dir.file_name().unwrap().to_string_lossy().into_owned();
 
-        let log_file = std::fs::File::create(&log_path).map_err(|err| {
+        let stdout_file = std::fs::File::create(&stdout_log_path).map_err(|err| {
             internal_error(format!(
-                "failed to create log file '{}': {err}",
-                log_path.display()
+                "failed to create stdout log file '{}': {err}",
+                stdout_log_path.display()
             ))
         })?;
-        let log_file_err = log_file
-            .try_clone()
-            .map_err(|err| internal_error(format!("failed to clone log file handle: {err}")))?;
+        let stderr_file = std::fs::File::create(&stderr_log_path).map_err(|err| {
+            internal_error(format!(
+                "failed to create stderr log file '{}': {err}",
+                stderr_log_path.display()
+            ))
+        })?;
 
         let mut command = CommandWrap::with_new("bash", |command| {
             command
                 .args(["-c", &params.command])
                 .current_dir(&working_dir)
                 .stdin(Stdio::null())
-                .stdout(Stdio::from(log_file))
-                .stderr(Stdio::from(log_file_err));
+                .stdout(Stdio::from(stdout_file))
+                .stderr(Stdio::from(stderr_file));
         });
         #[cfg(unix)]
         command.wrap(ProcessGroup::leader());
@@ -776,26 +831,28 @@ impl BashServer {
             .spawn()
             .map_err(|err| internal_error(format!("failed to spawn command: {err}")))?;
 
-        let pid = child
-            .id()
-            .ok_or_else(|| internal_error("spawned process exited before PID could be read"))?;
-
         let entry = SpawnedProcess {
             child,
             command: params.command.clone(),
             working_dir: working_dir.clone(),
-            log_path: log_path.clone(),
+            stdout_log_path: stdout_log_path.clone(),
+            stderr_log_path: stderr_log_path.clone(),
             before_snap_ids,
         };
 
-        self.inner.spawned.lock().await.insert(pid, entry);
+        self.inner
+            .spawned
+            .lock()
+            .await
+            .insert(execution_id.clone(), entry);
 
         let mut output = String::new();
-        let _ = writeln!(output, "pid: {pid}");
-        let _ = writeln!(output, "log_path: {}", log_path.display());
+        let _ = writeln!(output, "execution_id: {execution_id}");
+        let _ = writeln!(output, "stdout_log_path: {}", stdout_log_path.display());
+        let _ = writeln!(output, "stderr_log_path: {}", stderr_log_path.display());
         let _ = writeln!(output, "working_dir: {}", working_dir.display());
         let _ = write!(output, "command: {}", params.command);
-        let summary = format!("spawned pid {pid}, log: {}", log_path.display());
+        let summary = format!("spawned {execution_id}");
 
         Ok(CallToolResult::success(vec![
             Content::text(output).with_audience(vec![Role::Assistant]),
@@ -809,15 +866,25 @@ impl BashServer {
 
     async fn wait_impl(&self, params: WaitParams) -> Result<CallToolResult, ErrorData> {
         let timeout_secs = params.timeout_secs.unwrap_or(120);
-        let tail_line_count = params.tail_lines.unwrap_or(20);
+        let default_opts = TruncateOpts::default();
+        let truncate_opts = TruncateOpts {
+            head_lines: params.head_lines.unwrap_or(default_opts.head_lines),
+            tail_lines: params.tail_lines.unwrap_or(default_opts.tail_lines),
+            line_head_bytes: default_opts.line_head_bytes,
+            line_tail_bytes: default_opts.line_tail_bytes,
+            max_output_bytes: params
+                .max_output_bytes
+                .unwrap_or(default_opts.max_output_bytes),
+            ..default_opts
+        };
 
-        let (mut child, command, working_dir, log_path, before_snap_ids) = {
+        let (mut child, command, working_dir, stdout_log_path, stderr_log_path, before_snap_ids) = {
             let mut map = self.inner.spawned.lock().await;
-            let entry = map.remove(&params.pid).ok_or_else(|| {
+            let entry = map.remove(&params.execution_id).ok_or_else(|| {
                 ErrorData::invalid_params(
                     format!(
-                        "pid {} is not a tracked background process (or already waited on)",
-                        params.pid
+                        "execution_id '{}' is not a tracked background process (or already waited on)",
+                        params.execution_id
                     ),
                     None,
                 )
@@ -826,7 +893,8 @@ impl BashServer {
                 entry.child,
                 entry.command,
                 entry.working_dir,
-                entry.log_path,
+                entry.stdout_log_path,
+                entry.stderr_log_path,
                 entry.before_snap_ids,
             )
         };
@@ -834,20 +902,55 @@ impl BashServer {
         let timeout = Duration::from_secs(timeout_secs);
         let wait_result = tokio::time::timeout(timeout, child.wait()).await;
 
-        let log_tail = read_log_tail(&log_path, tail_line_count);
+        // Read both log files
+        let stdout_content = tokio::fs::read_to_string(&stdout_log_path)
+            .await
+            .unwrap_or_default();
+        let stderr_content = tokio::fs::read_to_string(&stderr_log_path)
+            .await
+            .unwrap_or_default();
+
+        let grep_regex = match params.grep.as_deref() {
+            Some(pattern) => Some(Regex::new(pattern).map_err(|err| {
+                ErrorData::invalid_params(format!("invalid grep pattern: {err}"), None)
+            })?),
+            None => None,
+        };
+        let (streams_block, stdout_lines, stderr_lines, stdout_bytes_len, stderr_bytes_len) =
+            render_streams_block(
+                &stdout_content,
+                &stderr_content,
+                &truncate_opts,
+                grep_regex.as_ref(),
+                &params.execution_id,
+                &stdout_log_path,
+                &stderr_log_path,
+            );
+        let total_lines = stdout_lines + stderr_lines;
+        let total_bytes = stdout_bytes_len + stderr_bytes_len;
 
         match wait_result {
             Ok(Ok(status)) => {
                 let exit_code = status.code().unwrap_or(-1);
                 let mut output = String::new();
-                let _ = writeln!(output, "pid: {}", params.pid);
+                let _ = writeln!(output, "execution_id: {}", params.execution_id);
                 let _ = writeln!(output, "status: exited");
                 let _ = writeln!(output, "exit_code: {exit_code}");
                 let _ = writeln!(output, "working_dir: {}", working_dir.display());
                 let _ = writeln!(output, "command: {command}");
-                let _ = writeln!(output, "log_path: {}", log_path.display());
-                let _ = write!(output, "\n{log_tail}");
-                let summary = format!("pid {} exited with code {exit_code}", params.pid);
+                let _ = writeln!(output, "stdout_log_path: {}", stdout_log_path.display());
+                let _ = writeln!(output, "stderr_log_path: {}", stderr_log_path.display());
+                let _ = writeln!(output, "total_lines: {total_lines}");
+                let _ = writeln!(
+                    output,
+                    "total_bytes: {total_bytes} ({})",
+                    format_size(total_bytes)
+                );
+                let _ = write!(output, "\n{streams_block}");
+                let summary = format!(
+                    "execution_id '{}' exited with code {exit_code}",
+                    params.execution_id
+                );
 
                 // HISTORY: after snapshot + diff (non-fatal)
                 let mut diff_parts: Vec<String> = Vec::new();
@@ -891,30 +994,41 @@ impl BashServer {
                 Ok(CallToolResult::success(contents))
             }
             Ok(Err(err)) => Err(internal_error(format!(
-                "failed waiting for pid {}: {err}",
-                params.pid
+                "failed waiting for execution_id '{}': {err}",
+                params.execution_id
             ))),
             Err(_) => {
                 let mut map = self.inner.spawned.lock().await;
                 map.insert(
-                    params.pid,
+                    params.execution_id.clone(),
                     SpawnedProcess {
                         child,
                         command: command.clone(),
                         working_dir: working_dir.clone(),
-                        log_path: log_path.clone(),
+                        stdout_log_path: stdout_log_path.clone(),
+                        stderr_log_path: stderr_log_path.clone(),
                         before_snap_ids,
                     },
                 );
 
                 let mut output = String::new();
-                let _ = writeln!(output, "pid: {}", params.pid);
+                let _ = writeln!(output, "execution_id: {}", params.execution_id);
                 let _ = writeln!(output, "status: running");
                 let _ = writeln!(output, "working_dir: {}", working_dir.display());
                 let _ = writeln!(output, "command: {command}");
-                let _ = writeln!(output, "log_path: {}", log_path.display());
-                let _ = write!(output, "\n{log_tail}");
-                let summary = format!("pid {} still running after {}s", params.pid, timeout_secs);
+                let _ = writeln!(output, "stdout_log_path: {}", stdout_log_path.display());
+                let _ = writeln!(output, "stderr_log_path: {}", stderr_log_path.display());
+                let _ = writeln!(output, "total_lines: {total_lines}");
+                let _ = writeln!(
+                    output,
+                    "total_bytes: {total_bytes} ({})",
+                    format_size(total_bytes)
+                );
+                let _ = write!(output, "\n{streams_block}");
+                let summary = format!(
+                    "execution_id '{}' still running after {}s",
+                    params.execution_id, timeout_secs
+                );
                 Ok(CallToolResult::success(vec![
                     Content::text(output).with_audience(vec![Role::Assistant]),
                     Content::text(summary).with_audience(vec![Role::User]),
@@ -946,26 +1060,38 @@ impl BashServer {
             };
 
             let map = self.inner.spawned.lock().await;
-            let entry = map.get(&params.pid).ok_or_else(|| {
+            let entry = map.get(&params.execution_id).ok_or_else(|| {
                 ErrorData::invalid_params(
-                    format!("pid {} is not a tracked background process", params.pid),
+                    format!(
+                        "execution_id '{}' is not a tracked background process",
+                        params.execution_id
+                    ),
                     None,
                 )
             })?;
 
             entry.child.signal(signum).map_err(|err| {
                 internal_error(format!(
-                    "failed to send {signal_name} to pid {}: {err}",
-                    params.pid
+                    "failed to send {signal_name} to execution_id '{}': {err}",
+                    params.execution_id
                 ))
             })?;
 
             let mut output = String::new();
-            let _ = writeln!(output, "pid: {}", params.pid);
+            let _ = writeln!(output, "execution_id: {}", params.execution_id);
             let _ = writeln!(output, "signal: {}", normalized);
             let _ = writeln!(output, "command: {}", entry.command);
-            let _ = write!(output, "log_path: {}", entry.log_path.display());
-            let summary = format!("sent {} to pid {}", normalized, params.pid);
+            let _ = writeln!(
+                output,
+                "stdout_log_path: {}",
+                entry.stdout_log_path.display()
+            );
+            let _ = write!(
+                output,
+                "stderr_log_path: {}",
+                entry.stderr_log_path.display()
+            );
+            let summary = format!("sent {} to {}", normalized, params.execution_id);
 
             Ok(CallToolResult::success(vec![
                 Content::text(output).with_audience(vec![Role::Assistant]),
@@ -976,29 +1102,34 @@ impl BashServer {
         #[cfg(windows)]
         {
             let mut map = self.inner.spawned.lock().await;
-            let entry = map.get_mut(&params.pid).ok_or_else(|| {
+            let entry = map.get_mut(&params.execution_id).ok_or_else(|| {
                 ErrorData::invalid_params(
-                    format!("pid {} is not a tracked background process", params.pid),
+                    format!(
+                        "execution_id '{}' is not a tracked background process",
+                        params.execution_id
+                    ),
                     None,
                 )
             })?;
 
             if let Err(e) = entry.child.start_kill() {
                 return Err(internal_error(format!(
-                    "failed to terminate pid {}: {e}",
-                    params.pid
+                    "failed to terminate execution_id '{}': {e}",
+                    params.execution_id
                 )));
             }
 
             let command = entry.command.clone();
-            let log_path = entry.log_path.clone();
+            let stdout_log_path = entry.stdout_log_path.clone();
+            let stderr_log_path = entry.stderr_log_path.clone();
 
             let mut output = String::new();
-            let _ = writeln!(output, "pid: {}", params.pid);
+            let _ = writeln!(output, "execution_id: {}", params.execution_id);
             let _ = writeln!(output, "signal: {}", normalized);
             let _ = writeln!(output, "command: {}", command);
-            let _ = write!(output, "log_path: {}", log_path.display());
-            let summary = format!("sent {} to pid {}", normalized, params.pid);
+            let _ = writeln!(output, "stdout_log_path: {}", stdout_log_path.display());
+            let _ = write!(output, "stderr_log_path: {}", stderr_log_path.display());
+            let summary = format!("sent {} to {}", normalized, params.execution_id);
 
             Ok(CallToolResult::success(vec![
                 Content::text(output).with_audience(vec![Role::Assistant]),
@@ -1147,17 +1278,17 @@ impl ServerHandler for BashServer {
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "read_exec_log",
-                    "Read a temp stdout/stderr log file generated by this bash server. Supports offset/limit/tail/grep/head_lines/tail_lines/max_output_bytes, but only for server-owned temp logs.",
+                    "Read a temp stdout/stderr log file generated by this bash server. Use execution_id from exec/wait response with stream 'stdout' or 'stderr'. Supports offset/limit/tail/grep/head_lines/tail_lines/max_output_bytes, but only for server-owned temp logs.",
                     Map::new(),
                 )
                 .with_input_schema::<ReadExecLogParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**read log** `{{ args.path }}`",
+                    "call_template": "**read log** `{{ args.execution_id }}/{{ args.stream }}`",
                     "result_template": "{{ result.content[0].text | default('') }}"
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "spawn",
-                    "Spawn a background bash command. Returns the PID and log file path immediately without waiting for the command to finish. Output is written to a log file. Use 'wait' to check for completion and 'terminate' to stop it.",
+                    "Spawn a background bash command. Returns an execution_id and log file paths immediately without waiting for the command to finish. Output is written to separate stdout.log and stderr.log files. Use 'wait' to check for completion and 'terminate' to stop it.",
                     Map::new(),
                 )
                 .with_input_schema::<SpawnCommandParams>()
@@ -1167,12 +1298,12 @@ impl ServerHandler for BashServer {
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "wait",
-                    "Wait for a spawned background process to exit. Returns the exit code and tail of the log file. If the process does not exit within the timeout, returns its current status and log tail without killing it.",
+                    "Wait for a spawned background process to exit. Returns the exit code, output metrics, and truncated output. If the process does not exit within the timeout, returns its current status and partial output without killing it.",
                     Map::new(),
                 )
                 .with_input_schema::<WaitParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**wait** for PID {{ args.pid }}",
+                    "call_template": "**wait** for {{ args.execution_id }}",
                     "result_template": "{{ result.content[0].text | default('') }}"
                 }).as_object().unwrap().clone())),
                 Tool::new(
@@ -1182,7 +1313,7 @@ impl ServerHandler for BashServer {
                 )
                 .with_input_schema::<TerminateParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**terminate** PID {{ args.pid }}{% if args.signal %} ({{ args.signal }}){% endif %}",
+                    "call_template": "**terminate** {{ args.execution_id }}{% if args.signal %} ({{ args.signal }}){% endif %}",
                     "result_template": "{{ result.content[0].text | default('') }}"
                 }).as_object().unwrap().clone())),
                 Tool::new(
@@ -1340,24 +1471,6 @@ async fn join_pipe(
         .map_err(|err| internal_error(format!("failed to read {name}: {err}")))
 }
 
-fn merge_output(stdout: &[u8], stderr: &[u8]) -> Vec<u8> {
-    if stdout.is_empty() {
-        return stderr.to_vec();
-    }
-    if stderr.is_empty() {
-        return stdout.to_vec();
-    }
-
-    let needs_separator = !stdout.ends_with(b"\n") && !stderr.starts_with(b"\n");
-    let mut merged = Vec::with_capacity(stdout.len() + stderr.len() + usize::from(needs_separator));
-    merged.extend_from_slice(stdout);
-    if needs_separator {
-        merged.push(b'\n');
-    }
-    merged.extend_from_slice(stderr);
-    merged
-}
-
 fn count_lines(s: &str) -> usize {
     if s.is_empty() {
         0
@@ -1366,65 +1479,135 @@ fn count_lines(s: &str) -> usize {
     }
 }
 
-fn render_output_block(
-    original: &str,
-    truncated: &str,
-    log_paths: Option<(&Path, &Path)>,
+/// Render one stream's output block with `===== stdout =====` / `===== /stdout =====` markers.
+/// Each stream is truncated independently using `truncate_opts`.
+/// Returns the rendered block string (no trailing newline).
+fn render_stream_block(
+    name: &str,
+    content: &str,
+    truncate_opts: &TruncateOpts,
+    log_hint: Option<(&str, &Path)>, // (execution_id, log_path) for truncation hint
 ) -> String {
-    if truncated.is_empty() {
-        return "output: <empty>".to_string();
+    let sanitized = sanitize_output_text(content);
+    if sanitized.is_empty() {
+        return format!("===== {name} (empty) =====");
     }
-
-    if original == truncated {
-        format!("output:\n{truncated}")
-    } else {
-        let mut message = format!(
-            "output:\n{truncated}\n\n[output truncated from {} to {}. Use max_output_bytes, head_lines, or tail_lines to see more",
-            format_size(original.len()),
-            format_size(truncated.len())
-        );
-        if let Some((stdout_log_path, stderr_log_path)) = log_paths {
+    let truncated = truncate_output(&sanitized, truncate_opts);
+    let was_truncated = truncated != sanitized;
+    let mut block = format!("===== {name} =====\n{truncated}");
+    if was_truncated {
+        if let Some((execution_id, log_path)) = log_hint {
             let _ = write!(
-                message,
-                "; full logs available via read_exec_log: stdout={}, stderr={}",
-                stdout_log_path.display(),
-                stderr_log_path.display()
+                block,
+                "\n\n[{name} truncated from {} to {}. Use max_output_bytes, head_lines, or tail_lines to see more; full log via read_exec_log: execution_id={execution_id}, stream={name} ({})]",
+                format_size(sanitized.len()),
+                format_size(truncated.len()),
+                log_path.display()
+            );
+        } else {
+            let _ = write!(
+                block,
+                "\n\n[{name} truncated from {} to {}. Use max_output_bytes, head_lines, or tail_lines to see more]",
+                format_size(sanitized.len()),
+                format_size(truncated.len())
             );
         }
-        message.push(']');
-        message
     }
+    let _ = write!(block, "\n===== /{name} =====");
+    block
+}
+
+/// Render separate stdout and stderr blocks, each truncated independently.
+/// Returns (rendered_string, stdout_lines, stderr_lines, stdout_bytes, stderr_bytes).
+/// Apply a grep regex filter to each line of `content`, returning only matching lines joined by `\n`.
+/// Lines that fail regex evaluation are kept (fail-open).
+fn grep_filter(content: &str, grep_regex: &Regex) -> String {
+    content
+        .lines()
+        .filter(|line| grep_regex.is_match(line).unwrap_or(true))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Render separate stdout and stderr blocks, each grep-filtered and truncated independently.
+/// Returns (rendered_string, stdout_lines, stderr_lines, stdout_bytes, stderr_bytes).
+/// Metrics reflect post-grep content so callers see accurate totals.
+fn render_streams_block(
+    stdout: &str,
+    stderr: &str,
+    truncate_opts: &TruncateOpts,
+    grep_regex: Option<&Regex>,
+    execution_id: &str,
+    stdout_log_path: &Path,
+    stderr_log_path: &Path,
+) -> (String, usize, usize, usize, usize) {
+    let stdout_filtered = grep_regex
+        .map(|r| grep_filter(stdout, r))
+        .unwrap_or_else(|| stdout.to_owned());
+    let stderr_filtered = grep_regex
+        .map(|r| grep_filter(stderr, r))
+        .unwrap_or_else(|| stderr.to_owned());
+
+    let stdout_lines = count_lines(&stdout_filtered);
+    let stderr_lines = count_lines(&stderr_filtered);
+    let stdout_bytes = stdout_filtered.len();
+    let stderr_bytes = stderr_filtered.len();
+
+    let stdout_block = render_stream_block(
+        "stdout",
+        &stdout_filtered,
+        truncate_opts,
+        Some((execution_id, stdout_log_path)),
+    );
+    let stderr_block = render_stream_block(
+        "stderr",
+        &stderr_filtered,
+        truncate_opts,
+        Some((execution_id, stderr_log_path)),
+    );
+
+    let rendered = format!("{stdout_block}\n{stderr_block}");
+    (
+        rendered,
+        stdout_lines,
+        stderr_lines,
+        stdout_bytes,
+        stderr_bytes,
+    )
 }
 
 struct TimeoutRenderContext<'a> {
     working_dir: &'a Path,
+    execution_id: &'a str,
     timeout_secs: u64,
     total_lines: usize,
     total_bytes: usize,
-    original: &'a str,
-    truncated: &'a str,
+    stdout: &'a str,
+    stderr: &'a str,
+    truncate_opts: &'a TruncateOpts,
     stdout_log_path: &'a Path,
     stderr_log_path: &'a Path,
-    output_truncated: bool,
 }
 
 fn render_timeout_message(ctx: TimeoutRenderContext<'_>) -> String {
     let TimeoutRenderContext {
         working_dir,
+        execution_id,
         timeout_secs,
         total_lines,
         total_bytes,
-        original,
-        truncated,
+        stdout,
+        stderr,
+        truncate_opts,
         stdout_log_path,
         stderr_log_path,
-        output_truncated,
     } = ctx;
     let mut output = String::new();
     let _ = writeln!(
         output,
         "command timed out after {timeout_secs}s and was terminated"
     );
+    let _ = writeln!(output, "execution_id: {execution_id}");
     let _ = writeln!(output, "working_dir: {}", working_dir.display());
     let _ = writeln!(output, "stdout_log_path: {}", stdout_log_path.display());
     let _ = writeln!(output, "stderr_log_path: {}", stderr_log_path.display());
@@ -1434,34 +1617,17 @@ fn render_timeout_message(ctx: TimeoutRenderContext<'_>) -> String {
         "total_bytes: {total_bytes} ({})",
         format_size(total_bytes)
     );
-    let _ = write!(
-        output,
-        "\n{}",
-        render_output_block(
-            original,
-            truncated,
-            output_truncated.then_some((stdout_log_path, stderr_log_path)),
-        )
+    let (streams_block, _, _, _, _) = render_streams_block(
+        stdout,
+        stderr,
+        truncate_opts,
+        None,
+        execution_id,
+        stdout_log_path,
+        stderr_log_path,
     );
+    let _ = write!(output, "\n{streams_block}");
     output
-}
-
-fn read_log_tail(path: &Path, n: usize) -> String {
-    let content = match std::fs::read_to_string(path) {
-        Ok(s) => s,
-        Err(err) => return format!("log: <error reading {}: {err}>", path.display()),
-    };
-    if content.is_empty() {
-        return "log: <empty>".to_string();
-    }
-    let lines: Vec<&str> = content.lines().collect();
-    let total = lines.len();
-    if total <= n {
-        format!("log ({total} lines):\n{content}")
-    } else {
-        let tail = lines[total - n..].join("\n");
-        format!("log (last {n} of {total} lines):\n{tail}")
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1612,7 +1778,7 @@ mod tests {
             )
             .with_input_schema::<WaitParams>()
             .with_meta(Meta(json!({
-                "call_template": "**wait** for PID {{ args.pid }}",
+                "call_template": "**wait** for {{ args.execution_id }}",
                 "result_template": "{{ result.content[0].text | default('') }}"
             }).as_object().unwrap().clone())),
             Tool::new(
@@ -1622,7 +1788,7 @@ mod tests {
             )
             .with_input_schema::<TerminateParams>()
             .with_meta(Meta(json!({
-                "call_template": "**terminate** PID {{ args.pid }}{% if args.signal %} ({{ args.signal }}){% endif %}",
+                "call_template": "**terminate** {{ args.execution_id }}{% if args.signal %} ({{ args.signal }}){% endif %}",
                 "result_template": "{{ result.content[0].text | default('') }}"
             }).as_object().unwrap().clone())),
         ];
@@ -1787,15 +1953,14 @@ mod tests {
             .unwrap();
 
         let text = text_content(&result);
-        let stdout_log_path = extract_field(&text, "stdout_log_path");
-        let stderr_log_path = extract_field(&text, "stderr_log_path");
-        assert!(text.contains("full logs available via read_exec_log"));
-        assert!(text.contains(&stdout_log_path));
-        assert!(text.contains(&stderr_log_path));
+        let execution_id = extract_field(&text, "execution_id");
+        assert!(text.contains("full log via read_exec_log"));
+        assert!(text.contains(&execution_id));
 
         let stdout_read = server
             .read_exec_log_impl(ReadExecLogParams {
-                path: stdout_log_path.clone(),
+                execution_id: execution_id.clone(),
+                stream: "stdout".to_string(),
                 offset: None,
                 limit: None,
                 tail: None,
@@ -1813,7 +1978,8 @@ mod tests {
 
         let stderr_read = server
             .read_exec_log_impl(ReadExecLogParams {
-                path: stderr_log_path,
+                execution_id,
+                stream: "stderr".to_string(),
                 offset: None,
                 limit: None,
                 tail: Some(1),
@@ -1830,15 +1996,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_read_exec_log_rejects_outside_path() {
+    async fn test_read_exec_log_rejects_invalid_stream() {
         let temp_dir = TestDir::new();
-        let outside = temp_dir.path().join("outside.log");
-        std::fs::write(&outside, "hello\n").unwrap();
         let server = BashServer::new(vec![temp_dir.path().to_path_buf()]);
 
         let result = server
             .read_exec_log_impl(ReadExecLogParams {
-                path: outside.to_string_lossy().to_string(),
+                execution_id: "exec-test".to_string(),
+                stream: "invalid".to_string(),
                 offset: None,
                 limit: None,
                 tail: None,
@@ -1853,7 +2018,7 @@ mod tests {
         assert!(result
             .unwrap_err()
             .message
-            .contains("outside the bash server temp log directory"));
+            .contains("stream must be 'stdout' or 'stderr'"));
     }
 
     #[tokio::test]
@@ -1896,20 +2061,16 @@ mod tests {
             .unwrap();
 
         let text = text_content(&result);
-        let pid: u32 = text
-            .lines()
-            .find(|l| l.starts_with("pid:"))
-            .unwrap()
-            .trim_start_matches("pid:")
-            .trim()
-            .parse()
-            .unwrap();
+        let execution_id = extract_field(&text, "execution_id");
 
         let result = server
             .wait_impl(WaitParams {
-                pid,
+                execution_id,
                 timeout_secs: Some(5),
+                head_lines: None,
                 tail_lines: Some(10),
+                max_output_bytes: None,
+                grep: None,
             })
             .await
             .unwrap();
@@ -1933,20 +2094,16 @@ mod tests {
             .unwrap();
 
         let text = text_content(&result);
-        let pid: u32 = text
-            .lines()
-            .find(|l| l.starts_with("pid:"))
-            .unwrap()
-            .trim_start_matches("pid:")
-            .trim()
-            .parse()
-            .unwrap();
+        let execution_id = extract_field(&text, "execution_id");
 
         let result = server
             .wait_impl(WaitParams {
-                pid,
+                execution_id,
                 timeout_secs: Some(1),
+                head_lines: None,
                 tail_lines: Some(10),
+                max_output_bytes: None,
+                grep: None,
             })
             .await
             .unwrap();
@@ -1969,18 +2126,11 @@ mod tests {
             .unwrap();
 
         let text = text_content(&result);
-        let pid: u32 = text
-            .lines()
-            .find(|l| l.starts_with("pid:"))
-            .unwrap()
-            .trim_start_matches("pid:")
-            .trim()
-            .parse()
-            .unwrap();
+        let execution_id = extract_field(&text, "execution_id");
 
         let result = server
             .terminate_impl(TerminateParams {
-                pid,
+                execution_id,
                 signal: Some("SIGTERM".to_string()),
             })
             .await
@@ -1991,15 +2141,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_wait_unknown_pid() {
+    async fn test_wait_unknown_execution_id() {
         let temp_dir = TestDir::new();
         let server = BashServer::new(vec![temp_dir.path().to_path_buf()]);
 
         let result = server
             .wait_impl(WaitParams {
-                pid: 99999999,
+                execution_id: "exec-does-not-exist".to_string(),
                 timeout_secs: Some(1),
+                head_lines: None,
                 tail_lines: None,
+                max_output_bytes: None,
+                grep: None,
             })
             .await;
 
@@ -2007,13 +2160,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_terminate_unknown_pid() {
+    async fn test_terminate_unknown_execution_id() {
         let temp_dir = TestDir::new();
         let server = BashServer::new(vec![temp_dir.path().to_path_buf()]);
 
         let result = server
             .terminate_impl(TerminateParams {
-                pid: 99999999,
+                execution_id: "exec-does-not-exist".to_string(),
                 signal: None,
             })
             .await;
@@ -2035,20 +2188,16 @@ mod tests {
             .unwrap();
 
         let text = text_content(&result);
-        let pid: u32 = text
-            .lines()
-            .find(|l| l.starts_with("pid:"))
-            .unwrap()
-            .trim_start_matches("pid:")
-            .trim()
-            .parse()
-            .unwrap();
+        let execution_id = extract_field(&text, "execution_id");
 
         let result = server
             .wait_impl(WaitParams {
-                pid,
+                execution_id,
                 timeout_secs: Some(5),
+                head_lines: None,
                 tail_lines: Some(10),
+                max_output_bytes: None,
+                grep: None,
             })
             .await
             .unwrap();

--- a/crates/harnx-runtime/src/bootstrap.rs
+++ b/crates/harnx-runtime/src/bootstrap.rs
@@ -16,6 +16,11 @@ use harnx_core::path::ensure_parent_exists;
 /// (HTTP serve, ACP) default to `harnx::serve` whereas CLI/TUI default to
 /// the top-level `harnx` filter so dot-command logs aren't suppressed.
 pub fn setup_logger(is_server: bool) -> Result<()> {
+    // LLM trace is independent of the simplelog filter — it must work even
+    // when log_level is Off, since it's the user's primary tool for debugging
+    // request/response correctness.
+    harnx_core::llm_trace::init_from_env();
+
     let (log_level, log_path) = Config::log_config(is_server)?;
     if log_level == LevelFilter::Off {
         return Ok(());

--- a/crates/harnx-runtime/src/config/input.rs
+++ b/crates/harnx-runtime/src/config/input.rs
@@ -168,16 +168,25 @@ pub fn prepare_completion_data(
 }
 
 pub fn build_messages(input: &Input, config: &GlobalConfig) -> Result<Vec<Message>> {
-    let mut messages = if let Some(session) = session_of(input, &config.read().session) {
+    let guard = config.read();
+    let session = session_of(input, &guard.session);
+    let with_session = session.is_some();
+    let mut messages = if let Some(session) = session {
         crate::config::session::build_messages(session, input)?
     } else {
         input.agent().build_messages(input)?
     };
-    if let Some(tool_calls) = &input.tool_calls {
-        messages.push(Message::new(
-            MessageRole::Assistant,
-            MessageContent::ToolCalls(tool_calls.clone()),
-        ))
+    drop(guard);
+    // Append `input.tool_calls` only when there's no session. With a session,
+    // `save_session_tool_calls` + `save_session_tool_results` already pushed
+    // the same `(call, result)` pair into `session.messages`.
+    if !with_session {
+        if let Some(tool_calls) = &input.tool_calls {
+            messages.push(Message::new(
+                MessageRole::Assistant,
+                MessageContent::ToolCalls(tool_calls.clone()),
+            ))
+        }
     }
     if let Some(text) = &input.injected_user_text {
         messages.push(Message::new(
@@ -365,4 +374,99 @@ fn read_media_to_data_url(image_path: &str) -> Result<String> {
     let data_url = format!("data:{mime_type};base64,{encoded_image}");
 
     Ok(data_url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{session, Config, ConfigData, GlobalConfig};
+    use crate::tool::{ToolCall, ToolResult};
+    use parking_lot::RwLock;
+    use serde_json::json;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    /// Regression test for the "continue replayed all Edits" bug.
+    ///
+    /// The agent loop saves each tool round to `session.messages` via
+    /// `save_session_tool_calls` + `save_session_tool_results`, then
+    /// calls `Input::merge_tool_results` to accumulate the same
+    /// `(call, result)` pair onto `input.tool_calls`. On the next loop
+    /// iteration, `build_messages` (this module) was appending
+    /// `input.tool_calls` as an extra `Assistant(ToolCalls)` message —
+    /// so the wire-format request contained the same tool round twice:
+    /// once as a Tool message in `session.messages`, and once as the
+    /// trailing assistant turn from `input.tool_calls`.
+    ///
+    /// As multi-round tool execution accumulated, the trailing duplicate
+    /// grew round by round. The model, seeing a single assistant turn
+    /// listing every prior tool call, generated narrations like
+    /// "continue replayed all Edits in order".
+    #[test]
+    fn build_messages_does_not_duplicate_tool_calls_when_session_has_them() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config {
+            data: ConfigData {
+                stream: false,
+                save_session: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut sess = session::new(&config, "trace-repro").unwrap();
+        sess.set_sessions_dir(tmp.path().to_path_buf());
+        config.session = Some(sess);
+        let global_config: GlobalConfig = Arc::new(RwLock::new(config));
+
+        let call = ToolCall {
+            name: "Edit".to_string(),
+            arguments: json!({"file_path": "/tmp/x", "old_string": "a", "new_string": "b"}),
+            id: Some("toolu_round1".to_string()),
+            thought_signature: None,
+        };
+        let result = ToolResult::new(
+            call.clone(),
+            json!({"content": [{"type": "text", "text": "edited"}]}),
+        );
+
+        let input = from_str(&global_config, "do the edit", None);
+        global_config
+            .write()
+            .save_session_tool_calls(
+                &input,
+                "thinking out loud",
+                None,
+                std::slice::from_ref(&call),
+            )
+            .unwrap();
+        global_config
+            .write()
+            .save_session_tool_results(std::slice::from_ref(&result))
+            .unwrap();
+
+        let merged =
+            input.merge_tool_results("thinking out loud".to_string(), None, vec![result.clone()]);
+
+        let messages = build_messages(&merged, &global_config).unwrap();
+
+        let id = call.id.as_deref().unwrap();
+        let hits = messages
+            .iter()
+            .filter(|msg| match &msg.content {
+                MessageContent::ToolCalls(tc) => tc
+                    .tool_results
+                    .iter()
+                    .any(|r| r.call.id.as_deref() == Some(id)),
+                _ => false,
+            })
+            .count();
+
+        assert_eq!(
+            hits, 1,
+            "tool call id {id} should appear in exactly one message; \
+             duplication makes the wire request re-send the prior tool \
+             round and triggers 'continue replayed all Edits' narrations \
+             from the model. messages: {messages:#?}",
+        );
+    }
 }

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -979,6 +979,16 @@ pub fn build_messages(session: &Session, input: &Input) -> Result<Vec<Message>> 
             messages.extend(session.compressed_messages[index..].to_vec());
         }
     }
+    // Continuation: if the last saved message is a pending Tool round,
+    // we're mid-tool-round (the agent loop is iterating with the same
+    // `Input`). The user's original message is already in the session,
+    // so don't append a duplicate copy at the end — that fooled the
+    // model into treating each round as a fresh user re-ask and looping
+    // on "Let me look at the current state…". Mirrors the same heuristic
+    // `begin_turn` uses when saving the round.
+    if need_add_msg && messages.last().is_some_and(|m| m.role == MessageRole::Tool) {
+        need_add_msg = false;
+    }
     if need_add_msg {
         // When the agent was swapped after construction (e.g. compaction),
         // inject_system_prompt is true and we must prepend the agent's
@@ -1467,6 +1477,78 @@ mod tests {
         assert_eq!(
             injected_count_after_clear, 2,
             "after clearing injected_user_text, no further duplicates are appended"
+        );
+    }
+
+    /// Regression test: during multi-round tool execution, the agent
+    /// loop reuses the same `Input` per round. `session.messages`
+    /// already contains the user's original query (saved by
+    /// `begin_turn` on round 1), so `build_messages` must NOT append
+    /// another copy of `input.message_content()` at the end. The
+    /// continuation marker is the last in-memory message being a
+    /// `Tool`-role pending tool round — same heuristic `begin_turn`
+    /// uses to skip its own user-message push.
+    ///
+    /// Original symptom: every multi-round request ended with the
+    /// user's original question appended after the tool_result, so the
+    /// model treated each round as if the user had re-asked the same
+    /// question and looped emitting "Let me look at the current state…"
+    /// forever.
+    #[test]
+    fn build_messages_does_not_append_duplicate_user_during_tool_round() {
+        use crate::tool::{ToolCall, ToolResult};
+        use serde_json::json;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let mut session = test_session();
+        session.set_sessions_dir(tmp.path().to_path_buf());
+
+        let config = Config::default();
+        let agent = config.extract_agent();
+        let global_config = std::sync::Arc::new(parking_lot::RwLock::new(config));
+        let user_text =
+            "I noticed something in the agent prompts and want to look at it".to_string();
+        let input = crate::config::input::from_str(&global_config, &user_text, Some(agent));
+
+        // Round 1: save a tool round to the session as the agent loop would.
+        let call = ToolCall {
+            name: "Read".to_string(),
+            arguments: json!({"path": "/tmp/x"}),
+            id: Some("toolu_round1".to_string()),
+            thought_signature: None,
+        };
+        super::add_tool_calls(
+            &mut session,
+            &input,
+            "Let me look at the directory.",
+            None,
+            std::slice::from_ref(&call),
+        )
+        .unwrap();
+        super::add_tool_results(
+            &mut session,
+            &[ToolResult::new(call, json!({"content": "file body"}))],
+        )
+        .unwrap();
+
+        // session.messages now ends with a Tool message — that's the
+        // signal that we're mid-tool-round. The next agent_loop iteration
+        // calls build_messages with the *same* input.
+        assert_eq!(session.messages.last().unwrap().role, MessageRole::Tool);
+
+        let messages = super::build_messages(&session, &input).unwrap();
+
+        let user_text_count = messages
+            .iter()
+            .filter(|m| m.role == MessageRole::User && m.content.to_text() == user_text)
+            .count();
+        assert_eq!(
+            user_text_count, 1,
+            "user's original question should appear exactly once in the wire-format \
+             request; appending it again after the tool round makes the model think \
+             the user re-asked and loops on 'Let me look at the current state…'. \
+             messages: {messages:#?}"
         );
     }
 }

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -65,6 +65,14 @@ Harnx can load environment variables from a `.env` file located in the configura
 
 - **HARNX_LOG_LEVEL**: The log level (e.g., `debug`, `info`).
 - **HARNX_LOG_FILE**: The path to the log file.
+- **HARNX_LLM_TRACE**: Path to a file that receives one JSON line per LLM
+  HTTP request and per response chunk. Independent of `HARNX_LOG_LEVEL`.
+  Each line is `{ts, kind, ...}` where `kind` is `request`, `response`, or
+  `stream-event`. Use this to inspect exactly what the harness sent to the
+  model and what it received — for example, when the model claims tool
+  results were "replayed" or "cached" and you want to confirm whether the
+  message history the harness built is responsible. The file is appended,
+  not truncated, so set a fresh path per session.
 
 ## Generic Envs
 

--- a/docs/solutions/integration-issues/stable-execution-identifiers-2026-04-27.md
+++ b/docs/solutions/integration-issues/stable-execution-identifiers-2026-04-27.md
@@ -1,0 +1,232 @@
+---
+title: "Stable execution identifiers via UUID tempdir pattern in bash MCP server"
+date: 2026-04-27
+category: "integration-issues"
+problem_type: integration_issue
+component: "harnx-mcp-bash"
+root_cause: "PID reuse and counter-based identifiers created unstable, collision-prone execution tracking"
+resolution_type: code_fix
+severity: high
+tags:
+  - tempfile
+  - uuid
+  - execution-tracking
+  - bash-mcp
+  - validate_path
+plan_ref: "issue-352-bash-mcp-refactor"
+---
+
+## Problem
+
+The bash MCP server used OS PIDs (`u32`) as HashMap keys for tracking spawned processes and `AtomicU64` counters for generating log file names. PIDs are reused by the OS after process exit, causing collisions. Counter-based log names (`bg-{seq}.log`, `exec-{seq}.stdout.log`) required global state, had potential for wrap-around collisions, and were not stable external identifiers. Additionally, `spawn` merged stdout/stderr into a single file while `exec` kept them separate, creating inconsistency.
+
+## Symptoms
+
+```
+- spawned HashMap keyed on PID — PID reuse could orphan or misidentify processes
+- spawn returned `pid: <u32>` field that clients had to track
+- spawn wrote merged stdout+stderr to single file; exec used separate files
+- wait output format differed from exec: missing filtering params, different field
+  structure
+- read_exec_log required clients to construct file paths manually
+- Counter state persisted across server restarts, no uniqueness guarantee
+```
+
+## Investigation Steps
+
+Reviewed `BashServerInner` struct in `crates/harnx-mcp-bash/src/server.rs`. Found `spawned: Mutex<HashMap<u32, SpawnedProcess>>` keyed on PID, plus `spawn_counter` and `exec_counter` AtomicU64 fields. Traced `spawn_impl` to see merged log file creation via `bg-{seq}.log` pattern. Compared `wait_impl` response formatting against `exec_command_impl` — confirmed field mismatches and missing filter params.
+
+Noted that `tempfile` crate was already a workspace dependency. Investigated `tempfile::Builder::prefix().tempdir_in()` pattern for generating unique directories whose names serve as stable identifiers.
+
+First attempt at bulk refactor via regex substitution failed — produced duplicate `ExecCommandParams` definition and schema drift. Reverted to HEAD and used targeted Edit-tool replacements section by section.
+
+## Root Cause
+
+1. **PID reuse vulnerability**: OS reuses PIDs after process exit. A long-running server could see the same PID for different processes, corrupting the `spawned` map.
+
+2. **Counter brittleness**: `AtomicU64` counters required global state in `BashServerInner`, added complexity, and were semantically disconnected from the actual execution lifecycle.
+
+3. **Format inconsistency**: `spawn` merged streams; `exec` kept them separate. `wait` lacked grep/head_lines params and used different response schema.
+
+4. **Path construction burden**: `read_exec_log` accepted raw `path: String`, forcing clients to know internal log directory structure.
+
+## Solution
+
+### Per-execution directory pattern
+
+Replaced counters with `tempfile::Builder` to create unique directories per execution. The directory name becomes the stable `execution_id`.
+
+```rust
+fn next_exec_dir(&self) -> Result<tempfile::TempDir, ErrorData> {
+    tempfile::Builder::new()
+        .prefix("exec-")
+        .tempdir_in(&self.inner.log_dir)
+        .map_err(|err| internal_error(format!("failed to create exec directory: {err}")))
+}
+```
+
+Usage in `exec_command_impl` and `spawn_impl`:
+
+```rust
+let exec_dir = self.next_exec_dir()?;
+let stdout_log_path = exec_dir.path().join("stdout.log");
+let stderr_log_path = exec_dir.path().join("stderr.log");
+let execution_id = exec_dir.path()
+    .file_name()
+    .unwrap()
+    .to_string_lossy()
+    .into_owned();
+// Keep TempDir alive until response built (exec) or persist via into_path() (spawn)
+```
+
+### Struct refactoring
+
+Changed `spawned` HashMap key from `u32` to `String`:
+
+```rust
+// Before
+spawned: Mutex<HashMap<u32, SpawnedProcess>>,
+
+// After
+spawned: Mutex<HashMap<String, SpawnedProcess>>,
+```
+
+Removed `SpawnedProcess.log_path` and added `stdout_log_path`/`stderr_log_path`. Removed `spawn_counter` and `exec_counter` from `BashServerInner`.
+
+### Independent stream rendering with clear markers
+
+Added `render_stream_block` and `render_streams_block` for per-stream independent truncation:
+
+```rust
+fn render_stream_block(
+    name: &str,
+    content: &str,
+    truncate_opts: &TruncateOpts,
+    log_hint: Option<(&str, &Path)>,
+) -> String {
+    let sanitized = sanitize_output_text(content);
+    if sanitized.is_empty() {
+        return format!("===== {name} (empty) =====");
+    }
+
+    let (truncated, _) = truncate_output(&sanitized, truncate_opts);
+    let mut block = format!("===== {name} =====\n{truncated}");
+
+    // Add truncation hint if content was reduced
+    if truncated.len() < sanitized.len() {
+        if let Some((execution_id, log_path)) = log_hint {
+            let _ = write!(
+                block,
+                "\n\n[{name} truncated from {} to {}. Use max_output_bytes, head_lines, or tail_lines to see more; full log via read_exec_log: execution_id={execution_id}, stream={name} ({})]",
+                format_size(sanitized.len()),
+                format_size(truncated.len()),
+                log_path.display()
+            );
+        }
+    }
+
+    let _ = write!(block, "\n===== /{name} =====");
+    block
+}
+```
+
+Result format:
+
+```
+===== stdout =====
+<content>
+===== /stdout =====
+===== stderr (empty) =====
+```
+
+### read_exec_log refactor to use execution_id
+
+Changed params from `path: String` to `execution_id: String` + `stream: String`:
+
+```rust
+struct ReadExecLogParams {
+    execution_id: String,
+    stream: String,  // "stdout" or "stderr"
+    // ...filter params...
+}
+```
+
+Path construction now happens server-side:
+
+```rust
+// Validate stream parameter
+if params.stream != "stdout" && params.stream != "stderr" {
+    return Err(ErrorData::invalid_params(
+        format!("stream must be 'stdout' or 'stderr', got '{}'", params.stream),
+        None,
+    ));
+}
+
+// Construct absolute path: log_dir/execution_id/stream.log
+// We pass the absolute path string so validate_path uses canonicalize() correctly
+// (passing a relative string would resolve against cwd, not log_dir).
+let abs = self.inner.log_dir
+    .join(&params.execution_id)
+    .join(format!("{}.log", params.stream));
+let path = validate_path(
+    abs.to_string_lossy().as_ref(),
+    std::slice::from_ref(&self.inner.log_dir),
+)?;
+```
+
+## Why This Works
+
+**UUID-based tempdir names** (`exec-<random>`) are globally unique, stable for the execution lifetime, and require no global counter state. The `tempfile` crate handles collision avoidance internally.
+
+**String execution_id** as HashMap key is stable and opaque — clients don't need to know it's a directory name.
+
+**Independent stream files** (`stdout.log`, `stderr.log`) allow per-stream filtering, truncation, and retrieval via `read_exec_log` with `stream` param.
+
+**Marker convention** (`===== stdout =====` / `===== /stdout =====`) lets LLM/agent readers unambiguously parse output blocks. Empty streams render as `===== stderr (empty) =====` (compact, no end marker).
+
+**Server-side path construction** in `read_exec_log` hides log directory layout from clients and ensures `validate_path` security check works correctly.
+
+## Gotcha: validate_path requires absolute paths
+
+The `read_exec_log_impl` implementation constructs an absolute path before passing to `validate_path`:
+
+```rust
+let abs = self.inner.log_dir.join(&params.execution_id).join(format!("{}.log", params.stream));
+let path = validate_path(
+    abs.to_string_lossy().as_ref(),  // absolute path string
+    std::slice::from_ref(&self.inner.log_dir),
+)?;
+```
+
+Reason: `validate_path` internally uses `std::fs::canonicalize()` on the input path. If a relative path string is passed, canonicalize resolves it against the **current working directory**, not `log_dir`. This causes "Cannot resolve path" errors or incorrect path validation.
+
+Always construct the absolute path before calling `validate_path` when the root is not cwd.
+
+## Advisory: server.rs file size
+
+CodeScene flagged server.rs growing from 1549 → 1664 lines, along with increased Low Cohesion metric (12 → 13 responsibilities). This is **not a CI gate** (cs delta exited 0). The file was already over-threshold before this change.
+
+**Future work**: Split `server.rs` into sub-modules (e.g., `exec.rs`, `spawn.rs`, `render.rs`, `tool_defs.rs`) to reduce file size and improve cohesion. Out of scope for this refactor.
+
+## Prevention Strategies
+
+**Test cases:**
+- Verify `execution_id` is present in all exec/spawn/wait/terminate responses
+- Test that `wait` accepts same filtering params as `exec`
+- Test `read_exec_log` with `execution_id` + `stream` params for both stdout and stderr
+- Test `read_exec_log` rejects invalid stream values
+- Verify spawned processes tracked by String execution_id, not PID
+
+**Code review checklist:**
+- [ ] No PID-based HashMap keys for long-lived state
+- [ ] `validate_path` called with absolute path strings
+- [ ] TempDir kept alive until response built (exec) or converted with `into_path()` (spawn)
+- [ ] Empty streams rendered as `===== name (empty) =====` without end marker
+
+**Monitoring:**
+- Consider alerting if `spawned` HashMap grows unbounded (orphaned entries detection)
+
+## Related Issues
+
+- **Issue:** [#352](https://github.com/example/harnx-2/issues/352) — Bash tool inconsistencies fixup
+- **CodeScene advisory:** File size 1549→1664, cohesion 12→13 — not blocking, tracked for future refactor


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LLM request/response tracing via `HARNX_LLM_TRACE` environment variable for auditing LLM I/O.
  * Bash MCP server now uses stable execution identifiers instead of PIDs; logs stdout and stderr separately per execution.

* **Bug Fixes**
  * Fixed duplicate assistant tool call messages in session-enabled configurations.
  * Fixed message duplication during multi-round tool conversations.

* **Documentation**
  * Added `HARNX_LLM_TRACE` environment variable documentation.
  * Added solution guide for stable execution identifier implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->