### PR TITLE
fix(sinks): render MCP MiniJinja templates in TUI and CLI tool events

### DIFF
--- a/.changesets/fix-mcp-template-rendering-in-sinks.md
+++ b/.changesets/fix-mcp-template-rendering-in-sinks.md
@@ -1,0 +1,41 @@
+---
+harnx: patch
+---
+Fix MCP MiniJinja templates not appearing in TUI or CLI output.
+
+PR #349 wired template rendering into `ToolEvent::Started.title` and the
+`Completed` event, but every consumer discarded those fields — so configured
+templates were rendered into events that nobody read. This PR makes them
+actually display:
+
+- TUI `Started` handler now uses the rendered title instead of yaml-formatting
+  the raw input.
+- TUI `Completed` rendering uses the rendered template when present, falls
+  back to the historic extract+truncate behavior otherwise.
+- CLI `Started` line now appends the rendered title after the tool name.
+- CLI `Completed` is no longer silent — renders the templated form when
+  present, or the extracted/truncated raw output otherwise. (Restores the
+  pre-`0daecac` CLI behavior; the silent default introduced when the sink
+  architecture landed was a regression.)
+
+Renamed `ToolEvent::Completed.content: Vec<ContentBlock>` → `title:
+Option<String>` to mirror `Started.title`/`Update.title` and reflect the
+single-string display semantics. Display text is producer-side render output
+only; `output: Value` continues to carry the raw tool result that the LLM
+sees and that gets persisted.
+
+Extracted a shared `render_tool_result_text` helper into
+`harnx_runtime::utils` so the TUI and CLI sinks format identically.
+
+Test changes:
+- New TUI tests verify the title/content path for both Started and Completed.
+- New CLI tests verify the helper covers the template-present, MCP content
+  extraction, raw String, JSON YAML fallback, and empty-title paths.
+- New producer-side tests in `harnx-runtime` verify that the emit functions
+  populate the title fields when a matching declaration carries a template.
+- Fixed a pre-existing flaky test in `harnx-core::sink` (two tests racing on
+  the global sink without locking) by adding a poison-safe module-level mutex.
+
+Session restoration still re-renders saved tool calls/results without
+templates because `lifecycle.rs` doesn't have access to the live tool
+declaration map at replay time. Tracked in #385.

--- a/.changesets/fix-mcp-template-rendering-in-sinks.md
+++ b/.changesets/fix-mcp-template-rendering-in-sinks.md
@@ -28,7 +28,9 @@ Extracted a shared `render_tool_result_text` helper into
 `harnx_runtime::utils` so the TUI and CLI sinks format identically.
 
 Test changes:
-- New TUI tests verify the title/content path for both Started and Completed.
+- New TUI tests verify the templated title and fallback rendering paths for
+  both `ToolEvent::Started` and `ToolEvent::Completed` (templated `title`
+  honored, raw input/output used when `title` is `None`).
 - New CLI tests verify the helper covers the template-present, MCP content
   extraction, raw String, JSON YAML fallback, and empty-title paths.
 - New producer-side tests in `harnx-runtime` verify that the emit functions

