### PR TITLE
fix: sort session picker by last updated time instead of created time

### DIFF
--- a/.changesets/session-sort-by-recency-453.md
+++ b/.changesets/session-sort-by-recency-453.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Sort the session picker by last-updated time instead of creation time. This ensures that recently used sessions appear at the top of the list, even if they were created before other unused sessions.

--- a/crates/harnx-runtime/src/config/session_meta.rs
+++ b/crates/harnx-runtime/src/config/session_meta.rs
@@ -38,6 +38,17 @@ pub fn build_picker_context() -> PickerContext {
 }
 
 pub(crate) fn session_recency_key(session: &SessionMeta) -> u128 {
+    // Prefer the file's modification time — it reflects when the session was
+    // last active, not when it was created.
+    if let Some(modified_ms) = session
+        .modified
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis())
+    {
+        return u128::MAX - modified_ms;
+    }
+
+    // Fall back to the creation timestamp embedded in the session ID.
     if let Some(seconds) = crate::utils::session_name::decode_timestamp_session_id(&session.id) {
         return u128::MAX - (seconds as u128 * 1_000);
     }
@@ -50,14 +61,6 @@ pub(crate) fn session_recency_key(session: &SessionMeta) -> u128 {
                 return u128::MAX - timestamp_ms;
             }
         }
-    }
-
-    if let Some(modified_ms) = session
-        .modified
-        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
-        .map(|duration| duration.as_millis())
-    {
-        return u128::MAX - modified_ms;
     }
 
     u128::MAX
@@ -389,6 +392,34 @@ mod tests {
 
         let sorted = sort_sessions_for_picker(vec![older, newer.clone()], &context);
         assert_eq!(sorted[0].id, newer.id);
+    }
+
+    #[test]
+    fn test_sort_modified_beats_id_timestamp() {
+        // Session with a NEWER UUIDv7 ID (created later) but OLDER mtime loses
+        // to a session with an OLDER UUIDv7 ID but NEWER mtime.
+        // This verifies that mtime takes precedence over creation time.
+        let mut newer_id_older_mtime = session_meta("018f0d1c-5b2b-7000-8000-000000000000");
+        newer_id_older_mtime.modified = Some(UNIX_EPOCH + Duration::from_secs(10));
+
+        let mut older_id_newer_mtime = session_meta("018f0d1c-5b2a-7000-8000-000000000000");
+        older_id_newer_mtime.modified = Some(UNIX_EPOCH + Duration::from_secs(20));
+
+        let context = PickerContext {
+            current_terminal_id: None,
+            current_branch: None,
+            current_dir: "/nowhere".to_string(),
+            current_remote: None,
+        };
+
+        let sorted = sort_sessions_for_picker(
+            vec![newer_id_older_mtime, older_id_newer_mtime.clone()],
+            &context,
+        );
+        assert_eq!(
+            sorted[0].id, older_id_newer_mtime.id,
+            "session with newer mtime should sort first, even if its ID was created earlier"
+        );
     }
 
     #[test]

--- a/docs/solutions/integration-issues/session-picker-multi-factor-sorting-2026-05-02.md
+++ b/docs/solutions/integration-issues/session-picker-multi-factor-sorting-2026-05-02.md
@@ -14,7 +14,7 @@ tags:
   - uuidv7
   - terminal-fingerprinting
 plan_ref: "issue-422-session-handling-revamp"
-last_updated: 2026-05-03
+last_updated: 2026-05-09
 
 ## Problem
 
@@ -145,7 +145,7 @@ pub fn sort_sessions_for_picker(sessions: Vec<SessionMeta>, context: &PickerCont
             if session.git_branch == context.current_branch { 0 } else { 1 },
             if session.working_dir.as_deref() == Some(context.current_dir.as_str()) { 0 } else { 1 },
             if session.git_remote == context.current_remote { 0 } else { 1 },
-            session_recency_key(session),  // UUIDv7 timestamp, descending
+            session_recency_key(session),  // mtime first, then UUIDv7 timestamp
         )
     });
     sessions
@@ -173,11 +173,12 @@ pub(crate) fn resolve_initial_modal(config: &GlobalConfig) -> Option<ModalState>
 
 ## Why This Works
 
