### PR TITLE
ci(release): drop i686-unknown-linux-musl too

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,19 +46,16 @@ jobs:
           os: ubuntu-latest
           use-cross: true
           cargo-flags: ""
-        - target: i686-unknown-linux-musl
-          os: ubuntu-latest
-          use-cross: true
-          cargo-flags: ""
         - target: i686-pc-windows-msvc
           os: windows-latest
           use-cross: true
           cargo-flags: ""
-        # 32-bit ARM Linux targets (armv7-unknown-linux-musleabihf,
-        # arm-unknown-linux-musleabihf) are intentionally excluded:
-        # `birdcage` (used by `harnx-mcp-bash` for filesystem sandboxing)
-        # references syscall constants that aren't defined in libc for
-        # those targets, so the build can't currently produce a working
+        # 32-bit Linux targets (i686-unknown-linux-musl,
+        # armv7-unknown-linux-musleabihf, arm-unknown-linux-musleabihf) are
+        # intentionally excluded: `birdcage` (used by `harnx-mcp-bash` for
+        # filesystem sandboxing) references syscall constants that aren't
+        # defined in libc for those targets (`SYS_shmget`, `SYS_accept`,
+        # `SYS_mmap`, ...), so the build can't currently produce a working
         # set of artifacts. Re-add once birdcage gains support or it's
         # made optional in harnx-mcp-bash.
 


### PR DESCRIPTION
## Summary
0.30.1 shipped successfully on 7 platforms but the workflow ran reported \"failure\" because of \`i686-unknown-linux-musl\` — same root cause as the 32-bit ARM Linux targets we dropped earlier:

> error[E0425]: cannot find value \`SYS_shmget\` in crate \`libc\`
> error[E0425]: cannot find value \`SYS_accept\` in crate \`libc\`
> error[E0425]: cannot find value \`SYS_mmap\` in crate \`libc\`

\`birdcage\` (used by \`harnx-mcp-bash\` for filesystem sandboxing) references syscall constants not defined for 32-bit Linux ABIs.

Drop \`i686-unknown-linux-musl\` from the release matrix so future releases report a clean overall status. Every remaining target actually produces shippable artifacts.

## Follow-up
The proper fix is to make \`birdcage\` an optional dependency of \`harnx-mcp-bash\` gated on a \`cfg\` that excludes 32-bit Linux ABIs — that would let us add the three dropped targets back. Tracked outside this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build platform support: 32-bit Windows builds are now available, while 32-bit Linux builds are no longer supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->