### PR TITLE
chore(release): prep workspace for knope-driven releases

### DIFF
--- a/.changesets/release-mcp-server-bins.md
+++ b/.changesets/release-mcp-server-bins.md
@@ -1,0 +1,9 @@
+---
+harnx: minor
+---
+Release archives now include the MCP server binaries (`harnx-mcp-bash`,
+`harnx-mcp-fs`, `harnx-mcp-plans`, `harnx-mcp-time`) alongside `harnx`,
+`harnx-serve`, and `harnx-acp-server`. The example MCP server configs
+under `example_config/mcp_servers/` reference these by command name, so
+shipping them lets users adopt those configs out of the box without a
+local cargo build.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,11 @@ name: Release
 on:
   push:
     tags:
-    - v[0-9]+.[0-9]+.[0-9]+*
+    # Knope tags releases as `harnx/v<version>` (monorepo-style prefix from
+    # the [packages.harnx] config). Earlier `v<version>` tag pattern is kept
+    # for any manual tags that don't go through knope.
+    - 'harnx/v[0-9]+.[0-9]+.[0-9]+*'
+    - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   release:
@@ -105,7 +109,8 @@ jobs:
       shell: bash
       run: |
         $BUILD_CMD build --locked --release --target=${{ matrix.target }} ${{ matrix.cargo-flags }} \
-          -p harnx -p harnx-serve -p harnx-acp-server
+          -p harnx -p harnx-serve -p harnx-acp-server \
+          -p harnx-mcp-bash -p harnx-mcp-fs -p harnx-mcp-plans -p harnx-mcp-time
 
     - name: Build Archives
       shell: bash
@@ -119,18 +124,35 @@ jobs:
         dist_dir=`pwd`/dist
         mkdir $dist_dir
 
+        # Each entry is "archive-name:bin1[,bin2...]" — the archive's
+        # filename uses archive-name; staged contents are the listed bins.
+        # harnx-mcp-bash ships its sandbox helper alongside the main bin.
+        archive_specs=(
+          "harnx:harnx"
+          "harnx-serve:harnx-serve"
+          "harnx-acp-server:harnx-acp-server"
+          "harnx-mcp-bash:harnx-mcp-bash,harnx-mcp-bash-sandbox-run"
+          "harnx-mcp-fs:harnx-mcp-fs"
+          "harnx-mcp-plans:harnx-mcp-plans"
+          "harnx-mcp-time:harnx-mcp-time"
+        )
+
         archives=()
-        for bin in harnx harnx-serve harnx-acp-server; do
-          name=$bin-$version-$target
-          executable=target/$target/release/$bin
+        for spec in "${archive_specs[@]}"; do
+          archive_base="${spec%%:*}"
+          IFS=',' read -ra bins <<< "${spec#*:}"
 
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            executable=$executable.exe
-          fi
-
-          staging=$dist_dir/$bin-stage
+          name=$archive_base-$version-$target
+          staging=$dist_dir/$archive_base-stage
           mkdir $staging
-          cp $executable $staging/
+
+          for bin in "${bins[@]}"; do
+            executable=target/$target/release/$bin
+            if [[ "$RUNNER_OS" == "Windows" ]]; then
+              executable=$executable.exe
+            fi
+            cp $executable $staging/
+          done
 
           if [[ "$RUNNER_OS" == "Windows" ]]; then
               archive=$dist_dir/$name.zip

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
 ]
 
 [workspace.package]
+version = "0.30.0"
 edition = "2021"
 authors = ["sigoden <sigoden@gmail.com>"]
 description = "All-in-one LLM CLI Tool"
@@ -115,10 +116,10 @@ jiff = { version = "0.2.23", features = ["serde"] }
 reqwest = { version = "0.13.0", features = ["json", "multipart", "socks", "rustls", "stream"], default-features = false }
 syntect = { version = "5.0.0", features = ["parsing", "regex-onig", "plist-load"], default-features = false }
 arboard = { version = "3.3.0", default-features = false }
-harnx-acp = { path = "crates/harnx-acp", version = "0.30.0" }
-harnx-acp-server = { path = "crates/harnx-acp-server", version = "0.30.0" }
+harnx-acp = { path = "crates/harnx-acp" }
+harnx-acp-server = { path = "crates/harnx-acp-server" }
 minijinja = { version = "2.19.0", default-features = false, features = ["builtins", "debug", "serde"] }
-harnx-mcp-history = { path = "crates/harnx-mcp-history", version = "0.30.0" }
+harnx-mcp-history = { path = "crates/harnx-mcp-history" }
 
 [patch.crates-io]
 ratatui_widget_scrolling = { path = "crates/ratatui-widget-scrolling" }

