### PR TITLE
Add --extra-rwx flag and make sandbox roots executable

### DIFF
--- a/.changesets/sandbox-roots-exec-extra-rwx.md
+++ b/.changesets/sandbox-roots-exec-extra-rwx.md
@@ -1,0 +1,8 @@
+---
+harnx: minor
+---
+
+Improve filesystem sandboxing in `harnx-mcp-bash`:
+
+- Sandbox roots are now automatically executable. This fixes issues when running compilers like `cargo build` and loading native extensions (e.g., Python `.so` files or Rust proc-macros) that are built inside the project tree.
+- Add `--extra-rwx <path>` CLI flag and `HARNX_BASH_EXTRA_RWX` environment variable for granting read, write, and execute permissions to a path outside of roots (e.g., `~/.cargo`).

--- a/crates/harnx-mcp-bash/src/main.rs
+++ b/crates/harnx-mcp-bash/src/main.rs
@@ -125,6 +125,7 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
         extra_exec: parse_env_paths("HARNX_BASH_EXTRA_EXEC"),
         extra_readable: parse_env_paths("HARNX_BASH_EXTRA_READABLE"),
         extra_writable: parse_env_paths("HARNX_BASH_EXTRA_WRITABLE"),
+        extra_rwx: parse_env_paths("HARNX_BASH_EXTRA_RWX"),
         sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
         extra_env_passthrough: parse_env_passthrough(),
         env_overrides: vec![],
@@ -181,9 +182,20 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
                     std::process::exit(1);
                 }
             }
+            "--extra-rwx" => {
+                if i + 1 < args.len() {
+                    sandbox_config
+                        .extra_rwx
+                        .push(PathBuf::from(expand_tilde(&args[i + 1])));
+                    i += 2;
+                } else {
+                    eprintln!("harnx-mcp-bash: --extra-rwx requires a path argument");
+                    std::process::exit(1);
+                }
+            }
             "--sandbox-run" => {
                 if i + 1 < args.len() {
-                    sandbox_run_override = Some(PathBuf::from(&args[i + 1]));
+                    sandbox_run_override = Some(PathBuf::from(expand_tilde(&args[i + 1])));
                     i += 2;
                 } else {
                     eprintln!("harnx-mcp-bash: --sandbox-run requires a path argument");
@@ -225,6 +237,9 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
                 eprintln!("  --extra-read <path> Add sandbox read-only path (repeatable)");
                 eprintln!("  --extra-exec <path>     Add sandbox execute path (repeatable)");
                 eprintln!("  --extra-write <path>    Add sandbox writable path (repeatable)");
+                eprintln!(
+                    "  --extra-rwx <path>      Add sandbox read/write/exec path (repeatable)"
+                );
                 eprintln!("  --sandbox-run <path>    Override sandbox helper binary path");
                 eprintln!("  --env, -e <VAR>         Pass VAR from host env to child (repeatable)");
                 eprintln!("  --env, -e <VAR=VALUE>   Set VAR=VALUE in child env (repeatable)");
@@ -239,6 +254,9 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
                 );
                 eprintln!(
                     "  HARNX_BASH_EXTRA_WRITABLE   Colon-separated extra sandbox writable paths"
+                );
+                eprintln!(
+                    "  HARNX_BASH_EXTRA_RWX        Colon-separated extra sandbox read/write/exec paths"
                 );
                 eprintln!(
                     "  HARNX_BASH_ENV_PASSTHROUGH  Comma-separated extra env var names to pass through"
@@ -311,6 +329,7 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
         extra_exec: vec![],
         extra_readable: vec![],
         extra_writable: vec![],
+        extra_rwx: vec![],
         sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
         extra_env_passthrough: parse_env_passthrough(),
         env_overrides: vec![],
@@ -352,6 +371,25 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
                     std::process::exit(1);
                 }
             }
