### PR TITLE
Add agent role metadata and filtering

### DIFF
--- a/crates/harnx-core/src/agent_config.rs
+++ b/crates/harnx-core/src/agent_config.rs
@@ -140,6 +140,8 @@ pub struct AgentConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     compaction_agent: Option<String>,
     #[serde(default)]
+    pub role: AgentRole,
+    #[serde(default)]
     prompt: String,
 
     #[serde(skip, default)]
@@ -186,6 +188,7 @@ impl AgentConfig {
             instructions: frontmatter.instructions,
             hooks: frontmatter.hooks,
             compaction_agent: frontmatter.compaction_agent,
+            role: frontmatter.role,
             prompt,
             ..Default::default()
         })
@@ -490,6 +493,16 @@ impl AgentConfig {
     }
 }
 
+/// Role of an agent — controls visibility in the agent picker and completions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRole {
+    #[default]
+    Assistant,
+    Subagent,
+    Compaction,
+}
+
 // --- AgentFrontMatter (serialized shape of an agent.md front-matter block) ---
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -532,6 +545,8 @@ struct AgentFrontMatter {
     hooks: Option<HooksConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     compaction_agent: Option<String>,
+    #[serde(default)]
+    role: AgentRole,
 }
 
 impl AgentFrontMatter {
@@ -552,6 +567,7 @@ impl AgentFrontMatter {
             instructions: config.instructions.clone(),
             hooks: config.hooks.clone(),
             compaction_agent: config.compaction_agent.clone(),
+            role: config.role,
         }
     }
 
@@ -571,6 +587,7 @@ impl AgentFrontMatter {
             && self.instructions.is_none()
             && self.hooks.is_none()
             && self.compaction_agent.is_none()
+            && self.role == AgentRole::Assistant
     }
 }
 
@@ -663,6 +680,43 @@ mod tests {
             msg.contains("Template error"),
             "expected error message to contain 'Template error', got: {msg:?}"
         );
+    }
+
+    #[test]
+    fn test_agent_role_defaults_to_assistant() {
+        let content = "---\nmodel: openai:gpt-4o\n---\nYou are an agent.";
+        let agent = AgentConfig::from_markdown("my-agent", content).unwrap();
+        assert_eq!(agent.role, AgentRole::Assistant);
+    }
+
+    #[test]
+    fn test_agent_role_subagent_parsed() {
+        let content = "---\nrole: subagent\nmodel: openai:gpt-4o\n---\nYou are a sub-agent.";
+        let agent = AgentConfig::from_markdown("my-subagent", content).unwrap();
+        assert_eq!(agent.role, AgentRole::Subagent);
+    }
+
+    #[test]
+    fn test_agent_role_compaction_parsed() {
+        let content = "---\nrole: compaction\nmodel: openai:gpt-4o\n---\nSummarize.";
+        let agent = AgentConfig::from_markdown("my-compaction", content).unwrap();
+        assert_eq!(agent.role, AgentRole::Compaction);
+    }
+
+    #[test]
+    fn test_agent_role_subagent_roundtrip() {
+        let content = "---\nrole: subagent\nmodel: openai:gpt-4o\n---\nYou are a sub-agent.";
+        let agent = AgentConfig::from_markdown("my-subagent", content).unwrap();
+        let exported = agent.export().unwrap();
+        let reparsed = AgentConfig::from_markdown("my-subagent", &exported).unwrap();
+        assert_eq!(reparsed.role, AgentRole::Subagent);
+    }
+
+    #[test]
+    fn test_agent_no_role_field_is_assistant() {
+        // Completely empty frontmatter — AgentRole::Assistant is the serde default
+        let agent = AgentConfig::from_markdown("plain", "You are plain.").unwrap();
+        assert_eq!(agent.role, AgentRole::Assistant);
     }
 }
 

--- a/crates/harnx-runtime/src/config/agent.rs
+++ b/crates/harnx-runtime/src/config/agent.rs
@@ -7,7 +7,9 @@ use std::{
     path::Path,
 };
 
