### PR TITLE
feat(tui): improve transcript navigation and browsing experience

### DIFF
--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -126,39 +126,138 @@ fn tool_completed_to_transcript_items(
 }
 
 impl Tui {
+    async fn handle_detail_view_key(&mut self, key: KeyEvent) -> Result<()> {
+        match (key.code, key.modifiers) {
+            (KeyCode::Esc, KeyModifiers::NONE) => {
+                self.app.detail_view_open = false;
+                // Return to browsing view (transcript_browsing stays true)
+            }
+            (KeyCode::Up, KeyModifiers::NONE) => {
+                self.app.detail_view_scroll.scroll_up();
+            }
+            (KeyCode::Down, KeyModifiers::NONE) => {
+                self.app.detail_view_scroll.scroll_down();
+            }
+            (KeyCode::PageUp, KeyModifiers::NONE) => {
+                for _ in 0..10 {
+                    self.app.detail_view_scroll.scroll_up();
+                }
+            }
+            (KeyCode::PageDown, KeyModifiers::NONE) => {
+                for _ in 0..10 {
+                    self.app.detail_view_scroll.scroll_down();
+                }
+            }
+            (KeyCode::Char('e'), KeyModifiers::NONE) => {
+                // Edit: close detail, run edit, then reopen detail with updated content.
+                // Save focus and browsing state before editing since handle_transcript_edit
+                // clears both.
+                let had_focus = self.app.transcript_focus;
+                let prior_browsing = self.app.transcript_browsing;
+                self.app.detail_view_open = false;
+                self.handle_transcript_edit().await?;
+                // After edit, if we had a valid focused item, try to reopen detail view.
+                // Note: transcript may have changed, so restore focus tentatively.
+                if let Some(focus_idx) = had_focus {
+                    // Check that the focus index still exists in the (possibly reloaded) transcript
+                    if focus_idx < self.app.transcript.len() {
+                        self.app.transcript_focus = Some(focus_idx);
+                        self.app.transcript_selection_anchor = None;
+                        self.app.transcript_browsing = prior_browsing;
+                        self.app.detail_view_scroll = {
+                            let mut s = ratatui_widget_scrolling::ScrollState::new();
+                            s.follow = false;
+                            s
+                        };
+                        self.app.detail_view_raw_yaml =
+                            self.selected_seq_range().and_then(|(from, to)| {
+                                self.config.read().get_message_range_yaml(from, to)
+                            });
+                        self.app.detail_view_open = true;
+                    }
+                }
+            }
+            (KeyCode::Delete, KeyModifiers::NONE) | (KeyCode::Char('d'), KeyModifiers::NONE) => {
+                // Delete: show confirm modal ON TOP of detail view (do NOT close detail_view_open)
+                self.handle_transcript_delete();
+            }
+            (KeyCode::Char('r'), KeyModifiers::NONE) => {
+                // Rewind: show confirm modal ON TOP of detail view
+                self.handle_transcript_rewind();
+            }
+            (KeyCode::Char('c'), KeyModifiers::NONE) => {
+                self.handle_transcript_copy();
+                // Show clipboard notice for 2 seconds
+                self.app.copy_notice_until =
+                    Some(std::time::Instant::now() + std::time::Duration::from_secs(2));
+            }
+            _ => {} // all other keys silently consumed
+        }
+        Ok(())
+    }
+
+    async fn handle_browsing_key(&mut self, key: KeyEvent) -> Result<()> {
+        match (key.code, key.modifiers) {
+            (KeyCode::Esc, KeyModifiers::NONE) => {
+                self.app.transcript_browsing = false;
+                self.app.transcript_focus = None;
+                self.app.transcript_selection_anchor = None;
+                self.app.scroll_state.follow = true;
+            }
+            (KeyCode::Up, KeyModifiers::NONE) => {
+                self.handle_up_key(key);
+            }
+            (KeyCode::Down, KeyModifiers::NONE) => {
+                self.handle_down_key(key);
+            }
+            (KeyCode::Enter, KeyModifiers::NONE) => {
+                // Open detail view for current focused item
+                self.app.detail_view_scroll = {
+                    let mut s = ratatui_widget_scrolling::ScrollState::new();
+                    s.follow = false;
+                    s
+                };
+                self.app.detail_view_raw_yaml = self
+                    .selected_seq_range()
+                    .and_then(|(from, to)| self.config.read().get_message_range_yaml(from, to));
+                self.app.detail_view_open = true;
+            }
+            (KeyCode::Char('e'), KeyModifiers::NONE) => {
+                self.handle_transcript_edit().await?;
+            }
+            (KeyCode::Char('i'), KeyModifiers::NONE) => {
+                self.handle_transcript_insert();
+            }
+            (KeyCode::Delete, KeyModifiers::NONE) | (KeyCode::Char('d'), KeyModifiers::NONE) => {
+                self.handle_transcript_delete();
+            }
+            (KeyCode::Char('c'), KeyModifiers::NONE) => {
+                self.handle_transcript_copy();
+            }
+            (KeyCode::Char('r'), KeyModifiers::NONE) => {
+                self.handle_transcript_rewind();
+            }
+            _ => {} // consume all other keys to prevent bleed to input
+        }
+        Ok(())
+    }
+
     pub(super) async fn handle_key(&mut self, key: KeyEvent) -> Result<()> {
         // If a modal is open, intercept all keys and route to modal handler
         if self.app.modal.is_some() {
             return self.handle_modal_key(key).await;
         }
 
-        // While the detail view is open, only navigation / close keys are
-        // handled.  All other keys are silently consumed so they cannot bleed
-        // into the hidden background input field or trigger background actions.
+        // While the detail view is open, handle navigation + mutation keys.
+        // All other keys are silently consumed so they cannot bleed into the
+        // hidden background input field or trigger background actions.
         if self.app.detail_view_open {
-            match (key.code, key.modifiers) {
-                (KeyCode::Esc, KeyModifiers::NONE) => {
-                    self.app.detail_view_open = false;
-                }
-                (KeyCode::Up, KeyModifiers::NONE) => {
-                    self.app.detail_view_scroll.scroll_up();
-                }
-                (KeyCode::Down, KeyModifiers::NONE) => {
-                    self.app.detail_view_scroll.scroll_down();
-                }
-                (KeyCode::PageUp, KeyModifiers::NONE) => {
-                    for _ in 0..10 {
-                        self.app.detail_view_scroll.scroll_up();
-                    }
-                }
-                (KeyCode::PageDown, KeyModifiers::NONE) => {
-                    for _ in 0..10 {
-                        self.app.detail_view_scroll.scroll_down();
-                    }
-                }
-                _ => {} // all other keys silently consumed
-            }
-            return Ok(());
+            return self.handle_detail_view_key(key).await;
+        }
+
+        // Browsing mode guard: when user is navigating history fullscreen
+        if self.app.transcript_browsing {
+            return self.handle_browsing_key(key).await;
         }
 
         match (key.code, key.modifiers) {
@@ -238,9 +337,11 @@ impl Tui {
             (KeyCode::Esc, KeyModifiers::NONE) => {
                 if self.app.detail_view_open {
                     self.app.detail_view_open = false;
+                    // Return to browsing view (transcript_browsing stays true if it was true)
                 } else if self.app.transcript_focus.is_some() {
                     self.app.transcript_focus = None;
                     self.app.transcript_selection_anchor = None;
+                    self.app.transcript_browsing = false;
                     self.app.scroll_state.follow = true;
                 } else if !self.app.completions.is_empty() {
                     self.app.completions.clear();
@@ -248,33 +349,29 @@ impl Tui {
             }
             // D4: Keyboard actions on selected transcript item(s)
             // All mutation shortcuts are blocked while the detail view is open.
-            (KeyCode::Char('e'), KeyModifiers::NONE)
-                if self.app.transcript_focus.is_some() && !self.app.detail_view_open =>
-            {
+            (KeyCode::Char('e'), KeyModifiers::NONE) if self.app.transcript_focus.is_some() => {
                 self.handle_transcript_edit().await?;
             }
             (KeyCode::Delete, KeyModifiers::NONE) | (KeyCode::Char('d'), KeyModifiers::NONE)
-                if self.app.transcript_focus.is_some() && !self.app.detail_view_open =>
+                if self.app.transcript_focus.is_some() =>
             {
                 self.handle_transcript_delete();
             }
-            (KeyCode::Char('i'), KeyModifiers::NONE)
-                if self.app.transcript_focus.is_some() && !self.app.detail_view_open =>
-            {
+            (KeyCode::Char('i'), KeyModifiers::NONE) if self.app.transcript_focus.is_some() => {
                 self.handle_transcript_insert();
             }
-            (KeyCode::Char('c'), KeyModifiers::NONE)
-                if self.app.transcript_focus.is_some() && !self.app.detail_view_open =>
-            {
+            (KeyCode::Char('c'), KeyModifiers::NONE) if self.app.transcript_focus.is_some() => {
                 self.handle_transcript_copy();
             }
-            (KeyCode::Char('r'), KeyModifiers::NONE)
-                if self.app.transcript_focus.is_some() && !self.app.detail_view_open =>
-            {
+            (KeyCode::Char('r'), KeyModifiers::NONE) if self.app.transcript_focus.is_some() => {
                 self.handle_transcript_rewind();
             }
             (KeyCode::Enter, KeyModifiers::NONE) if self.app.transcript_focus.is_some() => {
-                self.app.detail_view_scroll = ratatui_widget_scrolling::ScrollState::new();
+                self.app.detail_view_scroll = {
+                    let mut s = ratatui_widget_scrolling::ScrollState::new();
+                    s.follow = false;
+                    s
+                };
                 // Pre-load raw session YAML (same content .edit message would open).
                 self.app.detail_view_raw_yaml = self
                     .selected_seq_range()
@@ -500,8 +597,9 @@ impl Tui {
     }
 
     pub(super) async fn handle_paste(&mut self, text: String) {
-        // Ignore paste while the detail view is open — same isolation policy as handle_key.
-        if self.app.detail_view_open {
+        // Ignore paste while the detail view or browsing view is open — same isolation
+        // policy as handle_key: these overlays hide the input field.
+        if self.app.detail_view_open || self.app.transcript_browsing {
             return;
         }
         if let Some(pending) = self.app.pending_message.take() {
@@ -564,6 +662,12 @@ impl Tui {
                     }
                     return;
                 }
+                if self.app.transcript_browsing {
+                    for _ in 0..3 {
+                        self.app.browsing_view_scroll.scroll_up();
+                    }
+                    return;
+                }
                 for _ in 0..3 {
                     self.app.scroll_state.scroll_up();
                 }
@@ -572,6 +676,12 @@ impl Tui {
                 if self.app.detail_view_open {
                     for _ in 0..3 {
                         self.app.detail_view_scroll.scroll_down();
+                    }
+                    return;
+                }
+                if self.app.transcript_browsing {
+                    for _ in 0..3 {
+                        self.app.browsing_view_scroll.scroll_down();
                     }
                     return;
                 }
@@ -1164,12 +1274,19 @@ impl Tui {
         } else if let Some(focus) = self.app.transcript_focus {
             if let Some(prev) = self.find_prev_navigable(focus) {
                 self.app.transcript_focus = Some(prev);
+                self.app.transcript_browsing = true;
+                self.app.browsing_view_scroll = {
+                    let mut s = ratatui_widget_scrolling::ScrollState::new();
+                    s.follow = false;
+                    s
+                };
                 self.app.scroll_state.follow = false;
                 self.app.scroll_to_focused_item = true;
                 self.app.transcript_selection_anchor = None;
             } else {
                 self.app.transcript_focus = None;
                 self.app.transcript_selection_anchor = None;
+                self.app.transcript_browsing = false;
                 // Do NOT restore follow here — user is entering history preview
                 // and the transcript position should stay where it is.
                 // follow is restored by Esc or when a new message is submitted.
@@ -1186,6 +1303,12 @@ impl Tui {
         } else if self.input_is_blank() && !self.app.transcript.is_empty() {
             if let Some(prev) = self.find_prev_navigable(self.app.transcript.len()) {
                 self.app.transcript_focus = Some(prev);
+                self.app.transcript_browsing = true;
+                self.app.browsing_view_scroll = {
+                    let mut s = ratatui_widget_scrolling::ScrollState::new();
+                    s.follow = false;
+                    s
+                };
                 self.app.scroll_state.follow = false;
                 self.app.scroll_to_focused_item = true;
                 self.app.transcript_selection_anchor = None;
@@ -1224,12 +1347,19 @@ impl Tui {
         } else if let Some(focus) = self.app.transcript_focus {
             if let Some(next) = self.find_next_navigable(focus) {
                 self.app.transcript_focus = Some(next);
+                self.app.transcript_browsing = true;
+                self.app.browsing_view_scroll = {
+                    let mut s = ratatui_widget_scrolling::ScrollState::new();
+                    s.follow = false;
+                    s
+                };
                 self.app.scroll_state.follow = false;
                 self.app.scroll_to_focused_item = true;
                 self.app.transcript_selection_anchor = None;
             } else {
                 self.app.transcript_focus = None;
                 self.app.transcript_selection_anchor = None;
+                self.app.transcript_browsing = false;
                 self.app.scroll_state.follow = true;
             }
         } else if self.app.history_preview {
@@ -1956,6 +2086,11 @@ impl Tui {
                         format!(".delete message {}-{}", from, to)
                     };
                     self.run_command(&cmd).await?;
+                    self.app.detail_view_open = false;
+                    self.app.detail_view_raw_yaml = None;
+                    self.app.transcript_browsing = false;
+                    self.app.transcript_focus = None;
+                    self.app.transcript_selection_anchor = None;
                 }
                 crate::types::ModalState::ConfirmRewind { seq, user_text } => {
                     // Execute rewind via dot-command
@@ -1975,6 +2110,11 @@ impl Tui {
                             });
                         }
                     }
+                    self.app.detail_view_open = false;
+                    self.app.detail_view_raw_yaml = None;
+                    self.app.transcript_browsing = false;
+                    self.app.transcript_focus = None;
+                    self.app.transcript_selection_anchor = None;
                 }
                 _ => {}
             }
@@ -2046,6 +2186,7 @@ impl Tui {
         self.run_command(&cmd).await?;
         self.app.transcript_focus = None;
         self.app.transcript_selection_anchor = None;
+        self.app.transcript_browsing = false;
         self.app.scroll_state.follow = true;
         Ok(())
     }
@@ -2073,6 +2214,7 @@ impl Tui {
         }
         self.app.transcript_focus = None;
         self.app.transcript_selection_anchor = None;
+        self.app.transcript_browsing = false;
         self.app.scroll_state.follow = true;
     }
 

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -96,9 +96,20 @@ impl Tui {
             transcript_focus: None,
             transcript_selection_anchor: None,
             modal: None,
-            detail_view_scroll: ratatui_widget_scrolling::ScrollState::new(),
+            detail_view_scroll: {
+                let mut s = ratatui_widget_scrolling::ScrollState::new();
+                s.follow = false;
+                s
+            },
             detail_view_open: false,
             detail_view_raw_yaml: None,
+            transcript_browsing: false,
+            browsing_view_scroll: {
+                let mut s = ratatui_widget_scrolling::ScrollState::new();
+                s.follow = false;
+                s
+            },
+            copy_notice_until: None,
             scroll_to_focused_item: false,
             use_utc_timestamps: false,
         };

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -520,6 +520,18 @@ impl Tui {
         // Render detail view if open (exclusive — returns early)
         if self.app.detail_view_open {
             self.render_detail_view(frame, size);
+            // Render modal ON TOP of detail view if active (e.g. delete/rewind confirm)
+            if let Some(modal) = &self.app.modal.clone() {
+                self.render_modal(frame, size, modal);
+            }
+            return;
+        }
+
+        if self.app.transcript_browsing {
+            self.render_browsing_view(frame, size);
+            if let Some(modal) = &self.app.modal.clone() {
+                self.render_modal(frame, size, modal);
+            }
             return;
         }
 
@@ -1138,8 +1150,97 @@ impl Tui {
             .min(self.app.detail_view_scroll.last_max_position);
 
         // Render footer
-        let footer =
-            Paragraph::new(" ↑↓/scroll — ESC to close").style(Style::default().fg(Color::DarkGray));
+        let footer_text = if self
+            .app
+            .copy_notice_until
+            .map(|t| std::time::Instant::now() < t)
+            .unwrap_or(false)
+        {
+            " ✓ Copied to clipboard".to_string()
+        } else {
+            " ↑↓/scroll  e/edit  d/delete  r/rewind  c/copy  ESC/back".to_string()
+        };
+        let footer = Paragraph::new(footer_text).style(Style::default().fg(Color::DarkGray));
         frame.render_widget(footer, chunks[1]);
+    }
+
+    pub(super) fn render_browsing_view(
+        &mut self,
+        frame: &mut Frame<'_>,
+        size: ratatui::layout::Rect,
+    ) {
+        // Clear the full area first
+        frame.render_widget(ratatui::widgets::Clear, size);
+
+        // Split vertically: content area + footer (2 rows)
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(2)])
+            .split(size);
+
+        // Count navigable items and find display index
+        let mut navigable_count = 0;
+        let mut display_idx = 0;
+
+        let mut content_lines = Vec::new();
+
+        for (i, item) in self.app.transcript.iter().enumerate() {
+            if item.is_navigable() {
+                navigable_count += 1;
+                if Some(i) == self.app.transcript_focus {
+                    display_idx = navigable_count;
+                    content_lines = Self::render_entry_detail(item);
+                }
+            }
+        }
+
+        let entries_as_vec = if content_lines.is_empty() {
+            vec![]
+        } else {
+            vec![content_lines]
+        };
+
+        // Create block with border and title
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title("History Browser");
+
+        // Get inner area for content
+        let inner_area = block.inner(chunks[0]);
+
+        // Render the block into the content chunk
+        frame.render_widget(block, chunks[0]);
+
+        // Render the scrollable content
+        self.app
+            .browsing_view_scroll
+            .render(frame, inner_area, &entries_as_vec, |lines| {
+                let paragraph = Paragraph::new(lines.clone()).wrap(Wrap { trim: false });
+                let height = paragraph.line_count(inner_area.width);
+                (height, paragraph)
+            });
+
+        // Clamp position to the freshly-updated last_max_position
+        self.app.browsing_view_scroll.position = self
+            .app
+            .browsing_view_scroll
+            .position
+            .min(self.app.browsing_view_scroll.last_max_position);
+
+        // Split footer into two rows
+        let footer_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Length(1)])
+            .split(chunks[1]);
+
+        let counter_text = format!(" Item {} of {} (navigable)", display_idx, navigable_count);
+        let counter_para = Paragraph::new(counter_text).style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(counter_para, footer_chunks[0]);
+
+        let shortcuts_text =
+            " ↑↓/browse  ENTER/view raw  e/edit  d/delete  r/rewind  c/copy  ESC/close";
+        let shortcuts_para =
+            Paragraph::new(shortcuts_text).style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(shortcuts_para, footer_chunks[1]);
     }
 }

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -5721,7 +5721,7 @@ async fn test_detail_view_esc_closes_view_and_preserves_focus() {
 }
 
 #[tokio::test]
-async fn test_detail_view_blocks_mutation_shortcuts() {
+async fn test_detail_view_mutation_shortcuts_work() {
     let mut harness = TuiTestHarness::new();
     harness.tui().app.transcript.clear();
     harness.tui().app.transcript.push(TranscriptItem::UserText {
@@ -5731,9 +5731,7 @@ async fn test_detail_view_blocks_mutation_shortcuts() {
     });
     harness.tui().app.transcript_focus = Some(0);
     harness.tui().app.detail_view_open = true;
-    let initial_len = harness.tui().app.transcript.len();
 
-    // 'd' delete shortcut must be blocked while detail view is open.
     harness
         .tui()
         .handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE))
@@ -5742,12 +5740,14 @@ async fn test_detail_view_blocks_mutation_shortcuts() {
 
     assert!(
         harness.tui().app.detail_view_open,
-        "detail view should still be open"
+        "detail view should remain open while delete confirm modal is shown"
     );
-    assert_eq!(
-        harness.tui().app.transcript.len(),
-        initial_len,
-        "transcript must not be mutated while detail view is open"
+    assert!(
+        matches!(
+            harness.tui().app.modal,
+            Some(crate::types::ModalState::ConfirmDelete { from: 1, to: 1 })
+        ),
+        "delete shortcut in detail view should open confirm delete modal"
     );
 }
 

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -107,6 +107,14 @@ pub(super) struct App {
     /// detail_view_open is set.  None when no session is active or the item
     /// has no sequence number.
     pub(super) detail_view_raw_yaml: Option<String>,
+    /// True when the user is browsing history in fullscreen mode.
+    /// Distinct from detail_view_open which shows raw YAML.
+    pub(super) transcript_browsing: bool,
+    /// Scroll state for the browsing view (used when transcript_browsing is true).
+    /// Reset to follow=false, position=0 when focused item changes.
+    pub(super) browsing_view_scroll: ratatui_widget_scrolling::ScrollState,
+    /// When set, detail view footer shows "Copied to clipboard ✓" until this instant.
+    pub(super) copy_notice_until: Option<std::time::Instant>,
     /// Set to true whenever transcript_focus changes so draw() scrolls once
     /// to keep the newly focused item visible, then clears it.
     pub(super) scroll_to_focused_item: bool,

--- a/crates/ratatui-widget-scrolling/src/lib.rs
+++ b/crates/ratatui-widget-scrolling/src/lib.rs
@@ -1029,4 +1029,127 @@ mod tests {
             );
         }
     }
+
+    // ========================================
+    // Tests for scroll_position_to_show_item
+    // ========================================
+
+    /// Helper to create a ScrollState with a pre-populated height cache.
+    fn scroll_state_with_heights(width: u16, heights: Vec<usize>) -> ScrollState {
+        let mut state = ScrollState::new();
+        state.render_height_cache.insert(width, heights);
+        state
+    }
+
+    /// Test 1: Everything fits in viewport — returns 0
+    #[test]
+    fn scroll_position_to_show_item_everything_fits() {
+        let mut state = scroll_state_with_heights(80, vec![2, 3, 2]); // total = 7
+        let viewport_height = 10;
+
+        // Request any item — should return 0 since all fit
+        let pos = state.scroll_position_to_show_item(1, 80, viewport_height, 3);
+        assert_eq!(pos, 0, "all items fit, position should be 0");
+    }
+
+    /// Test 2: Item at top (first item) with content taller than viewport — returns 0
+    #[test]
+    fn scroll_position_to_show_item_first_item_returns_zero() {
+        let mut state = scroll_state_with_heights(80, vec![5, 5, 5, 5]); // total = 20
+        let viewport_height = 10;
+
+        let pos = state.scroll_position_to_show_item(0, 80, viewport_height, 4);
+        assert_eq!(pos, 0, "first item should be at position 0");
+    }
+
+    /// Test 3: Item in middle — returns offset that centers the item
+    #[test]
+    fn scroll_position_to_show_item_middle_item_centered() {
+        // heights: [3, 3, 3, 3, 3] = 15 total
+        // viewport_height = 10, so max_scroll_offset = 15 - 10 = 5
+        // item_index = 2, top_offset = 3 + 3 = 6
+        // centering: 6 - (10 - 3) / 2 = 6 - 3 = 3, clamped to max_scroll_offset = 5
+        let mut state = scroll_state_with_heights(80, vec![3, 3, 3, 3, 3]);
+        let viewport_height = 10;
+
+        // Item at index 2: top_offset = items[0] + items[1] = 6
+        // Centered: 6 - (10-3)/2 = 6 - 3 = 3
+        let pos = state.scroll_position_to_show_item(2, 80, viewport_height, 5);
+        assert_eq!(pos, 3, "middle item should be centered");
+    }
+
+    /// Test 4: Item at bottom (last item) — returns max_scroll_offset
+    #[test]
+    fn scroll_position_to_show_item_last_item_returns_max() {
+        // heights: [2, 3, 4, 6] = 15 total
+        // viewport_height = 10, max_scroll_offset = 5
+        // item_index = 3, top_offset = 2 + 3 + 4 = 9
+        // item_height = 6, centering: 9 - (10-6)/2 = 9 - 2 = 7, clamped to 5
+        let mut state = scroll_state_with_heights(80, vec![2, 3, 4, 6]);
+        let viewport_height = 10;
+
+        let pos = state.scroll_position_to_show_item(3, 80, viewport_height, 4);
+        assert_eq!(pos, 5, "last item should be at max_scroll_offset");
+    }
+
+    /// Test 5: Item taller than viewport — top-aligns (returns top_offset, clamped to max)
+    #[test]
+    fn scroll_position_to_show_item_taller_than_viewport_top_aligned() {
+        // heights: [3, 15, 3] = 21 total
+        // viewport_height = 10, max_scroll_offset = 11
+        // item_index = 1, top_offset = 3, item_height = 15 >= viewport_height
+        // Since item is taller, top-align: return 3
+        let mut state = scroll_state_with_heights(80, vec![3, 15, 3]);
+        let viewport_height = 10;
+
+        let pos = state.scroll_position_to_show_item(1, 80, viewport_height, 3);
+        assert_eq!(pos, 3, "tall item should be top-aligned at its top_offset");
+    }
+
+    /// Test 5b: Item taller than viewport at bottom — clamped to max_scroll_offset
+    #[test]
+    fn scroll_position_to_show_item_taller_than_viewport_clamped() {
+        // heights: [5, 20] = 25 total
+        // viewport_height = 10, max_scroll_offset = 15
+        // item_index = 1, top_offset = 5, item_height = 20 >= viewport_height
+        // Top-align would be 5, but it's already within bounds
+        let mut state = scroll_state_with_heights(80, vec![5, 20]);
+        let viewport_height = 10;
+
+        let pos = state.scroll_position_to_show_item(1, 80, viewport_height, 2);
+        assert_eq!(pos, 5, "tall item at bottom should be at its top_offset");
+    }
+
+    /// Test 6: Empty/no cache — returns best-effort (doesn't panic)
+    #[test]
+    fn scroll_position_to_show_item_empty_cache_no_panic() {
+        let mut state = ScrollState::new(); // No cache populated
+        let viewport_height = 10;
+
+        // Without cache, get_height_log_from_cache_for_width creates vec![1; n]
+        // For 5 elements: heights = [1, 1, 1, 1, 1], total = 5 < viewport_height
+        // So max_scroll_offset = 0, returns 0
+        let pos = state.scroll_position_to_show_item(2, 80, viewport_height, 5);
+        assert_eq!(
+            pos, 0,
+            "empty cache creates default heights, everything fits"
+        );
+    }
+
+    /// Test 6b: Empty cache with more elements than viewport height
+    #[test]
+    fn scroll_position_to_show_item_empty_cache_with_many_elements() {
+        let mut state = ScrollState::new();
+        let viewport_height = 5;
+
+        // 10 elements with default height 1 each = 10 total
+        // max_scroll_offset = 10 - 5 = 5
+        // item_index = 5, top_offset = 5, item_height = 1
+        // centering: 5 - (5-1)/2 = 5 - 2 = 3
+        let pos = state.scroll_position_to_show_item(5, 80, viewport_height, 10);
+        assert_eq!(
+            pos, 3,
+            "empty cache with many elements should center the item"
+        );
+    }
 }

--- a/docs/solutions/logic-errors/tui-browsing-overlay-and-detail-shortcuts-2026-05-04.md
+++ b/docs/solutions/logic-errors/tui-browsing-overlay-and-detail-shortcuts-2026-05-04.md
@@ -1,0 +1,249 @@
+---
+title: "TUI browsing mode overlay and detail view mutation shortcuts"
+date: 2026-05-04
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-tui"
+root_cause: "multiple overlapping UX issues in transcript navigation: scroll state defaults, modal render order, focus loss during edit, and missing input guards"
+resolution_type: code_fix
+severity: high
+tags:
+  - tui
+  - overlay
+  - scroll-state
+  - modal
+  - ratatui
+  - navigation
+  - focus
+plan_ref: "harnx-tui-transcript-navigation-ux"
+---
+
+## Problem
+
+Four related UX bugs in harnx-tui transcript navigation: (1) detail view opened scrolled to bottom instead of top, (2) focused transcript items could scroll off-screen, (3) mutation shortcuts (e/d/r/c) were unavailable in detail view, and (4) confirmation modals rendered behind the detail view overlay.
+
+## Symptoms
+
+- **#441:** Detail view opened at bottom of content; user had to scroll up to see beginning
+- **#433/#454:** Focused transcript item could scroll out of visible area during browsing, losing context
+- **#455:** Pressing `e`, `d`, `r`, `c` in detail view did nothing — user had to exit to run mutations
+- **Modal render bug:** Delete/rewind confirmation modal appeared behind the detail view overlay, invisible to user
+
+## Investigation Steps
+
+1. Traced `detail_view_scroll` initialization — found default `ScrollState::new()` sets `follow = true`, causing immediate scroll-to-bottom on first render
+2. Identified `transcript_browsing` mode as solution for #433/#454 — allows fullscreen history navigation while keeping focused item visible
+3. Discovered modal rendered after `render_detail_view()` return, preventing modal from appearing on top
+4. Found `handle_transcript_edit()` clears `transcript_focus` and `transcript_browsing`, breaking detail view reopen after edit
+
+## Root Cause
+
+**Scroll state default:** `ScrollState::new()` defaults `follow = true`, auto-scrolling to bottom. Opening detail view at bottom confused users expecting to see item header first.
+
+**Missing browsing mode:** No fullscreen mode for history navigation; focused items could scroll off-screen as new content arrived.
+
+**Guard ordering:** Mutation shortcuts were only available in the main match block, not inside the `detail_view_open` guard.
+
+**Render order bug:** Modal rendered after fullscreen overlay returned early, so modal appeared behind overlay content.
+
+**Edit-focus loss:** `handle_transcript_edit()` clears focus state. Without saving focus before calling it, the detail view couldn't reopen at the same position.
+
+## Solution
+
+### 1. ScrollState `follow=false` initialization pattern
+
+Always initialize detail view scroll with `follow = false`:
+
+```rust
+self.app.detail_view_scroll = {
+    let mut s = ratatui_widget_scrolling::ScrollState::new();
+    s.follow = false;
+    s
+};
+```
+
+Applied in:
+- `handle_key` when opening detail view (lines 361-365)
+- `handle_up_key`/`handle_down_key` when entering browsing mode (lines 1256-1260, 1285-1289)
+- In detail view edit handler before reopening (lines 173-177)
+
+### 2. Browsing mode overlay pattern
+
+Enter browsing mode on Up/Down from blank input. ESC exits, ENTER opens detail:
+
+```rust
+// In handle_key, after modal and detail_view_open guards:
+if self.app.transcript_browsing && !self.app.detail_view_open {
+    match (key.code, key.modifiers) {
+        (KeyCode::Esc, KeyModifiers::NONE) => {
+            self.app.transcript_browsing = false;
+            self.app.transcript_focus = None;
+            self.app.transcript_selection_anchor = None;
+            self.app.scroll_state.follow = true;
+        }
+        (KeyCode::Up, KeyModifiers::NONE) => {
+            self.handle_up_key(key);
+        }
+        (KeyCode::Down, KeyModifiers::NONE) => {
+            self.handle_down_key(key);
+        }
+        (KeyCode::Enter, KeyModifiers::NONE) => {
+            // Open detail view for current focused item
+            self.app.detail_view_scroll = {
+                let mut s = ratatui_widget_scrolling::ScrollState::new();
+                s.follow = false;
+                s
+            };
+            self.app.detail_view_raw_yaml = self
+                .selected_seq_range()
+                .and_then(|(from, to)| self.config.read().get_message_range_yaml(from, to));
+            self.app.detail_view_open = true;
+        }
+        (KeyCode::Char('e'), KeyModifiers::NONE) => {
+            self.handle_transcript_edit().await?;
+        }
+        (KeyCode::Char('i'), KeyModifiers::NONE) => {
+            self.handle_transcript_insert();
+        }
+        // ... other mutation shortcuts ...
+        _ => {} // consume all other keys to prevent bleed to input
+    }
+    return Ok(());
+}
+```
+
+### 3. Modal-on-top-of-overlay render fix
+
+Render modal after overlay content, before return:
+
+```rust
+// In draw():
+if self.app.detail_view_open {
+    self.render_detail_view(frame, size);
+    // Render modal ON TOP of detail view if active
+    if let Some(modal) = &self.app.modal.clone() {
+        self.render_modal(frame, size, modal);
+    }
+    return;
+}
+
+if self.app.transcript_browsing {
+    self.render_browsing_view(frame, size);
+    if let Some(modal) = &self.app.modal.clone() {
+        self.render_modal(frame, size, modal);
+    }
+    return;
+}
+```
+
+Key insight: modal must render **after** overlay content but **before** the early return.
+
+### 4. Edit-flow focus preservation pattern
+
+Save focus before calling handler that clears it:
+
+```rust
+(KeyCode::Char('e'), KeyModifiers::NONE) => {
+    // Save focus before editing since handle_transcript_edit clears it
+    let had_focus = self.app.transcript_focus;
+    self.app.detail_view_open = false;
+    self.handle_transcript_edit().await?;
+    // After edit, try to reopen detail view at same position
+    if let Some(focus_idx) = had_focus {
+        if focus_idx < self.app.transcript.len() {
+            self.app.transcript_focus = Some(focus_idx);
+            self.app.transcript_selection_anchor = None;
+            self.app.detail_view_scroll = {
+                let mut s = ratatui_widget_scrolling::ScrollState::new();
+                s.follow = false;
+                s
+            };
+            self.app.detail_view_raw_yaml =
+                self.selected_seq_range().and_then(|(from, to)| {
+                    self.config.read().get_message_range_yaml(from, to)
+                });
+            self.app.detail_view_open = true;
+        }
+    }
+}
+```
+
+### 5. Guard ordering in handle_key
+
+Order: modal → detail_view → browsing_mode → main match:
+
+```rust
+pub(super) async fn handle_key(&mut self, key: KeyEvent) -> Result<()> {
+    // 1. Modal guard — highest priority
+    if self.app.modal.is_some() {
+        return self.handle_modal_key(key).await;
+    }
+
+    // 2. Detail view guard — navigation + mutations inside
+    if self.app.detail_view_open {
+        match (key.code, key.modifiers) {
+            (KeyCode::Esc, KeyModifiers::NONE) => { /* close */ }
+            (KeyCode::Up, KeyModifiers::NONE) => { /* scroll up */ }
+            (KeyCode::Down, KeyModifiers::NONE) => { /* scroll down */ }
+            (KeyCode::Char('e'), KeyModifiers::NONE) => { /* edit with focus save */ }
+            (KeyCode::Char('d'), KeyModifiers::NONE) => { /* delete */ }
+            (KeyCode::Char('r'), KeyModifiers::NONE) => { /* rewind */ }
+            (KeyCode::Char('c'), KeyModifiers::NONE) => { /* copy */ }
+            _ => {} // consume all other keys
+        }
+        return Ok(());
+    }
+
+    // 3. Browsing mode guard
+    if self.app.transcript_browsing && !self.app.detail_view_open {
+        match (key.code, key.modifiers) { /* ... */ }
+        return Ok(());
+    }
+
+    // 4. Main match block — normal input handling
+    match (key.code, key.modifiers) { /* ... */ }
+}
+```
+
+## Why This Works
+
+**`follow=false` initialization:** Prevents automatic scroll-to-bottom. User sees item header first, matching mental model of "opening a document."
+
+**Browsing mode overlay:** Fullscreen history navigation keeps focused item visible in dedicated `browsing_view_scroll` state, isolated from live transcript scroll. User can explore history without losing position.
+
+**Modal render order:** Ratatui renders widgets in call order. Rendering modal after overlay content but before return ensures modal appears on top visually.
+
+**Focus preservation:** Saving `transcript_focus` before calling edit handler allows reopening detail view at same position after transcript reload. Without this, focus would be `None` and detail view wouldn't reopen.
+
+**Guard ordering:** Top-down guard structure ensures each mode intercepts relevant keys before they reach lower-priority handlers. Catch-all `_ => {}` arms prevent key bleed-through.
+
+## Prevention Strategies
+
+**Test cases:**
+- Test detail view opens at top (position 0), not bottom
+- Test browsing mode enters on Up from blank input, exits on ESC
+- Test mutation shortcuts (e/d/r/c) work in detail view
+- Test modal renders on top of detail/browsing overlay
+- Test edit from detail view reopens detail at same position
+
+**Best practices:**
+- Always initialize `ScrollState` with `follow = false` for static content views
+- Render modals after overlay content, before early return
+- Save focus state before calling handlers that clear it
+- Order input guards from highest to lowest priority: modal → overlay → main
+- Use catch-all `_ => {}` to consume unhandled keys in exclusive modes
+
+**Code review checklist:**
+- [ ] Is `ScrollState` initialized with `follow = false` for non-live views?
+- [ ] Does modal render after overlay content in draw()?
+- [ ] Is focus saved before calling handlers that clear it?
+- [ ] Is guard ordering correct: modal → detail_view → browsing → main?
+- [ ] Do overlay guards have catch-all consumption arms?
+
+## Related Issues
+
+- **GitHub:** [#441](https://github.com/dobesv/harnx/issues/441) — Detail view opens at bottom
+- **GitHub:** [#433](https://github.com/dobesv/harnx/issues/433) — Keep focused item visible
+- **GitHub:** [#454](https://github.com/dobesv/harnx/issues/454) — Fullscreen history browsing
+- **GitHub:** [#455](https://github.com/dobesv/harnx/issues/455) — Mutation shortcuts in detail view
+- **Related Solution:** [logic-errors/tui-exclusive-overlay-pattern-2026-05-02.md](./tui-exclusive-overlay-pattern-2026-05-02.md) — Base overlay pattern for detail view


### PR DESCRIPTION
Adds a new fullscreen transcript browsing mode that supports navigation and direct mutation shortcuts (edit, delete, retry, copy). Updates the TUI rendering logic to ensure modals correctly overlay the detail and browsing views. Improves scrolling behavior by ensuring the selected item is always visible and fixes issues where 'follow' mode was not correctly disabled during manual navigation.

- Add browsing_mode state and navigation logic
- Implement render_browsing_view() with full mutation shortcut support
- Fix modal rendering order to prevent clipping by detail views
- Add unit tests for TUI scrolling calculations
- Clear transcript browsing state when focus is lost

#433 #441 #454 #455

Plan: harnx-tui-transcript-navigation-ux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fullscreen transcript browsing mode for improved history navigation with keyboard shortcuts.
  * Introduced copy-to-clipboard feedback notice displayed in detail view.
  * Enhanced keyboard shortcuts in detail view for edit, delete, rewind, and copy actions.

* **Bug Fixes**
  * Fixed modal rendering to properly appear on top of views.
  * Improved scroll behavior and focus restoration when reopening detail view after edits.
  * Enhanced ESC key behavior for clearer state management.

* **Tests**
  * Added comprehensive scroll position and centering tests.

* **Documentation**
  * Added navigation and interaction logic guide with examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->