### PR TITLE
fix(tui): resolve duplicate exit_session call preventing resume hint

### DIFF
--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -253,7 +253,6 @@ impl Tui {
         let mut event_source = CrosstermEventSource;
         let result = self.run_loop_inner(&mut terminal, &mut event_source).await;
         Self::restore_terminal(&mut terminal)?;
-        self.config.write().exit_session()?;
         result
     }
 

--- a/docs/solutions/logic-errors/session-resume-hint-on-exit-2026-05-05.md
+++ b/docs/solutions/logic-errors/session-resume-hint-on-exit-2026-05-05.md
@@ -1,6 +1,7 @@
 ---
 title: "Session resume hint on exit in a Rust CLI"
 date: 2026-05-05
+last_updated: 2026-05-12
 category: logic-errors
 problem_type: logic_error
 component: cli-session-management
@@ -12,6 +13,8 @@ tags:
   - cli-ux
   - shell-escaping
   - terminal-output
+  - ownership-lifecycle
+  - cross-crate-integration
 plan_ref: "issue-417"
 ---
 
@@ -109,3 +112,44 @@ fn test_resume_hint_empty_session_suppressed() {
 
 - **Changeset:** `.changesets/417-session-resume-hint.md`
 - **Related Solution:** [logic-errors/non-tui-terminal-output-fixes-2026-04-30.md](./non-tui-terminal-output-fixes-2026-04-30.md) — TUI vs non-TUI output handling
+
+---
+
+## Postscript: Double-Exit Bug (2026-05-12)
+
+### Problem
+
+Session resume hint worked in CMD mode but silently failed in TUI mode. The hint never printed because the session was already consumed.
+
+### Root Cause
+
+**Duplicate teardown in call stack.** The `Tui::run()` method in `crates/harnx-tui/src/lifecycle.rs` had a pre-existing `exit_session()` call that consumed session state. When `exit_session_with_hook()` was added to `start_interactive()` (the caller of `tui.run()`), PR #464 forgot to remove the redundant call inside `Tui::run()`.
+
+Execution order in TUI mode:
+
+1. `Tui::run()` → `exit_session()` → `config.session = None`
+2. `exit_session_with_hook()` → `session_resume_command(config)` → returns `None` (session already gone) → hint never printed
+
+### Fix
+
+Remove the `exit_session()` call from `Tui::run()`:
+
+```diff
+- self.config.write().exit_session()?;
+```
+
+The caller (`start_interactive`) owns the session lifecycle via `exit_session_with_hook()`. Lower-level TUI code should not clear session before top-level cleanup runs.
+
+### Key Lesson
+
+When layering new behavior on top of existing teardown logic, check every layer in the call stack for duplicate teardown that would consume state before new code can read it.
+
+**Easy to miss when:**
+- Duplicate is in a different crate (`harnx-tui`) from new code (`harnx/main.rs`)
+- Original teardown was correct for its local context but conflicts with new ownership expectations
+
+### Prevention Strategies
+
+- **Ownership audit**: When adding cleanup hooks, trace the full call stack for existing cleanup calls
+- **Cross-crate vigilance**: Session state ownership spans crates; implicit cleanup in lower layers can break higher-level hooks
+- **Test coverage**: Integration tests should verify cross-crate handoffs, not just isolated unit behavior


### PR DESCRIPTION
Remove duplicate exit_session() call from Tui::run() in crates/harnx-tui/src/lifecycle.rs. This caused session resume hint to never print on TUI exit because the session state was consumed before exit_session_with_hook() could read it.

Also updates documentation with details on this regression and its fix.

[#417]

Plan: harnx-417-session-resume-hint-fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session cleanup logic in TUI mode that prevented the session resume hint from displaying on exit.

* **Documentation**
  * Updated documentation to reflect the session lifecycle correction.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/522)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->