### PR TITLE
fix(acp): track I/O task JoinHandle to detect unexpected subprocess exit

### DIFF
--- a/.changesets/fix-71-acp-io-task-tracking.md
+++ b/.changesets/fix-71-acp-io-task-tracking.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Fix ACP client to detect and react to unexpected I/O task exit, preventing silent command failures when the subprocess crashes.

--- a/crates/harnx-acp/src/client.rs
+++ b/crates/harnx-acp/src/client.rs
@@ -769,7 +769,7 @@ async fn worker_main(
     );
     let conn = Rc::new(conn);
 
-    tokio::task::spawn_local(async move {
+    let mut io_handle = tokio::task::spawn_local(async move {
         if let Err(err) = handle_io.await {
             log::debug!("ACP I/O loop exited: {err}");
         }
@@ -800,120 +800,134 @@ async fn worker_main(
 
     let child = Rc::new(RefCell::new(Some(child)));
 
-    while let Some(command) = rx.recv().await {
-        match command {
-            WorkerCommand::NewSession { respond_to } => {
-                let conn = Rc::clone(&conn);
-                let sessions = sessions.clone();
-                let server_name = name.clone();
-                tokio::task::spawn_local(async move {
-                    let result = async {
-                        let response = conn
-                            .new_session(acp::NewSessionRequest::new(std::env::current_dir()?))
-                            .await
-                            .with_context(|| {
-                                format!("Failed to create ACP session on '{}'", server_name)
-                            })?;
-                        let session_id = response.session_id.0.to_string();
-                        sessions
-                            .write()
-                            .await
-                            .insert(session_id.clone(), SessionState::default());
-                        Ok(session_id)
-                    }
-                    .await;
-                    let _ = respond_to.send(result);
-                });
-            }
-            WorkerCommand::Prompt {
-                session_id,
-                message,
-                respond_to,
-            } => {
-                let conn = Rc::clone(&conn);
-                let sessions = sessions.clone();
-                let server_name = name.clone();
-                tokio::task::spawn_local(async move {
-                    let result = async {
-                        {
-                            let mut sessions = sessions.write().await;
-                            let state = sessions.entry(session_id.clone()).or_default();
-                            state.response_text.clear();
-                            state.stop_reason = None;
+    loop {
+        tokio::select! {
+            command = rx.recv() => {
+                match command {
+                    Some(command) => match command {
+                        WorkerCommand::NewSession { respond_to } => {
+                            let conn = Rc::clone(&conn);
+                            let sessions = sessions.clone();
+                            let server_name = name.clone();
+                            tokio::task::spawn_local(async move {
+                                let result = async {
+                                    let response = conn
+                                        .new_session(acp::NewSessionRequest::new(std::env::current_dir()?))
+                                        .await
+                                        .with_context(|| {
+                                            format!("Failed to create ACP session on '{}'", server_name)
+                                        })?;
+                                    let session_id = response.session_id.0.to_string();
+                                    sessions
+                                        .write()
+                                        .await
+                                        .insert(session_id.clone(), SessionState::default());
+                                    Ok(session_id)
+                                }
+                                .await;
+                                let _ = respond_to.send(result);
+                            });
                         }
+                        WorkerCommand::Prompt {
+                            session_id,
+                            message,
+                            respond_to,
+                        } => {
+                            let conn = Rc::clone(&conn);
+                            let sessions = sessions.clone();
+                            let server_name = name.clone();
+                            tokio::task::spawn_local(async move {
+                                let result = async {
+                                    {
+                                        let mut sessions = sessions.write().await;
+                                        let state = sessions.entry(session_id.clone()).or_default();
+                                        state.response_text.clear();
+                                        state.stop_reason = None;
+                                    }
 
-                        let response = conn
-                            .prompt(acp::PromptRequest::new(
-                                session_id.clone(),
-                                vec![message.into()],
-                            ))
-                            .await
-                            .with_context(|| {
-                                format!(
-                                    "Failed to send ACP prompt to session '{}' on '{}'",
-                                    session_id, server_name
-                                )
-                            })?;
+                                    let response = conn
+                                        .prompt(acp::PromptRequest::new(
+                                            session_id.clone(),
+                                            vec![message.into()],
+                                        ))
+                                        .await
+                                        .with_context(|| {
+                                            format!(
+                                                "Failed to send ACP prompt to session '{}' on '{}'",
+                                                session_id, server_name
+                                            )
+                                        })?;
 
-                        let mut sessions = sessions.write().await;
-                        let state = sessions.entry(session_id.clone()).or_default();
-                        state.stop_reason = Some(format!("{:?}", response.stop_reason));
-                        Ok(state.response_text.clone())
-                    }
-                    .await;
-                    let _ = respond_to.send(result);
-                });
-            }
-            WorkerCommand::LoadSession {
-                session_id,
-                respond_to,
-            } => {
-                let conn = Rc::clone(&conn);
-                let sessions = sessions.clone();
-                let server_name = name.clone();
-                tokio::task::spawn_local(async move {
-                    let result = async {
-                        conn.load_session(acp::LoadSessionRequest::new(
-                            session_id.clone(),
-                            std::env::current_dir()?,
-                        ))
-                        .await
-                        .with_context(|| {
-                            format!(
-                                "Failed to load ACP session '{}' on '{}'",
-                                session_id, server_name
-                            )
-                        })?;
+                                    let mut sessions = sessions.write().await;
+                                    let state = sessions.entry(session_id.clone()).or_default();
+                                    state.stop_reason = Some(format!("{:?}", response.stop_reason));
+                                    Ok(state.response_text.clone())
+                                }
+                                .await;
+                                let _ = respond_to.send(result);
+                            });
+                        }
+                        WorkerCommand::LoadSession {
+                            session_id,
+                            respond_to,
+                        } => {
+                            let conn = Rc::clone(&conn);
+                            let sessions = sessions.clone();
+                            let server_name = name.clone();
+                            tokio::task::spawn_local(async move {
+                                let result = async {
+                                    conn.load_session(acp::LoadSessionRequest::new(
+                                        session_id.clone(),
+                                        std::env::current_dir()?,
+                                    ))
+                                    .await
+                                    .with_context(|| {
+                                        format!(
+                                            "Failed to load ACP session '{}' on '{}'",
+                                            session_id, server_name
+                                        )
+                                    })?;
 
-                        sessions.write().await.entry(session_id).or_default();
-                        Ok(())
-                    }
-                    .await;
-                    let _ = respond_to.send(result);
-                });
+                                    sessions.write().await.entry(session_id).or_default();
+                                    Ok(())
+                                }
+                                .await;
+                                let _ = respond_to.send(result);
+                            });
+                        }
+                        WorkerCommand::CancelSession {
+                            session_id,
+                            respond_to,
+                        } => {
+                            let conn = Rc::clone(&conn);
+                            let server_name = name.clone();
+                            tokio::task::spawn_local(async move {
+                                let result = conn
+                                    .cancel(acp::CancelNotification::new(session_id.clone()))
+                                    .await
+                                    .with_context(|| {
+                                        format!(
+                                            "Failed to cancel ACP session '{}' on '{}'",
+                                            session_id, server_name
+                                        )
+                                    });
+                                let _ = respond_to.send(result);
+                            });
+                        }
+                        WorkerCommand::Shutdown { respond_to } => {
+                            let result = shutdown_child(&child).await;
+                            let _ = respond_to.send(result);
+                            break;
+                        }
+                    },
+                    None => break,
+                }
             }
-            WorkerCommand::CancelSession {
-                session_id,
-                respond_to,
-            } => {
-                let conn = Rc::clone(&conn);
-                let server_name = name.clone();
-                tokio::task::spawn_local(async move {
-                    let result = conn
-                        .cancel(acp::CancelNotification::new(session_id.clone()))
-                        .await
-                        .with_context(|| {
-                            format!(
-                                "Failed to cancel ACP session '{}' on '{}'",
-                                session_id, server_name
-                            )
-                        });
-                    let _ = respond_to.send(result);
-                });
-            }
-            WorkerCommand::Shutdown { respond_to } => {
-                let result = shutdown_child(&child).await;
-                let _ = respond_to.send(result);
+            _ = &mut io_handle => {
+                log::warn!(
+                    "ACP I/O loop for '{}' exited unexpectedly; terminating worker",
+                    name
+                );
                 break;
             }
         }

--- a/docs/solutions/async-patterns/acp-io-task-supervision-2026-05-07.md
+++ b/docs/solutions/async-patterns/acp-io-task-supervision-2026-05-07.md
@@ -1,0 +1,119 @@
+---
+title: "Supervised background task in LocalSet command loop"
+date: 2026-05-07
+category: async-patterns
+problem_type: logic_error
+component: harnx-acp-client
+root_cause: "dropped JoinHandle from spawn_local allowed command loop to continue after I/O task death"
+resolution_type: code_fix
+severity: medium
+tags:
+  - tokio
+  - spawn_local
+  - LocalSet
+  - JoinHandle
+  - select!
+  - supervision
+  - acp
+plan_ref: issue-71-acp-io-task-tracking
+---
+
+## Problem
+
+ACP client used `tokio::task::spawn_local` to run I/O loop but immediately dropped the `JoinHandle`. Command loop continued indefinitely even when underlying subprocess crashed, causing silent failures.
+
+## Symptoms
+
+- ACP commands hang indefinitely after subprocess crashes
+- No error messages or warnings when transport dies unexpectedly
+- In-flight `oneshot::Receiver` calls return `RecvError` ("disconnected")
+- Client appears functional but all commands timeout
+
+## Investigation Steps
+
+1. Reviewed `client.rs` — found `spawn_local(...)` called without binding to variable
+2. Understood `JoinHandle` drops immediately, detaching I/O task from supervision
+3. Recognized: if subprocess crashes, I/O task exits silently while command loop keeps running
+4. Traced oneshot channels: senders dropped when I/O loop breaks → receivers get `RecvError`
+5. Identified need for supervision: command loop must observe I/O task termination
+
+## Root Cause
+
+`tokio::task::spawn_local` returns a `JoinHandle` that represents the spawned task. When dropped:
+- Task continues running but becomes detached (unobservable)
+- No way to detect task termination from outside
+- Command loop has no signal that transport layer died
+
+In this case, I/O task handles subprocess communication. If subprocess crashes:
+- I/O task terminates
+- `JoinHandle` already dropped → no notification
+- Command loop continues accepting commands that can never succeed
+
+## Solution
+
+Capture `JoinHandle` and supervise it in the command loop using `tokio::select!`:
+
+**Before:**
+```rust
+LocalSet::new().run_until(async {
+    tokio::task::spawn_local(io_loop(subprocess));
+
+    while let Some(cmd) = command_stream.recv().await {
+        // process commands - no visibility into io_loop health
+    }
+});
+```
+
+**After:**
+```rust
+LocalSet::new().run_until(async {
+    let mut io_handle = tokio::task::spawn_local(io_loop(subprocess));
+
+    loop {
+        tokio::select! {
+            Some(cmd) = command_stream.recv() => {
+                // process command
+            }
+            _ = &mut io_handle => {
+                tracing::warn!("I/O task exited unexpectedly");
+                break;
+            }
+        }
+    }
+});
+```
+
+Additional safety: `kill_on_drop(true)` on subprocess ensures cleanup even without explicit shutdown.
+
+## Why This Works
+
+1. **`&mut io_handle` in select**: Borrows handle mutably, allowing repeated polls without consuming it. Each select iteration checks if I/O task completed.
+
+2. **Early termination detection**: If I/O loop exits (normally or due to crash), select branch fires immediately. Command loop can log warning and stop accepting new commands.
+
+3. **Channel propagation**: When loop breaks, in-flight `oneshot::Sender`s drop → callers receive `RecvError`, getting proper error signal instead of hanging.
+
+4. **`kill_on_drop(true)`**: Ensures subprocess terminates when handle drops, even during panics or early returns.
+
+## Prevention Strategies
+
+**Code Review Checklist:**
+- [ ] `spawn_local` results captured when task lifecycle matters
+- [ ] Background task termination observable (JoinHandle supervised or abortable)
+- [ ] `select!` used to supervise multiple async lifetimes in one loop
+
+**Best Practices:**
+- Always capture `JoinHandle` from `spawn`/`spawn_local` unless fire-and-forget is intentional
+- Use `tokio::select!` when coordinating main loop with background task lifetime
+- Set `kill_on_drop(true)` on child processes for reliable cleanup
+- Document why a task can be safely detached (if intentionally dropped)
+
+**Test Cases:**
+- Simulate subprocess crash, verify command loop exits
+- Verify in-flight commands receive errors, not hangs
+- Test: I/O task panic still triggers cleanup
+
+## Related Issues
+
+- **GitHub:** [issue #71](https://github.com/dobesv/harnx/issues/71) — ACP I/O task tracking
+- **Related Solution:** [raw-mode-ctrl-c-interrupt-2026-04-30.md](../integration-issues/raw-mode-ctrl-c-interrupt-2026-04-30.md) — `JoinHandle::abort()` cancellation patterns for `spawn_blocking`


### PR DESCRIPTION
## Summary

Fixes #71

The ACP worker spawned the `handle_io` future with `spawn_local` but immediately dropped the `JoinHandle`. If the ACP server's I/O loop exited unexpectedly (subprocess crash, broken pipe), the command loop kept running and all subsequent commands failed silently.

## Fix

- Capture the `JoinHandle` as `let mut io_handle`
- Add a `tokio::select!` branch in the command loop that logs a warning and breaks out when the I/O task completes unexpectedly
- In-flight callers receive a channel-closed error (`RecvError`) instead of hanging indefinitely — this surfaces the failure rather than hiding it

## Testing

- `cargo build --workspace` ✅
- `cargo fmt --all` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo nextest run --workspace --stress-count=5` ✅ (825/825 tests, 5 iterations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ACP client to properly detect and handle unexpected I/O task termination, preventing silent command failures and infinite hangs.

* **Documentation**
  * Added documentation for I/O task supervision patterns and related safety measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->