### PR TITLE
refactor: narrow dead code suppression

### DIFF
--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -143,8 +143,6 @@ pub struct HarnxAgent {
 
 #[derive(Clone)]
 struct HarnxSession {
-    #[allow(dead_code)]
-    id: String,
     abort_signal: AbortSignal,
     /// Fires when the session receives an ACP `session/cancel` notification.
     /// We use `notify_one` (rather than `notify_waiters`) so a cancel that
@@ -225,7 +223,6 @@ impl acp::Agent for HarnxAgent {
                 .clone();
         }
         let session = HarnxSession {
-            id: session_id.clone(),
             abort_signal: AbortSignalInner::new(),
             cancel_notify: Arc::new(tokio::sync::Notify::new()),
         };

--- a/crates/harnx-acp/src/manager.rs
+++ b/crates/harnx-acp/src/manager.rs
@@ -320,7 +320,6 @@ fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
     ]
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
 pub async fn session_prompt_with_abort<Fut>(
     client: &AcpClient,
     session_id: String,
@@ -351,7 +350,6 @@ where
     }))
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
 pub async fn session_prompt_with_abort_for_test<
     PromptFn,
     PromptFut,

--- a/crates/harnx-hooks/src/persistent.rs
+++ b/crates/harnx-hooks/src/persistent.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::{HookOutcome, HookPayload, HookResult, HookResultControl};
 
 use anyhow::{bail, Result};


### PR DESCRIPTION
Removes stale dead_code suppressors from harnx-acp and harnx-hooks crates.
- In harnx-acp, removes allow(dead_code) from public functions.
- In harnx-hooks, removes module-wide suppression.
- In harnx-acp-server, removes unused id field from HarnxSession.

#80

Plan: narrow-dead-code-suppression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal session management architecture by optimizing session identity handling.
  * Cleaned up internal code directives to improve code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/525)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->