### PR TITLE
feat: print session resume instructions on exit (#417)

### DIFF
--- a/.changesets/417-session-resume-hint.md
+++ b/.changesets/417-session-resume-hint.md
@@ -1,0 +1,15 @@
+---
+harnx: minor
+---
+Print session resume instructions to the terminal on exit.
+
+When harnx exits a saved session (TUI or CMD mode) it now prints:
+
+```
+Resume this session by running:
+  harnx -a <agent> -s <session>
+```
+
+The `-a <agent>` flag is omitted when no agent is active. The hint is
+suppressed for empty sessions and for sessions that are explicitly opted
+out of saving (`save_session: false`).

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -292,11 +292,44 @@ async fn dispatch_session_start(
     .await;
 }
 
+fn session_resume_command(config: &GlobalConfig) -> Option<String> {
+    let config_read = config.read();
+    let session = config_read.session.as_ref()?;
+    if session.is_empty() {
+        return None;
+    }
+
+    let save_session = session.save_session;
+    let save_session_this_time = session.save_session_this_time;
+    if save_session == Some(false) && !save_session_this_time {
+        return None;
+    }
+
+    let session_name = session
+        .resolved_save_name
+        .as_ref()
+        .map(|(_, name)| name.as_str())
+        .unwrap_or_else(|| session.id());
+
+    let agent_name = config_read.agent.as_ref().map(|a| a.name());
+
+    let mut args = vec!["harnx".to_string()];
+    if let Some(agent) = agent_name {
+        args.push("-a".to_string());
+        args.push(agent.to_string());
+    }
+    args.push("-s".to_string());
+    args.push(session_name.to_string());
+
+    Some(shell_words::join(args))
+}
+
 async fn exit_session_with_hook(
     config: &GlobalConfig,
     async_manager: &AsyncHookManager,
     persistent_manager: &Arc<tokio::sync::Mutex<PersistentHookManager>>,
 ) -> Result<()> {
+    let resume_cmd = session_resume_command(config);
     let (hooks, session_id, cwd) = hook_dispatch_context(config);
     config.write().exit_session()?;
     let event = HookEvent::SessionEnd {
@@ -314,6 +347,15 @@ async fn exit_session_with_hook(
         ),
     )
     .await;
+
+    if let Some(cmd) = resume_cmd {
+        eprintln!(
+            "\n{}\n  {}",
+            dimmed_text("Resume this session by running:"),
+            cmd
+        );
+    }
+
     Ok(())
 }
 
@@ -625,3 +667,117 @@ async fn create_input(
 }
 
 use harnx_runtime::bootstrap::setup_logger;
+
+#[cfg(test)]
+mod resume_tests {
+    use super::*;
+    use harnx_runtime::config::session::Session;
+
+    fn make_config(session: Option<Session>) -> GlobalConfig {
+        let config = Config {
+            session,
+            ..Default::default()
+        };
+        Arc::new(RwLock::new(config))
+    }
+
+    fn session_with_message(id: &str) -> Session {
+        let mut session = Session {
+            id: id.to_string(),
+            ..Default::default()
+        };
+        session.messages.push(crate::client::Message::default());
+        session
+    }
+
+    #[test]
+    fn returns_none_when_no_session() {
+        let config = make_config(None);
+        assert!(session_resume_command(&config).is_none());
+    }
+
+    #[test]
+    fn returns_none_for_empty_session() {
+        let config = make_config(Some(Session {
+            id: "test".to_string(),
+            ..Default::default()
+        }));
+        assert!(session_resume_command(&config).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_save_session_false() {
+        let mut session = session_with_message("test");
+        session.save_session = Some(false);
+        let config = make_config(Some(session));
+        assert!(session_resume_command(&config).is_none());
+    }
+
+    #[test]
+    fn returns_command_when_save_session_false_but_save_this_time() {
+        let mut session = session_with_message("test");
+        session.save_session = Some(false);
+        session.save_session_this_time = true;
+        let config = make_config(Some(session));
+        assert_eq!(session_resume_command(&config).unwrap(), "harnx -s test");
+    }
+
+    #[test]
+    fn returns_command_for_plain_named_session() {
+        let session = session_with_message("my-session");
+        let config = make_config(Some(session));
+        assert_eq!(
+            session_resume_command(&config).unwrap(),
+            "harnx -s my-session"
+        );
+    }
+
+    #[test]
+    fn includes_agent_when_set_in_session() {
+        let session = session_with_message("my-session");
+        let mut agent = crate::config::Agent::default();
+        agent.set_name("my-agent");
+
+        let config = Config {
+            agent: Some(agent),
+            session: Some(session),
+            ..Default::default()
+        };
+        let config = Arc::new(RwLock::new(config));
+
+        assert_eq!(
+            session_resume_command(&config).unwrap(),
+            "harnx -a my-agent -s my-session"
+        );
+    }
+
+    #[test]
+    fn shell_quotes_names_with_spaces() {
+        let session = session_with_message("my session");
+        let mut agent = crate::config::Agent::default();
+        agent.set_name("my agent");
+
+        let config = Config {
+            agent: Some(agent),
+            session: Some(session),
+            ..Default::default()
+        };
+        let config = Arc::new(RwLock::new(config));
+
+        assert_eq!(
+            session_resume_command(&config).unwrap(),
+            "harnx -a 'my agent' -s 'my session'"
+        );
+    }
+
+    #[test]
+    fn uses_resolved_save_name_when_available() {
+        let mut session = session_with_message("temp");
+        session.resolved_save_name = Some((PathBuf::from("_"), "20240505-resolved".to_string()));
+        let config = make_config(Some(session));
+        assert_eq!(
+            session_resume_command(&config).unwrap(),
+            "harnx -s 20240505-resolved"
+        );
+    }
+}

--- a/docs/solutions/logic-errors/session-resume-hint-on-exit-2026-05-05.md
+++ b/docs/solutions/logic-errors/session-resume-hint-on-exit-2026-05-05.md
@@ -1,0 +1,111 @@
+---
+title: "Session resume hint on exit in a Rust CLI"
+date: 2026-05-05
+category: logic-errors
+problem_type: logic_error
+component: cli-session-management
+root_cause: "missing user-facing guidance after session exit"
+resolution_type: code_fix
+severity: low
+tags:
+  - session-management
+  - cli-ux
+  - shell-escaping
+  - terminal-output
+plan_ref: "issue-417"
+---
+
+## Problem
+
+Users had no way to know how to resume a harnx session after exiting. No command or hint was printed, requiring users to manually recall agent and session names.
+
+## Symptoms
+
+- After exiting a harnx session (TUI or CMD mode), terminal returned to prompt with no guidance
+- Users had to remember session names and agent to resume: `harnx -a <agent> -s <session>`
+- Temp sessions (with timestamped filenames) were especially hard to resume — id shows as "temp" but file is timestamped
+
+## Investigation Steps
+
+1. Identified exit path in `exit_session()` which takes ownership of session via `.take()` — data gone after call
+2. Found `session.resolved_save_name()` returns actual on-disk filename for temp sessions (not `"temp"`)
+3. Determined hint must print BEFORE `exit_session()` consumes session state
+4. Tested output destination: TUI restores terminal before this point, so stdout goes to TUI buffer
+5. Added shell escaping for copy-paste safety — names may contain spaces or special characters
+
+## Root Cause
+
+Session exit logic provided no user-facing feedback. Session data was consumed by `exit_session()` before any hint could access it, and the distinction between `session.id()` (logical ID) and `resolved_save_name` (on-disk name) was not surfaced.
+
+## Solution
+
+Capture session state BEFORE calling `exit_session()`, print hint to stderr:
+
+```rust
+// Capture BEFORE exit_session() takes ownership
+let session_name = session.resolved_save_name();
+let agent_name = config.read().agent.as_ref().map(|a| a.name.clone());
+
+// Suppress conditions
+let is_empty_session = session.is_empty();
+let save_disabled = save_session == Some(false) && !save_session_this_time;
+
+if !is_empty_session && !save_disabled {
+    eprintln!("\nResume this session by running:");
+    let quoted_session = shell_words::quote(&session_name);
+    if let Some(agent) = agent_name {
+        let quoted_agent = shell_words::quote(&agent);
+        eprintln!("  harnx -a {} -s {}", quoted_agent, quoted_session);
+    } else {
+        eprintln!("  harnx -s {}", quoted_session);
+    }
+}
+
+// NOW safe to call exit_session()
+exit_session(&config, save_session, save_session_this_time)?;
+```
+
+**Unit test pattern** — construct `Config::default()` with mock `Session`:
+
+```rust
+#[test]
+fn test_resume_hint_empty_session_suppressed() {
+    let mut config = Config::default();
+    config.session = Some(Session::default()); // derives Default
+    // assertion logic here
+}
+```
+
+## Why This Works
+
+1. **Capture before consume** — session state is read before `exit_session()` takes ownership via `.take()`
+2. **`resolved_save_name` over `id()`** — temp sessions have id `"temp"` but save to timestamped files; `resolved_save_name()` returns actual on-disk name
+3. **`shell_words::quote()`** — names are copy-paste commands; must handle spaces and special chars safely
+4. **`eprintln!` to stderr** — TUI restores terminal before this point; stdout goes to TUI's alternate screen buffer, stderr goes to raw terminal
+5. **Suppression logic** — avoid noise for empty sessions and explicitly-disabled save cases
+
+## Prevention Strategies
+
+**Best Practices:**
+
+- Always capture data BEFORE ownership-transfer methods like `.take()` or `.remove()`
+- Use `shell_words::quote()` for any user-facing shell commands
+- Print CLI hints to stderr when TUI has restored terminal state
+- Test mock objects by deriving `Default` — no filesystem needed
+
+**Code Review Checklist:**
+
+- [ ] Is session state captured before ownership transfer?
+- [ ] Are copy-paste commands shell-safe?
+- [ ] Does output go to correct stream (stderr vs stdout)?
+- [ ] Are hints suppressed for edge cases (empty, disabled)?
+
+**Related Tests:**
+
+- Unit test with `Config::default()` and `Session::default()` — validates suppression logic
+- Integration test: run harnx with temp session, exit, verify hint shows timestamped name
+
+## Related Issues
+
+- **Changeset:** `.changesets/417-session-resume-hint.md`
+- **Related Solution:** [logic-errors/non-tui-terminal-output-fixes-2026-04-30.md](./non-tui-terminal-output-fixes-2026-04-30.md) — TUI vs non-TUI output handling


### PR DESCRIPTION
When harnx exits a saved session it now prints to stderr:

  Resume this session by running:
    harnx [-a <agent>] -s <session>

The hint is suppressed for empty sessions and sessions with save_session: false. Agent and session names are shell-quoted for safe copy-paste. Covers TUI and CMD modes via the shared exit_session_with_hook path.

Issue: #417
Plan: harnx-417-session-resume

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On exiting a saved session the terminal now prints a ready-to-run resume command to restore that session; it includes agent info when applicable and is suppressed for empty or explicitly non-saved sessions.

* **Documentation**
  * Added guidance detailing the resume-hint behavior, rationale, examples, and testing recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->