### PR TITLE
chore(ci): disable crates.io publish job for now

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -156,7 +156,9 @@ jobs:
 
   publish-crate:
     name: Publish to crates.io
-    if: ${{ needs.release.outputs.rc == 'false' }}
+    # Disabled: not yet ready to publish to crates.io. Re-enable by restoring
+    # the original condition: `${{ needs.release.outputs.rc == 'false' }}`.
+    if: false
     runs-on: ubuntu-latest
     needs: release
     steps:


### PR DESCRIPTION
## Summary
- Sets the `publish-crate` job's `if:` to `false` so tag pushes won't try `cargo publish`.
- The release matrix job still runs: builds binaries for all 10 target triples and attaches archives to the GitHub Release.
- Re-enable by restoring the original condition `${{ needs.release.outputs.rc == 'false' }}`.

## Why
We want to cut a GitHub Release for `0.31.0` but we're not ready to publish to crates.io yet.

## Test plan
- [ ] Merge to `main`.
- [ ] Run `knope release` to bump versions, generate the changelog, and push tag `v0.31.0`.
- [ ] Confirm the `release` matrix job runs and `publish-crate` is skipped.