### PR TITLE
chore: pin rust toolchain via rust-toolchain.toml to match CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Harnx is a modular command-line LLM agent harness written in **Rust**. It lets u
 
 ## Technology Stack
 
-- **Language:** Rust (edition 2021, toolchain pinned in `.tool-versions`)
+- **Language:** Rust (edition 2021, toolchain pinned in `rust-toolchain.toml` — rustup and CI both read this file automatically)
 - **Async runtime:** Tokio (multi-threaded)
 - **HTTP client:** reqwest (rustls-tls)
 - **CLI framework:** clap (derive)
@@ -65,7 +65,7 @@ Run the full verification pipeline before committing:
 
 ```sh
 cargo build --workspace                                       # Compile the project
-cargo fmt --all                                               # Auto-format code (run without --check to fix)
+cargo fmt --all                                               # Auto-format code (rustup uses rust-toolchain.toml version — matches CI)
 cargo clippy --workspace --all-targets -- -D warnings         # Lint — treat warnings as errors
 cargo nextest run --workspace --stress-count=5                # Run all tests, repeat several times to catch flaky tests
 cs delta $(git merge-base HEAD origin/main)                   # Run CodeScene code quality analysis on current branch changes                                          

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Problem

`dtolnay/rust-toolchain@stable` (used in CI) reads `rust-toolchain.toml` if present. Without it, both CI and local developers use whatever `stable` resolves to on their machine — different versions produce different rustfmt output, causing spurious fmt failures in CI.

The toolchain version was already pinned in `.tool-versions` (for asdf/mise users), but `rustup` ignores `.tool-versions` when asdf/mise is not active. This means developers not using asdf/mise get a floating `stable` and hit fmt divergence.

## Fix

Add `rust-toolchain.toml` pinning `channel = "1.95.0"` — the same version already in `.tool-versions` and the version CI was already running. Both rustup (local) and `dtolnay/rust-toolchain` (CI) read this file automatically.

Also update AGENTS.md to reference `rust-toolchain.toml` rather than `.tool-versions`.