### PR TITLE
feat(tui): improve tool call display and output appearance

### DIFF
--- a/crates/harnx-acp/src/manager.rs
+++ b/crates/harnx-acp/src/manager.rs
@@ -209,6 +209,18 @@ impl Default for AcpManager {
 }
 
 fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
+    let session_new_call_template = format!("@ {} new session", server_name);
+    let session_prompt_call_template =
+        format!("@ {} {{{{ args.message | truncate(60) }}}}", server_name);
+    let session_load_call_template = format!(
+        "@ {} load {{{{ args.session_id | truncate(8, end='') }}}}",
+        server_name
+    );
+    let session_cancel_call_template = format!(
+        "@ {} cancel {{{{ args.session_id | truncate(8, end='') }}}}",
+        server_name
+    );
+
     vec![
         ToolDeclaration {
             name: format!("{server_name}_session_new"),
@@ -219,7 +231,7 @@ fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
                 ..Default::default()
             },
             mcp_tool_name: Some("session_new".to_string()),
-            call_template: None,
+            call_template: Some(session_new_call_template),
             result_template: None,
         },
         ToolDeclaration {
@@ -255,7 +267,7 @@ fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
                 ..Default::default()
             },
             mcp_tool_name: Some("session_prompt".to_string()),
-            call_template: None,
+            call_template: Some(session_prompt_call_template),
             result_template: None,
         },
         ToolDeclaration {
@@ -279,7 +291,7 @@ fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
                 ..Default::default()
             },
             mcp_tool_name: Some("session_load".to_string()),
-            call_template: None,
+            call_template: Some(session_load_call_template),
             result_template: None,
         },
         ToolDeclaration {
@@ -303,7 +315,7 @@ fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
                 ..Default::default()
             },
             mcp_tool_name: Some("session_cancel".to_string()),
-            call_template: None,
+            call_template: Some(session_cancel_call_template),
             result_template: None,
         },
     ]

--- a/crates/harnx-core/src/tool.rs
+++ b/crates/harnx-core/src/tool.rs
@@ -102,6 +102,20 @@ pub struct ToolDeclaration {
 fn make_template_env<'a>() -> Environment<'a> {
     let mut env = Environment::new();
     env.set_undefined_behavior(UndefinedBehavior::Lenient);
+    // `truncate` is not a minijinja built-in; register it so templates can do
+    // `{{ args.message | truncate(60) }}` or `{{ args.id | truncate(8, end='') }}`.
+    env.add_filter(
+        "truncate",
+        |value: &str, length: usize, end: Option<&str>| -> String {
+            let ellipsis = end.unwrap_or("...");
+            if value.len() <= length {
+                value.to_string()
+            } else {
+                let cut = length.saturating_sub(ellipsis.len());
+                format!("{}{}", &value[..cut], ellipsis)
+            }
+        },
+    );
     env
 }
 

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -2031,7 +2031,7 @@ impl ServerHandler for BashServer {
                 )
                 .with_input_schema::<ExecCommandParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**$** `{{ args.command }}`{% if args.working_dir %} *(in {{ args.working_dir }})*{% endif %}",
+                    "call_template": "`$ {{ args.command }}`{% if args.working_dir %} ({{ args.working_dir }}){% endif %}{% if args.timeout_secs %} [{{ args.timeout_secs }}s]{% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "read_exec_log",
@@ -2040,7 +2040,7 @@ impl ServerHandler for BashServer {
                 )
                 .with_input_schema::<ReadExecLogParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**read log** `{{ args.execution_id }}/{{ args.stream }}`",
+                    "call_template": "log {{ args.execution_id }}/{{ args.stream }}{% if args.grep %} grep={{ args.grep }}{% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "spawn",
@@ -2049,7 +2049,7 @@ impl ServerHandler for BashServer {
                 )
                 .with_input_schema::<SpawnCommandParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**spawn** `{{ args.command }}`{% if args.working_dir %} *(in {{ args.working_dir }})*{% endif %}",
+                    "call_template": "`> {{ args.command }}`{% if args.working_dir %} ({{ args.working_dir }}){% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "wait",
@@ -2058,7 +2058,7 @@ impl ServerHandler for BashServer {
                 )
                 .with_input_schema::<WaitParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**wait** for {{ args.execution_id }}",
+                    "call_template": "wait {{ args.execution_id }}{% if args.timeout_secs %} [{{ args.timeout_secs }}s]{% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "terminate",
@@ -2067,7 +2067,7 @@ impl ServerHandler for BashServer {
                 )
                 .with_input_schema::<TerminateParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**terminate** {{ args.execution_id }}{% if args.signal %} ({{ args.signal }}){% endif %}",
+                    "call_template": "kill {{ args.execution_id }}{% if args.signal %} ({{ args.signal }}){% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "rollback_file",
@@ -2076,7 +2076,7 @@ impl ServerHandler for BashServer {
                 )
                 .with_input_schema::<RollbackParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**rollback_file** to `{{ args.commit_id | truncate(8, end='') }}`",
+                    "call_template": "rollback {{ args.commit_id | truncate(8, end='') }}",
                 }).as_object().unwrap().clone())),
             ],
             next_cursor: None,

