### PR TITLE
feat: support show_timestamps and show_sequence_numbers in config.yaml

### DIFF
--- a/crates/harnx-core/src/config_data.rs
+++ b/crates/harnx-core/src/config_data.rs
@@ -70,6 +70,9 @@ pub struct ConfigData {
     pub highlight: bool,
     pub theme: Option<String>,
 
+    pub show_sequence_numbers: bool,
+    pub show_timestamps: bool,
+
     pub serve_addr: Option<String>,
     pub user_agent: Option<String>,
     pub save_shell_history: bool,
@@ -112,6 +115,9 @@ impl Default for ConfigData {
 
             highlight: true,
             theme: None,
+
+            show_sequence_numbers: false,
+            show_timestamps: false,
 
             serve_addr: None,
             user_agent: None,

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -473,8 +473,8 @@ impl Default for Config {
             model_cooldowns: std::sync::Arc::new(parking_lot::Mutex::new(Default::default())),
             macro_flag: false,
             info_flag: false,
-            show_sequence_numbers: false,
-            show_timestamps: false,
+            show_sequence_numbers: ConfigData::default().show_sequence_numbers,
+            show_timestamps: ConfigData::default().show_timestamps,
             agent_variables: None,
             mcp_root: vec![],
 
@@ -2849,6 +2849,8 @@ impl Config {
             ConfigData::default()
         };
         let mut config = Self {
+            show_sequence_numbers: data.show_sequence_numbers,
+            show_timestamps: data.show_timestamps,
             data,
             ..Self::default()
         };


### PR DESCRIPTION
Add both fields to ConfigData so they can be set in config.yaml. Config::load_from_file and Config::default now propagate the values from ConfigData instead of always defaulting to false.