### PR TITLE
refactor(session): remove temp session and title generation

### DIFF
--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -616,9 +616,12 @@ mod tests {
     use agent_client_protocol::Agent;
     use harnx_runtime::{
         client::{ClientConfig, ModelType, TestStateGuard},
-        config::{Config, CREATE_TITLE_AGENT},
+        config::Config,
         test_utils::{MockClient, MockTurnBuilder},
     };
+
+    /// Built-in agent used as a lightweight test fixture for ACP protocol tests.
+    const TEST_BUILTIN_AGENT: &str = harnx_core::agent_config::CREATE_TITLE_AGENT_NAME;
     use std::{cell::RefCell, rc::Rc, sync::Arc};
     use tempfile::TempDir;
     use tokio::task::LocalSet;
@@ -920,7 +923,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("create temp dir");
         write_test_agent(
             &temp,
-            CREATE_TITLE_AGENT,
+            TEST_BUILTIN_AGENT,
             "You create concise titles for conversations.",
         );
         let config = test_config();
@@ -940,7 +943,7 @@ mod tests {
             let _env = EnvGuard::new("HARNX_CONFIG_DIR", &temp_path);
 
             let (client_conn, chunks, server_handle, client_handle) =
-                setup_roundtrip(CREATE_TITLE_AGENT, config.clone());
+                setup_roundtrip(TEST_BUILTIN_AGENT, config.clone());
 
             timeout(
                 Duration::from_secs(5),
@@ -990,7 +993,7 @@ mod tests {
 
             let session_id = session.session_id.to_string();
             let session_path =
-                harnx_core::config_paths::session_file(Some(CREATE_TITLE_AGENT), &session_id);
+                harnx_core::config_paths::session_file(Some(TEST_BUILTIN_AGENT), &session_id);
             let top_level_path = harnx_core::config_paths::session_file(None, &session_id);
             assert!(
                 session_path.exists(),

--- a/crates/harnx-core/src/event.rs
+++ b/crates/harnx-core/src/event.rs
@@ -117,7 +117,6 @@ pub enum SessionEvent {
         path: PathBuf,
     },
     CompactingStarted,
-    Autonaming,
     AgentInitializing {
         agent: String,
     },

--- a/crates/harnx-core/src/session.rs
+++ b/crates/harnx-core/src/session.rs
@@ -194,11 +194,7 @@ pub struct Session {
     #[serde(skip)]
     pub compressing: bool,
     #[serde(skip)]
-    pub autoname: Option<AutoName>,
-    #[serde(skip)]
     pub sessions_dir: Option<PathBuf>,
-    #[serde(skip)]
-    pub resolved_save_name: Option<(PathBuf, String)>,
     #[serde(skip)]
     pub log_entry_count: usize,
     #[serde(skip)]
@@ -432,32 +428,6 @@ impl Session {
         self.compressing = compressing;
     }
 
-    pub fn need_autoname(&self) -> bool {
-        self.autoname.as_ref().map(|v| v.need()).unwrap_or_default()
-    }
-
-    pub fn set_autonaming(&mut self, naming: bool) {
-        if let Some(v) = self.autoname.as_mut() {
-            v.naming = naming;
-        }
-    }
-
-    pub fn chat_history_for_autonaming(&self) -> Option<String> {
-        self.autoname.as_ref().and_then(|v| v.chat_history.clone())
-    }
-
-    pub fn autoname(&self) -> Option<&str> {
-        self.autoname.as_ref().and_then(|v| v.name.as_deref())
-    }
-
-    pub fn set_autoname(&mut self, value: &str) {
-        let name = value
-            .chars()
-            .map(|v| if v.is_alphanumeric() { v } else { '-' })
-            .collect();
-        self.autoname = Some(AutoName::new(name));
-    }
-
     pub fn guard_empty(&self) -> Result<()> {
         if !self.is_empty() {
             bail!("Cannot perform this operation because the session has messages, please `.empty session` first.");
@@ -548,31 +518,6 @@ impl Session {
             self.compaction_agent = value;
             self.dirty = true;
         }
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct AutoName {
-    pub(crate) naming: bool,
-    pub(crate) chat_history: Option<String>,
-    pub(crate) name: Option<String>,
-}
-
-impl AutoName {
-    pub fn new(name: String) -> Self {
-        Self {
-            name: Some(name),
-            ..Default::default()
-        }
-    }
-    pub fn new_from_chat_history(chat_history: String) -> Self {
-        Self {
-            chat_history: Some(chat_history),
-            ..Default::default()
-        }
-    }
-    pub fn need(&self) -> bool {
-        !self.naming && self.chat_history.is_some() && self.name.is_none()
     }
 }
 

--- a/crates/harnx-runtime/src/agent_loop.rs
+++ b/crates/harnx-runtime/src/agent_loop.rs
@@ -462,7 +462,6 @@ pub async fn run_agent_loop(ctx: &AgentLoopContext, initial_input: Input) -> Res
     if abort_signal.aborted() {
         bail!("interrupted by user");
     }
-    Config::maybe_autoname_session(config.clone());
     Config::maybe_compact_session(config.clone());
     Ok(())
 }

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -228,7 +228,6 @@ pub async fn run_command_with_output(
                     return Ok(CommandOutcome::OpenSessionPicker);
                 }
                 config.write().use_session(args)?;
-                Config::maybe_autoname_session(config.clone());
             }
             ".rag" => {
                 Config::use_rag(config, args, abort_signal.clone()).await?;

--- a/crates/harnx-runtime/src/config/agent.rs
+++ b/crates/harnx-runtime/src/config/agent.rs
@@ -11,9 +11,6 @@ pub use harnx_core::agent_config::{
     AgentConfig, AgentRole, AgentVariable, AgentVariables, TEMP_AGENT_NAME,
 };
 
-/// Built-in agent name: routes to the title-creation prompt.
-pub const CREATE_TITLE_AGENT: &str = harnx_core::agent_config::CREATE_TITLE_AGENT_NAME;
-
 const DEFAULT_AGENT_NAME: &str = "rag";
 
 #[derive(Debug, Clone, Default)]

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -3,11 +3,11 @@ pub mod input;
 pub mod session;
 pub mod session_meta;
 
+pub use self::agent::TEMP_AGENT_NAME;
 pub use self::agent::{
     complete_agent_variables, list_agents, list_assistant_agents, Agent, AgentConfig,
     AgentVariables,
 };
-pub use self::agent::{CREATE_TITLE_AGENT, TEMP_AGENT_NAME};
 pub use self::input::Input;
 use self::session::Session;
 pub use self::session_meta::{
@@ -57,7 +57,6 @@ use syntect::highlighting::ThemeSet;
 use terminal_colorsaurus::{theme_mode, QueryOptions, ThemeMode};
 
 pub use harnx_rag::TEMP_RAG_NAME;
-pub const TEMP_SESSION_NAME: &str = "temp";
 
 const SERVE_ADDR: &str = "127.0.0.1:8000";
 
@@ -646,7 +645,7 @@ impl Config {
 
     /// Generate a unique short session ID and atomically claim it on disk.
     /// Retries with the next second's timestamp if the claim loses a race.
-    fn new_anonymous_session_id(&self) -> Result<String> {
+    pub fn new_session_id(&self) -> Result<String> {
         loop {
             let candidate =
                 crate::utils::session_name::generate_session_id(|c| self.session_file(c).exists());
@@ -1428,17 +1427,8 @@ impl Config {
         let mut session;
         match session_name {
             None => {
-                let short_id = self.new_anonymous_session_id()?;
+                let short_id = self.new_session_id()?;
                 session = Some(self::session::new(self, &short_id)?);
-            }
-            Some(TEMP_SESSION_NAME) => {
-                let session_file = self.session_file(TEMP_SESSION_NAME);
-                if session_file.exists() {
-                    remove_file(session_file).with_context(|| {
-                        format!("Failed to cleanup previous '{TEMP_SESSION_NAME}' session")
-                    })?;
-                }
-                session = Some(self::session::new(self, TEMP_SESSION_NAME)?);
             }
             Some(name) => {
                 let session_path = self.session_file(name);
@@ -1518,10 +1508,7 @@ impl Config {
         let session_name = match &self.session {
             Some(session) => match name {
                 Some(v) => v.to_string(),
-                None => session
-                    .autoname()
-                    .unwrap_or_else(|| session.id())
-                    .to_string(),
+                None => session.id().to_string(),
             },
             None => bail!("No session"),
         };
@@ -1943,55 +1930,6 @@ impl Config {
             .as_ref()
             .map(|v| v.compressing())
             .unwrap_or_default()
-    }
-
-    pub fn maybe_autoname_session(config: GlobalConfig) {
-        let mut need_autoname = false;
-        if let Some(session) = config.write().session.as_mut() {
-            if session.need_autoname() {
-                session.set_autonaming(true);
-                need_autoname = true;
-            }
-        }
-        if !need_autoname {
-            return;
-        }
-        let color = if config.read().light_theme() {
-            nu_ansi_term::Color::LightGray
-        } else {
-            nu_ansi_term::Color::DarkGray
-        };
-        crate::utils::emit_info(format!(
-            "📢 {}",
-            color.italic().paint("Autonaming the session.")
-        ));
-        tokio::spawn(async move {
-            if let Err(err) = Config::autoname_session(&config).await {
-                warn!("Failed to autonaming the session: {err}");
-            }
-            if let Some(session) = config.write().session.as_mut() {
-                session.set_autonaming(false);
-            }
-        });
-    }
-
-    pub async fn autoname_session(config: &GlobalConfig) -> Result<()> {
-        let text = match config
-            .read()
-            .session
-            .as_ref()
-            .and_then(|v| v.chat_history_for_autonaming())
-        {
-            Some(v) => v,
-            None => bail!("No chat history"),
-        };
-        let agent = config.read().retrieve_agent(CREATE_TITLE_AGENT)?;
-        let input = crate::config::input::from_str(config, &text, Some(agent));
-        let text = crate::config::input::fetch_chat_text(&input, config).await?;
-        if let Some(session) = config.write().session.as_mut() {
-            session.set_autoname(&text);
-        }
-        Ok(())
     }
 
     pub async fn use_rag(

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -1,7 +1,7 @@
 use super::input::*;
 use super::*;
 
-pub use harnx_core::session::{AutoName, Session, SessionLogEntry};
+pub use harnx_core::session::{Session, SessionLogEntry};
 
 use crate::client::{
     render_message_input, CompletionTokenUsage, Message, MessageContent, MessageRole,
@@ -502,8 +502,7 @@ pub fn ensure_log_file(session: &mut Session) {
         return;
     };
 
-    let (dir, session_name) = resolve_save_path(session, &sessions_dir);
-    let session_path = dir.join(format!("{session_name}.yaml"));
+    let session_path = sessions_dir.join(format!("{}.yaml", session.id));
     if ensure_parent_exists(&session_path).is_err() {
         return;
     }
@@ -543,33 +542,6 @@ pub fn append_event(session: &mut Session, entry: &SessionLogEntry) -> bool {
     }
 }
 
-pub fn resolve_save_path(session: &mut Session, session_dir: &Path) -> (PathBuf, String) {
-    if let Some((dir, name)) = session.resolved_save_name.clone() {
-        // Update the cached name with autoname if it arrived since
-        // the first resolution.
-        if session.id == TEMP_SESSION_NAME && !name.contains('-') {
-            if let Some(autoname) = session.autoname() {
-                let name = format!("{name}-{autoname}");
-                session.resolved_save_name = Some((dir.clone(), name.clone()));
-                return (dir, name);
-            }
-        }
-        return (dir, name);
-    }
-    let mut dir = session_dir.to_path_buf();
-    let mut name = session.id.clone();
-    if name == TEMP_SESSION_NAME {
-        dir = dir.join("_");
-        let now = chrono::Local::now();
-        name = now.format("%Y%m%dT%H%M%S").to_string();
-        if let Some(autoname) = session.autoname() {
-            name = format!("{name}-{autoname}");
-        }
-    }
-    session.resolved_save_name = Some((dir.clone(), name.clone()));
-    (dir, name)
-}
-
 pub fn render(
     session: &Session,
     render: &mut MarkdownRender,
@@ -579,10 +551,6 @@ pub fn render(
 
     if let Some(path) = &session.path {
         items.push(("path", path.to_string()));
-    }
-
-    if let Some(autoname) = session.autoname() {
-        items.push(("autoname", autoname.to_string()));
     }
 
     items.push(("model", session.model().id()));
@@ -674,8 +642,8 @@ pub fn exit(session: &mut Session, session_dir: &Path, is_tui: bool) -> Result<(
     }
     // Session has unsaved changes that were not yet appended (e.g. legacy
     // callers or sessions that didn't go through init_log). Do a full save.
-    let (session_dir, session_name) = resolve_save_path(session, session_dir);
-    let session_path = session_dir.join(format!("{session_name}.yaml"));
+    let session_name = session.id.clone();
+    let session_path = session_dir.join(format!("{}.yaml", session.id));
     save(session, &session_name, &session_path, is_tui)?;
     Ok(())
 }
@@ -1049,15 +1017,10 @@ fn is_tool_continuation(input: &Input, messages: &[Message]) -> bool {
 /// push (skipped on continuation rounds), data-URL persistence, and
 /// any queued injected-user-text.  Returns `true` iff every log
 /// append succeeded.
-fn begin_turn(session: &mut Session, input: &Input, output: &str) -> Result<bool> {
+fn begin_turn(session: &mut Session, input: &Input, _output: &str) -> Result<bool> {
     let mut all_appended = true;
     let is_continuation = is_tool_continuation(input, &session.messages);
     if session.messages.is_empty() {
-        if session.id == TEMP_SESSION_NAME && session.save_session != Some(false) {
-            let raw_input = input.raw();
-            let chat_history = format!("USER: {raw_input}\nASSISTANT: {output}\n");
-            session.autoname = Some(AutoName::new_from_chat_history(chat_history));
-        }
         let agent_messages = input.agent().build_messages(input)?;
         for msg in agent_messages {
             let seq = session.next_seq();
@@ -1120,7 +1083,6 @@ pub fn clear_messages(session: &mut Session) {
     session.messages.clear();
     session.compressed_messages.clear();
     session.data_urls.clear();
-    session.autoname = None;
     session.completion_usage = CompletionTokenUsage::default();
     session.update_tokens();
     if !append_event(session, &SessionLogEntry::Clear) {

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -18,7 +18,7 @@ use crate::cli::Cli;
 use crate::client::{list_models, retry::call_with_retry_and_fallback, ModelType};
 use crate::config::{
     list_agents, list_assistant_agents, load_env_file, macro_execute, Config, GlobalConfig, Input,
-    WorkingMode, TEMP_SESSION_NAME,
+    WorkingMode,
 };
 use crate::tui::Tui;
 use harnx_hooks::{
@@ -128,10 +128,19 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
     }
 
     if let Some(agent) = &cli.agent {
-        let session = cli.session.as_ref().map(|v| match v {
-            Some(v) => v.as_str(),
-            None => TEMP_SESSION_NAME,
-        });
+        // cli.session is Option<Option<String>>:
+        //   None          → --session not provided; no session
+        //   Some(None)    → bare --session flag; generate a new session ID
+        //   Some(Some(s)) → --session <id>; use that ID
+        let generated_session_id;
+        let session = match &cli.session {
+            None => None,
+            Some(None) => {
+                generated_session_id = config.read().new_session_id()?;
+                Some(generated_session_id.as_str())
+            }
+            Some(Some(s)) => Some(s.as_str()),
+        };
         if !cli.agent_variable.is_empty() {
             config.write().agent_variables = Some(
                 cli.agent_variable
@@ -328,11 +337,7 @@ fn session_resume_command(config: &GlobalConfig) -> Option<String> {
         return None;
     }
 
-    let session_name = session
-        .resolved_save_name
-        .as_ref()
-        .map(|(_, name)| name.as_str())
-        .unwrap_or_else(|| session.id());
+    let session_name = session.id();
 
     let agent_name = config_read.agent.as_ref().map(|a| a.name());
 
@@ -810,17 +815,6 @@ mod resume_tests {
         assert_eq!(
             session_resume_command(&config).unwrap(),
             "harnx -a 'my agent' -s 'my session'"
-        );
-    }
-
-    #[test]
-    fn uses_resolved_save_name_when_available() {
-        let mut session = session_with_message("temp");
-        session.resolved_save_name = Some((PathBuf::from("_"), "20240505-resolved".to_string()));
-        let config = make_config(Some(session));
-        assert_eq!(
-            session_resume_command(&config).unwrap(),
-            "harnx -s 20240505-resolved"
         );
     }
 }

--- a/crates/harnx/tests/snapshots/tmux_e2e__nested_sub_agent_activity_no_duplicates.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__nested_sub_agent_activity_no_duplicates.snap
@@ -1,11 +1,10 @@
 ---
 source: crates/harnx/tests/tmux_e2e.rs
-assertion_line: 1332
 expression: normalized
 ---
 Welcome to harnx [VERSION]  *  Type .help for commands, Tab to complete.
 nested-parent v
-🤖 nested-parent ▸ temp
+🤖 nested-parent ▸ [SID]
 > do nested delegation
 
 Parent delegating to researcher.
@@ -29,9 +28,6 @@ session_id: [SID]
 response: Researcher delegating to analyst.
 Nested task complete
 
-📢 Autonaming the session.
-> nested-parent ▸ temp
-No more scripted responses.
 
 
 
@@ -80,4 +76,7 @@ No more scripted responses.
 
 
 
-* 🤖 nested-parent ▸ temp   Context: [N](0%)
+
+
+
+* 🤖 nested-parent ▸ [SID]   Context: [N](0%)

--- a/crates/harnx/tests/snapshots/tmux_e2e__retry_all_fail_shows_warnings_in_tui.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__retry_all_fail_shows_warnings_in_tui.snap
@@ -1,11 +1,10 @@
 ---
 source: crates/harnx/tests/tmux_e2e.rs
-assertion_line: 1672
 expression: normalized
 ---
 Welcome to harnx [VERSION]  *  Type .help for commands, Tab to complete.
 retry-agent v
-🤖 retry-agent ▸ temp
+🤖 retry-agent ▸ [SID]
 > hello
 
 ⚠ Retryable error (status 500, Internal Server Error (type: server_error)), attempt 1/3. Retrying in 10ms...
@@ -50,4 +49,4 @@ Caused by:
 
 
 
-* 🤖 retry-agent ▸ temp   Context: 19(0%)
+* 🤖 retry-agent ▸ [SID]   Context: 19(0%)

--- a/crates/harnx/tests/snapshots/tmux_e2e__retry_succeed_after_fallback_shows_transition.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__retry_succeed_after_fallback_shows_transition.snap
@@ -1,11 +1,10 @@
 ---
 source: crates/harnx/tests/tmux_e2e.rs
-assertion_line: 1850
 expression: normalized
 ---
 Welcome to harnx [VERSION]  *  Type .help for commands, Tab to complete.
 retry-agent v
-🤖 retry-agent ▸ temp
+🤖 retry-agent ▸ [SID]
 > hello
 
 ⚠ Retryable error (status 500, Primary down (type: server_error)), attempt 1/2. Retrying in 10ms...
@@ -13,7 +12,6 @@ retry-agent v
 mock-llm:primary)), cooldown 60s. Trying next fallback.
 FALLBACK_SUCCESS: The fallback model handled it!
 
-📢 Autonaming the session.
 
 
 
@@ -50,4 +48,5 @@ FALLBACK_SUCCESS: The fallback model handled it!
 
 
 
-* 🤖 retry-agent ▸ temp   Context: 27(0%)
+
+* 🤖 retry-agent ▸ [SID]   Context: 27(0%)

--- a/crates/harnx/tests/snapshots/tmux_e2e__retry_succeed_after_retry_shows_warning_then_response.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__retry_succeed_after_retry_shows_warning_then_response.snap
@@ -1,19 +1,15 @@
 ---
 source: crates/harnx/tests/tmux_e2e.rs
-assertion_line: 1754
 expression: normalized
 ---
 Welcome to harnx [VERSION]  *  Type .help for commands, Tab to complete.
 retry-agent v
-🤖 retry-agent ▸ temp
+🤖 retry-agent ▸ [SID]
 > hello
 
 ⚠ Retryable error (status 500, Temporary failure (type: server_error)), attempt 1/3. Retrying in 10ms...
 RETRY_SUCCESS_RESPONSE: Hello from the retried model!
 
-📢 Autonaming the session.
-> retry-agent ▸ temp
-Should not reach here.
 
 
 
@@ -50,4 +46,7 @@ Should not reach here.
 
 
 
-* 🤖 retry-agent ▸ temp   Context: 27(0%)
+
+
+
+* 🤖 retry-agent ▸ [SID]   Context: 27(0%)

--- a/crates/harnx/tests/tmux_e2e.rs
+++ b/crates/harnx/tests/tmux_e2e.rs
@@ -1670,7 +1670,9 @@ fn retry_all_fail_shows_warnings_in_tui() -> Result<()> {
         "fallback exhaustion message not visible in TUI transcript:\n{screen}"
     );
 
-    let normalized = normalize_spinner_chars(&normalize_uuids(&normalize_screen(&screen)));
+    let normalized = normalize_short_session_ids(&normalize_spinner_chars(&normalize_uuids(
+        &normalize_screen(&screen),
+    )));
     assert_snapshot!("retry_all_fail_shows_warnings_in_tui", normalized);
 
     Ok(())
@@ -1750,7 +1752,9 @@ fn retry_succeed_after_retry_shows_warning_then_response() -> Result<()> {
         "successful response not visible after retry:\n{screen}"
     );
 
-    let normalized = normalize_spinner_chars(&normalize_uuids(&normalize_screen(&screen)));
+    let normalized = normalize_short_session_ids(&normalize_spinner_chars(&normalize_uuids(
+        &normalize_screen(&screen),
+    )));
     assert_snapshot!(
         "retry_succeed_after_retry_shows_warning_then_response",
         normalized
@@ -1848,7 +1852,9 @@ fn retry_succeed_after_fallback_shows_transition() -> Result<()> {
         "fallback model response not visible:\n{screen}"
     );
 
-    let normalized = normalize_spinner_chars(&normalize_uuids(&normalize_screen(&screen)));
+    let normalized = normalize_short_session_ids(&normalize_spinner_chars(&normalize_uuids(
+        &normalize_screen(&screen),
+    )));
     assert_snapshot!("retry_succeed_after_fallback_shows_transition", normalized);
 
     Ok(())

--- a/docs/solutions/logic-errors/dot-commands-picker-signals-2026-05-10.md
+++ b/docs/solutions/logic-errors/dot-commands-picker-signals-2026-05-10.md
@@ -72,7 +72,6 @@ Modified `.agent` and `.session` handlers to return appropriate outcomes:
         return Ok(CommandOutcome::OpenSessionPicker);
     }
     config.write().use_session(args)?;
-    Config::maybe_autoname_session(config.clone());
 }
 
 // .agent with no args → open agent picker

--- a/docs/solutions/workflow-issues/temp-session-title-removal-2026-05-12.md
+++ b/docs/solutions/workflow-issues/temp-session-title-removal-2026-05-12.md
@@ -1,0 +1,147 @@
+---
+title: "Remove defunct temp session and title generation machinery"
+date: 2026-05-12
+category: "workflow-issues"
+problem_type: workflow_issue
+component: "harnx-core, harnx-runtime"
+root_cause: "Legacy temp session concept superseded by generated IDs; title generation machinery became unreachable dead code"
+resolution_type: code_fix
+severity: medium
+tags:
+  - dead-code-removal
+  - session-management
+  - refactoring
+  - legacy-cleanup
+plan_ref: "harnx-session-autoname"
+---
+
+## Problem
+
+The session title generation feature (`SessionTitle`, formerly `AutoName`) was designed to generate human-readable titles for `"temp"` sessions. However, the concept of a `"temp"` session was legacy — superseded by modern generated session IDs. The title generation machinery had become unreachable dead code that complicated the session model.
+
+## Symptoms
+
+- `SessionTitle` struct and supporting methods existed but were only triggered for `"temp"` sessions
+- `TEMP_SESSION_NAME` constant (`"temp"`) was a legacy sentinel never used in modern session creation
+- `resolve_save_path()` contained special `_` subdirectory logic for temp sessions that was never exercised
+- `GeneratingTitle` event variant defined but never emitted in practice
+- `CREATE_TITLE_AGENT` re-exported from `harnx-runtime` but unused
+- Session save path logic had two branches: `{sessions_dir}/{session.id}.yaml` for normal sessions vs `_/{datetime-slug}.yaml` for temp sessions — the latter never triggered
+
+## Investigation Steps
+
+1. Initial task was rename: `AutoName` → `SessionTitle` to improve discoverability
+2. Rename completed: structs, methods, event variant (`Autonaming` → `GeneratingTitle`), user-facing messages
+3. Post-rename audit revealed the feature was only partially reachable — trigger condition checked for `TEMP_SESSION_NAME` which was never set by modern session creation paths
+4. Analyzed session creation flow: `harnx -a <agent> --session` bare flag generated `"temp"` sentinel session instead of real session ID
+5. Recognized the entire `"temp"` session concept was legacy — modern approach generates real session IDs immediately
+6. Decision: remove entire feature rather than fix trigger conditions
+
+## Root Cause
+
+Session model had evolved to always generate real session IDs via `new_session_id()`, but legacy `"temp"` session support remained. The title generation feature was built to provide nice names for these temp sessions, but:
+
+1. Temp sessions were a transitional pattern now obsolete
+2. Generated IDs (e.g., `abc123`) are sufficient for session identification
+3. The special `_` subdirectory convention for temp sessions was never documented or consistently used
+4. Title generation added complexity without current value
+
+## Solution
+
+Removed the entire temp session and title generation machinery:
+
+**Removed from `harnx-core/src/session.rs`:**
+```rust
+// Deleted
+pub const TEMP_SESSION_NAME: &str = "temp";
+
+pub struct SessionTitle { ... }
+pub session_title: Option<SessionTitle>
+pub fn need_session_title(&self) -> bool
+pub fn set_generating_title(&mut self, generating: bool)
+pub fn chat_history_for_title_generation(&self) -> Option<String>
+pub fn session_title(&self) -> Option<&str>
+pub fn set_session_title(&mut self, value: &str)
+```
+
+**Removed from `harnx-core/src/event.rs`:**
+```rust
+// Deleted
+SessionEvent::GeneratingTitle,
+```
+
+**Removed from `harnx-runtime`:**
+```rust
+// Deleted re-export
+pub use harnx_core::session::CREATE_TITLE_AGENT;
+
+// Removed from resolve_save_path()
+// Special _/ subdirectory logic for temp sessions
+// Datetime-slug naming for temp sessions
+```
+
+**Updated session creation:**
+```rust
+// Before: bare --session flag created "temp" sentinel
+if args.session.is_some() {
+    session_name = TEMP_SESSION_NAME.to_string();
+}
+
+// After: bare --session flag generates real ID immediately
+if args.session.is_some() {
+    session_name = new_session_id();
+}
+```
+
+**Unified session save path:**
+```rust
+// All sessions now save as:
+// {sessions_dir}/{session.id}.yaml
+
+// No more special cases for temp sessions
+// No more _/ subdirectory
+// No more datetime-slug naming
+```
+
+## Why This Works
+
+Removing dead code simplifies the codebase:
+
+1. **One session path**: All sessions follow the same save path pattern
+2. **No sentinel values**: No need to check for `"temp"` session name anywhere
+3. **Real IDs immediately**: Session IDs are stable from the moment of creation
+4. **Less state**: No `session_title` field, no title generation state machine
+5. **Cleaner event model**: Fewer event variants to maintain
+
+The title generation feature was well-intentioned but addressed a problem (naming temp sessions) that no longer exists. Modern session IDs serve the identification purpose adequately.
+
+## Learnings
+
+1. **Rename as exploration**: The initial `AutoName` → `SessionTitle` rename made the feature's scope visible enough to recognize it should be removed rather than maintained.
+
+2. **Legacy sentinels accumulate**: Constants like `TEMP_SESSION_NAME` often indicate transitional patterns that should be removed once superseded. If modern code never sets the sentinel, consider removing the sentinel and the code that checks for it.
+
+3. **Partially-reachable features are dead code**: If a feature only triggers under conditions that modern code paths never produce, it's effectively dead code — remove it.
+
+4. **Simplification over feature-drift maintenance**: Attempting to "fix" the trigger condition for title generation would have added complexity to a legacy pattern. Removing the feature simplified the system.
+
+## Prevention Strategies
+
+**During Model Refactors:**
+- Audit for sentinel values and transitional patterns in the old model
+- Check if code checking for those sentinels is still reachable
+- Remove or update unreachable branches rather than leaving them
+
+**Code Review Checklist:**
+- [ ] Does this constant represent a transitional/legacy pattern?
+- [ ] Is code that checks for legacy patterns still reachable from modern paths?
+- [ ] Would removing the legacy pattern simplify the model?
+
+**Health Checks:**
+- Grep for sentinel values like `"temp"`, `DEFAULT_*`, `LEGACY_*` — verify they're still set somewhere
+- Check conditionals for feature trigger conditions — are they reachable from all entry points?
+
+## Related Issues
+
+- **GitHub:** [Issue #502](https://github.com/dobesv/harnx/issues/502) — Rename confusing "autoname" session feature
+- **Related Solution:** [removing-dead-config-fields-rust-2026-05-05.md](removing-dead-config-fields-rust-2026-05-05.md) — Dead field removal checklist


### PR DESCRIPTION
The "temp" session was a legacy special case predating generated session IDs. Sessions now always use a generated 6-char base64 timestamp ID (e.g. agOgwA) and are saved as <sessions_dir>/<id>.yaml.

Removed:
- TEMP_SESSION_NAME ("temp") constant and all code paths conditioned on it
- SessionTitle struct, Session.session_title field, and related methods (need_session_title, set_generating_title, chat_history_for_title_generation, session_title, set_session_title)
- Session.resolved_save_name field
- maybe_generate_session_title / generate_session_title in Config
- resolve_save_path function (temp session used _/<datetime>-<slug> naming)
- SessionEvent::GeneratingTitle variant
- CREATE_TITLE_AGENT re-export from harnx-runtime (was only used for the title generation flow; ACP server tests now use CREATE_TITLE_AGENT_NAME from harnx-core directly as TEST_BUILTIN_AGENT)

Changed:
- harnx -a <agent> --session (bare -s) now generates a real session ID immediately via new_session_id() instead of creating a "temp" sentinel
- new_anonymous_session_id → new_session_id (pub) for use by main.rs
- save_session(None) uses session.id() directly (no title fallback)
- session_resume_command() uses session.id() directly

TUI snapshots updated for new behavior (no title-generation banner, session IDs normalized to [SID] in retry test snapshots).

#502

Plan: harnx-session-autoname

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified session persistence: sessions are now saved using direct session IDs for consistent file organization
  * Updated `.session` command behavior: now opens a session picker when invoked without arguments
  * Removed automatic session title generation system for clearer, more predictable session management

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/524)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->