### PR TITLE
chore(release): stage changeset deletions in knope's release commit

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -19,13 +19,17 @@ name = "release"
 [[workflows.steps]]
 type = "PrepareRelease"
 
+# `PrepareRelease` deletes the consumed changeset files from disk but
+# (in our setup) doesn't always stage those deletions. Force-stage
+# everything in the working tree so the upcoming commit captures the
+# deletions, the version bump, the changelog, and the lockfile refresh.
 [[workflows.steps]]
 type = "Command"
 command = "cargo build --workspace"
 
 [[workflows.steps]]
 type = "Command"
-command = "git add Cargo.lock"
+command = "git add -A"
 
 [[workflows.steps]]
 type = "Command"


### PR DESCRIPTION
## Summary
The 0.30.1 release commit (e4edfb40) shows the bug: 43 files changed, but **none of the 68 consumed changesets** got removed from \`.changesets/\`. They're still on disk and would be re-aggregated into the next release's CHANGELOG.

**Cause:** \`PrepareRelease\` removes the changeset files from disk but in our setup didn't always stage the deletions. The explicit \`git add Cargo.lock\` only captured the lockfile, so the subsequent \`git commit\` missed the deletions plus any other working-tree changes.

**Fix:** replace the targeted \`git add Cargo.lock\` with \`git add -A\`. One step now covers the version bump, the changelog rewrite, the lockfile refresh, *and* the changeset deletions.

\`knope release --dry-run\` confirms the new flow:
\`\`\`
Would run cargo build --workspace
Would run git add -A
Would run git commit -m \"chore: prepare release\"
Would run git push --follow-tags
\`\`\`

## After this lands
Run \`knope release\` once (locally or via the upcoming \`release-prepare.yaml\` workflow) to clear the 68-changeset backlog. The next release will carry the right scope.