### PR TITLE
feat(pkg): support pulling packages from private OCI registries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,3 +119,7 @@ The YAML front matter specifies the version bump: `patch`, `minor`, or `major`.
 - **Client modules:** Each LLM provider lives in `crates/harnx/src/client/` and follows the patterns in `client/common.rs` and `client/macros.rs`.
 - **Configuration:** YAML-based; `config.yaml` holds global settings. Clients, MCP servers, and ACP servers each live in their own subdirectory (`clients/`, `mcp_servers/`, `acp_servers/`) as individual `<name>.yaml` files. Agents are Markdown files with YAML front matter in `agents/`. All agents are auto-registered as ACP servers.
 - **Dual license:** MIT OR Apache-2.0. Preserve license headers where present.
+
+## Issue/task tracker
+
+GitHub Issues is the issue/task tracker for this project.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3216,6 +3216,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "base64",
  "bytes",
  "chrono",
  "clap",

--- a/crates/harnx-core/src/config_paths.rs
+++ b/crates/harnx-core/src/config_paths.rs
@@ -16,6 +16,9 @@ pub const MACROS_DIR_NAME: &str = "macros";
 /// Subdirectory holding installed packages.
 pub const PACKAGES_DIR_NAME: &str = "packages";
 
+/// Subdirectory holding per-registry credential configuration files.
+pub const PACKAGE_REPOS_DIR_NAME: &str = "package_repos";
+
 /// Filename of the manifest written by harnx-pkg at install time.
 pub const PACKAGE_MANIFEST_FILE_NAME: &str = "manifest.yaml";
 
@@ -188,6 +191,11 @@ pub fn acp_servers_dir() -> PathBuf {
 /// Root directory for all installed packages: `<config_dir>/packages/`.
 pub fn packages_dir() -> PathBuf {
     config_dir().join(PACKAGES_DIR_NAME)
+}
+
+/// Root directory for per-registry credential config files: `<config_dir>/package_repos/`.
+pub fn package_repos_dir() -> PathBuf {
+    config_dir().join(PACKAGE_REPOS_DIR_NAME)
 }
 
 /// Directory for a specific installed package: `<config_dir>/packages/<name>/`.
@@ -675,6 +683,20 @@ mod tests {
         assert!(
             got.ends_with(PACKAGES_DIR_NAME),
             "packages_dir() should end with 'packages'"
+        );
+    }
+
+    #[test]
+    fn package_repos_dir_under_config_dir() {
+        let test_dir = "/tmp/harnx_pkg_repos_path_test_5c8d";
+        let got = with_env("HARNX_CONFIG_DIR", test_dir, package_repos_dir);
+        assert!(
+            got.starts_with(test_dir),
+            "package_repos_dir() should be under config_dir"
+        );
+        assert!(
+            got.ends_with(PACKAGE_REPOS_DIR_NAME),
+            "package_repos_dir() should end with 'package_repos'"
         );
     }
 

--- a/crates/harnx-pkg/Cargo.toml
+++ b/crates/harnx-pkg/Cargo.toml
@@ -35,6 +35,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 axum = { workspace = true }
+base64 = { workspace = true }
 bytes = { workspace = true }
 mockall = { workspace = true }
 registry-testkit = { workspace = true }

--- a/crates/harnx-pkg/Cargo.toml
+++ b/crates/harnx-pkg/Cargo.toml
@@ -31,7 +31,7 @@ serde_yaml = { workspace = true }
 simplelog = { workspace = true }
 tar = "0.4"
 tempfile = "3"
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
 
 [dev-dependencies]
 axum = { workspace = true }

--- a/crates/harnx-pkg/src/commands/add.rs
+++ b/crates/harnx-pkg/src/commands/add.rs
@@ -15,7 +15,7 @@ pub async fn run(args: &AddArgs) -> Result<()> {
     })?;
 
     let is_oci = is_oci_url(&args.url);
-    let fetcher: Box<dyn PackageFetcher> = fetcher_for_url(&args.url);
+    let fetcher: Box<dyn PackageFetcher> = fetcher_for_url(&args.url).await?;
     let name = args
         .name
         .clone()
@@ -53,9 +53,10 @@ pub fn is_oci_url(url: &str) -> bool {
         && !url.starts_with("ssh://")
 }
 
