### PR TITLE
fix(tui): use triple-tick code fences for bash tool call display

### DIFF
--- a/crates/harnx-core/src/tool.rs
+++ b/crates/harnx-core/src/tool.rs
@@ -552,4 +552,70 @@ mod tests {
         );
         assert_eq!(rendered.unwrap(), "ERROR: boom");
     }
+
+    /// Issue #434: the bash exec call_template must always close its code
+    /// fence on its own line regardless of which optional args are present,
+    /// so `is_fence_marker_line` in the TUI can reliably strip it.
+    #[test]
+    fn test_bash_exec_call_template_fence_closes_on_own_line() {
+        // This is the actual template used by the bash exec tool.
+        let template = "```sh\n$ {{ args.command }}\n```{% if args.working_dir or args.timeout_secs %}\n{% if args.working_dir %}({{ args.working_dir }}) {% endif %}{% if args.timeout_secs %}[{{ args.timeout_secs }}s]{% endif %}{% endif %}";
+
+        // No extras — bare fence, closing ``` is the last line.
+        let out =
+            render_tool_call_template(template, &serde_json::json!({"command": "ls"}), "").unwrap();
+        assert!(
+            out.lines().any(|l| l == "```"),
+            "closing fence must be on own line (no extras): {out:?}"
+        );
+
+        // timeout_secs only — ``` must still appear alone on its line.
+        let out = render_tool_call_template(
+            template,
+            &serde_json::json!({"command": "ls", "timeout_secs": 30}),
+            "",
+        )
+        .unwrap();
+        assert!(
+            out.lines().any(|l| l == "```"),
+            "closing fence must be on own line (timeout only): {out:?}"
+        );
+        assert!(
+            out.contains("[30s]"),
+            "timeout must appear in output: {out:?}"
+        );
+
+        // working_dir only.
+        let out = render_tool_call_template(
+            template,
+            &serde_json::json!({"command": "ls", "working_dir": "/tmp"}),
+            "",
+        )
+        .unwrap();
+        assert!(
+            out.lines().any(|l| l == "```"),
+            "closing fence must be on own line (working_dir only): {out:?}"
+        );
+        assert!(
+            out.contains("(/tmp)"),
+            "working_dir must appear in output: {out:?}"
+        );
+
+        // Both args present.
+        let out = render_tool_call_template(
+            template,
+            &serde_json::json!({"command": "ls", "working_dir": "/tmp", "timeout_secs": 10}),
+            "",
+        )
+        .unwrap();
+        assert!(
+            out.lines().any(|l| l == "```"),
+            "closing fence must be on own line (both args): {out:?}"
+        );
+        assert!(
+            out.contains("(/tmp)"),
+            "working_dir in combined output: {out:?}"
+        );
+        assert!(out.contains("[10s]"), "timeout in combined output: {out:?}");
+    }
 }

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -2031,7 +2031,7 @@ impl ServerHandler for BashServer {
                 )
                 .with_input_schema::<ExecCommandParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "`$ {{ args.command }}`{% if args.working_dir %} ({{ args.working_dir }}){% endif %}{% if args.timeout_secs %} [{{ args.timeout_secs }}s]{% endif %}",
+                    "call_template": "```sh\n$ {{ args.command }}\n```{% if args.working_dir or args.timeout_secs %}\n{% if args.working_dir %}({{ args.working_dir }}) {% endif %}{% if args.timeout_secs %}[{{ args.timeout_secs }}s]{% endif %}{% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "read_exec_log",
@@ -2049,7 +2049,7 @@ impl ServerHandler for BashServer {
                 )
                 .with_input_schema::<SpawnCommandParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "`> {{ args.command }}`{% if args.working_dir %} ({{ args.working_dir }}){% endif %}",
+                    "call_template": "```sh\n> {{ args.command }}\n```{% if args.working_dir %}\n({{ args.working_dir }}){% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "wait",

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -47,38 +47,13 @@ impl Tui {
         lines
     }
 
