### PR TITLE
fix: correctly serialize tool-call rounds in session rewrite

### DIFF
--- a/.changesets/fix-437-edit-session-corruption.md
+++ b/.changesets/fix-437-edit-session-corruption.md
@@ -1,0 +1,9 @@
+---
+harnx: patch
+---
+Fix `.edit session` corrupting the session when tool calls are present.
+
+The full-save path (used by `.edit session` and the exit handler) now
+correctly serializes tool-call rounds as `tool_calls`/`tool_results`
+log entry pairs instead of the legacy `message` entries that the loader
+rejects.

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -680,6 +680,67 @@ pub fn exit(session: &mut Session, session_dir: &Path, is_tui: bool) -> Result<(
     Ok(())
 }
 
+/// Appends YAML log entry/entries for `msg` to `content`.
+///
+/// Tool-role messages containing `MessageContent::ToolCalls` are split
+/// into a `tool_calls` entry (the LLM's request) followed by a
+/// `tool_results` entry (the tool outputs), matching the format that
+/// `replay_log_entries` expects. All other messages are written as a
+/// single `message` entry.
+fn append_message_entries(content: &mut String, msg: &Message, session_id: &str) -> Result<()> {
+    if msg.role == MessageRole::Tool {
+        if let MessageContent::ToolCalls(tc) = &msg.content {
+            let calls: Vec<crate::tool::ToolCall> =
+                tc.tool_results.iter().map(|r| r.call.clone()).collect();
+            let tool_calls_entry = SessionLogEntry::ToolCalls {
+                text: tc.text.clone(),
+                thought: tc.thought.clone(),
+                calls,
+                timestamp: None,
+            };
+            content.push_str("---\n");
+            content
+                .push_str(&serde_yaml::to_string(&tool_calls_entry).with_context(|| {
+                    format!("Failed to serialize tool_calls in '{session_id}'")
+                })?);
+
+            let results: Vec<harnx_core::session::ToolOutput> = tc
+                .tool_results
+                .iter()
+                .map(|r| harnx_core::session::ToolOutput {
+                    id: r.call.id.clone(),
+                    name: r.call.name.clone(),
+                    output: r.output.clone(),
+                    switch_agent: r.switch_agent.clone(),
+                })
+                .collect();
+            let tool_results_entry = SessionLogEntry::ToolResults {
+                results,
+                timestamp: None,
+            };
+            content.push_str("---\n");
+            content.push_str(
+                &serde_yaml::to_string(&tool_results_entry).with_context(|| {
+                    format!("Failed to serialize tool_results in '{session_id}'")
+                })?,
+            );
+            return Ok(());
+        }
+    }
+
+    let entry = SessionLogEntry::Message {
+        role: msg.role,
+        content: msg.content.clone(),
+        timestamp: None,
+    };
+    content.push_str("---\n");
+    content.push_str(
+        &serde_yaml::to_string(&entry)
+            .with_context(|| format!("Failed to serialize message in '{session_id}'"))?,
+    );
+    Ok(())
+}
+
 /// Full save: rewrites the entire session file in log format.
 /// Used as a fallback when events were not incrementally appended.
 pub fn save(
@@ -696,16 +757,7 @@ pub fn save(
     let mut content = serde_yaml::to_string(&session.build_header_entry())
         .with_context(|| format!("Failed to serialize session header for '{}'", session.id))?;
     for msg in &session.compressed_messages {
-        let entry = SessionLogEntry::Message {
-            timestamp: None,
-            role: msg.role,
-            content: msg.content.clone(),
-        };
-        content.push_str("---\n");
-        content.push_str(
-            &serde_yaml::to_string(&entry)
-                .with_context(|| format!("Failed to serialize message in '{}'", session.id))?,
-        );
+        append_message_entries(&mut content, msg, &session.id)?;
     }
     if !session.compressed_messages.is_empty() {
         // Write a compress entry to mark the boundary.
@@ -730,29 +782,11 @@ pub fn save(
         // Write remaining messages (skip the system message from compress only if we wrote a compress entry).
         let start_idx = if wrote_compress { 1 } else { 0 };
         for msg in session.messages.iter().skip(start_idx) {
-            let entry = SessionLogEntry::Message {
-                role: msg.role,
-                content: msg.content.clone(),
-                timestamp: None, // Session save rewrites all entries; timestamps are from live events
-            };
-            content.push_str("---\n");
-            content.push_str(
-                &serde_yaml::to_string(&entry)
-                    .with_context(|| format!("Failed to serialize message in '{}'", session.id))?,
-            );
+            append_message_entries(&mut content, msg, &session.id)?;
         }
     } else {
         for msg in &session.messages {
-            let entry = SessionLogEntry::Message {
-                role: msg.role,
-                content: msg.content.clone(),
-                timestamp: None, // Session save rewrites all entries; timestamps are from live events
-            };
-            content.push_str("---\n");
-            content.push_str(
-                &serde_yaml::to_string(&entry)
-                    .with_context(|| format!("Failed to serialize message in '{}'", session.id))?,
-            );
+            append_message_entries(&mut content, msg, &session.id)?;
         }
     }
     if !session.data_urls.is_empty() {

--- a/docs/solutions/logic-errors/session-save-format-consistency-2026-05-05.md
+++ b/docs/solutions/logic-errors/session-save-format-consistency-2026-05-05.md
@@ -1,0 +1,147 @@
+---
+title: "Session save format consistency between incremental append and full rewrite"
+date: 2026-05-05
+category: "logic-errors"
+problem_type: logic_error
+component: "session-persistence"
+root_cause: "Format divergence between two write paths (incremental append vs full-rewrite save)"
+resolution_type: code_fix
+severity: high
+tags:
+  - session-persistence
+  - serialization
+  - format-consistency
+  - tool-calls
+plan_ref: "fix-437-edit-session-corruption"
+---
+
+## Problem
+
+Running `.edit session` in harnx followed by exiting the editor (even without changes) corrupted session files containing tool-call history. The session became permanently unreadable with error:
+
+```
+error: Invalid log entry in session ...: Tool-role Message entries are no longer supported; use tool_calls/tool_results entries
+```
+
+## Symptoms
+
+- Error when loading sessions after `.edit session` operation
+- Sessions with tool-call history became corrupted
+- Corruption occurred even when editor exited without changes
+- No recovery possible without manual file editing
+
+## Investigation Steps
+
+1. Traced `.edit session` flow: calls `save_session()` before opening editor
+2. Examined `save()` function in `session.rs` — full-rewrite path serializes ALL messages as `SessionLogEntry::Message`
+3. Found loader rejection in `replay_log_entries()`: explicitly rejects `Message` entries with `role: Tool`
+4. Identified mismatch: incremental append path writes `ToolCalls` + `ToolResults` pairs, but full-rewrite wrote `Message` for everything
+5. Verified: messages with `role: Tool` and `MessageContent::ToolCalls(...)` represent tool-call rounds and MUST be serialized differently
+
+## Root Cause
+
+Session persistence has two write paths:
+
+1. **Incremental append**: writes events one at a time (e.g., `tool_calls`, `tool_results`)
+2. **Full-rewrite `save()`**: rewrites entire file (used by `.edit session`, session exit handler)
+
+The `save()` function serialized ALL messages as `SessionLogEntry::Message` entries. But messages with `role: Tool` and `MessageContent::ToolCalls(...)` are the in-memory representation of tool-call rounds — they require serialization as:
+1. `SessionLogEntry::ToolCalls { text, thought, calls, timestamp }`
+2. `SessionLogEntry::ToolResults { results, timestamp }`
+
+The loader explicitly rejects `Message` entries with `role: Tool`:
+
+```rust
+if role == MessageRole::Tool {
+    anyhow::bail!(
+        "Invalid log entry in session {name}: Tool-role Message entries are no longer supported; use tool_calls/tool_results entries"
+    );
+}
+```
+
+When two separate paths write session data, format divergence between them causes corruption. The full-rewrite path must produce files the loader can read.
+
+## Solution
+
+Added `append_message_entries()` helper in `save()` that detects `role: Tool` + `MessageContent::ToolCalls(...)` messages and emits the correct two-entry format:
+
+```rust
+/// Appends YAML log entry/entries for `msg` to `content`.
+///
+/// Tool-role messages containing `MessageContent::ToolCalls` are split
+/// into a `tool_calls` entry (the LLM's request) followed by a
+/// `tool_results` entry (the tool outputs), matching the format that
+/// `replay_log_entries` expects.
+fn append_message_entries(content: &mut String, msg: &Message, session_id: &str) -> Result<()> {
+    if msg.role == MessageRole::Tool {
+        if let MessageContent::ToolCalls(tc) = &msg.content {
+            let calls: Vec<ToolCall> = tc.tool_results.iter().map(|r| r.call.clone()).collect();
+            let tool_calls_entry = SessionLogEntry::ToolCalls {
+                text: tc.text.clone(),
+                thought: tc.thought.clone(),
+                calls,
+                timestamp: None,
+            };
+            content.push_str("---\n");
+            content.push_str(&serde_yaml::to_string(&tool_calls_entry)?);
+
+            let results: Vec<ToolOutput> = tc.tool_results.iter().map(|r| ToolOutput {
+                id: r.call.id.clone(),
+                name: r.call.name.clone(),
+                output: r.output.clone(),
+                switch_agent: r.switch_agent.clone(),
+            }).collect();
+            let tool_results_entry = SessionLogEntry::ToolResults { results, timestamp: None };
+            content.push_str("---\n");
+            content.push_str(&serde_yaml::to_string(&tool_results_entry)?);
+            return Ok(());
+        }
+    }
+
+    // Default: write as Message entry
+    let entry = SessionLogEntry::Message {
+        role: msg.role,
+        content: msg.content.clone(),
+        timestamp: None,
+    };
+    content.push_str("---\n");
+    content.push_str(&serde_yaml::to_string(&entry)?);
+    Ok(())
+}
+```
+
+Applied this helper in all three message-serialization loops in `save()`:
+- Line 760: `session.compressed_messages`
+- Line 785: `session.messages` after compress entry
+- Line 789: `session.messages` without compress entry
+
+## Why This Works
+
+The `SessionLogEntry` enum has two distinct variants for tool interactions:
+
+1. `ToolCalls` — written immediately after LLM returns, before tool execution
+2. `ToolResults` — written after tools complete
+
+This design ensures the transcript is recoverable even if the process crashes mid-execution. The `Message` variant with `role: Tool` is a legacy format that the loader no longer accepts.
+
+By detecting the in-memory representation (`Message { role: Tool, content: MessageContent::ToolCalls(...) }`) and emitting the correct log entries, the full-rewrite path now produces files the loader can read.
+
+## Prevention Strategies
+
+**Test Coverage:**
+- Add unit test: save a session with tool-call history, reload it, verify messages match
+- Add integration test: `.edit session` on a session with tools, verify no corruption
+
+**Code Review Checklist:**
+- [ ] When adding new `SessionLogEntry` variants, update both `save()` and `replay_log_entries()`
+- [ ] When modifying serialization logic, ensure both write paths stay in sync
+- [ ] Test the full-rewrite path when changing format expectations
+
+**Architecture Consideration:**
+- Centralize format knowledge in one place (e.g., a `serialize_message()` function both paths call)
+- Consider a "write entry" trait that both append and full-rewrite use
+
+## Related Issues
+
+- **GitHub:** [Issue #437](https://github.com/dobesv/harnx/issues/437) — .edit session corrupts session file
+- **Plans:** `fix-437-edit-session-corruption`


### PR DESCRIPTION
The full-save path (used by .edit session and the on-exit handler) was emitting every Message as a plain message log entry, including Tool-role messages that hold tool-call/result data. The session loader now explicitly rejects role: Tool message entries, so any session containing tool-call history was corrupted by the next full-save (e.g. after .edit session).

Added append_message_entries() helper that detects role: Tool + MessageContent::ToolCalls(…) messages and emits the correct tool_calls + tool_results entry pair instead. Applied the helper across all three message-serialization loops in save(), covering both the compressed-messages and regular-messages paths.

#437

Plan: fix-437-edit-session-corruption

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where edit sessions could become corrupted when saved with tool interactions.

* **Documentation**
  * Added documentation describing session persistence and consistency improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->