### PR TITLE
feat(tui): open agent/session picker for bare .agent/.session commands

### DIFF
--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -20,6 +20,10 @@ pub enum CommandOutcome {
     Continue,
     /// Exit the interactive session.
     Exit,
+    /// Open agent picker in TUI.
+    OpenAgentPicker,
+    /// Open session picker in TUI.
+    OpenSessionPicker,
 }
 
 pub static COMMANDS: LazyLock<[Command; 45]> = LazyLock::new(|| {
@@ -220,6 +224,9 @@ pub async fn run_command_with_output(
                 None => writeln!(output, "Usage: .prompt <text>...")?,
             },
             ".session" => {
+                if args.is_none() {
+                    return Ok(CommandOutcome::OpenSessionPicker);
+                }
                 config.write().use_session(args)?;
                 Config::maybe_autoname_session(config.clone());
             }
@@ -251,10 +258,7 @@ pub async fn run_command_with_output(
                     config.write().agent_variables = None;
                     ret?;
                 }
-                None => writeln!(
-                    output,
-                    r#"Usage: .agent <agent-name> [session-name] [key=value]..."#
-                )?,
+                None => return Ok(CommandOutcome::OpenAgentPicker),
             },
             ".starter" => match args {
                 Some(id) => {

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -6,7 +6,9 @@ use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use harnx_core::event::{AgentEvent, AgentSource};
 use harnx_render::pretty_error_string;
-use harnx_runtime::config::{build_picker_context, sort_sessions_for_picker};
+use harnx_runtime::config::{
+    build_picker_context, list_assistant_agents, sort_sessions_for_picker,
+};
 use harnx_runtime::utils::pretty_yaml_block;
 use ratatui_textarea::{Input as TextInput, Key};
 use std::path::Path;
@@ -20,6 +22,25 @@ const ATTACHMENT_PREVIEW_MAX_LINES: usize = 12;
 /// cooperative tools to observe the abort and return; short enough that
 /// the user does not feel a stall.
 const PROMPT_TASK_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PickerCommand {
+    Agent,
+    Session,
+}
+
+fn picker_command_for_input(line: &str, pos: usize) -> Option<PickerCommand> {
+    let upto_cursor = &line[..pos];
+    // Normalise the same way the command parser does: strip leading whitespace,
+    // then check that the only remaining content is the bare command name
+    // (no argument started after the command).
+    let trimmed = upto_cursor.trim_start();
+    match trimmed.trim_end() {
+        ".agent" => Some(PickerCommand::Agent),
+        ".session" => Some(PickerCommand::Session),
+        _ => None,
+    }
+}
 
 fn unique_attachment_display_name(
     attachments: &[crate::types::Attachment],
@@ -1548,9 +1569,20 @@ impl Tui {
             p.min(line.len())
         };
 
+        let picker_command = picker_command_for_input(&line, pos);
         let completions = self.compute_completions(&line, pos).await;
         if completions.is_empty() {
-            return;
+            match picker_command {
+                Some(PickerCommand::Agent) => {
+                    self.open_agent_picker();
+                    return;
+                }
+                Some(PickerCommand::Session) => {
+                    self.open_session_picker();
+                    return;
+                }
+                None => return,
+            }
         }
 
         // Compute replacement bounds so we only replace the token under the cursor.
@@ -1684,11 +1716,74 @@ impl Tui {
                     .collect();
             }
 
+            if matches!(cmd, ".agent" | ".session") && args.iter().all(|arg| arg.is_empty()) {
+                return vec![];
+            }
+
             let filter = args.last().copied().unwrap_or("");
             return self.config.read().command_complete(cmd, &args, filter);
         }
 
         vec![]
+    }
+
+    fn open_agent_picker(&mut self) {
+        self.app.modal = Some(crate::types::ModalState::AgentPicker {
+            agents: list_assistant_agents(),
+            selected: 0,
+            query: String::new(),
+        });
+    }
+
+    fn open_session_picker(&mut self) {
+        let sessions = self.config.read().list_sessions_with_meta();
+        let ctx = build_picker_context();
+        let sessions = sort_sessions_for_picker(sessions, &ctx);
+        let origin_agent = self
+            .config
+            .read()
+            .agent
+            .as_ref()
+            .map(|a| a.name().to_string());
+        let origin_session = self
+            .config
+            .read()
+            .session
+            .as_ref()
+            .map(|s| s.id().to_string());
+        self.app.modal = Some(crate::types::ModalState::SessionPicker {
+            sessions,
+            selected: 0,
+            origin_agent,
+            origin_session,
+        });
+    }
+
+    fn maybe_open_picker_after_command(
+        &mut self,
+        outcome: harnx_runtime::commands::CommandOutcome,
+        prev_agent: Option<String>,
+    ) {
+        match outcome {
+            harnx_runtime::commands::CommandOutcome::Continue => {
+                let cfg = self.config.read();
+                let curr_agent = cfg.agent.as_ref().map(|a| a.name().to_string());
+                let session_missing = cfg.session.is_none();
+                drop(cfg);
+                if prev_agent != curr_agent && session_missing {
+                    self.open_session_picker();
+                }
+            }
+            harnx_runtime::commands::CommandOutcome::Exit => {
+                self.app.should_quit = true;
+            }
+            harnx_runtime::commands::CommandOutcome::OpenAgentPicker => {
+                self.open_agent_picker();
+            }
+            harnx_runtime::commands::CommandOutcome::OpenSessionPicker => {
+                self.open_session_picker();
+            }
+        }
     }
 
     fn reconcile_transcript_after_command(
@@ -1774,9 +1869,7 @@ impl Tui {
 
         match result {
             Ok(outcome) => {
-                if matches!(outcome, harnx_runtime::commands::CommandOutcome::Exit) {
-                    self.app.should_quit = true;
-                }
+                self.maybe_open_picker_after_command(outcome, prev_agent.clone());
                 let llm_busy = self.app.llm_busy;
                 let pending_message = self.app.pending_message.is_some();
                 Self::refresh_input_chrome_from_state(

--- a/docs/solutions/logic-errors/dot-commands-picker-signals-2026-05-10.md
+++ b/docs/solutions/logic-errors/dot-commands-picker-signals-2026-05-10.md
@@ -1,0 +1,195 @@
+---
+title: "Runtime signals for TUI picker modals via CommandOutcome"
+date: 2026-05-10
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-runtime, harnx-tui"
+root_cause: "No mechanism for runtime to request TUI modal opening; bare .agent/.session commands had unclear behavior"
+resolution_type: code_fix
+severity: medium
+tags:
+  - tui
+  - modal-state
+  - command-handling
+  - picker
+  - runtime-tui-contract
+plan_ref: "harnx-505-506"
+---
+
+## Problem
+
+Two issues in `.agent`/`.session` dot-command handling:
+
+1. **#505**: Switching agents via `.agent <agentname>` (no session arg) left user in no-session state — transcript showed no messages, subsequent commands had no session context.
+
+2. **#506**: Bare `.agent` (0 args) showed usage text; bare `.session` did nothing. TAB on `.agent ` or `.session ` triggered text completions instead of opening their respective picker modals.
+
+## Symptoms
+
+- Running `.agent claude` successfully switched agent but left `session == None`
+- `.agent` alone printed usage message (unhelpful)
+- `.session` alone called `use_session(None)` which was a no-op
+- TAB after `.agent ` or `.session ` would list completions rather than opening picker
+- Inconsistent UX compared to startup picker flow
+
+## Investigation Steps
+
+1. Traced `.agent` command handler in `commands.rs` — found `None` case only wrote usage text
+2. Traced `.session` handler — found `args.is_none()` case fell through to `use_session(None)`
+3. Reviewed TUI's `handle_tab()` — always called `compute_completions();` no picker-aware logic
+4. Noted existing picker opening: `open_agent_picker()`, `open_session_picker()` helpers existed but were only called from startup flow
+5. Identified pattern: runtime needs way to signal TUI behavior beyond Continue/Exit
+
+## Root Cause
+
+No communication mechanism existed for runtime to request TUI modal behavior. The `CommandOutcome` enum only had `Continue` and `Exit` variants. Bare commands couldn't express "open the agent picker" or "open the session picker" as outcomes.
+
+Additionally, TAB completion had no awareness of picker-commands — it always computed text completions, even when the user expected a modal picker.
+
+## Solution
+
+### 1. Extended CommandOutcome enum
+
+Added two new variants to `CommandOutcome` in `crates/harnx-runtime/src/commands.rs`:
+
+```rust
+pub enum CommandOutcome {
+    Continue,
+    Exit,
+    OpenAgentPicker,    // NEW
+    OpenSessionPicker,  // NEW
+}
+```
+
+### 2. Runtime returns picker outcomes
+
+Modified `.agent` and `.session` handlers to return appropriate outcomes:
+
+```rust
+// .session with no args → open session picker
+".session" => {
+    if args.is_none() {
+        return Ok(CommandOutcome::OpenSessionPicker);
+    }
+    config.write().use_session(args)?;
+    Config::maybe_autoname_session(config.clone());
+}
+
+// .agent with no args → open agent picker
+".agent" => match split_first_arg(args) {
+    Some((agent_name, args)) => {
+        // ... existing agent switching logic ...
+    }
+    None => return Ok(CommandOutcome::OpenAgentPicker),
+},
+```
+
+### 3. TUI wires outcomes to modal opening
+
+In `run_command()`, added handling for new outcomes:
+
+```rust
+match outcome {
+    CommandOutcome::OpenAgentPicker => {
+        self.open_agent_picker();
+    }
+    CommandOutcome::OpenSessionPicker => {
+        self.open_session_picker();
+    }
+    // ... existing handlers ...
+}
+```
+
+### 4. Agent switch triggers session picker when needed
+
+Added logic to open SessionPicker after agent switch if no session selected:
+
+```rust
+// After successful .agent <name> command
+let curr_agent = cfg.agent.as_ref().map(|a| a.name().to_string());
+let session_missing = cfg.session.is_none();
+drop(cfg);
+if prev_agent != curr_agent && session_missing {
+    self.open_session_picker();
+}
+```
+
+### 5. TAB-to-picker detection
+
+Added `picker_command_for_input()` helper in `crates/harnx-tui/src/input.rs`:
+
+```rust
+fn picker_command_for_input(line: &str, pos: usize) -> Option<PickerCommand> {
+    let upto_cursor = &line[..pos];
+    let trimmed = upto_cursor.trim_start();
+    match trimmed.trim_end() {
+        ".agent" => Some(PickerCommand::Agent),
+        ".session" => Some(PickerCommand::Session),
+        _ => None,
+    }
+}
+```
+
+Modified `handle_tab()` to check for picker commands when completions empty:
+
+```rust
+let picker_command = picker_command_for_input(&line, pos);
+let completions = self.compute_completions(&line, pos).await;
+if completions.is_empty() {
+    match picker_command {
+        Some(PickerCommand::Agent) => {
+            self.open_agent_picker();
+            return;
+        }
+        Some(PickerCommand::Session) => {
+            self.open_session_picker();
+            return;
+        }
+        None => return,
+    }
+}
+```
+
+### 6. Suppress text completions for picker-commands
+
+In `compute_completions()`, return empty when detecting bare picker command:
+
+```rust
+// Suppress completions for bare .agent/.session commands
+if matches!(cmd, ".agent" | ".session") && args.iter().all(|arg| arg.is_empty()) {
+    return vec![];
+}
+```
+
+The `args.iter().all(|arg| arg.is_empty())` check correctly matches both:
+- `.agent` (no space after command, parsed as 0 args with empty first arg)
+- `.agent ` (trailing space, parsed as 1 empty arg)
+
+## Why This Works
+
+`CommandOutcome` provides clean separation: runtime signals intent, TUI decides implementation. This avoids the runtime directly manipulating UI state (which it shouldn't know about).
+
+The `picker_command_for_input()` helper normalizes whitespace the same way the command parser does (`trim_start()` + `trim_end()`), ensuring consistent detection of bare commands.
+
+Suppressing completions for picker-commands ensures `handle_tab()` receives empty completions, triggering the picker-opening branch.
+
+## Prevention Strategies
+
+**Test Cases:**
+- Verify `.agent` alone opens AgentPicker modal
+- Verify `.session` alone opens SessionPicker modal
+- Verify `.agent <name>` with no session opens SessionPicker after switch
+- Verify TAB on `.agent ` opens picker (not completions)
+- Verify TAB on `.agent cl` shows completions (not picker)
+
+**Best Practices:**
+- Use `CommandOutcome` variants for runtime → TUI communication; never call TUI methods from runtime
+- Centralize modal-opening logic in TUI helpers (`open_agent_picker()`, `open_session_picker()`)
+- Keep completion suppression logic synchronized with picker detection (`args.iter().all(|arg| arg.is_empty())`)
+
+## Related Issues
+
+- **Issue:** #505 — `.agent <agent>` leaves no session
+- **Issue:** #506 — `.agent`/`.session` alone should open pickers
+- **Related Solution:** [picker-flow-state-continuity-2026-05-03.md](picker-flow-state-continuity-2026-05-03.md) — AgentPicker/SessionPicker modal state management
+- **Related Solution:** [session-picker-multi-factor-sorting-2026-05-02.md](../integration-issues/session-picker-multi-factor-sorting-2026-05-02.md) — SessionPicker sorting and metadata


### PR DESCRIPTION
Fixes #505: switching agents via `.agent <name>` with no session arg now automatically opens the SessionPicker modal so the user can pick or create a session, preventing the "no-session" dead-end state.

Fixes #506: `.agent` with no args and `.session` with no args now open their respective TUI picker modals instead of printing usage text or creating a blank session. Tab on `.agent ` or `.session ` similarly opens the picker rather than showing text completions.

Implementation: added CommandOutcome::OpenAgentPicker and OpenSessionPicker variants; TUI handles them in maybe_open_picker_after_command() and handle_tab()/compute_completions().

Plan: harnx-505-506

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent and session selection pickers now open when using `.agent` or `.session` commands without arguments.
  * Tab key now triggers agent/session picker modals for bare dot commands instead of text completions.
  * Session picker automatically opens after switching agents when no session is selected.

* **Documentation**
  * Added guide explaining picker modal signaling improvements for agent and session commands.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/508)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->