-    /// 3-space indent + a single line of inline-markdown body, used by
-    /// templated tool result/call lines so `**bold**` / `` `code` `` add
-    /// styling on top of the dim base without losing visual subordination.
-    fn render_indented_markdown_line(text: &str) -> Line<'static> {
-        let dim_gray = Style::default()
-            .fg(Color::DarkGray)
-            .add_modifier(Modifier::DIM);
-        let body_base = Style::default().add_modifier(Modifier::DIM);
-        let mut spans = vec![Span::styled("   ".to_string(), dim_gray)];
-        let parsed = crate::render_helpers::markdown_line_spans(text, body_base);
-        spans.extend(parsed.spans);
-        Line::from(spans)
-    }
-
-    /// 3-space indent + multi-line markdown body, used for tool results
-    /// where block-level constructs like fenced ```diff need the
-    /// whole-document parser to see them. Each parsed ratatui line gets
-    /// the indent prefixed and the dim base style patched under each
-    /// span so plain text still reads as dim.
-    fn render_indented_markdown_block(text: &str) -> Vec<Line<'static>> {
-        let dim_gray = Style::default()
-            .fg(Color::DarkGray)
-            .add_modifier(Modifier::DIM);
+    /// Multi-line markdown body renderer — used for tool call bodies and
+    /// tool results. Block-level constructs like fenced ```diff are handled
+    /// by the whole-document parser. The dim base style is patched under
+    /// each span so plain text still reads as dim.
+    fn render_markdown_block(text: &str) -> Vec<Line<'static>> {
         let body_base = Style::default().add_modifier(Modifier::DIM);
         crate::render_helpers::markdown_lines(text, body_base)
-            .into_iter()
-            .map(|line| {
-                let mut spans = vec![Span::styled("   ".to_string(), dim_gray)];
-                spans.extend(line.spans);
-                Line::from(spans)
-            })
-            .collect()
     }
 
     /// Render a `ToolCall` transcript item: `→ tool_name` header followed
