### PR TITLE
fix: guard against divide-by-zero in need_rows_local when columns=0

### DIFF
--- a/crates/harnx/src/cli_event_sink.rs
+++ b/crates/harnx/src/cli_event_sink.rs
@@ -437,6 +437,9 @@ fn split_line_tail_local(text: &str) -> (&str, &str) {
 }
 
 fn need_rows_local(text: &str, columns: u16) -> u16 {
+    if columns == 0 {
+        return 0;
+    }
     let buffer_width = display_width(text).max(1) as u16;
     buffer_width.div_ceil(columns)
 }


### PR DESCRIPTION
When the terminal size query fails or hasn't been called yet, columns stays at its initial value of 0. Calling div_ceil(0) panics at runtime.

Guard: return 0 rows when columns == 0 (nothing can be rendered).

Fixes #407