### PR TITLE
feat(tui): markdown rendering for tool templates and assistant messages

### DIFF
--- a/.changesets/markdown-rendering-for-tool-templates.md
+++ b/.changesets/markdown-rendering-for-tool-templates.md
@@ -1,0 +1,25 @@
+---
+harnx: patch
+---
+Render inline markdown in MCP tool-template output for both TUI and CLI.
+
+The built-in tool templates use Markdown like `**$** \`{{ args.command }}\``
+to make the rendered call/result lines scannable. PR #386 wired the
+rendered text into the transcript but displayed it verbatim, so the
+markers leaked through as literal asterisks and backticks instead of
+producing styling.
+
+- TUI: new `ToolCallBody::Markdown` and `TranscriptItem::ToolResultMarkdown`
+  variants route templated text through a small inline-markdown helper that
+  produces ratatui spans with `BOLD` / `ITALIC` modifiers and a code-color
+  fg for `` `code` `` runs. Raw YAML/output bodies still render plain so
+  YAML keys/values are never accidentally styled.
+- CLI: templated `Started` titles and templated `Completed` lines run
+  through the existing `MarkdownRender` (syntect ANSI). Raw output keeps
+  the dim plain-text path. Markdown rendering is bypassed when the renderer
+  can't initialize, when `--no-highlight` is set, or when stdout isn't a
+  TTY.
+
+The TUI's other transcript items (`AssistantText`, `Plan`, etc.) still
+render plain — broadening markdown support across the TUI is a separate
+concern outside this fix.

--- a/.changesets/markdown-rendering-for-tool-templates.md
+++ b/.changesets/markdown-rendering-for-tool-templates.md
@@ -20,6 +20,12 @@ producing styling.
   can't initialize, when `--no-highlight` is set, or when stdout isn't a
   TTY.
 
-The TUI's other transcript items (`AssistantText`, `Plan`, etc.) still
-render plain — broadening markdown support across the TUI is a separate
-concern outside this fix.
+`AssistantText` is also wired through the same renderer so headings,
+lists, code fences, and inline emphasis from the LLM display correctly
+(this rendering was lost in the original ratatui transition). Single
+input newlines are preserved as visible line breaks rather than being
+collapsed into reflowed paragraphs the way CommonMark normally would.
+
+Other transcript items (`Plan`, `SystemText`, `ErrorText`, etc.) still
+render plain — they're not user-content and don't benefit from
+markdown.

--- a/.changesets/markdown-rendering-for-tool-templates.md
+++ b/.changesets/markdown-rendering-for-tool-templates.md
@@ -10,9 +10,9 @@ markers leaked through as literal asterisks and backticks instead of
 producing styling.
 
 - TUI: new `ToolCallBody::Markdown` and `TranscriptItem::ToolResultMarkdown`
-  variants route templated text through a small inline-markdown helper that
-  produces ratatui spans with `BOLD` / `ITALIC` modifiers and a code-color
-  fg for `` `code` `` runs. Raw YAML/output bodies still render plain so
+  variants route templated text through `tui-markdown`, which produces
+  ratatui spans with `BOLD` / `ITALIC` modifiers and a styled fg/bg for
+  inline `` `code` `` runs. Raw YAML/output bodies still render plain so
   YAML keys/values are never accidentally styled.
 - CLI: templated `Started` titles and templated `Completed` lines run
   through the existing `MarkdownRender` (syntect ANSI). Raw output keeps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-to-tui"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42366bb9d958f042bf58f0a85e1b2d091997c1257ca49bddd7e4827aadc65fd"
+dependencies = [
+ "nom 8.0.0",
+ "ratatui-core",
+ "simdutf8",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ansi_colours"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,6 +1574,15 @@ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
  "windows-link",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -3108,6 +3130,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-test",
+ "tui-markdown",
  "unicode-width",
  "uuid",
 ]