@@ -100,13 +75,11 @@ impl Tui {
         match body {
             Some(ToolCallBody::Yaml(yaml)) => {
                 for line in yaml.lines() {
-                    lines.extend(Self::render_text_entry("   ", line, dim_gray, false));
+                    lines.extend(Self::render_text_entry("", line, dim_gray, false));
                 }
             }
             Some(ToolCallBody::Markdown(md)) => {
-                for line_text in md.lines() {
-                    lines.push(Self::render_indented_markdown_line(line_text));
-                }
+                lines.extend(Self::render_markdown_block(md));
             }
             None => {}
         }
@@ -247,7 +220,7 @@ impl Tui {
                     .add_modifier(Modifier::DIM),
                 false,
             ),
-            TranscriptItem::ToolResultMarkdown(text) => Self::render_indented_markdown_block(text),
+            TranscriptItem::ToolResultMarkdown(text) => Self::render_markdown_block(text),
             TranscriptItem::StatusLine(text) => Self::render_text_entry(
                 "",
                 text,

--- a/crates/harnx-tui/src/render_helpers.rs
+++ b/crates/harnx-tui/src/render_helpers.rs
@@ -2,7 +2,7 @@ use harnx_core::event::AgentSource;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 
-/// Render one line of MCP tool template text into ratatui spans, applying
+/// Render one line of inline markdown into ratatui spans, applying
 /// `base_style` as the foreground/modifier base. Delegates to the
 /// `tui-markdown` crate (which wraps `pulldown-cmark` + `syntect` +
 /// `ansi-to-tui` internally), so we get the same inline emphasis handling
@@ -12,6 +12,10 @@ use ratatui::text::{Line, Span};
 /// On render failure (empty result), returns the input as a single plain
 /// span so the user still sees the text — markdown styling is a
 /// presentation nicety, not a correctness requirement.
+///
+/// Currently only used in tests; production rendering uses
+/// `markdown_lines` for full block parsing.
+#[cfg(test)]
 pub(crate) fn markdown_line_spans(text: &str, base_style: Style) -> Line<'static> {
     let plain_fallback = || Line::from(Span::styled(text.to_string(), base_style));
 
@@ -55,8 +59,28 @@ pub(crate) fn markdown_lines(text: &str, base_style: Style) -> Vec<Line<'static>
     parsed
         .lines
         .into_iter()
+        .filter(|line| !is_fence_marker_line(line))
         .map(|line| Line::from(patch_spans(line.spans, base_style)))
         .collect()
+}
+
+/// Return true if `line` is a bare code-fence marker emitted by `tui-markdown`
+/// (e.g. `` ```sh `` or `` ``` ``). These lines have a single unstyled span
+/// whose trimmed content consists entirely of backticks with an optional
+/// ASCII-lowercase language hint — they carry no information the user needs
+/// to see once the code block content is already rendered.
+fn is_fence_marker_line(line: &ratatui::text::Line<'_>) -> bool {
+    if line.spans.len() != 1 {
+        return false;
+    }
+    let span = &line.spans[0];
+    // Must be unstyled (no fg/bg override set by tui-markdown).
+    if span.style.fg.is_some() || span.style.bg.is_some() {
+        return false;
+    }
+    let content = span.content.trim();
+    // Match ``` optionally followed by an ASCII-lowercase language hint.
+    content.starts_with("```") && content[3..].chars().all(|c| c.is_ascii_lowercase())
 }
 
 /// Patch `base_style` under each parsed span so caller context (e.g. dim
@@ -215,9 +239,9 @@ mod markdown_tests {
 
     #[test]
     fn bash_template_example_renders_bold_and_code() {
-        // Mirror the actual built-in bash exec template:
-        //   "**$** `{{ args.command }}`"
-        // After Jinja rendering this becomes "**$** `ls -la /tmp`"
+        // Test inline code span rendering (used by older single-line templates
+        // and any template that produces inline backtick markup).
+        // "**$** `ls -la /tmp`" exercises both bold and inline code styling.
         let line = markdown_line_spans("**$** `ls -la /tmp`", Style::default());
         assert_eq!(span_text(&line), "$ ls -la /tmp");
         let bold = line
@@ -347,5 +371,33 @@ mod markdown_tests {
             .unwrap();
         assert!(bold.style.add_modifier.contains(Modifier::BOLD));
         assert!(bold.style.add_modifier.contains(Modifier::DIM));
+    }
+
+    #[test]
+    fn markdown_lines_filters_out_fence_markers() {
+        // Issue #434: code fence marker lines (```sh, ```) emitted by
+        // tui_markdown must be stripped so they don't appear as literal text.
+        let input = "```rust\nfn main() {}\n```";
+        let lines = markdown_lines(input, Style::default());
+        let texts: Vec<String> = lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect();
+
+        // Code block content must appear.
+        assert!(
+            texts.iter().any(|t| t.contains("fn main()")),
+            "code content missing: {texts:?}"
+        );
+        // Fence markers must not appear.
+        assert!(
+            !texts.iter().any(|t| t.trim().starts_with("```")),
+            "fence markers leaked: {texts:?}"
+        );
     }
 }

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__sub_agent_activity_dedup_after_all_tools.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__sub_agent_activity_dedup_after_all_tools.snap
@@ -5,16 +5,16 @@ expression: rendered_mid2
 I'll look into that for you. Delegating now.
 
 → researcher_session_prompt
-   message: investigate the data
+message: investigate the data
 > researcher ▸ research-session-1
 <think>Let me analyze the situation carefully.</think>
 → bash
-   command: find /data -name '*.csv'
+command: find /data -name '*.csv'
 → read_file
-   path: /data/results.csv
+path: /data/results.csv
 <think>Now I see the pattern in the data.</think>
 → write_file
-   path: /data/summary.md
+path: /data/summary.md
 
 
 

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__sub_agent_activity_dedup_after_first_tools.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__sub_agent_activity_dedup_after_first_tools.snap
@@ -5,13 +5,13 @@ expression: rendered_mid1
 I'll look into that for you. Delegating now.
 
 → researcher_session_prompt
-   message: investigate the data
+message: investigate the data
 > researcher ▸ research-session-1
 <think>Let me analyze the situation carefully.</think>
 → bash
-   command: find /data -name '*.csv'
+command: find /data -name '*.csv'
 → read_file
-   path: /data/results.csv
+path: /data/results.csv
 
 
 

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__sub_agent_activity_dedup_final.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__sub_agent_activity_dedup_final.snap
@@ -5,16 +5,16 @@ expression: rendered_final
 I'll look into that for you. Delegating now.
 
 → researcher_session_prompt
-   message: investigate the data
+message: investigate the data
 > researcher ▸ research-session-1
 <think>Let me analyze the situation carefully.</think>
 → bash
-   command: find /data -name '*.csv'
+command: find /data -name '*.csv'
 → read_file
-   path: /data/results.csv
+path: /data/results.csv
 <think>Now I see the pattern in the data.</think>
 → write_file
-   path: /data/summary.md
+path: /data/summary.md
 Here are my findings: the data shows a clear trend.
 
 > researcher ▸ research-session-1   in 500   out 200   cache 100

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__thinking_stream_coalescing_around_tool_calls.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__thinking_stream_coalescing_around_tool_calls.snap
@@ -6,7 +6,7 @@ Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
 > argus ▸ session-1
 <think>thinking before tool</think>
 → argus_session_prompt
-   message: delegate
+message: delegate
 <think>thinking after tool</think>
 
 

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__tool_call_display_format.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__tool_call_display_format.snap
@@ -4,14 +4,14 @@ expression: rendered
 ---
 Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
 → exec
-   command: ls -la
-   working_dir: /tmp
-   write hello.txt with 3 lines
+command: ls -la
+working_dir: /tmp
+write hello.txt with 3 lines
 → think
 → search
-   query: rust async patterns
-   max_results: 10
-   include_code: true
+query: rust async patterns
+max_results: 10
+include_code: true
 
 
 

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__tool_call_with_seq_number.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__tool_call_with_seq_number.snap
@@ -5,7 +5,7 @@ expression: rendered
 Welcome to harnx 0.30.0  •  Type .help for commands, Tab to complete.
   [7]
 → read
-   path: /tmp/foo.txt
+path: /tmp/foo.txt
 
 
 

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -792,7 +792,7 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         vec![
             "<think>thinking before tool</think>",
             "→ argus_session_prompt",
-            "   message: delegate",
+            "message: delegate",
             "<think>thinking after tool</think>",
         ]
     );
@@ -872,7 +872,7 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
             "> argus ▸ session-1",
             "<think>thinking before tool</think>",
             "→ argus_session_prompt",
-            "   message: delegate",
+            "message: delegate",
             "<think>thinking after tool</think>",
         ]
     );
