### PR TITLE
feat(hooks): add hook mutation support for tool calls

### DIFF
--- a/.changesets/hooks-tool-mutation.md
+++ b/.changesets/hooks-tool-mutation.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+hooks: PreToolUse and PostToolUse hooks can now mutate tool_input and tool_response via hookSpecificOutput.toolInput / toolResponse. Mutations chain across multiple hooks. Full hooks reference documentation added.

--- a/crates/harnx-core/src/hooks.rs
+++ b/crates/harnx-core/src/hooks.rs
@@ -90,6 +90,10 @@ pub struct HookSpecificOutput {
     pub permission_decision: Option<String>,
     #[serde(default)]
     pub permission_decision_reason: Option<String>,
+    #[serde(default)]
+    pub tool_input: Option<Value>,
+    #[serde(default)]
+    pub tool_response: Option<Value>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -103,6 +107,10 @@ pub struct HookResult {
     pub system_message: Option<String>,
     #[serde(default, rename = "hookSpecificOutput")]
     pub hook_specific_output: Option<HookSpecificOutput>,
+    #[serde(default)]
+    pub mutated_tool_input: Option<Value>,
+    #[serde(default)]
+    pub mutated_tool_response: Option<Value>,
 }
 
 #[derive(Debug, Clone)]
@@ -521,6 +529,36 @@ entries:
             output.permission_decision_reason.as_deref(),
             Some("blocked")
         );
+        assert!(output.tool_input.is_none());
+        assert!(output.tool_response.is_none());
+    }
+
+    #[test]
+    fn test_hook_specific_output_deserializes_tool_input() {
+        let output: HookSpecificOutput = serde_json::from_str(r#"{"toolInput":{"mutated":true}}"#)
+            .expect("deserialize tool input mutation");
+
+        assert_eq!(output.tool_input, Some(json!({"mutated": true})));
+        assert!(output.tool_response.is_none());
+    }
+
+    #[test]
+    fn test_hook_specific_output_deserializes_tool_response() {
+        let output: HookSpecificOutput = serde_json::from_str(r#"{"toolResponse":{"ok":true}}"#)
+            .expect("deserialize tool response mutation");
+
+        assert!(output.tool_input.is_none());
+        assert_eq!(output.tool_response, Some(json!({"ok": true})));
+    }
+
+    #[test]
+    fn test_hook_specific_output_deserializes_both_mutations() {
+        let output: HookSpecificOutput =
+            serde_json::from_str(r#"{"toolInput":{"mutated":true},"toolResponse":{"ok":true}}"#)
+                .expect("deserialize both hook mutations");
+
+        assert_eq!(output.tool_input, Some(json!({"mutated": true})));
+        assert_eq!(output.tool_response, Some(json!({"ok": true})));
     }
 
     #[test]
@@ -530,6 +568,8 @@ entries:
 
         assert_eq!(output.permission_decision.as_deref(), Some("ask"));
         assert!(output.permission_decision_reason.is_none());
+        assert!(output.tool_input.is_none());
+        assert!(output.tool_response.is_none());
     }
 
     #[test]
@@ -555,5 +595,18 @@ entries:
         assert_eq!(result.resume, Some(true));
         assert_eq!(result.additional_context.as_deref(), Some("keep going"));
         assert!(result.hook_specific_output.is_none());
+        assert!(result.mutated_tool_input.is_none());
+        assert!(result.mutated_tool_response.is_none());
+    }
+
+    #[test]
+    fn test_hook_result_deserializes_mutated_tool_fields() {
+        let result: HookResult = serde_json::from_str(
+            r#"{"mutatedToolInput":{"mutated":true},"mutatedToolResponse":{"ok":true}}"#,
+        )
+        .expect("deserialize mutated tool fields");
+
+        assert_eq!(result.mutated_tool_input, Some(json!({"mutated": true})));
+        assert_eq!(result.mutated_tool_response, Some(json!({"ok": true})));
     }
 }

--- a/crates/harnx-engine/src/tool.rs
+++ b/crates/harnx-engine/src/tool.rs
@@ -141,6 +141,12 @@ pub async fn eval_tool_calls(
             is_all_null = false;
             continue;
         }
