### PR TITLE
feat: implement Session History Editing Phase 2

### DIFF
--- a/.changesets/review-3-blockers.md
+++ b/.changesets/review-3-blockers.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Fix transcript edit validation for tool results without IDs, remove runtime retry prompts after failed edit validation, and add regression coverage for stacked mutation replay of expanded edit ranges.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tokio = { version = "1.48", features = ["rt", "time", "macros", "signal", "rt-mu
 tokio-graceful = "0.2.2"
 tokio-stream = { version = "0.1.15", default-features = false, features = ["sync"] }
 crossterm = "0.29"
-chrono = "0.4.23"
+chrono = { version = "0.4.23", features = ["serde"] }
 chrono-tz = "0.10"
 iana-time-zone = "0.1"
 bincode = { version = "2.0.1", features = ["serde", "std"], default-features = false }

--- a/crates/harnx-core/src/message.rs
+++ b/crates/harnx-core/src/message.rs
@@ -18,6 +18,10 @@ pub struct Message {
     /// Never serialised — not sent to the LLM.
     #[serde(skip)]
     pub log_seq: Option<usize>,
+    /// Stored log timestamp for message-like entries. Seq is positional-only;
+    /// timestamp is persisted in YAML and propagated for transcript rendering.
+    #[serde(skip)]
+    pub log_timestamp: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl Default for Message {
@@ -26,6 +30,7 @@ impl Default for Message {
             role: MessageRole::User,
             content: MessageContent::Text(String::new()),
             log_seq: None,
+            log_timestamp: None,
         }
     }
 }
@@ -36,11 +41,17 @@ impl Message {
             role,
             content,
             log_seq: None,
+            log_timestamp: None,
         }
     }
 
     pub fn with_log_seq(mut self, seq: usize) -> Self {
         self.log_seq = Some(seq);
+        self
+    }
+
+    pub fn with_log_timestamp(mut self, timestamp: chrono::DateTime<chrono::Utc>) -> Self {
+        self.log_timestamp = Some(timestamp);
         self
     }
 

--- a/crates/harnx-core/src/session.rs
+++ b/crates/harnx-core/src/session.rs
@@ -12,6 +12,7 @@ use crate::model::Model;
 use crate::tool::{SwitchAgentData, ToolCall};
 
 use anyhow::{bail, Context, Result};
+use chrono::{DateTime, Utc};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -54,6 +55,8 @@ pub enum SessionLogEntry {
     Message {
         role: MessageRole,
         content: MessageContent,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timestamp: Option<DateTime<Utc>>,
     },
     /// Assistant turn that issued tool calls. The text/thought are the
     /// LLM's prose preceding the calls. This entry is written
@@ -69,10 +72,16 @@ pub enum SessionLogEntry {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         thought: Option<String>,
         calls: Vec<ToolCall>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timestamp: Option<DateTime<Utc>>,
     },
     /// Results for the immediately preceding `ToolCalls` entry.
     #[serde(rename = "tool_results")]
-    ToolResults { results: Vec<ToolOutput> },
+    ToolResults {
+        results: Vec<ToolOutput>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timestamp: Option<DateTime<Utc>>,
+    },
     #[serde(rename = "data_urls")]
     DataUrls { urls: HashMap<String, String> },
     #[serde(rename = "compress")]
@@ -541,6 +550,100 @@ impl AutoName {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn session_log_entry_message_timestamp_serde_round_trip() {
+        let entry = SessionLogEntry::Message {
+            role: MessageRole::User,
+            content: MessageContent::Text("hello".to_string()),
+            timestamp: Some(Utc::now()),
+        };
+
+        let yaml = serde_yaml::to_string(&entry).unwrap();
+        // Verify timestamp is serialized
+        assert!(yaml.contains("timestamp:"));
+
+        let round_tripped: SessionLogEntry = serde_yaml::from_str(&yaml).unwrap();
+
+        match round_tripped {
+            SessionLogEntry::Message {
+                role,
+                content,
+                timestamp,
+            } => {
+                assert_eq!(role, MessageRole::User);
+                assert!(timestamp.is_some());
+                match content {
+                    MessageContent::Text(text) => assert_eq!(text, "hello"),
+                    _ => panic!("expected text content"),
+                }
+            }
+            other => panic!("expected message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_log_entry_message_without_timestamp_deserializes() {
+        // Old logs without timestamp field should deserialize successfully
+        let yaml = "type: message\nrole: user\ncontent: hello\n";
+        let entry: SessionLogEntry = serde_yaml::from_str(yaml).unwrap();
+
+        match entry {
+            SessionLogEntry::Message {
+                role,
+                content,
+                timestamp,
+            } => {
+                assert_eq!(role, MessageRole::User);
+                assert!(timestamp.is_none());
+                match content {
+                    MessageContent::Text(text) => assert_eq!(text, "hello"),
+                    _ => panic!("expected text content"),
+                }
+            }
+            other => panic!("expected message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_log_entry_tool_calls_timestamp_serde_round_trip() {
+        let entry = SessionLogEntry::ToolCalls {
+            text: "doing work".to_string(),
+            thought: None,
+            calls: vec![],
+            timestamp: Some(Utc::now()),
+        };
+
+        let yaml = serde_yaml::to_string(&entry).unwrap();
+        assert!(yaml.contains("timestamp:"));
+
+        let round_tripped: SessionLogEntry = serde_yaml::from_str(&yaml).unwrap();
+        match round_tripped {
+            SessionLogEntry::ToolCalls { timestamp, .. } => {
+                assert!(timestamp.is_some());
+            }
+            other => panic!("expected tool_calls, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_log_entry_tool_results_timestamp_serde_round_trip() {
+        let entry = SessionLogEntry::ToolResults {
+            results: vec![],
+            timestamp: Some(Utc::now()),
+        };
+
+        let yaml = serde_yaml::to_string(&entry).unwrap();
+        assert!(yaml.contains("timestamp:"));
+
+        let round_tripped: SessionLogEntry = serde_yaml::from_str(&yaml).unwrap();
+        match round_tripped {
+            SessionLogEntry::ToolResults { timestamp, .. } => {
+                assert!(timestamp.is_some());
+            }
+            other => panic!("expected tool_results, got {other:?}"),
+        }
+    }
 
     #[test]
     fn session_header_serde_round_trip_preserves_model_fallbacks() {

--- a/crates/harnx-runtime/src/client/message.rs
+++ b/crates/harnx-runtime/src/client/message.rs
@@ -73,6 +73,7 @@ pub fn patch_messages(messages: &mut Vec<Message>, model: &Model) {
                     role: MessageRole::System,
                     content: prefix_content,
                     log_seq: None,
+                    log_timestamp: None,
                 },
             );
         }

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -22,7 +22,7 @@ pub enum CommandOutcome {
     Exit,
 }
 
-pub static COMMANDS: LazyLock<[Command; 45]> = LazyLock::new(|| {
+pub static COMMANDS: LazyLock<[Command; 47]> = LazyLock::new(|| {
     [
         Command::new(".help", "Show this help guide"),
         Command::new(".info", "Show system info"),
@@ -50,7 +50,10 @@ pub static COMMANDS: LazyLock<[Command; 45]> = LazyLock::new(|| {
         ),
         Command::new(".info session", "Show session info"),
         Command::new(".edit session", "Modify current session"),
-        Command::new(".edit message <n>", "Edit a log entry by sequence number"),
+        Command::new(
+            ".edit message <n>",
+            "Edit a single log entry by sequence number",
+        ),
         Command::new(
             ".edit message <n>-<m>",
             "Edit a range of log entries by sequence number",
@@ -79,6 +82,14 @@ pub static COMMANDS: LazyLock<[Command; 45]> = LazyLock::new(|| {
         Command::new(".regenerate", "Regenerate last response"),
         Command::new(".copy", "Copy last response"),
         Command::new(".set", "Modify runtime settings"),
+        Command::new(
+            ".set show_sequence_numbers",
+            "Toggle [n] prefix in transcript (on/off)",
+        ),
+        Command::new(
+            ".set show_timestamps",
+            "Toggle timestamp in transcript (on/off)",
+        ),
         Command::new(".delete", "Delete agents, sessions, RAGs, or macros"),
         Command::new(
             ".delete message <n>",

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -160,34 +160,62 @@ fn adjust_range_for_tool_pairs(
 }
 
 fn validate_tool_pair_integrity(start_seq: usize, documents: &[String]) -> Result<()> {
-    if documents.len() < 2 {
-        return Ok(());
-    }
-
     let entries = documents
         .iter()
-        .map(|document| serde_yaml::from_str::<SessionLogEntry>(document))
-        .collect::<std::result::Result<Vec<_>, _>>()?;
+        .map(|document| {
+            serde_yaml::from_str::<SessionLogEntry>(document).with_context(|| {
+                format!(
+                    "Invalid session log entry YAML:
+{document}"
+                )
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
 
-    for index in 0..entries.len() - 1 {
-        let (SessionLogEntry::ToolCalls { calls, .. }, SessionLogEntry::ToolResults { results }) =
-            (&entries[index], &entries[index + 1])
-        else {
+    for (index, entry) in entries.iter().enumerate() {
+        let SessionLogEntry::ToolCalls { calls, .. } = entry else {
             continue;
         };
 
-        let call_ids = calls
-            .iter()
-            .map(|call| call.id.as_deref())
-            .collect::<Vec<_>>();
-        let result_ids = results
-            .iter()
-            .map(|result| result.id.as_deref())
-            .collect::<Vec<_>>();
-        if call_ids != result_ids {
+        let Some(SessionLogEntry::ToolResults { results, .. }) = entries.get(index + 1) else {
             let call_seq = start_seq + index;
-            let result_seq = start_seq + index + 1;
-            bail!("Edited tool call/result IDs do not match for entries {call_seq}-{result_seq}");
+            bail!(
+                "Edited tool call entry at {call_seq} must be followed immediately by matching tool results"
+            );
+        };
+
+        let call_ids: HashSet<_> = calls.iter().filter_map(|call| call.id.as_deref()).collect();
+        let result_seq = start_seq + index + 1;
+        let missing_result_ids = results
+            .iter()
+            .filter(|result| result.id.as_deref().is_none_or(str::is_empty))
+            .count();
+
+        if missing_result_ids == results.len() {
+            if results.len() != calls.len() {
+                bail!(
+                    "Edited tool result at {result_seq} is missing tool_call_id for positional matching and count {} does not match tool calls count {}",
+                    results.len(),
+                    calls.len()
+                );
+            }
+            continue;
+        }
+
+        if missing_result_ids > 0 {
+            bail!(
+                "Edited tool result at {result_seq} mixes tool_call_id values with missing tool_call_id entries"
+            );
+        }
+
+        for result in results {
+            let call_id = result.id.as_deref().filter(|id| !id.is_empty()).unwrap();
+            if !call_ids.contains(call_id) {
+                let expected_ids = call_ids.iter().copied().collect::<Vec<_>>().join(", ");
+                bail!(
+                    "Edited tool result at {result_seq} references unknown tool_call_id '{call_id}' (expected one of: {expected_ids})"
+                );
+            }
         }
     }
 
@@ -267,6 +295,8 @@ pub struct Config {
     pub model_cooldowns: std::sync::Arc<parking_lot::Mutex<crate::client::retry::ModelCooldownMap>>,
     pub macro_flag: bool,
     pub info_flag: bool,
+    pub show_sequence_numbers: bool,
+    pub show_timestamps: bool,
     pub agent_variables: Option<AgentVariables>,
     pub mcp_root: Vec<String>,
 
@@ -335,6 +365,8 @@ impl Clone for Config {
             model_cooldowns: self.model_cooldowns.clone(),
             macro_flag: self.macro_flag,
             info_flag: self.info_flag,
+            show_sequence_numbers: self.show_sequence_numbers,
+            show_timestamps: self.show_timestamps,
             agent_variables: self.agent_variables.clone(),
             mcp_root: self.mcp_root.clone(),
             model: self.model.clone(),
@@ -365,6 +397,8 @@ impl Default for Config {
             model_cooldowns: std::sync::Arc::new(parking_lot::Mutex::new(Default::default())),
             macro_flag: false,
             info_flag: false,
+            show_sequence_numbers: false,
+            show_timestamps: false,
             agent_variables: None,
             mcp_root: vec![],
 
@@ -802,6 +836,14 @@ impl Config {
             "dry_run" => {
                 let value = value.parse().with_context(|| "Invalid value")?;
                 config.write().dry_run = value;
+            }
+            "show_sequence_numbers" => {
+                let value = value.parse().with_context(|| "Invalid value")?;
+                config.write().show_sequence_numbers = value;
+            }
+            "show_timestamps" => {
+                let value = value.parse().with_context(|| "Invalid value")?;
+                config.write().show_timestamps = value;
             }
             "tool_use" => {
                 let value = value.parse().with_context(|| "Invalid value")?;
@@ -1402,8 +1444,12 @@ impl Config {
             bail!("Sequence numbers out of range");
         }
 
+        // Replacement list order becomes new order for edited range. Reordering
+        // plain message entries in editor is supported as long as edited YAML still
+        // passes structural validation (including tool-call/result pairing).
         let selected_documents = documents[from..=to].to_vec();
         let temp_file = temp_file("message-edit", ".yaml");
+
         std::fs::write(&temp_file, selected_documents.join("\n---\n"))
             .with_context(|| format!("Failed to write to '{}'", temp_file.display()))?;
 
@@ -1415,12 +1461,13 @@ impl Config {
         });
         let edited_content = std::fs::read_to_string(&temp_file)
             .with_context(|| format!("Failed to read '{}'", temp_file.display()));
-        let _ = std::fs::remove_file(&temp_file);
         edit_result?;
         let edited_content = edited_content?;
 
         let edited_documents = validate_edited_session_documents(&edited_content)?;
         validate_tool_pair_integrity(from, &edited_documents)?;
+
+        let _ = std::fs::remove_file(&temp_file);
 
         let edit_entry = SessionLogEntry::EditEntries {
             from,
@@ -3503,6 +3550,7 @@ mod tests {
 
     fn tool_calls_yaml(call_ids: &[&str]) -> String {
         serde_yaml::to_string(&SessionLogEntry::ToolCalls {
+            timestamp: None,
             text: String::new(),
             thought: None,
             calls: call_ids
@@ -3519,11 +3567,21 @@ mod tests {
     }
 
     fn tool_results_yaml(result_ids: &[&str]) -> String {
+        tool_results_yaml_with_optional_ids(
+            &result_ids
+                .iter()
+                .map(|id| Some((*id).to_string()))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    fn tool_results_yaml_with_optional_ids(result_ids: &[Option<String>]) -> String {
         serde_yaml::to_string(&SessionLogEntry::ToolResults {
+            timestamp: None,
             results: result_ids
                 .iter()
                 .map(|id| ToolOutput {
-                    id: Some((*id).to_string()),
+                    id: id.clone(),
                     name: "bash_exec".to_string(),
                     output: serde_json::json!({"ok": true}),
                     switch_agent: None,
@@ -3535,7 +3593,17 @@ mod tests {
 
     fn user_yaml(text: &str) -> String {
         serde_yaml::to_string(&SessionLogEntry::Message {
+            timestamp: None,
             role: MessageRole::User,
+            content: MessageContent::Text(text.to_string()),
+        })
+        .unwrap()
+    }
+
+    fn assistant_yaml(text: &str) -> String {
+        serde_yaml::to_string(&SessionLogEntry::Message {
+            timestamp: None,
+            role: MessageRole::Assistant,
             content: MessageContent::Text(text.to_string()),
         })
         .unwrap()
@@ -3577,15 +3645,66 @@ mod tests {
 
         assert_eq!(
             err.to_string(),
-            "Edited tool call/result IDs do not match for entries 7-8"
+            "Edited tool result at 8 references unknown tool_call_id 'call-2' (expected one of: call-1)"
         );
     }
 
     #[test]
-    fn validate_tool_pair_integrity_allows_orphan_tool_calls_as_advisory() {
-        let documents = vec![tool_calls_yaml(&["call-1"])];
+    fn validate_tool_pair_integrity_rejects_missing_immediate_tool_results() {
+        let documents = vec![
+            tool_calls_yaml(&["call-1"]),
+            user_yaml("intervening message"),
+        ];
 
-        validate_tool_pair_integrity(3, &documents).unwrap();
+        let err = validate_tool_pair_integrity(3, &documents)
+            .expect_err("tool calls without immediate tool results should fail");
+
+        assert_eq!(
+            err.to_string(),
+            "Edited tool call entry at 3 must be followed immediately by matching tool results"
+        );
+    }
+
+    #[test]
+    fn validate_tool_pair_integrity_accepts_positional_tool_results_without_ids() {
+        let documents = vec![
+            tool_calls_yaml(&["call-1", "call-2"]),
+            tool_results_yaml_with_optional_ids(&[None, None]),
+        ];
+
+        validate_tool_pair_integrity(4, &documents).unwrap();
+    }
+
+    #[test]
+    fn validate_tool_pair_integrity_rejects_positional_tool_results_when_counts_differ() {
+        let documents = vec![
+            tool_calls_yaml(&["call-1", "call-2"]),
+            tool_results_yaml_with_optional_ids(&[None]),
+        ];
+
+        let err = validate_tool_pair_integrity(10, &documents)
+            .expect_err("count mismatch should fail positional matching");
+
+        assert_eq!(
+            err.to_string(),
+            "Edited tool result at 11 is missing tool_call_id for positional matching and count 1 does not match tool calls count 2"
+        );
+    }
+
+    #[test]
+    fn validate_tool_pair_integrity_rejects_mixed_present_and_missing_result_ids() {
+        let documents = vec![
+            tool_calls_yaml(&["call-1", "call-2"]),
+            tool_results_yaml_with_optional_ids(&[Some("call-1".to_string()), None]),
+        ];
+
+        let err = validate_tool_pair_integrity(12, &documents)
+            .expect_err("mixed id presence should fail");
+
+        assert_eq!(
+            err.to_string(),
+            "Edited tool result at 13 mixes tool_call_id values with missing tool_call_id entries"
+        );
     }
 
     #[test]
@@ -3593,6 +3712,104 @@ mod tests {
         let documents = vec![user_yaml("plain message")];
 
         validate_tool_pair_integrity(2, &documents).unwrap();
+    }
+
+    #[test]
+    fn validate_tool_pair_integrity_allows_reordered_non_tool_documents() {
+        let documents = vec![assistant_yaml("second"), user_yaml("first")];
+
+        validate_tool_pair_integrity(1, &documents).unwrap();
+    }
+
+    #[test]
+    fn edit_message_range_supports_reordering_plain_messages() {
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let original_editor = std::env::var_os("EDITOR");
+        std::env::set_var("EDITOR", "true");
+
+        let result = (|| -> Result<()> {
+            let mut config = Config {
+                sessions_dir_override: Some(tmp.path().to_path_buf()),
+                working_mode: WorkingMode::Cmd,
+                ..Config::default()
+            };
+            config
+                .clients
+                .push(harnx_client::ClientConfig::OpenAICompatibleConfig(
+                    harnx_core::provider_config::openai_compatible::OpenAICompatibleConfig {
+                        name: Some("test".to_string()),
+                        api_base: None,
+                        api_key: None,
+                        models: vec![],
+                        patch: None,
+                        extra: None,
+                        system_prompt_prefix: None,
+                    },
+                ));
+            config.model = harnx_client::Model::new("test", "model");
+            config.model_id = "test:model".to_string();
+            config.use_session(Some("reorder"))?;
+
+            let session = config.session.as_mut().context("No session")?;
+            assert!(crate::config::session::append_event(
+                session,
+                &SessionLogEntry::Message {
+                    timestamp: None,
+                    role: MessageRole::User,
+                    content: MessageContent::Text("first".to_string()),
+                },
+            ));
+            assert!(crate::config::session::append_event(
+                session,
+                &SessionLogEntry::Message {
+                    timestamp: None,
+                    role: MessageRole::Assistant,
+                    content: MessageContent::Text("second".to_string()),
+                },
+            ));
+
+            let replacement_yaml = assistant_yaml("second") + "\n---\n" + &user_yaml("first");
+            config.set_tui_editor_hooks(
+                None,
+                Some(Box::new(move || {
+                    let temp_path = std::fs::read_dir(std::env::temp_dir())
+                        .unwrap()
+                        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+                        .filter(|path| {
+                            path.extension().and_then(|ext| ext.to_str()) == Some("yaml")
+                        })
+                        .filter_map(|path| {
+                            let modified = std::fs::metadata(&path).ok()?.modified().ok()?;
+                            Some((modified, path))
+                        })
+                        .max_by_key(|(modified, _)| *modified)
+                        .map(|(_, path)| path)
+                        .expect("message edit temp file");
+                    std::fs::write(&temp_path, &replacement_yaml).unwrap();
+                })),
+            );
+
+            config.edit_message_range(1, 2)?;
+
+            let reloaded = config.session.as_ref().context("No session after reload")?;
+            let texts: Vec<_> = reloaded
+                .messages
+                .iter()
+                .map(|msg| msg.content.to_text())
+                .collect();
+            assert_eq!(texts, vec!["second", "first"]);
+
+            Ok(())
+        })();
+
+        match original_editor {
+            Some(value) => std::env::set_var("EDITOR", value),
+            None => std::env::remove_var("EDITOR"),
+        }
+
+        result.unwrap();
     }
 
     // --- adjust_range_for_tool_pairs ---
@@ -3606,6 +3823,7 @@ mod tests {
 
     fn tool_calls_entry(id: &str) -> SessionLogEntry {
         SessionLogEntry::ToolCalls {
+            timestamp: None,
             text: String::new(),
             thought: None,
             calls: vec![ToolCall {
@@ -3619,6 +3837,7 @@ mod tests {
 
     fn tool_results_entry(id: &str) -> SessionLogEntry {
         SessionLogEntry::ToolResults {
+            timestamp: None,
             results: vec![ToolOutput {
                 id: Some(id.to_string()),
                 name: "bash_exec".to_string(),
@@ -3630,6 +3849,7 @@ mod tests {
 
     fn user_entry(text: &str) -> SessionLogEntry {
         SessionLogEntry::Message {
+            timestamp: None,
             role: MessageRole::User,
             content: MessageContent::Text(text.to_string()),
         }

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -226,9 +226,7 @@ fn validate_tool_pair_integrity(start_seq: usize, documents: &[String]) -> Resul
 
         let result_id_set: HashSet<&str> = result_ids.iter().copied().collect();
         if result_id_set.len() != result_ids.len() {
-            bail!(
-                "Edited tool result at {result_seq} contains duplicate tool_call_id values"
-            );
+            bail!("Edited tool result at {result_seq} contains duplicate tool_call_id values");
         }
 
         for call_id in &result_ids {
@@ -1477,10 +1475,7 @@ impl Config {
         // passes structural validation (including tool-call/result pairing).
         let selected_documents = documents[from..=to].to_vec();
         let temp_file = if let Some(ref dir) = self.temp_dir_override {
-            dir.join(format!(
-                "message-edit-{}.yaml",
-                uuid::Uuid::new_v4()
-            ))
+            dir.join(format!("message-edit-{}.yaml", uuid::Uuid::new_v4()))
         } else {
             temp_file("message-edit", ".yaml")
         };

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -208,8 +208,30 @@ fn validate_tool_pair_integrity(start_seq: usize, documents: &[String]) -> Resul
             );
         }
 
-        for result in results {
-            let call_id = result.id.as_deref().filter(|id| !id.is_empty()).unwrap();
+        // All results have IDs: enforce strict 1:1 mapping.
+        // Collect in order so duplicate detection and count check work together.
+        let result_ids: Vec<&str> = results
+            .iter()
+            .map(|r| r.id.as_deref().filter(|id| !id.is_empty()).unwrap())
+            .collect();
+
+        if result_ids.len() != calls.len() {
+            let expected_ids = call_ids.iter().copied().collect::<Vec<_>>().join(", ");
+            bail!(
+                "Edited tool result at {result_seq} has {} result(s) but {} call(s) (expected ids: {expected_ids})",
+                result_ids.len(),
+                calls.len()
+            );
+        }
+
+        let result_id_set: HashSet<&str> = result_ids.iter().copied().collect();
+        if result_id_set.len() != result_ids.len() {
+            bail!(
+                "Edited tool result at {result_seq} contains duplicate tool_call_id values"
+            );
+        }
+
+        for call_id in &result_ids {
             if !call_ids.contains(call_id) {
                 let expected_ids = call_ids.iter().copied().collect::<Vec<_>>().join(", ");
                 bail!(
@@ -316,6 +338,10 @@ pub struct Config {
     /// Override the sessions directory — used in tests to redirect session
     /// log writes to a temp directory without touching real user data.
     pub sessions_dir_override: Option<std::path::PathBuf>,
+    /// Override the directory used for editor temp files — used in tests so
+    /// the after-hook closure can find the file without scanning the global
+    /// temp directory. Never set in production.
+    pub temp_dir_override: Option<std::path::PathBuf>,
 }
 
 impl std::ops::Deref for Config {
@@ -381,6 +407,7 @@ impl Clone for Config {
             tui_before_editor: None,
             tui_after_editor: None,
             sessions_dir_override: self.sessions_dir_override.clone(),
+            temp_dir_override: self.temp_dir_override.clone(),
         }
     }
 }
@@ -415,6 +442,7 @@ impl Default for Config {
             tui_before_editor: None,
             tui_after_editor: None,
             sessions_dir_override: None,
+            temp_dir_override: None,
         }
     }
 }
@@ -1448,7 +1476,14 @@ impl Config {
         // plain message entries in editor is supported as long as edited YAML still
         // passes structural validation (including tool-call/result pairing).
         let selected_documents = documents[from..=to].to_vec();
-        let temp_file = temp_file("message-edit", ".yaml");
+        let temp_file = if let Some(ref dir) = self.temp_dir_override {
+            dir.join(format!(
+                "message-edit-{}.yaml",
+                uuid::Uuid::new_v4()
+            ))
+        } else {
+            temp_file("message-edit", ".yaml")
+        };
 
         std::fs::write(&temp_file, selected_documents.join("\n---\n"))
             .with_context(|| format!("Failed to write to '{}'", temp_file.display()))?;
@@ -3771,21 +3806,20 @@ mod tests {
             ));
 
             let replacement_yaml = assistant_yaml("second") + "\n---\n" + &user_yaml("first");
+
+            // Use an isolated temp dir so the after-hook can find the single
+            // .yaml file without scanning the global temp directory.
+            let editor_tmp = TempDir::new().unwrap();
+            let editor_tmp_path = editor_tmp.path().to_path_buf();
+            config.temp_dir_override = Some(editor_tmp_path.clone());
+
             config.set_tui_editor_hooks(
                 None,
                 Some(Box::new(move || {
-                    let temp_path = std::fs::read_dir(std::env::temp_dir())
+                    let temp_path = std::fs::read_dir(&editor_tmp_path)
                         .unwrap()
-                        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
-                        .filter(|path| {
-                            path.extension().and_then(|ext| ext.to_str()) == Some("yaml")
-                        })
-                        .filter_map(|path| {
-                            let modified = std::fs::metadata(&path).ok()?.modified().ok()?;
-                            Some((modified, path))
-                        })
-                        .max_by_key(|(modified, _)| *modified)
-                        .map(|(_, path)| path)
+                        .filter_map(|e| e.ok().map(|e| e.path()))
+                        .find(|p| p.extension().and_then(|e| e.to_str()) == Some("yaml"))
                         .expect("message edit temp file");
                     std::fs::write(&temp_path, &replacement_yaml).unwrap();
                 })),

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -6,9 +6,14 @@ pub use harnx_core::session::{AutoName, Session, SessionLogEntry};
 use crate::client::{
     render_message_input, CompletionTokenUsage, Message, MessageContent, MessageRole,
 };
+use harnx_core::{
+    event::{AgentEvent, SessionEvent},
+    sink::emit_agent_event,
+};
 use harnx_render::MarkdownRender;
 
 use anyhow::{Context, Result};
+use chrono::Utc;
 use fancy_regex::Regex;
 use serde::Deserialize;
 use std::fs::{read_to_string, write, OpenOptions};
@@ -66,6 +71,7 @@ struct PendingToolCalls {
     text: String,
     thought: Option<String>,
     calls: Vec<crate::tool::ToolCall>,
+    timestamp: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 fn collect_raw_log_entries(content: &str, name: &str) -> Result<Vec<(usize, SessionLogEntry)>> {
@@ -134,7 +140,7 @@ fn build_effective_log_entries(
                 };
                 let Some(end_idx) = effective_entries
                     .iter()
-                    .position(|(existing_seq, _)| existing_seq == to)
+                    .rposition(|(existing_seq, _)| existing_seq == to)
                 else {
                     log::warn!(
                         "Skipping edit_entries entry #{seq} in session {name}: to seq {to} not present in replay state"
@@ -144,15 +150,6 @@ fn build_effective_log_entries(
                 if start_idx > end_idx {
                     log::warn!(
                         "Skipping edit_entries entry #{seq} in session {name}: range [{from}, {to}] not in replay order"
-                    );
-                    continue;
-                }
-                if effective_entries[start_idx..=end_idx]
-                    .iter()
-                    .any(|(existing_seq, _)| *existing_seq < *from || *existing_seq > *to)
-                {
-                    log::warn!(
-                        "Skipping edit_entries entry #{seq} in session {name}: range [{from}, {to}] is not contiguous in replay state"
                     );
                     continue;
                 }
@@ -226,7 +223,11 @@ fn replay_log_entries(raw_entries: &[(usize, SessionLogEntry)], name: &str) -> R
                 session.model_fallbacks = model_fallbacks;
                 session.compaction_agent = compaction_agent;
             }
-            SessionLogEntry::Message { role, content } => {
+            SessionLogEntry::Message {
+                role,
+                content,
+                timestamp,
+            } => {
                 if let Some(pending) = pending.take() {
                     session
                         .messages
@@ -237,14 +238,17 @@ fn replay_log_entries(raw_entries: &[(usize, SessionLogEntry)], name: &str) -> R
                         "Invalid log entry in session {name}: Tool-role Message entries are                          no longer supported; use tool_calls/tool_results entries"
                     );
                 }
-                session
-                    .messages
-                    .push(Message::new(role, content).with_log_seq(seq));
+                let mut message = Message::new(role, content).with_log_seq(seq);
+                if let Some(timestamp) = timestamp {
+                    message = message.with_log_timestamp(timestamp);
+                }
+                session.messages.push(message);
             }
             SessionLogEntry::ToolCalls {
                 text,
                 thought,
                 calls,
+                timestamp,
             } => {
                 if let Some(pending) = pending.take() {
                     session
@@ -256,23 +260,28 @@ fn replay_log_entries(raw_entries: &[(usize, SessionLogEntry)], name: &str) -> R
                     text,
                     thought,
                     calls,
+                    timestamp,
                 });
             }
-            SessionLogEntry::ToolResults { results } => {
+            SessionLogEntry::ToolResults { results, .. } => {
                 let Some(PendingToolCalls {
                     seq,
                     text,
                     thought,
                     calls,
+                    timestamp,
                 }) = pending.take()
                 else {
                     anyhow::bail!(
                         "Invalid log entry in session {name}: tool_results without a                          preceding tool_calls entry"
                     );
                 };
-                session
-                    .messages
-                    .push(assemble_tool_message(text, thought, calls, results).with_log_seq(seq));
+                let mut message =
+                    assemble_tool_message(text, thought, calls, results).with_log_seq(seq);
+                if let Some(timestamp) = timestamp {
+                    message = message.with_log_timestamp(timestamp);
+                }
+                session.messages.push(message);
             }
             SessionLogEntry::DataUrls { urls } => {
                 session.data_urls.extend(urls);
@@ -328,6 +337,7 @@ fn repair_orphan_tool_calls(pending: PendingToolCalls, _name: &str) -> Result<Me
         text,
         thought,
         calls,
+        timestamp,
     } = pending;
     let lost = harnx_core::session::ToolOutput {
         id: None,
@@ -346,7 +356,11 @@ fn repair_orphan_tool_calls(pending: PendingToolCalls, _name: &str) -> Result<Me
             ..lost.clone()
         })
         .collect();
-    Ok(assemble_tool_message(text, thought, calls, results).with_log_seq(seq))
+    let mut message = assemble_tool_message(text, thought, calls, results).with_log_seq(seq);
+    if let Some(timestamp) = timestamp {
+        message = message.with_log_timestamp(timestamp);
+    }
+    Ok(message)
 }
 
 fn assemble_tool_message(
@@ -657,6 +671,7 @@ pub fn save(
         .with_context(|| format!("Failed to serialize session header for '{}'", session.name))?;
     for msg in &session.compressed_messages {
         let entry = SessionLogEntry::Message {
+            timestamp: None,
             role: msg.role,
             content: msg.content.clone(),
         };
@@ -692,6 +707,7 @@ pub fn save(
             let entry = SessionLogEntry::Message {
                 role: msg.role,
                 content: msg.content.clone(),
+                timestamp: None, // Session save rewrites all entries; timestamps are from live events
             };
             content.push_str("---\n");
             content.push_str(
@@ -705,6 +721,7 @@ pub fn save(
             let entry = SessionLogEntry::Message {
                 role: msg.role,
                 content: msg.content.clone(),
+                timestamp: None, // Session save rewrites all entries; timestamps are from live events
             };
             content.push_str("---\n");
             content.push_str(
@@ -812,15 +829,20 @@ pub fn add_assistant_text(
             _ => MessageContent::Text(output.to_string()),
         };
         let seq = session.next_seq();
-        let assistant_msg = Message::new(MessageRole::Assistant, content).with_log_seq(seq);
+        let timestamp = Utc::now();
+        let assistant_msg = Message::new(MessageRole::Assistant, content)
+            .with_log_seq(seq)
+            .with_log_timestamp(timestamp);
         all_appended &= append_event(
             session,
             &SessionLogEntry::Message {
                 role: assistant_msg.role,
                 content: assistant_msg.content.clone(),
+                timestamp: Some(timestamp),
             },
         );
         session.messages.push(assistant_msg);
+        emit_agent_event(AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }));
         session.dirty = !all_appended;
     }
     session.update_tokens();
@@ -855,8 +877,12 @@ pub fn add_tool_calls(
             text: output.to_string(),
             thought: thought.map(str::to_string),
             calls: calls.clone(),
+            timestamp: Some(Utc::now()),
         },
     );
+    emit_agent_event(AgentEvent::Session(SessionEvent::LogSeqAssigned {
+        seq: tool_calls_seq,
+    }));
     // Push a pending Tool message.  Outputs are filled in by
     // add_tool_results; synthetic error placeholders mean that if the
     // pending message ever leaks (e.g. a mid-round abort without a
@@ -937,6 +963,7 @@ pub fn add_tool_results(session: &mut Session, results: &[crate::tool::ToolResul
         session,
         &SessionLogEntry::ToolResults {
             results: log_results,
+            timestamp: Some(Utc::now()),
         },
     );
     if !appended {
@@ -981,6 +1008,7 @@ fn begin_turn(session: &mut Session, input: &Input, output: &str) -> Result<bool
                 &SessionLogEntry::Message {
                     role: msg.role,
                     content: msg.content.clone(),
+                    timestamp: Some(Utc::now()),
                 },
             );
             session.messages.push(msg.with_log_seq(seq));
@@ -993,9 +1021,11 @@ fn begin_turn(session: &mut Session, input: &Input, output: &str) -> Result<bool
             &SessionLogEntry::Message {
                 role: user_msg.role,
                 content: user_msg.content.clone(),
+                timestamp: Some(Utc::now()),
             },
         );
         session.messages.push(user_msg);
+        emit_agent_event(AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }));
     }
     let new_data_urls = input.data_urls();
     if !new_data_urls.is_empty() {
@@ -1019,9 +1049,11 @@ fn begin_turn(session: &mut Session, input: &Input, output: &str) -> Result<bool
             &SessionLogEntry::Message {
                 role: injected_msg.role,
                 content: injected_msg.content.clone(),
+                timestamp: Some(Utc::now()),
             },
         );
         session.messages.push(injected_msg);
+        emit_agent_event(AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }));
     }
     Ok(all_appended)
 }
@@ -1137,7 +1169,16 @@ content: second
 
         assert_eq!(seqs.len(), 5);
         assert!(matches!(seqs[0], (0, SessionLogEntry::Header { .. })));
-        assert!(matches!(seqs[1], (1, SessionLogEntry::Message { .. })));
+        assert!(matches!(
+            seqs[1],
+            (
+                1,
+                SessionLogEntry::Message {
+                    timestamp: None,
+                    ..
+                }
+            )
+        ));
         assert!(matches!(
             seqs[2],
             (2, SessionLogEntry::Rewind { after_seq: 1 })
@@ -1146,7 +1187,16 @@ content: second
             seqs[3],
             (3, SessionLogEntry::EditEntries { from: 1, to: 1, .. })
         ));
-        assert!(matches!(seqs[4], (4, SessionLogEntry::Message { .. })));
+        assert!(matches!(
+            seqs[4],
+            (
+                4,
+                SessionLogEntry::Message {
+                    timestamp: None,
+                    ..
+                }
+            )
+        ));
 
         let session = super::load_from_log_for_test(content);
         assert_eq!(session.messages.len(), 1);
@@ -1185,6 +1235,50 @@ content: second
         assert!(output.contains("model_fallbacks:"));
         assert!(output.contains("- anthropic:claude"));
         assert!(output.contains("- google:gemini"));
+    }
+
+    /// Test that timestamps are persisted to log entries and survive reload.
+    #[test]
+    fn timestamp_persists_across_session_reload() {
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let mut session = test_session();
+        session.set_sessions_dir(tmp.path().to_path_buf());
+
+        let config = Config::default();
+        let agent = config.extract_agent();
+        let global_config = std::sync::Arc::new(parking_lot::RwLock::new(config.clone()));
+        let input = crate::config::input::from_str(&global_config, "hello", Some(agent.clone()));
+
+        // Add a user message
+        super::begin_turn(&mut session, &input, "response").unwrap();
+
+        // Verify the log file contains the timestamp field
+        let path = session.path.clone().unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("timestamp:"),
+            "log should contain timestamp field"
+        );
+
+        // Parse the log entries directly
+        let entries: Vec<(usize, SessionLogEntry)> = serde_yaml::Deserializer::from_str(&content)
+            .enumerate()
+            .map(|(seq, doc)| {
+                let entry = SessionLogEntry::deserialize(doc).expect("valid entry");
+                (seq, entry)
+            })
+            .collect();
+
+        // Find a Message entry and verify it has a timestamp
+        for (_, entry) in &entries {
+            if let SessionLogEntry::Message { timestamp, .. } = entry {
+                assert!(timestamp.is_some(), "message entry should have a timestamp");
+                return;
+            }
+        }
+        panic!("no Message entry found in session log");
     }
 
     /// The tool round splits into two independent log entries: a
@@ -1593,6 +1687,32 @@ content: second
     /// reload it through `load_from_log`.  Verify the in-memory
     /// messages are reconstructed correctly.
     #[test]
+    fn append_message_persists_timestamp_and_reloads() {
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let mut session = test_session();
+        session.set_sessions_dir(tmp.path().to_path_buf());
+
+        let config = Config::default();
+        let agent = config.extract_agent();
+        let global_config = std::sync::Arc::new(parking_lot::RwLock::new(config.clone()));
+        let input = crate::config::input::from_str(&global_config, "hello", Some(agent));
+
+        super::add_assistant_text(&mut session, &input, "world", None).unwrap();
+
+        let content = std::fs::read_to_string(session.path.as_ref().unwrap()).unwrap();
+        assert!(content.contains("timestamp:"));
+
+        let reloaded = super::load_from_log_for_test(&content);
+        let last = reloaded
+            .messages
+            .last()
+            .expect("assistant message reloaded");
+        assert!(last.log_timestamp.is_some());
+    }
+
+    #[test]
     fn session_round_trips_through_load() {
         use crate::tool::{ToolCall, ToolResult};
         use serde_json::json;
@@ -1850,6 +1970,98 @@ replacements:
     }
 
     #[test]
+    fn load_replays_stacked_mutations_edit_one_to_many_then_edit_later_entry() {
+        let content = r#"type: header
+model: test
+---
+type: message
+role: user
+content: original 1
+---
+type: message
+role: assistant
+content: original 2
+---
+type: edit_entries
+from: 1
+to: 1
+replacements:
+  - |
+    type: message
+    role: user
+    content: 1a
+  - |
+    type: message
+    role: assistant
+    content: 1b
+---
+type: edit_entries
+from: 2
+to: 2
+replacements:
+  - |
+    type: message
+    role: assistant
+    content: 2x
+"#;
+
+        let session = super::load_from_log_for_test(content);
+        let texts: Vec<_> = session
+            .messages
+            .iter()
+            .map(|m| m.content.to_text())
+            .collect();
+
+        assert_eq!(texts, vec!["1a", "1b", "2x"]);
+    }
+
+    #[test]
+    fn load_replays_stacked_mutations_reedit_expanded_mutation_seq() {
+        let content = r#"type: header
+model: test
+---
+type: message
+role: user
+content: msg1
+---
+type: message
+role: assistant
+content: msg2
+---
+type: edit_entries
+from: 1
+to: 1
+replacements:
+  - |
+    type: message
+    role: user
+    content: expanded_a
+  - |
+    type: message
+    role: assistant
+    content: expanded_b
+---
+type: edit_entries
+from: 3
+to: 3
+replacements:
+  - |
+    type: message
+    role: user
+    content: re-edited
+"#;
+
+        let session = super::load_from_log_for_test(content);
+        let texts: Vec<_> = session
+            .messages
+            .iter()
+            .map(|m| m.content.to_text())
+            .collect();
+
+        assert_eq!(texts, vec!["re-edited", "msg2"]);
+    }
+
+    #[test]
     fn load_tracks_log_entry_count_and_append_event_increments_next_seq() {
         use tempfile::TempDir;
 
@@ -1878,6 +2090,7 @@ content: second
         let appended = super::append_event(
             &mut session,
             &SessionLogEntry::Message {
+                timestamp: None,
                 role: MessageRole::User,
                 content: MessageContent::Text("third".to_string()),
             },

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -437,6 +437,8 @@ impl Tui {
         if let Some(pending) = self.app.pending_message.take() {
             self.app.attachments = pending.attachments;
             self.app.attachment_dir = pending.attachment_dir;
+            self.app.paste_count = pending.paste_count;
+            self.clear_shared_pending_message().await;
             self.refresh_input_chrome();
         }
         // Exit history preview on paste — keep current content as new draft
@@ -650,11 +652,9 @@ impl Tui {
         if is_turn_boundary {
             self.app.streaming_assistant_idx = None;
         }
-        if !is_thought {
-            self.flush_pending_thought();
-        }
-        self.render_ui_output_heading(source.as_ref(), is_usage);
-
+        // Handle LogSeqAssigned before any heading/thought side-effects — it
+        // is a pure seq-assignment event and should not create stray headings
+        // or flush pending thoughts.
         if let AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }) = event {
             for item in self.app.transcript.iter_mut().rev() {
                 match item {
@@ -678,6 +678,11 @@ impl Tui {
             }
             return;
         }
+
+        if !is_thought {
+            self.flush_pending_thought();
+        }
+        self.render_ui_output_heading(source.as_ref(), is_usage);
 
         let rendered_entries = match event {
             AgentEvent::Notice(NoticeEvent::Info(text)) => {
@@ -1675,12 +1680,15 @@ impl Tui {
     }
 
     /// Handle 'r' key: open rewind confirmation modal.
+    ///
+    /// Always rewinds to the *earliest* selected item regardless of selection
+    /// direction, so Shift+selecting up vs down yields the same target.
     fn handle_transcript_rewind(&mut self) {
-        let focus = self.app.transcript_selection_anchor.unwrap_or_else(|| {
-            self.app
-                .transcript_focus
-                .expect("transcript_focus required")
-        });
+        let focus = self.app.transcript_focus.expect("transcript_focus required");
+        let focus = match self.app.transcript_selection_anchor {
+            Some(anchor) => focus.min(anchor),
+            None => focus,
+        };
         let item = match self.app.transcript.get(focus) {
             Some(item) => item,
             None => return,

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1684,7 +1684,10 @@ impl Tui {
     /// Always rewinds to the *earliest* selected item regardless of selection
     /// direction, so Shift+selecting up vs down yields the same target.
     fn handle_transcript_rewind(&mut self) {
-        let focus = self.app.transcript_focus.expect("transcript_focus required");
+        let focus = self
+            .app
+            .transcript_focus
+            .expect("transcript_focus required");
         let focus = match self.app.transcript_selection_anchor {
             Some(anchor) => focus.min(anchor),
             None => focus,

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -126,6 +126,11 @@ fn tool_completed_to_transcript_items(
 
 impl Tui {
     pub(super) async fn handle_key(&mut self, key: KeyEvent) -> Result<()> {
+        // If a modal is open, intercept all keys and route to modal handler
+        if self.app.modal.is_some() {
+            return self.handle_modal_key(key).await;
+        }
+
         match (key.code, key.modifiers) {
             (KeyCode::Char('d'), KeyModifiers::CONTROL) => {
                 self.abort_signal.set_ctrld();
@@ -163,8 +168,14 @@ impl Tui {
             (KeyCode::Up, KeyModifiers::NONE) => {
                 self.handle_up_key(key);
             }
+            (KeyCode::Up, KeyModifiers::SHIFT) => {
+                self.handle_up_key_shift();
+            }
             (KeyCode::Down, KeyModifiers::NONE) => {
                 self.handle_down_key(key);
+            }
+            (KeyCode::Down, KeyModifiers::SHIFT) => {
+                self.handle_down_key_shift();
             }
             (KeyCode::PageUp, KeyModifiers::NONE) => {
                 for _ in 0..10 {
@@ -183,9 +194,33 @@ impl Tui {
                 self.handle_tab(true).await;
             }
             (KeyCode::Esc, KeyModifiers::NONE) => {
-                if !self.app.completions.is_empty() {
+                if self.app.transcript_focus.is_some() {
+                    self.app.transcript_focus = None;
+                    self.app.transcript_selection_anchor = None;
+                } else if !self.app.completions.is_empty() {
                     self.app.completions.clear();
                 }
+            }
+            // D4: Keyboard actions on selected transcript item(s)
+            (KeyCode::Char('e'), KeyModifiers::NONE) if self.app.transcript_focus.is_some() => {
+                self.handle_transcript_edit().await?;
+            }
+            (KeyCode::Delete, KeyModifiers::NONE) | (KeyCode::Char('d'), KeyModifiers::NONE)
+                if self.app.transcript_focus.is_some() =>
+            {
+                self.handle_transcript_delete();
+            }
+            (KeyCode::Char('i'), KeyModifiers::NONE) if self.app.transcript_focus.is_some() => {
+                self.handle_transcript_insert();
+            }
+            (KeyCode::Char('c'), KeyModifiers::NONE) if self.app.transcript_focus.is_some() => {
+                self.handle_transcript_copy();
+            }
+            (KeyCode::Char('r'), KeyModifiers::NONE) if self.app.transcript_focus.is_some() => {
+                self.handle_transcript_rewind();
+            }
+            (KeyCode::Enter, KeyModifiers::NONE) if self.app.transcript_focus.is_some() => {
+                self.app.action_menu_open = true;
             }
             (KeyCode::Enter, KeyModifiers::NONE) => {
                 if self.try_handle_attach_command().await {
@@ -221,6 +256,7 @@ impl Tui {
                         self.app.transcript.push(TranscriptItem::UserText {
                             text: text.clone(),
                             seq: None,
+                            timestamp: Some(chrono::Utc::now()),
                         });
                         self.render_submitted_attachments(&attachments_snapshot);
                         self.pin_transcript_to_bottom();
@@ -232,6 +268,7 @@ impl Tui {
                         self.app.transcript.push(TranscriptItem::UserText {
                             text: text.clone(),
                             seq: None,
+                            timestamp: Some(chrono::Utc::now()),
                         });
                         self.render_submitted_attachments(&attachments_snapshot);
                         self.pin_transcript_to_bottom();
@@ -492,6 +529,7 @@ impl Tui {
                 self.app.transcript.push(TranscriptItem::UserText {
                     text: pending.text.clone(),
                     seq: None,
+                    timestamp: Some(chrono::Utc::now()),
                 });
                 self.render_submitted_attachments(&pending.attachments);
                 self.pin_transcript_to_bottom();
@@ -525,6 +563,7 @@ impl Tui {
         self.app.transcript.push(TranscriptItem::UserText {
             text: pending.text.clone(),
             seq: None,
+            timestamp: Some(chrono::Utc::now()),
         });
         self.render_submitted_attachments(&pending.attachments);
         self.pin_transcript_to_bottom();
@@ -616,23 +655,27 @@ impl Tui {
         }
         self.render_ui_output_heading(source.as_ref(), is_usage);
 
-        // LogSeqAssigned patches the seq on the next unassigned sequenceable
-        // item (UserText, AssistantText, or ToolCall) AFTER the last item
-        // that already has a seq.  Searching after the last-assigned position
-        // forward lets multiple LogSeqAssigned events in a turn target
-        // distinct items in source order, while skipping pre-existing
-        // unassigned items like the agent banner that pre-date any real
-        // log entries.
-        // LogSeqAssigned events are emitted by the engine after each log
-        // append so that future TUI work can show seq numbers on live
-        // messages.  For now the TUI only displays seq numbers on messages
-        // loaded from a saved session log (via messages_to_transcript_items).
-        // Live-event seq propagation across the streaming model is more
-        // intricate than a simple retroactive patch and is deferred.
-        if matches!(
-            event,
-            AgentEvent::Session(SessionEvent::LogSeqAssigned { .. })
-        ) {
+        if let AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }) = event {
+            for item in self.app.transcript.iter_mut().rev() {
+                match item {
+                    TranscriptItem::UserText {
+                        seq: item_seq @ None,
+                        ..
+                    }
+                    | TranscriptItem::AssistantText {
+                        seq: item_seq @ None,
+                        ..
+                    }
+                    | TranscriptItem::ToolCall {
+                        seq: item_seq @ None,
+                        ..
+                    } => {
+                        *item_seq = Some(seq);
+                        break;
+                    }
+                    _ => {}
+                }
+            }
             return;
         }
 
@@ -708,6 +751,7 @@ impl Tui {
                                 self.app.transcript.push(TranscriptItem::AssistantText {
                                     text: output,
                                     seq: None,
+                                    timestamp: Some(chrono::Utc::now()),
                                 });
                                 self.app.streaming_assistant_idx =
                                     Some(self.app.transcript.len() - 1);
@@ -717,6 +761,7 @@ impl Tui {
                         self.app.transcript.push(TranscriptItem::AssistantText {
                             text: output,
                             seq: None,
+                            timestamp: Some(chrono::Utc::now()),
                         });
                         self.app.streaming_assistant_idx = Some(self.app.transcript.len() - 1);
                     }
@@ -826,6 +871,7 @@ impl Tui {
                     tool_name: name,
                     body: tool_call_body(markdown.as_deref(), &input),
                     seq: None,
+                    timestamp: Some(chrono::Utc::now()),
                 }]
             }
             // Not rendered by the TUI: Turn, Session, Status, Tool::Progress,
@@ -1002,6 +1048,26 @@ impl Tui {
     fn handle_up_key(&mut self, key: KeyEvent) {
         if !self.app.completions.is_empty() {
             self.app.scroll_state.scroll_up();
+        } else if let Some(focus) = self.app.transcript_focus {
+            if focus > 0 {
+                self.app.transcript_focus = Some(focus - 1);
+                self.app.transcript_selection_anchor = None;
+            } else {
+                self.app.transcript_focus = None;
+                self.app.transcript_selection_anchor = None;
+
+                let before = self.app.history_index;
+                self.history_prev();
+                let moved = self.app.history_index.is_some()
+                    && (self.app.history_index != before || self.app.history_preview);
+                if moved {
+                    self.app.history_preview = true;
+                    self.refresh_input_chrome();
+                }
+            }
+        } else if self.input_is_blank() && !self.app.transcript.is_empty() {
+            self.app.transcript_focus = Some(self.app.transcript.len() - 1);
+            self.app.transcript_selection_anchor = None;
         } else if self.app.history_preview || self.input_is_blank() {
             let before = self.app.history_index;
             self.history_prev();
@@ -1019,6 +1085,15 @@ impl Tui {
     fn handle_down_key(&mut self, key: KeyEvent) {
         if !self.app.completions.is_empty() {
             self.app.scroll_state.scroll_down();
+        } else if let Some(focus) = self.app.transcript_focus {
+            let next = focus + 1;
+            if next < self.app.transcript.len() {
+                self.app.transcript_focus = Some(next);
+                self.app.transcript_selection_anchor = None;
+            } else {
+                self.app.transcript_focus = None;
+                self.app.transcript_selection_anchor = None;
+            }
         } else if self.app.history_preview {
             self.history_next();
             if self.app.history_index.is_none() {
@@ -1027,6 +1102,29 @@ impl Tui {
             self.refresh_input_chrome();
         } else {
             self.app.input.input(TextInput::from(key));
+        }
+    }
+
+    fn handle_up_key_shift(&mut self) {
+        if let Some(focus) = self.app.transcript_focus {
+            if self.app.transcript_selection_anchor.is_none() {
+                self.app.transcript_selection_anchor = Some(focus);
+            }
+            if focus > 0 {
+                self.app.transcript_focus = Some(focus - 1);
+            }
+        }
+    }
+
+    fn handle_down_key_shift(&mut self) {
+        if let Some(focus) = self.app.transcript_focus {
+            if self.app.transcript_selection_anchor.is_none() {
+                self.app.transcript_selection_anchor = Some(focus);
+            }
+            let next = focus + 1;
+            if next < self.app.transcript.len() {
+                self.app.transcript_focus = Some(next);
+            }
         }
     }
 
@@ -1410,5 +1508,190 @@ fn format_usage(usage: &harnx_core::api_types::CompletionTokenUsage) -> String {
         String::new()
     } else {
         format!("{usage}")
+    }
+}
+
+impl Tui {
+    /// Handle keystrokes while a confirmation modal is open.
+    ///
+    /// - `y` or `Enter` → confirm action, clear modal, execute the action.
+    /// - `n` or `Esc` → cancel, clear modal.
+    /// - All other keys are consumed (no action).
+    pub(super) async fn handle_modal_key(&mut self, key: KeyEvent) -> Result<()> {
+        match (key.code, key.modifiers) {
+            // Confirm with 'y' or Enter
+            (KeyCode::Char('y'), KeyModifiers::NONE) | (KeyCode::Enter, KeyModifiers::NONE) => {
+                self.confirm_modal_action().await?;
+            }
+            // Cancel with 'n' or Esc
+            (KeyCode::Char('n'), KeyModifiers::NONE) | (KeyCode::Esc, KeyModifiers::NONE) => {
+                self.app.modal = None;
+            }
+            // All other keys are consumed by the modal (no action)
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Execute the action associated with the current modal and clear it.
+    async fn confirm_modal_action(&mut self) -> Result<()> {
+        let modal = self.app.modal.take();
+        if let Some(modal) = modal {
+            match modal {
+                crate::types::ModalState::ConfirmDelete { from, to } => {
+                    // Execute delete via dot-command
+                    let cmd = if from == to {
+                        format!(".delete message {}", from)
+                    } else {
+                        format!(".delete message {}-{}", from, to)
+                    };
+                    self.run_command(&cmd).await?;
+                }
+                crate::types::ModalState::ConfirmRewind { seq, user_text } => {
+                    // Execute rewind via dot-command
+                    let cmd = format!(".rewind {}", seq);
+                    self.run_command(&cmd).await?;
+                    // If user_text was saved, restore it to the input
+                    if let Some(text) = user_text {
+                        self.app.input = Self::new_input();
+                        for c in text.chars() {
+                            self.app.input.input(ratatui_textarea::Input {
+                                key: if c == '\n' {
+                                    ratatui_textarea::Key::Enter
+                                } else {
+                                    ratatui_textarea::Key::Char(c)
+                                },
+                                ..Default::default()
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    // =========================================================================
+    // D4: Keyboard actions on selected transcript item(s)
+    // =========================================================================
+
+    /// Compute selected transcript index range [min, max] from focus+anchor.
+    fn get_selected_index_range(&self) -> (usize, usize) {
+        let focus = self
+            .app
+            .transcript_focus
+            .expect("transcript_focus required");
+        let anchor = self.app.transcript_selection_anchor.unwrap_or(focus);
+        (focus.min(anchor), focus.max(anchor))
+    }
+
+    /// Get seq range (from_seq, to_seq) for selected items.
+    /// Returns None when selected items do not have sequence numbers.
+    fn selected_seq_range(&self) -> Option<(usize, usize)> {
+        let (start_idx, end_idx) = self.get_selected_index_range();
+        let from = self
+            .app
+            .transcript
+            .get(start_idx)
+            .and_then(|item| item.seq());
+        let to = self.app.transcript.get(end_idx).and_then(|item| item.seq());
+        match (from, to) {
+            (Some(from), Some(to)) => Some((from.min(to), from.max(to))),
+            _ => None,
+        }
+    }
+
+    /// Get text content from transcript item for copy/insert operations.
+    fn get_transcript_item_text(item: &TranscriptItem) -> Option<String> {
+        match item {
+            TranscriptItem::UserText { text, .. } => Some(text.clone()),
+            TranscriptItem::AssistantText { text, .. } => Some(text.clone()),
+            TranscriptItem::ToolCall {
+                tool_name,
+                body: Some(crate::types::ToolCallBody::Yaml(body)),
+                ..
+            }
+            | TranscriptItem::ToolCall {
+                tool_name,
+                body: Some(crate::types::ToolCallBody::Markdown(body)),
+                ..
+            } => Some(format!("{}({})", tool_name, body)),
+            TranscriptItem::ToolCall { tool_name, .. } => Some(format!("{}()", tool_name)),
+            _ => None,
+        }
+    }
+
+    /// Handle 'e' key: open edit command for selected item(s).
+    async fn handle_transcript_edit(&mut self) -> Result<()> {
+        let Some((from, to)) = self.selected_seq_range() else {
+            return Ok(());
+        };
+        let cmd = if from == to {
+            format!(".edit message {}", from)
+        } else {
+            format!(".edit message {}-{}", from, to)
+        };
+        self.run_command(&cmd).await?;
+        self.app.transcript_focus = None;
+        self.app.transcript_selection_anchor = None;
+        Ok(())
+    }
+
+    /// Handle 'd' or Delete key: open delete confirmation modal.
+    fn handle_transcript_delete(&mut self) {
+        let Some((from, to)) = self.selected_seq_range() else {
+            return;
+        };
+        self.app.modal = Some(crate::types::ModalState::ConfirmDelete { from, to });
+    }
+
+    /// Handle 'i' key: copy item text into input field, clear focus.
+    fn handle_transcript_insert(&mut self) {
+        let focus = match self.app.transcript_focus {
+            Some(f) => f,
+            None => return,
+        };
+        let item = match self.app.transcript.get(focus) {
+            Some(item) => item.clone(),
+            None => return,
+        };
+        if let Some(text) = Self::get_transcript_item_text(&item) {
+            self.set_input_text(&text);
+        }
+        self.app.transcript_focus = None;
+        self.app.transcript_selection_anchor = None;
+    }
+
+    /// Handle 'c' key: copy item text to clipboard.
+    fn handle_transcript_copy(&mut self) {
+        if let Some(text) = self
+            .app
+            .transcript_focus
+            .and_then(|focus| self.app.transcript.get(focus))
+            .and_then(Self::get_transcript_item_text)
+        {
+            let _ = harnx_runtime::utils::set_text(&text);
+        }
+    }
+
+    /// Handle 'r' key: open rewind confirmation modal.
+    fn handle_transcript_rewind(&mut self) {
+        let focus = self.app.transcript_selection_anchor.unwrap_or_else(|| {
+            self.app
+                .transcript_focus
+                .expect("transcript_focus required")
+        });
+        let item = match self.app.transcript.get(focus) {
+            Some(item) => item,
+            None => return,
+        };
+        let Some(seq) = item.seq() else {
+            return;
+        };
+        let user_text = match item {
+            TranscriptItem::UserText { text, .. } => Some(text.clone()),
+            _ => None,
+        };
+        self.app.modal = Some(crate::types::ModalState::ConfirmRewind { seq, user_text });
     }
 }

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -99,6 +99,12 @@ impl Tui {
                 attachment_dir: None,
                 paste_count: 0,
                 last_known_input_width: 1,
+                show_sequence_numbers: config.read().show_sequence_numbers,
+                show_timestamps: config.read().show_timestamps,
+                transcript_focus: None,
+                transcript_selection_anchor: None,
+                modal: None,
+                action_menu_open: false,
             },
             event_tx,
             event_rx,
@@ -127,6 +133,7 @@ impl Tui {
                         entries.push(TranscriptItem::AssistantText {
                             text: banner,
                             seq: None,
+                            timestamp: None, // Banner has no timestamp
                         });
                     }
                 }
@@ -216,6 +223,11 @@ impl Tui {
 
             if last_tick.elapsed() >= TICK_RATE {
                 self.app.spinner_index = (self.app.spinner_index + 1) % SPINNER_FRAMES.len();
+                {
+                    let cfg = self.config.read();
+                    self.app.show_sequence_numbers = cfg.show_sequence_numbers;
+                    self.app.show_timestamps = cfg.show_timestamps;
+                }
                 self.refresh_input_chrome();
                 last_tick = Instant::now();
 
@@ -301,6 +313,7 @@ pub(crate) fn messages_to_transcript_items(
                     items.push(TranscriptItem::UserText {
                         text,
                         seq: msg.log_seq,
+                        timestamp: msg.log_timestamp,
                     });
                 }
             }
@@ -310,6 +323,7 @@ pub(crate) fn messages_to_transcript_items(
                     items.push(TranscriptItem::AssistantText {
                         text,
                         seq: msg.log_seq,
+                        timestamp: msg.log_timestamp,
                     });
                 }
             }
@@ -324,6 +338,7 @@ pub(crate) fn messages_to_transcript_items(
                         items.push(TranscriptItem::AssistantText {
                             text: tc.text.clone(),
                             seq: msg.log_seq,
+                            timestamp: msg.log_timestamp,
                         });
                     }
                     for r in &tc.tool_results {
@@ -350,6 +365,7 @@ pub(crate) fn messages_to_transcript_items(
                             tool_name: r.call.name.clone(),
                             body,
                             seq: msg.log_seq,
+                            timestamp: msg.log_timestamp,
                         });
                         let raw_result_fallback = harnx_core::tool::extract_user_display_text(
                             &r.output,
@@ -437,6 +453,7 @@ mod tests {
             role: MessageRole::Tool,
             content: MessageContent::ToolCalls(tc),
             log_seq: None,
+            log_timestamp: None,
         }];
 
         let items = messages_to_transcript_items(&messages, &decl_map);
@@ -490,6 +507,7 @@ mod tests {
             role: MessageRole::Tool,
             content: MessageContent::ToolCalls(tc),
             log_seq: None,
+            log_timestamp: None,
         }];
 
         let items = messages_to_transcript_items(&messages, &decl_map);

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -105,6 +105,7 @@ impl Tui {
                 transcript_selection_anchor: None,
                 modal: None,
                 action_menu_open: false,
+                use_utc_timestamps: false,
             },
             event_tx,
             event_rx,

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -82,6 +82,7 @@ impl Tui {
         timestamp: Option<chrono::DateTime<chrono::Utc>>,
         show_seq: bool,
         show_ts: bool,
+        use_utc: bool,
     ) -> Vec<Line<'static>> {
         let dim_gray = Style::default()
             .fg(Color::DarkGray)
@@ -89,7 +90,7 @@ impl Tui {
 
         let header_text = format!("→ {tool_name}");
         let mut lines = Self::render_text_entry("", &header_text, dim_gray, false);
-        if let Some(suffix) = Self::render_meta_suffix(seq, timestamp, show_seq, show_ts) {
+        if let Some(suffix) = Self::render_meta_suffix(seq, timestamp, show_seq, show_ts, use_utc) {
             if let Some(first_line) = lines.first_mut() {
                 first_line.spans.push(suffix);
             }
@@ -115,6 +116,7 @@ impl Tui {
         timestamp: Option<chrono::DateTime<chrono::Utc>>,
         show_seq: bool,
         show_ts: bool,
+        use_utc: bool,
     ) -> Option<Span<'static>> {
         let mut parts = vec![];
         if show_seq {
@@ -124,8 +126,14 @@ impl Tui {
         }
         if show_ts {
             if let Some(ts) = timestamp {
-                let local = ts.with_timezone(&chrono::Local);
-                parts.push(local.format("%H:%M:%S").to_string());
+                let formatted = if use_utc {
+                    ts.format("%H:%M:%S").to_string()
+                } else {
+                    ts.with_timezone(&chrono::Local)
+                        .format("%H:%M:%S")
+                        .to_string()
+                };
+                parts.push(formatted);
             }
         }
         if parts.is_empty() {
@@ -143,6 +151,7 @@ impl Tui {
         entry: &TranscriptItem,
         show_seq: bool,
         show_ts: bool,
+        use_utc: bool,
     ) -> Vec<Line<'static>> {
         match entry {
             TranscriptItem::SourceHeading(source) => Self::render_text_entry(
@@ -182,7 +191,8 @@ impl Tui {
                         .add_modifier(Modifier::BOLD),
                     true,
                 );
-                if let Some(suffix) = Self::render_meta_suffix(*seq, *timestamp, show_seq, show_ts)
+                if let Some(suffix) =
+                    Self::render_meta_suffix(*seq, *timestamp, show_seq, show_ts, use_utc)
                 {
                     if let Some(first_line) = lines.first_mut() {
                         first_line.spans.push(suffix);
@@ -202,7 +212,8 @@ impl Tui {
                 // asterisks for the moment, then upgrades to bold once the
                 // closing `**` arrives in a later chunk.
                 let mut lines = crate::render_helpers::markdown_lines(text, Style::default());
-                if let Some(suffix) = Self::render_meta_suffix(*seq, *timestamp, show_seq, show_ts)
+                if let Some(suffix) =
+                    Self::render_meta_suffix(*seq, *timestamp, show_seq, show_ts, use_utc)
                 {
                     if lines.is_empty() {
                         lines.push(Line::from(""));
@@ -284,6 +295,7 @@ impl Tui {
                 *timestamp,
                 show_seq,
                 show_ts,
+                use_utc,
             ),
             TranscriptItem::AttachmentHeader(text) => Self::render_text_entry(
                 "",
@@ -333,6 +345,7 @@ impl Tui {
 
         let show_seq = self.app.show_sequence_numbers;
         let show_ts = self.app.show_timestamps;
+        let use_utc = self.app.use_utc_timestamps;
         let selected_range = if let Some(f) = self.app.transcript_focus {
             let start = self.app.transcript_selection_anchor.unwrap_or(f).min(f);
             let end = self.app.transcript_selection_anchor.unwrap_or(f).max(f);
@@ -349,7 +362,7 @@ impl Tui {
                 .iter()
                 .enumerate()
                 .map(|(i, entry)| {
-                    let mut lines = Self::render_entry(entry, show_seq, show_ts);
+                    let mut lines = Self::render_entry(entry, show_seq, show_ts, use_utc);
                     if let Some(range) = &selected_range {
                         if range.contains(&i) {
                             if let Some(first_line) = lines.first_mut() {

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -1,6 +1,7 @@
 use crate::types::Tui;
 use crate::types::{
-    App, ToolCallBody, TranscriptItem, MAX_INPUT_HEIGHT, MIN_INPUT_HEIGHT, SPINNER_FRAMES,
+    App, ModalState, ToolCallBody, TranscriptItem, MAX_INPUT_HEIGHT, MIN_INPUT_HEIGHT,
+    SPINNER_FRAMES,
 };
 use harnx_runtime::config::GlobalConfig;
 use ratatui::layout::{Constraint, Direction, Layout};
@@ -78,18 +79,21 @@ impl Tui {
         tool_name: &str,
         body: Option<&ToolCallBody>,
         seq: Option<usize>,
+        timestamp: Option<chrono::DateTime<chrono::Utc>>,
+        show_seq: bool,
+        show_ts: bool,
     ) -> Vec<Line<'static>> {
         let dim_gray = Style::default()
             .fg(Color::DarkGray)
             .add_modifier(Modifier::DIM);
 
-        let header_text = if let Some(n) = seq {
-            format!("→ {tool_name}  [{n}]")
-        } else {
-            format!("→ {tool_name}")
-        };
-
+        let header_text = format!("→ {tool_name}");
         let mut lines = Self::render_text_entry("", &header_text, dim_gray, false);
+        if let Some(suffix) = Self::render_meta_suffix(seq, timestamp, show_seq, show_ts) {
+            if let Some(first_line) = lines.first_mut() {
+                first_line.spans.push(suffix);
+            }
+        }
         match body {
             Some(ToolCallBody::Yaml(yaml)) => {
                 for line in yaml.lines() {
@@ -106,7 +110,40 @@ impl Tui {
         lines
     }
 
-    pub(super) fn render_entry(entry: &TranscriptItem) -> Vec<Line<'static>> {
+    fn render_meta_suffix(
+        seq: Option<usize>,
+        timestamp: Option<chrono::DateTime<chrono::Utc>>,
+        show_seq: bool,
+        show_ts: bool,
+    ) -> Option<Span<'static>> {
+        let mut parts = vec![];
+        if show_seq {
+            if let Some(n) = seq {
+                parts.push(format!("[{n}]"));
+            }
+        }
+        if show_ts {
+            if let Some(ts) = timestamp {
+                let local = ts.with_timezone(&chrono::Local);
+                parts.push(local.format("%H:%M:%S").to_string());
+            }
+        }
+        if parts.is_empty() {
+            return None;
+        }
+        Some(Span::styled(
+            format!("  {}", parts.join(" ")),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::DIM),
+        ))
+    }
+
+    pub(super) fn render_entry(
+        entry: &TranscriptItem,
+        show_seq: bool,
+        show_ts: bool,
+    ) -> Vec<Line<'static>> {
         match entry {
             TranscriptItem::SourceHeading(source) => Self::render_text_entry(
                 "",
@@ -132,7 +169,11 @@ impl Tui {
                     .add_modifier(Modifier::DIM),
                 false,
             ),
-            TranscriptItem::UserText { text, seq } => {
+            TranscriptItem::UserText {
+                text,
+                seq,
+                timestamp,
+            } => {
                 let mut lines = Self::render_text_entry(
                     "> ",
                     text,
@@ -141,19 +182,19 @@ impl Tui {
                         .add_modifier(Modifier::BOLD),
                     true,
                 );
-                if let Some(n) = seq {
+                if let Some(suffix) = Self::render_meta_suffix(*seq, *timestamp, show_seq, show_ts)
+                {
                     if let Some(first_line) = lines.first_mut() {
-                        first_line.spans.push(Span::styled(
-                            format!("  [{n}]"),
-                            Style::default()
-                                .fg(Color::DarkGray)
-                                .add_modifier(Modifier::DIM),
-                        ));
+                        first_line.spans.push(suffix);
                     }
                 }
                 lines
             }
-            TranscriptItem::AssistantText { text, seq } => {
+            TranscriptItem::AssistantText {
+                text,
+                seq,
+                timestamp,
+            } => {
                 // Render assistant messages as markdown so headings, lists,
                 // code fences, and inline emphasis show their styling.
                 // Streaming chunks rebuild this entry on every render — an
@@ -161,17 +202,13 @@ impl Tui {
                 // asterisks for the moment, then upgrades to bold once the
                 // closing `**` arrives in a later chunk.
                 let mut lines = crate::render_helpers::markdown_lines(text, Style::default());
-                if let Some(n) = seq {
+                if let Some(suffix) = Self::render_meta_suffix(*seq, *timestamp, show_seq, show_ts)
+                {
                     if lines.is_empty() {
                         lines.push(Line::from(""));
                     }
                     if let Some(first_line) = lines.first_mut() {
-                        first_line.spans.push(Span::styled(
-                            format!("  [{n}]"),
-                            Style::default()
-                                .fg(Color::DarkGray)
-                                .add_modifier(Modifier::DIM),
-                        ));
+                        first_line.spans.push(suffix);
                     }
                 }
                 // Match the prior trailing-spacing rule: pad after a
@@ -239,7 +276,15 @@ impl Tui {
                 tool_name,
                 body,
                 seq,
-            } => Self::render_tool_call(tool_name, body.as_ref(), *seq),
+                timestamp,
+            } => Self::render_tool_call(
+                tool_name,
+                body.as_ref(),
+                *seq,
+                *timestamp,
+                show_seq,
+                show_ts,
+            ),
             TranscriptItem::AttachmentHeader(text) => Self::render_text_entry(
                 "",
                 &format!("{text}:"),
@@ -286,10 +331,39 @@ impl Tui {
             ])
             .split(size);
 
+        let show_seq = self.app.show_sequence_numbers;
+        let show_ts = self.app.show_timestamps;
+        let selected_range = if let Some(f) = self.app.transcript_focus {
+            let start = self.app.transcript_selection_anchor.unwrap_or(f).min(f);
+            let end = self.app.transcript_selection_anchor.unwrap_or(f).max(f);
+            Some(start..=end)
+        } else {
+            None
+        };
+
         let transcript_entries: Vec<Vec<Line<'static>>> = if self.app.transcript.is_empty() {
             vec![vec![Line::from(Span::raw(""))]]
         } else {
-            self.app.transcript.iter().map(Self::render_entry).collect()
+            self.app
+                .transcript
+                .iter()
+                .enumerate()
+                .map(|(i, entry)| {
+                    let mut lines = Self::render_entry(entry, show_seq, show_ts);
+                    if let Some(range) = &selected_range {
+                        if range.contains(&i) {
+                            if let Some(first_line) = lines.first_mut() {
+                                first_line.style =
+                                    first_line.style.add_modifier(Modifier::REVERSED);
+                                for span in &mut first_line.spans {
+                                    span.style = span.style.add_modifier(Modifier::REVERSED);
+                                }
+                            }
+                        }
+                    }
+                    lines
+                })
+                .collect()
         };
 
         self.app
@@ -441,6 +515,16 @@ impl Tui {
             frame.render_widget(ratatui::widgets::Clear, popup_area);
             frame.render_widget(popup, popup_area);
         }
+
+        // Render action menu if open
+        if self.app.action_menu_open && self.app.transcript_focus.is_some() {
+            self.render_action_menu(frame, size);
+        }
+
+        // Render confirmation modal on top of everything else
+        if let Some(modal) = &self.app.modal {
+            self.render_modal(frame, size, modal);
+        }
     }
 
     pub(super) fn input_height(&self, available_width: u16) -> u16 {
@@ -509,6 +593,7 @@ impl Tui {
                 self.app.transcript.push(TranscriptItem::AssistantText {
                     text: String::new(),
                     seq: None,
+                    timestamp: Some(chrono::Utc::now()),
                 });
                 self.app.streaming_assistant_idx = Some(self.app.transcript.len() - 1);
             }
@@ -618,5 +703,95 @@ impl Tui {
         };
         app.input.set_style(input_style);
         app.input.set_cursor_style(cursor_style);
+    }
+
+    /// Render a centered action menu overlay.
+    fn render_action_menu(&self, frame: &mut Frame<'_>, screen_size: ratatui::layout::Rect) {
+        let lines = vec![
+            Line::from(vec![
+                Span::styled("[e] ", Style::default().fg(Color::Yellow)),
+                Span::raw("Edit     "),
+                Span::styled("[d] ", Style::default().fg(Color::Yellow)),
+                Span::raw("Delete   "),
+                Span::styled("[i] ", Style::default().fg(Color::Yellow)),
+                Span::raw("Insert"),
+            ]),
+            Line::from(vec![
+                Span::styled("[c] ", Style::default().fg(Color::Yellow)),
+                Span::raw("Copy     "),
+                Span::styled("[r] ", Style::default().fg(Color::Yellow)),
+                Span::raw("Rewind   "),
+                Span::styled("[Esc] ", Style::default().fg(Color::Yellow)),
+                Span::raw("Cancel"),
+            ]),
+        ];
+
+        let modal_width = 40;
+        let modal_height = 4; // 2 lines of text + borders
+
+        // Center the modal
+        let modal_x = (screen_size.width.saturating_sub(modal_width)) / 2;
+        let modal_y = (screen_size.height.saturating_sub(modal_height)) / 2;
+        let modal_area = ratatui::layout::Rect::new(modal_x, modal_y, modal_width, modal_height);
+
+        // Clear the area behind the modal
+        frame.render_widget(ratatui::widgets::Clear, modal_area);
+
+        // Render the modal box
+        let modal = Paragraph::new(lines).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Actions")
+                .border_style(Style::default().fg(Color::Reset)),
+        );
+
+        frame.render_widget(modal, modal_area);
+    }
+
+    /// Render a centered confirmation modal overlay.
+    fn render_modal(
+        &self,
+        frame: &mut Frame<'_>,
+        screen_size: ratatui::layout::Rect,
+        modal: &ModalState,
+    ) {
+        let prompt_text = match modal {
+            ModalState::ConfirmDelete { from, to } => {
+                if from == to {
+                    format!("Delete entry {}? [y/N]", from)
+                } else {
+                    format!("Delete entries {}–{}? [y/N]", from, to)
+                }
+            }
+            ModalState::ConfirmRewind { seq, .. } => {
+                format!("Rewind to entry {}? [y/N]", seq)
+            }
+        };
+
+        // Calculate modal size based on content
+        let prompt_len = prompt_text.len() as u16;
+        let modal_width = (prompt_len + 6).min(screen_size.width.saturating_sub(4));
+        let modal_height = 3u16; // Single line of text + borders
+
+        // Center the modal
+        let modal_x = (screen_size.width.saturating_sub(modal_width)) / 2;
+        let modal_y = (screen_size.height.saturating_sub(modal_height)) / 2;
+        let modal_area = ratatui::layout::Rect::new(modal_x, modal_y, modal_width, modal_height);
+
+        // Clear the area behind the modal
+        frame.render_widget(ratatui::widgets::Clear, modal_area);
+
+        // Render the modal box
+        let modal = Paragraph::new(Line::from(Span::styled(
+            prompt_text,
+            Style::default().fg(Color::Reset),
+        )))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Reset)),
+        );
+
+        frame.render_widget(modal, modal_area);
     }
 }

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__action_menu_popup.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__action_menu_popup.snap
@@ -1,0 +1,26 @@
+---
+source: crates/harnx-tui/src/tests.rs
+expression: rendered
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
+> hello  [1]
+
+
+
+
+
+
+
+
+                    ┌Actions───────────────────────────────┐
+                    │[e] Edit     [d] Delete   [i] Insert  │
+                    │[c] Copy     [r] Rewind   [Esc] Cancel│
+                    └──────────────────────────────────────┘
+
+
+
+
+
+
+
+• Input

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__help_in_tui.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__help_in_tui.snap
@@ -1,10 +1,7 @@
 ---
 source: crates/harnx-tui/src/tests.rs
-assertion_line: 1366
 expression: rendered
 ---
-.sources rag             Show citation sources used in last query
-.info rag                Show RAG info
 .exit rag                Leave RAG
 .attach                  Attach a file to the next message
 .detach                  Remove attached files
@@ -15,6 +12,8 @@ expression: rendered
 .regenerate              Regenerate last response
 .copy                    Copy last response
 .set                     Modify runtime settings
+.set show_sequence_numbers Toggle [n] prefix in transcript (on/off)
+.set show_timestamps     Toggle timestamp in transcript (on/off)
 .delete                  Delete agents, sessions, RAGs, or macros
 .delete message <n>      Delete a log entry by sequence number
 .delete message <n>-<m>  Delete a range of log entries

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__highlight_range.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__highlight_range.snap
@@ -1,0 +1,17 @@
+---
+source: crates/harnx-tui/src/tests.rs
+expression: rendered
+---
+Welcome to harnx 0.30.0  •  Type .help
+for commands, Tab to complete.
+> Line 0
+
+Line 1
+
+> Line 2
+
+Line 3
+
+
+
+• Input

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__highlight_single_item.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__highlight_single_item.snap
@@ -1,0 +1,17 @@
+---
+source: crates/harnx-tui/src/tests.rs
+expression: rendered
+---
+Welcome to harnx 0.30.0  •  Type .help
+for commands, Tab to complete.
+> Line 0
+
+Line 1
+
+> Line 2
+
+
+
+
+
+• Input

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__meta_suffix_both_off.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__meta_suffix_both_off.snap
@@ -1,0 +1,26 @@
+---
+source: crates/harnx-tui/src/tests.rs
+expression: r4
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
+> hello
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+• Input

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__meta_suffix_both_on.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__meta_suffix_both_on.snap
@@ -1,0 +1,27 @@
+---
+source: crates/harnx-tui/src/tests.rs
+assertion_line: 4760
+expression: r1
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
+> hello  [1] 05:34:56
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+• Input

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__meta_suffix_both_on.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__meta_suffix_both_on.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/harnx-tui/src/tests.rs
-assertion_line: 4760
 expression: r1
 ---
 Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
-> hello  [1] 05:34:56
+> hello  [1] 12:34:56
 
 
 

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__meta_suffix_seq_only.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__meta_suffix_seq_only.snap
@@ -1,0 +1,26 @@
+---
+source: crates/harnx-tui/src/tests.rs
+expression: r2
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
+> hello  [1]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+• Input

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__meta_suffix_ts_only.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__meta_suffix_ts_only.snap
@@ -1,0 +1,27 @@
+---
+source: crates/harnx-tui/src/tests.rs
+assertion_line: 4774
+expression: r3
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
+> hello  05:34:56
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+• Input

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__meta_suffix_ts_only.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__meta_suffix_ts_only.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/harnx-tui/src/tests.rs
-assertion_line: 4774
 expression: r3
 ---
 Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
-> hello  05:34:56
+> hello  12:34:56
 
 
 

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__modal_confirm_delete_range.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__modal_confirm_delete_range.snap
@@ -1,0 +1,14 @@
+---
+source: crates/harnx-tui/src/tests.rs
+expression: rendered
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to
+complete.
+
+
+             ┌───────────────────────────────┐
+             │Delete entries 3–5? [y/N]      │
+             └───────────────────────────────┘
+
+
+• Input

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__modal_confirm_delete_single.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__modal_confirm_delete_single.snap
@@ -1,0 +1,14 @@
+---
+source: crates/harnx-tui/src/tests.rs
+expression: rendered
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to
+complete.
+
+
+                ┌─────────────────────────┐
+                │Delete entry 3? [y/N]    │
+                └─────────────────────────┘
+
+
+• Input

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__modal_confirm_rewind.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__modal_confirm_rewind.snap
@@ -1,0 +1,14 @@
+---
+source: crates/harnx-tui/src/tests.rs
+expression: rendered
+---
+Welcome to harnx 0.30.0  •  Type .help for commands, Tab to
+complete.
+
+
+               ┌────────────────────────────┐
+               │Rewind to entry 7? [y/N]    │
+               └────────────────────────────┘
+
+
+• Input

--- a/crates/harnx-tui/src/test_utils/tui_harness.rs
+++ b/crates/harnx-tui/src/test_utils/tui_harness.rs
@@ -36,7 +36,7 @@ use tokio::sync::Mutex;
 /// ```
 pub struct TuiTestHarness {
     tui: Tui,
-    terminal: Terminal<TestBackend>,
+    pub(crate) terminal: Terminal<TestBackend>,
     sync: SyncHarness,
 }
 

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -3,8 +3,8 @@ use crate::types::Tui;
 use crate::types::{ToolCallBody, TranscriptItem, TuiEvent};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use harnx_core::event::{
-    AgentEvent, AgentSource, ContentBlock, ModelEvent, NoticeEvent, PlanEntry, ToolEvent, ToolKind,
-    ToolStatus,
+    AgentEvent, AgentSource, ContentBlock, ModelEvent, NoticeEvent, PlanEntry, SessionEvent,
+    ToolEvent, ToolKind, ToolStatus,
 };
 use harnx_hooks::{AsyncHookManager, PersistentHookManager};
 use harnx_runtime::client::{Client, ClientConfig, TestStateGuard};
@@ -440,7 +440,7 @@ async fn ui_output_inserts_heading_when_source_changes() {
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -519,7 +519,7 @@ async fn info_commands_render_into_tui_transcript() {
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -772,7 +772,7 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -851,7 +851,7 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -1080,7 +1080,7 @@ async fn structured_ui_output_variants_render_in_transcript() {
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -1161,7 +1161,7 @@ async fn nested_subagent_tool_call_renders_with_heading_and_usage() {
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -1220,7 +1220,7 @@ async fn consecutive_usage_updates_replace_previous_usage_row_for_same_source() 
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -1326,7 +1326,7 @@ async fn submitting_message_with_attachments_renders_attachment_list_and_preview
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -1429,6 +1429,7 @@ async fn test_basic_message_and_streaming_response() {
     harness.tui().app.transcript.push(TranscriptItem::UserText {
         text: "Test message".to_string(),
         seq: None,
+        timestamp: None,
     });
     harness
         .tui()
@@ -1558,6 +1559,62 @@ fn seq_numbers_appear_after_session_reload() {
     );
 }
 
+#[tokio::test]
+async fn live_log_seq_assignment_patches_latest_unsequenced_transcript_items() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+    tui.app.show_sequence_numbers = true;
+
+    tui.app.transcript.push(TranscriptItem::UserText {
+        timestamp: None,
+        text: "older user".to_string(),
+        seq: Some(1),
+    });
+    tui.app.transcript.push(TranscriptItem::UserText {
+        timestamp: None,
+        text: "live user".to_string(),
+        seq: None,
+    });
+
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 2 }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    tui.app.transcript.push(TranscriptItem::AssistantText {
+        timestamp: None,
+        text: "live assistant".to_string(),
+        seq: None,
+    });
+
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 3 }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let pairs: Vec<(&'static str, Option<usize>)> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|item| match item {
+            TranscriptItem::UserText { text, seq, .. } if text == "live user" => {
+                Some(("user", *seq))
+            }
+            TranscriptItem::AssistantText { text, seq, .. } if text == "live assistant" => {
+                Some(("assistant", *seq))
+            }
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(pairs, vec![("user", Some(2)), ("assistant", Some(3))]);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_streaming_with_tool_calls() {
     let config =
@@ -1587,6 +1644,7 @@ async fn test_streaming_with_tool_calls() {
     let mut harness = TuiTestHarness::with_config(config.clone());
     harness.tui().clear_transcript();
     harness.tui().app.transcript.push(TranscriptItem::UserText {
+        timestamp: None,
         text: "What is the answer?".to_string(),
         seq: None,
     });
@@ -1675,6 +1733,7 @@ async fn test_sub_agent_delegation_tool_appears() {
     let mut harness = TuiTestHarness::with_config(config.clone());
     harness.tui().clear_transcript();
     harness.tui().app.transcript.push(TranscriptItem::UserText {
+        timestamp: None,
         text: "Help me".to_string(),
         seq: None,
     });
@@ -1831,6 +1890,7 @@ async fn test_screen_overflow_and_word_wrap() {
     let mut harness = TuiTestHarness::with_size(40, 10);
     harness.tui().clear_transcript();
     harness.tui().app.transcript.push(TranscriptItem::UserText {
+        timestamp: None,
         text: user_message.to_string(),
         seq: None,
     });
@@ -1949,6 +2009,7 @@ async fn test_submitted_message_with_text_attachment_snapshot() {
     // AttachmentPreviewLines.
     let tui = harness.tui();
     tui.app.transcript.push(TranscriptItem::UserText {
+        timestamp: None,
         text: "check this file".to_string(),
         seq: None,
     });
@@ -1969,6 +2030,7 @@ async fn test_submitted_message_with_text_attachment_snapshot() {
             "Line 2 of notes".to_string(),
         ));
     tui.app.transcript.push(TranscriptItem::AssistantText {
+        timestamp: None,
         text: "Got it, thanks!".to_string(),
         seq: None,
     });
@@ -2045,6 +2107,7 @@ async fn test_ctrl_c_cancels_streaming() {
     let mut harness = TuiTestHarness::with_config(config.clone());
     harness.tui().clear_transcript();
     harness.tui().app.transcript.push(TranscriptItem::UserText {
+        timestamp: None,
         text: "Long request".to_string(),
         seq: None,
     });
@@ -2133,6 +2196,7 @@ async fn test_streaming_error_shows_in_transcript() {
     let mut harness = TuiTestHarness::with_config(config.clone());
     harness.tui().clear_transcript();
     harness.tui().app.transcript.push(TranscriptItem::UserText {
+        timestamp: None,
         text: "Error test".to_string(),
         seq: None,
     });
@@ -2307,6 +2371,7 @@ async fn test_cancel_during_tool_execution() {
     let mut harness = TuiTestHarness::with_config(config.clone());
     harness.tui().clear_transcript();
     harness.tui().app.transcript.push(TranscriptItem::UserText {
+        timestamp: None,
         text: "Search test".to_string(),
         seq: None,
     });
@@ -2934,6 +2999,7 @@ async fn test_recovery_after_cancellation() {
 
     // Send first message
     harness.tui().app.transcript.push(TranscriptItem::UserText {
+        timestamp: None,
         text: "First request".to_string(),
         seq: None,
     });
@@ -2998,6 +3064,7 @@ async fn test_recovery_after_cancellation() {
     // User can send a new message
     harness.tui().clear_transcript();
     harness.tui().app.transcript.push(TranscriptItem::UserText {
+        timestamp: None,
         text: "Second request".to_string(),
         seq: None,
     });
@@ -3288,7 +3355,7 @@ async fn sub_agent_activity_no_duplicates_snapshot() {
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -3356,6 +3423,7 @@ fn make_tui_with_history(entries: &[&str]) -> (crate::types::Tui, GlobalConfig) 
 #[tokio::test]
 async fn history_up_on_blank_enters_preview() {
     let (mut tui, _config) = make_tui_with_history(&["first message", "second message"]);
+    tui.app.transcript.clear();
 
     tui.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
         .await
@@ -3370,10 +3438,236 @@ async fn history_up_on_blank_enters_preview() {
     );
 }
 
+#[tokio::test]
+async fn transcript_up_on_blank_input_enters_transcript_navigation() {
+    let mut harness = TuiTestHarness::with_size(40, 12);
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Line 0".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "Line 1".to_string(),
+            seq: None,
+            timestamp: None,
+        });
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.tui().app.transcript_focus, Some(2));
+    assert_eq!(harness.tui().app.transcript_selection_anchor, None);
+    assert!(!harness.tui().app.history_preview);
+}
+
+#[tokio::test]
+async fn transcript_up_moves_focus_and_clears_anchor() {
+    let mut harness = TuiTestHarness::with_size(40, 12);
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Line 0".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "Line 1".to_string(),
+            seq: None,
+            timestamp: None,
+        });
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Line 2".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness.tui().app.transcript_focus = Some(2);
+    harness.tui().app.transcript_selection_anchor = Some(0);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.tui().app.transcript_focus, Some(1));
+    assert_eq!(harness.tui().app.transcript_selection_anchor, None);
+}
+
+#[tokio::test]
+async fn transcript_down_from_last_returns_focus_to_input() {
+    let mut harness = TuiTestHarness::with_size(40, 12);
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Line 0".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "Line 1".to_string(),
+            seq: None,
+            timestamp: None,
+        });
+    harness.tui().app.transcript_focus = Some(harness.tui().app.transcript.len() - 1);
+    harness.tui().app.transcript_selection_anchor = Some(0);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.tui().app.transcript_focus, None);
+    assert_eq!(harness.tui().app.transcript_selection_anchor, None);
+}
+
+#[tokio::test]
+async fn transcript_shift_up_sets_anchor_and_moves_focus() {
+    let mut harness = TuiTestHarness::with_size(40, 12);
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Line 0".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "Line 1".to_string(),
+            seq: None,
+            timestamp: None,
+        });
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Line 2".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness.tui().app.transcript_focus = Some(2);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::SHIFT))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.tui().app.transcript_focus, Some(1));
+    assert_eq!(harness.tui().app.transcript_selection_anchor, Some(2));
+}
+
+#[tokio::test]
+async fn transcript_shift_down_sets_anchor_and_moves_focus() {
+    let mut harness = TuiTestHarness::with_size(40, 12);
+    harness.tui().app.transcript.clear();
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Line 0".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "Line 1".to_string(),
+            seq: None,
+            timestamp: None,
+        });
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Line 2".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "Line 3".to_string(),
+            seq: None,
+            timestamp: None,
+        });
+    harness.tui().app.transcript_focus = Some(0);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::SHIFT))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.tui().app.transcript_selection_anchor, Some(0));
+    assert_eq!(harness.tui().app.transcript_focus, Some(1));
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::SHIFT))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.tui().app.transcript_selection_anchor, Some(0));
+    assert_eq!(harness.tui().app.transcript_focus, Some(2));
+}
+
+#[tokio::test]
+async fn transcript_esc_clears_focus_and_anchor() {
+    let mut harness = TuiTestHarness::with_size(40, 12);
+    harness.tui().app.transcript_focus = Some(1);
+    harness.tui().app.transcript_selection_anchor = Some(0);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.tui().app.transcript_focus, None);
+    assert_eq!(harness.tui().app.transcript_selection_anchor, None);
+}
+
 /// Blank input + Up with empty history → no preview mode, no-op.
+#[tokio::test]
+async fn history_up_from_transcript_top_enters_history_preview() {
+    let (mut tui, _config) = make_tui_with_history(&["first message", "second message"]);
+    tui.app.transcript.clear();
+    tui.app.transcript.push(TranscriptItem::UserText {
+        text: "Line 0".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    tui.app.transcript.push(TranscriptItem::AssistantText {
+        text: "Line 1".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    tui.app.transcript_focus = Some(0);
+    tui.app.transcript_selection_anchor = Some(1);
+
+    tui.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(tui.app.transcript_focus, None);
+    assert_eq!(tui.app.transcript_selection_anchor, None);
+    assert!(tui.app.history_preview, "should enter preview mode");
+    assert_eq!(tui.app.history_index, Some(0));
+    assert_eq!(tui.app.input.lines().join("\n"), "first message");
+}
+
 #[tokio::test]
 async fn history_up_on_blank_empty_history_no_preview() {
     let (mut tui, _config) = make_tui_with_history(&[]);
+    tui.app.transcript.clear();
 
     tui.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
         .await
@@ -3391,6 +3685,7 @@ async fn history_up_on_blank_empty_history_no_preview() {
 #[tokio::test]
 async fn history_up_up_navigates_older() {
     let (mut tui, _config) = make_tui_with_history(&["first message", "second message"]);
+    tui.app.transcript.clear();
 
     tui.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
         .await
@@ -3412,6 +3707,7 @@ async fn history_up_up_navigates_older() {
 #[tokio::test]
 async fn history_down_returns_to_draft() {
     let (mut tui, _config) = make_tui_with_history(&["first message"]);
+    tui.app.transcript.clear();
 
     // Start with blank input and press Up to enter preview mode.
     // history_prev() saves the current input ("") into history_draft.
@@ -3442,6 +3738,7 @@ async fn history_down_returns_to_draft() {
 #[tokio::test]
 async fn history_typing_exits_preview() {
     let (mut tui, _config) = make_tui_with_history(&["hello"]);
+    tui.app.transcript.clear();
 
     // Enter preview
     tui.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
@@ -3516,6 +3813,7 @@ async fn history_down_not_preview_moves_cursor() {
 #[tokio::test]
 async fn history_paste_exits_preview() {
     let (mut tui, _config) = make_tui_with_history(&["hello"]);
+    tui.app.transcript.clear();
 
     // Enter preview
     tui.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
@@ -3587,6 +3885,7 @@ async fn test_ctrl_c_interrupts_in_flight_streaming() {
 
     let mut harness = TuiTestHarness::with_config(config.clone());
     harness.tui().app.transcript.push(TranscriptItem::UserText {
+        timestamp: None,
         text: "Long request".to_string(),
         seq: None,
     });
@@ -3943,6 +4242,7 @@ async fn test_tall_item_scroll_shows_correct_portion_and_no_dead_zone() {
         .app
         .transcript
         .push(TranscriptItem::AssistantText {
+            timestamp: None,
             text: tall_text.clone(),
             seq: None,
         });
@@ -4057,6 +4357,7 @@ async fn test_tall_item_scroll_window_moves_in_correct_direction() {
         .app
         .transcript
         .push(TranscriptItem::AssistantText {
+            timestamp: None,
             text: tall_text,
             seq: None,
         });
@@ -4144,7 +4445,7 @@ async fn tui_renders_started_title_when_template_provides_it() {
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .map(|line| line_to_plain(&line))
         .collect();
 
@@ -4188,7 +4489,7 @@ async fn tui_falls_back_to_yaml_when_no_template_title() {
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .map(|line| line_to_plain(&line))
         .collect();
     let joined = lines.join("\n");
@@ -4231,7 +4532,7 @@ async fn tui_renders_completed_template_title_when_provided() {
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .map(|line| line_to_plain(&line))
         .collect();
     let joined = lines.join("\n");
@@ -4280,7 +4581,7 @@ async fn tui_renders_fenced_diff_tool_result_with_per_line_syntect_styling() {
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .collect();
     let plain: Vec<String> = lines.iter().map(line_to_plain).collect();
     let joined = plain.join("\n");
@@ -4353,7 +4654,7 @@ async fn tui_falls_back_to_output_when_no_template_title() {
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .map(|line| line_to_plain(&line))
         .collect();
     let joined = lines.join("\n");
@@ -4387,7 +4688,7 @@ fn rendered_lines(tui: &Tui) -> Vec<ratatui::text::Line<'static>> {
     tui.app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .collect()
 }
 
@@ -4477,7 +4778,7 @@ async fn tui_started_no_template_keeps_yaml_unstyled() {
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .collect();
     let plain = rendered
         .iter()
@@ -4555,6 +4856,7 @@ async fn tui_assistant_text_renders_inline_markdown() {
     tui.app
         .transcript
         .push(crate::types::TranscriptItem::AssistantText {
+            timestamp: None,
             text: "Here's some **bold** and `code`.".to_string(),
             seq: None,
         });
@@ -4594,6 +4896,7 @@ async fn tui_assistant_text_preserves_line_breaks() {
     tui.app
         .transcript
         .push(crate::types::TranscriptItem::AssistantText {
+            timestamp: None,
             text: "first line\nsecond line\nthird line".to_string(),
             seq: None,
         });
@@ -4602,7 +4905,7 @@ async fn tui_assistant_text_preserves_line_breaks() {
         .app
         .transcript
         .iter()
-        .flat_map(Tui::render_entry)
+        .flat_map(|entry| Tui::render_entry(entry, true, false))
         .collect();
     let line_texts: Vec<String> = rendered
         .iter()
@@ -4635,6 +4938,7 @@ async fn tool_call_display_format() {
             "command: ls -la\nworking_dir: /tmp\n".to_string(),
         )),
         seq: None,
+        timestamp: None,
     });
     harness.tui().app.transcript.push(TranscriptItem::ToolCall {
         tool_name: "write_file".to_string(),
@@ -4642,11 +4946,13 @@ async fn tool_call_display_format() {
             "write **hello.txt** with 3 lines".to_string(),
         )),
         seq: None,
+        timestamp: None,
     });
     harness.tui().app.transcript.push(TranscriptItem::ToolCall {
         tool_name: "think".to_string(),
         body: None,
         seq: None,
+        timestamp: None,
     });
     harness.tui().app.transcript.push(TranscriptItem::ToolCall {
         tool_name: "search".to_string(),
@@ -4654,6 +4960,7 @@ async fn tool_call_display_format() {
             "query: rust async patterns\nmax_results: 10\ninclude_code: true\n".to_string(),
         )),
         seq: None,
+        timestamp: None,
     });
     harness.render();
     let rendered = normalize_screen(&harness.screen_contents());
@@ -4663,10 +4970,12 @@ async fn tool_call_display_format() {
 #[tokio::test]
 async fn tool_call_with_seq_number() {
     let mut harness = TuiTestHarness::new();
+    harness.tui().app.show_sequence_numbers = true;
     harness.tui().app.transcript.push(TranscriptItem::ToolCall {
         tool_name: "read".to_string(),
         body: Some(ToolCallBody::Yaml("path: /tmp/foo.txt\n".to_string())),
         seq: Some(7),
+        timestamp: None,
     });
     harness.render();
     let rendered = normalize_screen(&harness.screen_contents());
@@ -4676,9 +4985,11 @@ async fn tool_call_with_seq_number() {
 #[tokio::test]
 async fn user_text_with_seq_number() {
     let mut harness = TuiTestHarness::new();
+    harness.tui().app.show_sequence_numbers = true;
     harness.tui().app.transcript.push(TranscriptItem::UserText {
         text: "hello world".to_string(),
         seq: Some(3),
+        timestamp: None,
     });
     harness.render();
     let rendered = normalize_screen(&harness.screen_contents());
@@ -4688,6 +4999,7 @@ async fn user_text_with_seq_number() {
 #[tokio::test]
 async fn assistant_text_with_seq_number() {
     let mut harness = TuiTestHarness::new();
+    harness.tui().app.show_sequence_numbers = true;
     harness
         .tui()
         .app
@@ -4695,6 +5007,7 @@ async fn assistant_text_with_seq_number() {
         .push(TranscriptItem::AssistantText {
             text: "hello back".to_string(),
             seq: Some(5),
+            timestamp: None,
         });
     harness.render();
     let rendered = normalize_screen(&harness.screen_contents());
@@ -4714,4 +5027,558 @@ async fn mutation_notice_renders_with_yellow_dim_style() {
     harness.render();
     let rendered = normalize_screen(&harness.screen_contents());
     insta::assert_snapshot!("mutation_notice_renders_with_yellow_dim_style", rendered);
+}
+
+#[tokio::test]
+async fn meta_suffix_combinations() {
+    let mut harness = TuiTestHarness::new();
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "hello".to_string(),
+        seq: Some(1),
+        timestamp: Some(
+            chrono::DateTime::parse_from_rfc3339("2026-05-02T12:34:56Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        ),
+    });
+
+    // Both on
+    harness.tui().app.show_sequence_numbers = true;
+    harness.tui().app.show_timestamps = true;
+    harness.render();
+    let r1 = normalize_screen(&harness.screen_contents());
+    insta::assert_snapshot!("meta_suffix_both_on", r1);
+
+    // Sequence only
+    harness.tui().app.show_sequence_numbers = true;
+    harness.tui().app.show_timestamps = false;
+    harness.render();
+    let r2 = normalize_screen(&harness.screen_contents());
+    insta::assert_snapshot!("meta_suffix_seq_only", r2);
+
+    // Timestamp only
+    harness.tui().app.show_sequence_numbers = false;
+    harness.tui().app.show_timestamps = true;
+    harness.render();
+    let r3 = normalize_screen(&harness.screen_contents());
+    insta::assert_snapshot!("meta_suffix_ts_only", r3);
+
+    // Both off
+    harness.tui().app.show_sequence_numbers = false;
+    harness.tui().app.show_timestamps = false;
+    harness.render();
+    let r4 = normalize_screen(&harness.screen_contents());
+    insta::assert_snapshot!("meta_suffix_both_off", r4);
+}
+
+// =============================================================================
+// D5: Modal confirmation tests
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_d5_modal_confirm_delete_single_entry() {
+    let mut harness = TuiTestHarness::with_size(60, 12);
+
+    // Open delete modal for single entry
+    harness.tui().app.modal = Some(crate::types::ModalState::ConfirmDelete { from: 3, to: 3 });
+    harness.render();
+
+    let rendered = normalize_screen(&harness.screen_contents());
+    assert!(
+        rendered.contains("Delete entry 3?"),
+        "Expected modal text 'Delete entry 3?', got: {}",
+        rendered
+    );
+    assert!(
+        rendered.contains("[y/N]"),
+        "Expected prompt '[y/N]', got: {}",
+        rendered
+    );
+
+    insta::assert_snapshot!("modal_confirm_delete_single", rendered);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_d5_modal_confirm_delete_range() {
+    let mut harness = TuiTestHarness::with_size(60, 12);
+
+    // Open delete modal for range
+    harness.tui().app.modal = Some(crate::types::ModalState::ConfirmDelete { from: 3, to: 5 });
+    harness.render();
+
+    let rendered = normalize_screen(&harness.screen_contents());
+    assert!(
+        rendered.contains("Delete entries 3–5?"),
+        "Expected modal text 'Delete entries 3–5?', got: {}",
+        rendered
+    );
+
+    insta::assert_snapshot!("modal_confirm_delete_range", rendered);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_d5_modal_confirm_rewind() {
+    let mut harness = TuiTestHarness::with_size(60, 12);
+
+    // Open rewind modal
+    harness.tui().app.modal = Some(crate::types::ModalState::ConfirmRewind {
+        seq: 7,
+        user_text: None,
+    });
+    harness.render();
+
+    let rendered = normalize_screen(&harness.screen_contents());
+    assert!(
+        rendered.contains("Rewind to entry 7?"),
+        "Expected modal text 'Rewind to entry 7?', got: {}",
+        rendered
+    );
+
+    insta::assert_snapshot!("modal_confirm_rewind", rendered);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_d5_modal_y_confirms_n_cancels() {
+    let mut harness = TuiTestHarness::with_size(60, 12);
+
+    // Test 'n' cancels the modal
+    harness.tui().app.modal = Some(crate::types::ModalState::ConfirmDelete { from: 1, to: 1 });
+    let _ = harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE))
+        .await;
+    assert!(
+        harness.tui().app.modal.is_none(),
+        "Expected modal to be cleared after 'n'"
+    );
+
+    // Test 'y' clears the modal (actual delete requires session context)
+    harness.tui().app.modal = Some(crate::types::ModalState::ConfirmDelete { from: 1, to: 1 });
+    // Note: Confirming will try to run .delete command, which will fail without session
+    // The test verifies that modal is taken and processed
+    let _ = harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE))
+        .await;
+    // Modal should be cleared
+    assert!(
+        harness.tui().app.modal.is_none(),
+        "Expected modal to be cleared after 'y'"
+    );
+
+    // Test Esc cancels
+    harness.tui().app.modal = Some(crate::types::ModalState::ConfirmRewind {
+        seq: 1,
+        user_text: None,
+    });
+    let _ = harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .await;
+    assert!(
+        harness.tui().app.modal.is_none(),
+        "Expected modal to be cleared after Esc"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_d5_modal_consumes_other_keys() {
+    let mut harness = TuiTestHarness::with_size(60, 12);
+
+    // Open modal
+    harness.tui().app.modal = Some(crate::types::ModalState::ConfirmDelete { from: 1, to: 1 });
+
+    // Press various keys that should be consumed
+    let _ = harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE))
+        .await;
+    let _ = harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+        .await;
+    let _ = harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+        .await;
+    let _ = harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+        .await;
+
+    // Modal should still be open (keys were consumed)
+    assert!(
+        harness.tui().app.modal.is_some(),
+        "Expected modal to remain open after other keys were consumed"
+    );
+}
+
+#[tokio::test]
+async fn test_d4_key_d_opens_delete_modal_single() {
+    let mut harness = TuiTestHarness::new();
+    harness.tui().app.transcript.clear();
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Delete me".to_string(),
+        seq: Some(3),
+        timestamp: None,
+    });
+    harness.tui().app.transcript_focus = Some(0);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        harness.tui().app.modal,
+        Some(crate::types::ModalState::ConfirmDelete { from: 3, to: 3 })
+    );
+}
+
+#[tokio::test]
+async fn test_d4_delete_key_opens_delete_modal() {
+    let mut harness = TuiTestHarness::new();
+    harness.tui().app.transcript.clear();
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Delete me".to_string(),
+        seq: Some(7),
+        timestamp: None,
+    });
+    harness.tui().app.transcript_focus = Some(0);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Delete, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        harness.tui().app.modal,
+        Some(crate::types::ModalState::ConfirmDelete { from: 7, to: 7 })
+    );
+}
+
+#[tokio::test]
+async fn test_d4_key_d_opens_delete_modal_range() {
+    let mut harness = TuiTestHarness::new();
+    harness.tui().app.transcript.clear();
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "One".to_string(),
+        seq: Some(3),
+        timestamp: None,
+    });
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "Two".to_string(),
+            seq: Some(4),
+            timestamp: None,
+        });
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Three".to_string(),
+        seq: Some(5),
+        timestamp: None,
+    });
+    harness.tui().app.transcript_focus = Some(2);
+    harness.tui().app.transcript_selection_anchor = Some(0);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        harness.tui().app.modal,
+        Some(crate::types::ModalState::ConfirmDelete { from: 3, to: 5 })
+    );
+}
+
+#[tokio::test]
+async fn test_d4_key_i_copies_text_to_input() {
+    let mut harness = TuiTestHarness::new();
+    harness.tui().app.transcript.clear();
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Hello from transcript".to_string(),
+        seq: Some(1),
+        timestamp: None,
+    });
+    harness.tui().app.transcript_focus = Some(0);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.tui().app.input.lines(), ["Hello from transcript"]);
+    assert_eq!(harness.tui().app.transcript_focus, None);
+    assert_eq!(harness.tui().app.transcript_selection_anchor, None);
+}
+
+#[tokio::test]
+async fn test_d4_key_i_copies_assistant_text() {
+    let mut harness = TuiTestHarness::new();
+    harness.tui().app.transcript.clear();
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "Assistant reply".to_string(),
+            seq: Some(2),
+            timestamp: None,
+        });
+    harness.tui().app.transcript_focus = Some(0);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.tui().app.input.lines(), ["Assistant reply"]);
+}
+
+#[tokio::test]
+async fn test_d4_key_i_copies_tool_call() {
+    let mut harness = TuiTestHarness::new();
+    harness.tui().app.transcript.clear();
+    harness.tui().app.transcript.push(TranscriptItem::ToolCall {
+        tool_name: "search".to_string(),
+        body: Some(crate::types::ToolCallBody::Yaml("query: rust".to_string())),
+        seq: Some(9),
+        timestamp: None,
+    });
+    harness.tui().app.transcript_focus = Some(0);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.tui().app.input.lines(), ["search(query: rust)"]);
+}
+
+#[tokio::test]
+async fn test_d4_key_r_opens_rewind_modal_user_text() {
+    let mut harness = TuiTestHarness::new();
+    harness.tui().app.transcript.clear();
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Original prompt".to_string(),
+        seq: Some(11),
+        timestamp: None,
+    });
+    harness.tui().app.transcript_focus = Some(0);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        harness.tui().app.modal,
+        Some(crate::types::ModalState::ConfirmRewind {
+            seq: 11,
+            user_text: Some("Original prompt".to_string()),
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_d4_key_r_opens_rewind_modal_assistant_text() {
+    let mut harness = TuiTestHarness::new();
+    harness.tui().app.transcript.clear();
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "Assistant response".to_string(),
+            seq: Some(12),
+            timestamp: None,
+        });
+    harness.tui().app.transcript_focus = Some(0);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        harness.tui().app.modal,
+        Some(crate::types::ModalState::ConfirmRewind {
+            seq: 12,
+            user_text: None,
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_d4_enter_opens_action_menu() {
+    let mut harness = TuiTestHarness::new();
+    harness.tui().app.transcript.clear();
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Selected".to_string(),
+        seq: Some(4),
+        timestamp: None,
+    });
+    harness.tui().app.transcript_focus = Some(0);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert!(harness.tui().app.action_menu_open);
+}
+
+#[tokio::test]
+async fn test_d4_skips_delete_when_selected_items_have_no_seq() {
+    let mut harness = TuiTestHarness::new();
+    harness.tui().app.transcript.clear();
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "First".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "Second".to_string(),
+            seq: None,
+            timestamp: None,
+        });
+    harness.tui().app.transcript_focus = Some(1);
+    harness.tui().app.transcript_selection_anchor = Some(0);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.tui().app.modal, None);
+}
+
+#[tokio::test]
+async fn test_highlight_single_item() {
+    let mut harness = TuiTestHarness::with_size(40, 15);
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Line 0".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "Line 1".to_string(),
+            seq: None,
+            timestamp: None,
+        });
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Line 2".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness.tui().app.transcript_focus = Some(2);
+    harness.render();
+    let rendered = normalize_screen(&harness.screen_contents());
+    insta::assert_snapshot!("highlight_single_item", rendered);
+
+    // Line 2 should have Modifier::REVERSED
+    let buffer = harness.terminal.backend().buffer();
+    let mut found_reversed = false;
+    let mut lines_with_reversed = vec![];
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            let cell = &buffer[(x, y)];
+            if cell
+                .style()
+                .add_modifier
+                .contains(ratatui::style::Modifier::REVERSED)
+                && cell.symbol() != " "
+                && cell.symbol() != ""
+            {
+                found_reversed = true;
+                lines_with_reversed.push(cell.symbol().to_string());
+            }
+        }
+    }
+    assert!(
+        found_reversed,
+        "Expected to find a reversed cell for Line 2. Found chars: {:?}",
+        lines_with_reversed
+    );
+}
+
+#[tokio::test]
+async fn test_highlight_range() {
+    let mut harness = TuiTestHarness::with_size(40, 15);
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Line 0".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "Line 1".to_string(),
+            seq: None,
+            timestamp: None,
+        });
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Line 2".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "Line 3".to_string(),
+            seq: None,
+            timestamp: None,
+        });
+    harness.tui().app.transcript_focus = Some(2);
+    harness.tui().app.transcript_selection_anchor = Some(0);
+    harness.render();
+    let rendered = normalize_screen(&harness.screen_contents());
+    insta::assert_snapshot!("highlight_range", rendered);
+
+    let buffer = harness.terminal.backend().buffer();
+    let mut num_reversed_starts = 0;
+    for y in 0..buffer.area.height {
+        let mut x = 0;
+        while x < buffer.area.width {
+            let cell = &buffer[(x, y)];
+            if (cell.symbol() == ">" || cell.symbol() == "L")
+                && cell
+                    .style()
+                    .add_modifier
+                    .contains(ratatui::style::Modifier::REVERSED)
+            {
+                num_reversed_starts += 1;
+            }
+            x += 1;
+        }
+    }
+    assert!(
+        num_reversed_starts >= 3,
+        "Expected at least 3 items to have reversed lines"
+    );
 }

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -440,7 +440,7 @@ async fn ui_output_inserts_heading_when_source_changes() {
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -519,7 +519,7 @@ async fn info_commands_render_into_tui_transcript() {
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -772,7 +772,7 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -851,7 +851,7 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -1080,7 +1080,7 @@ async fn structured_ui_output_variants_render_in_transcript() {
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -1161,7 +1161,7 @@ async fn nested_subagent_tool_call_renders_with_heading_and_usage() {
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -1220,7 +1220,7 @@ async fn consecutive_usage_updates_replace_previous_usage_row_for_same_source() 
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -1326,7 +1326,7 @@ async fn submitting_message_with_attachments_renders_attachment_list_and_preview
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -3355,7 +3355,7 @@ async fn sub_agent_activity_no_duplicates_snapshot() {
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .filter_map(|line| {
             let text = line
                 .spans
@@ -4445,7 +4445,7 @@ async fn tui_renders_started_title_when_template_provides_it() {
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .map(|line| line_to_plain(&line))
         .collect();
 
@@ -4489,7 +4489,7 @@ async fn tui_falls_back_to_yaml_when_no_template_title() {
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .map(|line| line_to_plain(&line))
         .collect();
     let joined = lines.join("\n");
@@ -4532,7 +4532,7 @@ async fn tui_renders_completed_template_title_when_provided() {
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .map(|line| line_to_plain(&line))
         .collect();
     let joined = lines.join("\n");
@@ -4581,7 +4581,7 @@ async fn tui_renders_fenced_diff_tool_result_with_per_line_syntect_styling() {
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .collect();
     let plain: Vec<String> = lines.iter().map(line_to_plain).collect();
     let joined = plain.join("\n");
@@ -4654,7 +4654,7 @@ async fn tui_falls_back_to_output_when_no_template_title() {
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .map(|line| line_to_plain(&line))
         .collect();
     let joined = lines.join("\n");
@@ -4688,7 +4688,7 @@ fn rendered_lines(tui: &Tui) -> Vec<ratatui::text::Line<'static>> {
     tui.app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .collect()
 }
 
@@ -4778,7 +4778,7 @@ async fn tui_started_no_template_keeps_yaml_unstyled() {
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .collect();
     let plain = rendered
         .iter()
@@ -4905,7 +4905,7 @@ async fn tui_assistant_text_preserves_line_breaks() {
         .app
         .transcript
         .iter()
-        .flat_map(|entry| Tui::render_entry(entry, true, false))
+        .flat_map(|entry| Tui::render_entry(entry, true, false, false))
         .collect();
     let line_texts: Vec<String> = rendered
         .iter()
@@ -5041,6 +5041,9 @@ async fn meta_suffix_combinations() {
                 .with_timezone(&chrono::Utc),
         ),
     });
+
+    // Use UTC so snapshot output is timezone-independent
+    harness.tui().app.use_utc_timestamps = true;
 
     // Both on
     harness.tui().app.show_sequence_numbers = true;

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -98,6 +98,10 @@ pub(super) struct App {
     pub(super) modal: Option<ModalState>,
     /// true when the Enter-triggered action menu is visible.
     pub(super) action_menu_open: bool,
+    /// When true, render timestamps in UTC instead of local time.
+    /// Always false in production; set to true in tests so snapshot
+    /// output is timezone-independent.
+    pub(super) use_utc_timestamps: bool,
 }
 
 /// Create a unique temporary attachment directory in the system temp area.

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -3,6 +3,7 @@ use harnx_hooks::{AsyncHookManager, PersistentHookManager};
 use harnx_runtime::config::GlobalConfig;
 use harnx_runtime::utils::AbortSignal;
 
+use chrono::{DateTime, Utc};
 use ratatui_textarea::TextArea;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -83,6 +84,20 @@ pub(super) struct App {
     pub(super) attachment_dir: Option<PathBuf>,
     pub(super) paste_count: usize,
     pub(super) last_known_input_width: u16,
+    pub(super) show_sequence_numbers: bool,
+    pub(super) show_timestamps: bool,
+    /// Index of the cursor item in the transcript (None = input focused).
+    /// Used by D2 for Up/Down navigation within transcript.
+    #[allow(dead_code)]
+    pub(super) transcript_focus: Option<usize>,
+    /// Anchor index for shift-select range.
+    /// Used by D2 for extending selection with Shift+Up/Down.
+    #[allow(dead_code)]
+    pub(super) transcript_selection_anchor: Option<usize>,
+    /// Modal dialog state for destructive action confirmations.
+    pub(super) modal: Option<ModalState>,
+    /// true when the Enter-triggered action menu is visible.
+    pub(super) action_menu_open: bool,
 }
 
 /// Create a unique temporary attachment directory in the system temp area.
@@ -119,6 +134,20 @@ pub(crate) enum ToolCallBody {
     Markdown(String),
 }
 
+/// Modal dialog state for destructive action confirmations.
+/// Used by D5 for delete/rewind confirmations.
+#[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
+pub(super) enum ModalState {
+    /// Confirmation for deleting one or more transcript entries.
+    ConfirmDelete { from: usize, to: usize },
+    /// Confirmation for rewinding session to a specific entry.
+    ConfirmRewind {
+        seq: usize,
+        user_text: Option<String>,
+    },
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum TranscriptItem {
     SourceHeading(AgentSource),
@@ -126,10 +155,12 @@ pub(crate) enum TranscriptItem {
     UserText {
         text: String,
         seq: Option<usize>,
+        timestamp: Option<DateTime<Utc>>,
     },
     AssistantText {
         text: String,
         seq: Option<usize>,
+        timestamp: Option<DateTime<Utc>>,
     },
     ErrorText(String),
     ThoughtText(String),
@@ -145,11 +176,24 @@ pub(crate) enum TranscriptItem {
         tool_name: String,
         body: Option<ToolCallBody>,
         seq: Option<usize>,
+        timestamp: Option<DateTime<Utc>>,
     },
     AttachmentHeader(String),
     AttachmentItem(String),
     AttachmentPreviewLine(String),
     MutationNotice(String),
+}
+
+impl TranscriptItem {
+    /// Get the seq number of this transcript item, if available.
+    pub(crate) fn seq(&self) -> Option<usize> {
+        match self {
+            TranscriptItem::UserText { seq, .. } => *seq,
+            TranscriptItem::AssistantText { seq, .. } => *seq,
+            TranscriptItem::ToolCall { seq, .. } => *seq,
+            _ => None,
+        }
+    }
 }
 
 pub(crate) enum TuiEvent {

--- a/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap2_after_delete.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap2_after_delete.snap
@@ -3,13 +3,13 @@ source: crates/harnx/tests/tmux_e2e.rs
 expression: s
 ---
 Welcome to harnx 0.30.0  *  Type .help for commands, Tab to complete.
-> first message  [2]
+> first message
 
-FIRST_RESPONSE_SENTINEL  [3]
+FIRST_RESPONSE_SENTINEL
 
-> third message  [6]
+> third message
 
-THIRD_RESPONSE_SENTINEL  [7]
+THIRD_RESPONSE_SENTINEL
 
 🤖 mutation-test-agent ▸ mutation-e2e-session
 Deleted entries 4-5.

--- a/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap3_after_rewind.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap3_after_rewind.snap
@@ -3,9 +3,9 @@ source: crates/harnx/tests/tmux_e2e.rs
 expression: s
 ---
 Welcome to harnx 0.30.0  *  Type .help for commands, Tab to complete.
-> first message  [2]
+> first message
 
-FIRST_RESPONSE_SENTINEL  [3]
+FIRST_RESPONSE_SENTINEL
 
 🤖 mutation-test-agent ▸ mutation-e2e-session
 ↩ Rewound session to entry 3.

--- a/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap4_after_edit.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap4_after_edit.snap
@@ -7,9 +7,9 @@ expression: s
 
 
 
-> fifth message  [12]
+> fifth message
 
-EDITED_RESPONSE_SENTINEL  [14]
+EDITED_RESPONSE_SENTINEL
 
 🤖 mutation-test-agent ▸ mutation-e2e-session
 

--- a/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap5_session2_loaded.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap5_session2_loaded.snap
@@ -3,13 +3,13 @@ source: crates/harnx/tests/tmux_e2e.rs
 expression: s
 ---
 Welcome to harnx 0.30.0  *  Type .help for commands, Tab to complete.
-> first message  [2]
+> first message
 
-FIRST_RESPONSE_SENTINEL  [3]
+FIRST_RESPONSE_SENTINEL
 
-> fifth message  [12]
+> fifth message
 
-EDITED_RESPONSE_SENTINEL  [14]
+EDITED_RESPONSE_SENTINEL
 
 🤖 mutation-test-agent ▸ mutation-e2e-session
 

--- a/docs/solutions/integration-issues/tui-transcript-focus-navigation-2026-05-01.md
+++ b/docs/solutions/integration-issues/tui-transcript-focus-navigation-2026-05-01.md
@@ -1,0 +1,148 @@
+---
+title: "TUI transcript focus navigation with bidirectional exit"
+date: 2026-05-01
+category: "integration-issues"
+problem_type: integration_issue
+component: "harnx-tui"
+root_cause: "navigation between history and transcript required explicit focus states and clear bidirectional exit paths"
+resolution_type: code_fix
+severity: medium
+tags:
+  - tui
+  - navigation
+  - transcript-focus
+  - user-experience
+  - focus-state
+plan_ref: "harnx-342-phase2"
+---
+
+## Problem
+
+TUI needed arrow-key navigation within the transcript for selecting entries to edit/delete. Without explicit focus state and bidirectional exit paths, users could enter transcript navigation but become trapped with no way back to input.
+
+## Symptoms
+
+- Up arrow from empty input entered transcript mode (correct)
+- No way to exit transcript mode back to input
+- Users stuck navigating transcript with no escape route
+- Confusion about whether they were in "history mode" or "transcript mode"
+
+## Investigation Steps
+
+1. Reviewed `handle_up_key` and `handle_down_key` in `input.rs`
+2. Found `transcript_focus: Option<usize>` field on App for tracking cursor position
+3. Identified the need for explicit entry/exit conditions
+4. Designed bidirectional exit: Up at top of transcript returns to history, Down at bottom stays
+5. Implemented Shift+Up/Down for range selection extension
+
+## Root Cause
+
+Single state variable (`transcript_focus: Option<usize>`) must communicate two distinct modes:
+- `None` → input focused, regular typing/history navigation
+- `Some(idx)` → transcript focused, Up/Down navigates within transcript
+
+The transition conditions needed careful design to avoid mode confusion and ensure users can always return to input.
+
+## Solution
+
+Added focus state to App and bidirectional navigation in `crates/harnx-tui/src/types.rs` and `input.rs`:
+
+**State fields (types.rs):**
+```rust
+pub(super) struct App {
+    // ...
+    /// Index of the cursor item in the transcript (None = input focused).
+    pub(super) transcript_focus: Option<usize>,
+    /// Anchor index for shift-select range.
+    pub(super) transcript_selection_anchor: Option<usize>,
+}
+```
+
+**Entry logic (input.rs):**
+```rust
+fn handle_up_key(&mut self, key: KeyEvent) {
+    if self.app.input.line_count() <= 1 && self.app.input.lines()[0].is_empty() {
+        // Blank input: enter transcript focus mode
+        if self.app.transcript_focus.is_none() {
+            // First Up: focus last transcript item
+            if !self.app.transcript.is_empty() {
+                self.app.transcript_focus = Some(self.app.transcript.len() - 1);
+            }
+        } else if let Some(0) = self.app.transcript_focus {
+            // Up at top: exit transcript focus, return to history
+            self.app.transcript_focus = None;
+            self.history_prev();
+        } else if let Some(focus) = self.app.transcript_focus {
+            // Up in middle: move up
+            self.app.transcript_focus = Some(focus.saturating_sub(1));
+        }
+    } else {
+        // Text in input: navigate within textarea
+        self.app.input.input(ratatui_textarea::Input::from(key));
+    }
+}
+
+fn handle_down_key(&mut self, key: KeyEvent) {
+    if self.app.transcript_focus.is_none() {
+        // Input focused: normal history navigation
+        self.history_next();
+    } else if let Some(focus) = self.app.transcript_focus {
+        if focus + 1 < self.app.transcript.len() {
+            // Down in middle: move down
+            self.app.transcript_focus = Some(focus + 1);
+        } else {
+            // Down at bottom: exit to input
+            self.app.transcript_focus = None;
+            self.app.transcript_selection_anchor = None;
+        }
+    }
+}
+```
+
+## Why This Works
+
+**Bidirectional exit:**
+- Up at top of transcript → history mode (reverse to entry path)
+- Down at bottom of transcript → input mode (natural forward exit)
+
+**Mode transitions:**
+- `None` → `Some(last)`: First Up on blank input
+- `Some(0)` + Up → `None` + history_prev: Exit to history
+- `Some(last)` + Down → `None`: Exit to input
+
+**Shift+Up/Down for selection:**
+```rust
+fn handle_up_key_shift(&mut self) {
+    if let Some(focus) = self.app.transcript_focus {
+        if self.app.transcript_selection_anchor.is_none() {
+            self.app.transcript_selection_anchor = Some(focus);
+        }
+        self.app.transcript_focus = Some(focus.saturating_sub(1));
+    }
+}
+```
+
+This enables range selection for multi-entry operations (delete range, etc.).
+
+## Prevention Strategies
+
+**Test cases:**
+- Up on blank input enters transcript mode
+- Up at top of transcript exits to history
+- Down at bottom of transcript exits to input
+- Shift+Up/Down extends selection range
+
+**Best practices:**
+- Focus states should always have clear entry AND exit paths
+- Navigation should feel reversible — users can always back out
+- Avoid "mode traps" where users can't return to previous mode
+
+**Code review checklist:**
+- [ ] Does every mode entry have a corresponding exit?
+- [ ] Can users escape from any state?
+- [ ] Are navigation paths documented?
+
+## Related Issues
+
+- **PR:** #423 — Non-destructive session history editing
+- **Requirement:** D1-D3 — Transcript selection state and navigation

--- a/docs/solutions/integration-issues/tui-transcript-focus-navigation-2026-05-01.md
+++ b/docs/solutions/integration-issues/tui-transcript-focus-navigation-2026-05-01.md
@@ -32,7 +32,7 @@ TUI needed arrow-key navigation within the transcript for selecting entries to e
 1. Reviewed `handle_up_key` and `handle_down_key` in `input.rs`
 2. Found `transcript_focus: Option<usize>` field on App for tracking cursor position
 3. Identified the need for explicit entry/exit conditions
-4. Designed bidirectional exit: Up at top of transcript returns to history, Down at bottom stays
+4. Designed bidirectional exit: Up at top of transcript returns to history, Down at bottom: exit to input (sets transcript_focus = None)
 5. Implemented Shift+Up/Down for range selection extension
 
 ## Root Cause

--- a/docs/solutions/logic-errors/non-destructive-session-mutation-two-pass-replay-2026-05-01.md
+++ b/docs/solutions/logic-errors/non-destructive-session-mutation-two-pass-replay-2026-05-01.md
@@ -1,6 +1,7 @@
 ---
 title: "Non-destructive session mutation with two-pass log replay"
 date: 2026-05-01
+last_updated: 2026-05-01
 category: "logic-errors"
 problem_type: logic_error
 component: "harnx-session-log"
@@ -190,6 +191,51 @@ if !clean.is_empty() {
 
 4. **Replacement seq assignment**: All replacements from an `EditEntries` get the seq of the mutation entry itself, not their original positions. This makes replacements addressable as a block for further edits.
 
+### Stacked Mutation rposition Fix (Phase 2)
+
+When a 1→N edit creates multiple replacements, they all share the mutation's seq number. A subsequent edit targeting that seq must replace ALL entries with that seq. Using `position()` found only the first match; changed to `rposition()` for the `to` bound:
+
+```rust
+// In build_effective_log_entries:
+let Some(start_idx) = effective_entries
+    .iter()
+    .position(|(existing_seq, _)| existing_seq == from)  // first occurrence
+else { ... };
+let Some(end_idx) = effective_entries
+    .iter()
+    .rposition(|(existing_seq, _)| existing_seq == to)   // last occurrence!
+else { ... };
+```
+
+This asymmetry is critical: `from` needs the first matching entry (forward scan), `to` needs the last matching entry (backward scan). Without `rposition`, stacked edits would splice only part of the duplicated-seq block.
+
+See [stacked-mutation-replay-rposition-2026-05-01.md](stacked-mutation-replay-rposition-2026-05-01.md) for full details.
+
+### Tool Result Validation for No-ID Positional Matching (Phase 2)
+
+Some LLM providers omit `tool_call_id` in results, relying on positional correspondence. Validation now supports three cases:
+
+1. **All results have IDs** → validate by ID matching
+2. **All results lack IDs** → validate by count matching (positional)
+3. **Mixed presence** → reject as ambiguous
+
+```rust
+if missing_result_ids == results.len() {
+    // All absent: positional matching
+    if results.len() != calls.len() {
+        bail!("count mismatch for positional matching");
+    }
+    continue;
+}
+if missing_result_ids > 0 {
+    // Mixed: ambiguous
+    bail!("mixes IDs with missing IDs");
+}
+// All present: ID matching
+```
+
+See [tool-result-validation-no-id-positional-2026-05-01.md](tool-result-validation-no-id-positional-2026-05-01.md) for full details.
+
 ## Why This Works
 
 **Append-only guarantees audit trail**: Every mutation is recorded. The original entries exist in the log forever. History can be reconstructed at any point.
@@ -224,3 +270,6 @@ if !clean.is_empty() {
 - **Jira:** #342 — Non-destructive session editing
 - **Jira:** #396 — Sequence numbers for transcript items
 - **PR:** [harnx-event-tagging-tui-redesign] — Full implementation of mutation commands
+- **Phase 2 fixes:**
+  - [stacked-mutation-replay-rposition-2026-05-01.md](stacked-mutation-replay-rposition-2026-05-01.md) — rposition for stacked mutations
+  - [tool-result-validation-no-id-positional-2026-05-01.md](tool-result-validation-no-id-positional-2026-05-01.md) — No-ID positional matching

--- a/docs/solutions/logic-errors/stacked-mutation-replay-rposition-2026-05-01.md
+++ b/docs/solutions/logic-errors/stacked-mutation-replay-rposition-2026-05-01.md
@@ -43,7 +43,7 @@ After a 1-to-N edit (single entry replaced by multiple entries), all replacement
 - `to` seq (end of range): Use `rposition()` — last occurrence needed when multiple entries share `to` seq
 
 When edit_entries with `from: 1, to: 1` creates two replacements, both get the mutation's seq (say, 3). The raw log becomes:
-```
+```yaml
 seq 0: header
 seq 1: user message      ← edited away
 seq 2: assistant message
@@ -51,7 +51,7 @@ seq 3: edit_entries { from: 1, to: 1, replacements: [user-a, user-b] }
 ```
 
 After replay, effective_entries has:
-```
+```text
 (3, Message "user-a")
 (3, Message "user-b")   ← same seq!
 (2, Message "assistant")

--- a/docs/solutions/logic-errors/stacked-mutation-replay-rposition-2026-05-01.md
+++ b/docs/solutions/logic-errors/stacked-mutation-replay-rposition-2026-05-01.md
@@ -1,0 +1,117 @@
+---
+title: "Stacked mutation replay uses rposition for duplicate seq ranges"
+date: 2026-05-01
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-session-log"
+root_cause: "position() finds first match; 1-to-N edits create multiple entries with same seq requiring last match"
+resolution_type: code_fix
+severity: high
+tags:
+  - session-log
+  - mutation
+  - stacked-edits
+  - rposition
+  - rust-patterns
+plan_ref: "harnx-342-phase2"
+---
+
+## Problem
+
+After a 1-to-N edit (single entry replaced by multiple entries), all replacements share the mutation's seq number. A subsequent edit targeting that seq must replace ALL entries with that seq. Using `position()` found only the first match, corrupting replay state.
+
+## Symptoms
+
+- `load_replays_stacked_mutations_reedit_expanded_mutation_seq` test failed
+- After editing entry 1 → [1a, 1b], then editing "entry 3" (which is actually the second replacement sharing seq 3), only the first replacement was removed
+- Effective log state showed wrong entries: `[1a, 1b, ...]` instead of `[re-edited, ...]`
+- Replay logic silently produced incorrect session state with no error message
+
+## Investigation Steps
+
+1. Wrote test `load_replays_stacked_mutations_reedit_expanded_mutation_seq` showing the failure
+2. Traced through `build_effective_log_entries` and found the `start_idx`/`end_idx` computation
+3. Realized `position()` always returns the first matching element
+4. After a 1→2 edit creating `[seq=3, seq=3]`, `position(|seq| seq == 3)` finds index 0, not index 1
+5. The range splice would splice `[0..=1]` when it should splice `[0..=1]` for `from` but `[0..=1]` for `to` correctly requires finding the LAST occurrence
+
+## Root Cause
+
+**Asymmetric iterator direction requirement:**
+
+- `from` seq (start of range): Use `position()` — first occurrence is correct because entries are in log order
+- `to` seq (end of range): Use `rposition()` — last occurrence needed when multiple entries share `to` seq
+
+When edit_entries with `from: 1, to: 1` creates two replacements, both get the mutation's seq (say, 3). The raw log becomes:
+```
+seq 0: header
+seq 1: user message      ← edited away
+seq 2: assistant message
+seq 3: edit_entries { from: 1, to: 1, replacements: [user-a, user-b] }
+```
+
+After replay, effective_entries has:
+```
+(3, Message "user-a")
+(3, Message "user-b")   ← same seq!
+(2, Message "assistant")
+```
+
+A subsequent edit `from: 3, to: 3` must replace BOTH `(3, _)` entries. `position()` finds the first, `rposition()` finds the last.
+
+## Solution
+
+Changed `build_effective_log_entries` in `crates/harnx-runtime/src/config/session.rs`:
+
+**Before:**
+```rust
+let Some(start_idx) = effective_entries
+    .iter()
+    .position(|(existing_seq, _)| existing_seq == from)
+else { ... };
+let Some(end_idx) = effective_entries
+    .iter()
+    .position(|(existing_seq, _)| existing_seq == to)  // BUG
+else { ... };
+```
+
+**After:**
+```rust
+let Some(start_idx) = effective_entries
+    .iter()
+    .position(|(existing_seq, _)| existing_seq == from)
+else { ... };
+let Some(end_idx) = effective_entries
+    .iter()
+    .rposition(|(existing_seq, _)| existing_seq == to)  // FIXED
+else { ... };
+```
+
+The splice operation `effective_entries.splice(start_idx..=end_idx, ...)` now correctly captures the full block of entries sharing the same seq.
+
+## Why This Works
+
+`rposition()` scans from the end, returning the index of the LAST element matching the predicate. When an edit creates multiple replacements (1→N), they all share the mutation seq as a block. The `to` bound of a subsequent edit must find the end of that block, not its beginning.
+
+This is a **directional asymmetry**: `from` needs the earliest occurrence (forward scan), `to` needs the latest occurrence (backward scan).
+
+## Prevention Strategies
+
+**Test cases:**
+- Add test for stacked 1→N edit followed by another edit targeting the mutation seq
+- Verify effective entries count matches expected
+- Verify message content after replay matches expected
+
+**Best practices:**
+- When splicing ranges in collections that may have duplicate keys, consider whether bounds should use `position` or `rposition`
+- Document why the asymmetry exists — it's not arbitrary
+
+**Code review checklist:**
+- [ ] Does `position` vs `rposition` match the semantic intent (first vs last)?
+- [ ] Are there tests for 1→N edit scenarios?
+- [ ] Does the code handle multiple entries sharing the same seq?
+
+## Related Issues
+
+- **PR:** #423 — Non-destructive session history editing
+- **Related Solution:** [non-destructive-session-mutation-two-pass-replay-2026-05-01.md](non-destructive-session-mutation-two-pass-replay-2026-05-01.md)

--- a/docs/solutions/logic-errors/tool-result-validation-no-id-positional-2026-05-01.md
+++ b/docs/solutions/logic-errors/tool-result-validation-no-id-positional-2026-05-01.md
@@ -1,0 +1,151 @@
+---
+title: "Tool result validation supports all-no-ID positional matching"
+date: 2026-05-01
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-session-log"
+root_cause: "validation rejected missing tool_call_id without considering legitimate all-absent case for positional matching"
+resolution_type: code_fix
+severity: medium
+tags:
+  - session-log
+  - tool-pair-validation
+  - positional-matching
+  - serde
+  - field-pattern-trap
+plan_ref: "harnx-342-phase2"
+---
+
+## Problem
+
+`.edit` command on entries containing tool calls/results failed validation when tool results lacked `tool_call_id` fields, even though some LLM providers never include these IDs. Validation needed to support positional matching when ALL results lack IDs.
+
+## Symptoms
+
+- `.edit message 5` on tool-call entries failed with "missing tool_call_id" error
+- Users with OpenAI-compatible providers that omit `tool_call_id` in results could not edit sessions
+- `validate_tool_pair_integrity` tests failed for no-ID scenarios
+- Existing sessions with no-ID tool results could not be edited
+
+## Investigation Steps
+
+1. Reviewed `validate_tool_pair_integrity` function in `mod.rs`
+2. Found the validation loop checking each result for `tool_call_id`
+3. Realized the validation only handled the "all IDs present" case
+4. Consulted API docs — some providers return results without IDs, relying on positional correspondence
+5. Identified three valid scenarios:
+   - All results have IDs → validate by ID matching
+   - All results lack IDs → validate by count matching (positional)
+   - Mixed (some with, some without) → invalid, reject explicitly
+
+## Root Cause
+
+The validation function iterated over results and rejected any missing `tool_call_id`. This was too strict.
+
+Some LLM providers (especially non-OpenAI) return tool results without `tool_call_id` fields. The LLM is expected to match results to calls by position: first result goes with first call, second with second, etc.
+
+The validation needed to:
+1. Check if ALL results lack IDs → positional matching (count must match)
+2. Check if MIXED presence → error (ambiguous)
+3. Check if ALL results have IDs → ID matching (IDs must match call IDs)
+
+## Solution
+
+Updated `validate_tool_pair_integrity` in `crates/harnx-runtime/src/config/mod.rs`:
+
+**Before:**
+```rust
+for result in results {
+    let call_id = result.id.as_deref().filter(|id| !id.is_empty());
+    if call_id.is_none() {
+        bail!("tool result missing tool_call_id");
+    }
+    if !call_ids.contains(call_id.unwrap()) {
+        bail!("unknown tool_call_id");
+    }
+}
+```
+
+**After:**
+```rust
+let missing_result_ids = results
+    .iter()
+    .filter(|result| result.id.as_deref().is_none_or(str::is_empty))
+    .count();
+
+// All results lack IDs → positional matching by count
+if missing_result_ids == results.len() {
+    if results.len() != calls.len() {
+        bail!(
+            "Edited tool result at {result_seq} is missing tool_call_id for positional matching and count {} does not match tool calls count {}",
+            results.len(), calls.len()
+        );
+    }
+    continue;  // positional match OK
+}
+
+// Mixed presence → ambiguous, reject
+if missing_result_ids > 0 {
+    bail!(
+        "Edited tool result at {result_seq} mixes tool_call_id values with missing tool_call_id entries"
+    );
+}
+
+// All results have IDs → validate by ID matching
+for result in results {
+    let call_id = result.id.as_deref().filter(|id| !id.is_empty()).unwrap();
+    if !call_ids.contains(call_id) {
+        bail!("unknown tool_call_id '{}'", call_id);
+    }
+}
+```
+
+## Why This Works
+
+The validation now handles all three cases explicitly:
+
+1. **All-no-ID (positional)**: When every result lacks `tool_call_id`, the LLM provider is using positional matching. We validate that the count matches (3 calls = 3 results).
+
+2. **Mixed presence**: This is ambiguous. We can't tell if result[0] without ID corresponds to call[0] while result[1] with ID "call-2" corresponds to... which call? Safer to reject.
+
+3. **All-have-ID (ID-based)**: Standard OpenAI-style matching. Each result's ID must match one of the call IDs.
+
+The count check ensures positional validity: if an edit produces 2 results for 3 calls, the LLM will fail to match them at inference time anyway. Better to catch this at edit validation.
+
+## Prevention Strategies
+
+**Test cases:**
+```rust
+#[test]
+fn validate_tool_pair_integrity_accepts_positional_tool_results_without_ids() {
+    let documents = vec![
+        tool_calls_yaml(&["call-1", "call-2"]),
+        tool_results_yaml_with_optional_ids(&[None, None]),
+    ];
+    validate_tool_pair_integrity(4, &documents).unwrap();
+}
+
+#[test]
+fn validate_tool_pair_integrity_rejects_mixed_present_and_missing_result_ids() {
+    let documents = vec![
+        tool_calls_yaml(&["call-1", "call-2"]),
+        tool_results_yaml_with_optional_ids(&[Some("call-1".to_string()), None]),
+    ];
+    let err = validate_tool_pair_integrity(12, &documents).expect_err("mixed id presence should fail");
+    assert!(err.to_string().contains("mixes tool_call_id values with missing"));
+}
+```
+
+**Best practices:**
+- When validating optional fields, consider whether "all present" vs "all absent" vs "mixed" have different semantics
+- Document the three-case logic explicitly in comments
+
+**Code review checklist:**
+- [ ] Does validation handle optional field correctly in all three cases?
+- [ ] Are there tests for the all-absent case?
+- [ ] Are there tests for the mixed case?
+
+## Related Issues
+
+- **PR:** #423 — Non-destructive session history editing
+- **Related Solution:** [non-destructive-session-mutation-two-pass-replay-2026-05-01.md](non-destructive-session-mutation-two-pass-replay-2026-05-01.md)


### PR DESCRIPTION
Implements deferred requirements for non-destructive session history editing. Updates the runtime to use rposition() for stacked mutation replay, ensuring correct targeting of duplicated sequence blocks after one-to-many edits. Enhances tool-pair validation to support all-no-ID positional matching for LLM providers that omit tool_call_id in results.

In the TUI, improves transcript focus navigation with bidirectional exit (Up at top to history, Down at bottom to input) to avoid mode traps. Removes the interactive retry loop in edit_message_range in favor of direct error propagation. Adds comprehensive regression tests and solution documentation for the new patterns.

#342

Plan: harnx-342-phase2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transcript display toggles for sequence numbers and timestamps
  * Enhanced transcript navigation with focus and multi-item selection
  * Added confirmation modals for destructive operations
  * New single-entry editor command (`.edit message <n>`)
  * New keyboard shortcuts for transcript operations (edit, delete, insert, copy, rewind)
  * Timestamp tracking for transcript events

* **Bug Fixes**
  * Fixed edit validation for tool results without IDs
  * Removed runtime retry prompts after failed validation
  * Fixed stacked mutation replay for expanded edit ranges

* **Tests**
  * Added regression test coverage for mutation replay scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->