### PR TITLE
fix(tui): scroll history into view on first navigation press

### DIFF
--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -417,19 +417,6 @@ impl Tui {
             None
         };
 
-        if self.app.scroll_to_focused_item {
-            if let Some(focus) = self.app.transcript_focus {
-                let position = self.app.scroll_state.scroll_position_to_show_item(
-                    focus,
-                    chunks[0].width,
-                    chunks[0].height as usize,
-                    self.app.transcript.len(),
-                );
-                self.app.scroll_state.position = position;
-            }
-            self.app.scroll_to_focused_item = false;
-        }
-
         let transcript_entries = self.prepare_transcript_entries(
             chunks[0].width,
             show_seq,
@@ -1340,6 +1327,14 @@ impl Tui {
 
         if self.app.scroll_to_focused_item {
             if let Some(focus) = self.app.transcript_focus {
+                // Prime the browsing-view height cache from the main scroll state so that
+                // scroll_position_to_show_item has accurate per-item heights even on the
+                // very first render of the browsing overlay (before it has rendered anything
+                // itself). Without this, the cache defaults to height=1 per item, producing
+                // a wildly incorrect scroll position for multi-line transcript items.
+                self.app
+                    .browsing_view_scroll
+                    .copy_height_cache_from(&self.app.scroll_state);
                 let position = self.app.browsing_view_scroll.scroll_position_to_show_item(
                     focus,
                     chunks[0].width,

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -7056,6 +7056,96 @@ async fn test_browsing_mode_non_navigable_items_visible_not_focusable() {
     );
 }
 
+/// Regression test for GitHub issue #507.
+///
+/// When entering browsing mode with enough items to overflow the viewport,
+/// pressing UP should scroll the selected item into view immediately.
+///
+/// Before the fix two bugs combined to break this:
+/// 1. The `scroll_to_focused_item` flag was consumed (cleared) by dead code in
+///    the non-browsing render path, so `render_browsing_view` never saw it.
+/// 2. `browsing_view_scroll` had an empty height cache on first entry into
+///    browsing mode, making `scroll_position_to_show_item` default all items to
+///    height=1 and produce a wrong position.
+#[tokio::test]
+async fn test_browsing_mode_first_up_scrolls_last_item_into_view() {
+    // Small viewport: 60 wide, 12 tall.
+    // Browsing view reserves 2 rows for footer → 10 rows of content.
+    // 20 items means they do not all fit at once.
+    let mut harness = TuiTestHarness::with_size(60, 12);
+
+    harness.tui().app.transcript.clear();
+
+    for i in 0..20usize {
+        // Every fifth item is long enough to wrap at width 60, ensuring the
+        // height cache holds values > 1 for some entries.  If cache-priming
+        // were broken, scroll_position_to_show_item would use height=1 for
+        // every item and compute a wrong (too-small) scroll position.
+        let text = if i % 5 == 0 {
+            format!(
+                "Message {i} — this is a deliberately long line that exceeds sixty columns and must wrap"
+            )
+        } else {
+            format!("Message {i}")
+        };
+        harness.tui().app.transcript.push(TranscriptItem::UserText {
+            text,
+            seq: None,
+            timestamp: None,
+        });
+    }
+
+    // Render once in normal (non-browsing) mode so the main scroll_state
+    // builds an accurate height cache for these items.
+    harness.render();
+
+    // Simulate pressing UP from a blank input.  The handler sets
+    // transcript_focus to the last navigable item and scroll_to_focused_item = true.
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert!(
+        harness.tui().app.transcript_browsing,
+        "transcript_browsing should be true after pressing UP"
+    );
+    assert_eq!(
+        harness.tui().app.transcript_focus,
+        Some(19),
+        "focus should be on the last item (index 19)"
+    );
+    assert!(
+        harness.tui().app.scroll_to_focused_item,
+        "scroll_to_focused_item should be set before first browsing render"
+    );
+
+    // Render the browsing view.  The fix primes the height cache from
+    // scroll_state before computing the position.
+    harness.render();
+
+    assert!(
+        !harness.tui().app.scroll_to_focused_item,
+        "scroll_to_focused_item should be cleared after render"
+    );
+
+    // A position of 0 would mean the viewport is showing the top of the list —
+    // the bug.  Any positive value means we scrolled toward the focused item.
+    let pos = harness.tui().app.browsing_view_scroll.position;
+    assert!(
+        pos > 0,
+        "browsing_view_scroll.position should be > 0 (scrolled to last item), got {pos}"
+    );
+
+    // The last message must be visible on screen.
+    let screen = harness.screen_contents();
+    assert!(
+        screen.contains("Message 19"),
+        "Last item 'Message 19' should be visible on screen after UP press.\nScreen:\n{screen}"
+    );
+}
+
 #[tokio::test]
 async fn test_agent_command_leaves_tui_without_session_gap() {
     let mut harness = TuiTestHarness::with_size(60, 20);

--- a/crates/ratatui-widget-scrolling/src/lib.rs
+++ b/crates/ratatui-widget-scrolling/src/lib.rs
@@ -73,6 +73,18 @@ impl ScrollState {
         value_change
     }
 
+    /// Copy the height cache from `other` into `self`.
+    ///
+    /// This is used when a secondary scroll view (e.g. the browsing-mode overlay)
+    /// needs to immediately compute an accurate scroll position for
+    /// `scroll_position_to_show_item` without having rendered any content yet.
+    /// Copying the cache from the primary scroll view — which has already rendered
+    /// the same items at the same width — primes the secondary view with accurate
+    /// per-item heights so the first position calculation is correct.
+    pub fn copy_height_cache_from(&mut self, other: &Self) {
+        self.render_height_cache = other.render_height_cache.clone();
+    }
+
     fn get_height_log_from_cache_for_width(
         &mut self,
         width: u16,

--- a/docs/solutions/logic-errors/tui-browsing-mode-initial-scroll-2026-05-10.md
+++ b/docs/solutions/logic-errors/tui-browsing-mode-initial-scroll-2026-05-10.md
@@ -1,0 +1,177 @@
+---
+title: "TUI browsing mode initial scroll to last item (dead code flag consumption and empty height cache)"
+date: 2026-05-10
+category: logic-errors
+problem_type: logic_error
+component: harnx-tui
+root_cause: "flag consumed by dead code in wrong render path, and empty height cache on first browsing entry"
+resolution_type: code_fix
+severity: medium
+tags:
+  - tui
+  - scroll-state
+  - browsing-mode
+  - ratatui
+  - height-cache
+  - flag-lifecycle
+plan_ref: "harnx-507-history-nav-scroll"
+---
+
+## Problem
+
+Pressing UP to enter browsing mode in the TUI would select the last transcript item but the viewport remained at the top of the transcript instead of scrolling the focused item into view. Footer showed "Item 850 of 850" while the screen displayed items from the top.
+
+## Symptoms
+
+- Pressing UP from blank input line focused last navigable item but viewport stayed at top
+- `transcript_focus` set correctly (e.g., index 850)
+- `scroll_to_focused_item` flag set to `true` by input handler
+- After render, `browsing_view_scroll.position` remained 0
+- Only reproducible on first entry into browsing mode with transcript taller than viewport
+
+## Investigation Steps
+
+1. Traced `handle_key(Up)` in `input.rs` — confirmed `transcript_focus = Some(last_navigable)` and `scroll_to_focused_item = true` set correctly.
+2. Added debug logging to `render_browsing_view` — discovered flag was always `false` when browsing view rendered.
+3. Searched for all consumers of `scroll_to_focused_item` flag in `render.rs`.
+4. Found **dead code block** in non-browsing `draw()` path (lines ~420-450) that consumed and cleared the flag even when `transcript_browsing = true`.
+5. Confirmed: every setter of `scroll_to_focused_item` also sets `transcript_browsing = true` — the flag is only meaningful in browsing-mode code paths.
+6. Even after fixing flag consumption, position calculation was still wrong — traced to `scroll_position_to_show_item()` using empty height cache.
+7. `browsing_view_scroll` is a separate `ScrollState` that starts with empty `render_height_cache`, so all items default to height=1, producing wildly incorrect scroll positions for multi-line items.
+
+## Root Cause
+
+**Bug 1 — Dead code consuming the flag:**
+
+The non-browsing render path in `draw()` contained a block that checked and cleared `scroll_to_focused_item`:
+
+```rust
+// Dead code in non-browsing path
+if self.app.scroll_to_focused_item {
+    // ... scroll logic for normal view
+    self.app.scroll_to_focused_item = false;
+}
+```
+
+This block ran even when `transcript_browsing = true`, consuming the flag before `render_browsing_view` could see it. Since `scroll_to_focused_item` is only ever set when entering or navigating within browsing mode (every setter also sets `transcript_browsing = true`), this code should never execute when browsing is active.
+
+**Bug 2 — Empty height cache:**
+
+`browsing_view_scroll` is a separate `ScrollState` initialized with an empty `render_height_cache`. On first entry into browsing mode, `scroll_position_to_show_item()` has no cached heights and defaults all items to height=1. For multi-line transcript items (messages, code blocks), this produces incorrect scroll positions — often an order of magnitude wrong.
+
+## Solution
+
+### 1. Remove dead code from non-browsing path
+
+Removed the entire `scroll_to_focused_item` block from the non-browsing `draw()` path. The non-browsing view has no concept of a focused item — this code was never intended to exist there.
+
+**Key insight:** The `scroll_to_focused_item` flag is **only ever set when entering or navigating within browsing mode** — every setter in `input.rs` also sets `transcript_browsing = true`. The non-browsing render path never has a reason to process this flag.
+
+### 2. Prime height cache from main scroll state
+
+Added `copy_height_cache_from()` method to `ScrollState` in `ratatui-widget-scrolling`:
+
+```rust
+/// Copy the height cache from `other` into `self`.
+///
+/// This is used when a secondary scroll view (e.g. the browsing-mode overlay)
+/// needs to immediately compute an accurate scroll position for
+/// `scroll_position_to_show_item` without having rendered any content yet.
+pub fn copy_height_cache_from(&mut self, other: &Self) {
+    self.render_height_cache = other.render_height_cache.clone();
+}
+```
+
+Inside `render_browsing_view`, before computing the scroll position:
+
+```rust
+if self.app.scroll_to_focused_item {
+    if let Some(focus) = self.app.transcript_focus {
+        // Prime the browsing-view height cache from the main scroll state so that
+        // scroll_position_to_show_item has accurate per-item heights even on the
+        // very first render of the browsing overlay.
+        self.app
+            .browsing_view_scroll
+            .copy_height_cache_from(&self.app.scroll_state);
+        let position = self.app.browsing_view_scroll.scroll_position_to_show_item(
+            focus,
+            chunks[0].width,
+            chunks[0].height as usize,
+            self.app.transcript.len(),
+        );
+        self.app.browsing_view_scroll.position = position;
+    }
+    self.app.scroll_to_focused_item = false;
+}
+```
+
+The main `scroll_state` has already rendered the same items at the same width, so its height cache is accurate. Copying it primes `browsing_view_scroll` with correct heights before the first position calculation.
+
+### 3. Regression test
+
+Added `test_browsing_mode_first_up_scrolls_last_item_into_view` in `tests.rs`:
+
+```rust
+#[tokio::test]
+async fn test_browsing_mode_first_up_scrolls_last_item_into_view() {
+    let mut harness = TuiTestHarness::with_size(60, 12);
+
+    // 20 items in a 10-row viewport
+    for i in 0..20usize {
+        harness.tui().app.transcript.push(TranscriptItem::UserText {
+            text: format!("Message {i}"),
+            seq: None,
+            timestamp: None,
+        });
+    }
+
+    harness.render(); // Prime main scroll_state height cache
+
+    // Press UP to enter browsing mode
+    harness.tui().handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)).await.unwrap();
+
+    assert!(harness.tui().app.transcript_browsing);
+    assert_eq!(harness.tui().app.transcript_focus, Some(19));
+
+    harness.render();
+
+    // Position > 0 means we scrolled toward the focused item
+    let pos = harness.tui().app.browsing_view_scroll.position;
+    assert!(pos > 0, "position should be > 0, got {pos}");
+
+    // The last message must be visible on screen
+    let screen = harness.screen_contents();
+    assert!(screen.contains("Message 19"));
+}
+```
+
+## Why This Works
+
+**Flag lifecycle correction:** By removing the dead code block, `scroll_to_focused_item` now survives from the input handler through to `render_browsing_view`. The browsing view renderer is the sole consumer of this flag, matching its sole producer (browsing-mode input handlers).
+
+**Height cache priming:** The main `scroll_state` has accurate per-item heights from its normal rendering loop. Copying this cache to `browsing_view_scroll` before computing position ensures `scroll_position_to_show_item()` sees accurate heights even before the browsing view has rendered anything itself. The first position calculation is correct rather than an order-of-magnitude estimate.
+
+## Prevention Strategies
+
+**Code review checklist:**
+
+- [ ] When a flag/field is only meaningful in one mode (browsing vs normal), ensure only that mode's code paths consume it
+- [ ] When adding new `ScrollState` instances, consider whether they need height cache priming from existing state
+- [ ] Check all flag consumers when adding new flag producers — ensure producer/consumer are in the same mode
+
+**Testing patterns:**
+
+- Always test first-entry scenarios for stateful overlays (height cache starts empty)
+- Verify flag lifecycle: set flag, render once, assert flag consumed, assert state changed
+- When copying caches between states, test that cache is primed before dependent calculation runs
+
+**Related patterns:**
+
+- The `scroll_to_focused_item` flag is a "one-shot request" pattern — set by input handler, consumed by renderer on next frame, then cleared. This pattern requires exactly one consumer.
+- Secondary `ScrollState` instances may need cache priming from primary state when computing positions before their first render.
+
+## Related Issues
+
+- **GitHub:** [#507](https://github.com/dobesv/harnx/issues/507) — History nav scroll to selected item
+- **Related Solution:** [logic-errors/tui-browsing-full-transcript-render-2026-05-05.md](./tui-browsing-full-transcript-render-2026-05-05.md) — Full transcript rendering and scroll state ownership in browsing mode
+- **Related Solution:** [logic-errors/tui-transcript-navigation-focus.md](./tui-transcript-navigation-focus.md) — Keyboard navigation with focus management and auto-scroll (introduced `scroll_to_focused_item` flag)


### PR DESCRIPTION
Fixes history navigation not scrolling selected item into view on first UP keypress.

Two bugs fixed:
1. Removed dead scroll_to_focused_item block in non-browsing render path that consumed the flag before browsing view could see it.
2. Primes browsing_view_scroll cache from scroll_state before computing position to fix wrong position calculation due to empty height cache.

Adds copy_height_cache_from() to ScrollState and a regression test.

[#507]

Plan: harnx-507-history-nav-scroll

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed initial-entry browsing mode so the focused transcript item (e.g., the last message) is correctly scrolled into view by reusing previously computed item heights.

* **Tests**
  * Added a regression test verifying initial UP-triggered entry into browsing mode focuses and reveals the last transcript item.

* **Documentation**
  * Added write-up describing the browsing-mode initial-scroll issue and its resolution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/509)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->