-pub fn fetcher_for_url(url: &str) -> Box<dyn PackageFetcher> {
+pub async fn fetcher_for_url(url: &str) -> Result<Box<dyn PackageFetcher>> {
     if is_oci_url(url) {
-        return Box::new(OciFetcher);
+        let auth = crate::credentials::resolve_oci_auth(url).await?;
+        return Ok(Box::new(OciFetcher::with_auth(auth)));
     }
     if url.ends_with(".git")
         || url.contains("github.com")
@@ -65,11 +66,11 @@ pub fn fetcher_for_url(url: &str) -> Box<dyn PackageFetcher> {
         || url.starts_with("git://")
         || url.starts_with("ssh://")
     {
-        return Box::new(GitFetcher);
+        return Ok(Box::new(GitFetcher));
     }
     // Default: try git
     log::warn!("Cannot determine source type from URL '{url}', trying git");
-    Box::new(GitFetcher)
+    Ok(Box::new(GitFetcher))
 }
 
 pub fn infer_package_name(url: &str) -> String {

--- a/crates/harnx-pkg/src/commands/check_updates.rs
+++ b/crates/harnx-pkg/src/commands/check_updates.rs
@@ -13,7 +13,7 @@ pub async fn run(args: &CheckForUpdatesArgs) -> Result<()> {
     };
 
     for manifest in &packages {
-        let fetcher = fetcher_for_source(&manifest.source);
+        let fetcher = fetcher_for_source(&manifest.source).await?;
         let url = source_url(&manifest.source);
         let installed_tag = source_tag(&manifest.source);
         let installed_ver = parse_semver_tag(installed_tag)?;
@@ -37,10 +37,13 @@ pub async fn run(args: &CheckForUpdatesArgs) -> Result<()> {
     Ok(())
 }
 
-pub fn fetcher_for_source(source: &PackageSource) -> Box<dyn PackageFetcher> {
+pub async fn fetcher_for_source(source: &PackageSource) -> Result<Box<dyn PackageFetcher>> {
     match source {
-        PackageSource::Git { .. } => Box::new(GitFetcher),
-        PackageSource::Oci { .. } => Box::new(OciFetcher),
+        PackageSource::Git { .. } => Ok(Box::new(GitFetcher)),
+        PackageSource::Oci { url, .. } => {
+            let auth = crate::credentials::resolve_oci_auth(url).await?;
+            Ok(Box::new(OciFetcher::with_auth(auth)))
+        }
     }
 }
 

--- a/crates/harnx-pkg/src/commands/update.rs
+++ b/crates/harnx-pkg/src/commands/update.rs
@@ -21,7 +21,7 @@ pub async fn run(args: &UpdateArgs) -> Result<()> {
 }
 
 async fn update_one(manifest: PackageManifest) -> Result<()> {
-    let fetcher = fetcher_for_source(&manifest.source);
+    let fetcher = fetcher_for_source(&manifest.source).await?;
     let url = source_url(&manifest.source);
     let installed_tag = source_tag(&manifest.source);
     let installed_ver = parse_semver_tag(installed_tag)?;

--- a/crates/harnx-pkg/src/credentials.rs
+++ b/crates/harnx-pkg/src/credentials.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
@@ -64,7 +63,9 @@ fn normalized_prefix(value: &str) -> &str {
 }
 
 fn stripped_url(url: &str) -> &str {
-    url.strip_prefix("oci://").unwrap_or(url)
+    url.strip_prefix("oci://")
+        .or_else(|| url.strip_prefix("OCI://"))
+        .unwrap_or(url)
 }
 
 fn split_host_and_path(url: &str) -> (&str, &str) {
@@ -79,7 +80,7 @@ fn is_repo_prefix_match(target: &str, config: &str) -> bool {
     let (target_host, target_path) = split_host_and_path(target);
     let (config_host, config_path) = split_host_and_path(config);
 
-    if target_host != config_host {
+    if !target_host.eq_ignore_ascii_case(config_host) {
         return false;
     }
 
@@ -97,23 +98,29 @@ fn is_repo_prefix_match(target: &str, config: &str) -> bool {
         .is_none_or(|byte| *byte == b'/')
 }
 
-fn load_repo_config(path: &Path) -> Result<PackageRepoConfig> {
-    let raw = fs::read_to_string(path)
+async fn load_repo_config(path: &Path) -> Result<PackageRepoConfig> {
+    let raw = tokio::fs::read_to_string(path)
+        .await
         .with_context(|| format!("failed to read package repo config {}", path.display()))?;
     serde_yaml::from_str(&raw)
         .with_context(|| format!("failed to parse package repo config {}", path.display()))
 }
 
-fn repo_config_paths(dir: &Path) -> Result<Vec<PathBuf>> {
+async fn repo_config_paths(dir: &Path) -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
+    let mut entries = tokio::fs::read_dir(dir)
+        .await
+        .with_context(|| format!("failed to read package repo dir {}", dir.display()))?;
 
-    for entry in fs::read_dir(dir)
-        .with_context(|| format!("failed to read package repo dir {}", dir.display()))?
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .with_context(|| "failed to read package repo dir entry")?
     {
-        let entry = entry.with_context(|| "failed to read package repo dir entry")?;
         let path = entry.path();
         if entry
             .file_type()
+            .await
             .with_context(|| format!("failed to read file type for {}", path.display()))?
             .is_file()
             && path.extension().is_some_and(|ext| ext == "yaml")
@@ -125,20 +132,29 @@ fn repo_config_paths(dir: &Path) -> Result<Vec<PathBuf>> {
     Ok(paths)
 }
 
-fn find_repo_config(url: &str) -> Result<Option<PackageRepoConfig>> {
+async fn find_repo_config(url: &str) -> Result<Option<PackageRepoConfig>> {
     let dir = harnx_core::config_paths::package_repos_dir();
-    if !dir.exists() {
+    if tokio::fs::metadata(&dir).await.is_err() {
         return Ok(None);
     }
 
     let target = stripped_url(url);
-    let mut matches = repo_config_paths(&dir)?
-        .into_iter()
-        .map(|path| load_repo_config(&path))
-        .collect::<Result<Vec<_>>>()?
-        .into_iter()
-        .filter(|config| is_repo_prefix_match(target, &config.url))
-        .collect::<Vec<_>>();
+    let mut matches = Vec::new();
+    for path in repo_config_paths(&dir).await? {
+        match load_repo_config(&path).await {
+            Ok(config) => {
+                if is_repo_prefix_match(target, &config.url) {
+                    matches.push(config);
+                }
+            }
+            Err(e) => {
+                log::warn!(
+                    "Skipping malformed credential config {}: {e}",
+                    path.display()
+                );
+            }
+        }
+    }
 
     matches.sort_by(|a, b| {
         normalized_prefix(stripped_url(&b.url))
@@ -150,7 +166,7 @@ fn find_repo_config(url: &str) -> Result<Option<PackageRepoConfig>> {
 }
 
 pub async fn resolve_oci_auth(url: &str) -> Result<RegistryAuth> {
-    let Some(config) = find_repo_config(url)? else {
+    let Some(config) = find_repo_config(url).await? else {
         return Ok(RegistryAuth::Anonymous);
     };
 
@@ -187,25 +203,13 @@ mod tests {
         ENV_MUTEX.get_or_init(|| Mutex::new(()))
     }
 
-    fn with_env_var<F, R>(key: &str, value: Option<&str>, f: F) -> R
-    where
-        F: FnOnce() -> R,
-    {
-        let _guard = env_mutex().lock().unwrap_or_else(|e| e.into_inner());
-        let prior = env::var_os(key);
+    fn set_env_var(key: &'static str, value: Option<&str>) -> std::sync::MutexGuard<'static, ()> {
+        let guard = env_mutex().lock().unwrap_or_else(|e| e.into_inner());
         match value {
             Some(value) => unsafe { env::set_var(key, value) },
             None => unsafe { env::remove_var(key) },
         }
-
-        let result = f();
-
-        match prior {
-            Some(value) => unsafe { env::set_var(key, value) },
-            None => unsafe { env::remove_var(key) },
-        }
-
-        result
+        guard
     }
 
     #[test]
@@ -311,8 +315,9 @@ mod tests {
         assert_eq!(resolved, "literal-secret");
     }
 
-    #[test]
-    fn prefix_match_most_specific() {
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn prefix_match_most_specific() {
         let temp_dir = tempfile::tempdir().unwrap();
         let repo_dir = temp_dir.path().join("package_repos");
         fs::create_dir_all(&repo_dir).unwrap();
@@ -327,17 +332,18 @@ mod tests {
         )
         .unwrap();
 
-        let found = with_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str(), || {
-            find_repo_config("ghcr.io/myorg/pkg")
-        })
-        .unwrap()
-        .unwrap();
+        let _guard = set_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str());
+        let found = find_repo_config("ghcr.io/myorg/pkg")
+            .await
+            .unwrap()
+            .unwrap();
 
         assert_eq!(found.url, "ghcr.io/myorg");
     }
 
-    #[test]
-    fn prefix_match_no_partial_path_segment() {
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn prefix_match_no_partial_path_segment() {
         let temp_dir = tempfile::tempdir().unwrap();
         let repo_dir = temp_dir.path().join("package_repos");
         fs::create_dir_all(&repo_dir).unwrap();
@@ -347,16 +353,36 @@ mod tests {
         )
         .unwrap();
 
-        let found = with_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str(), || {
-            find_repo_config("ghcr.io/myorg-evil/pkg")
-        })
-        .unwrap();
+        let _guard = set_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str());
+        let found = find_repo_config("ghcr.io/myorg-evil/pkg").await.unwrap();
 
         assert!(found.is_none());
     }
 
-    #[test]
-    fn prefix_match_no_host_suffix() {
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn prefix_match_host_case_insensitive() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_dir = temp_dir.path().join("package_repos");
+        fs::create_dir_all(&repo_dir).unwrap();
+        fs::write(
+            repo_dir.join("ghcr.yaml"),
+            "url: GHCR.IO/myorg\npassword:\n  value: token\n",
+        )
+        .unwrap();
+
+        let _guard = set_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str());
+        let found = find_repo_config("ghcr.io/myorg/pkg")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(found.url, "GHCR.IO/myorg");
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn prefix_match_no_host_suffix() {
         let temp_dir = tempfile::tempdir().unwrap();
         let repo_dir = temp_dir.path().join("package_repos");
         fs::create_dir_all(&repo_dir).unwrap();
@@ -366,16 +392,17 @@ mod tests {
         )
         .unwrap();
 
-        let found = with_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str(), || {
-            find_repo_config("registry.internal.attacker.com/pkg")
-        })
-        .unwrap();
+        let _guard = set_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str());
+        let found = find_repo_config("registry.internal.attacker.com/pkg")
+            .await
+            .unwrap();
 
         assert!(found.is_none());
     }
 
-    #[test]
-    fn prefix_match_none() {
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn prefix_match_none() {
         let temp_dir = tempfile::tempdir().unwrap();
         let repo_dir = temp_dir.path().join("package_repos");
         fs::create_dir_all(&repo_dir).unwrap();
@@ -385,16 +412,15 @@ mod tests {
         )
         .unwrap();
 
-        let found = with_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str(), || {
-            find_repo_config("example.com/other/pkg")
-        })
-        .unwrap();
+        let _guard = set_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str());
+        let found = find_repo_config("example.com/other/pkg").await.unwrap();
 
         assert!(found.is_none());
     }
 
-    #[test]
-    fn prefix_match_strips_scheme() {
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn prefix_match_strips_scheme() {
         let temp_dir = tempfile::tempdir().unwrap();
         let repo_dir = temp_dir.path().join("package_repos");
         fs::create_dir_all(&repo_dir).unwrap();
@@ -404,11 +430,11 @@ mod tests {
         )
         .unwrap();
 
-        let found = with_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str(), || {
-            find_repo_config("oci://ghcr.io/myorg/pkg")
-        })
-        .unwrap()
-        .unwrap();
+        let _guard = set_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str());
+        let found = find_repo_config("oci://ghcr.io/myorg/pkg")
+            .await
+            .unwrap()
+            .unwrap();
 
         assert_eq!(found.url, "ghcr.io/myorg");
     }

--- a/crates/harnx-pkg/src/credentials.rs
+++ b/crates/harnx-pkg/src/credentials.rs
@@ -29,6 +29,13 @@ pub async fn resolve(source: &CredentialSource) -> Result<String> {
             std::env::var(env).with_context(|| format!("env var '{env}' not set"))
         }
         CredentialSource::Command { command } => {
+            #[cfg(windows)]
+            let output = Command::new("cmd")
+                .args(["/C", command])
+                .output()
+                .await
+                .with_context(|| "failed to execute credential command")?;
+            #[cfg(not(windows))]
             let output = Command::new("sh")
                 .args(["-c", command])
                 .output()
@@ -232,19 +239,17 @@ mod tests {
             .contains("env var 'HARNX_TEST_CREDENTIAL_MISSING' not set"));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn resolve_command_success() {
         let temp_dir = tempfile::tempdir().unwrap();
         let script_path = temp_dir.path().join("echo-token.sh");
         fs::write(&script_path, "#!/bin/sh\necho mytoken\n").unwrap();
 
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut permissions = fs::metadata(&script_path).unwrap().permissions();
-            permissions.set_mode(0o755);
-            fs::set_permissions(&script_path, permissions).unwrap();
-        }
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(&script_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).unwrap();
 
         let resolved = resolve(&CredentialSource::Command {
             command: script_path.display().to_string(),
@@ -255,6 +260,20 @@ mod tests {
         assert_eq!(resolved, "mytoken");
     }
 
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn resolve_command_success() {
+        // On Windows use cmd /C echo — the trailing space is trimmed by resolve()
+        let resolved = resolve(&CredentialSource::Command {
+            command: "echo mytoken".to_string(),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(resolved, "mytoken");
+    }
+
+    #[cfg(unix)]
     #[tokio::test]
     async fn resolve_command_failure() {
         let err = resolve(&CredentialSource::Command {
@@ -266,6 +285,19 @@ mod tests {
         let message = err.to_string();
         assert!(message.contains("failed (exit 12)"));
         assert!(!message.contains("sensitive output"));
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn resolve_command_failure() {
+        let err = resolve(&CredentialSource::Command {
+            command: "exit 12".to_string(),
+        })
+        .await
+        .unwrap_err();
+
+        let message = err.to_string();
+        assert!(message.contains("failed (exit"));
     }
 
     #[tokio::test]

--- a/crates/harnx-pkg/src/credentials.rs
+++ b/crates/harnx-pkg/src/credentials.rs
@@ -1,0 +1,434 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use oci_client::secrets::RegistryAuth;
+use serde::Deserialize;
+use tokio::process::Command;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum CredentialSource {
+    Env { env: String },
+    Command { command: String },
+    Value { value: String },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PackageRepoConfig {
+    pub url: String,
+    #[serde(default)]
+    pub username: Option<CredentialSource>,
+    #[serde(default)]
+    pub password: Option<CredentialSource>,
+}
+
+pub async fn resolve(source: &CredentialSource) -> Result<String> {
+    match source {
+        CredentialSource::Env { env } => {
+            std::env::var(env).with_context(|| format!("env var '{env}' not set"))
+        }
+        CredentialSource::Command { command } => {
+            let output = Command::new("sh")
+                .args(["-c", command])
+                .output()
+                .await
+                .with_context(|| "failed to execute credential command")?;
+
+            if !output.status.success() {
+                let exit = output
+                    .status
+                    .code()
+                    .map_or_else(|| "signal".to_string(), |code| code.to_string());
+                bail!("credential command failed (exit {exit})");
+            }
+
+            Ok(String::from_utf8(output.stdout)
+                .context("credential command output was not valid UTF-8")?
+                .trim()
+                .to_string())
+        }
+        CredentialSource::Value { value } => Ok(value.clone()),
+    }
+}
+
+fn normalized_prefix(value: &str) -> &str {
+    value.trim_end_matches('/')
+}
+
+fn stripped_url(url: &str) -> &str {
+    url.strip_prefix("oci://").unwrap_or(url)
+}
+
+fn split_host_and_path(url: &str) -> (&str, &str) {
+    let normalized = normalized_prefix(stripped_url(url));
+    match normalized.split_once('/') {
+        Some((host, path)) => (host, path),
+        None => (normalized, ""),
+    }
+}
+
+fn is_repo_prefix_match(target: &str, config: &str) -> bool {
+    let (target_host, target_path) = split_host_and_path(target);
+    let (config_host, config_path) = split_host_and_path(config);
+
+    if target_host != config_host {
+        return false;
+    }
+
+    if config_path.is_empty() {
+        return true;
+    }
+
+    if !target_path.starts_with(config_path) {
+        return false;
+    }
+
+    target_path
+        .as_bytes()
+        .get(config_path.len())
+        .is_none_or(|byte| *byte == b'/')
+}
+
+fn load_repo_config(path: &Path) -> Result<PackageRepoConfig> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read package repo config {}", path.display()))?;
+    serde_yaml::from_str(&raw)
+        .with_context(|| format!("failed to parse package repo config {}", path.display()))
+}
+
+fn repo_config_paths(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+
+    for entry in fs::read_dir(dir)
+        .with_context(|| format!("failed to read package repo dir {}", dir.display()))?
+    {
+        let entry = entry.with_context(|| "failed to read package repo dir entry")?;
+        let path = entry.path();
+        if entry
+            .file_type()
+            .with_context(|| format!("failed to read file type for {}", path.display()))?
+            .is_file()
+            && path.extension().is_some_and(|ext| ext == "yaml")
+        {
+            paths.push(path);
+        }
+    }
+
+    Ok(paths)
+}
+
+fn find_repo_config(url: &str) -> Result<Option<PackageRepoConfig>> {
+    let dir = harnx_core::config_paths::package_repos_dir();
+    if !dir.exists() {
+        return Ok(None);
+    }
+
+    let target = stripped_url(url);
+    let mut matches = repo_config_paths(&dir)?
+        .into_iter()
+        .map(|path| load_repo_config(&path))
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .filter(|config| is_repo_prefix_match(target, &config.url))
+        .collect::<Vec<_>>();
+
+    matches.sort_by(|a, b| {
+        normalized_prefix(stripped_url(&b.url))
+            .len()
+            .cmp(&normalized_prefix(stripped_url(&a.url)).len())
+    });
+
+    Ok(matches.into_iter().next())
+}
+
+pub async fn resolve_oci_auth(url: &str) -> Result<RegistryAuth> {
+    let Some(config) = find_repo_config(url)? else {
+        return Ok(RegistryAuth::Anonymous);
+    };
+
+    let Some(password_source) = config.password.as_ref() else {
+        log::warn!(
+            "package repo config matched '{}' but no password was configured; using anonymous auth",
+            config.url
+        );
+        return Ok(RegistryAuth::Anonymous);
+    };
+
+    let username = match config.username.as_ref() {
+        Some(source) => resolve(source).await?,
+        None => String::new(),
+    };
+    let password = resolve(password_source).await?;
+
+    Ok(RegistryAuth::Basic(username, password))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::fs;
+    use std::sync::{Mutex, OnceLock};
+
+    use oci_client::secrets::RegistryAuth;
+
+    use super::{find_repo_config, resolve, resolve_oci_auth, CredentialSource};
+
+    static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn env_mutex() -> &'static Mutex<()> {
+        ENV_MUTEX.get_or_init(|| Mutex::new(()))
+    }
+
+    fn with_env_var<F, R>(key: &str, value: Option<&str>, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let _guard = env_mutex().lock().unwrap_or_else(|e| e.into_inner());
+        let prior = env::var_os(key);
+        match value {
+            Some(value) => unsafe { env::set_var(key, value) },
+            None => unsafe { env::remove_var(key) },
+        }
+
+        let result = f();
+
+        match prior {
+            Some(value) => unsafe { env::set_var(key, value) },
+            None => unsafe { env::remove_var(key) },
+        }
+
+        result
+    }
+
+    #[test]
+    fn resolve_env_var_present() {
+        let _guard = env_mutex().lock().unwrap_or_else(|e| e.into_inner());
+        unsafe { env::set_var("HARNX_TEST_CREDENTIAL", "secret-token") };
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let resolved = runtime
+            .block_on(resolve(&CredentialSource::Env {
+                env: "HARNX_TEST_CREDENTIAL".to_string(),
+            }))
+            .unwrap();
+        unsafe { env::remove_var("HARNX_TEST_CREDENTIAL") };
+
+        assert_eq!(resolved, "secret-token");
+    }
+
+    #[test]
+    fn resolve_env_var_missing() {
+        let _guard = env_mutex().lock().unwrap_or_else(|e| e.into_inner());
+        unsafe { env::remove_var("HARNX_TEST_CREDENTIAL_MISSING") };
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let err = runtime
+            .block_on(resolve(&CredentialSource::Env {
+                env: "HARNX_TEST_CREDENTIAL_MISSING".to_string(),
+            }))
+            .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("env var 'HARNX_TEST_CREDENTIAL_MISSING' not set"));
+    }
+
+    #[tokio::test]
+    async fn resolve_command_success() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let script_path = temp_dir.path().join("echo-token.sh");
+        fs::write(&script_path, "#!/bin/sh\necho mytoken\n").unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(&script_path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&script_path, permissions).unwrap();
+        }
+
+        let resolved = resolve(&CredentialSource::Command {
+            command: script_path.display().to_string(),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(resolved, "mytoken");
+    }
+
+    #[tokio::test]
+    async fn resolve_command_failure() {
+        let err = resolve(&CredentialSource::Command {
+            command: "printf 'sensitive output'; exit 12".to_string(),
+        })
+        .await
+        .unwrap_err();
+
+        let message = err.to_string();
+        assert!(message.contains("failed (exit 12)"));
+        assert!(!message.contains("sensitive output"));
+    }
+
+    #[tokio::test]
+    async fn resolve_value() {
+        let resolved = resolve(&CredentialSource::Value {
+            value: "literal-secret".to_string(),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(resolved, "literal-secret");
+    }
+
+    #[test]
+    fn prefix_match_most_specific() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_dir = temp_dir.path().join("package_repos");
+        fs::create_dir_all(&repo_dir).unwrap();
+        fs::write(
+            repo_dir.join("base.yaml"),
+            "url: ghcr.io\npassword:\n  value: base-token\n",
+        )
+        .unwrap();
+        fs::write(
+            repo_dir.join("org.yaml"),
+            "url: ghcr.io/myorg\npassword:\n  value: org-token\n",
+        )
+        .unwrap();
+
+        let found = with_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str(), || {
+            find_repo_config("ghcr.io/myorg/pkg")
+        })
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(found.url, "ghcr.io/myorg");
+    }
+
+    #[test]
+    fn prefix_match_no_partial_path_segment() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_dir = temp_dir.path().join("package_repos");
+        fs::create_dir_all(&repo_dir).unwrap();
+        fs::write(
+            repo_dir.join("ghcr.yaml"),
+            "url: ghcr.io/myorg\npassword:\n  value: token\n",
+        )
+        .unwrap();
+
+        let found = with_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str(), || {
+            find_repo_config("ghcr.io/myorg-evil/pkg")
+        })
+        .unwrap();
+
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn prefix_match_no_host_suffix() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_dir = temp_dir.path().join("package_repos");
+        fs::create_dir_all(&repo_dir).unwrap();
+        fs::write(
+            repo_dir.join("internal.yaml"),
+            "url: registry.internal\npassword:\n  value: token\n",
+        )
+        .unwrap();
+
+        let found = with_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str(), || {
+            find_repo_config("registry.internal.attacker.com/pkg")
+        })
+        .unwrap();
+
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn prefix_match_none() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_dir = temp_dir.path().join("package_repos");
+        fs::create_dir_all(&repo_dir).unwrap();
+        fs::write(
+            repo_dir.join("ghcr.yaml"),
+            "url: ghcr.io/myorg\npassword:\n  value: token\n",
+        )
+        .unwrap();
+
+        let found = with_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str(), || {
+            find_repo_config("example.com/other/pkg")
+        })
+        .unwrap();
+
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn prefix_match_strips_scheme() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_dir = temp_dir.path().join("package_repos");
+        fs::create_dir_all(&repo_dir).unwrap();
+        fs::write(
+            repo_dir.join("ghcr.yaml"),
+            "url: ghcr.io/myorg\npassword:\n  value: token\n",
+        )
+        .unwrap();
+
+        let found = with_env_var("HARNX_CONFIG_DIR", temp_dir.path().to_str(), || {
+            find_repo_config("oci://ghcr.io/myorg/pkg")
+        })
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(found.url, "ghcr.io/myorg");
+    }
+
+    #[test]
+    fn resolve_oci_auth_password_only() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_dir = temp_dir.path().join("package_repos");
+        fs::create_dir_all(&repo_dir).unwrap();
+        fs::write(
+            repo_dir.join("ghcr.yaml"),
+            "url: ghcr.io/myorg\npassword:\n  value: mytoken\n",
+        )
+        .unwrap();
+
+        let _guard = env_mutex().lock().unwrap_or_else(|e| e.into_inner());
+        let prior = env::var_os("HARNX_CONFIG_DIR");
+        unsafe { env::set_var("HARNX_CONFIG_DIR", temp_dir.path()) };
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let auth = runtime
+            .block_on(resolve_oci_auth("oci://ghcr.io/myorg/pkg"))
+            .unwrap();
+        match prior {
+            Some(value) => unsafe { env::set_var("HARNX_CONFIG_DIR", value) },
+            None => unsafe { env::remove_var("HARNX_CONFIG_DIR") },
+        }
+
+        assert_eq!(
+            auth,
+            RegistryAuth::Basic(String::new(), "mytoken".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_oci_auth_no_creds_warns() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_dir = temp_dir.path().join("package_repos");
+        fs::create_dir_all(&repo_dir).unwrap();
+        fs::write(repo_dir.join("ghcr.yaml"), "url: ghcr.io/myorg\n").unwrap();
+
+        let _guard = env_mutex().lock().unwrap_or_else(|e| e.into_inner());
+        let prior = env::var_os("HARNX_CONFIG_DIR");
+        unsafe { env::set_var("HARNX_CONFIG_DIR", temp_dir.path()) };
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let auth = runtime
+            .block_on(resolve_oci_auth("oci://ghcr.io/myorg/pkg"))
+            .unwrap();
+        match prior {
+            Some(value) => unsafe { env::set_var("HARNX_CONFIG_DIR", value) },
+            None => unsafe { env::remove_var("HARNX_CONFIG_DIR") },
+        }
+
+        assert_eq!(auth, RegistryAuth::Anonymous);
+    }
+}

--- a/crates/harnx-pkg/src/fetch/oci.rs
+++ b/crates/harnx-pkg/src/fetch/oci.rs
@@ -14,7 +14,23 @@ use oci_client::{
 use super::{FetchedPackage, PackageFetcher};
 use crate::semver_util::parse_semver_tag;
 
-pub struct OciFetcher;
+pub struct OciFetcher {
+    auth: RegistryAuth,
+}
+
+impl OciFetcher {
+    // Used by integration tests; binary resolves auth via resolve_oci_auth → with_auth
+    #[allow(dead_code)]
+    pub fn anonymous() -> Self {
+        Self {
+            auth: RegistryAuth::Anonymous,
+        }
+    }
+
+    pub fn with_auth(auth: RegistryAuth) -> Self {
+        Self { auth }
+    }
+}
 
 #[async_trait]
 impl PackageFetcher for OciFetcher {
@@ -27,7 +43,7 @@ impl PackageFetcher for OciFetcher {
             .with_context(|| format!("invalid OCI reference for '{url}:{tag}'"))?;
 
         let client = oci_client_for_registry(&registry);
-        let auth = RegistryAuth::Anonymous;
+        let auth = self.auth.clone();
         let accepted_media_types = [
             manifest::IMAGE_LAYER_MEDIA_TYPE,
             manifest::IMAGE_LAYER_GZIP_MEDIA_TYPE,
@@ -79,7 +95,7 @@ impl PackageFetcher for OciFetcher {
 
         let client = oci_client_for_registry(&registry);
         let response = client
-            .list_tags(&reference, &RegistryAuth::Anonymous, None, None)
+            .list_tags(&reference, &self.auth, None, None)
             .await
             .with_context(|| format!("failed to list OCI tags for '{url}'"))?;
 

--- a/crates/harnx-pkg/src/lib.rs
+++ b/crates/harnx-pkg/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod commands;
+pub mod credentials;
 pub mod fetch;
 pub mod install;
 pub mod semver_util;

--- a/crates/harnx-pkg/src/main.rs
+++ b/crates/harnx-pkg/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod commands;
+mod credentials;
 mod fetch;
 mod install;
 mod semver_util;

--- a/crates/harnx-pkg/tests/oci_fetcher.rs
+++ b/crates/harnx-pkg/tests/oci_fetcher.rs
@@ -5,14 +5,18 @@ use std::sync::Arc;
 use axum::{
     body::Body,
     extract::{Path as AxumPath, Query, Request, State},
-    http::{HeaderMap, HeaderValue, StatusCode},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
     middleware::{self, Next},
     response::Response,
     routing::{get, head, patch, post, put},
     Json, Router,
 };
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use bytes::Bytes;
-use harnx_pkg::fetch::{oci::OciFetcher, PackageFetcher};
+use harnx_pkg::{
+    credentials::resolve_oci_auth,
+    fetch::{oci::OciFetcher, PackageFetcher},
+};
 use oci_client::{
     client::{ClientConfig, ClientProtocol, Config, ImageLayer},
     manifest,
@@ -27,7 +31,7 @@ use uuid::Uuid;
 
 #[tokio::test]
 async fn test_oci_fetch_basic() {
-    let server = TestRegistry::new().await;
+    let server = TestRegistry::new().start().await;
     let image = format!("localhost:{}/harnx-test-pkg", server.port());
 
     push_test_package(
@@ -38,7 +42,7 @@ async fn test_oci_fetch_basic() {
     )
     .await;
 
-    let fetcher = OciFetcher;
+    let fetcher = OciFetcher::anonymous();
     let result = fetcher
         .fetch(&format!("oci://{image}"), "v1.0.0", None)
         .await
@@ -51,7 +55,7 @@ async fn test_oci_fetch_basic() {
 
 #[tokio::test]
 async fn test_oci_list_tags() {
-    let server = TestRegistry::new().await;
+    let server = TestRegistry::new().start().await;
     let image = format!("localhost:{}/harnx-test-pkg", server.port());
 
     push_test_package(
@@ -76,7 +80,7 @@ async fn test_oci_list_tags() {
     )
     .await;
 
-    let fetcher = OciFetcher;
+    let fetcher = OciFetcher::anonymous();
     let versions = fetcher.list_tags(&format!("oci://{image}")).await.unwrap();
 
     assert_eq!(versions, vec![Version::new(1, 0, 0), Version::new(2, 0, 0)]);
@@ -84,14 +88,156 @@ async fn test_oci_list_tags() {
 
 #[tokio::test]
 async fn test_oci_fetch_non_semver_rejected() {
-    let fetcher = OciFetcher;
+    let fetcher = OciFetcher::anonymous();
     let result = fetcher
         .fetch("oci://localhost:5000/harnx/test-pkg", "latest", None)
         .await;
     assert!(result.is_err(), "Expected error for non-semver tag");
 }
 
+#[tokio::test]
+async fn test_oci_fetch_with_basic_auth() {
+    let server = TestRegistry::new()
+        .with_auth("testuser", "testpass")
+        .start()
+        .await;
+    let image = format!("localhost:{}/harnx-private-pkg", server.port());
+
+    let push_auth = RegistryAuth::Basic("testuser".to_string(), "testpass".to_string());
+    push_test_package_with_auth(
+        &server.registry_host(),
+        &image,
+        "v1.0.0",
+        &[("agents/private.md", "---\nmodel: test\n---\nPrivate")],
+        &push_auth,
+    )
+    .await;
+
+    let config_dir = tempfile::tempdir().unwrap();
+    write_registry_config(
+        config_dir.path(),
+        &server.registry_host(),
+        "testuser",
+        "testpass",
+    );
+
+    // Set config dir, resolve auth (async-safe), then restore
+    unsafe { std::env::set_var("HARNX_CONFIG_DIR", config_dir.path()) };
+    let auth = resolve_oci_auth(&format!("oci://{image}")).await.unwrap();
+    unsafe { std::env::remove_var("HARNX_CONFIG_DIR") };
+
+    let fetcher = OciFetcher::with_auth(auth);
+    let result = fetcher
+        .fetch(&format!("oci://{image}"), "v1.0.0", None)
+        .await
+        .unwrap();
+
+    assert!(result.dir.path().join("agents/private.md").exists());
+    assert_eq!(
+        std::fs::read_to_string(result.dir.path().join("agents/private.md")).unwrap(),
+        "---\nmodel: test\n---\nPrivate"
+    );
+}
+
+#[tokio::test]
+async fn test_oci_fetch_wrong_auth_fails() {
+    let server = TestRegistry::new()
+        .with_auth("testuser", "testpass")
+        .start()
+        .await;
+    let image = format!("localhost:{}/harnx-private-pkg", server.port());
+
+    let push_auth = RegistryAuth::Basic("testuser".to_string(), "testpass".to_string());
+    push_test_package_with_auth(
+        &server.registry_host(),
+        &image,
+        "v1.0.0",
+        &[("agents/private.md", "---\nmodel: test\n---\nPrivate")],
+        &push_auth,
+    )
+    .await;
+
+    let config_dir = tempfile::tempdir().unwrap();
+    write_registry_config(
+        config_dir.path(),
+        &server.registry_host(),
+        "wronguser",
+        "wrongpass",
+    );
+
+    // Set config dir, resolve auth (async-safe), then restore
+    unsafe { std::env::set_var("HARNX_CONFIG_DIR", config_dir.path()) };
+    let auth = resolve_oci_auth(&format!("oci://{image}")).await.unwrap();
+    unsafe { std::env::remove_var("HARNX_CONFIG_DIR") };
+
+    let fetcher = OciFetcher::with_auth(auth);
+    let result = fetcher
+        .fetch(&format!("oci://{image}"), "v1.0.0", None)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "Expected fetch to fail with wrong basic auth"
+    );
+}
+
+#[tokio::test]
+async fn test_oci_fetch_anon_against_private_fails() {
+    let server = TestRegistry::new()
+        .with_auth("testuser", "testpass")
+        .start()
+        .await;
+    let image = format!("localhost:{}/harnx-private-pkg", server.port());
+
+    let push_auth = RegistryAuth::Basic("testuser".to_string(), "testpass".to_string());
+    push_test_package_with_auth(
+        &server.registry_host(),
+        &image,
+        "v1.0.0",
+        &[("agents/private.md", "---\nmodel: test\n---\nPrivate")],
+        &push_auth,
+    )
+    .await;
+
+    let fetcher = OciFetcher::anonymous();
+    let result = fetcher
+        .fetch(&format!("oci://{image}"), "v1.0.0", None)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "Expected anonymous fetch to fail against private registry"
+    );
+}
+
+fn write_registry_config(
+    config_dir: &std::path::Path,
+    registry_url: &str,
+    username: &str,
+    password: &str,
+) {
+    let repo_dir = config_dir.join("package_repos");
+    std::fs::create_dir_all(&repo_dir).unwrap();
+    std::fs::write(
+        repo_dir.join("test-registry.yaml"),
+        format!(
+            "url: \"{registry_url}\"\nusername:\n  value: \"{username}\"\npassword:\n  value: \"{password}\"\n"
+        ),
+    )
+    .unwrap();
+}
+
 async fn push_test_package(registry_host: &str, image: &str, tag: &str, files: &[(&str, &str)]) {
+    push_test_package_with_auth(registry_host, image, tag, files, &RegistryAuth::Anonymous).await;
+}
+
+async fn push_test_package_with_auth(
+    registry_host: &str,
+    image: &str,
+    tag: &str,
+    files: &[(&str, &str)],
+    auth: &RegistryAuth,
+) {
     let archive = build_tar_gz(files);
     let reference: Reference = format!("{image}:{tag}").parse().unwrap();
     let client = Client::new(ClientConfig {
@@ -109,13 +255,7 @@ async fn push_test_package(registry_host: &str, image: &str, tag: &str, files: &
     let image_manifest = manifest::OciImageManifest::build(&layers, &config, None);
 
     client
-        .push(
-            &reference,
-            &layers,
-            config,
-            &RegistryAuth::Anonymous,
-            Some(image_manifest),
-        )
+        .push(&reference, &layers, config, auth, Some(image_manifest))
         .await
         .unwrap_or_else(|err| panic!("push failed for {registry_host}: {err:?}"));
 }
@@ -141,14 +281,26 @@ fn build_tar_gz(files: &[(&str, &str)]) -> Bytes {
 }
 
 struct TestRegistry {
-    _server: JoinHandle<()>,
-    registry_host: String,
-    port: u16,
+    expected_auth: Option<(String, String)>,
 }
 
 impl TestRegistry {
-    async fn new() -> Self {
-        let state = Arc::new(RegistryState::default());
+    fn new() -> Self {
+        Self {
+            expected_auth: None,
+        }
+    }
+
+    fn with_auth(mut self, username: &str, password: &str) -> Self {
+        self.expected_auth = Some((username.to_string(), password.to_string()));
+        self
+    }
+
+    async fn start(self) -> RunningTestRegistry {
+        let state = Arc::new(RegistryState {
+            expected_auth: self.expected_auth,
+            ..Default::default()
+        });
         let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let registry_host = format!("localhost:{port}");
@@ -164,20 +316,31 @@ impl TestRegistry {
             .route("/v2/{name}/manifests/{reference}", get(get_manifest))
             .route("/v2/{name}/manifests/{reference}", head(check_manifest))
             .route("/v2/{name}/tags/list", get(list_tags))
-            .layer(middleware::from_fn(log_request))
+            .layer(middleware::from_fn_with_state(
+                Arc::clone(&state),
+                log_request,
+            ))
             .with_state(state);
 
         let server = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });
 
-        Self {
+        RunningTestRegistry {
             _server: server,
             registry_host,
             port,
         }
     }
+}
 
+struct RunningTestRegistry {
+    _server: JoinHandle<()>,
+    registry_host: String,
+    port: u16,
+}
+
+impl RunningTestRegistry {
     fn port(&self) -> u16 {
         self.port
     }
@@ -189,6 +352,7 @@ impl TestRegistry {
 
 #[derive(Default)]
 struct RegistryState {
+    expected_auth: Option<(String, String)>,
     blobs: RwLock<HashMap<String, Bytes>>,
     uploads: RwLock<HashMap<String, Vec<u8>>>,
     manifests: RwLock<HashMap<(String, String), ManifestEntry>>,
@@ -437,7 +601,52 @@ async fn list_tags(
     Json(TagListResponse { name, tags })
 }
 
-async fn log_request(req: Request, next: Next) -> Response {
+async fn log_request(
+    State(state): State<Arc<RegistryState>>,
+    req: Request,
+    next: Next,
+) -> Response {
     eprintln!("test registry {} {}", req.method(), req.uri());
+
+    let Some((expected_username, expected_password)) = state.expected_auth.as_ref() else {
+        return next.run(req).await;
+    };
+
+    let Some(auth_header) = req.headers().get(header::AUTHORIZATION) else {
+        return unauthorized_response();
+    };
+
+    let Ok(auth_header) = auth_header.to_str() else {
+        return unauthorized_response();
+    };
+
+    let Some(encoded) = auth_header.strip_prefix("Basic ") else {
+        return unauthorized_response();
+    };
+
+    let Ok(decoded) = STANDARD.decode(encoded) else {
+        return unauthorized_response();
+    };
+
+    let Ok(decoded) = String::from_utf8(decoded) else {
+        return unauthorized_response();
+    };
+
+    let Some((username, password)) = decoded.split_once(":") else {
+        return unauthorized_response();
+    };
+
+    if username != expected_username || password != expected_password {
+        return unauthorized_response();
+    }
+
     next.run(req).await
+}
+
+fn unauthorized_response() -> Response {
+    Response::builder()
+        .status(StatusCode::UNAUTHORIZED)
+        .header(header::WWW_AUTHENTICATE, "Basic realm=\"test\"")
+        .body(Body::empty())
+        .unwrap()
 }

--- a/crates/harnx-pkg/tests/oci_fetcher.rs
+++ b/crates/harnx-pkg/tests/oci_fetcher.rs
@@ -17,6 +17,30 @@ use harnx_pkg::{
     credentials::resolve_oci_auth,
     fetch::{oci::OciFetcher, PackageFetcher},
 };
+
+static ENV_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+struct EnvGuard {
+    key: &'static str,
+    prev: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn new(key: &'static str, val: impl AsRef<std::path::Path>) -> Self {
+        let prev = std::env::var_os(key);
+        unsafe { std::env::set_var(key, val.as_ref()) };
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(v) => unsafe { std::env::set_var(self.key, v) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
 use oci_client::{
     client::{ClientConfig, ClientProtocol, Config, ImageLayer},
     manifest,
@@ -121,10 +145,9 @@ async fn test_oci_fetch_with_basic_auth() {
         "testpass",
     );
 
-    // Set config dir, resolve auth (async-safe), then restore
-    unsafe { std::env::set_var("HARNX_CONFIG_DIR", config_dir.path()) };
+    let _env_lock = ENV_MUTEX.lock().await;
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", config_dir.path());
     let auth = resolve_oci_auth(&format!("oci://{image}")).await.unwrap();
-    unsafe { std::env::remove_var("HARNX_CONFIG_DIR") };
 
     let fetcher = OciFetcher::with_auth(auth);
     let result = fetcher
@@ -165,10 +188,9 @@ async fn test_oci_fetch_wrong_auth_fails() {
         "wrongpass",
     );
 
-    // Set config dir, resolve auth (async-safe), then restore
-    unsafe { std::env::set_var("HARNX_CONFIG_DIR", config_dir.path()) };
+    let _env_lock = ENV_MUTEX.lock().await;
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", config_dir.path());
     let auth = resolve_oci_auth(&format!("oci://{image}")).await.unwrap();
-    unsafe { std::env::remove_var("HARNX_CONFIG_DIR") };
 
     let fetcher = OciFetcher::with_auth(auth);
     let result = fetcher

--- a/docs/private-registries.md
+++ b/docs/private-registries.md
@@ -1,0 +1,92 @@
+# Private Package Registries and Repositories
+
+harnx supports installing packages from private OCI registries and private Git repositories.
+
+## OCI Private Registries
+
+To authenticate with private OCI registries, create YAML configuration files in the `~/.config/harnx/package_repos/` directory. Use one YAML file per registry.
+
+### Configuration Format
+
+A registry configuration file defines how to authenticate with a specific registry URL prefix.
+
+```yaml
+url: "ghcr.io/myorg"  # Prefix matched against the registry URL
+username:
+  env: "GHCR_USERNAME"       # Read from environment variable
+password:
+  env: "GITHUB_TOKEN"        # Read from environment variable
+```
+
+### Credential Sources
+
+Credentials (username and password) can be sourced in three ways:
+
+*   **`env`**: Reads the value from an environment variable at runtime.
+    ```yaml
+    password: { env: "VAR_NAME" }
+    ```
+*   **`command`**: Runs a shell command and uses its `stdout` (trimmed) as the credential.
+    ```yaml
+    password: { command: "sh cmd" }
+    ```
+*   **`value`**: Uses an inline literal value. Avoid using this for secrets.
+    ```yaml
+    username: { value: "literal" }
+    ```
+
+### Prefix Matching
+
+harnx uses prefix matching to find the correct credentials for a registry:
+*   **Most-specific wins**: If you have configs for both `ghcr.io` and `ghcr.io/myorg`, the latter will be used for any package matching that prefix.
+*   **Scheme stripping**: The `oci://` scheme is stripped from registry URLs before matching is performed.
+
+### Examples
+
+#### 1. GitHub Container Registry (GHCR)
+Configure access using a GitHub Personal Access Token (PAT).
+
+```yaml
+url: "ghcr.io/myorg"
+username:
+  env: "GHCR_USERNAME"
+password:
+  env: "GITHUB_TOKEN"
+```
+
+#### 2. Docker Hub
+Configure access using your Docker Hub credentials.
+
+```yaml
+url: "docker.io"
+username:
+  env: "DOCKER_USERNAME"
+password:
+  env: "DOCKER_PASSWORD"
+```
+
+#### 3. Amazon ECR
+ECR requires a fresh token for each session. Use the `command` source to fetch it dynamically.
+
+```yaml
+url: "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+username:
+  value: "AWS"
+password:
+  command: "aws ecr get-login-password --region us-east-1"
+```
+
+---
+
+## Git Private Repositories
+
+harnx uses the system `git` binary to manage git-based packages. No harnx-specific configuration is needed for private Git repositories.
+
+When you run `harnx-pkg add` or `harnx-pkg update`, harnx will use whatever git credentials are configured in your environment.
+
+### Common Authentication Methods
+
+1.  **GitHub CLI (Recommended for GitHub)**: Run `gh auth login` to authenticate. Git will automatically use your CLI session.
+2.  **SSH Keys**: Configure your `~/.ssh/config` as normal and ensure your keys are added to `ssh-agent`.
+3.  **`~/.netrc`**: For HTTPS authentication, store your credentials in a `~/.netrc` file.
+4.  **macOS Keychain**: On macOS, credentials can be managed automatically via the `osxkeychain` credential helper.

--- a/docs/private-registries.md
+++ b/docs/private-registries.md
@@ -26,9 +26,9 @@ Credentials (username and password) can be sourced in three ways:
     ```yaml
     password: { env: "VAR_NAME" }
     ```
-*   **`command`**: Runs a shell command and uses its `stdout` (trimmed) as the credential.
+*   **`command`**: Runs a command and uses its `stdout` (trimmed) as the credential.
     ```yaml
-    password: { command: "sh cmd" }
+    password: { command: "gh auth token" }
     ```
 *   **`value`**: Uses an inline literal value. Avoid using this for secrets.
     ```yaml

--- a/docs/solutions/integration-issues/private-oci-registry-auth-2026-05-14.md
+++ b/docs/solutions/integration-issues/private-oci-registry-auth-2026-05-14.md
@@ -1,0 +1,162 @@
+---
+title: "Private OCI registry authentication with per-registry credentials"
+date: 2026-05-14
+category: integration-issues
+problem_type: integration_issue
+component: harnx-pkg
+root_cause: OCI fetcher lacked authentication support for private registries
+resolution_type: code_fix
+severity: medium
+tags:
+  - oci
+  - authentication
+  - serde
+  - axum
+  - rust
+  - credentials
+plan_ref: harnx-536-private-registry-auth
+---
+
+## Problem
+
+harnx-pkg's OCI fetcher had no mechanism to authenticate against private OCI registries. Packages could only be fetched from public registries, blocking users from referencing private GitHub Container Registry or other authenticated registries.
+
+## Symptoms
+
+- Private registry package pulls failed with anonymous auth errors
+- No way to configure per-registry credentials
+- No integration test coverage for authenticated OCI fetches
+
+## Investigation Steps
+
+Implemented per-registry credential configuration stored in `~/.config/harnx/package_repos/*.yaml`. Each YAML file specifies a registry URL prefix and optional `username` and `password` fields. Credentials can be sourced from:
+- `env: VAR_NAME` — read from environment variable
+- `command: "sh -c ..."` — execute shell command (e.g., `gh auth token`)
+- `value: "literal"` — hardcoded value
+
+Created `credentials` module with `resolve_oci_auth(url)` that finds matching config and constructs `RegistryAuth::Basic` or `Anonymous`.
+
+Added mock OCI registry with Basic auth middleware for integration testing.
+
+## Root Cause
+
+The `OciFetcher` was stateless and always used `RegistryAuth::Anonymous`. No credential resolution logic existed. Test infrastructure had no way to simulate authenticated registries.
+
+## Solution
+
+### 1. CredentialSource enum with `#[serde(untagged)]`
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum CredentialSource {
+    Env { env: String },
+    Command { command: String },
+    Value { value: String },
+}
+```
+
+**Key insight**: `#[serde(untagged)]` is required for natural YAML like `{ env: GH_TOKEN }`. Using `rename_all` would NOT work — serde needs to try variants in order without a `type` discriminator field.
+
+### 2. Axum middleware State extraction
+
+```rust
+.layer(middleware::from_fn_with_state(
+    Arc::clone(&state),
+    auth_middleware,
+))
+```
+
+**Key insight**: `middleware::from_fn` does NOT support State extraction. Must use `from_fn_with_state` when middleware needs router state (like `expected_auth`).
+
+### 3. Registry URL prefix matching with boundary awareness
+
+```rust
+fn is_repo_prefix_match(target: &str, config: &str) -> bool {
+    let (target_host, target_path) = split_host_and_path(target);
+    let (config_host, config_path) = split_host_and_path(config);
+
+    if target_host != config_host {
+        return false;
+    }
+
+    if config_path.is_empty() {
+        return true;
+    }
+
+    if !target_path.starts_with(config_path) {
+        return false;
+    }
+
+    // CRITICAL: check next byte is '/' or end-of-string
+    target_path
+        .as_bytes()
+        .get(config_path.len())
+        .is_none_or(|byte| *byte == b'/')
+}
+```
+
+**Key insight**: Raw `starts_with` would leak credentials. `ghcr.io/myorg` MUST NOT match `ghcr.io/myorg-evil/pkg`. Must check that the character after the matched prefix is `/` or absent.
+
+### 4. Rust binary crate lib/main module visibility
+
+When splitting `main.rs` and `lib.rs`, modules used by both must be declared in both:
+
+```rust
+// main.rs
+mod credentials;
+mod commands;
+
+// lib.rs
+pub mod credentials;
+pub mod commands;
+```
+
+If `commands/add.rs` calls `crate::credentials::resolve_oci_auth`, the `mod credentials` declaration must be in `main.rs`, not just `lib.rs`. The `main.rs` sees `crate::` as itself.
+
+### 5. Avoid `block_on` inside async Tokio tests
+
+```rust
+// WRONG — panics in #[tokio::test]
+let auth = tokio::runtime::Handle::current().block_on(resolve_oci_auth(url))?;
+
+// CORRECT — just await
+let auth = resolve_oci_auth(url).await?;
+```
+
+`block_on` cannot be called inside an existing Tokio runtime. Use `.await` directly in `#[tokio::test]` functions.
+
+## Why This Works
+
+- `#[serde(untagged)]` allows YAML without type tags while maintaining variant disambiguation via distinct field names
+- `from_fn_with_state` passes router state through middleware extraction layers
+- Host equality + path boundary check prevents credential exfiltration to lookalike registries
+- Declaration in both `main.rs` and `lib.rs` ensures `crate::` paths resolve from either entry point
+- Direct `.await` in Tokio tests avoids nested runtime panic
+
+## Prevention Strategies
+
+**Test Cases:**
+- Negative tests for prefix matching: `ghcr.io/myorg` must not match `ghcr.io/myorg-evil/pkg`
+- Negative tests for host suffix: `registry.internal` must not match `registry.internal.attacker.com/pkg`
+- Command source success/failure paths
+- Token-only auth (empty username, non-empty password)
+- Missing password fallback to anonymous
+
+**Code Review Checklist:**
+- [ ] Credential matching is host+path-boundary aware, not raw string prefix
+- [ ] Serde enums with variant-distinguishing fields use `untagged`
+- [ ] Axum middleware needing State uses `from_fn_with_state`
+- [ ] Binary crates declare shared modules in both main.rs and lib.rs
+
+**Best Practices:**
+- Always use `from_fn_with_state` when middleware extracts State
+- Validate URL prefix matching includes boundary checks to prevent credential leakage
+- Test command-based credential sources with success and failure scenarios
+- Use dedicated test mutex for env var mutations in parallel tests
+
+## Related Issues
+
+- **Plan:** harnx-536-private-registry-auth
+- **Files:** `crates/harnx-pkg/src/credentials.rs`, `crates/harnx-pkg/tests/oci_fetcher.rs`
+- **Docs:** `docs/private-registries.md`

--- a/docs/solutions/integration-issues/private-oci-registry-auth-2026-05-14.md
+++ b/docs/solutions/integration-issues/private-oci-registry-auth-2026-05-14.md
@@ -31,7 +31,7 @@ harnx-pkg's OCI fetcher had no mechanism to authenticate against private OCI reg
 
 Implemented per-registry credential configuration stored in `~/.config/harnx/package_repos/*.yaml`. Each YAML file specifies a registry URL prefix and optional `username` and `password` fields. Credentials can be sourced from:
 - `env: VAR_NAME` — read from environment variable
-- `command: "sh -c ..."` — execute shell command (e.g., `gh auth token`)
+- `command: "..."` — execute command directly (e.g., `gh auth token`)
 - `value: "literal"` — hardcoded value
 
 Created `credentials` module with `resolve_oci_auth(url)` that finds matching config and constructs `RegistryAuth::Basic` or `Anonymous`.


### PR DESCRIPTION
Adds support for authenticating with private OCI registries using per-registry credential configuration.

- Adds package_repos_dir() to harnx-core to manage registry credential configurations in ~/.config/harnx/package_repos/.
- Implements a credentials module in harnx-pkg that resolves credentials from environment variables, shell commands, or literal values defined in YAML config files.
- Implements prefix-based registry matching with host and path boundary checks to ensure credentials are only sent to intended registries.
- Makes OciFetcher stateful to carry and use RegistryAuth for all operations.
- Updates add, update, and check-updates commands to resolve OCI credentials asynchronously before package operations.
- Adds an integration test suite using a mock OCI registry with Basic auth middleware.
- Documents private registry and repository authentication workflows.

#536

Plan: harnx-536-private-registry-auth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added private OCI registry authentication support with YAML-based per-registry credential configuration
  * Support for credentials from environment variables, shell commands, or literal values
  * Automatic registry URL prefix matching for credential selection

* **Documentation**
  * Added comprehensive guides for setting up private OCI registries and private Git repositories
  * Documented credential configuration and authentication methods

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/543)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->