### PR TITLE
Extract TokioCompat adapter to shared harnx-acp::compat module

### DIFF
--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -619,66 +619,12 @@ mod tests {
         config::{Config, CREATE_TITLE_AGENT},
         test_utils::{MockClient, MockTurnBuilder},
     };
-    use std::{
-        cell::RefCell,
-        pin::Pin,
-        rc::Rc,
-        sync::Arc,
-        task::{Context as TaskContext, Poll},
-    };
+    use std::{cell::RefCell, rc::Rc, sync::Arc};
     use tempfile::TempDir;
-    use tokio::io::{AsyncRead as TokioAsyncRead, AsyncWrite as TokioAsyncWrite, ReadBuf};
     use tokio::task::LocalSet;
     use tokio::time::{timeout, Duration};
 
-    struct TokioCompat<T> {
-        inner: T,
-    }
-
-    impl<T> TokioCompat<T> {
-        fn new(inner: T) -> Self {
-            Self { inner }
-        }
-    }
-
-    impl<T: TokioAsyncRead + Unpin> futures_util::io::AsyncRead for TokioCompat<T> {
-        fn poll_read(
-            mut self: Pin<&mut Self>,
-            cx: &mut TaskContext<'_>,
-            buf: &mut [u8],
-        ) -> Poll<std::io::Result<usize>> {
-            let mut read_buf = ReadBuf::new(buf);
-            match Pin::new(&mut self.inner).poll_read(cx, &mut read_buf) {
-                Poll::Ready(Ok(())) => Poll::Ready(Ok(read_buf.filled().len())),
-                Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
-                Poll::Pending => Poll::Pending,
-            }
-        }
-    }
-
-    impl<T: TokioAsyncWrite + Unpin> futures_util::io::AsyncWrite for TokioCompat<T> {
-        fn poll_write(
-            mut self: Pin<&mut Self>,
-            cx: &mut TaskContext<'_>,
-            buf: &[u8],
-        ) -> Poll<std::io::Result<usize>> {
-            Pin::new(&mut self.inner).poll_write(cx, buf)
-        }
-
-        fn poll_flush(
-            mut self: Pin<&mut Self>,
-            cx: &mut TaskContext<'_>,
-        ) -> Poll<std::io::Result<()>> {
-            Pin::new(&mut self.inner).poll_flush(cx)
-        }
-
-        fn poll_close(
-            mut self: Pin<&mut Self>,
-            cx: &mut TaskContext<'_>,
-        ) -> Poll<std::io::Result<()>> {
-            Pin::new(&mut self.inner).poll_shutdown(cx)
-        }
-    }
+    use harnx_acp::compat::TokioCompat;
 
     #[derive(Clone)]
     struct TestClient {

--- a/crates/harnx-acp-server/src/server_main.rs
+++ b/crates/harnx-acp-server/src/server_main.rs
@@ -5,14 +5,12 @@
 //! to `agent_client_protocol::AgentSideConnection`, and drives the I/O loop
 //! until stdin closes.
 
-use std::pin::Pin;
 use std::rc::Rc;
-use std::task::{Context as TaskContext, Poll};
 
 use agent_client_protocol as acp;
 use anyhow::{anyhow, Context, Result};
+use harnx_acp::compat::TokioCompat;
 use harnx_runtime::config::GlobalConfig;
-use tokio::io::{AsyncRead as TokioAsyncRead, AsyncWrite as TokioAsyncWrite, ReadBuf};
 
 use crate::HarnxAgent;
 
@@ -92,49 +90,4 @@ async fn run_local(config: GlobalConfig, agent_name: String) -> Result<()> {
 
     result.map_err(|err| anyhow!("ACP server I/O error: {err}"))?;
     Ok(())
-}
-
-/// Adapter between tokio's AsyncRead/AsyncWrite and futures_io's AsyncRead/AsyncWrite.
-/// `agent-client-protocol` takes futures_io traits; stdin/stdout give us tokio traits.
-struct TokioCompat<T> {
-    inner: T,
-}
-
-impl<T> TokioCompat<T> {
-    fn new(inner: T) -> Self {
-        Self { inner }
-    }
-}
-
-impl<T: TokioAsyncRead + Unpin> futures_util::io::AsyncRead for TokioCompat<T> {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut TaskContext<'_>,
-        buf: &mut [u8],
-    ) -> Poll<std::io::Result<usize>> {
-        let mut read_buf = ReadBuf::new(buf);
-        match Pin::new(&mut self.inner).poll_read(cx, &mut read_buf) {
-            Poll::Ready(Ok(())) => Poll::Ready(Ok(read_buf.filled().len())),
-            Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
-impl<T: TokioAsyncWrite + Unpin> futures_util::io::AsyncWrite for TokioCompat<T> {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut TaskContext<'_>,
-        buf: &[u8],
-    ) -> Poll<std::io::Result<usize>> {
-        Pin::new(&mut self.inner).poll_write(cx, buf)
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.inner).poll_flush(cx)
-    }
-
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.inner).poll_shutdown(cx)
-    }
 }

