### PR TITLE
feat(tui): surface hook-blocked tool calls in TUI transcript (#356)

### DIFF
--- a/crates/harnx-core/src/event.rs
+++ b/crates/harnx-core/src/event.rs
@@ -83,6 +83,12 @@ pub enum ToolEvent {
         id: String,
         error: String,
     },
+    Blocked {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+        reason: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/harnx-engine/src/tool.rs
+++ b/crates/harnx-engine/src/tool.rs
@@ -54,6 +54,11 @@ pub struct ToolEvalContext {
     /// (or YAML-pretty-prints the JSON), truncates to terminal
     /// dimensions, dims the text, and writes to stdout.
     pub emit_tool_result_fn: Arc<ToolCallEmitFn>,
+    /// Called when a PreToolUse hook blocks or a user denies a tool call.
+    /// Receives the tool call and the blocked result JSON (contains
+    /// `"error"` key). Harnx's default emits
+    /// `AgentEvent::Tool(ToolEvent::Blocked { .. })`.
+    pub emit_tool_blocked_fn: Arc<ToolCallEmitFn>,
     /// Called when a PreToolUse hook returns `Ask { reason }` and the
     /// user needs to confirm before the tool runs. Returns `true` if
     /// the user allows the tool; `false` otherwise. Harnx's default
@@ -131,6 +136,7 @@ pub async fn eval_tool_calls(
         }
         if let HookResultControl::Block { reason } = pre_outcome.control {
             let blocked_result = json!({"error": reason, "blocked_by_hook": true});
+            (ctx.emit_tool_blocked_fn)(&call, &blocked_result);
             output.push(ToolResult::new(call, blocked_result));
             is_all_null = false;
             continue;
@@ -139,6 +145,7 @@ pub async fn eval_tool_calls(
             if !(ctx.confirm_tool_use_fn)(&call.name, &json_data, reason.as_deref()) {
                 let deny_reason = reason.unwrap_or_else(|| "Denied by user".to_string());
                 let blocked_result = json!({"error": deny_reason, "blocked_by_hook": true});
+                (ctx.emit_tool_blocked_fn)(&call, &blocked_result);
                 output.push(ToolResult::new(call, blocked_result));
                 is_all_null = false;
                 continue;
@@ -410,7 +417,7 @@ mod tests {
         providers: Vec<Arc<dyn ToolProvider>>,
         dispatch_hook: impl Fn(HookEvent) -> HookOutcome + Send + Sync + 'static,
     ) -> ToolEvalContext {
-        test_context_with_emitters(providers, dispatch_hook, |_, _| {}, |_, _| {})
+        test_context_with_emitters(providers, dispatch_hook, |_, _| {}, |_, _| {}, |_, _| {})
     }
 
     fn test_context_with_emitters(
@@ -418,6 +425,7 @@ mod tests {
         dispatch_hook: impl Fn(HookEvent) -> HookOutcome + Send + Sync + 'static,
         emit_tool_call: impl Fn(&ToolCall, &Value) + Send + Sync + 'static,
         emit_tool_result: impl Fn(&ToolCall, &Value) + Send + Sync + 'static,
+        emit_tool_blocked: impl Fn(&ToolCall, &Value) + Send + Sync + 'static,
     ) -> ToolEvalContext {
         ToolEvalContext {
             providers,
@@ -425,6 +433,7 @@ mod tests {
             allowed_tool_names: HashSet::new(),
             emit_tool_call_fn: Arc::new(emit_tool_call),
             emit_tool_result_fn: Arc::new(emit_tool_result),
+            emit_tool_blocked_fn: Arc::new(emit_tool_blocked),
             confirm_tool_use_fn: Arc::new(|_, _, _| true),
             dispatch_hook_fn: Arc::new(move |event| {
                 let outcome = dispatch_hook(event);
@@ -566,6 +575,7 @@ mod tests {
             move |_, _| {
                 result_emit_count_clone.fetch_add(1, Ordering::SeqCst);
             },
+            |_, _| {},
         );
         let abort_signal = create_abort_signal();
 
@@ -578,9 +588,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn blocked_call_does_not_emit_started() {
+    async fn blocked_call_emits_blocked_event() {
         let started_emit_count = Arc::new(AtomicUsize::new(0));
         let started_emit_count_clone = Arc::clone(&started_emit_count);
+        let blocked_emit_count = Arc::new(AtomicUsize::new(0));
+        let blocked_emit_count_clone = Arc::clone(&blocked_emit_count);
         let ctx = test_context_with_emitters(
             vec![Arc::new(MockToolProvider::panic("tool_a"))],
             |event| match event {
@@ -596,6 +608,9 @@ mod tests {
                 started_emit_count_clone.fetch_add(1, Ordering::SeqCst);
             },
             |_, _| {},
+            move |_, _| {
+                blocked_emit_count_clone.fetch_add(1, Ordering::SeqCst);
+            },
         );
         let abort_signal = create_abort_signal();
 
@@ -605,5 +620,6 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(started_emit_count.load(Ordering::SeqCst), 0);
+        assert_eq!(blocked_emit_count.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/harnx-runtime/src/tool.rs
+++ b/crates/harnx-runtime/src/tool.rs
@@ -140,6 +140,11 @@ pub fn build_tool_eval_context(
         Arc::new(move |call: &ToolCall, result: &Value| {
             emit_tool_result_with_template(call, result, &decl_map_clone2);
         });
+    let decl_map_clone3 = Arc::clone(&decl_map);
+    let emit_tool_blocked_fn: Arc<ToolCallEmitFn> =
+        Arc::new(move |call: &ToolCall, blocked_result: &Value| {
+            emit_tool_blocked_with_template(call, blocked_result, &decl_map_clone3);
+        });
 
     let confirm_tool_use_fn: Arc<ConfirmToolUseFn> = Arc::new(default_confirm_tool_use);
 
@@ -149,6 +154,7 @@ pub fn build_tool_eval_context(
         allowed_tool_names,
         emit_tool_call_fn,
         emit_tool_result_fn,
+        emit_tool_blocked_fn,
         confirm_tool_use_fn,
         dispatch_hook_fn,
     }
@@ -265,6 +271,35 @@ fn emit_tool_result_with_template(
     if !harnx_core::sink::emit_agent_event(event) && *IS_STDOUT_TERMINAL {
         print_tool_result_fallback(call, result, decl_map, &raw_fallback);
     }
+}
+
+fn emit_tool_blocked_with_template(
+    call: &ToolCall,
+    blocked_result: &Value,
+    decl_map: &HashMap<String, ToolDeclaration>,
+) {
+    use harnx_core::event::{AgentEvent, ToolEvent};
+
+    let reason = blocked_result
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or("blocked by hook")
+        .to_string();
+
+    let raw_fallback = match &call.arguments {
+        Value::Null => String::new(),
+        _ => pretty_yaml_block(&call.arguments),
+    };
+    let input_rendered = render_call(call, &call.arguments, &raw_fallback, decl_map);
+
+    let event = AgentEvent::Tool(ToolEvent::Blocked {
+        id: call.id.clone().unwrap_or_default(),
+        name: call.name.clone(),
+        input: call.arguments.clone(),
+        reason,
+    });
+    let _ = input_rendered;
+    let _ = harnx_core::sink::emit_agent_event(event);
 }
 
 /// Look up `call.name` in `decl_map`, render `call_template` against `json_data`

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -842,7 +842,9 @@ impl Tui {
         // across those events.
         let is_turn_boundary = matches!(
             &event,
-            AgentEvent::Tool(ToolEvent::Started { .. }) | AgentEvent::Plan { .. }
+            AgentEvent::Tool(ToolEvent::Started { .. })
+                | AgentEvent::Tool(ToolEvent::Blocked { .. })
+                | AgentEvent::Plan { .. }
         );
         if is_turn_boundary {
             self.app.streaming_assistant_idx = None;
@@ -1076,6 +1078,32 @@ impl Tui {
                 vec![TranscriptItem::ToolCall {
                     tool_name: name,
                     body: tool_call_body(markdown.as_deref(), &input),
+                    seq: None,
+                    timestamp: Some(chrono::Utc::now()),
+                    rendered_cache: None,
+                }]
+            }
+            AgentEvent::Tool(ToolEvent::Blocked {
+                name,
+                input,
+                reason,
+                ..
+            }) => {
+                let body = {
+                    let reason_text = format!("⊘ blocked: {reason}");
+                    let input_text = match &input {
+                        serde_json::Value::Null => String::new(),
+                        _ => {
+                            let yaml = harnx_runtime::utils::pretty_yaml_block(&input);
+                            format!("{yaml}\n")
+                        }
+                    };
+                    let full = format!("{input_text}{reason_text}");
+                    Some(crate::types::ToolCallBody::Markdown(full))
+                };
+                vec![TranscriptItem::ToolCall {
+                    tool_name: name,
+                    body,
                     seq: None,
                     timestamp: Some(chrono::Utc::now()),
                     rendered_cache: None,

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -4486,6 +4486,46 @@ async fn tui_renders_started_title_when_template_provides_it() {
 }
 
 #[tokio::test]
+async fn tui_renders_blocked_tool_call_in_transcript() {
+    let mut tui = Tui::init(
+        &test_config(),
+        AsyncHookManager::new(),
+        Arc::new(Mutex::new(PersistentHookManager::new())),
+    )
+    .unwrap();
+
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Tool(ToolEvent::Blocked {
+            id: "call-1".into(),
+            name: "bash_exec".into(),
+            input: yaml_to_json("command: rm -rf /tmp/demo"),
+            reason: "hook denied".into(),
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let tool_call = tui
+        .app
+        .transcript
+        .iter()
+        .find_map(|entry| match entry {
+            TranscriptItem::ToolCall { body, .. } => Some(body),
+            _ => None,
+        })
+        .expect("expected ToolCall transcript item");
+
+    match tool_call {
+        Some(ToolCallBody::Markdown(body)) => {
+            assert!(body.contains("⊘ blocked: hook denied"));
+            assert!(body.contains("command: rm -rf /tmp/demo"));
+        }
+        other => panic!("expected markdown tool body, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn tui_falls_back_to_yaml_when_no_template_title() {
     // Regression guard: when title is None (no template configured), the
     // existing yaml-of-input behavior must be preserved.

--- a/crates/harnx/src/cli_event_sink.rs
+++ b/crates/harnx/src/cli_event_sink.rs
@@ -397,6 +397,9 @@ impl AgentEventSink for CliAgentEventSink {
             }) => {
                 state.print_tool_completed(&output, markdown.as_deref());
             }
+            AgentEvent::Tool(ToolEvent::Blocked { name, reason, .. }) => {
+                eprintln!("{}", warning_text(&format!("blocked: {name} — {reason}")));
+            }
             // Silent for Progress / Update — they are streamed mid-call
             // updates that would clutter stderr.
             AgentEvent::Tool(_) => {}
@@ -477,6 +480,15 @@ mod tests {
             None,
         );
         sink.emit(AgentEvent::Model(ModelEvent::Error("boom".into())), None);
+        sink.emit(
+            AgentEvent::Tool(ToolEvent::Blocked {
+                id: String::new(),
+                name: "test_tool".into(),
+                input: serde_json::Value::Null,
+                reason: "hook denied".into(),
+            }),
+            None,
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/docs/solutions/logic-errors/tool-event-blocked-visibility-2026-05-08.md
+++ b/docs/solutions/logic-errors/tool-event-blocked-visibility-2026-05-08.md
@@ -1,0 +1,167 @@
+---
+title: "ToolEvent::Blocked for hook-denied tool call visibility"
+date: 2026-05-08
+category: logic-errors
+problem_type: logic_error
+component: harnx-engine
+root_cause: "blocked tool calls short-circuited before event emission, leaving no trace in transcript"
+resolution_type: code_fix
+severity: medium
+tags:
+  - event-emission
+  - hooks
+  - tool-dispatch
+  - tui
+plan_ref: issue-356-blocked-tool-tui
+---
+
+## Problem
+
+Tool calls blocked by `dcg` or other PreToolUse hooks were invisible in the TUI transcript and CLI output. The engine short-circuited before calling `emit_tool_call_fn`, so no `ToolEvent` reached any consumer.
+
+## Symptoms
+
+- Hook-blocked tool calls left no trace in TUI transcript
+- User confirmation denials (Ask hook denied) equally invisible
+- Transcript showed no indication why an agent's attempted tool call never executed
+- Debugging hook behavior required examining logs outside the UI
+
+## Investigation Steps
+
+1. Traced code path in `harnx-engine/src/tool.rs` `eval_tool_calls`: both `HookResultControl::Block` and `HookResultControl::Ask` deny branch built a `blocked_result` JSON but never called any emit function
+2. Verified `emit_tool_call_fn` only invoked after approval (line 148), not before hook evaluation
+3. Checked `AgentEvent` enum — no `ToolEvent::Blocked` variant existed
+4. Considered alternatives:
+   - Repurpose `ToolEvent::Completed` with a `blocked` flag — conflates success/failure
+   - Emit `ToolEvent::Started` then `Failed` — misleading, implies tool ran
+   - Add dedicated `Blocked` variant — cleanest semantics, clearly distinct from success/failure
+
+## Root Cause
+
+The engine's two-phase dispatch pattern (validation/hooks/confirm → emit Started → dispatch) correctly avoided emitting `Started` for blocked calls (per parallel-tool-dispatch pattern). However, the blocked branches merely built a `blocked_result` JSON and returned early without calling any emit function. This left the TUI and CLI sinks with zero visibility into blocked calls.
+
+The engine had both blocked paths ready to return the rejection, but no mechanism existed to surface this information as an event.
+
+## Solution
+
+### 1. Add `ToolEvent::Blocked` variant
+
+```rust
+// crates/harnx-core/src/event.rs
+pub enum ToolEvent {
+    Started { /* ... */ },
+    Progress { /* ... */ },
+    Update { /* ... */ },
+    Completed { /* ... */ },
+    Failed { /* ... */ },
+    Blocked {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+        reason: String,
+    },
+}
+```
+
+### 2. Add `emit_tool_blocked_fn` to `ToolEvalContext`
+
+```rust
+// crates/harnx-engine/src/tool.rs
+pub struct ToolEvalContext {
+    // ...existing fields...
+    pub emit_tool_blocked_fn: Arc<ToolCallEmitFn>,
+}
+```
+
+Call it in both blocked branches:
+
+```rust
+// HookResultControl::Block path
+let blocked_result = json!({"is_error": true, "error": reason});
+(ctx.emit_tool_blocked_fn)(&call, &blocked_result);
+output.push(ToolResult::new(call.clone(), blocked_result));
+
+// HookResultControl::Ask deny path  
+let blocked_result = json!({"is_error": true, "error": "denied by user"});
+(ctx.emit_tool_blocked_fn)(&call, &blocked_result);
+output.push(ToolResult::new(call.clone(), blocked_result));
+```
+
+### 3. Wire emit function in runtime
+
+```rust
+// crates/harnx-runtime/src/tool.rs
+fn emit_tool_blocked_with_template(
+    call: &ToolCall,
+    blocked_result: &Value,
+    decl_map: &HashMap<String, ToolDeclaration>,
+) {
+    let reason = blocked_result
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or("blocked by hook")
+        .to_string();
+
+    let event = AgentEvent::Tool(ToolEvent::Blocked {
+        id: call.id.clone().unwrap_or_default(),
+        name: call.name.clone(),
+        input: call.arguments.clone(),
+        reason,
+    });
+    let _ = harnx_core::sink::emit_agent_event(event);
+}
+```
+
+### 4. Render in TUI
+
+```rust
+// crates/harnx-tui/src/input.rs
+AgentEvent::Tool(ToolEvent::Blocked { id, name, input, reason }) => {
+    let body = format!("{}\n⊘ blocked: {}", yaml_input, reason);
+    TranscriptItem::ToolCall { name, body, .. }
+    // Add to is_turn_boundary match for streaming-assistant index reset
+}
+```
+
+### 5. Handle in CLI sink
+
+```rust
+// crates/harnx/src/cli_event_sink.rs
+AgentEvent::Tool(ToolEvent::Blocked { name, reason, .. }) => {
+    println!("⊘ {} blocked: {}", name, reason);
+}
+```
+
+## Why This Works
+
+- **Dedicated variant**: `Blocked` is semantically distinct from `Started` (tool never ran), `Completed` (no result), and `Failed` (execution error during run). Prevents confusion.
+- **Emit from blocked branches**: Both hook-block and user-deny paths call `emit_tool_blocked_fn` before returning, guaranteeing visibility.
+- **Event-driven architecture**: Adding to `ToolEvent` enum automatically propagates to all consumers (TUI, CLI, future SSE/HTTP servers).
+- **YAML input + reason**: TUI shows what was attempted and why it was blocked, debugging-friendly.
+
+## Known Gap
+
+`emit_tool_blocked_with_template` computes `input_rendered` via `render_call()` but `ToolEvent::Blocked` lacks a `markdown: Option<String>` field. The rendered template is discarded. Future improvement: add `markdown` field and pass through to TUI, allowing blocked calls to honor tool `call_template` like `Started` events do.
+
+## Prevention Strategies
+
+**Test Cases:**
+- Verify `ToolEvent::Blocked` emitted for hook-blocked calls
+- Verify `ToolEvent::Blocked` emitted for user-denied confirmation
+- Verify TUI renders blocked calls with `⊘ blocked: <reason>`
+- Verify CLI outputs blocked message
+- Verify blocked call appears in transcript but not as "in-progress"
+
+**Code Review Checklist:**
+- [ ] All rejection/block paths emit appropriate event
+- [ ] New `ToolEvent` variants have corresponding TUI/CLI handlers
+- [ ] Context struct new fields wired through all call sites
+
+**Pattern:**
+When adding a new short-circuit path in tool dispatch, always emit an event before returning. The event stream is the single source of truth for UI consumers.
+
+## Related Issues
+
+- **Plan:** issue-356-blocked-tool-tui
+- **Related Solution:** [parallel-tool-dispatch-2026-04-30.md](../parallel-tool-dispatch-2026-04-30.md) — Establishes the "emit after approval" pattern that this solution extends with a dedicated blocked variant
+- **Files:** `crates/harnx-core/src/event.rs`, `crates/harnx-engine/src/tool.rs`, `crates/harnx-runtime/src/tool.rs`, `crates/harnx-tui/src/input.rs`, `crates/harnx/src/cli_event_sink.rs`


### PR DESCRIPTION
Blocked tool calls (hook-denied or user-denied via PreToolUse hooks) were previously invisible in both the TUI transcript and CLI output. The engine short-circuited before calling emit_tool_call_fn for blocked calls, so no event was ever emitted.

Adds ToolEvent::Blocked { id, name, input, reason } and wires it end-to-end:

- harnx-core: new ToolEvent::Blocked variant
- harnx-engine: new emit_tool_blocked_fn callback on ToolEvalContext; called in both blocked branches (HookResultControl::Block and Ask deny path)
- harnx-runtime: emit_tool_blocked_with_template; wired in build_tool_eval_context
- harnx-tui: ToolEvent::Blocked treated as turn boundary; renders as TranscriptItem::ToolCall with YAML input + "⊘ blocked: <reason>" body
- harnx: CLI sink prints "blocked: {name} — {reason}" warning for blocked calls
- Tests: engine test verifies blocked emitter called exactly once; TUI test verifies blocked event produces transcript item with "⊘ blocked" in body

Closes #356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool calls that are blocked by hooks or user denial are now visible in the transcript with the blocking reason, addressing previous invisibility in logs and transcripts.
  * TUI displays blocked tool calls with a visual indicator and the attempted input.
  * CLI displays blocked tool information in command output.

* **Documentation**
  * Added documentation explaining the blocked tool visibility feature and implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->