### PR TITLE
feat(mcp-fs): make insert_line optional — omit to append to end of file

### DIFF
--- a/.changesets/mcp-fs-insert-append-optional.md
+++ b/.changesets/mcp-fs-insert-append-optional.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+Make `insert_line` optional in the `fs_insert` MCP tool. When omitted, text is appended to the end of the file, making it easy to build up large files in chunks without needing to know the current line count.

--- a/crates/harnx-mcp-fs/src/server.rs
+++ b/crates/harnx-mcp-fs/src/server.rs
@@ -68,7 +68,8 @@ pub struct EditFileParams {
 #[derive(Debug, Deserialize)]
 pub struct InsertParams {
     pub path: String,
-    pub insert_line: usize,
+    #[serde(default)]
+    pub insert_line: Option<usize>,
     pub insert_text: String,
     #[serde(default)]
     pub column: Option<usize>,
@@ -213,17 +214,17 @@ impl JsonSchema for InsertParams {
 
     fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         let path = generator.subschema_for::<String>();
-        let insert_line = generator.subschema_for::<usize>();
+        let insert_line = generator.subschema_for::<Option<usize>>();
         let insert_text = generator.subschema_for::<String>();
         let column = generator.subschema_for::<Option<usize>>();
         object_schema_with_desc(
             vec![
                 ("path", "Absolute path to the file to insert into.", path),
-                ("insert_line", "Insert after this line number. 0 = prepend before line 1. N = total lines to append.", insert_line),
+                ("insert_line", "Insert after this line number. 0 = prepend before line 1; N = insert after line N; omit (or use N = total lines) to append to the end of the file.", insert_line),
                 ("insert_text", "Text to insert.", insert_text),
                 ("column", "1-indexed byte offset within the line for mid-line insertion. Default: 1 (start of line).", column),
             ],
-            &["path", "insert_line", "insert_text"],
+            &["path", "insert_text"],
         )
     }
 }
@@ -644,10 +645,16 @@ impl FsServer {
 
         let lines = content.split_inclusive('\n').collect::<Vec<_>>();
         let total_lines = lines.len();
-        if params.insert_line > total_lines {
+        // None means append (equivalent to insert after last line).
+        // We track the original presence separately: when the caller omitted
+        // insert_line we must never enter the mid-line (column) branch even if
+        // a column value was supplied, because the intent is EOF-append.
+        let append_mode = params.insert_line.is_none();
+        let insert_line = params.insert_line.unwrap_or(total_lines);
+        if insert_line > total_lines {
             return tool_error(format!(
                 "insert_line {} out of range for file with {} lines",
-                params.insert_line, total_lines
+                insert_line, total_lines
             ));
         }
 
@@ -657,17 +664,17 @@ impl FsServer {
             ));
         }
 
-        let new_content = if params.insert_line == 0 {
+        let new_content = if insert_line == 0 {
             format!("{}{}", params.insert_text, content)
-        } else if params.column.unwrap_or(1) <= 1 {
+        } else if append_mode || params.column.unwrap_or(1) <= 1 {
             format!(
                 "{}{}{}",
-                lines[..params.insert_line].join(""),
+                lines[..insert_line].join(""),
                 params.insert_text,
-                lines[params.insert_line..].join("")
+                lines[insert_line..].join("")
             )
         } else {
-            let line = lines[params.insert_line - 1];
+            let line = lines[insert_line - 1];
             let (stripped_line, had_newline) = match line.strip_suffix('\n') {
                 Some(stripped) => (stripped, true),
                 None => (line, false),
@@ -677,7 +684,7 @@ impl FsServer {
             if insert_index > stripped_line.len() || !stripped_line.is_char_boundary(insert_index) {
                 return tool_error(format!(
                     "column {} is not a valid UTF-8 character boundary in line {}",
-                    column, params.insert_line
+                    column, insert_line
                 ));
             }
             let new_line = if had_newline {
@@ -698,9 +705,9 @@ impl FsServer {
             };
             format!(
                 "{}{}{}",
-                lines[..params.insert_line - 1].join(""),
+                lines[..insert_line - 1].join(""),
                 new_line,
-                lines[params.insert_line..].join("")
+                lines[insert_line..].join("")
             )
         };
 
@@ -1248,11 +1255,11 @@ impl ServerHandler for FsServer {
                     .with_input_schema::<EditFileParams>()
                     .with_meta(make_tool_meta("🔧 {{ args.path }}{% if args.replace_all %} [all]{% endif %}\n▸ {{ args.old_text | truncate(60) }}\n↳ {{ args.new_text | truncate(60) }}")),
                 Tool::new("insert",
-                    "Insert text into a file at a specific line position.      insert_line: 0 prepends before line 1; insert_line: N inserts after line N      (use N = total lines to append). Optional column (1-indexed byte offset within      the line, default 1 = start of line) for mid-line insertion.      For exact-text replacement use edit; for regex replacement use re_replace.",
+                    "Insert text into a file at a specific line position.      insert_line: 0 prepends before line 1; insert_line: N inserts after line N; omit insert_line (or set N = total lines) to append to the end of the file. Optional column (1-indexed byte offset within      the line, default 1 = start of line) for mid-line insertion.      For exact-text replacement use edit; for regex replacement use re_replace.",
                     Map::new())
                     .with_input_schema::<InsertParams>()
                     .with_meta(make_tool_meta(
-                        "➕ {{ args.path }}:{{ args.insert_line }}{% if args.column %}:{{ args.column }}{% endif %}\n↳ {{ args.insert_text | truncate(60) }}"
+                        "➕ {{ args.path }}:{{ args.insert_line | default(value=\"end\") }}{% if args.column %}:{{ args.column }}{% endif %}\n↳ {{ args.insert_text | truncate(60) }}"
                     )),
                 Tool::new("re_replace",
                     "Replace text in a file using a regular expression.      Uses fancy_regex syntax (supports lookahead/lookbehind).      Use $0 for the full match, $1/$2 etc. for capture groups in replacement.      Errors if pattern matches nothing. If pattern matches more than once,      set replace_all=true; otherwise only the first match is replaced.      For exact-text replacement use edit instead.",
@@ -2480,7 +2487,7 @@ gamma
         let result = server
             .insert_impl(InsertParams {
                 path: file_path.to_string_lossy().to_string(),
-                insert_line: 0,
+                insert_line: Some(0),
                 insert_text: "alpha
 "
                 .to_string(),
@@ -2515,7 +2522,7 @@ beta
         let result = server
             .insert_impl(InsertParams {
                 path: file_path.to_string_lossy().to_string(),
-                insert_line: 2,
+                insert_line: Some(2),
                 insert_text: "gamma
 "
                 .to_string(),
@@ -2531,6 +2538,57 @@ beta
 beta
 gamma
 "
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_append_omit_line() {
+        // Omitting insert_line entirely should append to end of file
+        let temp_dir = TestDir::new();
+        let file_path = temp_dir.path().join("append_omit.txt");
+        std::fs::write(&file_path, "alpha\nbeta\n").unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .insert_impl(InsertParams {
+                path: file_path.to_string_lossy().to_string(),
+                insert_line: None,
+                insert_text: "gamma\n".to_string(),
+                column: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(
+            std::fs::read_to_string(&file_path).unwrap(),
+            "alpha\nbeta\ngamma\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_append_omit_line_ignores_column() {
+        // When insert_line is omitted, a supplied column must NOT trigger
+        // mid-line insertion — it must still append at EOF.
+        let temp_dir = TestDir::new();
+        let file_path = temp_dir.path().join("append_col.txt");
+        std::fs::write(&file_path, "alpha\nbeta\n").unwrap();
+        let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .insert_impl(InsertParams {
+                path: file_path.to_string_lossy().to_string(),
+                insert_line: None,
+                insert_text: "gamma\n".to_string(),
+                column: Some(3), // would have inserted into last line without the fix
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(
+            std::fs::read_to_string(&file_path).unwrap(),
+            "alpha\nbeta\ngamma\n"
         );
     }
 
@@ -2552,7 +2610,7 @@ four
         let result = server
             .insert_impl(InsertParams {
                 path: file_path.to_string_lossy().to_string(),
-                insert_line: 2,
+                insert_line: Some(2),
                 insert_text: "between
 "
                 .to_string(),
@@ -2589,7 +2647,7 @@ xyz
         let result = server
             .insert_impl(InsertParams {
                 path: file_path.to_string_lossy().to_string(),
-                insert_line: 1,
+                insert_line: Some(1),
                 insert_text: "-MID-".to_string(),
                 column: Some(5),
             })
@@ -2619,7 +2677,7 @@ xyz
         let ok_result = server
             .insert_impl(InsertParams {
                 path: file_path.to_string_lossy().to_string(),
-                insert_line: 1,
+                insert_line: Some(1),
                 insert_text: "X".to_string(),
                 column: Some(5),
             })
@@ -2642,7 +2700,7 @@ xyz
         let bad_result = server
             .insert_impl(InsertParams {
                 path: file_path.to_string_lossy().to_string(),
-                insert_line: 1,
+                insert_line: Some(1),
                 insert_text: "X".to_string(),
                 column: Some(2),
             })
@@ -2669,7 +2727,7 @@ beta
         let result = server
             .insert_impl(InsertParams {
                 path: file_path.to_string_lossy().to_string(),
-                insert_line: 3,
+                insert_line: Some(3),
                 insert_text: "gamma
 "
                 .to_string(),
@@ -2695,7 +2753,7 @@ beta
         let result = server
             .insert_impl(InsertParams {
                 path: file_path.to_string_lossy().to_string(),
-                insert_line: 1,
+                insert_line: Some(1),
                 insert_text: "X".to_string(),
                 column: Some(6),
             })

--- a/docs/solutions/api-design/optional-param-append-default-2026-05-12.md
+++ b/docs/solutions/api-design/optional-param-append-default-2026-05-12.md
@@ -1,0 +1,129 @@
+---
+title: "Making MCP tool parameters optional with append-to-end default"
+date: 2026-05-12
+category: "api-design"
+problem_type: integration_issue
+component: "harnx-mcp-fs"
+root_cause: "required usize parameter prevented natural append-to-end usage pattern"
+resolution_type: code_fix
+severity: medium
+tags:
+  - mcp
+  - api-design
+  - serde
+  - optional-parameters
+  - defaults
+plan_ref: "mcp-fs-insert-append"
+---
+
+## Problem
+
+`fs_insert` tool required `insert_line: usize` parameter. Users had to determine file line count before appending, forcing read-then-insert workflows. The natural append-to-end pattern was unnecessarily verbose.
+
+## Symptoms
+
+- Callers had to read file first to get `total_lines` before appending
+- Parameter documentation mentioned `insert_line: N` where "N = total lines appends at end" but required explicit value
+- No natural default for append operation
+
+## Investigation Steps
+
+Reviewed `InsertParams` struct and identified `insert_line` as required `usize`. Evaluated two approaches:
+1. Keep `usize` but use sentinel value (e.g., `usize::MAX`) for append
+2. Change to `Option<usize>` with `None` meaning append
+
+Chose option 2 — serde `None` default semantically clearer than sentinel value. Checked how this pattern propagates through JsonSchema impl and tool template rendering.
+
+## Root Cause
+
+Serde deserialization and schemars-rs `JsonSchema` both require coordination to make a parameter truly optional with a meaningful default. Changing struct field type alone is insufficient — schema generation must also remove field from `required` array.
+
+## Solution
+
+Three-part change to make `insert_line` optional with `None` → append behavior:
+
+**1. Struct field with serde default:**
+
+```rust
+#[derive(Debug, Deserialize)]
+pub struct InsertParams {
+    pub path: String,
+    #[serde(default)]
+    pub insert_line: Option<usize>,  // was: usize (required)
+    pub insert_text: String,
+    #[serde(default)]
+    pub column: Option<usize>,
+}
+```
+
+**2. Manual JsonSchema impl — remove from required array:**
+
+```rust
+impl JsonSchema for InsertParams {
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let insert_line = generator.subschema_for::<Option<usize>>();  // was: usize
+        // ...
+        object_schema_with_desc(
+            vec![
+                ("path", "Absolute path to the file to insert into.", path),
+                ("insert_line", "Insert after this line number. 0 = prepend before line 1; N = insert after line N; omit (or use N = total lines) to append to the end of the file.", insert_line),
+                // ...
+            ],
+            &["path", "insert_text"],  // removed "insert_line" from required
+        )
+    }
+}
+```
+
+**3. Implementation resolve default:**
+
+```rust
+async fn insert_impl(&self, params: InsertParams) -> Result<CallToolResult, ErrorData> {
+    // ...
+    let lines = content.split_inclusive('\n').collect::<Vec<_>>();
+    let total_lines = lines.len();
+    // None means append (equivalent to insert after last line)
+    let insert_line = params.insert_line.unwrap_or(total_lines);
+    // ...
+}
+```
+
+**4. Tool template display:**
+
+Minijinja template uses default filter for display:
+
+```jinja2
+{{ args.insert_line | default(value="end") }}
+```
+
+Shows "end" when `insert_line` absent, making tool description readable.
+
+## Why This Works
+
+- `#[serde(default)]` allows JSON without `insert_line` to deserialize with `None`
+- `Option<usize>` in schema generates `oneOf: [null, integer]` union type
+- Removing from `required` array lets callers omit field entirely
+- `unwrap_or(total_lines)` computes default at runtime when file content available
+- Template `default(value="end")` gives human-readable display without semantic ambiguity
+
+## Prevention Strategies
+
+**Pattern Checklist:**
+- [ ] Add `#[serde(default)]` attribute to optional field
+- [ ] Change field type from `T` to `Option<T>`
+- [ ] Update `JsonSchema` impl: `subschema_for::<Option<T>>()`
+- [ ] Remove field from `required` array in schema
+- [ ] Resolve default with `unwrap_or(computed_default)` at point where context available
+- [ ] Update tool description to document omit behavior
+- [ ] Update template rendering for missing field display
+- [ ] Update all test struct literals: `field: N` → `field: Some(N)`
+
+**Best Practices:**
+- Prefer `Option<T>` + `#[serde(default)]` over sentinel values
+- Compute defaults at point where required context available (e.g., after reading file)
+- Document omit behavior in schema description, not just docs
+
+## Related Issues
+
+- **Plan:** [mcp-fs-insert-append](/plans/mcp-fs-insert-append)
+- **Related Solution:** [mcp-fs-insert-rereplace-tools-2026-05-11.md](../integration-issues/mcp-fs-insert-rereplace-tools-2026-05-11.md) — original insert tool design


### PR DESCRIPTION
When insert_line is omitted, fs_insert now appends text to the end of the file. This makes it easy to build up large files in chunks without needing to know the current line count.

- InsertParams.insert_line: usize → Option<usize> with serde(default)
- JsonSchema updated: subschema uses Option<usize>, field removed from required array, description documents append-when-omitted
- insert_impl: resolves None → total_lines for append semantics
- Tool description and meta template updated
- All existing tests updated: bare integer → Some(N)
- New test: test_insert_append_omit_line verifies None appends

#519

Plan: mcp-fs-insert-append

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `fs_insert` MCP tool's `insert_line` parameter is now optional. Omitting it appends text to the end of the file; when appending any provided `column` is ignored.

* **Documentation**
  * Added guidance describing the optional-parameter behavior and append-by-default semantics.

* **Tests**
  * Updated and added tests to cover append-at-EOF behavior and related validations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/520)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/520)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->