### PR TITLE
fix(tui): agent/session picker — filter, correct sessions, ESC new se…

### DIFF
--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1554,10 +1554,15 @@ impl Tui {
                 }
             }
             KeyCode::Down => {
-                if let Some(crate::types::ModalState::AgentPicker { selected, agents }) =
-                    self.app.modal.as_mut()
+                if let Some(crate::types::ModalState::AgentPicker {
+                    selected,
+                    agents,
+                    query,
+                }) = self.app.modal.as_mut()
                 {
-                    if *selected + 1 < agents.len() {
+                    let filtered_len =
+                        crate::types::ModalState::filtered_agents(agents, query).len();
+                    if *selected + 1 < filtered_len {
                         *selected += 1;
                     }
                 } else if let Some(crate::types::ModalState::SessionPicker {
@@ -1574,48 +1579,72 @@ impl Tui {
             KeyCode::Enter => {
                 let modal = self.app.modal.take();
                 match modal {
-                    Some(crate::types::ModalState::AgentPicker { agents, selected }) => {
-                        if selected < agents.len() {
-                            let agent_name = agents[selected].clone();
+                    Some(crate::types::ModalState::AgentPicker {
+                        agents,
+                        selected,
+                        query,
+                    }) => {
+                        // Resolve the selected index against the filtered list.
+                        let filtered = crate::types::ModalState::filtered_agents(&agents, &query);
+                        let filtered: Vec<&str> = filtered.iter().map(|a| a.as_str()).collect();
+                        if selected >= filtered.len() {
+                            // Nothing valid selected (e.g. filter yields empty list) —
+                            // keep the picker open so the user can adjust the query.
+                            self.app.modal = Some(crate::types::ModalState::AgentPicker {
+                                agents,
+                                selected,
+                                query,
+                            });
+                        } else {
+                            let agent_name = filtered[selected].to_string();
 
-                            let sessions: Vec<_> = self
+                            let prev_session = self
                                 .config
                                 .read()
-                                .list_sessions_with_meta()
-                                .into_iter()
-                                .collect();
+                                .session
+                                .as_ref()
+                                .map(|s| s.id().to_string());
+                            let prev_agent = self
+                                .config
+                                .read()
+                                .agent
+                                .as_ref()
+                                .map(|a| a.name().to_string());
+
+                            // Activate the agent immediately so sessions_dir() is
+                            // already scoped to the correct per-agent directory.
+                            if let Err(e) = self.config.write().use_agent_by_name(&agent_name) {
+                                self.app.modal = Some(crate::types::ModalState::AgentPicker {
+                                    agents,
+                                    selected,
+                                    query,
+                                });
+                                return Err(e);
+                            }
+
+                            let sessions = self.config.read().list_sessions_with_meta();
                             if !sessions.is_empty() {
-                                // Defer use_agent_by_name until the session is confirmed so
-                                // that cancelling the session picker leaves state unchanged.
                                 let ctx = build_picker_context();
                                 let sessions = sort_sessions_for_picker(sessions, &ctx);
+                                // Carry the pre-activation origin state into SessionPicker so
+                                // reconcile_transcript_after_command sees the full transition.
                                 self.app.modal = Some(crate::types::ModalState::SessionPicker {
                                     sessions,
                                     selected: 0,
-                                    pending_agent: Some(agent_name),
+                                    origin_agent: prev_agent,
+                                    origin_session: prev_session,
                                 });
                             } else {
-                                // No sessions — commit the agent immediately and start fresh.
-                                let prev_session = self
-                                    .config
-                                    .read()
-                                    .session
-                                    .as_ref()
-                                    .map(|s| s.id().to_string());
-                                let prev_agent = self
-                                    .config
-                                    .read()
-                                    .agent
-                                    .as_ref()
-                                    .map(|a| a.name().to_string());
-                                if let Err(e) = self.config.write().use_agent_by_name(&agent_name) {
+                                // No sessions — start a fresh one right away.
+                                if let Err(e) = self.config.write().use_session(None) {
+                                    // Restore AgentPicker so the user can try again.
                                     self.app.modal = Some(crate::types::ModalState::AgentPicker {
                                         agents,
                                         selected,
+                                        query,
                                     });
                                     return Err(e);
                                 }
-                                self.config.write().use_session(None)?;
                                 let llm_busy = self.app.llm_busy;
                                 let pending = self.app.pending_message.is_some();
                                 Self::refresh_input_chrome_from_state(
@@ -1635,41 +1664,26 @@ impl Tui {
                     Some(crate::types::ModalState::SessionPicker {
                         sessions,
                         selected,
-                        pending_agent,
+                        origin_agent,
+                        origin_session,
                     }) => {
-                        if selected < sessions.len() {
+                        if selected >= sessions.len() {
+                            // Index out of range — keep picker open.
+                            self.app.modal = Some(crate::types::ModalState::SessionPicker {
+                                sessions,
+                                selected,
+                                origin_agent,
+                                origin_session,
+                            });
+                        } else {
                             let session_name = sessions[selected].id.clone();
-                            let prev_session = self
-                                .config
-                                .read()
-                                .session
-                                .as_ref()
-                                .map(|s| s.id().to_string());
-                            let prev_agent = self
-                                .config
-                                .read()
-                                .agent
-                                .as_ref()
-                                .map(|a| a.name().to_string());
-
-                            // Apply deferred agent selection before loading session.
-                            if let Some(ref agent_name) = pending_agent {
-                                if let Err(e) = self.config.write().use_agent_by_name(agent_name) {
-                                    self.app.modal =
-                                        Some(crate::types::ModalState::SessionPicker {
-                                            sessions,
-                                            selected,
-                                            pending_agent,
-                                        });
-                                    return Err(e);
-                                }
-                            }
 
                             if let Err(e) = self.config.write().use_session(Some(&session_name)) {
                                 self.app.modal = Some(crate::types::ModalState::SessionPicker {
                                     sessions,
                                     selected,
-                                    pending_agent,
+                                    origin_agent,
+                                    origin_session,
                                 });
                                 return Err(e);
                             }
@@ -1682,9 +1696,11 @@ impl Tui {
                                 llm_busy,
                                 pending,
                             );
+                            // Use origin_* to reflect the full transition from the start
+                            // of the picker flow (not just the session half of the switch).
                             self.reconcile_transcript_after_command(
-                                prev_session,
-                                prev_agent,
+                                origin_session,
+                                origin_agent,
                                 ".session",
                             );
                         }
@@ -1695,9 +1711,64 @@ impl Tui {
                 }
             }
             KeyCode::Esc => {
-                // Simply dismiss the picker — do not create a new session.
-                // A new anonymous session will be created on first message if needed.
-                self.app.modal = None;
+                // ESC on the SessionPicker starts a new session (agent is already
+                // active at this point).  ESC on the AgentPicker just cancels.
+                if let Some(crate::types::ModalState::SessionPicker {
+                    origin_agent,
+                    origin_session,
+                    ..
+                }) = self.app.modal.take()
+                {
+                    // Dismiss modal only after use_session succeeds, so a failure
+                    // does not leave the UI without any active modal or session.
+                    if let Err(e) = self.config.write().use_session(None) {
+                        // Restore a minimal SessionPicker so the user can try again.
+                        self.app.modal = Some(crate::types::ModalState::SessionPicker {
+                            sessions: vec![],
+                            selected: 0,
+                            origin_agent,
+                            origin_session,
+                        });
+                        return Err(e);
+                    }
+                    let llm_busy = self.app.llm_busy;
+                    let pending = self.app.pending_message.is_some();
+                    Self::refresh_input_chrome_from_state(
+                        &self.config,
+                        &mut self.app,
+                        llm_busy,
+                        pending,
+                    );
+                    self.reconcile_transcript_after_command(
+                        origin_session,
+                        origin_agent,
+                        ".session",
+                    );
+                } else {
+                    self.app.modal = None;
+                }
+            }
+
+            // Typing characters filters the AgentPicker list.
+            KeyCode::Char(c)
+                if key.modifiers == KeyModifiers::NONE || key.modifiers == KeyModifiers::SHIFT =>
+            {
+                if let Some(crate::types::ModalState::AgentPicker {
+                    query, selected, ..
+                }) = self.app.modal.as_mut()
+                {
+                    query.push(c);
+                    *selected = 0; // reset to top of filtered list
+                }
+            }
+            KeyCode::Backspace => {
+                if let Some(crate::types::ModalState::AgentPicker {
+                    query, selected, ..
+                }) = self.app.modal.as_mut()
+                {
+                    query.pop();
+                    *selected = 0;
+                }
             }
 
             _ => {}

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -125,24 +125,25 @@ impl Tui {
             return Some(ModalState::AgentPicker {
                 agents,
                 selected: 0,
+                query: String::new(),
             });
         } else if config.read().session.is_none() {
+            // sessions_dir() is already scoped to the active agent, so no
+            // extra agent_name filter is needed here.
             let sessions = config.read().list_sessions_with_meta();
-            let sessions: Vec<_> = if let Some(agent) = config.read().agent.as_ref() {
-                sessions
-                    .into_iter()
-                    .filter(|s| s.agent_name.as_deref() == Some(agent.name()))
-                    .collect()
-            } else {
-                sessions
-            };
             if !sessions.is_empty() {
                 let ctx = build_picker_context();
                 let sorted = sort_sessions_for_picker(sessions, &ctx);
+                // Opened directly (agent already configured, no picker transition).
+                // origin_* reflect current state so reconciliation sees the correct
+                // before/after diff when a session is selected or Esc is pressed.
+                let origin_agent = config.read().agent.as_ref().map(|a| a.name().to_string());
+                let origin_session = config.read().session.as_ref().map(|s| s.id().to_string());
                 return Some(ModalState::SessionPicker {
                     sessions: sorted,
                     selected: 0,
-                    pending_agent: None,
+                    origin_agent,
+                    origin_session,
                 });
             }
         }

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -10,6 +10,16 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 use ratatui::Frame;
 
+/// Options for `render_list_modal` — bundles the three metadata strings so the
+/// function stays within clippy's `too_many_arguments` limit.
+struct ListModalOpts<'a> {
+    title: &'a str,
+    footer: &'a str,
+    /// Optional live-filter query. When `Some`, renders a `🔍 <query>█` search
+    /// row above the list and a "No matches" placeholder when the list is empty.
+    query: Option<&'a str>,
+}
+
 impl Tui {
     fn render_text_entry(
         prefix: &str,
@@ -774,11 +784,25 @@ impl Tui {
                 let prompt_text = format!("Rewind to entry {}? [y/N]", seq);
                 self.render_simple_modal(frame, screen_size, &prompt_text);
             }
-            ModalState::AgentPicker { agents, selected } => {
+            ModalState::AgentPicker {
+                agents,
+                selected,
+                query,
+            } => {
                 let title = "Select Agent";
-                let footer = "↑↓ navigate  Enter select  Esc cancel";
-                let items: Vec<String> = agents.clone();
-                self.render_list_modal(frame, screen_size, title, footer, &items, *selected);
+                let footer = "type to filter  ↑↓ navigate  Enter select  Esc cancel";
+                let items = ModalState::filtered_agents(agents, query);
+                self.render_list_modal(
+                    frame,
+                    screen_size,
+                    &items,
+                    *selected,
+                    ListModalOpts {
+                        title,
+                        footer,
+                        query: Some(query),
+                    },
+                );
             }
             ModalState::SessionPicker {
                 sessions, selected, ..
@@ -802,7 +826,17 @@ impl Tui {
                         format!("{}  {}  {}", s.id, branch, cwd_tail)
                     })
                     .collect();
-                self.render_list_modal(frame, screen_size, title, footer, &items, *selected);
+                self.render_list_modal(
+                    frame,
+                    screen_size,
+                    &items,
+                    *selected,
+                    ListModalOpts {
+                        title,
+                        footer,
+                        query: None,
+                    },
+                );
             }
         }
     }
@@ -840,19 +874,28 @@ impl Tui {
         &self,
         frame: &mut Frame<'_>,
         screen_size: ratatui::layout::Rect,
-        title: &str,
-        footer: &str,
         items: &[String],
         selected: usize,
+        opts: ListModalOpts<'_>,
     ) {
+        let ListModalOpts {
+            title,
+            footer,
+            query,
+        } = opts;
         let max_item_len = items.iter().map(|s| s.len()).max().unwrap_or(0);
+        // Search row looks like "🔍 <query>█"; ensure minimum comfortable width.
+        let query_row_width: u16 = query.map(|q| (q.len() as u16 + 4).max(24)).unwrap_or(0);
         let modal_width = (max_item_len as u16 + 6)
             .max(title.len() as u16 + 4)
             .max(footer.len() as u16 + 4)
+            .max(query_row_width)
             .min(screen_size.width.saturating_sub(4));
 
         let visible_count = items.len().min(10);
-        let modal_height = (visible_count as u16 + 4).min(screen_size.height.saturating_sub(4));
+        let search_rows: u16 = if query.is_some() { 2 } else { 0 };
+        let list_rows = visible_count.max(usize::from(query.is_some() && items.is_empty())) as u16;
+        let modal_height = (list_rows + 4 + search_rows).min(screen_size.height.saturating_sub(4));
 
         let modal_x = (screen_size.width.saturating_sub(modal_width)) / 2;
         let modal_y = (screen_size.height.saturating_sub(modal_height)) / 2;
@@ -862,17 +905,34 @@ impl Tui {
 
         let mut lines = Vec::new();
 
-        let mut start = selected.saturating_sub(4);
-        let end = (start + 10).min(items.len());
-        start = end.saturating_sub(10);
+        // Search input row with magnifying-glass icon and simulated cursor.
+        if let Some(q) = query {
+            lines.push(Line::from(vec![
+                Span::styled("🔍 ", Style::default().fg(Color::Yellow)),
+                Span::styled(q.to_string(), Style::default().fg(Color::Reset)),
+                Span::styled("█", Style::default().fg(Color::Yellow)),
+            ]));
+            lines.push(Line::from(""));
+        }
 
-        for (i, item) in items.iter().enumerate().skip(start).take(10) {
-            let style = if i == selected {
-                Style::default().add_modifier(Modifier::REVERSED)
-            } else {
-                Style::default()
-            };
-            lines.push(Line::from(Span::styled(item.clone(), style)));
+        if items.is_empty() && query.is_some() {
+            lines.push(Line::from(Span::styled(
+                "No matches",
+                Style::default().fg(Color::DarkGray),
+            )));
+        } else {
+            let mut start = selected.saturating_sub(4);
+            let end = (start + 10).min(items.len());
+            start = end.saturating_sub(10);
+
+            for (i, item) in items.iter().enumerate().skip(start).take(10) {
+                let style = if i == selected {
+                    Style::default().add_modifier(Modifier::REVERSED)
+                } else {
+                    Style::default()
+                };
+                lines.push(Line::from(Span::styled(item.clone(), style)));
+            }
         }
 
         // Empty line

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -5682,3 +5682,632 @@ async fn test_picker_shown_when_no_agent_and_agents_exist() {
         "resolve_initial_modal must return a valid modal state"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Picker tests — AgentPicker filtering, SessionPicker ESC, agent activation
+// ---------------------------------------------------------------------------
+
+/// Process-wide async mutex that serialises tests which mutate `HARNX_CONFIG_DIR`.
+/// Env vars are process-global, so concurrent tests that each set their own
+/// temp dir would race.  Using `tokio::sync::Mutex` lets the guard be held
+/// safely across `.await` points (unlike `std::sync::Mutex`).
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// RAII guard that sets an env var for the duration of the test and restores
+/// the original value (or removes it) on drop.  Callers must hold `ENV_LOCK`
+/// for the duration the guard is alive.
+struct EnvGuard {
+    key: &'static str,
+    prior: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prior = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, prior }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.prior {
+            Some(v) => std::env::set_var(self.key, v),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+/// Build a minimal config for picker tests (alias for `test_config`).
+fn picker_test_config() -> GlobalConfig {
+    test_config()
+}
+
+/// Create agent .md stub files and return a list of agent names.
+fn create_agent_stubs(agents_dir: &std::path::Path, names: &[&str]) {
+    std::fs::create_dir_all(agents_dir).unwrap();
+    for name in names {
+        let f = agents_dir.join(format!("{name}.md"));
+        std::fs::write(f, format!("# {name}")).unwrap();
+    }
+}
+
+/// Create a minimal session .yaml stub for the given agent.
+/// The file must begin with a `type: header` YAML document so that
+/// `parse_session_meta` recognises it as a valid session header.
+fn create_session_stub(config_dir: &std::path::Path, agent_name: &str, session_id: &str) {
+    let dir = config_dir.join("agents").join(agent_name).join("sessions");
+    std::fs::create_dir_all(&dir).unwrap();
+    let content = format!(
+        "type: header\nmodel: test-model\nagent_name: {agent_name}\nworking_dir: /tmp\ngit_branch: main\n"
+    );
+    std::fs::write(dir.join(format!("{session_id}.yaml")), content).unwrap();
+}
+
+// --- AgentPicker filtering ---------------------------------------------------
+
+#[tokio::test]
+async fn agent_picker_typing_filters_list() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+    create_agent_stubs(&tmp.path().join("agents"), &["apollo", "argus", "hermes"]);
+
+    let config = picker_test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    // Manually set up AgentPicker with all three agents.
+    tui.app.modal = Some(crate::types::ModalState::AgentPicker {
+        agents: vec!["apollo".into(), "argus".into(), "hermes".into()],
+        selected: 0,
+        query: String::new(),
+    });
+
+    // Type "a" — should filter to ["apollo", "argus"].
+    tui.handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    match &tui.app.modal {
+        Some(crate::types::ModalState::AgentPicker {
+            query, selected, ..
+        }) => {
+            assert_eq!(query, "a");
+            assert_eq!(*selected, 0, "selection resets to 0 on filter change");
+        }
+        other => panic!("expected AgentPicker, got {other:?}"),
+    }
+
+    // Verify the filtered list via the helper.
+    let agents = vec![
+        "apollo".to_string(),
+        "argus".to_string(),
+        "hermes".to_string(),
+    ];
+    let filtered = crate::types::ModalState::filtered_agents(&agents, "a");
+    assert_eq!(filtered, vec!["apollo", "argus"]);
+}
+
+#[tokio::test]
+async fn agent_picker_filter_is_case_insensitive() {
+    let agents = vec![
+        "Apollo".to_string(),
+        "ARGUS".to_string(),
+        "hermes".to_string(),
+    ];
+    let filtered = crate::types::ModalState::filtered_agents(&agents, "ap");
+    assert_eq!(filtered, vec!["Apollo"]);
+
+    let filtered_upper = crate::types::ModalState::filtered_agents(&agents, "AP");
+    assert_eq!(filtered_upper, vec!["Apollo"]);
+}
+
+#[tokio::test]
+async fn agent_picker_empty_query_shows_all() {
+    let agents = vec![
+        "apollo".to_string(),
+        "argus".to_string(),
+        "hermes".to_string(),
+    ];
+    let filtered = crate::types::ModalState::filtered_agents(&agents, "");
+    assert_eq!(filtered.len(), 3);
+}
+
+#[tokio::test]
+async fn agent_picker_no_match_query_returns_empty() {
+    let agents = vec!["apollo".to_string(), "hermes".to_string()];
+    let filtered = crate::types::ModalState::filtered_agents(&agents, "zzz");
+    assert!(filtered.is_empty());
+}
+
+#[tokio::test]
+async fn agent_picker_backspace_removes_char_and_resets_selection() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    let config = picker_test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.app.modal = Some(crate::types::ModalState::AgentPicker {
+        agents: vec!["apollo".into(), "argus".into()],
+        selected: 1,
+        query: "ar".into(),
+    });
+
+    tui.handle_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    match &tui.app.modal {
+        Some(crate::types::ModalState::AgentPicker {
+            query, selected, ..
+        }) => {
+            assert_eq!(query, "a");
+            assert_eq!(*selected, 0);
+        }
+        other => panic!("expected AgentPicker, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn agent_picker_down_bounded_by_filtered_count() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    let config = picker_test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    // query "a" filters to ["apollo","argus"] — 2 items.
+    tui.app.modal = Some(crate::types::ModalState::AgentPicker {
+        agents: vec!["apollo".into(), "argus".into(), "hermes".into()],
+        selected: 0,
+        query: "a".into(),
+    });
+
+    // Down once → index 1 (last in filtered list).
+    tui.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+        .await
+        .unwrap();
+    let sel1 = match &tui.app.modal {
+        Some(crate::types::ModalState::AgentPicker { selected, .. }) => *selected,
+        _ => panic!("expected AgentPicker"),
+    };
+    assert_eq!(sel1, 1);
+
+    // Down again → should NOT advance past filtered count.
+    tui.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+        .await
+        .unwrap();
+    let sel2 = match &tui.app.modal {
+        Some(crate::types::ModalState::AgentPicker { selected, .. }) => *selected,
+        _ => panic!("expected AgentPicker"),
+    };
+    assert_eq!(sel2, 1, "should not advance past end of filtered list");
+}
+
+#[tokio::test]
+async fn agent_picker_enter_on_empty_filter_does_nothing() {
+    // When the filter yields no matches, Enter should be a no-op (modal stays open).
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    let config = picker_test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.app.modal = Some(crate::types::ModalState::AgentPicker {
+        agents: vec!["apollo".into()],
+        selected: 0,
+        query: "zzz".into(), // no matches
+    });
+
+    tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    // Modal must stay open — pressing Enter with no filtered matches should be a no-op,
+    // not close the picker and leave the user stranded.
+    assert!(
+        matches!(
+            tui.app.modal,
+            Some(crate::types::ModalState::AgentPicker { .. })
+        ),
+        "AgentPicker should remain open when Enter is pressed with no matching items, got {:?}",
+        tui.app.modal
+    );
+}
+
+// --- AgentPicker → immediate agent activation --------------------------------
+
+#[tokio::test]
+async fn agent_picker_enter_activates_agent_immediately() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    // Create a real agent .md file so use_agent_by_name succeeds.
+    let agents_dir = tmp.path().join("agents");
+    create_agent_stubs(&agents_dir, &["hermes"]);
+
+    let config = picker_test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.app.modal = Some(crate::types::ModalState::AgentPicker {
+        agents: vec!["hermes".into()],
+        selected: 0,
+        query: String::new(),
+    });
+
+    tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    // Agent should be activated immediately on config.
+    let agent_name = config.read().agent.as_ref().map(|a| a.name().to_string());
+    assert_eq!(
+        agent_name.as_deref(),
+        Some("hermes"),
+        "agent must be set immediately on Enter"
+    );
+}
+
+#[tokio::test]
+async fn agent_picker_enter_with_no_sessions_starts_new_session() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    create_agent_stubs(&tmp.path().join("agents"), &["hermes"]);
+    // No session files created → no sessions for this agent.
+
+    let config = picker_test_config();
+    {
+        let mut guard = config.write();
+        guard.sessions_dir_override =
+            Some(tmp.path().join("agents").join("hermes").join("sessions"));
+    }
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.app.modal = Some(crate::types::ModalState::AgentPicker {
+        agents: vec!["hermes".into()],
+        selected: 0,
+        query: String::new(),
+    });
+
+    tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    // Modal dismissed, agent set, and a new session created.
+    assert!(tui.app.modal.is_none(), "modal should be dismissed");
+    assert!(
+        config.read().session.is_some(),
+        "a new session should have been created"
+    );
+}
+
+#[tokio::test]
+async fn agent_picker_enter_with_sessions_shows_session_picker() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    create_agent_stubs(&tmp.path().join("agents"), &["hermes"]);
+    create_session_stub(tmp.path(), "hermes", "session-001");
+
+    let config = picker_test_config();
+    {
+        let mut guard = config.write();
+        // Override sessions dir to the hermes-specific path.
+        guard.sessions_dir_override =
+            Some(tmp.path().join("agents").join("hermes").join("sessions"));
+    }
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.app.modal = Some(crate::types::ModalState::AgentPicker {
+        agents: vec!["hermes".into()],
+        selected: 0,
+        query: String::new(),
+    });
+
+    tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    // Agent activated, SessionPicker should now be open.
+    let agent_name = config.read().agent.as_ref().map(|a| a.name().to_string());
+    assert_eq!(agent_name.as_deref(), Some("hermes"));
+    assert!(
+        matches!(
+            tui.app.modal,
+            Some(crate::types::ModalState::SessionPicker { .. })
+        ),
+        "expected SessionPicker after AgentPicker Enter with existing sessions, got {:?}",
+        tui.app.modal
+    );
+}
+
+// --- SessionPicker ESC creates new session -----------------------------------
+
+#[tokio::test]
+async fn session_picker_esc_creates_new_session() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    let config = picker_test_config();
+    {
+        let mut guard = config.write();
+        guard.sessions_dir_override = Some(tmp.path().join("sessions"));
+        // Give config a minimal agent so use_session doesn't fail on agent checks.
+        let model = MockClient::builder().build().model().clone();
+        let mut agent =
+            harnx_runtime::config::Agent::new(harnx_runtime::config::AgentConfig::from_prompt(""));
+        agent.set_name("hermes");
+        agent.set_model(model);
+        guard.agent = Some(agent);
+    }
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.app.modal = Some(crate::types::ModalState::SessionPicker {
+        sessions: vec![],
+        selected: 0,
+        origin_agent: None,
+        origin_session: None,
+    });
+
+    tui.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert!(
+        tui.app.modal.is_none(),
+        "modal should be dismissed after Esc"
+    );
+    assert!(
+        config.read().session.is_some(),
+        "Esc on SessionPicker must create a new session"
+    );
+}
+
+#[tokio::test]
+async fn agent_picker_esc_does_not_create_session() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    let config = picker_test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.app.modal = Some(crate::types::ModalState::AgentPicker {
+        agents: vec!["apollo".into()],
+        selected: 0,
+        query: String::new(),
+    });
+
+    tui.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert!(
+        tui.app.modal.is_none(),
+        "AgentPicker Esc should dismiss modal"
+    );
+    assert!(
+        config.read().session.is_none(),
+        "AgentPicker Esc must NOT create a session"
+    );
+}
+
+// --- SessionPicker Enter picks session ---------------------------------------
+
+#[tokio::test]
+async fn session_picker_enter_loads_selected_session() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    let sessions_dir = tmp.path().join("sessions");
+    std::fs::create_dir_all(&sessions_dir).unwrap();
+    // Use old (non-log) format so session::load takes the "old format" path
+    // and doesn't try to validate the model name against registered clients.
+    // All we need here is for the file to exist so use_session picks it up.
+    std::fs::write(sessions_dir.join("my-session.yaml"), "# old format stub\n").unwrap();
+
+    let config = picker_test_config();
+    {
+        let mut guard = config.write();
+        guard.sessions_dir_override = Some(sessions_dir.clone());
+        let model = MockClient::builder().build().model().clone();
+        let mut agent =
+            harnx_runtime::config::Agent::new(harnx_runtime::config::AgentConfig::from_prompt(""));
+        agent.set_name("hermes");
+        agent.set_model(model);
+        guard.agent = Some(agent);
+    }
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    let meta = harnx_runtime::config::SessionMeta {
+        id: "my-session".into(),
+        agent_name: Some("hermes".into()),
+        working_dir: Some("/tmp".into()),
+        git_branch: Some("main".into()),
+        git_remote: None,
+        session_id: None,
+        terminal_session_id: None,
+        modified: None,
+    };
+
+    tui.app.modal = Some(crate::types::ModalState::SessionPicker {
+        sessions: vec![meta],
+        selected: 0,
+        origin_agent: None,
+        origin_session: None,
+    });
+
+    tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert!(
+        tui.app.modal.is_none(),
+        "modal should be dismissed after Enter"
+    );
+    let session_id = config.read().session.as_ref().map(|s| s.id().to_string());
+    assert_eq!(
+        session_id.as_deref(),
+        Some("my-session"),
+        "selected session should be loaded"
+    );
+}
+
+// --- Reconciliation: origin_* baseline is used, not post-activation state ---
+
+#[tokio::test]
+async fn session_picker_enter_reconciles_from_origin_not_current_agent() {
+    // This test verifies the transcript reconciliation fix: when the user goes
+    // through AgentPicker → SessionPicker, the reconciliation must compare
+    // against the state *before* agent activation (origin_*), not against the
+    // already-mutated post-activation state.
+    //
+    // Setup: config already has agent "hermes" active (simulates post-activation).
+    //        SessionPicker carries origin_agent = Some("apollo") (different agent).
+    //        Selecting a session should trigger reconciliation (transcript clear)
+    //        because origin_agent ("apollo") != current_agent ("hermes").
+    //
+    //        If reconciliation used the post-activation agent (hermes == hermes),
+    //        it would be a no-op and the transcript would NOT be cleared — the bug.
+
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    // Create a session file for hermes.
+    let sessions_dir = tmp.path().join("sessions");
+    std::fs::create_dir_all(&sessions_dir).unwrap();
+    std::fs::write(sessions_dir.join("sess-1.yaml"), "# old format stub\n").unwrap();
+
+    let config = picker_test_config();
+    {
+        let mut guard = config.write();
+        guard.sessions_dir_override = Some(sessions_dir.clone());
+        let model = MockClient::builder().build().model().clone();
+        let mut agent =
+            harnx_runtime::config::Agent::new(harnx_runtime::config::AgentConfig::from_prompt(""));
+        agent.set_name("hermes");
+        agent.set_model(model);
+        guard.agent = Some(agent);
+    }
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    // Seed the transcript with a sentinel item so we can detect if it was cleared.
+    tui.app.transcript.push(TranscriptItem::SystemText(
+        "sentinel-pre-reconcile".to_string(),
+    ));
+    assert!(
+        tui.app
+            .transcript
+            .iter()
+            .any(|t| matches!(t, TranscriptItem::SystemText(s) if s == "sentinel-pre-reconcile")),
+        "sentinel should be present before picker action"
+    );
+
+    let meta = harnx_runtime::config::SessionMeta {
+        id: "sess-1".into(),
+        agent_name: Some("hermes".into()),
+        working_dir: Some("/tmp".into()),
+        git_branch: Some("main".into()),
+        git_remote: None,
+        session_id: None,
+        terminal_session_id: None,
+        modified: None,
+    };
+
+    // origin_agent = Some("apollo") simulates "user was on apollo before entering picker".
+    // Current config has "hermes" active (post-activation).
+    // Reconciliation should detect origin("apollo") != current("hermes") → clear transcript.
+    tui.app.modal = Some(crate::types::ModalState::SessionPicker {
+        sessions: vec![meta],
+        selected: 0,
+        origin_agent: Some("apollo".to_string()),
+        origin_session: None,
+    });
+
+    tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert!(tui.app.modal.is_none(), "modal should be dismissed");
+    // Transcript should have been cleared by reconciliation (sentinel gone).
+    assert!(
+        !tui.app
+            .transcript
+            .iter()
+            .any(|t| matches!(t, TranscriptItem::SystemText(s) if s == "sentinel-pre-reconcile")),
+        "transcript should be cleared by reconciliation when origin_agent differs from current agent"
+    );
+}
+
+#[tokio::test]
+async fn session_picker_esc_reconciles_from_origin_not_current_agent() {
+    // Same scenario as above but via Esc (new session) rather than Enter (select session).
+
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    let sessions_dir = tmp.path().join("sessions");
+    std::fs::create_dir_all(&sessions_dir).unwrap();
+
+    let config = picker_test_config();
+    {
+        let mut guard = config.write();
+        guard.sessions_dir_override = Some(sessions_dir.clone());
+        let model = MockClient::builder().build().model().clone();
+        let mut agent =
+            harnx_runtime::config::Agent::new(harnx_runtime::config::AgentConfig::from_prompt(""));
+        agent.set_name("hermes");
+        agent.set_model(model);
+        guard.agent = Some(agent);
+    }
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.app.transcript.push(TranscriptItem::SystemText(
+        "sentinel-esc-reconcile".to_string(),
+    ));
+
+    tui.app.modal = Some(crate::types::ModalState::SessionPicker {
+        sessions: vec![],
+        selected: 0,
+        origin_agent: Some("apollo".to_string()),
+        origin_session: None,
+    });
+
+    tui.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert!(tui.app.modal.is_none(), "modal dismissed after Esc");
+    assert!(config.read().session.is_some(), "new session created");
+    assert!(
+        !tui.app
+            .transcript
+            .iter()
+            .any(|t| matches!(t, TranscriptItem::SystemText(s) if s == "sentinel-esc-reconcile")),
+        "transcript should be cleared by reconciliation when origin_agent differs from current agent"
+    );
+}

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -155,18 +155,36 @@ pub(super) enum ModalState {
     AgentPicker {
         agents: Vec<String>,
         selected: usize,
+        /// Live filter string typed by the user; empty means show all.
+        query: String,
     },
     /// Session selection.
-    /// `pending_agent` carries the agent name chosen in the preceding AgentPicker
-    /// so the agent mutation is deferred until the session is confirmed (or a new
-    /// session is started), keeping state clean if the user cancels.
+    /// The agent is always activated before this picker is shown.
+    /// `origin_agent` / `origin_session` carry the pre-activation agent and
+    /// session names so that `reconcile_transcript_after_command` can detect
+    /// the full agent+session transition when the picker is eventually confirmed
+    /// or dismissed via Esc.
     SessionPicker {
         sessions: Vec<SessionMeta>,
         selected: usize,
-        /// Agent to activate when the session is confirmed. None when the session
-        /// picker was opened directly (agent already set or not applicable).
-        pending_agent: Option<String>,
+        /// Agent name *before* the picker flow started (pre-activation).
+        origin_agent: Option<String>,
+        /// Session id *before* the picker flow started (pre-activation).
+        origin_session: Option<String>,
     },
+}
+
+impl ModalState {
+    /// Return the subset of agents matching the current query (case-insensitive
+    /// substring). Returns all agents when the query is empty.
+    pub(super) fn filtered_agents(agents: &[String], query: &str) -> Vec<String> {
+        let q = query.to_lowercase();
+        agents
+            .iter()
+            .filter(|a| q.is_empty() || a.to_lowercase().contains(&q))
+            .cloned()
+            .collect()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/docs/solutions/integration-issues/session-picker-multi-factor-sorting-2026-05-02.md
+++ b/docs/solutions/integration-issues/session-picker-multi-factor-sorting-2026-05-02.md
@@ -14,7 +14,7 @@ tags:
   - uuidv7
   - terminal-fingerprinting
 plan_ref: "issue-422-session-handling-revamp"
----
+last_updated: 2026-05-03
 
 ## Problem
 
@@ -201,6 +201,7 @@ pub(crate) fn resolve_initial_modal(config: &GlobalConfig) -> Option<ModalState>
 ## Related Issues
 
 - **GitHub:** [Issue #422](https://github.com/dobesv/harnx/issues/422) — Session handling revamp
+- **Follow-up:** [logic-errors/picker-flow-state-continuity-2026-05-03.md](../logic-errors/picker-flow-state-continuity-2026-05-03.md) — Bug fixes for picker flow: filter UI, ESC behavior, modal restoration, origin tracking for transcript reconciliation
 - **Files Changed:**
   - `crates/harnx-core/src/session.rs` — Header metadata fields
   - `crates/harnx-runtime/src/config/session_meta.rs` — Header parsing, multi-tier sort

--- a/docs/solutions/logic-errors/picker-flow-state-continuity-2026-05-03.md
+++ b/docs/solutions/logic-errors/picker-flow-state-continuity-2026-05-03.md
@@ -1,0 +1,208 @@
+---
+title: "Picker flow state continuity and modal restoration patterns"
+date: 2026-05-03
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-tui"
+root_cause: "Multi-step picker flow lost initial state for reconciliation; modal dismissed before validating selection"
+resolution_type: code_fix
+severity: medium
+tags:
+  - tui
+  - modal-state
+  - state-machine
+  - error-handling
+  - picker
+plan_ref: "picker-bugs-435"
+---
+
+## Problem
+
+Three bugs in the agent/session picker flow caused incorrect behavior:
+1. AgentPicker lacked text filter — users couldn't narrow long agent lists
+2. SessionPicker ESC didn't create a new session — dismiss behavior was inconsistent
+3. SessionPicker showed wrong sessions — `list_sessions_with_meta()` was called before agent activation, returning sessions from the previous agent's directory
+
+Underlying issue: multi-step picker flow (AgentPicker → SessionPicker) lost the initial agent/session state, causing transcript reconciliation to see `prev_agent == curr_agent` after an agent switch and fail to clear stale messages.
+
+## Symptoms
+
+- **Filter bug**: AgentPicker displayed all agents with no way to search
+- **ESC bug**: Pressing ESC in SessionPicker did nothing (expected to start fresh session)
+- **Wrong sessions bug**: Switching from agent A to agent B showed agent A's sessions in SessionPicker
+- **Transcript bug**: Switching agents via picker left stale transcript messages from the previous agent
+
+Error patterns from code review:
+```rust
+// Bug: modal taken before validation, never restored on invalid selection
+let modal = self.app.modal.take();
+match modal {
+    Some(ModalState::AgentPicker { .. }) => {
+        if selected >= filtered.len() {
+            // Bug: falls through without restoring modal
+        }
+    }
+}
+
+// Bug: modal cleared before fallible operation
+self.app.modal = None;
+self.config.write().use_session(None)?;  // Error leaves UI inconsistent
+```
+
+## Investigation Steps
+
+1. Traced `list_sessions_with_meta()` call in `resolve_initial_modal()` — found it reads `sessions_dir()` which is agent-scoped, but agent wasn't activated yet
+2. Reviewed `SessionPicker` state — found `pending_agent` field was designed to defer activation, but ESC was redefined to mean "new session", making the deferral pointless
+3. Analyzed transcript reconciliation flow — `reconcile_transcript_after_command()` compares `prev_agent`/`prev_session` to current values to detect transitions; if agent activated mid-flow, comparison sees no change
+4. Identified modal restoration gap — `modal.take()` removes modal, then invalid selection path (empty filter) never restored it
+
+## Root Cause
+
+1. **Deferred activation was wrong abstraction**: `pending_agent` in SessionPicker tried to avoid "cancel leaves partial state", but ESC was redesigned to mean "new session" — no cancel path exists. Deferring activation caused `sessions_dir()` to return wrong directory.
+
+2. **State not preserved across picker steps**: AgentPicker activated agent immediately, then SessionPicker captured `prev_agent` from current config (already the new agent). Reconciliation saw no agent transition.
+
+3. **Modal dismissed before validation**: `modal.take()` followed by fallible operation with no restore path left UI in inconsistent state on error or invalid input.
+
+## Solution
+
+### Immediate Agent Activation with Origin Tracking
+
+```rust
+// crates/harnx-tui/src/types.rs
+pub(super) enum ModalState {
+    AgentPicker {
+        agents: Vec<String>,
+        selected: usize,
+        query: String,  // Added: live filter text
+    },
+    SessionPicker {
+        sessions: Vec<SessionMeta>,
+        selected: usize,
+        // Added: pre-activation state for reconciliation
+        origin_agent: Option<String>,
+        origin_session: Option<String>,
+    },
+}
+```
+
+Removed `pending_agent` from SessionPicker. Agent activates immediately on AgentPicker Enter, and `origin_agent`/`origin_session` carry the pre-activation baseline for reconciliation.
+
+### Modal Restoration on Error
+
+```rust
+// crates/harnx-tui/src/input.rs — Enter handler
+let modal = self.app.modal.take();
+match modal {
+    Some(ModalState::AgentPicker { agents, selected, query }) => {
+        let filtered = ModalState::filtered_agents(&agents, &query);
+        if selected >= filtered.len() {
+            // Fix: restore modal on invalid selection
+            self.app.modal = Some(ModalState::AgentPicker { agents, selected, query });
+        } else {
+            let agent_name = filtered[selected].to_string();
+            let prev_agent = self.config.read().agent.as_ref().map(|a| a.name().to_string());
+            let prev_session = self.config.read().session.as_ref().map(|s| s.id().to_string());
+
+            if let Err(e) = self.config.write().use_agent_by_name(&agent_name) {
+                // Fix: restore modal on error
+                self.app.modal = Some(ModalState::AgentPicker { agents, selected: 0, query });
+                return Err(e);
+            }
+
+            // Pass origin state to SessionPicker
+            self.app.modal = Some(ModalState::SessionPicker {
+                sessions: sorted,
+                selected: 0,
+                origin_agent: prev_agent,
+                origin_session: prev_session,
+            });
+        }
+    }
+}
+```
+
+### ESC Creates New Session (with modal restore on error)
+
+```rust
+// crates/harnx-tui/src/input.rs — ESC handler
+if let Some(ModalState::SessionPicker { origin_agent, origin_session, .. }) =
+    self.app.modal.take()
+{
+    // Fix: only clear modal after success
+    if let Err(e) = self.config.write().use_session(None) {
+        self.app.modal = Some(ModalState::SessionPicker {
+            sessions: vec![],
+            selected: 0,
+            origin_agent,
+            origin_session,
+        });
+        return Err(e);
+    }
+    self.reconcile_transcript_after_command(origin_session, origin_agent, ".session");
+} else {
+    self.app.modal = None;
+}
+```
+
+## Why This Works
+
+1. **Immediate activation** ensures `sessions_dir()` returns the correct agent-scoped path when listing sessions
+2. **origin_agent/origin_session** preserve the true pre-picker state so reconciliation detects the full agent+session transition, not just the session half
+3. **Modal restoration on error** prevents inconsistent UI state where modal is dismissed but operation failed
+4. **Validation before dismiss** keeps picker open when filter yields empty list (user can adjust query)
+
+## Prevention Strategies
+
+**Test Patterns:**
+
+```rust
+// RAII env var guard with mutex for serializing HARNX_CONFIG_DIR mutations
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+struct EnvGuard { key: &'static str, prior: Option<String> }
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prior = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, prior }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.prior {
+            Some(v) => std::env::set_var(self.key, v),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+// Usage in test:
+let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner()); // poison recovery
+let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+```
+
+Key test coverage:
+- `agent_picker_down_bounded_by_filtered_count` — navigation respects filter
+- `agent_picker_enter_on_empty_filter_does_nothing` — modal stays open
+- `session_picker_esc_creates_new_session` — ESC triggers new session
+- Sentinel transcript items to verify reconciliation clears stale state
+
+**Code Review Checklist:**
+- [ ] Does `modal.take()` have a restore path for every error/invalid branch?
+- [ ] Are fallible operations called before clearing modal state?
+- [ ] Does multi-step state machine preserve origin values for final reconciliation?
+- [ ] Are session YAML stubs using old format (comments, not `retrieve_model` calls) to avoid validation failures?
+
+**Key Learnings:**
+- `sessions_dir()` is agent-scoped; must activate agent before listing sessions
+- `unwrap_or_else(|e| e.into_inner())` recovers from mutex poison in tests
+- Multi-step flows need origin tracking for correct before/after comparison
+- Redesigned semantics (ESC = new session) can make previous defensive patterns (deferred activation) into bugs
+
+## Related Issues
+
+- **PR:** [#435](https://github.com/dobesv/harnx/pull/435) — Agent session revamp
+- **Related Solution:** [integration-issues/session-picker-multi-factor-sorting-2026-05-02.md](../integration-issues/session-picker-multi-factor-sorting-2026-05-02.md) — Original picker implementation


### PR DESCRIPTION
…ssion

Three bugs from PR #435 fixed:

- AgentPicker: add live text filter (type to filter, 🔍 UI, "No matches" state)
- SessionPicker: activate agent immediately on Enter so sessions_dir() is already scoped to the correct per-agent directory
- SessionPicker ESC: now creates a new UUIDv7 session instead of just dismissing

Additional fixes found during review:
- Remove pending_agent (dead weight — agent activates immediately, no cancel path)
- Add origin_agent/origin_session to SessionPicker so reconcile_transcript_after_command sees the full agent transition from the start of the picker flow, not just the session half
- Restore modal on all error paths (use_agent_by_name, use_session failures)
- Enter on empty filter keeps picker open (modal.take() moved inside valid branch)
- 17 new tests covering filtering, navigation bounds, ESC behavior, agent activation, and reconciliation regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added live search filtering to the agent picker for easier agent selection.

* **Bug Fixes**
  * Improved keyboard navigation and selection behavior in agent and session pickers.
  * Fixed ESC key behavior in session picker to create new anonymous sessions.
  * Enhanced state tracking and transcript reconciliation when switching between agents and sessions.
  * Fixed Enter key behavior to properly apply selected agents and sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->