### PR TITLE
feat(bash): improve sandboxing and tilde expansion (#376) (#377) (#379)

### DIFF
--- a/.changesets/bash-sandboxing-birdcage.md
+++ b/.changesets/bash-sandboxing-birdcage.md
@@ -11,7 +11,7 @@ New per-call MCP parameters on `exec` and `spawn`:
 
 New `harnx-mcp-bash` server flags (Unix only):
 - `--no-sandbox` — disable sandboxing (restore prior unsandboxed behavior).
-- `--extra-readable <path>` (repeatable) — additional read-only paths.
+- `--extra-read <path>` (repeatable) — additional read-only paths.
 - `--extra-exec <path>` (repeatable) — additional exec paths.
 - `--sandbox-run <path>` — override the helper-binary location.
 

--- a/.changesets/sandbox-extra-write-tempdir-tilde.md
+++ b/.changesets/sandbox-extra-write-tempdir-tilde.md
@@ -1,0 +1,9 @@
+---
+harnx: minor
+---
+
+Improve filesystem sandboxing configuration for `harnx-mcp-bash`:
+
+- Add `--extra-write <path>` CLI flag and `HARNX_BASH_EXTRA_WRITABLE` environment variable for adding extra writable paths to the sandbox (#376).
+- The system temporary directory is now writable by default in the sandbox (Linux: `/tmp`; macOS: `/private/tmp` and `$TMPDIR` if set) without requiring explicit configuration (#377).
+- Support `~` tilde expansion in all path-related configuration flags (`--root`, `--extra-read`, `--extra-write`, `--extra-exec`) and their corresponding environment variables (#379).

--- a/crates/harnx-mcp-bash/src/main.rs
+++ b/crates/harnx-mcp-bash/src/main.rs
@@ -55,6 +55,7 @@ fn parse_env_paths(var_name: &str) -> Vec<PathBuf> {
         .map(|value| {
             std::env::split_paths(&value)
                 .filter(|path| !path.as_os_str().is_empty())
+                .map(|path| PathBuf::from(expand_tilde(&path.to_string_lossy())))
                 .collect()
         })
         .unwrap_or_default()
@@ -80,8 +81,28 @@ fn path_is_executable(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+fn expand_tilde(raw: &str) -> String {
+    if !raw.starts_with('~') {
+        return raw.to_string();
+    }
+
+    let home = match std::env::var("HOME") {
+        Ok(home) => home,
+        Err(_) => return raw.to_string(),
+    };
+
+    if raw == "~" {
+        home
+    } else if let Some(suffix) = raw.strip_prefix("~/") {
+        format!("{home}/{suffix}")
+    } else {
+        raw.to_string()
+    }
+}
+
 fn push_root(roots: &mut Vec<PathBuf>, raw: &str) {
-    let path = PathBuf::from(raw);
+    let raw = expand_tilde(raw);
+    let path = PathBuf::from(&raw);
     if path.exists() {
         match path.canonicalize() {
             Ok(canonical) => roots.push(canonical),
@@ -103,6 +124,7 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
         enabled: true,
         extra_exec: parse_env_paths("HARNX_BASH_EXTRA_EXEC"),
         extra_readable: parse_env_paths("HARNX_BASH_EXTRA_READABLE"),
+        extra_writable: parse_env_paths("HARNX_BASH_EXTRA_WRITABLE"),
         sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
         extra_env_passthrough: parse_env_passthrough(),
         env_overrides: vec![],
@@ -126,23 +148,36 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
                 sandbox_config.enabled = false;
                 i += 1;
             }
-            "--extra-readable" => {
+            "--extra-read" => {
                 if i + 1 < args.len() {
                     sandbox_config
                         .extra_readable
-                        .push(PathBuf::from(&args[i + 1]));
+                        .push(PathBuf::from(expand_tilde(&args[i + 1])));
                     i += 2;
                 } else {
-                    eprintln!("harnx-mcp-bash: --extra-readable requires a path argument");
+                    eprintln!("harnx-mcp-bash: --extra-read requires a path argument");
                     std::process::exit(1);
                 }
             }
             "--extra-exec" => {
                 if i + 1 < args.len() {
-                    sandbox_config.extra_exec.push(PathBuf::from(&args[i + 1]));
+                    sandbox_config
+                        .extra_exec
+                        .push(PathBuf::from(expand_tilde(&args[i + 1])));
                     i += 2;
                 } else {
                     eprintln!("harnx-mcp-bash: --extra-exec requires a path argument");
+                    std::process::exit(1);
+                }
+            }
+            "--extra-write" => {
+                if i + 1 < args.len() {
+                    sandbox_config
+                        .extra_writable
+                        .push(PathBuf::from(expand_tilde(&args[i + 1])));
+                    i += 2;
+                } else {
+                    eprintln!("harnx-mcp-bash: --extra-write requires a path argument");
                     std::process::exit(1);
                 }
             }
@@ -187,8 +222,9 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
                 eprintln!("Options:");
                 eprintln!("  --root, -r <path>        Add an allowed root directory (repeatable)");
                 eprintln!("  --no-sandbox            Disable filesystem sandboxing explicitly");
-                eprintln!("  --extra-readable <path> Add sandbox read-only path (repeatable)");
+                eprintln!("  --extra-read <path> Add sandbox read-only path (repeatable)");
                 eprintln!("  --extra-exec <path>     Add sandbox execute path (repeatable)");
+                eprintln!("  --extra-write <path>    Add sandbox writable path (repeatable)");
                 eprintln!("  --sandbox-run <path>    Override sandbox helper binary path");
                 eprintln!("  --env, -e <VAR>         Pass VAR from host env to child (repeatable)");
                 eprintln!("  --env, -e <VAR=VALUE>   Set VAR=VALUE in child env (repeatable)");
@@ -200,6 +236,9 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
                 );
                 eprintln!(
                     "  HARNX_BASH_EXTRA_EXEC       Colon-separated extra sandbox execute paths"
+                );
+                eprintln!(
+                    "  HARNX_BASH_EXTRA_WRITABLE   Colon-separated extra sandbox writable paths"
                 );
                 eprintln!(
                     "  HARNX_BASH_ENV_PASSTHROUGH  Comma-separated extra env var names to pass through"
@@ -271,6 +310,7 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
         enabled: false,
         extra_exec: vec![],
         extra_readable: vec![],
+        extra_writable: vec![],
         sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
         extra_env_passthrough: parse_env_passthrough(),
         env_overrides: vec![],
@@ -285,6 +325,30 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
                     i += 2;
                 } else {
                     eprintln!("harnx-mcp-bash: --root requires a path argument");
+                    std::process::exit(1);
+                }
+            }
+            "--extra-read" => {
+                if i + 1 < args.len() {
+                    i += 2;
+                } else {
+                    eprintln!("harnx-mcp-bash: --extra-read requires a path argument");
+                    std::process::exit(1);
+                }
+            }
+            "--extra-exec" => {
+                if i + 1 < args.len() {
+                    i += 2;
+                } else {
+                    eprintln!("harnx-mcp-bash: --extra-exec requires a path argument");
+                    std::process::exit(1);
+                }
+            }
+            "--extra-write" => {
+                if i + 1 < args.len() {
+                    i += 2;
+                } else {
+                    eprintln!("harnx-mcp-bash: --extra-write requires a path argument");
                     std::process::exit(1);
                 }
             }
@@ -319,6 +383,9 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
                 eprintln!();
                 eprintln!("Options:");
                 eprintln!("  --root, -r <path>       Add an allowed root directory (repeatable)");
+                eprintln!("  --extra-read <path> Accept sandbox read-only path flag (ignored on this platform)");
+                eprintln!("  --extra-exec <path>     Accept sandbox execute path flag (ignored on this platform)");
+                eprintln!("  --extra-write <path>    Accept sandbox writable path flag (ignored on this platform)");
                 eprintln!("  --env, -e <VAR>         Pass VAR from host env to child (repeatable)");
                 eprintln!("  --env, -e <VAR=VALUE>   Set VAR=VALUE in child env (repeatable)");
                 eprintln!("  --help, -h              Show this help message");
@@ -344,4 +411,56 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
     }
 
     Ok((roots, sandbox_config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expand_tilde;
+    use std::ffi::{OsStr, OsString};
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        match LOCK.get_or_init(|| Mutex::new(())).lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    struct EnvVar {
+        key: String,
+        prev: Option<OsString>,
+    }
+
+    impl EnvVar {
+        fn set(key: &str, value: impl AsRef<OsStr>) -> Self {
+            let prev = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value.as_ref()) };
+            Self {
+                key: key.to_string(),
+                prev,
+            }
+        }
+    }
+
+    impl Drop for EnvVar {
+        fn drop(&mut self) {
+            unsafe {
+                match self.prev.take() {
+                    Some(value) => std::env::set_var(&self.key, value),
+                    None => std::env::remove_var(&self.key),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_expand_tilde_replaces_prefix() {
+        let _env_guard = env_lock();
+        let _home = EnvVar::set("HOME", "/tmp/test-home");
+
+        assert_eq!(expand_tilde("~/foo"), "/tmp/test-home/foo");
+        assert_eq!(expand_tilde("~"), "/tmp/test-home");
+        assert_eq!(expand_tilde("/abs/path"), "/abs/path");
+    }
 }

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -293,6 +293,8 @@ pub struct SandboxConfig {
     pub extra_exec: Vec<PathBuf>,
     #[cfg_attr(not(unix), allow(dead_code))]
     pub extra_readable: Vec<PathBuf>,
+    #[cfg_attr(not(unix), allow(dead_code))]
+    pub extra_writable: Vec<PathBuf>,
     /// Extra var names to pass through from host (allowlist additions).
     pub extra_env_passthrough: Vec<String>,
     /// Explicit overrides: KEY → VALUE (highest precedence).
@@ -367,6 +369,29 @@ impl BashServer {
     #[allow(dead_code)]
     const SYSTEM_EXEC_PATHS: &[&str] = &["/usr/bin", "/bin", "/tmp", "/etc"];
 
+    #[cfg(unix)]
+    fn system_writable_paths() -> Vec<PathBuf> {
+        #[cfg(target_os = "linux")]
+        {
+            vec![PathBuf::from("/tmp")]
+        }
+        #[cfg(target_os = "macos")]
+        {
+            let mut paths = vec![PathBuf::from("/private/tmp")];
+            if let Ok(tmpdir) = std::env::var("TMPDIR") {
+                let path = PathBuf::from(&tmpdir);
+                if path != Path::new("/private/tmp") {
+                    paths.push(path);
+                }
+            }
+            paths
+        }
+        #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+        {
+            vec![PathBuf::from("/tmp")]
+        }
+    }
+
     const DEFAULT_ENV_ALLOWLIST: &[&str] = &[
         "HOME",
         "PATH",
@@ -407,6 +432,7 @@ impl BashServer {
                 enabled: false,
                 extra_exec: vec![],
                 extra_readable: vec![],
+                extra_writable: vec![],
                 extra_env_passthrough: vec![],
                 env_overrides: vec![],
                 sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
@@ -571,6 +597,11 @@ impl BashServer {
             args.push(OsString::from(path));
         }
 
+        for path in Self::system_writable_paths() {
+            args.push(OsString::from("--write"));
+            args.push(path.into_os_string());
+        }
+
         if let Some(home) = std::env::var_os("HOME") {
             let home = PathBuf::from(home);
             args.push(OsString::from("--exec"));
@@ -595,6 +626,12 @@ impl BashServer {
             args.push(OsString::from("--read"));
             args.push(path.clone().into_os_string());
             readable_paths.push(path.clone());
+        }
+
+        for path in &self.inner.sandbox_config.extra_writable {
+            args.push(OsString::from("--write"));
+            args.push(path.clone().into_os_string());
+            writable_paths.push(path.clone());
         }
 
         match outputs {
@@ -2451,6 +2488,7 @@ mod tests {
             enabled: true,
             extra_exec: vec![],
             extra_readable: vec![],
+            extra_writable: vec![],
             extra_env_passthrough: vec![],
             env_overrides: vec![],
             sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
@@ -2473,6 +2511,7 @@ mod tests {
                 enabled: true,
                 extra_exec: vec![],
                 extra_readable: vec![],
+                extra_writable: vec![],
                 extra_env_passthrough: vec![],
                 env_overrides: vec![],
                 sandbox_run_path: sandbox_run_test_path(),
@@ -2660,6 +2699,61 @@ mod tests {
         assert!(!pairs.contains(&("--write".into(), "/test/root".into())));
         assert!(!pairs.contains(&("--read".into(), "/test/root".into())));
         assert!(!pairs.contains(&("--read".into(), "/tmp/test_wd_xxx".into())));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_sandbox_args_extra_writable() {
+        let mut config = enabled_sandbox_config();
+        config
+            .extra_writable
+            .push(PathBuf::from("/custom/writable"));
+        let server = BashServer::new_with_sandbox(vec![PathBuf::from("/test/root")], config);
+        let args = server.build_sandbox_args(
+            Path::new("/custom/writable/workdir"),
+            None,
+            None,
+            &[PathBuf::from("/test/root")],
+        );
+        let pairs = collect_arg_pairs(&args);
+
+        assert!(pairs.contains(&("--write".into(), "/custom/writable".into())));
+    }
+
+    #[cfg(all(unix, target_os = "linux"))]
+    #[test]
+    fn test_sandbox_args_temp_dir_writable() {
+        let server = BashServer::new_with_sandbox(
+            vec![PathBuf::from("/test/root")],
+            enabled_sandbox_config(),
+        );
+        let args = server.build_sandbox_args(
+            Path::new("/test/root/workdir"),
+            None,
+            None,
+            &[PathBuf::from("/test/root")],
+        );
+        let pairs = collect_arg_pairs(&args);
+
+        assert!(pairs.contains(&("--write".into(), "/tmp".into())));
+    }
+
+    #[cfg(all(unix, target_os = "macos"))]
+    #[test]
+    fn test_sandbox_args_temp_dir_writable() {
+        let server = BashServer::new_with_sandbox(
+            vec![PathBuf::from("/test/root")],
+            enabled_sandbox_config(),
+        );
+        let args = server.build_sandbox_args(
+            Path::new("/test/root/workdir"),
+            None,
+            None,
+            &[PathBuf::from("/test/root")],
+        );
+        let pairs = collect_arg_pairs(&args);
+
+        assert!(pairs.contains(&("--write".into(), "/private/tmp".into())));
     }
 
     #[cfg(unix)]

--- a/docs/bash-mcp-server.md
+++ b/docs/bash-mcp-server.md
@@ -84,9 +84,49 @@ When a variable is defined in multiple places, the value from the source highest
 3. `.env.bash` dotfile (value from file)
 4. Default allowlist (value from host environment)
 
+## Filesystem Sandboxing
+
+On Linux and macOS, `harnx-mcp-bash` uses [birdcage](https://github.com/phylum-dev/birdcage) to sandbox child processes. This restricts the agent's ability to read or write files outside of explicitly permitted locations.
+
+### Default Permissions
+
+- **Writable**:
+  - The repository root(s) specified via `--root`.
+  - The system temporary directory (`/tmp` on Linux, `/private/tmp` on macOS).
+  - The path in the `$TMPDIR` environment variable, if set.
+- **Readable/Executable**:
+  - Standard system directories required for bash and common utilities (e.g., `/usr/bin`, `/bin`, `/lib`).
+
+### Configuration Options
+
+You can grant additional filesystem access using CLI flags or environment variables. All path flags support the `~` prefix, which is expanded to the user's home directory.
+
+| CLI Flag | Environment Variable | Description |
+|----------|----------------------|-------------|
+| `--root <path>` | (N/A) | Adds a project root (writable). |
+| `--extra-read <path>` | `HARNX_BASH_EXTRA_READABLE` | Adds a path as read-only. |
+| `--extra-write <path>` | `HARNX_BASH_EXTRA_WRITABLE` | Adds a path as writable. |
+| `--extra-exec <path>` | `HARNX_BASH_EXTRA_EXEC` | Adds a path to the execution allowlist. |
+
+**Notes:**
+- CLI flags can be repeated to add multiple paths.
+- Environment variables accept a colon-separated list of paths (e.g., `HARNX_BASH_EXTRA_READABLE=/path/one:/path/two`).
+
+### Disabling Sandboxing
+
+Use the `--no-sandbox` flag to disable filesystem restrictions entirely.
+
+```yaml
+# mcp_servers/bash.yaml
+args:
+  - --no-sandbox
+```
+
 ## Common Recipes
 
-### Enable `git push` over SSH
+### Environment Variables
+
+#### Enable `git push` over SSH
 
 Pass `SSH_AUTH_SOCK` (and optionally `SSH_AGENT_PID`) so the agent's bash process can use your existing SSH agent connection:
 
@@ -94,7 +134,7 @@ Pass `SSH_AUTH_SOCK` (and optionally `SSH_AGENT_PID`) so the agent's bash proces
 args: ["-e", "SSH_AUTH_SOCK"]
 ```
 
-### Enable GitHub CLI (`gh`)
+#### Enable GitHub CLI (`gh`)
 
 Pass `GH_TOKEN` or `GITHUB_TOKEN`:
 
@@ -104,10 +144,34 @@ args: ["-e", "GITHUB_TOKEN"]
 
 Alternatively, you can persist these in `~/.config/harnx/.env.bash`.
 
-### Non-interactive Editor
+#### Non-interactive Editor
 
 Override the `EDITOR` variable to ensure that AI tools that shell out use a non-interactive editor:
 
 ```yaml
 args: ["-e", "EDITOR=true"]
+```
+
+### Sandbox Configuration
+
+Allow tools to use home-directory caches or persistent configuration:
+
+#### Allow cargo to cache
+```yaml
+args: ["--extra-write", "~/.cargo"]
+```
+
+#### Allow pip to cache
+```yaml
+args: ["--extra-write", "~/.cache/pip"]
+```
+
+#### Allow npm globals
+```yaml
+args: ["--extra-write", "~/.npm"]
+```
+
+#### Read-only cargo registry
+```yaml
+args: ["--extra-read", "~/.cargo/registry"]
 ```

--- a/docs/solutions/workflow-issues/sandbox-path-tilde-expansion-cross-platform-2026-04-29.md
+++ b/docs/solutions/workflow-issues/sandbox-path-tilde-expansion-cross-platform-2026-04-29.md
@@ -1,0 +1,221 @@
+---
+title: "Tilde Expansion and Cross-Platform CLI Patterns for Sandbox Path Flags"
+date: 2026-04-29
+category: workflow-issues
+problem_type: workflow_issue
+component: harnx-mcp-bash
+root_cause: "Incomplete application of tilde expansion across CLI and env-var paths; inconsistent non-Unix flag handling"
+resolution_type: code_fix
+severity: medium
+tags:
+  - sandboxing
+  - cross-platform
+  - cli-parsing
+  - environment-variables
+  - tilde-expansion
+plan_ref: harnx-sandbox-extra-write-tempdir-tilde
+---
+
+## Problem
+
+When adding `--extra-write`, `--extra-read`, `--extra-exec` path flags and their corresponding environment variables to `harnx-mcp-bash`, tilde expansion implementation was incomplete and non-Unix platforms lacked proper consume-and-ignore handling for cross-platform config compatibility.
+
+## Symptoms
+
+- `HARNX_BASH_EXTRA_WRITABLE=~/.cache` passed literal `~/.cache` to sandbox instead of expanding via `$HOME`
+- Non-Unix (Windows) builds crashed with "unknown argument" for `--extra-read` and `--extra-exec` even though these flags were documented for shared configs
+- Missing patterns in code review: `parse_env_paths()` lacked tilde expansion, incomplete non-Unix ignore handlers
+- Changeset claimed tilde support for "corresponding environment variables" but implementation only covered CLI flags
+
+## Investigation Steps
+
+1. Initial implementation added `expand_tilde()` helper for CLI flag parsing arms
+2. Code review identified: `parse_env_paths()` (lines 53-61) used `split_paths()` but never applied `expand_tilde()` to results
+3. Review also found: non-Unix parser only special-cased `--extra-write`, leaving sibling sandbox flags to hit "unknown argument" fallback
+4. Root cause: author implemented CLI path flow carefully, then missed parallel env/non-Unix compatibility surfaces
+
+## Root Cause
+
+**Tilde expansion gap:** `parse_env_paths()` function parsed environment variable paths via `std::env::split_paths()` and returned them unchanged. The `expand_tilde()` helper was only called in CLI flag match arms.
+
+**Non-Unix parity gap:** Cross-platform config compatibility requires accepting sandbox-only flags on non-sandbox platforms (Windows). Only `--extra-write` had a consume-and-ignore handler; `--extra-read` and `--extra-exec` fell through to the unknown-argument error path.
+
+## Solution
+
+### 1. Apply `expand_tilde()` in both CLI arms AND `parse_env_paths()`
+
+**Before (main.rs:53-60):**
+```rust
+fn parse_env_paths(var_name: &str) -> Vec<PathBuf> {
+    std::env::var_os(var_name)
+        .map(|value| {
+            std::env::split_paths(&value)
+                .filter(|path| !path.as_os_str().is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+```
+
+**After:**
+```rust
+fn parse_env_paths(var_name: &str) -> Vec<PathBuf> {
+    std::env::var_os(var_name)
+        .map(|value| {
+            std::env::split_paths(&value)
+                .filter(|path| !path.as_os_str().is_empty())
+                .map(|path| PathBuf::from(expand_tilde(&path.to_string_lossy())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+```
+
+**Pattern:** When adding path transformation logic (tilde expansion, canonicalization, etc.), apply it consistently in:
+1. CLI flag parsing arms (immediate call site)
+2. Environment variable parsing functions (easy to miss)
+
+### 2. Consume-and-ignore pattern for non-Unix sandbox flags
+
+**Non-Unix parse_args (main.rs:330-337):**
+```rust
+"--extra-read" => {
+    if i + 1 < args.len() {
+        i += 2; // consume flag and value, ignore both
+    } else {
+        eprintln!("harnx-mcp-bash: --extra-read requires a path argument");
+        std::process::exit(1);
+    }
+}
+"--extra-exec" => {
+    if i + 1 < args.len() {
+        i += 2;
+    } else {
+        eprintln!("harnx-mcp-bash: --extra-exec requires a path argument");
+        std::process::exit(1);
+    }
+}
+"--extra-write" => {
+    if i + 1 < args.len() {
+        i += 2;
+    } else {
+        eprintln!("harnx-mcp-bash: --extra-write requires a path argument");
+        std::process::exit(1);
+    }
+}
+```
+
+**Key insight:** Consume-and-ignore must:
+1. Increment `i` by 2 (flag + value) to avoid desynchronizing argv parsing
+2. Still validate that a value argument exists (error on missing value)
+3. Apply to ALL sandbox-only flags, not just one
+
+### 3. Platform-specific default paths via `#[cfg]` helper
+
+**system_writable_paths() pattern (server.rs:372-393):**
+```rust
+#[cfg(unix)]
+fn system_writable_paths() -> Vec<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        vec![PathBuf::from("/tmp")]
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let mut paths = vec![PathBuf::from("/private/tmp")];
+        if let Ok(tmpdir) = std::env::var("TMPDIR") {
+            let path = PathBuf::from(&tmpdir);
+            if path != PathBuf::from("/private/tmp") {
+                paths.push(path);
+            }
+        }
+        paths
+    }
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+    {
+        vec![PathBuf::from("/tmp")]
+    }
+}
+```
+
+**Pattern:** Nested `#[cfg]` conditionals within a single function provide:
+1. Compile-time elimination of unreachable branches
+2. Type-safe return value across all Unix targets
+3. Fallback catch-all for future Unix-like platforms
+
+### 4. Environment variable test isolation via Mutex + RAII
+
+**Pattern (main.rs:410-460):**
+```rust
+fn env_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    match LOCK.get_or_init(|| Mutex::new(())).lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+struct EnvVar {
+    key: String,
+    prev: Option<OsString>,
+}
+
+impl EnvVar {
+    fn set(key: &str, value: impl AsRef<OsStr>) -> Self {
+        let prev = std::env::var_os(key);
+        unsafe { std::env::set_var(key, value.as_ref()) };
+        Self { key: key.to_string(), prev }
+    }
+}
+
+impl Drop for EnvVar {
+    fn drop(&mut self) {
+        unsafe {
+            match self.prev.take() {
+                Some(value) => std::env::set_var(&self.key, value),
+                None => std::env::remove_var(&self.key),
+            }
+        }
+    }
+}
+
+#[test]
+fn test_expand_tilde_replaces_prefix() {
+    let _env_guard = env_lock();         // serialize env access
+    let _home = EnvVar::set("HOME", "/tmp/test-home");  // RAII restore
+    assert_eq!(expand_tilde("~/foo"), "/tmp/test-home/foo");
+}
+```
+
+**Pattern components:**
+- `OnceLock<Mutex<()>>` provides process-wide serialization for tests mutating env
+- RAII `EnvVar` guard saves previous value, restores on drop
+- `unsafe` blocks required for `set_var`/`remove_var` (documented UB in Rust 2024)
+
+## Why This Works
+
+**Tilde expansion in both sites:** Environment variables are parsed before CLI flags are fully processed. Missing expansion there means `HARNX_BASH_EXTRA_WRITABLE=~/.cache` creates a `PathBuf` from literal string, which sandbox interprets as relative path starting with `~`.
+
+**Consume-and-ignore parity:** Shared config files (e.g., dotfiles, team-wide configs) may include sandbox flags. On non-Unix platforms without sandbox support, these must be accepted to prevent startup failure. The `i += 2` pattern prevents the next flag from being misread as the value argument.
+
+**Platform-specific defaults:** System temp directories differ by OS. The `#[cfg]` helper pattern ensures compile-time correctness without runtime branching overhead.
+
+**Test isolation:** `std::env::set_var` is unsafe and process-global. Mutex ensures no concurrent tests mutate env vars simultaneously. RAII pattern guarantees restoration even if test panics.
+
+## Prevention Strategies
+
+**Test Cases:**
+- Add tests for `parse_env_paths()` with tilde-prefixed paths
+- Add tests asserting all sandbox flags are consumed on non-Unix without error
+- Test with `HOME` unset to verify graceful fallback
+
+**Best Practices:**
+- When implementing path transformations, search for ALL sites where paths enter the system (CLI, env vars, config files)
+- For cross-platform flags, maintain a checklist of all related flags needing consume-and-ignore handlers
+- Use `grep` or AST tools to verify all call sites receive transformation
+
+**Code Review Checklist:**
+- [ ] Are CLI flags and env vars handled consistently?
+- [ ] Does non-Unix parser consume-and-ignore ALL sandbox-only flags?
+- [ ] Are platform-specific defaults cleanly separated via `#[cfg]`?
+- [ ] Do tests serialize env mutations and restore original values?

--- a/example_config/mcp_servers/bash.yaml
+++ b/example_config/mcp_servers/bash.yaml
@@ -8,18 +8,74 @@ rename_tools:
 
 # Sandbox configuration examples (uncomment as needed):
 #
-# args:
+args:
 #   - --no-sandbox                                          # Disable sandboxing entirely
-#   - --extra-readable                                      # Add read-only path to sandbox
-#   - /opt/sdk
-#   - --extra-exec                                          # Add executable path to sandbox
-#   - /opt/tools/bin
+  # Allow access to asdf installed binaries
+  - --extra-exec
+  - ~/.asdf
+  # Allow access to bun binaries and cache
+  - --extra-exec
+  - ~/.bun
+  - --extra-write
+  - ~/.bun/install/cache
+  # Allow access to various caches
+  - --extra-write
+  - ~/.cache
+  # Alllow access to various config files
+  - --extra-read
+  - ~/.config/acli
+  - --extra-write
+  - ~/.config/chromium
+  - --extra-read
+  - ~/.config/dcg
+  - --extra-read
+  - ~/.config/git
+  - --extra-write
+  - ~/.config/go
+  - --extra-read
+  - ~/.config/rtk
+  # Allow access to codescene config/license
+  - --extra-write
+  - ~/.codescene
+  # Git config
+  - --extra-read
+  - ~/.gitconfig
+  - --extra-read
+  - ~/.gitignore
+  - --extra-read
+  - ~/.gitignore_global
+  # Allow access to user-local binaries
+  - --extra-exec
+  - ~/.local/bin
+  # Allow access to mono
+  - --extra-exec
+  - ~/.mono
+  - --extra-write
+  - ~/.mono
+  # Allow access to npm config and cache
+  - --extra-write
+  - ~/.npm
+  # Allow access to npm config and cache
+  - --extra-write
+  - ~/.nvm
+  - --extra-write
+  - ~/.ruff_cache
+  - --extra-exec
+  - ~/.rustup
+  - --extra-write
+  - ~/.yarn
+  # Disable interactive editor
+  - --env
+  - EDITOR=true
+  # Passthrough GITHUB_TOKEN and GH_TOKEN so the agent can do remote git operations
+  - --env
+  - GITHUB_TOKEN
+  - --env
+  - GH_TOKEN
+  - --env
+  - CS_ACCESS_TOKEN
 #   - --sandbox-run                                         # Override sandbox helper binary
 #   - /opt/harnx/harnx-mcp-bash-sandbox-run
-#   - --env                                                 # Pass through a host env var (e.g. for git push / gh)
-#   - GITHUB_TOKEN
-#   - --env                                                 # Set an env var explicitly
-#   - MY_VAR=my_value
 #   - --env                                                 # Allow git push over SSH
 #   - SSH_AUTH_SOCK
 #


### PR DESCRIPTION
Adds support for additive writable paths in the MCP Bash server via the --extra-write CLI flag and HARNX_BASH_EXTRA_WRITABLE environment variable. Configures system temporary directories (/tmp on Linux, /private/tmp and $TMPDIR on macOS) to be writable by default in the sandbox.

Implements ~ tilde expansion for all path-related configuration flags (--root, --extra-readable, --extra-exec, --extra-write) and their corresponding environment variables. To ensure configuration portability, sandbox-specific flags are now accepted and ignored on non-Unix platforms instead of causing startup errors.

Includes unit tests for tilde expansion, environment variable parsing, and sandbox argument generation.

Plan: harnx-sandbox-extra-write-tempdir-tilde

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --extra-write and HARNX_BASH_EXTRA_WRITABLE to grant extra writable sandbox paths.
  * System temporary directories are writable in the sandbox by default.
  * Tilde (~) expansion now works for all path flags and env-var path lists.
  * Renamed --extra-readable to --extra-read; path flags behave consistently across platforms (accepted/ignored where appropriate).

* **Documentation**
  * Added comprehensive sandboxing guide, workflow note on tilde/flag behavior, and updated example config with common cache dirs and env passthrough.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->