### PR TITLE
fix(mcp-bash): change bash_spawn display from `> command` to `$ comma…

### DIFF
--- a/.changesets/bash-spawn-display-format.md
+++ b/.changesets/bash-spawn-display-format.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Change `bash_spawn` call display from `> command` to `$ command &`, matching shell background-job syntax.

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -2153,7 +2153,7 @@ impl ServerHandler for BashServer {
                 )
                 .with_input_schema::<SpawnCommandParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "```sh\n> {{ args.command }}\n```{% if args.working_dir or args.inputs or args.outputs %}\n{% if args.working_dir %}({{ args.working_dir }}) {% endif %}{% if args.inputs %}[<{{ args.inputs | length }}] {% endif %}{% if args.outputs %}[>{{ args.outputs | length }}]{% endif %}{% endif %}",
+                    "call_template": "```sh\n$ {{ args.command }} &\n```{% if args.working_dir or args.inputs or args.outputs %}\n{% if args.working_dir %}({{ args.working_dir }}) {% endif %}{% if args.inputs %}[<{{ args.inputs | length }}] {% endif %}{% if args.outputs %}[>{{ args.outputs | length }}]{% endif %}{% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "wait",


### PR DESCRIPTION
…nd &`

Closes #549

The spawn call_template previously used `> command` which doesn't reflect the background-job nature of the call. Changed to `$ command &` to match standard shell background-job syntax and enable syntax highlighting of the `&`.