-pub use harnx_core::agent_config::{AgentConfig, AgentVariable, AgentVariables, TEMP_AGENT_NAME};
+pub use harnx_core::agent_config::{
+    AgentConfig, AgentRole, AgentVariable, AgentVariables, TEMP_AGENT_NAME,
+};
 
 /// Built-in agent name: routes to the title-creation prompt.
 pub const CREATE_TITLE_AGENT: &str = harnx_core::agent_config::CREATE_TITLE_AGENT_NAME;
@@ -332,6 +334,36 @@ pub fn list_agents() -> Vec<String> {
             .collect(),
         Err(_) => vec![],
     };
+    output.sort();
+    output.dedup();
+    output
+}
+
+/// Returns names of agents whose role is [`AgentRole::Assistant`].
+/// Unlike [`list_agents`], this reads and parses each agent file.
+/// Silently skips files that fail to parse.
+pub fn list_assistant_agents() -> Vec<String> {
+    let agents_dir = Config::agents_config_dir();
+    let Ok(entries) = read_dir(&agents_dir) else {
+        return vec![];
+    };
+    let mut output: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let path = e.path();
+            if path.extension().and_then(|x| x.to_str()) != Some("md") {
+                return None;
+            }
+            let name = path.file_stem()?.to_str()?.to_string();
+            let contents = read_to_string(&path).ok()?;
+            let config = AgentConfig::from_markdown(&name, &contents).ok()?;
+            if config.role == AgentRole::Assistant {
+                Some(name)
+            } else {
+                None
+            }
+        })
+        .collect();
     output.sort();
     output.dedup();
     output
@@ -859,5 +891,90 @@ You are a test agent.
             agent.defined_variables()[0].default.as_deref(),
             Some("Nested prompt")
         );
