### PR TITLE
ci: add manual/scheduled release-prepare workflow

### DIFF
--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -1,0 +1,105 @@
+# Cuts a release: bumps the workspace version, aggregates changesets into
+# CHANGELOG.md, refreshes Cargo.lock, commits, tags `harnx/v<version>`, and
+# pushes both the commit and the tag. The tag push then triggers
+# `release.yaml`, which builds and uploads the platform binaries.
+#
+# Setup required (one-time, see this workflow's PR for full instructions):
+#   1. Create a GitHub App with `contents: write` permission and install it
+#      on this repo.
+#   2. Add the App as a Bypass actor on the `main` branch ruleset, so the
+#      release commit pushes directly to `main` without going through a PR.
+#   3. Set repo variable  `RELEASE_BOT_APP_ID`     (the App's numeric ID)
+#      Set repo secret    `RELEASE_BOT_PRIVATE_KEY` (the App's private key,
+#      including the BEGIN/END PRIVATE KEY lines).
+#
+# Manual trigger: Actions → Prepare Release → Run workflow.
+# Optional: uncomment the `schedule` block to auto-release on a cadence.
+
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '0 18 * * 1'  # every Monday 18:00 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-prepare
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Run knope release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint release-bot token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          # Persist the bot token for subsequent `git push` from knope.
+          persist-credentials: true
+
+      - name: Bail if no changesets
+        id: check
+        shell: bash
+        run: |
+          # Knope's PrepareRelease errors out when there are no consumable
+          # changesets. Detect that ahead of time so the workflow exits 0
+          # with a friendly status instead of a confusing failure.
+          shopt -s nullglob
+          changesets=( .changesets/*.md )
+          # Strip the `.gitkeep` placeholder if present.
+          actual=()
+          for c in "${changesets[@]}"; do
+            [[ "$(basename "$c")" == ".gitkeep" ]] && continue
+            actual+=("$c")
+          done
+          if (( ${#actual[@]} == 0 )); then
+            echo "No changesets pending — nothing to release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found ${#actual[@]} pending changesets."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Rust toolchain (matches rust-toolchain.toml)
+        if: steps.check.outputs.skip != 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and target
+        if: steps.check.outputs.skip != 'true'
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install knope
+        if: steps.check.outputs.skip != 'true'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: knope
+
+      - name: Configure git as the release bot
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          # `actions/create-github-app-token` exposes the App's owner ID
+          # via `outputs.app-slug`; commits will be attributed to
+          # `<slug>[bot]@users.noreply.github.com`.
+          slug='${{ steps.app-token.outputs.app-slug }}'
+          git config user.name  "${slug}[bot]"
+          git config user.email "${{ steps.app-token.outputs.installation-id }}+${slug}[bot]@users.noreply.github.com"
+
+      - name: knope release --dry-run (sanity check)
+        if: steps.check.outputs.skip != 'true'
+        run: knope release --dry-run
+
+      - name: knope release
+        if: steps.check.outputs.skip != 'true'
+        run: knope release


### PR DESCRIPTION
## Summary
Adds \`.github/workflows/release-prepare.yaml\`. Click \"Run workflow\" in the Actions tab → it cuts the next release: bumps version, aggregates changesets, refreshes lockfile, commits, pushes the \`chore: prepare release\` commit + the \`harnx/v<version>\` tag, and the tag push triggers the existing \`release.yaml\` to build binaries.

The workflow uses a GitHub App's installation token to bypass the \`main\` branch ruleset, so the release commit lands directly on \`main\` instead of going through a PR.

A \`schedule\` block (currently commented out) is ready to enable for cadenced releases once you trust the manual flow.

## One-time setup before the workflow can run

### 1. Create the GitHub App
- Go to https://github.com/settings/apps/new (or under your org's settings if this lives in an org).
- Name: \`harnx-release-bot\` (or whatever you like).
- Homepage URL: anything (\`https://github.com/dobesv/harnx\`).
- Webhook: **uncheck** \"Active\".
- Permissions:
  - **Repository permissions → Contents:** Read and write
  - (Optional) **Metadata:** Read-only (forced)
- Where can this app be installed? \"Only on this account\".
- Click \"Create GitHub App\".
- Note the **App ID** (visible on the app's settings page).
- Click \"Generate a private key\" → save the \`.pem\` file (you'll need its contents).

### 2. Install the App on this repo
- On the App's settings page, click \"Install App\" in the left sidebar → install on \`dobesv/harnx\` only.

### 3. Add the App as a Bypass actor on the \`main\` ruleset
- Repo settings → Rules → Rulesets → click the rule guarding \`main\`.
- \"Bypass list\" → Add bypass → \"Repository role\" tab → there should now be an \"Integrations\" or \"Apps\" section showing \`harnx-release-bot\`. Add it.
  - If you only see role options, you may need to add via the API; happy to help if so.

### 4. Add the repo variable + secret
- Repo settings → Secrets and variables → Actions:
  - **Variables tab:** \`RELEASE_BOT_APP_ID\` = the numeric App ID from step 1.
  - **Secrets tab:** \`RELEASE_BOT_PRIVATE_KEY\` = paste the **entire** \`.pem\` contents (including \`-----BEGIN PRIVATE KEY-----\` and \`-----END PRIVATE KEY-----\` lines).

### 5. Run it once manually
- Actions → \"Prepare Release\" → \"Run workflow\" → main.
- First run will consume the 68 stale changesets and cut \`0.30.2\` (or whatever the current backlog computes to).

### 6. (optional) Enable the schedule
- Once you're happy with manual runs, edit the workflow file and uncomment the \`schedule\` block.

## Test plan
- [x] Workflow YAML parses (lint via \`actionlint\` welcome).
- [ ] After merge: complete steps 1–4 above.
- [ ] Trigger a manual run. Confirm the \`chore: prepare release\` commit lands on \`main\` and the \`harnx/v<version>\` tag triggers \`release.yaml\`.

## Depends on
PR #482 (knope changeset-deletion fix). If that doesn't land first, the first run of this workflow would still leave the consumed changesets on disk.