### PR TITLE
docs: add comprehensive LLM provider configuration reference and examples

### DIFF
--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -64,6 +64,8 @@ The `config.yaml` file contains global behavior and appearance settings.
 
 Each LLM provider is configured in its own YAML file within the `clients/` directory (e.g., `clients/openai.yaml`).
 
+For a complete list of supported providers and their specific configuration options, see the [**LLM Providers Reference**](providers.md).
+
 **Note:** The filename is for organization only. The client's ID used in `model` settings (e.g., `myclient:gpt-4`) is determined by the `name` field inside the configuration file.
 
 ### General Client Options
@@ -158,7 +160,7 @@ A comprehensive reference for the new folder structure and common provider/serve
 
 This directory includes:
 - `config.yaml` with recommended global settings.
-- `clients/` examples for OpenAI, Claude, Gemini, and Ollama.
+- `clients/` examples for OpenAI, Claude, Gemini, Bedrock, Azure, Vertex AI, and more.
 - `mcp_servers/` examples for filesystem, shell, and web search.
 - `agents/` and `acp_servers/` usage documentation.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -80,9 +80,9 @@ Access models hosted on AWS Bedrock.
 | `access_key_id` | AWS Access Key ID. | `BEDROCK_ACCESS_KEY_ID` |
 | `secret_access_key` | AWS Secret Access Key. | `BEDROCK_SECRET_ACCESS_KEY` |
 | `session_token` | AWS Session Token. | `BEDROCK_SESSION_TOKEN` |
-| `profile` | AWS Profile name. | Config file only (no env var override). |
+| `profile` | AWS Profile name. Pin a specific `~/.aws/config` profile. | Use `AWS_PROFILE` env var (standard AWS convention) or set `profile` in config. |
 
-**Special Behavior:** Credentials are optional. If omitted, `harnx` uses the standard AWS credential provider chain (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars, `~/.aws/config`, IAM roles, etc.).
+**Special Behavior:** Credentials are optional. If omitted, `harnx` uses the standard AWS credential provider chain (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars, `AWS_PROFILE`, `~/.aws/config`, IAM roles, EC2 instance profiles, SSO, etc.).
 
 **Example:**
 ```yaml

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -219,5 +219,5 @@ api_base: https://api.groq.com/openai/v1
 ```
 
 > **Note:** The shorthand names (e.g., `groq`, `deepseek`, `xai`) are used as the `name` field, **not** the `type` field. The `type` must always be `openai-compatible`. The `api_base` is pre-configured by harnx when the name matches a known provider, so you can omit it if using a standard provider name.
-
+>
 > ² Cloudflare's URL contains a literal `{ACCOUNT_ID}` placeholder. You must supply the correct URL explicitly via `api_base` in your config file — the placeholder is not substituted automatically.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,223 @@