@@ -1093,16 +1093,16 @@ async fn structured_ui_output_variants_render_in_transcript() {
 
     assert!(system_entries.contains(&"> argus ▸ session-1".to_string()));
     assert!(system_entries.contains(&"→ argus_session_prompt".to_string()));
-    assert!(system_entries.contains(&"   message: hello".to_string()));
+    assert!(system_entries.contains(&"message: hello".to_string()));
     assert!(system_entries.contains(&"<think>thinking hard</think>".to_string()));
     assert!(system_entries.contains(&"-> argus_session_prompt completed".to_string()));
     assert!(system_entries.contains(&"Plan:".to_string()));
     assert!(system_entries.contains(&"  [in_progress] Refactor ACP formatting".to_string()));
     assert!(system_entries.contains(&"> argus ▸ session-1   in 12   out 34   cache 5".to_string()));
     assert!(system_entries.contains(&"→ bash".to_string()));
-    assert!(system_entries.contains(&"   command: ls".to_string()));
-    assert!(system_entries.contains(&"   line one".to_string()));
-    assert!(system_entries.contains(&"   line two".to_string()));
+    assert!(system_entries.contains(&"command: ls".to_string()));
+    assert!(system_entries.contains(&"line one".to_string()));
+    assert!(system_entries.contains(&"line two".to_string()));
 }
 
 #[tokio::test]
