### PR TITLE
ci(release): drop 32-bit ARM Linux targets, disable matrix fail-fast

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,10 @@ jobs:
       rc: ${{ steps.check-tag.outputs.rc }}
 
     strategy:
+      # Surface every target's failure in one run instead of cancelling on
+      # the first error. Each platform builds independently, and partial
+      # success is still useful to ship.
+      fail-fast: false
       matrix:
         include:
         - target: aarch64-unknown-linux-musl
@@ -50,14 +54,13 @@ jobs:
           os: windows-latest
           use-cross: true
           cargo-flags: ""
-        - target: armv7-unknown-linux-musleabihf
-          os: ubuntu-latest
-          use-cross: true
-          cargo-flags: ""
-        - target: arm-unknown-linux-musleabihf
-          os: ubuntu-latest
-          use-cross: true
-          cargo-flags: ""
+        # 32-bit ARM Linux targets (armv7-unknown-linux-musleabihf,
+        # arm-unknown-linux-musleabihf) are intentionally excluded:
+        # `birdcage` (used by `harnx-mcp-bash` for filesystem sandboxing)
+        # references syscall constants that aren't defined in libc for
+        # those targets, so the build can't currently produce a working
+        # set of artifacts. Re-add once birdcage gains support or it's
+        # made optional in harnx-mcp-bash.
 
     runs-on: ${{matrix.os}}
     env:


### PR DESCRIPTION
## Summary
Two related changes to break out of the iterative \"fix one target, hit next failure\" cycle on the 0.30.1 release:

**Drop \`armv7-unknown-linux-musleabihf\` and \`arm-unknown-linux-musleabihf\`.** The \`birdcage\` crate (used by \`harnx-mcp-bash\` for filesystem sandboxing) references libc syscall constants (\`SYS_mmap\`, \`SYS_migrate_pages\`, \`SYS_newfstatat\`, …) that aren't defined for these targets. The matrix has been failing the moment those jobs reach the \`harnx-mcp-bash\` build. Re-add once birdcage gains support or it's made optional inside \`harnx-mcp-bash\`.

**\`fail-fast: false\` on the build matrix.** The default cancels every remaining job the moment one fails, which has masked compounding failures across the prior release attempts. Each target is independent and a partial release is still useful, so we'd rather see all the failures at once.

## Test plan
- [ ] Merge.
- [ ] Re-tag \`harnx/v0.30.1\` at the new HEAD on \`main\`, push, watch the matrix run to completion. Any remaining failures will all surface in one pass instead of being hidden behind fail-fast.