+# LLM Providers Reference
+
+This document provides a complete reference for every supported LLM provider in `harnx`.
+
+## Global Client Configuration
+
+All clients support these common fields:
+
+| Field | Description | Env Var Override |
+|-------|-------------|------------------|
+| `name` | Unique ID for the client (used in model identifiers like `my-name:gpt-4`). Defaults to the provider type. | N/A |
+| `patch` | Regex-based patches for API requests (url, headers, body). | N/A |
+| `extra` | Provider-specific extra configuration. | N/A |
+| `system_prompt_prefix` | List of strings prepended to all system prompts for this client (each item is a separate paragraph). | N/A |
+| `models` | List of manual model definitions. | N/A |
+
+> **Note on Environment Variables:** The `{NAME}` prefix in environment variables is the `name` field of the client (uppercased). If `name` is not set, it defaults to the provider `type` (e.g., `OPENAI_API_KEY`).
+
+---
+
+## OpenAI
+
+Standard OpenAI API integration.
+
+| Field | Description | Env Var Override |
+|-------|-------------|------------------|
+| `api_key` | Your OpenAI API key. | `OPENAI_API_KEY` |
+| `api_base` | Custom API base URL. | `OPENAI_API_BASE` |
+| `organization_id` | OpenAI Organization ID. | Config file only (no env var override). |
+
+**Example:**
+```yaml
+type: openai
+api_key: "sk-..."
+```
+
+---
+
+## Claude (Anthropic)
+
+Integration for Anthropic's Claude models.
+
+| Field | Description | Env Var Override |
+|-------|-------------|------------------|
+| `api_key` | Your Anthropic API key. | `CLAUDE_API_KEY` |
+| `api_base` | Custom API base URL. | `CLAUDE_API_BASE` |
+
+**Example:**
+```yaml
+type: claude
+api_key: "sk-ant-..."
+```
+
+---
+
+## Gemini (Google)
+
+Integration for Google Gemini models via the Google AI Studio API.
+
+| Field | Description | Env Var Override |
+|-------|-------------|------------------|
+| `api_key` | Your Gemini API key. | `GEMINI_API_KEY` |
+| `api_base` | Custom API base URL. | `GEMINI_API_BASE` |
+
+**Example:**
+```yaml
+type: gemini
+api_key: "..."
+```
+
+---
+
+## AWS Bedrock
+
+Access models hosted on AWS Bedrock.
+
+| Field | Description | Env Var Override |
+|-------|-------------|------------------|
+| `region` | **Required.** AWS Region (e.g., `us-east-1`). | `BEDROCK_REGION` |
+| `access_key_id` | AWS Access Key ID. | `BEDROCK_ACCESS_KEY_ID` |
+| `secret_access_key` | AWS Secret Access Key. | `BEDROCK_SECRET_ACCESS_KEY` |
+| `session_token` | AWS Session Token. | `BEDROCK_SESSION_TOKEN` |
+| `profile` | AWS Profile name. | Config file only (no env var override). |
+
+**Special Behavior:** Credentials are optional. If omitted, `harnx` uses the standard AWS credential provider chain (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars, `~/.aws/config`, IAM roles, etc.).
+
+**Example:**
+```yaml
+type: bedrock
+region: us-east-1
+```
+
+---
+
+## Vertex AI (Google Cloud)
+
+Access models on Google Cloud Vertex AI.
+
+| Field | Description | Env Var Override |
+|-------|-------------|------------------|
+| `project_id` | **Required.** Google Cloud Project ID. | `VERTEXAI_PROJECT_ID` |
+| `location` | **Required.** Google Cloud Location. | `VERTEXAI_LOCATION` |
+| `adc_file` | Path to a service account JSON file. | Config file only (no env var override). |
+
+**Special Behavior:** Uses Google Application Default Credentials (ADC). `adc_file` can be used to override the default ADC path.
+
+**Example:**
+```yaml
+type: vertexai
+project_id: "my-project"
+location: "us-central1"
+```
+
+---
+
+## Azure OpenAI
+
+Integration for Azure-hosted OpenAI deployments.
+
+| Field | Description | Env Var Override |
+|-------|-------------|------------------|
+| `api_base` | **Required.** Format: `https://{RESOURCE}.openai.azure.com` | `AZURE-OPENAI_API_BASE` ¹ |
+| `api_key` | **Required.** Your Azure OpenAI API key. | `AZURE-OPENAI_API_KEY` ¹ |
+
+**Special Behavior:** Models must be listed manually in the `models` field, with `name` matching the Azure deployment name.
+
+> ¹ The env var names contain a hyphen (`AZURE-OPENAI_*`), which most shells do not allow in variable names. To use env var overrides for Azure OpenAI, set `name: azure_openai` (underscore) in your config file — this makes the env vars `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_API_BASE`, which are shell-safe.
+
+**Example:**
+```yaml
+type: azure-openai
+api_base: "https://my-resource.openai.azure.com"
+api_key: "..."
+models:
+  - name: "gpt-4o-deployment"
+    type: chat
+```
+
+---
+
+## Cohere
+
+Integration for Cohere models.
+
+| Field | Description | Env Var Override |
+|-------|-------------|------------------|
+| `api_key` | Your Cohere API key. | `COHERE_API_KEY` |
+| `api_base` | Custom API base URL. | `COHERE_API_BASE` |
+
+**Example:**
+```yaml
+type: cohere
+api_key: "..."
+```
+
+---
+
+## OpenAI Compatible
+
+Used for any provider that implements the OpenAI API specification.
+
+| Field | Description | Env Var Override |
+|-------|-------------|------------------|
+| `api_base` | **Required.** The base URL of the API. | `{NAME}_API_BASE` |
+| `api_key` | API key. | `{NAME}_API_KEY` |
+
+**Example:**
+```yaml
+type: openai-compatible
+name: my-provider
+api_base: "https://api.example.com/v1"
+api_key: "..."
+```
+
+---
+
+## Ollama
+
+Ollama provides a local OpenAI-compatible API.
+
+**Example:**
+```yaml
+type: openai-compatible
+name: ollama
+api_base: "http://localhost:11434/v1"
+```
+
+### Named Shortcuts
+
+The following providers have pre-configured `api_base` URLs. Use `type: openai-compatible` with `name:` set to one of the names below, and harnx will fill in the correct `api_base` automatically (you can still override it explicitly). The env var prefix for the API key is the name uppercased.
+
+| Name | API Base URL | Env Var Prefix |
+|------|--------------|----------------|
+| `ai21` | `https://api.ai21.com/studio/v1` | `AI21` |
+| `cloudflare` | `https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai/v1` ² | `CLOUDFLARE` |
+| `deepinfra` | `https://api.deepinfra.com/v1/openai` | `DEEPINFRA` |
+| `deepseek` | `https://api.deepseek.com` | `DEEPSEEK` |
+| `ernie` | `https://qianfan.baidubce.com/v2` | `ERNIE` |
+| `github` | `https://models.inference.ai.azure.com` | `GITHUB` |
+| `groq` | `https://api.groq.com/openai/v1` | `GROQ` |
+| `hunyuan` | `https://api.hunyuan.cloud.tencent.com/v1` | `HUNYUAN` |
+| `jina` | `https://api.jina.ai/v1` | `JINA` |
+| `minimax` | `https://api.minimax.chat/v1` | `MINIMAX` |
+| `mistral` | `https://api.mistral.ai/v1` | `MISTRAL` |
+| `moonshot` | `https://api.moonshot.cn/v1` | `MOONSHOT` |
+| `openrouter` | `https://openrouter.ai/api/v1` | `OPENROUTER` |
+| `perplexity` | `https://api.perplexity.ai` | `PERPLEXITY` |
+| `qianwen` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `QIANWEN` |
+| `voyageai` | `https://api.voyageai.com/v1` | `VOYAGEAI` |
+| `xai` | `https://api.x.ai/v1` | `XAI` |
+| `zhipuai` | `https://open.bigmodel.cn/api/paas/v4` | `ZHIPUAI` |
+
+**Example (using `type: openai-compatible` with `name:`):**
+```yaml
+type: openai-compatible
+name: groq
+api_base: https://api.groq.com/openai/v1
+# api_key: "..."   # or set GROQ_API_KEY
+```
+
+> **Note:** The shorthand names (e.g., `groq`, `deepseek`, `xai`) are used as the `name` field, **not** the `type` field. The `type` must always be `openai-compatible`. The `api_base` is pre-configured by harnx when the name matches a known provider, so you can omit it if using a standard provider name.
+
+> ² Cloudflare's URL contains a literal `{ACCOUNT_ID}` placeholder. You must supply the correct URL explicitly via `api_base` in your config file — the placeholder is not substituted automatically.

