### PR TITLE
feat(mcp-fs): add insert and re_replace tools (#511)

### DIFF
--- a/.changesets/mcp-fs-insert-rereplace.md
+++ b/.changesets/mcp-fs-insert-rereplace.md
@@ -1,0 +1,7 @@
+---
+harnx: minor
+---
+Add `insert` and `re_replace` tools to `harnx-mcp-fs`.
+
+- `insert`: insert text at a line position (0 = prepend, N = after line N, supports optional column for mid-line insertion)
+- `re_replace`: regex find-and-replace using fancy_regex syntax with capture group back-references

--- a/crates/harnx-mcp-fs/src/server.rs
+++ b/crates/harnx-mcp-fs/src/server.rs
@@ -65,6 +65,24 @@ pub struct EditFileParams {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct InsertParams {
+    pub path: String,
+    pub insert_line: usize,
+    pub insert_text: String,
+    #[serde(default)]
+    pub column: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ReReplaceParams {
+    pub path: String,
+    pub pattern: String,
+    pub replacement: String,
+    #[serde(default)]
+    pub replace_all: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct ListDirectoryParams {
     pub path: String,
     #[serde(default)]
@@ -164,6 +182,50 @@ impl JsonSchema for EditFileParams {
                 ("replace_all", replace_all),
             ],
             &["path", "old_text", "new_text"],
+        )
+    }
+}
+
+impl JsonSchema for InsertParams {
+    fn schema_name() -> Cow<'static, str> {
+        Cow::Borrowed("InsertParams")
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let path = generator.subschema_for::<String>();
+        let insert_line = generator.subschema_for::<usize>();
+        let insert_text = generator.subschema_for::<String>();
+        let column = generator.subschema_for::<Option<usize>>();
+        object_schema(
+            vec![
+                ("path", path),
+                ("insert_line", insert_line),
+                ("insert_text", insert_text),
+                ("column", column),
+            ],
+            &["path", "insert_line", "insert_text"],
+        )
+    }
+}
+
+impl JsonSchema for ReReplaceParams {
+    fn schema_name() -> Cow<'static, str> {
+        Cow::Borrowed("ReReplaceParams")
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let path = generator.subschema_for::<String>();
+        let pattern = generator.subschema_for::<String>();
+        let replacement = generator.subschema_for::<String>();
+        let replace_all = generator.subschema_for::<Option<bool>>();
+        object_schema(
+            vec![
+                ("path", path),
+                ("pattern", pattern),
+                ("replacement", replacement),
+                ("replace_all", replace_all),
+            ],
+            &["path", "pattern", "replacement"],
         )
     }
 }
@@ -497,9 +559,239 @@ impl FsServer {
         Ok(CallToolResult::success(contents))
     }
 
