### PR TITLE
chore: recover v0.31.0 release-prep on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## 0.31.0 (2026-05-07)
+
+### Breaking Changes
+
+- remove all default session related features and configurations (#477)
+
+### Features
+
+- markdown table rendering with widget architecture and render cache (#351) (#486)
+
 ## 0.30.1 (2026-05-06)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "harnx"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "agent-client-protocol",
  "ansi_colours",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-acp"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2831,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-acp-server"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2854,7 +2854,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-client"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2891,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-core"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-engine"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-fetch"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "fancy-regex 0.18.0",
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-hooks"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "fancy-regex 0.18.0",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-mcp"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-mcp-bash"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "birdcage",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-mcp-fs"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "fancy-regex 0.18.0",
@@ -3030,7 +3030,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-mcp-history"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "gix",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-mcp-plans"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-mcp-time"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3072,7 +3072,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-pkg"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-rag"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3128,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-render"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "ansi_colours",
  "anyhow",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-runtime"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3206,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-serve"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3234,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-spinner"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-test-bins"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "harnx-tui"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.30.1"
+version = "0.31.0"
 edition = "2021"
 authors = ["sigoden <sigoden@gmail.com>"]
 description = "All-in-one LLM CLI Tool"


### PR DESCRIPTION
## Summary

Recovers the release-prep commit that should have landed on `main` when v0.31.0 was published on 2026-05-07.

The published [v0.31.0 release](https://github.com/dobesv/harnx/releases/tag/harnx/v0.31.0) (tag, GitHub release, all binaries) succeeded — but the matching `chore: prepare release` commit was rejected by a now-deleted legacy classic branch protection rule. The release bot's bypass only applied to the ruleset, not to the classic rule.

This PR ports the three file changes from the dangling release-prep commit (`f24999ec`) onto current main:
- `Cargo.toml`: workspace version `0.30.1` → `0.31.0`
- `CHANGELOG.md`: new `## 0.31.0 (2026-05-07)` section (same content as the published release)
- `Cargo.lock`: refreshed via `cargo build --workspace`

After this merges, future `Prepare Release` runs will cleanly produce `0.32.0`.

## Caveat

The published `v0.31.0` artifacts are based on `f24999ec` (parent `ddd8ee86`). Roughly 5 PRs landed on main after that, so those changes are NOT in the v0.31.0 binaries — they'll be in v0.32.0.

## Test plan

- [ ] CI green
- [ ] Diff matches the dangling `f24999ec` commit shape (3 files, same +/-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * All default session-related features and configurations have been removed. Applications relying on automatic session management will require manual configuration.

* **New Features**
  * Markdown table rendering is now supported with performance optimizations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/523)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->