--- a/example_config/clients/azure-openai.yaml
+++ b/example_config/clients/azure-openai.yaml
@@ -2,7 +2,7 @@
 # Note: Azure OpenAI requires manual model listing as deployment names vary.
 
 type: azure-openai
-name: azure-openai   # Use azure_openai (underscore) for shell-safe env var names
+name: azure_openai   # Underscore keeps env var names shell-safe (AZURE_OPENAI_API_KEY)
 
 # Required: The base URL of your Azure OpenAI resource
 # Format: https://{RESOURCE}.openai.azure.com

--- a/example_config/clients/azure-openai.yaml
+++ b/example_config/clients/azure-openai.yaml
@@ -1,0 +1,19 @@
+# Azure OpenAI Configuration
+# Note: Azure OpenAI requires manual model listing as deployment names vary.
+
+type: azure-openai
+name: azure-openai   # Use azure_openai (underscore) for shell-safe env var names
+
+# Required: The base URL of your Azure OpenAI resource
+# Format: https://{RESOURCE}.openai.azure.com
+api_base: "https://your-resource.openai.azure.com"
+
+# Required: Your Azure OpenAI API key
+api_key: "your-api-key"
+
+# Models must be listed manually with 'name' matching your Azure deployment name.
+models:
+  - name: "gpt-4o"           # Deployment name on Azure
+    type: chat
+  - name: "text-embedding-3-small"
+    type: embeddings

--- a/example_config/clients/bedrock.yaml
+++ b/example_config/clients/bedrock.yaml
@@ -14,7 +14,7 @@ region: us-east-1
 # secret_access_key: "..."
 # session_token: "..."
 
-# Optional: AWS Profile name
+# Optional: AWS Profile name (overrides AWS_PROFILE env var)
 # profile: "default"
 
 # Optional: System prompt prefix for all models on this client (list of strings)

