### PR TITLE
Implement separate file storage for plan notes

### DIFF
--- a/crates/harnx-mcp-todo/Cargo.toml
+++ b/crates/harnx-mcp-todo/Cargo.toml
@@ -14,7 +14,7 @@ rmcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
 schemars = { workspace = true }
 
 [[bin]]

--- a/crates/harnx-mcp-todo/src/server.rs
+++ b/crates/harnx-mcp-todo/src/server.rs
@@ -1,7 +1,7 @@
 //! Todo MCP server implementation.
 //!
 //! Stores todos under per-plan directories using YAML front matter + markdown body.
-//! Layout: `<data-dir>/<plan>/plan.md` and `<data-dir>/<plan>/todo-<8-hex-id>.md`.
+//! Layout: `<data-dir>/<plan>/plan.md`, `<data-dir>/<plan>/todo-<8-hex-id>.md`, and `<data-dir>/<plan>/note-<8-hex-id>.md`.
 
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, Content, ErrorData, Implementation, ListToolsResult,
@@ -168,6 +168,12 @@ struct PlanAddNoteParams {
 struct PlanGetTodoParams {
     plan: String,
     key: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlanReadNoteParams {
+    plan: String,
+    note_id: String,
 }
 
 macro_rules! impl_json_schema {
@@ -398,6 +404,16 @@ impl_json_schema!(
     &["plan", "key"]
 );
 
+impl_json_schema!(
+    PlanReadNoteParams,
+    "PlanReadNoteParams",
+    |gen: &mut SchemaGenerator| vec![
+        ("plan", "Plan name or ID", gen.subschema_for::<String>()),
+        ("note_id", "Note ID (8-hex string or note-<id> prefix)", gen.subschema_for::<String>()),
+    ],
+    &["plan", "note_id"]
+);
+
 fn plan_dir(dir: &Path, plan_name: &str) -> PathBuf {
     dir.join(plan_name)
 }
@@ -408,6 +424,10 @@ fn todo_file_path(dir: &Path, plan_name: &str, id: &str) -> PathBuf {
 
 fn plan_file_path(dir: &Path, plan_name: &str) -> PathBuf {
     plan_dir(dir, plan_name).join("plan.md")
+}
+
+fn note_file_path(dir: &Path, plan_name: &str, id: &str) -> PathBuf {
+    plan_dir(dir, plan_name).join(format!("note-{}.md", id))
 }
 
 fn parse_yaml_frontmatter(content: &str) -> Result<(TodoFrontMatter, String), String> {
@@ -782,10 +802,55 @@ impl TodoServer {
         let name = normalize_plan_name(&params.name)
             .map_err(|err| ErrorData::invalid_params(err, None))?;
         let path = plan_file_path(&self.dir, &name);
-        let content = std::fs::read_to_string(&path).map_err(|err| {
-            ErrorData::invalid_params(format!("failed to read {}: {err}", path.display()), None)
-        })?;
-        Ok(result_text(content, format!("Read plan {name}")))
+        let dir = plan_dir(&self.dir, &name);
+        if !dir.exists() {
+            return Err(ErrorData::invalid_params(
+                format!("plan '{name}' not found"),
+                None,
+            ));
+        }
+        let content = match std::fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(err) => {
+                return Err(ErrorData::internal_error(
+                    format!("failed to read {}: {err}", path.display()),
+                    None,
+                ))
+            }
+        };
+        let mut note_ids = Vec::new();
+        let mut todo_ids = Vec::new();
+
+        if let Ok(entries) = std::fs::read_dir(&dir) {
+            for entry in entries.flatten() {
+                let file_name = entry.file_name().to_string_lossy().into_owned();
+                if let Some(note_id) = file_name
+                    .strip_prefix("note-")
+                    .and_then(|name| name.strip_suffix(".md"))
+                {
+                    note_ids.push(note_id.to_string());
+                } else if let Some(todo_id) = file_name
+                    .strip_prefix("todo-")
+                    .and_then(|name| name.strip_suffix(".md"))
+                {
+                    todo_ids.push(todo_id.to_string());
+                }
+            }
+        }
+
+        note_ids.sort();
+        todo_ids.sort();
+
+        Ok(result_json(
+            json!({
+                "plan": name,
+                "content": content,
+                "note_ids": note_ids,
+                "todo_ids": todo_ids,
+            }),
+            format!("Read plan {name}"),
+        ))
     }
 
     fn handle_plan_write(&self, params: PlanWriteParams) -> Result<CallToolResult, ErrorData> {
@@ -877,33 +942,18 @@ impl TodoServer {
     fn handle_plan_add_note(&self, params: PlanAddNoteParams) -> Result<CallToolResult, ErrorData> {
         let name = normalize_plan_name(&params.name)
             .map_err(|err| ErrorData::invalid_params(err, None))?;
+        let id = generate_id();
         let dir = plan_dir(&self.dir, &name);
         std::fs::create_dir_all(&dir).map_err(|err| {
             ErrorData::internal_error(format!("failed to create {}: {err}", dir.display()), None)
         })?;
-        let path = plan_file_path(&self.dir, &name);
-        let mut content = match std::fs::read_to_string(&path) {
-            Ok(content) => content,
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
-            Err(err) => {
-                return Err(ErrorData::internal_error(
-                    format!("failed to read {}: {err}", path.display()),
-                    None,
-                ))
-            }
-        };
-        if !content.is_empty() && !content.ends_with('\n') {
-            content.push('\n');
-        }
-        content.push_str("\n### Note\n\n");
-        content.push_str(&params.text);
-        content.push('\n');
-        std::fs::write(&path, content).map_err(|err| {
+        let path = note_file_path(&self.dir, &name, &id);
+        std::fs::write(&path, &params.text).map_err(|err| {
             ErrorData::internal_error(format!("failed to write {}: {err}", path.display()), None)
         })?;
         Ok(result_text(
-            format!("Added note to plan {name}"),
-            format!("Added note to plan {name}"),
+            format!("Created note {id} in plan {name}"),
+            format!("Created note {id} in plan {name}"),
         ))
     }
 
@@ -933,6 +983,21 @@ impl TodoServer {
             todo_to_json(todo),
             format!("Found {}: {}", display_id(&todo.front.id), todo.front.title),
         ))
+    }
+
+    fn handle_plan_read_note(&self, params: PlanReadNoteParams) -> Result<CallToolResult, ErrorData> {
+        let plan = normalize_plan_name(&params.plan)
+            .map_err(|err| ErrorData::invalid_params(err, None))?;
+        let raw_id = params.note_id.trim();
+        let id = raw_id
+            .strip_prefix("note-")
+            .unwrap_or(raw_id)
+            .to_ascii_lowercase();
+        let path = note_file_path(&self.dir, &plan, &id);
+        let content = std::fs::read_to_string(&path).map_err(|_| {
+            ErrorData::invalid_params(format!("note '{id}' not found in plan '{plan}'"), None)
+        })?;
+        Ok(result_text(content, format!("Read note {id} in plan {plan}")))
     }
 }
 
@@ -1013,7 +1078,7 @@ impl ServerHandler for TodoServer {
                         "call_template": "- todo {{ args.id }}",
                         "result_template": "{{ result.content[0].text | default('') }}"
                     }).as_object().unwrap().clone())),
-                Tool::new("read_plan", "Read plan markdown file.", Map::new())
+                Tool::new("read_plan", "Read plan markdown file and list available note and todo IDs.", Map::new())
                     .with_input_schema::<PlanReadParams>()
                     .with_meta(Meta(json!({
                         "call_template": "plan {{ args.name }}",
@@ -1031,7 +1096,7 @@ impl ServerHandler for TodoServer {
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "plan_add_note",
-                    "Append note section to plan markdown.",
+                    "Append note section to plan markdown as a dedicated note file.",
                     Map::new(),
                 )
                 .with_input_schema::<PlanAddNoteParams>()
@@ -1047,6 +1112,16 @@ impl ServerHandler for TodoServer {
                 .with_input_schema::<PlanGetTodoParams>()
                 .with_meta(Meta(json!({
                     "call_template": "plan {{ args.plan }} / {{ args.key }}",
+                    "result_template": "{{ result.content[0].text | default('') }}"
+                }).as_object().unwrap().clone())),
+                Tool::new(
+                    "plan_read_note",
+                    "Read a note file in a plan by note ID.",
+                    Map::new(),
+                )
+                .with_input_schema::<PlanReadNoteParams>()
+                .with_meta(Meta(json!({
+                    "call_template": "note {{ args.plan }}/{{ args.note_id }}",
                     "result_template": "{{ result.content[0].text | default('') }}"
                 }).as_object().unwrap().clone())),
             ],
@@ -1098,6 +1173,10 @@ impl ServerHandler for TodoServer {
             "plan_get_todo" => {
                 let params = parse_arguments::<PlanGetTodoParams>(request.arguments)?;
                 self.handle_plan_get_todo(params)
+            }
+            "plan_read_note" => {
+                let params = parse_arguments::<PlanReadNoteParams>(request.arguments)?;
+                self.handle_plan_read_note(params)
             }
             other => Err(ErrorData::invalid_params(
                 format!("unknown tool: {other}"),
@@ -1191,11 +1270,15 @@ mod tests {
     fn temp_test_dir(name: &str) -> PathBuf {
         let mut path = std::env::temp_dir();
         let unique = format!(
-            "harnx-mcp-todo-{name}-{}-{}",
+            "harnx-mcp-todo-{name}-{}-{}-{}",
             std::process::id(),
-            TEST_COUNTER.fetch_add(1, Ordering::Relaxed)
+            TEST_COUNTER.fetch_add(1, Ordering::Relaxed),
+            unique_iso()
         );
         path.push(unique);
+        if path.exists() {
+            fs::remove_dir_all(&path).unwrap();
+        }
         fs::create_dir_all(&path).unwrap();
         path
     }
@@ -1568,11 +1651,22 @@ mod tests {
             })
             .unwrap();
         let summary = extract_text(result);
-        assert!(summary.contains("Added note to plan plan-a"));
+        assert!(summary.contains("Created note"));
+        assert!(summary.contains("plan-a"));
 
-        let content = fs::read_to_string(dir.join("plan-a").join("plan.md")).unwrap();
-        assert!(content.contains("### Note"));
+        let note_id = summary
+            .split("note ")
+            .nth(1)
+            .unwrap()
+            .split(" in plan")
+            .next()
+            .unwrap();
+        let note_path = dir.join("plan-a").join(format!("note-{note_id}.md"));
+        assert!(note_path.exists());
+
+        let content = fs::read_to_string(&note_path).unwrap();
         assert!(content.contains("hello note"));
+        assert!(!dir.join("plan-a").join("plan.md").exists());
     }
 
     #[test]
@@ -1633,5 +1727,194 @@ mod tests {
         let open_todos: Vec<Value> = serde_json::from_str(&extract_text(open)).unwrap();
         assert_eq!(open_todos.len(), 1);
         assert_eq!(open_todos[0]["status"], "open");
+    }
+
+    #[test]
+    fn plan_add_note_multiple_notes_create_separate_files() {
+        let dir = temp_test_dir("plan-add-note-multi");
+        let server = TodoServer::new(dir.clone());
+
+        let r1 = server
+            .handle_plan_add_note(PlanAddNoteParams {
+                name: "plan-a".to_string(),
+                text: "note one".to_string(),
+            })
+            .unwrap();
+        let r2 = server
+            .handle_plan_add_note(PlanAddNoteParams {
+                name: "plan-a".to_string(),
+                text: "note two".to_string(),
+            })
+            .unwrap();
+
+        let s1 = extract_text(r1);
+        let s2 = extract_text(r2);
+        assert!(s1.contains("Created note"));
+        assert!(s2.contains("Created note"));
+        assert_ne!(s1, s2);
+
+        let plan_dir = dir.join("plan-a");
+        let note_files: Vec<_> = fs::read_dir(&plan_dir)
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().starts_with("note-"))
+            .collect();
+        assert_eq!(note_files.len(), 2);
+        assert!(!plan_dir.join("plan.md").exists());
+    }
+
+    #[test]
+    fn read_plan_returns_json_with_note_and_todo_ids() {
+        let dir = temp_test_dir("read-plan-json");
+        let server = TodoServer::new(dir.clone());
+
+        server
+            .handle_plan_write(PlanWriteParams {
+                name: "my-plan".to_string(),
+                content: "# My Plan\n".to_string(),
+                todos: None,
+            })
+            .unwrap();
+
+        let note_result = server
+            .handle_plan_add_note(PlanAddNoteParams {
+                name: "my-plan".to_string(),
+                text: "some note".to_string(),
+            })
+            .unwrap();
+        let note_summary = extract_text(note_result);
+        let note_id = note_summary
+            .split_whitespace()
+            .nth(2)
+            .unwrap()
+            .to_string();
+
+        let todo_result = server
+            .handle_create(TodoCreateParams {
+                title: "task one".to_string(),
+                tags: vec![],
+                plan: "my-plan".to_string(),
+                status: None,
+                body: None,
+                key: None,
+                dependencies: vec![],
+            })
+            .unwrap();
+        let todo_json: Value = serde_json::from_str(&extract_text(todo_result)).unwrap();
+        let todo_id = todo_json["id"].as_str().unwrap().to_string();
+
+        let read_result = server
+            .handle_plan_read(PlanReadParams {
+                name: "my-plan".to_string(),
+            })
+            .unwrap();
+        let overview: Value = serde_json::from_str(&extract_text(read_result)).unwrap();
+
+        assert_eq!(overview["plan"], "my-plan");
+        assert!(overview["content"].as_str().unwrap().contains("# My Plan"));
+
+        let note_ids: Vec<String> = serde_json::from_value(overview["note_ids"].clone()).unwrap();
+        let todo_ids: Vec<String> = serde_json::from_value(overview["todo_ids"].clone()).unwrap();
+
+        assert_eq!(note_ids.len(), 1);
+        assert!(note_ids.contains(&note_id));
+
+        assert_eq!(todo_ids.len(), 1);
+        assert!(todo_ids.contains(&todo_id));
+    }
+
+    #[test]
+    fn plan_read_note_returns_content() {
+        let dir = temp_test_dir("plan-read-note-content");
+        let server = TodoServer::new(dir.clone());
+
+        let add_result = server
+            .handle_plan_add_note(PlanAddNoteParams {
+                name: "plan-a".to_string(),
+                text: "my important note".to_string(),
+            })
+            .unwrap();
+        let summary = extract_text(add_result);
+        let note_id = summary.split_whitespace().nth(2).unwrap().to_string();
+
+        let read_result = server
+            .handle_plan_read_note(PlanReadNoteParams {
+                plan: "plan-a".to_string(),
+                note_id: note_id.clone(),
+            })
+            .unwrap();
+        let content = extract_text(read_result);
+        assert!(content.contains("my important note"));
+    }
+
+    #[test]
+    fn plan_read_note_returns_error_for_missing_note() {
+        let dir = temp_test_dir("plan-read-note-missing");
+        let server = TodoServer::new(dir.clone());
+
+        fs::create_dir_all(dir.join("plan-a")).unwrap();
+
+        let result = server.handle_plan_read_note(PlanReadNoteParams {
+            plan: "plan-a".to_string(),
+            note_id: "deadbeef".to_string(),
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn plan_read_note_normalizes_note_id_variants() {
+        let dir = temp_test_dir("plan-read-note-normalizes");
+        let server = TodoServer::new(dir.clone());
+
+        let add_result = server
+            .handle_plan_add_note(PlanAddNoteParams {
+                name: "plan-a".to_string(),
+                text: "normalized note text".to_string(),
+            })
+            .unwrap();
+        let summary = extract_text(add_result);
+        let note_id = summary.split_whitespace().nth(2).unwrap().to_string();
+
+        for variant in [
+            format!("note-{note_id}"),
+            note_id.to_uppercase(),
+            format!(" {note_id} "),
+        ] {
+            let read_result = server
+                .handle_plan_read_note(PlanReadNoteParams {
+                    plan: "plan-a".to_string(),
+                    note_id: variant,
+                })
+                .unwrap();
+            let content = extract_text(read_result);
+            assert!(content.contains("normalized note text"));
+        }
+    }
+
+    #[test]
+    fn read_plan_returns_json_for_note_only_plan() {
+        let dir = temp_test_dir("read-plan-note-only");
+        let server = TodoServer::new(dir.clone());
+
+        server
+            .handle_plan_add_note(PlanAddNoteParams {
+                name: "note-only-plan".to_string(),
+                text: "orphan note".to_string(),
+            })
+            .unwrap();
+
+        let read_result = server
+            .handle_plan_read(PlanReadParams {
+                name: "note-only-plan".to_string(),
+            })
+            .unwrap();
+        let overview: Value = serde_json::from_str(&extract_text(read_result)).unwrap();
+
+        let note_ids: Vec<String> = serde_json::from_value(overview["note_ids"].clone()).unwrap();
+        let todo_ids: Vec<String> = serde_json::from_value(overview["todo_ids"].clone()).unwrap();
+
+        assert_eq!(note_ids.len(), 1);
+        assert_eq!(todo_ids.len(), 0);
+        assert_eq!(overview["content"], "");
     }
 }

--- a/crates/harnx-mcp-todo/src/server.rs
+++ b/crates/harnx-mcp-todo/src/server.rs
@@ -802,18 +802,18 @@ impl TodoServer {
         ))
     }
 
-    fn handle_plan_read(&self, params: PlanReadParams) -> Result<CallToolResult, ErrorData> {
+    async fn handle_plan_read(&self, params: PlanReadParams) -> Result<CallToolResult, ErrorData> {
         let name = normalize_plan_name(&params.name)
             .map_err(|err| ErrorData::invalid_params(err, None))?;
         let path = plan_file_path(&self.dir, &name);
         let dir = plan_dir(&self.dir, &name);
-        if !dir.exists() {
+        if !dir.is_dir() {
             return Err(ErrorData::invalid_params(
                 format!("plan '{name}' not found"),
                 None,
             ));
         }
-        let content = match std::fs::read_to_string(&path) {
+        let content = match tokio::fs::read_to_string(&path).await {
             Ok(content) => content,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
             Err(err) => {
@@ -826,20 +826,26 @@ impl TodoServer {
         let mut note_ids = Vec::new();
         let mut todo_ids = Vec::new();
 
-        if let Ok(entries) = std::fs::read_dir(&dir) {
-            for entry in entries.flatten() {
-                let file_name = entry.file_name().to_string_lossy().into_owned();
-                if let Some(note_id) = file_name
-                    .strip_prefix("note-")
-                    .and_then(|name| name.strip_suffix(".md"))
-                {
-                    note_ids.push(note_id.to_string());
-                } else if let Some(todo_id) = file_name
-                    .strip_prefix("todo-")
-                    .and_then(|name| name.strip_suffix(".md"))
-                {
-                    todo_ids.push(todo_id.to_string());
-                }
+        let mut entries = tokio::fs::read_dir(&dir).await.map_err(|e| {
+            ErrorData::internal_error(format!("failed to read dir {}: {e}", dir.display()), None)
+        })?;
+        while let Some(entry) = entries.next_entry().await.map_err(|e| {
+            ErrorData::internal_error(
+                format!("failed to read dir entry in {}: {e}", dir.display()),
+                None,
+            )
+        })? {
+            let file_name = entry.file_name().to_string_lossy().into_owned();
+            if let Some(note_id) = file_name
+                .strip_prefix("note-")
+                .and_then(|name| name.strip_suffix(".md"))
+            {
+                note_ids.push(note_id.to_string());
+            } else if let Some(todo_id) = file_name
+                .strip_prefix("todo-")
+                .and_then(|name| name.strip_suffix(".md"))
+            {
+                todo_ids.push(todo_id.to_string());
             }
         }
 
@@ -943,16 +949,19 @@ impl TodoServer {
         ))
     }
 
-    fn handle_plan_add_note(&self, params: PlanAddNoteParams) -> Result<CallToolResult, ErrorData> {
+    async fn handle_plan_add_note(
+        &self,
+        params: PlanAddNoteParams,
+    ) -> Result<CallToolResult, ErrorData> {
         let name = normalize_plan_name(&params.name)
             .map_err(|err| ErrorData::invalid_params(err, None))?;
         let id = generate_id();
         let dir = plan_dir(&self.dir, &name);
-        std::fs::create_dir_all(&dir).map_err(|err| {
+        tokio::fs::create_dir_all(&dir).await.map_err(|err| {
             ErrorData::internal_error(format!("failed to create {}: {err}", dir.display()), None)
         })?;
         let path = note_file_path(&self.dir, &name, &id);
-        std::fs::write(&path, &params.text).map_err(|err| {
+        tokio::fs::write(&path, &params.text).await.map_err(|err| {
             ErrorData::internal_error(format!("failed to write {}: {err}", path.display()), None)
         })?;
         Ok(result_text(
@@ -989,21 +998,34 @@ impl TodoServer {
         ))
     }
 
-    fn handle_plan_read_note(
+    async fn handle_plan_read_note(
         &self,
         params: PlanReadNoteParams,
     ) -> Result<CallToolResult, ErrorData> {
         let plan = normalize_plan_name(&params.plan)
             .map_err(|err| ErrorData::invalid_params(err, None))?;
-        let raw_id = params.note_id.trim();
-        let id = raw_id
+        // Strip "note-" case-insensitively: lowercase first, then strip the prefix.
+        let lowered = params.note_id.trim().to_ascii_lowercase();
+        let id = lowered
             .strip_prefix("note-")
-            .unwrap_or(raw_id)
-            .to_ascii_lowercase();
+            .unwrap_or(&lowered)
+            .to_string();
         let path = note_file_path(&self.dir, &plan, &id);
-        let content = std::fs::read_to_string(&path).map_err(|_| {
-            ErrorData::invalid_params(format!("note '{id}' not found in plan '{plan}'"), None)
-        })?;
+        let content = match tokio::fs::read_to_string(&path).await {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(ErrorData::invalid_params(
+                    format!("note '{id}' not found in plan '{plan}'"),
+                    None,
+                ))
+            }
+            Err(e) => {
+                return Err(ErrorData::internal_error(
+                    format!("failed to read {}: {e}", path.display()),
+                    None,
+                ))
+            }
+        };
         Ok(result_text(
             content,
             format!("Read note {id} in plan {plan}"),
@@ -1170,7 +1192,7 @@ impl ServerHandler for TodoServer {
             }
             "read_plan" => {
                 let params = parse_arguments::<PlanReadParams>(request.arguments)?;
-                self.handle_plan_read(params)
+                self.handle_plan_read(params).await
             }
             "write_plan" => {
                 let params = parse_arguments::<PlanWriteParams>(request.arguments)?;
@@ -1178,7 +1200,7 @@ impl ServerHandler for TodoServer {
             }
             "plan_add_note" => {
                 let params = parse_arguments::<PlanAddNoteParams>(request.arguments)?;
-                self.handle_plan_add_note(params)
+                self.handle_plan_add_note(params).await
             }
             "plan_get_todo" => {
                 let params = parse_arguments::<PlanGetTodoParams>(request.arguments)?;
@@ -1186,7 +1208,7 @@ impl ServerHandler for TodoServer {
             }
             "plan_read_note" => {
                 let params = parse_arguments::<PlanReadNoteParams>(request.arguments)?;
-                self.handle_plan_read_note(params)
+                self.handle_plan_read_note(params).await
             }
             other => Err(ErrorData::invalid_params(
                 format!("unknown tool: {other}"),
@@ -1649,8 +1671,8 @@ mod tests {
         assert_eq!(todos.len(), 2);
     }
 
-    #[test]
-    fn plan_add_note_creates_missing_plan_file() {
+    #[tokio::test]
+    async fn plan_add_note_creates_missing_plan_file() {
         let dir = temp_test_dir("plan-add-note-not-found");
         let server = TodoServer::new(dir.clone());
 
@@ -1659,6 +1681,7 @@ mod tests {
                 name: "plan-a".to_string(),
                 text: "hello note".to_string(),
             })
+            .await
             .unwrap();
         let summary = extract_text(result);
         assert!(summary.contains("Created note"));
@@ -1739,8 +1762,8 @@ mod tests {
         assert_eq!(open_todos[0]["status"], "open");
     }
 
-    #[test]
-    fn plan_add_note_multiple_notes_create_separate_files() {
+    #[tokio::test]
+    async fn plan_add_note_multiple_notes_create_separate_files() {
         let dir = temp_test_dir("plan-add-note-multi");
         let server = TodoServer::new(dir.clone());
 
@@ -1749,12 +1772,14 @@ mod tests {
                 name: "plan-a".to_string(),
                 text: "note one".to_string(),
             })
+            .await
             .unwrap();
         let r2 = server
             .handle_plan_add_note(PlanAddNoteParams {
                 name: "plan-a".to_string(),
                 text: "note two".to_string(),
             })
+            .await
             .unwrap();
 
         let s1 = extract_text(r1);
@@ -1773,8 +1798,8 @@ mod tests {
         assert!(!plan_dir.join("plan.md").exists());
     }
 
-    #[test]
-    fn read_plan_returns_json_with_note_and_todo_ids() {
+    #[tokio::test]
+    async fn read_plan_returns_json_with_note_and_todo_ids() {
         let dir = temp_test_dir("read-plan-json");
         let server = TodoServer::new(dir.clone());
 
@@ -1791,6 +1816,7 @@ mod tests {
                 name: "my-plan".to_string(),
                 text: "some note".to_string(),
             })
+            .await
             .unwrap();
         let note_summary = extract_text(note_result);
         let note_id = note_summary.split_whitespace().nth(2).unwrap().to_string();
@@ -1813,6 +1839,7 @@ mod tests {
             .handle_plan_read(PlanReadParams {
                 name: "my-plan".to_string(),
             })
+            .await
             .unwrap();
         let overview: Value = serde_json::from_str(&extract_text(read_result)).unwrap();
 
@@ -1829,8 +1856,8 @@ mod tests {
         assert!(todo_ids.contains(&todo_id));
     }
 
-    #[test]
-    fn plan_read_note_returns_content() {
+    #[tokio::test]
+    async fn plan_read_note_returns_content() {
         let dir = temp_test_dir("plan-read-note-content");
         let server = TodoServer::new(dir.clone());
 
@@ -1839,6 +1866,7 @@ mod tests {
                 name: "plan-a".to_string(),
                 text: "my important note".to_string(),
             })
+            .await
             .unwrap();
         let summary = extract_text(add_result);
         let note_id = summary.split_whitespace().nth(2).unwrap().to_string();
@@ -1848,27 +1876,30 @@ mod tests {
                 plan: "plan-a".to_string(),
                 note_id: note_id.clone(),
             })
+            .await
             .unwrap();
         let content = extract_text(read_result);
         assert!(content.contains("my important note"));
     }
 
-    #[test]
-    fn plan_read_note_returns_error_for_missing_note() {
+    #[tokio::test]
+    async fn plan_read_note_returns_error_for_missing_note() {
         let dir = temp_test_dir("plan-read-note-missing");
         let server = TodoServer::new(dir.clone());
 
         fs::create_dir_all(dir.join("plan-a")).unwrap();
 
-        let result = server.handle_plan_read_note(PlanReadNoteParams {
-            plan: "plan-a".to_string(),
-            note_id: "deadbeef".to_string(),
-        });
+        let result = server
+            .handle_plan_read_note(PlanReadNoteParams {
+                plan: "plan-a".to_string(),
+                note_id: "deadbeef".to_string(),
+            })
+            .await;
         assert!(result.is_err());
     }
 
-    #[test]
-    fn plan_read_note_normalizes_note_id_variants() {
+    #[tokio::test]
+    async fn plan_read_note_normalizes_note_id_variants() {
         let dir = temp_test_dir("plan-read-note-normalizes");
         let server = TodoServer::new(dir.clone());
 
@@ -1877,6 +1908,7 @@ mod tests {
                 name: "plan-a".to_string(),
                 text: "normalized note text".to_string(),
             })
+            .await
             .unwrap();
         let summary = extract_text(add_result);
         let note_id = summary.split_whitespace().nth(2).unwrap().to_string();
@@ -1891,14 +1923,15 @@ mod tests {
                     plan: "plan-a".to_string(),
                     note_id: variant,
                 })
+                .await
                 .unwrap();
             let content = extract_text(read_result);
             assert!(content.contains("normalized note text"));
         }
     }
 
-    #[test]
-    fn read_plan_returns_json_for_note_only_plan() {
+    #[tokio::test]
+    async fn read_plan_returns_json_for_note_only_plan() {
         let dir = temp_test_dir("read-plan-note-only");
         let server = TodoServer::new(dir.clone());
 
@@ -1907,12 +1940,14 @@ mod tests {
                 name: "note-only-plan".to_string(),
                 text: "orphan note".to_string(),
             })
+            .await
             .unwrap();
 
         let read_result = server
             .handle_plan_read(PlanReadParams {
                 name: "note-only-plan".to_string(),
             })
+            .await
             .unwrap();
         let overview: Value = serde_json::from_str(&extract_text(read_result)).unwrap();
 

--- a/crates/harnx-mcp-todo/src/server.rs
+++ b/crates/harnx-mcp-todo/src/server.rs
@@ -409,7 +409,11 @@ impl_json_schema!(
     "PlanReadNoteParams",
     |gen: &mut SchemaGenerator| vec![
         ("plan", "Plan name or ID", gen.subschema_for::<String>()),
-        ("note_id", "Note ID (8-hex string or note-<id> prefix)", gen.subschema_for::<String>()),
+        (
+            "note_id",
+            "Note ID (8-hex string or note-<id> prefix)",
+            gen.subschema_for::<String>()
+        ),
     ],
     &["plan", "note_id"]
 );
@@ -985,7 +989,10 @@ impl TodoServer {
         ))
     }
 
-    fn handle_plan_read_note(&self, params: PlanReadNoteParams) -> Result<CallToolResult, ErrorData> {
+    fn handle_plan_read_note(
+        &self,
+        params: PlanReadNoteParams,
+    ) -> Result<CallToolResult, ErrorData> {
         let plan = normalize_plan_name(&params.plan)
             .map_err(|err| ErrorData::invalid_params(err, None))?;
         let raw_id = params.note_id.trim();
@@ -997,7 +1004,10 @@ impl TodoServer {
         let content = std::fs::read_to_string(&path).map_err(|_| {
             ErrorData::invalid_params(format!("note '{id}' not found in plan '{plan}'"), None)
         })?;
-        Ok(result_text(content, format!("Read note {id} in plan {plan}")))
+        Ok(result_text(
+            content,
+            format!("Read note {id} in plan {plan}"),
+        ))
     }
 }
 
@@ -1783,11 +1793,7 @@ mod tests {
             })
             .unwrap();
         let note_summary = extract_text(note_result);
-        let note_id = note_summary
-            .split_whitespace()
-            .nth(2)
-            .unwrap()
-            .to_string();
+        let note_id = note_summary.split_whitespace().nth(2).unwrap().to_string();
 
         let todo_result = server
             .handle_create(TodoCreateParams {

--- a/docs/solutions/integration-issues/plan-note-file-storage-2026-05-03.md
+++ b/docs/solutions/integration-issues/plan-note-file-storage-2026-05-03.md
@@ -1,0 +1,186 @@
+---
+title: "Plan note file storage with per-note files and JSON overview for read_plan"
+date: 2026-05-03
+category: integration-issues
+problem_type: integration_issue
+component: harnx-mcp-todo
+root_cause: plan_add_note appended to plan.md instead of writing dedicated note files; read_plan returned raw text instead of structured JSON
+resolution_type: code_fix
+severity: medium
+tags:
+  - mcp-tools
+  - plan-notes
+  - json-response
+  - file-per-note
+plan_ref: fix-plan-add-note
+---
+
+## Problem
+
+`plan_add_note` incorrectly appended notes to `plan.md` instead of writing dedicated `note-<id>.md` files. `read_plan` returned raw `plan.md` text, forcing consumers to parse it themselves. No tool existed to read a specific note by ID.
+
+## Symptoms
+
+- Calling `plan_add_note` multiple times modified `plan.md` with appended `### Note` sections
+- No `note-*.md` files created in plan directory
+- No way to enumerate or read individual notes
+- `read_plan` consumers had to parse raw markdown text
+
+## Investigation Steps
+
+Reviewed `handle_plan_add_note` in `server.rs` — confirmed it appended to `plan.md`. Traced PR #424 which established `todo-<id>.md` pattern for todos. Issue #392 specified same pattern for notes but wasn't implemented. Executed `cargo test -p harnx-mcp-todo` — existing test `plan_add_note_creates_missing_plan_file` failed on expected summary format, confirming old behavior.
+
+## Root Cause
+
+Design oversight: `plan_add_note` predated the per-file pattern. `read_plan` returned raw text because no JSON structure was specified. The note functionality needed:
+
+1. `note_file_path()` helper (parallel to `todo_file_path()`)
+2. `handle_plan_add_note` to write `note-<id>.md` files
+3. `handle_plan_read` to scan directory and return JSON overview
+4. New `plan_read_note` tool to read note content by ID
+
+## Solution
+
+### 1. Note File Path Helper
+
+```rust
+fn note_file_path(dir: &Path, plan_name: &str, id: &str) -> PathBuf {
+    plan_dir(dir, plan_name).join(format!("note-{}.md", id))
+}
+```
+
+### 2. Fixed `handle_plan_add_note`
+
+```rust
+fn handle_plan_add_note(&self, params: PlanAddNoteParams) -> Result<CallToolResult, ErrorData> {
+    let name = normalize_plan_name(&params.name)
+        .map_err(|err| ErrorData::invalid_params(err, None))?;
+    let id = generate_id();
+    let dir = plan_dir(&self.dir, &name);
+    std::fs::create_dir_all(&dir).map_err(|err| {
+        ErrorData::internal_error(format!("failed to create {}: {err}", dir.display()), None)
+    })?;
+    let path = note_file_path(&self.dir, &name, &id);
+    std::fs::write(&path, &params.text).map_err(|err| {
+        ErrorData::internal_error(format!("failed to write {}: {err}", path.display()), None)
+    })?;
+    Ok(result_text(
+        format!("Created note {id} in plan {name}"),
+        format!("Created note {id} in plan {name}"),
+    ))
+}
+```
+
+### 3. Enhanced `handle_plan_read` with JSON Response
+
+```rust
+fn handle_plan_read(&self, params: PlanReadParams) -> Result<CallToolResult, ErrorData> {
+    let name = normalize_plan_name(&params.name)
+        .map_err(|err| ErrorData::invalid_params(err, None))?;
+    let path = plan_file_path(&self.dir, &name);
+    let dir = plan_dir(&self.dir, &name);
+    if !dir.exists() {
+        return Err(ErrorData::invalid_params(
+            format!("plan '{name}' not found"),
+            None,
+        ));
+    }
+    let content = match std::fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(err) => {
+            return Err(ErrorData::internal_error(
+                format!("failed to read {}: {err}", path.display()),
+                None,
+            ))
+        }
+    };
+    let mut note_ids = Vec::new();
+    let mut todo_ids = Vec::new();
+
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let file_name = entry.file_name().to_string_lossy().into_owned();
+            if let Some(note_id) = file_name
+                .strip_prefix("note-")
+                .and_then(|name| name.strip_suffix(".md"))
+            {
+                note_ids.push(note_id.to_string());
+            } else if let Some(todo_id) = file_name
+                .strip_prefix("todo-")
+                .and_then(|name| name.strip_suffix(".md"))
+            {
+                todo_ids.push(todo_id.to_string());
+            }
+        }
+    }
+
+    note_ids.sort();
+    todo_ids.sort();
+
+    Ok(result_json(
+        json!({
+            "plan": name,
+            "content": content,
+            "note_ids": note_ids,
+            "todo_ids": todo_ids,
+        }),
+        format!("Read plan {name}"),
+    ))
+}
+```
+
+### 4. New `plan_read_note` Tool
+
+```rust
+struct PlanReadNoteParams {
+    plan: String,
+    note_id: String,
+}
+
+fn handle_plan_read_note(&self, params: PlanReadNoteParams) -> Result<CallToolResult, ErrorData> {
+    let plan = normalize_plan_name(&params.plan)
+        .map_err(|err| ErrorData::invalid_params(err, None))?;
+    let raw_id = params.note_id.trim();
+    let id = raw_id
+        .strip_prefix("note-")
+        .unwrap_or(raw_id)
+        .to_ascii_lowercase();
+    let path = note_file_path(&self.dir, &plan, &id);
+    let content = std::fs::read_to_string(&path).map_err(|_| {
+        ErrorData::invalid_params(format!("note '{id}' not found in plan '{plan}'"), None)
+    })?;
+    Ok(result_text(content, format!("Read note {id} in plan {plan}")))
+}
+```
+
+## Why This Works
+
+**Per-file notes**: Each note gets `note-<id>.md` — independent lifecycle, no merge conflicts, easy enumeration via directory scan.
+
+**JSON overview**: `{plan, content, note_ids, todo_ids}` gives consumers structured data without parsing markdown. Bare IDs (`abcd1234`) without prefix — cleaner API.
+
+**Note-only plans**: `handle_plan_read` checks directory existence before `plan.md`. Plan dir exists without `plan.md` = valid (returns `content: ""`). Enables note-first workflows.
+
+**Defensive normalization**: `handle_plan_read_note` trims whitespace, strips `note-` prefix if caller provides it, lowercases for case-insensitive matching. Order matters: strip before lowercase to handle mixed-case prefixes.
+
+## Prevention Strategies
+
+**Test Cases:**
+- `plan_add_note` creates `note-<id>.md`, never touches `plan.md`
+- `plan_add_note` multiple times creates separate files
+- `read_plan` returns JSON with correct `note_ids` and `todo_ids`
+- `read_plan` handles missing `plan.md` (returns empty content)
+- `read_plan` errors when plan directory missing
+- `plan_read_note` normalizes `note-` prefix, whitespace, case
+
+**Code Review Checklist:**
+- [ ] Does `handle_plan_read` check directory before `plan.md`?
+- [ ] Does note ID normalization handle prefix case correctly?
+- [ ] Are note files plain markdown (no YAML frontmatter)?
+
+## Related Issues
+
+- **Plan:** fix-plan-add-note
+- **Issue:** [#392](https://github.com/dobesv/harnx/issues/392)
+- **Prior Solution:** [logic-errors/mcp-todo-fs-restructure-2026-05-01.md](../logic-errors/mcp-todo-fs-restructure-2026-05-01.md) — established `todo-<id>.md` pattern and YAML frontmatter


### PR DESCRIPTION
## Summary

Rewrites `plan_add_note` to store notes in individual `note-<id>.md` files instead of appending sections to `plan.md`. Upgrades `read_plan` to return a JSON overview and adds a new `plan_read_note` tool.

Closes #392

## Changes

- **`plan_add_note`**: generates an 8-hex ID, writes `note-<id>.md` (plain markdown, no YAML frontmatter) in the plan directory. Never touches `plan.md`.
- **`read_plan`**: returns `{plan, content, note_ids, todo_ids}` JSON. Scans plan dir for `note-*.md` / `todo-*.md`, exposes bare sorted IDs. Tolerates missing `plan.md` (note-first workflow returns `content: ""`).
- **New `plan_read_note` tool**: reads a note by ID (`{plan, note_id}` params). Strips `note-` prefix defensively.
- **18 tests**, 0 failures — including note creation, multiple notes, JSON overview, note read, normalization variants, and note-only plan.

## Non-obvious details
- Plan directory without `plan.md` is valid — `read_plan` returns empty content with any note/todo IDs present
- `read_plan` contract change: now returns JSON instead of raw markdown (intentional per #392)
- Known non-blocking: `NOTE-` uppercase prefix in `note_id` not handled — will be addressed as follow-up

Plan: fix-plan-add-note

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Notes are now stored as individual files per plan, improving organization and management
  * Added flexible note identification with automatic format normalization
  * Plan information now includes structured lists of associated notes and todos

* **Documentation**
  * Added specification for note file storage and management approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->