### PR TITLE
feat(tui): replace browsing mode detail panel with full transcript view

### DIFF
--- a/.changesets/browsing-mode-transcript-view.md
+++ b/.changesets/browsing-mode-transcript-view.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+Replace the browsing mode detail panel with a full transcript view for better readability and navigation.

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1275,11 +1275,6 @@ impl Tui {
             if let Some(prev) = self.find_prev_navigable(focus) {
                 self.app.transcript_focus = Some(prev);
                 self.app.transcript_browsing = true;
-                self.app.browsing_view_scroll = {
-                    let mut s = ratatui_widget_scrolling::ScrollState::new();
-                    s.follow = false;
-                    s
-                };
                 self.app.scroll_state.follow = false;
                 self.app.scroll_to_focused_item = true;
                 self.app.transcript_selection_anchor = None;
@@ -1304,11 +1299,6 @@ impl Tui {
             if let Some(prev) = self.find_prev_navigable(self.app.transcript.len()) {
                 self.app.transcript_focus = Some(prev);
                 self.app.transcript_browsing = true;
-                self.app.browsing_view_scroll = {
-                    let mut s = ratatui_widget_scrolling::ScrollState::new();
-                    s.follow = false;
-                    s
-                };
                 self.app.scroll_state.follow = false;
                 self.app.scroll_to_focused_item = true;
                 self.app.transcript_selection_anchor = None;
@@ -1348,11 +1338,6 @@ impl Tui {
             if let Some(next) = self.find_next_navigable(focus) {
                 self.app.transcript_focus = Some(next);
                 self.app.transcript_browsing = true;
-                self.app.browsing_view_scroll = {
-                    let mut s = ratatui_widget_scrolling::ScrollState::new();
-                    s.follow = false;
-                    s
-                };
                 self.app.scroll_state.follow = false;
                 self.app.scroll_to_focused_item = true;
                 self.app.transcript_selection_anchor = None;

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -1178,45 +1178,59 @@ impl Tui {
             .constraints([Constraint::Min(1), Constraint::Length(2)])
             .split(size);
 
-        // Count navigable items and find display index
-        let mut navigable_count = 0;
-        let mut display_idx = 0;
-
-        let mut content_lines = Vec::new();
-
-        for (i, item) in self.app.transcript.iter().enumerate() {
-            if item.is_navigable() {
-                navigable_count += 1;
-                if Some(i) == self.app.transcript_focus {
-                    display_idx = navigable_count;
-                    content_lines = Self::render_entry_detail(item);
-                }
-            }
-        }
-
-        let entries_as_vec = if content_lines.is_empty() {
-            vec![]
+        let show_seq = self.app.show_sequence_numbers;
+        let show_ts = self.app.show_timestamps;
+        let use_utc = self.app.use_utc_timestamps;
+        let selected_range = if let Some(f) = self.app.transcript_focus {
+            let start = self.app.transcript_selection_anchor.unwrap_or(f).min(f);
+            let end = self.app.transcript_selection_anchor.unwrap_or(f).max(f);
+            Some(start..=end)
         } else {
-            vec![content_lines]
+            None
         };
 
-        // Create block with border and title
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .title("History Browser");
+        if self.app.scroll_to_focused_item {
+            if let Some(focus) = self.app.transcript_focus {
+                let position = self.app.browsing_view_scroll.scroll_position_to_show_item(
+                    focus,
+                    chunks[0].width,
+                    chunks[0].height as usize,
+                    self.app.transcript.len(),
+                );
+                self.app.browsing_view_scroll.position = position;
+            }
+            self.app.scroll_to_focused_item = false;
+        }
 
-        // Get inner area for content
-        let inner_area = block.inner(chunks[0]);
+        let transcript_entries: Vec<Vec<Line<'static>>> = if self.app.transcript.is_empty() {
+            vec![vec![Line::from(Span::raw(""))]]
+        } else {
+            self.app
+                .transcript
+                .iter()
+                .enumerate()
+                .map(|(i, entry)| {
+                    let mut lines = Self::render_entry(entry, show_seq, show_ts, use_utc);
+                    if let Some(range) = &selected_range {
+                        if range.contains(&i) {
+                            for line in &mut lines {
+                                line.style = line.style.add_modifier(Modifier::REVERSED);
+                                for span in &mut line.spans {
+                                    span.style = span.style.add_modifier(Modifier::REVERSED);
+                                }
+                            }
+                        }
+                    }
+                    lines
+                })
+                .collect()
+        };
 
-        // Render the block into the content chunk
-        frame.render_widget(block, chunks[0]);
-
-        // Render the scrollable content
         self.app
             .browsing_view_scroll
-            .render(frame, inner_area, &entries_as_vec, |lines| {
+            .render(frame, chunks[0], &transcript_entries, |lines| {
                 let paragraph = Paragraph::new(lines.clone()).wrap(Wrap { trim: false });
-                let height = paragraph.line_count(inner_area.width);
+                let height = paragraph.line_count(chunks[0].width);
                 (height, paragraph)
             });
 
@@ -1226,6 +1240,18 @@ impl Tui {
             .browsing_view_scroll
             .position
             .min(self.app.browsing_view_scroll.last_max_position);
+
+        // Count navigable items and find display index
+        let mut navigable_count = 0;
+        let mut display_idx = 0;
+        for (i, item) in self.app.transcript.iter().enumerate() {
+            if item.is_navigable() {
+                navigable_count += 1;
+                if Some(i) == self.app.transcript_focus {
+                    display_idx = navigable_count;
+                }
+            }
+        }
 
         // Split footer into two rows
         let footer_chunks = Layout::default()

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -6523,3 +6523,204 @@ async fn session_picker_esc_restores_origin() {
         "should restore origin session"
     );
 }
+
+// =============================================================================
+// Browsing Mode Rendering Tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_browsing_mode_shows_full_transcript() {
+    let mut harness = TuiTestHarness::with_size(60, 20);
+
+    // Clear the initial welcome message
+    harness.tui().app.transcript.clear();
+
+    // Add 3 transcript items
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "User message".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "Assistant reply".to_string(),
+            seq: None,
+            timestamp: None,
+        });
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Second user msg".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+
+    // Enable browsing mode
+    harness.tui().app.transcript_browsing = true;
+    harness.tui().app.transcript_focus = Some(0);
+    harness.tui().app.scroll_to_focused_item = true;
+
+    harness.render();
+    let screen = harness.screen_contents();
+
+    // All three items should be visible
+    assert!(
+        screen.contains("User message"),
+        "Screen should contain 'User message', got:\n{screen}"
+    );
+    assert!(
+        screen.contains("Assistant reply"),
+        "Screen should contain 'Assistant reply', got:\n{screen}"
+    );
+    assert!(
+        screen.contains("Second user msg"),
+        "Screen should contain 'Second user msg', got:\n{screen}"
+    );
+
+    // Old bordered panel title should NOT appear (the browsing view is now full-screen)
+    assert!(
+        !screen.contains("History Browser"),
+        "Screen should NOT contain 'History Browser', got:\n{screen}"
+    );
+}
+
+#[tokio::test]
+async fn test_browsing_mode_focused_item_has_reversed_style() {
+    let mut harness = TuiTestHarness::with_size(60, 20);
+
+    // Clear the initial welcome message
+    harness.tui().app.transcript.clear();
+
+    // Add 3 transcript items
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Alpha".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "Beta".to_string(),
+            seq: None,
+            timestamp: None,
+        });
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "Gamma".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+
+    // Enable browsing mode, focus on first item (Alpha at index 0)
+    harness.tui().app.transcript_browsing = true;
+    harness.tui().app.transcript_focus = Some(0); // Alpha is at index 0
+    harness.tui().app.scroll_to_focused_item = true;
+
+    harness.render();
+
+    // Check the buffer for styles
+    let buffer = harness.terminal.backend().buffer();
+
+    // Collect full text of each row and track which rows have REVERSED cells
+    let mut reversed_rows: std::collections::HashSet<u16> = std::collections::HashSet::new();
+    let mut row_texts: std::collections::HashMap<u16, String> = std::collections::HashMap::new();
+
+    for y in 0..buffer.area.height {
+        let mut row_text = String::new();
+        let mut row_has_reversed = false;
+
+        for x in 0..buffer.area.width {
+            let cell = &buffer[(x, y)];
+            row_text.push_str(cell.symbol());
+            if cell.style().add_modifier.contains(Modifier::REVERSED) {
+                row_has_reversed = true;
+            }
+        }
+
+        row_texts.insert(y, row_text);
+        if row_has_reversed {
+            reversed_rows.insert(y);
+        }
+    }
+
+    // Check: rows with "Alpha" should have REVERSED (it's focused at index 0)
+    let alpha_rows: Vec<(&u16, &String)> = row_texts
+        .iter()
+        .filter(|(_, text)| text.contains("Alpha"))
+        .collect();
+    let alpha_rows_reversed: Vec<_> = alpha_rows
+        .iter()
+        .filter(|(y, _)| reversed_rows.contains(*y))
+        .collect();
+
+    assert!(
+        !alpha_rows_reversed.is_empty(),
+        "Rows containing 'Alpha' should have REVERSED style. Got {} rows with Alpha, {} of those reversed. Screen:\n{:?}",
+        alpha_rows.len(),
+        alpha_rows_reversed.len(),
+        row_texts
+    );
+
+    // Check: rows with "Beta" or "Gamma" should NOT have REVERSED (not focused)
+    for (y, text) in &row_texts {
+        if text.contains("Beta") || text.contains("Gamma") {
+            assert!(
+                !reversed_rows.contains(y),
+                "Non-focused item row should NOT have REVERSED style. Row {}: '{}'",
+                y,
+                text.trim()
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_browsing_mode_non_navigable_items_visible_not_focusable() {
+    let mut harness = TuiTestHarness::with_size(60, 20);
+
+    // Clear the initial welcome message
+    harness.tui().app.transcript.clear();
+
+    // Add transcript items: UserText (navigable), ToolResultMarkdown (non-navigable), AssistantText (navigable)
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "User turn".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    // ToolResultMarkdown is non-navigable per is_navigable() implementation
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::ToolResultMarkdown(
+            "thinking...".to_string(),
+        ));
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "AI response".to_string(),
+            seq: None,
+            timestamp: None,
+        });
+
+    // Enable browsing mode, focus on first item (index 0)
+    harness.tui().app.transcript_browsing = true;
+    harness.tui().app.transcript_focus = Some(0);
+
+    // Press Down - should skip ToolResultMarkdown at index 1 and jump to AssistantText at index 2
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        harness.tui().app.transcript_focus,
+        Some(2),
+        "Down should skip non-navigable ToolResultMarkdown at index 1 and focus AssistantText at index 2"
+    );
+}

--- a/docs/solutions/logic-errors/tui-browsing-full-transcript-render-2026-05-05.md
+++ b/docs/solutions/logic-errors/tui-browsing-full-transcript-render-2026-05-05.md
@@ -1,0 +1,164 @@
+---
+title: "TUI browsing mode full transcript render and scroll state ownership"
+date: 2026-05-05
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-tui"
+root_cause: "browsing view rendered single-item detail panel instead of full transcript, and scroll state was reset per keypress instead of managed by renderer"
+resolution_type: code_fix
+severity: medium
+tags:
+  - tui
+  - overlay
+  - scroll-state
+  - ratatui
+  - navigation
+  - rendering
+plan_ref: "harnx-tui-browsing-mode-transcript-view"
+---
+
+## Problem
+
+Browsing mode in harnx-tui had two UX bugs: (1) keyboard shortcuts were not visible because the view rendered only a single focused item in a bordered "History Browser" panel, obscuring full transcript context, and (2) arrow navigation moved line-by-line instead of item-by-item because scroll state was reset to a fresh `ScrollState` on every keypress, fighting the centering logic.
+
+## Symptoms
+
+- Browsing mode showed a narrow bordered panel with one item detail, not the full transcript list
+- Keyboard shortcuts footer was rendered but the transcript list was hidden behind the detail panel
+- Arrow Up/Down in browsing mode would sometimes lose position or scroll unexpectedly
+- Focused item highlighting wasn't visible across multiple items
+- GitHub #454: keyboard shortcuts not visible during history browse
+- GitHub #431: arrow navigation was line-by-line instead of item-by-item
+
+## Investigation Steps
+
+1. Reviewed `render_browsing_view()` — found it called `render_entry_detail()` inside a `Block::default().borders(Borders::ALL).title("History Browser")` panel
+2. Compared with normal `draw()` — realized normal view iterates all transcript items with `Modifier::REVERSED` for focused item
+3. Traced `handle_up_key()` and `handle_down_key()` — discovered `browsing_view_scroll` was reset to fresh `ScrollState::new()` on every keypress
+4. Found `scroll_to_focused_item` flag was set in input handler but reset logic interfered
+5. Understood the pattern: flag signals "center on focus next render", but resetting scroll state to position 0 defeated the centering
+
+## Root Cause
+
+**Single-item detail panel:** `render_browsing_view()` was designed as a "History Browser" panel showing one item via `render_entry_detail()`, similar to the detail view pattern. This was inappropriate for browsing mode, which should show the full transcript with focus highlighting — an overlay that replaces the screen, not a narrow inspection panel.
+
+**Per-keypress scroll reset:** The input handlers for Up/Down in browsing mode reset `browsing_view_scroll` to a fresh `ScrollState` on every keypress:
+
+```rust
+self.app.browsing_view_scroll = {
+    let mut s = ratatui_widget_scrolling::ScrollState::new();
+    s.follow = false;
+    s
+};
+```
+
+This fought the centering logic. The `scroll_to_focused_item` flag said "center on focused item", but the reset said "start from position 0". The flag and the reset were in conflict.
+
+**Principle violated:** When a flag signals "do X on next render", input handlers should only set the flag — the renderer owns the state mutation. Mutating state in the input path creates conflicting sources of truth.
+
+## Solution
+
+### 1. Replace detail panel with full transcript rendering
+
+`render_browsing_view()` now mirrors `draw()`: iterates all transcript items, applies `Modifier::REVERSED` to the focused item, uses the same `ScrollState.render()` + `Paragraph::wrap()` closure pattern.
+
+Removed the bordered "History Browser" block and `render_entry_detail()` usage.
+
+```rust
+// Before: bordered panel showing single item
+let block = Block::default()
+    .borders(Borders::ALL)
+    .title("History Browser");
+let inner_area = block.inner(chunks[0]);
+frame.render_widget(block, chunks[0]);
+
+let entries_as_vec = /* single focused item */;
+self.app.browsing_view_scroll.render(frame, inner_area, &entries_as_vec, |lines| { ... });
+
+// After: full transcript with focus highlight
+let transcript_entries: Vec<Vec<Line>> = self.app.transcript
+    .iter()
+    .enumerate()
+    .map(|(i, entry)| {
+        let mut lines = Self::render_entry(entry, show_seq, show_ts, use_utc);
+        if let Some(range) = &selected_range {
+            if range.contains(&i) {
+                for line in &mut lines {
+                    line.style = line.style.add_modifier(Modifier::REVERSED);
+                }
+            }
+        }
+        lines
+    })
+    .collect();
+
+self.app.browsing_view_scroll.render(frame, chunks[0], &transcript_entries, |lines| {
+    let paragraph = Paragraph::new(lines.clone()).wrap(Wrap { trim: false });
+    let height = paragraph.line_count(chunks[0].width);
+    (height, paragraph)
+});
+```
+
+### 2. Remove scroll state reset from input handlers
+
+Removed the per-keypress `browsing_view_scroll` reset from `handle_up_key()` and `handle_down_key()`. The input handler only sets `scroll_to_focused_item = true`. The renderer calls `scroll_position_to_show_item()` to compute the correct position — that's the single source of truth.
+
+```rust
+// Input handler: only set the flag
+if let Some(prev) = self.find_prev_navigable(focus) {
+    self.app.transcript_focus = Some(prev);
+    self.app.transcript_browsing = true;
+    self.app.scroll_to_focused_item = true;
+    // NO scroll state reset here
+}
+
+// Renderer: owns the position calculation
+if self.app.scroll_to_focused_item {
+    if let Some(focus) = self.app.transcript_focus {
+        let position = self.app.browsing_view_scroll.scroll_position_to_show_item(
+            focus,
+            chunks[0].width,
+            chunks[0].height as usize,
+            self.app.transcript.len(),
+        );
+        self.app.browsing_view_scroll.position = position;
+    }
+    self.app.scroll_to_focused_item = false;
+}
+```
+
+## Why This Works
+
+**Full transcript rendering:** Browsing mode is an overlay that replaces the entire screen. It should render the same content as the normal view but with focus highlighting — not a separate narrow panel. This ensures keyboard shortcuts and other UI elements remain visible in the footer, and the user sees the full context around the focused item.
+
+**Flag ownership pattern:** The `scroll_to_focused_item` flag is a request from the input handler to the renderer: "on next render, center on the focused item". The renderer computes the position via `scroll_position_to_show_item()` and clears the flag. The input handler never touches scroll position directly. This prevents conflicting mutations and ensures the renderer is the single source of truth for scroll state.
+
+**No position reset:** By removing the fresh `ScrollState` on each keypress, the scroll position persists across navigation, and the centering logic works correctly. The `follow = false` setting is preserved from initial setup (not reset each time), maintaining the "don't auto-follow new content" behavior appropriate for history browsing.
+
+## Prevention Strategies
+
+**Test cases:**
+- Test browsing mode renders full transcript list with focus highlighting
+- Test arrow Up/Down moves focus item-by-item, not line-by-line
+- Test focused item stays centered after navigation
+- Test keyboard shortcuts visible in footer during browsing mode
+- Test scroll position persists across multiple arrow keypresses
+
+**Best practices:**
+- When an overlay replaces the full screen, render the same content as the main view with focus/style modifications — not a separate specialized panel
+- Use flags to signal "do X on next render" — the renderer owns the state mutation
+- Never reset scroll state in input handlers; let the renderer manage position via flags
+- Preserve scroll state across navigation events; don't create fresh instances per keypress
+
+**Code review checklist:**
+- [ ] Does browsing overlay render full content with focus highlight, not a narrow panel?
+- [ ] Is scroll state reset removed from input handlers?
+- [ ] Does renderer own scroll position calculation via flags?
+- [ ] Are flags cleared by renderer after state mutation?
+
+## Related Issues
+
+- **GitHub:** [#454](https://github.com/dobesv/harnx/issues/454) — Keyboard shortcuts not visible during history browse
+- **GitHub:** [#431](https://github.com/dobesv/harnx/issues/431) — Arrow navigation line-by-line vs item-by-item
+- **Related Solution:** [logic-errors/tui-browsing-overlay-and-detail-shortcuts-2026-05-04.md](./tui-browsing-overlay-and-detail-shortcuts-2026-05-04.md) — Modal rendering order and input guards for detail/browsing overlays
+- **Related Solution:** [logic-errors/tui-exclusive-overlay-pattern-2026-05-02.md](./tui-exclusive-overlay-pattern-2026-05-02.md) — Base overlay pattern with input isolation


### PR DESCRIPTION
Updates the TUI browsing mode to render the full session transcript in the main viewing area instead of a side detail panel. This provides more space for reading long message history and aligns with the fullscreen navigation UX. Includes documentation on scroll ownership patterns and new rendering tests for the browsing mode.

#454
#431

Plan: harnx-tui-browsing-mode-transcript-view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browsing mode now displays full transcript view replacing the single-item detail panel
  * Added two-line footer showing current item count and navigation shortcuts
  * Focused transcript items highlighted with reversed styling
  * Non-navigable transcript items remain visible but cannot be selected

* **Bug Fixes**
  * Optimized scroll state handling during keyboard navigation

* **Tests**
  * Added comprehensive browsing mode rendering test suite

<!-- end of auto-generated comment: release notes by coderabbit.ai -->