### PR TITLE
ci(release): install rust target on pinned toolchain (fixes 0.30.1 release build)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,6 +84,15 @@ jobs:
       with:
         targets: ${{ matrix.target }}
 
+    # rust-toolchain.toml pins the active toolchain to a specific 1.x.y, so
+    # `cargo build` ignores the `stable` toolchain dtolnay set up. The target
+    # stdlib must be added to the pinned toolchain too. Skipped for cross
+    # builds — cross images carry the target stdlib themselves.
+    - name: Install Rust target for pinned toolchain
+      if: '!matrix.use-cross'
+      shell: bash
+      run: rustup target add ${{ matrix.target }}
+
     - name: Install cross
       if: matrix.use-cross
       uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Summary
The first attempted release (`harnx/v0.30.1`) failed at the `x86_64-apple-darwin` build:

> error[E0463]: can't find crate for \`core\`
> note: the \`x86_64-apple-darwin\` target may not be installed

`macos-latest` is arm64 now, so `x86_64-apple-darwin` (no `use-cross`) is a cross-target build. `dtolnay/rust-toolchain@stable` installs the target for the `stable` toolchain it provisions, but `rust-toolchain.toml` pins the active toolchain to a specific 1.x.y. `cargo build` uses the pinned toolchain — and the x86_64 stdlib was never added to it.

This PR adds an explicit `rustup target add ${{ matrix.target }}` step for non-cross builds, after `dtolnay/rust-toolchain@stable`. Cross builds skip it (cross's Docker images carry the target stdlibs themselves).

## Test plan
- [ ] Merge.
- [ ] Re-tag `harnx/v0.30.1` at the merged release commit, push, watch the release workflow build all 7 binaries × 10 targets cleanly.

## Context
The release commit itself is in PR #475 (the knope-generated `chore: prepare release`). Once both this PR and #475 are on `main`, we re-tag and re-run the release workflow.