--- a/crates/harnx-mcp-fs/src/server.rs
+++ b/crates/harnx-mcp-fs/src/server.rs
@@ -884,28 +884,28 @@ impl ServerHandler for FsServer {
                 Tool::new("read", "Read a text file with line numbers, pagination, grep filtering, and smart truncation.", Map::new())
                     .with_input_schema::<ReadFileParams>()
                     .annotate(read_only.clone())
-                    .with_meta(make_tool_meta("**read** `{{ args.path }}`")),
+                    .with_meta(make_tool_meta("`# {{ args.path }}`{% if args.offset %} +{{ args.offset }}{% endif %}{% if args.limit %} :{{ args.limit }}{% endif %}{% if args.grep %} /{{ args.grep }}/{% endif %}")),
                 Tool::new("write", "Write or create a file, replacing its contents.", Map::new())
                     .with_input_schema::<WriteFileParams>()
-                    .with_meta(make_tool_meta("**write** `{{ args.path }}` ({{ args.content | length }} chars)")),
+                    .with_meta(make_tool_meta("`+ {{ args.path }}`")),
                 Tool::new("edit", "Replace exact text within an existing file.", Map::new())
                     .with_input_schema::<EditFileParams>()
-                    .with_meta(make_tool_meta("**edit** `{{ args.path }}`")),
+                    .with_meta(make_tool_meta("`* {{ args.path }}`")),
                 Tool::new("ls", "List directory contents, optionally recursively.", Map::new())
                     .with_input_schema::<ListDirectoryParams>()
                     .annotate(read_only.clone())
-                    .with_meta(make_tool_meta("**ls** `{{ args.path }}`{% if args.recursive %} (recursive){% endif %}")),
+                    .with_meta(make_tool_meta("`? {{ args.path }}`{% if args.recursive %} -r{% endif %}")),
                 Tool::new("grep", "Search file contents with regex and optional context lines.", Map::new())
                     .with_input_schema::<SearchFilesParams>()
                     .annotate(read_only.clone())
-                    .with_meta(make_tool_meta("**grep** `{{ args.pattern }}`")),
+                    .with_meta(make_tool_meta("`? /{{ args.pattern }}/`{% if args.path %} {{ args.path }}{% endif %}")),
                 Tool::new("find", "Find files by glob pattern.", Map::new())
                     .with_input_schema::<FindFilesParams>()
                     .annotate(read_only.clone())
-                    .with_meta(make_tool_meta("**find** `{{ args.pattern }}`")),
+                    .with_meta(make_tool_meta("`? {{ args.pattern }}`{% if args.path %} {{ args.path }}{% endif %}")),
                 Tool::new("rollback_file", "Restore a repository to a prior harnx history snapshot. Pass the commit SHA from the 'commit <sha>' line at the top of a prior tool response's diff as the commit_id parameter.", Map::new())
                     .with_input_schema::<RollbackParams>()
-                    .with_meta(make_tool_meta("**rollback_file** to `{{ args.commit_id | truncate(8, end='') }}`")),
+                    .with_meta(make_tool_meta("rollback {{ args.commit_id | truncate(8, end='') }}")),
             ];
 
         Ok(ListToolsResult {

--- a/crates/harnx-mcp-time/src/server.rs
+++ b/crates/harnx-mcp-time/src/server.rs
@@ -272,7 +272,7 @@ impl ServerHandler for TimeServer {
             )
             .annotate(read_only.clone())
             .with_meta(Meta(json!({
-                "call_template": "**get time**{% if args.timezone %} ({{ args.timezone }}){% endif %}",
+                "call_template": "time{% if args.timezone %} ({{ args.timezone }}){% endif %}",
                 "result_template": "{{ result.content[0].text | default('') }}"
             }).as_object().unwrap().clone())),
             Tool::new(
@@ -335,7 +335,7 @@ impl ServerHandler for TimeServer {
             )
             .annotate(read_only.clone())
             .with_meta(Meta(json!({
-                "call_template": "**convert time**{% if args.isoTimestamp %} from {{ args.isoTimestamp }}{% endif %}",
+                "call_template": "convert time{% if args.isoTimestamp %} {{ args.isoTimestamp }}{% endif %}{% if args.unixTimestamp %} unix={{ args.unixTimestamp }}{% endif %}",
                 "result_template": "{{ result.content[0].text | default('') }}"
             }).as_object().unwrap().clone())),
             Tool::new(
@@ -358,7 +358,7 @@ impl ServerHandler for TimeServer {
                     .open_world(false),
             )
             .with_meta(Meta(json!({
-                "call_template": "**wait** {{ args.seconds }}s",
+                "call_template": "wait {{ args.seconds }}s",
                 "result_template": "{{ result.content[0].text | default('') }}"
             }).as_object().unwrap().clone())),
             Tool::new(
@@ -390,7 +390,7 @@ impl ServerHandler for TimeServer {
                     .open_world(false),
             )
             .with_meta(Meta(json!({
-                "call_template": "**wait until** {{ args.time }}",
+                "call_template": "wait until {{ args.time }}{% if args.timezone %} ({{ args.timezone }}){% endif %}",
                 "result_template": "{{ result.content[0].text | default('') }}"
             }).as_object().unwrap().clone())),
         ];

--- a/crates/harnx-mcp-todo/src/server.rs
+++ b/crates/harnx-mcp-todo/src/server.rs
@@ -964,7 +964,7 @@ impl ServerHandler for TodoServer {
                 )
                 .with_input_schema::<TodoListParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**list todos**",
+                    "call_template": "todos{% if args.filter %} [{{ args.filter }}]{% endif %}{% if args.plan %} plan={{ args.plan }}{% endif %}",
                     "result_template": "{{ result.content[0].text | default('') }}"
                 }).as_object().unwrap().clone())),
                 Tool::new(
@@ -974,7 +974,7 @@ impl ServerHandler for TodoServer {
                 )
                 .with_input_schema::<TodoGetParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**get todo** {{ args.id }}",
+                    "call_template": "todo {{ args.id }}",
                     "result_template": "{{ result.content[0].text | default('') }}"
                 }).as_object().unwrap().clone())),
                 Tool::new(
@@ -984,7 +984,7 @@ impl ServerHandler for TodoServer {
                 )
                 .with_input_schema::<TodoCreateParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**create todo** {{ args.title }}",
+                    "call_template": "+ todo {{ args.title }}{% if args.plan %} ({{ args.plan }}){% endif %}",
                     "result_template": "{{ result.content[0].text | default('') }}"
                 }).as_object().unwrap().clone())),
                 Tool::new(
@@ -994,7 +994,7 @@ impl ServerHandler for TodoServer {
                 )
                 .with_input_schema::<TodoUpdateParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**update todo** {{ args.id }}",
+                    "call_template": "* todo {{ args.id }}{% if args.title %} \"{{ args.title }}\"{% endif %}",
                     "result_template": "{{ result.content[0].text | default('') }}"
                 }).as_object().unwrap().clone())),
                 Tool::new(
@@ -1004,19 +1004,19 @@ impl ServerHandler for TodoServer {
                 )
                 .with_input_schema::<TodoAppendParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**append** to {{ args.id }}",
+                    "call_template": ">> todo {{ args.id }}",
                     "result_template": "{{ result.content[0].text | default('') }}"
                 }).as_object().unwrap().clone())),
                 Tool::new("todo_delete", "Delete todo by ID.", Map::new())
                     .with_input_schema::<TodoDeleteParams>()
                     .with_meta(Meta(json!({
-                        "call_template": "**delete todo** {{ args.id }}",
+                        "call_template": "- todo {{ args.id }}",
                         "result_template": "{{ result.content[0].text | default('') }}"
                     }).as_object().unwrap().clone())),
                 Tool::new("read_plan", "Read plan markdown file.", Map::new())
                     .with_input_schema::<PlanReadParams>()
                     .with_meta(Meta(json!({
-                        "call_template": "**read plan** {{ args.name }}",
+                        "call_template": "plan {{ args.name }}",
                         "result_template": "{{ result.content[0].text | default('') }}"
                     }).as_object().unwrap().clone())),
                 Tool::new(
@@ -1026,7 +1026,7 @@ impl ServerHandler for TodoServer {
                 )
                 .with_input_schema::<PlanWriteParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**write plan** {{ args.name }}",
+                    "call_template": "+ plan {{ args.name }}",
                     "result_template": "{{ result.content[0].text | default('') }}"
                 }).as_object().unwrap().clone())),
                 Tool::new(
@@ -1036,7 +1036,7 @@ impl ServerHandler for TodoServer {
                 )
                 .with_input_schema::<PlanAddNoteParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**plan add note** {{ args.name }}",
+                    "call_template": ">> plan {{ args.name }}",
                     "result_template": "{{ result.content[0].text | default('') }}"
                 }).as_object().unwrap().clone())),
                 Tool::new(
@@ -1046,7 +1046,7 @@ impl ServerHandler for TodoServer {
                 )
                 .with_input_schema::<PlanGetTodoParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "**plan get todo** {{ args.plan }} {{ args.key }}",
+                    "call_template": "plan {{ args.plan }} / {{ args.key }}",
                     "result_template": "{{ result.content[0].text | default('') }}"
                 }).as_object().unwrap().clone())),
             ],

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1706,3 +1706,40 @@ impl Tui {
         self.app.modal = Some(crate::types::ModalState::ConfirmRewind { seq, user_text });
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::tool_completed_to_transcript_items;
+    use crate::types::TranscriptItem;
+    use serde_json::json;
+
+    #[test]
+    fn tool_completed_preserves_fenced_diff_in_transcript() {
+        let output = json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Applied patch successfully"
+                },
+                {
+                    "type": "text",
+                    "text": "```diff\n-old line\n+new line\n```"
+                }
+            ],
+            "isError": false
+        });
+
+        let items = tool_completed_to_transcript_items(&output, None);
+
+        assert_eq!(items.len(), 1);
+        match &items[0] {
+            TranscriptItem::ToolResultMarkdown(text) => {
+                assert!(text.contains("Applied patch successfully"));
+                assert!(text.contains("```diff"));
+                assert!(text.contains("-old line"));
+                assert!(text.contains("+new line"));
+            }
+            other => panic!("unexpected transcript item: {other:?}"),
+        }
+    }
+}

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -75,26 +75,18 @@ impl Tui {
     /// by the body lines. Body rendering depends on its origin —
     /// `Markdown` (from a `call_template`) is rendered inline; `Yaml`
     /// (raw args, no template) is displayed verbatim, each line indented.
-    fn render_tool_call(
-        tool_name: &str,
-        body: Option<&ToolCallBody>,
-        seq: Option<usize>,
-        timestamp: Option<chrono::DateTime<chrono::Utc>>,
-        show_seq: bool,
-        show_ts: bool,
-        use_utc: bool,
-    ) -> Vec<Line<'static>> {
+    fn render_tool_call(tool_name: &str, body: Option<&ToolCallBody>) -> Vec<Line<'static>> {
         let dim_gray = Style::default()
             .fg(Color::DarkGray)
             .add_modifier(Modifier::DIM);
 
-        let header_text = format!("→ {tool_name}");
-        let mut lines = Self::render_text_entry("", &header_text, dim_gray, false);
-        if let Some(suffix) = Self::render_meta_suffix(seq, timestamp, show_seq, show_ts, use_utc) {
-            if let Some(first_line) = lines.first_mut() {
-                first_line.spans.push(suffix);
+        let mut lines = match body {
+            Some(ToolCallBody::Markdown(_)) => Vec::new(),
+            _ => {
+                let header_text = format!("→ {tool_name}");
+                Self::render_text_entry("", &header_text, dim_gray, false)
             }
-        }
+        };
         match body {
             Some(ToolCallBody::Yaml(yaml)) => {
                 for line in yaml.lines() {
@@ -288,15 +280,16 @@ impl Tui {
                 body,
                 seq,
                 timestamp,
-            } => Self::render_tool_call(
-                tool_name,
-                body.as_ref(),
-                *seq,
-                *timestamp,
-                show_seq,
-                show_ts,
-                use_utc,
-            ),
+            } => {
+                let mut lines = vec![];
+                if let Some(suffix) =
+                    Self::render_meta_suffix(*seq, *timestamp, show_seq, show_ts, use_utc)
+                {
+                    lines.push(Line::from(suffix));
+                }
+                lines.extend(Self::render_tool_call(tool_name, body.as_ref()));
+                lines
+            }
             TranscriptItem::AttachmentHeader(text) => Self::render_text_entry(
                 "",
                 &format!("{text}:"),

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__tool_call_display_format.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__tool_call_display_format.snap
@@ -6,13 +6,13 @@ Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
 → exec
    command: ls -la
    working_dir: /tmp
-→ write_file
    write hello.txt with 3 lines
 → think
 → search
    query: rust async patterns
    max_results: 10
    include_code: true
+
 
 
 

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__tool_call_with_seq_number.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__tool_call_with_seq_number.snap
@@ -3,9 +3,9 @@ source: crates/harnx-tui/src/tests.rs
 expression: rendered
 ---
 Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
-→ read  [7]
+  [7]
+→ read
    path: /tmp/foo.txt
-
 
 
 

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -4967,6 +4967,72 @@ async fn tool_call_display_format() {
     insta::assert_snapshot!("tool_call_display_format", rendered);
 }
 
+#[test]
+fn render_tool_call_markdown_body_suppresses_header() {
+    let lines = Tui::render_entry(
+        &TranscriptItem::ToolCall {
+            tool_name: "write_file".to_string(),
+            body: Some(ToolCallBody::Markdown(
+                "write **hello.txt** with 3 lines".to_string(),
+            )),
+            seq: None,
+            timestamp: None,
+        },
+        false,
+        false,
+        false,
+    );
+
+    let plain = lines.iter().map(line_to_plain).collect::<Vec<_>>();
+    assert_eq!(plain, vec!["   write hello.txt with 3 lines".to_string()]);
+    assert!(plain.iter().all(|line| !line.contains("→")));
+}
+
+#[test]
+fn render_tool_call_yaml_body_keeps_header() {
+    let lines = Tui::render_entry(
+        &TranscriptItem::ToolCall {
+            tool_name: "read".to_string(),
+            body: Some(ToolCallBody::Yaml("path: /tmp/foo.txt\n".to_string())),
+            seq: None,
+            timestamp: None,
+        },
+        false,
+        false,
+        false,
+    );
+
+    let plain = lines.iter().map(line_to_plain).collect::<Vec<_>>();
+    assert_eq!(plain.first().map(String::as_str), Some("→ read"));
+}
+
+#[test]
+fn render_tool_call_meta_line_precedes_markdown_body() {
+    let timestamp = chrono::DateTime::parse_from_rfc3339("2026-05-02T14:23:01Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    let lines = Tui::render_entry(
+        &TranscriptItem::ToolCall {
+            tool_name: "write_file".to_string(),
+            body: Some(ToolCallBody::Markdown("write hello.txt".to_string())),
+            seq: Some(3),
+            timestamp: Some(timestamp),
+        },
+        true,
+        true,
+        true,
+    );
+
+    let plain = lines.iter().map(line_to_plain).collect::<Vec<_>>();
+    assert_eq!(
+        plain,
+        vec![
+            "  [3] 14:23:01".to_string(),
+            "   write hello.txt".to_string()
+        ]
+    );
+}
+
 #[tokio::test]
 async fn tool_call_with_seq_number() {
     let mut harness = TuiTestHarness::new();

--- a/crates/harnx/src/cli_event_sink.rs
+++ b/crates/harnx/src/cli_event_sink.rs
@@ -185,17 +185,29 @@ impl CliSinkState {
         Ok(())
     }
 
-    /// Stderr render for `ToolEvent::Started`: dim "[tool] {name}", and
-    /// when the producer rendered an MCP `call_template` into `markdown`,
-    /// append the markdown-styled rendering after it.
+    /// Stderr render for `ToolEvent::Started`: when the producer rendered an
+    /// MCP `call_template` into `markdown`, print only the markdown-styled
+    /// line (no `[tool] name` prefix). When no markdown is present, fall back
+    /// to the dim `[tool] {name}` prefix.
     fn print_tool_started(&mut self, name: &str, markdown: Option<&str>) {
-        let prefix = dimmed_text(&format!("[tool] {name}"));
-        match markdown.map(str::trim).filter(|t| !t.is_empty()) {
-            Some(t) => {
-                let rendered = self.render_markdown_line(t);
-                eprintln!("{prefix} {rendered}");
+        let rendered = Self::format_tool_started(name, markdown, |text| {
+            if text.contains('\n') {
+                self.render_markdown_block(text)
+            } else {
+                self.render_markdown_line(text)
             }
-            None => eprintln!("{prefix}"),
+        });
+        eprintln!("{rendered}");
+    }
+
+    fn format_tool_started(
+        name: &str,
+        markdown: Option<&str>,
+        mut render_markdown: impl FnMut(&str) -> String,
+    ) -> String {
+        match markdown.map(str::trim).filter(|t| !t.is_empty()) {
+            Some(t) => render_markdown(t),
+            None => dimmed_text(&format!("[tool] {name}")),
         }
     }
 
@@ -412,6 +424,17 @@ mod tests {
     use super::*;
     use harnx_core::event::{ContentBlock, StatusLine};
 
+    fn make_state(highlight: bool) -> CliSinkState {
+        CliSinkState {
+            spinner: None,
+            render: None,
+            buffer: String::new(),
+            last_ui_output_source: None,
+            highlight,
+            render_options: RenderOptions::default(),
+        }
+    }
+
     // The sink writes to stdout (Info notices, streaming chunks) and stderr
     // (Warning/Error notices, status lines), which is hard to capture in a
     // unit test without subprocess machinery. We verify here only that
@@ -522,6 +545,41 @@ mod tests {
     // future tweak to the rendering rules updates a single test surface.
 
     #[test]
+    fn print_tool_started_with_markdown_omits_tool_prefix() {
+        let mut state = make_state(false);
+        let rendered =
+            CliSinkState::format_tool_started("bash_exec", Some("` $ cargo build`"), |text| {
+                state.render_markdown_line(text)
+            });
+
+        assert!(
+            !rendered.contains("[tool]"),
+            "unexpected tool prefix in output: {rendered}"
+        );
+        assert!(
+            rendered.contains("cargo build"),
+            "expected markdown text in output: {rendered}"
+        );
+    }
+
+    #[test]
+    fn print_tool_started_without_markdown_shows_tool_prefix() {
+        let mut state = make_state(false);
+        let rendered = CliSinkState::format_tool_started("bash_exec", None, |text| {
+            state.render_markdown_line(text)
+        });
+
+        assert!(
+            rendered.contains("[tool]"),
+            "expected tool prefix in output: {rendered}"
+        );
+        assert!(
+            rendered.contains("bash_exec"),
+            "expected tool name in output: {rendered}"
+        );
+    }
+
+    #[test]
     fn completed_uses_template_markdown_when_present() {
         // With a template-rendered markdown, prefer it over the raw output.
         let raw_output = serde_json::json!({
@@ -589,17 +647,6 @@ mod tests {
     // the renderer can't initialize, otherwise it produces ANSI-styled
     // output via syntect.
     // ----------------------------------------------------------------
-
-    fn make_state(highlight: bool) -> CliSinkState {
-        CliSinkState {
-            spinner: None,
-            render: None,
-            buffer: String::new(),
-            last_ui_output_source: None,
-            highlight,
-            render_options: RenderOptions::default(),
-        }
-    }
 
     #[test]
     fn render_markdown_line_passthrough_when_highlight_disabled() {

--- a/crates/harnx/tests/snapshots/tmux_e2e__nested_sub_agent_activity_no_duplicates.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__nested_sub_agent_activity_no_duplicates.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/harnx/tests/tmux_e2e.rs
-assertion_line: 1214
+assertion_line: 1212
 expression: normalized
 ---
 Welcome to harnx 0.30.0  *  Type .help for commands, Tab to complete.
@@ -10,13 +10,11 @@ Welcome to harnx 0.30.0  *  Type .help for commands, Tab to complete.
 
 Parent delegating to researcher.
 
-→ nested-researcher_session_prompt
-   message: Research this deeply and delegate analysis.
+   @ nested-researcher Research this deeply and delegate analysis.
 > nested-researcher ▸ [UUID]
 Researcher delegating to analyst.
 
-→ nested-analyst_session_prompt
-   message: Analyze data and report back.
+   @ nested-analyst Analyze data and report back.
 > nested-analyst ▸ [UUID]
 Analyst complete
 
@@ -28,6 +26,8 @@ Researcher complete
    session_id: [UUID]
    response: Researcher delegating to analyst.Analyst completeResearcher complete
 Nested task complete
+
+
 
 
 

--- a/crates/harnx/tests/tmux_e2e.rs
+++ b/crates/harnx/tests/tmux_e2e.rs
@@ -94,8 +94,6 @@ fn repro_249_top_level_delegation_markers() -> Result<()> {
         "sub-agent not listed in --list-agents output:\n{agents_screen}"
     );
 
-    let delegate_tool_name = format!("{}_session_prompt", TEST_SUB_AGENT_NAME);
-
     // Step 5: Start interactive TUI session
     tmux.send_text(&format!(
         "{} -a {} || echo HARNX_EXIT:$?",
@@ -113,7 +111,7 @@ fn repro_249_top_level_delegation_markers() -> Result<()> {
     })?;
 
     assert_eq!(
-        count_occurrences(&screen, &format!("→ {delegate_tool_name}")),
+        count_occurrences(&screen, &format!("@ {}", TEST_SUB_AGENT_NAME)),
         1,
         "expected exactly one top-level delegation marker, got screen:\n{screen}"
     );
@@ -1186,15 +1184,13 @@ fn nested_sub_agent_activity_no_duplicates() -> Result<()> {
         |screen| screen.contains("Nested task complete"),
     )?;
 
-    let delegate_tool_name = format!("{}_session_prompt", NESTED_SUB_AGENT);
-    let nested_delegate_tool_name = format!("{}_session_prompt", NESTED_SUB_SUB_AGENT);
     assert_eq!(
-        count_occurrences(&screen, &format!("→ {delegate_tool_name}")),
+        count_occurrences(&screen, &format!("@ {}", NESTED_SUB_AGENT)),
         1,
         "expected exactly one parent→sub-agent marker:\n{screen}"
     );
     assert_eq!(
-        count_occurrences(&screen, &format!("→ {nested_delegate_tool_name}")),
+        count_occurrences(&screen, &format!("@ {}", NESTED_SUB_SUB_AGENT)),
         1,
         "expected exactly one sub-agent→sub-sub-agent marker:\n{screen}"
     );

--- a/docs/solutions/logic-errors/tool-output-header-suppression-2026-05-02.md
+++ b/docs/solutions/logic-errors/tool-output-header-suppression-2026-05-02.md
@@ -1,0 +1,171 @@
+---
+title: "Tool output header suppression and template-driven display"
+date: 2026-05-02
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-tui, harnx-cli, harnx-acp, harnx-mcp-bash, harnx-mcp-fs, harnx-mcp-time, harnx-mcp-todo"
+root_cause: "redundant tool name headers cluttered output when markdown templates already described the action"
+resolution_type: code_fix
+severity: medium
+tags:
+  - tui
+  - cli
+  - templates
+  - display
+  - enum-driven
+  - header-suppression
+plan_ref: "issue-396-tool-output-appearance"
+---
+
+## Problem
+
+Tool call output displayed redundant headers (TUI: `→ tool_name`, CLI: `[tool] name`) even when `call_template` markdown already provided a concise description. This cluttered the transcript and reduced information density.
+
+## Symptoms
+
+```text
+# Before (TUI):
+→ Bash
+   $ cargo build
+
+# Before (CLI):
+[tool] bash_exec
+$ cargo build
+```
+
+The `→ Bash` / `[tool] bash_exec` header added no value when the template `$ cargo build` already clearly identified the action.
+
+## Investigation Steps
+
+1. Traced `render_tool_call()` in `harnx-tui/src/render.rs` — found it always emitted header line followed by body
+2. Identified `ToolCallBody` enum variants: `Markdown` (template-rendered) vs `Yaml` (raw args)
+3. Analyzed CLI `print_tool_started()` in `harnx/src/cli_event_sink.rs` — always prefixed with `[tool] name`
+4. Recognized pattern: presence of markdown template determines whether header is useful
+5. Designed enum-driven suppression: `ToolCallBody::Markdown` suppresses header, `Yaml`/`None` keeps it
+
+## Root Cause
+
+Display logic did not distinguish between template-rendered markdown (self-describing) and raw YAML args (needs header context). Both paths emitted the same header regardless of whether it added information.
+
+## Solution
+
+### TUI: Enum-driven header suppression in `render_tool_call()`
+
+```rust
+fn render_tool_call(tool_name: &str, body: Option<&ToolCallBody>) -> Vec<Line<'static>> {
+    let mut lines = match body {
+        Some(ToolCallBody::Markdown(_)) => Vec::new(),  // No header
+        _ => {
+            let header_text = format!("→ {tool_name}");
+            Self::render_text_entry("", &header_text, dim_gray, false)
+        }
+    };
+    // ... body rendering
+}
+```
+
+### TUI: Metadata relocation to separate line
+
+Sequence numbers and timestamps moved from inline suffix to standalone dim line above tool body:
+
+```rust
+TranscriptItem::ToolCall { tool_name, body, seq, timestamp } => {
+    let mut lines = vec![];
+    if let Some(suffix) = Self::render_meta_suffix(*seq, *timestamp, show_seq, show_ts, use_utc) {
+        lines.push(Line::from(suffix));  // Meta line FIRST
+    }
+    lines.extend(Self::render_tool_call(tool_name, body.as_ref()));  // Body AFTER
+    lines
+}
+```
+
+Result: 2-space indent for meta line (`[3] 14:23:01`), 3-space indent for tool body.
+
+### CLI: Extract `format_tool_started()` helper for testability
+
+```rust
+fn print_tool_started(&mut self, name: &str, markdown: Option<&str>) {
+    let rendered = Self::format_tool_started(name, markdown, |text| {
+        self.render_markdown_line(text)
+    });
+    eprintln!("{rendered}");
+}
+
+fn format_tool_started(
+    name: &str,
+    markdown: Option<&str>,
+    mut render_markdown: impl FnMut(&str) -> String,
+) -> String {
+    match markdown.map(str::trim).filter(|t| !t.is_empty()) {
+        Some(t) => render_markdown(t),  // Just markdown, no prefix
+        None => dimmed_text(&format!("[tool] {name}")),  // Fallback to header
+    }
+}
+```
+
+Extraction enables unit testing without stderr capture — pass a closure instead of writing to stdout/stderr.
+
+### Template policy: ASCII icons, no emoji/bold
+
+All tool declarations updated with terse ASCII icon prefixes:
+
+| Icon | Tool category | Examples |
+|------|---------------|----------|
+| `$` | Execution | `` `$ {{ args.command }}` `` |
+| `>` | Spawn | `` `> {{ args.command }}` `` |
+| `#` | Read | `# {{ args.path }}` |
+| `+` | Create | `+ plan {{ args.name }}` |
+| `*` | Edit | `* todo {{ args.id }}` |
+| `?` | Search | `? {{ args.pattern }}` |
+| `@` | Agent | `@ {{ server_name }} prompt` |
+| `-` | Delete | `- todo {{ args.id }}` |
+| `>>` | Append | `>> todo {{ args.id }}` |
+
+### ACP dynamic templates via `format!()`
+
+`generate_acp_tools(server_name)` builds templates programmatically:
+
+```rust
+fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
+    let session_new_call_template = format!("@ {} new session", server_name);
+    let session_prompt_call_template = format!("@ {} {{{{ args.message | truncate(60) }}}}", server_name);
+    // ...
+}
+```
+
+Server name interpolated at tool generation time; result is valid MiniJinja template.
+
+## Why This Works
+
+**Enum-driven suppression**: `ToolCallBody::Markdown` indicates the template already describes the action — header would be redundant. `ToolCallBody::Yaml` shows raw arguments — header provides essential context.
+
+**Helper extraction**: Separating formatting from I/O enables direct unit testing. Tests call `format_tool_started()` with a passthrough closure and assert on the returned string.
+
+**Metadata separation**: Moving seq/timestamp to a pre-line decouples metadata display from header logic. Visual hierarchy: meta (dim, 2-space) → body (3-space).
+
+**Icon consistency**: ASCII prefixes provide visual scanning cues without emoji/bloat. Backticks highlight primary arguments (command, path).
+
+## Prevention Strategies
+
+**Test Cases:**
+- `render_tool_call_markdown_body_suppresses_header` — assert no `→` when markdown present
+- `render_tool_call_yaml_body_keeps_header` — assert header present for YAML
+- `render_tool_call_meta_line_precedes_markdown_body` — assert `[seq] timestamp` on separate line before body
+- `print_tool_started_with_markdown_omits_tool_prefix` — CLI: no `[tool]` with markdown
+- `print_tool_started_without_markdown_shows_tool_prefix` — CLI: `[tool]` fallback
+
+**Code Review Checklist:**
+- [ ] New MCP tools include `call_template` with ASCII icon prefix
+- [ ] Template uses backticks for primary argument (command, path, query)
+- [ ] No emoji or bold markdown in templates
+- [ ] `ToolCallBody::Markdown` path suppresses header in both TUI and CLI
+
+**Best Practices:**
+- Use `ToolCallBody` enum variant to drive display decisions — one source of truth
+- Extract formatting helpers for testability — avoid I/O in pure logic
+- Keep metadata (seq/timestamp) separate from content for flexible layout
+
+## Related Issues
+
+- **GitHub:** [issue #396](https://github.com/dobesv/harnx/issues/396) — Improve tool output appearance
+- **Related Solution:** [mcp-tool-template-acp-propagation-2026-04-30.md](../integration-issues/mcp-tool-template-acp-propagation-2026-04-30.md) — Template rendering and ACP propagation


### PR DESCRIPTION
Suppresses tool output headers and relocates timestamps to improve the TUI and CLI tool call display. Updates call templates for bash, fs, time, todo, and acp tools to use a more terse format with ASCII icons. Includes regression tests for header suppression and CLI tool prefix handling. Also includes formatting fixes and removal of stray scratch files.

Closes #396

Plan: issue-396-tool-output-appearance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Eliminated redundant tool name headers in markdown-formatted tool call outputs for cleaner display.
  * Improved CLI rendering of tool execution events to avoid duplicate information.

* **Enhancements**
  * Updated tool call template formatting across all tool servers for improved readability.
  * Refactored tool call rendering logic for better consistency.

* **Tests**
  * Added test coverage for transcript handling with code block preservation.
  * Added tests for tool call rendering with markdown and YAML bodies.

* **Documentation**
  * Added solution guide documenting tool output header suppression behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->