--- a/example_config/clients/bedrock.yaml
+++ b/example_config/clients/bedrock.yaml
@@ -1,0 +1,27 @@
+# AWS Bedrock Configuration
+# Bedrock uses AWS credentials to authenticate.
+# If credentials are omitted, the standard AWS credential chain is used
+# (env vars AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, ~/.aws/config, IAM roles, etc.).
+
+type: bedrock
+name: bedrock             # Optional: defaults to "bedrock"
+
+# Required: AWS Region (e.g., us-east-1, us-west-2)
+region: us-east-1
+
+# Optional: Explicit credentials (overrides environment/profiles)
+# access_key_id: "..."
+# secret_access_key: "..."
+# session_token: "..."
+
+# Optional: AWS Profile name
+# profile: "default"
+
+# Optional: System prompt prefix for all models on this client (list of strings)
+# system_prompt_prefix:
+#   - "You are a helpful assistant."
+
+# Optional: Custom model list (if not using built-in catalog)
+# models:
+#   - name: "anthropic.claude-3-sonnet-20240229-v1:0"
+#     type: chat

--- a/example_config/clients/cohere.yaml
+++ b/example_config/clients/cohere.yaml
@@ -1,0 +1,10 @@
+# Cohere Configuration
+
+type: cohere
+name: cohere
+
+# Your Cohere API key
+api_key: "your-api-key"
+
+# Optional: Custom API base
+# api_base: "https://api.cohere.ai/v1"

--- a/example_config/clients/deepseek.yaml
+++ b/example_config/clients/deepseek.yaml
@@ -1,0 +1,7 @@
+# DeepSeek Configuration (OpenAI-compatible)
+# Env var: DEEPSEEK_API_KEY
+
+type: openai-compatible
+name: deepseek
+api_base: https://api.deepseek.com
+# api_key: "..."   # or set DEEPSEEK_API_KEY

--- a/example_config/clients/groq.yaml
+++ b/example_config/clients/groq.yaml
@@ -1,0 +1,7 @@
+# Groq Configuration (OpenAI-compatible)
+# Env var: GROQ_API_KEY
+
+type: openai-compatible
+name: groq
+api_base: https://api.groq.com/openai/v1
+# api_key: "..."   # or set GROQ_API_KEY

--- a/example_config/clients/vertexai.yaml
+++ b/example_config/clients/vertexai.yaml
@@ -1,0 +1,14 @@
+# Google Vertex AI Configuration
+# Vertex AI uses Google Application Default Credentials (ADC).
+
+type: vertexai
+name: vertexai
+
+# Required: Google Cloud Project ID
+project_id: "your-project-id"
+
+# Required: Google Cloud Location (e.g., us-central1)
+location: "us-central1"
+
+# Optional: Path to a service account key file (overrides default ADC)
+# adc_file: "/path/to/service-account.json"

--- a/example_config/clients/xai.yaml
+++ b/example_config/clients/xai.yaml
@@ -1,0 +1,7 @@
+# xAI (Grok) Configuration (OpenAI-compatible)
+# Env var: XAI_API_KEY
+
+type: openai-compatible
+name: xai
+api_base: https://api.x.ai/v1
+# api_key: "..."   # or set XAI_API_KEY


### PR DESCRIPTION
Adds `docs/providers.md` — a complete reference for every supported LLM provider. Also adds 7 missing `example_config/clients/` files and links the new reference from the configuration guide.

## What's in this PR

### New `docs/providers.md`
Complete reference for all providers with: config field tables, env var override names, and ready-to-use YAML examples.

### 7 new `example_config/clients/` files
`bedrock.yaml`, `azure-openai.yaml`, `vertexai.yaml`, `cohere.yaml`, `groq.yaml`, `deepseek.yaml`, `xai.yaml`

### Updated `docs/configuration-guide.md`
Links to the new providers reference.

## Providers covered
OpenAI, Claude (Anthropic), Gemini, AWS Bedrock, Google Vertex AI, Azure OpenAI, Cohere, and all 18 OpenAI-compatible shortcuts (Groq, DeepSeek, xAI, Mistral, OpenRouter, Perplexity, etc.)

## Notable accuracy details
- **Bedrock**: credential chain fallback documented (SSO/IAM roles/env vars), `profile` is config-file-only
- **Azure OpenAI**: shell-safe naming guidance (`azure_openai` underscore avoids hyphenated env vars), models must be listed manually
- **OpenAI-compatible shortcuts**: correctly documented as `type: openai-compatible` with `name:` — shorthand type names like `type: groq` are not valid
- **Cloudflare**: explicit note that `{ACCOUNT_ID}` must be substituted manually in `api_base`
- **`system_prompt_prefix`**: documented as list type (`Vec<String>`), not plain string
- **`organization_id`, `adc_file`, `profile`**: documented as config-file-only (no env var override in current implementation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive LLM providers reference documentation covering OpenAI, Claude, Gemini, AWS Bedrock, Vertex AI, Azure OpenAI, Cohere, and additional providers.
  * Created example configurations for Azure OpenAI, Bedrock, Cohere, DeepSeek, Groq, Vertex AI, and xAI.
  * Updated configuration guide with pointer to provider reference documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->