### PR TITLE
feat(bash): restrict and curate child process environment

### DIFF
--- a/.changesets/bash-env-sanitization.md
+++ b/.changesets/bash-env-sanitization.md
@@ -1,0 +1,29 @@
+---
+harnx: minor
+---
+**Behaviour change** — `harnx-mcp-bash` no longer passes the full host
+environment to child bash processes. The child receives only a curated
+allowlist (`HOME`, `PATH`, `LANG`, `LANGUAGE`, `USER`, `SHELL`, `TERM`,
+`DISPLAY`, `EDITOR`, `NODE_OPTIONS`, `NODE_EXTRA_CA_CERTS`, `PWD`, `SHLVL`,
+`LOGNAME`, `TMPDIR`, `TMP`, `TEMP`, plus all `XDG_*` variables) plus any
+explicitly opted-in extras. This applies on every platform — including
+Windows, where sandboxing remains unavailable but environment curation is
+still performed.
+
+To opt vars back in, use any of:
+
+- CLI flags `-e VAR` (passthrough from host) or `-e VAR=VALUE` (explicit
+  override), repeatable.
+- Env var `HARNX_BASH_ENV_PASSTHROUGH=A,B,C` for a comma-separated list.
+- A `$HARNX_CONFIG_DIR/.env.bash` dotfile with `KEY=VALUE` lines for
+  persistent secrets.
+
+Precedence (highest wins): CLI > `HARNX_BASH_ENV_PASSTHROUGH` > `.env.bash`
+> default allowlist.
+
+**Upgrade impact**: existing workflows that relied on inheriting host env
+vars (e.g. `git push` over SSH needing `SSH_AUTH_SOCK`, `gh` needing
+`GITHUB_TOKEN`, custom tools reading project-specific vars) need to declare
+those vars explicitly. See `docs/bash-mcp-server.md` for recipes.
+
+Closes #375.

