### PR TITLE
fix(acp): propagate session/cancel to nested sub-agents on Ctrl-C

### DIFF
--- a/.changesets/sub-agent-tui-ctrl-c-propagates-cancel.md
+++ b/.changesets/sub-agent-tui-ctrl-c-propagates-cancel.md
@@ -1,0 +1,12 @@
+---
+harnx: patch
+---
+fix(acp): propagate `session/cancel` to nested ACP sub-agents on Ctrl-C / cancel.
+
+Two bugs sat in series:
+
+1. `<AcpManager as ToolProvider>::call_tool` raced the inner call against `wait_abort_signal(abort)` in an outer `tokio::select!` and on abort just dropped the inner future. The actual `session_cancel` dispatch lived inside that future (gated on `tokio::signal::ctrl_c()`, which never fires while the TUI is in raw mode), so it never ran. Late chunks from the still-running sub-agent then leaked through `AcpNotificationClient`'s no-forwarder fallback into the parent transcript.
+
+2. `HarnxAgent::prompt` raced `run_agent_loop` against `cancel_notify` in another `tokio::select!`. When cancel arrived (the outermost case in pure-ACP-server mode), it synchronously dropped `run_agent_loop` — and any `AcpManager::call_tool` inside it — before the `AcpManager`'s abort handler could observe `abort_signal` and dispatch `session/cancel` further down. The sub-agent process kept running.
+
+The fix plumbs the `AbortSignal` into `AcpManager::call_tool_inner`'s `session_prompt` branch so abort drives the existing cancel path, and replaces the hard-cancel `tokio::select!` in `HarnxAgent::prompt` with a two-stage cancel: cooperatively wait for `run_agent_loop` to unwind on `abort_signal` (giving nested ACP layers time to dispatch their own cancels), with a 100 ms grace before falling back to a `select!`-style hard-cancel for layers that don't observe abort.

--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -385,16 +385,49 @@ impl acp::Agent for HarnxAgent {
             pending_async_context: None,
         };
 