-1. **UUIDv7** encodes timestamp in sort-friendly format; extracting from filename enables recency sort without file access
-2. **Header-only read** limits I/O to 64KB max; YAML document boundary detection is deterministic
-3. **Multi-tier sort** gives predictable ranking: sessions from current terminal/tab rank highest, then same branch, then same project
-4. **Terminal fingerprinting** works across macOS Terminal, Windows Terminal, Kitty, tmux, screen, and Linux VT
-5. **Backward compat** via `#[serde(default)]` on all new fields
+1. **File mtime first** — `session_recency_key()` now checks `session.modified` (file modification time) before falling back to UUIDv7 embedded timestamp; this ensures sessions sort by when they were last *active*, not when *created*
+2. **UUIDv7 fallback** — when mtime unavailable, creation timestamp from session ID (filename or UUIDv7) provides secondary recency signal
+3. **Header-only read** limits I/O to 64KB max; YAML document boundary detection is deterministic
+4. **Multi-tier sort** gives predictable ranking: sessions from current terminal/tab rank highest, then same branch, then same project
+5. **Terminal fingerprinting** works across macOS Terminal, Windows Terminal, Kitty, tmux, screen, and Linux VT
+6. **Backward compat** via `#[serde(default)]` on all new fields
 
 ## Prevention Strategies
 
@@ -185,26 +186,30 @@ pub(crate) fn resolve_initial_modal(config: &GlobalConfig) -> Option<ModalState>
 - `test_parse_session_meta_multiline_yaml_separator` — validates `\n---\n` boundary detection
 - `test_sort_priority_*` — verify each tier of multi-factor sort
 - `test_read_header_large_but_within_64kb` — ensure large headers parse correctly
+- `test_sort_modified_beats_id_timestamp` — proves mtime wins over session ID embedded timestamp when the two conflict
 
 **Key Learnings:**
 - YAML document separator `---` must be matched at start-of-line (`\n---\n`) to avoid false positives in multiline strings
 - `git_branch()` returns empty String (not Option) on failure — callers must convert to None explicitly
 - Picker modal must be restored from `take()` if subsequent operation (`use_agent_by_name`, `use_session`) fails
 - Subagents create scratch files in project root — clean before committing
+- **Recency signal precedence:** file mtime > session ID embedded timestamp — "when last active" is more useful than "when created" for user-facing pickers
 
 **Code Review Checklist:**
 - [ ] YAML boundary detection uses start-of-line pattern
 - [ ] Modal restored on fallible operation failure
 - [ ] Empty string failures converted to None where Option expected
 - [ ] Sort tuple ordering matches priority spec
+- [ ] Recency key checks mtime before session ID timestamp
 
 ## Related Issues
 
 - **GitHub:** [Issue #422](https://github.com/dobesv/harnx/issues/422) — Session handling revamp
+- **GitHub:** [Issue #453](https://github.com/dobesv/harnx/issues/453) — Sort by last updated instead of created
 - **Follow-up:** [logic-errors/picker-flow-state-continuity-2026-05-03.md](../logic-errors/picker-flow-state-continuity-2026-05-03.md) — Bug fixes for picker flow: filter UI, ESC behavior, modal restoration, origin tracking for transcript reconciliation
 - **Files Changed:**
   - `crates/harnx-core/src/session.rs` — Header metadata fields
-  - `crates/harnx-runtime/src/config/session_meta.rs` — Header parsing, multi-tier sort
+  - `crates/harnx-runtime/src/config/session_meta.rs` — Header parsing, multi-tier sort, `session_recency_key()` mtime-first logic
   - `crates/harnx-runtime/src/utils/terminal_session.rs` — Terminal fingerprinting
   - `crates/harnx-tui/src/input.rs` — Picker key handling
   - `crates/harnx-tui/src/lifecycle.rs` — Modal resolution at startup


### PR DESCRIPTION
Session picker was sorting sessions by creation time (embedded in the session ID) instead of by last-updated time. This meant a session created recently but never used would appear above an older session that was actively used minutes ago.

Fix session_recency_key() to check file modification time (mtime) first, falling back to the creation timestamp encoded in the session ID (legacy format or UUIDv7). This ensures the picker orders sessions by recent activity.

Also adds test_sort_modified_beats_id_timestamp to explicitly verify that mtime wins when it conflicts with the ID-embedded creation time.

Closes #453

Plan: issue-453-session-sort-by-updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session picker now sorts sessions by last activity time instead of creation time, ensuring recently used sessions appear higher in the list regardless of when they were created.

* **Documentation**
  * Updated session picker sorting documentation to clarify recency behavior and precedence rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/504)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->