@@ -1175,7 +1175,7 @@ async fn nested_subagent_tool_call_renders_with_heading_and_usage() {
     assert!(rendered.contains(&"→ pytheas_session_prompt".to_string()));
     assert!(rendered.contains(&"> pytheas ▸ session-nested".to_string()));
     assert!(rendered.contains(&"→ bash".to_string()));
-    assert!(rendered.contains(&"   command: ls -1 /tmp | wc -l".to_string()));
+    assert!(rendered.contains(&"command: ls -1 /tmp | wc -l".to_string()));
     assert!(
         rendered.contains(&"> pytheas ▸ session-nested   in 10   out 20".to_string()),
         "rendered transcript missing nested usage line: {rendered:?}"
@@ -4424,7 +4424,7 @@ async fn tui_renders_started_title_when_template_provides_it() {
     .unwrap();
 
     // Producer-side render result: a `call_template` like
-    // `**$** \`{{ args.command }}\`` produces this `title`. The raw
+    // "```sh\n$ {{ args.command }}\n```" produces this `markdown`. The raw
     // `input` JSON is also kept on the event for transcript serialization,
     // but the user-facing rendering must prefer the rendered title.
     tui.handle_tui_event(TuiEvent::Agent(
@@ -4432,7 +4432,7 @@ async fn tui_renders_started_title_when_template_provides_it() {
             id: "call-1".into(),
             name: "bash_exec".into(),
             kind: ToolKind::Other,
-            markdown: Some("**$** `ls -la /tmp`".into()),
+            markdown: Some("```sh\n$ ls -la /tmp\n```".into()),
             input: yaml_to_json("command: ls -la /tmp"),
             locations: vec![],
         }),
@@ -4701,13 +4701,13 @@ async fn tui_started_template_strips_markers_and_styles_spans() {
     )
     .unwrap();
 
-    // Producer-side render of `**$** \`{{ args.command }}\``.
+    // Producer-side render of "```sh\n$ {{ args.command }}\n```".
     tui.handle_tui_event(TuiEvent::Agent(
         AgentEvent::Tool(ToolEvent::Started {
             id: "call-1".into(),
             name: "bash_exec".into(),
             kind: ToolKind::Other,
-            markdown: Some("**$** `ls -la /tmp`".into()),
+            markdown: Some("```sh\n$ ls -la /tmp\n```".into()),
             input: yaml_to_json("command: ls -la /tmp"),
             locations: vec![],
         }),
@@ -4716,7 +4716,6 @@ async fn tui_started_template_strips_markers_and_styles_spans() {
     .await
     .unwrap();
 
-    use ratatui::style::Modifier;
     let lines = rendered_lines(&tui);
     let plain = lines
         .iter()
@@ -4724,28 +4723,70 @@ async fn tui_started_template_strips_markers_and_styles_spans() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    // Markers should be consumed and stripped text should appear.
-    assert!(!plain.contains("**$**"), "markers leaked: {plain}");
-    assert!(
-        !plain.contains("`ls -la /tmp`"),
-        "backticks leaked: {plain}"
-    );
+    // Fence markers should be consumed and command text should appear.
+    assert!(!plain.contains("```"), "fence markers leaked: {plain}");
     assert!(
         plain.contains("$ ls -la /tmp"),
-        "stripped text missing: {plain}"
+        "command text missing: {plain}"
     );
 
-    // `**$**` → BOLD; `` `ls -la /tmp` `` → visually distinct (fg or bg).
+    // The command line should be rendered by the code-block highlighter —
+    // at least one span on the line containing the command must have an fg
+    // color set (syntect applies per-token colors inside code fences).
+    let cmd_line = lines
+        .iter()
+        .find(|l| line_to_plain(l).contains("$ ls -la /tmp"));
     assert!(
-        rendered_span_matches(&lines, "$", |s| s.add_modifier.contains(Modifier::BOLD)),
-        "expected a BOLD span for `$`"
+        cmd_line.is_some_and(|l| l.spans.iter().any(|s| s.style.fg.is_some())),
+        "expected at least one fg-colored span on the command line"
     );
-    assert!(
-        rendered_span_matches(&lines, "ls -la /tmp", |s| {
-            s.fg.is_some() || s.bg.is_some()
+}
+
+#[tokio::test]
+async fn tui_started_multiline_command_renders_without_fence_markers() {
+    // Regression test for issue #434: multi-line commands in the bash exec
+    // call_template ("```sh\n$ ...\n```") must render with the command text
+    // visible and fence markers consumed, not shown as literal text.
+    let mut tui = Tui::init(
+        &test_config(),
+        AsyncHookManager::new(),
+        Arc::new(Mutex::new(PersistentHookManager::new())),
+    )
+    .unwrap();
+
+    let multiline_cmd = "cat <<EOF\nline1\nEOF";
+    let markdown = format!("```sh\n$ {multiline_cmd}\n```");
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Tool(ToolEvent::Started {
+            id: "call-1".into(),
+            name: "bash_exec".into(),
+            kind: ToolKind::Other,
+            markdown: Some(markdown),
+            input: yaml_to_json(&format!("command: '{multiline_cmd}'")),
+            locations: vec![],
         }),
-        "expected a visually distinct span for `ls -la /tmp`"
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let lines = rendered_lines(&tui);
+    let plain = lines
+        .iter()
+        .map(line_to_plain)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Fence markers must not appear as literal text.
+    assert!(!plain.contains("```"), "fence markers leaked: {plain}");
+
+    // Each line of the command must appear in the output.
+    assert!(
+        plain.contains("cat <<EOF"),
+        "first command line missing: {plain}"
     );
+    assert!(plain.contains("line1"), "heredoc body missing: {plain}");
+    assert!(plain.contains("EOF"), "heredoc close missing: {plain}");
 }
 
 #[tokio::test]
@@ -4984,7 +5025,7 @@ fn render_tool_call_markdown_body_suppresses_header() {
     );
 
     let plain = lines.iter().map(line_to_plain).collect::<Vec<_>>();
-    assert_eq!(plain, vec!["   write hello.txt with 3 lines".to_string()]);
+    assert_eq!(plain, vec!["write hello.txt with 3 lines".to_string()]);
     assert!(plain.iter().all(|line| !line.contains("→")));
 }
 
@@ -5026,10 +5067,7 @@ fn render_tool_call_meta_line_precedes_markdown_body() {
     let plain = lines.iter().map(line_to_plain).collect::<Vec<_>>();
     assert_eq!(
         plain,
-        vec![
-            "  [3] 14:23:01".to_string(),
-            "   write hello.txt".to_string()
-        ]
+        vec!["  [3] 14:23:01".to_string(), "write hello.txt".to_string()]
     );
 }
 

--- a/crates/harnx/tests/snapshots/tmux_e2e__interactive_handoff_planner_to_executor.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__interactive_handoff_planner_to_executor.snap
@@ -14,15 +14,15 @@ plan-executor. Proceed?
 Great! Handing off to plan-executor.
 
 → plan-executor_session_handoff
-   prompt: 'Execute the plan: add dark mode toggle with keyboard shortcut.'
-   session_id: exec-session-1
-   Handing off to plan-executor…
+prompt: 'Execute the plan: add dark mode toggle with keyboard shortcut.'
+session_id: exec-session-1
+Handing off to plan-executor…
 > plan-executor ▸ exec-session-1
 Executing step 1: creating theme toggle component.
 
 → create_file
-   path: src/components/ThemeToggle.tsx
-   content: // Theme toggle component
+path: src/components/ThemeToggle.tsx
+content: // Theme toggle component
 Plan execution complete. Theme toggle is ready.
 
 > Actually, can you also add a shortcut key?
@@ -30,8 +30,8 @@ Plan execution complete. Theme toggle is ready.
 Adding keyboard shortcut for theme toggle.
 
 → edit_file
-   path: src/components/ThemeToggle.tsx
-   edit: Add keyboard shortcut Ctrl+Shift+T
+path: src/components/ThemeToggle.tsx
+edit: Add keyboard shortcut Ctrl+Shift+T
 Done! Theme toggle now has keyboard shortcut Ctrl+Shift+T.
 
 • 🤖 plan-executor ▸ exec-session-1   Context: 189(1%)

--- a/crates/harnx/tests/snapshots/tmux_e2e__nested_sub_agent_activity_no_duplicates.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__nested_sub_agent_activity_no_duplicates.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/harnx/tests/tmux_e2e.rs
-assertion_line: 1212
 expression: normalized
 ---
 Welcome to harnx 0.30.0  *  Type .help for commands, Tab to complete.
@@ -10,21 +9,21 @@ Welcome to harnx 0.30.0  *  Type .help for commands, Tab to complete.
 
 Parent delegating to researcher.
 
-   @ nested-researcher Research this deeply and delegate analysis.
+@ nested-researcher Research this deeply and delegate analysis.
 > nested-researcher ▸ [UUID]
 Researcher delegating to analyst.
 
-   @ nested-analyst Analyze data and report back.
+@ nested-analyst Analyze data and report back.
 > nested-analyst ▸ [UUID]
 Analyst complete
 
 > nested-researcher ▸ [UUID]
-   session_id: [UUID]
-   response: Analyst complete
+session_id: [UUID]
+response: Analyst complete
 Researcher complete
 
-   session_id: [UUID]
-   response: Researcher delegating to analyst.Analyst completeResearcher complete
+session_id: [UUID]
+response: Researcher delegating to analyst.Analyst completeResearcher complete
 Nested task complete
 
 

--- a/docs/solutions/logic-errors/tui-triple-tick-code-fences-2026-05-03.md
+++ b/docs/solutions/logic-errors/tui-triple-tick-code-fences-2026-05-03.md
@@ -1,0 +1,152 @@
+---
+title: "TUI code fence rendering for multi-line bash commands"
+date: 2026-05-03
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-tui"
+root_cause: "inline markdown renderer couldn't handle block-level code fences"
+resolution_type: code_fix
+severity: medium
+tags:
+  - markdown
+  - code-fences
+  - tui
+  - rendering
+  - templates
+plan_ref: "bash-triple-tick-434"
+---
+
+## Problem
+
+Bash tool `call_template` used single backticks for command display, causing multi-line commands to render as inline code on a single line in the TUI. The 3-space indentation applied to tool call bodies also interfered with block-level markdown parsing.
+
+## Symptoms
+
+- Multi-line bash commands displayed as single run-on line: `$ echo 'a\nb\nc'` instead of properly formatted blocks
+- Single backticks rendered literally in some contexts instead of creating code formatting
+- Tool call bodies had fixed 3-space indentation regardless of content type
+
+## Investigation Steps
+
+1. Traced rendering path: `ToolCallBody::Markdown` passed through `render_indented_markdown_line` which used `tui_markdown` on each line individually
+2. Identified that block-level constructs (code fences, lists, blockquotes) require whole-document parsing, not line-by-line
+3. Found `tui_markdown::from_str` emits fence marker lines (`` ```sh ``, `` ``` ``) as unstyled single-span lines that leaked into output
+4. Tested triple-tick templates with multi-line commands — worked in block mode but showed literal fence markers
+
+## Root Cause
+
+Two issues compounded:
+
+1. **Inline renderer limitation**: The old `render_indented_markdown_line` function parsed each line independently with `tui_markdown::from_str`. This works for inline emphasis (`**bold**`, `` `code` ``) but cannot handle block-level markdown like fenced code blocks which span multiple lines.
+
+2. **Fence marker pass-through**: `tui_markdown::from_str` emits opening and closing fence lines as unstyled `Line` objects with a single span containing the fence text. These passed through to the TUI as visible `` ```sh `` and `` ``` `` lines.
+
+## Solution
+
+### 1. Switch to block renderer
+
+Replaced line-by-line inline rendering with `render_markdown_block` that parses the entire text as a document:
+
+```rust
+// Before: line-by-line inline parsing
+fn render_indented_markdown_line(text: &str, base_style: Style) -> Line<'static> {
+    let parsed = tui_markdown::from_str(text, None);
+    // ...process single line...
+}
+
+// After: whole-document block parsing
+fn render_markdown_block(text: &str) -> Vec<Line<'static>> {
+    let body_base = Style::default().add_modifier(Modifier::DIM);
+    crate::render_helpers::markdown_lines(text, body_base)
+}
+```
+
+### 2. Filter fence marker lines
+
+Added `is_fence_marker_line` to detect and remove fence markers from `tui_markdown` output:
+
+```rust
+fn is_fence_marker_line(line: &ratatui::text::Line<'_>) -> bool {
+    if line.spans.len() != 1 {
+        return false;
+    }
+    let span = &line.spans[0];
+    // Must be unstyled (no fg/bg override set by tui-markdown).
+    if span.style.fg.is_some() || span.style.bg.is_some() {
+        return false;
+    }
+    let content = span.content.trim();
+    // Match ``` optionally followed by an ASCII-lowercase language hint.
+    content.starts_with("```") && content[3..].chars().all(|c| c.is_ascii_lowercase())
+}
+
+pub(crate) fn markdown_lines(text: &str, base_style: Style) -> Vec<Line<'static>> {
+    tui_markdown::from_str(text, None)
+        .lines
+        .into_iter()
+        .filter(|line| !is_fence_marker_line(line))
+        .map(|line| { /* patch base_style */ })
+        .collect()
+}
+```
+
+### 3. Update templates with proper fence structure
+
+Changed bash tool templates to use triple-tick fences. Critical: closing fence must be on its own line when optional metadata follows:
+
+```rust
+// exec tool template
+"```sh\n$ {{ args.command }}\n```{% if args.working_dir or args.timeout_secs %}\n{% if args.working_dir %}({{ args.working_dir }}) {% endif %}{% if args.timeout_secs %}[{{ args.timeout_secs }}s]{% endif %}{% endif %}"
+
+// spawn tool template
+"```sh\n> {{ args.command }}\n```{% if args.working_dir %}\n({{ args.working_dir }}){% endif %}"
+```
+
+The newline before `{% if args.working_dir %}` ensures the closing ` ``` ` is isolated. Without it, metadata would render on the fence line (`` ``` [10s] ``), breaking the filter.
+
+### 4. Remove 3-space indentation
+
+Removed the fixed indentation prefix from `render_tool_call` and `render_tool_result_markdown`. Block-level markdown now renders at the same column as other transcript content.
+
+### 5. Gate test-only functions with `#[cfg(test)]`
+
+Functions like `markdown_line_spans` used only in tests caused dead-code warnings:
+
+```rust
+#[cfg(test)]
+pub(crate) fn markdown_line_spans(text: &str, base_style: Style) -> Line<'static> {
+    // ...
+}
+```
+
+## Why This Works
+
+**Block parsing**: `tui_markdown::from_str` on the full text lets the underlying `pulldown-cmark` parser recognize block boundaries correctly. Code fences become proper code blocks with syntax highlighting, not inline text.
+
+**Fence filtering**: `tui_markdown` emits fence markers as unstyled single-span lines. Code body lines get syntax highlighting (styled spans), so they pass the `fg.is_some()` check. The filter removes only the structural markers.
+
+**Template structure**: Putting the closing fence on its own line means `is_fence_marker_line` sees pure `` ``` `` (content = "```"), which matches the filter. Metadata lines appear after the fence and render as inline text.
+
+**Conservative filter design**: The filter fails safe — false negatives (leaving fence markers visible) are cosmetic, false positives (dropping content lines) would lose user data. The strict single-span, unstyled, lowercase-hint checks ensure only genuine fence markers are removed.
+
+## Prevention Strategies
+
+**Test Cases:**
+- Add tests for multi-line commands in code fences
+- Test `timeout_secs` without `working_dir` template branch
+- Test metadata rendering after fenced code block
+
+**Template Design Checklist:**
+- [ ] Closing fence always on its own line when metadata follows
+- [ ] Use `\n{% if %}` not `{% if %}` on same line as fence
+- [ ] Test both branches of conditional metadata
+
+**Code Review Checklist:**
+- [ ] Test-only functions marked `#[cfg(test)]`
+- [ ] Block-level markdown uses `markdown_lines`, not line-by-line parsing
+- [ ] Fence marker filter handles language hints used in templates
+
+## Related Issues
+
+- **Issue:** [#434](https://github.com/example/repo/issues/434) — Multi-line bash commands render incorrectly
+- **Related Solution:** [logic-errors/unified-tool-metadata-rendering-2026-04-30.md](../logic-errors/unified-tool-metadata-rendering-2026-04-30.md) — Tool response metadata consistency


### PR DESCRIPTION
Fixes the bash tool call_templates to use triple-tick code fences for multi-line command rendering, removes 3-space indentation from tool call body and result rendering, and adds is_fence_marker_line filtering in markdown_lines to strip fence markers that tui_markdown passes through as literal text.

#434

Plan: bash-triple-tick-434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed markdown rendering to properly hide code-fence markers when displaying multi-line bash commands in the terminal interface
  * Removed excess indentation spacing from tool output for improved alignment with surrounding transcript content

* **Tests**
  * Added regression tests ensuring bash command templates with fenced code blocks render correctly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->