### PR TITLE
feat(demos): scripted GIF rendering for TUI and web UIs

### DIFF
--- a/demos/.gitignore
+++ b/demos/.gitignore
@@ -1,0 +1,2 @@
+out/
+web/node_modules/

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,0 +1,85 @@
+# Demo GIFs
+
+Scripted, deterministic recordings of the harnx UIs. The LLM responses come
+from `harnx-mock-llm` (in `crates/harnx-test-bins`), so every render is
+bit-for-bit reproducible — no API keys, no flakiness, no rate limits.
+
+Two pipelines:
+
+| Pipeline      | What it records              | Tooling                        |
+|---------------|------------------------------|--------------------------------|
+| TUI (`*.tape`) | Terminal UI (`harnx -a …`)   | [VHS](https://github.com/charmbracelet/vhs) |
+| Web (`*.mjs`)  | `harnx --serve` playground / arena | [Playwright](https://playwright.dev) + ffmpeg |
+
+## Layout
+
+```
+demos/
+├── agent.tape                  TUI tape — agent demo
+├── render.sh                   TUI orchestrator: mock-llm → vhs → cleanup
+├── render-web.sh               Web orchestrator: mock-llm → harnx --serve → playwright → ffmpeg
+├── config/                     Self-contained HARNX_CONFIG_DIR (shared by both)
+│   ├── config.yaml
+│   ├── agents/demo-agent.md
+│   └── clients/mock.yaml       openai-compatible client pointed at :3829
+├── scripts/                    Mock-LLM response scripts (one entry per request)
+│   ├── agent-flow.yaml
+│   ├── playground-flow.yaml
+│   └── arena-flow.yaml
+├── web/                        Playwright scripts
+│   ├── package.json
+│   ├── lib.mjs                 Shared helpers (browser, recording, selectors)
+│   ├── playground.mjs
+│   └── arena.mjs
+└── out/                        Rendered artifacts (gitignored)
+```
+
+## Render
+
+### TUI
+
+Prerequisite: VHS (`brew install vhs` / `go install github.com/charmbracelet/vhs@latest`).
+On Linux you'll also need `ttyd` and `ffmpeg`.
+
+```sh
+./demos/render.sh agent
+# → demos/out/agent.gif
+```
+
+### Web (playground / arena)
+
+Prerequisite: `node` and `ffmpeg`. Playwright + chromium are installed
+automatically on first run (into `demos/web/node_modules/`).
+
+```sh
+./demos/render-web.sh playground
+./demos/render-web.sh arena
+# → demos/out/playground.gif and demos/out/arena.gif
+```
+
+`render-web.sh` builds release binaries if missing, starts `harnx-mock-llm` on
+:3829, starts `harnx --serve` on :8000, runs the matching Playwright script
+(which records a WebM via Chromium), then converts to GIF with ffmpeg using a
+palette filter for size + colour quality. Everything is torn down on exit.
+
+## Add a new demo
+
+1. Add scripted LLM responses to `demos/scripts/<name>-flow.yaml`. Each entry
+   under `turns:` is consumed by one chat-completion request. Schema lives in
+   `crates/harnx-test-bins/src/bin/harnx-mock-llm/main.rs` (text chunks, tool
+   calls, chunk delay, fallback text). The arena consumes one turn per panel.
+2. Add either `demos/<name>.tape` (VHS) or `demos/web/<name>.mjs` (Playwright).
+3. Render: `./demos/render.sh <name>` or `./demos/render-web.sh <name>`.
+
+## Replacing the README GIFs
+
+| README image            | Pipeline      | Script                           |
+|-------------------------|---------------|----------------------------------|
+| `harnx-agent`           | TUI           | `demos/agent.tape`               |
+| `harnx-llm-playground`  | Web           | `demos/web/playground.mjs`       |
+| `harnx-llm-arena`       | Web           | `demos/web/arena.mjs`            |
+| `harnx-themes`          | TUI (no demo yet) | swap in custom `.tmTheme` files; see `docs/custom-theme.md` |
+
+Once a recording looks right, upload the GIF (GitHub releases, an `assets/`
+branch, or `user-attachments` drag-and-drop) and update the matching
+`![…](…)` link in the top-level `README.md`.

--- a/demos/agent.tape
+++ b/demos/agent.tape
@@ -1,0 +1,49 @@
+# VHS tape for the harnx agent demo.
+#
+# Render with:   ./demos/render.sh agent
+# (which starts harnx-mock-llm, points HARNX_CONFIG_DIR at demos/config, runs
+# `vhs demos/agent.tape`, then cleans up.)
+#
+# To render this tape standalone (mock-llm already running on :3829):
+#   HARNX_CONFIG_DIR=demos/config vhs demos/agent.tape
+
+Output demos/out/agent.gif
+
+# render.sh points HOME at an empty tmpdir so the user's shell init (jetbrains
+# hooks, git-aware prompts, etc.) stays out of the recording.
+Set Shell    bash
+Set FontSize 16
+Set Width    1100
+Set Height   520
+Set Theme    "Catppuccin Mocha"
+Set TypingSpeed 60ms
+Set PlaybackSpeed 1.0
+
+# Launch harnx into the TUI. HARNX_CONFIG_DIR is exported by render.sh; if
+# you're invoking vhs directly, export it yourself first.
+#
+# Hide/Show keeps the bare-prompt frame from appearing in the GIF — recording
+# only resumes once harnx has painted its first screen.
+Hide
+# --session demo bypasses the "Select Session" picker that would otherwise
+# eat the first keystrokes; --empty-session forces a fresh history each run.
+Type "harnx -a demo-agent --session demo --empty-session"
+Enter
+Sleep 3s
+Show
+
+# First turn.
+Type "How many Rust files are in this workspace?"
+Sleep 400ms
+Enter
+Sleep 5s
+
+# Second turn — uses the next scripted mock-llm response.
+Type "Which crate is the largest?"
+Sleep 400ms
+Enter
+Sleep 6s
+
+# Ctrl+D exits the TUI; Ctrl+C only aborts in-flight operations.
+Ctrl+D
+Sleep 500ms

--- a/demos/config/agents/demo-agent.md
+++ b/demos/config/agents/demo-agent.md
@@ -1,0 +1,9 @@
+---
+model: mock:mock-llm
+description: Demo agent used for rendering README GIFs against the mock LLM.
+conversation_starters:
+  - How many Rust files are in this workspace?
+  - Show me the project layout.
+---
+
+You are a helpful assistant inside a recording of the harnx TUI. Keep answers tight.

--- a/demos/config/clients/mock.yaml
+++ b/demos/config/clients/mock.yaml
@@ -1,0 +1,9 @@
+type: openai-compatible
+name: mock
+api_key: sk-mock
+api_base: http://127.0.0.1:3829/v1
+models:
+  - name: mock-llm
+    max_input_tokens: 32000
+    max_output_tokens: 4000
+    supports_tool_use: true

--- a/demos/config/config.yaml
+++ b/demos/config/config.yaml
@@ -1,0 +1,4 @@
+model: mock:mock-llm
+stream: true
+save_session: false
+keybindings: emacs

--- a/demos/render-web.sh
+++ b/demos/render-web.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Render a web-UI GIF by driving the harnx server with Playwright against a
+# scripted harnx-mock-llm.
+#
+# Usage:  demos/render-web.sh <demo>
+#   <demo> ∈ { playground, arena }
+#   Reads demos/scripts/<demo>-flow.yaml and runs demos/web/<demo>.mjs.
+#   Output: demos/out/<demo>.gif
+#
+# Requires: node, cargo, ffmpeg. Installs Playwright + chromium on first run.
+
+set -euo pipefail
+
+DEMO="${1:-playground}"
+DEMOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$DEMOS_DIR/.." && pwd)"
+
+SCRIPT_PATH="$DEMOS_DIR/scripts/$DEMO-flow.yaml"
+PLAY_SCRIPT="$DEMOS_DIR/web/$DEMO.mjs"
+MOCK_PORT="${HARNX_MOCK_LLM_PORT:-3829}"
+SERVE_PORT="${HARNX_SERVE_PORT:-8000}"
+OUT_DIR="$DEMOS_DIR/out/$DEMO"
+FINAL_GIF="$DEMOS_DIR/out/$DEMO.gif"
+
+[[ -f "$SCRIPT_PATH" ]] || { echo "error: no mock-llm script at $SCRIPT_PATH" >&2; exit 1; }
+[[ -f "$PLAY_SCRIPT" ]] || { echo "error: no Playwright script at $PLAY_SCRIPT" >&2; exit 1; }
+command -v node    >/dev/null 2>&1 || { echo "error: node not found" >&2; exit 1; }
+command -v ffmpeg  >/dev/null 2>&1 || { echo "error: ffmpeg not found" >&2; exit 1; }
+command -v cargo   >/dev/null 2>&1 || { echo "error: cargo not found" >&2; exit 1; }
+
+cd "$REPO_ROOT"
+
+if [[ ! -x "$REPO_ROOT/target/release/harnx" ]] || [[ ! -x "$REPO_ROOT/target/release/harnx-mock-llm" ]]; then
+  echo "Building release binaries..."
+  cargo build --release -p harnx -p harnx-test-bins
+fi
+
+(
+  cd "$DEMOS_DIR/web"
+  if [[ ! -d node_modules ]]; then
+    echo "Installing Playwright (one-time)..."
+    npm install --silent
+    npx --yes playwright install chromium
+  fi
+)
+
+export PATH="$REPO_ROOT/target/release:$PATH"
+export HARNX_CONFIG_DIR="$DEMOS_DIR/config"
+export HARNX_SERVE_URL="http://127.0.0.1:$SERVE_PORT"
+
+mkdir -p "$OUT_DIR"
+rm -f "$OUT_DIR"/*.webm 2>/dev/null || true
+
+MOCK_LOG="$(mktemp -t harnx-mock-llm.XXXXXX.log)"
+SERVE_LOG="$(mktemp -t harnx-serve.XXXXXX.log)"
+MOCK_PID=""
+SERVE_PID=""
+
+cleanup() {
+  for pid in "$SERVE_PID" "$MOCK_PID"; do
+    [[ -n "$pid" ]] || continue
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+  rm -f "$MOCK_LOG" "$SERVE_LOG"
+}
+trap cleanup EXIT INT TERM
+
+harnx-mock-llm --port "$MOCK_PORT" --script "$SCRIPT_PATH" >"$MOCK_LOG" 2>&1 &
+MOCK_PID=$!
+for _ in $(seq 1 30); do
+  grep -q "^READY" "$MOCK_LOG" 2>/dev/null && break
+  sleep 0.1
+done
+grep -q "^READY" "$MOCK_LOG" 2>/dev/null || { echo "error: mock-llm did not start" >&2; cat "$MOCK_LOG" >&2; exit 1; }
+
+harnx --serve "127.0.0.1:$SERVE_PORT" >"$SERVE_LOG" 2>&1 &
+SERVE_PID=$!
+for _ in $(seq 1 50); do
+  curl -sf "http://127.0.0.1:$SERVE_PORT/v1/models" >/dev/null 2>&1 && break
+  sleep 0.2
+done
+if ! curl -sf "http://127.0.0.1:$SERVE_PORT/v1/models" >/dev/null 2>&1; then
+  echo "error: harnx --serve did not come up" >&2
+  cat "$SERVE_LOG" >&2
+  exit 1
+fi
+
+echo "Recording $DEMO with Playwright..."
+( cd "$DEMOS_DIR/web" && node "$PLAY_SCRIPT" --out "$OUT_DIR" )
+
+WEBM="$(find "$OUT_DIR" -maxdepth 1 -name "*.webm" -type f | head -n1)"
+[[ -f "$WEBM" ]] || { echo "error: no .webm produced by Playwright" >&2; exit 1; }
+
+echo "Converting to GIF..."
+ffmpeg -y -loglevel error \
+  -i "$WEBM" \
+  -vf "fps=15,scale=1280:-1:flags=lanczos,split[s0][s1];[s0]palettegen=stats_mode=diff[p];[s1][p]paletteuse=dither=bayer:bayer_scale=5" \
+  "$FINAL_GIF"
+
+echo "Done. Output: $FINAL_GIF"

--- a/demos/render.sh
+++ b/demos/render.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Render a VHS tape against a local harnx-mock-llm server.
+#
+# Usage: demos/render.sh <tape-name>
+#   <tape-name> matches a file at demos/<tape-name>.tape and a script at
+#   demos/scripts/<tape-name>-flow.yaml. Output GIF is written to
+#   demos/out/<tape-name>.gif (path is set inside the .tape file).
+#
+# Requirements:
+#   - vhs   (https://github.com/charmbracelet/vhs)
+#   - cargo (the script builds harnx + harnx-mock-llm in release mode if absent)
+
+set -euo pipefail
+
+TAPE_NAME="${1:-agent}"
+DEMOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$DEMOS_DIR/.." && pwd)"
+TAPE_PATH="$DEMOS_DIR/$TAPE_NAME.tape"
+SCRIPT_PATH="$DEMOS_DIR/scripts/$TAPE_NAME-flow.yaml"
+PORT="${HARNX_MOCK_LLM_PORT:-3829}"
+
+if [[ ! -f "$TAPE_PATH" ]]; then
+  echo "error: no tape at $TAPE_PATH" >&2
+  exit 1
+fi
+if [[ ! -f "$SCRIPT_PATH" ]]; then
+  echo "error: no mock-llm script at $SCRIPT_PATH" >&2
+  exit 1
+fi
+if ! command -v vhs >/dev/null 2>&1; then
+  echo "error: vhs not found on PATH. Install: https://github.com/charmbracelet/vhs#installation" >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+
+# Build release binaries if missing — VHS will type `harnx`, so it must be on PATH.
+if [[ ! -x "$REPO_ROOT/target/release/harnx" ]] || [[ ! -x "$REPO_ROOT/target/release/harnx-mock-llm" ]]; then
+  echo "Building release binaries..."
+  cargo build --release -p harnx -p harnx-test-bins
+fi
+
+export PATH="$REPO_ROOT/target/release:$PATH"
+export HARNX_CONFIG_DIR="$DEMOS_DIR/config"
+
+# VHS spawns bash inside ttyd, which sources $HOME/.bashrc. Point HOME at an
+# empty dir so the user's shell init doesn't leak into the recording.
+CLEAN_HOME="$(mktemp -d -t harnx-demo-home.XXXXXX)"
+export HOME="$CLEAN_HOME"
+
+mkdir -p "$DEMOS_DIR/out"
+
+# Start the mock LLM in the background and ensure it's torn down on exit.
+MOCK_LOG="$(mktemp -t harnx-mock-llm.XXXXXX.log)"
+harnx-mock-llm --port "$PORT" --script "$SCRIPT_PATH" >"$MOCK_LOG" 2>&1 &
+MOCK_PID=$!
+cleanup() {
+  if kill -0 "$MOCK_PID" 2>/dev/null; then
+    kill "$MOCK_PID" 2>/dev/null || true
+    wait "$MOCK_PID" 2>/dev/null || true
+  fi
+  rm -f "$MOCK_LOG"
+  rm -rf "$CLEAN_HOME"
+}
+trap cleanup EXIT INT TERM
+
+# Wait for the READY line (server is single-threaded but binds before logging).
+for _ in $(seq 1 30); do
+  if grep -q "^READY" "$MOCK_LOG" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+if ! grep -q "^READY" "$MOCK_LOG" 2>/dev/null; then
+  echo "error: mock-llm did not start; log:" >&2
+  cat "$MOCK_LOG" >&2
+  exit 1
+fi
+
+echo "Rendering $TAPE_PATH..."
+vhs "$TAPE_PATH"
+echo "Done. Output: $DEMOS_DIR/out/$TAPE_NAME.gif"

--- a/demos/scripts/agent-flow.yaml
+++ b/demos/scripts/agent-flow.yaml
@@ -1,0 +1,12 @@
+chunk_delay_ms: 35
+turns:
+  - text_chunks:
+      - "Sure! "
+      - "Let me count the Rust source files "
+      - "in this workspace."
+  - text_chunks:
+      - "There are **42 Rust files** in the workspace, "
+      - "split across the `crates/` directory. "
+      - "The largest crate is `harnx-tui`, "
+      - "which holds the terminal UI built on ratatui."
+fallback_text: "(demo complete)"

--- a/demos/scripts/arena-flow.yaml
+++ b/demos/scripts/arena-flow.yaml
@@ -1,0 +1,16 @@
+chunk_delay_ms: 25
+# Arena renders two panels; each panel sends its own /v1/chat/completions
+# request, so every "user turn" the UI sends consumes two mock-llm turns.
+turns:
+  # First user prompt — panel A then panel B.
+  - text_chunks:
+      - "I think I'm faster — I started writing this reply almost instantly."
+  - text_chunks:
+      - "Speed isn't everything. "
+      - "I'm taking my time so the answer is actually right."
+  # Second user prompt — panel A then panel B.
+  - text_chunks:
+      - "Harnx is a CLI that puts a TUI, local API server, and tools around any LLM."
+  - text_chunks:
+      - "Harnx is your all-in-one LLM workbench: chat, agents, RAG, and an API in one binary."
+fallback_text: "(arena demo complete)"

--- a/demos/scripts/playground-flow.yaml
+++ b/demos/scripts/playground-flow.yaml
@@ -1,0 +1,13 @@
+chunk_delay_ms: 35
+turns:
+  - text_chunks:
+      - "Harnx is an all-in-one LLM CLI: "
+      - "a terminal UI, an OpenAI-compatible local server, "
+      - "and a plugin layer for MCP tools, RAG, and per-agent prompts. "
+      - "Everything is configured from YAML files in a single config directory."
+  - text_chunks:
+      - "Here's a tiny example:\n\n"
+      - "```rust\nfn greet(name: &str) {\n"
+      - "    println!(\"Hello, {name}!\");\n}\n```\n\n"
+      - "Run it with `cargo run`."
+fallback_text: "(playground demo complete)"

--- a/demos/web/arena.mjs
+++ b/demos/web/arena.mjs
@@ -1,0 +1,33 @@
+// Records a scripted run of the harnx LLM Arena (?num=2).
+//
+// Both panels are pointed at the same mock-llm model — the script intentionally
+// uses different responses across turns so the panels diverge visually.
+
+import { withRecording, typeAndSend, DEFAULTS } from "./lib.mjs";
+
+const argv = Object.fromEntries(
+  process.argv.slice(2).reduce((acc, arg, i, arr) => {
+    if (arg.startsWith("--")) acc.push([arg.slice(2), arr[i + 1]]);
+    return acc;
+  }, []),
+);
+const outDir = argv.out ?? "./out/arena";
+
+await withRecording(outDir, async (page) => {
+  await page.goto(`${DEFAULTS.serveUrl}/arena?num=2`);
+
+  // Both <select id="model"> in the arena populate from /v1/models. Wait for
+  // them to be ready, then set both panels to the mock model.
+  const selects = page.locator("select#model");
+  await selects.first().waitFor({ state: "visible", timeout: 15000 });
+  const count = await selects.count();
+  for (let i = 0; i < count; i++) {
+    await selects.nth(i).selectOption("mock:mock-llm");
+  }
+
+  await typeAndSend(page, "Which of you is faster?");
+  await page.waitForTimeout(4000);
+
+  await typeAndSend(page, "Summarise harnx in one sentence.");
+  await page.waitForTimeout(5000);
+});

--- a/demos/web/lib.mjs
+++ b/demos/web/lib.mjs
@@ -1,0 +1,50 @@
+// Shared helpers for the web-demo Playwright scripts.
+
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+export const DEFAULTS = {
+  serveUrl: process.env.HARNX_SERVE_URL ?? "http://127.0.0.1:8000",
+  viewport: { width: 1280, height: 800 },
+};
+
+export async function withRecording(outDir, fn) {
+  const absOut = resolve(outDir);
+  mkdirSync(absOut, { recursive: true });
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: DEFAULTS.viewport,
+    recordVideo: { dir: absOut, size: DEFAULTS.viewport },
+  });
+  const page = await context.newPage();
+
+  try {
+    await fn(page);
+  } finally {
+    await page.close();
+    await context.close();
+    await browser.close();
+  }
+}
+
+export async function selectModel(page, modelId) {
+  // The playground/arena populate the <select id="model"> from /v1/models on
+  // load. Wait for the option to appear before changing it.
+  const sel = page.locator("select#model").first();
+  await sel.waitFor({ state: "visible", timeout: 15000 });
+  // <option> elements inside <select> are reported as hidden by Playwright's
+  // default visibility heuristic; wait for "attached" instead.
+  await sel
+    .locator(`option[value="${modelId}"]`)
+    .waitFor({ state: "attached", timeout: 15000 });
+  await sel.selectOption(modelId);
+}
+
+export async function typeAndSend(page, text, { perChar = 25 } = {}) {
+  const input = page.locator("textarea#chat-input").first();
+  await input.click();
+  await input.type(text, { delay: perChar });
+  await page.keyboard.press("Enter");
+}

--- a/demos/web/package-lock.json
+++ b/demos/web/package-lock.json
@@ -1,0 +1,56 @@
+{
+  "name": "harnx-web-demos",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "harnx-web-demos",
+      "version": "0.0.0",
+      "dependencies": {
+        "playwright": "^1.48.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/demos/web/package.json
+++ b/demos/web/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "harnx-web-demos",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "description": "Playwright scripts that render scripted GIFs of the harnx web UIs (playground, arena).",
+  "scripts": {
+    "playground": "node playground.mjs",
+    "arena": "node arena.mjs"
+  },
+  "dependencies": {
+    "playwright": "^1.48.0"
+  }
+}

--- a/demos/web/playground.mjs
+++ b/demos/web/playground.mjs
@@ -1,0 +1,30 @@
+// Records a scripted run of the harnx LLM Playground.
+//
+// Expects:
+//   - harnx --serve running on $HARNX_SERVE_URL (default :8000)
+//   - harnx-mock-llm running on :3829 (configured in HARNX_CONFIG_DIR)
+//
+// Output: writes a WebM into the directory passed via --out (the orchestrator
+// then converts it to GIF with ffmpeg).
+
+import { withRecording, selectModel, typeAndSend, DEFAULTS } from "./lib.mjs";
+
+const argv = Object.fromEntries(
+  process.argv.slice(2).reduce((acc, arg, i, arr) => {
+    if (arg.startsWith("--")) acc.push([arg.slice(2), arr[i + 1]]);
+    return acc;
+  }, []),
+);
+const outDir = argv.out ?? "./out/playground";
+
+await withRecording(outDir, async (page) => {
+  await page.goto(`${DEFAULTS.serveUrl}/playground`);
+  await selectModel(page, "mock:mock-llm");
+
+  await typeAndSend(page, "Explain what harnx is in one paragraph.");
+  // Wait for the assistant bubble to settle.
+  await page.waitForTimeout(4000);
+
+  await typeAndSend(page, "Now show me a small code example.");
+  await page.waitForTimeout(5000);
+});


### PR DESCRIPTION
## Summary

Adds a `demos/` directory with two reproducible pipelines for regenerating the README's demo GIFs against `harnx-mock-llm`. Renders are deterministic and require no API keys, so the GIFs can be refreshed any time the UI changes without flaky LLM output drifting between runs.

## What's covered

| README image           | Pipeline | Script                       |
|------------------------|----------|------------------------------|
| `harnx-agent`          | TUI      | `demos/agent.tape` (VHS)     |
| `harnx-llm-playground` | Web      | `demos/web/playground.mjs`   |
| `harnx-llm-arena`      | Web      | `demos/web/arena.mjs`        |
| `harnx-themes`         | (not scripted) | docs only — themes are TUI-only via `.tmTheme` files |

## How it works

Both pipelines share `demos/config/` — a self-contained `HARNX_CONFIG_DIR` with an `openai-compatible` client named `mock` pointed at `127.0.0.1:3829`, and a `demo-agent` that uses it. The mock server (`harnx-mock-llm` in `crates/harnx-test-bins`) serves scripted responses from `demos/scripts/<name>-flow.yaml`; each YAML entry under `turns:` is consumed by exactly one `/v1/chat/completions` request, so the arena consumes two turns per user prompt (one per panel).

- `demos/render.sh <name>` — starts `harnx-mock-llm`, runs `vhs demos/<name>.tape`, tears down on exit. Output GIF path is set inside the tape (default `demos/out/<name>.gif`).
- `demos/render-web.sh <name>` — starts `harnx-mock-llm` and `harnx --serve`, runs the matching Playwright script which records Chromium into WebM, then converts to GIF via `ffmpeg` with a `palettegen`/`paletteuse` filter. Output: `demos/out/<name>.gif`.

Both scripts build release binaries on first run and clean up child processes via `trap`.

## Out of scope

- `harnx-themes`: themes are a TUI-only feature (`.tmTheme` files in the config dir) and the original GIF predates this workflow. `demos/README.md` notes how someone could add it later.
- The rendered GIFs are not checked in (`demos/out/` is gitignored). Once a render looks right, upload it to GitHub releases / `user-attachments` and point the README at the new URL.

## Test plan

- [ ] `./demos/render.sh agent` produces `demos/out/agent.gif`
- [ ] `./demos/render-web.sh playground` produces `demos/out/playground.gif` (sidebar visible, prompt → streamed markdown response)
- [ ] `./demos/render-web.sh arena` produces `demos/out/arena.gif` (two panels, divergent scripted responses)