+        // Bridge cancel_notify → abort_signal for any caller that signals
+        // via the notify without setting the signal directly (HarnxAgent::
+        // cancel does both, but this keeps the contract resilient).
+        let abort_for_listener = abort_signal.clone();
+        let cancel_listener = tokio::task::spawn_local(async move {
+            cancel_notify.notified().await;
+            abort_for_listener.set_ctrlc();
+        });
+
+        // Two-stage cancellation:
+        //   1. When `abort_signal` fires, give cooperative-cancel layers
+        //      (e.g. AcpManager.session_prompt_with_abort) a grace
+        //      window to dispatch `session/cancel` down to any
+        //      sub-agents. They poll abort every ~25 ms and then send
+        //      a JSON-RPC cancel notification — fast, but not free.
+        //   2. After the grace window, hard-cancel `run_agent_loop` by
+        //      losing the select! race. This drops any stuck SSE/TCP
+        //      reads or stuck tool dispatchers that don't observe
+        //      abort — so a hung upstream can't pin the prompt.
+        // Pure hard-cancel-on-notify (the previous approach) skipped
+        // step 1 — sub-agents were leaked because the AcpManager call
+        // was dropped before it could dispatch `session/cancel`.
+        // 100 ms is well above the ~30 ms a single AcpManager
+        // observes-abort + dispatches-cancel takes; nested layers each
+        // run their own grace in parallel, so the bound doesn't
+        // compound across depth.
+        let abort_for_grace = abort_signal.clone();
+        let grace_cancel = async move {
+            harnx_core::abort::wait_abort_signal(&abort_for_grace).await;
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        };
+
         let loop_result = tokio::select! {
             r = harnx_runtime::run_agent_loop(&loop_ctx, input) => r,
-            _ = cancel_notify.notified() => {
-                abort_signal.set_ctrlc();
+            _ = grace_cancel => {
+                cancel_listener.abort();
                 harnx_core::sink::clear_agent_event_sink();
                 fwd_task.abort();
                 return Ok(acp::PromptResponse::new(acp::StopReason::Cancelled));
             }
         };
 
+        cancel_listener.abort();
         harnx_core::sink::clear_agent_event_sink();
         // Drop loop_ctx so all senders into chunk_rx are dropped and
         // fwd_task can exit cleanly.

--- a/crates/harnx-acp/src/manager.rs
+++ b/crates/harnx-acp/src/manager.rs
@@ -94,6 +94,15 @@ impl AcpManager {
     }
 
     pub async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value> {
+        self.call_tool_inner(name, arguments, None).await
+    }
+
+    async fn call_tool_inner(
+        &self,
+        name: &str,
+        arguments: Value,
+        abort: Option<&AbortSignal>,
+    ) -> Result<Value> {
         let (client, method) = self
             .find_client_for_tool(name)
             .ok_or_else(|| anyhow!("Unknown ACP tool '{}'", name))?;
@@ -112,8 +121,28 @@ impl AcpManager {
                     None => client.session_new().await?,
                 };
 
-                session_prompt_with_abort(&client, session_id, message, tokio::signal::ctrl_c())
-                    .await
+                // Race against the AbortSignal when one was provided so a
+                // TUI Ctrl-C (which never produces SIGINT in raw mode)
+                // still triggers `session/cancel` to the ACP subprocess.
+                // Falls back to `tokio::signal::ctrl_c()` for callers that
+                // don't have an AbortSignal — primarily one-shot mode and
+                // direct unit tests.
+                match abort {
+                    Some(abort) => {
+                        let abort = abort.clone();
+                        let abort_future = async move { wait_abort_signal(&abort).await };
+                        session_prompt_with_abort(&client, session_id, message, abort_future).await
+                    }
+                    None => {
+                        session_prompt_with_abort(
+                            &client,
+                            session_id,
+                            message,
+                            tokio::signal::ctrl_c(),
+                        )
+                        .await
+                    }
+                }
             }
             "session_load" => {
                 let session_id = required_string(&arguments, "session_id")?.to_owned();
@@ -427,16 +456,20 @@ impl ToolProvider for AcpManager {
         let spinner_msg = format!("  {} working…", tool_name);
         let forward_handle = tokio::spawn(forward_acp_chunks(chunk_rx, spinner_clone, spinner_msg));
 
-        // Race the sub-agent call against our abort_signal so Ctrl-C
-        // interrupts nested ACP delegations the same way it interrupts
-        // MCP tools.
+        // Plumb the AbortSignal into the inner dispatcher so a TUI Ctrl-C
+        // — which never reaches us as SIGINT because crossterm captures
+        // the keystroke in raw mode — still triggers `session/cancel` on
+        // the ACP subprocess. Previously an outer `select!` raced the
+        // call against `wait_abort_signal(abort)` and on abort just
+        // dropped the inner future, so `session_prompt_with_abort`'s
+        // cancel branch (gated on `tokio::signal::ctrl_c()`) was never
+        // reached. The sub-agent then kept running and its late chunks
+        // leaked into the parent transcript through
+        // `AcpNotificationClient`'s no-forwarder fallback path.
         let tool_name_owned = tool_name.to_string();
-        let call_result = tokio::select! {
-            result = AcpManager::call_tool(self, &tool_name_owned, arguments) => result,
-            _ = wait_abort_signal(abort) => {
-                Err(anyhow!("ACP tool call aborted by user"))
-            }
-        };
+        let call_result = self
+            .call_tool_inner(&tool_name_owned, arguments, Some(abort))
+            .await;
 
         // Tear down: drop every sender for this subscription, then await
         // the forwarder so it can drain anything still queued before

--- a/crates/harnx/src/test_utils/interrupt.rs
+++ b/crates/harnx/src/test_utils/interrupt.rs
@@ -86,6 +86,25 @@ pub fn script_stall_streaming() -> MockOpenAiScript {
     }
 }
 
+/// A mock-LLM response that emits a quick first chunk, then a `SENTINEL_END`
+/// chunk after a delay. Used by sub-agent cancellation tests: if cancel
+/// propagation works, the child's mock stream is closed before the sentinel
+/// is written and `SENTINEL_END` never reaches the parent transcript. If
+/// cancellation does NOT propagate (the bug), the child keeps reading from
+/// the mock and `SENTINEL_END` eventually appears.
+pub fn script_streaming_with_sentinel() -> MockOpenAiScript {
+    MockOpenAiScript {
+        turns: vec![MockOpenAiTurn {
+            text_chunks: vec!["tick-first".to_string(), "SENTINEL_END".to_string()],
+            tool_calls: vec![],
+            expect: None,
+            error: None,
+        }],
+        fallback_text: "sentinel script exhausted".to_string(),
+        chunk_delay_ms: 1_500,
+    }
+}
+
 pub struct ConfigPaths {
     pub dir: PathBuf,
     pub harnx_config_dir: PathBuf,

--- a/crates/harnx/src/test_utils/mock_openai_server.rs
+++ b/crates/harnx/src/test_utils/mock_openai_server.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::io::{Read, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
@@ -67,15 +68,27 @@ struct ServerState {
     script: MockOpenAiScript,
     consumed_turns: Mutex<Vec<bool>>,
     request_log: Arc<Mutex<Vec<Value>>>,
+    /// Total number of chunks the streaming responder has successfully
+    /// written to client connections across all requests. Useful for
+    /// cancellation tests: if a client closes its stream mid-flight
+    /// (e.g. because it was cancelled), later chunks fail to write and
+    /// don't bump this counter. Live, atomic; readable while the server
+    /// is still serving.
+    chunks_written: Arc<AtomicUsize>,
 }
 
 impl ServerState {
-    fn new(script: MockOpenAiScript, request_log: Arc<Mutex<Vec<Value>>>) -> Self {
+    fn new(
+        script: MockOpenAiScript,
+        request_log: Arc<Mutex<Vec<Value>>>,
+        chunks_written: Arc<AtomicUsize>,
+    ) -> Self {
         let consumed_turns = vec![false; script.turns.len()];
         Self {
             script,
             consumed_turns: Mutex::new(consumed_turns),
             request_log,
+            chunks_written,
         }
     }
 
@@ -207,6 +220,7 @@ pub struct MockOpenAiServer {
     shutdown: Option<TcpStream>,
     accept_thread: Option<JoinHandle<()>>,
     request_log: Arc<Mutex<Vec<Value>>>,
+    chunks_written: Arc<AtomicUsize>,
 }
 
 impl MockOpenAiServer {
@@ -232,7 +246,12 @@ impl MockOpenAiServer {
             .context("failed to accept shutdown channel")?;
 
         let request_log = Arc::new(Mutex::new(Vec::new()));
-        let state = Arc::new(ServerState::new(script, Arc::clone(&request_log)));
+        let chunks_written = Arc::new(AtomicUsize::new(0));
+        let state = Arc::new(ServerState::new(
+            script,
+            Arc::clone(&request_log),
+            Arc::clone(&chunks_written),
+        ));
         let accept_thread =
             thread::spawn(move || run_accept_loop(listener, shutdown_server, state));
 
@@ -241,6 +260,7 @@ impl MockOpenAiServer {
             shutdown: Some(shutdown),
             accept_thread: Some(accept_thread),
             request_log,
+            chunks_written,
         })
     }
 
@@ -250,6 +270,15 @@ impl MockOpenAiServer {
 
     pub fn get_request_log(&self) -> Vec<Value> {
         self.request_log.lock().unwrap().clone()
+    }
+
+    /// Cumulative count of streaming text/tool-call chunks that this
+    /// server has successfully written to client sockets. Useful for
+    /// validating that a client actually closed its stream mid-flight
+    /// when it was supposed to be cancelled — later chunks then fail to
+    /// write and don't increment this counter.
+    pub fn chunks_written(&self) -> usize {
+        self.chunks_written.load(Ordering::SeqCst)
     }
 }
 
@@ -454,6 +483,7 @@ fn handle_chat_completions(request: Value, state: &ServerState, stream: &mut Tcp
             &turn.text_chunks,
             state.script.chunk_delay_ms,
             &tool_calls,
+            &state.chunks_written,
         );
     } else {
         let full_text = turn.text_chunks.join("");
@@ -464,11 +494,25 @@ fn handle_chat_completions(request: Value, state: &ServerState, stream: &mut Tcp
     }
 }
 
+/// Returns true if the peer has half-closed the connection (sent FIN).
+/// Uses a non-blocking peek: read of 0 bytes on a fully connected socket
+/// returns WouldBlock; on a half-closed socket it returns Ok(0).
+fn peer_closed(stream: &TcpStream) -> bool {
+    if stream.set_nonblocking(true).is_err() {
+        return false;
+    }
+    let mut probe = [0u8; 1];
+    let result = stream.peek(&mut probe);
+    let _ = stream.set_nonblocking(false);
+    matches!(result, Ok(0))
+}
+
 fn write_streaming_response(
     stream: &mut TcpStream,
     text_chunks: &[String],
     chunk_delay_ms: u64,
     tool_calls: &[Value],
+    chunks_written: &AtomicUsize,
 ) {
     // Write HTTP headers for SSE (no Content-Length so we can flush per-event).
     let header = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n";
@@ -485,6 +529,14 @@ fn write_streaming_response(
         if i > 0 && chunk_delay_ms > 0 {
             thread::sleep(delay);
         }
+        // Bail out if the client closed its end while we were sleeping.
+        // `write_all` on a half-closed socket can still succeed (kernel
+        // accepts into its send buffer), which would falsely bump
+        // chunks_written even though the peer is gone. Cancellation
+        // tests rely on this counter being accurate.
+        if peer_closed(stream) {
+            return;
+        }
         let event = format!(
             "data: {}\n\n",
             json!({
@@ -499,14 +551,19 @@ fn write_streaming_response(
                 }]
             })
         );
-        let _ = stream.write_all(event.as_bytes());
-        let _ = stream.flush();
+        if stream.write_all(event.as_bytes()).is_err() || stream.flush().is_err() {
+            return;
+        }
+        chunks_written.fetch_add(1, Ordering::SeqCst);
     }
 
     // Emit tool_calls or stop event.
     if !tool_calls.is_empty() {
         if chunk_delay_ms > 0 && !text_chunks.is_empty() {
             thread::sleep(delay);
+        }
+        if peer_closed(stream) {
+            return;
         }
         let event = format!(
             "data: {}\n\n",
@@ -522,8 +579,10 @@ fn write_streaming_response(
                 }]
             })
         );
-        let _ = stream.write_all(event.as_bytes());
-        let _ = stream.flush();
+        if stream.write_all(event.as_bytes()).is_err() || stream.flush().is_err() {
+            return;
+        }
+        chunks_written.fetch_add(1, Ordering::SeqCst);
     } else {
         let event = format!(
             "data: {}\n\n",

--- a/crates/harnx/tests/interrupt_e2e.rs
+++ b/crates/harnx/tests/interrupt_e2e.rs
@@ -13,9 +13,9 @@ use std::time::Duration;
 
 use harnx::test_utils::interrupt::{
     script_call_sub_agent, script_call_trivial_tool, script_call_wait_tool, script_stall_streaming,
-    send_sigint, spawn_acp_client, spawn_oneshot, spawn_tui, wait_for_exit, wait_for_prompt_return,
-    write_acp_agent, write_minimal_config, write_with_blocking_hook, write_with_sub_agent,
-    write_with_wait_tool,
+    script_streaming_with_sentinel, send_sigint, spawn_acp_client, spawn_oneshot, spawn_tui,
+    wait_for_exit, wait_for_prompt_return, write_acp_agent, write_minimal_config,
+    write_with_blocking_hook, write_with_sub_agent, write_with_wait_tool,
 };
 use harnx::test_utils::mock_openai_server::MockOpenAiServer;
 use harnx::test_utils::tmux_harness::TmuxHarness;
@@ -152,6 +152,61 @@ fn interrupt_tui_during_sub_agent() -> Result<()> {
     tmux.send_keys(&["C-c"])?;
 
     wait_for_prompt_return(&tmux, Duration::from_secs(2))?;
+    Ok(())
+}
+
+/// Regression for issue #358: Ctrl-C in the parent TUI must propagate
+/// `session/cancel` to a sub-agent that is actively streaming, otherwise
+/// the child's late chunks leak through `AcpNotificationClient`'s
+/// fallback path and continue to render in the parent transcript after
+/// the abort message.
+///
+/// The child mock emits `tick-first` immediately and `SENTINEL_END` after
+/// 1.5s. We Ctrl-C right after `tick-first` arrives. With the bug, the
+/// child keeps running, the mock writes `SENTINEL_END`, and the chunk
+/// reaches the parent transcript via the fallback emit. With the fix,
+/// the child receives ACP cancel, drops its mock stream, and the sentinel
+/// is never written.
+#[test]
+fn interrupt_tui_sub_agent_cancel_stops_late_chunks() -> Result<()> {
+    if !TmuxHarness::is_available() {
+        eprintln!("tmux unavailable; skipping interrupt_tui_sub_agent_cancel_stops_late_chunks");
+        return Ok(());
+    }
+
+    let parent_mock = MockOpenAiServer::start(script_call_sub_agent("child"))?;
+    let child_mock = MockOpenAiServer::start(script_streaming_with_sentinel())?;
+    let tmp = tempfile::tempdir()?;
+    let harnx_bin = PathBuf::from(env!("CARGO_BIN_EXE_harnx"));
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let paths = write_with_sub_agent(
+        tmp.path(),
+        &format!("http://127.0.0.1:{}/v1", parent_mock.port()),
+        &format!("http://127.0.0.1:{}/v1", child_mock.port()),
+        &harnx_bin,
+    )?;
+    let tmux = spawn_tui(&paths, &harnx_bin, &repo_root)?;
+
+    tmux.send_text("delegate please")?;
+    tmux.send_keys(&["Enter"])?;
+    // Confirm parent delegated and child started streaming.
+    tmux.wait_for_contains("Delegating", Duration::from_secs(10))?;
+    tmux.wait_for_contains("tick-first", Duration::from_secs(5))?;
+
+    tmux.send_keys(&["C-c"])?;
+    wait_for_prompt_return(&tmux, Duration::from_secs(2))?;
+
+    // Wait past the child mock's 1.5s sentinel deadline plus margin. If
+    // the child was actually cancelled, no further chunks reach the
+    // parent. If cancel propagation is broken, `SENTINEL_END` lands in
+    // the transcript via AcpNotificationClient's fallback emit path.
+    std::thread::sleep(Duration::from_millis(2500));
+
+    let screen = tmux.capture_pane()?;
+    assert!(
+        !screen.contains("SENTINEL_END"),
+        "SENTINEL_END appeared in transcript after Ctrl-C — sub-agent was not cancelled.\nTranscript:\n{screen}"
+    );
     Ok(())
 }
 
@@ -358,11 +413,24 @@ async fn interrupt_acp_session_cancel_during_hook() -> Result<()> {
     Ok(())
 }
 
+/// Cancel sent to the top-level ACP server must propagate `session/cancel`
+/// down to its sub-agent so the sub-agent stops reading from its upstream.
+///
+/// Why the assertion uses `child_mock.chunks_written()` rather than the
+/// test client's `response_text`: the parent ACP server clears its
+/// agent-event sink as part of returning `Cancelled`, so any leaked
+/// chunks the sub-agent forwards arrive at a `None` sink and never reach
+/// the test client. The child mock's chunk counter, with its
+/// peer-closed peek before every write, is what catches the leak — if
+/// the child's ACP-side cancel never fires, its connection to the mock
+/// stays open past the 1.5 s chunk delay and the mock writes a second
+/// chunk; if cancel propagates correctly, the child closes the
+/// connection and the second chunk write is skipped.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg(unix)]
 async fn interrupt_acp_session_cancel_propagates_to_sub_agent() -> Result<()> {
     let parent_mock = MockOpenAiServer::start(script_call_sub_agent("child"))?;
-    let child_mock = MockOpenAiServer::start(script_stall_streaming())?;
+    let child_mock = MockOpenAiServer::start(script_streaming_with_sentinel())?;
     let tmp = tempfile::tempdir()?;
     let harnx_bin = PathBuf::from(env!("CARGO_BIN_EXE_harnx"));
     let paths = write_with_sub_agent(
@@ -373,19 +441,51 @@ async fn interrupt_acp_session_cancel_propagates_to_sub_agent() -> Result<()> {
     )?;
     write_acp_agent(&paths, "default")?;
 
-    let client = spawn_acp_client(&paths, &harnx_bin, "default").await?;
+    let client = std::sync::Arc::new(spawn_acp_client(&paths, &harnx_bin, "default").await?);
     let session = client.session_new().await?;
 
-    let prompt_fut = client.session_prompt(Some(&session), "delegate please");
-    tokio::pin!(prompt_fut);
-    tokio::time::sleep(TokioDuration::from_millis(2000)).await;
+    // Spawn the prompt on its own task so the runtime polls it while
+    // we sleep. The previous `tokio::pin!(prompt_fut) + sleep` shape
+    // never actually dispatched the prompt during the sleep — the
+    // cancel-notify permit then fired immediately on the next prompt's
+    // first `.notified()` poll and aborted it before any chunks
+    // accumulated, masking the bug.
+    let prompt_client = std::sync::Arc::clone(&client);
+    let prompt_session = session.clone();
+    let prompt_handle = tokio::spawn(async move {
+        prompt_client
+            .session_prompt(Some(&prompt_session), "delegate please")
+            .await
+    });
+
+    // Wait long enough for "tick-first" to flow through the chain
+    // (parent delegates → child harnx subprocess starts up → child
+    // receives prompt → child streams first chunk). Subprocess startup
+    // + ACP handshake is the slow link (~1 s on CI). The 1.5 s sentinel
+    // deadline inside the child mock starts when the child opens its
+    // mock connection, so cancelling at 1.2 s — before the child has
+    // advanced to its second chunk — is the right window for catching
+    // missed cancel propagation.
+    tokio::time::sleep(TokioDuration::from_millis(1200)).await;
 
     client.session_cancel(&session).await?;
 
-    let result = timeout(TokioDuration::from_secs(2), &mut prompt_fut).await;
+    let _response = timeout(TokioDuration::from_secs(5), prompt_handle)
+        .await
+        .expect("parent prompt task should resolve within 5 s after cancel")
+        .expect("prompt task should not panic")?;
+
+    // Wait past the child mock's 1.5 s sentinel deadline before
+    // reading the counter. With cancel propagating, the child closes
+    // its mock connection inside the 100 ms HarnxAgent grace and the
+    // mock skips the second write; without propagation, the mock
+    // bumps chunks_written to 2.
+    tokio::time::sleep(TokioDuration::from_millis(2500)).await;
+
+    let chunks = child_mock.chunks_written();
     assert!(
-        result.is_ok(),
-        "parent prompt did not resolve after cancel — sub-agent likely not cancelled"
+        chunks <= 1,
+        "child mock wrote {chunks} chunks; expected at most 1 (tick-first). Cancel did not propagate to the sub-agent."
     );
     Ok(())
 }


### PR DESCRIPTION
Closes #358.

## Summary

Two bugs sat in series and dropped the in-flight `session/cancel` dispatch before it could reach the sub-agent. Together they reproduced the issue's exact symptom (a sub-sub-agent's tool calls streaming into the parent transcript after Ctrl-C):

1. **`<AcpManager as ToolProvider>::call_tool`** raced the inner call against `wait_abort_signal(abort)` in an outer `tokio::select!` and on abort just dropped the inner future. The actual `session_cancel` dispatch lived inside that future, gated on `tokio::signal::ctrl_c()` — which never fires while the TUI is in raw mode — so it never ran. Late chunks from the still-running sub-agent then leaked through `AcpNotificationClient`'s no-forwarder fallback into the parent transcript.

2. **`HarnxAgent::prompt`** raced `run_agent_loop` against `cancel_notify` in another `tokio::select!`. When cancel arrived (the outermost case in pure-ACP-server mode), it synchronously dropped `run_agent_loop` — and any `AcpManager::call_tool` inside it — before AcpManager's abort handler could observe `abort_signal` and dispatch `session/cancel` further down. The sub-agent process kept running.

## Fix

- Plumb the `AbortSignal` through `AcpManager::call_tool_inner`'s `session_prompt` branch so abort drives the existing cancel path, replacing `tokio::signal::ctrl_c()`.
- Replace `HarnxAgent::prompt`'s hard-cancel `select!` with a two-stage cancel: cooperatively wait for `run_agent_loop` to unwind on `abort_signal` (giving nested ACP layers ~100 ms grace to dispatch their own cancels), with a `select!` hard-cancel fallback for layers that don't observe abort.

## Tests

- New `interrupt_tui_sub_agent_cancel_stops_late_chunks` covers the **TUI shape**: parent → child via the tmux harness, child mock streams a `SENTINEL_END` chunk after a delay; asserts the sentinel never lands in the parent transcript after Ctrl-C. This is the exact symptom from issue #358.
- Strengthened `interrupt_acp_session_cancel_propagates_to_sub_agent` covers the **pure-ACP-server shape** (no TUI). The previous version used `tokio::pin!(prompt_fut) + sleep` — which never drives the prompt during the sleep, so the cancel-notify permit consumed the next prompt's first `.notified()` poll and masked the bug — and only checked `result.is_ok()`. Replaced with a spawned-task pattern + sentinel script + `chunks_written` assertion.
- New `MockOpenAiServer::chunks_written()`, with a non-blocking peek before each chunk write so the counter only bumps when the peer hasn't half-closed. The test client's `response_text` can't observe the leak in pure-ACP-server mode (parent's sink is cleared on cancel, leaked sub-agent chunks emit into a `None` sink); the mock counter is what catches it.

## Test plan

- [x] `cargo test --package harnx --test interrupt_e2e` (14 passed, including both new/strengthened tests)
- [x] `cargo test --package harnx-acp` (21 passed)
- [x] `cargo test --package harnx-acp-server` (8 passed)
- [x] `cargo test --workspace --lib` (all green)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --tests --no-deps`
- [x] Reverting either fix individually causes the new tests to fail with the precise symptom they're written to catch (sentinel chunk in transcript / `chunks_written = 2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)