### PR TITLE
Implement session history editing (part 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /target
 /tmp
 /.env
-*.log
+*.log*.snap.new

--- a/crates/harnx-client/src/bedrock.rs
+++ b/crates/harnx-client/src/bedrock.rs
@@ -410,7 +410,7 @@ fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Resu
         .into_iter()
         .enumerate()
         .flat_map(|(i, message)| {
-            let Message { role, content } = message;
+            let Message { role, content, .. } = message;
             match content {
                 MessageContent::Text(text) if role.is_assistant() && i != messages_len - 1 => {
                     vec![json!({ "role": role, "content": [ { "text": strip_think_tag(&text) } ] })]

--- a/crates/harnx-client/src/claude.rs
+++ b/crates/harnx-client/src/claude.rs
@@ -292,7 +292,7 @@ pub fn claude_build_chat_completions_body(
         .into_iter()
         .enumerate()
         .flat_map(|(i, message)| {
-            let Message { role, content } = message;
+            let Message { role, content, .. } = message;
             match content {
                 MessageContent::Text(text) if role.is_assistant() && i != messages_len - 1 => {
                     vec![json!({ "role": role, "content": strip_think_tag(&text) })]

--- a/crates/harnx-client/src/openai.rs
+++ b/crates/harnx-client/src/openai.rs
@@ -301,7 +301,7 @@ pub fn openai_build_chat_completions_body(data: ChatCompletionsData, model: &Mod
         .into_iter()
         .enumerate()
         .flat_map(|(i, message)| {
-            let Message { role, content } = message;
+            let Message { role, content, .. } = message;
             match content {
                 MessageContent::ToolCalls(MessageContentToolCalls {
                     tool_results,

--- a/crates/harnx-client/src/vertexai.rs
+++ b/crates/harnx-client/src/vertexai.rs
@@ -369,7 +369,7 @@ pub fn gemini_build_chat_completions_body(
     let contents: Vec<Value> = messages
         .into_iter()
         .flat_map(|message| {
-            let Message { role, content } = message;
+            let Message { role, content, .. } = message;
             let role = match role {
                 MessageRole::User => "user",
                 _ => "model",

--- a/crates/harnx-core/src/event.rs
+++ b/crates/harnx-core/src/event.rs
@@ -127,6 +127,12 @@ pub enum SessionEvent {
     Generic {
         text: String,
     },
+    /// Emitted after a message or tool-calls entry has been written to the
+    /// session log. The TUI uses this to patch the `seq` field on the
+    /// most-recently-pushed `AssistantText` or `ToolCall` transcript item.
+    LogSeqAssigned {
+        seq: usize,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/harnx-core/src/message.rs
+++ b/crates/harnx-core/src/message.rs
@@ -12,6 +12,12 @@ use crate::tool::ToolResult;
 pub struct Message {
     pub role: MessageRole,
     pub content: MessageContent,
+    /// 0-based index of the YAML document in the session log that produced
+    /// this message. Set during log replay; `None` for messages created
+    /// during a live session (before they are persisted and reloaded).
+    /// Never serialised — not sent to the LLM.
+    #[serde(skip)]
+    pub log_seq: Option<usize>,
 }
 
 impl Default for Message {
@@ -19,13 +25,23 @@ impl Default for Message {
         Self {
             role: MessageRole::User,
             content: MessageContent::Text(String::new()),
+            log_seq: None,
         }
     }
 }
 
 impl Message {
     pub fn new(role: MessageRole, content: MessageContent) -> Self {
-        Self { role, content }
+        Self {
+            role,
+            content,
+            log_seq: None,
+        }
+    }
+
+    pub fn with_log_seq(mut self, seq: usize) -> Self {
+        self.log_seq = Some(seq);
+        self
     }
 
     pub fn merge_system(&mut self, system: MessageContent) {

--- a/crates/harnx-core/src/session.rs
+++ b/crates/harnx-core/src/session.rs
@@ -79,6 +79,22 @@ pub enum SessionLogEntry {
     Compress { prompt: String },
     #[serde(rename = "clear")]
     Clear,
+    #[serde(rename = "edit_entries")]
+    EditEntries {
+        /// Inclusive range of entry sequence numbers being replaced.
+        from: usize,
+        to: usize,
+        /// Replacement YAML documents (raw strings, one per replaced entry).
+        /// Empty vec = deletion.
+        replacements: Vec<String>,
+    },
+    #[serde(rename = "rewind")]
+    Rewind {
+        /// All entries with seq > after_seq are excluded from context on replay.
+        after_seq: usize,
+    },
+    #[serde(other)]
+    Unknown,
 }
 
 /// A single tool-call result as persisted in the session log. Matches
@@ -151,6 +167,8 @@ pub struct Session {
     #[serde(skip)]
     pub resolved_save_name: Option<(PathBuf, String)>,
     #[serde(skip)]
+    pub log_entry_count: usize,
+    #[serde(skip)]
     pub tokens: usize,
     #[serde(skip)]
     pub completion_usage: CompletionTokenUsage,
@@ -206,6 +224,12 @@ impl Session {
 
     pub fn tokens(&self) -> usize {
         self.tokens
+    }
+
+    /// Returns sequence number that next appended entry will receive.
+    /// This is equal to number of YAML documents currently in log file.
+    pub fn next_seq(&self) -> usize {
+        self.log_entry_count
     }
 
     pub fn update_tokens(&mut self) {
@@ -540,6 +564,79 @@ mod tests {
             }
             _ => panic!("expected header entry"),
         }
+    }
+
+    #[test]
+    fn session_log_entry_edit_entries_serde_round_trip() {
+        let entry = SessionLogEntry::EditEntries {
+            from: 3,
+            to: 5,
+            replacements: vec![
+                "type: message
+role: user
+content: replacement one
+"
+                .to_string(),
+                "type: message
+role: assistant
+content: replacement two
+"
+                .to_string(),
+            ],
+        };
+
+        let yaml = serde_yaml::to_string(&entry).unwrap();
+        let round_tripped: SessionLogEntry = serde_yaml::from_str(&yaml).unwrap();
+
+        match round_tripped {
+            SessionLogEntry::EditEntries {
+                from,
+                to,
+                replacements,
+            } => {
+                assert_eq!(from, 3);
+                assert_eq!(to, 5);
+                assert_eq!(
+                    replacements,
+                    vec![
+                        "type: message
+role: user
+content: replacement one
+"
+                        .to_string(),
+                        "type: message
+role: assistant
+content: replacement two
+"
+                        .to_string(),
+                    ]
+                );
+            }
+            other => panic!("expected edit_entries, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_log_entry_rewind_serde_round_trip() {
+        let entry = SessionLogEntry::Rewind { after_seq: 7 };
+
+        let yaml = serde_yaml::to_string(&entry).unwrap();
+        let round_tripped: SessionLogEntry = serde_yaml::from_str(&yaml).unwrap();
+
+        match round_tripped {
+            SessionLogEntry::Rewind { after_seq } => assert_eq!(after_seq, 7),
+            other => panic!("expected rewind, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_log_entry_unknown_type_deserializes_to_unknown() {
+        let yaml = "type: future_variant
+field: value
+";
+        let entry: SessionLogEntry = serde_yaml::from_str(yaml).unwrap();
+
+        assert!(matches!(entry, SessionLogEntry::Unknown));
     }
 
     #[test]

--- a/crates/harnx-runtime/src/client/message.rs
+++ b/crates/harnx-runtime/src/client/message.rs
@@ -72,6 +72,7 @@ pub fn patch_messages(messages: &mut Vec<Message>, model: &Model) {
                 Message {
                     role: MessageRole::System,
                     content: prefix_content,
+                    log_seq: None,
                 },
             );
         }

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -22,7 +22,7 @@ pub enum CommandOutcome {
     Exit,
 }
 
-pub static COMMANDS: LazyLock<[Command; 40]> = LazyLock::new(|| {
+pub static COMMANDS: LazyLock<[Command; 45]> = LazyLock::new(|| {
     [
         Command::new(".help", "Show this help guide"),
         Command::new(".info", "Show system info"),
@@ -50,6 +50,11 @@ pub static COMMANDS: LazyLock<[Command; 40]> = LazyLock::new(|| {
         ),
         Command::new(".info session", "Show session info"),
         Command::new(".edit session", "Modify current session"),
+        Command::new(".edit message <n>", "Edit a log entry by sequence number"),
+        Command::new(
+            ".edit message <n>-<m>",
+            "Edit a range of log entries by sequence number",
+        ),
         Command::new(".save session", "Save current session to file"),
         Command::new(".exit session", "Exit active session"),
         Command::new(".agent", "Use an agent"),
@@ -75,6 +80,15 @@ pub static COMMANDS: LazyLock<[Command; 40]> = LazyLock::new(|| {
         Command::new(".copy", "Copy last response"),
         Command::new(".set", "Modify runtime settings"),
         Command::new(".delete", "Delete agents, sessions, RAGs, or macros"),
+        Command::new(
+            ".delete message <n>",
+            "Delete a log entry by sequence number",
+        ),
+        Command::new(".delete message <n>-<m>", "Delete a range of log entries"),
+        Command::new(
+            ".rewind <n>",
+            "Rewind session context to entry N (all later entries excluded)",
+        ),
         Command::new(".exit", "Exit the interactive session"),
     ]
 });
@@ -295,7 +309,11 @@ pub async fn run_command_with_output(
                     Some("rag-docs") => {
                         Config::edit_rag_docs(config, abort_signal.clone()).await?;
                     }
-                    _ => writeln!(output, r#"Usage: .edit <config|agent|session|rag-docs>"#)?,
+                    Some(args) if args.starts_with("message ") => {
+                        let (from, to) = parse_message_range(&args[8..])?;
+                        config.write().edit_message_range(from, to)?;
+                    }
+                    _ => writeln!(output, r#"Usage: .edit <config|agent|session|rag-docs|message <n>|message <n>-<m>>"#)?,
                 }
             }
             ".compact" => match args {
@@ -599,14 +617,28 @@ Commands:
                 _ => writeln!(output, "Usage: .set <key> <value>...")?,
             },
             ".delete" => match args {
+                Some(args) if args.starts_with("message ") => {
+                    let (from, to) = parse_message_range(&args[8..])?;
+                    config.write().delete_message_range(from, to)?;
+                    writeln!(output, "Deleted entries {from}-{to}.")?;
+                }
                 Some(args) => {
                     Config::delete(config, args)?;
                 }
                 _ => writeln!(
                     output,
-                    "Usage: .delete <agent|session|rag|macro|agent-data>"
+                    "Usage: .delete <agent|session|rag|macro|agent-data|message <n>|message <n>-<m>>"
                 )?,
             },
+            ".rewind" => {
+                let n = args
+                    .ok_or_else(|| anyhow!("Usage: .rewind <n>"))?
+                    .trim()
+                    .parse::<usize>()
+                    .context("Invalid sequence number")?;
+                config.write().rewind_session(n)?;
+                writeln!(output, "↩ Rewound session to entry {n}.")?;
+            }
             ".copy" => {
                 let output = match config
                     .read()
@@ -795,6 +827,27 @@ Press Ctrl+C to cancel the response, Ctrl+D to exit."###,
     Ok(())
 }
 
+fn parse_message_range(s: &str) -> Result<(usize, usize)> {
+    let s = s.trim();
+    if let Some((from, to)) = s.split_once('-') {
+        let from = from
+            .trim()
+            .parse::<usize>()
+            .context("Invalid starting sequence number")?;
+        let to = to
+            .trim()
+            .parse::<usize>()
+            .context("Invalid ending sequence number")?;
+        if from > to {
+            bail!("Invalid range: start is greater than end");
+        }
+        Ok((from, to))
+    } else {
+        let n = s.parse::<usize>().context("Invalid sequence number")?;
+        Ok((n, n))
+    }
+}
+
 fn parse_command(line: &str) -> Option<(&str, Option<&str>)> {
     match COMMAND_RE.captures(line) {
         Ok(Some(captures)) => {
@@ -907,6 +960,17 @@ mod tests {
             parse_command(".prompt \nabc\n"),
             Some((".prompt", Some("abc")))
         );
+    }
+
+    #[test]
+    fn test_parse_message_range() {
+        assert_eq!(parse_message_range("5").unwrap(), (5, 5));
+        assert_eq!(parse_message_range("3-7").unwrap(), (3, 7));
+        assert_eq!(parse_message_range(" 9 - 12 ").unwrap(), (9, 12));
+        assert!(parse_message_range("").is_err());
+        assert!(parse_message_range("abc").is_err());
+        assert!(parse_message_range("7-3").is_err());
+        assert!(parse_message_range("1-2-3").is_err());
     }
 
     #[test]

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -15,6 +15,7 @@ pub use harnx_core::working_mode::WorkingMode;
 
 use harnx_core::config_data::ConfigData;
 use harnx_core::config_paths as paths;
+use harnx_core::session::SessionLogEntry;
 
 use crate::client::{
     create_client_config, list_client_types, list_models, ClientConfig, MessageContentToolCalls,
@@ -81,6 +82,117 @@ __INPUT__
 static EDITOR: OnceLock<Option<String>> = OnceLock::new();
 
 use harnx_core::agent_config::{normalize_toolset_value, split_tool_selectors, ToolsetValue};
+
+fn split_session_log_documents(raw_log: &str) -> Vec<String> {
+    raw_log
+        .split("\n---\n")
+        .filter_map(|document| {
+            let document = document.trim();
+            let document = document.strip_prefix("---\n").unwrap_or(document).trim();
+            if document.is_empty() {
+                None
+            } else {
+                Some(document.to_string())
+            }
+        })
+        .collect()
+}
+
+fn validate_edited_session_documents(content: &str) -> Result<Vec<String>> {
+    let documents = split_session_log_documents(content);
+    for document in &documents {
+        serde_yaml::from_str::<SessionLogEntry>(document).with_context(|| {
+            format!(
+                "Invalid session log entry YAML:
+{document}"
+            )
+        })?;
+    }
+    Ok(documents)
+}
+
+/// Adjust `[from, to]` so that `ToolCalls`/`ToolResults` pairs are never
+/// split across the range boundary, then return the (possibly expanded) range.
+///
+/// Rules:
+/// - If `from` points at a `ToolResults` entry (i.e. the pair's `ToolCalls` is
+///   at `from - 1`, outside the range), that is an error: we can't silently
+///   expand backward because the caller's intent is unclear.
+/// - If `to` points at a `ToolCalls` entry and `to + 1` is its paired
+///   `ToolResults`, auto-expand `to` by one.
+///
+/// Returns `(adjusted_from, adjusted_to)`.
+fn adjust_range_for_tool_pairs(
+    from: usize,
+    to: usize,
+    documents: &[String],
+) -> Result<(usize, usize)> {
+    // Parse only the entries we need: the one just before `from` (to check if
+    // `from` is a dangling ToolResults) and up through `to + 1` (to check if
+    // `to` is a ToolCalls that needs its partner).
+    let parse = |idx: usize| -> Option<SessionLogEntry> {
+        documents
+            .get(idx)
+            .and_then(|raw| serde_yaml::from_str::<SessionLogEntry>(raw).ok())
+    };
+
+    // Reject: range starts on a ToolResults whose ToolCalls is outside the range.
+    if matches!(parse(from), Some(SessionLogEntry::ToolResults { .. })) {
+        // Check if the immediately preceding entry is a ToolCalls — if so,
+        // this is definitely a dangling-results situation.
+        bail!(
+            "Sequence {from} is a tool-results entry; its paired tool-calls entry ({}) \
+             would be outside the range. Expand your range to include it.",
+            from.saturating_sub(1)
+        );
+    }
+
+    // Auto-expand: range ends on a ToolCalls whose ToolResults is just outside.
+    let mut adjusted_to = to;
+    if matches!(parse(to), Some(SessionLogEntry::ToolCalls { .. }))
+        && to + 1 < documents.len()
+        && matches!(parse(to + 1), Some(SessionLogEntry::ToolResults { .. }))
+    {
+        adjusted_to = to + 1;
+    }
+
+    Ok((from, adjusted_to))
+}
+
+fn validate_tool_pair_integrity(start_seq: usize, documents: &[String]) -> Result<()> {
+    if documents.len() < 2 {
+        return Ok(());
+    }
+
+    let entries = documents
+        .iter()
+        .map(|document| serde_yaml::from_str::<SessionLogEntry>(document))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    for index in 0..entries.len() - 1 {
+        let (SessionLogEntry::ToolCalls { calls, .. }, SessionLogEntry::ToolResults { results }) =
+            (&entries[index], &entries[index + 1])
+        else {
+            continue;
+        };
+
+        let call_ids = calls
+            .iter()
+            .map(|call| call.id.as_deref())
+            .collect::<Vec<_>>();
+        let result_ids = results
+            .iter()
+            .map(|result| result.id.as_deref())
+            .collect::<Vec<_>>();
+        if call_ids != result_ids {
+            let call_seq = start_seq + index;
+            let result_seq = start_seq + index + 1;
+            bail!("Edited tool call/result IDs do not match for entries {call_seq}-{result_seq}");
+        }
+    }
+
+    Ok(())
+}
 
 fn parse_toolsets_json(value: &str) -> serde_json::Result<IndexMap<String, Vec<String>>> {
     let values = serde_json::from_str::<IndexMap<String, ToolsetValue>>(value)?;
@@ -170,6 +282,10 @@ pub struct Config {
     pub agent: Option<Agent>,
     pub tui_before_editor: Option<Box<dyn FnMut() + Send + Sync>>,
     pub tui_after_editor: Option<Box<dyn FnMut() + Send + Sync>>,
+
+    /// Override the sessions directory — used in tests to redirect session
+    /// log writes to a temp directory without touching real user data.
+    pub sessions_dir_override: Option<std::path::PathBuf>,
 }
 
 impl std::ops::Deref for Config {
@@ -232,6 +348,7 @@ impl Clone for Config {
             agent: self.agent.clone(),
             tui_before_editor: None,
             tui_after_editor: None,
+            sessions_dir_override: self.sessions_dir_override.clone(),
         }
     }
 }
@@ -263,6 +380,7 @@ impl Default for Config {
             agent: None,
             tui_before_editor: None,
             tui_after_editor: None,
+            sessions_dir_override: None,
         }
     }
 }
@@ -374,6 +492,9 @@ impl Config {
     }
 
     pub fn sessions_dir(&self) -> PathBuf {
+        if let Some(ref override_dir) = self.sessions_dir_override {
+            return override_dir.clone();
+        }
         paths::sessions_dir(self.agent.as_ref().map(|a| a.name()))
     }
 
@@ -382,7 +503,10 @@ impl Config {
     }
 
     pub fn session_file(&self, name: &str) -> PathBuf {
-        paths::session_file(self.agent.as_ref().map(|a| a.name()), name)
+        match name.split_once('/') {
+            Some((sub, leaf)) => self.sessions_dir().join(sub).join(format!("{leaf}.yaml")),
+            None => self.sessions_dir().join(format!("{name}.yaml")),
+        }
     }
 
     pub fn rag_file(&self, name: &str) -> PathBuf {
@@ -1255,6 +1379,147 @@ impl Config {
             after();
         }
         result
+    }
+
+    pub fn edit_message_range(&mut self, from: usize, to: usize) -> Result<()> {
+        let name = match &self.session {
+            Some(session) => session.name().to_string(),
+            None => bail!("No session"),
+        };
+        let session_path = self.session_file(&name);
+
+        let raw_log = std::fs::read_to_string(&session_path)
+            .with_context(|| format!("Failed to read '{}'", session_path.display()))?;
+        let documents = split_session_log_documents(&raw_log);
+        if from == 0 {
+            bail!("Cannot edit or delete the session header (sequence 0)");
+        }
+        if to >= documents.len() {
+            bail!("Sequence numbers out of range");
+        }
+        let (from, to) = adjust_range_for_tool_pairs(from, to, &documents)?;
+        if from > to || to >= documents.len() {
+            bail!("Sequence numbers out of range");
+        }
+
+        let selected_documents = documents[from..=to].to_vec();
+        let temp_file = temp_file("message-edit", ".yaml");
+        std::fs::write(&temp_file, selected_documents.join("\n---\n"))
+            .with_context(|| format!("Failed to write to '{}'", temp_file.display()))?;
+
+        let edit_result = self.edit_with_tui_hooks(|this| {
+            let editor = this.editor()?;
+            edit_file(&editor, &temp_file).with_context(|| {
+                format!("Failed to edit '{}' with '{}'", temp_file.display(), editor)
+            })
+        });
+        let edited_content = std::fs::read_to_string(&temp_file)
+            .with_context(|| format!("Failed to read '{}'", temp_file.display()));
+        let _ = std::fs::remove_file(&temp_file);
+        edit_result?;
+        let edited_content = edited_content?;
+
+        let edited_documents = validate_edited_session_documents(&edited_content)?;
+        validate_tool_pair_integrity(from, &edited_documents)?;
+
+        let edit_entry = SessionLogEntry::EditEntries {
+            from,
+            to,
+            replacements: edited_documents,
+        };
+        let session = self.session.as_mut().context("No session")?;
+        if !crate::config::session::append_event(session, &edit_entry) {
+            bail!("Failed to append session edit entry")
+        }
+        self.session = Some(self::session::load(self, &name, &session_path)?);
+        self.discontinuous_last_message();
+        Ok(())
+    }
+
+    pub fn delete_message_range(&mut self, from: usize, to: usize) -> Result<()> {
+        let name = match &self.session {
+            Some(session) => session.name().to_string(),
+            None => bail!("No session"),
+        };
+        let session_path = self.session_file(&name);
+
+        let raw_log = std::fs::read_to_string(&session_path)
+            .with_context(|| format!("Failed to read '{}'", session_path.display()))?;
+        let documents = split_session_log_documents(&raw_log);
+        if from == 0 {
+            bail!("Cannot edit or delete the session header (sequence 0)");
+        }
+        if to >= documents.len() {
+            bail!("Sequence numbers out of range");
+        }
+        let (from, to) = adjust_range_for_tool_pairs(from, to, &documents)?;
+        if from > to || to >= documents.len() {
+            bail!("Sequence numbers out of range");
+        }
+
+        let edit_entry = SessionLogEntry::EditEntries {
+            from,
+            to,
+            replacements: vec![],
+        };
+        let session = self.session.as_mut().context("No session")?;
+        if !crate::config::session::append_event(session, &edit_entry) {
+            bail!("Failed to append session delete entry")
+        }
+        self.session = Some(self::session::load(self, &name, &session_path)?);
+        self.discontinuous_last_message();
+        Ok(())
+    }
+
+    pub fn rewind_session(&mut self, after_seq: usize) -> Result<()> {
+        let name = match &self.session {
+            Some(session) => session.name().to_string(),
+            None => bail!("No session"),
+        };
+        let session_path = self.session_file(&name);
+
+        let session = self.session.as_ref().context("No session")?;
+        if after_seq >= session.log_entry_count {
+            bail!(
+                "Sequence number {} is out of range (log has {} entries)",
+                after_seq,
+                session.log_entry_count
+            );
+        }
+
+        // Reject a cut point that splits a ToolCalls/ToolResults pair.
+        let raw_log = std::fs::read_to_string(&session_path)
+            .with_context(|| format!("Failed to read '{}'", session_path.display()))?;
+        let documents = split_session_log_documents(&raw_log);
+        let parse = |idx: usize| -> Option<SessionLogEntry> {
+            documents
+                .get(idx)
+                .and_then(|raw| serde_yaml::from_str::<SessionLogEntry>(raw).ok())
+        };
+        if matches!(parse(after_seq), Some(SessionLogEntry::ToolCalls { .. }))
+            && matches!(
+                parse(after_seq + 1),
+                Some(SessionLogEntry::ToolResults { .. })
+            )
+        {
+            bail!(
+                "Sequence {after_seq} is a tool-calls entry paired with tool-results at {}; \
+                 rewinding here would orphan the tool calls. \
+                 Use {} to keep the pair or {} to exclude it.",
+                after_seq + 1,
+                after_seq + 1,
+                after_seq.saturating_sub(1),
+            );
+        }
+
+        let rewind_entry = SessionLogEntry::Rewind { after_seq };
+        let session = self.session.as_mut().context("No session")?;
+        if !crate::config::session::append_event(session, &rewind_entry) {
+            bail!("Failed to append session rewind entry")
+        }
+        self.session = Some(self::session::load(self, &name, &session_path)?);
+        self.discontinuous_last_message();
+        Ok(())
     }
 
     pub fn edit_session(&mut self) -> Result<()> {
@@ -3230,6 +3495,228 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harnx_core::{
+        message::{MessageContent, MessageRole},
+        session::ToolOutput,
+        tool::ToolCall,
+    };
+
+    fn tool_calls_yaml(call_ids: &[&str]) -> String {
+        serde_yaml::to_string(&SessionLogEntry::ToolCalls {
+            text: String::new(),
+            thought: None,
+            calls: call_ids
+                .iter()
+                .map(|id| ToolCall {
+                    name: "bash_exec".to_string(),
+                    arguments: serde_json::json!({"cmd": "echo hi"}),
+                    id: Some((*id).to_string()),
+                    thought_signature: None,
+                })
+                .collect(),
+        })
+        .unwrap()
+    }
+
+    fn tool_results_yaml(result_ids: &[&str]) -> String {
+        serde_yaml::to_string(&SessionLogEntry::ToolResults {
+            results: result_ids
+                .iter()
+                .map(|id| ToolOutput {
+                    id: Some((*id).to_string()),
+                    name: "bash_exec".to_string(),
+                    output: serde_json::json!({"ok": true}),
+                    switch_agent: None,
+                })
+                .collect(),
+        })
+        .unwrap()
+    }
+
+    fn user_yaml(text: &str) -> String {
+        serde_yaml::to_string(&SessionLogEntry::Message {
+            role: MessageRole::User,
+            content: MessageContent::Text(text.to_string()),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn validate_edited_session_documents_accepts_valid_yaml_documents() {
+        let content = format!("{}---\n{}", user_yaml("hi"), user_yaml("there"));
+
+        let documents = validate_edited_session_documents(&content).unwrap();
+
+        assert_eq!(documents.len(), 2);
+    }
+
+    #[test]
+    fn validate_edited_session_documents_rejects_invalid_yaml_documents() {
+        let err = validate_edited_session_documents("---\ntype: user\ntext: [")
+            .expect_err("invalid yaml should fail");
+
+        assert!(err.to_string().contains("Invalid session log entry YAML"));
+    }
+
+    #[test]
+    fn validate_tool_pair_integrity_accepts_matching_ids() {
+        let documents = vec![
+            tool_calls_yaml(&["call-1", "call-2"]),
+            tool_results_yaml(&["call-1", "call-2"]),
+        ];
+
+        validate_tool_pair_integrity(5, &documents).unwrap();
+    }
+
+    #[test]
+    fn validate_tool_pair_integrity_rejects_mismatched_ids() {
+        let documents = vec![tool_calls_yaml(&["call-1"]), tool_results_yaml(&["call-2"])];
+
+        let err =
+            validate_tool_pair_integrity(7, &documents).expect_err("mismatched ids should fail");
+
+        assert_eq!(
+            err.to_string(),
+            "Edited tool call/result IDs do not match for entries 7-8"
+        );
+    }
+
+    #[test]
+    fn validate_tool_pair_integrity_allows_orphan_tool_calls_as_advisory() {
+        let documents = vec![tool_calls_yaml(&["call-1"])];
+
+        validate_tool_pair_integrity(3, &documents).unwrap();
+    }
+
+    #[test]
+    fn validate_tool_pair_integrity_ignores_single_non_tool_document() {
+        let documents = vec![user_yaml("plain message")];
+
+        validate_tool_pair_integrity(2, &documents).unwrap();
+    }
+
+    // --- adjust_range_for_tool_pairs ---
+
+    fn make_docs(entries: &[SessionLogEntry]) -> Vec<String> {
+        entries
+            .iter()
+            .map(|e| serde_yaml::to_string(e).unwrap().trim().to_string())
+            .collect()
+    }
+
+    fn tool_calls_entry(id: &str) -> SessionLogEntry {
+        SessionLogEntry::ToolCalls {
+            text: String::new(),
+            thought: None,
+            calls: vec![ToolCall {
+                name: "bash_exec".to_string(),
+                arguments: serde_json::json!({}),
+                id: Some(id.to_string()),
+                thought_signature: None,
+            }],
+        }
+    }
+
+    fn tool_results_entry(id: &str) -> SessionLogEntry {
+        SessionLogEntry::ToolResults {
+            results: vec![ToolOutput {
+                id: Some(id.to_string()),
+                name: "bash_exec".to_string(),
+                output: serde_json::json!("ok"),
+                switch_agent: None,
+            }],
+        }
+    }
+
+    fn user_entry(text: &str) -> SessionLogEntry {
+        SessionLogEntry::Message {
+            role: MessageRole::User,
+            content: MessageContent::Text(text.to_string()),
+        }
+    }
+
+    #[test]
+    fn adjust_range_no_tool_pairs_unchanged() {
+        // [0:header, 1:user, 2:user] — no pairs, range stays as-is
+        let docs = make_docs(&[user_entry("a"), user_entry("b"), user_entry("c")]);
+        assert_eq!(adjust_range_for_tool_pairs(1, 2, &docs).unwrap(), (1, 2));
+    }
+
+    #[test]
+    fn adjust_range_expands_to_include_paired_results() {
+        // [0:user, 1:tool_calls, 2:tool_results, 3:user]
+        // Requesting range [1,1] (calls only) → auto-expands to [1,2]
+        let docs = make_docs(&[
+            user_entry("before"),
+            tool_calls_entry("c1"),
+            tool_results_entry("c1"),
+            user_entry("after"),
+        ]);
+        assert_eq!(adjust_range_for_tool_pairs(1, 1, &docs).unwrap(), (1, 2));
+    }
+
+    #[test]
+    fn adjust_range_pair_already_fully_included_unchanged() {
+        // [0:user, 1:tool_calls, 2:tool_results, 3:user]
+        // Range [1,2] already covers both — no change
+        let docs = make_docs(&[
+            user_entry("before"),
+            tool_calls_entry("c1"),
+            tool_results_entry("c1"),
+            user_entry("after"),
+        ]);
+        assert_eq!(adjust_range_for_tool_pairs(1, 2, &docs).unwrap(), (1, 2));
+    }
+
+    #[test]
+    fn adjust_range_rejects_range_starting_on_tool_results() {
+        // [0:user, 1:tool_calls, 2:tool_results, 3:user]
+        // Range starting at 2 (results only) → error
+        let docs = make_docs(&[
+            user_entry("before"),
+            tool_calls_entry("c1"),
+            tool_results_entry("c1"),
+            user_entry("after"),
+        ]);
+        let err = adjust_range_for_tool_pairs(2, 2, &docs)
+            .expect_err("starting on tool-results should fail");
+        assert!(err.to_string().contains("tool-results entry"));
+    }
+
+    #[test]
+    fn adjust_range_tool_calls_at_end_of_log_no_expansion() {
+        // [0:user, 1:tool_calls] — ToolCalls is the last doc, no results follow
+        // → no expansion (orphan ToolCalls is the user's problem after editing)
+        let docs = make_docs(&[user_entry("before"), tool_calls_entry("c1")]);
+        assert_eq!(adjust_range_for_tool_pairs(1, 1, &docs).unwrap(), (1, 1));
+    }
+
+    #[test]
+    fn adjust_range_rewind_orphan_rejected() {
+        // Simulate rewind check: after_seq=1 lands on ToolCalls paired with results at 2
+        // [0:user, 1:tool_calls, 2:tool_results, 3:user]
+        let docs = make_docs(&[
+            user_entry("before"),
+            tool_calls_entry("c1"),
+            tool_results_entry("c1"),
+            user_entry("after"),
+        ]);
+        // after_seq=1 means entries 0..=1 kept, entry 2 (results) excluded → orphan calls
+        // Verify the guard logic that rewind_session uses
+        let parse = |idx: usize| -> Option<SessionLogEntry> {
+            docs.get(idx)
+                .and_then(|raw| serde_yaml::from_str::<SessionLogEntry>(raw).ok())
+        };
+        assert!(matches!(parse(1), Some(SessionLogEntry::ToolCalls { .. })));
+        assert!(matches!(
+            parse(2),
+            Some(SessionLogEntry::ToolResults { .. })
+        ));
+        // The condition that rewind_session checks:
+        let would_orphan = matches!(parse(1), Some(SessionLogEntry::ToolCalls { .. }))
+            && matches!(parse(2), Some(SessionLogEntry::ToolResults { .. }));
+        assert!(would_orphan);
+    }
 
     #[test]
     fn test_split_tool_selectors_simple() {
@@ -3390,8 +3877,6 @@ mod tests {
     }
 
     // ── compact_session tests ────────────────────────────────────────────────
-
-    use crate::client::{MessageContent, MessageRole};
 
     /// Helper: create a GlobalConfig with a session that already has one user
     /// message in it, suitable for compaction tests.

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -50,6 +50,146 @@ pub fn load(config: &Config, name: &str, path: &Path) -> Result<Session> {
 }
 
 fn load_from_log(config: &Config, name: &str, path: &Path, content: &str) -> Result<Session> {
+    let raw_entries = collect_raw_log_entries(content, name)?;
+    let mut session = replay_log_entries(&raw_entries, name)?;
+    session.log_entry_count = raw_entries.len();
+
+    session.model =
+        crate::client::retrieve_model(&config.clients, &session.model_id, ModelType::Chat)?;
+    apply_name_and_path(&mut session, name, path, config)?;
+    session.update_tokens();
+    Ok(session)
+}
+
+struct PendingToolCalls {
+    seq: usize,
+    text: String,
+    thought: Option<String>,
+    calls: Vec<crate::tool::ToolCall>,
+}
+
+fn collect_raw_log_entries(content: &str, name: &str) -> Result<Vec<(usize, SessionLogEntry)>> {
+    serde_yaml::Deserializer::from_str(content)
+        .enumerate()
+        .map(|(seq, document)| {
+            let entry = SessionLogEntry::deserialize(document)
+                .with_context(|| format!("Invalid log entry #{seq} in session {name}"))?;
+            Ok((seq, entry))
+        })
+        .collect()
+}
+
+fn build_effective_log_entries(
+    raw_entries: &[(usize, SessionLogEntry)],
+    name: &str,
+) -> Vec<(usize, SessionLogEntry)> {
+    let mut effective_entries = Vec::new();
+
+    for (seq, entry) in raw_entries {
+        match entry {
+            SessionLogEntry::Rewind { after_seq } => {
+                if *after_seq >= *seq {
+                    log::warn!(
+                        "Skipping rewind entry #{seq} in session {name}: after_seq {after_seq} must be less than current seq"
+                    );
+                    continue;
+                }
+                if !effective_entries
+                    .iter()
+                    .any(|(existing_seq, _)| existing_seq == after_seq)
+                {
+                    log::warn!(
+                        "Skipping rewind entry #{seq} in session {name}: after_seq {after_seq} not present in replay state"
+                    );
+                    continue;
+                }
+                effective_entries.retain(|(existing_seq, _)| *existing_seq <= *after_seq);
+            }
+            SessionLogEntry::EditEntries {
+                from,
+                to,
+                replacements,
+            } => {
+                if from > to {
+                    log::warn!(
+                        "Skipping edit_entries entry #{seq} in session {name}: invalid range [{from}, {to}]"
+                    );
+                    continue;
+                }
+                if *to >= *seq {
+                    log::warn!(
+                        "Skipping edit_entries entry #{seq} in session {name}: range [{from}, {to}] must reference earlier entries only"
+                    );
+                    continue;
+                }
+
+                let Some(start_idx) = effective_entries
+                    .iter()
+                    .position(|(existing_seq, _)| existing_seq == from)
+                else {
+                    log::warn!(
+                        "Skipping edit_entries entry #{seq} in session {name}: from seq {from} not present in replay state"
+                    );
+                    continue;
+                };
+                let Some(end_idx) = effective_entries
+                    .iter()
+                    .position(|(existing_seq, _)| existing_seq == to)
+                else {
+                    log::warn!(
+                        "Skipping edit_entries entry #{seq} in session {name}: to seq {to} not present in replay state"
+                    );
+                    continue;
+                };
+                if start_idx > end_idx {
+                    log::warn!(
+                        "Skipping edit_entries entry #{seq} in session {name}: range [{from}, {to}] not in replay order"
+                    );
+                    continue;
+                }
+                if effective_entries[start_idx..=end_idx]
+                    .iter()
+                    .any(|(existing_seq, _)| *existing_seq < *from || *existing_seq > *to)
+                {
+                    log::warn!(
+                        "Skipping edit_entries entry #{seq} in session {name}: range [{from}, {to}] is not contiguous in replay state"
+                    );
+                    continue;
+                }
+
+                let parsed_replacements: Vec<_> = replacements
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(replacement_idx, replacement)| {
+                        match serde_yaml::from_str::<SessionLogEntry>(replacement) {
+                            Ok(parsed) => {
+                                // Replacements inherit EditEntries seq because originals are
+                                // logically removed from effective stream. Future rewind/edit
+                                // operations must target mutation seq, not replaced seqs.
+                                Some((*seq, parsed))
+                            },
+                            Err(err) => {
+                                log::warn!(
+                                    "Skipping replacement #{replacement_idx} in edit_entries entry #{seq} for session {name}: {err}"
+                                );
+                                None
+                            }
+                        }
+                    })
+                    .collect();
+
+                effective_entries.splice(start_idx..=end_idx, parsed_replacements);
+            }
+            SessionLogEntry::Unknown => {}
+            _ => effective_entries.push((*seq, entry.clone())),
+        }
+    }
+
+    effective_entries
+}
+
+fn replay_log_entries(raw_entries: &[(usize, SessionLogEntry)], name: &str) -> Result<Session> {
+    let effective_entries = build_effective_log_entries(raw_entries, name);
     let mut session = Session::default();
 
     // Pending ToolCalls entry awaiting a matching ToolResults entry.
@@ -59,9 +199,7 @@ fn load_from_log(config: &Config, name: &str, path: &Path, content: &str) -> Res
     // mid-log corruption would be an invariant violation.
     let mut pending: Option<PendingToolCalls> = None;
 
-    for document in serde_yaml::Deserializer::from_str(content) {
-        let entry = SessionLogEntry::deserialize(document)
-            .with_context(|| format!("Invalid log entry in session {name}"))?;
+    for (seq, entry) in effective_entries {
         match entry {
             SessionLogEntry::Header {
                 model_id,
@@ -95,12 +233,13 @@ fn load_from_log(config: &Config, name: &str, path: &Path, content: &str) -> Res
                         .push(repair_orphan_tool_calls(pending, name)?);
                 }
                 if role == MessageRole::Tool {
-                    bail!(
-                        "Invalid log entry in session {name}: Tool-role Message entries are \
-                         no longer supported; use tool_calls/tool_results entries"
+                    anyhow::bail!(
+                        "Invalid log entry in session {name}: Tool-role Message entries are                          no longer supported; use tool_calls/tool_results entries"
                     );
                 }
-                session.messages.push(Message::new(role, content));
+                session
+                    .messages
+                    .push(Message::new(role, content).with_log_seq(seq));
             }
             SessionLogEntry::ToolCalls {
                 text,
@@ -113,6 +252,7 @@ fn load_from_log(config: &Config, name: &str, path: &Path, content: &str) -> Res
                         .push(repair_orphan_tool_calls(pending, name)?);
                 }
                 pending = Some(PendingToolCalls {
+                    seq,
                     text,
                     thought,
                     calls,
@@ -120,19 +260,19 @@ fn load_from_log(config: &Config, name: &str, path: &Path, content: &str) -> Res
             }
             SessionLogEntry::ToolResults { results } => {
                 let Some(PendingToolCalls {
+                    seq,
                     text,
                     thought,
                     calls,
                 }) = pending.take()
                 else {
-                    bail!(
-                        "Invalid log entry in session {name}: tool_results without a \
-                         preceding tool_calls entry"
+                    anyhow::bail!(
+                        "Invalid log entry in session {name}: tool_results without a                          preceding tool_calls entry"
                     );
                 };
                 session
                     .messages
-                    .push(assemble_tool_message(text, thought, calls, results));
+                    .push(assemble_tool_message(text, thought, calls, results).with_log_seq(seq));
             }
             SessionLogEntry::DataUrls { urls } => {
                 session.data_urls.extend(urls);
@@ -155,104 +295,36 @@ fn load_from_log(config: &Config, name: &str, path: &Path, content: &str) -> Res
                 session.compressed_messages.clear();
                 session.data_urls.clear();
             }
+            SessionLogEntry::EditEntries { .. }
+            | SessionLogEntry::Rewind { .. }
+            | SessionLogEntry::Unknown => {}
         }
     }
 
-    // EOF with an orphan ToolCalls: the process was interrupted
-    // between dispatching tools and persisting their results. Repair
-    // so we can still replay a valid alternating user/assistant
-    // sequence to the model.
     if let Some(pending) = pending.take() {
         session
             .messages
             .push(repair_orphan_tool_calls(pending, name)?);
     }
 
-    session.model =
-        crate::client::retrieve_model(&config.clients, &session.model_id, ModelType::Chat)?;
-    apply_name_and_path(&mut session, name, path, config)?;
-    session.update_tokens();
     Ok(session)
 }
 
-struct PendingToolCalls {
-    text: String,
-    thought: Option<String>,
-    calls: Vec<crate::tool::ToolCall>,
-}
-
-/// Test-only log parser — runs the full load pipeline (including the
-/// orphan-ToolCalls repair pass) but skips the model-catalog lookup
-/// that `super::load` performs, so it works against the minimal
-/// `Config::default` used in unit tests.
+/// Test-only log parser — runs full load pipeline (including replay and
+/// orphan-ToolCalls repair) but skips model-catalog lookup that
+/// `super::load` performs, so it works against minimal `Config::default`
+/// used in unit tests.
 #[cfg(test)]
 fn load_from_log_for_test(content: &str) -> Session {
-    let mut session = Session::default();
-    let mut pending: Option<PendingToolCalls> = None;
-    for document in serde_yaml::Deserializer::from_str(content) {
-        let entry = SessionLogEntry::deserialize(document).expect("valid log entry");
-        match entry {
-            SessionLogEntry::Header { .. } => {}
-            SessionLogEntry::Message { role, content } => {
-                if let Some(pending) = pending.take() {
-                    session
-                        .messages
-                        .push(repair_orphan_tool_calls(pending, "test").unwrap());
-                }
-                assert_ne!(role, MessageRole::Tool, "legacy Tool Message unsupported");
-                session.messages.push(Message::new(role, content));
-            }
-            SessionLogEntry::ToolCalls {
-                text,
-                thought,
-                calls,
-            } => {
-                if let Some(pending) = pending.take() {
-                    session
-                        .messages
-                        .push(repair_orphan_tool_calls(pending, "test").unwrap());
-                }
-                pending = Some(PendingToolCalls {
-                    text,
-                    thought,
-                    calls,
-                });
-            }
-            SessionLogEntry::ToolResults { results } => {
-                let pending = pending.take().expect("tool_results must follow tool_calls");
-                session.messages.push(assemble_tool_message(
-                    pending.text,
-                    pending.thought,
-                    pending.calls,
-                    results,
-                ));
-            }
-            SessionLogEntry::DataUrls { urls } => session.data_urls.extend(urls),
-            SessionLogEntry::Compress { prompt } => {
-                session.compressed_messages.append(&mut session.messages);
-                session.messages.push(Message::new(
-                    MessageRole::System,
-                    MessageContent::Text(prompt),
-                ));
-            }
-            SessionLogEntry::Clear => {
-                pending = None;
-                session.messages.clear();
-                session.compressed_messages.clear();
-                session.data_urls.clear();
-            }
-        }
-    }
-    if let Some(pending) = pending.take() {
-        session
-            .messages
-            .push(repair_orphan_tool_calls(pending, "test").unwrap());
-    }
+    let raw_entries = collect_raw_log_entries(content, "test").expect("valid log entries");
+    let mut session = replay_log_entries(&raw_entries, "test").expect("replay should succeed");
+    session.log_entry_count = raw_entries.len();
     session
 }
 
 fn repair_orphan_tool_calls(pending: PendingToolCalls, _name: &str) -> Result<Message> {
     let PendingToolCalls {
+        seq,
         text,
         thought,
         calls,
@@ -274,7 +346,7 @@ fn repair_orphan_tool_calls(pending: PendingToolCalls, _name: &str) -> Result<Me
             ..lost.clone()
         })
         .collect();
-    Ok(assemble_tool_message(text, thought, calls, results))
+    Ok(assemble_tool_message(text, thought, calls, results).with_log_seq(seq))
 }
 
 fn assemble_tool_message(
@@ -402,6 +474,7 @@ pub fn ensure_log_file(session: &mut Session) {
     };
     if write(&session_path, &content).is_ok() {
         session.path = Some(session_path.display().to_string());
+        session.log_entry_count = 1;
     }
 }
 
@@ -422,7 +495,12 @@ pub fn append_event(session: &mut Session, entry: &SessionLogEntry) -> bool {
     let Ok(mut file) = OpenOptions::new().append(true).open(path) else {
         return false;
     };
-    file.write_all(data.as_bytes()).is_ok()
+    if file.write_all(data.as_bytes()).is_ok() {
+        session.log_entry_count += 1;
+        true
+    } else {
+        false
+    }
 }
 
 pub fn resolve_save_path(session: &mut Session, session_dir: &Path) -> (PathBuf, String) {
@@ -647,7 +725,7 @@ pub fn save(
         );
     }
 
-    write(session_path, content).with_context(|| {
+    write(session_path, &content).with_context(|| {
         format!(
             "Failed to write session '{}' to '{}'",
             session.name,
@@ -666,6 +744,7 @@ pub fn save(
         session.name = session_name.to_string()
     }
 
+    session.log_entry_count = serde_yaml::Deserializer::from_str(&content).count();
     session.dirty = false;
 
     Ok(())
@@ -732,7 +811,8 @@ pub fn add_assistant_text(
             Some(v) => MessageContent::Text(format!("<think>\n{v}\n</think>\n{output}")),
             _ => MessageContent::Text(output.to_string()),
         };
-        let assistant_msg = Message::new(MessageRole::Assistant, content);
+        let seq = session.next_seq();
+        let assistant_msg = Message::new(MessageRole::Assistant, content).with_log_seq(seq);
         all_appended &= append_event(
             session,
             &SessionLogEntry::Message {
@@ -768,6 +848,7 @@ pub fn add_tool_calls(
     // log (issue: multiple results with the same id sent to the LLM).
     let calls = crate::tool::ToolCall::dedup(calls.to_vec());
     let mut all_appended = begin_turn(session, input, output)?;
+    let tool_calls_seq = session.next_seq();
     all_appended &= append_event(
         session,
         &SessionLogEntry::ToolCalls {
@@ -799,7 +880,7 @@ pub fn add_tool_calls(
     ));
     session
         .messages
-        .push(Message::new(MessageRole::Tool, content));
+        .push(Message::new(MessageRole::Tool, content).with_log_seq(tool_calls_seq));
     session.dirty = !all_appended;
     session.update_tokens();
     Ok(())
@@ -893,7 +974,8 @@ fn begin_turn(session: &mut Session, input: &Input, output: &str) -> Result<bool
             session.autoname = Some(AutoName::new_from_chat_history(chat_history));
         }
         let agent_messages = input.agent().build_messages(input)?;
-        for msg in &agent_messages {
+        for msg in agent_messages {
+            let seq = session.next_seq();
             all_appended &= append_event(
                 session,
                 &SessionLogEntry::Message {
@@ -901,10 +983,11 @@ fn begin_turn(session: &mut Session, input: &Input, output: &str) -> Result<bool
                     content: msg.content.clone(),
                 },
             );
+            session.messages.push(msg.with_log_seq(seq));
         }
-        session.messages.extend(agent_messages);
     } else if !is_continuation {
-        let user_msg = Message::new(MessageRole::User, input.message_content());
+        let seq = session.next_seq();
+        let user_msg = Message::new(MessageRole::User, input.message_content()).with_log_seq(seq);
         all_appended &= append_event(
             session,
             &SessionLogEntry::Message {
@@ -925,10 +1008,12 @@ fn begin_turn(session: &mut Session, input: &Input, output: &str) -> Result<bool
     }
     session.data_urls.extend(new_data_urls);
     if let Some(injected) = input.injected_user_text() {
+        let seq = session.next_seq();
         let injected_msg = Message::new(
             MessageRole::User,
             MessageContent::Text(injected.to_string()),
-        );
+        )
+        .with_log_seq(seq);
         all_appended &= append_event(
             session,
             &SessionLogEntry::Message {
@@ -1017,6 +1102,57 @@ mod tests {
 
     fn test_session() -> Session {
         new(&Config::default(), "test").unwrap()
+    }
+
+    #[test]
+    fn load_from_log_enumerates_document_sequence_numbers() {
+        let content = r#"---
+type: header
+model: openai:gpt-4o
+---
+type: message
+role: user
+content: first
+---
+type: rewind
+after_seq: 1
+---
+type: edit_entries
+from: 1
+to: 1
+replacements: []
+---
+type: message
+role: assistant
+content: second
+"#;
+
+        let seqs: Vec<_> = serde_yaml::Deserializer::from_str(content)
+            .enumerate()
+            .map(|(seq, document)| {
+                let entry = SessionLogEntry::deserialize(document).expect("valid entry");
+                (seq, entry)
+            })
+            .collect();
+
+        assert_eq!(seqs.len(), 5);
+        assert!(matches!(seqs[0], (0, SessionLogEntry::Header { .. })));
+        assert!(matches!(seqs[1], (1, SessionLogEntry::Message { .. })));
+        assert!(matches!(
+            seqs[2],
+            (2, SessionLogEntry::Rewind { after_seq: 1 })
+        ));
+        assert!(matches!(
+            seqs[3],
+            (3, SessionLogEntry::EditEntries { from: 1, to: 1, .. })
+        ));
+        assert!(matches!(seqs[4], (4, SessionLogEntry::Message { .. })));
+
+        let session = super::load_from_log_for_test(content);
+        assert_eq!(session.messages.len(), 1);
+        assert_eq!(session.messages[0].content.to_text(), "second");
+        assert_eq!(session.log_entry_count, 5);
+        assert_eq!(session.next_seq(), 5);
     }
 
     #[test]
@@ -1518,6 +1654,238 @@ mod tests {
             json!({"results": ["a", "b"]}),
             "reloaded tool output should match what we wrote"
         );
+    }
+
+    #[test]
+    fn load_replays_rewind_entries() {
+        let content = r#"type: header
+model: test
+---
+type: message
+role: user
+content: zero
+---
+type: message
+role: assistant
+content: one
+---
+type: message
+role: user
+content: two
+---
+type: message
+role: assistant
+content: three
+---
+type: message
+role: user
+content: four
+---
+type: rewind
+after_seq: 2
+"#;
+
+        let session = super::load_from_log_for_test(content);
+        let texts: Vec<_> = session
+            .messages
+            .iter()
+            .map(|m| m.content.to_text())
+            .collect();
+
+        assert_eq!(texts, vec!["zero", "one"]);
+    }
+
+    #[test]
+    fn load_replays_edit_entries_replace() {
+        let content = r#"type: header
+model: test
+---
+type: message
+role: user
+content: before
+---
+type: message
+role: assistant
+content: replace me
+---
+type: message
+role: user
+content: after
+---
+type: edit_entries
+from: 2
+to: 2
+replacements:
+  - |
+    type: message
+    role: assistant
+    content: replaced
+"#;
+
+        let session = super::load_from_log_for_test(content);
+        let texts: Vec<_> = session
+            .messages
+            .iter()
+            .map(|m| m.content.to_text())
+            .collect();
+
+        assert_eq!(texts, vec!["before", "replaced", "after"]);
+    }
+
+    #[test]
+    fn load_replays_edit_entries_delete() {
+        let content = r#"type: header
+model: test
+---
+type: message
+role: user
+content: keep one
+---
+type: message
+role: assistant
+content: delete me
+---
+type: message
+role: user
+content: keep two
+---
+type: edit_entries
+from: 2
+to: 2
+replacements: []
+"#;
+
+        let session = super::load_from_log_for_test(content);
+        let texts: Vec<_> = session
+            .messages
+            .iter()
+            .map(|m| m.content.to_text())
+            .collect();
+
+        assert_eq!(texts, vec!["keep one", "keep two"]);
+    }
+
+    #[test]
+    fn load_replays_stacked_mutations_edit_then_rewind() {
+        let content = r#"type: header
+model: test
+---
+type: message
+role: user
+content: zero
+---
+type: message
+role: assistant
+content: one
+---
+type: message
+role: user
+content: two
+---
+type: edit_entries
+from: 2
+to: 2
+replacements:
+  - |
+    type: message
+    role: assistant
+    content: one edited
+---
+type: rewind
+after_seq: 3
+"#;
+
+        let session = super::load_from_log_for_test(content);
+        let texts: Vec<_> = session
+            .messages
+            .iter()
+            .map(|m| m.content.to_text())
+            .collect();
+
+        assert_eq!(texts, vec!["zero", "two"]);
+    }
+
+    #[test]
+    fn load_replays_stacked_mutations_rewind_then_edit() {
+        let content = r#"type: header
+model: test
+---
+type: message
+role: user
+content: zero
+---
+type: message
+role: assistant
+content: one
+---
+type: message
+role: user
+content: two
+---
+type: message
+role: assistant
+content: three
+---
+type: rewind
+after_seq: 2
+---
+type: edit_entries
+from: 1
+to: 1
+replacements:
+  - |
+    type: message
+    role: user
+    content: zero edited
+"#;
+
+        let session = super::load_from_log_for_test(content);
+        let texts: Vec<_> = session
+            .messages
+            .iter()
+            .map(|m| m.content.to_text())
+            .collect();
+
+        assert_eq!(texts, vec!["zero edited", "one"]);
+    }
+
+    #[test]
+    fn load_tracks_log_entry_count_and_append_event_increments_next_seq() {
+        use tempfile::TempDir;
+
+        let content = r#"type: header
+model: test
+---
+type: message
+role: user
+content: first
+---
+type: message
+role: assistant
+content: second
+"#;
+
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("session.yaml");
+        std::fs::write(&path, content).unwrap();
+
+        let mut session = super::load_from_log_for_test(content);
+        session.path = Some(path.display().to_string());
+
+        assert_eq!(session.log_entry_count, 3);
+        assert_eq!(session.next_seq(), 3);
+
+        let appended = super::append_event(
+            &mut session,
+            &SessionLogEntry::Message {
+                role: MessageRole::User,
+                content: MessageContent::Text("third".to_string()),
+            },
+        );
+
+        assert!(appended);
+        assert_eq!(session.log_entry_count, 4);
+        assert_eq!(session.next_seq(), 4);
     }
 
     #[test]

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -218,9 +218,10 @@ impl Tui {
                     } else if text.trim_start().starts_with('.') {
                         // Dot-command: route through command handler
                         let attachments_snapshot = self.app.attachments.clone();
-                        self.app
-                            .transcript
-                            .push(TranscriptItem::UserText(text.clone()));
+                        self.app.transcript.push(TranscriptItem::UserText {
+                            text: text.clone(),
+                            seq: None,
+                        });
                         self.render_submitted_attachments(&attachments_snapshot);
                         self.pin_transcript_to_bottom();
                         self.app.input = Self::new_input();
@@ -228,9 +229,10 @@ impl Tui {
                         self.refresh_input_chrome();
                     } else {
                         let attachments_snapshot = self.app.attachments.clone();
-                        self.app
-                            .transcript
-                            .push(TranscriptItem::UserText(text.clone()));
+                        self.app.transcript.push(TranscriptItem::UserText {
+                            text: text.clone(),
+                            seq: None,
+                        });
                         self.render_submitted_attachments(&attachments_snapshot);
                         self.pin_transcript_to_bottom();
                         self.app.input = Self::new_input();
@@ -487,9 +489,10 @@ impl Tui {
                 // transcript.
                 self.app.pending_message = None;
                 self.app.input = Self::new_input();
-                self.app
-                    .transcript
-                    .push(TranscriptItem::UserText(pending.text.clone()));
+                self.app.transcript.push(TranscriptItem::UserText {
+                    text: pending.text.clone(),
+                    seq: None,
+                });
                 self.render_submitted_attachments(&pending.attachments);
                 self.pin_transcript_to_bottom();
                 self.refresh_input_chrome();
@@ -519,9 +522,10 @@ impl Tui {
         pending: crate::types::PendingMessage,
     ) -> Result<()> {
         self.app.input = Self::new_input();
-        self.app
-            .transcript
-            .push(TranscriptItem::UserText(pending.text.clone()));
+        self.app.transcript.push(TranscriptItem::UserText {
+            text: pending.text.clone(),
+            seq: None,
+        });
         self.render_submitted_attachments(&pending.attachments);
         self.pin_transcript_to_bottom();
         if pending.text.trim_start().starts_with('.') {
@@ -586,7 +590,7 @@ impl Tui {
     }
 
     async fn render_agent_event(&mut self, event: AgentEvent, source: Option<AgentSource>) {
-        use harnx_core::event::{ModelEvent, NoticeEvent, ToolEvent};
+        use harnx_core::event::{ModelEvent, NoticeEvent, SessionEvent, ToolEvent};
 
         let is_thought = matches!(&event, AgentEvent::Model(ModelEvent::ThoughtChunk { .. }));
         let is_usage = matches!(&event, AgentEvent::Model(ModelEvent::Usage { .. }));
@@ -611,6 +615,26 @@ impl Tui {
             self.flush_pending_thought();
         }
         self.render_ui_output_heading(source.as_ref(), is_usage);
+
+        // LogSeqAssigned patches the seq on the next unassigned sequenceable
+        // item (UserText, AssistantText, or ToolCall) AFTER the last item
+        // that already has a seq.  Searching after the last-assigned position
+        // forward lets multiple LogSeqAssigned events in a turn target
+        // distinct items in source order, while skipping pre-existing
+        // unassigned items like the agent banner that pre-date any real
+        // log entries.
+        // LogSeqAssigned events are emitted by the engine after each log
+        // append so that future TUI work can show seq numbers on live
+        // messages.  For now the TUI only displays seq numbers on messages
+        // loaded from a saved session log (via messages_to_transcript_items).
+        // Live-event seq propagation across the streaming model is more
+        // intricate than a simple retroactive patch and is deferred.
+        if matches!(
+            event,
+            AgentEvent::Session(SessionEvent::LogSeqAssigned { .. })
+        ) {
+            return;
+        }
 
         let rendered_entries = match event {
             AgentEvent::Notice(NoticeEvent::Info(text)) => {
@@ -673,7 +697,7 @@ impl Tui {
                 if !output.is_empty() {
                     if let Some(idx) = self.app.streaming_assistant_idx {
                         match self.app.transcript.get_mut(idx) {
-                            Some(TranscriptItem::AssistantText(existing))
+                            Some(TranscriptItem::AssistantText { text: existing, .. })
                                 if !existing.is_empty() =>
                             {
                                 if existing != &output {
@@ -681,17 +705,19 @@ impl Tui {
                                 }
                             }
                             _ => {
-                                self.app
-                                    .transcript
-                                    .push(TranscriptItem::AssistantText(output));
+                                self.app.transcript.push(TranscriptItem::AssistantText {
+                                    text: output,
+                                    seq: None,
+                                });
                                 self.app.streaming_assistant_idx =
                                     Some(self.app.transcript.len() - 1);
                             }
                         }
                     } else {
-                        self.app
-                            .transcript
-                            .push(TranscriptItem::AssistantText(output));
+                        self.app.transcript.push(TranscriptItem::AssistantText {
+                            text: output,
+                            seq: None,
+                        });
                         self.app.streaming_assistant_idx = Some(self.app.transcript.len() - 1);
                     }
                     self.pin_transcript_to_bottom();
@@ -799,6 +825,7 @@ impl Tui {
                 vec![TranscriptItem::ToolCall {
                     tool_name: name,
                     body: tool_call_body(markdown.as_deref(), &input),
+                    seq: None,
                 }]
             }
             // Not rendered by the TUI: Turn, Session, Status, Tool::Progress,
@@ -1258,7 +1285,10 @@ impl Tui {
             || command_was.starts_with(".reset session")
             || command_was.starts_with(".reset repl")
             || command_was.starts_with(".compact session")
-            || command_was.starts_with(".edit session");
+            || command_was.starts_with(".edit session")
+            || command_was.starts_with(".edit message ")
+            || command_was.starts_with(".delete message ")
+            || command_was.starts_with(".rewind ");
 
         if !needs_reconcile {
             return;
@@ -1266,6 +1296,9 @@ impl Tui {
 
         self.app.transcript.clear();
         self.app.streaming_assistant_idx = None;
+        // Reset scroll state so the widget doesn't subtract-overflow when
+        // the rebuilt transcript is shorter than the previous one.
+        self.app.scroll_state = ratatui_widget_scrolling::ScrollState::new();
         self.app.transcript = Self::build_initial_transcript(&self.config);
         self.pin_transcript_to_bottom();
     }
@@ -1309,10 +1342,10 @@ impl Tui {
         };
 
         let clean = strip_ansi(&captured).trim_end_matches('\n').to_string();
-        if !clean.is_empty() {
-            self.app.transcript.push(TranscriptItem::SystemText(clean));
-            self.pin_transcript_to_bottom();
-        }
+        let line_cmd = line.trim_start();
+        let is_mutation_command = line_cmd.starts_with(".edit message ")
+            || line_cmd.starts_with(".delete message ")
+            || line_cmd.starts_with(".rewind ");
 
         match result {
             Ok(outcome) => {
@@ -1328,6 +1361,18 @@ impl Tui {
                     pending_message,
                 );
                 self.reconcile_transcript_after_command(prev_session, prev_agent, line);
+                if !clean.is_empty() {
+                    if is_mutation_command {
+                        self.app
+                            .transcript
+                            .push(TranscriptItem::MutationNotice(clean.clone()));
+                    } else {
+                        self.app
+                            .transcript
+                            .push(TranscriptItem::SystemText(clean.clone()));
+                    }
+                    self.pin_transcript_to_bottom();
+                }
             }
             Err(err) => {
                 self.app

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -124,7 +124,10 @@ impl Tui {
             if state.contains(harnx_runtime::config::StateFlags::AGENT) {
                 if let Ok(banner) = cfg.agent_banner() {
                     if !banner.trim().is_empty() {
-                        entries.push(TranscriptItem::AssistantText(banner));
+                        entries.push(TranscriptItem::AssistantText {
+                            text: banner,
+                            seq: None,
+                        });
                     }
                 }
                 if let Some(agent) = &cfg.agent {
@@ -295,13 +298,19 @@ pub(crate) fn messages_to_transcript_items(
             MessageRole::User => {
                 let text = msg.content.to_text();
                 if !text.is_empty() {
-                    items.push(TranscriptItem::UserText(text));
+                    items.push(TranscriptItem::UserText {
+                        text,
+                        seq: msg.log_seq,
+                    });
                 }
             }
             MessageRole::Assistant => {
                 let text = msg.content.to_text();
                 if !text.is_empty() {
-                    items.push(TranscriptItem::AssistantText(text));
+                    items.push(TranscriptItem::AssistantText {
+                        text,
+                        seq: msg.log_seq,
+                    });
                 }
             }
             MessageRole::Tool => {
@@ -312,7 +321,10 @@ pub(crate) fn messages_to_transcript_items(
                         ));
                     }
                     if !tc.text.trim().is_empty() {
-                        items.push(TranscriptItem::AssistantText(tc.text.clone()));
+                        items.push(TranscriptItem::AssistantText {
+                            text: tc.text.clone(),
+                            seq: msg.log_seq,
+                        });
                     }
                     for r in &tc.tool_results {
                         let raw_call_fallback = if r.call.arguments == Value::Null {
@@ -337,6 +349,7 @@ pub(crate) fn messages_to_transcript_items(
                         items.push(TranscriptItem::ToolCall {
                             tool_name: r.call.name.clone(),
                             body,
+                            seq: msg.log_seq,
                         });
                         let raw_result_fallback = harnx_core::tool::extract_user_display_text(
                             &r.output,
@@ -423,6 +436,7 @@ mod tests {
         let messages = vec![Message {
             role: MessageRole::Tool,
             content: MessageContent::ToolCalls(tc),
+            log_seq: None,
         }];
 
         let items = messages_to_transcript_items(&messages, &decl_map);
@@ -475,6 +489,7 @@ mod tests {
         let messages = vec![Message {
             role: MessageRole::Tool,
             content: MessageContent::ToolCalls(tc),
+            log_seq: None,
         }];
 
         let items = messages_to_transcript_items(&messages, &decl_map);

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -72,17 +72,24 @@ impl Tui {
 
     /// Render a `ToolCall` transcript item: `→ tool_name` header followed
     /// by the body lines. Body rendering depends on its origin —
-    /// `Yaml` is shown verbatim (raw arguments), `Markdown` is rendered
-    /// inline (templated `call_template` output).
-    fn render_tool_call(tool_name: &str, body: Option<&ToolCallBody>) -> Vec<Line<'static>> {
-        // Use the plain rightwards arrow `→` (U+2192). The previous glyph
-        // was `->` followed by VS16 (U+FE0F) which requested an emoji-style
-        // presentation and produced unicode-width vs. terminal-rendered-
-        // width disagreement, leaving stray glyphs in subsequent frames.
+    /// `Markdown` (from a `call_template`) is rendered inline; `Yaml`
+    /// (raw args, no template) is displayed verbatim, each line indented.
+    fn render_tool_call(
+        tool_name: &str,
+        body: Option<&ToolCallBody>,
+        seq: Option<usize>,
+    ) -> Vec<Line<'static>> {
         let dim_gray = Style::default()
             .fg(Color::DarkGray)
             .add_modifier(Modifier::DIM);
-        let mut lines = Self::render_text_entry("", &format!("→ {tool_name}"), dim_gray, false);
+
+        let header_text = if let Some(n) = seq {
+            format!("→ {tool_name}  [{n}]")
+        } else {
+            format!("→ {tool_name}")
+        };
+
+        let mut lines = Self::render_text_entry("", &header_text, dim_gray, false);
         match body {
             Some(ToolCallBody::Yaml(yaml)) => {
                 for line in yaml.lines() {
@@ -117,15 +124,36 @@ impl Tui {
                     .add_modifier(Modifier::DIM),
                 false,
             ),
-            TranscriptItem::UserText(text) => Self::render_text_entry(
-                "> ",
+            TranscriptItem::MutationNotice(text) => Self::render_text_entry(
+                "",
                 text,
                 Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-                true,
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::DIM),
+                false,
             ),
-            TranscriptItem::AssistantText(text) => {
+            TranscriptItem::UserText { text, seq } => {
+                let mut lines = Self::render_text_entry(
+                    "> ",
+                    text,
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                    true,
+                );
+                if let Some(n) = seq {
+                    if let Some(first_line) = lines.first_mut() {
+                        first_line.spans.push(Span::styled(
+                            format!("  [{n}]"),
+                            Style::default()
+                                .fg(Color::DarkGray)
+                                .add_modifier(Modifier::DIM),
+                        ));
+                    }
+                }
+                lines
+            }
+            TranscriptItem::AssistantText { text, seq } => {
                 // Render assistant messages as markdown so headings, lists,
                 // code fences, and inline emphasis show their styling.
                 // Streaming chunks rebuild this entry on every render — an
@@ -133,6 +161,19 @@ impl Tui {
                 // asterisks for the moment, then upgrades to bold once the
                 // closing `**` arrives in a later chunk.
                 let mut lines = crate::render_helpers::markdown_lines(text, Style::default());
+                if let Some(n) = seq {
+                    if lines.is_empty() {
+                        lines.push(Line::from(""));
+                    }
+                    if let Some(first_line) = lines.first_mut() {
+                        first_line.spans.push(Span::styled(
+                            format!("  [{n}]"),
+                            Style::default()
+                                .fg(Color::DarkGray)
+                                .add_modifier(Modifier::DIM),
+                        ));
+                    }
+                }
                 // Match the prior trailing-spacing rule: pad after a
                 // single-line message (so the next entry has breathing
                 // room) but skip the pad when the text already contains
@@ -194,9 +235,11 @@ impl Tui {
                     .add_modifier(Modifier::DIM),
                 false,
             ),
-            TranscriptItem::ToolCall { tool_name, body } => {
-                Self::render_tool_call(tool_name, body.as_ref())
-            }
+            TranscriptItem::ToolCall {
+                tool_name,
+                body,
+                seq,
+            } => Self::render_tool_call(tool_name, body.as_ref(), *seq),
             TranscriptItem::AttachmentHeader(text) => Self::render_text_entry(
                 "",
                 &format!("{text}:"),
@@ -426,7 +469,7 @@ impl Tui {
         while !remainder.is_empty() {
             if let Some(idx) = self.app.streaming_assistant_idx {
                 match self.app.transcript.get_mut(idx) {
-                    Some(TranscriptItem::AssistantText(existing)) => {
+                    Some(TranscriptItem::AssistantText { text: existing, .. }) => {
                         if existing.is_empty() {
                             if let Some(split_at) = remainder.find('\n') {
                                 let (segment, rest) = remainder.split_at(split_at + 1);
@@ -463,9 +506,10 @@ impl Tui {
                     _ => self.app.streaming_assistant_idx = None,
                 }
             } else {
-                self.app
-                    .transcript
-                    .push(TranscriptItem::AssistantText(String::new()));
+                self.app.transcript.push(TranscriptItem::AssistantText {
+                    text: String::new(),
+                    seq: None,
+                });
                 self.app.streaming_assistant_idx = Some(self.app.transcript.len() - 1);
             }
         }

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__assistant_text_with_seq_number.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__assistant_text_with_seq_number.snap
@@ -1,0 +1,26 @@
+---
+source: crates/harnx-tui/src/tests.rs
+expression: rendered
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
+hello back  [5]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+• Input

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__help_in_tui.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__help_in_tui.snap
@@ -1,11 +1,8 @@
 ---
-source: src/tests.rs
+source: crates/harnx-tui/src/tests.rs
+assertion_line: 1366
 expression: rendered
 ---
-.exit agent              Leave agent
-.rag                     Initialize or access RAG
-.edit rag-docs           Add or remove documents from an existing RAG
-.rebuild rag             Rebuild RAG for document changes
 .sources rag             Show citation sources used in last query
 .info rag                Show RAG info
 .exit rag                Leave RAG
@@ -19,6 +16,10 @@ expression: rendered
 .copy                    Copy last response
 .set                     Modify runtime settings
 .delete                  Delete agents, sessions, RAGs, or macros
+.delete message <n>      Delete a log entry by sequence number
+.delete message <n>-<m>  Delete a range of log entries
+.rewind <n>              Rewind session context to entry N (all later
+entries excluded)
 .exit                    Exit the interactive session
 
 Type ::: to start multi-line editing, type ::: to finish it.

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__mutation_notice_renders_with_yellow_dim_style.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__mutation_notice_renders_with_yellow_dim_style.snap
@@ -1,0 +1,26 @@
+---
+source: crates/harnx-tui/src/tests.rs
+expression: rendered
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
+✎ Edited entries 3-5
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+• Input

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__sub_agent_activity_dedup_after_all_tools.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__sub_agent_activity_dedup_after_all_tools.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests.rs
+source: crates/harnx-tui/src/tests.rs
 expression: rendered_mid2
 ---
 I'll look into that for you. Delegating now.

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__sub_agent_activity_dedup_after_first_tools.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__sub_agent_activity_dedup_after_first_tools.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests.rs
+source: crates/harnx-tui/src/tests.rs
 expression: rendered_mid1
 ---
 I'll look into that for you. Delegating now.

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__sub_agent_activity_dedup_final.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__sub_agent_activity_dedup_final.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests.rs
+source: crates/harnx-tui/src/tests.rs
 expression: rendered_final
 ---
 I'll look into that for you. Delegating now.

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__tool_call_display_format.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__tool_call_display_format.snap
@@ -1,0 +1,26 @@
+---
+source: crates/harnx-tui/src/tests.rs
+expression: rendered
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
+→ exec
+   command: ls -la
+   working_dir: /tmp
+→ write_file
+   write hello.txt with 3 lines
+→ think
+→ search
+   query: rust async patterns
+   max_results: 10
+   include_code: true
+
+
+
+
+
+
+
+
+
+
+• Input

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__tool_call_with_seq_number.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__tool_call_with_seq_number.snap
@@ -1,0 +1,26 @@
+---
+source: crates/harnx-tui/src/tests.rs
+expression: rendered
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
+→ read  [7]
+   path: /tmp/foo.txt
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+• Input

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__user_text_with_seq_number.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__user_text_with_seq_number.snap
@@ -1,0 +1,26 @@
+---
+source: crates/harnx-tui/src/tests.rs
+expression: rendered
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
+> hello world  [3]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+• Input

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::test_utils::TuiTestHarness;
 use crate::types::Tui;
-use crate::types::{TranscriptItem, TuiEvent};
+use crate::types::{ToolCallBody, TranscriptItem, TuiEvent};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use harnx_core::event::{
     AgentEvent, AgentSource, ContentBlock, ModelEvent, NoticeEvent, PlanEntry, ToolEvent, ToolKind,
@@ -140,7 +140,7 @@ async fn shift_enter_inserts_newline_without_submitting() {
         .app
         .transcript
         .iter()
-        .all(|entry| !matches!(entry, TranscriptItem::UserText(_))));
+        .all(|entry| !matches!(entry, TranscriptItem::UserText { text: _, .. })));
 }
 
 #[tokio::test]
@@ -163,11 +163,10 @@ async fn pending_message_is_auto_sent_after_finish() {
 
     assert!(tui.app.llm_busy);
     assert!(tui.app.pending_message.is_none());
-    let has_user_entry = tui
-        .app
-        .transcript
-        .iter()
-        .any(|entry| matches!(entry, TranscriptItem::UserText(text) if text == "follow up"));
+    let has_user_entry =
+        tui.app.transcript.iter().any(
+            |entry| matches!(entry, TranscriptItem::UserText { text, .. } if text == "follow up"),
+        );
     assert!(has_user_entry);
 }
 
@@ -240,10 +239,9 @@ async fn pending_message_consumed_clears_pending_and_shows_in_transcript() {
     // Input field should be cleared.
     assert!(tui.app.input.lines().join("").is_empty());
     // The consumed text should appear in the transcript as a UserText entry.
-    let has_user_entry =
-        tui.app.transcript.iter().any(
-            |entry| matches!(entry, TranscriptItem::UserText(text) if text == "interject here"),
-        );
+    let has_user_entry = tui.app.transcript.iter().any(
+        |entry| matches!(entry, TranscriptItem::UserText { text, .. } if text == "interject here"),
+    );
     assert!(has_user_entry);
 }
 
@@ -285,7 +283,9 @@ async fn pending_message_not_double_submitted_after_consumed() {
         .app
         .transcript
         .iter()
-        .filter(|entry| matches!(entry, TranscriptItem::UserText(text) if text == "once only"))
+        .filter(
+            |entry| matches!(entry, TranscriptItem::UserText { text, .. } if text == "once only"),
+        )
         .count();
     assert_eq!(user_text_count, 1);
 }
@@ -391,7 +391,7 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
         .transcript
         .iter()
         .filter_map(|entry| match entry {
-            TranscriptItem::AssistantText(text) => Some(text.as_str()),
+            TranscriptItem::AssistantText { text, .. } => Some(text.as_str()),
             _ => None,
         })
         .collect();
@@ -1286,7 +1286,7 @@ async fn acp_message_chunks_coalesce_like_direct_llm_streaming() {
         .transcript
         .iter()
         .filter_map(|entry| match entry {
-            TranscriptItem::AssistantText(text) => Some(text.as_str()),
+            TranscriptItem::AssistantText { text, .. } => Some(text.as_str()),
             _ => None,
         })
         .collect();
@@ -1338,8 +1338,8 @@ async fn submitting_message_with_attachments_renders_attachment_list_and_preview
         .collect();
 
     assert!(matches!(
-        tui.app.transcript.iter().find(|entry| matches!(entry, TranscriptItem::UserText(_))),
-        Some(TranscriptItem::UserText(text)) if text == "hello with files"
+        tui.app.transcript.iter().find(|entry| matches!(entry, TranscriptItem::UserText { text: _, .. })),
+        Some(TranscriptItem::UserText { text, .. }) if text == "hello with files"
     ));
     assert!(system_entries.contains(&"Attachments (1):".to_string()));
     assert!(system_entries.contains(&"  - notes.txt".to_string()));
@@ -1426,11 +1426,10 @@ async fn test_basic_message_and_streaming_response() {
         "harness config should not have a session before prompt starts"
     );
     harness.tui().clear_transcript();
-    harness
-        .tui()
-        .app
-        .transcript
-        .push(TranscriptItem::UserText("Test message".to_string()));
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Test message".to_string(),
+        seq: None,
+    });
     harness
         .tui()
         .start_prompt(crate::types::PendingMessage {
@@ -1477,22 +1476,86 @@ async fn test_basic_message_and_streaming_response() {
         .transcript
         .iter()
         .filter_map(|entry| match entry {
-            TranscriptItem::AssistantText(text) => Some(text.clone()),
+            TranscriptItem::AssistantText { text, .. } => Some(text.clone()),
             _ => None,
         })
         .collect();
     assert_eq!(assistant_entries, vec!["Hello from the mock client!"]);
-    assert!(harness
-        .tui()
-        .app
-        .transcript
-        .iter()
-        .any(|entry| matches!(entry, TranscriptItem::UserText(text) if text == "Test message")));
+    assert!(harness.tui().app.transcript.iter().any(
+        |entry| matches!(entry, TranscriptItem::UserText { text, .. } if text == "Test message")
+    ));
 
     let rendered = normalize_screen(&harness.screen_contents());
     insta::assert_snapshot!("basic_message_and_streaming_response", rendered);
 
     harness.drain_and_settle().await.unwrap();
+}
+
+/// Verifies that `[n]` sequence number labels propagate from a saved
+/// session log through `messages_to_transcript_items` onto `UserText` and
+/// `AssistantText` items.  This is the path used when a session is
+/// resumed from disk (e.g. `harnx -a foo -s existing-session`).
+///
+/// Live-event seq propagation (assigning seqs to messages as they stream
+/// in during an active turn, before a session reload) is intentionally
+/// deferred — the streaming render path interacts subtly with the agent
+/// banner and per-chunk AssistantText updates.  Resumed sessions exercise
+/// the full data flow without those complications.
+#[test]
+fn seq_numbers_appear_after_session_reload() {
+    use harnx_core::message::{Message, MessageContent, MessageRole};
+    use harnx_runtime::tool::ToolDeclaration;
+    use std::collections::HashMap;
+
+    // Build a Vec<Message> the way replay_log_entries would, with log_seq
+    // populated for each.  This bypasses the file I/O of full session
+    // load while exercising the same TUI conversion logic.
+    let messages = vec![
+        Message::new(
+            MessageRole::User,
+            MessageContent::Text("user message 1".to_string()),
+        )
+        .with_log_seq(2),
+        Message::new(
+            MessageRole::Assistant,
+            MessageContent::Text("assistant reply 1".to_string()),
+        )
+        .with_log_seq(3),
+        Message::new(
+            MessageRole::User,
+            MessageContent::Text("user message 2".to_string()),
+        )
+        .with_log_seq(4),
+        Message::new(
+            MessageRole::Assistant,
+            MessageContent::Text("assistant reply 2".to_string()),
+        )
+        .with_log_seq(5),
+    ];
+
+    let decl_map: HashMap<String, ToolDeclaration> = HashMap::new();
+    let items = crate::lifecycle::messages_to_transcript_items(&messages, &decl_map);
+
+    // Verify each TranscriptItem carries the correct seq.
+    let pairs: Vec<(&'static str, Option<usize>)> = items
+        .iter()
+        .filter_map(|item| match item {
+            TranscriptItem::UserText { seq, .. } => Some(("user", *seq)),
+            TranscriptItem::AssistantText { seq, .. } => Some(("assistant", *seq)),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        pairs,
+        vec![
+            ("user", Some(2)),
+            ("assistant", Some(3)),
+            ("user", Some(4)),
+            ("assistant", Some(5)),
+        ],
+        "seq numbers should propagate from Message.log_seq into TranscriptItem.seq",
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1523,11 +1586,10 @@ async fn test_streaming_with_tool_calls() {
 
     let mut harness = TuiTestHarness::with_config(config.clone());
     harness.tui().clear_transcript();
-    harness
-        .tui()
-        .app
-        .transcript
-        .push(TranscriptItem::UserText("What is the answer?".to_string()));
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "What is the answer?".to_string(),
+        seq: None,
+    });
     harness
         .tui()
         .start_prompt(crate::types::PendingMessage {
@@ -1599,8 +1661,8 @@ async fn test_sub_agent_delegation_tool_appears() {
                     .add_tool_call(
                         "specialist_session_handoff",
                         serde_json::json!({
-                            "prompt": "Please help with this task",
-                            "session_id": "handoff-session-1"
+                            "session_id": "handoff-session-1",
+                            "prompt": "Please help with this task"
                         }),
                     )
                     .build(),
@@ -1612,11 +1674,10 @@ async fn test_sub_agent_delegation_tool_appears() {
 
     let mut harness = TuiTestHarness::with_config(config.clone());
     harness.tui().clear_transcript();
-    harness
-        .tui()
-        .app
-        .transcript
-        .push(TranscriptItem::UserText("Help me".to_string()));
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Help me".to_string(),
+        seq: None,
+    });
     harness
         .tui()
         .start_prompt(crate::types::PendingMessage {
@@ -1769,11 +1830,10 @@ async fn test_screen_overflow_and_word_wrap() {
 
     let mut harness = TuiTestHarness::with_size(40, 10);
     harness.tui().clear_transcript();
-    harness
-        .tui()
-        .app
-        .transcript
-        .push(TranscriptItem::UserText(user_message.to_string()));
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: user_message.to_string(),
+        seq: None,
+    });
     harness
         .tui()
         .start_prompt(crate::types::PendingMessage {
@@ -1888,9 +1948,10 @@ async fn test_submitted_message_with_text_attachment_snapshot() {
     // would create: UserText, then AttachmentHeader + AttachmentItem +
     // AttachmentPreviewLines.
     let tui = harness.tui();
-    tui.app
-        .transcript
-        .push(TranscriptItem::UserText("check this file".to_string()));
+    tui.app.transcript.push(TranscriptItem::UserText {
+        text: "check this file".to_string(),
+        seq: None,
+    });
     tui.app.transcript.push(TranscriptItem::AttachmentHeader(
         "Attachments (1)".to_string(),
     ));
@@ -1907,9 +1968,10 @@ async fn test_submitted_message_with_text_attachment_snapshot() {
         .push(TranscriptItem::AttachmentPreviewLine(
             "Line 2 of notes".to_string(),
         ));
-    tui.app
-        .transcript
-        .push(TranscriptItem::AssistantText("Got it, thanks!".to_string()));
+    tui.app.transcript.push(TranscriptItem::AssistantText {
+        text: "Got it, thanks!".to_string(),
+        seq: None,
+    });
 
     harness.render();
     let rendered = normalize_screen(&harness.screen_contents());
@@ -1982,11 +2044,10 @@ async fn test_ctrl_c_cancels_streaming() {
 
     let mut harness = TuiTestHarness::with_config(config.clone());
     harness.tui().clear_transcript();
-    harness
-        .tui()
-        .app
-        .transcript
-        .push(TranscriptItem::UserText("Long request".to_string()));
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Long request".to_string(),
+        seq: None,
+    });
     harness
         .tui()
         .start_prompt(crate::types::PendingMessage {
@@ -2071,11 +2132,10 @@ async fn test_streaming_error_shows_in_transcript() {
 
     let mut harness = TuiTestHarness::with_config(config.clone());
     harness.tui().clear_transcript();
-    harness
-        .tui()
-        .app
-        .transcript
-        .push(TranscriptItem::UserText("Error test".to_string()));
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Error test".to_string(),
+        seq: None,
+    });
 
     // The error should propagate through start_prompt
     let result = harness
@@ -2246,11 +2306,10 @@ async fn test_cancel_during_tool_execution() {
 
     let mut harness = TuiTestHarness::with_config(config.clone());
     harness.tui().clear_transcript();
-    harness
-        .tui()
-        .app
-        .transcript
-        .push(TranscriptItem::UserText("Search test".to_string()));
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Search test".to_string(),
+        seq: None,
+    });
     harness
         .tui()
         .start_prompt(crate::types::PendingMessage {
@@ -2343,7 +2402,7 @@ async fn paste_multiline_creates_temp_attachment() {
         .app
         .transcript
         .iter()
-        .filter(|entry| matches!(entry, TranscriptItem::UserText(_)))
+        .filter(|entry| matches!(entry, TranscriptItem::UserText { text: _, .. }))
         .collect();
     assert!(
         user_entries.is_empty(),
@@ -2526,7 +2585,7 @@ async fn attach_command_adds_attachment() {
         .app
         .transcript
         .iter()
-        .filter(|e| matches!(e, TranscriptItem::UserText(_)))
+        .filter(|e| matches!(e, TranscriptItem::UserText { text: _, .. }))
         .collect();
     assert!(user_entries.is_empty());
 
@@ -2553,7 +2612,7 @@ async fn attach_command_preserves_draft_text() {
         .app
         .transcript
         .iter()
-        .filter(|e| matches!(e, TranscriptItem::UserText(_)))
+        .filter(|e| matches!(e, TranscriptItem::UserText { text: _, .. }))
         .collect();
     assert!(user_entries.is_empty());
 
@@ -2584,7 +2643,7 @@ async fn direct_submit_with_attachments_renders_attachment_entries_in_transcript
         .transcript
         .iter()
         .position(
-            |item| matches!(item, TranscriptItem::UserText(text) if text == "check attachment"),
+            |item| matches!(item, TranscriptItem::UserText { text, .. } if text == "check attachment"),
         )
         .expect("expected submitted user text in transcript");
 
@@ -2622,7 +2681,7 @@ async fn dot_command_with_attachments_renders_attachment_entries_in_transcript()
         .transcript
         .iter()
         .position(
-            |item| matches!(item, TranscriptItem::UserText(text) if text == ".info attachments"),
+            |item| matches!(item, TranscriptItem::UserText { text, .. } if text == ".info attachments"),
         )
         .expect("expected dot-command user text in transcript");
 
@@ -2874,11 +2933,10 @@ async fn test_recovery_after_cancellation() {
     harness.tui().clear_transcript();
 
     // Send first message
-    harness
-        .tui()
-        .app
-        .transcript
-        .push(TranscriptItem::UserText("First request".to_string()));
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "First request".to_string(),
+        seq: None,
+    });
     harness
         .tui()
         .start_prompt(crate::types::PendingMessage {
@@ -2939,11 +2997,10 @@ async fn test_recovery_after_cancellation() {
 
     // User can send a new message
     harness.tui().clear_transcript();
-    harness
-        .tui()
-        .app
-        .transcript
-        .push(TranscriptItem::UserText("Second request".to_string()));
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Second request".to_string(),
+        seq: None,
+    });
     harness
         .tui()
         .start_prompt(crate::types::PendingMessage {
@@ -3529,11 +3586,10 @@ async fn test_ctrl_c_interrupts_in_flight_streaming() {
     let _guard = TestStateGuard::new(Some(mock_client)).await;
 
     let mut harness = TuiTestHarness::with_config(config.clone());
-    harness
-        .tui()
-        .app
-        .transcript
-        .push(TranscriptItem::UserText("Long request".to_string()));
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Long request".to_string(),
+        seq: None,
+    });
     harness
         .tui()
         .start_prompt(crate::types::PendingMessage {
@@ -3886,7 +3942,10 @@ async fn test_tall_item_scroll_shows_correct_portion_and_no_dead_zone() {
         .tui()
         .app
         .transcript
-        .push(TranscriptItem::AssistantText(tall_text.clone()));
+        .push(TranscriptItem::AssistantText {
+            text: tall_text.clone(),
+            seq: None,
+        });
     // Pin to bottom (follow=true) — the default on new content
     harness.tui().pin_transcript_to_bottom();
 
@@ -3997,7 +4056,10 @@ async fn test_tall_item_scroll_window_moves_in_correct_direction() {
         .tui()
         .app
         .transcript
-        .push(TranscriptItem::AssistantText(tall_text));
+        .push(TranscriptItem::AssistantText {
+            text: tall_text,
+            seq: None,
+        });
     harness.tui().pin_transcript_to_bottom();
 
     // Helper: assert the visible portion of the transcript shows exactly
@@ -4492,9 +4554,10 @@ async fn tui_assistant_text_renders_inline_markdown() {
     .unwrap();
     tui.app
         .transcript
-        .push(crate::types::TranscriptItem::AssistantText(
-            "Here's some **bold** and `code`.".to_string(),
-        ));
+        .push(crate::types::TranscriptItem::AssistantText {
+            text: "Here's some **bold** and `code`.".to_string(),
+            seq: None,
+        });
 
     use ratatui::style::Modifier;
     let lines = rendered_lines(&tui);
@@ -4530,9 +4593,10 @@ async fn tui_assistant_text_preserves_line_breaks() {
     .unwrap();
     tui.app
         .transcript
-        .push(crate::types::TranscriptItem::AssistantText(
-            "first line\nsecond line\nthird line".to_string(),
-        ));
+        .push(crate::types::TranscriptItem::AssistantText {
+            text: "first line\nsecond line\nthird line".to_string(),
+            seq: None,
+        });
 
     let rendered: Vec<ratatui::text::Line<'static>> = tui
         .app
@@ -4560,4 +4624,94 @@ async fn tui_assistant_text_preserves_line_breaks() {
             .any(|t| t.contains("first line") && t.contains("second line")),
         "lines were collapsed instead of preserved: {line_texts:?}"
     );
+}
+
+#[tokio::test]
+async fn tool_call_display_format() {
+    let mut harness = TuiTestHarness::new();
+    harness.tui().app.transcript.push(TranscriptItem::ToolCall {
+        tool_name: "exec".to_string(),
+        body: Some(ToolCallBody::Yaml(
+            "command: ls -la\nworking_dir: /tmp\n".to_string(),
+        )),
+        seq: None,
+    });
+    harness.tui().app.transcript.push(TranscriptItem::ToolCall {
+        tool_name: "write_file".to_string(),
+        body: Some(ToolCallBody::Markdown(
+            "write **hello.txt** with 3 lines".to_string(),
+        )),
+        seq: None,
+    });
+    harness.tui().app.transcript.push(TranscriptItem::ToolCall {
+        tool_name: "think".to_string(),
+        body: None,
+        seq: None,
+    });
+    harness.tui().app.transcript.push(TranscriptItem::ToolCall {
+        tool_name: "search".to_string(),
+        body: Some(ToolCallBody::Yaml(
+            "query: rust async patterns\nmax_results: 10\ninclude_code: true\n".to_string(),
+        )),
+        seq: None,
+    });
+    harness.render();
+    let rendered = normalize_screen(&harness.screen_contents());
+    insta::assert_snapshot!("tool_call_display_format", rendered);
+}
+
+#[tokio::test]
+async fn tool_call_with_seq_number() {
+    let mut harness = TuiTestHarness::new();
+    harness.tui().app.transcript.push(TranscriptItem::ToolCall {
+        tool_name: "read".to_string(),
+        body: Some(ToolCallBody::Yaml("path: /tmp/foo.txt\n".to_string())),
+        seq: Some(7),
+    });
+    harness.render();
+    let rendered = normalize_screen(&harness.screen_contents());
+    insta::assert_snapshot!("tool_call_with_seq_number", rendered);
+}
+
+#[tokio::test]
+async fn user_text_with_seq_number() {
+    let mut harness = TuiTestHarness::new();
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "hello world".to_string(),
+        seq: Some(3),
+    });
+    harness.render();
+    let rendered = normalize_screen(&harness.screen_contents());
+    insta::assert_snapshot!("user_text_with_seq_number", rendered);
+}
+
+#[tokio::test]
+async fn assistant_text_with_seq_number() {
+    let mut harness = TuiTestHarness::new();
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "hello back".to_string(),
+            seq: Some(5),
+        });
+    harness.render();
+    let rendered = normalize_screen(&harness.screen_contents());
+    insta::assert_snapshot!("assistant_text_with_seq_number", rendered);
+}
+
+#[tokio::test]
+async fn mutation_notice_renders_with_yellow_dim_style() {
+    let mut harness = TuiTestHarness::new();
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::MutationNotice(
+            "✎ Edited entries 3-5".to_string(),
+        ));
+    harness.render();
+    let rendered = normalize_screen(&harness.screen_contents());
+    insta::assert_snapshot!("mutation_notice_renders_with_yellow_dim_style", rendered);
 }

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -123,8 +123,14 @@ pub(crate) enum ToolCallBody {
 pub(crate) enum TranscriptItem {
     SourceHeading(AgentSource),
     SystemText(String),
-    UserText(String),
-    AssistantText(String),
+    UserText {
+        text: String,
+        seq: Option<usize>,
+    },
+    AssistantText {
+        text: String,
+        seq: Option<usize>,
+    },
     ErrorText(String),
     ThoughtText(String),
     /// Tool result body — the full multi-line text extracted from the
@@ -138,10 +144,12 @@ pub(crate) enum TranscriptItem {
     ToolCall {
         tool_name: String,
         body: Option<ToolCallBody>,
+        seq: Option<usize>,
     },
     AttachmentHeader(String),
     AttachmentItem(String),
     AttachmentPreviewLine(String),
+    MutationNotice(String),
 }
 
 pub(crate) enum TuiEvent {

--- a/crates/harnx/tests/snapshots/tmux_e2e__interactive_handoff_planner_to_executor.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__interactive_handoff_planner_to_executor.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/harnx/tests/tmux_e2e.rs
-assertion_line: 533
 expression: normalized
 ---
 What feature would you like me to plan?

--- a/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap1_baseline_three_turns.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap1_baseline_three_turns.snap
@@ -1,0 +1,45 @@
+---
+source: crates/harnx/tests/tmux_e2e.rs
+expression: s
+---
+Welcome to harnx 0.30.0  *  Type .help for commands, Tab to complete.
+# mutation-test-agent v
+🤖 mutation-test-agent ▸ mutation-e2e-session
+> first message
+
+FIRST_RESPONSE_SENTINEL
+
+> second message
+
+SECOND_RESPONSE_SENTINEL
+
+> third message
+
+THIRD_RESPONSE_SENTINEL
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+* 🤖 mutation-test-agent ▸ mutation-e2e-session   Context: 57(0%)
+
+
+# snap: 1-baseline-three-turns

--- a/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap2_after_delete.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap2_after_delete.snap
@@ -1,0 +1,45 @@
+---
+source: crates/harnx/tests/tmux_e2e.rs
+expression: s
+---
+Welcome to harnx 0.30.0  *  Type .help for commands, Tab to complete.
+> first message  [2]
+
+FIRST_RESPONSE_SENTINEL  [3]
+
+> third message  [6]
+
+THIRD_RESPONSE_SENTINEL  [7]
+
+🤖 mutation-test-agent ▸ mutation-e2e-session
+Deleted entries 4-5.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+* 🤖 mutation-test-agent ▸ mutation-e2e-session   Context: 42(0%)
+
+
+# snap: 2-after-delete

--- a/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap3_after_rewind.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap3_after_rewind.snap
@@ -1,0 +1,45 @@
+---
+source: crates/harnx/tests/tmux_e2e.rs
+expression: s
+---
+Welcome to harnx 0.30.0  *  Type .help for commands, Tab to complete.
+> first message  [2]
+
+FIRST_RESPONSE_SENTINEL  [3]
+
+🤖 mutation-test-agent ▸ mutation-e2e-session
+↩ Rewound session to entry 3.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+* 🤖 mutation-test-agent ▸ mutation-e2e-session   Context: 27(0%)
+
+
+# snap: 3-after-rewind

--- a/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap4_after_edit.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap4_after_edit.snap
@@ -1,0 +1,45 @@
+---
+source: crates/harnx/tests/tmux_e2e.rs
+expression: s
+---
+
+
+
+
+
+> fifth message  [12]
+
+EDITED_RESPONSE_SENTINEL  [14]
+
+🤖 mutation-test-agent ▸ mutation-e2e-session
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# snap: 4-after-edit

--- a/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap5_session2_loaded.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap5_session2_loaded.snap
@@ -1,0 +1,45 @@
+---
+source: crates/harnx/tests/tmux_e2e.rs
+expression: s
+---
+Welcome to harnx 0.30.0  *  Type .help for commands, Tab to complete.
+> first message  [2]
+
+FIRST_RESPONSE_SENTINEL  [3]
+
+> fifth message  [12]
+
+EDITED_RESPONSE_SENTINEL  [14]
+
+🤖 mutation-test-agent ▸ mutation-e2e-session
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+* 🤖 mutation-test-agent ▸ mutation-e2e-session   Context: 42(0%)
+
+
+# snap: 5-session2-loaded

--- a/crates/harnx/tests/tmux_e2e.rs
+++ b/crates/harnx/tests/tmux_e2e.rs
@@ -4,6 +4,8 @@ use harnx::test_utils::{
     MockOpenAiToolCall, MockOpenAiTurn, MockTurnExpectation, TmuxHarness,
 };
 use harnx_acp::AcpServerConfig;
+use harnx_core::message::MessageRole;
+use harnx_core::session::SessionLogEntry;
 
 use anyhow::{Context, Result};
 use insta::assert_snapshot;
@@ -1731,5 +1733,468 @@ fn retry_succeed_after_fallback_shows_transition() -> Result<()> {
     let normalized = normalize_spinner_chars(&normalize_uuids(&normalize_screen(&screen)));
     assert_snapshot!("retry_succeed_after_fallback_shows_transition", normalized);
 
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// session_mutation_e2e
+//
+// End-to-end test for .edit message, .delete message, and .rewind across two
+// harnx sessions.  Sequence:
+//
+//   Session 1
+//     Turn 1  user: "first message"   → LLM: "first response"
+//     Turn 2  user: "second message"  → LLM: "second response"
+//     Turn 3  user: "third message"   → LLM: "third response"
+//     SNAP 1  (baseline — three turns visible, seq numbers shown)
+//     .delete message  removes turn 2 (user + assistant pair)
+//     SNAP 2  (after delete — mutation notice visible)
+//     .rewind  rewinds to after the first turn
+//     SNAP 3  (after rewind — only turn 1 context remains)
+//     Turn 4  user: "fourth message"  → LLM: "fourth response"
+//     .edit message  opens turn 4 in $EDITOR (mock editor rewrites content)
+//     SNAP 4  (after edit — edited content visible, mutation notice visible)
+//     Exit harnx
+//
+//   Session 2 (same agent + session name, resuming from disk)
+//     Wait for TUI to load history
+//     SNAP 5  (session reload — history reconstructed from mutations)
+//     Turn 5  user: "fifth message"   → LLM: "fifth response"
+//     SNAP 6  (new turn in reloaded session, seq numbers continue)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MUTATION_AGENT_NAME: &str = "mutation-test-agent";
+const MUTATION_SESSION_NAME: &str = "mutation-e2e-session";
+
+const RESP_FIRST: &str = "FIRST_RESPONSE_SENTINEL";
+const RESP_SECOND: &str = "SECOND_RESPONSE_SENTINEL";
+const RESP_THIRD: &str = "THIRD_RESPONSE_SENTINEL";
+const RESP_FOURTH: &str = "FOURTH_RESPONSE_SENTINEL";
+const RESP_EDITED: &str = "EDITED_RESPONSE_SENTINEL";
+const RESP_FIFTH: &str = "FIFTH_RESPONSE_SENTINEL";
+
+fn mutation_script() -> MockOpenAiScript {
+    MockOpenAiScript {
+        turns: vec![
+            MockOpenAiTurn {
+                text_chunks: vec![RESP_FIRST.to_string()],
+                tool_calls: vec![],
+                error: None,
+                expect: None,
+            },
+            MockOpenAiTurn {
+                text_chunks: vec![RESP_SECOND.to_string()],
+                tool_calls: vec![],
+                error: None,
+                expect: None,
+            },
+            MockOpenAiTurn {
+                text_chunks: vec![RESP_THIRD.to_string()],
+                tool_calls: vec![],
+                error: None,
+                expect: None,
+            },
+            // Turn 4: the original response before .edit rewrites it
+            MockOpenAiTurn {
+                text_chunks: vec![RESP_FOURTH.to_string()],
+                tool_calls: vec![],
+                error: None,
+                expect: None,
+            },
+            // Session 2, turn 5
+            MockOpenAiTurn {
+                text_chunks: vec![RESP_FIFTH.to_string()],
+                tool_calls: vec![],
+                error: None,
+                expect: None,
+            },
+        ],
+        fallback_text: "No more scripted responses.".to_string(),
+        chunk_delay_ms: 0,
+    }
+}
+
+/// Write a tiny shell script that acts as $EDITOR: replaces the file contents
+/// with `replacement` and exits 0.  Returns the path to the script.
+fn write_mock_editor(dir: &Path, replacement: &str) -> Result<PathBuf> {
+    let script_path = dir.join("mock-editor.sh");
+    // The script receives the temp file path as $1.
+    std::fs::write(
+        &script_path,
+        format!("#!/bin/sh\ncat > \"$1\" <<'MOCK_EOF'\n{replacement}\nMOCK_EOF\n"),
+    )?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))?;
+    }
+    Ok(script_path)
+}
+
+fn write_mutation_fixture_files(paths: &TestPaths, editor_path: &Path) -> Result<()> {
+    std::fs::create_dir_all(&paths.harnx_config_dir)?;
+
+    // save_session enabled by default — but set editor to our mock script.
+    // Also set a fixed session name so session 2 can resume it.
+    std::fs::write(
+        &paths.config_path,
+        format!(
+            "editor: {}\n",
+            shell_escape(editor_path.to_string_lossy().as_ref())
+        ),
+    )?;
+
+    let clients_dir = paths.harnx_config_dir.join("clients");
+    std::fs::create_dir_all(&clients_dir)?;
+
+    let client = serde_yaml::Value::Mapping(serde_yaml::Mapping::from_iter([
+        (
+            serde_yaml::Value::String("type".to_string()),
+            serde_yaml::Value::String("openai-compatible".to_string()),
+        ),
+        (
+            serde_yaml::Value::String("name".to_string()),
+            serde_yaml::Value::String("mock-llm".to_string()),
+        ),
+        (
+            serde_yaml::Value::String("api_base".to_string()),
+            serde_yaml::Value::String(format!("http://127.0.0.1:{}/v1", paths.port)),
+        ),
+        (
+            serde_yaml::Value::String("api_key".to_string()),
+            serde_yaml::Value::String("dummy".to_string()),
+        ),
+        (
+            serde_yaml::Value::String("models".to_string()),
+            serde_yaml::Value::Sequence(vec![serde_yaml::Value::Mapping(
+                serde_yaml::Mapping::from_iter([
+                    (
+                        serde_yaml::Value::String("name".to_string()),
+                        serde_yaml::Value::String("test".to_string()),
+                    ),
+                    (
+                        serde_yaml::Value::String("max_input_tokens".to_string()),
+                        serde_yaml::Value::Number(32000.into()),
+                    ),
+                    (
+                        serde_yaml::Value::String("max_output_tokens".to_string()),
+                        serde_yaml::Value::Number(4096.into()),
+                    ),
+                    (
+                        serde_yaml::Value::String("supports_tool_use".to_string()),
+                        serde_yaml::Value::Bool(false),
+                    ),
+                ]),
+            )]),
+        ),
+    ]));
+    std::fs::write(
+        clients_dir.join("mock-llm.yaml"),
+        serde_yaml::to_string(&client)?,
+    )?;
+
+    std::fs::write(
+        paths.agents_dir.join(format!("{MUTATION_AGENT_NAME}.md")),
+        format!(
+            "---\nname: {MUTATION_AGENT_NAME}\nmodel: mock-llm:test\n\
+             agent_default_session: {MUTATION_SESSION_NAME}\n---\n\
+             You are a test agent for mutation e2e testing.\n"
+        ),
+    )?;
+
+    Ok(())
+}
+
+fn snap(label: &str, screen: &str) -> String {
+    normalize_spinner_chars(&normalize_uuids(&normalize_screen(screen)))
+        .lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n")
+        + &format!("\n\n# snap: {label}")
+}
+
+#[test]
+fn session_mutation_edit_delete_rewind_persists_across_sessions() -> Result<()> {
+    if option_env!("CARGO_BIN_NAME") == Some("harnx") {
+        eprintln!("skipping session_mutation_e2e: binary test target");
+        return Ok(());
+    }
+    if !TmuxHarness::is_available() {
+        eprintln!("skipping session_mutation_e2e: tmux unavailable");
+        return Ok(());
+    }
+
+    let harnx_bin = PathBuf::from(env!("CARGO_BIN_EXE_harnx"));
+
+    let temp = TempDir::new()?;
+    let mock = MockOpenAiServer::start(mutation_script())?;
+    let paths = TestPaths::new(temp.path(), mock.port())?;
+
+    // Mock editor: writes EDITED_RESPONSE_SENTINEL as the assistant message body.
+    // The edit target will be the assistant message YAML — we replace the whole
+    // document with a valid message entry containing our sentinel text.
+    let edited_yaml = format!("type: message\nrole: assistant\ncontent: {RESP_EDITED}\n");
+    let editor_path = write_mock_editor(temp.path(), &edited_yaml)?;
+
+    write_mutation_fixture_files(&paths, &editor_path)?;
+
+    let path_env = format!(
+        "{}:{}",
+        harnx_bin.parent().context("no parent")?.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let root = repo_root()?;
+
+    // ── Shared tmux setup helper ────────────────────────────────────────────
+    let setup_env = |tmux: &TmuxHarness, marker: &str| -> Result<()> {
+        tmux.send_keys(&["C-l"])?;
+        tmux.send_text(&format!(
+            "export HARNX_CONFIG_DIR={} PATH={} && cd {}; printf '{marker}\\n'",
+            shell_escape(paths.harnx_config_dir.to_string_lossy().as_ref()),
+            shell_escape(&path_env),
+            shell_escape(root.to_string_lossy().as_ref()),
+        ))?;
+        tmux.send_keys(&["Enter"])?;
+        tmux.wait_for(Duration::from_secs(10), |s| {
+            count_occurrences(s, marker) >= 2
+        })?;
+        Ok(())
+    };
+
+    let wait = Duration::from_secs(20);
+    let settle = Duration::from_millis(400);
+
+    // ════════════════════════════════════════════════════════════════════════
+    // SESSION 1
+    // ════════════════════════════════════════════════════════════════════════
+    let tmux = match TmuxHarness::new(&root, 120, 40) {
+        Ok(t) => t,
+        Err(err) => {
+            eprintln!("skipping: tmux unusable ({err:#})");
+            return Ok(());
+        }
+    };
+    setup_env(&tmux, "__MUTATION_READY__")?;
+
+    // Start harnx with the mutation agent and an explicit session name so
+    // both session 1 and session 2 operate on the same log file.
+    tmux.send_text(&format!(
+        "{} -a {} -s {} || echo HARNX_EXIT:$?",
+        shell_escape(harnx_bin.to_string_lossy().as_ref()),
+        MUTATION_AGENT_NAME,
+        MUTATION_SESSION_NAME,
+    ))?;
+    tmux.send_keys(&["Enter"])?;
+    tmux.wait_for_contains("Welcome to harnx", Duration::from_secs(15))?;
+
+    // ── Turn 1 ───────────────────────────────────────────────────────────
+    tmux.send_text("first message")?;
+    tmux.send_keys(&["Enter"])?;
+    tmux.wait_for_contains(RESP_FIRST, wait)?;
+
+    // ── Turn 2 ───────────────────────────────────────────────────────────
+    tmux.send_text("second message")?;
+    tmux.send_keys(&["Enter"])?;
+    tmux.wait_for_contains(RESP_SECOND, wait)?;
+
+    // ── Turn 3 ───────────────────────────────────────────────────────────
+    tmux.send_text("third message")?;
+    tmux.send_keys(&["Enter"])?;
+    let screen_after_three_turns =
+        tmux.wait_for_stable(wait, settle, |s| s.contains(RESP_THIRD))?;
+
+    // SNAP 1 — three turns, seq numbers visible on each
+    {
+        let s = snap("1-baseline-three-turns", &screen_after_three_turns);
+        assert!(
+            screen_after_three_turns.contains(RESP_FIRST),
+            "snap1: RESP_FIRST missing\n{s}"
+        );
+        assert!(
+            screen_after_three_turns.contains(RESP_SECOND),
+            "snap1: RESP_SECOND missing\n{s}"
+        );
+        assert!(
+            screen_after_three_turns.contains(RESP_THIRD),
+            "snap1: RESP_THIRD missing\n{s}"
+        );
+        insta::assert_snapshot!("mutation_snap1_baseline_three_turns", s);
+    }
+
+    let session_log_path = paths
+        .harnx_config_dir
+        .join("agents")
+        .join(MUTATION_AGENT_NAME)
+        .join("sessions")
+        .join(format!("{MUTATION_SESSION_NAME}.yaml"));
+    let log_content = std::fs::read_to_string(&session_log_path)
+        .with_context(|| format!("failed to read session log {}", session_log_path.display()))?;
+    let mut first_assistant_seq = None;
+    let mut second_user_seq = None;
+    let mut second_assistant_seq = None;
+    let mut user_count = 0usize;
+    for (seq, document) in serde_yaml::Deserializer::from_str(&log_content).enumerate() {
+        let entry = serde::Deserialize::deserialize(document)?;
+        match entry {
+            SessionLogEntry::Message {
+                role: MessageRole::User,
+                ..
+            } => {
+                user_count += 1;
+                if user_count == 2 {
+                    second_user_seq = Some(seq);
+                }
+            }
+            SessionLogEntry::Message {
+                role: MessageRole::Assistant,
+                ..
+            } => {
+                if first_assistant_seq.is_none() {
+                    first_assistant_seq = Some(seq);
+                }
+                if second_user_seq.is_some() && second_assistant_seq.is_none() {
+                    second_assistant_seq = Some(seq);
+                }
+            }
+            _ => {}
+        }
+    }
+    let second_user_seq = second_user_seq.context("failed to find seq for second user message")?;
+    let second_assistant_seq =
+        second_assistant_seq.context("failed to find seq for second assistant message")?;
+    let first_assistant_seq =
+        first_assistant_seq.context("failed to find seq for first assistant message")?;
+
+    // ── .delete message — remove turn 2 (user + assistant) ───────────────
+    tmux.send_text(&format!(
+        ".delete message {second_user_seq}-{second_assistant_seq}"
+    ))?;
+    tmux.send_keys(&["Enter"])?;
+    let screen_after_delete =
+        tmux.wait_for_stable(wait, settle, |s| s.contains("✗") || s.contains("Deleted"))?;
+
+    // SNAP 2 — after delete: mutation notice visible, turn 2 gone
+    {
+        let s = snap("2-after-delete", &screen_after_delete);
+        assert!(
+            !screen_after_delete.contains(RESP_SECOND),
+            "snap2: RESP_SECOND should be deleted from view\n{s}"
+        );
+        insta::assert_snapshot!("mutation_snap2_after_delete", s);
+    }
+
+    // ── Turn 4 ───────────────────────────────────────────────────────────
+    tmux.send_text("fourth message")?;
+    tmux.send_keys(&["Enter"])?;
+    tmux.wait_for_contains(RESP_FOURTH, wait)?;
+
+    // ── .rewind — rewind to after turn 1
+    tmux.send_text(&format!(".rewind {first_assistant_seq}"))?;
+    tmux.send_keys(&["Enter"])?;
+    let screen_after_rewind =
+        tmux.wait_for_stable(wait, settle, |s| s.contains("↩") || s.contains("Rewound"))?;
+
+    // SNAP 3 — after rewind: only turn 1 in context, notice visible
+    {
+        let s = snap("3-after-rewind", &screen_after_rewind);
+        assert!(
+            !screen_after_rewind.contains(RESP_FOURTH),
+            "snap3: RESP_FOURTH should be rewound from view
+{s}"
+        );
+        insta::assert_snapshot!("mutation_snap3_after_rewind", s);
+    }
+
+    // ── Turn 5 (new turn after rewind, becomes the 2nd in effective context)
+    tmux.send_text("fifth message")?;
+    tmux.send_keys(&["Enter"])?;
+    tmux.wait_for_contains(RESP_FIFTH, wait)?;
+
+    // ── .edit message — open the fifth message assistant response in $EDITOR
+    // Calculate the actual last seq by counting YAML documents in the session log.
+    // The last entry (assistant response to fifth message) is at seq = doc_count - 1.
+    let session_log_path = paths
+        .harnx_config_dir
+        .join("agents")
+        .join(MUTATION_AGENT_NAME)
+        .join("sessions")
+        .join(format!("{MUTATION_SESSION_NAME}.yaml"));
+    let log_content = std::fs::read_to_string(&session_log_path)
+        .with_context(|| format!("failed to read session log {}", session_log_path.display()))?;
+    // Count documents: number of "\n---\n" separators + 1 (for the opening doc).
+    let doc_count = serde_yaml::Deserializer::from_str(&log_content).count();
+    let last_seq = doc_count - 1;
+    tmux.send_text(&format!(".edit message {last_seq}"))?;
+    tmux.send_keys(&["Enter"])?;
+    // Mock editor runs non-interactively and exits immediately.
+    let screen_after_edit = tmux.wait_for_stable(wait, settle, |s| {
+        s.contains(RESP_EDITED) || s.contains("✎") || s.contains("Edited")
+    })?;
+
+    // SNAP 4 — after edit: edited content visible, mutation notice
+    {
+        let s = snap("4-after-edit", &screen_after_edit);
+        assert!(
+            screen_after_edit.contains(RESP_EDITED),
+            "snap4: edited sentinel not visible\n{s}"
+        );
+        insta::assert_snapshot!("mutation_snap4_after_edit", s);
+    }
+
+    // Exit harnx
+    tmux.send_keys(&["C-d"])?;
+    tmux.wait_for_stable(Duration::from_secs(10), settle, |s| {
+        // Back at shell prompt
+        !s.contains("Welcome to harnx") || s.contains("HARNX_EXIT")
+    })?;
+
+    drop(tmux);
+
+    // ════════════════════════════════════════════════════════════════════════
+    // SESSION 2 — resume the same agent+session from disk
+    // ════════════════════════════════════════════════════════════════════════
+    let tmux2 = match TmuxHarness::new(&root, 120, 40) {
+        Ok(t) => t,
+        Err(err) => {
+            eprintln!("skipping session2: tmux unusable ({err:#})");
+            return Ok(());
+        }
+    };
+    setup_env(&tmux2, "__MUTATION_S2_READY__")?;
+
+    tmux2.send_text(&format!(
+        "{} -a {} -s {} || echo HARNX_EXIT:$?",
+        shell_escape(harnx_bin.to_string_lossy().as_ref()),
+        MUTATION_AGENT_NAME,
+        MUTATION_SESSION_NAME,
+    ))?;
+    tmux2.send_keys(&["Enter"])?;
+    tmux2.wait_for_contains("Welcome to harnx", Duration::from_secs(15))?;
+
+    // Wait for session history to load (edited sentinel should appear if
+    // the replay replayed EditEntries correctly)
+    let screen_s2_loaded = tmux2.wait_for_stable(wait, settle, |s| {
+        // Either the edited content is visible, or we see seq [1] from turn 1
+        s.contains(RESP_EDITED) || s.contains(RESP_FIRST)
+    })?;
+
+    // SNAP 5 — session reload from disk: mutations replayed, seq numbers shown
+    {
+        let s = snap("5-session2-loaded", &screen_s2_loaded);
+        assert!(
+            screen_s2_loaded.contains(RESP_FIRST),
+            "snap5: turn 1 missing after reload\n{s}"
+        );
+        // Deleted turn 2 should NOT be visible in reconstructed history
+        assert!(
+            !screen_s2_loaded.contains(RESP_SECOND),
+            "snap5: deleted turn 2 still visible after reload\n{s}"
+        );
+        insta::assert_snapshot!("mutation_snap5_session2_loaded", s);
+    }
+
+    drop(tmux2);
+    drop(mock);
     Ok(())
 }

--- a/docs/solutions/logic-errors/non-destructive-session-mutation-two-pass-replay-2026-05-01.md
+++ b/docs/solutions/logic-errors/non-destructive-session-mutation-two-pass-replay-2026-05-01.md
@@ -1,0 +1,226 @@
+---
+title: "Non-destructive session mutation with two-pass log replay"
+date: 2026-05-01
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-session-log"
+root_cause: "append-only log requires mutation entries interpreted at replay time, not in-place edits"
+resolution_type: code_fix
+severity: medium
+tags:
+  - session-log
+  - mutation
+  - two-pass-replay
+  - serde
+  - forward-compatibility
+plan_ref: "harnx-event-tagging-tui-redesign"
+---
+
+## Problem
+
+Session logs needed edit, delete, and rewind capabilities without destructively overwriting history. Direct file modification would lose audit trail, break crash recovery, and prevent undo. Needed a mutation model that preserves the original log entries while allowing the session state to reflect changes.
+
+## Symptoms
+
+- Users wanted to fix typos in previous messages without restarting the session
+- Long-running sessions needed ability to rewind to earlier points and branch
+- Tool call/result pairs needed integrity protection during edits
+- Future log entry variants (added in newer versions) needed graceful handling when opened in older clients
+
+## Investigation Steps
+
+Evaluated three approaches for session mutation:
+
+1. **In-place file edit**: Direct modification of the session file. Rejected because:
+   - Loses audit trail
+   - Cannot undo
+   - Complex recovery if edit is interrupted mid-write
+   - Breaks if user manually edits the file
+
+2. **Copy-on-write snapshots**: Each mutation creates a new snapshot file. Rejected because:
+   - Proliferates files
+   - Complex cleanup
+   - Difficult to determine "current" state
+
+3. **Append-only mutation entries** (chosen): Each mutation appends a log entry that describes the edit. On reload, mutations are applied to build the effective session state.
+
+Key insight: sequence numbers must be stable across mutations. If seq is stored in each entry, editing entry 5 to become two entries breaks numbering. Solution: derive seq from YAML document position (0-based index in the multi-document stream).
+
+## Root Cause
+
+Traditional in-place mutation doesn't work for append-only logs. The log is the source of truth, but the effective session state must be computed by replaying mutation entries in order. This requires a two-phase approach:
+
+1. **Pass 1**: Collect all raw (seq, entry) pairs from the YAML document stream
+2. **Pass 2**: Apply mutations (EditEntries, Rewind) to build the effective entry list
+
+## Solution
+
+### Mutation Schema
+
+Added two new `SessionLogEntry` variants in `crates/harnx-core/src/session.rs`:
+
+```rust
+#[serde(rename = "edit_entries")]
+EditEntries {
+    /// Inclusive range of entry sequence numbers being replaced.
+    from: usize,
+    to: usize,
+    /// Replacement YAML documents (raw strings, one per replaced entry).
+    /// Empty vec = deletion.
+    replacements: Vec<String>,
+},
+#[serde(rename = "rewind")]
+Rewind {
+    /// All entries with seq > after_seq are excluded from context on replay.
+    after_seq: usize,
+},
+#[serde(other)]
+Unknown,
+```
+
+### Two-Pass Log Replay
+
+In `crates/harnx-runtime/src/config/session.rs`:
+
+```rust
+fn load_from_log(config: &Config, name: &str, path: &Path, content: &str) -> Result<Session> {
+    let raw_entries = collect_raw_log_entries(content, name)?;
+    let mut session = replay_log_entries(&raw_entries, name)?;
+    session.log_entry_count = raw_entries.len();
+    // ... rest of initialization
+}
+
+fn collect_raw_log_entries(content: &str, name: &str) -> Result<Vec<(usize, SessionLogEntry)>> {
+    serde_yaml::Deserializer::from_str(content)
+        .enumerate()
+        .map(|(seq, document)| {
+            let entry = SessionLogEntry::deserialize(document)
+                .with_context(|| format!("Invalid log entry #{} in session {}", seq, name))?;
+            Ok((seq, entry))
+        })
+        .collect()
+}
+
+fn build_effective_log_entries(
+    raw_entries: &[(usize, SessionLogEntry)],
+    name: &str,
+) -> Vec<(usize, SessionLogEntry)> {
+    let mut effective_entries = Vec::new();
+
+    for (seq, entry) in raw_entries {
+        match entry {
+            SessionLogEntry::Rewind { after_seq } => {
+                // Validate: after_seq must be < current seq
+                // Validate: after_seq must exist in effective_entries
+                // Remove all entries with seq > after_seq
+                effective_entries.retain(|(s, _)| *s <= *after_seq);
+            }
+            SessionLogEntry::EditEntries { from, to, replacements } => {
+                // Validate: from and to exist in effective_entries
+                // Validate: range [from, to] is contiguous
+                // Parse replacement YAML strings into entries
+                // Splice replacements into effective_entries
+                let parsed: Vec<_> = replacements.iter()
+                    .filter_map(|r| serde_yaml::from_str(r).ok())
+                    .map(|e| (*seq, e))
+                    .collect();
+                effective_entries.splice(start_idx..=end_idx, parsed);
+            }
+            SessionLogEntry::Unknown => {} // Skip unknown future variants
+            _ => effective_entries.push((*seq, entry.clone())),
+        }
+    }
+    effective_entries
+}
+```
+
+### Sequence Numbers Derived from Position
+
+Seq is never stored in the entry itself. It's derived from the document position in the YAML stream:
+
+```rust
+// In Session struct:
+#[serde(skip)]
+pub log_entry_count: usize,  // Tracks total documents for next_seq()
+
+pub fn next_seq(&self) -> usize {
+    self.log_entry_count
+}
+```
+
+This guarantees stability: even if an edit replaces entry 5 with 3 entries, they all get seq of the mutation entry, not fractional numbers. The original entry 5 still exists in the raw log at position 5.
+
+### Unknown Variant for Forward Compatibility
+
+```rust
+#[serde(other)]
+Unknown,
+```
+
+The `#[serde(other)]` attribute causes unknown `type:` values to deserialize to `Unknown` instead of failing. During replay, `Unknown` entries are skipped. This allows:
+
+- Old clients opening logs with new entry types (graceful degradation)
+- Future schema evolution without breaking existing deployments
+- Unknown `type:` tag values deserialize to `Unknown` instead of failing (field-level typos or malformed documents still return an error)
+
+### MutationNotice Ordering
+
+Initially, `run_command` pushed `MutationNotice` to the transcript, then called `reconcile_transcript_after_command`, which cleared the transcript. The notice was destroyed before the user could see it.
+
+Fix: push the notice *after* reconciliation completes:
+
+```rust
+// In crates/harnx-tui/src/input.rs run_command:
+self.reconcile_transcript_after_command(prev_session, prev_agent, line);
+if !clean.is_empty() {
+    if is_mutation_command {
+        self.app.transcript.push(TranscriptItem::MutationNotice(clean));
+    }
+    // ...
+}
+```
+
+### Non-Obvious Decisions
+
+1. **Empty replacements = delete**: `EditEntries { from: 3, to: 5, replacements: [] }` deletes entries 3-5. The empty vec is a valid edit that removes content without a separate `DeleteEntries` variant.
+
+2. **Seq 0 header protection**: The first YAML document is always a `Header` entry with metadata (model, agent, etc.). `.edit` and `.delete` commands must reject `from == 0` to prevent corrupting the session structure.
+
+3. **Rewind bounds validation**: `rewind_session(after_seq)` validates `after_seq < session.log_entry_count` *before* appending the `Rewind` entry. Without this, `.rewind 999999` would append silently and only warn on reload.
+
+4. **Replacement seq assignment**: All replacements from an `EditEntries` get the seq of the mutation entry itself, not their original positions. This makes replacements addressable as a block for further edits.
+
+## Why This Works
+
+**Append-only guarantees audit trail**: Every mutation is recorded. The original entries exist in the log forever. History can be reconstructed at any point.
+
+**Two-pass replay isolates concerns**: Raw log collection doesn't know about mutations. Replay logic only processes mutations. Clean separation of parsing from interpretation.
+
+**Position-derived seq is stable**: Even after edits, the original seq numbers remain valid as positions in the raw log file. An edit at position 5 doesn't shift positions of other entries.
+
+**Unknown variant enables evolution**: Adding new entry types in future versions won't break old clients. They'll see `Unknown` and skip, rather than failing to deserialize entirely.
+
+## Prevention Strategies
+
+**Test cases:**
+- Unit tests for `build_effective_log_entries` with overlapping mutations
+- Integration tests for `.edit`, `.delete`, `.rewind` commands in TUI
+- Test that `Unknown` entries are gracefully skipped
+- Test that seq 0 header protection rejects edits
+
+**Best practices:**
+- Always use `serde_yaml::Deserializer` for multi-document parsing (not string split)
+- Validate mutation bounds before appending entries
+- Re-run session load after any mutation to verify effective state
+
+**Code review checklist:**
+- [ ] Does the mutation command validate bounds?
+- [ ] Does the mutation command protect seq 0?
+- [ ] Does the mutation notice survive transcript reconciliation?
+- [ ] Are unknown entry types handled gracefully?
+
+## Related Issues
+
+- **Jira:** #342 — Non-destructive session editing
+- **Jira:** #396 — Sequence numbers for transcript items
+- **PR:** [harnx-event-tagging-tui-redesign] — Full implementation of mutation commands


### PR DESCRIPTION
Adds non-destructive session history editing capabilities to harnx, allowing users to edit, delete, and rewind history without losing the audit trail of original log entries. Implements a two-pass log loader that collects raw entries and then applies EditEntries and Rewind mutations during replay.

Adds stable sequence numbers [n] to replayed transcript items for precise targeting of mutations. Includes new .edit message <range>, .delete message <range>, and .rewind <n> commands with visual feedback via a yellow MutationNotice widget.

Key changes:
- Adds EditEntries and Rewind variants to SessionLogEntry
- Implements two-pass log loading with mutation replay logic
- Populates sequence numbers from log position into transcript items
- Protects session header (seq 0) and validates mutation bounds
- Includes E2E tmux tests for mutation persistence and UI feedback
- Documents the two-pass replay pattern and forward compatibility design

[#342]

Plan: harnx-event-tagging-tui-redesign