--- a/crates/harnx-acp/src/client.rs
+++ b/crates/harnx-acp/src/client.rs
@@ -1,4 +1,4 @@
-use crate::{AcpServerConfig, NestedAcpEvent};
+use crate::{compat::TokioCompat, AcpServerConfig, NestedAcpEvent};
 
 use agent_client_protocol::{self as acp, Agent as _};
 use anyhow::{anyhow, Context, Result};
@@ -8,16 +8,12 @@ use harnx_core::event::{
 use serde_json::json;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::pin::Pin;
 use std::process::Stdio;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::task::{Context as TaskContext, Poll};
 use std::thread;
 use std::time::Duration;
-use tokio::io::{
-    AsyncBufReadExt, AsyncRead as TokioAsyncRead, AsyncWrite as TokioAsyncWrite, BufReader, ReadBuf,
-};
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::runtime::Builder;
 use tokio::sync::{broadcast, mpsc, oneshot, Mutex, RwLock};
@@ -82,10 +78,6 @@ struct AcpNotificationClient {
     activity_tx: broadcast::Sender<String>,
 }
 
-struct TokioCompat<T> {
-    inner: T,
-}
-
 impl AcpNotificationClient {
     fn new(
         agent_name: String,
@@ -128,45 +120,6 @@ impl AcpNotificationClient {
             use harnx_core::sink::emit_agent_event_with_source;
             emit_agent_event_with_source(event, Some(source));
         }
-    }
-}
-
-impl<T> TokioCompat<T> {
-    fn new(inner: T) -> Self {
-        Self { inner }
-    }
-}
-
-impl<T: TokioAsyncRead + Unpin> futures_util::io::AsyncRead for TokioCompat<T> {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut TaskContext<'_>,
-        buf: &mut [u8],
-    ) -> Poll<std::io::Result<usize>> {
-        let mut read_buf = ReadBuf::new(buf);
-        match Pin::new(&mut self.inner).poll_read(cx, &mut read_buf) {
-            Poll::Ready(Ok(())) => Poll::Ready(Ok(read_buf.filled().len())),
-            Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
-impl<T: TokioAsyncWrite + Unpin> futures_util::io::AsyncWrite for TokioCompat<T> {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut TaskContext<'_>,
-        buf: &[u8],
-    ) -> Poll<std::io::Result<usize>> {
-        Pin::new(&mut self.inner).poll_write(cx, buf)
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.inner).poll_flush(cx)
-    }
-
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.inner).poll_shutdown(cx)
     }
 }
 

--- a/crates/harnx-acp/src/compat.rs
+++ b/crates/harnx-acp/src/compat.rs
@@ -1,0 +1,54 @@
+//! Adapter between tokio's `AsyncRead`/`AsyncWrite` and `futures_io`'s
+//! `AsyncRead`/`AsyncWrite`.
+//!
+//! `agent-client-protocol` accepts the `futures_io` traits; tokio's
+//! stdio/process streams implement the tokio traits.  `TokioCompat` bridges
+//! the gap.
+
+use std::pin::Pin;
+use std::task::{Context as TaskContext, Poll};
+
+use tokio::io::{AsyncRead as TokioAsyncRead, AsyncWrite as TokioAsyncWrite, ReadBuf};
+
+pub struct TokioCompat<T> {
+    inner: T,
+}
+
+impl<T> TokioCompat<T> {
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+}
+
+impl<T: TokioAsyncRead + Unpin> futures_util::io::AsyncRead for TokioCompat<T> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let mut read_buf = ReadBuf::new(buf);
+        match Pin::new(&mut self.inner).poll_read(cx, &mut read_buf) {
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(read_buf.filled().len())),
+            Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<T: TokioAsyncWrite + Unpin> futures_util::io::AsyncWrite for TokioCompat<T> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}

