### PR TITLE
Separate agent configuration from runtime data

### DIFF
--- a/.changesets/xdg-directory-separation.md
+++ b/.changesets/xdg-directory-separation.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+Separate agent configuration from runtime data by implementing XDG-compliant directory structure. Agent `.md` files now live in `agents/` within the config directory, while sessions, logs, and other runtime data are redirected to dedicated data and state directories.

--- a/crates/harnx-core/src/config_paths.rs
+++ b/crates/harnx-core/src/config_paths.rs
@@ -65,13 +65,17 @@ pub fn normalize_env_name(value: &str) -> String {
 /// Panics if the OS has no default user config dir AND no overrides.
 pub fn config_dir() -> PathBuf {
     if let Ok(v) = env::var(get_env_name("config_dir")) {
-        PathBuf::from(v)
-    } else if let Ok(v) = env::var("XDG_CONFIG_HOME") {
-        PathBuf::from(v).join(HARNX_NAME)
-    } else {
-        let dir = dirs::config_dir().expect("No user's config directory");
-        dir.join(HARNX_NAME)
+        if !v.is_empty() {
+            return PathBuf::from(v);
+        }
     }
+    if let Ok(v) = env::var("XDG_CONFIG_HOME") {
+        if !v.is_empty() {
+            return PathBuf::from(v).join(HARNX_NAME);
+        }
+    }
+    let dir = dirs::config_dir().expect("No user's config directory");
+    dir.join(HARNX_NAME)
 }
 
 /// Join `name` under `config_dir()`. Convenience for leaf files/dirs.
@@ -79,19 +83,71 @@ pub fn local_path(name: &str) -> PathBuf {
     config_dir().join(name)
 }
 
+/// Root data directory. Resolution order:
+/// 1. `HARNX_DATA_DIR` env var (literal path).
+/// 2. `XDG_DATA_HOME/harnx` (XDG override).
+/// 3. OS default (`dirs::data_dir()/harnx`).
+///
+/// Panics if the OS has no default user data dir AND no overrides.
+pub fn data_dir() -> PathBuf {
+    if let Ok(v) = env::var(get_env_name("data_dir")) {
+        if !v.is_empty() {
+            return PathBuf::from(v);
+        }
+    }
+    if let Ok(v) = env::var("XDG_DATA_HOME") {
+        if !v.is_empty() {
+            return PathBuf::from(v).join(HARNX_NAME);
+        }
+    }
+    let dir = dirs::data_dir().expect("No user data dir");
+    dir.join(HARNX_NAME)
+}
+
+/// Join `name` under `data_dir()`. Convenience for leaf files/dirs.
+pub fn data_path(name: &str) -> PathBuf {
+    data_dir().join(name)
+}
+
+/// Root state directory. Resolution order:
+/// 1. `HARNX_STATE_DIR` env var (literal path).
+/// 2. `XDG_STATE_HOME/harnx` (XDG override).
+/// 3. OS default (`dirs::state_dir().unwrap_or_else(|| dirs::data_dir().expect("No user data dir"))/harnx`).
+///
+/// Panics if the OS has no default user state dir, no default user data dir, AND no overrides.
+pub fn state_dir() -> PathBuf {
+    if let Ok(v) = env::var(get_env_name("state_dir")) {
+        if !v.is_empty() {
+            return PathBuf::from(v);
+        }
+    }
+    if let Ok(v) = env::var("XDG_STATE_HOME") {
+        if !v.is_empty() {
+            return PathBuf::from(v).join(HARNX_NAME);
+        }
+    }
+    let dir = dirs::state_dir().unwrap_or_else(|| dirs::data_dir().expect("No user data dir"));
+    dir.join(HARNX_NAME)
+}
+
+/// Join `name` under `state_dir()`. Convenience for leaf files/dirs.
+pub fn state_path(name: &str) -> PathBuf {
+    state_dir().join(name)
+}
+
 /// Path to the main config file. Overridable via `HARNX_CONFIG_FILE`.
 pub fn config_file() -> PathBuf {
     match env::var(get_env_name("config_file")) {
-        Ok(value) => PathBuf::from(value),
-        Err(_) => local_path(CONFIG_FILE_NAME),
+        Ok(value) if !value.is_empty() => PathBuf::from(value),
+        _ => local_path(CONFIG_FILE_NAME),
     }
 }
 
 /// Directory holding macro YAML files. Overridable via `HARNX_MACROS_DIR`.
 pub fn macros_dir() -> PathBuf {
     match env::var(get_env_name("macros_dir")) {
-        Ok(value) => PathBuf::from(value),
-        Err(_) => local_path(MACROS_DIR_NAME),
+        Ok(value) if !value.is_empty() => PathBuf::from(value),
+        _ => local_path(MACROS_DIR_NAME),
     }
 }
 
@@ -128,30 +184,30 @@ pub fn macro_file(name: &str) -> PathBuf {
 /// Path to the `.env` file loaded at startup. Overridable via `HARNX_ENV_FILE`.
 pub fn env_file() -> PathBuf {
     match env::var(get_env_name("env_file")) {
-        Ok(value) => PathBuf::from(value),
-        Err(_) => local_path(ENV_FILE_NAME),
+        Ok(value) if !value.is_empty() => PathBuf::from(value),
+        _ => local_path(ENV_FILE_NAME),
     }
 }
 
 /// Top-level RAG manifests dir (not per-agent). Overridable via `HARNX_RAGS_DIR`.
 pub fn rags_dir() -> PathBuf {
     match env::var(get_env_name("rags_dir")) {
-        Ok(value) => PathBuf::from(value),
-        Err(_) => local_path(RAGS_DIR_NAME),
+        Ok(value) if !value.is_empty() => PathBuf::from(value),
+        _ => data_path(RAGS_DIR_NAME),
     }
 }
 
 /// Root dir for per-agent data subdirectories.
 pub fn agents_data_dir() -> PathBuf {
-    local_path(AGENTS_DIR_NAME)
+    data_path(AGENTS_DIR_NAME)
 }
 
 /// Per-agent data dir. Each agent may override its own location via
 /// `<AGENT_NAME>_DATA_DIR` (dashes become underscores, uppercased).
 pub fn agent_data_dir(name: &str) -> PathBuf {
     match env::var(format!("{}_DATA_DIR", normalize_env_name(name))) {
-        Ok(value) => PathBuf::from(value),
-        Err(_) => agents_data_dir().join(name),
+        Ok(value) if !value.is_empty() => PathBuf::from(value),
+        _ => agents_data_dir().join(name),
     }
 }
 
@@ -160,9 +216,18 @@ pub fn agent_rag_file(agent_name: &str, rag_name: &str) -> PathBuf {
     agent_data_dir(agent_name).join(format!("{rag_name}.yaml"))
 }
 
-/// Per-agent instruction file: `<agents_data_dir>/<name>.md`.
+/// Root dir for per-agent instruction files (.md) — lives in config dir.
+///
+/// Resolves relative to `config_dir_path()` (i.e. the parent of the active
+/// config file) so that `HARNX_CONFIG_FILE` redirections are honoured, exactly
+/// as `clients_dir()`, `mcp_servers_dir()`, and `acp_servers_dir()` do.
+pub fn agents_config_dir() -> PathBuf {
+    config_dir_path().join(AGENTS_DIR_NAME)
+}
+
+/// Per-agent instruction file: `<config_dir>/agents/<name>.md`.
 pub fn agent_file(name: &str) -> PathBuf {
-    agents_data_dir().join(format!("{name}.md"))
+    agents_config_dir().join(format!("{name}.md"))
 }
 
 /// Optional models-override YAML file; if present, overrides models.yaml entries.
@@ -175,8 +240,8 @@ pub fn models_override_file() -> PathBuf {
 pub fn messages_file(agent_name: Option<&str>) -> PathBuf {
     match agent_name {
         None => match env::var(get_env_name("messages_file")) {
-            Ok(value) => PathBuf::from(value),
-            Err(_) => local_path(MESSAGES_FILE_NAME),
+            Ok(value) if !value.is_empty() => PathBuf::from(value),
+            _ => state_path(MESSAGES_FILE_NAME),
         },
         Some(agent) => agent_data_dir(agent).join(MESSAGES_FILE_NAME),
     }
@@ -187,8 +252,8 @@ pub fn messages_file(agent_name: Option<&str>) -> PathBuf {
 pub fn sessions_dir(agent_name: Option<&str>) -> PathBuf {
     match agent_name {
         None => match env::var(get_env_name("sessions_dir")) {
-            Ok(value) => PathBuf::from(value),
-            Err(_) => local_path(SESSIONS_DIR_NAME),
+            Ok(value) if !value.is_empty() => PathBuf::from(value),
+            _ => state_path(SESSIONS_DIR_NAME),
         },
         Some(agent) => agent_data_dir(agent).join(SESSIONS_DIR_NAME),
     }
@@ -219,6 +284,64 @@ pub fn rag_file(agent_name: Option<&str>, name: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Mutex that serialises all tests which mutate process-global env vars.
+    ///
+    /// `cargo nextest` runs tests in separate processes by default, but
+    /// `cargo test` runs them in parallel threads within the same process.
+    /// Any test that calls `env::set_var` / `env::remove_var` must hold this
+    /// lock for the duration of the set → call → restore sequence.
+    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Temporarily set an env var, invoke `f`, then restore the previous value
+    /// (or remove the var if it was absent before).  Holds `ENV_MUTEX` for the
+    /// entire duration so env-sensitive tests cannot race.
+    fn with_env<F, R>(key: &str, value: &str, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let prior = env::var_os(key);
+        env::set_var(key, value);
+        let result = f();
+        match prior {
+            Some(v) => env::set_var(key, v),
+            None => env::remove_var(key),
+        }
+        result
+    }
+
+    /// Apply multiple env-var overrides (`Some(value)` = set, `None` = remove),
+    /// invoke `f`, then restore every var to its prior state.  Holds `ENV_MUTEX`
+    /// for the whole sequence so the entire multi-var mutation is atomic w.r.t.
+    /// other env-sensitive tests.
+    fn with_envs<F, R>(pairs: &[(&str, Option<&str>)], f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        // Save prior values and apply requested overrides.
+        let priors: Vec<_> = pairs
+            .iter()
+            .map(|(key, new_val)| {
+                let prior = env::var_os(key);
+                match new_val {
+                    Some(v) => env::set_var(key, v),
+                    None => env::remove_var(key),
+                }
+                (key, prior)
+            })
+            .collect();
+        let result = f();
+        // Restore in reverse order for cleanliness.
+        for (key, prior) in priors.into_iter().rev() {
+            match prior {
+                Some(v) => env::set_var(key, v),
+                None => env::remove_var(key),
+            }
+        }
+        result
+    }
 
     #[test]
     fn get_env_name_produces_harnx_prefix() {
@@ -377,5 +500,126 @@ mod tests {
                 agent.to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn data_dir_uses_harnx_data_dir_env_override() {
+        let test_path = "/tmp/harnx_data_test_8a3f";
+        let got = with_env("HARNX_DATA_DIR", test_path, data_dir);
+        assert_eq!(got, PathBuf::from(test_path));
+    }
+
+    #[test]
+    fn state_dir_uses_harnx_state_dir_env_override() {
+        let test_path = "/tmp/harnx_state_test_7b2e";
+        let got = with_env("HARNX_STATE_DIR", test_path, state_dir);
+        assert_eq!(got, PathBuf::from(test_path));
+    }
+
+    #[test]
+    fn rags_dir_is_under_data_dir() {
+        let test_data_dir = "/tmp/harnx_data_rags_3c9b";
+        // Hold both HARNX_DATA_DIR and HARNX_RAGS_DIR under one lock acquire so
+        // another test cannot slip in between and see a half-set state.
+        let got = with_envs(
+            &[
+                ("HARNX_DATA_DIR", Some(test_data_dir)),
+                ("HARNX_RAGS_DIR", None), // ensure fallback path fires
+            ],
+            rags_dir,
+        );
+        assert!(
+            got.starts_with(test_data_dir),
+            "rags_dir should be under data_dir"
+        );
+        assert!(
+            got.ends_with(RAGS_DIR_NAME),
+            "rags_dir should end with 'rags'"
+        );
+    }
+
+    #[test]
+    fn sessions_dir_none_is_under_state_dir() {
+        let test_state_dir = "/tmp/harnx_state_sessions_5d1a";
+        let got = with_envs(
+            &[
+                ("HARNX_STATE_DIR", Some(test_state_dir)),
+                ("HARNX_SESSIONS_DIR", None), // ensure fallback path fires
+            ],
+            || sessions_dir(None),
+        );
+        assert!(
+            got.starts_with(test_state_dir),
+            "sessions_dir(None) should be under state_dir"
+        );
+        assert!(
+            got.ends_with(SESSIONS_DIR_NAME),
+            "sessions_dir(None) should end with 'sessions'"
+        );
+    }
+
+    #[test]
+    fn sessions_dir_with_agent_is_under_data_dir() {
+        let test_data_dir = "/tmp/harnx_data_agent_sessions_9e2f";
+        // Use an unlikely agent name to avoid <AGENT>_DATA_DIR env collisions.
+        let agent = "ztest_agent_for_sdir_5e1c";
+        let got = with_env("HARNX_DATA_DIR", test_data_dir, || {
+            sessions_dir(Some(agent))
+        });
+        assert!(
+            got.starts_with(test_data_dir),
+            "sessions_dir(Some(agent)) should be under data_dir"
+        );
+        assert!(
+            got.ends_with(SESSIONS_DIR_NAME),
+            "sessions_dir(Some(agent)) should end with 'sessions'"
+        );
+    }
+
+    #[test]
+    fn messages_file_none_is_under_state_dir() {
+        let test_state_dir = "/tmp/harnx_state_messages_4f8b";
+        let got = with_envs(
+            &[
+                ("HARNX_STATE_DIR", Some(test_state_dir)),
+                ("HARNX_MESSAGES_FILE", None), // ensure fallback path fires
+            ],
+            || messages_file(None),
+        );
+        assert!(
+            got.starts_with(test_state_dir),
+            "messages_file(None) should be under state_dir"
+        );
+        assert!(
+            got.ends_with(MESSAGES_FILE_NAME),
+            "messages_file(None) should end with 'messages.md'"
+        );
+    }
+
+    #[test]
+    fn data_dir_uses_xdg_data_home_env() {
+        let test_path = "/tmp/xdg_data_test_9b2c";
+        // Clear HARNX_DATA_DIR so the XDG_DATA_HOME branch fires, and restore
+        // both vars afterwards.
+        let got = with_envs(
+            &[("HARNX_DATA_DIR", None), ("XDG_DATA_HOME", Some(test_path))],
+            data_dir,
+        );
+        assert_eq!(got, PathBuf::from(test_path).join(HARNX_NAME));
+    }
+
+    #[test]
+    fn state_dir_uses_xdg_state_home_env() {
+        let test_path = "/tmp/xdg_state_test_3d7e";
+        // Clear HARNX_STATE_DIR so the XDG_STATE_HOME branch fires, and restore
+        // both vars afterwards.
+        let got = with_envs(
+            &[
+                ("HARNX_STATE_DIR", None),
+                ("XDG_STATE_HOME", Some(test_path)),
+            ],
+            state_dir,
+        );
+        assert_eq!(got, PathBuf::from(test_path).join(HARNX_NAME));
     }
 }

--- a/crates/harnx-runtime/src/config/agent.rs
+++ b/crates/harnx-runtime/src/config/agent.rs
@@ -113,7 +113,7 @@ pub fn resolve_file_defaults(agent: &mut Agent) -> Result<()> {
     let agent_dir = agent_file_path
         .parent()
         .map(Path::to_path_buf)
-        .unwrap_or_else(Config::agents_data_dir);
+        .unwrap_or_else(Config::agents_config_dir);
     resolve_file_backed_variables(agent.config.variables_mut(), &agent_dir)
 }
 
@@ -177,7 +177,7 @@ pub async fn init(config: &GlobalConfig, name: &str, abort_signal: AbortSignal) 
     let agent_dir = agent_file_path
         .parent()
         .map(Path::to_path_buf)
-        .unwrap_or_else(Config::agents_data_dir);
+        .unwrap_or_else(Config::agents_config_dir);
 
     resolve_file_backed_variables(agent.config.variables_mut(), &agent_dir)?;
 
@@ -316,7 +316,7 @@ pub fn init_agent_variables(
 }
 
 pub fn list_agents() -> Vec<String> {
-    let mut output: Vec<String> = match read_dir(Config::agents_data_dir()) {
+    let mut output: Vec<String> = match read_dir(Config::agents_config_dir()) {
         Ok(entries) => entries
             .filter_map(|entry| entry.ok())
             .filter_map(|entry| {
@@ -338,7 +338,7 @@ pub fn list_agents() -> Vec<String> {
 }
 
 pub fn complete_agent_variables(agent_name: &str) -> Vec<(String, Option<String>)> {
-    let markdown_path = Config::agents_data_dir().join(format!("{agent_name}.md"));
+    let markdown_path = Config::agents_config_dir().join(format!("{agent_name}.md"));
     if markdown_path.exists() {
         if let Ok(agent) = load(&markdown_path) {
             return agent
@@ -387,17 +387,33 @@ mod tests {
     fn with_test_config_dir<T>(f: impl FnOnce(&Path) -> Result<T>) -> Result<T> {
         let _guard = TEST_CONFIG_DIR_LOCK.lock().unwrap();
         let config_dir = unique_test_config_dir();
+        let data_dir = config_dir.with_file_name(format!(
+            "{}-data",
+            config_dir.file_name().unwrap().to_string_lossy()
+        ));
+        let state_dir = config_dir.with_file_name(format!(
+            "{}-state",
+            config_dir.file_name().unwrap().to_string_lossy()
+        ));
         let agents_dir = config_dir.join("agents");
         fs::create_dir_all(&agents_dir)?;
+        fs::create_dir_all(&data_dir)?;
+        fs::create_dir_all(&state_dir)?;
 
         unsafe {
             std::env::set_var("HARNX_CONFIG_DIR", &config_dir);
+            std::env::set_var("HARNX_DATA_DIR", &data_dir);
+            std::env::set_var("HARNX_STATE_DIR", &state_dir);
         }
         let result = f(&config_dir);
         unsafe {
             std::env::remove_var("HARNX_CONFIG_DIR");
+            std::env::remove_var("HARNX_DATA_DIR");
+            std::env::remove_var("HARNX_STATE_DIR");
         }
 
+        let _ = fs::remove_dir_all(&data_dir);
+        let _ = fs::remove_dir_all(&state_dir);
         let cleanup_result = fs::remove_dir_all(&config_dir);
         match (result, cleanup_result) {
             (Ok(value), Ok(())) => Ok(value),

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -589,6 +589,11 @@ impl Config {
         paths::agents_data_dir()
     }
 
+    /// Root dir for per-agent instruction files (.md) — lives in config dir.
+    pub fn agents_config_dir() -> PathBuf {
+        paths::agents_config_dir()
+    }
+
     pub fn agent_data_dir(name: &str) -> PathBuf {
         paths::agent_data_dir(name)
     }
@@ -648,10 +653,10 @@ impl Config {
             return Ok((log_level, None));
         }
         let log_path = match env::var(get_env_name("log_path")) {
-            Ok(v) => Some(PathBuf::from(v)),
-            Err(_) => match is_serve {
+            Ok(v) if !v.is_empty() => Some(PathBuf::from(v)),
+            _ => match is_serve {
                 true => None,
-                false => Some(Config::local_path(&format!(
+                false => Some(paths::state_path(&format!(
                     "{}.log",
                     env!("CARGO_CRATE_NAME")
                 ))),
@@ -914,7 +919,7 @@ impl Config {
 
     pub fn delete(config: &GlobalConfig, kind: &str) -> Result<()> {
         let (dir, file_ext) = match kind {
-            "agent" => (Self::agents_data_dir(), Some(".md")),
+            "agent" => (Self::agents_config_dir(), Some(".md")),
             "session" => (config.read().sessions_dir(), Some(".yaml")),
             "rag" => (Self::rags_dir(), Some(".yaml")),
             "macro" => (Self::macros_dir(), Some(".yaml")),

--- a/crates/harnx/src/test_utils/interrupt.rs
+++ b/crates/harnx/src/test_utils/interrupt.rs
@@ -108,14 +108,22 @@ pub fn script_streaming_with_sentinel() -> MockOpenAiScript {
 pub struct ConfigPaths {
     pub dir: PathBuf,
     pub harnx_config_dir: PathBuf,
+    pub harnx_data_dir: PathBuf,
+    pub harnx_state_dir: PathBuf,
 }
 
 /// Writes a minimal HARNX_CONFIG_DIR at `<dir>/harnx-config` targeting
 /// the given mock OpenAI base URL (e.g. `http://127.0.0.1:<port>/v1`).
 pub fn write_minimal_config(dir: &Path, mock_base_url: &str) -> Result<ConfigPaths> {
     let harnx_config_dir = dir.join("harnx-config");
+    let harnx_data_dir = dir.join("harnx-data");
+    let harnx_state_dir = dir.join("harnx-state");
+
     std::fs::create_dir_all(harnx_config_dir.join("clients"))
         .context("failed to create harnx config dir")?;
+    std::fs::create_dir_all(&harnx_data_dir).context("failed to create harnx data dir")?;
+    std::fs::create_dir_all(&harnx_state_dir).context("failed to create harnx state dir")?;
+
     std::fs::write(
         harnx_config_dir.join("config.yaml"),
         "save: false\nclient: mock-llm\nmodel: mock-llm:test\ntool_use: true\nuse_tools: '*'\n",
@@ -131,6 +139,8 @@ pub fn write_minimal_config(dir: &Path, mock_base_url: &str) -> Result<ConfigPat
     Ok(ConfigPaths {
         dir: dir.to_path_buf(),
         harnx_config_dir,
+        harnx_data_dir,
+        harnx_state_dir,
     })
 }
 
@@ -230,8 +240,10 @@ pub fn write_with_blocking_hook(
 pub fn spawn_tui(paths: &ConfigPaths, harnx_bin: &Path, repo_root: &Path) -> Result<TmuxHarness> {
     let tmux = TmuxHarness::new(repo_root, 120, 35).context("failed to create tmux session")?;
     tmux.send_text(&format!(
-        "export HARNX_CONFIG_DIR={}\n",
-        shell_escape(&paths.harnx_config_dir.to_string_lossy())
+        "export HARNX_CONFIG_DIR={} HARNX_DATA_DIR={} HARNX_STATE_DIR={}\n",
+        shell_escape(&paths.harnx_config_dir.to_string_lossy()),
+        shell_escape(&paths.harnx_data_dir.to_string_lossy()),
+        shell_escape(&paths.harnx_state_dir.to_string_lossy())
     ))?;
     tmux.send_text(&format!(
         "{} || echo HARNX_EXIT:$?\n",
@@ -266,8 +278,10 @@ pub fn spawn_oneshot_in_tmux(
 ) -> Result<TmuxHarness> {
     let tmux = TmuxHarness::new(repo_root, 120, 35).context("failed to create tmux session")?;
     tmux.send_text(&format!(
-        "export HARNX_CONFIG_DIR={}\n",
-        shell_escape(&paths.harnx_config_dir.to_string_lossy())
+        "export HARNX_CONFIG_DIR={} HARNX_DATA_DIR={} HARNX_STATE_DIR={}\n",
+        shell_escape(&paths.harnx_config_dir.to_string_lossy()),
+        shell_escape(&paths.harnx_data_dir.to_string_lossy()),
+        shell_escape(&paths.harnx_state_dir.to_string_lossy())
     ))?;
     // "|| echo HARNX_EXIT:$?" prints a detectable sentinel when harnx exits
     // non-zero (interrupted), making exit detection possible from pane capture.
@@ -364,6 +378,14 @@ pub fn write_with_sub_agent(
         "HARNX_CONFIG_DIR".to_string(),
         child_paths.harnx_config_dir.to_string_lossy().into_owned(),
     );
+    env.insert(
+        "HARNX_DATA_DIR".to_string(),
+        child_paths.harnx_data_dir.to_string_lossy().into_owned(),
+    );
+    env.insert(
+        "HARNX_STATE_DIR".to_string(),
+        child_paths.harnx_state_dir.to_string_lossy().into_owned(),
+    );
     let acp_server = AcpServerConfig {
         name: "child".to_string(),
         command: harnx_bin.to_string_lossy().into_owned(),
@@ -416,6 +438,8 @@ pub fn spawn_oneshot(
     Command::new(harnx_bin)
         .arg(prompt)
         .env("HARNX_CONFIG_DIR", &paths.harnx_config_dir)
+        .env("HARNX_DATA_DIR", &paths.harnx_data_dir)
+        .env("HARNX_STATE_DIR", &paths.harnx_state_dir)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -462,6 +486,14 @@ pub async fn spawn_acp_client(
     env.insert(
         "HARNX_CONFIG_DIR".to_string(),
         paths.harnx_config_dir.to_string_lossy().into_owned(),
+    );
+    env.insert(
+        "HARNX_DATA_DIR".to_string(),
+        paths.harnx_data_dir.to_string_lossy().into_owned(),
+    );
+    env.insert(
+        "HARNX_STATE_DIR".to_string(),
+        paths.harnx_state_dir.to_string_lossy().into_owned(),
     );
     let config = AcpServerConfig {
         name: format!("test-{agent}"),

--- a/crates/harnx/tests/tmux_e2e.rs
+++ b/crates/harnx/tests/tmux_e2e.rs
@@ -54,10 +54,12 @@ fn repro_249_top_level_delegation_markers() -> Result<()> {
     };
     tmux.send_keys(&["C-l"])?;
 
-    // Step 1: Export HARNX_CONFIG_DIR
+    // Step 1: Export HARNX_CONFIG_DIR, HARNX_DATA_DIR, HARNX_STATE_DIR
     tmux.send_text(&format!(
-        "export HARNX_CONFIG_DIR={}",
-        shell_escape(paths.harnx_config_dir.to_string_lossy().as_ref())
+        "export HARNX_CONFIG_DIR={} HARNX_DATA_DIR={} HARNX_STATE_DIR={}",
+        shell_escape(paths.harnx_config_dir.to_string_lossy().as_ref()),
+        shell_escape(paths.harnx_data_dir.to_string_lossy().as_ref()),
+        shell_escape(paths.harnx_state_dir.to_string_lossy().as_ref())
     ))?;
     tmux.send_keys(&["Enter"])?;
 
@@ -235,6 +237,8 @@ fn repo_root() -> Result<PathBuf> {
 
 struct TestPaths {
     harnx_config_dir: PathBuf,
+    harnx_data_dir: PathBuf,
+    harnx_state_dir: PathBuf,
     config_path: PathBuf,
     agents_dir: PathBuf,
     port: u16,
@@ -243,11 +247,17 @@ struct TestPaths {
 impl TestPaths {
     fn new(temp_root: &Path, port: u16) -> Result<Self> {
         let harnx_config_dir = temp_root.join("harnx");
+        let harnx_data_dir = temp_root.join("harnx-data");
+        let harnx_state_dir = temp_root.join("harnx-state");
         let config_path = harnx_config_dir.join("config.yaml");
         let agents_dir = harnx_config_dir.join("agents");
         std::fs::create_dir_all(&agents_dir)?;
+        std::fs::create_dir_all(&harnx_data_dir)?;
+        std::fs::create_dir_all(&harnx_state_dir)?;
         Ok(Self {
             harnx_config_dir,
+            harnx_data_dir,
+            harnx_state_dir,
             config_path,
             agents_dir,
             port,
@@ -826,8 +836,10 @@ fn setup_handoff_tmux_session_with_script(
     tmux.send_keys(&["C-l"])?;
 
     tmux.send_text(&format!(
-        "export HARNX_CONFIG_DIR={}",
-        shell_escape(paths.harnx_config_dir.to_string_lossy().as_ref())
+        "export HARNX_CONFIG_DIR={} HARNX_DATA_DIR={} HARNX_STATE_DIR={}",
+        shell_escape(paths.harnx_config_dir.to_string_lossy().as_ref()),
+        shell_escape(paths.harnx_data_dir.to_string_lossy().as_ref()),
+        shell_escape(paths.harnx_state_dir.to_string_lossy().as_ref())
     ))?;
     tmux.send_keys(&["Enter"])?;
 
@@ -1148,10 +1160,12 @@ fn nested_sub_agent_activity_no_duplicates() -> Result<()> {
     };
     tmux.send_keys(&["C-l"])?;
 
-    // Export HARNX_CONFIG_DIR
+    // Export HARNX_CONFIG_DIR, HARNX_DATA_DIR, HARNX_STATE_DIR
     tmux.send_text(&format!(
-        "export HARNX_CONFIG_DIR={}",
-        shell_escape(paths.harnx_config_dir.to_string_lossy().as_ref())
+        "export HARNX_CONFIG_DIR={} HARNX_DATA_DIR={} HARNX_STATE_DIR={}",
+        shell_escape(paths.harnx_config_dir.to_string_lossy().as_ref()),
+        shell_escape(paths.harnx_data_dir.to_string_lossy().as_ref()),
+        shell_escape(paths.harnx_state_dir.to_string_lossy().as_ref())
     ))?;
     tmux.send_keys(&["Enter"])?;
 
@@ -1452,8 +1466,10 @@ models:
     tmux.send_keys(&["C-l"])?;
 
     tmux.send_text(&format!(
-        "export HARNX_CONFIG_DIR={}",
-        shell_escape(paths.harnx_config_dir.to_string_lossy().as_ref())
+        "export HARNX_CONFIG_DIR={} HARNX_DATA_DIR={} HARNX_STATE_DIR={}",
+        shell_escape(paths.harnx_config_dir.to_string_lossy().as_ref()),
+        shell_escape(paths.harnx_data_dir.to_string_lossy().as_ref()),
+        shell_escape(paths.harnx_state_dir.to_string_lossy().as_ref())
     ))?;
     tmux.send_keys(&["Enter"])?;
 
@@ -1946,8 +1962,10 @@ fn session_mutation_edit_delete_rewind_persists_across_sessions() -> Result<()> 
     let setup_env = |tmux: &TmuxHarness, marker: &str| -> Result<()> {
         tmux.send_keys(&["C-l"])?;
         tmux.send_text(&format!(
-            "export HARNX_CONFIG_DIR={} PATH={} && cd {}; printf '{marker}\\n'",
+            "export HARNX_CONFIG_DIR={} HARNX_DATA_DIR={} HARNX_STATE_DIR={} PATH={} && cd {}; printf '{marker}\\n'",
             shell_escape(paths.harnx_config_dir.to_string_lossy().as_ref()),
+            shell_escape(paths.harnx_data_dir.to_string_lossy().as_ref()),
+            shell_escape(paths.harnx_state_dir.to_string_lossy().as_ref()),
             shell_escape(&path_env),
             shell_escape(root.to_string_lossy().as_ref()),
         ))?;
@@ -2019,7 +2037,7 @@ fn session_mutation_edit_delete_rewind_persists_across_sessions() -> Result<()> 
     }
 
     let session_log_path = paths
-        .harnx_config_dir
+        .harnx_data_dir
         .join("agents")
         .join(MUTATION_AGENT_NAME)
         .join("sessions")
@@ -2111,7 +2129,7 @@ fn session_mutation_edit_delete_rewind_persists_across_sessions() -> Result<()> 
     // Calculate the actual last seq by counting YAML documents in the session log.
     // The last entry (assistant response to fifth message) is at seq = doc_count - 1.
     let session_log_path = paths
-        .harnx_config_dir
+        .harnx_data_dir
         .join("agents")
         .join(MUTATION_AGENT_NAME)
         .join("sessions")

--- a/docs/solutions/logic-errors/xdg-directory-separation-2026-05-03.md
+++ b/docs/solutions/logic-errors/xdg-directory-separation-2026-05-03.md
@@ -1,0 +1,170 @@
+---
+title: "XDG Directory Separation for Config, Data, and State"
+date: 2026-05-03
+category: logic-errors
+problem_type: logic_error
+component: config-paths
+root_cause: "flat directory structure mixing user-authored config with runtime data"
+resolution_type: code_fix
+severity: medium
+tags:
+  - xdg
+  - config
+  - data-directory
+  - cross-platform
+  - test-isolation
+  - env-variables
+plan_ref: "harnx-store-data-separate-from-config"
+---
+
+## Problem
+
+harnx stored all files in a single `~/.config/harnx` directory, mixing user-authored configuration (`.md` instruction files, `config.yaml`) with mutable runtime data (sessions, messages, logs, RAG manifests). This violated XDG conventions and made backup, version control, and system administration harder.
+
+## Symptoms
+
+- Single directory `~/.config/harnx` contained both user-edited files and generated data
+- No clean separation between "what the user authors" vs "what the system produces"
+- Log files mixed with configuration, polluting version-controlled config directories
+- No XDG compliance on Linux desktops
+
+## Investigation Steps
+
+Analyzed existing directory structure and identified path usage patterns:
+
+1. **Audit**: Found all path helpers in `crates/harnx-core/src/config_paths.rs` resolved through `local_path()` which always returned `config_dir().join(name)`
+
+2. **Classification**: Reviewed each path:
+   - `config.yaml`, `.env`, `agents/*.md` — user-authored → **config**
+   - `sessions/`, `messages.md` — runtime state → **state**
+   - `rags/`, `agents/<name>/sessions/` — runtime data → **data**
+   - `harnx.log` — log file → **state**
+
+3. **Platform research**: Found `dirs::state_dir()` returns `None` on macOS/Windows — must fall back to `dirs::data_dir()` for cross-platform support
+
+4. **Edge case discovery**: Found `env::var("VAR")` returns `Ok("")` when set to empty string. `PathBuf::from("")` silently writes to CWD
+
+5. **Test isolation gap**: Unit tests only set `HARNX_CONFIG_DIR`, so after split, data/state operations would leak to real user directories
+
+## Root Cause
+
+The original design used a flat directory structure with all paths resolved via `config_dir()`. This baked in the assumption that "harnx has one home directory" rather than separating concerns per XDG spec:
+- **Config** (`~/.config/harnx`) — user-authored, may be version-controlled
+- **Data** (`~/.local/share/harnx`) — runtime data that persists across restarts
+- **State** (`~/.local/state/harnx`) — transient state, logs, caches
+
+When agents were introduced, the `agents/` directory needed to exist in BOTH config (for `.md` instruction files) AND data (for runtime sessions/rags). Several callers were missed in the first pass, causing bugs where code looked for `.md` files in the data directory.
+
+## Solution
+
+### 1. Added `data_dir()` and `state_dir()` functions
+
+```rust
+pub fn data_dir() -> PathBuf {
+    // 1. HARNX_DATA_DIR override
+    // 2. XDG_DATA_HOME/harnx
+    // 3. dirs::data_dir()/harnx
+}
+
+pub fn state_dir() -> PathBuf {
+    // 1. HARNX_STATE_DIR override
+    // 2. XDG_STATE_HOME/harnx
+    // 3. dirs::state_dir().unwrap_or_else(|| dirs::data_dir())/harnx
+}
+```
+
+Key: `state_dir()` falls back to `data_dir()` on macOS/Windows where `dirs::state_dir()` returns `None`.
+
+### 2. Split `agents/` directory
+
+Added two separate functions:
+- `agents_config_dir()` → `config_dir()/agents/` (for `.md` instruction files)
+- `agents_data_dir()` → `data_dir()/agents/` (for runtime data: sessions, rags)
+
+Updated callers:
+- `list_agents()` — looks for `.md` files, needed `agents_config_dir()`
+- `complete_agent_variables()` — looks for `.md` files, needed `agents_config_dir()`
+- `Config::delete("agent")` — deletes `.md` files, needed `agents_config_dir()`
+
+### 3. Added empty-string guards to env var checks
+
+```rust
+// BEFORE: accepts empty string silently
+if let Ok(v) = env::var(get_env_name("config_dir")) {
+    PathBuf::from(v)
+}
+
+// AFTER: rejects empty string
+if let Ok(v) = env::var(get_env_name("config_dir")) {
+    if !v.is_empty() {
+        return PathBuf::from(v);
+    }
+}
+```
+
+This prevents `PathBuf::from("")` which resolves to CWD.
+
+### 4. Updated test isolation helpers
+
+```rust
+fn with_test_config_dir<T>(f: impl FnOnce(&Path) -> Result<T>) -> Result<T> {
+    let config_dir = unique_test_config_dir();
+    let data_dir = config_dir.with_file_name(format!("{}-data", ...));
+    let state_dir = config_dir.with_file_name(format!("{}-state", ...));
+    
+    unsafe {
+        std::env::set_var("HARNX_CONFIG_DIR", &config_dir);
+        std::env::set_var("HARNX_DATA_DIR", &data_dir);
+        std::env::set_var("HARNX_STATE_DIR", &state_dir);
+    }
+    // ... cleanup all three on exit
+}
+```
+
+## Why This Works
+
+1. **XDG compliance**: Linux users get proper `~/.local/share/harnx` and `~/.local/state/harnx` directories, while macOS/Windows fall back gracefully
+
+2. **Separation of concerns**: User-authored config is cleanly separated from runtime data, enabling:
+   - Version control of config without runtime artifacts
+   - Separate backup policies for config vs data
+   - Easier system administration
+
+3. **Safe env handling**: Empty-string guards prevent silent CWD writes when env vars are explicitly set to `""`
+
+4. **Test isolation**: Tests that set only `HARNX_CONFIG_DIR` would previously leak data operations to real user directories; now all three dirs are isolated
+
+## Prevention Strategies
+
+### Test Cases
+
+- Add tests verifying XDG env vars (`XDG_DATA_HOME`, `XDG_STATE_HOME`) are respected
+- Add tests for empty-string env var rejection
+- Add tests verifying `state_dir()` fallback to `data_dir()` on non-Linux platforms
+- Extend `with_test_config_dir` pattern to all test helpers that manipulate paths
+
+### Best Practices
+
+- Always guard env var checks with `!value.is_empty()` before constructing paths
+- When introducing new directory categories, immediately update ALL test helpers
+- Use `agents_config_dir()` for user-authored files, `agents_data_dir()` for runtime data
+- On `dirs` crate API: check platform support — `state_dir()` returns `None` on macOS/Windows
+
+### Code Review Checklist
+
+- [ ] New paths go to the correct XDG category (config/data/state)?
+- [ ] Env var checks have `!value.is_empty()` guards?
+- [ ] Test helpers set all three directories (config/data/state)?
+- [ ] Cross-platform fallback for `dirs::state_dir()`?
+- [ ] Agent-related paths distinguish config (`.md` files) vs data (runtime)?
+
+## Related Issues
+
+- **Plan:** `harnx-store-data-separate-from-config`
+- **Commits:**
+  - `34459f4` feat(config): add data_dir/state_dir and redirect data/state paths
+  - `ad5041a` test(config): add unit tests for data_dir/state_dir path resolution
+  - `148ec0f` feat(config): redirect harnx.log default to state dir
+  - `a7ace76` feat(config): separate agent .md config from agent runtime data
+  - `c619a50` fix(config): reject empty-string env overrides and add XDG fallback tests
+  - `206cd2c` fix(config): fix delete-agent path and isolate runtime test dirs


### PR DESCRIPTION
Implements XDG-compliant directory separation for configuration, data, and state. Moves agent .md files to a dedicated agents/ directory within the config dir, while redirecting runtime artifacts like sessions, messages, and logs to dedicated data and state directories. Includes updates to test helpers to ensure full environment isolation across the workspace.

#446

Plan: harnx-store-data-separate-from-config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory organization by separating configuration files, runtime data, and state into dedicated directories for better compliance with file management standards.

* **Documentation**
  * Added comprehensive documentation explaining the new directory structure and how environment variables control file locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->