### PR TITLE
fix(mcp): surface MCP startup errors with stderr context in TUI (#391)

### DIFF
--- a/crates/harnx-core/src/sink.rs
+++ b/crates/harnx-core/src/sink.rs
@@ -8,26 +8,64 @@
 //! be able to install/clear sinks even though harnx-core is compiled
 //! as a non-test dep). The uncontended-lock cost per emit is
 //! negligible compared to rendering.
+//!
+//! Events emitted before any sink is installed (e.g. MCP connection
+//! warnings raised during `agent::init`, which runs before the TUI/CLI
+//! sink is wired up) are held in a small bounded buffer and replayed
+//! to the first sink that gets installed. Without this, those early
+//! events fall through to ad-hoc `eprintln!` fallbacks and never reach
+//! the TUI transcript (issue #391).
 
 use std::sync::Arc;
 use std::sync::Mutex;
 
 use crate::event::{AgentEvent, AgentEventSink, AgentSource};
 
-static AGENT_EVENT_SINK: Mutex<Option<Arc<dyn AgentEventSink>>> = Mutex::new(None);
+/// Cap on the pre-install buffer. Large enough to capture a handful of
+/// startup warnings (one per misconfigured MCP server, plus a few
+/// hook/config notices), small enough that we don't grow unboundedly
+/// if a sink never gets installed (e.g. a non-interactive subcommand
+/// that never enters the chat path).
+const PENDING_EVENTS_CAP: usize = 64;
+
+struct SinkState {
+    sink: Option<Arc<dyn AgentEventSink>>,
+    pending: Vec<(AgentEvent, Option<AgentSource>)>,
+}
+
+impl SinkState {
+    const fn new() -> Self {
+        Self {
+            sink: None,
+            pending: Vec::new(),
+        }
+    }
+}
+
+static AGENT_EVENT_SINK: Mutex<SinkState> = Mutex::new(SinkState::new());
 
 pub fn install_agent_event_sink(sink: Arc<dyn AgentEventSink>) {
-    let mut guard = AGENT_EVENT_SINK
-        .lock()
-        .expect("AGENT_EVENT_SINK mutex poisoned");
-    *guard = Some(sink);
+    // Take the buffered events out under the lock, install the new
+    // sink, then drop the lock before replaying — replaying while
+    // holding the lock would deadlock any sink whose `emit` reaches
+    // back into the registry (none today, but cheap insurance).
+    let pending = {
+        let mut guard = AGENT_EVENT_SINK
+            .lock()
+            .expect("AGENT_EVENT_SINK mutex poisoned");
+        guard.sink = Some(sink.clone());
+        std::mem::take(&mut guard.pending)
+    };
+    for (event, source) in pending {
+        sink.emit(event, source);
+    }
 }
 
 pub fn has_agent_event_sink() -> bool {
     let guard = AGENT_EVENT_SINK
         .lock()
         .expect("AGENT_EVENT_SINK mutex poisoned");
-    guard.is_some()
+    guard.sink.is_some()
 }
 
 pub fn emit_agent_event(event: AgentEvent) -> bool {
@@ -36,28 +74,34 @@ pub fn emit_agent_event(event: AgentEvent) -> bool {
 
 pub fn emit_agent_event_with_source(event: AgentEvent, source: Option<AgentSource>) -> bool {
     let sink = {
-        let guard = AGENT_EVENT_SINK
+        let mut guard = AGENT_EVENT_SINK
             .lock()
             .expect("AGENT_EVENT_SINK mutex poisoned");
-        guard.as_ref().cloned()
-    };
-    match sink {
-        Some(sink) => {
-            sink.emit(event, source);
-            true
+        match guard.sink.as_ref().cloned() {
+            Some(sink) => sink,
+            None => {
+                if guard.pending.len() == PENDING_EVENTS_CAP {
+                    guard.pending.remove(0);
+                }
+                guard.pending.push((event, source));
+                return true;
+            }
         }
-        None => false,
-    }
+    };
+    sink.emit(event, source);
+    true
 }
 
-/// Clear the installed sink. Intended for test use — both harnx-core's
-/// own `#[cfg(test)]` tests and harnx's cross-crate tests call this
-/// between cases to prevent sink leakage.
+/// Clear the installed sink and drop any buffered pending events.
+/// Intended for test use — both harnx-core's own `#[cfg(test)]` tests
+/// and harnx's cross-crate tests call this between cases to prevent
+/// sink leakage.
 pub fn clear_agent_event_sink() {
     let mut guard = AGENT_EVENT_SINK
         .lock()
         .expect("AGENT_EVENT_SINK mutex poisoned");
-    *guard = None;
+    guard.sink = None;
+    guard.pending.clear();
 }
 
 #[cfg(test)]
@@ -101,8 +145,11 @@ mod tests {
     fn install_and_emit_cycle() {
         let _guard = lock_sink_tests();
         clear_agent_event_sink();
+        // No sink installed yet — the event is buffered (delivered=true
+        // because the caller no longer needs to fall back to ad-hoc
+        // stderr output).
         let delivered = emit_agent_event(AgentEvent::Notice(NoticeEvent::Info("hi".into())));
-        assert!(!delivered);
+        assert!(delivered);
         assert!(!has_agent_event_sink());
 
         let sink = CollectingSink::new();
@@ -111,10 +158,79 @@ mod tests {
         let delivered = emit_agent_event(AgentEvent::Notice(NoticeEvent::Warning("whoa".into())));
         assert!(delivered);
         let events = sink.events.lock().unwrap();
-        assert_eq!(events.len(), 1);
+        // Both the pre-install "hi" (replayed) and the post-install
+        // "whoa" reach the sink in order.
+        assert_eq!(events.len(), 2);
         match &events[0] {
+            AgentEvent::Notice(NoticeEvent::Info(msg)) => assert_eq!(msg, "hi"),
+            other => panic!("unexpected first event: {other:?}"),
+        }
+        match &events[1] {
             AgentEvent::Notice(NoticeEvent::Warning(msg)) => assert_eq!(msg, "whoa"),
-            other => panic!("unexpected event: {other:?}"),
+            other => panic!("unexpected second event: {other:?}"),
+        }
+        drop(events);
+        clear_agent_event_sink();
+    }
+
+    #[test]
+    fn pending_events_replayed_to_first_installed_sink() {
+        use crate::event::AgentSource;
+        let _guard = lock_sink_tests();
+        clear_agent_event_sink();
+
+        emit_agent_event(AgentEvent::Notice(NoticeEvent::Warning("first".into())));
+        emit_agent_event_with_source(
+            AgentEvent::Notice(NoticeEvent::Warning("second".into())),
+            Some(AgentSource {
+                agent: "argus".into(),
+                session_id: None,
+            }),
+        );
+
+        let sink = Arc::new(SourceRecordingSink::default());
+        install_agent_event_sink(sink.clone());
+
+        let events = sink.events.lock().unwrap();
+        assert_eq!(events.len(), 2);
+        match &events[0].0 {
+            AgentEvent::Notice(NoticeEvent::Warning(msg)) => assert_eq!(msg, "first"),
+            other => panic!("unexpected first event: {other:?}"),
+        }
+        assert!(events[0].1.is_none());
+        match &events[1].0 {
+            AgentEvent::Notice(NoticeEvent::Warning(msg)) => assert_eq!(msg, "second"),
+            other => panic!("unexpected second event: {other:?}"),
+        }
+        assert_eq!(events[1].1.as_ref().unwrap().agent, "argus");
+        drop(events);
+        clear_agent_event_sink();
+    }
+
+    #[test]
+    fn pending_buffer_is_capped() {
+        let _guard = lock_sink_tests();
+        clear_agent_event_sink();
+
+        for i in 0..(PENDING_EVENTS_CAP + 5) {
+            emit_agent_event(AgentEvent::Notice(NoticeEvent::Info(format!("e{i}"))));
+        }
+
+        let sink = CollectingSink::new();
+        install_agent_event_sink(sink.clone());
+
+        let events = sink.events.lock().unwrap();
+        assert_eq!(events.len(), PENDING_EVENTS_CAP);
+        // Oldest events are dropped first — first survivor is e5.
+        match &events[0] {
+            AgentEvent::Notice(NoticeEvent::Info(msg)) => assert_eq!(msg, "e5"),
+            other => panic!("unexpected first event: {other:?}"),
+        }
+        match events.last().unwrap() {
+            AgentEvent::Notice(NoticeEvent::Info(msg)) => {
+                assert_eq!(msg, &format!("e{}", PENDING_EVENTS_CAP + 4))
+            }
+            other => panic!("unexpected last event: {other:?}"),
         }
         drop(events);
         clear_agent_event_sink();

--- a/crates/harnx-mcp/src/client.rs
+++ b/crates/harnx-mcp/src/client.rs
@@ -18,12 +18,45 @@ use rmcp::model::{
 use rmcp::service::{RequestContext, RoleClient, RunningService, ServiceError};
 use rmcp::transport::TokioChildProcess;
 use serde_json::Value;
+use std::collections::VecDeque;
 use std::process::Stdio;
 use std::time::Duration;
 use std::{collections::HashMap, fmt, path::Path, sync::Arc};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio::runtime::{Builder, Handle, RuntimeFlavor};
+
+/// Maximum number of stderr lines to keep from an MCP child process for
+/// inclusion in connection error messages. Old lines are dropped first.
+const MCP_STDERR_TAIL_LINES: usize = 64;
+
+/// How long to wait for the stderr reader to drain after a connection
+/// error before snapshotting the buffer for the error message. Short
+/// enough to keep startup snappy, long enough that a child that exited
+/// just before initialize completed has time to flush.
+const MCP_STDERR_DRAIN_DELAY: Duration = Duration::from_millis(150);
+
+type StderrBuffer = Arc<parking_lot::Mutex<VecDeque<String>>>;
+
+fn new_stderr_buffer() -> StderrBuffer {
+    Arc::new(parking_lot::Mutex::new(VecDeque::with_capacity(
+        MCP_STDERR_TAIL_LINES,
+    )))
+}
+
+fn render_stderr_tail(buffer: &StderrBuffer) -> String {
+    let buf = buffer.lock();
+    if buf.is_empty() {
+        return String::new();
+    }
+    let joined = buf.iter().cloned().collect::<Vec<_>>().join("\n");
+    format!("\nMCP server stderr:\n{joined}")
+}
+
+async fn snapshot_stderr_tail(buffer: &StderrBuffer) -> String {
+    tokio::time::sleep(MCP_STDERR_DRAIN_DELAY).await;
+    render_stderr_tail(buffer)
+}
 
 pub struct McpClient {
     name: String,
@@ -160,6 +193,8 @@ impl McpClient {
         #[cfg(unix)]
         wrap.wrap(ProcessGroup::leader());
 
+        let stderr_buffer = new_stderr_buffer();
+
         let (transport, stderr) = TokioChildProcess::builder(wrap)
             .stderr(Stdio::piped())
             .spawn()
@@ -167,85 +202,124 @@ impl McpClient {
 
         if let Some(stderr) = stderr {
             let server_name = self.name.clone();
+            let buffer = stderr_buffer.clone();
             tokio::spawn(async move {
                 let reader = BufReader::new(stderr);
                 let mut lines = reader.lines();
                 while let Ok(Some(line)) = lines.next_line().await {
                     log::debug!("[mcp:{}] {}", server_name, line);
+                    let mut buf = buffer.lock();
+                    if buf.len() == MCP_STDERR_TAIL_LINES {
+                        buf.pop_front();
+                    }
+                    buf.push_back(line);
                 }
             });
         }
 
         let handler = McpClientHandler::new(self.roots.clone());
-        let service = tokio::time::timeout(
+        let serve_result = tokio::time::timeout(
             Duration::from_secs(30),
             rmcp::service::serve_client(handler, transport),
         )
-        .await
-        .map_err(|_| {
-            anyhow!(
-                "MCP server '{}' timed out during initialization (30s)",
-                self.name
-            )
-        })?
-        .with_context(|| format!("Failed to initialize MCP client for server '{}'", self.name))?;
+        .await;
+        let service = match serve_result {
+            Err(_) => {
+                let tail = snapshot_stderr_tail(&stderr_buffer).await;
+                bail!(
+                    "MCP server '{}' timed out during initialization (30s){}",
+                    self.name,
+                    tail,
+                );
+            }
+            Ok(Err(err)) => {
+                let tail = snapshot_stderr_tail(&stderr_buffer).await;
+                return Err(anyhow::Error::from(err)).with_context(|| {
+                    format!(
+                        "Failed to initialize MCP client for server '{}'{}",
+                        self.name, tail,
+                    )
+                });
+            }
+            Ok(Ok(service)) => service,
+        };
 
-        let functions = tokio::time::timeout(
+        let list_result = tokio::time::timeout(
             Duration::from_secs(10),
             service.peer().list_tools(Default::default()),
         )
-        .await
-        .map_err(|_| anyhow!("MCP server '{}' timed out listing tools (10s)", self.name))?
-        .with_context(|| format!("Failed to list tools for MCP server '{}'", self.name))?
-        .tools
-        .into_iter()
-        .map(|tool| {
-            let input_schema = Value::Object((*tool.input_schema).clone());
-            let server_tool_name = tool.name.to_string();
-            let final_name =
-                if let Some(renamed) = self.config.rename_tools.get(server_tool_name.as_str()) {
+        .await;
+        let tools_result = match list_result {
+            Err(_) => {
+                let tail = snapshot_stderr_tail(&stderr_buffer).await;
+                bail!(
+                    "MCP server '{}' timed out listing tools (10s){}",
+                    self.name,
+                    tail,
+                );
+            }
+            Ok(Err(err)) => {
+                let tail = snapshot_stderr_tail(&stderr_buffer).await;
+                return Err(anyhow::Error::from(err)).with_context(|| {
+                    format!(
+                        "Failed to list tools for MCP server '{}'{}",
+                        self.name, tail
+                    )
+                });
+            }
+            Ok(Ok(result)) => result,
+        };
+        let functions = tools_result
+            .tools
+            .into_iter()
+            .map(|tool| {
+                let input_schema = Value::Object((*tool.input_schema).clone());
+                let server_tool_name = tool.name.to_string();
+                let final_name = if let Some(renamed) =
+                    self.config.rename_tools.get(server_tool_name.as_str())
+                {
                     renamed.clone()
                 } else {
                     format!("{}_{}", self.name, server_tool_name)
                 };
 
-            // Extract _meta templates (server-provided)
-            let meta_call_tmpl = tool
-                .meta
-                .as_ref()
-                .and_then(|m| m.0.get("call_template"))
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-            let meta_result_tmpl = tool
-                .meta
-                .as_ref()
-                .and_then(|m| m.0.get("result_template"))
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
+                // Extract _meta templates (server-provided)
+                let meta_call_tmpl = tool
+                    .meta
+                    .as_ref()
+                    .and_then(|m| m.0.get("call_template"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let meta_result_tmpl = tool
+                    .meta
+                    .as_ref()
+                    .and_then(|m| m.0.get("result_template"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
 
-            // Apply config override (higher precedence)
-            let cfg_templates: Option<&ToolDisplayTemplates> =
-                self.config.tool_templates.get(&server_tool_name);
-            let call_template = cfg_templates
-                .and_then(|t| t.call_template.clone())
-                .or(meta_call_tmpl);
-            let result_template = cfg_templates
-                .and_then(|t| t.result_template.clone())
-                .or(meta_result_tmpl);
-            let templates = ToolTemplates {
-                call_template,
-                result_template,
-            };
+                // Apply config override (higher precedence)
+                let cfg_templates: Option<&ToolDisplayTemplates> =
+                    self.config.tool_templates.get(&server_tool_name);
+                let call_template = cfg_templates
+                    .and_then(|t| t.call_template.clone())
+                    .or(meta_call_tmpl);
+                let result_template = cfg_templates
+                    .and_then(|t| t.result_template.clone())
+                    .or(meta_result_tmpl);
+                let templates = ToolTemplates {
+                    call_template,
+                    result_template,
+                };
 
-            mcp_tool_to_declaration(
-                &final_name,
-                &server_tool_name,
-                tool.description.as_deref().unwrap_or_default(),
-                &input_schema,
-                templates,
-            )
-        })
-        .collect::<Result<Vec<_>>>()?;
+                mcp_tool_to_declaration(
+                    &final_name,
+                    &server_tool_name,
+                    tool.description.as_deref().unwrap_or_default(),
+                    &input_schema,
+                    templates,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         *self.tools.write() = functions;
         *self.connected.write() = true;
@@ -771,6 +845,66 @@ mod tests {
         assert_eq!(call_template, Some("cfg call".to_string()));
         assert_eq!(result_template, Some("meta result".to_string()));
     }
+
+    #[test]
+    fn test_render_stderr_tail_empty() {
+        let buffer = new_stderr_buffer();
+        assert_eq!(render_stderr_tail(&buffer), "");
+    }
+
+    #[test]
+    fn test_render_stderr_tail_caps_lines() {
+        let buffer = new_stderr_buffer();
+        for i in 0..(MCP_STDERR_TAIL_LINES + 5) {
+            let mut buf = buffer.lock();
+            if buf.len() == MCP_STDERR_TAIL_LINES {
+                buf.pop_front();
+            }
+            buf.push_back(format!("line-{i}"));
+        }
+        let rendered = render_stderr_tail(&buffer);
+        assert!(rendered.starts_with("\nMCP server stderr:\n"));
+        let body = rendered.trim_start_matches("\nMCP server stderr:\n");
+        let lines: Vec<&str> = body.split('\n').collect();
+        assert_eq!(lines.len(), MCP_STDERR_TAIL_LINES);
+        assert_eq!(lines[0], "line-5");
+        assert_eq!(
+            lines[lines.len() - 1],
+            format!("line-{}", MCP_STDERR_TAIL_LINES + 4)
+        );
+    }
+
+    /// Spawning a fake "MCP server" (`sh -c "echo MARKER >&2; exit 1"`)
+    /// fails initialization and the resulting error message must include
+    /// the captured stderr line so users can diagnose bad-args failures
+    /// (issue #391) instead of seeing a generic transport error.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_connect_includes_child_stderr_in_error() {
+        let mut config = test_mcp_config("badserver");
+        config.command = "sh".to_string();
+        config.args = vec![
+            "-c".to_string(),
+            "echo 'unknown argument: --xyz' >&2; exit 1".to_string(),
+        ];
+        let client = McpClient::new(config);
+
+        let err = client.connect().await.expect_err("expected connect error");
+        let rendered = format!("{:#}", err);
+
+        assert!(
+            rendered.contains("badserver"),
+            "error should mention server name; got: {rendered}"
+        );
+        assert!(
+            rendered.contains("MCP server stderr:"),
+            "error should include captured stderr header; got: {rendered}"
+        );
+        assert!(
+            rendered.contains("unknown argument: --xyz"),
+            "error should include actual stderr line; got: {rendered}"
+        );
+    }
 }
 
 #[derive(Debug)]
@@ -827,8 +961,12 @@ impl McpManager {
                 let client = client.clone();
                 async move {
                     if let Err(err) = client.connect().await {
+                        // {:#} renders the full anyhow error chain so the
+                        // MCP server's actual error (and any captured
+                        // stderr tail) reaches the user, not just the
+                        // outermost context.
                         let msg = format!(
-                            "MCP server '{}' failed to connect: {}. Use '.mcp connect {}' to retry.",
+                            "MCP server '{}' failed to connect: {:#}\nUse '.mcp connect {}' to retry.",
                             client.name(),
                             err,
                             client.name(),
@@ -840,7 +978,7 @@ impl McpManager {
                             eprintln!("Warning: {msg}");
                         }
                         log::warn!(
-                            "MCP server '{}' connection failed: {}",
+                            "MCP server '{}' connection failed: {:#}",
                             client.name(),
                             err,
                         );


### PR DESCRIPTION
## Summary
- Capture MCP child stderr into a bounded 64-line buffer; attach the captured tail to connection errors so users see the actual reason (e.g. `harnx-mcp-bash: unknown argument: --xyz`) instead of a generic "Failed to initialize".
- Format the user-facing warning with `{:#}` so the full error chain (including the stderr tail) reaches the sink, not just the outermost context.
- Buffer events emitted before any `AgentEventSink` is installed and replay them to the first installed sink — `agent::init` connects MCP before TUI/CLI sink install, so without this the warning fell through to ad-hoc `eprintln!` and was hidden by the TUI's alternate-screen takeover.

Fixes #391.

## Test plan
- [x] `cargo test --workspace` — 572 tests pass, 0 failures
- [x] `cargo clippy --workspace --all-targets --no-deps` — clean
- [x] New unit test (`test_connect_includes_child_stderr_in_error`) spawns `sh -c 'echo MSG >&2; exit 1'` and asserts the connect error contains the stderr line
- [x] New sink tests cover pre-install buffering, replay order with sources, and the cap dropping oldest events first
- [ ] Manual TUI repro: `cargo run -- -a <agent>` with a misconfigured MCP server (`--extra-rwxxx`) shows the captured stderr inside the TUI transcript instead of the parent terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)