### PR TITLE
fix(bash): drop empty-key dotfile lines and extend allowlist for Windows

### DIFF
--- a/.changesets/bash-env-sanitization-followups.md
+++ b/.changesets/bash-env-sanitization-followups.md
@@ -1,0 +1,9 @@
+---
+harnx: patch
+---
+`harnx-mcp-bash`: skip dotfile lines with empty keys (e.g. `=value`) so
+they don't reach the sandbox as malformed `--env =value` args; extend
+the default env allowlist with Windows-specific names (`SYSTEMROOT`,
+`SystemRoot`, `WINDIR`, `USERPROFILE`, `USERNAME`, `APPDATA`,
+`LOCALAPPDATA`, `COMSPEC`, `HOMEDRIVE`, `HOMEPATH`) so `bash` on Windows
+runs with the env it needs after `env_clear()` curation.

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -385,6 +385,18 @@ impl BashServer {
         "TMPDIR",
         "TMP",
         "TEMP",
+        // Windows-specific names. std::env::var returns Err on Unix where
+        // these are unset, so listing them here is a no-op on POSIX builds.
+        "SYSTEMROOT",
+        "SystemRoot",
+        "WINDIR",
+        "USERPROFILE",
+        "USERNAME",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "COMSPEC",
+        "HOMEDRIVE",
+        "HOMEPATH",
     ];
 
     #[allow(dead_code)]
@@ -1959,6 +1971,9 @@ fn load_bash_env_file() -> Vec<(String, String)> {
             let mut parts = trimmed.splitn(2, '=');
             let key = parts.next()?.trim();
             let value = parts.next()?.trim();
+            if key.is_empty() {
+                return None;
+            }
             Some((key.to_string(), value.to_string()))
         })
         .collect()

--- a/docs/solutions/security-issues/environment-sanitization-bash-sandbox-2026-04-29.md
+++ b/docs/solutions/security-issues/environment-sanitization-bash-sandbox-2026-04-29.md
@@ -22,6 +22,8 @@ Bash child processes inherited the full host environment, exposing secrets (AWS 
 
 ## Symptoms
 
+These symptoms describe the original implementation before the fix in PR #381 (gh-375), where `Exception::FullEnvironment` allowed the birdcage sandbox to inherit the full host environment, the `--no-sandbox` path inherited host env unchanged, and `#[cfg(unix)]`-gated env curation left Windows builds without any sanitization.
+
 - `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, and other secrets visible to bash commands via `echo $VAR`
 - Non-sandboxed path (`--no-sandbox`) inherited full host environment unchanged
 - Windows builds bypassed env curation entirely via `#[cfg(unix)]` guards
@@ -38,7 +40,7 @@ Bash child processes inherited the full host environment, exposing secrets (AWS 
 
 Two separate issues:
 
-1. **birdcage environment model**: `birdcage::process::Command` (wrapper around `std::process::Command`) does NOT expose `env`/`envs`/`env_clear`. To restrict environment, you must (a) call `std::env::set_var()` to set desired values on the current process BEFORE `sandbox.spawn()`, and (b) add `Exception::Environment(name)` for each var. Birdcage's `restrict_env_variables()` then iterates `std::env::vars()` and removes anything not excepted — operating on the current process env, not the Command.
+1. **birdcage environment model**: `birdcage::process::Command` (a wrapper around `std::process::Command`) does not expose `env`, `envs`, or `env_clear`, so child env cannot be set on the Command directly. The required workaround is two-step: (a) call `std::env::set_var()` on the current process to stage each desired value before invoking `sandbox.spawn()`, and (b) add an `Exception::Environment(name)` entry to the sandbox for every var that should survive. Birdcage's `restrict_env_variables()` (invoked from inside `spawn`) then iterates `std::env::vars()` and removes everything except the names listed via `Exception::Environment` — it operates on the current process env, not on the Command.
 
 2. **Platform-gated env curation**: Env sanitization was `#[cfg(unix)]`-guarded, matching the sandboxing code. This meant Windows builds inherited full host env even for non-sandboxed spawns.
 
@@ -90,7 +92,9 @@ Plus `XDG_*` prefix pattern expanded at runtime.
 
 ### 3. Layered env configuration with explicit precedence
 
-**Precedence (CLI > Passthrough > Dotfile > Allowlist):**
+**Precedence (CLI > Passthrough > Dotfile > XDG_* > Allowlist):**
+
+`XDG_*` is treated as part of the default allowlist layer: applied after `DEFAULT_ENV_ALLOWLIST` but before `.env.bash` (so dotfile values override `XDG_*`).
 
 ```rust
 fn build_child_env(&self) -> Vec<(String, String)> {


### PR DESCRIPTION
## Summary

Follow-ups to #381 (env sanitization for `harnx-mcp-bash`) from review feedback:

- `load_bash_env_file` now skips dotfile lines with empty keys (e.g. `=value`) so they no longer reach the sandbox as malformed `--env =value` args.
- `DEFAULT_ENV_ALLOWLIST` gains Windows-specific names (`SYSTEMROOT`, `SystemRoot`, `WINDIR`, `USERPROFILE`, `USERNAME`, `APPDATA`, `LOCALAPPDATA`, `COMSPEC`, `HOMEDRIVE`, `HOMEPATH`) so `bash -c` on Windows survives `env_clear()` + curated env. POSIX is unaffected — `std::env::var` returns `Err` for these on Unix.
- Docs (`environment-sanitization-bash-sandbox-2026-04-29.md`): clarify the Symptoms section describes pre-fix behaviour, split the long birdcage Root Cause sentence and drop the all-caps `NOT`, and spell out where `XDG_*` sits in the precedence chain.

## Notes on review feedback intentionally not applied

- **Async file I/O for `load_bash_env_file`**: skipped. Sub-millisecond synchronous read of a small local config file; converting to async would propagate through `build_child_env` → `build_sandbox_args` and three call sites for negligible gain, and a startup cache would change semantics (mid-session edits no longer pick up).
- **Per-platform CI tests for `env_clear()` + curated env**: skipped as scope creep — the existing test cases cover env-construction logic, and cross-platform spawn validation is broader infra work.

## Test plan

- [x] `cargo build -p harnx-mcp-bash`
- [x] `cargo clippy -p harnx-mcp-bash --all-targets -- -D warnings`
- [x] `cargo nextest run -p harnx-mcp-bash` (33/33 pass)
- [x] `cargo fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)