### PR TITLE
ci(release): make rustup target add unconditional

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,10 +86,13 @@ jobs:
 
     # rust-toolchain.toml pins the active toolchain to a specific 1.x.y, so
     # `cargo build` ignores the `stable` toolchain dtolnay set up. The target
-    # stdlib must be added to the pinned toolchain too. Skipped for cross
-    # builds — cross images carry the target stdlib themselves.
+    # stdlib must be added to the pinned toolchain too. Run unconditionally:
+    # cross silently falls back to plain cargo when no Docker image exists
+    # for the target (e.g. i686/aarch64-pc-windows-msvc), so the rustup
+    # target needs to be present even on `use-cross: true` jobs. When cross
+    # does run a real container build, `rustup target add` is a harmless
+    # no-op against the host toolchain.
     - name: Install Rust target for pinned toolchain
-      if: '!matrix.use-cross'
       shell: bash
       run: rustup target add ${{ matrix.target }}
 


### PR DESCRIPTION
## Summary
Second attempt to release 0.30.1 failed at \`i686-pc-windows-msvc\` build with the same \`can't find crate for \\\`core\\\`\` error we hit on macOS x86_64.

**Root cause:** \`cross\` has no Docker image for several Windows targets (\`i686-pc-windows-msvc\`, \`aarch64-pc-windows-msvc\`) and silently falls back to plain \`cargo\`:
\`\`\`
[cross] warning: \`cross\` does not provide a Docker image for target i686-pc-windows-msvc, specify a custom image in \`Cross.toml\`.
[cross] note: Falling back to \`cargo\` on the host.
\`\`\`
The prior fix gated \`rustup target add\` on \`!matrix.use-cross\`, so this fallback path got no target stdlib.

**Fix:** drop the \`if:\`. \`rustup target add\` is idempotent. When cross actually runs a containerized build (Linux musl), the host-side install is unused. When cross silently falls back, this install is exactly what's needed.

## Test plan
- [ ] Merge.
- [ ] Re-tag \`harnx/v0.30.1\` at the new HEAD on \`main\`, push, watch all 10 build matrix jobs go green.

## Follow-up
Several of the \`use-cross: true\` matrix entries don't actually benefit from cross (Windows targets, native macOS aarch64). Worth a follow-up to flatten the matrix and drop unused \`taiki-e/install-action\` invocations.