--- a/crates/harnx-acp-server/Cargo.toml
+++ b/crates/harnx-acp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-acp-server"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/harnx-acp/Cargo.toml
+++ b/crates/harnx-acp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-acp"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-client/Cargo.toml
+++ b/crates/harnx-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-client"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-core/Cargo.toml
+++ b/crates/harnx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-core"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-engine/Cargo.toml
+++ b/crates/harnx-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-engine"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-fetch/Cargo.toml
+++ b/crates/harnx-fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-fetch"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-hooks/Cargo.toml
+++ b/crates/harnx-hooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-hooks"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-mcp-bash/Cargo.toml
+++ b/crates/harnx-mcp-bash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-mcp-bash"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-mcp-fs/Cargo.toml
+++ b/crates/harnx-mcp-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-mcp-fs"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-mcp-history/Cargo.toml
+++ b/crates/harnx-mcp-history/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-mcp-history"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-mcp-plans/Cargo.toml
+++ b/crates/harnx-mcp-plans/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-mcp-plans"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-mcp-time/Cargo.toml
+++ b/crates/harnx-mcp-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-mcp-time"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-mcp/Cargo.toml
+++ b/crates/harnx-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-mcp"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-rag/Cargo.toml
+++ b/crates/harnx-rag/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-rag"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-render/Cargo.toml
+++ b/crates/harnx-render/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-render"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-runtime/Cargo.toml
+++ b/crates/harnx-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-runtime"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/harnx-serve/Cargo.toml
+++ b/crates/harnx-serve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-serve"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/harnx-spinner/Cargo.toml
+++ b/crates/harnx-spinner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-spinner"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-test-bins/Cargo.toml
+++ b/crates/harnx-test-bins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-test-bins"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/harnx-tui/Cargo.toml
+++ b/crates/harnx-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx-tui"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/harnx/Cargo.toml
+++ b/crates/harnx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harnx"
-version = "0.30.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/knope.toml
+++ b/knope.toml
@@ -1,15 +1,16 @@
-[[packages]]
-name = "harnx"
-# All three shippable bins keep their literal `version = "0.30.0"` in sync
-# with each other. knope bumps them together as a single package unit so
-# the release artifacts (harnx-$ver, harnx-serve-$ver, harnx-acp-server-$ver)
-# always match.
-versioned_files = [
-    "crates/harnx/Cargo.toml",
-    "crates/harnx-serve/Cargo.toml",
-    "crates/harnx-acp-server/Cargo.toml",
-]
+# Multi-package syntax (`[packages.harnx]`) is used so existing changeset
+# files keep their `harnx: <level>` front matter. With single-package
+# `[package]` syntax, changesets would need to drop the package name.
+[packages.harnx]
+# All workspace crates (except ratatui-widget-scrolling) inherit `version`
+# from `[workspace.package]` in the root Cargo.toml. knope updates that one
+# field; running `cargo build --workspace` afterwards refreshes Cargo.lock.
+versioned_files = ["Cargo.toml"]
 changelog = "CHANGELOG.md"
+
+# With multi-package syntax knope prepends the package name to tags, so
+# tags look like `harnx/v0.30.1` (NOT `v0.30.1`). The release workflow
+# trigger pattern in `.github/workflows/release.yaml` matches accordingly.
 tag_prefix = "v"
 
 [[workflows]]
@@ -19,4 +20,20 @@ name = "release"
 type = "PrepareRelease"
 
 [[workflows.steps]]
+type = "Command"
+command = "cargo build --workspace"
+
+[[workflows.steps]]
+type = "Command"
+command = "git add Cargo.lock"
+
+[[workflows.steps]]
+type = "Command"
+command = "git commit -m \"chore: prepare release\""
+
+[[workflows.steps]]
 type = "Release"
+
+[[workflows.steps]]
+type = "Command"
+command = "git push --follow-tags"


### PR DESCRIPTION
## Summary
Brings the workspace and release tooling into a state where `knope release` produces correct, runnable artifacts. Verified end-to-end with `knope release --dry-run` plus the full local verification pipeline (build, fmt, clippy, nextest — 846 tests pass).

## What changed and why

**Single source of truth for the release version.** Add `version = "0.30.0"` to `[workspace.package]` and switch every member crate to `version.workspace = true`. `ratatui-widget-scrolling` keeps its own `0.1.0` lifecycle (it's a vendored widget crate, conceptually independent).

**Drop `version = "0.30.0"` from internal path deps in the root `Cargo.toml`.** Path deps inside a workspace don't need version constraints (those are only required for crates.io publishing). With them in place, the moment knope bumped one crate but didn't update the dep spec, the workspace would refuse to build (`^0.30.0` constraint vs. new `0.30.1`/`0.31.0` actual).

**Migrate `knope.toml` to v0.22 syntax** (`[[packages]]` → `[packages.harnx]`). The old syntax fails to parse on knope 0.22+. Point `versioned_files` at the workspace root so knope updates one place and all members inherit. Insert a `cargo build --workspace` Command step between `PrepareRelease` and `Release` to refresh `Cargo.lock`, then `git add` + `git commit` it before tagging — otherwise the release CI build (`--locked`) would fail. Final `git push --follow-tags` step delivers the tag to origin.

**Expand `release.yaml` to build and ship the four MCP server bins.** `example_config/mcp_servers/{bash,fs,plans,time}.yaml` reference these as `command: harnx-mcp-X`, expecting them on PATH. Without shipping them, users on a release tarball can't use the example MCP server configs out of the box. Now the matrix builds and packages:
- `harnx`, `harnx-serve`, `harnx-acp-server` (existing)
- `harnx-mcp-bash` + `harnx-mcp-bash-sandbox-run` helper
- `harnx-mcp-fs`, `harnx-mcp-plans`, `harnx-mcp-time`

**Update workflow tag trigger** to match knope's monorepo-style tag prefix (`harnx/v...`); keeps `v...` as a fallback for any manual tags.

## What the next release will look like

`knope release --dry-run` confirms the planned bump is `0.30.0 → 0.30.1` (knope correctly applies pre-1.0 semver — `minor` changesets in `0.x` collapse to patch). To force a `0.31.0` cut you'd need a `major` changeset (which is the right level for any breaking change).

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo fmt --all` (no changes)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (846/846 pass)
- [x] `knope release --dry-run` (planned: tag `harnx/v0.30.1`, refreshes `Cargo.lock`, commits, tags, pushes)
- [ ] Merge, then run `knope release` from `main` to cut `harnx/v0.30.1`.
- [ ] Confirm the tag triggers `release.yaml` and all 7 binaries × 10 targets land in the GitHub Release.