### PR TITLE
fix(cli): handle CTRL-C and CTRL-D in non-TUI terminal mode

### DIFF
--- a/crates/harnx-spinner/src/lib.rs
+++ b/crates/harnx-spinner/src/lib.rs
@@ -167,6 +167,78 @@ pub fn spawn_spinner(message: &str) -> Spinner {
     spinner
 }
 
+/// A handle to a raw-mode key-event watcher started by
+/// [`spawn_raw_mode_key_watcher`].
+///
+/// Call [`stop`][RawModeKeyWatcher::stop] to signal the watcher to exit and
+/// wait for it to wind down.  The watcher loop polls in 25 ms slices, so
+/// shutdown completes within one poll interval.
+pub struct RawModeKeyWatcher {
+    /// Signals the watcher thread to exit on the next poll iteration.
+    stop: AbortSignal,
+    /// Keeps the `spawn_blocking` task alive for the duration of the watcher.
+    /// Dropped (and the task detached) when [`stop`][RawModeKeyWatcher::stop]
+    /// is called; the thread exits shortly after via the stop flag.
+    #[allow(dead_code)]
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl RawModeKeyWatcher {
+    /// Signal the watcher to exit on its next poll iteration and forget the
+    /// handle.  The thread exits within one 25 ms poll slice.
+    ///
+    /// This is deliberately non-blocking: it sets a stop flag and returns
+    /// immediately so the caller is not forced into an async context.  After
+    /// `raw_mode_active` is false, the watcher thread will see either the stop
+    /// flag or a crossterm error from the now-cooked terminal and exit cleanly.
+    pub fn stop(self) {
+        self.stop.set_ctrlc();
+        // The JoinHandle is intentionally dropped here; the thread exits on its
+        // own within the next poll interval (≤25 ms).
+    }
+}
+
+/// Spawn a background task that polls for raw-mode key events and translates
+/// Ctrl-C / Ctrl-D into `AbortSignal` flags.
+///
+/// In crossterm raw mode, pressing Ctrl-C does **not** deliver SIGINT to the
+/// process — the terminal driver is bypassed and the keystroke arrives as a
+/// key event instead.  Call this when raw mode is being enabled so that those
+/// keystrokes still cancel the active operation.
+///
+/// Returns a [`RawModeKeyWatcher`] whose [`stop`][RawModeKeyWatcher::stop]
+/// method signals the watcher thread to exit cleanly (within one 25 ms poll
+/// interval).  Returns `None` when stdout is not a terminal.
+///
+/// **Ownership note**: only one live instance of this watcher should exist at
+/// a time — crossterm's terminal event stream is a process-wide singleton, and
+/// two concurrent readers will race.  Stop the previous watcher before
+/// spawning a new one.
+pub fn spawn_raw_mode_key_watcher(abort_signal: AbortSignal) -> Option<RawModeKeyWatcher> {
+    if !is_stdout_terminal() {
+        return None;
+    }
+    let stop = harnx_core::abort::create_abort_signal();
+    let stop_clone = stop.clone();
+    let handle = tokio::task::spawn_blocking(move || {
+        loop {
+            // Exit if the operation was cancelled or the caller requested stop.
+            if abort_signal.aborted() || stop_clone.aborted() {
+                break;
+            }
+            // poll_abort_signal blocks for up to 25 ms waiting for a key
+            // event, then returns.  We run on spawn_blocking to avoid stalling
+            // the Tokio worker pool.
+            match poll_abort_signal(&abort_signal) {
+                Ok(true) => break, // signal set — we're done
+                Ok(false) => {}
+                Err(_) => break, // crossterm error — give up silently
+            }
+        }
+    });
+    Some(RawModeKeyWatcher { stop, handle })
+}
+
 pub async fn abortable_run_with_spinner<F, T>(
     task: F,
     message: &str,
@@ -245,10 +317,6 @@ async fn run_abortable_spinner(
                 spinner.clear_message()?;
             }
             Err(_) => {}
-        }
-
-        if poll_abort_signal(&abort_signal)? {
-            break;
         }
 
         spinner.step()?;

--- a/crates/harnx/src/agent_event_sink.rs
+++ b/crates/harnx/src/agent_event_sink.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 pub use harnx_core::sink::{has_agent_event_sink, install_agent_event_sink};
 
 use crate::cli_event_sink::CliAgentEventSink;
+use harnx_core::abort::AbortSignal;
 use harnx_render::RenderOptions;
 
 /// Install the stderr-backed `CliAgentEventSink`. Used by the CLI
@@ -27,8 +28,18 @@ use harnx_render::RenderOptions;
 /// and `RenderOptions` snapshot so the sink can render streaming
 /// Model::MessageChunk / ThoughtChunk events directly to stdout (with
 /// markdown rendering + raw-mode cursor manipulation on terminals).
-pub fn install_cli_agent_event_sink(highlight: bool, render_options: RenderOptions) {
-    install_agent_event_sink(Arc::new(CliAgentEventSink::new(highlight, render_options)));
+/// The `abort_signal` is used to forward Ctrl-C / Ctrl-D key events
+/// captured during crossterm raw mode back to the running command.
+pub fn install_cli_agent_event_sink(
+    highlight: bool,
+    render_options: RenderOptions,
+    abort_signal: AbortSignal,
+) {
+    install_agent_event_sink(Arc::new(CliAgentEventSink::new(
+        highlight,
+        render_options,
+        abort_signal,
+    )));
     debug_assert!(
         has_agent_event_sink(),
         "CLI AgentEventSink must be installed after startup call"

--- a/crates/harnx/src/cli_event_sink.rs
+++ b/crates/harnx/src/cli_event_sink.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, Mutex};
 use crossterm::{cursor, queue, style, terminal};
 use textwrap::core::display_width;
 
+use harnx_core::abort::AbortSignal;
 use harnx_core::event::{
     AgentEvent, AgentEventSink, AgentSource, ContentBlock, ModelEvent, NoticeEvent, ToolEvent,
     TurnEvent,
@@ -44,12 +45,17 @@ struct CliSinkState {
     buffer_rows: u16,
     columns: u16,
     raw_mode_active: bool,
+    /// Background task that polls raw-mode key events and wires Ctrl-C/Ctrl-D
+    /// to `abort_signal`.  Started when raw mode is enabled; stopped on cleanup.
+    key_watcher: Option<harnx_spinner::RawModeKeyWatcher>,
     highlight: bool,
     render_options: RenderOptions,
+    /// Propagates Ctrl-C / Ctrl-D key events from raw mode to the caller.
+    abort_signal: AbortSignal,
 }
 
 impl CliAgentEventSink {
-    pub fn new(highlight: bool, render_options: RenderOptions) -> Self {
+    pub fn new(highlight: bool, render_options: RenderOptions, abort_signal: AbortSignal) -> Self {
         Self {
             state: Arc::new(Mutex::new(CliSinkState {
                 spinner: None,
@@ -58,8 +64,10 @@ impl CliAgentEventSink {
                 buffer_rows: 1,
                 columns: 0,
                 raw_mode_active: false,
+                key_watcher: None,
                 highlight,
                 render_options,
+                abort_signal,
             })),
         }
     }
@@ -96,10 +104,26 @@ impl CliSinkState {
         if !self.raw_mode_active {
             crossterm::terminal::enable_raw_mode()?;
             self.raw_mode_active = true;
+            // In raw mode, Ctrl-C does not deliver SIGINT and Ctrl-D does not
+            // deliver EOF — both become raw key events.  Start a watcher that
+            // reads those key events and forwards them to the abort signal.
+            // The watcher is scoped to the raw-mode window and aborted in
+            // cleanup() when raw mode is disabled.
+            self.key_watcher = harnx_spinner::spawn_raw_mode_key_watcher(self.abort_signal.clone());
         }
         if self.render.is_none() {
-            self.render = Some(MarkdownRender::init(self.render_options.clone())?);
-            self.columns = crossterm::terminal::size()?.0;
+            // Any failure here happens after enable_raw_mode() — clean up raw
+            // mode (and the key watcher) before propagating the error so the
+            // terminal is not left in a corrupted state.
+            let init_result = (|| -> anyhow::Result<()> {
+                self.render = Some(MarkdownRender::init(self.render_options.clone())?);
+                self.columns = crossterm::terminal::size()?.0;
+                Ok(())
+            })();
+            if let Err(e) = init_result {
+                let _ = self.cleanup();
+                return Err(e);
+            }
         }
 
         let mut writer = stdout();
@@ -172,6 +196,12 @@ impl CliSinkState {
             spinner.stop();
         }
         if self.raw_mode_active {
+            // Signal the raw-mode key watcher to stop.  The watcher thread
+            // exits within one 25 ms poll slice after seeing the stop flag or
+            // a crossterm error from the now-cooked terminal.
+            if let Some(watcher) = self.key_watcher.take() {
+                watcher.stop();
+            }
             crossterm::terminal::disable_raw_mode()?;
             self.raw_mode_active = false;
         }
@@ -458,7 +488,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn emit_handles_each_top_level_variant_without_panic() {
-        let sink = CliAgentEventSink::new(false, RenderOptions::default());
+        let sink = CliAgentEventSink::new(
+            false,
+            RenderOptions::default(),
+            harnx_core::abort::create_abort_signal(),
+        );
 
         sink.emit(AgentEvent::Turn(TurnEvent::Started), None);
         sink.emit(
@@ -491,7 +525,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn status_event_starts_spinner_without_panic() {
-        let sink = CliAgentEventSink::new(false, RenderOptions::default());
+        let sink = CliAgentEventSink::new(
+            false,
+            RenderOptions::default(),
+            harnx_core::abort::create_abort_signal(),
+        );
         sink.emit(
             AgentEvent::Status(StatusLine {
                 text: "[test-model] generating".into(),
@@ -509,7 +547,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn status_event_updates_existing_spinner() {
-        let sink = CliAgentEventSink::new(false, RenderOptions::default());
+        let sink = CliAgentEventSink::new(
+            false,
+            RenderOptions::default(),
+            harnx_core::abort::create_abort_signal(),
+        );
         sink.emit(AgentEvent::Turn(TurnEvent::Started), None);
         sink.emit(
             AgentEvent::Status(StatusLine {
@@ -623,8 +665,10 @@ mod tests {
             buffer_rows: 1,
             columns: 0,
             raw_mode_active: false,
+            key_watcher: None,
             highlight,
             render_options: RenderOptions::default(),
+            abort_signal: harnx_core::abort::create_abort_signal(),
         }
     }
 

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -212,7 +212,11 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
                 let cfg = config.read();
                 (cfg.highlight, cfg.render_options().unwrap_or_default())
             };
-            agent_event_sink::install_cli_agent_event_sink(highlight, render_options);
+            agent_event_sink::install_cli_agent_event_sink(
+                highlight,
+                render_options,
+                abort_signal.clone(),
+            );
             let input = create_input(&config, text, &cli.file, abort_signal.clone()).await?;
             let mut async_manager = AsyncHookManager::new();
             let persistent_manager =

--- a/crates/harnx/src/test_utils/interrupt.rs
+++ b/crates/harnx/src/test_utils/interrupt.rs
@@ -248,6 +248,65 @@ fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
+/// Starts tmux + bash, exports `HARNX_CONFIG_DIR`, and launches harnx in
+/// one-shot (Cmd) mode with `prompt` as the argument.  Returns the harness
+/// immediately; the harnx process runs inside the pane and the exit code will
+/// appear as `HARNX_EXIT:<code>` when it finishes.
+///
+/// Use [`wait_for_cmd_exit`] to block until harnx exits and retrieve whether
+/// the exit was non-zero.
+///
+/// `repo_root` is used as the working directory for the tmux session; pass
+/// `PathBuf::from(env!("CARGO_MANIFEST_DIR"))` from the test.
+pub fn spawn_oneshot_in_tmux(
+    paths: &ConfigPaths,
+    harnx_bin: &Path,
+    prompt: &str,
+    repo_root: &Path,
+) -> Result<TmuxHarness> {
+    let tmux = TmuxHarness::new(repo_root, 120, 35).context("failed to create tmux session")?;
+    tmux.send_text(&format!(
+        "export HARNX_CONFIG_DIR={}\n",
+        shell_escape(&paths.harnx_config_dir.to_string_lossy())
+    ))?;
+    // "|| echo HARNX_EXIT:$?" prints a detectable sentinel when harnx exits
+    // non-zero (interrupted), making exit detection possible from pane capture.
+    tmux.send_text(&format!(
+        "{} {} || echo HARNX_EXIT:$?\n",
+        shell_escape(&harnx_bin.to_string_lossy()),
+        shell_escape(prompt),
+    ))?;
+    Ok(tmux)
+}
+
+/// Waits until `HARNX_EXIT:` appears in the tmux pane (indicating the harnx
+/// one-shot command has finished) and returns whether the exit was non-zero.
+/// Returns `Err` if the budget elapses without seeing the sentinel.
+pub fn wait_for_cmd_exit(tmux: &TmuxHarness, budget: Duration) -> Result<bool> {
+    let deadline = Instant::now() + budget;
+    loop {
+        let screen = tmux.capture_pane()?;
+        if let Some(line) = screen.lines().find(|l| l.contains("HARNX_EXIT:")) {
+            // "HARNX_EXIT:1" -> non-zero (interrupted); "HARNX_EXIT:0" -> success
+            let nonzero = line
+                .split("HARNX_EXIT:")
+                .nth(1)
+                .and_then(|s| s.split_whitespace().next())
+                .map(|code| code != "0")
+                .unwrap_or(true);
+            return Ok(nonzero);
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "HARNX_EXIT not seen in tmux pane after {:?}; last screen:\n{}",
+                budget,
+                screen
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
 /// A mock-LLM response that emits one short text chunk and immediately
 /// issues a `<agent_name>_session_prompt` tool call to delegate to a
 /// sub-agent via ACP.

--- a/crates/harnx/tests/engine_smoke.rs
+++ b/crates/harnx/tests/engine_smoke.rs
@@ -28,6 +28,7 @@ impl ProxySink {
             inner: harnx::cli_event_sink::CliAgentEventSink::new(
                 false,
                 harnx_render::RenderOptions::default(),
+                harnx_core::abort::create_abort_signal(),
             ),
             recorded: Arc::new(Mutex::new(vec![])),
         }

--- a/crates/harnx/tests/interrupt_e2e.rs
+++ b/crates/harnx/tests/interrupt_e2e.rs
@@ -13,9 +13,10 @@ use std::time::Duration;
 
 use harnx::test_utils::interrupt::{
     script_call_sub_agent, script_call_trivial_tool, script_call_wait_tool, script_stall_streaming,
-    script_streaming_with_sentinel, send_sigint, spawn_acp_client, spawn_oneshot, spawn_tui,
-    wait_for_exit, wait_for_prompt_return, write_acp_agent, write_minimal_config,
-    write_with_blocking_hook, write_with_sub_agent, write_with_wait_tool,
+    script_streaming_with_sentinel, send_sigint, spawn_acp_client, spawn_oneshot,
+    spawn_oneshot_in_tmux, spawn_tui, wait_for_cmd_exit, wait_for_exit, wait_for_prompt_return,
+    write_acp_agent, write_minimal_config, write_with_blocking_hook, write_with_sub_agent,
+    write_with_wait_tool,
 };
 use harnx::test_utils::mock_openai_server::MockOpenAiServer;
 use harnx::test_utils::tmux_harness::TmuxHarness;
@@ -541,5 +542,47 @@ fn interrupt_acp_sigint_cancels_and_exits() -> Result<()> {
     send_sigint(&child)?;
 
     let _status = wait_for_exit(&mut child, Duration::from_secs(2))?;
+    Ok(())
+}
+
+/// Verify that Ctrl-C cancels a one-shot (Cmd) prompt while streaming output
+/// is in progress and crossterm raw mode is active.
+///
+/// Unlike the existing `interrupt_oneshot_during_streaming` test (which sends
+/// `SIGINT` directly via `kill(2)`, bypassing the terminal), this test runs
+/// harnx inside a real tmux pane so that Ctrl-C is delivered as a terminal key
+/// event through crossterm's event stream — exactly as a real user would
+/// experience it.  If the raw-mode key watcher (`spawn_raw_mode_key_watcher`)
+/// is missing or broken, Ctrl-C is swallowed and this test times out.
+#[test]
+fn interrupt_cmd_raw_mode_ctrlc() -> Result<()> {
+    if !TmuxHarness::is_available() {
+        eprintln!("tmux unavailable; skipping interrupt_cmd_raw_mode_ctrlc");
+        return Ok(());
+    }
+
+    let mock = MockOpenAiServer::start(script_stall_streaming())?;
+    let tmp = tempfile::tempdir()?;
+    let paths = write_minimal_config(tmp.path(), &format!("http://127.0.0.1:{}/v1", mock.port()))?;
+    let harnx_bin = PathBuf::from(env!("CARGO_BIN_EXE_harnx"));
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let tmux = spawn_oneshot_in_tmux(&paths, &harnx_bin, "hello", &repo_root)?;
+
+    // Wait until at least the first streaming chunk ("Thinking") is visible
+    // in the pane — this means harnx has received data from the mock LLM and
+    // crossterm raw mode is active inside CliAgentEventSink.
+    tmux.wait_for_contains("Thinking", Duration::from_secs(10))?;
+
+    // Send Ctrl-C as a real terminal key event (not SIGINT).  In raw mode
+    // this is the only reliable way to interrupt the process.
+    tmux.send_keys(&["C-c"])?;
+
+    // harnx should exit non-zero quickly.  On success the shell prints
+    // "HARNX_EXIT:<code>"; wait_for_cmd_exit polls for that sentinel.
+    let nonzero = wait_for_cmd_exit(&tmux, Duration::from_secs(5))?;
+    assert!(
+        nonzero,
+        "expected non-zero exit after Ctrl-C in raw-mode streaming"
+    );
     Ok(())
 }

--- a/docs/solutions/integration-issues/raw-mode-ctrl-c-interrupt-2026-04-30.md
+++ b/docs/solutions/integration-issues/raw-mode-ctrl-c-interrupt-2026-04-30.md
@@ -1,0 +1,187 @@
+---
+title: "Raw-mode terminal interrupt handling for Ctrl-C and Ctrl-D"
+date: 2026-04-30
+category: integration-issues
+problem_type: integration_issue
+component: cli-event-sink
+root_cause: "crossterm raw mode bypasses terminal driver signal processing"
+resolution_type: code_fix
+severity: high
+tags:
+  - crossterm
+  - raw-mode
+  - ctrl-c
+  - terminal
+  - spawn_blocking
+  - abort-signal
+plan_ref: harnx-406-ctrl-c-interrupt
+---
+
+## Problem
+
+In CLI one-shot mode with streaming markdown rendering, Ctrl-C and Ctrl-D were ignored. `crossterm::terminal::enable_raw_mode()` disables terminal driver signal processing — Ctrl-C becomes a raw key event rather than SIGINT, and Ctrl-D becomes a key event rather than EOF. The process never received the interrupt.
+
+## Symptoms
+
+- User presses Ctrl-C during streaming output — process continues running
+- User presses Ctrl-D during streaming output — process continues running
+- Terminal left in raw mode after certain error paths (no line buffering, no echo)
+- Issue only reproduced with real terminal (tmux), not with `kill(SIGINT)`
+
+## Investigation Steps
+
+1. Traced the streaming path: `CliAgentEventSink::handle_markdown_chunk` calls `enable_raw_mode()` before rendering streaming chunks.
+2. Verified crossterm raw mode behavior: terminal driver signal processing is disabled; keystrokes arrive as `Event::Key` rather than signals.
+3. Confirmed existing `tokio::signal::ctrl_c()` handler does not fire — SIGINT is never delivered.
+4. Identified that `poll_abort_signal` existed in spinner but was never called during streaming.
+5. Recognized `spawn_blocking` requirement: `crossterm::event::poll` is blocking and would stall Tokio worker threads.
+6. Discovered `JoinHandle::abort()` does NOT interrupt `spawn_blocking` threads — must use cooperative cancellation.
+
+## Root Cause
+
+`crossterm::terminal::enable_raw_mode()` disables the terminal driver's signal processing. When raw mode is active:
+
+- Ctrl-C → `Event::Key(KeyEvent { code: Char('c'), modifiers: CONTROL })` — not SIGINT
+- Ctrl-D → `Event::Key(KeyEvent { code: Char('d'), modifiers: CONTROL })` — not EOF
+
+The existing code had no mechanism to poll crossterm events during raw mode. Additionally:
+
+1. `run_abortable_spinner` had a blocking `poll_abort_signal` call inside an async function — stalls Tokio workers.
+2. `handle_markdown_chunk` enabled raw mode before fallible setup (`MarkdownRender::init`, `terminal::size`) — failures left terminal corrupted.
+3. `JoinHandle::abort()` cannot interrupt a `spawn_blocking` thread — requires cooperative stop mechanism.
+
+## Solution
+
+### 1. Added `RawModeKeyWatcher` with Cooperative Stop
+
+```rust
+// harnx-spinner/src/lib.rs
+pub struct RawModeKeyWatcher {
+    stop: AbortSignal,                              // Dedicated stop flag
+    handle: tokio::task::JoinHandle<()>,            // spawn_blocking handle
+}
+
+impl RawModeKeyWatcher {
+    pub fn stop(self) {
+        self.stop.set_ctrlc();  // Thread exits on next poll iteration
+    }
+}
+
+pub fn spawn_raw_mode_key_watcher(abort_signal: AbortSignal) -> Option<RawModeKeyWatcher> {
+    let stop = create_abort_signal();
+    let stop_clone = stop.clone();
+    let handle = tokio::task::spawn_blocking(move || {
+        loop {
+            if abort_signal.aborted() || stop_clone.aborted() {
+                break;
+            }
+            match poll_abort_signal(&abort_signal) {
+                Ok(true) => break,
+                Ok(false) => {}
+                Err(_) => break,
+            }
+        }
+    });
+    Some(RawModeKeyWatcher { stop, handle })
+}
+```
+
+Key design decisions:
+- **`spawn_blocking`** (not `tokio::spawn`) because `crossterm::event::poll` is blocking.
+- **Dedicated stop signal** separate from the operation's abort signal — `JoinHandle::abort()` cannot interrupt blocking I/O.
+- **Singleton constraint**: only one watcher should exist at a time (crossterm event stream is process-global).
+
+### 2. Scoped Watcher to Raw-Mode Window
+
+```rust
+// cli_event_sink.rs
+fn handle_markdown_chunk(&mut self, text: &str) -> anyhow::Result<()> {
+    if !self.raw_mode_active {
+        enable_raw_mode()?;
+        self.raw_mode_active = true;
+        self.key_watcher = spawn_raw_mode_key_watcher(self.abort_signal.clone());
+    }
+    // ... rendering ...
+}
+
+fn cleanup(&mut self) -> anyhow::Result<()> {
+    if self.raw_mode_active {
+        if let Some(watcher) = self.key_watcher.take() {
+            watcher.stop();  // Signals thread to exit within 25ms
+        }
+        disable_raw_mode()?;
+        self.raw_mode_active = false;
+    }
+    // ...
+}
+```
+
+### 3. Added Cleanup Guard for Fallible Setup
+
+```rust
+// cli_event_sink.rs
+if self.render.is_none() {
+    let init_result = (|| -> anyhow::Result<()> {
+        self.render = Some(MarkdownRender::init(self.render_options.clone())?);
+        self.columns = crossterm::terminal::size()?.0;
+        Ok(())
+    })();
+    if let Err(e) = init_result {
+        let _ = self.cleanup();  // Disable raw mode before propagating error
+        return Err(e);
+    }
+}
+```
+
+### 4. Removed Blocking Poll from Async Spinner
+
+`run_abortable_spinner` no longer calls `poll_abort_signal`. It checks `abort_signal.aborted()` (non-blocking atomic) and uses `tokio::time::sleep` (async-compatible).
+
+### 5. Added Tmux-Based E2E Test
+
+```rust
+// tests/interrupt_e2e.rs
+#[test]
+fn interrupt_cmd_raw_mode_ctrlc() -> Result<()> {
+    let tmux = spawn_oneshot_in_tmux(&paths, &harnx_bin, "hello", &repo_root)?;
+    tmux.wait_for_contains("Thinking", Duration::from_secs(10))?;
+    tmux.send_keys(&["C-c"])?;  // Real terminal key event
+    let nonzero = wait_for_cmd_exit(&tmux, Duration::from_secs(5))?;
+    assert!(nonzero);
+    Ok(())
+}
+```
+
+This test exercises the actual raw-mode Ctrl-C path through crossterm's event stream — unlike `kill(SIGINT)` tests which bypass the terminal.
+
+## Why This Works
+
+1. **`spawn_blocking`** isolates blocking `crossterm::event::poll` from Tokio's worker pool — no executor stalls.
+2. **Dedicated stop signal** enables clean shutdown of `spawn_blocking` threads that `JoinHandle::abort()` cannot interrupt.
+3. **Scoped lifecycle** (start on raw-mode enable, stop on disable) ensures no concurrent crossterm readers.
+4. **Cleanup guard** ensures terminal is never left corrupted on init failures.
+5. **Tmux test** verifies the actual user-reported issue path, not a synthetic approximation.
+
+## Prevention Strategies
+
+**Test Cases:**
+- E2E test `interrupt_cmd_raw_mode_ctrlc` sends real Ctrl-C through tmux terminal
+- Verify non-zero exit after Ctrl-C during streaming
+- Test covers raw-mode path that `kill(SIGINT)` bypasses
+
+**Best Practices:**
+- Always use `spawn_blocking` for blocking crossterm operations
+- Use cooperative cancellation (dedicated AbortSignal or channel) for `spawn_blocking` threads
+- Scope raw-mode setup/teardown tightly with guard patterns
+- Test terminal behavior with real PTY (tmux), not just signal injection
+
+**Code Review Checklist:**
+- [ ] Is `crossterm::event::poll` inside `spawn_blocking`, not `tokio::spawn`?
+- [ ] Does `spawn_blocking` thread check a stop signal each iteration?
+- [ ] Is raw mode disabled on all error paths after being enabled?
+- [ ] Are there unit/E2E tests that exercise raw-mode interrupt handling?
+
+## Related Issues
+
+- **GitHub:** [#406](https://github.com/dobesv/harnx/issues/406) — CTRL-C and CTRL-D ignored in terminal mode
+- **Related Solution:** [git-backed-local-history-rollback-2026-04-26.md](../logic-errors/git-backed-local-history-rollback-2026-04-26.md) — `spawn_blocking` pattern for gix I/O


### PR DESCRIPTION
Fixes the issue where CTRL-C and CTRL-D were ignored during streaming markdown rendering in non-TUI (Cmd) terminal mode. This was caused by crossterm raw mode silencing SIGINT and EOF signals.

Implements RawModeKeyWatcher in harnx-spinner to poll crossterm key events via spawn_blocking, scoped to the raw-mode window with a cooperative stop signal. Removes the blocking poll_abort_signal from the async run_abortable_spinner, adds a raw-mode setup cleanup guard, and includes a new tmux-based E2E test.

Fixes #406

Plan: harnx-406-ctrl-c-interrupt