### PR TITLE
fix(mcp-history): lazy-discover tracked repos so edit diffs survive empty initial_roots

### DIFF
--- a/.changesets/edit-tool-diff-restored.md
+++ b/.changesets/edit-tool-diff-restored.md
@@ -1,0 +1,9 @@
+---
+harnx: patch
+---
+Edit and other mutating filesystem/bash tools no longer silently drop their
+unified-diff content block when harnx-mcp-fs / harnx-mcp-bash receive their
+roots via the MCP `roots/list` protocol rather than `--root` CLI arguments
+(the production launch path). `HistoryManager` now lazily discovers and
+tracks the git repo containing each touched path at snapshot time instead of
+freezing the tracked-repo set at construction.

--- a/crates/harnx-mcp-fs/src/server.rs
+++ b/crates/harnx-mcp-fs/src/server.rs
@@ -1639,6 +1639,50 @@ mod tests {
         assert!(result.content[1].audience().is_none(), "diff audience");
     }
 
+    /// Production launch path: harnx-mcp-fs starts with empty
+    /// `initial_roots` (no `--root` CLI args) and only learns its roots
+    /// later via the MCP `roots/list` protocol. `HistoryManager` was
+    /// constructed with the empty initial roots and never refreshed, so
+    /// it never tracked any repos and silently dropped the diff content
+    /// block on every edit. This guards the lazy-discovery fallback in
+    /// `HistoryManager::snapshot_file`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn edit_file_emits_diff_when_roots_only_set_via_protocol() {
+        let temp_dir = TestDir::new();
+        let dir = temp_dir.path();
+        if !seed_committed_file(dir, "tracked.txt", "old value\n") {
+            return;
+        }
+
+        // Mimic the production launch: empty initial_roots.
+        let server = FsServer::new(vec![]);
+        // Mimic `refresh_roots` populating roots after the MCP handshake.
+        *server.roots.write().await = vec![dir.to_path_buf()];
+
+        let result = server
+            .edit_file_impl(EditFileParams {
+                path: dir.join("tracked.txt").to_string_lossy().into_owned(),
+                old_text: "old value".into(),
+                new_text: "new value".into(),
+                replace_all: None,
+            })
+            .await
+            .expect("edit succeeds");
+
+        let texts: Vec<&str> = result
+            .content
+            .iter()
+            .filter_map(|c| c.raw.as_text().map(|t| t.text.as_str()))
+            .collect();
+        assert!(
+            texts.len() >= 2,
+            "expected summary + diff content blocks, got {}: {texts:?}",
+            texts.len()
+        );
+        assert!(texts[1].contains("-old value"), "diff missing: {texts:?}");
+    }
+
     #[tokio::test]
     async fn test_read_file_with_offset_limit() {
         let temp_dir = TestDir::new();

--- a/crates/harnx-mcp-history/src/discover.rs
+++ b/crates/harnx-mcp-history/src/discover.rs
@@ -12,7 +12,15 @@ fn discover_repo(path: &Path) -> Option<gix::Repository> {
 
 pub fn find_repo_for_path(path: &Path) -> Option<PathBuf> {
     let repo = discover_repo(path)?;
-    repo.workdir().map(Path::to_path_buf)
+    let workdir = repo.workdir()?;
+    // Canonicalize so the path matches the canonical keys
+    // `find_repos_under_roots` and `HistoryManager::ensure_repo_for_path`
+    // store in the tracked-repo map.
+    Some(
+        workdir
+            .canonicalize()
+            .unwrap_or_else(|_| workdir.to_path_buf()),
+    )
 }
 
 pub fn find_repos_under_roots(roots: &[PathBuf]) -> Vec<PathBuf> {

--- a/crates/harnx-mcp-history/src/history.rs
+++ b/crates/harnx-mcp-history/src/history.rs
@@ -83,10 +83,66 @@ impl HistoryManager {
         }
     }
 
+    /// Ensure a tracked repo exists for `file_path`, discovering and
+    /// inserting one if necessary. Returns silently when the path lies
+    /// outside any git repo — the caller's existing "no tracked repo"
+    /// branch then handles the miss.
+    async fn ensure_repo_for_path(&self, file_path: &Path) {
+        {
+            let repos = self.inner.repos.lock().await;
+            if repos
+                .iter()
+                .any(|(workdir, _)| file_path.starts_with(workdir.as_path()))
+            {
+                return;
+            }
+        }
+        let Some(workdir) = crate::discover::find_repo_for_path(file_path) else {
+            return;
+        };
+        let Ok(repo) = gix::open(&workdir) else {
+            return;
+        };
+        let mut repos = self.inner.repos.lock().await;
+        repos.entry(workdir).or_insert_with(|| RepoSession {
+            repo: repo.into_sync(),
+            last_commit_id: None,
+        });
+    }
+
+    /// Ensure tracked repos exist for any git workdirs found under
+    /// `working_dir`. Mirrors `find_repos_under_roots`, but runs at
+    /// snapshot time rather than at construction time so repos that
+    /// arrive via the MCP `roots/list` protocol are picked up.
+    async fn ensure_repos_under(&self, working_dir: &Path) {
+        let discovered = crate::discover::find_repos_under_roots(&[working_dir.to_path_buf()]);
+        if discovered.is_empty() {
+            return;
+        }
+        let mut repos = self.inner.repos.lock().await;
+        for workdir in discovered {
+            if repos.contains_key(&workdir) {
+                continue;
+            }
+            let Ok(repo) = gix::open(&workdir) else {
+                continue;
+            };
+            repos.insert(
+                workdir,
+                RepoSession {
+                    repo: repo.into_sync(),
+                    last_commit_id: None,
+                },
+            );
+        }
+    }
+
     pub async fn snapshot(&self, paths: &[PathBuf], label: &str) -> Result<gix::ObjectId> {
         let path = paths
             .first()
             .context("snapshot requires at least one path")?;
+        // Same lazy-discovery rationale as `snapshot_file`.
+        self.ensure_repo_for_path(path).await;
         let (repo_workdir, ts_repo, parent) = {
             let repos = self.inner.repos.lock().await;
             // Pick the longest matching workdir so an inner repo wins over an
@@ -124,6 +180,15 @@ impl HistoryManager {
     }
 
     pub async fn snapshot_file(&self, file_path: &Path, label: &str) -> Result<gix::ObjectId> {
+        // Lazily discover and track a repo covering this file path. This is
+        // load-bearing in production: harnx-mcp-fs / harnx-mcp-bash launch
+        // with empty `--root` args and only learn their roots later via the
+        // MCP `roots/list` protocol, so `HistoryManager::new(&[])` finds no
+        // repos at construction. Without this fallback every snapshot would
+        // silently fail with "no tracked repo" and edit_file would omit its
+        // diff content block.
+        self.ensure_repo_for_path(file_path).await;
+
         let (repo_workdir, ts_repo, parent) = {
             let repos = self.inner.repos.lock().await;
             let (workdir, session) = repos
@@ -170,6 +235,8 @@ impl HistoryManager {
         working_dir: &Path,
         label: &str,
     ) -> Result<Vec<(PathBuf, gix::ObjectId)>> {
+        // Lazy discovery — same rationale as `snapshot_file`.
+        self.ensure_repos_under(working_dir).await;
         let candidates = {
             let repos = self.inner.repos.lock().await;
             repos
@@ -216,6 +283,7 @@ impl HistoryManager {
         files: &[PathBuf],
         label: &str,
     ) -> Result<Vec<(PathBuf, gix::ObjectId)>> {
+        self.ensure_repos_under(working_dir).await;
         let candidates = {
             let repos = self.inner.repos.lock().await;
             repos
@@ -263,10 +331,17 @@ impl HistoryManager {
         before_id: gix::ObjectId,
         after_id: gix::ObjectId,
     ) -> Result<String> {
+        // Tracked repos are stored under their canonical workdir; canonicalize
+        // the caller's path so lookups still succeed when they came from a
+        // non-canonical source like `gix::Repository::workdir()`.
+        let canonical = repo_workdir
+            .canonicalize()
+            .unwrap_or_else(|_| repo_workdir.to_path_buf());
         let ts_repo = {
             let repos = self.inner.repos.lock().await;
             repos
-                .get(repo_workdir)
+                .get(&canonical)
+                .or_else(|| repos.get(repo_workdir))
                 .map(|session| session.repo.clone())
                 .context("repo not tracked for diff")?
         };
@@ -776,5 +851,44 @@ mod tests {
             .filter_map(|name| std::str::from_utf8(name).ok())
             .collect::<Vec<_>>();
         assert_eq!(names, vec!["kept.txt"], "tree should contain only kept.txt");
+    }
+
+    /// When `HistoryManager` is constructed with empty initial roots (the
+    /// production launch path for harnx-mcp-fs and harnx-mcp-bash, which
+    /// receive their roots later via the MCP `roots/list` protocol),
+    /// `snapshot_file` must still discover and track the git repo
+    /// containing the file rather than silently failing with "no tracked
+    /// repo found for file path".
+    #[tokio::test]
+    async fn snapshot_file_lazy_discovers_repo_with_empty_initial_roots() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let repo_dir = temp_dir.path().canonicalize().expect("canonicalize");
+        init_git_repo(&repo_dir);
+        add_file_to_git(&repo_dir, "tracked.txt", b"old\n");
+        commit_git(&repo_dir);
+
+        let history = HistoryManager::new(&[]);
+        let file_path = repo_dir.join("tracked.txt");
+        let before = history
+            .snapshot_file(&file_path, "before edit")
+            .await
+            .expect("snapshot succeeds via lazy discovery");
+
+        // Subsequent edit + snapshot + diff must all succeed against the
+        // lazily-tracked repo so end-to-end edit_file diff generation works.
+        std::fs::write(&file_path, b"new\n").expect("rewrite tracked.txt");
+        let after = history
+            .snapshot_file(&file_path, "after edit")
+            .await
+            .expect("second snapshot succeeds");
+        let diff = history
+            .diff_commits(&repo_dir, before, after)
+            .await
+            .expect("diff between snapshots");
+        assert!(diff.contains("-old"), "diff should include removal: {diff}");
+        assert!(
+            diff.contains("+new"),
+            "diff should include addition: {diff}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #436. Edit (and other mutating fs / bash tools) silently dropped the unified-diff content block in production. Users saw only `Edited <path> (1 replacement)` with no patch attached.

## Root cause

`HistoryManager` froze its tracked-repo set at construction. In production, harnx launches `harnx-mcp-fs` / `harnx-mcp-bash` with no `--root` CLI args — roots arrive later via the MCP `roots/list` protocol — so `HistoryManager::new(&[])` discovered zero repos and every `snapshot_file` call silently failed with "no tracked repo found." `before_snap` stayed `None`, the diff path short-circuited, and the diff content block was never appended.

The previously merged unit test `edit_file_emits_unaudienced_diff_content` calls `make_server(dir)` with the temp dir as `initial_roots`, so the HistoryManager always tracked the repo in tests — exercising a code path that never runs in production. That's why prior fixes "kept getting missed."

## Fix (`crates/harnx-mcp-history`)

- `snapshot_file` and `snapshot` now lazily discover and track the repo containing the touched path when no tracked repo covers it.
- `snapshot_repos_for_dir{_targeted}` lazily discover repos under the working dir (same fix benefits bash diffs).
- `find_repo_for_path` and `diff_commits` canonicalize their paths so lookups match the canonical keys stored at insert time.

## Regression tests

- `harnx-mcp-history` — `snapshot_file_lazy_discovers_repo_with_empty_initial_roots` exercises the full snapshot + diff cycle starting from `HistoryManager::new(&[])`.
- `harnx-mcp-fs` — `edit_file_emits_diff_when_roots_only_set_via_protocol` simulates the production launch (empty `initial_roots`, roots populated post-construction) and verifies the diff content block is present.

Both tests fail on the pre-fix code and pass on the fixed code.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` — 766/766 pass
- [x] `cargo nextest run -p harnx-mcp-history -p harnx-mcp-fs -p harnx-mcp-bash --stress-count=5` — all 5 iterations pass
- [x] `cs delta` — Code Health unchanged at 8.28; minor mean-complexity uptick (4.08 → 4.29) from two helper methods with let-else patterns
- [ ] Manual verification: edit a tracked file in a TUI session and confirm the patch is visible after the `Edit` summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)