+    }
+
+    #[test]
+    fn test_list_assistant_agents_filters_by_role() {
+        with_test_config_dir(|config_dir| {
+            let agents_dir = config_dir.join("agents");
+            fs::write(
+                agents_dir.join("alpha.md"),
+                "---\nrole: assistant\nmodel: openai:gpt-4o\n---\nAssistant agent.",
+            )?;
+            fs::write(
+                agents_dir.join("beta.md"),
+                "---\nrole: subagent\nmodel: openai:gpt-4o\n---\nSub-agent.",
+            )?;
+            fs::write(
+                agents_dir.join("gamma.md"),
+                "---\nrole: compaction\nmodel: openai:gpt-4o\n---\nCompaction agent.",
+            )?;
+            let result = list_assistant_agents();
+            assert_eq!(result, vec!["alpha"]);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_list_assistant_agents_includes_no_role_field() {
+        with_test_config_dir(|config_dir| {
+            let agents_dir = config_dir.join("agents");
+            fs::write(
+                agents_dir.join("no-role.md"),
+                "---\nmodel: openai:gpt-4o\n---\nNo role field.",
+            )?;
+            fs::write(
+                agents_dir.join("explicit-subagent.md"),
+                "---\nrole: subagent\n---\nSub-agent.",
+            )?;
+            let result = list_assistant_agents();
+            assert_eq!(result, vec!["no-role"]);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_list_assistant_agents_empty_dir() {
+        with_test_config_dir(|_config_dir| {
+            let result = list_assistant_agents();
+            assert!(result.is_empty());
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_list_assistant_agents_skips_malformed() {
+        with_test_config_dir(|config_dir| {
+            let agents_dir = config_dir.join("agents");
+            fs::write(
+                agents_dir.join("broken.md"),
+                "---\nmodel: [unclosed bracket\n---\nBroken agent.",
+            )?;
+            fs::write(
+                agents_dir.join("good.md"),
+                "---\nmodel: openai:gpt-4o\n---\nGood agent.",
+            )?;
+            let result = list_assistant_agents();
+            assert_eq!(result, vec!["good"]);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_list_assistant_agents_sorted() {
+        with_test_config_dir(|config_dir| {
+            let agents_dir = config_dir.join("agents");
+            fs::write(agents_dir.join("zebra.md"), "You are zebra.")?;
+            fs::write(agents_dir.join("apple.md"), "You are apple.")?;
+            fs::write(agents_dir.join("mango.md"), "You are mango.")?;
+            let result = list_assistant_agents();
+            assert_eq!(result, vec!["apple", "mango", "zebra"]);
+            Ok(())
+        })
+        .unwrap();
     }
 }

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -3,7 +3,10 @@ pub mod input;
 pub mod session;
 pub mod session_meta;
 
-pub use self::agent::{complete_agent_variables, list_agents, Agent, AgentConfig, AgentVariables};
+pub use self::agent::{
+    complete_agent_variables, list_agents, list_assistant_agents, Agent, AgentConfig,
+    AgentVariables,
+};
 pub use self::agent::{CREATE_TITLE_AGENT, TEMP_AGENT_NAME};
 pub use self::input::Input;
 use self::session::Session;
@@ -2482,7 +2485,7 @@ impl Config {
                     .collect(),
                 ".session" => map_completion_values(self.list_sessions()),
                 ".rag" => map_completion_values(Self::list_rags()),
-                ".agent" => map_completion_values(list_agents()),
+                ".agent" => map_completion_values(list_assistant_agents()),
                 ".macro" => map_completion_values(Self::list_macros()),
                 ".info" => map_completion_values(vec!["session", "agent", "rag", "tools"]),
                 ".mcp" => map_completion_values(vec![

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -15,7 +15,9 @@ use crossterm::ExecutableCommand;
 use harnx_core::message::Message;
 use harnx_hooks::{drain_async_results, AsyncHookManager, PersistentHookManager};
 use harnx_runtime::config::GlobalConfig;
-use harnx_runtime::config::{build_picker_context, list_agents, sort_sessions_for_picker};
+use harnx_runtime::config::{
+    build_picker_context, list_assistant_agents, sort_sessions_for_picker,
+};
 use harnx_runtime::tool::ToolDeclaration;
 use harnx_runtime::utils::create_abort_signal;
 use ratatui::Terminal;
@@ -135,7 +137,7 @@ impl Tui {
     }
 
     pub(crate) fn resolve_initial_modal(config: &GlobalConfig) -> Option<ModalState> {
-        let agents = list_agents();
+        let agents = list_assistant_agents();
         if config.read().agent.is_none() {
             if agents.is_empty() {
                 return None;

--- a/crates/harnx/src/cli.rs
+++ b/crates/harnx/src/cli.rs
@@ -66,6 +66,9 @@ pub struct Cli {
     /// List all agents
     #[clap(long)]
     pub list_agents: bool,
+    /// List agents available for direct interaction (excludes subagent and compaction roles)
+    #[clap(long)]
+    pub list_assistant_agents: bool,
     /// List all RAGs
     #[clap(long)]
     pub list_rags: bool,

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -17,8 +17,8 @@ pub use harnx_tui as tui;
 use crate::cli::Cli;
 use crate::client::{list_models, retry::call_with_retry_and_fallback, ModelType};
 use crate::config::{
-    list_agents, load_env_file, macro_execute, Config, GlobalConfig, Input, WorkingMode,
-    TEMP_SESSION_NAME,
+    list_agents, list_assistant_agents, load_env_file, macro_execute, Config, GlobalConfig, Input,
+    WorkingMode, TEMP_SESSION_NAME,
 };
 use crate::tui::Tui;
 use harnx_hooks::{
@@ -56,6 +56,7 @@ async fn main() -> Result<()> {
         || cli.sync_models
         || cli.list_models
         || cli.list_agents
+        || cli.list_assistant_agents
         || cli.list_rags
         || cli.list_macros
         || cli.list_sessions;
@@ -103,6 +104,11 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
     }
     if cli.list_agents {
         let agents = list_agents().join("\n");
+        println!("{agents}");
+        return Ok(());
+    }
+    if cli.list_assistant_agents {
+        let agents = list_assistant_agents().join("\n");
         println!("{agents}");
         return Ok(());
     }

--- a/docs/solutions/logic-errors/agent-role-filtering-completions-2026-05-04.md
+++ b/docs/solutions/logic-errors/agent-role-filtering-completions-2026-05-04.md
@@ -1,0 +1,125 @@
+---
+title: "Agent role field for filtering non-assistant agents from picker and completions"
+date: 2026-05-04
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-core, harnx-runtime, completions"
+root_cause: "No mechanism to distinguish user-facing agents from internal subagents and compaction agents"
+resolution_type: code_fix
+severity: medium
+tags:
+  - agent-configuration
+  - shell-completions
+  - yaml-frontmatter
+  - serde-default
+  - zsh
+plan_ref: "gh-457-agent-role-metadata"
+---
+
+## Problem
+
+All agents appeared in the TUI agent picker and shell completions regardless of their intended purpose. Subagents (used internally by the orchestrator) and compaction agents (used for context compression) cluttered the UI and created confusing UX for end users who only need to select primary assistant agents.
+
+## Symptoms
+
+- Agent picker displayed internal subagents alongside user-facing agents
+- Shell tab-completion suggested non-interactive agents (compaction, subagents)
+- No way to categorize agents by role in the configuration system
+
+## Investigation Steps
+
+Reviewed existing `list_agents()` function — fast directory scan returning all `.md` filenames without parsing. Considered adding a `hidden` boolean field but recognized the need for explicit role categorization. Examined `MessageRole` enum pattern in `message.rs` as precedent for serde-based enum with defaults.
+
+Evaluated adding filter logic directly to `list_agents()` but decided against it because:
+1. Fast dir scan is valuable for other use cases
+2. Filtering requires parsing (O(N) file reads)
+3. Two-function pattern preserves backward compatibility
+
+## Root Cause
+
+Agent frontmatter had no `role` field. All agents were treated identically in UI contexts. The system lacked metadata to distinguish user-facing "assistant" agents from internal "subagent" and "compaction" agents.
+
+## Solution
+
+Added `AgentRole` enum and `list_assistant_agents()` function:
+
+**AgentRole enum (harnx-core/src/agent_config.rs):**
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRole {
+    #[default]
+    Assistant,
+    Subagent,
+    Compaction,
+}
+```
+
+**Struct-level serde(default) on AgentFrontMatter:**
+
+```rust
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]  // ← enables adding fields without breaking existing YAML
+struct AgentFrontMatter {
+    // ... other fields ...
+    #[serde(default)]
+    role: AgentRole,
+}
+```
+
+**Two-function pattern (harnx-runtime/src/config/agent.rs):**
+
+```rust
+// Fast dir scan, no parsing — unchanged for backward compat
+pub fn list_agents() -> Vec<String> { /* ... */ }
+
+// Parses each file, filters by role
+pub fn list_assistant_agents() -> Vec<String> {
+    // ... reads each .md file, parses AgentConfig, filters by role == Assistant
+}
+```
+
+**Zsh completion special case:**
+
+```zsh
+case $state in
+    models|sessions|rags|macros)
+        values=( ${(f)"$(_call_program values harnx --list-$state)"} )
+        _wanted values expl $state compadd -a values && ret=0 ;;
+    agents)  # ← must break pattern: flag is --list-assistant-agents, not --list-agents
+        values=( ${(f)"$(_call_program values harnx --list-assistant-agents)"} )
+        _wanted values expl $state compadd -a values && ret=0 ;;
+esac
+```
+
+Other shell completions (bash, fish, nu, ps1) updated to call `--list-assistant-agents`.
+
+## Why This Works
+
+1. **Serde default semantics**: `#[serde(default)]` at struct level means YAML files without `role:` field deserialize successfully with `AgentRole::Assistant` as the implicit default. Existing agent configs require no modification.
+
+2. **Enum rename_all**: `#[serde(rename_all = "snake_case")]` maps YAML `role: subagent` to `AgentRole::Subagent` automatically.
+
+3. **Two-function pattern**: `list_agents()` remains fast (dir scan only) for code paths that don't need filtering. `list_assistant_agents()` pays the parsing cost only when preparing UI lists — infrequent, user-triggered operations.
+
+4. **Zsh pattern break**: The zsh dynamic `--list-$state` pattern works for flags matching the state name. Since `--list-assistant-agents` doesn't match state `agents`, an explicit case arm is required.
+
+## Prevention Strategies
+
+**Test coverage:**
+- Agent role parsing (default, each variant, roundtrip)
+- `list_assistant_agents()` filtering (only assistants returned, malformed files skipped, sorted output)
+
+**Code review checklist:**
+- [ ] New YAML frontmatter fields include `#[serde(default)]` if they have `Default` impls
+- [ ] Shell completion scripts updated when adding new `--list-*` flags
+- [ ] Zsh state machine requires explicit case arm if flag name diverges from `--list-$state` pattern
+
+**Performance consideration:**
+If agent count grows significantly (hundreds of agents), `list_assistant_agents()` could become slow. Future optimization: frontmatter-only parser that doesn't parse the full markdown body.
+
+## Related Issues
+
+- **Jira:** [GH-457](https://github.com/dobesv/harnx/issues/457) — Add agent role metadata
+- **Related Solution:** [logic-errors/extract-agent-precedence-2026-05-03.md](extract-agent-precedence-2026-05-03.md) — Agent configuration precedence rules

--- a/example_config/agents/example-agent.md
+++ b/example_config/agents/example-agent.md
@@ -15,7 +15,7 @@ use_tools:                       # Which MCP tools to allow
 description: ""                  # Short description of the agent
 version: ""                      # Agent version string
 agent_default_session: null      # Set a session to use when starting the agent
-# compaction_agent: null          # Agent to use for context compression (uses its model/system prompt)
+compaction_agent: example-compaction-agent  # Agent to use for context compression (uses its model/system prompt)
 instructions: null               # Override the instructions below
 
 variables:                       # Agent variables (prompted on first use)

--- a/example_config/agents/example-compaction-agent.md
+++ b/example_config/agents/example-compaction-agent.md
@@ -1,0 +1,6 @@
+---
+role: compaction
+model: openai:gpt-4o-mini
+description: "Example compaction agent for context compression"
+---
+Summarize the conversation history concisely, preserving all key decisions and context.

--- a/example_config/agents/example-subagent.md
+++ b/example_config/agents/example-subagent.md
@@ -1,0 +1,6 @@
+---
+role: subagent
+model: openai:gpt-4o-mini
+description: "Example sub-agent not shown in the agent picker"
+---
+You are a focused sub-agent used internally by other agents.

--- a/scripts/completions/harnx.bash
+++ b/scripts/completions/harnx.bash
@@ -17,7 +17,7 @@ _harnx() {
 
     case "${cmd}" in
         harnx)
-            opts="-m -s -a -f -S -t -h -V --model --prompt --session --empty-session --save-session --agent --agent-variable --rag --rebuild-rag --macro --serve --acp --file --no-stream --dry-run --info --sync-models --list-models --list-sessions --list-agents --list-rags --list-macros --mcp-root --tool --help --version"
+            opts="-m -s -a -f -S -t -h -V --model --prompt --session --empty-session --save-session --agent --agent-variable --rag --rebuild-rag --macro --serve --acp --file --no-stream --dry-run --info --sync-models --list-models --list-sessions --list-agents --list-assistant-agents --list-rags --list-macros --mcp-root --tool --help --version"
             if [[ ${cur} == -* || ${cword} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -39,7 +39,7 @@ _harnx() {
                     return 0
                     ;;
                 -a|--agent)
-                    COMPREPLY=($(compgen -W "$("$1" --list-agents)" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "$("$1" --list-assistant-agents)" -- "${cur}"))
                     __ltrim_colon_completions "$cur"
                     return 0
                     ;;
@@ -58,7 +58,7 @@ _harnx() {
                     return 0
                     ;;
                 --acp)
-                    COMPREPLY=($(compgen -W "$("$1" --list-agents)" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "$("$1" --list-assistant-agents)" -- "${cur}"))
                     __ltrim_colon_completions "$cur"
                     return 0
                     ;;

--- a/scripts/completions/harnx.fish
+++ b/scripts/completions/harnx.fish
@@ -3,13 +3,13 @@ complete -c harnx -l prompt -d 'Use the system prompt'
 complete -c harnx -s s -l session -x  -a "(harnx --list-sessions)" -d 'Start or join a session' -r
 complete -c harnx -l empty-session -d 'Ensure the session is empty'
 complete -c harnx -l save-session -d 'Ensure the new conversation is saved to the session'
-complete -c harnx -s a -l agent -x  -a "(harnx --list-agents)" -d 'Start a agent' -r
+complete -c harnx -s a -l agent -x  -a "(harnx --list-assistant-agents)" -d 'Start a agent' -r
 complete -c harnx -l agent-variable -d 'Set agent variables'
 complete -c harnx -l rag -x  -a"(harnx --list-rags)" -d 'Start a RAG' -r
 complete -c harnx -l rebuild-rag -d 'Rebuild the RAG to sync document changes'
 complete -c harnx -l macro -x  -a"(harnx --list-macros)" -d 'Execute a macro' -r
 complete -c harnx -l serve -d 'Serve the LLM API and WebAPP' -r
-complete -c harnx -l acp -x -a "(harnx --list-agents)" -d 'Serve as an ACP agent over stdio' -r
+complete -c harnx -l acp -x -a "(harnx --list-assistant-agents)" -d 'Serve as an ACP agent over stdio' -r
 complete -c harnx -s f -l file -d 'Include files, directories, or URLs' -r -F
 complete -c harnx -s S -l no-stream -d 'Turn off stream mode'
 complete -c harnx -l dry-run -d 'Display the message without sending it'

--- a/scripts/completions/harnx.nu
+++ b/scripts/completions/harnx.nu
@@ -17,7 +17,7 @@ module completions {
   }
 
   def "nu-complete harnx agent" [] {
-    ^harnx --list-agents |
+    ^harnx --list-assistant-agents |
     | lines 
     | parse "{value}" 
   }

--- a/scripts/completions/harnx.ps1
+++ b/scripts/completions/harnx.ps1
@@ -73,13 +73,13 @@ Register-ArgumentCompleter -Native -CommandName 'harnx' -ScriptBlock {
         } elseif ($flag -ceq "-s" -or $flag -eq "--session") {
             $completions = Get-HarnxValues "--list-sessions"
         } elseif ($flag -ceq "-a" -or $flag -eq "--agent") {
-            $completions = Get-HarnxValues "--list-agents"
+            $completions = Get-HarnxValues "--list-assistant-agents"
         } elseif ($flag -eq "--rag") {
             $completions = Get-HarnxValues "--list-rags"
         } elseif ($flag -eq "--macro") {
             $completions = Get-HarnxValues "--list-macros"
         } elseif ($flag -eq "--acp") {
-            $completions = Get-HarnxValues "--list-agents"
+            $completions = Get-HarnxValues "--list-assistant-agents"
         } elseif ($flag -ceq "-f" -or $flag -eq "--file") {
             $completions = @()
         } elseif ($flag -eq "--mcp-root") {

--- a/scripts/completions/harnx.zsh
+++ b/scripts/completions/harnx.zsh
@@ -56,11 +56,14 @@ _harnx() {
     _arguments "${_arguments_options[@]}" $common \
         && ret=0 
     case $state in
-        models|sessions|agents|rags|macros)
+        models|sessions|rags|macros)
             local -a values expl
             values=( ${(f)"$(_call_program values harnx --list-$state)"} )
-            _wanted values expl $state compadd -a values && ret=0
-            ;;
+            _wanted values expl $state compadd -a values && ret=0 ;;
+        agents)
+            local -a values expl
+            values=( ${(f)"$(_call_program values harnx --list-assistant-agents)"} )
+            _wanted values expl $state compadd -a values && ret=0 ;;
     esac
     return ret
 }


### PR DESCRIPTION
Introduces AgentRole metadata (Assistant, Subagent, Compaction) to agent configuration. This allows distinguishing between agents intended for direct user interaction and those used internally for sub-tasks or context compaction.

Updates the CLI with a --list-assistant-agents flag and modifies shell completion scripts and the TUI agent picker to use this filtered list. This prevents internal utility agents from cluttering the main agent selection menus while still allowing them to be configured and used programmatically.

Includes a new solution document detailing the implementation and prevention strategies for future agent metadata additions.

[gh-457]
Plan: gh-457-agent-role-metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents can be assigned roles (Assistant, Subagent, Compaction) via front-matter.
  * CLI gains --list-assistant-agents and runtime/TUI now suggest only Assistant agents.
  * Shell completions (bash/fish/ps1/nu/zsh) updated to use the filtered assistant list.

* **Documentation**
  * Added guide on role filtering, completion behavior, and migration considerations.

* **Tests**
  * Added unit tests covering role parsing, filtering, and deterministic listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->