--- a/crates/harnx-mcp-bash/src/bin/sandbox_run.rs
+++ b/crates/harnx-mcp-bash/src/bin/sandbox_run.rs
@@ -19,6 +19,7 @@ struct SandboxConfig {
     exec_paths: Vec<PathBuf>,
     write_paths: Vec<PathBuf>,
     read_paths: Vec<PathBuf>,
+    env_vars: Vec<(String, String)>,
     no_network: bool,
     working_dir: Option<PathBuf>,
     command: Vec<OsString>,
@@ -27,7 +28,7 @@ struct SandboxConfig {
 #[cfg(unix)]
 fn print_usage() {
     println!(
-        "harnx-mcp-bash-sandbox-run [OPTIONS] -- <command> [args...]\n\nOptions:\n  --write <path>       Allow read+write (repeatable)\n  --read <path>        Allow read-only (repeatable)\n  --exec <path>        Allow read+execute (repeatable)\n  --no-network         Disable networking (default: networking allowed)\n  --working-dir <path> Set working directory of spawned command\n  --help, -h           Print this help"
+        "harnx-mcp-bash-sandbox-run [OPTIONS] -- <command> [args...]\n\nOptions:\n  --write <path>       Allow read+write (repeatable)\n  --read <path>        Allow read-only (repeatable)\n  --exec <path>        Allow read+execute (repeatable)\n  --env VAR[=VALUE]    Pass VAR from host env or set VALUE explicitly (repeatable)\n  --no-network         Disable networking (default: networking allowed)\n  --working-dir <path> Set working directory of spawned command\n  --help, -h           Print this help"
     );
 }
 
@@ -42,11 +43,31 @@ where
 }
 
 #[cfg(unix)]
+fn parse_env_arg(raw: &OsStr) -> Result<(String, Option<String>), String> {
+    let s = raw
+        .to_str()
+        .ok_or_else(|| "sandbox-run: --env value is not valid UTF-8".to_string())?;
+    if s.is_empty() {
+        return Err("sandbox-run: --env requires a non-empty variable name".to_string());
+    }
+    match s.split_once('=') {
+        Some((key, value)) => {
+            if key.is_empty() {
+                return Err("sandbox-run: --env requires a non-empty variable name".to_string());
+            }
+            Ok((key.to_string(), Some(value.to_string())))
+        }
+        None => Ok((s.to_string(), None)),
+    }
+}
+
+#[cfg(unix)]
 fn parse_args() -> Result<Option<SandboxConfig>, String> {
     let mut args = env::args_os().skip(1);
     let mut exec_paths = Vec::new();
     let mut write_paths = Vec::new();
     let mut read_paths = Vec::new();
+    let mut env_vars = Vec::new();
     let mut no_network = false;
     let mut working_dir = None;
 
@@ -60,6 +81,7 @@ fn parse_args() -> Result<Option<SandboxConfig>, String> {
                 exec_paths,
                 write_paths,
                 read_paths,
+                env_vars,
                 no_network,
                 working_dir,
                 command,
@@ -75,6 +97,17 @@ fn parse_args() -> Result<Option<SandboxConfig>, String> {
             }
             flag if flag == OsStr::new("--exec") => {
                 exec_paths.push(parse_path_arg(&mut args, "--exec")?);
+            }
+            flag if flag == OsStr::new("--env") => {
+                let raw = args
+                    .next()
+                    .ok_or_else(|| "sandbox-run: missing value for --env".to_string())?;
+                let (key, value) = parse_env_arg(&raw)?;
+                if let Some(value) = value {
+                    env_vars.push((key, value));
+                } else if let Ok(value) = env::var(&key) {
+                    env_vars.push((key, value));
+                }
             }
             flag if flag == OsStr::new("--working-dir") => {
                 working_dir = Some(parse_path_arg(&mut args, "--working-dir")?);
@@ -162,11 +195,6 @@ fn run() -> Result<i32, String> {
     };
 
     let mut sandbox = Birdcage::new();
-    sandbox
-        .add_exception(Exception::FullEnvironment)
-        .map_err(|error| {
-            format!("sandbox-run: failed to add FullEnvironment exception: {error}")
-        })?;
 
     for path in &config.exec_paths {
         add_path_exception(&mut sandbox, path, Exception::ExecuteAndRead)?;
@@ -181,6 +209,28 @@ fn run() -> Result<i32, String> {
         sandbox
             .add_exception(Exception::Networking)
             .map_err(|error| format!("sandbox-run: failed to add Networking exception: {error}"))?;
+    }
+
+    for (key, value) in &config.env_vars {
+        // Ensure the value lives in the current process env so birdcage's
+        // restrict_env_variables() preserves it for the child.
+        //
+        // SAFETY: `env::set_var` is unsafe because it mutates process-global
+        // state and is not thread-safe. This binary is the `sandbox_run`
+        // helper, which runs single-threaded up to this point — `parse_args`
+        // and the sandbox setup never spawn threads, and we have not yet
+        // called `sandbox.spawn(...)`. No other code in the process can be
+        // observing the environment concurrently, so the call is sound. We
+        // must do this before `sandbox.spawn(...)` because birdcage's
+        // `restrict_env_variables()` (invoked from `Birdcage::lock` inside
+        // `spawn`) inspects `std::env::vars()` and removes any variable not
+        // listed via `Exception::Environment`.
+        unsafe { env::set_var(key, value) };
+        sandbox
+            .add_exception(Exception::Environment(key.clone()))
+            .map_err(|error| {
+                format!("sandbox-run: failed to add env exception for {key}: {error}")
+            })?;
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/harnx-mcp-bash/src/main.rs
+++ b/crates/harnx-mcp-bash/src/main.rs
@@ -8,10 +8,7 @@ use std::path::PathBuf;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    #[cfg(unix)]
     let (roots, sandbox_config) = parse_args()?;
-    #[cfg(not(unix))]
-    let roots = parse_args();
 
     eprintln!(
         "harnx-mcp-bash v{}: starting ({} root{})",
@@ -39,10 +36,7 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    #[cfg(unix)]
     let server = BashServer::new_with_sandbox(roots, sandbox_config);
-    #[cfg(not(unix))]
-    let server = BashServer::new(roots);
     let cleanup_server = server.clone();
     let transport = rmcp::transport::stdio();
     let service = server.serve(transport).await?;
@@ -64,6 +58,17 @@ fn parse_env_paths(var_name: &str) -> Vec<PathBuf> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+#[cfg(unix)]
+fn parse_env_passthrough() -> Vec<String> {
+    std::env::var("HARNX_BASH_ENV_PASSTHROUGH")
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
 }
 
 #[cfg(unix)]
@@ -99,6 +104,8 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
         extra_exec: parse_env_paths("HARNX_BASH_EXTRA_EXEC"),
         extra_readable: parse_env_paths("HARNX_BASH_EXTRA_READABLE"),
         sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
+        extra_env_passthrough: parse_env_passthrough(),
+        env_overrides: vec![],
     };
     let mut sandbox_run_override = None;
     let mut i = 1;
@@ -148,6 +155,30 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
                     std::process::exit(1);
                 }
             }
+            "--env" | "-e" => {
+                if i + 1 < args.len() {
+                    let raw = &args[i + 1];
+                    if let Some((key, value)) = raw.split_once('=') {
+                        if key.is_empty() {
+                            eprintln!("harnx-mcp-bash: --env requires a non-empty variable name");
+                            std::process::exit(1);
+                        }
+                        sandbox_config
+                            .env_overrides
+                            .push((key.to_string(), value.to_string()));
+                    } else {
+                        if raw.is_empty() {
+                            eprintln!("harnx-mcp-bash: --env requires a non-empty variable name");
+                            std::process::exit(1);
+                        }
+                        sandbox_config.extra_env_passthrough.push(raw.clone());
+                    }
+                    i += 2;
+                } else {
+                    eprintln!("harnx-mcp-bash: --env requires an argument");
+                    std::process::exit(1);
+                }
+            }
             "--help" | "-h" => {
                 eprintln!("harnx-mcp-bash: MCP shell command server");
                 eprintln!();
@@ -159,14 +190,19 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
                 eprintln!("  --extra-readable <path> Add sandbox read-only path (repeatable)");
                 eprintln!("  --extra-exec <path>     Add sandbox execute path (repeatable)");
                 eprintln!("  --sandbox-run <path>    Override sandbox helper binary path");
+                eprintln!("  --env, -e <VAR>         Pass VAR from host env to child (repeatable)");
+                eprintln!("  --env, -e <VAR=VALUE>   Set VAR=VALUE in child env (repeatable)");
                 eprintln!("  --help, -h              Show this help message");
                 eprintln!();
                 eprintln!("Environment:");
                 eprintln!(
-                    "  HARNX_BASH_EXTRA_READABLE  Colon-separated extra sandbox read-only paths"
+                    "  HARNX_BASH_EXTRA_READABLE   Colon-separated extra sandbox read-only paths"
                 );
                 eprintln!(
-                    "  HARNX_BASH_EXTRA_EXEC      Colon-separated extra sandbox execute paths"
+                    "  HARNX_BASH_EXTRA_EXEC       Colon-separated extra sandbox execute paths"
+                );
+                eprintln!(
+                    "  HARNX_BASH_ENV_PASSTHROUGH  Comma-separated extra env var names to pass through"
                 );
                 eprintln!();
                 eprintln!("Sandboxing is enabled by default on Unix. Use --no-sandbox to disable it explicitly.");
@@ -216,9 +252,29 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
 }
 
 #[cfg(not(unix))]
-fn parse_args() -> Vec<PathBuf> {
+fn parse_env_passthrough() -> Vec<String> {
+    std::env::var("HARNX_BASH_ENV_PASSTHROUGH")
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+#[cfg(not(unix))]
+fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
     let args: Vec<String> = std::env::args().collect();
     let mut roots = Vec::new();
+    let mut sandbox_config = server::SandboxConfig {
+        // Sandbox itself is Unix-only; on Windows these fields are unused.
+        enabled: false,
+        extra_exec: vec![],
+        extra_readable: vec![],
+        sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
+        extra_env_passthrough: parse_env_passthrough(),
+        env_overrides: vec![],
+    };
     let mut i = 1;
 
     while i < args.len() {
@@ -232,19 +288,51 @@ fn parse_args() -> Vec<PathBuf> {
                     std::process::exit(1);
                 }
             }
+            "--env" | "-e" => {
+                if i + 1 < args.len() {
+                    let raw = &args[i + 1];
+                    if let Some((key, value)) = raw.split_once('=') {
+                        if key.is_empty() {
+                            eprintln!("harnx-mcp-bash: --env requires a non-empty variable name");
+                            std::process::exit(1);
+                        }
+                        sandbox_config
+                            .env_overrides
+                            .push((key.to_string(), value.to_string()));
+                    } else {
+                        if raw.is_empty() {
+                            eprintln!("harnx-mcp-bash: --env requires a non-empty variable name");
+                            std::process::exit(1);
+                        }
+                        sandbox_config.extra_env_passthrough.push(raw.clone());
+                    }
+                    i += 2;
+                } else {
+                    eprintln!("harnx-mcp-bash: --env requires an argument");
+                    std::process::exit(1);
+                }
+            }
             "--help" | "-h" => {
                 eprintln!("harnx-mcp-bash: MCP shell command server");
                 eprintln!();
                 eprintln!("Usage: harnx-mcp-bash [OPTIONS]");
                 eprintln!();
                 eprintln!("Options:");
-                eprintln!("  --root, -r <path>  Add an allowed root directory (repeatable)");
-                eprintln!("  --help, -h         Show this help message");
+                eprintln!("  --root, -r <path>       Add an allowed root directory (repeatable)");
+                eprintln!("  --env, -e <VAR>         Pass VAR from host env to child (repeatable)");
+                eprintln!("  --env, -e <VAR=VALUE>   Set VAR=VALUE in child env (repeatable)");
+                eprintln!("  --help, -h              Show this help message");
                 eprintln!();
-                eprintln!("Sandboxing is enabled by default on Unix. Use --no-sandbox to disable it explicitly.");
+                eprintln!("Environment:");
+                eprintln!(
+                    "  HARNX_BASH_ENV_PASSTHROUGH  Comma-separated extra env var names to pass through"
+                );
+                eprintln!();
+                eprintln!("Sandboxing is Unix-only. On other platforms the child bash process");
+                eprintln!("still receives only the curated environment built from the default");
+                eprintln!("allowlist plus any --env / passthrough configuration.");
                 eprintln!("The server communicates via stdio using the MCP protocol.");
                 eprintln!("If no roots are specified, operations are denied until the client provides roots.");
-                eprintln!("Roots can also be provided dynamically by the MCP client.");
                 std::process::exit(0);
             }
             other => {
@@ -255,5 +343,5 @@ fn parse_args() -> Vec<PathBuf> {
         }
     }
 
-    roots
+    Ok((roots, sandbox_config))
 }

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -276,12 +276,28 @@ struct SpawnedProcess {
     output_paths: Option<Vec<PathBuf>>,
 }
 
-#[cfg(unix)]
+/// Configuration for the bash MCP server's sandboxing and child env handling.
+///
+/// The sandboxing fields (`enabled`, `extra_exec`, `extra_readable`,
+/// `sandbox_run_path`) are honoured only on Unix; on other platforms they
+/// are accepted for API compatibility and ignored.
+///
+/// The env-control fields (`extra_env_passthrough`, `env_overrides`) are
+/// honoured on every platform — even when sandboxing is unavailable, the
+/// child bash process receives only the curated environment.
 #[derive(Clone, Debug)]
 pub struct SandboxConfig {
+    #[cfg_attr(not(unix), allow(dead_code))]
     pub enabled: bool,
+    #[cfg_attr(not(unix), allow(dead_code))]
     pub extra_exec: Vec<PathBuf>,
+    #[cfg_attr(not(unix), allow(dead_code))]
     pub extra_readable: Vec<PathBuf>,
+    /// Extra var names to pass through from host (allowlist additions).
+    pub extra_env_passthrough: Vec<String>,
+    /// Explicit overrides: KEY → VALUE (highest precedence).
+    pub env_overrides: Vec<(String, String)>,
+    #[cfg_attr(not(unix), allow(dead_code))]
     pub sandbox_run_path: PathBuf,
 }
 
@@ -291,7 +307,10 @@ struct BashServerInner {
     spawned: Mutex<HashMap<String, SpawnedProcess>>,
     log_dir: PathBuf,
     history: Arc<HistoryManager>,
-    #[cfg(unix)]
+    /// Sandbox + env config. Sandbox-specific fields (`enabled`,
+    /// `extra_exec`, `extra_readable`, `sandbox_run_path`) are only used on
+    /// Unix; env fields (`extra_env_passthrough`, `env_overrides`) are
+    /// honoured on every platform.
     sandbox_config: SandboxConfig,
 }
 
@@ -348,41 +367,41 @@ impl BashServer {
     #[allow(dead_code)]
     const SYSTEM_EXEC_PATHS: &[&str] = &["/usr/bin", "/bin", "/tmp", "/etc"];
 
-    #[cfg_attr(unix, allow(dead_code))]
-    pub fn new(initial_roots: Vec<PathBuf>) -> Self {
-        #[cfg(unix)]
-        {
-            Self::new_with_sandbox(
-                initial_roots,
-                SandboxConfig {
-                    enabled: false,
-                    extra_exec: vec![],
-                    extra_readable: vec![],
-                    sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
-                },
-            )
-        }
+    const DEFAULT_ENV_ALLOWLIST: &[&str] = &[
+        "HOME",
+        "PATH",
+        "LANG",
+        "LANGUAGE",
+        "USER",
+        "SHELL",
+        "TERM",
+        "DISPLAY",
+        "EDITOR",
+        "NODE_OPTIONS",
+        "NODE_EXTRA_CA_CERTS",
+        "PWD",
+        "SHLVL",
+        "LOGNAME",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+    ];
 
-        #[cfg(not(unix))]
-        {
-            let log_dir = std::env::temp_dir().join(format!(
-                "harnx-bash-{}-{}",
-                std::process::id(),
-                Uuid::new_v4()
-            ));
-            Self {
-                inner: Arc::new(BashServerInner {
-                    roots: RwLock::new(initial_roots.clone()),
-                    roots_initialized: AtomicBool::new(false),
-                    spawned: Mutex::new(HashMap::new()),
-                    log_dir,
-                    history: Arc::new(HistoryManager::new(&initial_roots)),
-                }),
-            }
-        }
+    #[allow(dead_code)]
+    pub fn new(initial_roots: Vec<PathBuf>) -> Self {
+        Self::new_with_sandbox(
+            initial_roots,
+            SandboxConfig {
+                enabled: false,
+                extra_exec: vec![],
+                extra_readable: vec![],
+                extra_env_passthrough: vec![],
+                env_overrides: vec![],
+                sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
+            },
+        )
     }
 
-    #[cfg(unix)]
     pub fn new_with_sandbox(initial_roots: Vec<PathBuf>, sandbox_config: SandboxConfig) -> Self {
         let log_dir = std::env::temp_dir().join(format!(
             "harnx-bash-{}-{}",
@@ -463,6 +482,63 @@ impl BashServer {
             .prefix("exec-")
             .tempdir_in(&self.inner.log_dir)
             .map_err(|err| internal_error(format!("failed to create exec directory: {err}")))
+    }
+
+    /// Build the child process environment from the configured sources.
+    ///
+    /// Layers, applied in order from lowest to highest precedence (later
+    /// entries replace earlier ones with the same key):
+    /// 1. Default allowlist values inherited from the host process env.
+    /// 2. `XDG_*` variables inherited from the host process env.
+    /// 3. `.env.bash` dotfile values.
+    /// 4. `extra_env_passthrough` — host values for explicitly named vars.
+    /// 5. `env_overrides` — explicit `KEY=VALUE` overrides.
+    ///
+    /// This applies on every platform; sandbox-specific behaviour
+    /// (birdcage exceptions, `sandbox_run` helper) remains Unix-only.
+    fn build_child_env(&self) -> Vec<(String, String)> {
+        fn upsert(env_vars: &mut Vec<(String, String)>, key: String, value: String) {
+            if let Some((_, existing)) = env_vars.iter_mut().find(|(k, _)| k == &key) {
+                *existing = value;
+            } else {
+                env_vars.push((key, value));
+            }
+        }
+
+        let mut env_vars: Vec<(String, String)> = Vec::new();
+
+        // 1. Default allowlist.
+        for name in Self::DEFAULT_ENV_ALLOWLIST {
+            if let Ok(value) = std::env::var(name) {
+                upsert(&mut env_vars, (*name).to_string(), value);
+            }
+        }
+
+        // 2. XDG_* vars from host env.
+        for (name, value) in std::env::vars() {
+            if name.starts_with("XDG_") {
+                upsert(&mut env_vars, name, value);
+            }
+        }
+
+        // 3. .env.bash dotfile.
+        for (key, value) in load_bash_env_file() {
+            upsert(&mut env_vars, key, value);
+        }
+
+        // 4. Explicit passthrough names — host value wins over dotfile.
+        for name in &self.inner.sandbox_config.extra_env_passthrough {
+            if let Ok(value) = std::env::var(name) {
+                upsert(&mut env_vars, name.clone(), value);
+            }
+        }
+
+        // 5. Explicit overrides — highest precedence.
+        for (key, value) in &self.inner.sandbox_config.env_overrides {
+            upsert(&mut env_vars, key.clone(), value.clone());
+        }
+
+        env_vars
     }
 
     #[cfg(unix)]
@@ -554,6 +630,11 @@ impl BashServer {
                 args.push(OsString::from("--read"));
                 args.push(working_dir.as_os_str().to_os_string());
             }
+        }
+
+        for (key, value) in self.build_child_env() {
+            args.push(OsString::from("--env"));
+            args.push(OsString::from(format!("{key}={value}")));
         }
 
         args
@@ -682,13 +763,15 @@ impl BashServer {
             #[cfg(not(unix))]
             unreachable!()
         } else {
+            let child_env = self.build_child_env();
             CommandWrap::with_new("bash", |command| {
                 command
                     .args(["-c", &params.command])
                     .current_dir(&working_dir)
-                    .stdin(Stdio::null())
-                    .stdout(Stdio::piped())
-                    .stderr(Stdio::piped());
+                    .stdin(Stdio::null());
+                command.env_clear();
+                command.envs(child_env.iter().map(|(k, v)| (k, v)));
+                command.stdout(Stdio::piped()).stderr(Stdio::piped());
             })
         };
         command.wrap(KillOnDrop);
@@ -1155,11 +1238,15 @@ impl BashServer {
             #[cfg(not(unix))]
             unreachable!()
         } else {
+            let child_env = self.build_child_env();
             CommandWrap::with_new("bash", |command| {
                 command
                     .args(["-c", &params.command])
                     .current_dir(&working_dir)
-                    .stdin(Stdio::null())
+                    .stdin(Stdio::null());
+                command.env_clear();
+                command.envs(child_env.iter().map(|(k, v)| (k, v)));
+                command
                     .stdout(Stdio::from(stdout_file))
                     .stderr(Stdio::from(stderr_file));
             })
@@ -1842,6 +1929,41 @@ fn parse_validated_path_list(
     }
 }
 
+fn load_bash_env_file() -> Vec<(String, String)> {
+    fn bash_config_dir() -> PathBuf {
+        if let Ok(v) = std::env::var("HARNX_CONFIG_DIR") {
+            return PathBuf::from(v);
+        }
+        if let Ok(v) = std::env::var("XDG_CONFIG_HOME") {
+            return PathBuf::from(v).join("harnx");
+        }
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home).join(".config/harnx");
+        }
+        PathBuf::from(".config/harnx")
+    }
+
+    let env_file = bash_config_dir().join(".env.bash");
+    let Ok(contents) = std::fs::read_to_string(env_file) else {
+        return vec![];
+    };
+
+    contents
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                return None;
+            }
+
+            let mut parts = trimmed.splitn(2, '=');
+            let key = parts.next()?.trim();
+            let value = parts.next()?.trim();
+            Some((key.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
 fn object_schema(properties: Vec<(&str, Schema)>, required: &[&str]) -> Schema {
     let mut schema = Map::new();
     schema.insert("type".to_string(), Value::String("object".to_string()));
@@ -2067,7 +2189,9 @@ mod tests {
     use super::*;
 
     #[cfg(unix)]
-    use std::ffi::OsString;
+    use std::ffi::{OsStr, OsString};
+    #[cfg(unix)]
+    use std::sync::{Mutex, MutexGuard, OnceLock};
 
     use rmcp::handler::client::ClientHandler;
     use rmcp::model::{ClientCapabilities, InitializeRequestParams, ListRootsResult, Root};
@@ -2259,12 +2383,70 @@ mod tests {
     }
 
     #[cfg(unix)]
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        match LOCK.get_or_init(|| Mutex::new(())).lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    #[cfg(unix)]
+    struct EnvVar {
+        key: String,
+        prev: Option<OsString>,
+    }
+
+    #[cfg(unix)]
+    impl EnvVar {
+        fn set(key: &str, value: impl AsRef<OsStr>) -> Self {
+            let prev = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value.as_ref()) };
+            Self {
+                key: key.to_string(),
+                prev,
+            }
+        }
+
+        fn unset(key: &str) -> Self {
+            let prev = std::env::var_os(key);
+            unsafe { std::env::remove_var(key) };
+            Self {
+                key: key.to_string(),
+                prev,
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for EnvVar {
+        fn drop(&mut self) {
+            unsafe {
+                match self.prev.take() {
+                    Some(value) => std::env::set_var(&self.key, value),
+                    None => std::env::remove_var(&self.key),
+                }
+            }
+        }
+    }
+
+    #[cfg(unix)]
     fn enabled_sandbox_config() -> SandboxConfig {
         SandboxConfig {
             enabled: true,
             extra_exec: vec![],
             extra_readable: vec![],
+            extra_env_passthrough: vec![],
+            env_overrides: vec![],
             sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
+        }
+    }
+
+    #[cfg(unix)]
+    fn disabled_sandbox_config() -> SandboxConfig {
+        SandboxConfig {
+            enabled: false,
+            ..enabled_sandbox_config()
         }
     }
 
@@ -2276,6 +2458,8 @@ mod tests {
                 enabled: true,
                 extra_exec: vec![],
                 extra_readable: vec![],
+                extra_env_passthrough: vec![],
+                env_overrides: vec![],
                 sandbox_run_path: sandbox_run_test_path(),
             },
         )
@@ -2461,6 +2645,132 @@ mod tests {
         assert!(!pairs.contains(&("--write".into(), "/test/root".into())));
         assert!(!pairs.contains(&("--read".into(), "/test/root".into())));
         assert!(!pairs.contains(&("--read".into(), "/tmp/test_wd_xxx".into())));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn env_default_allowlist_vars_passed_through() {
+        let _env_guard = env_lock();
+        let _home = EnvVar::set("HOME", "/tmp/harnx-home-4-1");
+        let _path = EnvVar::set("PATH", "/tmp/harnx-bin-4-1");
+        let _secret = EnvVar::set("HARNX_TEST_SECRET_4_1", "hunter2");
+        let _config_dir = EnvVar::unset("HARNX_CONFIG_DIR");
+
+        let server = BashServer::new_with_sandbox(vec![], enabled_sandbox_config());
+        let child_env = server.build_child_env();
+
+        assert!(child_env
+            .iter()
+            .any(|(key, value)| key == "HOME" && value == "/tmp/harnx-home-4-1"));
+        assert!(child_env
+            .iter()
+            .any(|(key, value)| key == "PATH" && value == "/tmp/harnx-bin-4-1"));
+        assert!(
+            !child_env
+                .iter()
+                .any(|(key, _)| key == "HARNX_TEST_SECRET_4_1"),
+            "non-allowlisted env leaked into child env: {child_env:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn env_overrides_and_passthrough() {
+        let _env_guard = env_lock();
+        let _host_value = EnvVar::set("HARNX_TEST_CUSTOM_4_2", "from_host");
+        let _config_dir = EnvVar::unset("HARNX_CONFIG_DIR");
+
+        let mut passthrough_config = enabled_sandbox_config();
+        passthrough_config.extra_env_passthrough = vec!["HARNX_TEST_CUSTOM_4_2".to_string()];
+        let passthrough_server = BashServer::new_with_sandbox(vec![], passthrough_config);
+        let passthrough_env = passthrough_server.build_child_env();
+        assert!(passthrough_env
+            .iter()
+            .any(|(key, value)| { key == "HARNX_TEST_CUSTOM_4_2" && value == "from_host" }));
+
+        let mut override_config = enabled_sandbox_config();
+        override_config.extra_env_passthrough = vec!["HARNX_TEST_CUSTOM_4_2".to_string()];
+        override_config.env_overrides = vec![(
+            "HARNX_TEST_CUSTOM_4_2".to_string(),
+            "overridden".to_string(),
+        )];
+        let override_server = BashServer::new_with_sandbox(vec![], override_config);
+        let override_env = override_server.build_child_env();
+        assert!(override_env
+            .iter()
+            .any(|(key, value)| { key == "HARNX_TEST_CUSTOM_4_2" && value == "overridden" }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn env_precedence_cli_over_passthrough_over_dotfile() {
+        let _env_guard = env_lock();
+
+        // Set host value for the var so passthrough can pick it up.
+        let _host_value = EnvVar::set("HARNX_TEST_PRECEDENCE_VAR", "from_host_passthrough");
+
+        // Point dotfile at a tempdir whose .env.bash sets a different value.
+        let temp_dir = TestDir::new();
+        std::fs::write(
+            temp_dir.path().join(".env.bash"),
+            "HARNX_TEST_PRECEDENCE_VAR=from_dotfile\n",
+        )
+        .unwrap();
+        let _config_dir = EnvVar::set("HARNX_CONFIG_DIR", temp_dir.path().as_os_str());
+
+        // Case 1: dotfile only (no passthrough, no override).
+        // Expect dotfile value to win over (absent) default allowlist value.
+        let dotfile_only = enabled_sandbox_config();
+        let dotfile_server = BashServer::new_with_sandbox(vec![], dotfile_only);
+        let dotfile_env = dotfile_server.build_child_env();
+        assert!(dotfile_env
+            .iter()
+            .any(|(k, v)| { k == "HARNX_TEST_PRECEDENCE_VAR" && v == "from_dotfile" }));
+
+        // Case 2: dotfile + passthrough → passthrough beats dotfile.
+        let mut passthrough_cfg = enabled_sandbox_config();
+        passthrough_cfg.extra_env_passthrough = vec!["HARNX_TEST_PRECEDENCE_VAR".to_string()];
+        let passthrough_server = BashServer::new_with_sandbox(vec![], passthrough_cfg);
+        let passthrough_env = passthrough_server.build_child_env();
+        assert!(passthrough_env
+            .iter()
+            .any(|(k, v)| { k == "HARNX_TEST_PRECEDENCE_VAR" && v == "from_host_passthrough" }));
+
+        // Case 3: dotfile + passthrough + override → override beats both.
+        let mut override_cfg = enabled_sandbox_config();
+        override_cfg.extra_env_passthrough = vec!["HARNX_TEST_PRECEDENCE_VAR".to_string()];
+        override_cfg.env_overrides = vec![(
+            "HARNX_TEST_PRECEDENCE_VAR".to_string(),
+            "from_cli_override".to_string(),
+        )];
+        let override_server = BashServer::new_with_sandbox(vec![], override_cfg);
+        let override_env = override_server.build_child_env();
+        assert!(override_env
+            .iter()
+            .any(|(k, v)| { k == "HARNX_TEST_PRECEDENCE_VAR" && v == "from_cli_override" }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn env_bash_dotfile_loaded() {
+        let _env_guard = env_lock();
+        let temp_dir = TestDir::new();
+        std::fs::write(
+            temp_dir.path().join(".env.bash"),
+            "# comment line\n\nHARNX_TEST_INJECT_4_3=s3cr3t\nHARNX_TEST_INJECT_KV_4_3=a=b\n",
+        )
+        .unwrap();
+        let _config_dir = EnvVar::set("HARNX_CONFIG_DIR", temp_dir.path().as_os_str());
+
+        let env_vars = load_bash_env_file();
+
+        assert!(env_vars
+            .iter()
+            .any(|(key, value)| { key == "HARNX_TEST_INJECT_4_3" && value == "s3cr3t" }));
+        assert!(env_vars
+            .iter()
+            .any(|(key, value)| { key == "HARNX_TEST_INJECT_KV_4_3" && value == "a=b" }));
+        assert!(!env_vars.iter().any(|(key, _)| key == "# comment line"));
     }
 
     #[cfg(unix)]
@@ -2790,6 +3100,43 @@ mod tests {
         let stderr_log_path = PathBuf::from(extract_field(&text, "stderr_log_path"));
         assert!(stdout_log_path.exists());
         assert!(stderr_log_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn env_secret_not_leaked_to_child() {
+        let _env_guard = env_lock();
+        let _secret = EnvVar::set("AWS_SECRET_ACCESS_KEY", "hunter2_4_4");
+        let _config_dir = EnvVar::unset("HARNX_CONFIG_DIR");
+        let root = TestDir::new();
+        let server = BashServer::new_with_sandbox(
+            vec![root.path().to_path_buf()],
+            disabled_sandbox_config(),
+        );
+
+        let result = server
+            .exec_command_impl(ExecCommandParams {
+                command: "echo ${AWS_SECRET_ACCESS_KEY:-empty}".to_string(),
+                working_dir: Some(root.path().to_string_lossy().to_string()),
+                timeout_secs: Some(5),
+                head_lines: None,
+                tail_lines: None,
+                max_output_bytes: None,
+                inputs: None,
+                outputs: None,
+            })
+            .await
+            .unwrap();
+
+        let text = text_content(&result);
+        assert_eq!(result.is_error, Some(false));
+        assert!(text.contains("exit_code: 0"));
+        assert!(text.contains("empty"), "unexpected exec output: {text}");
+        assert!(
+            !text.contains("hunter2_4_4"),
+            "secret leaked into child output: {text}"
+        );
     }
 
     #[tokio::test]

--- a/docs/bash-mcp-server.md
+++ b/docs/bash-mcp-server.md
@@ -1,0 +1,113 @@
+# Bash MCP Server
+
+## Overview
+
+`harnx-mcp-bash` is the MCP server that exposes shell command execution to agents. Filesystem sandboxing (via [birdcage](https://github.com/phylum-dev/birdcage)) is enabled by default on Unix-like systems; it is unavailable on Windows.
+
+The server starts child bash processes with a curated environment, NOT the full host environment. This prevents sensitive information (like API keys or other secrets) in the parent shell from being accidentally exposed to the LLM agent's tool calls. Environment curation is independent of sandboxing — it applies on every platform, including Windows where filesystem sandboxing is unavailable.
+
+## Default Environment Allowlist
+
+By default, only a minimal set of host environment variables is passed through to the child bash process:
+
+- `HOME`
+- `PATH`
+- `LANG`
+- `LANGUAGE`
+- `USER`
+- `SHELL`
+- `TERM`
+- `DISPLAY`
+- `EDITOR`
+- `NODE_OPTIONS`
+- `NODE_EXTRA_CA_CERTS`
+- `PWD`
+- `SHLVL`
+- `LOGNAME`
+- `TMPDIR`
+- `TMP`
+- `TEMP`
+- All variables prefixed with `XDG_*` (e.g., `XDG_CONFIG_HOME`, `XDG_RUNTIME_DIR`)
+
+## Adding Extra Variables
+
+You can add extra environment variables to the child process in three ways. These methods are additive.
+
+### 1. Per-server CLI flags
+
+Use the `-e` or `--env` flags in your MCP server configuration. This is useful for passing specific variables or setting explicit values.
+
+```yaml
+# mcp_servers/bash.yaml
+command: harnx-mcp-bash
+args:
+  - -e
+  - GITHUB_TOKEN              # Pass through from host env
+  - -e
+  - GIT_AUTHOR_NAME=My Bot    # Set an explicit value
+```
+
+### 2. Environment variable
+
+Use `HARNX_BASH_ENV_PASSTHROUGH` to specify a comma-separated list of host environment variable names to pass through.
+
+```yaml
+# mcp_servers/bash.yaml
+env:
+  HARNX_BASH_ENV_PASSTHROUGH: GITHUB_TOKEN,SSH_AUTH_SOCK
+```
+
+### 3. Dotfile (`.env.bash`)
+
+You can create a `.env.bash` file in your Harnx configuration directory (typically `~/.config/harnx/.env.bash`). This file uses a plain `KEY=VALUE` format.
+
+- `#` comments and blank lines are ignored.
+- The first `=` separates the key from the value (e.g., `KEY=a=b` produces value `a=b`).
+- No shell substitution is performed.
+
+**Example `~/.config/harnx/.env.bash`:**
+
+```text
+# GitHub Token
+GITHUB_TOKEN=ghp_xxx
+
+# SSH agent (resolved at MCP server startup)
+SSH_AUTH_SOCK=/tmp/ssh-XXXX/agent.123
+```
+
+## Precedence
+
+When a variable is defined in multiple places, the value from the source highest in this list wins:
+
+1. CLI flags (`-e VAR=VALUE`)
+2. `HARNX_BASH_ENV_PASSTHROUGH` (value taken from host environment)
+3. `.env.bash` dotfile (value from file)
+4. Default allowlist (value from host environment)
+
+## Common Recipes
+
+### Enable `git push` over SSH
+
+Pass `SSH_AUTH_SOCK` (and optionally `SSH_AGENT_PID`) so the agent's bash process can use your existing SSH agent connection:
+
+```yaml
+args: ["-e", "SSH_AUTH_SOCK"]
+```
+
+### Enable GitHub CLI (`gh`)
+
+Pass `GH_TOKEN` or `GITHUB_TOKEN`:
+
+```yaml
+args: ["-e", "GITHUB_TOKEN"]
+```
+
+Alternatively, you can persist these in `~/.config/harnx/.env.bash`.
+
+### Non-interactive Editor
+
+Override the `EDITOR` variable to ensure that AI tools that shell out use a non-interactive editor:
+
+```yaml
+args: ["-e", "EDITOR=true"]
+```

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -74,6 +74,12 @@ Harnx can load environment variables from a `.env` file located in the configura
   message history the harness built is responsible. The file is appended,
   not truncated, so set a fresh path per session.
 
+## Bash MCP Server Envs
+
+- **HARNX_BASH_ENV_PASSTHROUGH**: Comma-separated list of extra host env var names to pass through to child bash processes spawned by `harnx-mcp-bash`. Example: `HARNX_BASH_ENV_PASSTHROUGH=GITHUB_TOKEN,SSH_AUTH_SOCK`.
+- **HARNX_BASH_EXTRA_READABLE**: Colon-separated extra sandbox read-only paths.
+- **HARNX_BASH_EXTRA_EXEC**: Colon-separated extra sandbox executable paths.
+
 ## Generic Envs
 
 - **HTTPS_PROXY / ALL_PROXY**: Proxy settings for network requests.

--- a/docs/solutions/integration-issues/cli-wrapper-sandboxing-for-tokio-servers-2026-04-28.md
+++ b/docs/solutions/integration-issues/cli-wrapper-sandboxing-for-tokio-servers-2026-04-28.md
@@ -86,8 +86,10 @@ This preserves:
 - `Exception::Read` — read-only access
 - `Exception::WriteAndRead` — read-write access (NOT `Write` alone)
 - `Exception::ExecuteAndRead` — execute + read (NOT `Execute`)
-- `Exception::FullEnvironment` — full environment access (required for basic process spawning)
+- `Exception::Environment(String)` — allow single environment variable (repeatable)
 - `Exception::Networking` — allow network access
+
+> ⚠️ **Avoid `Exception::FullEnvironment`** — it bypasses all env restrictions and leaks secrets to child processes. Use `Exception::Environment(name)` per variable instead. See [environment-sanitization-bash-sandbox-2026-04-29.md](../security-issues/environment-sanitization-bash-sandbox-2026-04-29.md) for the full pattern.
 
 **Working directory handling is platform-conditional:**
 - macOS: birdcage re-exports `std::process::Command`, so wrapper uses `current_dir(working_dir)` directly.
@@ -166,3 +168,4 @@ fn sandbox_run_test_path() -> PathBuf {
 - **GitHub Issue:** [#360 — Good sandboxing for bash commands](https://github.com/dobesv/harnx/issues/360)
 - **Plan:** bash-sandboxing-birdcage
 - **Commit:** f6a0449 — Add filesystem sandboxing to harnx-mcp-bash using birdcage
+- **Related Solution:** [security-issues/environment-sanitization-bash-sandbox-2026-04-29.md](../security-issues/environment-sanitization-bash-sandbox-2026-04-29.md) — Environment variable sanitization pattern

--- a/docs/solutions/security-issues/environment-sanitization-bash-sandbox-2026-04-29.md
+++ b/docs/solutions/security-issues/environment-sanitization-bash-sandbox-2026-04-29.md
@@ -1,0 +1,240 @@
+---
+title: "Environment Variable Sanitization for Sandboxed Child Processes"
+date: 2026-04-29
+category: security-issues
+problem_type: security_issue
+component: harnx-mcp-bash
+root_cause: "Full host environment leaked to sandboxed child processes via Exception::FullEnvironment"
+resolution_type: code_fix
+severity: high
+tags:
+  - environment-variables
+  - sandboxing
+  - birdcage
+  - security
+  - cross-platform
+plan_ref: gh-375-bash-env-sanitization
+---
+
+## Problem
+
+Bash child processes inherited the full host environment, exposing secrets (AWS keys, API tokens, SSH keys) to potentially compromised or malicious agent-controlled commands. Original implementation used `Exception::FullEnvironment` which bypassed all env restrictions in birdcage sandbox.
+
+## Symptoms
+
+- `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, and other secrets visible to bash commands via `echo $VAR`
+- Non-sandboxed path (`--no-sandbox`) inherited full host environment unchanged
+- Windows builds bypassed env curation entirely via `#[cfg(unix)]` guards
+
+## Investigation Steps
+
+1. Traced env handling through both sandboxed and non-sandboxed spawn paths
+2. Discovered `Exception::FullEnvironment` allowed all vars through
+3. Investigated birdcage 0.8.1 API: `birdcage::process::Command` lacks `env()`, `envs()`, `env_clear()` methods — cannot set env on Command directly
+4. Found birdcage's `restrict_env_variables()` iterates `std::env::vars()` and removes non-excepted vars at sandbox lock time
+5. Identified `#[cfg(unix)]` guard on env curation leaked full env on Windows/non-Unix builds
+
+## Root Cause
+
+Two separate issues:
+
+1. **birdcage environment model**: `birdcage::process::Command` (wrapper around `std::process::Command`) does NOT expose `env`/`envs`/`env_clear`. To restrict environment, you must (a) call `std::env::set_var()` to set desired values on the current process BEFORE `sandbox.spawn()`, and (b) add `Exception::Environment(name)` for each var. Birdcage's `restrict_env_variables()` then iterates `std::env::vars()` and removes anything not excepted — operating on the current process env, not the Command.
+
+2. **Platform-gated env curation**: Env sanitization was `#[cfg(unix)]`-guarded, matching the sandboxing code. This meant Windows builds inherited full host env even for non-sandboxed spawns.
+
+## Solution
+
+### 1. Replace `Exception::FullEnvironment` with per-var exceptions
+
+**Before (sandbox_run.rs):**
+```rust
+sandbox
+    .add_exception(Exception::FullEnvironment)
+    .map_err(|error| {
+        format!("sandbox-run: failed to add FullEnvironment exception: {error}")
+    })?;
+```
+
+**After:**
+```rust
+for (key, value) in &config.env_vars {
+    // SAFETY: `env::set_var` is unsafe because it mutates process-global
+    // state and is not thread-safe. This binary is the `sandbox_run` helper,
+    // which runs single-threaded up to this point — `parse_args` and the
+    // sandbox setup never spawn threads, and we have not yet called
+    // `sandbox.spawn(...)`. No other code in the process can be observing
+    // the environment concurrently, so the call is sound. We must do this
+    // before `sandbox.spawn(...)` because birdcage's `restrict_env_variables()`
+    // (invoked from `Birdcage::lock` inside `spawn`) inspects `std::env::vars()`
+    // and removes any variable not listed via `Exception::Environment`.
+    unsafe { env::set_var(key, value) };
+    sandbox
+        .add_exception(Exception::Environment(key.clone()))
+        .map_err(|error| {
+            format!("sandbox-run: failed to add env exception for {key}: {error}")
+        })?;
+}
+```
+
+### 2. Add curated default allowlist
+
+```rust
+const DEFAULT_ENV_ALLOWLIST: &[&str] = &[
+    "HOME", "PATH", "LANG", "LANGUAGE", "USER", "SHELL", "TERM",
+    "DISPLAY", "EDITOR", "NODE_OPTIONS", "NODE_EXTRA_CA_CERTS",
+    "PWD", "SHLVL", "LOGNAME", "TMPDIR", "TMP", "TEMP",
+];
+```
+
+Plus `XDG_*` prefix pattern expanded at runtime.
+
+### 3. Layered env configuration with explicit precedence
+
+**Precedence (CLI > Passthrough > Dotfile > Allowlist):**
+
+```rust
+fn build_child_env(&self) -> Vec<(String, String)> {
+    fn upsert(env_vars: &mut Vec<(String, String)>, key: String, value: String) {
+        if let Some((_, existing)) = env_vars.iter_mut().find(|(k, _)| k == &key) {
+            *existing = value;
+        } else {
+            env_vars.push((key, value));
+        }
+    }
+
+    let mut env_vars: Vec<(String, String)> = Vec::new();
+
+    // 1. Default allowlist (lowest precedence)
+    for name in Self::DEFAULT_ENV_ALLOWLIST {
+        if let Ok(value) = std::env::var(name) {
+            upsert(&mut env_vars, (*name).to_string(), value);
+        }
+    }
+
+    // 2. XDG_* vars from host env
+    for (name, value) in std::env::vars() {
+        if name.starts_with("XDG_") {
+            upsert(&mut env_vars, name, value);
+        }
+    }
+
+    // 3. .env.bash dotfile
+    for (key, value) in load_bash_env_file() {
+        upsert(&mut env_vars, key, value);
+    }
+
+    // 4. Explicit passthrough names — host value wins over dotfile
+    for name in &self.inner.sandbox_config.extra_env_passthrough {
+        if let Ok(value) = std::env::var(name) {
+            upsert(&mut env_vars, name.clone(), value);
+        }
+    }
+
+    // 5. Explicit overrides — highest precedence
+    for (key, value) in &self.inner.sandbox_config.env_overrides {
+        upsert(&mut env_vars, key.clone(), value.clone());
+    }
+
+    env_vars
+}
+```
+
+### 4. Make env curation cross-platform
+
+Removed `#[cfg(unix)]` guard from `build_child_env()`. Applied to non-sandboxed spawn path on all platforms:
+
+```rust
+let child_env = self.build_child_env();
+CommandWrap::with_new("bash", |command| {
+    command
+        .args(["-c", &params.command])
+        .current_dir(&working_dir)
+        .stdin(Stdio::null());
+    command.env_clear();
+    command.envs(child_env.iter().map(|(k, v)| (k, v)));
+    // ...
+})
+```
+
+### 5. Process-global env mutation in tests
+
+Tests that mutate `std::env` require serialization. Pattern:
+
+```rust
+#[cfg(unix)]
+fn env_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    match LOCK.get_or_init(|| Mutex::new(())).lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[cfg(unix)]
+struct EnvVar {
+    key: String,
+    prev: Option<OsString>,
+}
+
+#[cfg(unix)]
+impl EnvVar {
+    fn set(key: &str, value: impl AsRef<OsStr>) -> Self {
+        let prev = std::env::var_os(key);
+        unsafe { std::env::set_var(key, value.as_ref()) };
+        Self { key: key.to_string(), prev }
+    }
+
+    fn unset(key: &str) -> Self {
+        let prev = std::env::var_os(key);
+        unsafe { std::env::remove_var(key) };
+        Self { key: key.to_string(), prev }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for EnvVar {
+    fn drop(&mut self) {
+        unsafe {
+            match self.prev.take() {
+                Some(value) => std::env::set_var(&self.key, value),
+                None => std::env::remove_var(&self.key),
+            }
+        }
+    }
+}
+```
+
+Usage: `let _guard = env_lock(); let _var = EnvVar::set("KEY", "value");` — guard serializes, RAII restores.
+
+## Why This Works
+
+1. **birdcage env model**: Setting vars on current process before `spawn()` works because birdcage's internal `restrict_env_variables()` inspects `std::env::vars()` at lock time. The child inherits the sanitized env from the wrapper process.
+
+2. **Cross-platform curation**: Env sanitization is now independent of sandbox enforcement. Windows, macOS, Linux all apply the same env curation — only the sandbox activation layer remains Unix-only.
+
+3. **Ordered Vec with upsert**: Preserves insertion order (reflects precedence layers) while allowing later layers to replace values. Simpler than HashMap for this use case.
+
+## Prevention Strategies
+
+**Test Cases:**
+- Verify secrets (`AWS_SECRET_ACCESS_KEY`) not leaked to child processes
+- Verify allowlist vars (`HOME`, `PATH`) passed through
+- Verify precedence: CLI override beats passthrough beats dotfile beats default
+
+**Best Practices:**
+- When implementing security controls with sandboxed and non-sandboxed paths, make sanitization layer platform-independent
+- Document and test precedence explicitly when multiple config sources exist
+- For birdcage: understand that `Exception::Environment` + `set_var` on current process is the only way to control child env
+
+**Code Review Checklist:**
+- [ ] Are secrets prevented from reaching child processes?
+- [ ] Is env curation applied on all platforms, not just sandbox-capable ones?
+- [ ] Is precedence documented and tested?
+- [ ] If using birdcage, are env vars set on current process before `spawn()`?
+
+## Related Issues
+
+- **GitHub Issue:** [#375 — Environment sanitization for bash MCP server](https://github.com/dobesv/harnx/issues/375)
+- **Plan:** gh-375-bash-env-sanitization
+- **Commit:** 9161557 — feat(bash): restrict and curate child process environment
+- **Related Solution:** [integration-issues/cli-wrapper-sandboxing-for-tokio-servers-2026-04-28.md](../integration-issues/cli-wrapper-sandboxing-for-tokio-servers-2026-04-28.md) — CLI wrapper pattern for birdcage sandboxing

--- a/example_config/mcp_servers/bash.yaml
+++ b/example_config/mcp_servers/bash.yaml
@@ -16,7 +16,14 @@ rename_tools:
 #   - /opt/tools/bin
 #   - --sandbox-run                                         # Override sandbox helper binary
 #   - /opt/harnx/harnx-mcp-bash-sandbox-run
+#   - --env                                                 # Pass through a host env var (e.g. for git push / gh)
+#   - GITHUB_TOKEN
+#   - --env                                                 # Set an env var explicitly
+#   - MY_VAR=my_value
+#   - --env                                                 # Allow git push over SSH
+#   - SSH_AUTH_SOCK
 #
 # env:
 #   HARNX_BASH_EXTRA_READABLE: /opt/sdk      # Extra readable path via environment
 #   HARNX_BASH_EXTRA_EXEC: /opt/tools/bin    # Extra executable path via environment
+#   HARNX_BASH_ENV_PASSTHROUGH: GITHUB_TOKEN,SSH_AUTH_SOCK  # Comma-separated list to pass through


### PR DESCRIPTION

Implements environment variable sanitization for the Bash MCP server to
prevent leaking host secrets to child processes. By default, only a
minimal allowlist of safe variables (HOME, PATH, LANG, etc.) and XDG_*
prefixed variables are passed through.

Provides three mechanisms for opting-in additional variables or
overriding values:
- CLI flags: `-e VAR` (passthrough) or `-e VAR=VALUE` (explicit)
- Environment: `HARNX_BASH_ENV_PASSTHROUGH` (comma-separated list)
- Dotfile: `$HARNX_CONFIG_DIR/.env.bash` for persistent secrets

Precedence for variable values follows the order: CLI overrides >
passthrough from host > .env.bash file > default allowlist.

These controls apply to both sandboxed (via birdcage) and non-sandboxed
executions on all supported platforms.

Closes https://github.com/dobesv/harnx/issues/375

Plan: https://github.com/dobesv/harnx/issues/375-bash-env-sanitization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added environment variable control for bash child processes via `--env`/`-e` CLI flags, `HARNX_BASH_ENV_PASSTHROUGH` environment variable, or `.env.bash` configuration file.

* **Bug Fixes**
  * Child bash processes now receive only a curated set of environment variables (default allowlist + XDG_* + explicitly configured variables) instead of inheriting the full host environment.

* **Documentation**
  * Added comprehensive guides for environment variable configuration and security best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->