### PR TITLE
Fix pending messages ignored after session resume or interrupt

### DIFF
--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -865,6 +865,19 @@ pub fn add_tool_results(session: &mut Session, results: &[crate::tool::ToolResul
     Ok(())
 }
 
+/// Returns `true` when `input` is a genuine tool-call continuation of
+/// `session` — i.e. the session's last message is a `Tool` result AND
+/// the input carries accumulated tool-call results from `merge_tool_results`.
+///
+/// Used in both `begin_turn` (persistence) and `build_messages` (wire
+/// format) so that future edits to the heuristic only need to happen
+/// in one place.  Fixes #390: without the `tool_calls.is_some()` guard,
+/// a fresh user prompt arriving after an interrupted/resumed session that
+/// ended with a `Tool` message was silently dropped.
+fn is_tool_continuation(input: &Input, messages: &[Message]) -> bool {
+    input.tool_calls.is_some() && messages.last().is_some_and(|m| m.role == MessageRole::Tool)
+}
+
 /// Shared round-opening setup used by both `add_assistant_text` and
 /// `add_tool_calls`: first-turn agent-message injection, user-message
 /// push (skipped on continuation rounds), data-URL persistence, and
@@ -872,13 +885,7 @@ pub fn add_tool_results(session: &mut Session, results: &[crate::tool::ToolResul
 /// append succeeded.
 fn begin_turn(session: &mut Session, input: &Input, output: &str) -> Result<bool> {
     let mut all_appended = true;
-    // Detect continuation rounds: if the last saved message is a Tool
-    // message, we're continuing after tool execution and should NOT
-    // add a duplicate user message.
-    let is_continuation = session
-        .messages
-        .last()
-        .is_some_and(|m| m.role == MessageRole::Tool);
+    let is_continuation = is_tool_continuation(input, &session.messages);
     if session.messages.is_empty() {
         if session.name == TEMP_SESSION_NAME && session.save_session != Some(false) {
             let raw_input = input.raw();
@@ -979,14 +986,9 @@ pub fn build_messages(session: &Session, input: &Input) -> Result<Vec<Message>> 
             messages.extend(session.compressed_messages[index..].to_vec());
         }
     }
-    // Continuation: if the last saved message is a pending Tool round,
-    // we're mid-tool-round (the agent loop is iterating with the same
-    // `Input`). The user's original message is already in the session,
-    // so don't append a duplicate copy at the end — that fooled the
-    // model into treating each round as a fresh user re-ask and looping
-    // on "Let me look at the current state…". Mirrors the same heuristic
-    // `begin_turn` uses when saving the round.
-    if need_add_msg && messages.last().is_some_and(|m| m.role == MessageRole::Tool) {
+    // Continuation: suppress the duplicate user message only when the
+    // input is genuinely mid-tool-round — see `is_tool_continuation`.
+    if need_add_msg && is_tool_continuation(input, &messages) {
         need_add_msg = false;
     }
     if need_add_msg {
@@ -1117,7 +1119,11 @@ mod tests {
 
         // Now a second round with a plain text reply — continuation
         // detection should skip the duplicate user message.
-        let input2 = crate::config::input::from_str(&global_config, "hello", Some(agent));
+        // The agent loop always calls merge_tool_results before the next
+        // LLM call (setting tool_calls on the input), so the continuation
+        // input must carry those tool results to be recognised as a
+        // mid-round continuation rather than a fresh user prompt.
+        let input2 = input.merge_tool_results("I'll call a tool".to_string(), None, results);
         super::add_assistant_text(&mut session, &input2, "final answer", None).unwrap();
 
         let user_count = session
@@ -1132,6 +1138,122 @@ mod tests {
         assert_eq!(
             session.messages.last().unwrap().content.to_text(),
             "final answer"
+        );
+    }
+
+    /// Regression test for #390: a fresh user message sent after a
+    /// session that ended with a Tool message (e.g. Ctrl-C mid-round,
+    /// then resume) must NOT be dropped.
+    ///
+    /// Old code: `build_messages` checked only `last.role == Tool` →
+    /// treated a fresh prompt as a continuation and suppressed the
+    /// user message entirely.
+    ///
+    /// Fixed: also requires `input.tool_calls.is_some()`.
+    #[test]
+    fn fresh_message_after_tool_tail_is_included_in_build_messages() {
+        use crate::tool::{ToolCall, ToolResult};
+        use serde_json::json;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let mut session = test_session();
+        session.set_sessions_dir(tmp.path().to_path_buf());
+
+        let config = Config::default();
+        let agent = config.extract_agent();
+        let global_config = std::sync::Arc::new(parking_lot::RwLock::new(config.clone()));
+
+        // Build a session that ends with a Tool message (simulates
+        // an interrupted session or one resumed after Ctrl-C).
+        let input1 =
+            crate::config::input::from_str(&global_config, "original query", Some(agent.clone()));
+        let call = ToolCall {
+            name: "Bash".to_string(),
+            arguments: json!({"command": "ls"}),
+            id: Some("c1".to_string()),
+            thought_signature: None,
+        };
+        let result = ToolResult::new(call.clone(), json!({"stdout": "file1\n"}));
+        super::add_tool_calls(&mut session, &input1, "running bash", None, &[call]).unwrap();
+        super::add_tool_results(&mut session, &[result]).unwrap();
+        assert_eq!(
+            session.messages.last().unwrap().role,
+            MessageRole::Tool,
+            "session tail must be Tool to exercise the regression"
+        );
+
+        // Now simulate a fresh user message (no tool_calls on the input —
+        // this is the post-interrupt / post-resume scenario from #390).
+        let fresh_input = crate::config::input::from_str(
+            &global_config,
+            "new message after interrupt",
+            Some(agent),
+        );
+        assert!(
+            fresh_input.tool_calls.is_none(),
+            "fresh input must have no tool_calls"
+        );
+
+        let messages = super::build_messages(&session, &fresh_input).unwrap();
+
+        // The fresh user message must appear in the built message list.
+        let user_messages: Vec<_> = messages.iter().filter(|m| m.role.is_user()).collect();
+        assert!(
+            user_messages
+                .iter()
+                .any(|m| m.content.to_text().contains("new message after interrupt")),
+            "fresh user message must be included; got messages: {messages:#?}"
+        );
+    }
+
+    /// Regression test for #390 (persistence side): `begin_turn` must
+    /// persist a fresh user message even when the session tail is Tool.
+    #[test]
+    fn fresh_message_after_tool_tail_is_saved_by_begin_turn() {
+        use crate::tool::{ToolCall, ToolResult};
+        use serde_json::json;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let mut session = test_session();
+        session.set_sessions_dir(tmp.path().to_path_buf());
+
+        let config = Config::default();
+        let agent = config.extract_agent();
+        let global_config = std::sync::Arc::new(parking_lot::RwLock::new(config.clone()));
+
+        // Build a session ending in a Tool message.
+        let input1 =
+            crate::config::input::from_str(&global_config, "original query", Some(agent.clone()));
+        let call = ToolCall {
+            name: "Bash".to_string(),
+            arguments: json!({"command": "ls"}),
+            id: Some("c2".to_string()),
+            thought_signature: None,
+        };
+        let result = ToolResult::new(call.clone(), json!({"stdout": "file1\n"}));
+        super::add_tool_calls(&mut session, &input1, "running bash", None, &[call]).unwrap();
+        super::add_tool_results(&mut session, &[result]).unwrap();
+
+        // Fresh message (no tool_calls) — `add_assistant_text` calls
+        // `begin_turn` internally.
+        let fresh_input =
+            crate::config::input::from_str(&global_config, "follow-up after resume", Some(agent));
+        super::add_assistant_text(&mut session, &fresh_input, "here is my reply", None).unwrap();
+
+        // The follow-up user message must have been saved to the session.
+        let user_messages: Vec<_> = session
+            .messages
+            .iter()
+            .filter(|m| m.role.is_user())
+            .collect();
+        assert!(
+            user_messages
+                .iter()
+                .any(|m| m.content.to_text().contains("follow-up after resume")),
+            "fresh user message must be persisted; messages: {:#?}",
+            session.messages
         );
     }
 
@@ -1274,6 +1396,60 @@ mod tests {
         assert!(
             output_str.contains("tool response lost"),
             "expected synthesized lost-response error, got: {output_str}"
+        );
+    }
+
+    /// Regression test for #390 (orphan-repair path): after a crash
+    /// mid-tool-round the session is repaired on reload (orphan tool
+    /// calls get a synthesised "lost" result so the tail is a proper
+    /// `Tool` message).  A fresh user prompt sent to that repaired
+    /// session must still be included in `build_messages` — not dropped
+    /// because the session tail happens to be `Tool`.
+    #[test]
+    fn fresh_message_after_orphan_repair_is_included_in_build_messages() {
+        use crate::tool::ToolCall;
+        use serde_json::json;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let mut session = test_session();
+        session.set_sessions_dir(tmp.path().to_path_buf());
+
+        let config = Config::default();
+        let agent = config.extract_agent();
+        let global_config = std::sync::Arc::new(parking_lot::RwLock::new(config.clone()));
+        let input = crate::config::input::from_str(&global_config, "first query", Some(agent));
+
+        // Write tool_calls but NOT tool_results — simulates crash mid-round.
+        let call = ToolCall {
+            name: "Bash".to_string(),
+            arguments: json!({"command": "ls"}),
+            id: Some("orphan_c1".to_string()),
+            thought_signature: None,
+        };
+        super::add_tool_calls(&mut session, &input, "running bash", None, &[call]).unwrap();
+
+        // Reload — orphan repair synthesises a lost-response Tool tail.
+        let content = std::fs::read_to_string(session.path.as_ref().unwrap()).unwrap();
+        let repaired = super::load_from_log_for_test(&content);
+        assert_eq!(
+            repaired.messages.last().unwrap().role,
+            MessageRole::Tool,
+            "repaired session tail must be Tool"
+        );
+
+        // Fresh user prompt after resume — no tool_calls on the input.
+        let fresh_input =
+            crate::config::input::from_str(&global_config, "fresh prompt after crash", None);
+        let messages = super::build_messages(&repaired, &fresh_input).unwrap();
+
+        assert!(
+            messages
+                .iter()
+                .filter(|m| m.role.is_user())
+                .any(|m| m.content.to_text().contains("fresh prompt after crash")),
+            "fresh user message must be included in build_messages after orphan repair; \
+             got: {messages:#?}"
         );
     }
 
@@ -1534,10 +1710,26 @@ mod tests {
 
         // session.messages now ends with a Tool message — that's the
         // signal that we're mid-tool-round. The next agent_loop iteration
-        // calls build_messages with the *same* input.
+        // calls `merge_tool_results` on the input to carry the tool-call
+        // context, then calls `build_messages` with that merged input.
         assert_eq!(session.messages.last().unwrap().role, MessageRole::Tool);
 
-        let messages = super::build_messages(&session, &input).unwrap();
+        let result = ToolResult::new(
+            ToolCall {
+                name: "Read".to_string(),
+                arguments: json!({"path": "/tmp/x"}),
+                id: Some("toolu_round1".to_string()),
+                thought_signature: None,
+            },
+            json!({"content": "file body"}),
+        );
+        let merged_input = input.merge_tool_results(
+            "Let me look at the directory.".to_string(),
+            None,
+            vec![result],
+        );
+
+        let messages = super::build_messages(&session, &merged_input).unwrap();
 
         let user_text_count = messages
             .iter()

--- a/docs/solutions/logic-errors/fresh-message-tool-tail-heuristic-2026-04-30.md
+++ b/docs/solutions/logic-errors/fresh-message-tool-tail-heuristic-2026-04-30.md
@@ -1,0 +1,119 @@
+---
+title: "Fresh user messages silently ignored after tool-tail session state"
+date: 2026-04-30
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-runtime/session"
+root_cause: "overly-broad heuristic for tool-call continuation detection"
+resolution_type: code_fix
+severity: high
+tags:
+  - session-management
+  - tool-calls
+  - message-handling
+  - heuristic-bug
+  - interrupt-recovery
+plan_ref: "harnx-390-pending-messages-ignored"
+---
+
+## Problem
+
+User messages typed while the LLM was working — particularly after a Ctrl-C interrupt or when resuming a session that ended mid-tool-round — were silently ignored instead of being processed as fresh prompts.
+
+## Symptoms
+
+- User types a new message while LLM is processing tool calls
+- User presses Ctrl-C to interrupt
+- User types a fresh prompt
+- Fresh prompt is silently suppressed; session continues as if no input was received
+- Resuming a crashed/interrupted session that ended with a `Tool` message also suppresses fresh user input
+
+## Investigation Steps
+
+1. Observed that after Ctrl-C interrupt during tool execution, the session's message list ends with a `Tool` message (the last tool result before interrupt).
+
+2. Traced the message handling through `begin_turn()` and `build_messages()` in `crates/harnx-runtime/src/config/session.rs`.
+
+3. Found both functions used an overly-broad heuristic to detect "tool-call continuation" rounds:
+   ```rust
+   let is_continuation = session.messages.last().is_some_and(|m| m.role == MessageRole::Tool);
+   ```
+
+4. This single condition only checked whether the last message was a `Tool` message, but didn't distinguish between:
+   - Genuine tool continuations (agent loop calling `merge_tool_results()`)
+   - Fresh user prompts arriving after session state coincidentally matched the pattern
+
+5. Reviewed PR #361 (Bash tool inconsistencies fixups) which introduced the session-tail-Tool check to prevent duplicate user messages during multi-round tool loops. The single condition was correct for that use case but too broad.
+
+## Root Cause
+
+The continuation detection logic in `begin_turn()` and `build_messages()` used a single-condition heuristic:
+
+```rust
+// TOO BROAD — matches fresh prompts after interrupted tool rounds
+let is_continuation = session.messages.last().is_some_and(|m| m.role == MessageRole::Tool);
+```
+
+After an interrupt or session resume, the session might legitimately end with a `Tool` message even though the user is sending a **fresh** new prompt, not continuing a tool loop. The heuristic incorrectly classified these as continuations, causing fresh user messages to be suppressed.
+
+The missing signal: genuine tool continuations are always initiated by `merge_tool_results()` in the agent loop, which sets `input.tool_calls = Some(...)` on the input. Fresh user prompts never have `tool_calls` set.
+
+## Solution
+
+Added a second condition requiring `input.tool_calls.is_some()` to confirm genuine tool continuation:
+
+```rust
+fn is_tool_continuation(input: &Input, messages: &[Message]) -> bool {
+    input.tool_calls.is_some()
+        && messages
+            .last()
+            .is_some_and(|m| m.role == MessageRole::Tool)
+}
+```
+
+Extracted the heuristic into a private helper `is_tool_continuation(input, messages)` used in both `begin_turn()` and `build_messages()` to avoid duplication and ensure consistency.
+
+**Before (in both functions):**
+```rust
+let is_continuation = session.messages.last().is_some_and(|m| m.role == MessageRole::Tool);
+if is_continuation {
+    // skip adding user message
+}
+```
+
+**After:**
+```rust
+if is_tool_continuation(input, &session.messages) {
+    // skip adding user message — genuine tool continuation
+}
+```
+
+## Why This Works
+
+The dual condition correctly distinguishes:
+
+1. **Genuine tool continuations**: `tool_calls.is_some()` AND session ends with `Tool` message. These are mid-tool-loop iterations where the agent called `merge_tool_results()` to accumulate tool context. User message already present from original turn; skipping prevents duplicates.
+
+2. **Fresh prompts after tool-tail**: `tool_calls.is_none()` despite session ending with `Tool`. These are new user inputs after interrupts or session resumes. The `tool_calls` field is only populated by `merge_tool_results()` during active tool loops; fresh prompts never have it set.
+
+The `tool_calls` field serves as the authoritative signal that the agent loop is actively managing a tool continuation, eliminating false positives from coincidental session state.
+
+## Prevention Strategies
+
+**Test Cases:**
+- `fresh_message_after_tool_tail_is_included_in_build_messages` — verifies `build_messages` includes fresh user message when `tool_calls == None`
+- `fresh_message_after_tool_tail_is_saved_by_begin_turn` — verifies `begin_turn` persists fresh user message
+- `fresh_message_after_orphan_repair_is_included_in_build_messages` — verifies behavior for crash-interrupted sessions repaired on reload
+
+**Code Review Checklist:**
+- [ ] Do heuristics with multiple valid states use all necessary conditions?
+- [ ] Are edge cases (interrupts, crashes, resumes) considered in state-dependent logic?
+- [ ] Are continuation/interruption patterns tested explicitly?
+
+**Design Principle:**
+When a single-condition heuristic matches multiple semantically different states, add distinguishing signals. Coincidental state overlap is a common source of logic bugs in state machines.
+
+## Related Issues
+
+- **Issue:** [#390](https://github.com/example/harnx/issues/390) — Pending messages ignored after tool rounds
+- **PR #361:** Introduced the session-tail-Tool check to prevent duplicate user messages; single condition was correct for that use case but didn't account for fresh prompts after coincidental tool-tail state


### PR DESCRIPTION
Introduces a dual-condition heuristic is_tool_continuation to correctly distinguish between genuine tool-call continuations and fresh user prompts. Previously, if a session ended with a Tool message (due to an interrupt or crash), any subsequent user message was silently dropped because the logic assumed it was a continuation of the prior tool round.

The new logic requires both a Tool message tail in the session history AND accumulated tool-call results in the input to trigger continuation behavior.

[#390]

Plan: harnx-390-pending-messages-ignored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where fresh user messages were incorrectly suppressed after interrupting and resuming sessions with tool interactions.
  * Improved session message continuation logic to correctly distinguish between tool-call continuations and new user prompts.

* **Documentation**
  * Added documentation detailing session message handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->