### PR TITLE
fix(sandbox): grant write access to /dev/shm on Linux for Chrome/Puppeteer

### DIFF
--- a/.changesets/chrome-puppeteer-dev-shm.md
+++ b/.changesets/chrome-puppeteer-dev-shm.md
@@ -1,0 +1,15 @@
+---
+harnx: patch
+---
+Allow Chrome/Puppeteer to run inside the birdcage sandbox.
+
+`/dev/shm` is now granted write access on Linux. Chrome uses this tmpfs for
+inter-process shared memory; without write access it crashed immediately with
+a fatal error. Fixes #528.
+
+> **Note:** Chrome's own sub-process sandbox (`credentials.cc`) requires
+> ptrace/user-namespace capabilities that are unavailable when already running
+> inside birdcage's user namespace. You must launch Chrome (or Puppeteer) with
+> `--no-sandbox --disable-dev-shm-usage` in container environments regardless
+> of harnx sandboxing — this is a Chrome-level constraint that cannot be
+> resolved inside birdcage.

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -535,7 +535,11 @@ impl BashServer {
     fn system_writable_paths() -> Vec<PathBuf> {
         #[cfg(target_os = "linux")]
         {
-            vec![PathBuf::from("/tmp")]
+            // /dev/shm is a tmpfs used by Chrome/Puppeteer for inter-process
+            // shared memory.  Without write access the browser crashes on
+            // startup inside the sandbox (issue #528).  /tmp is included as
+            // the standard temporary-file directory.
+            vec![PathBuf::from("/tmp"), PathBuf::from("/dev/shm")]
         }
         #[cfg(target_os = "macos")]
         {
@@ -3102,7 +3106,10 @@ mod tests {
         );
         let pairs = collect_arg_pairs(&args);
 
+        // Both /tmp and /dev/shm must be writable — /dev/shm is a tmpfs used
+        // by Chrome/Puppeteer for inter-process shared memory (issue #528).
         assert!(pairs.contains(&("--write".into(), "/tmp".into())));
+        assert!(pairs.contains(&("--write".into(), "/dev/shm".into())));
     }
 
     #[cfg(all(unix, target_os = "macos"))]

--- a/docs/bash-mcp-server.md
+++ b/docs/bash-mcp-server.md
@@ -200,3 +200,19 @@ args: ["--extra-rwx", "~/.npm"]
 ```yaml
 args: ["--extra-rwx", "~/.cargo"]
 ```
+
+
+#### Run Chrome or Puppeteer
+
+Chrome uses `/dev/shm` for inter-process shared memory. Starting with this release, `/dev/shm` is already granted write access inside the sandbox, so Puppeteer scripts should start Chrome without any extra `--extra-write` flag.
+
+However, Chrome's own sub-process sandbox tries to create a nested Linux user namespace, which is blocked when it is already running inside birdcage's user namespace. You must launch Chrome with `--no-sandbox` and `--disable-dev-shm-usage` to work around this limitation:
+
+```js
+// puppeteer example
+const browser = await puppeteer.launch({
+  args: ['--no-sandbox', '--disable-dev-shm-usage'],
+});
+```
+
+These flags are also required in Docker containers and CI environments where the kernel restricts nested user namespaces (`ptrace_scope=1`). They are not related to harnx — they are standard container-mode Chrome flags.

--- a/docs/solutions/integration-issues/chrome-puppeteer-birdcage-sandbox-2026-05-13.md
+++ b/docs/solutions/integration-issues/chrome-puppeteer-birdcage-sandbox-2026-05-13.md
@@ -1,0 +1,115 @@
+---
+title: "Chrome/Puppeteer crashes inside birdcage Linux sandbox"
+date: 2026-05-13
+category: "integration-issues"
+problem_type: integration_issue
+component: "birdcage-sandbox"
+root_cause: "missing bind mount for /dev/shm submount, nested user namespace blocked by ptrace_scope"
+resolution_type: code_fix
+severity: high
+tags:
+  - chrome
+  - puppeteer
+  - birdcage
+  - sandbox
+  - user-namespaces
+  - dev-shm
+  - container
+plan_ref: "dobesv/harnx#528"
+---
+
+## Problem
+
+Chrome (and Puppeteer) crashes with two fatal errors when run inside the harnx birdcage sandbox:
+1. `FATAL sandbox/linux/services/credentials.cc:131` — Chrome's sub-process sandbox fails because birdcage uses `CLONE_NEWUSER` (user namespaces), and the kernel's `ptrace_scope=1` blocks nested user namespace creation
+2. `/dev/shm` is mounted read-only inside birdcage's mount namespace — Chrome uses this tmpfs for IPC shared memory and crashes on first write
+
+## Symptoms
+
+```
+FATAL:sandbox/linux/services/credentials.cc(131)] setresuid: Operation not permitted
+(trace/bp trap by Chrome subprocess trying to create nested user namespace)
+
+# Additionally:
+Error: EROFS: read-only file system, open '/dev/shm/.com.google.Chrome.xxx'
+```
+
+- Chrome processes exit immediately when launched inside birdcage sandbox
+- Puppeteer connection fails with "Target closed" errors
+- Reproducible in any container-like environment with user namespaces
+
+## Investigation Steps
+
+1. Analyzed Chrome sandbox architecture — Chrome creates nested user namespaces for process isolation
+2. Checked kernel Yama security settings — `ptrace_scope=1` (default in containers) blocks unprivileged processes from creating nested user namespaces
+3. Inspected birdcage mount namespace — discovered `/dev/shm` is a separate tmpfs mount, NOT included in bind mount of `/dev`
+4. Tested Chrome with `--no-sandbox --disable-dev-shm-usage` — confirmed workaround works
+5. Verified birdcage's `system_writable_paths()` mechanism — only `/tmp` was included, `/dev/shm` missing
+
+## Root Cause
+
+**Issue 1: `/dev/shm` not bind-mounted**
+
+Birdcage creates a new mount namespace and bind-mounts `/dev` into it. However, `/dev/shm` is a separate tmpfs mount point. Bind mounting `/dev` with `MS_BIND` (without `MS_REC`) does NOT recursively include submounts. Without an explicit exception in `system_writable_paths()`, `/dev/shm` is either invisible or read-only inside the sandbox.
+
+**Issue 2: Nested user namespaces blocked**
+
+Birdcage uses `CLONE_NEWUSER` to create a user namespace. Inside this namespace, Chrome attempts to create a nested user namespace for its sandbox. The kernel's Yama security module (`/proc/sys/kernel/yama/ptrace_scope ≥ 1`) blocks unprivileged creation of nested user namespaces in container environments. This is by design and cannot be bypassed by birdcage.
+
+## Solution
+
+**Fix: Add `/dev/shm` to system writable paths**
+
+Modified `system_writable_paths()` in `crates/harnx-mcp-bash/src/server.rs`:
+
+```rust
+// Before:
+#[cfg(target_os = "linux")]
+fn system_writable_paths() -> Vec<&'static str> {
+    vec!["/tmp"]
+}
+
+// After:
+#[cfg(target_os = "linux")]
+fn system_writable_paths() -> Vec<&'static str> {
+    vec!["/tmp", "/dev/shm"]
+}
+```
+
+This causes birdcage to create a writable bind mount for `/dev/shm` in the sandboxed mount namespace.
+
+**Workaround for nested user namespace issue:**
+
+Launch Chrome/Puppeteer with:
+```
+--no-sandbox --disable-dev-shm-usage
+```
+
+This is standard practice for container environments (Docker, CI, birdcage). No code fix possible — kernel security policy blocks nested user namespaces.
+
+## Why This Works
+
+Adding `/dev/shm` to `system_writable_paths()` tells birdcage to create a separate writable bind mount for that path. Chrome's IPC shared memory operations succeed because the tmpfs is now writable inside the sandbox.
+
+The nested user namespace issue is a kernel-level security restriction. Using `--no-sandbox` disables Chrome's own sandboxing (which requires nested namespaces) and is safe inside birdcage since birdcage already provides sandbox isolation.
+
+## Prevention Strategies
+
+**Checklist for adding new sandbox-aware applications:**
+
+- [ ] Identify tmpfs mounts the application uses (`findmnt -t tmpfs`)
+- [ ] Add required paths to `system_writable_paths()` for Linux
+- [ ] Document required application flags for container environments
+- [ ] Test in sandbox before merging
+
+**Code review items:**
+
+- [ ] Does the app use `/dev/shm`, `/run`, or other tmpfs mounts?
+- [ ] Does the app create its own sandbox (browsers, Electron apps)?
+- [ ] Add recipe to `docs/bash-mcp-server.md` for future reference
+
+## Related Issues
+
+- **Reference:** [dobesv/harnx#528](https://github.com/dobesv/harnx/issues/528)
+- **Puppeteer docs:** [Running Puppeteer in Docker](https://pptr.dev/guides/docker) — same flags required
+- **Chrome Linux sandbox:** `chrome_sandbox_linux_services_credentials.cc`


### PR DESCRIPTION
Chrome and Puppeteer use /dev/shm (a separate tmpfs) for inter-process shared memory. Birdcage's bind mount of /dev does not capture this submount (MS_BIND without MS_REC), so it was invisible/read-only inside the sandbox, causing a fatal Chrome crash on startup.

Add /dev/shm to system_writable_paths() on Linux so birdcage creates a writable bind mount for it. Update the test assertion and add a Chrome/Puppeteer recipe to the docs.

Note: Chrome's sub-process sandbox (credentials.cc) requires nested user namespaces which are blocked by ptrace_scope=1 inside birdcage's user namespace — this is a Chrome-level constraint. Users must pass --no-sandbox --disable-dev-shm-usage to Chrome in container environments.

#528

Plan: chrome-puppeteer-birdcage-fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added configuration guide for running Chrome/Puppeteer in the sandbox environment
  * Added troubleshooting documentation for Chrome/Puppeteer sandbox compatibility issues

* **Improvements**
  * Enabled Chrome/Puppeteer support in the sandbox with proper shared-memory write access

Note: Chrome/Puppeteer requires the `--no-sandbox --disable-dev-shm-usage` flags when used in the sandbox environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/529)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->