--- a/crates/harnx-core/src/event.rs
+++ b/crates/harnx-core/src/event.rs
@@ -72,7 +72,12 @@ pub enum ToolEvent {
     Completed {
         id: String,
         output: serde_json::Value,
-        content: Vec<ContentBlock>,
+        /// Pre-rendered display text for the result. `Some(text)` when an
+        /// MCP `result_template` (or per-tool config override) has been
+        /// rendered against `output`; `None` when no template applied,
+        /// in which case consumers fall back to extracting text from
+        /// `output` themselves. Mirrors `title` on `Started`/`Update`.
+        title: Option<String>,
     },
     Failed {
         id: String,

--- a/crates/harnx-core/src/sink.rs
+++ b/crates/harnx-core/src/sink.rs
@@ -66,6 +66,19 @@ mod tests {
     use crate::event::{AgentEvent, NoticeEvent};
     use std::sync::Mutex;
 
+    /// `AGENT_EVENT_SINK` is process-global state, but cargo runs tests in
+    /// the same process in parallel. Without serialization, two tests
+    /// racing on `clear_agent_event_sink` / `install_agent_event_sink` /
+    /// `emit_agent_event` see each other's sinks and events. Acquire this
+    /// guard at the top of every test that touches the global sink.
+    static SINK_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Ignore `PoisonError` so a panic in one test doesn't cascade-fail
+    /// every other sink test in this module.
+    fn lock_sink_tests() -> std::sync::MutexGuard<'static, ()> {
+        SINK_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     struct CollectingSink {
         events: Mutex<Vec<AgentEvent>>,
     }
@@ -86,6 +99,7 @@ mod tests {
 
     #[test]
     fn install_and_emit_cycle() {
+        let _guard = lock_sink_tests();
         clear_agent_event_sink();
         let delivered = emit_agent_event(AgentEvent::Notice(NoticeEvent::Info("hi".into())));
         assert!(!delivered);
@@ -120,6 +134,7 @@ mod tests {
     #[test]
     fn emit_with_source_preserves_source() {
         use crate::event::AgentSource;
+        let _guard = lock_sink_tests();
         clear_agent_event_sink();
         let sink = Arc::new(SourceRecordingSink::default());
         install_agent_event_sink(sink.clone());

--- a/crates/harnx-runtime/src/tool.rs
+++ b/crates/harnx-runtime/src/tool.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use anyhow::Result;
 use harnx_hooks::HookEvent;
-use harnx_mcp::safety::{truncate_output, TruncateOpts};
 
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
@@ -268,39 +267,18 @@ fn emit_tool_result_with_template(
     }
 }
 
-/// Fallback print for tool result when no sink is installed.
+/// Fallback print for tool result when no sink is installed. Routes
+/// through the shared `render_tool_result_text` helper so this no-sink
+/// path stays consistent with what the TUI/CLI sinks render.
 fn print_tool_result_fallback(
     call: &ToolCall,
     result: &Value,
     decl_map: &HashMap<String, ToolDeclaration>,
     raw_fallback: &str,
 ) {
-    let output_str = render_result(call, result, raw_fallback, decl_map)
-        .unwrap_or_else(|| raw_fallback.to_string());
-
-    let mut opts = TruncateOpts::default();
-    let marker = " [...] ";
-    match crossterm::terminal::size() {
-        Ok((cols, rows)) => {
-            opts.head_lines = 5.max((rows / 2) as usize);
-            opts.tail_lines = 0;
-            opts.line_head_bytes = (cols as usize).saturating_sub(3 + marker.len());
-            opts.line_tail_bytes = 0;
-            opts.marker = Some(marker.to_string());
-        }
-        Err(e) => {
-            // Terminal size unavailable (e.g. CI, piped output) — use safe defaults
-            log::debug!("failed to get terminal size: {e}");
-            opts.head_lines = 20;
-            opts.tail_lines = 0;
-            opts.line_head_bytes = 200;
-            opts.line_tail_bytes = 0;
-            opts.marker = Some(marker.to_string());
-        }
-    }
-    let truncated = truncate_output(&output_str, &opts);
-    let text = format!("{}\n", dimmed_text(&truncated));
-    print!("{text}");
+    let title = render_result(call, result, raw_fallback, decl_map);
+    let truncated = render_tool_result_text(result, title.as_deref());
+    println!("{}", dimmed_text(&truncated));
 }
 
 fn default_confirm_tool_use(tool_name: &str, arguments: &Value, reason: Option<&str>) -> bool {

--- a/crates/harnx-runtime/src/tool.rs
+++ b/crates/harnx-runtime/src/tool.rs
@@ -156,7 +156,8 @@ pub fn build_tool_eval_context(
 }
 
 /// Look up and render the call template for a tool, returning rendered string or None.
-/// Logs warning to stderr on render error.
+/// On template render error, logs a warning via `log::warn!` and falls back to
+/// `raw_fallback` so display continues uninterrupted.
 fn render_call(
     call: &ToolCall,
     json_data: &Value,
@@ -166,17 +167,15 @@ fn render_call(
     let tmpl = decl_map.get(&call.name)?.call_template.as_ref()?;
     Some(
         render_tool_call_template(tmpl, json_data, raw_fallback).unwrap_or_else(|e| {
-            eprintln!(
-                "⚠ template error in tool '{}' call_template: {e}",
-                call.name
-            );
+            log::warn!("template error in tool '{}' call_template: {e}", call.name);
             raw_fallback.to_string()
         }),
     )
 }
 
 /// Look up and render result template for a tool, returning rendered string or None.
-/// Logs warning to stderr on render error.
+/// On template render error, logs a warning via `log::warn!` and falls back to
+/// `raw_fallback` so display continues uninterrupted.
 fn render_result(
     call: &ToolCall,
     result: &Value,
@@ -186,8 +185,8 @@ fn render_result(
     let tmpl = decl_map.get(&call.name)?.result_template.as_ref()?;
     Some(
         render_tool_result_template(tmpl, result, raw_fallback).unwrap_or_else(|e| {
-            eprintln!(
-                "⚠ template error in tool '{}' result_template: {e}",
+            log::warn!(
+                "template error in tool '{}' result_template: {e}",
                 call.name
             );
             raw_fallback.to_string()
@@ -249,21 +248,19 @@ fn emit_tool_result_with_template(
     result: &Value,
     decl_map: &HashMap<String, ToolDeclaration>,
 ) {
-    use harnx_core::event::{AgentEvent, ContentBlock, ToolEvent};
+    use harnx_core::event::{AgentEvent, ToolEvent};
 
     let raw_fallback = extract_user_display_text(result).unwrap_or_else(|| match result {
         Value::String(s) => s.clone(),
         _ => pretty_yaml_block(result),
     });
 
-    let content = render_result(call, result, &raw_fallback, decl_map)
-        .map(|text| vec![ContentBlock::Text(text)])
-        .unwrap_or_default();
+    let title = render_result(call, result, &raw_fallback, decl_map);
 
     let event = AgentEvent::Tool(ToolEvent::Completed {
         id: call.id.clone().unwrap_or_default(),
         output: result.clone(),
-        content,
+        title,
     });
 
     if !harnx_core::sink::emit_agent_event(event) && *IS_STDOUT_TERMINAL {
@@ -293,7 +290,7 @@ fn print_tool_result_fallback(
         }
         Err(e) => {
             // Terminal size unavailable (e.g. CI, piped output) — use safe defaults
-            eprintln!("debug: failed to get terminal size: {e}");
+            log::debug!("failed to get terminal size: {e}");
             opts.head_lines = 20;
             opts.tail_lines = 0;
             opts.line_head_bytes = 200;
@@ -402,5 +399,180 @@ mod tests {
         let flattened = schema.flatten_any_of();
         assert_eq!(flattened.type_value.as_deref(), Some("string"));
         assert_eq!(flattened.description.as_deref(), Some("A name"));
+    }
+
+    // ----------------------------------------------------------------
+    // MCP MiniJinja templating, producer side: verify that
+    // `emit_tool_call_with_template` and `emit_tool_result_with_template`
+    // populate `title` on both `ToolEvent::Started` and
+    // `ToolEvent::Completed` when the matching tool declaration carries
+    // a `call_template` / `result_template`. These are the values the
+    // TUI/CLI consumers then render — without these events being
+    // populated, the consumer-side rendering has nothing to display.
+    // ----------------------------------------------------------------
+
+    use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource, ToolEvent};
+    use std::sync::Mutex as StdMutex;
+
+    #[derive(Default)]
+    struct RecordingSink {
+        events: StdMutex<Vec<AgentEvent>>,
+    }
+    impl AgentEventSink for RecordingSink {
+        fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
+    fn make_decl_with_templates(
+        name: &str,
+        call_template: Option<&str>,
+        result_template: Option<&str>,
+    ) -> ToolDeclaration {
+        ToolDeclaration {
+            name: name.to_string(),
+            description: String::new(),
+            parameters: Default::default(),
+            mcp_tool_name: Some(name.to_string()),
+            call_template: call_template.map(String::from),
+            result_template: result_template.map(String::from),
+        }
+    }
+
+    /// Lock around the global sink so producer-side emit tests don't race
+    /// with each other. The sink is process-global state. Ignore poisoning
+    /// so a panic in one test doesn't cascade-fail every other test that
+    /// touches the sink.
+    fn with_recording_sink<R>(test_body: impl FnOnce(Arc<RecordingSink>) -> R) -> R {
+        static TEST_LOCK: StdMutex<()> = StdMutex::new(());
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        harnx_core::sink::clear_agent_event_sink();
+        let sink: Arc<RecordingSink> = Arc::new(RecordingSink::default());
+        harnx_core::sink::install_agent_event_sink(sink.clone());
+        let result = test_body(sink);
+        harnx_core::sink::clear_agent_event_sink();
+        result
+    }
+
+    #[test]
+    fn emit_tool_call_with_template_sets_started_title() {
+        let decl = make_decl_with_templates("bash_exec", Some("$ {{ args.command }}"), None);
+        let mut decl_map = HashMap::new();
+        decl_map.insert(decl.name.clone(), decl);
+
+        let call = ToolCall::new(
+            "bash_exec".to_string(),
+            json!({"command": "ls -la"}),
+            Some("call-1".to_string()),
+            None,
+        );
+        let args = json!({"command": "ls -la"});
+
+        with_recording_sink(|sink| {
+            emit_tool_call_with_template(&call, &args, &decl_map);
+            let events = sink.events.lock().unwrap();
+            assert_eq!(events.len(), 1, "expected one Started event");
+            match &events[0] {
+                AgentEvent::Tool(ToolEvent::Started { title, name, .. }) => {
+                    assert_eq!(name, "bash_exec");
+                    assert_eq!(
+                        title.as_deref(),
+                        Some("$ ls -la"),
+                        "template should be rendered into Started.title"
+                    );
+                }
+                other => panic!("expected Started event, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn emit_tool_call_without_template_leaves_title_none() {
+        let decl = make_decl_with_templates("plain_tool", None, None);
+        let mut decl_map = HashMap::new();
+        decl_map.insert(decl.name.clone(), decl);
+        let call = ToolCall::new(
+            "plain_tool".to_string(),
+            json!({"x": 1}),
+            Some("call-1".to_string()),
+            None,
+        );
+        let args = json!({"x": 1});
+
+        with_recording_sink(|sink| {
+            emit_tool_call_with_template(&call, &args, &decl_map);
+            let events = sink.events.lock().unwrap();
+            assert_eq!(events.len(), 1);
+            match &events[0] {
+                AgentEvent::Tool(ToolEvent::Started { title, .. }) => {
+                    assert!(title.is_none(), "no template => title must be None");
+                }
+                other => panic!("expected Started event, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn emit_tool_result_with_template_sets_completed_title() {
+        let decl =
+            make_decl_with_templates("bash_exec", None, Some("OK: {{ result.content[0].text }}"));
+        let mut decl_map = HashMap::new();
+        decl_map.insert(decl.name.clone(), decl);
+
+        let call = ToolCall::new(
+            "bash_exec".to_string(),
+            json!({}),
+            Some("call-1".to_string()),
+            None,
+        );
+        let result_json = json!({
+            "content": [{"type": "text", "text": "hello"}],
+            "isError": false,
+        });
+
+        with_recording_sink(|sink| {
+            emit_tool_result_with_template(&call, &result_json, &decl_map);
+            let events = sink.events.lock().unwrap();
+            assert_eq!(events.len(), 1, "expected one Completed event");
+            match &events[0] {
+                AgentEvent::Tool(ToolEvent::Completed { title, .. }) => {
+                    assert_eq!(
+                        title.as_deref(),
+                        Some("OK: hello"),
+                        "template should be rendered into Completed.title"
+                    );
+                }
+                other => panic!("expected Completed event, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn emit_tool_result_without_template_leaves_title_none() {
+        let decl = make_decl_with_templates("plain_tool", None, None);
+        let mut decl_map = HashMap::new();
+        decl_map.insert(decl.name.clone(), decl);
+        let call = ToolCall::new(
+            "plain_tool".to_string(),
+            json!({}),
+            Some("call-1".to_string()),
+            None,
+        );
+        let result_json = json!({"content": [{"type": "text", "text": "hi"}]});
+
+        with_recording_sink(|sink| {
+            emit_tool_result_with_template(&call, &result_json, &decl_map);
+            let events = sink.events.lock().unwrap();
+            assert_eq!(events.len(), 1);
+            match &events[0] {
+                AgentEvent::Tool(ToolEvent::Completed { title, .. }) => {
+                    assert!(
+                        title.is_none(),
+                        "no template => title must be None (consumer falls back to output)"
+                    );
+                }
+                other => panic!("expected Completed event, got {other:?}"),
+            }
+        });
     }
 }

--- a/crates/harnx-runtime/src/utils/mod.rs
+++ b/crates/harnx-runtime/src/utils/mod.rs
@@ -66,6 +66,47 @@ pub fn pretty_yaml_block(value: &serde_json::Value) -> String {
         .unwrap_or_else(|_| value.to_string())
 }
 
+/// Format a tool's `Completed` event for terminal display.
+///
+/// Prefers `title` (set by harnx-runtime when an MCP `result_template`
+/// matched the call) over the raw `output`. When `title` is `None` or
+/// renders to whitespace, falls back to `extract_user_display_text` →
+/// string passthrough → YAML, then truncates to fit the current
+/// terminal. Both the TUI sink and the CLI sink call this so they
+/// render identically.
+pub fn render_tool_result_text(output: &serde_json::Value, title: Option<&str>) -> String {
+    use harnx_core::tool::extract_user_display_text;
+    use harnx_mcp::safety::{truncate_output, TruncateOpts};
+
+    let mut opts = TruncateOpts::default();
+    let marker = " [...] ";
+    // Drop (0, 0) sizes from non-TTY environments — `(cols as usize)
+    // .saturating_sub(...)` would yield 0 and truncate every line to
+    // nothing. Falling through leaves the safer `TruncateOpts::default()`
+    // (head_lines=25, line_head_bytes=500) in place.
+    if let Ok((cols, rows)) = crossterm::terminal::size().and_then(|(c, r)| {
+        if c > 0 && r > 0 {
+            Ok((c, r))
+        } else {
+            Err(std::io::Error::other("non-TTY: terminal size unavailable"))
+        }
+    }) {
+        opts.head_lines = 5.max((rows / 2) as usize);
+        opts.tail_lines = 0;
+        opts.line_head_bytes = (cols as usize).saturating_sub(3 + marker.len());
+        opts.line_tail_bytes = 0;
+        opts.marker = Some(marker.to_string());
+    }
+    let text = match title.map(str::trim).filter(|t| !t.is_empty()) {
+        Some(t) => t.to_string(),
+        None => extract_user_display_text(output).unwrap_or_else(|| match output {
+            serde_json::Value::String(s) => s.clone(),
+            _ => pretty_yaml_block(output),
+        }),
+    };
+    truncate_output(&text, &opts)
+}
+
 pub use harnx_core::config_paths::get_env_name;
 
 pub fn parse_bool(value: &str) -> Option<bool> {

--- a/crates/harnx-tui/src/agent_event_sink.rs
+++ b/crates/harnx-tui/src/agent_event_sink.rs
@@ -29,37 +29,12 @@ impl AgentEventSink for TuiAgentEventSink {
     }
 }
 
-/// Extract and truncate a tool result for transcript display. Used by
-/// `render_agent_event`'s `Tool::Completed` arm in `input.rs`. The
+/// Re-export of `harnx_runtime::utils::render_tool_result_text` so the
+/// TUI sink and the CLI sink format tool results identically. The
 /// returned text is NOT dim-wrapped — the TUI renderer applies the dim
-/// `Modifier` via `TranscriptItem::ToolResultText`'s style so an ANSI
-/// dim escape would be redundant (and would fight test inputs that
-/// pre-dim their text — `sanitize_output_text` strips the ESC, leaving
-/// literal `[2m`/`[0m` markers visible).
-///
-/// Mirrors the head/line sizing used by `default_emit_tool_result` so
-/// production and TUI transcripts truncate at the same boundary.
-pub(crate) fn render_tool_result_text(
-    output: &serde_json::Value,
-    _content: &[harnx_core::event::ContentBlock],
-) -> String {
-    use harnx_core::tool::extract_user_display_text;
-    use harnx_mcp::safety::{truncate_output, TruncateOpts};
-
-    let mut opts = TruncateOpts::default();
-    let marker = " [...] ";
-    if let Ok((cols, rows)) = crossterm::terminal::size() {
-        opts.head_lines = 5.max((rows / 2) as usize);
-        opts.tail_lines = 0;
-        opts.line_head_bytes = (cols as usize).saturating_sub(3 + marker.len());
-        opts.line_tail_bytes = 0;
-        opts.marker = Some(marker.to_string());
-    }
-    let output_str = extract_user_display_text(output).unwrap_or_else(|| match output {
-        serde_json::Value::String(s) => s.clone(),
-        _ => harnx_runtime::utils::pretty_yaml_block(output),
-    });
-    truncate_output(&output_str, &opts)
+/// `Modifier` via `TranscriptItem::ToolResultText`'s style.
+pub(crate) fn render_tool_result_text(output: &serde_json::Value, title: Option<&str>) -> String {
+    harnx_runtime::utils::render_tool_result_text(output, title)
 }
 
 /// Install the `TuiAgentEventSink`. Called by TUI-mode startup with
@@ -132,7 +107,7 @@ mod tests {
             AgentEvent::Tool(ToolEvent::Completed {
                 id: String::new(),
                 output: serde_json::Value::String("ok".into()),
-                content: vec![],
+                title: None,
             }),
             Some(AgentSource {
                 agent: "hephaestus".into(),

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -598,9 +598,7 @@ impl Tui {
                     vec![TranscriptItem::SystemText(clean)]
                 }
             }
-            AgentEvent::Tool(ToolEvent::Completed {
-                output, content, ..
-            }) => {
+            AgentEvent::Tool(ToolEvent::Completed { output, title, .. }) => {
                 // The TuiAgentEventSink forwards Tool::Completed through
                 // render_agent_event. The truncation + formatting live
                 // here (mirror of default_emit_tool_result). Strip ANSI
@@ -616,7 +614,7 @@ impl Tui {
                     serde_json::Value::String(s) => serde_json::Value::String(strip_ansi(s)),
                     _ => output.clone(),
                 };
-                let text = crate::agent_event_sink::render_tool_result_text(&raw, &content);
+                let text = crate::agent_event_sink::render_tool_result_text(&raw, title.as_deref());
                 let clean = strip_ansi(&text).trim_end_matches('\n').to_string();
                 if clean.is_empty() {
                     vec![]
@@ -773,10 +771,15 @@ impl Tui {
                     vec![]
                 }
             }
-            AgentEvent::Tool(ToolEvent::Started { name, input, .. }) => {
-                let input_yaml = match &input {
-                    serde_json::Value::Null => None,
-                    _ => Some(pretty_yaml_block(&input)),
+            AgentEvent::Tool(ToolEvent::Started {
+                name, title, input, ..
+            }) => {
+                let input_yaml = match title.as_deref().map(str::trim).filter(|t| !t.is_empty()) {
+                    Some(t) => Some(t.to_string()),
+                    None => match &input {
+                        serde_json::Value::Null => None,
+                        _ => Some(pretty_yaml_block(&input)),
+                    },
                 };
                 vec![TranscriptItem::ToolCall {
                     tool_name: name,

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -319,8 +319,9 @@ pub(crate) fn messages_to_transcript_items(messages: &[Message]) -> Vec<Transcri
                             tool_name: r.call.name.clone(),
                             input_yaml,
                         });
-                        for line in crate::agent_event_sink::render_tool_result_text(&r.output, &[])
-                            .split('\n')
+                        for line in
+                            crate::agent_event_sink::render_tool_result_text(&r.output, None)
+                                .split('\n')
                         {
                             if !line.is_empty() {
                                 items.push(TranscriptItem::ToolResultText(line.to_string()));

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -1069,7 +1069,7 @@ async fn structured_ui_output_variants_render_in_transcript() {
         AgentEvent::Tool(ToolEvent::Completed {
             id: String::new(),
             output: serde_json::Value::String("\u{1b}[2mline one\nline two\u{1b}[0m\n".to_string()),
-            content: vec![],
+            title: None,
         }),
         None,
     ))
@@ -4041,4 +4041,178 @@ async fn test_tall_item_scroll_window_moves_in_correct_direction() {
     }
     harness.render();
     assert_window(&mut harness, 1, 10, "after scroll_up x10 (top of item)");
+}
+
+// ----------------------------------------------------------------------------
+// MCP MiniJinja templating: TUI must use the rendered title/content fields
+// produced by harnx-runtime when a tool's `_meta.call_template` /
+// `_meta.result_template` (or config override) is set. Covers issue #340 /
+// PR #349 — the producer side wires templates into ToolEvent fields, but the
+// TUI consumer was discarding them prior to these tests.
+// ----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tui_renders_started_title_when_template_provides_it() {
+    let mut tui = Tui::init(
+        &test_config(),
+        AsyncHookManager::new(),
+        Arc::new(Mutex::new(PersistentHookManager::new())),
+    )
+    .unwrap();
+
+    // Producer-side render result: a `call_template` like
+    // `**$** \`{{ args.command }}\`` produces this `title`. The raw
+    // `input` JSON is also kept on the event for transcript serialization,
+    // but the user-facing rendering must prefer the rendered title.
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Tool(ToolEvent::Started {
+            id: "call-1".into(),
+            name: "bash_exec".into(),
+            kind: ToolKind::Other,
+            title: Some("**$** `ls -la /tmp`".into()),
+            input: yaml_to_json("command: ls -la /tmp"),
+            locations: vec![],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let lines: Vec<String> = tui
+        .app
+        .transcript
+        .iter()
+        .flat_map(Tui::render_entry)
+        .map(|line| line_to_plain(&line))
+        .collect();
+
+    let joined = lines.join("\n");
+    assert!(
+        joined.contains("ls -la /tmp"),
+        "expected rendered title `ls -la /tmp` in transcript, got:\n{joined}"
+    );
+    assert!(
+        !joined.contains("command: ls -la /tmp"),
+        "expected rendered title to replace yaml-formatted input, but raw yaml is still shown:\n{joined}"
+    );
+}
+
+#[tokio::test]
+async fn tui_falls_back_to_yaml_when_no_template_title() {
+    // Regression guard: when title is None (no template configured), the
+    // existing yaml-of-input behavior must be preserved.
+    let mut tui = Tui::init(
+        &test_config(),
+        AsyncHookManager::new(),
+        Arc::new(Mutex::new(PersistentHookManager::new())),
+    )
+    .unwrap();
+
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Tool(ToolEvent::Started {
+            id: "call-1".into(),
+            name: "no_template_tool".into(),
+            kind: ToolKind::Other,
+            title: None,
+            input: yaml_to_json("command: ls"),
+            locations: vec![],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let lines: Vec<String> = tui
+        .app
+        .transcript
+        .iter()
+        .flat_map(Tui::render_entry)
+        .map(|line| line_to_plain(&line))
+        .collect();
+    let joined = lines.join("\n");
+    assert!(
+        joined.contains("command: ls"),
+        "expected raw yaml of input when no template; got:\n{joined}"
+    );
+}
+
+#[tokio::test]
+async fn tui_renders_completed_template_title_when_provided() {
+    let mut tui = Tui::init(
+        &test_config(),
+        AsyncHookManager::new(),
+        Arc::new(Mutex::new(PersistentHookManager::new())),
+    )
+    .unwrap();
+
+    // Producer-side render result: a `result_template` like
+    // `OK: {{ result.content[0].text }}` is rendered into `title`. The
+    // raw `output` JSON would yaml-render to something like
+    // `content:\n- text: hello\n  type: text` — the user-facing rendering
+    // must prefer the rendered title.
+    let raw_output = serde_json::json!({
+        "content": [{"type": "text", "text": "hello"}],
+        "isError": false,
+    });
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Tool(ToolEvent::Completed {
+            id: "call-1".into(),
+            output: raw_output,
+            title: Some("OK: hello".into()),
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let lines: Vec<String> = tui
+        .app
+        .transcript
+        .iter()
+        .flat_map(Tui::render_entry)
+        .map(|line| line_to_plain(&line))
+        .collect();
+    let joined = lines.join("\n");
+    assert!(
+        joined.contains("OK: hello"),
+        "expected rendered template title `OK: hello` in transcript, got:\n{joined}"
+    );
+    assert!(
+        !joined.contains("isError"),
+        "raw output JSON leaked into transcript instead of using rendered title:\n{joined}"
+    );
+}
+
+#[tokio::test]
+async fn tui_falls_back_to_output_when_no_template_title() {
+    // Regression guard: when title is None (no result template), the
+    // existing extract-from-output behavior must be preserved.
+    let mut tui = Tui::init(
+        &test_config(),
+        AsyncHookManager::new(),
+        Arc::new(Mutex::new(PersistentHookManager::new())),
+    )
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Tool(ToolEvent::Completed {
+            id: "call-1".into(),
+            output: serde_json::Value::String("plain output line".into()),
+            title: None,
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+    let lines: Vec<String> = tui
+        .app
+        .transcript
+        .iter()
+        .flat_map(Tui::render_entry)
+        .map(|line| line_to_plain(&line))
+        .collect();
+    let joined = lines.join("\n");
+    assert!(
+        joined.contains("plain output line"),
+        "expected raw output when no template title; got:\n{joined}"
+    );
 }

--- a/crates/harnx/src/cli_event_sink.rs
+++ b/crates/harnx/src/cli_event_sink.rs
@@ -319,15 +319,24 @@ impl AgentEventSink for CliAgentEventSink {
                     );
                 }
             }
-            AgentEvent::Tool(ToolEvent::Started { name, .. }) => {
-                eprintln!("{}", dimmed_text(&format!("[tool] {name}")));
+            AgentEvent::Tool(ToolEvent::Started { name, title, .. }) => {
+                eprintln!(
+                    "{}",
+                    dimmed_text(&format_tool_started_line(&name, title.as_deref()))
+                );
             }
             AgentEvent::Tool(ToolEvent::Failed { error, .. }) => {
                 eprintln!("{}", warning_text(&format!("tool error: {error}")));
             }
-            // Silent for Progress / Update / Completed: CLI doesn't stream
-            // per-chunk tool updates; Completed's output is usually internal
-            // and shouldn't clutter stderr.
+            AgentEvent::Tool(ToolEvent::Completed { output, title, .. }) => {
+                let text = harnx_runtime::utils::render_tool_result_text(&output, title.as_deref());
+                let trimmed = text.trim_end_matches('\n');
+                if !trimmed.is_empty() {
+                    eprintln!("{}", dimmed_text(trimmed));
+                }
+            }
+            // Silent for Progress / Update — they are streamed mid-call
+            // updates that would clutter stderr.
             AgentEvent::Tool(_) => {}
             // Every other variant — Session, Status, Plan — still gets
             // captured so nothing silently disappears. These receive dedicated
@@ -367,6 +376,17 @@ fn split_line_tail_local(text: &str) -> (&str, &str) {
 fn need_rows_local(text: &str, columns: u16) -> u16 {
     let buffer_width = display_width(text).max(1) as u16;
     buffer_width.div_ceil(columns)
+}
+
+/// Format the line printed for `ToolEvent::Started`. When the producer has
+/// rendered a MiniJinja `call_template` into `title`, append it after the
+/// tool name so the user sees the templated form instead of just the bare
+/// tool name. Public for testing the pure formatting decision.
+pub(crate) fn format_tool_started_line(name: &str, title: Option<&str>) -> String {
+    match title.map(str::trim).filter(|t| !t.is_empty()) {
+        Some(t) => format!("[tool] {name} {t}"),
+        None => format!("[tool] {name}"),
+    }
 }
 
 #[cfg(test)]
@@ -447,6 +467,110 @@ mod tests {
                 outcome: Default::default(),
             }),
             None,
+        );
+    }
+
+    // ----------------------------------------------------------------
+    // MCP MiniJinja templating: CLI must surface the rendered title/
+    // content fields produced by harnx-runtime when an MCP tool's
+    // `_meta.call_template` / `_meta.result_template` is set. Covers
+    // issue #340 / PR #349 — the producer wired templates into the
+    // ToolEvent fields, but the CLI consumer was discarding them
+    // prior to these tests.
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn started_line_includes_template_title_when_present() {
+        let line = format_tool_started_line("bash_exec", Some("$ ls -la /tmp"));
+        assert_eq!(line, "[tool] bash_exec $ ls -la /tmp");
+    }
+
+    #[test]
+    fn started_line_uses_bare_name_when_title_absent() {
+        let line = format_tool_started_line("bash_exec", None);
+        assert_eq!(line, "[tool] bash_exec");
+    }
+
+    #[test]
+    fn started_line_treats_empty_title_as_absent() {
+        // A template that renders to whitespace-only must not pollute the
+        // line with trailing whitespace — matches the "no template" path.
+        assert_eq!(
+            format_tool_started_line("name", Some("")),
+            "[tool] name",
+            "empty title should fall back"
+        );
+        assert_eq!(
+            format_tool_started_line("name", Some("   ")),
+            "[tool] name",
+            "whitespace-only title should fall back"
+        );
+    }
+
+    // The CLI Completed handler delegates to
+    // `harnx_runtime::utils::render_tool_result_text`, the same shared
+    // helper the TUI uses. We assert against that helper directly so any
+    // future tweak to the rendering rules updates a single test surface.
+
+    #[test]
+    fn completed_uses_template_title_when_present() {
+        // With a template-rendered title, prefer it over the raw output.
+        let raw_output = serde_json::json!({
+            "content": [{"type": "text", "text": "hello"}],
+            "isError": false,
+        });
+        let rendered =
+            harnx_runtime::utils::render_tool_result_text(&raw_output, Some("OK: hello"));
+        assert!(rendered.contains("OK: hello"));
+        assert!(
+            !rendered.contains("isError"),
+            "raw output JSON leaked when title was provided: {rendered}"
+        );
+    }
+
+    #[test]
+    fn completed_falls_back_to_extracted_text_when_no_title() {
+        // No template => extract user-display text from MCP-style output.
+        // Restores pre-0daecac CLI behavior (was silent in the interim).
+        let raw_output = serde_json::json!({
+            "content": [{"type": "text", "text": "tool stdout here"}],
+        });
+        let rendered = harnx_runtime::utils::render_tool_result_text(&raw_output, None);
+        assert!(
+            rendered.contains("tool stdout here"),
+            "expected extracted user-display text in output: {rendered}"
+        );
+    }
+
+    #[test]
+    fn completed_falls_back_to_string_when_no_title_and_string_output() {
+        // String-typed output passes through without yaml-wrapping.
+        let raw_output = serde_json::Value::String("plain stdout line".into());
+        let rendered = harnx_runtime::utils::render_tool_result_text(&raw_output, None);
+        assert!(rendered.contains("plain stdout line"));
+    }
+
+    #[test]
+    fn completed_falls_back_to_yaml_for_arbitrary_json() {
+        // Arbitrary JSON with no extractable text falls through to YAML —
+        // not silent, not the Debug form. Better-than-nothing display.
+        let raw_output = serde_json::json!({"exitCode": 0, "duration_ms": 42});
+        let rendered = harnx_runtime::utils::render_tool_result_text(&raw_output, None);
+        assert!(
+            rendered.contains("exitCode") && rendered.contains("duration_ms"),
+            "expected YAML keys in fallback output: {rendered}"
+        );
+    }
+
+    #[test]
+    fn completed_treats_empty_title_as_no_title() {
+        // A template that renders to "" must not blank out the result —
+        // fall back to extraction so the user still sees the tool's work.
+        let raw_output = serde_json::Value::String("important output".into());
+        let rendered = harnx_runtime::utils::render_tool_result_text(&raw_output, Some(""));
+        assert!(
+            rendered.contains("important output"),
+            "empty title should fall back to extraction: {rendered}"
         );
     }
 }


### PR DESCRIPTION
## Summary

PR #349 added MiniJinja templates for MCP tool calls/results, but I found when using the tool that templates weren't actually appearing. Root cause: the producer (\`harnx-runtime\`) renders templates into \`ToolEvent::Started.title\` and the \`Completed\` event, but every consumer (TUI, CLI, history replay) discarded those fields and re-rendered from raw input/output.

This PR fixes the consumer side, restores non-silent CLI tool-result rendering (which was a regression from commit \`0daecac\`), cleans up the data model, adds end-to-end test coverage, and fixes a pre-existing flaky test that surfaced along the way.

## Changes

**Templates now display in TUI and CLI**
- TUI \`Started\` handler uses the rendered title instead of yaml-formatting the raw input.
- TUI \`Completed\` rendering uses the rendered template when present, falls back to extract+truncate otherwise.
- CLI \`Started\` line appends the rendered title after the tool name.
- CLI \`Completed\` is no longer silent — renders the templated form when present, or extracted/truncated raw output otherwise.

**CLI no longer silent on tool results**
Commit \`0daecac\` (\"feat(sink): handle AgentEvent::Tool in Cli + Tui sinks\") explicitly silenced \`Completed\` in the CLI sink to \"match current CLI behavior.\" In practice it removed the YAML/extracted printing the old \`default_emit_tool_result\` path was doing — non-interactive mode lost visibility into what tools did. With templates now in place, the sensible default is to show *something*: rendered template if available, extracted/truncated raw output otherwise. The TUI was already doing this; the CLI is now consistent.

**\`Completed.content: Vec<ContentBlock>\` → \`title: Option<String>\`**
The producer always set \`content\` to either \`vec![ContentBlock::Text(rendered)]\` or \`vec![]\` — never image/resource/opaque blocks. The new type matches what the field actually holds and mirrors \`Started.title\` / \`Update.title\`. This is display text only — the raw \`output: Value\` is unchanged and continues to carry what the LLM/session log/sub-agent see.

**Shared rendering helper**
Extracted \`render_tool_result_text(output, title)\` into \`harnx_runtime::utils\` so the TUI and CLI sinks format identically. The TUI's \`render_tool_result_text\` is now a thin re-export.

**Flaky test fix**
\`harnx-core::sink::tests\` had two tests racing on the global sink with no locking. Added a poison-safe module-level \`Mutex<()>\` (\`unwrap_or_else(|e| e.into_inner())\`) so panics don't cascade-fail subsequent tests. Verified with 10 consecutive parallel runs.

**Code review fixes** (from /code-review)
- Poison-safe \`with_recording_sink\` helper in producer tests
- Consistent whitespace/empty title handling across all three render paths
- Guard against \`(0, 0)\` terminal size from non-TTY environments
- Replace ad-hoc \`eprintln!\` with \`log::warn!\` / \`log::debug!\` for template errors and terminal-size probe failures
- Tightened a stale doc comment

## Test coverage

| Layer | What's verified |
|---|---|
| Producer (\`harnx-runtime/src/tool.rs\`) | \`emit_tool_call_with_template\` / \`emit_tool_result_with_template\` populate \`title\` when a matching declaration carries a template, leave \`None\` otherwise. Recording-sink based, serialized via poison-safe mutex. |
| TUI consumer (\`harnx-tui/src/tests.rs\`) | \`Started\` honors \`title\`; \`Completed\` honors \`title\`; both fall back correctly when \`title\` is \`None\`. |
| CLI helper (\`harnx/src/cli_event_sink.rs\`) | Title-present path, MCP \`content\` extraction, raw \`String\` passthrough, arbitrary-JSON YAML fallback, empty-title fallback. |

All workspace tests pass; \`cargo clippy --workspace --tests -- -D warnings\` clean.

## Out of scope

- **Session restore replay** doesn't apply templates either, because \`lifecycle.rs:318\` doesn't have access to the live tool declaration map. Documented as #385.

## Test plan

- [ ] Run a real bash MCP tool in TUI mode → confirm rendered \`\$ <command>\` form appears in transcript.
- [ ] Run the same in non-interactive CLI mode → confirm rendered call line + result text appear on stderr.
- [ ] Restart a session and verify the original (unrendered) form still appears (tracked in #385).
- [ ] Run \`cargo test --workspace\` and \`cargo clippy --workspace --tests -- -D warnings\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TUI and CLI now display template-rendered titles for tool execution events
  * TUI "Started" events show rendered template title instead of raw input
  * CLI "Started" events include rendered title after tool name

* **Bug Fixes**
  * CLI "Completed" events now display output (previously silent)

* **Tests**
  * Added regression tests verifying template title display in TUI and CLI
  * Improved test reliability with concurrency mitigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->