+    async fn insert_impl(&self, params: InsertParams) -> Result<CallToolResult, ErrorData> {
+        let roots = self.roots.read().await;
+        let path = validate_write_path(&params.path, &roots).map_err(invalid_params)?;
+        drop(roots);
+
+        let before_snap = self
+            .history
+            .snapshot_file(&path, "before insert")
+            .await
+            .map_err(|e| {
+                log::warn!("history before-snapshot failed: {e}");
+            })
+            .ok();
+
+        let content = std::fs::read_to_string(&path)
+            .map_err(|err| internal_error(format!("failed to read '{}': {err}", params.path)))?;
+
+        if content.len() > WRITE_MAX_BYTES {
+            return tool_error(format!(
+                "File too large for editing ({}, max {})",
+                format_size(content.len()),
+                format_size(WRITE_MAX_BYTES)
+            ));
+        }
+
+        let lines = content.split_inclusive('\n').collect::<Vec<_>>();
+        let total_lines = lines.len();
+        if params.insert_line > total_lines {
+            return tool_error(format!(
+                "insert_line {} out of range for file with {} lines",
+                params.insert_line, total_lines
+            ));
+        }
+
+        let new_content = if params.insert_line == 0 {
+            format!("{}{}", params.insert_text, content)
+        } else if params.column.unwrap_or(1) <= 1 {
+            format!(
+                "{}{}{}",
+                lines[..params.insert_line].join(""),
+                params.insert_text,
+                lines[params.insert_line..].join("")
+            )
+        } else {
+            let line = lines[params.insert_line - 1];
+            let (stripped_line, had_newline) = match line.strip_suffix('\n') {
+                Some(stripped) => (stripped, true),
+                None => (line, false),
+            };
+            let column = params.column.unwrap();
+            let insert_index = column - 1;
+            if insert_index > stripped_line.len() || !stripped_line.is_char_boundary(insert_index) {
+                return tool_error(format!(
+                    "column {} is not a valid UTF-8 character boundary in line {}",
+                    column, params.insert_line
+                ));
+            }
+            let new_line = if had_newline {
+                format!(
+                    "{}{}{}
+",
+                    &stripped_line[..insert_index],
+                    params.insert_text,
+                    &stripped_line[insert_index..]
+                )
+            } else {
+                format!(
+                    "{}{}{}",
+                    &stripped_line[..insert_index],
+                    params.insert_text,
+                    &stripped_line[insert_index..]
+                )
+            };
+            format!(
+                "{}{}{}",
+                lines[..params.insert_line - 1].join(""),
+                new_line,
+                lines[params.insert_line..].join("")
+            )
+        };
+
+        if new_content.len() > WRITE_MAX_BYTES {
+            return tool_error(format!(
+                "Insertion would produce a file too large ({}, max {})",
+                format_size(new_content.len()),
+                format_size(WRITE_MAX_BYTES)
+            ));
+        }
+
+        std::fs::write(&path, &new_content)
+            .map_err(|err| internal_error(format!("failed to write '{}': {err}", params.path)))?;
+
+        let after_snap_result = if let Some(before) = before_snap {
+            match self.history.snapshot_file(&path, "after insert").await {
+                Ok(after) => {
+                    let diff = if let Some(repo_dir) =
+                        harnx_mcp_history::discover::find_repo_for_path(&path)
+                    {
+                        self.history
+                            .diff_commits(&repo_dir, before, after)
+                            .await
+                            .unwrap_or_default()
+                    } else {
+                        String::new()
+                    };
+                    Some((after, diff))
+                }
+                Err(e) => {
+                    log::warn!("history after-snapshot failed: {e}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let mut contents = vec![Content::text(format!(
+            "Inserted {} bytes into {}",
+            params.insert_text.len(),
+            params.path
+        ))];
+        if let Some((_after_id, diff_content)) = after_snap_result {
+            if !diff_content.is_empty() {
+                contents.push(Content::text(diff_content));
+            }
+        }
+        Ok(CallToolResult::success(contents))
+    }
+
+    async fn re_replace_impl(&self, params: ReReplaceParams) -> Result<CallToolResult, ErrorData> {
+        let roots = self.roots.read().await;
+        let path = validate_write_path(&params.path, &roots).map_err(invalid_params)?;
+        drop(roots);
+
+        let before_snap = self
+            .history
+            .snapshot_file(&path, "before re_replace")
+            .await
+            .map_err(|e| {
+                log::warn!("history before-snapshot failed: {e}");
+            })
+            .ok();
+
+        let content = std::fs::read_to_string(&path)
+            .map_err(|err| internal_error(format!("failed to read '{}': {err}", params.path)))?;
+
+        if content.len() > WRITE_MAX_BYTES {
+            return tool_error(format!(
+                "File too large for editing ({}, max {})",
+                format_size(content.len()),
+                format_size(WRITE_MAX_BYTES)
+            ));
+        }
+
+        let regex = Regex::new(&params.pattern).map_err(|err| {
+            ErrorData::invalid_params(format!("invalid regex pattern: {err}"), None)
+        })?;
+        let count = regex
+            .find_iter(&content)
+            .filter_map(|result| result.ok())
+            .count();
+        if count == 0 {
+            return tool_error("pattern did not match anything in the file");
+        }
+
+        let replace_all = params.replace_all.unwrap_or(false);
+        if !replace_all && count > 1 {
+            return tool_error(format!(
+                "Found {} matches; set replace_all=true to replace all occurrences",
+                count
+            ));
+        }
+
+        let new_content = if replace_all {
+            regex
+                .replace_all(&content, params.replacement.as_str())
+                .into_owned()
+        } else {
+            regex
+                .replace(&content, params.replacement.as_str())
+                .into_owned()
+        };
+
+        if new_content.len() > WRITE_MAX_BYTES {
+            return tool_error(format!(
+                "Replacement would produce a file too large ({}, max {})",
+                format_size(new_content.len()),
+                format_size(WRITE_MAX_BYTES)
+            ));
+        }
+
+        std::fs::write(&path, &new_content)
+            .map_err(|err| internal_error(format!("failed to write '{}': {err}", params.path)))?;
+
+        let after_snap_result = if let Some(before) = before_snap {
+            match self.history.snapshot_file(&path, "after re_replace").await {
+                Ok(after) => {
+                    let diff = if let Some(repo_dir) =
+                        harnx_mcp_history::discover::find_repo_for_path(&path)
+                    {
+                        self.history
+                            .diff_commits(&repo_dir, before, after)
+                            .await
+                            .unwrap_or_default()
+                    } else {
+                        String::new()
+                    };
+                    Some((after, diff))
+                }
+                Err(e) => {
+                    log::warn!("history after-snapshot failed: {e}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let mut contents = vec![Content::text(format!(
+            "Replaced {} match(es) in {}",
+            count, params.path
+        ))];
+        if let Some((_after_id, diff_content)) = after_snap_result {
+            if !diff_content.is_empty() {
+                contents.push(Content::text(diff_content));
+            }
+        }
+        Ok(CallToolResult::success(contents))
+    }
+
     async fn edit_file_impl(&self, params: EditFileParams) -> Result<CallToolResult, ErrorData> {
         let roots = self.roots.read().await;
-        let path = validate_path(&params.path, &roots).map_err(invalid_params)?;
+        let path = validate_write_path(&params.path, &roots).map_err(invalid_params)?;
         drop(roots);
 
         // HISTORY: before snapshot
@@ -870,7 +1162,7 @@ impl ServerHandler for FsServer {
                 env!("CARGO_PKG_VERSION"),
             ))
             .with_instructions(
-                "Filesystem MCP server with read, write, edit, listing, grep, and glob tools.",
+                "Filesystem MCP server with read, write, edit, insert, re_replace, listing, grep, and glob tools.",
             )
     }
 
@@ -891,6 +1183,20 @@ impl ServerHandler for FsServer {
                 Tool::new("edit", "Replace exact text within an existing file.", Map::new())
                     .with_input_schema::<EditFileParams>()
                     .with_meta(make_tool_meta("🔧 {{ args.path }}{% if args.replace_all %} [all]{% endif %}\n▸ {{ args.old_text | truncate(60) }}\n↳ {{ args.new_text | truncate(60) }}")),
+                Tool::new("insert",
+                    "Insert text into a file at a specific line position.      insert_line: 0 prepends before line 1; insert_line: N inserts after line N      (use N = total lines to append). Optional column (1-indexed byte offset within      the line, default 1 = start of line) for mid-line insertion.      For exact-text replacement use edit; for regex replacement use re_replace.",
+                    Map::new())
+                    .with_input_schema::<InsertParams>()
+                    .with_meta(make_tool_meta(
+                        "➕ {{ args.path }}:{{ args.insert_line }}{% if args.column %}:{{ args.column }}{% endif %}\n↳ {{ args.insert_text | truncate(60) }}"
+                    )),
+                Tool::new("re_replace",
+                    "Replace text in a file using a regular expression.      Uses fancy_regex syntax (supports lookahead/lookbehind).      Use $0 for the full match, $1/$2 etc. for capture groups in replacement.      Errors if pattern matches nothing. If pattern matches more than once,      set replace_all=true; otherwise only the first match is replaced.      For exact-text replacement use edit instead.",
+                    Map::new())
+                    .with_input_schema::<ReReplaceParams>()
+                    .with_meta(make_tool_meta(
+                        "🔁 {{ args.path }}{% if args.replace_all %} [all]{% endif %}\n▸ /{{ args.pattern }}/\n↳ {{ args.replacement | truncate(60) }}"
+                    )),
                 Tool::new("ls", "List directory contents, optionally recursively.", Map::new())
                     .with_input_schema::<ListDirectoryParams>()
                     .annotate(read_only.clone())
@@ -936,6 +1242,14 @@ impl ServerHandler for FsServer {
             "edit" => {
                 let params = parse_arguments::<EditFileParams>(request.arguments)?;
                 self.edit_file_impl(params).await
+            }
+            "insert" => {
+                let params = parse_arguments::<InsertParams>(request.arguments)?;
+                self.insert_impl(params).await
+            }
+            "re_replace" => {
+                let params = parse_arguments::<ReReplaceParams>(request.arguments)?;
+                self.re_replace_impl(params).await
             }
             "ls" => {
                 let params = parse_arguments::<ListDirectoryParams>(request.arguments)?;
@@ -1447,6 +1761,8 @@ mod tests {
                 "read",
                 "write",
                 "edit",
+                "insert",
+                "re_replace",
                 "ls",
                 "grep",
                 "find",
@@ -2108,5 +2424,382 @@ mod tests {
 
             (case.check)(user_summary(&result).as_str());
         }
+    }
+
+    #[tokio::test]
+    async fn test_insert_prepend() {
+        let temp_dir = TestDir::new();
+        let file_path = temp_dir.path().join("prepend.txt");
+        std::fs::write(
+            &file_path,
+            "beta
+gamma
+",
+        )
+        .unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .insert_impl(InsertParams {
+                path: file_path.to_string_lossy().to_string(),
+                insert_line: 0,
+                insert_text: "alpha
+"
+                .to_string(),
+                column: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(
+            std::fs::read_to_string(&file_path).unwrap(),
+            "alpha
+beta
+gamma
+"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_append() {
+        let temp_dir = TestDir::new();
+        let file_path = temp_dir.path().join("append.txt");
+        std::fs::write(
+            &file_path,
+            "alpha
+beta
+",
+        )
+        .unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .insert_impl(InsertParams {
+                path: file_path.to_string_lossy().to_string(),
+                insert_line: 2,
+                insert_text: "gamma
+"
+                .to_string(),
+                column: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(
+            std::fs::read_to_string(&file_path).unwrap(),
+            "alpha
+beta
+gamma
+"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_middle() {
+        let temp_dir = TestDir::new();
+        let file_path = temp_dir.path().join("middle.txt");
+        std::fs::write(
+            &file_path,
+            "one
+two
+three
+four
+",
+        )
+        .unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .insert_impl(InsertParams {
+                path: file_path.to_string_lossy().to_string(),
+                insert_line: 2,
+                insert_text: "between
+"
+                .to_string(),
+                column: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(
+            std::fs::read_to_string(&file_path).unwrap(),
+            "one
+two
+between
+three
+four
+"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_column() {
+        let temp_dir = TestDir::new();
+        let file_path = temp_dir.path().join("column.txt");
+        std::fs::write(
+            &file_path,
+            "abcd
+xyz
+",
+        )
+        .unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .insert_impl(InsertParams {
+                path: file_path.to_string_lossy().to_string(),
+                insert_line: 1,
+                insert_text: "-MID-".to_string(),
+                column: Some(5),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(
+            std::fs::read_to_string(&file_path).unwrap(),
+            "abcd-MID-
+xyz
+"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_column_utf8_boundary() {
+        let temp_dir = TestDir::new();
+        let file_path = temp_dir.path().join("utf8_boundary.txt");
+        std::fs::write(
+            &file_path, "🦀abc
+",
+        )
+        .unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let ok_result = server
+            .insert_impl(InsertParams {
+                path: file_path.to_string_lossy().to_string(),
+                insert_line: 1,
+                insert_text: "X".to_string(),
+                column: Some(5),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(ok_result.is_error, Some(false));
+        assert_eq!(
+            std::fs::read_to_string(&file_path).unwrap(),
+            "🦀Xabc
+"
+        );
+
+        std::fs::write(
+            &file_path, "🦀abc
+",
+        )
+        .unwrap();
+
+        let bad_result = server
+            .insert_impl(InsertParams {
+                path: file_path.to_string_lossy().to_string(),
+                insert_line: 1,
+                insert_text: "X".to_string(),
+                column: Some(2),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(bad_result.is_error, Some(true));
+        assert!(text_content(&bad_result).contains("UTF-8 character boundary"));
+    }
+
+    #[tokio::test]
+    async fn test_insert_line_out_of_range() {
+        let temp_dir = TestDir::new();
+        let file_path = temp_dir.path().join("line_oob.txt");
+        std::fs::write(
+            &file_path,
+            "alpha
+beta
+",
+        )
+        .unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .insert_impl(InsertParams {
+                path: file_path.to_string_lossy().to_string(),
+                insert_line: 3,
+                insert_text: "gamma
+"
+                .to_string(),
+                column: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_insert_column_out_of_range() {
+        let temp_dir = TestDir::new();
+        let file_path = temp_dir.path().join("column_oob.txt");
+        std::fs::write(
+            &file_path, "abcd
+",
+        )
+        .unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .insert_impl(InsertParams {
+                path: file_path.to_string_lossy().to_string(),
+                insert_line: 1,
+                insert_text: "X".to_string(),
+                column: Some(6),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_re_replace_basic() {
+        let temp_dir = TestDir::new();
+        let file_path = temp_dir.path().join("re_basic.txt");
+        std::fs::write(
+            &file_path, "foo123
+",
+        )
+        .unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .re_replace_impl(ReReplaceParams {
+                path: file_path.to_string_lossy().to_string(),
+                pattern: r"foo(\d+)".to_string(),
+                replacement: "bar$1".to_string(),
+                replace_all: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(
+            std::fs::read_to_string(&file_path).unwrap(),
+            "bar123
+"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_re_replace_all() {
+        let temp_dir = TestDir::new();
+        let file_path = temp_dir.path().join("re_all.txt");
+        std::fs::write(
+            &file_path,
+            "foo1 foo2 foo3
+",
+        )
+        .unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .re_replace_impl(ReReplaceParams {
+                path: file_path.to_string_lossy().to_string(),
+                pattern: r"foo(\d+)".to_string(),
+                replacement: "bar$1".to_string(),
+                replace_all: Some(true),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(
+            std::fs::read_to_string(&file_path).unwrap(),
+            "bar1 bar2 bar3
+"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_re_replace_no_match() {
+        let temp_dir = TestDir::new();
+        let file_path = temp_dir.path().join("re_no_match.txt");
+        std::fs::write(
+            &file_path,
+            "alpha
+beta
+",
+        )
+        .unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .re_replace_impl(ReReplaceParams {
+                path: file_path.to_string_lossy().to_string(),
+                pattern: "foo".to_string(),
+                replacement: "bar".to_string(),
+                replace_all: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(true));
+        assert!(text_content(&result).contains("did not match"));
+    }
+
+    #[tokio::test]
+    async fn test_re_replace_multiple_no_flag() {
+        let temp_dir = TestDir::new();
+        let file_path = temp_dir.path().join("re_multiple.txt");
+        std::fs::write(
+            &file_path,
+            "foo1 foo2
+",
+        )
+        .unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .re_replace_impl(ReReplaceParams {
+                path: file_path.to_string_lossy().to_string(),
+                pattern: r"foo(\d+)".to_string(),
+                replacement: "bar$1".to_string(),
+                replace_all: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(true));
+        assert!(text_content(&result).contains("replace_all"));
+    }
+
+    #[tokio::test]
+    async fn test_re_replace_invalid_pattern() {
+        let temp_dir = TestDir::new();
+        let file_path = temp_dir.path().join("re_invalid.txt");
+        std::fs::write(
+            &file_path, "foo1
+",
+        )
+        .unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let err = server
+            .re_replace_impl(ReReplaceParams {
+                path: file_path.to_string_lossy().to_string(),
+                pattern: "(".to_string(),
+                replacement: "bar".to_string(),
+                replace_all: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(err.message.contains("invalid regex pattern"));
     }
 }

--- a/crates/harnx-mcp-fs/src/server.rs
+++ b/crates/harnx-mcp-fs/src/server.rs
@@ -573,7 +573,8 @@ impl FsServer {
             })
             .ok();
 
-        let content = std::fs::read_to_string(&path)
+        let content = tokio::fs::read_to_string(&path)
+            .await
             .map_err(|err| internal_error(format!("failed to read '{}': {err}", params.path)))?;
 
         if content.len() > WRITE_MAX_BYTES {
@@ -590,6 +591,12 @@ impl FsServer {
             return tool_error(format!(
                 "insert_line {} out of range for file with {} lines",
                 params.insert_line, total_lines
+            ));
+        }
+
+        if params.column == Some(0) {
+            return Err(invalid_params(
+                "column is 1-indexed; 0 is invalid (use 1 for start of line or omit for whole-line insert)",
             ));
         }
 
@@ -702,7 +709,8 @@ impl FsServer {
             })
             .ok();
 
-        let content = std::fs::read_to_string(&path)
+        let content = tokio::fs::read_to_string(&path)
+            .await
             .map_err(|err| internal_error(format!("failed to read '{}': {err}", params.path)))?;
 
         if content.len() > WRITE_MAX_BYTES {
@@ -716,10 +724,13 @@ impl FsServer {
         let regex = Regex::new(&params.pattern).map_err(|err| {
             ErrorData::invalid_params(format!("invalid regex pattern: {err}"), None)
         })?;
-        let count = regex
-            .find_iter(&content)
-            .filter_map(|result| result.ok())
-            .count();
+        let mut count = 0usize;
+        for result in regex.find_iter(&content) {
+            match result {
+                Ok(_) => count += 1,
+                Err(err) => return tool_error(format!("regex evaluation error: {err}")),
+            }
+        }
         if count == 0 {
             return tool_error("pattern did not match anything in the file");
         }
@@ -732,15 +743,11 @@ impl FsServer {
             ));
         }
 
-        let new_content = if replace_all {
-            regex
-                .replace_all(&content, params.replacement.as_str())
-                .into_owned()
-        } else {
-            regex
-                .replace(&content, params.replacement.as_str())
-                .into_owned()
-        };
+        let limit = if replace_all { 0 } else { 1 };
+        let new_content = regex
+            .try_replacen(&content, limit, params.replacement.as_str())
+            .map_err(|err| internal_error(format!("regex replacement error: {err}")))?
+            .into_owned();
 
         if new_content.len() > WRITE_MAX_BYTES {
             return tool_error(format!(

--- a/docs/solutions/integration-issues/mcp-fs-insert-rereplace-tools-2026-05-11.md
+++ b/docs/solutions/integration-issues/mcp-fs-insert-rereplace-tools-2026-05-11.md
@@ -1,0 +1,178 @@
+---
+title: "MCP-FS insert and re_replace tool implementation"
+date: 2026-05-11
+category: "integration-issues"
+problem_type: integration_issue
+component: "harnx-mcp-fs"
+root_cause: "missing insertion and regex replacement tools in filesystem MCP server"
+resolution_type: code_fix
+severity: medium
+tags:
+  - mcp
+  - filesystem
+  - editing
+  - regex
+  - utf-8
+plan_ref: "harnx-511-insert-rereplace"
+---
+
+## Problem
+
+harnx-mcp-fs MCP server lacked tools for position-based text insertion and regex-based find/replace. Users had to read files, apply transformations client-side, and write back — inefficient for common editing operations like inserting at a specific line/column or applying regex replacements with capture groups.
+
+## Symptoms
+
+- No MCP tool for inserting text at a specific line/column position
+- No MCP tool for regex-based find/replace with capture group backreferences
+- Clients forced to read-modify-write for simple edits
+- `edit` tool only supports exact text matching, not patterns
+
+## Investigation Steps
+
+1. Reviewed existing `edit` tool — exact text replacement only, no position insertion
+2. Identified need for two tools: position-based insert, regex-based replace
+3. Analyzed `write_file_impl` and `edit_file_impl` for mutation pattern: `validate_write_path`, history snapshots, size guards
+4. Researched `fancy_regex` crate — supports lookahead/lookbehind, retains `fancy_regex::Regex` API compatibility
+5. Tested `split_inclusive('\n')` — preserves line endings when splitting content for line-based operations
+6. Investigated `is_char_boundary()` — required for safe UTF-8 slicing with byte offsets
+
+## Root Cause
+
+**Missing tools**: No `insert` or `re_replace` tools in FsServer. Mutation tools existed only for full-file write (`write`) and exact-text replacement (`edit`).
+
+**UTF-8 slicing risk**: Column-based insertion uses byte offsets; slicing without boundary validation panics inside multibyte characters.
+
+**Regex error handling**: `fancy_regex::find_iter` returns `Result<Match>` per iteration; naive counting can swallow errors.
+
+## Solution
+
+### insert tool
+
+Position-based insertion with optional column offset:
+
+```rust
+#[derive(Debug, Deserialize)]
+pub struct InsertParams {
+    pub path: String,
+    pub insert_line: usize,       // 0-indexed: 0=prepend, N=after line N
+    pub insert_text: String,
+    #[serde(default)]
+    pub column: Option<usize>,   // 1-indexed byte offset within line
+}
+```
+
+**Implementation key points:**
+
+1. Use `validate_write_path` (not `validate_path`) — mutation requires write validation
+2. `split_inclusive('\n')` preserves line endings when splitting
+3. `insert_line: 0` prepends before first line
+4. `insert_line: N` where N = total_lines appends at end
+5. Column slicing requires `is_char_boundary()` check:
+
+```rust
+let insert_index = column - 1;
+if insert_index > stripped_line.len() || !stripped_line.is_char_boundary(insert_index) {
+    return tool_error(format!(
+        "column {} is not a valid UTF-8 character boundary in line {}",
+        column, params.insert_line
+    ));
+}
+let new_line = format!(
+    "{}{}{}",
+    &stripped_line[..insert_index],
+    params.insert_text,
+    &stripped_line[insert_index..]
+);
+```
+
+### re_replace tool
+
+Regex find/replace with fancy_regex:
+
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ReReplaceParams {
+    pub path: String,
+    pub pattern: String,         // fancy_regex pattern
+    pub replacement: String,     // $0, $1, $2 for groups
+    #[serde(default)]
+    pub replace_all: Option<bool>,
+}
+```
+
+**Implementation key points:**
+
+1. `Regex::new()` validates pattern, returns `invalid_params` error on invalid regex
+2. Match counting with graceful degradation:
+
+```rust
+let count = regex
+    .find_iter(&content)
+    .filter_map(|result| result.ok())  // best-effort: swallow iterator errors
+    .count();
+```
+
+3. Error on no match: `"pattern did not match anything in the file"`
+4. Error on multiple matches without flag: `"Found N matches; set replace_all=true to replace all occurrences"`
+5. Returns match count in success message: `"Replaced N match(es) in <path>"`
+
+### History snapshot pattern
+
+Both tools follow the before/after snapshot pattern from `edit_file_impl`:
+
+```rust
+let before_snap = self.history.snapshot_file(&path, "before insert").await
+    .map_err(|e| log::warn!("history before-snapshot failed: {e}")).ok();
+
+// ... perform mutation ...
+
+let after_snap_result = if let Some(before) = before_snap {
+    match self.history.snapshot_file(&path, "after insert").await {
+        Ok(after) => {
+            let diff = self.history.diff_commits(&repo_dir, before, after).await.unwrap_or_default();
+            Some((after, diff))
+        }
+        Err(e) => { log::warn!("history after-snapshot failed: {e}"); None }
+    }
+} else { None };
+```
+
+## Why This Works
+
+- **validate_write_path**: Mutation tools require write access validation, not just path resolution
+- **split_inclusive('\n')**: Preserves exact line endings (including trailing newline on last line) during split/join
+- **is_char_boundary()**: Rust strings are UTF-8; slicing at arbitrary byte offsets inside multibyte characters panics. Must validate boundary before slicing.
+- **filter_map(|r| r.ok())**: Matches existing project pattern for graceful degradation when regex iterator encounters runtime errors
+- **Error on no match**: Prevents silent no-ops; user explicitly wants replacement to occur
+- **Error on ambiguous multi-match**: Forces explicit `replace_all=true` decision, prevents accidental bulk replacement
+
+## Prevention Strategies
+
+**Test Cases:**
+- UTF-8 boundary validation: insertion at valid and invalid byte offsets in emoji/CJK lines
+- Line boundary edge cases: `insert_line: 0`, `insert_line: total_lines`, `insert_line > total_lines`
+- Column boundary: `column: 1` (start), `column: past_end`, `column: inside_multibyte`
+- Regex patterns with lookahead/lookbehind
+- Capture group backreferences: `$0`, `$1`, `$2`
+- No-match error, multi-match error, invalid-regex error
+- CRLF line ending preservation in column insertion
+
+**Code Review Checklist:**
+- [ ] Mutation tools use `validate_write_path`, not `validate_path`
+- [ ] Byte-offset slicing has `is_char_boundary()` guard
+- [ ] Regex tools handle iterator errors gracefully
+- [ ] Ambiguous operations require explicit flags (e.g., `replace_all`)
+- [ ] Size guards on both input and output (`WRITE_MAX_BYTES`)
+- [ ] History snapshot pattern consistent with existing mutation tools
+
+**Best Practices:**
+- Always check `is_char_boundary()` before slicing `&str` by byte offset
+- Prefer `split_inclusive('\n')` for line-based operations to preserve endings
+- Return specific errors for no-match and ambiguous-match cases in search/replace tools
+- Follow existing mutation-tool patterns for consistency (history, validation, size guards)
+
+## Related Issues
+
+- **Plan:** [harnx-511-insert-rereplace](/plans/harnx-511-insert-rereplace.md)
+- **Related Solution:** [mcp-tool-template-design-guidelines-2026-05-08.md](../integration-issues/mcp-tool-template-design-guidelines-2026-05-08.md) — call_template design for tool display
+- **Future Work:** Extract shared history snapshot/write/diff helper (~20 lines duplicated per mutation tool)

--- a/docs/solutions/integration-issues/mcp-fs-insert-rereplace-tools-2026-05-11.md
+++ b/docs/solutions/integration-issues/mcp-fs-insert-rereplace-tools-2026-05-11.md
@@ -54,7 +54,7 @@ Position-based insertion with optional column offset:
 #[derive(Debug, Deserialize)]
 pub struct InsertParams {
     pub path: String,
-    pub insert_line: usize,       // 0-indexed: 0=prepend, N=after line N
+    pub insert_line: usize,       // 0 = prepend; 1..=N = 1-based line numbers (N appends)
     pub insert_text: String,
     #[serde(default)]
     pub column: Option<usize>,   // 1-indexed byte offset within line


### PR DESCRIPTION
Adds 'insert' and 're_replace' tools to the mcp-fs server for more precise file editing. Includes a changeset and documentation for the new tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added text insertion capability for inserting content at specified line positions within files, with comprehensive support for prepending, appending, and mid-line insertion operations.
  * Added new regex-based find-and-replace functionality for advanced pattern matching and flexible text replacement, including options for both single and bulk replacement operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/514)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->