+            "--extra-rwx" => {
+                if i + 1 < args.len() {
+                    i += 2;
+                } else {
+                    eprintln!("harnx-mcp-bash: --extra-rwx requires a path argument");
+                    std::process::exit(1);
+                }
+            }
+            "--no-sandbox" => {
+                i += 1;
+            }
+            "--sandbox-run" => {
+                if i + 1 < args.len() {
+                    i += 2;
+                } else {
+                    eprintln!("harnx-mcp-bash: --sandbox-run requires a path argument");
+                    std::process::exit(1);
+                }
+            }
             "--env" | "-e" => {
                 if i + 1 < args.len() {
                     let raw = &args[i + 1];
@@ -386,6 +424,7 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
                 eprintln!("  --extra-read <path> Accept sandbox read-only path flag (ignored on this platform)");
                 eprintln!("  --extra-exec <path>     Accept sandbox execute path flag (ignored on this platform)");
                 eprintln!("  --extra-write <path>    Accept sandbox writable path flag (ignored on this platform)");
+                eprintln!("  --extra-rwx <path>      Accept sandbox read/write/exec path flag (ignored on this platform)");
                 eprintln!("  --env, -e <VAR>         Pass VAR from host env to child (repeatable)");
                 eprintln!("  --env, -e <VAR=VALUE>   Set VAR=VALUE in child env (repeatable)");
                 eprintln!("  --help, -h              Show this help message");

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -295,6 +295,8 @@ pub struct SandboxConfig {
     pub extra_readable: Vec<PathBuf>,
     #[cfg_attr(not(unix), allow(dead_code))]
     pub extra_writable: Vec<PathBuf>,
+    #[cfg_attr(not(unix), allow(dead_code))]
+    pub extra_rwx: Vec<PathBuf>,
     /// Extra var names to pass through from host (allowlist additions).
     pub extra_env_passthrough: Vec<String>,
     /// Explicit overrides: KEY → VALUE (highest precedence).
@@ -433,6 +435,7 @@ impl BashServer {
                 extra_exec: vec![],
                 extra_readable: vec![],
                 extra_writable: vec![],
+                extra_rwx: vec![],
                 extra_env_passthrough: vec![],
                 env_overrides: vec![],
                 sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
@@ -634,10 +637,23 @@ impl BashServer {
             writable_paths.push(path.clone());
         }
 
+        for path in &self.inner.sandbox_config.extra_rwx {
+            args.push(OsString::from("--read"));
+            args.push(path.clone().into_os_string());
+            args.push(OsString::from("--write"));
+            args.push(path.clone().into_os_string());
+            args.push(OsString::from("--exec"));
+            args.push(path.clone().into_os_string());
+            readable_paths.push(path.clone());
+            writable_paths.push(path.clone());
+        }
+
         match outputs {
             None => {
                 for root in roots {
                     args.push(OsString::from("--write"));
+                    args.push(root.clone().into_os_string());
+                    args.push(OsString::from("--exec"));
                     args.push(root.clone().into_os_string());
                     writable_paths.push(root.clone());
                 }
@@ -646,6 +662,8 @@ impl BashServer {
                 if !inputs_explicit_empty {
                     for root in roots {
                         args.push(OsString::from("--read"));
+                        args.push(root.clone().into_os_string());
+                        args.push(OsString::from("--exec"));
                         args.push(root.clone().into_os_string());
                         readable_paths.push(root.clone());
                     }
@@ -656,6 +674,10 @@ impl BashServer {
                     args.push(OsString::from("--write"));
                     args.push(path.clone().into_os_string());
                     writable_paths.push(path.clone());
+                }
+                for root in roots {
+                    args.push(OsString::from("--exec"));
+                    args.push(root.clone().into_os_string());
                 }
             }
         }
@@ -2489,6 +2511,7 @@ mod tests {
             extra_exec: vec![],
             extra_readable: vec![],
             extra_writable: vec![],
+            extra_rwx: vec![],
             extra_env_passthrough: vec![],
             env_overrides: vec![],
             sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
@@ -2512,6 +2535,7 @@ mod tests {
                 extra_exec: vec![],
                 extra_readable: vec![],
                 extra_writable: vec![],
+                extra_rwx: vec![],
                 extra_env_passthrough: vec![],
                 env_overrides: vec![],
                 sandbox_run_path: sandbox_run_test_path(),
@@ -2718,6 +2742,37 @@ mod tests {
         let pairs = collect_arg_pairs(&args);
 
         assert!(pairs.contains(&("--write".into(), "/custom/writable".into())));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_sandbox_args_extra_rwx() {
+        let mut config = enabled_sandbox_config();
+        config.extra_rwx.push(PathBuf::from("/custom/rwx"));
+        let server = BashServer::new_with_sandbox(vec![PathBuf::from("/test/root")], config);
+        let args = server.build_sandbox_args(
+            Path::new("/custom/rwx/workdir"),
+            None,
+            None,
+            &[PathBuf::from("/test/root")],
+        );
+        let pairs = collect_arg_pairs(&args);
+
+        assert!(pairs.contains(&("--read".into(), "/custom/rwx".into())));
+        assert!(pairs.contains(&("--write".into(), "/custom/rwx".into())));
+        assert!(pairs.contains(&("--exec".into(), "/custom/rwx".into())));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_sandbox_args_roots_get_exec() {
+        let root = PathBuf::from("/test/root");
+        let server = BashServer::new_with_sandbox(vec![root.clone()], enabled_sandbox_config());
+        let args = server.build_sandbox_args(Path::new("/test/root/workdir"), None, None, &[root]);
+        let pairs = collect_arg_pairs(&args);
+
+        assert!(pairs.contains(&("--write".into(), "/test/root".into())));
+        assert!(pairs.contains(&("--exec".into(), "/test/root".into())));
     }
 
     #[cfg(all(unix, target_os = "linux"))]

--- a/docs/bash-mcp-server.md
+++ b/docs/bash-mcp-server.md
@@ -90,8 +90,9 @@ On Linux and macOS, `harnx-mcp-bash` uses [birdcage](https://github.com/phylum-d
 
 ### Default Permissions
 
+- **Read/Write/Execute**:
+  - The repository root(s) specified via `--root`. This allows agents to run compilers (like `cargo build`) and load native extensions built within the project.
 - **Writable**:
-  - The repository root(s) specified via `--root`.
   - The system temporary directory (`/tmp` on Linux, `/private/tmp` on macOS).
   - The path in the `$TMPDIR` environment variable, if set.
 - **Readable/Executable**:
@@ -103,14 +104,15 @@ You can grant additional filesystem access using CLI flags or environment variab
 
 | CLI Flag | Environment Variable | Description |
 |----------|----------------------|-------------|
-| `--root <path>` | (N/A) | Adds a project root (writable). |
+| `--root <path>` | (N/A) | Adds a project root (read/write/exec). |
 | `--extra-read <path>` | `HARNX_BASH_EXTRA_READABLE` | Adds a path as read-only. |
 | `--extra-write <path>` | `HARNX_BASH_EXTRA_WRITABLE` | Adds a path as writable. |
 | `--extra-exec <path>` | `HARNX_BASH_EXTRA_EXEC` | Adds a path to the execution allowlist. |
+| `--extra-rwx <path>` | `HARNX_BASH_EXTRA_RWX` | Adds a path with read, write, and execute permissions. |
 
 **Notes:**
 - CLI flags can be repeated to add multiple paths.
-- Environment variables accept a colon-separated list of paths (e.g., `HARNX_BASH_EXTRA_READABLE=/path/one:/path/two`).
+- Environment variables accept a colon-separated list of paths (e.g., `HARNX_BASH_EXTRA_RWX=/path/one:/path/two`). This applies to all `HARNX_BASH_EXTRA_*` variables.
 
 ### Disabling Sandboxing
 
@@ -174,4 +176,9 @@ args: ["--extra-write", "~/.npm"]
 #### Read-only cargo registry
 ```yaml
 args: ["--extra-read", "~/.cargo/registry"]
+```
+
+#### Allow cargo registry proc-macros to be loaded (dlopen) by rustc
+```yaml
+args: ["--extra-rwx", "~/.cargo"]
 ```

--- a/docs/solutions/workflow-issues/sandbox-path-tilde-expansion-cross-platform-2026-04-29.md
+++ b/docs/solutions/workflow-issues/sandbox-path-tilde-expansion-cross-platform-2026-04-29.md
@@ -1,10 +1,10 @@
 ---
-title: "Tilde Expansion and Cross-Platform CLI Patterns for Sandbox Path Flags"
+title: "Sandbox Path Configuration: Tilde Expansion, Cross-Platform Flags, and Executable Roots"
 date: 2026-04-29
 category: workflow-issues
 problem_type: workflow_issue
 component: harnx-mcp-bash
-root_cause: "Incomplete application of tilde expansion across CLI and env-var paths; inconsistent non-Unix flag handling"
+root_cause: "Incomplete application of tilde expansion; inconsistent non-Unix flag handling; missing exec permission on sandbox roots"
 resolution_type: code_fix
 severity: medium
 tags:
@@ -13,16 +13,29 @@ tags:
   - cli-parsing
   - environment-variables
   - tilde-expansion
-plan_ref: harnx-sandbox-extra-write-tempdir-tilde
+  - proc-macros
+  - dlopen
+plan_ref: harnx-sandbox-roots-exec-extra-rwx
+last_updated: 2026-04-29
 ---
 
 ## Problem
 
 When adding `--extra-write`, `--extra-read`, `--extra-exec` path flags and their corresponding environment variables to `harnx-mcp-bash`, tilde expansion implementation was incomplete and non-Unix platforms lacked proper consume-and-ignore handling for cross-platform config compatibility.
 
+Additionally, sandbox roots lacked execute permission, causing compiler toolchains and native extension loaders (e.g., Rust proc-macros, Python `.so` files) to fail with `dlopen` errors when running inside the sandbox.
+
 ## Symptoms
 
 - `HARNX_BASH_EXTRA_WRITABLE=~/.cache` passed literal `~/.cache` to sandbox instead of expanding via `$HOME`
+- Non-Unix platforms crashed with "unknown argument" when parsing shared config files containing sandbox flags
+- **`cargo build` failed with `dlopen` errors for proc-macro `.so` files inside sandbox roots**:
+  ```
+  error: proc-macro derive produced error
+  error: could not open proc-macro library: Permission denied
+  ```
+- **Native extensions (`.so`, `.dylib`) failed to load when built inside project root**
+- **`--sandbox-run ~/bin/helper` failed to find helper binary** (tilde not expanded)
 - Non-Unix (Windows) builds crashed with "unknown argument" for `--extra-read` and `--extra-exec` even though these flags were documented for shared configs
 - Missing patterns in code review: `parse_env_paths()` lacked tilde expansion, incomplete non-Unix ignore handlers
 - Changeset claimed tilde support for "corresponding environment variables" but implementation only covered CLI flags
@@ -33,12 +46,20 @@ When adding `--extra-write`, `--extra-read`, `--extra-exec` path flags and their
 2. Code review identified: `parse_env_paths()` (lines 53-61) used `split_paths()` but never applied `expand_tilde()` to results
 3. Review also found: non-Unix parser only special-cased `--extra-write`, leaving sibling sandbox flags to hit "unknown argument" fallback
 4. Root cause: author implemented CLI path flow carefully, then missed parallel env/non-Unix compatibility surfaces
+5. **User reported: `cargo build` inside sandbox failed with dlopen errors loading proc-macro `.so` files**
+6. **Traced to: sandbox roots had write permission but not exec permission, blocking dynamic library loading**
+7. **Second review found: `--sandbox-run` flag also missing tilde expansion; legacy flags (`--no-sandbox`, `--sandbox-run`) not ignored on non-Unix**
 
 ## Root Cause
 
 **Tilde expansion gap:** `parse_env_paths()` function parsed environment variable paths via `std::env::split_paths()` and returned them unchanged. The `expand_tilde()` helper was only called in CLI flag match arms.
 
-**Non-Unix parity gap:** Cross-platform config compatibility requires accepting sandbox-only flags on non-sandbox platforms (Windows). Only `--extra-write` had a consume-and-ignore handler; `--extra-read` and `--extra-exec` fell through to the unknown-argument error path.
+**Non-Unix parity gap:** Cross-platform config compatibility requires accepting sandbox-only flags on non-sandbox platforms (Windows). Only `--extra-write` had a consume-and-ignore handler; `--extra-read`, `--extra-exec`, `--no-sandbox`, and `--sandbox-run` fell through to the unknown-argument error path.
+
+**Sandbox roots lacking exec permission:** When a sandbox hosts a compiler toolchain (e.g., Cargo building Rust code), the compiler writes `.so`/`.dylib` files into the project root and then attempts to `dlopen` them. Sandbox roots only had write permission — not execute permission — causing the `dlopen` to fail with "Permission denied". This breaks:
+- Rust proc-macros compiled as `.so` files and loaded by `rustc`
+- Python native extensions (`.so`) imported during test runs
+- Any JIT compiler or plugin loader that writes code then maps it executable
 
 ## Solution
 
@@ -108,9 +129,119 @@ fn parse_env_paths(var_name: &str) -> Vec<PathBuf> {
 **Key insight:** Consume-and-ignore must:
 1. Increment `i` by 2 (flag + value) to avoid desynchronizing argv parsing
 2. Still validate that a value argument exists (error on missing value)
-3. Apply to ALL sandbox-only flags, not just one
+3. Apply to ALL sandbox-only flags, not just new ones
 
-### 3. Platform-specific default paths via `#[cfg]` helper
+**Critical completeness rule:** When adding a new sandbox flag on Unix, you MUST add a consume-and-ignore handler on the non-Unix branch. Otherwise shared configs crash on Windows. This applies to legacy flags too — `--no-sandbox` and `--sandbox-run` were forgotten in the initial implementation.
+
+**Update to include all sandbox flags (main.rs non-Unix branch):**
+```rust
+"--extra-rwx" => {
+    if i + 1 < args.len() {
+        i += 2;
+    } else {
+        eprintln!("harnx-mcp-bash: --extra-rwx requires a path argument");
+        std::process::exit(1);
+    }
+}
+"--no-sandbox" => {
+    i += 1;  // flag only, no value
+}
+"--sandbox-run" => {
+    if i + 1 < args.len() {
+        i += 2;
+    } else {
+        eprintln!("harnx-mcp-bash: --sandbox-run requires a path argument");
+        std::process::exit(1);
+    }
+}
+```
+
+### 3. Grant execute permission on sandbox roots for compiler toolchains
+
+**The failure mode:** Compilers like `cargo build` write compiled artifacts (`.so`, `.dylib`) into the project directory, then immediately attempt to load them via `dlopen` for proc-macros, native extensions, or JIT code. If the sandbox grants write but not execute on the root, the `dlopen` fails:
+
+```
+error: could not open proc-macro library: Permission denied
+```
+
+**Fix in build_sandbox_args (server.rs:652-686):**
+
+```rust
+// In outputs: None branch (default full access)
+for root in roots {
+    args.push(OsString::from("--write"));
+    args.push(root.clone().into_os_string());
+    args.push(OsString::from("--exec"));
+    args.push(root.clone().into_os_string());
+}
+
+// In outputs: Some([]) and outputs: Some(paths) branches
+// Grant read+exec to roots so compilers can dlopen built artifacts
+for root in roots {
+    args.push(OsString::from("--read"));
+    args.push(root.clone().into_os_string());
+    args.push(OsString::from("--exec"));
+    args.push(root.clone().into_os_string());
+}
+```
+
+**Pattern:** Any sandbox hosting a compiler toolchain must grant exec on writable directories where the compiler will produce loadable artifacts.
+
+### 4. `--extra-rwx` for paths needing full read/write/execute access
+
+**When to use vs separate flags:**
+- `--extra-rwx ~/.cargo` — Cargo registries contain `.crate` archives (read), build scripts write to target dirs (write), and proc-macros are loaded via dlopen (exec)
+- `--extra-write` + `--extra-exec` — Use when a path needs write+exec but NOT read (rare; usually exec implies read)
+- `--extra-read` + `--extra-exec` — Use when a path has pre-built binaries that shouldn't be modified
+
+**Implementation (main.rs Unix branch):**
+```rust
+"--extra-rwx" => {
+    if i + 1 < args.len() {
+        sandbox_config
+            .extra_rwx
+            .push(PathBuf::from(expand_tilde(&args[i + 1])));
+        i += 2;
+    } else {
+        eprintln!("harnx-mcp-bash: --extra-rwx requires a path argument");
+        std::process::exit(1);
+    }
+}
+```
+
+**In build_sandbox_args (server.rs:640-646):**
+```rust
+for path in &self.sandbox_config.extra_rwx {
+    args.push(OsString::from("--read"));
+    args.push(path.clone().into_os_string());
+    args.push(OsString::from("--write"));
+    args.push(path.clone().into_os_string());
+    args.push(OsString::from("--exec"));
+    args.push(path.clone().into_os_string());
+    readable_paths.push(path.clone());
+    writable_paths.push(path.clone());
+}
+```
+
+### 5. Tilde expansion for `--sandbox-run` helper path
+
+**The gap:** All other path flags used `expand_tilde()`, but `--sandbox-run` was missed:
+
+```rust
+// BEFORE: literal ~/bin/helper fails
+"--sandbox-run" => {
+    sandbox_run_override = Some(PathBuf::from(&args[i + 1]));  // BUG: no tilde expansion
+    i += 2;
+}
+
+// AFTER: correctly expands home directory
+"--sandbox-run" => {
+    sandbox_run_override = Some(PathBuf::from(expand_tilde(&args[i + 1])));
+    i += 2;
+}
+```
+
+### 6. Platform-specific default paths via `#[cfg]` helper
 
 **system_writable_paths() pattern (server.rs:372-393):**
 ```rust
@@ -196,9 +327,13 @@ fn test_expand_tilde_replaces_prefix() {
 
 **Tilde expansion in both sites:** Environment variables are parsed before CLI flags are fully processed. Missing expansion there means `HARNX_BASH_EXTRA_WRITABLE=~/.cache` creates a `PathBuf` from literal string, which sandbox interprets as relative path starting with `~`.
 
-**Consume-and-ignore parity:** Shared config files (e.g., dotfiles, team-wide configs) may include sandbox flags. On non-Unix platforms without sandbox support, these must be accepted to prevent startup failure. The `i += 2` pattern prevents the next flag from being misread as the value argument.
+**Consume-and-ignore completeness:** Shared config files (e.g., dotfiles, team-wide configs) may include sandbox flags. On non-Unix platforms without sandbox support, these must be accepted to prevent startup failure. The `i += 2` pattern prevents the next flag from being misread as the value argument. Legacy flags like `--no-sandbox` and `--sandbox-run` must also be handled — adding a new sandbox flag on Unix requires remembering the non-Unix counterpart.
 
 **Platform-specific defaults:** System temp directories differ by OS. The `#[cfg]` helper pattern ensures compile-time correctness without runtime branching overhead.
+
+**Roots require exec for compilers:** Compiler toolchains (Cargo, rustc) write `.so`/`.dylib` artifacts and immediately `dlopen` them for proc-macros. Granting write but not execute on sandbox roots causes "Permission denied" at the dlopen step, even though the file exists and is readable. The fix grants `--exec` alongside `--write` on roots.
+
+**`--extra-rwx` convenience:** Paths like `~/.cargo` need all three permissions (read crates, write build artifacts, exec proc-macros). A single flag is less error-prone than repeating the path three times.
 
 **Test isolation:** `std::env::set_var` is unsafe and process-global. Mutex ensures no concurrent tests mutate env vars simultaneously. RAII pattern guarantees restoration even if test panics.
 
@@ -206,16 +341,31 @@ fn test_expand_tilde_replaces_prefix() {
 
 **Test Cases:**
 - Add tests for `parse_env_paths()` with tilde-prefixed paths
-- Add tests asserting all sandbox flags are consumed on non-Unix without error
+- Add tests asserting all sandbox flags (including legacy) are consumed on non-Unix without error
 - Test with `HOME` unset to verify graceful fallback
+- Add test asserting roots get `--exec` flag in sandbox args
+- Add test asserting `extra_rwx` paths get all three permission flags
 
 **Best Practices:**
 - When implementing path transformations, search for ALL sites where paths enter the system (CLI, env vars, config files)
-- For cross-platform flags, maintain a checklist of all related flags needing consume-and-ignore handlers
+- For cross-platform flags, maintain a checklist of ALL related flags needing consume-and-ignore handlers, including legacy ones
 - Use `grep` or AST tools to verify all call sites receive transformation
+- When granting write permission on a directory, ask: "Will anything need to execute files written here?" If yes, grant exec too.
+- Sandbox roots hosting compiler toolchains always need exec permission
 
 **Code Review Checklist:**
 - [ ] Are CLI flags and env vars handled consistently?
-- [ ] Does non-Unix parser consume-and-ignore ALL sandbox-only flags?
+- [ ] Does non-Unix parser consume-and-ignore ALL sandbox-only flags (new AND legacy)?
 - [ ] Are platform-specific defaults cleanly separated via `#[cfg]`?
 - [ ] Do tests serialize env mutations and restore original values?
+- [ ] Do sandbox roots get exec permission, not just write?
+- [ ] Have all path-bearing flags been checked for tilde expansion?
+
+**Windows Consume-and-Ignore Completeness Rule:**
+
+When adding a new Unix-only sandbox flag, check the non-Unix `parse_args` branch. The checklist of flags to ignore must remain complete. Example flags requiring consume-and-ignore on non-Unix:
+- `--extra-read`, `--extra-write`, `--extra-exec`, `--extra-rwx` (value-bearing)
+- `--no-sandbox`, `--sandbox-run` (legacy, easy to forget)
+- `--root`, `--sandbox-run` path argument (value-bearing)
+
+Missing any of these causes "unknown argument" crash on Windows when using shared configs.


### PR DESCRIPTION
Improves the harnx-mcp-bash filesystem sandbox by automatically granting execute permissions to sandbox roots, which resolves permission errors when loading native extensions or running compiler toolchains. Introduces the --extra-rwx CLI flag and HARNX_BASH_EXTRA_RWX environment variable to allow adding paths with full read, write, and execute permissions to the sandbox.

Additionally, this change ensures that all path-related configuration (roots, extra permissions, and the sandbox helper path) support tilde expansion, and improves cross-platform compatibility by ensuring that sandbox flags (including legacy ones) are safely ignored on non-Unix platforms.

Plan: harnx-sandbox-roots-exec-extra-rwx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `--extra-rwx <path>` CLI flag and `HARNX_BASH_EXTRA_RWX` environment variable to grant additional read/write/execute access to external paths.

* **Bug Fixes**
  * Sandbox roots now have execute permissions by default, enabling in-tree build steps and native extension loading.

* **Documentation**
  * Updated documentation with new sandboxing recipes and guidance for managing external path permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->