### PR TITLE
fix(acp): drain forwarder on teardown so nested events don't get dropped

### DIFF
--- a/crates/harnx-acp/src/manager.rs
+++ b/crates/harnx-acp/src/manager.rs
@@ -438,10 +438,14 @@ impl ToolProvider for AcpManager {
             }
         };
 
-        // Tear down: unsubscribe first (closes the channel), then
-        // await the forward task.
+        // Tear down: drop every sender for this subscription, then await
+        // the forwarder so it can drain anything still queued before
+        // exiting. Calling `abort()` here would race with that drain and
+        // silently swallow late events (e.g. the sub-agent's final text
+        // chunk arriving just before its session_prompt response), which
+        // showed up as flaky standalone activity rendering in the
+        // nested-sub-agent transcript.
         self.unsubscribe_chunks(subscription_id).await;
-        forward_handle.abort();
         let _ = forward_handle.await;
 
         if let Some(s) = spinner {


### PR DESCRIPTION
## Summary

`AcpManager::call_tool` was calling `forward_handle.abort()` before awaiting the chunk-forwarder task on teardown. `abort()` races with the channel drain, so nested events still queued in `chunk_rx` at that moment — most often the sub-agent's *final* text chunk — were silently discarded. Drop the abort and let `forward_acp_chunks` exit naturally once `unsubscribe_chunks` drops every sender for the subscription.

The sister forwarder in `harnx-acp-server` (`drop(loop_ctx); fwd_task.await`) already follows this pattern; this aligns the parent-side teardown with it and with the comment that already lived above the abort line ("unsubscribe first (closes the channel), then await the forward task").

## Why the test was still flaky after #370

PR #370 fixed a different race (mock turn ordering driven by a global counter). The 2026-04-29 CI failure on main has a different signature: the joined `response: …Researcher complete` text is correctly present in the parent's tool result, but the standalone `> nested-researcher ▸ [UUID] / Researcher complete` activity block is missing. The explicit `count_occurrences("Researcher complete") >= 1` assertion still passes (because the joined response line contains it), so only the snapshot catches the regression.

Two distinct paths populate that screen text:
1. **Joined `response_text`** — appended directly inside `AcpNotificationClient::session_notification` (`crates/harnx-acp/src/client.rs:303-308`). Becomes the body of the tool's `response:` field. Unaffected by the bug.
2. **Standalone activity rendering** — `forward_agent_event` → `chunk_forwarder` → `forward_acp_chunks` → `emit_agent_event_with_source` → TUI sink. **This is the path being aborted mid-drain.**

That's exactly the failure pattern in the snapshot diff.

## Test plan
- [x] `cargo test -p harnx-acp` — 21 passing, including the existing `forward_acp_chunks_preserves_*` drain tests
- [x] `cargo test --test tmux_e2e nested_sub_agent_activity_no_duplicates` x5 locally — all pass
- [x] `cargo test --test tmux_e2e` — all 8 e2e tests pass
- [x] `cargo test --workspace` — green
- [x] `cargo fmt --check` / `cargo clippy --tests` — clean
- [ ] CI to verify the failure mode no longer reproduces under load

Refs #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a race condition during tool-call termination that could result in loss of pending events. The system now properly drains all queued events before shutdown completes, improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->