+        let (json_data, tool_input) = if let Some(mutated) = pre_outcome.result.mutated_tool_input {
+            (mutated.clone(), mutated)
+        } else {
+            (json_data, tool_input)
+        };
+
         if let HookResultControl::Ask { reason } = pre_outcome.control {
             if !(ctx.confirm_tool_use_fn)(&call.name, &json_data, reason.as_deref()) {
                 let deny_reason = reason.unwrap_or_else(|| "Denied by user".to_string());
@@ -185,7 +191,10 @@ pub async fn eval_tool_calls(
                     tool_use_id: tool_use_id.clone(),
                     tool_response: result.clone(),
                 };
-                let _ = (ctx.dispatch_hook_fn)(post_event).await;
+                let post_outcome = (ctx.dispatch_hook_fn)(post_event).await;
+                if let Some(mutated_response) = post_outcome.result.mutated_tool_response {
+                    result = mutated_response;
+                }
                 (ctx.emit_tool_result_fn)(&call, &result);
                 if !result.is_null() {
                     is_all_null = false;
@@ -406,6 +415,51 @@ mod tests {
         }
     }
 
+    struct CapturingToolProvider {
+        tool_name: String,
+        received_arguments: Arc<Mutex<Vec<Value>>>,
+        result: Value,
+    }
+
+    impl CapturingToolProvider {
+        fn new(tool_name: &str, received_arguments: Arc<Mutex<Vec<Value>>>, result: Value) -> Self {
+            Self {
+                tool_name: tool_name.to_string(),
+                received_arguments,
+                result,
+            }
+        }
+    }
+
+    impl ToolProvider for CapturingToolProvider {
+        fn name(&self) -> &str {
+            "capturing-mock"
+        }
+
+        fn has_tool(&self, tool_name: &str) -> bool {
+            self.tool_name == tool_name
+        }
+
+        fn call_tool<'life0, 'life1, 'life2, 'async_trait>(
+            &'life0 self,
+            tool_name: &'life1 str,
+            arguments: Value,
+            _abort: &'life2 AbortSignal,
+        ) -> Pin<Box<dyn Future<Output = Result<Value, ToolError>> + Send + 'async_trait>>
+        where
+            'life0: 'async_trait,
+            'life1: 'async_trait,
+            'life2: 'async_trait,
+            Self: 'async_trait,
+        {
+            Box::pin(async move {
+                assert_eq!(tool_name, self.tool_name);
+                self.received_arguments.lock().await.push(arguments);
+                Ok(self.result.clone())
+            })
+        }
+    }
+
     fn continue_hook_outcome() -> HookOutcome {
         HookOutcome {
             control: HookResultControl::Continue,
@@ -621,5 +675,129 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(started_emit_count.load(Ordering::SeqCst), 0);
         assert_eq!(blocked_emit_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn pre_tool_use_mutation_applied_to_tool() {
+        let received_arguments = Arc::new(Mutex::new(Vec::new()));
+        let received_arguments_clone = Arc::clone(&received_arguments);
+        let ctx = test_context_with_emitters(
+            vec![Arc::new(CapturingToolProvider::new(
+                "tool_a",
+                received_arguments_clone,
+                json!({"raw": true}),
+            ))],
+            |event| match event {
+                HookEvent::PreToolUse { .. } => HookOutcome {
+                    control: HookResultControl::Continue,
+                    result: HookResult {
+                        mutated_tool_input: Some(json!({"injected": true})),
+                        ..HookResult::default()
+                    },
+                },
+                _ => continue_hook_outcome(),
+            },
+            |_, _| {},
+            |_, _| {},
+            |_, _| {},
+        );
+        let abort_signal = create_abort_signal();
+
+        let result = eval_tool_calls(
+            &ctx,
+            vec![ToolCall::new(
+                "tool_a".to_string(),
+                json!({"original": true}),
+                None,
+                None,
+            )],
+            &abort_signal,
+        )
+        .await
+        .expect("tool call should succeed");
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            received_arguments.lock().await.as_slice(),
+            &[json!({"injected": true})]
+        );
+    }
+
+    #[tokio::test]
+    async fn post_tool_use_mutation_replaces_result() {
+        let ctx = test_context_with_emitters(
+            vec![Arc::new(MockToolProvider::ok(
+                "tool_a",
+                Duration::ZERO,
+                json!({"raw": true}),
+            ))],
+            |event| match event {
+                HookEvent::PostToolUse { .. } => HookOutcome {
+                    control: HookResultControl::Continue,
+                    result: HookResult {
+                        mutated_tool_response: Some(json!({"mutated": true})),
+                        ..HookResult::default()
+                    },
+                },
+                _ => continue_hook_outcome(),
+            },
+            |_, _| {},
+            |_, _| {},
+            |_, _| {},
+        );
+        let abort_signal = create_abort_signal();
+
+        let result = eval_tool_calls(&ctx, vec![test_call("tool_a")], &abort_signal)
+            .await
+            .expect("tool call should succeed");
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].output, json!({"mutated": true}));
+    }
+
+    #[tokio::test]
+    async fn pre_mutation_reflected_in_post_tool_use_event() {
+        let post_tool_inputs = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let post_tool_inputs_clone = Arc::clone(&post_tool_inputs);
+        let ctx = test_context_with_emitters(
+            vec![Arc::new(MockToolProvider::ok(
+                "tool_a",
+                Duration::ZERO,
+                json!({"raw": true}),
+            ))],
+            move |event| match event {
+                HookEvent::PreToolUse { .. } => HookOutcome {
+                    control: HookResultControl::Continue,
+                    result: HookResult {
+                        mutated_tool_input: Some(json!({"injected": true})),
+                        ..HookResult::default()
+                    },
+                },
+                HookEvent::PostToolUse { tool_input, .. } => {
+                    post_tool_inputs_clone
+                        .lock()
+                        .expect("lock post tool inputs")
+                        .push(tool_input);
+                    continue_hook_outcome()
+                }
+                _ => continue_hook_outcome(),
+            },
+            |_, _| {},
+            |_, _| {},
+            |_, _| {},
+        );
+        let abort_signal = create_abort_signal();
+
+        eval_tool_calls(&ctx, vec![test_call("tool_a")], &abort_signal)
+            .await
+            .expect("tool call should succeed");
+
+        assert_eq!(
+            post_tool_inputs
+                .lock()
+                .expect("lock post tool inputs")
+                .as_slice(),
+            &[json!({"injected": true})]
+        );
     }
 }

--- a/crates/harnx-hooks/src/dispatch.rs
+++ b/crates/harnx-hooks/src/dispatch.rs
@@ -3,6 +3,7 @@ use crate::{
     HookOutcome, HookPayload, HookResult, HookResultControl, PersistentHookManager,
 };
 
+use serde_json::Value;
 use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Mutex as TokioMutex;
@@ -65,7 +66,7 @@ pub async fn dispatch_hooks_with_count_and_manager(
     async_manager: Option<&AsyncHookManager>,
     persistent_manager: Option<&Arc<TokioMutex<PersistentHookManager>>>,
 ) -> HookOutcome {
-    let payload = HookPayload {
+    let mut payload = HookPayload {
         session_id: session_id.to_string(),
         cwd: cwd.to_path_buf(),
         resume_count,
@@ -74,6 +75,8 @@ pub async fn dispatch_hooks_with_count_and_manager(
 
     let mut additional_contexts = vec![];
     let mut resume = false;
+    let mut current_tool_input: Option<Value> = None;
+    let mut current_tool_response: Option<Value> = None;
 
     for hook in hooks {
         if hook.event != event.event_name() || !hook.is_supported_type() {
@@ -95,6 +98,12 @@ pub async fn dispatch_hooks_with_count_and_manager(
             continue;
         }
 
+        patch_payload_mutation(
+            &mut payload.hook_event,
+            current_tool_input.as_ref(),
+            current_tool_response.as_ref(),
+        );
+
         if hook.async_hook == Some(true) {
             if let Some(manager) = async_manager {
                 manager.spawn_hook(payload.clone(), hook.command.clone(), hook.timeout);
@@ -111,17 +120,35 @@ pub async fn dispatch_hooks_with_count_and_manager(
                     .await;
                 let HookOutcome { control, result } = outcome;
 
+                // Extract mutations before branching so Ask/Block also carry them.
+                if let Some(ref hso) = result.hook_specific_output {
+                    if let Some(ref ti) = hso.tool_input {
+                        current_tool_input = Some(ti.clone());
+                    }
+                    if let Some(ref tr) = hso.tool_response {
+                        current_tool_response = Some(tr.clone());
+                    }
+                }
+
                 match control {
                     HookResultControl::Block { reason } => {
                         return HookOutcome {
                             control: HookResultControl::Block { reason },
-                            result,
+                            result: HookResult {
+                                mutated_tool_input: current_tool_input,
+                                mutated_tool_response: current_tool_response,
+                                ..result
+                            },
                         };
                     }
                     HookResultControl::Ask { reason } => {
                         return HookOutcome {
                             control: HookResultControl::Ask { reason },
-                            result,
+                            result: HookResult {
+                                mutated_tool_input: current_tool_input,
+                                mutated_tool_response: current_tool_response,
+                                ..result
+                            },
                         };
                     }
                     HookResultControl::Continue => {
@@ -143,17 +170,36 @@ pub async fn dispatch_hooks_with_count_and_manager(
         let outcome = execute_command_hook(&payload, &hook.command, hook.timeout).await;
         let HookOutcome { control, result } = outcome;
 
+        // Extract mutations from this hook before branching on control so that
+        // even Ask/Block outcomes carry the current hook's mutation forward.
+        if let Some(ref hso) = result.hook_specific_output {
+            if let Some(ref ti) = hso.tool_input {
+                current_tool_input = Some(ti.clone());
+            }
+            if let Some(ref tr) = hso.tool_response {
+                current_tool_response = Some(tr.clone());
+            }
+        }
+
         match control {
             HookResultControl::Block { reason } => {
                 return HookOutcome {
                     control: HookResultControl::Block { reason },
-                    result,
+                    result: HookResult {
+                        mutated_tool_input: current_tool_input,
+                        mutated_tool_response: current_tool_response,
+                        ..result
+                    },
                 };
             }
             HookResultControl::Ask { reason } => {
                 return HookOutcome {
                     control: HookResultControl::Ask { reason },
-                    result,
+                    result: HookResult {
+                        mutated_tool_input: current_tool_input,
+                        mutated_tool_response: current_tool_response,
+                        ..result
+                    },
                 };
             }
             HookResultControl::Continue => {
@@ -174,8 +220,40 @@ pub async fn dispatch_hooks_with_count_and_manager(
             additional_context: (!additional_contexts.is_empty())
                 .then(|| additional_contexts.join("\n")),
             resume: resume.then_some(true),
+            mutated_tool_input: current_tool_input,
+            mutated_tool_response: current_tool_response,
             ..HookResult::default()
         },
+    }
+}
+
+fn patch_payload_mutation(
+    event: &mut HookEvent,
+    tool_input: Option<&Value>,
+    tool_response: Option<&Value>,
+) {
+    match event {
+        HookEvent::PreToolUse {
+            tool_input: payload_tool_input,
+            ..
+        } => {
+            if let Some(tool_input) = tool_input {
+                *payload_tool_input = tool_input.clone();
+            }
+        }
+        HookEvent::PostToolUse {
+            tool_input: payload_tool_input,
+            tool_response: payload_tool_response,
+            ..
+        } => {
+            if let Some(tool_input) = tool_input {
+                *payload_tool_input = tool_input.clone();
+            }
+            if let Some(tool_response) = tool_response {
+                *payload_tool_response = tool_response.clone();
+            }
+        }
+        _ => {}
     }
 }
 
@@ -380,6 +458,64 @@ mod tests {
     }
 
     #[cfg(unix)]
+    fn tool_input_mutation_command(dir: &Path, value: serde_json::Value) -> String {
+        let output = json!({
+            "hookSpecificOutput": {
+                "toolInput": value,
+            }
+        })
+        .to_string();
+        write_script(
+            dir,
+            "tool-input-mutation",
+            &format!("printf '%s\n' {}", shell_quote(&output)),
+        )
+    }
+
+    #[cfg(unix)]
+    fn tool_response_mutation_command(dir: &Path, value: serde_json::Value) -> String {
+        let output = json!({
+            "hookSpecificOutput": {
+                "toolResponse": value,
+            }
+        })
+        .to_string();
+        write_script(
+            dir,
+            "tool-response-mutation",
+            &format!("printf '%s\n' {}", shell_quote(&output)),
+        )
+    }
+
+    #[cfg(unix)]
+    fn dump_and_mutate_tool_input_command(
+        dir: &Path,
+        path: &Path,
+        value: serde_json::Value,
+    ) -> String {
+        let output = json!({
+            "hookSpecificOutput": {
+                "toolInput": value,
+            }
+        })
+        .to_string();
+        write_script(
+            dir,
+            "dump-and-mutate-tool-input",
+            &format!(
+                "cat > {path}\nprintf '%s\n' {output}",
+                path = shell_quote(&path.display().to_string()),
+                output = shell_quote(&output),
+            ),
+        )
+    }
+
+    #[cfg(unix)]
+    fn invalid_json_command(dir: &Path) -> String {
+        write_script(dir, "invalid-json", "printf '%s\n' '{not json}'")
+    }
+
+    #[cfg(unix)]
     fn payload_dump_command(dir: &Path, path: &Path) -> String {
         write_script(
             dir,
@@ -468,6 +604,205 @@ mod tests {
             HookResultControl::Continue => panic!("expected ask hook outcome"),
         }
         assert!(!second_marker.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_dispatch_pre_tool_mutation_single_hook() {
+        let cwd = temp_test_dir("pre-tool-mutation-single");
+        let hooks = vec![hook_config(
+            "PreToolUse",
+            tool_input_mutation_command(&cwd, json!({"mutated": true})),
+        )];
+
+        let outcome = dispatch_hooks(
+            &pre_tool_use_event("shell"),
+            &hooks,
+            "session-mutate-1",
+            &cwd,
+        )
+        .await;
+
+        assert!(matches!(outcome.control, HookResultControl::Continue));
+        assert_eq!(
+            outcome.result.mutated_tool_input,
+            Some(json!({"mutated": true}))
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_dispatch_pre_tool_mutation_chains_between_hooks() {
+        let cwd = temp_test_dir("pre-tool-mutation-chain");
+        let payload_dump = cwd.join("second-payload.json");
+        let hooks = vec![
+            hook_config(
+                "PreToolUse",
+                tool_input_mutation_command(&cwd, json!({"step": 1})),
+            ),
+            hook_config(
+                "PreToolUse",
+                dump_and_mutate_tool_input_command(&cwd, &payload_dump, json!({"step": 2})),
+            ),
+        ];
+
+        let outcome = dispatch_hooks(
+            &pre_tool_use_event("shell"),
+            &hooks,
+            "session-mutate-2",
+            &cwd,
+        )
+        .await;
+
+        assert!(matches!(outcome.control, HookResultControl::Continue));
+        let payload: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(&payload_dump).expect("read chained payload dump"),
+        )
+        .expect("parse chained payload dump");
+        assert_eq!(payload["tool_input"], json!({"step": 1}));
+        assert_eq!(outcome.result.mutated_tool_input, Some(json!({"step": 2})));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_dispatch_post_tool_mutation_single_hook() {
+        let cwd = temp_test_dir("post-tool-mutation-single");
+        let event = HookEvent::PostToolUse {
+            tool_name: "shell".to_string(),
+            tool_input: json!({"command": "pwd"}),
+            tool_use_id: "call-post-1".to_string(),
+            tool_response: json!({"ok": false}),
+        };
+        let hooks = vec![hook_config(
+            "PostToolUse",
+            tool_response_mutation_command(&cwd, json!({"ok": true})),
+        )];
+
+        let outcome = dispatch_hooks(&event, &hooks, "session-post-1", &cwd).await;
+
+        assert!(matches!(outcome.control, HookResultControl::Continue));
+        assert_eq!(
+            outcome.result.mutated_tool_response,
+            Some(json!({"ok": true}))
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_dispatch_block_wins_over_mutation() {
+        let cwd = temp_test_dir("block-over-mutation");
+        let blocked_marker = cwd.join("blocked.txt");
+        let hooks = vec![
+            hook_config(
+                "PreToolUse",
+                tool_input_mutation_command(&cwd, json!({"step": 1})),
+            ),
+            hook_config("PreToolUse", block_command(&cwd, &blocked_marker)),
+        ];
+
+        let outcome = dispatch_hooks(
+            &pre_tool_use_event("shell"),
+            &hooks,
+            "session-block-1",
+            &cwd,
+        )
+        .await;
+
+        match outcome.control {
+            HookResultControl::Block { reason } => assert_eq!(reason, "blocked"),
+            HookResultControl::Ask { .. } => panic!("expected blocked hook outcome, got ask"),
+            HookResultControl::Continue => panic!("expected blocked hook outcome"),
+        }
+        assert!(blocked_marker.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_dispatch_ask_preserves_prior_tool_input_mutation() {
+        let cwd = temp_test_dir("ask-preserves-mutation");
+        let hooks = vec![
+            hook_config(
+                "PreToolUse",
+                tool_input_mutation_command(&cwd, json!({"mutated": true})),
+            ),
+            hook_config("PreToolUse", ask_json_command(&cwd, "confirm this")),
+        ];
+
+        let outcome = dispatch_hooks(
+            &pre_tool_use_event("shell"),
+            &hooks,
+            "session-ask-mutation",
+            &cwd,
+        )
+        .await;
+
+        match outcome.control {
+            HookResultControl::Ask { reason } => {
+                assert_eq!(reason.as_deref(), Some("confirm this"));
+            }
+            HookResultControl::Block { .. } => panic!("expected ask hook outcome, got block"),
+            HookResultControl::Continue => panic!("expected ask hook outcome"),
+        }
+        assert_eq!(
+            outcome.result.mutated_tool_input,
+            Some(json!({"mutated": true}))
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_dispatch_block_preserves_prior_tool_input_mutation() {
+        let cwd = temp_test_dir("block-preserves-mutation");
+        let hooks = vec![
+            hook_config(
+                "PreToolUse",
+                tool_input_mutation_command(&cwd, json!({"mutated": true})),
+            ),
+            hook_config(
+                "PreToolUse",
+                block_command(&cwd, &cwd.join("block-marker.txt")),
+            ),
+        ];
+
+        let outcome = dispatch_hooks(
+            &pre_tool_use_event("shell"),
+            &hooks,
+            "session-block-mutation",
+            &cwd,
+        )
+        .await;
+
+        match outcome.control {
+            HookResultControl::Block { reason } => assert_eq!(reason, "blocked"),
+            HookResultControl::Ask { .. } => panic!("expected blocked hook outcome, got ask"),
+            HookResultControl::Continue => panic!("expected blocked hook outcome"),
+        }
+        assert_eq!(
+            outcome.result.mutated_tool_input,
+            Some(json!({"mutated": true}))
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_dispatch_bad_json_yields_no_mutation() {
+        let cwd = temp_test_dir("bad-json-no-mutation");
+        let hooks = vec![hook_config("PreToolUse", invalid_json_command(&cwd))];
+
+        let outcome = dispatch_hooks(
+            &pre_tool_use_event("shell"),
+            &hooks,
+            "session-bad-json",
+            &cwd,
+        )
+        .await;
+
+        assert!(matches!(outcome.control, HookResultControl::Continue));
+        assert!(outcome.result.mutated_tool_input.is_none());
+        assert_eq!(
+            outcome.result.additional_context.as_deref(),
+            Some("{not json}")
+        );
     }
 
     #[tokio::test]

--- a/crates/harnx-hooks/src/executor.rs
+++ b/crates/harnx-hooks/src/executor.rs
@@ -103,34 +103,40 @@ pub async fn execute_command_hook(
     }
 }
 
-fn parse_success_output(stdout: &[u8]) -> HookOutcome {
+/// Derive the `HookResultControl` from a parsed `HookResult` based on the
+/// `hookSpecificOutput.permissionDecision` field. This is the shared control-
+/// derivation logic used by both one-shot and persistent hooks.
+pub fn control_from_result(result: &HookResult) -> HookResultControl {
+    match result
+        .hook_specific_output
+        .as_ref()
+        .and_then(|output| output.permission_decision.as_deref())
+    {
+        Some("deny") => HookResultControl::Block {
+            reason: result
+                .hook_specific_output
+                .as_ref()
+                .and_then(|output| output.permission_decision_reason.clone())
+                .unwrap_or_else(|| "Denied by hook".to_string()),
+        },
+        Some("ask") => HookResultControl::Ask {
+            reason: result
+                .hook_specific_output
+                .as_ref()
+                .and_then(|output| output.permission_decision_reason.clone()),
+        },
+        _ => HookResultControl::Continue,
+    }
+}
+
+pub fn parse_success_output(stdout: &[u8]) -> HookOutcome {
     if stdout.is_empty() {
         return continue_with_default();
     }
 
     match serde_json::from_slice::<HookResult>(stdout) {
         Ok(result) => {
-            let control = match result
-                .hook_specific_output
-                .as_ref()
-                .and_then(|output| output.permission_decision.as_deref())
-            {
-                Some("deny") => HookResultControl::Block {
-                    reason: result
-                        .hook_specific_output
-                        .as_ref()
-                        .and_then(|output| output.permission_decision_reason.clone())
-                        .unwrap_or_else(|| "Denied by hook".to_string()),
-                },
-                Some("ask") => HookResultControl::Ask {
-                    reason: result
-                        .hook_specific_output
-                        .as_ref()
-                        .and_then(|output| output.permission_decision_reason.clone()),
-                },
-                _ => HookResultControl::Continue,
-            };
-
+            let control = control_from_result(&result);
             HookOutcome { control, result }
         }
         Err(_) => {

--- a/crates/harnx-hooks/src/persistent.rs
+++ b/crates/harnx-hooks/src/persistent.rs
@@ -1,4 +1,6 @@
-use crate::{HookOutcome, HookPayload, HookResult, HookResultControl};
+use crate::{
+    executor::control_from_result, HookOutcome, HookPayload, HookResult, HookResultControl,
+};
 
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
@@ -214,10 +216,10 @@ impl PersistentHookProcess {
 
         let timeout = Duration::from_secs(timeout_secs.unwrap_or(30));
         match tokio::time::timeout(timeout, rx).await {
-            Ok(Ok(result)) => Ok(HookOutcome {
-                control: HookResultControl::Continue,
-                result,
-            }),
+            Ok(Ok(result)) => {
+                let control = control_from_result(&result);
+                Ok(HookOutcome { control, result })
+            }
             Ok(Err(_)) => {
                 self.pending.lock().await.remove(&id);
                 bail!("persistent hook process exited unexpectedly")

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -231,7 +231,7 @@ Relative paths are resolved from the agent's data directory.
 
 ## Hooks
 
-Hooks let you run external commands at specific points during agent execution. They're configured under the `hooks` front-matter field.
+Hooks let you run external commands at specific points during agent execution. They're configured under the `hooks` front-matter field. For a complete reference, see [Hooks Guide](hooks-guide.md).
 
 ### Configuration
 
@@ -257,7 +257,7 @@ hooks:
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `event` | `string` | yes | — | Hook event name (e.g. `PreToolUse`, `Stop`, `SessionStart`) |
-| `type` | `string` | yes | — | Execution protocol. Supported: `claude-command`, `claude-command-persistent` |
+| `type` | `string` | yes | — | Execution protocol. Supported: `claude-command`, `claude-command-persistent`. Note: `PreToolUse` hooks can return `hookSpecificOutput.toolInput` to mutate tool arguments; `PostToolUse` hooks can return `hookSpecificOutput.toolResponse` to mutate the response. |
 | `matcher` | `string` | no | none | Regex pattern to match against the tool name (for tool-related events) |
 | `command` | `string` | yes | — | Shell command to execute |
 | `timeout` | `integer` | no | `30` | Timeout in seconds |

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -1,0 +1,243 @@
+# Hooks Guide
+
+Hooks allow you to extend Harnx by running external commands at specific points during agent execution. They can be used for auditing, policy enforcement, environment injection, or even modifying the interaction between the agent and its tools.
+
+## 1. Overview
+
+Hooks are external programs or scripts that Harnx executes when specific events occur. Depending on the event and the hook configuration, a hook can:
+
+*   **Observe**: Record events for logging or auditing without affecting execution.
+*   **Block**: Prevent a tool from running or stop an agent turn.
+*   **Ask**: Pause execution and request user confirmation.
+*   **Mutate**: Modify tool arguments before execution or tool responses after execution.
+*   **Resume**: Trigger an additional agent turn after the agent has stopped.
+
+## 2. Configuration
+
+Hooks are configured in the `hooks` section of the global `config.yaml` or within an agent's front-matter.
+
+### Configuration Fields
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `event` | string | **Required.** The event that triggers the hook (e.g., `PreToolUse`). |
+| `type` | string | **Required.** The execution protocol: `claude-command` or `claude-command-persistent`. |
+| `matcher` | string | **Optional.** A regex matched against the `tool_name` for tool-related events. |
+| `command` | string | **Required.** The shell command or path to the executable to run. |
+| `timeout` | integer | **Optional.** Execution timeout in seconds (default: 30). |
+| `status_message` | string | **Optional.** A message displayed to the user while the hook is running. |
+| `async` | boolean | **Optional.** If `true`, the hook runs in the background. Async hooks cannot block or mutate. |
+| `max_resume` | integer | **Optional.** (Top-level only) Maximum number of times a `Stop` hook can request a resume. |
+
+### Hook Location and Merging
+
+Hooks can be defined globally in `config.yaml` or per-agent in the agent's front-matter.
+
+*   **Global Hooks**: Apply to all agents and sessions.
+*   **Agent Hooks**: Defined in an agent's YAML front-matter.
+*   **Merging**: Agent hooks extend the global list. If an agent hook has the same `event` and `matcher` as a global hook, the agent hook **replaces** the global one.
+*   **max_resume**: If set in an agent's front-matter, it overrides the global `max_resume` value.
+
+## 3. Event Reference
+
+Harnx supports the following events. Each event sends a JSON payload to the hook.
+
+| Event | When it fires | Payload Fields | Capabilities |
+| :--- | :--- | :--- | :--- |
+| `SessionStart` | At the beginning of a session. | `session_id`, `cwd`, `source`, `model` | Observe |
+| `SessionEnd` | When a session terminates. | `session_id`, `cwd`, `reason` | Observe |
+| `UserPromptSubmit` | When the user sends a prompt. | `session_id`, `cwd`, `prompt` | Observe |
+| `Stop` | When the agent finishes its turn. | `session_id`, `cwd`, `stop_hook_active`, `last_assistant_message` | Resume |
+| `StopFailure` | When an agent turn fails. | `session_id`, `cwd`, `error`, `error_type` | Observe |
+| `PreToolUse` | Before a tool is executed. | `session_id`, `cwd`, `tool_name`, `tool_input`, `tool_use_id` | Block, Ask, Mutate |
+| `PostToolUse` | After a tool successfully runs. | `session_id`, `cwd`, `tool_name`, `tool_input`, `tool_response`, `tool_use_id` | Mutate |
+| `PostToolUseFailure`| When a tool execution fails. | `session_id`, `cwd`, `tool_name`, `tool_input`, `tool_use_id`, `error` | Observe |
+
+## 4. Hook Types
+
+### `claude-command` (One-shot)
+
+The most common hook type. Harnx spawns the command as a subprocess for every event match.
+*   **Input**: The event payload is sent to the command's `stdin` as a single JSON object.
+*   **Output**: Harnx reads `stdout` for a JSON response (see Protocol below).
+*   **Control**:
+    *   Exit code `0`: Continue execution.
+    *   Exit code `2`: Block execution (equivalent to `permissionDecision: "deny"`).
+    *   Other non-zero codes: Logged as errors, but execution usually continues.
+
+### `claude-command-persistent` (Persistent)
+
+Useful for hooks that need to maintain state or have high startup overhead. The process is started at the beginning of the session and kept alive.
+*   **Protocol**: JSONL (JSON Lines) over `stdin` and `stdout`.
+*   **Correlation**: Each request from Harnx includes a unique `id` field. The hook must include the same `id` in its response line.
+
+### Async Hooks (`async: true`)
+
+Any hook can be marked as `async`.
+*   Harnx fires the hook and continues immediately without waiting for a response.
+*   Async hooks **cannot** block or mutate tool data. Any such fields in their response are ignored.
+*   They can still request a `resume` or provide `additionalContext`, which will be applied to the *next* agent turn.
+*   Harnx ensures all async hooks have completed their execution before starting a new LLM turn.
+
+## 5. Response Protocol
+
+Hooks communicate their results by printing a JSON object to `stdout`.
+
+```json
+{
+  "additionalContext": "Text to append to the agent's conversation history",
+  "resume": false,
+  "systemMessage": "A hidden message to inject into the system prompt for the next turn",
+  "hookSpecificOutput": {
+    "permissionDecision": "allow",
+    "permissionDecisionReason": "Reason for the decision",
+    "toolInput": { "arg": "mutated value" },
+    "toolResponse": { "result": "mutated response" }
+  }
+}
+```
+
+### Field Details
+
+*   **`additionalContext`**: String. Appended to the conversation context.
+*   **`resume`**: Boolean. If `true`, requests that the agent perform another turn (primary use for `Stop` hooks).
+*   **`systemMessage`**: String. Injected as a system-level message.
+*   **`hookSpecificOutput`**:
+    *   **`permissionDecision`**: One of `"allow"`, `"deny"`, or `"ask"`.
+    *   **`permissionDecisionReason`**: Description of why access was allowed, denied, or why the user is being asked.
+    *   **`toolInput`**: (PreToolUse only) An object that replaces the original arguments sent to the tool.
+    *   **`toolResponse`**: (PostToolUse only) A value (object or string) that replaces the original response from the tool.
+
+## 6. Mutation
+
+Mutation allows hooks to transparently modify the data flowing between the agent and its tools.
+
+### Chaining Semantics
+
+When multiple hooks are configured for the same event (e.g., two `PreToolUse` hooks for `bash_exec`):
+1.  Hooks fire in **document order** (global hooks first, then agent hooks).
+2.  Each hook receives the **current** value in its payload. If a previous hook mutated the value, the subsequent hook sees the mutated version.
+3.  The final value used by Harnx is the one produced by the **last** hook in the chain that provided a mutation.
+
+### Mutation Example: Injecting Environment Variables
+
+A `PreToolUse` hook can inject secrets or configuration into a `bash_exec` call.
+
+**hook-script.sh:**
+```bash
+#!/bin/bash
+# Read payload from stdin
+PAYLOAD=$(cat)
+TOOL_INPUT=$(echo "$PAYLOAD" | jq '.tool_input')
+
+# Inject AWS credentials into the command
+NEW_COMMAND="AWS_ACCESS_KEY_ID=xxx AWS_SECRET_ACCESS_KEY=yyy $(echo "$TOOL_INPUT" | jq -r '.command')"
+NEW_INPUT=$(echo "$TOOL_INPUT" | jq --arg cmd "$NEW_COMMAND" '.command = $cmd')
+
+# Return the mutated input
+echo "{\"hookSpecificOutput\": {\"toolInput\": $NEW_INPUT}}"
+```
+
+## 7. Permissions
+
+The `permissionDecision` field controls whether a tool is allowed to run.
+
+*   **`allow`**: Execution continues.
+*   **`deny`**: Execution is blocked. The agent receives a message indicating the tool was blocked.
+*   **`ask`**: Harnx prompts the user to allow or deny the execution. The `permissionDecisionReason` is shown to the user.
+
+**Shorthand**: A hook script can exit with code `2` to immediately signal a `deny` decision without printing a JSON response.
+
+## 8. Resume
+
+The `resume` field is primarily used with the `Stop` event. It allows a hook to decide if the agent should continue thinking or performing tasks.
+
+*   **Loop Protection**: To prevent infinite loops, the `max_resume` setting (default: 3) limits how many consecutive resumes can be triggered.
+*   **Async Drain**: Harnx waits for all pending async hooks to finish before checking if a resume was requested. This ensures that any context gathered by background tasks is available to the agent in the next turn.
+
+## 9. Persistent Hooks
+
+Persistent hooks (`type: claude-command-persistent`) use a JSONL-based protocol to avoid the overhead of spawning a new process for every event.
+
+### Request Format (Harnx to Hook)
+```json
+{"id": "1", "session_id": "...", "cwd": "...", "hook_event_name": "PreToolUse", ...}
+```
+
+### Response Format (Hook to Harnx)
+```json
+{"id": "1", "additionalContext": "...", "hookSpecificOutput": {...}}
+```
+
+The hook process must read one line from `stdin`, process it, and write exactly one line to `stdout`. The `id` must match the request.
+
+## 10. Examples
+
+### 1. AWS Credential Injector (PreToolUse Mutation)
+
+Injects AWS credentials into any `bash_exec` call.
+
+```yaml
+# config.yaml
+hooks:
+  entries:
+    - event: PreToolUse
+      type: claude-command
+      matcher: bash_exec
+      command: "inject-aws-creds.sh"
+```
+
+**inject-aws-creds.sh:**
+```bash
+#!/bin/bash
+# Replaces command with one prefixed with AWS env vars
+input=$(jq -r '.tool_input.command')
+new_input=$(jq -n --arg cmd "AWS_REGION=us-east-1 $input" '{"command": $cmd}')
+echo "{\"hookSpecificOutput\": {\"toolInput\": $new_input}}"
+```
+
+### 2. GitHub Auth Injector (PreToolUse Mutation)
+
+Intercepts GitHub API calls or git commands to inject a token.
+
+```bash
+#!/bin/bash
+input=$(cat)
+tool_name=$(echo "$input" | jq -r '.tool_name')
+
+if [[ "$tool_name" == "git_clone" ]]; then
+  url=$(echo "$input" | jq -r '.tool_input.url')
+  # Rewrite https://github.com/... to https://<token>@github.com/...
+  new_url=${url/https:\/\/github.com/https://$GH_TOKEN@github.com}
+  echo "{\"hookSpecificOutput\": {\"toolInput\": {\"url\": \"$new_url\"}}}"
+else
+  echo "{}"
+fi
+```
+
+### 3. Tool Deny-list (Block Tools)
+
+Prevents the use of `bash_exec` for security reasons.
+
+```yaml
+hooks:
+  entries:
+    - event: PreToolUse
+      type: claude-command
+      matcher: bash_exec
+      command: "exit 2"
+      status_message: "Blocking bash_exec for safety"
+```
+
+### 4. Audit Logger (Async PostToolUse)
+
+Logs all tool results to a file in the background.
+
+```yaml
+hooks:
+  entries:
+    - event: PostToolUse
+      type: claude-command
+      command: "tee -a tool_audit.log"
+      async: true
+```

--- a/docs/solutions/logic-errors/hooks-mutation-implementation-2026-05-14.md
+++ b/docs/solutions/logic-errors/hooks-mutation-implementation-2026-05-14.md
@@ -1,0 +1,207 @@
+---
+title: "Hook mutation for tool input and response replacement"
+date: 2026-05-14
+category: logic-errors
+problem_type: logic_error
+component: harnx-hooks
+root_cause: "Hook system could only observe and control tool calls, not mutate their arguments or responses"
+resolution_type: code_fix
+severity: medium
+tags:
+  - hooks
+  - mutation
+  - tool-execution
+  - chaining
+  - persistent-hooks
+plan_ref: harnx-533-hook-mutation
+---
+
+## Problem
+
+Hooks could observe tool calls and block/approve them, but could not mutate the tool arguments or responses. Users could not inject environment variables, rewrite paths, redact sensitive data, or otherwise modify what tools receive or return.
+
+## Symptoms
+
+- `PreToolUse` hooks could deny/allow but not modify `tool_input`
+- `PostToolUse` hooks could observe `tool_response` but not alter it
+- Multiple hooks could not compose mutations (e.g., one injects AWS creds, another adds GitHub proxy settings)
+- Persistent hooks (`claude-command-persistent`) never participated in mutation semantics
+
+## Investigation Steps
+
+1. Identified that `HookSpecificOutput` only had `permissionDecision` / `permissionDecisionReason` — no mutation fields
+2. `dispatch_hooks_with_count_and_manager` tracked `additional_context` across hooks but not `tool_input`/`tool_response`
+3. `persistent.rs::send_event` hardcoded `HookResultControl::Continue`, ignoring any permission decision from the hook output
+4. `eval_tool_calls` discarded `PostToolUse` outcome entirely (`let _ = ...`)
+5. Found that extraction from `hook_specific_output` must happen BEFORE the `match control` arms, otherwise a hook returning both mutation AND Ask/Block would lose the mutation
+
+## Root Cause
+
+1. **Missing mutation fields**: `HookSpecificOutput` and `HookResult` had no fields to carry mutated `tool_input`/`tool_response`
+2. **No chaining logic**: Dispatch loop didn't track or propagate mutations across hooks
+3. **Persistent hook parity gap**: `persistent.rs` ignored `hookSpecificOutput.permissionDecision`, always returning `Continue`
+4. **Engine discard**: `eval_tool_calls` didn't read mutation fields from hook outcomes
+5. **Ask timing issue**: Mutation was applied after Ask confirmation check, so users saw original args in confirm dialog
+
+## Solution
+
+### 1. Added mutation fields to core types (`harnx-core/src/hooks.rs`)
+
+```rust
+// HookSpecificOutput — what hooks return
+#[serde(default)]
+pub tool_input: Option<Value>,      // JSON key: toolInput
+#[serde(default)]
+pub tool_response: Option<Value>,   // JSON key: toolResponse
+
+// HookResult — dispatcher aggregate
+#[serde(default)]
+pub mutated_tool_input: Option<Value>,      // engine reads this
+#[serde(default)]
+pub mutated_tool_response: Option<Value>,   // engine reads this
+```
+
+**Naming rationale**: `tool_input`/`tool_response` in `HookSpecificOutput` = wire protocol from hooks; `mutated_tool_input`/`mutated_tool_response` in `HookResult` = dispatcher-internal aggregate for engine consumption.
+
+### 2. Chaining logic in dispatch (`harnx-hooks/src/dispatch.rs`)
+
+Track mutations across hooks and patch payload for each subsequent hook:
+
+```rust
+let mut current_tool_input: Option<Value> = None;
+let mut current_tool_response: Option<Value> = None;
+
+for hook in hooks {
+    // Patch payload so next hook sees already-mutated value
+    patch_payload_mutation(
+        &mut payload.hook_event,
+        current_tool_input.as_ref(),
+        current_tool_response.as_ref(),
+    );
+
+    // ... dispatch hook ...
+
+    // CRITICAL: Extract mutations BEFORE match control arms
+    if let Some(ref hso) = result.hook_specific_output {
+        if let Some(ref ti) = hso.tool_input {
+            current_tool_input = Some(ti.clone());
+        }
+        if let Some(ref tr) = hso.tool_response {
+            current_tool_response = Some(tr.clone());
+        }
+    }
+
+    match control {
+        HookResultControl::Block { reason } => {
+            return HookOutcome {
+                control: HookResultControl::Block { reason },
+                result: HookResult {
+                    mutated_tool_input: current_tool_input,
+                    mutated_tool_response: current_tool_response,
+                    ..result
+                },
+            };
+        }
+        // ... Ask and Continue arms also carry mutations ...
+    }
+}
+```
+
+**`patch_payload_mutation`** mutates `HookEvent::PreToolUse.tool_input` and `HookEvent::PostToolUse.tool_input`/`tool_response` so each hook receives the current value.
+
+### 3. Extracted shared control derivation (`harnx-hooks/src/executor.rs`)
+
+```rust
+/// Derive HookResultControl from HookResult based on
+/// hookSpecificOutput.permissionDecision. Used by both
+/// one-shot and persistent hooks.
+pub fn control_from_result(result: &HookResult) -> HookResultControl {
+    match result
+        .hook_specific_output
+        .as_ref()
+        .and_then(|output| output.permission_decision.as_deref())
+    {
+        Some("deny") => HookResultControl::Block { ... },
+        Some("ask") => HookResultControl::Ask { ... },
+        _ => HookResultControl::Continue,
+    }
+}
+```
+
+### 4. Fixed persistent hooks (`harnx-hooks/src/persistent.rs`)
+
+```rust
+// Before: hardcoded Continue
+Ok(HookOutcome {
+    control: HookResultControl::Continue,
+    result,
+})
+
+// After: use shared control derivation
+let control = control_from_result(&result);
+Ok(HookOutcome { control, result })
+```
+
+### 5. Applied mutations in engine (`harnx-engine/src/tool.rs`)
+
+**PreToolUse mutation BEFORE Ask check** (critical ordering):
+
+```rust
+let pre_outcome = (ctx.dispatch_hook_fn)(pre_event).await;
+
+// CRITICAL: Apply mutation BEFORE Ask check so user sees actual args
+let (json_data, tool_input) = if let Some(mutated) = pre_outcome.result.mutated_tool_input {
+    (mutated.clone(), mutated)
+} else {
+    (json_data, tool_input)
+};
+
+if let HookResultControl::Ask { reason } = pre_outcome.control {
+    // User now sees mutated args in confirmation prompt
+    if !(ctx.confirm_tool_use_fn)(&call.name, &json_data, reason.as_deref()) { ... }
+}
+```
+
+**PostToolUse mutation** (previously discarded):
+
+```rust
+let post_outcome = (ctx.dispatch_hook_fn)(post_event).await;
+if let Some(mutated_response) = post_outcome.result.mutated_tool_response {
+    result = mutated_response;
+}
+```
+
+## Why This Works
+
+1. **Chaining**: Each hook receives `tool_input`/`tool_response` patched with prior mutations, so they compose
+2. **Extraction before match**: Same hook can mutate AND return Ask/Block — mutation extracted before control branching
+3. **Mutation before Ask**: User confirmation shows the actual args that will be dispatched
+4. **Persistent parity**: `control_from_result` shared function ensures one-shot and persistent hooks have identical control semantics
+5. **Field naming clarity**: Wire protocol fields (`toolInput`/`toolResponse`) separate from engine aggregate fields (`mutatedToolInput`/`mutatedToolResponse`)
+
+## Prevention Strategies
+
+**Test Cases:**
+- Single `PreToolUse` hook returning `toolInput` mutation → outcome carries mutated value
+- Two `PreToolUse` hooks → second receives mutated payload from first; final outcome is second's mutation
+- Hook that mutates AND returns Ask/Block → both mutation and control preserved
+- Persistent hook returning `permissionDecision: "deny"` → actually blocks
+- Mutation chain with one hook returning bad JSON → falls back to Continue with no mutation
+
+**Code Review Checklist:**
+- [ ] Mutation extraction happens BEFORE `match control` arms in dispatch loop
+- [ ] Ask check happens AFTER mutation is applied to `json_data`
+- [ ] `patch_payload_mutation` is called before each hook execution
+- [ ] Persistent hooks call `control_from_result`, not hardcoded `Continue`
+- [ ] `HookResult.mutated_tool_*` fields set in all control branches (Block/Ask/Continue)
+
+**Best Practices:**
+- Use `patch_payload_mutation` to ensure chaining semantics
+- Test multi-hook scenarios, not just single hook
+- Verify mutation+Ask/Block combination works correctly
+
+## Related Issues
+
+- **GitHub Issue:** [#533 — Mutable tool call args and responses](https://github.com/dobesv/harnx/issues/533)
+- **Related Solution:** [api-design/per-call-env-param-bash-mcp-2026-05-13.md](../api-design/per-call-env-param-bash-mcp-2026-05-13.md) — Prior art for env injection that hooks mutation enables
+- **Documentation:** [docs/hooks-guide.md](../../hooks-guide.md) — Comprehensive hooks reference with mutation examples

--- a/example_config/config.yaml
+++ b/example_config/config.yaml
@@ -26,3 +26,25 @@ toolsets:
 #     type: claude-command
 #     matcher: "Bash"
 #     command: "dcg"
+#
+# Example: Mutate tool input via hookSpecificOutput.toolInput
+# This shows how a PreToolUse hook can inject environment variables into Bash calls.
+#
+# hooks:
+#   entries:
+#   - event: PreToolUse
+#     type: claude-command
+#     matcher: "Bash"
+#     command: "/path/to/inject-env-hook.sh"
+#
+# The inject-env-hook.sh script would look like:
+#   #!/usr/bin/env python3
+#   import json, sys
+#   data = json.load(sys.stdin)
+#   # Mutate tool_input to add env vars
+#   data["tool_input"]["env"] = {"MY_VAR": "secret-value"}
+#   # Emit mutated input via hookSpecificOutput
+#   json.dump({"hookSpecificOutput": {"toolInput": data["tool_input"]}}, sys.stdout)
+#
+# PreToolUse hooks can return hookSpecificOutput.toolInput to mutate tool arguments.
+# PostToolUse hooks can return hookSpecificOutput.toolResponse to mutate the tool response.


### PR DESCRIPTION
Adds tool_input and tool_response mutation support to PreToolUse and PostToolUse hooks. Multiple hooks now chain mutations in document order, with each hook receiving the output of the prior hook. Includes parity for persistent hooks and updates the engine to apply mutations before permission checks.

Includes comprehensive documentation in docs/hooks-guide.md covering all event types, hook protocols, and the new mutation API.

#533

Plan: harnx-533-hook-mutation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hooks can now mutate tool inputs and responses in `PreToolUse` and `PostToolUse` events, with mutations chaining across multiple hooks.

* **Documentation**
  * Added comprehensive Hooks Guide covering hook configuration, protocols, and mutation behavior.
  * Enhanced agent guide with hooks introduction and field descriptions.
  * Added implementation documentation and updated example configuration with hook mutation examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/537)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->