### PR TITLE
fix(render): don't treat 4+-space-indented backticks as code fences

### DIFF
--- a/.changesets/fix-indented-backtick-code-fence.md
+++ b/.changesets/fix-indented-backtick-code-fence.md
@@ -1,0 +1,9 @@
+---
+harnx: patch
+---
+Fix markdown renderer incorrectly treating 4+-space-indented triple-backtick lines as code fences.
+
+Per the CommonMark spec, a fenced code block opener must have 0–3 spaces of indentation.
+Lines with 4+ leading spaces (e.g. indented Python code in a bash command) were previously
+being recognised as code block delimiters, causing the TUI to render subsequent lines as
+highlighted code instead of plain text. Fixes #403.

--- a/crates/harnx-render/src/markdown.rs
+++ b/crates/harnx-render/src/markdown.rs
@@ -280,7 +280,13 @@ fn blend_fg_color(fg: SyntectColor, bg: SyntectColor) -> SyntectColor {
 }
 
 fn detect_code_block(line: &str) -> Option<String> {
-    let line = line.trim_start();
+    // Per CommonMark spec, a fenced code block may be indented by 0–3 spaces.
+    // Four or more spaces of indentation means this is NOT a code fence.
+    let indent = line.chars().take_while(|c| *c == ' ').count();
+    if indent >= 4 {
+        return None;
+    }
+    let line = &line[indent..];
     if !line.starts_with("```") {
         return None;
     }
@@ -387,7 +393,37 @@ std::error::Error>> {
         assert_eq!(detect_code_block("```rust"), Some("rust".into()));
         assert_eq!(detect_code_block("```c++"), Some("c++".into()));
         assert_eq!(detect_code_block("  ```rust"), Some("rust".into()));
+        assert_eq!(detect_code_block("   ```rust"), Some("rust".into()));
         assert_eq!(detect_code_block("```"), Some("".into()));
         assert_eq!(detect_code_block("``rust"), None);
+        // 4+ spaces of indentation must NOT be treated as a code fence (CommonMark spec).
+        // This is the regression test for issue #403: bash command text containing
+        // indented lines with triple backticks was incorrectly toggling code-block state.
+        assert_eq!(detect_code_block("    ```"), None);
+        assert_eq!(detect_code_block("    ```python"), None);
+        assert_eq!(detect_code_block("        ```"), None);
+    }
+
+    /// Regression test for issue #403: bash output containing indented triple-backtick
+    /// sequences (e.g. from a Python heredoc) must not toggle code-block rendering state.
+    #[test]
+    fn indented_backticks_not_treated_as_code_fence() {
+        // Simulate the bash command display that triggered the bug: a multi-line Python
+        // snippet where some lines happen to start with 4-space-indented triple backticks.
+        let input = "Here is some text\n\
+                     \n\
+                     ```python\n\
+                     for block in blocks:\n\
+                         items = re.findall(r'```', block)\n\
+                         print(items)\n\
+                     ```\n\
+                     \n\
+                     After code.\n";
+
+        let options = RenderOptions::default();
+        let mut render = MarkdownRender::init(options).unwrap();
+        let output = render.render(input);
+        // The output must be identical to the input when there is no theme (no ANSI escapes).
+        assert_eq!(output, input);
     }
 }


### PR DESCRIPTION
Per the CommonMark spec a fenced code block opener may be preceded by 0–3 spaces of indentation; four or more spaces means the line is NOT a fence.  Previously `detect_code_block` called `trim_start()` which stripped all leading whitespace, so indented triple-backtick lines inside bash command output (e.g. Python code with 4-space indent) were incorrectly toggling the code-block state and causing subsequent lines to be rendered as highlighted code instead of plain text.

Fixes #403

Add regression tests:
- `test_detect_code_block`: asserts 0–3 spaces detected, 4+ spaces not
- `indented_backticks_not_treated_as_code_fence`: full render round-trip