### PR TITLE
fix(tui): ESC, Ctrl+C, and Ctrl+D now exit pickers (#467)

### DIFF
--- a/.changesets/fix-picker-esc-ctrlc-ctrld.md
+++ b/.changesets/fix-picker-esc-ctrlc-ctrld.md
@@ -1,0 +1,12 @@
+---
+harnx: patch
+---
+
+Fix ESC, Ctrl+C, and Ctrl+D doing nothing in agent/session pickers (#467).
+
+- **Ctrl+D** in any picker now exits the process immediately.
+- **Ctrl+C** in any picker now exits the process (no in-flight prompt to abort).
+- **ESC on AgentPicker** with no agent active (startup) now exits the process.
+- **ESC on SessionPicker** when reached via `harnx` → agent picker → session picker (`origin_agent=None, origin_session=None`) now goes back to the AgentPicker.
+- **ESC on SessionPicker** when reached via `harnx -a <agent>` with no prior session (`origin_agent=Some, origin_session=None`) now exits the process.
+- The existing mid-switch cancel behaviour (ESC restores origin agent+session when `origin_session` is present) is unchanged.

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1808,6 +1808,16 @@ impl Tui {
     }
 
     async fn handle_picker_key(&mut self, key: KeyEvent) -> Result<()> {
+        // Ctrl+D always exits — no prompt running in picker state.
+        if key.code == KeyCode::Char('d') && key.modifiers == KeyModifiers::CONTROL {
+            self.app.should_quit = true;
+            return Ok(());
+        }
+        // Ctrl+C exits in picker state — there is no in-flight prompt to abort.
+        if key.code == KeyCode::Char('c') && key.modifiers == KeyModifiers::CONTROL {
+            self.app.should_quit = true;
+            return Ok(());
+        }
         match key.code {
             KeyCode::Up => {
                 if let Some(crate::types::ModalState::AgentPicker { selected, .. })
@@ -1979,33 +1989,61 @@ impl Tui {
                 }
             }
             KeyCode::Esc => {
-                // ESC on the SessionPicker restores the original state if there was a
-                // prior session. If there was no prior session, ESC does nothing (must
-                // select a session).
-                // ESC on the AgentPicker cancels only if an agent is already active
-                // (mid-session switch). If no agent is active (startup), ESC does
-                // nothing — selection is mandatory per #451.
+                // ESC behaviour depends on which picker is open and how it was reached.
+                //
+                // SessionPicker:
+                //   • origin_session is Some → restore origin agent+session (mid-switch cancel)
+                //   • origin_session is None AND origin_agent is None → came from AgentPicker
+                //     during startup; go back to the AgentPicker
+                //   • origin_session is None AND origin_agent is Some → direct startup with
+                //     `-a <agent>` and no session; ESC exits the process (#467)
+                //
+                // AgentPicker:
+                //   • agent already active (mid-switch) → dismiss picker (cancel switch)
+                //   • no agent active (startup) → exit the process (#467)
                 let mut should_restore_origin = false;
-                if let Some(crate::types::ModalState::SessionPicker { origin_session, .. }) =
-                    self.app.modal.as_ref()
+                let mut should_show_agent_picker = false;
+                if let Some(crate::types::ModalState::SessionPicker {
+                    origin_session,
+                    origin_agent,
+                    ..
+                }) = self.app.modal.as_ref()
                 {
                     if origin_session.is_some() {
                         should_restore_origin = true;
+                    } else if origin_agent.is_none() {
+                        // Came from AgentPicker (startup flow: harnx → pick agent → session
+                        // picker). ESC goes back to the AgentPicker.
+                        should_show_agent_picker = true;
+                    } else {
+                        // Direct startup with `-a <agent>`, no prior session. ESC exits.
+                        self.app.should_quit = true;
                     }
                 } else if matches!(
                     self.app.modal,
                     Some(crate::types::ModalState::AgentPicker { .. })
                 ) {
-                    // Only dismiss the AgentPicker if an agent is already active;
-                    // otherwise the picker is mandatory and must not be dismissed.
                     if self.config.read().agent.is_some() {
+                        // Agent already active — mid-switch cancel: just dismiss the picker.
                         self.app.modal = None;
+                    } else {
+                        // No agent active (startup). ESC exits the process (#467).
+                        self.app.should_quit = true;
                     }
                 } else if self.app.modal.is_some() {
                     self.app.modal = None;
                 }
 
-                if should_restore_origin {
+                if should_show_agent_picker {
+                    // Replace the SessionPicker with a fresh AgentPicker so the user can
+                    // pick a different agent (or the same one again).
+                    let agents = harnx_runtime::config::list_assistant_agents();
+                    self.app.modal = Some(crate::types::ModalState::AgentPicker {
+                        agents,
+                        selected: 0,
+                        query: String::new(),
+                    });
+                } else if should_restore_origin {
                     if let Some(crate::types::ModalState::SessionPicker {
                         origin_agent,
                         origin_session,

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -6208,10 +6208,16 @@ async fn agent_picker_enter_with_sessions_shows_session_picker() {
 // --- SessionPicker ESC behavior -----------------------------------
 
 #[tokio::test]
-async fn session_picker_esc_without_prior_session_keeps_picker_open() {
+async fn session_picker_esc_without_prior_session_goes_back_to_agent_picker() {
+    // When origin_agent is None and origin_session is None the user arrived here
+    // via `harnx` (no agent) → AgentPicker → picked an agent → SessionPicker.
+    // ESC must go BACK to the AgentPicker so the user can change their mind.
+    // It must NOT keep the SessionPicker open and must NOT create a session (#467).
     let tmp = tempfile::tempdir().unwrap();
     let _lock = ENV_LOCK.lock().await;
     let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    create_agent_stubs(&tmp.path().join("agents"), &["hermes"]);
 
     let config = picker_test_config();
     {
@@ -6231,7 +6237,7 @@ async fn session_picker_esc_without_prior_session_keeps_picker_open() {
     tui.app.modal = Some(crate::types::ModalState::SessionPicker {
         sessions: vec![],
         selected: 0,
-        origin_agent: None,
+        origin_agent: None, // came from AgentPicker during startup
         origin_session: None,
     });
 
@@ -6240,19 +6246,66 @@ async fn session_picker_esc_without_prior_session_keeps_picker_open() {
         .unwrap();
 
     assert!(
-        tui.app.modal.is_some(),
-        "modal should not be dismissed after Esc if no prior session"
+        matches!(
+            tui.app.modal,
+            Some(crate::types::ModalState::AgentPicker { .. })
+        ),
+        "ESC on SessionPicker with no origin should go back to AgentPicker, got: {:?}",
+        tui.app.modal
     );
     assert!(
         config.read().session.is_none(),
         "Esc on SessionPicker must not create a new session"
     );
+    assert!(
+        !tui.app.should_quit,
+        "ESC should not set should_quit when going back to AgentPicker"
+    );
 }
 
 #[tokio::test]
-async fn agent_picker_esc_does_not_dismiss_without_active_agent() {
-    // When no agent is active (startup case), ESC on AgentPicker must NOT
-    // dismiss the picker — selection is mandatory per #451.
+async fn session_picker_esc_with_agent_origin_but_no_session_exits() {
+    // When origin_agent is Some but origin_session is None, the user started
+    // harnx with `-a <agent>` (no session). ESC must exit the process (#467).
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    let config = picker_test_config();
+    {
+        let mut guard = config.write();
+        guard.sessions_dir_override = Some(tmp.path().join("sessions"));
+        let model = MockClient::builder().build().model().clone();
+        let mut agent =
+            harnx_runtime::config::Agent::new(harnx_runtime::config::AgentConfig::from_prompt(""));
+        agent.set_name("hermes");
+        agent.set_model(model);
+        guard.agent = Some(agent);
+    }
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.app.modal = Some(crate::types::ModalState::SessionPicker {
+        sessions: vec![],
+        selected: 0,
+        origin_agent: Some("hermes".to_string()), // direct startup with -a hermes
+        origin_session: None,
+    });
+
+    tui.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert!(
+        tui.app.should_quit,
+        "ESC on SessionPicker with no prior session and agent origin should exit the process"
+    );
+}
+
+#[tokio::test]
+async fn agent_picker_esc_exits_when_no_agent_active() {
+    // When no agent is active (startup case), ESC on AgentPicker must exit the
+    // process (#467). Previously this did nothing (wrong behaviour from #451).
     let tmp = tempfile::tempdir().unwrap();
     let _lock = ENV_LOCK.lock().await;
     let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
@@ -6273,12 +6326,123 @@ async fn agent_picker_esc_does_not_dismiss_without_active_agent() {
         .unwrap();
 
     assert!(
-        tui.app.modal.is_some(),
-        "AgentPicker Esc must NOT dismiss modal when no agent is active"
+        tui.app.should_quit,
+        "ESC on AgentPicker with no active agent must set should_quit (exit process)"
     );
     assert!(
         config.read().session.is_none(),
         "AgentPicker Esc must NOT create a session"
+    );
+}
+
+#[tokio::test]
+async fn picker_ctrl_d_exits_from_agent_picker() {
+    // Ctrl+D in AgentPicker must exit the process.
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    let config = picker_test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.app.modal = Some(crate::types::ModalState::AgentPicker {
+        agents: vec!["hermes".into()],
+        selected: 0,
+        query: String::new(),
+    });
+
+    tui.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL))
+        .await
+        .unwrap();
+
+    assert!(
+        tui.app.should_quit,
+        "Ctrl+D in AgentPicker must set should_quit"
+    );
+    // Modal may remain or be cleared — the important thing is should_quit.
+}
+
+#[tokio::test]
+async fn picker_ctrl_c_exits_from_agent_picker() {
+    // Ctrl+C in AgentPicker must exit the process (no prompt to abort).
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    let config = picker_test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.app.modal = Some(crate::types::ModalState::AgentPicker {
+        agents: vec!["hermes".into()],
+        selected: 0,
+        query: String::new(),
+    });
+
+    tui.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL))
+        .await
+        .unwrap();
+
+    assert!(
+        tui.app.should_quit,
+        "Ctrl+C in AgentPicker must set should_quit"
+    );
+}
+
+#[tokio::test]
+async fn picker_ctrl_d_exits_from_session_picker() {
+    // Ctrl+D in SessionPicker must exit the process.
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    let config = picker_test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.app.modal = Some(crate::types::ModalState::SessionPicker {
+        sessions: vec![],
+        selected: 0,
+        origin_agent: Some("hermes".to_string()),
+        origin_session: None,
+    });
+
+    tui.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL))
+        .await
+        .unwrap();
+
+    assert!(
+        tui.app.should_quit,
+        "Ctrl+D in SessionPicker must set should_quit"
+    );
+}
+
+#[tokio::test]
+async fn picker_ctrl_c_exits_from_session_picker() {
+    // Ctrl+C in SessionPicker must exit the process (no prompt to abort).
+    let tmp = tempfile::tempdir().unwrap();
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::set("HARNX_CONFIG_DIR", tmp.path().to_str().unwrap());
+
+    let config = picker_test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
+
+    tui.app.modal = Some(crate::types::ModalState::SessionPicker {
+        sessions: vec![],
+        selected: 0,
+        origin_agent: None,
+        origin_session: None,
+    });
+
+    tui.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL))
+        .await
+        .unwrap();
+
+    assert!(
+        tui.app.should_quit,
+        "Ctrl+C in SessionPicker must set should_quit"
     );
 }
 

--- a/docs/solutions/logic-errors/picker-flow-state-continuity-2026-05-03.md
+++ b/docs/solutions/logic-errors/picker-flow-state-continuity-2026-05-03.md
@@ -14,7 +14,7 @@ tags:
   - error-handling
   - picker
 plan_ref: "picker-bugs-435"
-last_updated: 2026-05-03
+last_updated: 2026-05-05
 ---
 
 ## Problem
@@ -24,6 +24,7 @@ Four bugs in the agent/session picker flow caused incorrect behavior:
 2. SessionPicker ESC didn't create a new session — dismiss behavior was inconsistent
 3. SessionPicker showed wrong sessions — `list_sessions_with_meta()` was called before agent activation, returning sessions from the previous agent's directory
 4. AgentPicker ESC dismissed picker when no agent was active — mandatory picker enforcement broken
+5. **(Issue #467)** ESC, Ctrl+C, Ctrl+D did nothing in pickers — no way to exit from picker modals
 
 Underlying issue: multi-step picker flow (AgentPicker → SessionPicker) lost the initial agent/session state, causing transcript reconciliation to see `prev_agent == curr_agent` after an agent switch and fail to clear stale messages.
 
@@ -34,6 +35,7 @@ Underlying issue: multi-step picker flow (AgentPicker → SessionPicker) lost th
 - **Wrong sessions bug**: Switching from agent A to agent B showed agent A's sessions in SessionPicker
 - **Transcript bug**: Switching agents via picker left stale transcript messages from the previous agent
 - **Mandatory picker bug**: Pressing ESC in AgentPicker when no agent was active dismissed the picker, leaving the app in an unusable state with no agent selected
+- **No-exit bug (#467)**: ESC, Ctrl+C, and Ctrl+D did nothing in pickers — user had no way to abort the picker flow and exit the process
 
 Error patterns from code review:
 ```rust
@@ -206,6 +208,9 @@ Key test coverage:
 - Multi-step flows need origin tracking for correct before/after comparison
 - Redesigned semantics (ESC = new session) can make previous defensive patterns (deferred activation) into bugs
 - **Mandatory picker enforcement**: For pickers shown at startup (no agent), ESC must NOT dismiss the picker. Check `config.read().agent.is_some()` before setting `self.app.modal = None`
+- **(#467) Ctrl+C/Ctrl+D early-return pattern**: When handling Ctrl key combinations in a function that already has a `match key.code` block, use `if` guards before the match rather than converting to `match (key.code, key.modifiers)`. This avoids rewriting existing match arms that check `key.modifiers == KeyModifiers::NONE || KeyModifiers::SHIFT`.
+- **(#467) Origin-based picker navigation**: Use `origin_agent` to distinguish "came from AgentPicker during startup" (`origin_agent.is_none()`) from "direct `-a <agent>` startup" (`origin_agent.is_some()`). In the former case, ESC goes back to AgentPicker; in the latter, ESC exits.
+- **(#467) `should_quit` for mandatory picker exit**: For mandatory pickers at startup, ESC now sets `should_quit = true` (process exit) instead of being a no-op. Issue #451's "mandatory selection" was overridden — users can now abort the flow.
 
 ### Mandatory Picker ESC Handling
 
@@ -231,7 +236,67 @@ KeyCode::Esc => {
 }
 ```
 
+### Ctrl+C/Ctrl+D Exit Handling (Issue #467)
+
+In picker state, Ctrl+C and Ctrl+D should exit the process rather than being ignored. The prompt is not running during picker display, so there's nothing to abort — the only sensible action is process exit.
+
+**Pattern: Early-return Ctrl checks before `match key.code`:**
+
+```rust
+// crates/harnx-tui/src/input.rs — handle_picker_key()
+async fn handle_picker_key(&mut self, key: KeyEvent) -> Result<()> {
+    // Ctrl+D always exits — no prompt running in picker state.
+    if key.code == KeyCode::Char('d') && key.modifiers == KeyModifiers::CONTROL {
+        self.app.should_quit = true;
+        return Ok(());
+    }
+    // Ctrl+C exits in picker state — there is no in-flight prompt to abort.
+    if key.code == KeyCode::Char('c') && key.modifiers == KeyModifiers::CONTROL {
+        self.app.should_quit = true;
+        return Ok(());
+    }
+    match key.code {
+        // ... existing match arms ...
+    }
+}
+```
+
+**Why early-return `if` guards?** Converting to `match (key.code, key.modifiers)` would require rewriting existing arms like `KeyCode::Char(c) if key.modifiers == KeyModifiers::NONE || KeyModifiers::SHIFT`. The `if` guard pattern keeps the change minimal and localized.
+
+### Origin-Based ESC Routing (Issue #467)
+
+SessionPicker ESC behavior depends on `origin_agent` and `origin_session`:
+
+```rust
+KeyCode::Esc => {
+    if let Some(ModalState::SessionPicker { origin_session, origin_agent, .. }) =
+        self.app.modal.as_ref()
+    {
+        if origin_session.is_some() {
+            // Mid-switch cancel: restore original agent+session
+            should_restore_origin = true;
+        } else if origin_agent.is_none() {
+            // Came from AgentPicker during startup (harnx → pick agent → session picker).
+            // ESC goes back to AgentPicker so user can choose a different agent.
+            let agents = list_assistant_agents();
+            self.app.modal = Some(ModalState::AgentPicker {
+                agents,
+                selected: 0,
+                query: String::new(),
+            });
+        } else {
+            // Direct startup with `-a <agent>`, no prior session. ESC exits.
+            self.app.should_quit = true;
+        }
+    }
+}
+```
+
+**Key distinction:** `origin_agent.is_none()` means "came from AgentPicker" (the agent was picked in this flow, not pre-existing). `origin_agent.is_some()` means direct `-a <agent>` startup where the user explicitly specified the agent.
+
 ## Related Issues
 
 - **PR:** [#435](https://github.com/dobesv/harnx/pull/435) — Agent session revamp
+- **Issue:** [#467](https://github.com/dobesv/harnx/issues/467) — ESC/Ctrl-C/Ctrl-D in pickers
 - **Related Solution:** [integration-issues/session-picker-multi-factor-sorting-2026-05-02.md](../integration-issues/session-picker-multi-factor-sorting-2026-05-02.md) — Original picker implementation
+- **Related Solution:** [integration-issues/raw-mode-ctrl-c-interrupt-2026-04-30.md](../integration-issues/raw-mode-ctrl-c-interrupt-2026-04-30.md) — Raw-mode terminal interrupt handling (Ctrl-C/Ctrl-D in CLI one-shot mode)


### PR DESCRIPTION
Adds consistent exit and navigation behavior for ESC, Ctrl+C, and Ctrl+D in agent and session pickers. Ctrl+C and Ctrl+D now exit the process immediately when a picker is active. ESC now exits the process during startup pickers if no session is active, or returns to the agent picker if a session was being selected after an agent.

Updates existing tests and adds five new test cases covering the new keyboard interaction paths.

Closes #467

Plan: harnx-467-picker-esc-ctrlc-ctrld

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard shortcut handling in agent and session selection screens. Ctrl+D and Ctrl+C now exit immediately. ESC behavior now correctly navigates between screens or exits based on context.

* **Documentation**
  * Updated picker flow documentation to reflect improved keyboard interaction and state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->