@@ -3847,6 +3870,12 @@ checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.11.1",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4834,6 +4863,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4866,6 +4904,25 @@ dependencies = [
  "human_format",
  "parking_lot",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+dependencies = [
+ "bitflags 2.11.1",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quick-xml"
@@ -5228,6 +5285,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5341,6 +5404,35 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -5835,6 +5927,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6069,6 +6167,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "walkdir",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -6431,6 +6530,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6552,6 +6681,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tui-markdown"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e766339aabad4528c3fccddf4acf03bc2b7ae6642def41e43c7af1a11f183122"
+dependencies = [
+ "ansi-to-tui",
+ "itertools",
+ "pretty_assertions",
+ "pulldown-cmark",
+ "ratatui-core",
+ "rstest",
+ "syntect",
+ "tracing",
+]
 
 [[package]]
 name = "typenum"
@@ -7502,6 +7647,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7646,6 +7800,15 @@ name = "xterm-color"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7008a9d8ba97a7e47d9b2df63fcdb8dade303010c5a7cd5bf2469d4da6eba673"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "yansi"

--- a/crates/harnx-tui/Cargo.toml
+++ b/crates/harnx-tui/Cargo.toml
@@ -38,6 +38,7 @@ sha2 = { workspace = true }
 textwrap = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+tui-markdown = "0.3.7"
 unicode-width = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -600,24 +600,32 @@ impl Tui {
             }
             AgentEvent::Tool(ToolEvent::Completed { output, title, .. }) => {
                 // The TuiAgentEventSink forwards Tool::Completed through
-                // render_agent_event. The truncation + formatting live
-                // here (mirror of default_emit_tool_result). Strip ANSI
-                // from a string-valued output BEFORE truncation so
-                // pre-dimmed test inputs get their ESC-introduced
-                // sequences removed cleanly — otherwise
-                // `truncate_output`'s `sanitize_output_text` strips the
-                // ESC char but leaves literal `[2m`/`[0m` markers.
-                // `render_tool_result_text` no longer wraps in ANSI dim:
-                // the TUI renderer applies `Modifier::DIM` via
-                // `TranscriptItem::ToolResultText`.
+                // render_agent_event. Strip ANSI from string-valued output
+                // BEFORE truncation so pre-dimmed test inputs get their
+                // ESC sequences removed cleanly. When `title` carries a
+                // rendered MCP `result_template`, route it through
+                // `ToolResultMarkdown` so the renderer styles `**bold**`
+                // / `` `code` `` / `*italic*`. Otherwise the extracted
+                // raw output goes through `ToolResultText` (plain dim).
+                let templated = title
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|t| !t.is_empty())
+                    .is_some();
                 let raw = match &output {
                     serde_json::Value::String(s) => serde_json::Value::String(strip_ansi(s)),
                     _ => output.clone(),
                 };
-                let text = crate::agent_event_sink::render_tool_result_text(&raw, title.as_deref());
+                let text =
+                    crate::agent_event_sink::render_tool_result_text(&raw, title.as_deref());
                 let clean = strip_ansi(&text).trim_end_matches('\n').to_string();
                 if clean.is_empty() {
                     vec![]
+                } else if templated {
+                    clean
+                        .lines()
+                        .map(|line| TranscriptItem::ToolResultMarkdown(line.to_string()))
+                        .collect()
                 } else {
                     clean
                         .lines()
@@ -774,16 +782,16 @@ impl Tui {
             AgentEvent::Tool(ToolEvent::Started {
                 name, title, input, ..
             }) => {
-                let input_yaml = match title.as_deref().map(str::trim).filter(|t| !t.is_empty()) {
-                    Some(t) => Some(t.to_string()),
+                let body = match title.as_deref().map(str::trim).filter(|t| !t.is_empty()) {
+                    Some(t) => Some(crate::types::ToolCallBody::Markdown(t.to_string())),
                     None => match &input {
                         serde_json::Value::Null => None,
-                        _ => Some(pretty_yaml_block(&input)),
+                        _ => Some(crate::types::ToolCallBody::Yaml(pretty_yaml_block(&input))),
                     },
                 };
                 vec![TranscriptItem::ToolCall {
                     tool_name: name,
-                    input_yaml,
+                    body,
                 }]
             }
             // Not rendered by the TUI: Turn, Session, Status, Tool::Progress,

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -83,6 +83,51 @@ fn render_attachment_preview(path: &Path) -> Option<String> {
     Some(preview)
 }
 
+/// Build the body for a `TranscriptItem::ToolCall` from a `Started`
+/// event's `title` and `input`. A non-empty rendered template `title`
+/// becomes `ToolCallBody::Markdown`; otherwise the raw input is YAML-
+/// formatted (or omitted entirely when input is `null`).
+fn tool_call_body(
+    title: Option<&str>,
+    input: &serde_json::Value,
+) -> Option<crate::types::ToolCallBody> {
+    match title.map(str::trim).filter(|t| !t.is_empty()) {
+        Some(t) => Some(crate::types::ToolCallBody::Markdown(t.to_string())),
+        None => match input {
+            serde_json::Value::Null => None,
+            _ => Some(crate::types::ToolCallBody::Yaml(pretty_yaml_block(input))),
+        },
+    }
+}
+
+/// Convert a `Completed` event's `output` + `title` into transcript items.
+/// Strips ANSI escapes from string outputs before truncation so pre-dimmed
+/// test inputs render cleanly. When `title` carries a rendered MCP
+/// `result_template`, each line goes through `ToolResultMarkdown` so
+/// `**bold**` / `` `code` `` / `*italic*` produce inline styling;
+/// otherwise the extracted output goes through plain `ToolResultText`.
+fn tool_completed_to_transcript_items(
+    output: &serde_json::Value,
+    title: Option<&str>,
+) -> Vec<TranscriptItem> {
+    let templated = title.map(str::trim).filter(|t| !t.is_empty()).is_some();
+    let raw = match output {
+        serde_json::Value::String(s) => serde_json::Value::String(strip_ansi(s)),
+        _ => output.clone(),
+    };
+    let text = crate::agent_event_sink::render_tool_result_text(&raw, title);
+    let clean = strip_ansi(&text).trim_end_matches('\n').to_string();
+    if clean.is_empty() {
+        return vec![];
+    }
+    let make = if templated {
+        |line: &str| TranscriptItem::ToolResultMarkdown(line.to_string())
+    } else {
+        |line: &str| TranscriptItem::ToolResultText(line.to_string())
+    };
+    clean.lines().map(make).collect()
+}
+
 impl Tui {
     pub(super) async fn handle_key(&mut self, key: KeyEvent) -> Result<()> {
         match (key.code, key.modifiers) {
@@ -599,39 +644,7 @@ impl Tui {
                 }
             }
             AgentEvent::Tool(ToolEvent::Completed { output, title, .. }) => {
-                // The TuiAgentEventSink forwards Tool::Completed through
-                // render_agent_event. Strip ANSI from string-valued output
-                // BEFORE truncation so pre-dimmed test inputs get their
-                // ESC sequences removed cleanly. When `title` carries a
-                // rendered MCP `result_template`, route it through
-                // `ToolResultMarkdown` so the renderer styles `**bold**`
-                // / `` `code` `` / `*italic*`. Otherwise the extracted
-                // raw output goes through `ToolResultText` (plain dim).
-                let templated = title
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|t| !t.is_empty())
-                    .is_some();
-                let raw = match &output {
-                    serde_json::Value::String(s) => serde_json::Value::String(strip_ansi(s)),
-                    _ => output.clone(),
-                };
-                let text =
-                    crate::agent_event_sink::render_tool_result_text(&raw, title.as_deref());
-                let clean = strip_ansi(&text).trim_end_matches('\n').to_string();
-                if clean.is_empty() {
-                    vec![]
-                } else if templated {
-                    clean
-                        .lines()
-                        .map(|line| TranscriptItem::ToolResultMarkdown(line.to_string()))
-                        .collect()
-                } else {
-                    clean
-                        .lines()
-                        .map(|line| TranscriptItem::ToolResultText(line.to_string()))
-                        .collect()
-                }
+                tool_completed_to_transcript_items(&output, title.as_deref())
             }
             AgentEvent::Model(ModelEvent::MessageChunk { blocks }) => {
                 let text = concat_text_blocks(&blocks);
@@ -782,16 +795,9 @@ impl Tui {
             AgentEvent::Tool(ToolEvent::Started {
                 name, title, input, ..
             }) => {
-                let body = match title.as_deref().map(str::trim).filter(|t| !t.is_empty()) {
-                    Some(t) => Some(crate::types::ToolCallBody::Markdown(t.to_string())),
-                    None => match &input {
-                        serde_json::Value::Null => None,
-                        _ => Some(crate::types::ToolCallBody::Yaml(pretty_yaml_block(&input))),
-                    },
-                };
                 vec![TranscriptItem::ToolCall {
                     tool_name: name,
-                    body,
+                    body: tool_call_body(title.as_deref(), &input),
                 }]
             }
             // Not rendered by the TUI: Turn, Session, Status, Tool::Progress,

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -310,14 +310,20 @@ pub(crate) fn messages_to_transcript_items(messages: &[Message]) -> Vec<Transcri
                         items.push(TranscriptItem::AssistantText(tc.text.clone()));
                     }
                     for r in &tc.tool_results {
-                        let input_yaml = if r.call.arguments == Value::Null {
+                        // Restored sessions don't have access to the live
+                        // tool declaration map, so templates can't be
+                        // re-rendered here — fall back to YAML/raw output.
+                        // Tracked in #385.
+                        let body = if r.call.arguments == Value::Null {
                             None
                         } else {
-                            Some(harnx_runtime::utils::pretty_yaml_block(&r.call.arguments))
+                            Some(crate::types::ToolCallBody::Yaml(
+                                harnx_runtime::utils::pretty_yaml_block(&r.call.arguments),
+                            ))
                         };
                         items.push(TranscriptItem::ToolCall {
                             tool_name: r.call.name.clone(),
-                            input_yaml,
+                            body,
                         });
                         for line in
                             crate::agent_event_sink::render_tool_result_text(&r.output, None)

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -1,5 +1,7 @@
 use crate::types::Tui;
-use crate::types::{App, TranscriptItem, MAX_INPUT_HEIGHT, MIN_INPUT_HEIGHT, SPINNER_FRAMES};
+use crate::types::{
+    App, ToolCallBody, TranscriptItem, MAX_INPUT_HEIGHT, MIN_INPUT_HEIGHT, SPINNER_FRAMES,
+};
 use harnx_runtime::config::GlobalConfig;
 use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Color, Modifier, Style};
@@ -85,6 +87,22 @@ impl Tui {
                     .add_modifier(Modifier::DIM),
                 false,
             ),
+            TranscriptItem::ToolResultMarkdown(text) => {
+                // Templated MCP `result_template` output. Render as inline
+                // markdown so `**bold**` / `*italic*` / `` `code` `` show
+                // their styling. The base style is dim gray so the result
+                // body stays visually subordinate to the conversation.
+                let base = Style::default().add_modifier(Modifier::DIM);
+                let mut spans = vec![Span::styled(
+                    "   ".to_string(),
+                    Style::default()
+                        .fg(Color::DarkGray)
+                        .add_modifier(Modifier::DIM),
+                )];
+                let line = crate::render_helpers::markdown_line_spans(text, base);
+                spans.extend(line.spans);
+                vec![Line::from(spans)]
+            }
             TranscriptItem::StatusLine(text) => Self::render_text_entry(
                 "",
                 text,
@@ -122,10 +140,7 @@ impl Tui {
                     .add_modifier(Modifier::DIM),
                 false,
             ),
-            TranscriptItem::ToolCall {
-                tool_name,
-                input_yaml,
-            } => {
+            TranscriptItem::ToolCall { tool_name, body } => {
                 // Use the plain rightwards arrow `→` (U+2192) as the
                 // tool-call marker.  The previous glyph was `->` followed by
                 // VS16 (U+FE0F), which requests an emoji-style presentation
@@ -135,25 +150,34 @@ impl Tui {
                 // same frame, leaving stray glyphs (stray letters, corrupted
                 // words) at columns the next render doesn't explicitly
                 // repaint.
-                let mut lines = Self::render_text_entry(
-                    "",
-                    &format!("→ {tool_name}"),
-                    Style::default()
-                        .fg(Color::DarkGray)
-                        .add_modifier(Modifier::DIM),
-                    false,
-                );
-                if let Some(yaml) = input_yaml {
-                    for line in yaml.lines() {
-                        lines.extend(Self::render_text_entry(
-                            "   ",
-                            line,
-                            Style::default()
-                                .fg(Color::DarkGray)
-                                .add_modifier(Modifier::DIM),
-                            false,
-                        ));
+                let dim_gray = Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM);
+                let mut lines =
+                    Self::render_text_entry("", &format!("→ {tool_name}"), dim_gray, false);
+                match body {
+                    Some(ToolCallBody::Yaml(yaml)) => {
+                        for line in yaml.lines() {
+                            lines.extend(Self::render_text_entry("   ", line, dim_gray, false));
+                        }
                     }
+                    Some(ToolCallBody::Markdown(md)) => {
+                        // Templated MCP `call_template` — render inline
+                        // markdown styling. Indent prefix stays dim gray;
+                        // the body uses DIM as its base style so `**`/`*`
+                        // /`` ` `` add styling on top without losing the
+                        // subordinate visual weight.
+                        let body_base = Style::default().add_modifier(Modifier::DIM);
+                        for line_text in md.lines() {
+                            let mut spans =
+                                vec![Span::styled("   ".to_string(), dim_gray)];
+                            let parsed =
+                                crate::render_helpers::markdown_line_spans(line_text, body_base);
+                            spans.extend(parsed.spans);
+                            lines.push(Line::from(spans));
+                        }
+                    }
+                    None => {}
                 }
                 lines
             }

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -63,7 +63,22 @@ impl Tui {
                 true,
             ),
             TranscriptItem::AssistantText(text) => {
-                Self::render_text_entry("", text, Style::default(), !text.contains('\n'))
+                // Render assistant messages as markdown so headings, lists,
+                // code fences, and inline emphasis show their styling.
+                // Streaming chunks rebuild this entry on every render — an
+                // unclosed `**bold` mid-stream simply renders as literal
+                // asterisks for the moment, then upgrades to bold once the
+                // closing `**` arrives in a later chunk.
+                let mut lines =
+                    crate::render_helpers::markdown_lines(text, Style::default());
+                // Match the prior trailing-spacing rule: pad after a
+                // single-line message (so the next entry has breathing
+                // room) but skip the pad when the text already contains
+                // newlines.
+                if !text.contains('\n') {
+                    lines.push(Line::from(""));
+                }
+                lines
             }
             TranscriptItem::ErrorText(text) => Self::render_text_entry(
                 "error: ",

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -36,6 +36,49 @@ impl Tui {
         lines
     }
 
+    /// 3-space indent + a single line of inline-markdown body, used by
+    /// templated tool result/call lines so `**bold**` / `` `code` `` add
+    /// styling on top of the dim base without losing visual subordination.
+    fn render_indented_markdown_line(text: &str) -> Line<'static> {
+        let dim_gray = Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::DIM);
+        let body_base = Style::default().add_modifier(Modifier::DIM);
+        let mut spans = vec![Span::styled("   ".to_string(), dim_gray)];
+        let parsed = crate::render_helpers::markdown_line_spans(text, body_base);
+        spans.extend(parsed.spans);
+        Line::from(spans)
+    }
+
+    /// Render a `ToolCall` transcript item: `→ tool_name` header followed
+    /// by the body lines. Body rendering depends on its origin —
+    /// `Yaml` is shown verbatim (raw arguments), `Markdown` is rendered
+    /// inline (templated `call_template` output).
+    fn render_tool_call(tool_name: &str, body: Option<&ToolCallBody>) -> Vec<Line<'static>> {
+        // Use the plain rightwards arrow `→` (U+2192). The previous glyph
+        // was `->` followed by VS16 (U+FE0F) which requested an emoji-style
+        // presentation and produced unicode-width vs. terminal-rendered-
+        // width disagreement, leaving stray glyphs in subsequent frames.
+        let dim_gray = Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::DIM);
+        let mut lines = Self::render_text_entry("", &format!("→ {tool_name}"), dim_gray, false);
+        match body {
+            Some(ToolCallBody::Yaml(yaml)) => {
+                for line in yaml.lines() {
+                    lines.extend(Self::render_text_entry("   ", line, dim_gray, false));
+                }
+            }
+            Some(ToolCallBody::Markdown(md)) => {
+                for line_text in md.lines() {
+                    lines.push(Self::render_indented_markdown_line(line_text));
+                }
+            }
+            None => {}
+        }
+        lines
+    }
+
     pub(super) fn render_entry(entry: &TranscriptItem) -> Vec<Line<'static>> {
         match entry {
             TranscriptItem::SourceHeading(source) => Self::render_text_entry(
@@ -69,8 +112,7 @@ impl Tui {
                 // unclosed `**bold` mid-stream simply renders as literal
                 // asterisks for the moment, then upgrades to bold once the
                 // closing `**` arrives in a later chunk.
-                let mut lines =
-                    crate::render_helpers::markdown_lines(text, Style::default());
+                let mut lines = crate::render_helpers::markdown_lines(text, Style::default());
                 // Match the prior trailing-spacing rule: pad after a
                 // single-line message (so the next entry has breathing
                 // room) but skip the pad when the text already contains
@@ -103,20 +145,7 @@ impl Tui {
                 false,
             ),
             TranscriptItem::ToolResultMarkdown(text) => {
-                // Templated MCP `result_template` output. Render as inline
-                // markdown so `**bold**` / `*italic*` / `` `code` `` show
-                // their styling. The base style is dim gray so the result
-                // body stays visually subordinate to the conversation.
-                let base = Style::default().add_modifier(Modifier::DIM);
-                let mut spans = vec![Span::styled(
-                    "   ".to_string(),
-                    Style::default()
-                        .fg(Color::DarkGray)
-                        .add_modifier(Modifier::DIM),
-                )];
-                let line = crate::render_helpers::markdown_line_spans(text, base);
-                spans.extend(line.spans);
-                vec![Line::from(spans)]
+                vec![Self::render_indented_markdown_line(text)]
             }
             TranscriptItem::StatusLine(text) => Self::render_text_entry(
                 "",
@@ -156,45 +185,7 @@ impl Tui {
                 false,
             ),
             TranscriptItem::ToolCall { tool_name, body } => {
-                // Use the plain rightwards arrow `→` (U+2192) as the
-                // tool-call marker.  The previous glyph was `->` followed by
-                // VS16 (U+FE0F), which requests an emoji-style presentation
-                // and causes unicode-width vs. terminal-rendered-width
-                // disagreement in some terminals.  That off-by-one width
-                // mismatch propagates through every subsequent line of the
-                // same frame, leaving stray glyphs (stray letters, corrupted
-                // words) at columns the next render doesn't explicitly
-                // repaint.
-                let dim_gray = Style::default()
-                    .fg(Color::DarkGray)
-                    .add_modifier(Modifier::DIM);
-                let mut lines =
-                    Self::render_text_entry("", &format!("→ {tool_name}"), dim_gray, false);
-                match body {
-                    Some(ToolCallBody::Yaml(yaml)) => {
-                        for line in yaml.lines() {
-                            lines.extend(Self::render_text_entry("   ", line, dim_gray, false));
-                        }
-                    }
-                    Some(ToolCallBody::Markdown(md)) => {
-                        // Templated MCP `call_template` — render inline
-                        // markdown styling. Indent prefix stays dim gray;
-                        // the body uses DIM as its base style so `**`/`*`
-                        // /`` ` `` add styling on top without losing the
-                        // subordinate visual weight.
-                        let body_base = Style::default().add_modifier(Modifier::DIM);
-                        for line_text in md.lines() {
-                            let mut spans =
-                                vec![Span::styled("   ".to_string(), dim_gray)];
-                            let parsed =
-                                crate::render_helpers::markdown_line_spans(line_text, body_base);
-                            spans.extend(parsed.spans);
-                            lines.push(Line::from(spans));
-                        }
-                    }
-                    None => {}
-                }
-                lines
+                Self::render_tool_call(tool_name, body.as_ref())
             }
             TranscriptItem::AttachmentHeader(text) => Self::render_text_entry(
                 "",

--- a/crates/harnx-tui/src/render_helpers.rs
+++ b/crates/harnx-tui/src/render_helpers.rs
@@ -164,26 +164,22 @@ mod markdown_tests {
     }
 
     #[test]
-    fn italic_asterisk_produces_italic_span() {
-        let line = markdown_line_spans("hi *there* you", Style::default());
-        assert_eq!(span_text(&line), "hi there you");
-        let it = line
-            .spans
-            .iter()
-            .find(|s| s.content.as_ref() == "there")
-            .unwrap();
-        assert!(it.style.add_modifier.contains(Modifier::ITALIC));
-    }
-
-    #[test]
-    fn italic_underscore_produces_italic_span() {
-        let line = markdown_line_spans("hi _there_ you", Style::default());
-        let it = line
-            .spans
-            .iter()
-            .find(|s| s.content.as_ref() == "there")
-            .unwrap();
-        assert!(it.style.add_modifier.contains(Modifier::ITALIC));
+    fn italic_marker_produces_italic_span() {
+        // Both `*text*` and `_text_` should produce an ITALIC-modifier span.
+        for input in ["hi *there* you", "hi _there_ you"] {
+            let line = markdown_line_spans(input, Style::default());
+            assert_eq!(span_text(&line), "hi there you", "input: {input}");
+            let it = line
+                .spans
+                .iter()
+                .find(|s| s.content.as_ref() == "there")
+                .unwrap_or_else(|| panic!("expected `there` span for {input}"));
+            assert!(
+                it.style.add_modifier.contains(Modifier::ITALIC),
+                "{input} should produce ITALIC; got {:?}",
+                it.style.add_modifier
+            );
+        }
     }
 
     #[test]

--- a/crates/harnx-tui/src/render_helpers.rs
+++ b/crates/harnx-tui/src/render_helpers.rs
@@ -25,19 +25,56 @@ pub(crate) fn markdown_line_spans(text: &str, base_style: Style) -> Line<'static
         _ => return plain_fallback(),
     };
 
-    // Patch `base_style` under each parsed span so the dim/grey context
-    // (set by the caller) applies wherever the parsed span doesn't
-    // explicitly override it. `Style::patch` keeps the right-hand side's
-    // explicit fields and falls through to the left for `None` ones.
-    let spans: Vec<Span<'static>> = first
-        .spans
+    Line::from(patch_spans(first.spans.into_iter().collect(), base_style))
+}
+
+/// Render multi-line markdown into ratatui lines, patching `base_style`
+/// under each parsed span. Used for assistant messages where the input
+/// may include code fences, lists, headings, and other block-level
+/// markdown — `tui-markdown` handles the whole document at once.
+///
+/// Single newlines in the input are converted to CommonMark hard line
+/// breaks (`  \n`) before parsing. CommonMark normally collapses single
+/// newlines into spaces (paragraph reflow), but in a CLI/TUI the LLM's
+/// chosen line breaks are part of the formatting the user wants to see.
+/// Paragraph breaks (`\n\n`) and fenced code blocks keep working: the
+/// extra trailing spaces inside fences are invisible.
+///
+/// Falls back to one plain `Line` per input newline when `tui-markdown`
+/// produces an empty result, so streaming partial markdown (e.g. an
+/// unclosed `**bold` while the chunk is still arriving) keeps showing.
+pub(crate) fn markdown_lines(text: &str, base_style: Style) -> Vec<Line<'static>> {
+    let with_hard_breaks = text.replace('\n', "  \n");
+    let parsed = tui_markdown::from_str(&with_hard_breaks);
+    if parsed.lines.is_empty() {
+        return text
+            .split('\n')
+            .map(|line| Line::from(Span::styled(line.to_string(), base_style)))
+            .collect();
+    }
+    parsed
+        .lines
+        .into_iter()
+        .map(|line| Line::from(patch_spans(line.spans, base_style)))
+        .collect()
+}
+
+/// Patch `base_style` under each parsed span so caller context (e.g. dim
+/// grey for tool body lines) flows through wherever the parsed span
+/// doesn't override it. `Style::patch(left, right)` keeps right's
+/// explicit fields and falls through to left for `None` ones.
+///
+/// Generic over the parsed span's lifetime so it can take output from
+/// `tui_markdown::from_str` (which borrows from the input string), then
+/// upgrades to `Span<'static>` via `Cow::into_owned`.
+fn patch_spans<'a>(spans: Vec<Span<'a>>, base_style: Style) -> Vec<Span<'static>> {
+    spans
         .into_iter()
         .map(|span| {
             let merged = base_style.patch(span.style);
             Span::styled(span.content.into_owned(), merged)
         })
-        .collect();
-    Line::from(spans)
+        .collect()
 }
 
 pub(crate) fn render_status_line(title: Option<&str>, status: Option<&str>) -> Option<String> {
@@ -197,6 +234,72 @@ mod markdown_tests {
             .find(|s| s.content.as_ref() == "ls -la /tmp")
             .unwrap();
         assert!(code.style.fg.is_some() || code.style.bg.is_some());
+    }
+
+    #[test]
+    fn multi_line_preserves_each_input_newline() {
+        // Without hard-break preprocessing CommonMark would collapse the
+        // three-line input into one line. We need each `\n` in the source
+        // to become a separate ratatui line.
+        let lines = markdown_lines("line-01\nline-02\nline-03", Style::default());
+        let texts: Vec<String> = lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect();
+        assert!(
+            texts.iter().any(|t| t == "line-01"),
+            "expected `line-01` as its own line; got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t == "line-03"),
+            "expected `line-03` as its own line; got {texts:?}"
+        );
+        // No "line-01 line-02 line-03" reflowed paragraph.
+        assert!(
+            !texts
+                .iter()
+                .any(|t| t.contains("line-01") && t.contains("line-02")),
+            "lines were collapsed instead of preserved: {texts:?}"
+        );
+    }
+
+    #[test]
+    fn multi_line_keeps_paragraph_breaks() {
+        // `\n\n` is a paragraph break — should still produce an empty
+        // line between paragraphs after preprocessing.
+        let lines = markdown_lines("para1\n\npara2", Style::default());
+        let texts: Vec<String> = lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect();
+        let para1_idx = texts.iter().position(|t| t.contains("para1")).unwrap();
+        let para2_idx = texts.iter().position(|t| t.contains("para2")).unwrap();
+        assert!(
+            para2_idx > para1_idx + 1,
+            "expected an empty line between paragraphs; got {texts:?}"
+        );
+    }
+
+    #[test]
+    fn multi_line_renders_inline_emphasis() {
+        // Emphasis still works across lines.
+        let lines = markdown_lines("first line\n**bold line**", Style::default());
+        let bold = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .find(|s| s.content.as_ref() == "bold line")
+            .expect("expected bold span");
+        assert!(bold.style.add_modifier.contains(Modifier::BOLD));
     }
 
     #[test]

--- a/crates/harnx-tui/src/render_helpers.rs
+++ b/crates/harnx-tui/src/render_helpers.rs
@@ -1,124 +1,43 @@
 use harnx_core::event::AgentSource;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 
-/// Render a single line of inline markdown into ratatui spans, applying
-/// `base_style` as the foreground color/modifier and adding bold/italic/
-/// code styling on top. Supports the small subset MCP tool templates use:
+/// Render one line of MCP tool template text into ratatui spans, applying
+/// `base_style` as the foreground/modifier base. Delegates to the
+/// `tui-markdown` crate (which wraps `pulldown-cmark` + `syntect` +
+/// `ansi-to-tui` internally), so we get the same inline emphasis handling
+/// (`**bold**`, `*italic*`, `` `code` ``) without maintaining our own
+/// parser.
 ///
-/// - `**bold**`
-/// - `*italic*` and `_italic_`
-/// - `` `code` ``
-///
-/// Backslash escapes any marker (`\*`, `\_`, `` \` ``, `\\`). Unmatched
-/// markers render literally. Block-level constructs (headings, lists,
-/// fenced code) are not parsed — caller is expected to split on `\n` and
-/// call this per line.
+/// On render failure (empty result), returns the input as a single plain
+/// span so the user still sees the text — markdown styling is a
+/// presentation nicety, not a correctness requirement.
 pub(crate) fn markdown_line_spans(text: &str, base_style: Style) -> Line<'static> {
-    let mut spans: Vec<Span<'static>> = Vec::new();
-    let mut buf = String::new();
-    let chars: Vec<char> = text.chars().collect();
-    let mut i = 0;
-    while i < chars.len() {
-        let c = chars[i];
-        match c {
-            '\\' if i + 1 < chars.len() && is_marker(chars[i + 1]) => {
-                buf.push(chars[i + 1]);
-                i += 2;
-            }
-            '*' if i + 1 < chars.len() && chars[i + 1] == '*' => {
-                if let Some(end) = find_close(&chars, i + 2, "**") {
-                    flush(&mut spans, &mut buf, base_style);
-                    let inner = collect_with_escapes(&chars, i + 2, end);
-                    let mut bold = base_style;
-                    bold.add_modifier.insert(Modifier::BOLD);
-                    spans.push(Span::styled(inner, bold));
-                    i = end + 2;
-                } else {
-                    buf.push('*');
-                    buf.push('*');
-                    i += 2;
-                }
-            }
-            '*' | '_' => {
-                let needle = c.to_string();
-                if let Some(end) = find_close(&chars, i + 1, &needle) {
-                    flush(&mut spans, &mut buf, base_style);
-                    let inner = collect_with_escapes(&chars, i + 1, end);
-                    let mut italic = base_style;
-                    italic.add_modifier.insert(Modifier::ITALIC);
-                    spans.push(Span::styled(inner, italic));
-                    i = end + 1;
-                } else {
-                    buf.push(c);
-                    i += 1;
-                }
-            }
-            '`' => {
-                if let Some(end) = find_close(&chars, i + 1, "`") {
-                    flush(&mut spans, &mut buf, base_style);
-                    let inner: String = chars[i + 1..end].iter().collect();
-                    let code_style = base_style.fg(Color::Yellow);
-                    spans.push(Span::styled(inner, code_style));
-                    i = end + 1;
-                } else {
-                    buf.push('`');
-                    i += 1;
-                }
-            }
-            _ => {
-                buf.push(c);
-                i += 1;
-            }
-        }
-    }
-    flush(&mut spans, &mut buf, base_style);
+    let plain_fallback = || Line::from(Span::styled(text.to_string(), base_style));
+
+    // `tui_markdown::from_str` returns a `Text` with zero or more lines.
+    // For a single input line we expect exactly one parsed line; any
+    // additional lines (which shouldn't happen for inline markdown) are
+    // dropped — caller is expected to split the input on `\n` first.
+    let parsed = tui_markdown::from_str(text);
+    let first = match parsed.into_iter().next() {
+        Some(line) if !line.spans.is_empty() => line,
+        _ => return plain_fallback(),
+    };
+
+    // Patch `base_style` under each parsed span so the dim/grey context
+    // (set by the caller) applies wherever the parsed span doesn't
+    // explicitly override it. `Style::patch` keeps the right-hand side's
+    // explicit fields and falls through to the left for `None` ones.
+    let spans: Vec<Span<'static>> = first
+        .spans
+        .into_iter()
+        .map(|span| {
+            let merged = base_style.patch(span.style);
+            Span::styled(span.content.into_owned(), merged)
+        })
+        .collect();
     Line::from(spans)
-}
-
-fn is_marker(c: char) -> bool {
-    matches!(c, '*' | '_' | '`' | '\\')
-}
-
-fn flush(spans: &mut Vec<Span<'static>>, buf: &mut String, style: Style) {
-    if !buf.is_empty() {
-        spans.push(Span::styled(std::mem::take(buf), style));
-    }
-}
-
-/// Find the next index in `chars[from..]` where `needle` (a 1- or 2-char
-/// marker) starts, treating backslash-escaped markers as literal.
-fn find_close(chars: &[char], from: usize, needle: &str) -> Option<usize> {
-    let needle_chars: Vec<char> = needle.chars().collect();
-    let mut i = from;
-    while i + needle_chars.len() <= chars.len() {
-        // Skip escapes: `\X` consumes two chars and is never a closing marker.
-        if chars[i] == '\\' && i + 1 < chars.len() && is_marker(chars[i + 1]) {
-            i += 2;
-            continue;
-        }
-        if chars[i..i + needle_chars.len()] == *needle_chars {
-            return Some(i);
-        }
-        i += 1;
-    }
-    None
-}
-
-/// Collect `chars[from..to]` into a String, processing backslash escapes.
-fn collect_with_escapes(chars: &[char], from: usize, to: usize) -> String {
-    let mut out = String::new();
-    let mut i = from;
-    while i < to {
-        if chars[i] == '\\' && i + 1 < to && is_marker(chars[i + 1]) {
-            out.push(chars[i + 1]);
-            i += 2;
-        } else {
-            out.push(chars[i]);
-            i += 1;
-        }
-    }
-    out
 }
 
 pub(crate) fn render_status_line(title: Option<&str>, status: Option<&str>) -> Option<String> {
@@ -166,7 +85,13 @@ pub(crate) fn render_usage_line(
 
 #[cfg(test)]
 mod markdown_tests {
+    //! These tests pin the *behaviors* the templating system relies on:
+    //! markers stripped, content preserved, BOLD/ITALIC modifiers attached
+    //! to emphasized text, and a non-default style on inline code. They do
+    //! not assert specific colors — the underlying `tui-markdown` crate
+    //! picks those, and we don't want to break on cosmetic changes there.
     use super::*;
+    use ratatui::style::{Color, Modifier};
 
     fn span_text(line: &Line<'static>) -> String {
         line.spans
@@ -175,34 +100,29 @@ mod markdown_tests {
             .collect::<String>()
     }
 
-    fn span_modifiers(line: &Line<'static>) -> Vec<(String, Modifier)> {
-        line.spans
-            .iter()
-            .map(|s| (s.content.to_string(), s.style.add_modifier))
-            .collect()
-    }
-
     #[test]
     fn plain_text_passes_through() {
         let line = markdown_line_spans("hello world", Style::default());
         assert_eq!(span_text(&line), "hello world");
-        assert_eq!(line.spans.len(), 1);
-        assert_eq!(line.spans[0].style.add_modifier, Modifier::empty());
+        for span in &line.spans {
+            assert!(!span.style.add_modifier.contains(Modifier::BOLD));
+            assert!(!span.style.add_modifier.contains(Modifier::ITALIC));
+        }
     }
 
     #[test]
     fn bold_marker_produces_bold_span() {
         let line = markdown_line_spans("hi **there** you", Style::default());
         assert_eq!(span_text(&line), "hi there you");
-        let mods = span_modifiers(&line);
-        let bold_part = mods
+        let bold = line
+            .spans
             .iter()
-            .find(|(t, _)| t == "there")
+            .find(|s| s.content.as_ref() == "there")
             .expect("expected 'there' span");
         assert!(
-            bold_part.1.contains(Modifier::BOLD),
+            bold.style.add_modifier.contains(Modifier::BOLD),
             "expected BOLD on 'there'; got {:?}",
-            bold_part.1
+            bold.style.add_modifier
         );
     }
 
@@ -210,36 +130,48 @@ mod markdown_tests {
     fn italic_asterisk_produces_italic_span() {
         let line = markdown_line_spans("hi *there* you", Style::default());
         assert_eq!(span_text(&line), "hi there you");
-        let mods = span_modifiers(&line);
-        let it = mods.iter().find(|(t, _)| t == "there").unwrap();
-        assert!(it.1.contains(Modifier::ITALIC));
+        let it = line
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "there")
+            .unwrap();
+        assert!(it.style.add_modifier.contains(Modifier::ITALIC));
     }
 
     #[test]
     fn italic_underscore_produces_italic_span() {
         let line = markdown_line_spans("hi _there_ you", Style::default());
-        let mods = span_modifiers(&line);
-        let it = mods.iter().find(|(t, _)| t == "there").unwrap();
-        assert!(it.1.contains(Modifier::ITALIC));
+        let it = line
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "there")
+            .unwrap();
+        assert!(it.style.add_modifier.contains(Modifier::ITALIC));
     }
 
     #[test]
-    fn code_marker_produces_yellow_span() {
+    fn code_marker_produces_styled_span() {
         let line = markdown_line_spans("run `ls -la`", Style::default());
         assert_eq!(span_text(&line), "run ls -la");
-        let code_span = line
+        let code = line
             .spans
             .iter()
             .find(|s| s.content.as_ref() == "ls -la")
             .expect("expected code span");
-        assert_eq!(code_span.style.fg, Some(Color::Yellow));
+        // Inline code should be visually distinct — it carries either an
+        // explicit fg or bg from `tui-markdown`. The exact color is left
+        // to that crate; we only require it isn't bare default.
+        assert!(
+            code.style.fg.is_some() || code.style.bg.is_some(),
+            "code span should be visually distinct; got {:?}",
+            code.style
+        );
     }
 
     #[test]
     fn unmatched_marker_renders_literally() {
         let line = markdown_line_spans("a * b _ c ` d", Style::default());
         assert_eq!(span_text(&line), "a * b _ c ` d");
-        // No styled span should have BOLD/ITALIC.
         for s in &line.spans {
             assert!(!s.style.add_modifier.contains(Modifier::BOLD));
             assert!(!s.style.add_modifier.contains(Modifier::ITALIC));
@@ -253,44 +185,47 @@ mod markdown_tests {
         // After Jinja rendering this becomes "**$** `ls -la /tmp`"
         let line = markdown_line_spans("**$** `ls -la /tmp`", Style::default());
         assert_eq!(span_text(&line), "$ ls -la /tmp");
-        let mods = span_modifiers(&line);
-        let bold = mods.iter().find(|(t, _)| t == "$").unwrap();
-        assert!(bold.1.contains(Modifier::BOLD));
+        let bold = line
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "$")
+            .unwrap();
+        assert!(bold.style.add_modifier.contains(Modifier::BOLD));
         let code = line
             .spans
             .iter()
             .find(|s| s.content.as_ref() == "ls -la /tmp")
             .unwrap();
-        assert_eq!(code.style.fg, Some(Color::Yellow));
-    }
-
-    #[test]
-    fn backslash_escape_keeps_marker_literal() {
-        let line = markdown_line_spans("not \\*bold\\* here", Style::default());
-        assert_eq!(span_text(&line), "not *bold* here");
-        for s in &line.spans {
-            assert!(!s.style.add_modifier.contains(Modifier::BOLD));
-            assert!(!s.style.add_modifier.contains(Modifier::ITALIC));
-        }
+        assert!(code.style.fg.is_some() || code.style.bg.is_some());
     }
 
     #[test]
     fn base_style_propagates_to_unstyled_runs() {
+        // `Style::patch` keeps the parsed span's explicit fields and falls
+        // through to the base for unset ones. So an unstyled run should
+        // inherit both fg=DarkGray and DIM from the base; emphasized spans
+        // keep their own fg but should still pick up DIM.
         let base = Style::default()
             .fg(Color::DarkGray)
             .add_modifier(Modifier::DIM);
         let line = markdown_line_spans("hi **bold** world", base);
-        for span in &line.spans {
-            // Every span should keep the DarkGray + DIM base, plus any extra modifiers.
-            assert_eq!(span.style.fg, Some(Color::DarkGray));
-            assert!(span.style.add_modifier.contains(Modifier::DIM));
-        }
-        // The 'bold' span should additionally be BOLD.
+
+        // Find the unstyled "hi " span and check it inherits the base.
+        let unstyled = line
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref().contains("hi"))
+            .expect("expected an unstyled run");
+        assert_eq!(unstyled.style.fg, Some(Color::DarkGray));
+        assert!(unstyled.style.add_modifier.contains(Modifier::DIM));
+
+        // The "bold" span should still be BOLD on top of the base DIM.
         let bold = line
             .spans
             .iter()
             .find(|s| s.content.as_ref() == "bold")
             .unwrap();
         assert!(bold.style.add_modifier.contains(Modifier::BOLD));
+        assert!(bold.style.add_modifier.contains(Modifier::DIM));
     }
 }

--- a/crates/harnx-tui/src/render_helpers.rs
+++ b/crates/harnx-tui/src/render_helpers.rs
@@ -1,4 +1,125 @@
 use harnx_core::event::AgentSource;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+
+/// Render a single line of inline markdown into ratatui spans, applying
+/// `base_style` as the foreground color/modifier and adding bold/italic/
+/// code styling on top. Supports the small subset MCP tool templates use:
+///
+/// - `**bold**`
+/// - `*italic*` and `_italic_`
+/// - `` `code` ``
+///
+/// Backslash escapes any marker (`\*`, `\_`, `` \` ``, `\\`). Unmatched
+/// markers render literally. Block-level constructs (headings, lists,
+/// fenced code) are not parsed — caller is expected to split on `\n` and
+/// call this per line.
+pub(crate) fn markdown_line_spans(text: &str, base_style: Style) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut buf = String::new();
+    let chars: Vec<char> = text.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        match c {
+            '\\' if i + 1 < chars.len() && is_marker(chars[i + 1]) => {
+                buf.push(chars[i + 1]);
+                i += 2;
+            }
+            '*' if i + 1 < chars.len() && chars[i + 1] == '*' => {
+                if let Some(end) = find_close(&chars, i + 2, "**") {
+                    flush(&mut spans, &mut buf, base_style);
+                    let inner = collect_with_escapes(&chars, i + 2, end);
+                    let mut bold = base_style;
+                    bold.add_modifier.insert(Modifier::BOLD);
+                    spans.push(Span::styled(inner, bold));
+                    i = end + 2;
+                } else {
+                    buf.push('*');
+                    buf.push('*');
+                    i += 2;
+                }
+            }
+            '*' | '_' => {
+                let needle = c.to_string();
+                if let Some(end) = find_close(&chars, i + 1, &needle) {
+                    flush(&mut spans, &mut buf, base_style);
+                    let inner = collect_with_escapes(&chars, i + 1, end);
+                    let mut italic = base_style;
+                    italic.add_modifier.insert(Modifier::ITALIC);
+                    spans.push(Span::styled(inner, italic));
+                    i = end + 1;
+                } else {
+                    buf.push(c);
+                    i += 1;
+                }
+            }
+            '`' => {
+                if let Some(end) = find_close(&chars, i + 1, "`") {
+                    flush(&mut spans, &mut buf, base_style);
+                    let inner: String = chars[i + 1..end].iter().collect();
+                    let code_style = base_style.fg(Color::Yellow);
+                    spans.push(Span::styled(inner, code_style));
+                    i = end + 1;
+                } else {
+                    buf.push('`');
+                    i += 1;
+                }
+            }
+            _ => {
+                buf.push(c);
+                i += 1;
+            }
+        }
+    }
+    flush(&mut spans, &mut buf, base_style);
+    Line::from(spans)
+}
+
+fn is_marker(c: char) -> bool {
+    matches!(c, '*' | '_' | '`' | '\\')
+}
+
+fn flush(spans: &mut Vec<Span<'static>>, buf: &mut String, style: Style) {
+    if !buf.is_empty() {
+        spans.push(Span::styled(std::mem::take(buf), style));
+    }
+}
+
+/// Find the next index in `chars[from..]` where `needle` (a 1- or 2-char
+/// marker) starts, treating backslash-escaped markers as literal.
+fn find_close(chars: &[char], from: usize, needle: &str) -> Option<usize> {
+    let needle_chars: Vec<char> = needle.chars().collect();
+    let mut i = from;
+    while i + needle_chars.len() <= chars.len() {
+        // Skip escapes: `\X` consumes two chars and is never a closing marker.
+        if chars[i] == '\\' && i + 1 < chars.len() && is_marker(chars[i + 1]) {
+            i += 2;
+            continue;
+        }
+        if chars[i..i + needle_chars.len()] == *needle_chars {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Collect `chars[from..to]` into a String, processing backslash escapes.
+fn collect_with_escapes(chars: &[char], from: usize, to: usize) -> String {
+    let mut out = String::new();
+    let mut i = from;
+    while i < to {
+        if chars[i] == '\\' && i + 1 < to && is_marker(chars[i + 1]) {
+            out.push(chars[i + 1]);
+            i += 2;
+        } else {
+            out.push(chars[i]);
+            i += 1;
+        }
+    }
+    out
+}
 
 pub(crate) fn render_status_line(title: Option<&str>, status: Option<&str>) -> Option<String> {
     let line = [title, status]
@@ -41,4 +162,135 @@ pub(crate) fn render_usage_line(
         parts.push(format!("cache {cached_tokens}"));
     }
     (!parts.is_empty()).then(|| parts.join("   "))
+}
+
+#[cfg(test)]
+mod markdown_tests {
+    use super::*;
+
+    fn span_text(line: &Line<'static>) -> String {
+        line.spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect::<String>()
+    }
+
+    fn span_modifiers(line: &Line<'static>) -> Vec<(String, Modifier)> {
+        line.spans
+            .iter()
+            .map(|s| (s.content.to_string(), s.style.add_modifier))
+            .collect()
+    }
+
+    #[test]
+    fn plain_text_passes_through() {
+        let line = markdown_line_spans("hello world", Style::default());
+        assert_eq!(span_text(&line), "hello world");
+        assert_eq!(line.spans.len(), 1);
+        assert_eq!(line.spans[0].style.add_modifier, Modifier::empty());
+    }
+
+    #[test]
+    fn bold_marker_produces_bold_span() {
+        let line = markdown_line_spans("hi **there** you", Style::default());
+        assert_eq!(span_text(&line), "hi there you");
+        let mods = span_modifiers(&line);
+        let bold_part = mods
+            .iter()
+            .find(|(t, _)| t == "there")
+            .expect("expected 'there' span");
+        assert!(
+            bold_part.1.contains(Modifier::BOLD),
+            "expected BOLD on 'there'; got {:?}",
+            bold_part.1
+        );
+    }
+
+    #[test]
+    fn italic_asterisk_produces_italic_span() {
+        let line = markdown_line_spans("hi *there* you", Style::default());
+        assert_eq!(span_text(&line), "hi there you");
+        let mods = span_modifiers(&line);
+        let it = mods.iter().find(|(t, _)| t == "there").unwrap();
+        assert!(it.1.contains(Modifier::ITALIC));
+    }
+
+    #[test]
+    fn italic_underscore_produces_italic_span() {
+        let line = markdown_line_spans("hi _there_ you", Style::default());
+        let mods = span_modifiers(&line);
+        let it = mods.iter().find(|(t, _)| t == "there").unwrap();
+        assert!(it.1.contains(Modifier::ITALIC));
+    }
+
+    #[test]
+    fn code_marker_produces_yellow_span() {
+        let line = markdown_line_spans("run `ls -la`", Style::default());
+        assert_eq!(span_text(&line), "run ls -la");
+        let code_span = line
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "ls -la")
+            .expect("expected code span");
+        assert_eq!(code_span.style.fg, Some(Color::Yellow));
+    }
+
+    #[test]
+    fn unmatched_marker_renders_literally() {
+        let line = markdown_line_spans("a * b _ c ` d", Style::default());
+        assert_eq!(span_text(&line), "a * b _ c ` d");
+        // No styled span should have BOLD/ITALIC.
+        for s in &line.spans {
+            assert!(!s.style.add_modifier.contains(Modifier::BOLD));
+            assert!(!s.style.add_modifier.contains(Modifier::ITALIC));
+        }
+    }
+
+    #[test]
+    fn bash_template_example_renders_bold_and_code() {
+        // Mirror the actual built-in bash exec template:
+        //   "**$** `{{ args.command }}`"
+        // After Jinja rendering this becomes "**$** `ls -la /tmp`"
+        let line = markdown_line_spans("**$** `ls -la /tmp`", Style::default());
+        assert_eq!(span_text(&line), "$ ls -la /tmp");
+        let mods = span_modifiers(&line);
+        let bold = mods.iter().find(|(t, _)| t == "$").unwrap();
+        assert!(bold.1.contains(Modifier::BOLD));
+        let code = line
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "ls -la /tmp")
+            .unwrap();
+        assert_eq!(code.style.fg, Some(Color::Yellow));
+    }
+
+    #[test]
+    fn backslash_escape_keeps_marker_literal() {
+        let line = markdown_line_spans("not \\*bold\\* here", Style::default());
+        assert_eq!(span_text(&line), "not *bold* here");
+        for s in &line.spans {
+            assert!(!s.style.add_modifier.contains(Modifier::BOLD));
+            assert!(!s.style.add_modifier.contains(Modifier::ITALIC));
+        }
+    }
+
+    #[test]
+    fn base_style_propagates_to_unstyled_runs() {
+        let base = Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::DIM);
+        let line = markdown_line_spans("hi **bold** world", base);
+        for span in &line.spans {
+            // Every span should keep the DarkGray + DIM base, plus any extra modifiers.
+            assert_eq!(span.style.fg, Some(Color::DarkGray));
+            assert!(span.style.add_modifier.contains(Modifier::DIM));
+        }
+        // The 'bold' span should additionally be BOLD.
+        let bold = line
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "bold")
+            .unwrap();
+        assert!(bold.style.add_modifier.contains(Modifier::BOLD));
+    }
 }

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -4222,6 +4222,29 @@ async fn tui_falls_back_to_output_when_no_template_title() {
 // (`**bold**`, `*italic*`, `` `code` ``). Plain output paths stay plain.
 // ----------------------------------------------------------------------------
 
+/// Walk the rendered transcript looking for a span whose content matches
+/// `text` and whose style satisfies `pred`. Used by the markdown styling
+/// tests to assert "this content was rendered with these style hints"
+/// without pinning specific colors that `tui-markdown` may tweak.
+fn rendered_span_matches(
+    lines: &[ratatui::text::Line<'static>],
+    text: &str,
+    pred: impl Fn(&ratatui::style::Style) -> bool,
+) -> bool {
+    lines
+        .iter()
+        .flat_map(|l| l.spans.iter())
+        .any(|s| s.content.as_ref() == text && pred(&s.style))
+}
+
+fn rendered_lines(tui: &Tui) -> Vec<ratatui::text::Line<'static>> {
+    tui.app
+        .transcript
+        .iter()
+        .flat_map(Tui::render_entry)
+        .collect()
+}
+
 #[tokio::test]
 async fn tui_started_template_strips_markers_and_styles_spans() {
     let mut tui = Tui::init(
@@ -4246,57 +4269,35 @@ async fn tui_started_template_strips_markers_and_styles_spans() {
     .await
     .unwrap();
 
-    let rendered_lines: Vec<ratatui::text::Line<'static>> = tui
-        .app
-        .transcript
-        .iter()
-        .flat_map(Tui::render_entry)
-        .collect();
-
-    // Markers should be consumed (not appear as literal text), and the
-    // styled span text should appear instead.
-    let plain = rendered_lines
+    use ratatui::style::Modifier;
+    let lines = rendered_lines(&tui);
+    let plain = lines
         .iter()
         .map(line_to_plain)
         .collect::<Vec<_>>()
         .join("\n");
-    assert!(
-        !plain.contains("**$**"),
-        "expected `**$**` markers to be consumed by markdown render; got:\n{plain}"
-    );
+
+    // Markers should be consumed and stripped text should appear.
+    assert!(!plain.contains("**$**"), "markers leaked: {plain}");
     assert!(
         !plain.contains("`ls -la /tmp`"),
-        "expected backticks to be consumed; got:\n{plain}"
+        "backticks leaked: {plain}"
     );
     assert!(
         plain.contains("$ ls -la /tmp"),
-        "expected stripped text in transcript; got:\n{plain}"
+        "stripped text missing: {plain}"
     );
 
-    // At least one span should be BOLD ("$"), and at least one should be
-    // visually distinct (fg or bg set) for the inline code ("ls -la /tmp").
-    // We don't pin a specific color — that's chosen by `tui-markdown`.
-    use ratatui::style::Modifier;
-    let mut saw_bold = false;
-    let mut saw_code = false;
-    for line in &rendered_lines {
-        for span in &line.spans {
-            if span.style.add_modifier.contains(Modifier::BOLD) {
-                saw_bold = true;
-            }
-            // The code span carries an explicit fg or bg — distinct from
-            // the dim grey base used for surrounding spans.
-            if span.content.as_ref() == "ls -la /tmp"
-                && (span.style.fg.is_some() || span.style.bg.is_some())
-            {
-                saw_code = true;
-            }
-        }
-    }
-    assert!(saw_bold, "expected a BOLD span from `**$**`");
+    // `**$**` → BOLD; `` `ls -la /tmp` `` → visually distinct (fg or bg).
     assert!(
-        saw_code,
-        "expected a visually distinct span for `` `ls -la /tmp` ``"
+        rendered_span_matches(&lines, "$", |s| s.add_modifier.contains(Modifier::BOLD)),
+        "expected a BOLD span for `$`"
+    );
+    assert!(
+        rendered_span_matches(&lines, "ls -la /tmp", |s| {
+            s.fg.is_some() || s.bg.is_some()
+        }),
+        "expected a visually distinct span for `ls -la /tmp`"
     );
 }
 
@@ -4373,41 +4374,23 @@ async fn tui_completed_template_styles_spans() {
     .unwrap();
 
     use ratatui::style::Modifier;
-    let rendered: Vec<ratatui::text::Line<'static>> = tui
-        .app
-        .transcript
-        .iter()
-        .flat_map(Tui::render_entry)
-        .collect();
-    let plain = rendered
+    let lines = rendered_lines(&tui);
+    let plain = lines
         .iter()
         .map(line_to_plain)
         .collect::<Vec<_>>()
         .join("\n");
-    assert!(
-        !plain.contains("**OK**"),
-        "expected `**OK**` markers to be consumed; got:\n{plain}"
-    );
+    assert!(!plain.contains("**OK**"), "markers leaked: {plain}");
     assert!(plain.contains("OK: hello"));
 
-    let mut saw_bold = false;
-    let mut saw_code = false;
-    for line in &rendered {
-        for span in &line.spans {
-            if span.style.add_modifier.contains(Modifier::BOLD) {
-                saw_bold = true;
-            }
-            // The `hello` code span is visually distinct via fg or bg —
-            // exact color picked by `tui-markdown`.
-            if span.content.as_ref() == "hello"
-                && (span.style.fg.is_some() || span.style.bg.is_some())
-            {
-                saw_code = true;
-            }
-        }
-    }
-    assert!(saw_bold, "expected a BOLD span from `**OK**`");
-    assert!(saw_code, "expected a visually distinct span for `` `hello` ``");
+    assert!(
+        rendered_span_matches(&lines, "OK", |s| s.add_modifier.contains(Modifier::BOLD)),
+        "expected a BOLD span for `OK`"
+    );
+    assert!(
+        rendered_span_matches(&lines, "hello", |s| s.fg.is_some() || s.bg.is_some()),
+        "expected a visually distinct span for `hello`"
+    );
 }
 
 #[tokio::test]
@@ -4423,49 +4406,30 @@ async fn tui_assistant_text_renders_inline_markdown() {
         Arc::new(Mutex::new(PersistentHookManager::new())),
     )
     .unwrap();
-    tui.app.transcript.push(crate::types::TranscriptItem::AssistantText(
-        "Here's some **bold** and `code`.".to_string(),
-    ));
+    tui.app
+        .transcript
+        .push(crate::types::TranscriptItem::AssistantText(
+            "Here's some **bold** and `code`.".to_string(),
+        ));
 
     use ratatui::style::Modifier;
-    let rendered: Vec<ratatui::text::Line<'static>> = tui
-        .app
-        .transcript
-        .iter()
-        .flat_map(Tui::render_entry)
-        .collect();
-    let plain = rendered
+    let lines = rendered_lines(&tui);
+    let plain = lines
         .iter()
         .map(line_to_plain)
         .collect::<Vec<_>>()
         .join("\n");
-    assert!(
-        !plain.contains("**bold**"),
-        "expected `**bold**` markers consumed; got:\n{plain}"
-    );
-    assert!(
-        !plain.contains("`code`"),
-        "expected backticks consumed; got:\n{plain}"
-    );
+    assert!(!plain.contains("**bold**"), "markers leaked: {plain}");
+    assert!(!plain.contains("`code`"), "backticks leaked: {plain}");
 
-    let mut saw_bold = false;
-    let mut saw_code = false;
-    for line in &rendered {
-        for span in &line.spans {
-            if span.content.as_ref() == "bold"
-                && span.style.add_modifier.contains(Modifier::BOLD)
-            {
-                saw_bold = true;
-            }
-            if span.content.as_ref() == "code"
-                && (span.style.fg.is_some() || span.style.bg.is_some())
-            {
-                saw_code = true;
-            }
-        }
-    }
-    assert!(saw_bold, "assistant text should style `**bold**`");
-    assert!(saw_code, "assistant text should style `` `code` ``");
+    assert!(
+        rendered_span_matches(&lines, "bold", |s| s.add_modifier.contains(Modifier::BOLD)),
+        "assistant text should style `**bold**`"
+    );
+    assert!(
+        rendered_span_matches(&lines, "code", |s| s.fg.is_some() || s.bg.is_some()),
+        "assistant text should style `` `code` ``"
+    );
 }
 
 #[tokio::test]
@@ -4480,9 +4444,11 @@ async fn tui_assistant_text_preserves_line_breaks() {
         Arc::new(Mutex::new(PersistentHookManager::new())),
     )
     .unwrap();
-    tui.app.transcript.push(crate::types::TranscriptItem::AssistantText(
-        "first line\nsecond line\nthird line".to_string(),
-    ));
+    tui.app
+        .transcript
+        .push(crate::types::TranscriptItem::AssistantText(
+            "first line\nsecond line\nthird line".to_string(),
+        ));
 
     let rendered: Vec<ratatui::text::Line<'static>> = tui
         .app

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -4409,3 +4409,105 @@ async fn tui_completed_template_styles_spans() {
     assert!(saw_bold, "expected a BOLD span from `**OK**`");
     assert!(saw_code, "expected a visually distinct span for `` `hello` ``");
 }
+
+#[tokio::test]
+async fn tui_assistant_text_renders_inline_markdown() {
+    // Sanity check that markdown styling on `AssistantText` survives the
+    // full transcript-render pass — the templated tool path was the
+    // motivating case for adding markdown rendering, but assistant
+    // messages benefit equally and are exercised here as a regression
+    // guard against future "pin every assistant line as plain" changes.
+    let mut tui = Tui::init(
+        &test_config(),
+        AsyncHookManager::new(),
+        Arc::new(Mutex::new(PersistentHookManager::new())),
+    )
+    .unwrap();
+    tui.app.transcript.push(crate::types::TranscriptItem::AssistantText(
+        "Here's some **bold** and `code`.".to_string(),
+    ));
+
+    use ratatui::style::Modifier;
+    let rendered: Vec<ratatui::text::Line<'static>> = tui
+        .app
+        .transcript
+        .iter()
+        .flat_map(Tui::render_entry)
+        .collect();
+    let plain = rendered
+        .iter()
+        .map(line_to_plain)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !plain.contains("**bold**"),
+        "expected `**bold**` markers consumed; got:\n{plain}"
+    );
+    assert!(
+        !plain.contains("`code`"),
+        "expected backticks consumed; got:\n{plain}"
+    );
+
+    let mut saw_bold = false;
+    let mut saw_code = false;
+    for line in &rendered {
+        for span in &line.spans {
+            if span.content.as_ref() == "bold"
+                && span.style.add_modifier.contains(Modifier::BOLD)
+            {
+                saw_bold = true;
+            }
+            if span.content.as_ref() == "code"
+                && (span.style.fg.is_some() || span.style.bg.is_some())
+            {
+                saw_code = true;
+            }
+        }
+    }
+    assert!(saw_bold, "assistant text should style `**bold**`");
+    assert!(saw_code, "assistant text should style `` `code` ``");
+}
+
+#[tokio::test]
+async fn tui_assistant_text_preserves_line_breaks() {
+    // LLM output frequently uses single `\n` for line breaks where they
+    // intend visible newlines. CommonMark would collapse those into a
+    // reflowed paragraph; the markdown_lines helper preprocesses to
+    // CommonMark hard breaks so each input newline shows.
+    let mut tui = Tui::init(
+        &test_config(),
+        AsyncHookManager::new(),
+        Arc::new(Mutex::new(PersistentHookManager::new())),
+    )
+    .unwrap();
+    tui.app.transcript.push(crate::types::TranscriptItem::AssistantText(
+        "first line\nsecond line\nthird line".to_string(),
+    ));
+
+    let rendered: Vec<ratatui::text::Line<'static>> = tui
+        .app
+        .transcript
+        .iter()
+        .flat_map(Tui::render_entry)
+        .collect();
+    let line_texts: Vec<String> = rendered
+        .iter()
+        .map(line_to_plain)
+        .filter(|t| !t.is_empty())
+        .collect();
+    assert!(
+        line_texts.iter().any(|t| t == "first line"),
+        "expected `first line` on its own line; got {line_texts:?}"
+    );
+    assert!(
+        line_texts.iter().any(|t| t == "third line"),
+        "expected `third line` on its own line; got {line_texts:?}"
+    );
+    // Should NOT be collapsed into one paragraph.
+    assert!(
+        !line_texts
+            .iter()
+            .any(|t| t.contains("first line") && t.contains("second line")),
+        "lines were collapsed instead of preserved: {line_texts:?}"
+    );
+}

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -4274,8 +4274,9 @@ async fn tui_started_template_strips_markers_and_styles_spans() {
     );
 
     // At least one span should be BOLD ("$"), and at least one should be
-    // styled with the code color (Yellow) for "ls -la /tmp".
-    use ratatui::style::{Color, Modifier};
+    // visually distinct (fg or bg set) for the inline code ("ls -la /tmp").
+    // We don't pin a specific color — that's chosen by `tui-markdown`.
+    use ratatui::style::Modifier;
     let mut saw_bold = false;
     let mut saw_code = false;
     for line in &rendered_lines {
@@ -4283,13 +4284,20 @@ async fn tui_started_template_strips_markers_and_styles_spans() {
             if span.style.add_modifier.contains(Modifier::BOLD) {
                 saw_bold = true;
             }
-            if span.style.fg == Some(Color::Yellow) {
+            // The code span carries an explicit fg or bg — distinct from
+            // the dim grey base used for surrounding spans.
+            if span.content.as_ref() == "ls -la /tmp"
+                && (span.style.fg.is_some() || span.style.bg.is_some())
+            {
                 saw_code = true;
             }
         }
     }
     assert!(saw_bold, "expected a BOLD span from `**$**`");
-    assert!(saw_code, "expected a code-colored span from `` `ls -la /tmp` ``");
+    assert!(
+        saw_code,
+        "expected a visually distinct span for `` `ls -la /tmp` ``"
+    );
 }
 
 #[tokio::test]
@@ -4364,7 +4372,7 @@ async fn tui_completed_template_styles_spans() {
     .await
     .unwrap();
 
-    use ratatui::style::{Color, Modifier};
+    use ratatui::style::Modifier;
     let rendered: Vec<ratatui::text::Line<'static>> = tui
         .app
         .transcript
@@ -4389,11 +4397,15 @@ async fn tui_completed_template_styles_spans() {
             if span.style.add_modifier.contains(Modifier::BOLD) {
                 saw_bold = true;
             }
-            if span.style.fg == Some(Color::Yellow) {
+            // The `hello` code span is visually distinct via fg or bg —
+            // exact color picked by `tui-markdown`.
+            if span.content.as_ref() == "hello"
+                && (span.style.fg.is_some() || span.style.bg.is_some())
+            {
                 saw_code = true;
             }
         }
     }
     assert!(saw_bold, "expected a BOLD span from `**OK**`");
-    assert!(saw_code, "expected a code-colored span from `` `hello` ``");
+    assert!(saw_code, "expected a visually distinct span for `` `hello` ``");
 }

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -4216,3 +4216,184 @@ async fn tui_falls_back_to_output_when_no_template_title() {
         "expected raw output when no template title; got:\n{joined}"
     );
 }
+
+// ----------------------------------------------------------------------------
+// Templated tool calls/results render with inline markdown styling
+// (`**bold**`, `*italic*`, `` `code` ``). Plain output paths stay plain.
+// ----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tui_started_template_strips_markers_and_styles_spans() {
+    let mut tui = Tui::init(
+        &test_config(),
+        AsyncHookManager::new(),
+        Arc::new(Mutex::new(PersistentHookManager::new())),
+    )
+    .unwrap();
+
+    // Producer-side render of `**$** \`{{ args.command }}\``.
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Tool(ToolEvent::Started {
+            id: "call-1".into(),
+            name: "bash_exec".into(),
+            kind: ToolKind::Other,
+            title: Some("**$** `ls -la /tmp`".into()),
+            input: yaml_to_json("command: ls -la /tmp"),
+            locations: vec![],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let rendered_lines: Vec<ratatui::text::Line<'static>> = tui
+        .app
+        .transcript
+        .iter()
+        .flat_map(Tui::render_entry)
+        .collect();
+
+    // Markers should be consumed (not appear as literal text), and the
+    // styled span text should appear instead.
+    let plain = rendered_lines
+        .iter()
+        .map(line_to_plain)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !plain.contains("**$**"),
+        "expected `**$**` markers to be consumed by markdown render; got:\n{plain}"
+    );
+    assert!(
+        !plain.contains("`ls -la /tmp`"),
+        "expected backticks to be consumed; got:\n{plain}"
+    );
+    assert!(
+        plain.contains("$ ls -la /tmp"),
+        "expected stripped text in transcript; got:\n{plain}"
+    );
+
+    // At least one span should be BOLD ("$"), and at least one should be
+    // styled with the code color (Yellow) for "ls -la /tmp".
+    use ratatui::style::{Color, Modifier};
+    let mut saw_bold = false;
+    let mut saw_code = false;
+    for line in &rendered_lines {
+        for span in &line.spans {
+            if span.style.add_modifier.contains(Modifier::BOLD) {
+                saw_bold = true;
+            }
+            if span.style.fg == Some(Color::Yellow) {
+                saw_code = true;
+            }
+        }
+    }
+    assert!(saw_bold, "expected a BOLD span from `**$**`");
+    assert!(saw_code, "expected a code-colored span from `` `ls -la /tmp` ``");
+}
+
+#[tokio::test]
+async fn tui_started_no_template_keeps_yaml_unstyled() {
+    // Regression guard: when no template, the body is YAML and must NOT
+    // get markdown styling — yaml content like `tags: [_priv]` would
+    // accidentally italicize.
+    let mut tui = Tui::init(
+        &test_config(),
+        AsyncHookManager::new(),
+        Arc::new(Mutex::new(PersistentHookManager::new())),
+    )
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Tool(ToolEvent::Started {
+            id: "call-1".into(),
+            name: "no_template_tool".into(),
+            kind: ToolKind::Other,
+            title: None,
+            input: yaml_to_json("flag: _priv_value"),
+            locations: vec![],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    use ratatui::style::Modifier;
+    let rendered: Vec<ratatui::text::Line<'static>> = tui
+        .app
+        .transcript
+        .iter()
+        .flat_map(Tui::render_entry)
+        .collect();
+    let plain = rendered
+        .iter()
+        .map(line_to_plain)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        plain.contains("_priv_value"),
+        "raw yaml value should appear unaltered; got:\n{plain}"
+    );
+    for line in &rendered {
+        for span in &line.spans {
+            assert!(
+                !span.style.add_modifier.contains(Modifier::ITALIC),
+                "yaml body should not be italicized: {:?}",
+                span.content
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn tui_completed_template_styles_spans() {
+    let mut tui = Tui::init(
+        &test_config(),
+        AsyncHookManager::new(),
+        Arc::new(Mutex::new(PersistentHookManager::new())),
+    )
+    .unwrap();
+
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Tool(ToolEvent::Completed {
+            id: "call-1".into(),
+            output: serde_json::json!({"content": [{"type": "text", "text": "hello"}]}),
+            title: Some("**OK**: `hello`".into()),
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    use ratatui::style::{Color, Modifier};
+    let rendered: Vec<ratatui::text::Line<'static>> = tui
+        .app
+        .transcript
+        .iter()
+        .flat_map(Tui::render_entry)
+        .collect();
+    let plain = rendered
+        .iter()
+        .map(line_to_plain)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !plain.contains("**OK**"),
+        "expected `**OK**` markers to be consumed; got:\n{plain}"
+    );
+    assert!(plain.contains("OK: hello"));
+
+    let mut saw_bold = false;
+    let mut saw_code = false;
+    for line in &rendered {
+        for span in &line.spans {
+            if span.style.add_modifier.contains(Modifier::BOLD) {
+                saw_bold = true;
+            }
+            if span.style.fg == Some(Color::Yellow) {
+                saw_code = true;
+            }
+        }
+    }
+    assert!(saw_bold, "expected a BOLD span from `**OK**`");
+    assert!(saw_code, "expected a code-colored span from `` `hello` ``");
+}

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -106,6 +106,19 @@ pub(super) fn cleanup_attachment_dir(dir: &std::path::Path) {
     let _ = std::fs::remove_dir_all(dir);
 }
 
+/// Body of a `ToolCall` transcript item. Distinguishes raw YAML (rendered
+/// plainly) from rendered MiniJinja template text (rendered with inline
+/// markdown styling). Mutually exclusive — a tool call has exactly one or
+/// no body, never both.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ToolCallBody {
+    /// YAML rendering of the raw tool-call arguments. Displayed verbatim.
+    Yaml(String),
+    /// Rendered MCP `call_template` output. Each line is treated as inline
+    /// markdown (`**bold**`, `*italic*`, `` `code` ``).
+    Markdown(String),
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum TranscriptItem {
     SourceHeading(AgentSource),
@@ -114,13 +127,17 @@ pub(crate) enum TranscriptItem {
     AssistantText(String),
     ErrorText(String),
     ThoughtText(String),
+    /// Plain tool result line — extracted from the raw output. Rendered dim.
     ToolResultText(String),
+    /// Templated tool result line — produced from a MCP `result_template`.
+    /// Rendered as inline markdown so the styling shows up.
+    ToolResultMarkdown(String),
     StatusLine(String),
     Plan(Vec<PlanEntry>),
     UsageLine(String),
     ToolCall {
         tool_name: String,
-        input_yaml: Option<String>,
+        body: Option<ToolCallBody>,
     },
     AttachmentHeader(String),
     AttachmentItem(String),

--- a/crates/harnx/src/cli_event_sink.rs
+++ b/crates/harnx/src/cli_event_sink.rs
@@ -184,6 +184,28 @@ impl CliSinkState {
         self.render = None;
         Ok(())
     }
+
+    /// Render a single line through `MarkdownRender` so MCP `call_template`/
+    /// `result_template` text shows its `**bold**` / `*italic*` / `` `code` ``
+    /// styling. Lazy-initializes the renderer (shared with the streaming
+    /// path) and returns the input unchanged when highlighting is disabled
+    /// (no TTY, --no-highlight, or render init failure).
+    fn render_markdown_line(&mut self, text: &str) -> String {
+        if !(self.highlight && *IS_STDOUT_TERMINAL) {
+            return text.to_string();
+        }
+        if self.render.is_none() {
+            match MarkdownRender::init(self.render_options.clone()) {
+                Ok(r) => self.render = Some(r),
+                Err(_) => return text.to_string(),
+            }
+        }
+        // `render_line` is `&self` — no `mut` borrow needed.
+        self.render
+            .as_ref()
+            .map(|r| r.render_line(text))
+            .unwrap_or_else(|| text.to_string())
+    }
 }
 
 impl AgentEventSink for CliAgentEventSink {
@@ -320,18 +342,42 @@ impl AgentEventSink for CliAgentEventSink {
                 }
             }
             AgentEvent::Tool(ToolEvent::Started { name, title, .. }) => {
-                eprintln!(
-                    "{}",
-                    dimmed_text(&format_tool_started_line(&name, title.as_deref()))
-                );
+                let templated_title = title
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|t| !t.is_empty());
+                match templated_title {
+                    Some(t) => {
+                        // Templated title — render markdown so `**bold**`,
+                        // `*italic*`, and `` `code` `` show their styling.
+                        let rendered = state.render_markdown_line(t);
+                        eprintln!("{} {}", dimmed_text(&format!("[tool] {name}")), rendered);
+                    }
+                    None => {
+                        eprintln!("{}", dimmed_text(&format!("[tool] {name}")));
+                    }
+                }
             }
             AgentEvent::Tool(ToolEvent::Failed { error, .. }) => {
                 eprintln!("{}", warning_text(&format!("tool error: {error}")));
             }
             AgentEvent::Tool(ToolEvent::Completed { output, title, .. }) => {
-                let text = harnx_runtime::utils::render_tool_result_text(&output, title.as_deref());
+                let templated = title
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|t| !t.is_empty())
+                    .is_some();
+                let text =
+                    harnx_runtime::utils::render_tool_result_text(&output, title.as_deref());
                 let trimmed = text.trim_end_matches('\n');
-                if !trimmed.is_empty() {
+                if trimmed.is_empty() {
+                    // nothing to show
+                } else if templated {
+                    // Render each line through markdown; preserve newlines.
+                    for line in trimmed.lines() {
+                        eprintln!("{}", state.render_markdown_line(line));
+                    }
+                } else {
                     eprintln!("{}", dimmed_text(trimmed));
                 }
             }
@@ -376,17 +422,6 @@ fn split_line_tail_local(text: &str) -> (&str, &str) {
 fn need_rows_local(text: &str, columns: u16) -> u16 {
     let buffer_width = display_width(text).max(1) as u16;
     buffer_width.div_ceil(columns)
-}
-
-/// Format the line printed for `ToolEvent::Started`. When the producer has
-/// rendered a MiniJinja `call_template` into `title`, append it after the
-/// tool name so the user sees the templated form instead of just the bare
-/// tool name. Public for testing the pure formatting decision.
-pub(crate) fn format_tool_started_line(name: &str, title: Option<&str>) -> String {
-    match title.map(str::trim).filter(|t| !t.is_empty()) {
-        Some(t) => format!("[tool] {name} {t}"),
-        None => format!("[tool] {name}"),
-    }
 }
 
 #[cfg(test)]
@@ -479,33 +514,12 @@ mod tests {
     // prior to these tests.
     // ----------------------------------------------------------------
 
-    #[test]
-    fn started_line_includes_template_title_when_present() {
-        let line = format_tool_started_line("bash_exec", Some("$ ls -la /tmp"));
-        assert_eq!(line, "[tool] bash_exec $ ls -la /tmp");
-    }
-
-    #[test]
-    fn started_line_uses_bare_name_when_title_absent() {
-        let line = format_tool_started_line("bash_exec", None);
-        assert_eq!(line, "[tool] bash_exec");
-    }
-
-    #[test]
-    fn started_line_treats_empty_title_as_absent() {
-        // A template that renders to whitespace-only must not pollute the
-        // line with trailing whitespace — matches the "no template" path.
-        assert_eq!(
-            format_tool_started_line("name", Some("")),
-            "[tool] name",
-            "empty title should fall back"
-        );
-        assert_eq!(
-            format_tool_started_line("name", Some("   ")),
-            "[tool] name",
-            "whitespace-only title should fall back"
-        );
-    }
+    // The CLI Started handler renders the bare "[tool] name" prefix
+    // dimmed and appends the markdown-rendered title (or nothing if no
+    // title). The whitespace/empty fallback decision lives inline in the
+    // emit handler, exercised end-to-end by
+    // `emit_handles_each_top_level_variant_without_panic` plus the
+    // markdown-line tests below.
 
     // The CLI Completed handler delegates to
     // `harnx_runtime::utils::render_tool_result_text`, the same shared
@@ -572,5 +586,47 @@ mod tests {
             rendered.contains("important output"),
             "empty title should fall back to extraction: {rendered}"
         );
+    }
+
+    // ----------------------------------------------------------------
+    // Markdown rendering for tool events. The state.render_markdown_line
+    // helper drops back to plain text when highlighting is disabled or
+    // the renderer can't initialize, otherwise it produces ANSI-styled
+    // output via syntect.
+    // ----------------------------------------------------------------
+
+    fn make_state(highlight: bool) -> CliSinkState {
+        CliSinkState {
+            spinner: None,
+            render: None,
+            buffer: String::new(),
+            buffer_rows: 1,
+            columns: 0,
+            raw_mode_active: false,
+            highlight,
+            render_options: RenderOptions::default(),
+        }
+    }
+
+    #[test]
+    fn render_markdown_line_passthrough_when_highlight_disabled() {
+        // highlight=false short-circuits the renderer init entirely —
+        // no ANSI codes regardless of TTY status.
+        let mut state = make_state(false);
+        let out = state.render_markdown_line("**bold** and `code`");
+        assert_eq!(out, "**bold** and `code`");
+        assert!(state.render.is_none(), "render should not be initialized");
+    }
+
+    #[test]
+    fn render_markdown_line_passes_through_when_no_tty() {
+        // When stdout isn't a TTY, IS_STDOUT_TERMINAL is false → return
+        // the input unchanged. In the test process stdout *is* the test
+        // harness's pipe, so this gate passes.
+        let mut state = make_state(true);
+        let out = state.render_markdown_line("**bold** and `code`");
+        // In the test environment IS_STDOUT_TERMINAL is false, so we
+        // expect the same plain passthrough.
+        assert_eq!(out, "**bold** and `code`");
     }
 }

--- a/crates/harnx/src/cli_event_sink.rs
+++ b/crates/harnx/src/cli_event_sink.rs
@@ -185,6 +185,40 @@ impl CliSinkState {
         Ok(())
     }
 
+    /// Stderr render for `ToolEvent::Started`: dim "[tool] {name}", and
+    /// when the producer rendered an MCP `call_template` into `title`,
+    /// append the markdown-styled rendering after it.
+    fn print_tool_started(&mut self, name: &str, title: Option<&str>) {
+        let prefix = dimmed_text(&format!("[tool] {name}"));
+        match title.map(str::trim).filter(|t| !t.is_empty()) {
+            Some(t) => {
+                let rendered = self.render_markdown_line(t);
+                eprintln!("{prefix} {rendered}");
+            }
+            None => eprintln!("{prefix}"),
+        }
+    }
+
+    /// Stderr render for `ToolEvent::Completed`: when an MCP
+    /// `result_template` produced a `title`, render each output line
+    /// through markdown (preserves emphasis); otherwise fall back to the
+    /// dim plain-text path the historic emit used.
+    fn print_tool_completed(&mut self, output: &serde_json::Value, title: Option<&str>) {
+        let templated = title.map(str::trim).filter(|t| !t.is_empty()).is_some();
+        let text = harnx_runtime::utils::render_tool_result_text(output, title);
+        let trimmed = text.trim_end_matches('\n');
+        if trimmed.is_empty() {
+            return;
+        }
+        if templated {
+            for line in trimmed.lines() {
+                eprintln!("{}", self.render_markdown_line(line));
+            }
+        } else {
+            eprintln!("{}", dimmed_text(trimmed));
+        }
+    }
+
     /// Render a single line through `MarkdownRender` so MCP `call_template`/
     /// `result_template` text shows its `**bold**` / `*italic*` / `` `code` ``
     /// styling. Lazy-initializes the renderer (shared with the streaming
@@ -342,44 +376,13 @@ impl AgentEventSink for CliAgentEventSink {
                 }
             }
             AgentEvent::Tool(ToolEvent::Started { name, title, .. }) => {
-                let templated_title = title
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|t| !t.is_empty());
-                match templated_title {
-                    Some(t) => {
-                        // Templated title — render markdown so `**bold**`,
-                        // `*italic*`, and `` `code` `` show their styling.
-                        let rendered = state.render_markdown_line(t);
-                        eprintln!("{} {}", dimmed_text(&format!("[tool] {name}")), rendered);
-                    }
-                    None => {
-                        eprintln!("{}", dimmed_text(&format!("[tool] {name}")));
-                    }
-                }
+                state.print_tool_started(&name, title.as_deref());
             }
             AgentEvent::Tool(ToolEvent::Failed { error, .. }) => {
                 eprintln!("{}", warning_text(&format!("tool error: {error}")));
             }
             AgentEvent::Tool(ToolEvent::Completed { output, title, .. }) => {
-                let templated = title
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|t| !t.is_empty())
-                    .is_some();
-                let text =
-                    harnx_runtime::utils::render_tool_result_text(&output, title.as_deref());
-                let trimmed = text.trim_end_matches('\n');
-                if trimmed.is_empty() {
-                    // nothing to show
-                } else if templated {
-                    // Render each line through markdown; preserve newlines.
-                    for line in trimmed.lines() {
-                        eprintln!("{}", state.render_markdown_line(line));
-                    }
-                } else {
-                    eprintln!("{}", dimmed_text(trimmed));
-                }
+                state.print_tool_completed(&output, title.as_deref());
             }
             // Silent for Progress / Update — they are streamed mid-call
             // updates that would clutter stderr.


### PR DESCRIPTION
Follow-up to #386. Built-in MCP tool templates use markdown like `**$** \`{{ args.command }}\``, but #386 displayed them verbatim — markers leaked through as literal asterisks/backticks. Also restores markdown rendering for assistant messages, which was lost in the TUI's ratatui transition (verified — `AssistantText` was being rendered as plain text).

## Changes

**TUI** — assistant messages and templated tool output now render through `tui-markdown` (which wraps `pulldown-cmark` + `syntect` + `ansi-to-tui`):
- `AssistantText` renders as markdown. Single newlines preprocess into CommonMark hard breaks (`  \n`) so each LLM-emitted line stays on its own row instead of getting reflowed into a paragraph.
- New `ToolCallBody::{Yaml, Markdown}` enum + `TranscriptItem::ToolResultMarkdown` variant tag whether a tool body should render plain or styled. Raw YAML/output bodies stay plain so values like `tags: [_priv]` aren't accidentally italicized.

**CLI** — `CliSinkState::render_markdown_line` lazy-inits the existing `MarkdownRender` and returns ANSI-styled output when `highlight && IS_STDOUT_TERMINAL`, plain text otherwise. Templated `Started` titles render after a dim `[tool] {name}` prefix; templated `Completed` lines render through markdown. Raw output keeps the dim plain-text path.

## Test coverage

15 new tests; all workspace tests pass; clippy clean with `-D warnings`; `cs delta` shows `input.rs`, `cli_event_sink.rs`, and `render.rs` health all improved.

| Layer | Verifies |
|---|---|
| `render_helpers::markdown_tests` (7) | bold, italic (`*`+`_`), code, unmatched markers, multi-line newline preservation, paragraph breaks, base-style propagation |
| `tests.rs` end-to-end (5) | templated tool started/completed render with BOLD + code styling, raw YAML stays unstyled, assistant text renders inline markdown, assistant text preserves line breaks |
| `cli_event_sink.rs` (2) | `render_markdown_line` passthrough when highlight=off / no-TTY |

## Out of scope

- Other plain-text transcript items (`Plan`, `SystemText`, `ErrorText`, etc.) — they're not user content, so no markdown.
- Session-restored tool calls don't apply templates (#385).

## Test plan

- [ ] Run a real bash MCP tool in TUI mode → confirm `$ <command>` shows with `$` BOLD and `<command>` in a distinct color, not as literal `**$**` / backticks.
- [ ] Send an assistant message with **bold**, _italic_, and \`code\` → confirm styling renders.
- [ ] Same in non-interactive CLI mode (stdout to TTY) → confirm ANSI styling appears.
- [ ] Pipe CLI to a file → confirm no ANSI escape codes leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)