### PR TITLE
Require agent and session for all activity

### DIFF
--- a/.changesets/require-agent-session-451.md
+++ b/.changesets/require-agent-session-451.md
@@ -1,0 +1,11 @@
+---
+harnx: minor
+---
+Require agent and session for all activity (#451).
+
+- **CLI**: Running `harnx <prompt>` without `--agent/-a` now errors with a clear message instead of proceeding anonymously.
+- **CLI**: Non-interactive runs auto-resume a matching session (same agent, terminal, git branch, remote, and working directory) instead of always creating a new one.
+- **TUI**: Starting `harnx` with no agents configured now exits with a helpful error message.
+- **Switching**: Agent and session can now be changed directly without running `.exit agent` or `.exit session` first.
+- **Removed commands**: `.exit session` and `.exit agent` are no longer available (use `.agent <name>` or `.session <name>` to switch directly).
+- **Cleanup**: Legacy message-file saving without an active session has been removed.

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -22,7 +22,7 @@ pub enum CommandOutcome {
     Exit,
 }
 
-pub static COMMANDS: LazyLock<[Command; 47]> = LazyLock::new(|| {
+pub static COMMANDS: LazyLock<[Command; 45]> = LazyLock::new(|| {
     [
         Command::new(".help", "Show this help guide"),
         Command::new(".info", "Show system info"),
@@ -59,11 +59,9 @@ pub static COMMANDS: LazyLock<[Command; 47]> = LazyLock::new(|| {
             "Edit a range of log entries by sequence number",
         ),
         Command::new(".save session", "Save current session to file"),
-        Command::new(".exit session", "Exit active session"),
         Command::new(".agent", "Use an agent"),
         Command::new(".starter", "Use a conversation starter"),
         Command::new(".info agent", "Show agent info"),
-        Command::new(".exit agent", "Leave agent"),
         Command::new(".rag", "Initialize or access RAG"),
         Command::new(
             ".edit rag-docs",
@@ -664,18 +662,8 @@ Commands:
                 set_text(&output).context("Failed to copy the last chat response")?;
             }
             ".exit" => match args {
-                Some("session") => {
-                    if config.read().agent.is_some() {
-                        config.write().exit_agent_session()?;
-                    } else {
-                        config.write().exit_session()?;
-                    }
-                }
                 Some("rag") => {
                     config.write().exit_rag()?;
-                }
-                Some("agent") => {
-                    config.write().exit_agent()?;
                 }
                 Some(_) => unknown_command()?,
                 None => {

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -11,7 +11,8 @@ pub use self::agent::{CREATE_TITLE_AGENT, TEMP_AGENT_NAME};
 pub use self::input::Input;
 use self::session::Session;
 pub use self::session_meta::{
-    build_picker_context, parse_session_meta, sort_sessions_for_picker, PickerContext, SessionMeta,
+    build_picker_context, find_matching_session, parse_session_meta, sort_sessions_for_picker,
+    PickerContext, SessionMeta,
 };
 pub use harnx_core::last_message::LastMessage;
 #[allow(unused_imports)]
@@ -25,8 +26,8 @@ use harnx_core::config_paths as paths;
 use harnx_core::session::SessionLogEntry;
 
 use crate::client::{
-    create_client_config, list_client_types, list_models, ClientConfig, MessageContentToolCalls,
-    Model, ModelType, ProviderModels, OPENAI_COMPATIBLE_PROVIDERS,
+    create_client_config, list_client_types, list_models, ClientConfig, Model, ModelType,
+    ProviderModels, OPENAI_COMPATIBLE_PROVIDERS,
 };
 use crate::commands::{run_command, split_args_text};
 use crate::tool::{ToolDeclaration, ToolResult, Tools};
@@ -47,8 +48,7 @@ use simplelog::LevelFilter;
 use std::collections::{HashMap, HashSet};
 use std::{
     env,
-    fs::{read_dir, read_to_string, remove_dir_all, remove_file, File, OpenOptions},
-    io::Write,
+    fs::{read_dir, read_to_string, remove_dir_all, remove_file},
     path::{Path, PathBuf},
     process,
     sync::{Arc, OnceLock},
@@ -1310,6 +1310,10 @@ impl Config {
     }
 
     pub fn use_agent_obj(&mut self, agent: Agent) -> Result<()> {
+        if self.agent.is_some() {
+            self.exit_agent()?;
+        }
+
         // Reinitialize MCP/ACP managers scoped to the incoming agent's package
         // (or None for top-level agents). This gives the agent a clean view:
         // same-package MCP servers appear under their bare names, others prefixed.
@@ -1317,12 +1321,7 @@ impl Config {
             harnx_core::package_namespace::pkg_from_qualified(agent.name()).map(str::to_string);
         self.reinit_managers_for_agent(agent_package.as_deref());
 
-        if let Some(session) = self.session.as_mut() {
-            session.guard_empty()?;
-            session.set_agent(&agent)?;
-        } else {
-            self.agent = Some(agent);
-        }
+        self.agent = Some(agent);
         Ok(())
     }
 
@@ -1424,9 +1423,7 @@ impl Config {
 
     pub fn use_session(&mut self, session_name: Option<&str>) -> Result<()> {
         if self.session.is_some() {
-            bail!(
-                "Already in a session, please run '.exit session' first to exit the current session."
-            );
+            self.exit_session()?;
         }
         let mut session;
         match session_name {
@@ -2287,7 +2284,7 @@ impl Config {
             bail!("Please enable tool use before using the agent.");
         }
         if config.read().agent.is_some() {
-            bail!("Already in a agent, please run '.exit agent' first to exit the current agent.");
+            config.write().exit_agent()?;
         }
         let agent = self::agent::init(config, agent_name, abort_signal).await?;
         let session = session_name.map(|v| v.to_string());
@@ -2848,54 +2845,7 @@ impl Config {
             }
         }
 
-        if !self.save {
-            return Ok(());
-        }
-        let mut file = self.open_message_file()?;
-        if output.is_empty() && input.tool_calls().is_none() {
-            return Ok(());
-        }
-        let now = now();
-        let summary = input.summary();
-        let raw_input = input.raw();
-        let scope = if self.agent.is_none() {
-            let agent_name = match input.agent().name() {
-                TEMP_AGENT_NAME => None,
-                "" => None,
-                name => Some(name),
-            };
-            match (agent_name, input.rag_name()) {
-                (Some(agent), Some(rag_name)) => format!(" ({agent}#{rag_name})"),
-                (Some(agent), _) => format!(" ({agent})"),
-                (None, Some(rag_name)) => format!(" (#{rag_name})"),
-                _ => String::new(),
-            }
-        } else {
-            String::new()
-        };
-        let tool_calls = match input.tool_calls() {
-            Some(MessageContentToolCalls {
-                tool_results, text, ..
-            }) => {
-                let mut lines = vec!["<tool_calls>".to_string()];
-                if !text.is_empty() {
-                    lines.push(text.clone());
-                }
-                lines.push(serde_json::to_string(&tool_results).unwrap_or_default());
-                lines.push("</tool_calls>\n".to_string());
-                lines.join("\n")
-            }
-            None => String::new(),
-        };
-        let thought = match thought {
-            Some(v) => format!("<think>\n{v}\n</think>\n"),
-            None => String::new(),
-        };
-        let output = format!(
-            "# CHAT: {summary} [{now}]{scope}\n{raw_input}\n--------\n{thought}{tool_calls}{output}\n--------\n\n",
-        );
-        file.write_all(output.as_bytes())
-            .with_context(|| "Failed to save message")
+        Ok(())
     }
 
     fn init_agent_shared_variables(&mut self) -> Result<()> {
@@ -2948,16 +2898,6 @@ impl Config {
             agent.set_session_variables(variables.clone());
         }
         Ok(())
-    }
-
-    fn open_message_file(&self) -> Result<File> {
-        let path = self.messages_file();
-        ensure_parent_exists(&path)?;
-        OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-            .with_context(|| format!("Failed to create/append {}", path.display()))
     }
 
     fn load_from_file(config_path: &Path) -> Result<Self> {

--- a/crates/harnx-runtime/src/config/session_meta.rs
+++ b/crates/harnx-runtime/src/config/session_meta.rs
@@ -37,7 +37,7 @@ pub fn build_picker_context() -> PickerContext {
     }
 }
 
-fn session_recency_key(session: &SessionMeta) -> u128 {
+pub(crate) fn session_recency_key(session: &SessionMeta) -> u128 {
     if let Some(seconds) = crate::utils::session_name::decode_timestamp_session_id(&session.id) {
         return u128::MAX - (seconds as u128 * 1_000);
     }
@@ -61,6 +61,47 @@ fn session_recency_key(session: &SessionMeta) -> u128 {
     }
 
     u128::MAX
+}
+
+/// For CLI auto-session: find a session that exactly matches all available
+/// context fields. All non-None current context fields must match.
+/// If a context field is None (e.g. no terminal ID, not in a git repo),
+/// that criterion is skipped (treated as matching).
+/// Returns the most recent matching session's id, or None if no match.
+pub fn find_matching_session(
+    sessions: &[SessionMeta],
+    context: &PickerContext,
+    agent_name: &str,
+) -> Option<String> {
+    let mut candidates: Vec<&SessionMeta> = sessions
+        .iter()
+        .filter(|s| {
+            if s.agent_name.as_deref() != Some(agent_name) {
+                return false;
+            }
+            if let Some(ref cur_terminal) = context.current_terminal_id {
+                if s.terminal_session_id.as_deref() != Some(cur_terminal.as_str()) {
+                    return false;
+                }
+            }
+            if let Some(ref cur_branch) = context.current_branch {
+                if s.git_branch.as_deref() != Some(cur_branch.as_str()) {
+                    return false;
+                }
+            }
+            if let Some(ref cur_remote) = context.current_remote {
+                if s.git_remote.as_deref() != Some(cur_remote.as_str()) {
+                    return false;
+                }
+            }
+            if s.working_dir.as_deref() != Some(context.current_dir.as_str()) {
+                return false;
+            }
+            true
+        })
+        .collect();
+    candidates.sort_by_key(|s| session_recency_key(s));
+    candidates.first().map(|s| s.id.clone())
 }
 
 pub fn sort_sessions_for_picker(
@@ -190,8 +231,8 @@ pub fn parse_session_meta(name: &str, path: &Path) -> Option<SessionMeta> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_picker_context, parse_session_meta, sort_sessions_for_picker, PickerContext,
-        SessionMeta,
+        build_picker_context, find_matching_session, parse_session_meta, sort_sessions_for_picker,
+        PickerContext, SessionMeta,
     };
     use std::fs;
     use std::time::{Duration, UNIX_EPOCH};
@@ -348,6 +389,54 @@ mod tests {
 
         let sorted = sort_sessions_for_picker(vec![older, newer.clone()], &context);
         assert_eq!(sorted[0].id, newer.id);
+    }
+
+    #[test]
+    fn test_find_matching_session_matches_all_available_context_fields() {
+        let mut matching = session_meta("018f0d1c-5b2a-7000-8000-000000000000");
+        matching.agent_name = Some("smith".to_string());
+        matching.terminal_session_id = Some("term-1".to_string());
+        matching.git_branch = Some("main".to_string());
+        matching.git_remote = Some("origin".to_string());
+        matching.working_dir = Some("/work".to_string());
+        matching.modified = Some(UNIX_EPOCH + Duration::from_secs(1));
+
+        let mut wrong_branch = matching.clone();
+        wrong_branch.id = "018f0d1c-5b2b-7000-8000-000000000000".to_string();
+        wrong_branch.git_branch = Some("feature".to_string());
+        wrong_branch.modified = Some(UNIX_EPOCH + Duration::from_secs(2));
+
+        let context = PickerContext {
+            current_terminal_id: Some("term-1".to_string()),
+            current_branch: Some("main".to_string()),
+            current_dir: "/work".to_string(),
+            current_remote: Some("origin".to_string()),
+        };
+
+        let found = find_matching_session(&[wrong_branch, matching.clone()], &context, "smith");
+        assert_eq!(found.as_deref(), Some(matching.id.as_str()));
+    }
+
+    #[test]
+    fn test_find_matching_session_skips_none_context_fields_and_picks_most_recent() {
+        let mut older = session_meta("018f0d1c-5b2a-7000-8000-000000000000");
+        older.agent_name = Some("smith".to_string());
+        older.working_dir = Some("/work".to_string());
+        older.modified = Some(UNIX_EPOCH + Duration::from_secs(1));
+
+        let mut newer = older.clone();
+        newer.id = "018f0d1c-5b2b-7000-8000-000000000000".to_string();
+        newer.modified = Some(UNIX_EPOCH + Duration::from_secs(2));
+
+        let context = PickerContext {
+            current_terminal_id: None,
+            current_branch: None,
+            current_dir: "/work".to_string(),
+            current_remote: None,
+        };
+
+        let found = find_matching_session(&[older, newer.clone()], &context, "smith");
+        assert_eq!(found.as_deref(), Some(newer.id.as_str()));
     }
 
     #[test]

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -423,6 +423,25 @@ impl Tui {
                         self.run_command(&text).await?;
                         self.refresh_input_chrome();
                     } else {
+                        // Guard: agent and session must both be active before
+                        // submitting a prompt. If not, open the appropriate picker
+                        // and keep the text in the input so the user can retry.
+                        // The in-memory check (agent/session None) is always safe;
+                        // resolve_initial_modal is only called when the check fires.
+                        {
+                            let needs_picker = {
+                                let cfg = self.config.read();
+                                cfg.agent.is_none() || cfg.session.is_none()
+                            };
+                            if needs_picker {
+                                if let Some(modal) =
+                                    crate::types::Tui::resolve_initial_modal(&self.config)
+                                {
+                                    self.app.modal = Some(modal);
+                                    return Ok(());
+                                }
+                            }
+                        }
                         let attachments_snapshot = self.app.attachments.clone();
                         self.app.transcript.push(TranscriptItem::UserText {
                             text: text.clone(),

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -56,11 +56,32 @@ impl Tui {
         self.refresh_input_chrome();
     }
 
+    /// Check whether agents are available to start the TUI.
+    /// Returns an error if no agent is configured and no assistant agents are
+    /// installed on disk. Extracted so it can be called and tested independently
+    /// of the full `init()` path.
+    pub(crate) fn check_agents_available(config: &GlobalConfig, agents: &[String]) -> Result<()> {
+        if config.read().agent.is_none() && agents.is_empty() {
+            anyhow::bail!(
+                "No agents configured. Create an agent file in the agents/ directory first."
+            );
+        }
+        Ok(())
+    }
+
     pub fn init(
         config: &GlobalConfig,
         async_manager: AsyncHookManager,
         persistent_manager: Arc<Mutex<PersistentHookManager>>,
     ) -> Result<Self> {
+        let agents = list_assistant_agents();
+        // Skip agents check in tests: test configs use a bare `Config::default()`
+        // with no agents directory populated, but the production check is covered
+        // by direct unit tests of `check_agents_available`.
+        if !cfg!(test) {
+            Self::check_agents_available(config, &agents)?;
+        }
+
         let (event_tx, event_rx) = mpsc::unbounded_channel();
         install_tui_agent_event_sink(event_tx.clone());
 

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -2705,7 +2705,8 @@ async fn direct_submit_with_attachments_renders_attachment_entries_in_transcript
     use crate::types::Attachment;
     use std::path::PathBuf;
 
-    let config = test_config();
+    // Agent + session required since #451 enforces both before prompt submission.
+    let config = test_config_with_mock_client_and_agent("test-agent", Some("test-session"));
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
     let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent).unwrap();
 
@@ -5957,6 +5958,52 @@ async fn test_picker_shown_when_no_agent_and_agents_exist() {
 }
 
 // ---------------------------------------------------------------------------
+// check_agents_available — startup guard for no-agents case
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_check_agents_available_errors_when_no_agent_and_no_agents() {
+    // When no agent is set in config AND no assistant agents are installed,
+    // check_agents_available must return an error.
+    let config = test_config();
+    let result = crate::types::Tui::check_agents_available(&config, &[]);
+    assert!(
+        result.is_err(),
+        "check_agents_available must error when no agent selected and no agents installed"
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("No agents configured"),
+        "error message should mention 'No agents configured', got: {err_msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_check_agents_available_ok_when_agents_exist() {
+    // When assistant agents exist on disk, check_agents_available must not error
+    // even if no agent is currently selected.
+    let config = test_config();
+    let agents = vec!["my-agent".to_string()];
+    let result = crate::types::Tui::check_agents_available(&config, &agents);
+    assert!(
+        result.is_ok(),
+        "check_agents_available must not error when agents are available"
+    );
+}
+
+#[tokio::test]
+async fn test_check_agents_available_ok_when_agent_selected_even_without_agents_dir() {
+    // When an agent is already selected in config, check_agents_available
+    // must succeed regardless of the agents directory state.
+    let config = test_config_with_mock_client_and_agent("test-agent", None);
+    let result = crate::types::Tui::check_agents_available(&config, &[]);
+    assert!(
+        result.is_ok(),
+        "check_agents_available must not error when an agent is already active"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Picker tests — AgentPicker filtering, SessionPicker ESC, agent activation
 // ---------------------------------------------------------------------------
 
@@ -7006,5 +7053,55 @@ async fn test_browsing_mode_non_navigable_items_visible_not_focusable() {
         harness.tui().app.transcript_focus,
         Some(2),
         "Down should skip non-navigable ToolResultMarkdown at index 1 and focus AssistantText at index 2"
+    );
+}
+
+#[tokio::test]
+async fn test_agent_command_leaves_tui_without_session_gap() {
+    let mut harness = TuiTestHarness::with_size(60, 20);
+    let tui = harness.tui();
+    let config = tui.config.clone();
+
+    // 1. Setup initial state: agent + session
+    {
+        let mut guard = config.write();
+        let mut agent = harnx_runtime::config::Agent::default();
+        agent.set_name("agent-a");
+        guard.agent = Some(agent);
+
+        let session = harnx_runtime::config::session::new(&guard, "session-a").unwrap();
+        guard.session = Some(session);
+    }
+
+    // 2. Simulate .agent command effect (manually for speed, or we can try run_command)
+    // Actually let's use run_command if we can, but we need agent-b to exist.
+    // Let's just manually clear session to simulate what .agent does.
+    {
+        let mut guard = config.write();
+        guard.exit_session().unwrap();
+    }
+
+    // 3. Try to send a message
+    harness.tui().set_input_text("hello");
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    // 4. Check if it allowed the prompt task to start
+    // If there's a gap, it will be Some. If it's blocked, it should be None (and maybe a modal open).
+    let task_started = harness.tui().current_prompt_handle.is_some();
+
+    // We also check if a modal was opened to fix the situation
+    let modal_open = harness.tui().app.modal.is_some();
+
+    assert!(
+        !task_started,
+        "Prompt task should NOT have started without a session!"
+    );
+    assert!(
+        modal_open,
+        "Expected a picker to be open when session is missing!"
     );
 }

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -223,9 +223,27 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
                 abort_signal.clone(),
             );
             {
+                let cfg = config.read();
+                if cfg.agent.is_none() {
+                    bail!("No agent selected. Use --agent/-a to specify an agent.");
+                }
+            }
+            {
                 let mut cfg = config.write();
                 if cfg.session.is_none() {
-                    cfg.use_session(None)?;
+                    use harnx_runtime::config::{build_picker_context, find_matching_session};
+                    let sessions = cfg.list_sessions_with_meta();
+                    let ctx = build_picker_context();
+                    let agent_name = cfg
+                        .agent
+                        .as_ref()
+                        .map(|a| a.name().to_string())
+                        .unwrap_or_default();
+                    let matching_id = find_matching_session(&sessions, &ctx, &agent_name);
+                    if let Some(ref id) = matching_id {
+                        eprintln!("{}", dimmed_text(&format!("Resuming session {id}")));
+                    }
+                    cfg.use_session(matching_id.as_deref())?;
                 }
             }
             let input = create_input(&config, text, &cli.file, abort_signal.clone()).await?;

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -301,7 +301,6 @@ harnx --agent coder --agent-variable language=rust "write a web server"
 .info agent          Show current agent info
 .edit agent          Edit the agent's .md file
 .save agent [name]   Save current agent configuration
-.exit agent          Exit the active agent
 ```
 
 ### Inline Prompt

--- a/docs/solutions/workflow-issues/testable-startup-guards-exact-session-matching-2026-05-08.md
+++ b/docs/solutions/workflow-issues/testable-startup-guards-exact-session-matching-2026-05-08.md
@@ -1,0 +1,210 @@
+---
+title: "Testable startup guards and exact session matching for CLI context reuse"
+date: 2026-05-08
+category: "workflow-issues"
+problem_type: workflow_issue
+component: "harnx-tui, harnx-runtime/config, harnx CLI"
+root_cause: "Disk-dependent startup checks untestable; CLI session matching used priority sort instead of exact match"
+resolution_type: code_fix
+severity: medium
+tags:
+  - testing
+  - cfg-test
+  - session-management
+  - cli
+  - tui
+  - agent-switching
+plan_ref: "harnx-451-require-agent-session"
+---
+
+## Problem
+
+TUI startup guard `list_assistant_agents()` reads from disk, making `init()` untestable. CLI session auto-selection used priority-sorted ranking designed for TUI pickers, causing ambiguity when user wanted exact context match. Switching agents saved session after agent field changed, writing to wrong directory.
+
+## Symptoms
+
+- No unit tests for TUI "no agents available" startup guard
+- CLI created new session instead of resuming exact-match session
+- Session files written to wrong agent directory after agent switch
+- `init()` required agents directory populated even for unit tests
+
+## Investigation Steps
+
+1. TUI `init()` called `list_assistant_agents()` directly; no way to inject agent list
+2. `sort_sessions_for_picker()` uses priority ranking: terminal ID match first, then branch, then remote — designed for TUI picker "best candidate" UX
+3. CLI needs exact match: resume if all context fields match, else create fresh session
+4. Reviewed `use_agent()` path: `self.agent = Some(agent)` happened before `self.session.save()`, but `save()` uses `sessions_dir()` which reads `self.agent`
+
+## Root Cause
+
+**Untestable startup guard:** Startup checks read from disk/env not populated in test environments. Without extraction, the guard logic could not be unit tested.
+
+**Wrong matching algorithm:** `sort_sessions_for_picker()` ranks sessions by priority for interactive pickers. CLI non-interactive mode needs exact match (all criteria must match, not "best match").
+
+**Agent-switch ordering bug:** `sessions_dir()` is computed from `self.agent`. If agent field changes before session save, session files written to wrong directory.
+
+## Solution
+
+### 1. Testable Startup Guard with `cfg!(test)` Bypass
+
+Extract pure logic into `pub(crate)` function that accepts the disk-dependent value as parameter:
+
+```rust
+// crates/harnx-tui/src/lifecycle.rs
+impl Tui {
+    /// Check whether agents are available to start the TUI.
+    /// Extracted so it can be called and tested independently.
+    pub(crate) fn check_agents_available(config: &GlobalConfig, agents: &[String]) -> Result<()> {
+        if config.read().agent.is_none() && agents.is_empty() {
+            anyhow::bail!(
+                "No agents configured. Create an agent file in the agents/ directory first."
+            );
+        }
+        Ok(())
+    }
+
+    pub fn init(...) -> Result<Self> {
+        let agents = list_assistant_agents();
+        // Skip agents check in tests: test configs use bare Config::default()
+        // with no agents directory, but check is covered by direct unit tests.
+        if !cfg!(test) {
+            Self::check_agents_available(config, &agents)?;
+        }
+        // ... rest of init
+    }
+}
+```
+
+Unit tests call `check_agents_available()` directly with controlled inputs:
+
+```rust
+// crates/harnx-tui/src/tests.rs
+#[tokio::test]
+async fn test_check_agents_available_errors_when_no_agent_and_no_agents() {
+    let config = GlobalConfig::default();
+    let result = Tui::check_agents_available(&config, &[]);
+    assert!(result.is_err(), "must error when no agent and no agents");
+}
+
+#[tokio::test]
+async fn test_check_agents_available_ok_when_agents_exist() {
+    let config = GlobalConfig::default();
+    let agents = vec!["assistant-agent".to_string()];
+    let result = Tui::check_agents_available(&config, &agents);
+    assert!(result.is_ok(), "must not error when agents are available");
+}
+```
+
+### 2. Exact Match for CLI Session Auto-Selection
+
+Add `find_matching_session()` that requires all non-None context fields to match:
+
+```rust
+// crates/harnx-runtime/src/config/session_meta.rs
+/// For CLI auto-session: find a session that exactly matches all available
+/// context fields. All non-None current context fields must match.
+/// Returns the most recent matching session's id, or None if no match.
+pub fn find_matching_session(
+    sessions: &[SessionMeta],
+    context: &PickerContext,
+    agent_name: &str,
+) -> Option<String> {
+    let candidates: Vec<_> = sessions
+        .iter()
+        .filter(|s| {
+            if s.agent_name.as_deref() != Some(agent_name) {
+                return false;
+            }
+            if let Some(term_id) = &context.current_terminal_id {
+                if s.terminal_session_id.as_deref() != Some(term_id.as_str()) {
+                    return false;
+                }
+            }
+            // ... same pattern for git_branch, git_remote, working_dir
+            true
+        })
+        .collect();
+    candidates.sort_by_key(|s| session_recency_key(s));
+    candidates.first().map(|s| s.id.clone())
+}
+```
+
+CLI entry calls this for context-aware session reuse:
+
+```rust
+// crates/harnx/src/main.rs, WorkingMode::Cmd branch
+let context = build_picker_context();
+let existing_session = find_matching_session(&sessions, &context, agent_name);
+config.write().use_session(existing_session.as_deref())?;
+```
+
+**Key distinction:**
+- `sort_sessions_for_picker()`: Priority-ranked for TUI interactive picker
+- `find_matching_session()`: Exact match for CLI non-interactive reuse
+
+### 3. Exit Session Before Changing Agent
+
+`use_agent()` now calls `exit_agent()` before setting `self.agent`:
+
+```rust
+// crates/harnx-runtime/src/config/mod.rs
+pub async fn use_agent(&mut self, agent_name: &str, ...) -> Result<()> {
+    if config.read().agent.is_some() {
+        config.write().exit_agent()?;  // Exit BEFORE agent field changes
+    }
+    let agent = init(config, agent_name, abort_signal).await?;
+    // Now safe to activate new agent
+}
+```
+
+`exit_agent()` calls `self.session.save()` which uses `sessions_dir()` computed from current `self.agent`. Order matters: save first, then change agent.
+
+## Why This Works
+
+1. **Testable extraction:** Pure function accepts disk-dependent value as parameter; unit tests verify logic without disk I/O
+2. **`cfg!(test)` is legitimate here:** Bypass only acceptable because (a) check logic is separately unit tested, (b) comment explains why bypass exists
+3. **Exact matching for CLI:** Non-interactive mode needs deterministic "resume or create fresh" behavior, not "pick best candidate"
+4. **Exit-before-change ordering:** Session save path computed from agent field; must save before field mutation
+
+## Prevention Strategies
+
+**Test Cases:**
+- `test_check_agents_available_errors_when_no_agent_and_no_agents` — guard fails with no agent configured
+- `test_check_agents_available_ok_when_agents_exist` — guard passes when agents available
+- `test_check_agents_available_ok_when_agent_selected` — guard passes when agent already active
+- `test_find_matching_session_matches_all_available_context_fields` — exact match on all fields
+- `test_find_matching_session_skips_none_context_fields` — None fields treated as wildcard
+
+**Pattern Recognition:**
+- `cfg!(test)` bypass is acceptable ONLY when bypassed logic is separately unit tested via extracted function
+- Document the bypass with a comment explaining why it exists
+- TUI picker uses priority sort; CLI non-interactive uses exact match
+
+**Code Review Checklist:**
+- [ ] Startup checks that read disk/env extracted to testable functions
+- [ ] `cfg!(test)` bypasses have explanatory comments
+- [ ] CLI session matching uses exact match, not priority sort
+- [ ] Session save happens before agent/session field mutation
+- [ ] Agent switching tests verify session files written to correct directory
+
+## Key Learnings
+
+1. **Testable startup guards:** Extract pure logic to `pub(crate)` function accepting disk-dependent value as parameter; use `cfg!(test)` in `init()` to bypass disk read; unit test extracted function directly
+2. **Session-context matching for CLI:** Non-interactive CLI needs exact matching (all criteria must match); TUI picker needs priority-sorted ranking (best candidate at top)
+3. **Agent-scoped session switching:** Save session BEFORE changing agent field; `sessions_dir()` computed from `self.agent`
+4. **`cfg!(test)` bypass pattern:** Legitimate when (a) bypassed logic is separately unit tested, (b) documented with explanatory comment
+
+## Related Issues
+
+- **GitHub:** [#451](https://github.com/dobesv/harnx/issues/451) — Require agent and session for all activity
+- **GitHub:** [#450](https://github.com/dobesv/harnx/issues/450) — Allow switching agent/session without .exit first
+- **Related Solution:** [logic-errors/agent-switch-with-session-consistency-2026-05-03.md](../logic-errors/agent-switch-with-session-consistency-2026-05-03.md) — Agent switching session ordering
+- **Related Solution:** [integration-issues/session-picker-multi-factor-sorting-2026-05-02.md](../integration-issues/session-picker-multi-factor-sorting-2026-05-02.md) — TUI picker priority sort
+- **Related Solution:** [logic-errors/cli-session-auto-created-cmd-mode-2026-05-08.md](../logic-errors/cli-session-auto-created-cmd-mode-2026-05-08.md) — CLI session bootstrap
+- **Files Changed:**
+  - `crates/harnx/src/main.rs` — CLI agent guard + context-aware session reuse
+  - `crates/harnx-runtime/src/config/mod.rs` — session/agent switching without forced exit, removed legacy save fallback
+  - `crates/harnx-runtime/src/config/session_meta.rs` — `find_matching_session()` for exact CLI context match
+  - `crates/harnx-tui/src/lifecycle.rs` — startup guard extracted to testable function
+  - `crates/harnx-tui/src/tests.rs` — 3 new tests for `check_agents_available`
+  - `crates/harnx-runtime/src/commands.rs` — removed `.exit session`/`.exit agent`

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -47,7 +47,6 @@ openai:gpt-4o     128000 /     4096  |       5 /     15    👁 ⚒
 .info session            Show session info
 .edit session            Modify current session
 .save session            Save current session to file
-.exit session            Exit active session
 ```
 
 ### `.agent` - agent management
@@ -57,7 +56,6 @@ openai:gpt-4o     128000 /     4096  |       5 /     15    👁 ⚒
 .info agent              Show agent info
 .edit agent              Edit agent .md file
 .save agent [name]       Save current agent to file
-.exit agent              Exit active agent
 .starter                 Use a conversation starter
 ```
 
@@ -146,8 +144,6 @@ If the response is interrupted or unsatisfactory, you can regenerate it with `.r
 ### `.exit` - exit the current scope
 
 ```text
-.exit session            Exit active session
-.exit agent              Exit active agent
 .exit rag                Leave RAG
 .exit                    Exit the interactive session
 ```


### PR DESCRIPTION
- CLI: bail with clear error if no --agent/-a provided in non-interactive mode
- CLI: auto-match existing session by agent, terminal, branch, remote, cwd instead of always creating a new anonymous session
- TUI: bail at startup when no agent configured and no assistant agents exist
- TUI: extract check_agents_available() as testable pub(crate) function; add 3 unit tests covering all code paths
- Remove .exit session and .exit agent dot-commands
- Allow switching agent/session without .exit first (closes #450): use_session() now exits current session before switching, use_agent() now exits current agent before switching, use_agent_obj() no longer requires session to be empty
- Remove legacy message-file saving without an active session
- Add find_matching_session() to session_meta for CLI context-aware reuse
- Update docs: remove .exit session/.exit agent from tui-guide.md and agent-guide.md
- Add changeset for minor version bump

#451

Plan: harnx-451-require-agent-session