--- a/crates/harnx-acp/src/lib.rs
+++ b/crates/harnx-acp/src/lib.rs
@@ -4,6 +4,8 @@
 //! crate and will move out in a later plan.
 
 mod client;
+#[doc(hidden)]
+pub mod compat;
 mod config;
 mod event;
 pub mod manager;

--- a/docs/solutions/workflow-issues/tokiocompat-deduplication-2026-05-07.md
+++ b/docs/solutions/workflow-issues/tokiocompat-deduplication-2026-05-07.md
@@ -1,0 +1,189 @@
+---
+title: "Deduplicate TokioCompat adapter across workspace crates"
+date: 2026-05-07
+category: workflow-issues
+problem_type: workflow_issue
+component: harnx-acp
+root_cause: "utility adapter struct duplicated in three locations across workspace"
+resolution_type: code_fix
+severity: low
+tags:
+  - deduplication
+  - workspace-organization
+  - doc-hidden
+  - tokio
+  - futures-io
+plan_ref: issue-72-tokiocompat-dedup
+---
+
+## Problem
+
+`TokioCompat<T>` adapter (bridging tokio's `AsyncRead`/`AsyncWrite` to `futures_io` traits) existed in three separate locations across `harnx-acp` and `harnx-acp-server` crates, causing maintenance burden and potential drift.
+
+## Symptoms
+
+```
+crates/harnx-acp/src/client.rs         — local TokioCompat struct (+50 lines)
+crates/harnx-acp-server/src/lib.rs      — local TokioCompat struct (+50 lines)
+crates/harnx-acp-server/src/server_main.rs — local TokioCompat struct (+50 lines)
+```
+
+Each duplicate included:
+- Identical struct definition
+- `AsyncRead` implementation for `futures_util::io::AsyncRead`
+- `AsyncWrite` implementation for `futures_util::io::AsyncWrite`
+- Supporting imports: `Pin`, `Poll`, `TaskContext`, `TokioAsyncRead`, `TokioAsyncWrite`, `ReadBuf`
+
+Risk: bug fixes or improvements applied to one copy but not others.
+
+## Investigation Steps
+
+1. Identified `harnx-acp` as common dependency of both `harnx-acp-server` and `harnx-acp` client code.
+2. Confirmed `TokioCompat` is internal workspace utility — not part of public API.
+3. Extracted to `crates/harnx-acp/src/compat.rs` with module comment explaining purpose.
+4. Used `#[doc(hidden)] pub mod compat;` to expose cross-crate without cluttering docs.
+
+## Root Cause
+
+Utility adapter needed in multiple crates but no shared location existed. Each location independently implemented the same `futures_io` ↔ tokio bridge.
+
+## Solution
+
+**1. Create canonical module** in lowest-level crate:
+
+```rust
+// crates/harnx-acp/src/compat.rs
+//! Adapter between tokio's `AsyncRead`/`AsyncWrite` and `futures_io`'s
+//! `AsyncRead`/`AsyncWrite`.
+//!
+//! `agent-client-protocol` accepts the `futures_io` traits; tokio's
+//! stdio/process streams implement the tokio traits.  `TokioCompat` bridges
+//! the gap.
+
+use std::pin::Pin;
+use std::task::{Context as TaskContext, Poll};
+
+use tokio::io::{AsyncRead as TokioAsyncRead, AsyncWrite as TokioAsyncWrite, ReadBuf};
+
+pub struct TokioCompat<T> {
+    inner: T,
+}
+
+impl<T> TokioCompat<T> {
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+}
+
+impl<T: TokioAsyncRead + Unpin> futures_util::io::AsyncRead for TokioCompat<T> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let mut read_buf = ReadBuf::new(buf);
+        match Pin::new(&mut self.inner).poll_read(cx, &mut read_buf) {
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(read_buf.filled().len())),
+            Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<T: TokioAsyncWrite + Unpin> futures_util::io::AsyncWrite for TokioCompat<T> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+```
+
+**2. Export as doc-hidden** from lib.rs:
+
+```rust
+// crates/harnx-acp/src/lib.rs
+mod client;
+#[doc(hidden)]
+pub mod compat;
+mod config;
+mod event;
+pub mod manager;
+```
+
+**3. Update consumers** to import from shared location:
+
+```rust
+// client.rs
+use crate::compat::TokioCompat;
+```
+
+```rust
+// server tests in lib.rs
+use harnx_acp::compat::TokioCompat;
+```
+
+**4. Remove local definitions and dead imports**:
+
+```rust
+// Before (client.rs):
+use std::pin::Pin;
+use std::task::{Context as TaskContext, Poll};
+use tokio::io::{AsyncRead as TokioAsyncRead, AsyncWrite as TokioAsyncWrite, ReadBuf};
+
+struct TokioCompat<T> { inner: T }
+// + 50 lines of impl
+```
+
+```rust
+// After (client.rs):
+use crate::compat::TokioCompat;
+```
+
+**5. Run `cargo fmt`** to fix module declaration order (alphabetical: `mod client;` before `pub mod compat;`).
+
+## Why This Works
+
+1. **Single canonical location**: `harnx-acp` is already a dependency of all consumers, so no new dependency edges needed.
+
+2. **`#[doc(hidden)]`**: Prevents internal utility from appearing in public API docs while allowing `pub` visibility for workspace consumers.
+
+3. **Dead import cleanup**: Removing local struct makes associated imports dead code — `cargo check` catches these.
+
+4. **`cargo fmt` ordering**: Rustfmt enforces alphabetical `mod` declarations. Running after structural changes prevents CI failures.
+
+## Prevention Strategies
+
+**Code Review Checklist:**
+- [ ] Check for duplicate utility structs before introducing new copies
+- [ ] Identify lowest-level crate that can host shared utilities
+- [ ] Use `#[doc(hidden)]` for internal workspace utilities
+
+**Best Practices:**
+- Extract shared utilities to crates already in dependency graph
+- Run `cargo fmt` after adding/removing module declarations
+- Clean up imports when removing local definitions (`cargo check -W unused_imports`)
+- Document rationale for internal utilities with module-level comments
+
+**Refactoring Pattern:**
+When utility exists in 3+ locations:
+1. Create shared module in lowest-level crate
+2. Mark `#[doc(hidden)] pub` if internal
+3. Update all consumers to import
+4. Remove locals + dead imports
+5. Run `cargo fmt && cargo check`
+
+## Related Issues
+
+- **GitHub:** [issue #72](https://github.com/dobesv/harnx/issues/72) — TokioCompat deduplication
+- **Related Solution:** [acp-io-task-supervision-2026-05-07.md](../async-patterns/acp-io-task-supervision-2026-05-07.md) — Same ACP client refactoring context


### PR DESCRIPTION
\`TokioCompat<T>\` — the bridge between tokio's AsyncRead/AsyncWrite and futures_io's AsyncRead/AsyncWrite — was duplicated in three places:

- \`crates/harnx-acp/src/client.rs\`
- \`crates/harnx-acp-server/src/server_main.rs\`
- \`crates/harnx-acp-server/src/lib.rs\` (test module)

Extract it to a single canonical location: \`crates/harnx-acp/src/compat.rs\`, exposed as \`#[doc(hidden)] pub mod compat\` so \`harnx-acp-server\` can import it without the module appearing in public API docs.

Remove all now-unused imports (\`Pin\`, \`Poll\`, \`TaskContext\`, \`TokioAsyncRead\`, \`TokioAsyncWrite\`, \`ReadBuf\`) from the consumer files.

Closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate utility implementations spread across multiple internal modules into a single centralized shared module to reduce code duplication and improve maintainability.

* **Documentation**
  * Added comprehensive documentation explaining the consolidation of internal utilities and the migration process for affected system components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->