### PR TITLE
Improve MCP tool schemas and descriptions for better agent UX

### DIFF
--- a/.changesets/mcp-schema-agent-ux.md
+++ b/.changesets/mcp-schema-agent-ux.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Add per-field descriptions to MCP tool schemas and update tool-level descriptions to guide agents toward using native tool parameters (head_lines, tail_lines, grep, offset, limit) instead of shell pipe alternatives. Fixes #491 and #513.

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -133,7 +133,11 @@ impl JsonSchema for ReadExecLogParams {
                     execution_id,
                 ),
                 ("stream", "'stdout' or 'stderr'.", stream),
-                ("offset", "Skip the first N lines of the log (1-indexed).", offset),
+                (
+                    "offset",
+                    "Skip the first N lines of the log (1-indexed).",
+                    offset,
+                ),
                 ("limit", "Return at most N lines.", limit),
                 ("tail", "Return only the last N lines.", tail),
                 ("grep", "Filter lines by regex before truncating.", grep),

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -5,6 +5,7 @@ use harnx_mcp::safety::{
 
 use fancy_regex::Regex;
 use gix::ObjectId;
+use harnx_mcp::schema::object_schema_with_desc;
 use harnx_mcp_history::classify::{classify_command, SnapshotDecision};
 use harnx_mcp_history::HistoryManager;
 #[cfg(windows)]
@@ -73,16 +74,16 @@ impl JsonSchema for ExecCommandParams {
         let max_output_bytes = generator.subschema_for::<Option<usize>>();
         let inputs = generator.subschema_for::<Option<Vec<String>>>();
         let outputs = generator.subschema_for::<Option<Vec<String>>>();
-        object_schema(
+        object_schema_with_desc(
             vec![
-                ("command", command),
-                ("working_dir", working_dir),
-                ("timeout_secs", timeout_secs),
-                ("head_lines", head_lines),
-                ("tail_lines", tail_lines),
-                ("max_output_bytes", max_output_bytes),
-                ("inputs", inputs),
-                ("outputs", outputs),
+                ("command", "Bash command to execute. Avoid shell pipes like | head, | tail, | grep — use head_lines, tail_lines, max_output_bytes instead.", command),
+                ("working_dir", "Working directory for the command. Defaults to the project root.", working_dir),
+                ("timeout_secs", "Kill the command after this many seconds. Default: no timeout.", timeout_secs),
+                ("head_lines", "Return only the first N lines of combined output. Prefer this over `| head -N` in the command.", head_lines),
+                ("tail_lines", "Return only the last N lines of combined output. Prefer this over `| tail -N` in the command.", tail_lines),
+                ("max_output_bytes", "Truncate output to this many bytes. Prefer this over `| head -c N` in the command.", max_output_bytes),
+                ("inputs", "Paths that the command will read (for sandbox allow-listing).", inputs),
+                ("outputs", "Paths that the command will write (triggers history snapshot).", outputs),
             ],
             &["command"],
         )
@@ -124,17 +125,25 @@ impl JsonSchema for ReadExecLogParams {
         let head_lines = generator.subschema_for::<Option<usize>>();
         let tail_lines = generator.subschema_for::<Option<usize>>();
         let max_output_bytes = generator.subschema_for::<Option<usize>>();
-        object_schema(
+        object_schema_with_desc(
             vec![
-                ("execution_id", execution_id),
-                ("stream", stream),
-                ("offset", offset),
-                ("limit", limit),
-                ("tail", tail),
-                ("grep", grep),
-                ("head_lines", head_lines),
-                ("tail_lines", tail_lines),
-                ("max_output_bytes", max_output_bytes),
+                (
+                    "execution_id",
+                    "The execution_id returned by exec or spawn.",
+                    execution_id,
+                ),
+                ("stream", "'stdout' or 'stderr'.", stream),
+                ("offset", "Skip the first N lines of the log (1-indexed).", offset),
+                ("limit", "Return at most N lines.", limit),
+                ("tail", "Return only the last N lines.", tail),
+                ("grep", "Filter lines by regex before truncating.", grep),
+                ("head_lines", "Return only the first N lines.", head_lines),
+                ("tail_lines", "Return only the last N lines.", tail_lines),
+                (
+                    "max_output_bytes",
+                    "Truncate output to this many bytes.",
+                    max_output_bytes,
+                ),
             ],
             &["execution_id", "stream"],
         )
@@ -163,12 +172,20 @@ impl JsonSchema for SpawnCommandParams {
         let working_dir = generator.subschema_for::<Option<String>>();
         let inputs = generator.subschema_for::<Option<Vec<String>>>();
         let outputs = generator.subschema_for::<Option<Vec<String>>>();
-        object_schema(
+        object_schema_with_desc(
             vec![
-                ("command", command),
-                ("working_dir", working_dir),
-                ("inputs", inputs),
-                ("outputs", outputs),
+                ("command", "Bash command to run in the background.", command),
+                (
+                    "working_dir",
+                    "Working directory. Defaults to the project root.",
+                    working_dir,
+                ),
+                ("inputs", "Paths the command will read.", inputs),
+                (
+                    "outputs",
+                    "Paths the command will write (triggers history snapshot on wait).",
+                    outputs,
+                ),
             ],
             &["command"],
         )
@@ -202,14 +219,14 @@ impl JsonSchema for WaitParams {
         let tail_lines = generator.subschema_for::<Option<usize>>();
         let max_output_bytes = generator.subschema_for::<Option<usize>>();
         let grep = generator.subschema_for::<Option<String>>();
-        object_schema(
+        object_schema_with_desc(
             vec![
-                ("execution_id", execution_id),
-                ("timeout_secs", timeout_secs),
-                ("head_lines", head_lines),
-                ("tail_lines", tail_lines),
-                ("max_output_bytes", max_output_bytes),
-                ("grep", grep),
+                ("execution_id", "The execution_id returned by spawn.", execution_id),
+                ("timeout_secs", "Seconds to wait before returning partial output without killing the process.", timeout_secs),
+                ("head_lines", "Return only the first N lines of output. Prefer this over post-processing with head.", head_lines),
+                ("tail_lines", "Return only the last N lines of output. Prefer this over post-processing with tail.", tail_lines),
+                ("max_output_bytes", "Truncate output to this many bytes.", max_output_bytes),
+                ("grep", "Filter output lines by regex.", grep),
             ],
             &["execution_id"],
         )
@@ -231,8 +248,19 @@ impl JsonSchema for TerminateParams {
     fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         let execution_id = generator.subschema_for::<String>();
         let signal = generator.subschema_for::<Option<String>>();
-        object_schema(
-            vec![("execution_id", execution_id), ("signal", signal)],
+        object_schema_with_desc(
+            vec![
+                (
+                    "execution_id",
+                    "The execution_id returned by spawn.",
+                    execution_id,
+                ),
+                (
+                    "signal",
+                    "Signal to send. One of: SIGTERM (default), SIGKILL, SIGINT, SIGHUP.",
+                    signal,
+                ),
+            ],
             &["execution_id"],
         )
     }
@@ -252,8 +280,19 @@ impl JsonSchema for RollbackParams {
     fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         let commit_id = generator.subschema_for::<String>();
         let repo_path = generator.subschema_for::<String>();
-        object_schema(
-            vec![("commit_id", commit_id), ("repo_path", repo_path)],
+        object_schema_with_desc(
+            vec![
+                (
+                    "commit_id",
+                    "The harnx snapshot commit SHA shown in a prior tool response diff header.",
+                    commit_id,
+                ),
+                (
+                    "repo_path",
+                    "Absolute path to the git repository root to roll back.",
+                    repo_path,
+                ),
+            ],
             &["commit_id", "repo_path"],
         )
     }
@@ -2026,7 +2065,7 @@ impl ServerHandler for BashServer {
             tools: vec![
                 Tool::new(
                     "exec",
-                    "Execute a local bash command and return truncated combined stdout/stderr. When output is cropped, stdout/stderr temp log files are included for later retrieval.",
+                    "Execute a local bash command and return truncated combined stdout/stderr. When output is cropped, stdout/stderr temp log files are included for later retrieval. Prefer head_lines/tail_lines/max_output_bytes params over piping to head/tail in the command string.",
                     Map::new(),
                 )
                 .with_input_schema::<ExecCommandParams>()
@@ -2053,7 +2092,7 @@ impl ServerHandler for BashServer {
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "wait",
-                    "Wait for a spawned background process to exit. Returns the exit code, output metrics, and truncated output. If the process does not exit within the timeout, returns its current status and partial output without killing it.",
+                    "Wait for a spawned background process to exit. Returns the exit code, output metrics, and truncated output. If the process does not exit within the timeout, returns its current status and partial output without killing it. Use head_lines/tail_lines/grep to filter output rather than post-processing with shell tools.",
                     Map::new(),
                 )
                 .with_input_schema::<WaitParams>()
@@ -2255,32 +2294,6 @@ fn load_bash_env_file() -> Vec<(String, String)> {
             Some((key.to_string(), value.to_string()))
         })
         .collect()
-}
-
-fn object_schema(properties: Vec<(&str, Schema)>, required: &[&str]) -> Schema {
-    let mut schema = Map::new();
-    schema.insert("type".to_string(), Value::String("object".to_string()));
-
-    let mut property_map = Map::new();
-    for (name, property_schema) in properties {
-        property_map.insert(name.to_string(), property_schema.as_value().clone());
-    }
-    schema.insert("properties".to_string(), Value::Object(property_map));
-    schema.insert("additionalProperties".to_string(), Value::Bool(false));
-
-    if !required.is_empty() {
-        schema.insert(
-            "required".to_string(),
-            Value::Array(
-                required
-                    .iter()
-                    .map(|name| Value::String((*name).to_string()))
-                    .collect(),
-            ),
-        );
-    }
-
-    schema.into()
 }
 
 async fn read_pipe_to_file<R>(mut reader: R, mut writer: TokioFile) -> std::io::Result<Vec<u8>>

--- a/crates/harnx-mcp-fs/src/server.rs
+++ b/crates/harnx-mcp-fs/src/server.rs
@@ -9,6 +9,7 @@ use harnx_mcp::safety::{
     DEFAULT_MAX_LINES, GREP_MAX_LINE_LENGTH, LS_SCAN_HARD_LIMIT, READ_MAX_FILE_BYTES,
     SEARCH_FILE_MAX_BYTES, WRITE_MAX_BYTES,
 };
+use harnx_mcp::schema::object_schema_with_desc;
 use harnx_mcp_history::HistoryManager;
 
 use fancy_regex::Regex;
@@ -133,16 +134,16 @@ impl JsonSchema for ReadFileParams {
         let head_lines = generator.subschema_for::<Option<usize>>();
         let tail_lines = generator.subschema_for::<Option<usize>>();
         let max_output_bytes = generator.subschema_for::<Option<usize>>();
-        object_schema(
+        object_schema_with_desc(
             vec![
-                ("path", path),
-                ("offset", offset),
-                ("limit", limit),
-                ("tail", tail),
-                ("grep", grep),
-                ("head_lines", head_lines),
-                ("tail_lines", tail_lines),
-                ("max_output_bytes", max_output_bytes),
+                ("path", "Absolute path to the file to read. Prefer this tool over shell commands like sed, cat, head, tail for reading files.", path),
+                ("offset", "Start reading at this line number (1-indexed). Use to read a specific line range instead of `sed -n 'N,Mp'`.", offset),
+                ("limit", "Maximum number of lines to return from offset. Combine with offset to read a range.", limit),
+                ("tail", "Return only the last N lines of the file.", tail),
+                ("grep", "Filter lines by regex pattern before returning.", grep),
+                ("head_lines", "Return only the first N lines. Prefer this over piping through head.", head_lines),
+                ("tail_lines", "Return only the last N lines. Prefer this over piping through tail.", tail_lines),
+                ("max_output_bytes", "Truncate output to at most this many bytes.", max_output_bytes),
             ],
             &["path"],
         )
@@ -157,8 +158,19 @@ impl JsonSchema for WriteFileParams {
     fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         let path = generator.subschema_for::<String>();
         let content = generator.subschema_for::<String>();
-        object_schema(
-            vec![("path", path), ("content", content)],
+        object_schema_with_desc(
+            vec![
+                (
+                    "path",
+                    "Absolute path to the file to write or create.",
+                    path,
+                ),
+                (
+                    "content",
+                    "Full file content to write (replaces existing content).",
+                    content,
+                ),
+            ],
             &["path", "content"],
         )
     }
@@ -174,12 +186,20 @@ impl JsonSchema for EditFileParams {
         let old_text = generator.subschema_for::<String>();
         let new_text = generator.subschema_for::<String>();
         let replace_all = generator.subschema_for::<Option<bool>>();
-        object_schema(
+        object_schema_with_desc(
             vec![
-                ("path", path),
-                ("old_text", old_text),
-                ("new_text", new_text),
-                ("replace_all", replace_all),
+                ("path", "Absolute path to the file to edit.", path),
+                (
+                    "old_text",
+                    "Exact text to find and replace. Must match exactly including whitespace.",
+                    old_text,
+                ),
+                ("new_text", "Replacement text.", new_text),
+                (
+                    "replace_all",
+                    "If true, replace all occurrences. Default: replace only the first.",
+                    replace_all,
+                ),
             ],
             &["path", "old_text", "new_text"],
         )
@@ -196,12 +216,12 @@ impl JsonSchema for InsertParams {
         let insert_line = generator.subschema_for::<usize>();
         let insert_text = generator.subschema_for::<String>();
         let column = generator.subschema_for::<Option<usize>>();
-        object_schema(
+        object_schema_with_desc(
             vec![
-                ("path", path),
-                ("insert_line", insert_line),
-                ("insert_text", insert_text),
-                ("column", column),
+                ("path", "Absolute path to the file to insert into.", path),
+                ("insert_line", "Insert after this line number. 0 = prepend before line 1. N = total lines to append.", insert_line),
+                ("insert_text", "Text to insert.", insert_text),
+                ("column", "1-indexed byte offset within the line for mid-line insertion. Default: 1 (start of line).", column),
             ],
             &["path", "insert_line", "insert_text"],
         )
@@ -218,12 +238,12 @@ impl JsonSchema for ReReplaceParams {
         let pattern = generator.subschema_for::<String>();
         let replacement = generator.subschema_for::<String>();
         let replace_all = generator.subschema_for::<Option<bool>>();
-        object_schema(
+        object_schema_with_desc(
             vec![
-                ("path", path),
-                ("pattern", pattern),
-                ("replacement", replacement),
-                ("replace_all", replace_all),
+                ("path", "Absolute path to the file.", path),
+                ("pattern", "fancy_regex pattern (supports lookahead/lookbehind). Use $0 for full match, $1/$2 for groups.", pattern),
+                ("replacement", "Replacement string. Use $0/$1/$2 for capture groups.", replacement),
+                ("replace_all", "If true, replace all matches. Default: replace only the first (errors if more than one match).", replace_all),
             ],
             &["path", "pattern", "replacement"],
         )
@@ -238,7 +258,13 @@ impl JsonSchema for ListDirectoryParams {
     fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         let path = generator.subschema_for::<String>();
         let recursive = generator.subschema_for::<Option<bool>>();
-        object_schema(vec![("path", path), ("recursive", recursive)], &["path"])
+        object_schema_with_desc(
+            vec![
+                ("path", "Absolute path to the directory to list. Prefer this tool over running bash ls.", path),
+                ("recursive", "If true, list recursively. Default: false.", recursive),
+            ],
+            &["path"],
+        )
     }
 }
 
@@ -254,14 +280,34 @@ impl JsonSchema for SearchFilesParams {
         let context_lines = generator.subschema_for::<Option<usize>>();
         let ignore_case = generator.subschema_for::<Option<bool>>();
         let max_results = generator.subschema_for::<Option<usize>>();
-        object_schema(
+        object_schema_with_desc(
             vec![
-                ("pattern", pattern),
-                ("path", path),
-                ("include", include),
-                ("context_lines", context_lines),
-                ("ignore_case", ignore_case),
-                ("max_results", max_results),
+                (
+                    "pattern",
+                    "Regex pattern to search for. Prefer this tool over running bash grep.",
+                    pattern,
+                ),
+                (
+                    "path",
+                    "Directory to search in. Defaults to project root.",
+                    path,
+                ),
+                (
+                    "include",
+                    "Glob pattern to filter files (e.g. '*.rs').",
+                    include,
+                ),
+                (
+                    "context_lines",
+                    "Number of lines of context around each match.",
+                    context_lines,
+                ),
+                ("ignore_case", "Case-insensitive search.", ignore_case),
+                (
+                    "max_results",
+                    "Maximum number of matching lines to return.",
+                    max_results,
+                ),
             ],
             &["pattern"],
         )
@@ -277,11 +323,11 @@ impl JsonSchema for FindFilesParams {
         let pattern = generator.subschema_for::<String>();
         let path = generator.subschema_for::<Option<String>>();
         let max_results = generator.subschema_for::<Option<usize>>();
-        object_schema(
+        object_schema_with_desc(
             vec![
-                ("pattern", pattern),
-                ("path", path),
-                ("max_results", max_results),
+                ("pattern", "Glob pattern to match file paths (e.g. '**/*.rs'). Prefer this tool over running bash find.", pattern),
+                ("path", "Directory to search in. Defaults to project root.", path),
+                ("max_results", "Maximum number of results to return.", max_results),
             ],
             &["pattern"],
         )
@@ -296,8 +342,19 @@ impl JsonSchema for RollbackParams {
     fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         let commit_id = generator.subschema_for::<String>();
         let repo_path = generator.subschema_for::<String>();
-        object_schema(
-            vec![("commit_id", commit_id), ("repo_path", repo_path)],
+        object_schema_with_desc(
+            vec![
+                (
+                    "commit_id",
+                    "The harnx snapshot commit SHA shown in a prior tool response diff header.",
+                    commit_id,
+                ),
+                (
+                    "repo_path",
+                    "Absolute path to the git repository root to roll back.",
+                    repo_path,
+                ),
+            ],
             &["commit_id", "repo_path"],
         )
     }
@@ -1180,7 +1237,7 @@ impl ServerHandler for FsServer {
     ) -> Result<ListToolsResult, ErrorData> {
         let read_only = ToolAnnotations::new().read_only(true);
         let tools = vec![
-                Tool::new("read", "Read a text file with line numbers, pagination, grep filtering, and smart truncation.", Map::new())
+                Tool::new("read", "Read a text file with line numbers, pagination, grep filtering, and smart truncation. Prefer this tool over shell commands like sed, cat, head, tail. Use offset+limit to read specific line ranges instead of sed -n.", Map::new())
                     .with_input_schema::<ReadFileParams>()
                     .annotate(read_only.clone())
                     .with_meta(make_tool_meta("📖 {{ args.path }}{% if args.offset %} +{{ args.offset }}{% endif %}{% if args.limit is not none %} [:{{ args.limit }}]{% endif %}{% if args.tail is not none %} [tail:{{ args.tail }}]{% endif %}{% if args.grep %} /{{ args.grep }}/{% endif %}{% if args.head_lines is not none %} [head:{{ args.head_lines }}]{% endif %}{% if args.tail_lines is not none %} [tail_lines:{{ args.tail_lines }}]{% endif %}{% if args.max_output_bytes is not none %} [:{{ args.max_output_bytes }}b]{% endif %}")),
@@ -1204,15 +1261,15 @@ impl ServerHandler for FsServer {
                     .with_meta(make_tool_meta(
                         "🔁 {{ args.path }}{% if args.replace_all %} [all]{% endif %}\n▸ /{{ args.pattern }}/\n↳ {{ args.replacement | truncate(60) }}"
                     )),
-                Tool::new("ls", "List directory contents, optionally recursively.", Map::new())
+                Tool::new("ls", "List directory contents, optionally recursively. Prefer this tool over running bash ls.", Map::new())
                     .with_input_schema::<ListDirectoryParams>()
                     .annotate(read_only.clone())
                     .with_meta(make_tool_meta("📂 {{ args.path }}{% if args.recursive %} -r{% endif %}")),
-                Tool::new("grep", "Search file contents with regex and optional context lines.", Map::new())
+                Tool::new("grep", "Search file contents with regex and optional context lines. Prefer this tool over running bash grep.", Map::new())
                     .with_input_schema::<SearchFilesParams>()
                     .annotate(read_only.clone())
                     .with_meta(make_tool_meta("🔍 /{{ args.pattern }}/{% if args.ignore_case %}i{% endif %}{% if args.path %} {{ args.path }}{% endif %}{% if args.include %} [{{ args.include }}]{% endif %}{% if args.context_lines %} ±{{ args.context_lines }}{% endif %}{% if args.max_results %} [max:{{ args.max_results }}]{% endif %}")),
-                Tool::new("find", "Find files by glob pattern.", Map::new())
+                Tool::new("find", "Find files by glob pattern. Prefer this tool over running bash find.", Map::new())
                     .with_input_schema::<FindFilesParams>()
                     .annotate(read_only.clone())
                     .with_meta(make_tool_meta("🔎 {{ args.pattern }}{% if args.path %} {{ args.path }}{% endif %}{% if args.max_results %} [max:{{ args.max_results }}]{% endif %}")),
@@ -1335,32 +1392,6 @@ fn default_search_path(roots: &[PathBuf]) -> PathBuf {
         .first()
         .cloned()
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
-}
-
-fn object_schema(properties: Vec<(&str, Schema)>, required: &[&str]) -> Schema {
-    let mut schema = Map::new();
-    schema.insert("type".to_string(), Value::String("object".to_string()));
-
-    let mut property_map = Map::new();
-    for (name, property_schema) in properties {
-        property_map.insert(name.to_string(), property_schema.as_value().clone());
-    }
-    schema.insert("properties".to_string(), Value::Object(property_map));
-    schema.insert("additionalProperties".to_string(), Value::Bool(false));
-
-    if !required.is_empty() {
-        schema.insert(
-            "required".to_string(),
-            Value::Array(
-                required
-                    .iter()
-                    .map(|name| Value::String((*name).to_string()))
-                    .collect(),
-            ),
-        );
-    }
-
-    schema.into()
 }
 
 fn walk_dir_flat(dir: &Path, entries: &mut Vec<String>, scan_count: &mut usize) {

--- a/crates/harnx-mcp/src/lib.rs
+++ b/crates/harnx-mcp/src/lib.rs
@@ -8,6 +8,7 @@ pub mod client;
 pub mod config;
 pub mod convert;
 pub mod safety;
+pub mod schema;
 
 pub use client::McpManager;
 pub use config::McpServerConfig;

--- a/crates/harnx-mcp/src/schema.rs
+++ b/crates/harnx-mcp/src/schema.rs
@@ -1,0 +1,33 @@
+use rmcp::schemars::Schema;
+use serde_json::{Map, Value};
+
+/// Build a JSON Schema object where each property carries a `description`.
+/// Signature matches `harnx-mcp-plans`'s gold-standard helper.
+pub fn object_schema_with_desc(properties: Vec<(&str, &str, Schema)>, required: &[&str]) -> Schema {
+    let mut schema = Map::new();
+    schema.insert("type".to_string(), Value::String("object".to_string()));
+
+    let mut property_map = Map::new();
+    for (name, desc, property_schema) in properties {
+        let mut prop = property_schema.as_value().clone();
+        if let Some(obj) = prop.as_object_mut() {
+            obj.insert("description".to_string(), Value::String(desc.to_string()));
+        }
+        property_map.insert(name.to_string(), prop);
+    }
+    schema.insert("properties".to_string(), Value::Object(property_map));
+    schema.insert("additionalProperties".to_string(), Value::Bool(false));
+
+    if !required.is_empty() {
+        schema.insert(
+            "required".to_string(),
+            Value::Array(
+                required
+                    .iter()
+                    .map(|n| Value::String((*n).to_string()))
+                    .collect(),
+            ),
+        );
+    }
+    schema.into()
+}

--- a/docs/solutions/integration-issues/mcp-schema-ux-native-params-2026-05-11.md
+++ b/docs/solutions/integration-issues/mcp-schema-ux-native-params-2026-05-11.md
@@ -1,0 +1,148 @@
+---
+title: "MCP schema UX: per-field descriptions guide agents toward native params"
+date: 2026-05-11
+category: "integration-issues"
+problem_type: integration_issue
+component: "harnx-mcp-servers"
+root_cause: "missing schema descriptions led agents to use shell pipes instead of native tool parameters"
+resolution_type: code_fix
+severity: medium
+tags:
+  - mcp
+  - schema
+  - json-schema
+  - agent-behavior
+  - descriptions
+plan_ref: "mcp-schema-agent-ux"
+---
+
+## Problem
+
+MCP tool schemas in `harnx-mcp-bash` and `harnx-mcp-fs` lacked per-field descriptions. Agents (Claude) bypassed native tool parameters (`head_lines`, `tail_lines`, `grep`, `offset`, `limit`) and used shell pipes (`| head`, `| tail`, `| grep`) instead, reducing efficiency and losing structured output handling.
+
+## Symptoms
+
+- Agents wrote `command: "git log --oneline | head -20"` instead of using `head_lines: 20`
+- Shell pipelines made output post-processing harder (no incremental streaming, no structured metadata)
+- No guidance in schema for agents to prefer native params
+- Field semantics unclear (line vs byte, optional vs required)
+
+## Investigation Steps
+
+1. Reviewed `list_tools` output — `inputSchema` had `properties` but no `description` fields
+2. Compared `harnx-mcp-plans` (which had a richer schema helper) to `harnx-mcp-bash`/`harnx-mcp-fs`
+3. Identified the pattern: `harnx-mcp-plans` used `object_schema_with_desc(vec![(name, desc, schema), ...], required)`
+4. Decided to centralize this helper in `harnx-mcp` shared crate and migrate all servers
+
+## Root Cause
+
+Schema generation used `object_schema()` helper producing bare JSON schema objects without descriptions. When agents inspect `inputSchema`, they see field names only — no guidance on semantics or preferred usage patterns.
+
+The fix required:
+1. Centralizing `object_schema_with_desc()` in `harnx-mcp/src/schema.rs`
+2. Migrating all `JsonSchema` impls in bash/fs servers to use it
+3. Writing accurate descriptions that mention native params and discourage shell anti-patterns
+
+## Solution
+
+### 1. Shared helper in `harnx-mcp/src/schema.rs`
+
+```rust
+/// Build a JSON Schema object where each property carries a `description`.
+pub fn object_schema_with_desc(
+    properties: Vec<(&str, &str, Schema)>,
+    required: &[&str],
+) -> Schema {
+    let mut schema = Map::new();
+    schema.insert("type".to_string(), Value::String("object".to_string()));
+
+    let mut property_map = Map::new();
+    for (name, desc, property_schema) in properties {
+        let mut prop = property_schema.as_value().clone();
+        if let Some(obj) = prop.as_object_mut() {
+            obj.insert("description".to_string(), Value::String(desc.to_string()));
+        }
+        property_map.insert(name.to_string(), prop);
+    }
+    schema.insert("properties".to_string(), Value::Object(property_map));
+    schema.insert("additionalProperties".to_string(), Value::Bool(false));
+
+    if !required.is_empty() {
+        schema.insert(
+            "required".to_string(),
+            Value::Array(
+                required.iter().map(|n| Value::String((*n).to_string())).collect(),
+            ),
+        );
+    }
+    schema.into()
+}
+```
+
+### 2. Migration pattern
+
+**Before (no descriptions):**
+```rust
+object_schema(
+    vec![
+        ("command", command),
+        ("head_lines", head_lines),
+    ],
+    &["command"],
+)
+```
+
+**After (with descriptions):**
+```rust
+object_schema_with_desc(
+    vec![
+        ("command", "Bash command to execute. Avoid shell pipes like | head, | tail, | grep — use head_lines, tail_lines, max_output_bytes instead.", command),
+        ("head_lines", "Return only the first N lines of combined output. Prefer this over `| head -N` in the command.", head_lines),
+    ],
+    &["command"],
+)
+```
+
+### 3. Accuracy rules discovered during review
+
+**Critical:** Schema descriptions must exactly match implementation:
+- If a tool has no `grep` param, do NOT mention `grep` in its descriptions
+- If `offset`/`limit`/`tail` are line-based, descriptions must say "lines" not "bytes"
+- Use same terminology across all tools for consistency
+
+### 4. Accepted duplication
+
+`harnx-mcp-plans` still has a local copy of `object_schema_with_desc` — not migrated because it would require adding a new dependency. This is accepted technical debt.
+
+## Why This Works
+
+**Agent behavior guidance:** MCP agents read `inputSchema` descriptions to understand tool parameters. Adding explicit "Prefer X over Y" guidance directly shapes agent behavior.
+
+**Semantics clarity:** Describing `head_lines` as "Return only the first N lines" removes ambiguity about line vs byte semantics.
+
+**Discoverability:** Field descriptions appear in `list_tools` output, making native params discoverable without reading source code.
+
+## Prevention Strategies
+
+**Schema description checklist:**
+- [ ] Every field has a description
+- [ ] Descriptions match actual semantics (lines vs bytes, 0-indexed vs 1-indexed)
+- [ ] Tool-level descriptions mention native params, not shell alternatives
+- [ ] If a param doesn't exist, don't mention it in descriptions
+- [ ] Prefer consistent phrasing across all servers
+
+**Review verification:**
+- Inspect `inputSchema` via `list_tools` after changes
+- Verify no shell-pipe guidance references unsupported params
+- Check line-vs-byte wording matches implementation
+
+**Test pattern:**
+- Add unit tests for `object_schema_with_desc` in shared crate
+- Add snapshot tests that verify `inputSchema` includes descriptions
+
+## Related Issues
+
+- **GitHub:** #491 — MCP schema UX improvements
+- **GitHub:** #513 — Agents using shell pipes instead of native params
+- **Changeset:** `.changesets/mcp-schema-agent-ux.md`
+- **Related Solution:** [integration-issues/mcp-tool-template-design-guidelines-2026-05-08.md](./mcp-tool-template-design-guidelines-2026-05-08.md) — Tool call_template design (display-side)


### PR DESCRIPTION
Adds per-field schema descriptions to harnx-mcp-bash and harnx-mcp-fs MCP tools and updates tool-level descriptions to guide agents toward using native parameters (head_lines, tail_lines, grep, offset, limit) instead of shell pipe alternatives. Centralizes the object_schema_with_desc helper in harnx-mcp to support this pattern.

Includes a solution document describing the integration pattern and associated schema improvements.

#491
#513

Plan: mcp-schema-agent-ux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP schema documentation with per-field descriptions for tool parameters.
  * Added guidance for AI agents to use native parameters (`head_lines`, `tail_lines`, `grep`, `offset`, `limit`) instead of shell-pipe alternatives.
  * Added comprehensive integration issue documentation explaining schema improvements.

* **Improvements**
  * Enhanced MCP tool schema generation across bash and filesystem tools with human-readable field descriptions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/515)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->