### PR TITLE
feat: add harnx-aws-creds for AWS container credential injection

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,7 +122,8 @@ jobs:
       run: |
         $BUILD_CMD build --locked --release --target=${{ matrix.target }} ${{ matrix.cargo-flags }} \
           -p harnx -p harnx-serve -p harnx-acp-server \
-          -p harnx-mcp-bash -p harnx-mcp-fs -p harnx-mcp-plans -p harnx-mcp-time
+          -p harnx-mcp-bash -p harnx-mcp-fs -p harnx-mcp-plans -p harnx-mcp-time \
+          -p harnx-aws-creds
 
     - name: Build Archives
       shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,6 +147,7 @@ jobs:
           "harnx-mcp-fs:harnx-mcp-fs"
           "harnx-mcp-plans:harnx-mcp-plans"
           "harnx-mcp-time:harnx-mcp-time"
+          "harnx-aws-creds:harnx-aws-creds"
         )
 
         archives=()
@@ -237,6 +238,8 @@ jobs:
             --pattern "harnx-mcp-plans-$V-x86_64-unknown-linux-musl.tar.gz" || true
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-mcp-time-$V-x86_64-unknown-linux-musl.tar.gz" || true
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern "harnx-aws-creds-$V-x86_64-unknown-linux-musl.tar.gz" || true
           # Download aarch64 (arm64) archives
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-$V-aarch64-unknown-linux-musl.tar.gz" || true
@@ -252,6 +255,8 @@ jobs:
             --pattern "harnx-mcp-plans-$V-aarch64-unknown-linux-musl.tar.gz" || true
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-mcp-time-$V-aarch64-unknown-linux-musl.tar.gz" || true
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern "harnx-aws-creds-$V-aarch64-unknown-linux-musl.tar.gz" || true
 
       - name: Extract archives
         run: |
@@ -267,7 +272,7 @@ jobs:
         run: |
           missing=0
           for dir in linux-amd64 linux-arm64; do
-            for bin in harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-bash-sandbox-run harnx-mcp-fs harnx-mcp-plans harnx-mcp-time; do
+            for bin in harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-bash-sandbox-run harnx-mcp-fs harnx-mcp-plans harnx-mcp-time harnx-aws-creds; do
               if [ ! -f "$dir/$bin" ]; then
                 echo "ERROR: missing $dir/$bin"
                 missing=1

--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -9,11 +9,11 @@ set -e
 # rebuilds that `cargo install --path` does. Release profile by default; pass --debug for
 # a faster build with slower runtime.
 # @flag --debug Install debug build instead of the default release build
-# @arg bins*[harnx|harnx-serve|harnx-acp-server|harnx-mcp-bash|harnx-mcp-bash-sandbox-run|harnx-mcp-fs|harnx-mcp-time|harnx-mcp-plans] Restrict the install to one or more bins (default: all)
+# @arg bins*[harnx|harnx-serve|harnx-acp-server|harnx-mcp-bash|harnx-mcp-bash-sandbox-run|harnx-mcp-fs|harnx-mcp-time|harnx-mcp-plans|harnx-aws-creds] Restrict the install to one or more bins (default: all)
 install() {
     bins=("${argc_bins[@]}")
     if [[ ${#bins[@]} -eq 0 ]]; then
-        bins=(harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-fs harnx-mcp-time harnx-mcp-plans harnx-mcp-bash-sandbox-run)
+        bins=(harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-fs harnx-mcp-time harnx-mcp-plans harnx-mcp-bash-sandbox-run harnx-aws-creds)
     fi
 
     build_args=(--locked)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3315,6 +3315,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "harnx-aws-creds"
+version = "0.32.0"
+dependencies = [
+ "anyhow",
+ "aws-config",
+ "aws-credential-types",
+ "axum",
+ "chrono",
+ "clap",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "harnx-client"
 version = "0.32.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/harnx-engine",
     "crates/harnx-acp",
     "crates/harnx-acp-server",
+    "crates/harnx-aws-creds",
     "crates/harnx-fetch",
     "crates/harnx-hooks",
     "crates/harnx-mcp",

--- a/crates/harnx-aws-creds/Cargo.toml
+++ b/crates/harnx-aws-creds/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "harnx-aws-creds"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
+
+[[bin]]
+name = "harnx-aws-creds"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+aws-config = { workspace = true }
+aws-credential-types = { workspace = true }
+axum = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["io-std"] }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-util"] }

--- a/crates/harnx-aws-creds/README.md
+++ b/crates/harnx-aws-creds/README.md
@@ -41,6 +41,17 @@ hooks:
     - event: PreToolUse
       type: claude-command-persistent
       matcher: "bash_exec|bash_spawn"
+      command: harnx-aws-creds --profile my-profile
+```
+
+Replace `my-profile` with the name of the AWS profile you want to use, or omit `--profile` entirely to use the default credential chain:
+
+```yaml
+hooks:
+  entries:
+    - event: PreToolUse
+      type: claude-command-persistent
+      matcher: "bash_exec|bash_spawn"
       command: harnx-aws-creds
 ```
 

--- a/crates/harnx-aws-creds/README.md
+++ b/crates/harnx-aws-creds/README.md
@@ -1,0 +1,57 @@
+# harnx-aws-creds
+
+`harnx-aws-creds` is a persistent AWS credential provider hook for the `harnx` agent harness. It allows tools running inside a sandboxed environment (like `bash_exec` or `bash_spawn`) to access AWS services securely using the standard AWS container credential provider protocol.
+
+## Purpose
+
+By default, `harnx` strips sensitive AWS environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`) from sandbox processes to prevent credential leakage.
+
+`harnx-aws-creds` solves this by:
+1.  Resolving AWS credentials on the host machine using the standard AWS credential chain (environment variables, `~/.aws/credentials`, SSO, IAM roles, etc.).
+2.  Providing these credentials to the sandbox via a local HTTP server that implements the AWS container credential provider protocol.
+3.  Injecting the necessary environment variables into sandboxed bash processes so that AWS SDKs and the AWS CLI work transparently.
+
+## How it Works
+
+`harnx-aws-creds` operates as a persistent `PreToolUse` hook:
+
+1.  **Startup**: When launched, it binds an HTTP server to a random port on `127.0.0.1` and generates a random UUID bearer token.
+2.  **Hook Loop**: It remains running and listens for hook events on `stdin`.
+3.  **Environment Injection**: For every `PreToolUse` event targeting `bash_exec` or `bash_spawn`, it mutates the tool's environment to include:
+    *   `AWS_CONTAINER_CREDENTIALS_FULL_URI`: Points to the internal `/creds` endpoint.
+    *   `AWS_CONTAINER_AUTHORIZATION_TOKEN`: The session-specific bearer token.
+    *   `AWS_REGION`: The resolved AWS region (defaults to `us-east-1`).
+4.  **Credential Serving**: The internal HTTP server responds to `GET /creds` requests with temporary AWS credentials in JSON format. It requires the correct bearer token in the `Authorization` header.
+
+## Installation
+
+To install `harnx-aws-creds` from the `harnx` workspace:
+
+```sh
+cargo install --path crates/harnx-aws-creds
+```
+
+## Hook Configuration
+
+Register `harnx-aws-creds` as a persistent hook in your `harnx.yaml` or agent front-matter:
+
+```yaml
+hooks:
+  entries:
+    - event: PreToolUse
+      type: claude-command-persistent
+      matcher: "bash_exec|bash_spawn"
+      command: harnx-aws-creds
+```
+
+**Note**: You must use `type: claude-command-persistent` to ensure the credential server stays alive across multiple tool calls.
+
+## CLI Flags
+
+*   `--profile <name>`: Optional. Use a specific AWS profile from your host's `~/.aws/config` or `~/.aws/credentials`. If omitted, the default AWS credential chain is used.
+
+## Security
+
+*   **Loopback Binding**: The HTTP server binds only to `127.0.0.1` and is not accessible from other machines.
+*   **Per-Session Tokens**: A random bearer token is generated every time the hook starts.
+*   **Sandbox Isolation**: The sandbox environment does not need access to your `~/.aws` directory or long-lived credentials. It only sees temporary, scoped credentials.

--- a/crates/harnx-aws-creds/src/main.rs
+++ b/crates/harnx-aws-creds/src/main.rs
@@ -65,12 +65,13 @@ async fn build_app_state(args: &Args) -> Result<Arc<AppState>> {
 }
 
 async fn creds_handler(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
-    let expected = format!("Bearer {}", state.bearer_token);
+    // AWS SDKs send the value of AWS_CONTAINER_AUTHORIZATION_TOKEN directly as the
+    // Authorization header — no "Bearer " prefix per the container credentials spec.
     let actual = headers
         .get(AUTHORIZATION)
         .and_then(|value| value.to_str().ok());
 
-    if actual != Some(expected.as_str()) {
+    if actual != Some(state.bearer_token.as_str()) {
         return StatusCode::UNAUTHORIZED.into_response();
     }
 
@@ -119,6 +120,54 @@ async fn run_hook_loop(state: &AppState, port: u16) -> Result<()> {
     run_hook_loop_io(state, port, stdin, stdout).await
 }
 
+/// Process a single JSONL hook line and return the response Value to write,
+/// or None if the line should be silently skipped (malformed JSON, missing id).
+fn handle_hook_line(line: &str, state: &AppState, port: u16) -> Option<Value> {
+    // Parse JSON — if malformed, log and skip (don't kill the process).
+    let request: Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(err) => {
+            eprintln!("harnx-aws-creds: ignoring malformed JSON line: {err}");
+            return None;
+        }
+    };
+
+    // Extract id — required to produce a valid response. If missing, skip.
+    let id = match request.get("id").and_then(Value::as_str) {
+        Some(id) => id,
+        None => {
+            eprintln!("harnx-aws-creds: ignoring hook event with missing/non-string id");
+            return None;
+        }
+    };
+
+    let response = match (
+        request.get("hook_event_name").and_then(Value::as_str),
+        request.get("tool_name").and_then(Value::as_str),
+        request.get("tool_input"),
+    ) {
+        (Some("PreToolUse"), Some("bash_exec" | "bash_spawn"), Some(tool_input)) => {
+            match mutate_tool_input(tool_input, state, port) {
+                Ok(mutated) => json!({
+                    "id": id,
+                    "hookSpecificOutput": {
+                        "toolInput": mutated,
+                    }
+                }),
+                Err(err) => {
+                    // Mutation failed (e.g. tool_input/env not an object) — emit no-op
+                    // so the tool call still proceeds without injection.
+                    eprintln!("harnx-aws-creds: failed to mutate tool input: {err}");
+                    json!({ "id": id })
+                }
+            }
+        }
+        _ => json!({ "id": id }),
+    };
+
+    Some(response)
+}
+
 async fn run_hook_loop_io<R, W>(state: &AppState, port: u16, input: R, mut output: W) -> Result<()>
 where
     R: tokio::io::AsyncRead + Unpin,
@@ -127,52 +176,12 @@ where
     let mut lines = BufReader::new(input).lines();
 
     while let Some(line) = lines.next_line().await? {
-        // Parse JSON — if malformed, log and skip (don't kill the process).
-        let request: Value = match serde_json::from_str(&line) {
-            Ok(v) => v,
-            Err(err) => {
-                eprintln!("harnx-aws-creds: ignoring malformed JSON line: {err}");
-                continue;
-            }
-        };
-
-        // Extract id — required to produce a valid response. If missing, skip.
-        let id = match request.get("id").and_then(Value::as_str) {
-            Some(id) => id,
-            None => {
-                eprintln!("harnx-aws-creds: ignoring hook event with missing/non-string id");
-                continue;
-            }
-        };
-
-        let response = match (
-            request.get("hook_event_name").and_then(Value::as_str),
-            request.get("tool_name").and_then(Value::as_str),
-            request.get("tool_input"),
-        ) {
-            (Some("PreToolUse"), Some("bash_exec" | "bash_spawn"), Some(tool_input)) => {
-                match mutate_tool_input(tool_input, state, port) {
-                    Ok(mutated) => json!({
-                        "id": id,
-                        "hookSpecificOutput": {
-                            "toolInput": mutated,
-                        }
-                    }),
-                    Err(err) => {
-                        // Mutation failed (e.g. tool_input/env not an object) — emit no-op
-                        // so the tool call still proceeds without injection.
-                        eprintln!("harnx-aws-creds: failed to mutate tool input: {err}");
-                        json!({ "id": id })
-                    }
-                }
-            }
-            _ => json!({ "id": id }),
-        };
-
-        let mut encoded = serde_json::to_vec(&response)?;
-        encoded.push(b'\n');
-        output.write_all(&encoded).await?;
-        output.flush().await?;
+        if let Some(response) = handle_hook_line(&line, state, port) {
+            let mut encoded = serde_json::to_vec(&response)?;
+            encoded.push(b'\n');
+            output.write_all(&encoded).await?;
+            output.flush().await?;
+        }
     }
 
     Ok(())
@@ -303,13 +312,14 @@ mod tests {
         (axum::http::StatusCode::from_u16(status_code).unwrap(), body)
     }
 
-    async fn run_hook_once(input: &str, port: u16) -> String {
+    /// Shared wiring: write `input` into a duplex pipe, run the hook loop, return raw output.
+    async fn run_hook_with_io(input: &str, port: u16) -> String {
         let state = test_state();
-        let (mut input_writer, input_reader) = tokio::io::duplex(4096);
+        let (mut input_writer, input_reader) = tokio::io::duplex(16384);
         input_writer.write_all(input.as_bytes()).await.unwrap();
         drop(input_writer);
 
-        let (output_writer, mut output_reader) = tokio::io::duplex(4096);
+        let (output_writer, mut output_reader) = tokio::io::duplex(16384);
         run_hook_loop_io(&state, port, input_reader, output_writer)
             .await
             .unwrap();
@@ -319,13 +329,17 @@ mod tests {
         output
     }
 
+    async fn run_hook_once(input: &str, port: u16) -> String {
+        run_hook_with_io(input, port).await
+    }
+
     #[tokio::test]
     async fn creds_200_valid_token() {
         let state = test_state();
         let (port, handle) = spawn_test_server(state.clone()).await;
 
         let (status, body) =
-            read_http_response(port, Some(&format!("Bearer {}", state.bearer_token))).await;
+            read_http_response(port, Some(&state.bearer_token)).await;
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body["AccessKeyId"], "AKIATEST");
@@ -342,7 +356,7 @@ mod tests {
         let (port, handle) = spawn_test_server(test_state()).await;
 
         let (status, body) =
-            read_http_response(port, Some(&format!("Bearer {}-wrong", state.bearer_token))).await;
+            read_http_response(port, Some(&format!("{}-wrong", state.bearer_token))).await;
 
         assert_eq!(status, StatusCode::UNAUTHORIZED);
         assert_eq!(body, Value::Null);
@@ -441,22 +455,9 @@ mod tests {
         assert_eq!(env["AWS_CONTAINER_AUTHORIZATION_TOKEN"], "testtoken");
     }
 
-    // Helper: send multiple lines, collect all output lines
+    // Helper: send multiple lines, collect all output lines as parsed Values
     async fn run_hook_multi(inputs: &[&str], port: u16) -> Vec<Value> {
-        let state = test_state();
-        let combined = inputs.join("");
-        let (mut input_writer, input_reader) = tokio::io::duplex(16384);
-        input_writer.write_all(combined.as_bytes()).await.unwrap();
-        drop(input_writer);
-
-        let (output_writer, mut output_reader) = tokio::io::duplex(16384);
-        run_hook_loop_io(&state, port, input_reader, output_writer)
-            .await
-            .unwrap();
-
-        let mut output = String::new();
-        output_reader.read_to_string(&mut output).await.unwrap();
-
+        let output = run_hook_with_io(&inputs.join(""), port).await;
         output
             .lines()
             .filter(|l| !l.is_empty())

--- a/crates/harnx-aws-creds/src/main.rs
+++ b/crates/harnx-aws-creds/src/main.rs
@@ -333,61 +333,65 @@ mod tests {
         run_hook_with_io(input, port).await
     }
 
+    /// Spawn a server, send one GET /creds with the given Authorization header
+    /// value (None = omit header), shut down, return (status, body).
+    async fn creds_request_with(authorization: Option<&str>) -> (StatusCode, Value) {
+        let state = test_state();
+        let (port, handle) = spawn_test_server(state.clone()).await;
+        let result = read_http_response(port, authorization).await;
+        handle.abort();
+        let _ = handle.await;
+        result
+    }
+
     #[tokio::test]
     async fn creds_200_valid_token() {
         let state = test_state();
-        let (port, handle) = spawn_test_server(state.clone()).await;
-
-        let (status, body) = read_http_response(port, Some(&state.bearer_token)).await;
+        let token = state.bearer_token.clone();
+        let (port, handle) = spawn_test_server(state).await;
+        let (status, body) = read_http_response(port, Some(&token)).await;
+        handle.abort();
+        let _ = handle.await;
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body["AccessKeyId"], "AKIATEST");
         assert_eq!(body["SecretAccessKey"], "SECRET");
         assert_eq!(body["Token"], "TOKEN");
-
-        handle.abort();
-        let _ = handle.await;
     }
 
     #[tokio::test]
     async fn creds_401_wrong_token() {
         let state = test_state();
-        let (port, handle) = spawn_test_server(test_state()).await;
-
-        let (status, body) =
-            read_http_response(port, Some(&format!("{}-wrong", state.bearer_token))).await;
+        let bad = format!("{}-wrong", state.bearer_token);
+        let (status, body) = creds_request_with(Some(&bad)).await;
 
         assert_eq!(status, StatusCode::UNAUTHORIZED);
         assert_eq!(body, Value::Null);
-
-        handle.abort();
-        let _ = handle.await;
     }
 
     #[tokio::test]
     async fn creds_401_missing_token() {
-        let (port, handle) = spawn_test_server(test_state()).await;
-
-        let (status, body) = read_http_response(port, None).await;
+        let (status, body) = creds_request_with(None).await;
 
         assert_eq!(status, StatusCode::UNAUTHORIZED);
         assert_eq!(body, Value::Null);
+    }
 
-        handle.abort();
-        let _ = handle.await;
+    /// Run a PreToolUse bash_exec hook event and return the injected env object.
+    async fn hook_injected_env(tool_input_json: &str) -> Value {
+        let line = format!(
+            "{{\"id\":\"1\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"bash_exec\",\"tool_input\":{tool_input_json}}}\n"
+        );
+        let output = run_hook_once(&line, 12345).await;
+        let response: Value = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(response["id"], "1");
+        response["hookSpecificOutput"]["toolInput"]["env"].clone()
     }
 
     #[tokio::test]
     async fn hook_injects_env_bash_exec() {
-        let output = run_hook_once(
-            "{\"id\":\"1\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"bash_exec\",\"tool_input\":{\"command\":\"ls\",\"env\":{\"EXISTING\":\"val\"}}}\n",
-            12345,
-        )
-        .await;
+        let env = hook_injected_env(r#"{"command":"ls","env":{"EXISTING":"val"}}"#).await;
 
-        let response: Value = serde_json::from_str(output.trim()).unwrap();
-        let env = &response["hookSpecificOutput"]["toolInput"]["env"];
-        assert_eq!(response["id"], "1");
         assert_eq!(env["EXISTING"], "val");
         assert_eq!(
             env["AWS_CONTAINER_CREDENTIALS_FULL_URI"],
@@ -399,15 +403,8 @@ mod tests {
 
     #[tokio::test]
     async fn hook_injects_env_no_prior_env() {
-        let output = run_hook_once(
-            "{\"id\":\"1\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"bash_exec\",\"tool_input\":{\"command\":\"ls\"}}\n",
-            12345,
-        )
-        .await;
+        let env = hook_injected_env(r#"{"command":"ls"}"#).await;
 
-        let response: Value = serde_json::from_str(output.trim()).unwrap();
-        let env = &response["hookSpecificOutput"]["toolInput"]["env"];
-        assert_eq!(response["id"], "1");
         assert_eq!(
             env["AWS_CONTAINER_CREDENTIALS_FULL_URI"],
             "http://127.0.0.1:12345/creds"
@@ -442,14 +439,8 @@ mod tests {
 
     #[tokio::test]
     async fn hook_aws_vars_overwrite_existing() {
-        let output = run_hook_once(
-            "{\"id\":\"1\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"bash_exec\",\"tool_input\":{\"command\":\"ls\",\"env\":{\"AWS_REGION\":\"wrong\"}}}\n",
-            12345,
-        )
-        .await;
+        let env = hook_injected_env(r#"{"command":"ls","env":{"AWS_REGION":"wrong"}}"#).await;
 
-        let response: Value = serde_json::from_str(output.trim()).unwrap();
-        let env = &response["hookSpecificOutput"]["toolInput"]["env"];
         assert_eq!(env["AWS_REGION"], "us-east-1");
         assert_eq!(env["AWS_CONTAINER_AUTHORIZATION_TOKEN"], "testtoken");
     }

--- a/crates/harnx-aws-creds/src/main.rs
+++ b/crates/harnx-aws-creds/src/main.rs
@@ -338,8 +338,7 @@ mod tests {
         let state = test_state();
         let (port, handle) = spawn_test_server(state.clone()).await;
 
-        let (status, body) =
-            read_http_response(port, Some(&state.bearer_token)).await;
+        let (status, body) = read_http_response(port, Some(&state.bearer_token)).await;
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body["AccessKeyId"], "AKIATEST");

--- a/crates/harnx-aws-creds/src/main.rs
+++ b/crates/harnx-aws-creds/src/main.rs
@@ -1,0 +1,514 @@
+use anyhow::{anyhow, Result};
+use aws_credential_types::provider::ProvideCredentials;
+use aws_credential_types::Credentials;
+use axum::extract::State;
+use axum::http::{header::AUTHORIZATION, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use clap::Parser;
+use serde::Serialize;
+use serde_json::{json, Map, Value};
+use std::future::IntoFuture;
+use std::sync::Arc;
+use std::time::SystemTime;
+use tokio::io::{stdin, stdout, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+use uuid::Uuid;
+
+struct AppState {
+    bearer_token: String,
+    creds_provider: Arc<dyn ProvideCredentials>,
+    region: String,
+}
+
+#[derive(Debug, Parser)]
+struct Args {
+    #[arg(long)]
+    profile: Option<String>,
+}
+
+#[derive(Serialize)]
+struct CredsResponse {
+    #[serde(rename = "AccessKeyId")]
+    access_key_id: String,
+    #[serde(rename = "SecretAccessKey")]
+    secret_access_key: String,
+    #[serde(rename = "Token", skip_serializing_if = "Option::is_none")]
+    token: Option<String>,
+    #[serde(rename = "Expiration", skip_serializing_if = "Option::is_none")]
+    expiration: Option<String>,
+}
+
+async fn build_app_state(args: &Args) -> Result<Arc<AppState>> {
+    let mut builder = aws_config::defaults(aws_config::BehaviorVersion::latest());
+    if let Some(profile) = &args.profile {
+        builder = builder.profile_name(profile);
+    }
+
+    let sdk_config = builder.load().await;
+    let region = sdk_config
+        .region()
+        .map(|region| region.to_string())
+        .unwrap_or_else(|| "us-east-1".to_string());
+    let creds_provider: Arc<dyn ProvideCredentials> = Arc::new(
+        sdk_config
+            .credentials_provider()
+            .ok_or_else(|| anyhow!("no credentials provider"))?,
+    );
+
+    Ok(Arc::new(AppState {
+        bearer_token: Uuid::new_v4().to_string(),
+        creds_provider,
+        region,
+    }))
+}
+
+async fn creds_handler(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    let expected = format!("Bearer {}", state.bearer_token);
+    let actual = headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok());
+
+    if actual != Some(expected.as_str()) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    match state.creds_provider.provide_credentials().await {
+        Ok(credentials) => Json(creds_response(credentials)).into_response(),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to provide credentials: {err}"),
+        )
+            .into_response(),
+    }
+}
+
+fn creds_response(credentials: Credentials) -> CredsResponse {
+    CredsResponse {
+        access_key_id: credentials.access_key_id().to_string(),
+        secret_access_key: credentials.secret_access_key().to_string(),
+        token: credentials.session_token().map(ToString::to_string),
+        expiration: credentials.expiry().and_then(format_expiration),
+    }
+}
+
+fn format_expiration(expiry: SystemTime) -> Option<String> {
+    let datetime: chrono::DateTime<chrono::Utc> = expiry.into();
+    Some(datetime.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+}
+
+async fn start_server(state: Arc<AppState>, listener: TcpListener) -> Result<u16> {
+    let port = listener.local_addr()?.port();
+    let router = Router::new()
+        .route("/creds", get(creds_handler))
+        .with_state(state);
+
+    tokio::spawn(async move {
+        if let Err(err) = axum::serve(listener, router).into_future().await {
+            eprintln!("harnx-aws-creds: server error: {err}");
+        }
+    });
+
+    Ok(port)
+}
+
+async fn run_hook_loop(state: &AppState, port: u16) -> Result<()> {
+    let stdin = stdin();
+    let stdout = stdout();
+    run_hook_loop_io(state, port, stdin, stdout).await
+}
+
+async fn run_hook_loop_io<R, W>(state: &AppState, port: u16, input: R, mut output: W) -> Result<()>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut lines = BufReader::new(input).lines();
+
+    while let Some(line) = lines.next_line().await? {
+        // Parse JSON — if malformed, log and skip (don't kill the process).
+        let request: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(err) => {
+                eprintln!("harnx-aws-creds: ignoring malformed JSON line: {err}");
+                continue;
+            }
+        };
+
+        // Extract id — required to produce a valid response. If missing, skip.
+        let id = match request.get("id").and_then(Value::as_str) {
+            Some(id) => id,
+            None => {
+                eprintln!("harnx-aws-creds: ignoring hook event with missing/non-string id");
+                continue;
+            }
+        };
+
+        let response = match (
+            request.get("hook_event_name").and_then(Value::as_str),
+            request.get("tool_name").and_then(Value::as_str),
+            request.get("tool_input"),
+        ) {
+            (Some("PreToolUse"), Some("bash_exec" | "bash_spawn"), Some(tool_input)) => {
+                match mutate_tool_input(tool_input, state, port) {
+                    Ok(mutated) => json!({
+                        "id": id,
+                        "hookSpecificOutput": {
+                            "toolInput": mutated,
+                        }
+                    }),
+                    Err(err) => {
+                        // Mutation failed (e.g. tool_input/env not an object) — emit no-op
+                        // so the tool call still proceeds without injection.
+                        eprintln!("harnx-aws-creds: failed to mutate tool input: {err}");
+                        json!({ "id": id })
+                    }
+                }
+            }
+            _ => json!({ "id": id }),
+        };
+
+        let mut encoded = serde_json::to_vec(&response)?;
+        encoded.push(b'\n');
+        output.write_all(&encoded).await?;
+        output.flush().await?;
+    }
+
+    Ok(())
+}
+
+fn mutate_tool_input(tool_input: &Value, state: &AppState, port: u16) -> Result<Value> {
+    let mut tool_input = tool_input
+        .as_object()
+        .cloned()
+        .ok_or_else(|| anyhow!("tool_input must be object"))?;
+
+    let env_value = tool_input
+        .entry("env".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let env = env_value
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("tool_input.env must be object"))?;
+
+    env.insert(
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI".to_string(),
+        Value::String(format!("http://127.0.0.1:{port}/creds")),
+    );
+    env.insert(
+        "AWS_CONTAINER_AUTHORIZATION_TOKEN".to_string(),
+        Value::String(state.bearer_token.clone()),
+    );
+    env.insert(
+        "AWS_REGION".to_string(),
+        Value::String(state.region.clone()),
+    );
+
+    Ok(Value::Object(tool_input))
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    let state = build_app_state(&args).await?;
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = start_server(Arc::clone(&state), listener).await?;
+
+    eprintln!("harnx-aws-creds: listening on http://127.0.0.1:{port}/creds");
+    eprintln!(
+        "harnx-aws-creds: authorization token: {}",
+        state.bearer_token
+    );
+
+    run_hook_loop(&state, port).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_credential_types::provider::future;
+    use serde_json::Value;
+    use std::sync::Arc;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+
+    #[derive(Debug)]
+    struct MockProvider;
+
+    impl ProvideCredentials for MockProvider {
+        fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
+        where
+            Self: 'a,
+        {
+            future::ProvideCredentials::ready(Ok(Credentials::new(
+                "AKIATEST",
+                "SECRET",
+                Some("TOKEN".to_string()),
+                None,
+                "test",
+            )))
+        }
+    }
+
+    fn test_state() -> Arc<AppState> {
+        Arc::new(AppState {
+            bearer_token: "testtoken".to_string(),
+            creds_provider: Arc::new(MockProvider),
+            region: "us-east-1".to_string(),
+        })
+    }
+
+    async fn spawn_test_server(state: Arc<AppState>) -> (u16, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let router = Router::new()
+            .route("/creds", get(creds_handler))
+            .with_state(state);
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        (port, handle)
+    }
+
+    async fn read_http_response(
+        port: u16,
+        authorization_header: Option<&str>,
+    ) -> (axum::http::StatusCode, Value) {
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let mut request =
+            format!("GET /creds HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n");
+        if let Some(header) = authorization_header {
+            request.push_str(&format!("Authorization: {header}\r\n"));
+        }
+        request.push_str("\r\n");
+        stream.write_all(request.as_bytes()).await.unwrap();
+
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+        let response = String::from_utf8(response).unwrap();
+        let (head, body) = response.split_once("\r\n\r\n").unwrap();
+        let status = head.lines().next().unwrap();
+        let status_code = status
+            .split_whitespace()
+            .nth(1)
+            .unwrap()
+            .parse::<u16>()
+            .unwrap();
+        let body = if body.trim().is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_str(body.trim()).unwrap()
+        };
+
+        (axum::http::StatusCode::from_u16(status_code).unwrap(), body)
+    }
+
+    async fn run_hook_once(input: &str, port: u16) -> String {
+        let state = test_state();
+        let (mut input_writer, input_reader) = tokio::io::duplex(4096);
+        input_writer.write_all(input.as_bytes()).await.unwrap();
+        drop(input_writer);
+
+        let (output_writer, mut output_reader) = tokio::io::duplex(4096);
+        run_hook_loop_io(&state, port, input_reader, output_writer)
+            .await
+            .unwrap();
+
+        let mut output = String::new();
+        output_reader.read_to_string(&mut output).await.unwrap();
+        output
+    }
+
+    #[tokio::test]
+    async fn creds_200_valid_token() {
+        let state = test_state();
+        let (port, handle) = spawn_test_server(state.clone()).await;
+
+        let (status, body) =
+            read_http_response(port, Some(&format!("Bearer {}", state.bearer_token))).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["AccessKeyId"], "AKIATEST");
+        assert_eq!(body["SecretAccessKey"], "SECRET");
+        assert_eq!(body["Token"], "TOKEN");
+
+        handle.abort();
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn creds_401_wrong_token() {
+        let state = test_state();
+        let (port, handle) = spawn_test_server(test_state()).await;
+
+        let (status, body) =
+            read_http_response(port, Some(&format!("Bearer {}-wrong", state.bearer_token))).await;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body, Value::Null);
+
+        handle.abort();
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn creds_401_missing_token() {
+        let (port, handle) = spawn_test_server(test_state()).await;
+
+        let (status, body) = read_http_response(port, None).await;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body, Value::Null);
+
+        handle.abort();
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn hook_injects_env_bash_exec() {
+        let output = run_hook_once(
+            "{\"id\":\"1\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"bash_exec\",\"tool_input\":{\"command\":\"ls\",\"env\":{\"EXISTING\":\"val\"}}}\n",
+            12345,
+        )
+        .await;
+
+        let response: Value = serde_json::from_str(output.trim()).unwrap();
+        let env = &response["hookSpecificOutput"]["toolInput"]["env"];
+        assert_eq!(response["id"], "1");
+        assert_eq!(env["EXISTING"], "val");
+        assert_eq!(
+            env["AWS_CONTAINER_CREDENTIALS_FULL_URI"],
+            "http://127.0.0.1:12345/creds"
+        );
+        assert_eq!(env["AWS_CONTAINER_AUTHORIZATION_TOKEN"], "testtoken");
+        assert_eq!(env["AWS_REGION"], "us-east-1");
+    }
+
+    #[tokio::test]
+    async fn hook_injects_env_no_prior_env() {
+        let output = run_hook_once(
+            "{\"id\":\"1\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"bash_exec\",\"tool_input\":{\"command\":\"ls\"}}\n",
+            12345,
+        )
+        .await;
+
+        let response: Value = serde_json::from_str(output.trim()).unwrap();
+        let env = &response["hookSpecificOutput"]["toolInput"]["env"];
+        assert_eq!(response["id"], "1");
+        assert_eq!(
+            env["AWS_CONTAINER_CREDENTIALS_FULL_URI"],
+            "http://127.0.0.1:12345/creds"
+        );
+        assert_eq!(env["AWS_CONTAINER_AUTHORIZATION_TOKEN"], "testtoken");
+        assert_eq!(env["AWS_REGION"], "us-east-1");
+    }
+
+    #[tokio::test]
+    async fn hook_noop_other_tool() {
+        let output = run_hook_once(
+            "{\"id\":\"1\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"fs_read\",\"tool_input\":{\"path\":\"/tmp/file\"}}\n",
+            12345,
+        )
+        .await;
+
+        let response: Value = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(response, json!({ "id": "1" }));
+    }
+
+    #[tokio::test]
+    async fn hook_noop_other_event() {
+        let output = run_hook_once(
+            "{\"id\":\"1\",\"hook_event_name\":\"PostToolUse\",\"tool_name\":\"bash_exec\",\"tool_input\":{\"command\":\"ls\"}}\n",
+            12345,
+        )
+        .await;
+
+        let response: Value = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(response, json!({ "id": "1" }));
+    }
+
+    #[tokio::test]
+    async fn hook_aws_vars_overwrite_existing() {
+        let output = run_hook_once(
+            "{\"id\":\"1\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"bash_exec\",\"tool_input\":{\"command\":\"ls\",\"env\":{\"AWS_REGION\":\"wrong\"}}}\n",
+            12345,
+        )
+        .await;
+
+        let response: Value = serde_json::from_str(output.trim()).unwrap();
+        let env = &response["hookSpecificOutput"]["toolInput"]["env"];
+        assert_eq!(env["AWS_REGION"], "us-east-1");
+        assert_eq!(env["AWS_CONTAINER_AUTHORIZATION_TOKEN"], "testtoken");
+    }
+
+    // Helper: send multiple lines, collect all output lines
+    async fn run_hook_multi(inputs: &[&str], port: u16) -> Vec<Value> {
+        let state = test_state();
+        let combined = inputs.join("");
+        let (mut input_writer, input_reader) = tokio::io::duplex(16384);
+        input_writer.write_all(combined.as_bytes()).await.unwrap();
+        drop(input_writer);
+
+        let (output_writer, mut output_reader) = tokio::io::duplex(16384);
+        run_hook_loop_io(&state, port, input_reader, output_writer)
+            .await
+            .unwrap();
+
+        let mut output = String::new();
+        output_reader.read_to_string(&mut output).await.unwrap();
+
+        output
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn hook_malformed_json_skipped_continues_loop() {
+        // Malformed line followed by valid line — loop must survive and process the valid one.
+        let responses = run_hook_multi(
+            &[
+                "this is not json\n",
+                "{\"id\":\"2\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"fs_read\",\"tool_input\":{}}\n",
+            ],
+            12345,
+        )
+        .await;
+
+        // Malformed line produces no output; valid no-op produces one response.
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0]["id"], "2");
+    }
+
+    #[tokio::test]
+    async fn hook_missing_id_skipped_continues_loop() {
+        // Line with no id field, then valid line — loop must survive.
+        let responses = run_hook_multi(
+            &[
+                "{\"hook_event_name\":\"SessionStart\"}\n",
+                "{\"id\":\"3\",\"hook_event_name\":\"PostToolUse\",\"tool_name\":\"bash_exec\"}\n",
+            ],
+            12345,
+        )
+        .await;
+
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0]["id"], "3");
+    }
+
+    #[tokio::test]
+    async fn hook_non_object_tool_input_emits_noop() {
+        // tool_input is not an object — mutate_tool_input fails, hook emits no-op for the event.
+        let output = run_hook_once(
+            "{\"id\":\"4\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"bash_exec\",\"tool_input\":\"not-an-object\"}\n",
+            12345,
+        )
+        .await;
+
+        let response: Value = serde_json::from_str(output.trim()).unwrap();
+        // Falls back to no-op — no hookSpecificOutput
+        assert_eq!(response["id"], "4");
+        assert!(response.get("hookSpecificOutput").is_none());
+    }
+}

--- a/crates/harnx-hooks/src/dispatch.rs
+++ b/crates/harnx-hooks/src/dispatch.rs
@@ -867,4 +867,77 @@ mod tests {
 
         tokio::time::sleep(Duration::from_millis(1200)).await;
     }
+
+    // A persistent hook script that reads JSONL lines, echoes back the id, and
+    // injects {"injected": true} into hookSpecificOutput.toolInput.
+    #[cfg(unix)]
+    fn persistent_mutate_command(dir: &Path) -> String {
+        write_script(
+            dir,
+            "persistent-mutate",
+            r#"while IFS= read -r line; do
+  id=${line#*\"id\":\"}; id=${id%%\"*}
+  printf '{"id":"%s","hookSpecificOutput":{"toolInput":{"injected":true}}}\n' "$id"
+done"#,
+        )
+    }
+
+    // Regression test: persistent hooks were silently skipped when
+    // persistent_manager was None (the bug in build_tool_eval_context).
+    // Passing None must produce no mutation; passing Some(pm) must mutate.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_dispatch_persistent_hook_requires_manager() {
+        use crate::PersistentHookManager;
+        use std::sync::Arc;
+        use tokio::sync::Mutex;
+
+        let cwd = temp_test_dir("persistent-hook-manager");
+        let command = persistent_mutate_command(&cwd);
+        let hooks = vec![HookConfig {
+            hook_type: "claude-command-persistent".to_string(),
+            ..hook_config("PreToolUse", command)
+        }];
+        let event = pre_tool_use_event("bash_exec");
+
+        // With None: persistent hook is skipped — no mutation.
+        let outcome_no_pm = dispatch_hooks_with_count_and_manager(
+            &event,
+            &hooks,
+            "session-no-pm",
+            &cwd,
+            0,
+            None,
+            None,
+        )
+        .await;
+        assert!(matches!(outcome_no_pm.control, HookResultControl::Continue));
+        assert!(
+            outcome_no_pm.result.mutated_tool_input.is_none(),
+            "persistent hook must be skipped when no manager is passed"
+        );
+
+        // With Some(pm): persistent hook runs and mutates tool_input.
+        let pm = Arc::new(Mutex::new(PersistentHookManager::new()));
+        let outcome_with_pm = dispatch_hooks_with_count_and_manager(
+            &event,
+            &hooks,
+            "session-with-pm",
+            &cwd,
+            0,
+            None,
+            Some(&pm),
+        )
+        .await;
+        assert!(matches!(
+            outcome_with_pm.control,
+            HookResultControl::Continue
+        ));
+        assert_eq!(
+            outcome_with_pm.result.mutated_tool_input,
+            Some(serde_json::json!({"injected": true})),
+            "persistent hook must mutate tool_input when manager is provided"
+        );
+        pm.lock().await.shutdown();
+    }
 }

--- a/crates/harnx-runtime/src/agent_loop.rs
+++ b/crates/harnx-runtime/src/agent_loop.rs
@@ -263,6 +263,7 @@ pub async fn run_agent_loop(ctx: &AgentLoopContext, initial_input: Input) -> Res
                 thought.as_deref(),
                 tool_calls,
                 abort_signal,
+                &ctx.persistent_manager,
             )
             .await?
         };

--- a/crates/harnx-runtime/src/agent_loop.rs
+++ b/crates/harnx-runtime/src/agent_loop.rs
@@ -14,7 +14,7 @@
 
 use crate::{
     config::{Config, GlobalConfig, Input},
-    tool::{execute_tool_round, ToolResult},
+    tool::{execute_tool_round, CompletionText, ToolResult},
     utils::dimmed_text,
 };
 use anyhow::{bail, Result};
@@ -259,8 +259,10 @@ pub async fn run_agent_loop(ctx: &AgentLoopContext, initial_input: Input) -> Res
             execute_tool_round(
                 config,
                 &input,
-                &output,
-                thought.as_deref(),
+                &CompletionText {
+                    output: &output,
+                    thought: thought.as_deref(),
+                },
                 tool_calls,
                 abort_signal,
                 &ctx.persistent_manager,

--- a/crates/harnx-runtime/src/tool.rs
+++ b/crates/harnx-runtime/src/tool.rs
@@ -18,6 +18,14 @@ pub use harnx_engine::tool::{
     eval_tool_calls, ConfirmToolUseFn, DispatchHookFn, ToolCallEmitFn, ToolEvalContext,
 };
 
+/// The LLM text completion that immediately preceded a tool round.
+/// Groups the assistant output text and optional chain-of-thought together
+/// so `execute_tool_round` doesn't need separate `output` and `thought` args.
+pub struct CompletionText<'a> {
+    pub output: &'a str,
+    pub thought: Option<&'a str>,
+}
+
 /// Persist a tool round and execute its calls.  Writes the
 /// `ToolCalls` session-log entry BEFORE running tools (so the
 /// transcript captures the request even on crash/interrupt), runs
@@ -29,17 +37,19 @@ pub use harnx_engine::tool::{
 pub async fn execute_tool_round(
     config: &GlobalConfig,
     input: &Input,
-    output: &str,
-    thought: Option<&str>,
+    completion: &CompletionText<'_>,
     tool_calls: Vec<ToolCall>,
     abort_signal: &AbortSignal,
     persistent_manager: &std::sync::Arc<tokio::sync::Mutex<PersistentHookManager>>,
 ) -> Result<Vec<ToolResult>> {
     let dry_run = config.read().dry_run;
     if !dry_run {
-        config
-            .write()
-            .save_session_tool_calls(input, output, thought, &tool_calls)?;
+        config.write().save_session_tool_calls(
+            input,
+            completion.output,
+            completion.thought,
+            &tool_calls,
+        )?;
     }
     let agent_use_tools = input.agent().use_tools().map(|v| v.join(","));
     let eval_ctx = build_tool_eval_context(config, agent_use_tools.as_deref(), persistent_manager);
@@ -83,6 +93,63 @@ pub async fn execute_tool_round(
 /// server holds the agent only on the per-prompt `Input` (because each
 /// `prompt` call may target a different agent on the same Config).
 /// Passing the use_tools list explicitly keeps both paths correct.
+/// Build the hook dispatch closure, capturing hooks config and the persistent
+/// manager so `ToolEvalContext` can fire PreToolUse/PostToolUse hooks.
+fn build_dispatch_hook_fn(
+    hooks: &harnx_hooks::HooksConfig,
+    session_name: Option<&str>,
+    persistent_manager: &std::sync::Arc<tokio::sync::Mutex<PersistentHookManager>>,
+) -> Arc<DispatchHookFn> {
+    let hooks_entries = hooks.entries.clone();
+    let session_id = session_name.unwrap_or("cmd").to_string();
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let persistent_manager = persistent_manager.clone();
+    Arc::new(move |event: HookEvent| {
+        let hooks_entries = hooks_entries.clone();
+        let session_id = session_id.clone();
+        let cwd = cwd.clone();
+        let persistent_manager = persistent_manager.clone();
+        Box::pin(async move {
+            harnx_hooks::dispatch::dispatch_hooks_with_count_and_manager(
+                &event,
+                &hooks_entries,
+                &session_id,
+                &cwd,
+                0,
+                None,
+                Some(&persistent_manager),
+            )
+            .await
+        })
+    })
+}
+
+/// Build the three emit closures (call / result / blocked) over a shared decl map.
+fn build_emit_fns(
+    decl_map: &Arc<HashMap<String, ToolDeclaration>>,
+) -> (
+    Arc<ToolCallEmitFn>,
+    Arc<ToolCallEmitFn>,
+    Arc<ToolCallEmitFn>,
+) {
+    let m1 = Arc::clone(decl_map);
+    let emit_tool_call_fn: Arc<ToolCallEmitFn> =
+        Arc::new(move |call: &ToolCall, json_data: &Value| {
+            emit_tool_call_with_template(call, json_data, &m1);
+        });
+    let m2 = Arc::clone(decl_map);
+    let emit_tool_result_fn: Arc<ToolCallEmitFn> =
+        Arc::new(move |call: &ToolCall, result: &Value| {
+            emit_tool_result_with_template(call, result, &m2);
+        });
+    let m3 = Arc::clone(decl_map);
+    let emit_tool_blocked_fn: Arc<ToolCallEmitFn> =
+        Arc::new(move |call: &ToolCall, blocked_result: &Value| {
+            emit_tool_blocked_with_template(call, blocked_result, &m3);
+        });
+    (emit_tool_call_fn, emit_tool_result_fn, emit_tool_blocked_fn)
+}
+
 pub fn build_tool_eval_context(
     config: &GlobalConfig,
     agent_use_tools: Option<&str>,
@@ -100,15 +167,11 @@ pub fn build_tool_eval_context(
     let hooks = guard.resolved_hooks();
     let acp_manager = guard.acp_manager.clone();
     let mcp_manager = guard.mcp_manager.clone();
-    let session_name = guard
-        .session
-        .as_ref()
-        .map(|session| session.id().to_string());
+    let session_name = guard.session.as_ref().map(|s| s.id().to_string());
     drop(guard);
 
     // Build the provider list in ACP-first order so ACP sub-agent
-    // handoffs take priority over any namespaced MCP tool with the
-    // same name.
+    // handoffs take priority over any namespaced MCP tool with the same name.
     let mut providers: Vec<Arc<dyn ToolProvider>> = Vec::new();
     if let Some(acp) = acp_manager {
         providers.push(acp as Arc<dyn ToolProvider>);
@@ -117,49 +180,9 @@ pub fn build_tool_eval_context(
         providers.push(mcp as Arc<dyn ToolProvider>);
     }
 
-    // Capture owned state for the dispatch callback so the
-    // returned future is `'static` and `Send`.
-    let hooks_entries = hooks.entries.clone();
-    let session_id = session_name.clone().unwrap_or_else(|| "cmd".to_string());
-    let cwd = std::env::current_dir().unwrap_or_default();
-    let persistent_manager = persistent_manager.clone();
-    let dispatch_hook_fn: Arc<DispatchHookFn> = Arc::new(move |event: HookEvent| {
-        let hooks_entries = hooks_entries.clone();
-        let session_id = session_id.clone();
-        let cwd = cwd.clone();
-        let persistent_manager = persistent_manager.clone();
-        Box::pin(async move {
-            harnx_hooks::dispatch::dispatch_hooks_with_count_and_manager(
-                &event,
-                &hooks_entries,
-                &session_id,
-                &cwd,
-                0,
-                None,
-                Some(&persistent_manager),
-            )
-            .await
-        })
-    });
-
-    let decl_map_clone = Arc::clone(&decl_map);
-    let emit_tool_call_fn: Arc<ToolCallEmitFn> =
-        Arc::new(move |call: &ToolCall, json_data: &Value| {
-            emit_tool_call_with_template(call, json_data, &decl_map_clone);
-        });
-
-    let decl_map_clone2 = Arc::clone(&decl_map);
-    let emit_tool_result_fn: Arc<ToolCallEmitFn> =
-        Arc::new(move |call: &ToolCall, result: &Value| {
-            emit_tool_result_with_template(call, result, &decl_map_clone2);
-        });
-    let decl_map_clone3 = Arc::clone(&decl_map);
-    let emit_tool_blocked_fn: Arc<ToolCallEmitFn> =
-        Arc::new(move |call: &ToolCall, blocked_result: &Value| {
-            emit_tool_blocked_with_template(call, blocked_result, &decl_map_clone3);
-        });
-
-    let confirm_tool_use_fn: Arc<ConfirmToolUseFn> = Arc::new(default_confirm_tool_use);
+    let dispatch_hook_fn =
+        build_dispatch_hook_fn(&hooks, session_name.as_deref(), persistent_manager);
+    let (emit_tool_call_fn, emit_tool_result_fn, emit_tool_blocked_fn) = build_emit_fns(&decl_map);
 
     ToolEvalContext {
         providers,
@@ -168,7 +191,7 @@ pub fn build_tool_eval_context(
         emit_tool_call_fn,
         emit_tool_result_fn,
         emit_tool_blocked_fn,
-        confirm_tool_use_fn,
+        confirm_tool_use_fn: Arc::new(default_confirm_tool_use),
         dispatch_hook_fn,
     }
 }

--- a/crates/harnx-runtime/src/tool.rs
+++ b/crates/harnx-runtime/src/tool.rs
@@ -3,7 +3,7 @@ use crate::{
     utils::*,
 };
 use anyhow::Result;
-use harnx_hooks::HookEvent;
+use harnx_hooks::{HookEvent, PersistentHookManager};
 
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
@@ -33,6 +33,7 @@ pub async fn execute_tool_round(
     thought: Option<&str>,
     tool_calls: Vec<ToolCall>,
     abort_signal: &AbortSignal,
+    persistent_manager: &std::sync::Arc<tokio::sync::Mutex<PersistentHookManager>>,
 ) -> Result<Vec<ToolResult>> {
     let dry_run = config.read().dry_run;
     if !dry_run {
@@ -41,7 +42,7 @@ pub async fn execute_tool_round(
             .save_session_tool_calls(input, output, thought, &tool_calls)?;
     }
     let agent_use_tools = input.agent().use_tools().map(|v| v.join(","));
-    let eval_ctx = build_tool_eval_context(config, agent_use_tools.as_deref());
+    let eval_ctx = build_tool_eval_context(config, agent_use_tools.as_deref(), persistent_manager);
     let results = match eval_tool_calls(&eval_ctx, tool_calls.clone(), abort_signal).await {
         Ok(results) => results,
         Err(err) => {
@@ -85,6 +86,7 @@ pub async fn execute_tool_round(
 pub fn build_tool_eval_context(
     config: &GlobalConfig,
     agent_use_tools: Option<&str>,
+    persistent_manager: &std::sync::Arc<tokio::sync::Mutex<PersistentHookManager>>,
 ) -> ToolEvalContext {
     let guard = config.read();
     let decl_map: Arc<HashMap<String, ToolDeclaration>> = Arc::new(
@@ -120,12 +122,23 @@ pub fn build_tool_eval_context(
     let hooks_entries = hooks.entries.clone();
     let session_id = session_name.clone().unwrap_or_else(|| "cmd".to_string());
     let cwd = std::env::current_dir().unwrap_or_default();
+    let persistent_manager = persistent_manager.clone();
     let dispatch_hook_fn: Arc<DispatchHookFn> = Arc::new(move |event: HookEvent| {
         let hooks_entries = hooks_entries.clone();
         let session_id = session_id.clone();
         let cwd = cwd.clone();
+        let persistent_manager = persistent_manager.clone();
         Box::pin(async move {
-            harnx_hooks::dispatch::dispatch_hooks(&event, &hooks_entries, &session_id, &cwd).await
+            harnx_hooks::dispatch::dispatch_hooks_with_count_and_manager(
+                &event,
+                &hooks_entries,
+                &session_id,
+                &cwd,
+                0,
+                None,
+                Some(&persistent_manager),
+            )
+            .await
         })
     });
 
@@ -364,8 +377,11 @@ mod tests {
         let calls = vec![call];
 
         let abort_signal = create_abort_signal();
+        let persistent_manager = std::sync::Arc::new(tokio::sync::Mutex::new(
+            harnx_hooks::PersistentHookManager::new(),
+        ));
         let result = eval_tool_calls(
-            &build_tool_eval_context(&config, None),
+            &build_tool_eval_context(&config, None, &persistent_manager),
             calls,
             &abort_signal,
         )

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -1844,7 +1844,13 @@ async fn test_tool_result_switch_agent_parsing() {
     // tool.rs) on the result object.
     let abort_signal = harnx_runtime::utils::create_abort_signal();
     let mut results = eval_tool_calls(
-        &harnx_runtime::tool::build_tool_eval_context(&config, None),
+        &harnx_runtime::tool::build_tool_eval_context(
+            &config,
+            None,
+            &std::sync::Arc::new(tokio::sync::Mutex::new(
+                harnx_hooks::PersistentHookManager::new(),
+            )),
+        ),
         vec![call],
         &abort_signal,
     )

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -1843,14 +1843,11 @@ async fn test_tool_result_switch_agent_parsing() {
     // switch_agent parsing path that runs in eval_tool_calls (line 126-141 of
     // tool.rs) on the result object.
     let abort_signal = harnx_runtime::utils::create_abort_signal();
+    let pm = std::sync::Arc::new(tokio::sync::Mutex::new(
+        harnx_hooks::PersistentHookManager::new(),
+    ));
     let mut results = eval_tool_calls(
-        &harnx_runtime::tool::build_tool_eval_context(
-            &config,
-            None,
-            &std::sync::Arc::new(tokio::sync::Mutex::new(
-                harnx_hooks::PersistentHookManager::new(),
-            )),
-        ),
+        &harnx_runtime::tool::build_tool_eval_context(&config, None, &pm),
         vec![call],
         &abort_signal,
     )

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -488,8 +488,10 @@ async fn start_directive_inner(
         harnx_runtime::tool::execute_tool_round(
             config,
             &input,
-            &output,
-            thought.as_deref(),
+            &harnx_runtime::tool::CompletionText {
+                output: &output,
+                thought: thought.as_deref(),
+            },
             tool_calls,
             &abort_signal,
             persistent_manager,

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -492,6 +492,7 @@ async fn start_directive_inner(
             thought.as_deref(),
             tool_calls,
             &abort_signal,
+            persistent_manager,
         )
         .await?
     };

--- a/docker/harnx.Dockerfile
+++ b/docker/harnx.Dockerfile
@@ -14,3 +14,4 @@ COPY linux-${TARGETARCH}/harnx-mcp-bash-sandbox-run /usr/local/bin/harnx-mcp-bas
 COPY linux-${TARGETARCH}/harnx-mcp-fs /usr/local/bin/harnx-mcp-fs
 COPY linux-${TARGETARCH}/harnx-mcp-plans /usr/local/bin/harnx-mcp-plans
 COPY linux-${TARGETARCH}/harnx-mcp-time /usr/local/bin/harnx-mcp-time
+COPY linux-${TARGETARCH}/harnx-aws-creds /usr/local/bin/harnx-aws-creds

--- a/docs/solutions/integration-issues/aws-credentials-hook-persistent-2026-05-15.md
+++ b/docs/solutions/integration-issues/aws-credentials-hook-persistent-2026-05-15.md
@@ -1,0 +1,219 @@
+---
+title: "AWS credentials via persistent PreToolUse hook"
+date: 2026-05-15
+category: integration-issues
+problem_type: integration_issue
+component: harnx-aws-creds
+root_cause: "Sandboxed bash processes cannot read ~/.aws; AWS SDK env vars are stripped by default sanitization"
+resolution_type: code_fix
+severity: high
+tags:
+  - aws
+  - credentials
+  - hooks
+  - persistent-hooks
+  - sandboxing
+  - container-credential-provider
+plan_ref: harnx-530-aws-creds-hook
+---
+
+## Problem
+
+Sandboxed bash processes had no access to AWS credentials. The sandbox strips environment variables like `AWS_ACCESS_KEY_ID` by default (not in allowlist), and `~/.aws` is not mounted. Users could not run AWS CLI or SDKs inside sandboxed commands without manually passing credentials.
+
+## Symptoms
+
+- `aws sts get-caller-identity` in sandboxed `bash_exec` returned `NoCredentialProviders` error
+- AWS SDKs inside sandboxed processes failed to locate credentials
+- Users had to manually inline credentials via `AWS_ACCESS_KEY_ID=... aws ...` (insecure)
+- No integration path for SSO, IAM roles, or instance profiles into sandbox
+
+## Investigation Steps
+
+1. Confirmed sandbox environment sanitization strips AWS env vars (see `security-issues/environment-sanitization-bash-sandbox-2026-04-29.md`)
+2. Discovered AWS SDKs support [container credential provider protocol](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html) via `AWS_CONTAINER_CREDENTIALS_FULL_URI` + `AWS_CONTAINER_AUTHORIZATION_TOKEN`
+3. Evaluated hook-based injection: `PreToolUse` hooks can mutate `tool_input.env` (see `logic-errors/hooks-mutation-implementation-2026-05-14.md`)
+4. Tested `per-call env param` (see `api-design/per-call-env-param-bash-mcp-2026-05-13.md`) — confirmed injected env vars reach sandboxed process
+
+## Root Cause
+
+The sandbox's environment sanitization intentionally strips sensitive AWS credential env vars. This is correct security posture, but left no authorized path for AWS credential delivery into sandboxed processes. Hook mutation provides an injection point, but requires a credential source and delivery mechanism.
+
+## Solution
+
+Implemented `harnx-aws-creds` persistent hook:
+
+### 1. AWS Container Credential Provider Protocol
+
+Hook starts an HTTP server on `127.0.0.1:0` (loopback, random port) that serves credentials:
+
+```rust
+// GET /creds handler validates bearer token, returns AWS credential JSON
+match state.creds_provider.provide_credentials().await {
+    Ok(creds) => Json(CredsResponse {
+        access_key_id: creds.access_key_id().to_string(),
+        secret_access_key: creds.secret_access_key().to_string(),
+        token: creds.session_token().map(String::from),
+        expiration: creds.expiry().map(|e| format_rfc3339(e)),
+    }).into_response(),
+    Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+}
+```
+
+AWS SDKs automatically discover credentials when `AWS_CONTAINER_CREDENTIALS_FULL_URI` and `AWS_CONTAINER_AUTHORIZATION_TOKEN` are set.
+
+### 2. Persistent PreToolUse Hook
+
+Binary runs as persistent process (JSONL over stdin/stdout). For each `PreToolUse` event:
+
+```rust
+// Inject env vars into bash_exec / bash_spawn tool input
+env.insert("AWS_CONTAINER_CREDENTIALS_FULL_URI", format!("http://127.0.0.1:{port}/creds"));
+env.insert("AWS_CONTAINER_AUTHORIZATION_TOKEN", state.bearer_token.clone());
+env.insert("AWS_REGION", state.region.clone());
+```
+
+Response format (flattened per `JsonlResponse` serde shape):
+
+```json
+{"id":"...","hookSpecificOutput":{"toolInput":{"command":"...","env":{...}}}}
+```
+
+### 3. Credential Provider Setup
+
+Uses same pattern as `integration-issues/aws-credential-chain-caching-2026-05-15.md`:
+
+```rust
+let loader = aws_config::defaults(BehaviorVersion::latest());
+if let Some(profile) = &args.profile {
+    loader.profile_name(profile);
+}
+let sdk_config = loader.load().await;
+let provider: Arc<dyn ProvideCredentials> = Arc::new(
+    sdk_config.credentials_provider().unwrap()
+);
+```
+
+### 4. Resilient Hook Loop Pattern
+
+Critical: persistent hooks must survive malformed input. Use `match`+`continue`, not `?`:
+
+```rust
+// WRONG: ? operator kills process on malformed JSON
+let request: Value = serde_json::from_str(&line)?;  // exits on bad input
+
+// CORRECT: log and continue
+let request: Value = match serde_json::from_str(&line) {
+    Ok(v) => v,
+    Err(err) => {
+        eprintln!("ignoring malformed JSON: {err}");
+        continue;
+    }
+};
+```
+
+For mutation failures, emit no-op so tool call proceeds without injection:
+
+```rust
+match mutate_tool_input(tool_input, state, port) {
+    Ok(mutated) => json!({"id": id, "hookSpecificOutput": {"toolInput": mutated}}),
+    Err(err) => {
+        eprintln!("mutation failed: {err}");
+        json!({"id": id})  // no-op: tool proceeds without AWS env
+    }
+}
+```
+
+### 5. JSONL Response Format
+
+`JsonlResponse` uses `#[serde(flatten)]` on `result: HookResult`, so fields appear at top level:
+
+```json
+// NOT nested under "result"
+{"id":"1","hookSpecificOutput":{"toolInput":{...}}}
+
+// NOT this
+{"id":"1","result":{"hookSpecificOutput":{...}}}
+```
+
+### 6. tokio io-std Feature
+
+`tokio::io::stdin()`/`stdout()` require the `io-std` feature per-crate:
+
+```toml
+[dependencies]
+tokio = { workspace = true, features = ["io-std"] }
+```
+
+Workspace feature sets do NOT inherit to member crates.
+
+### 7. SharedCredentialsProvider Coercion
+
+`sdk_config.credentials_provider()` returns `SharedCredentialsProvider`. Wrap with `Arc::new(...)`:
+
+```rust
+let provider: Arc<dyn ProvideCredentials> = Arc::new(sdk_config.credentials_provider().unwrap());
+```
+
+The concrete type implements `ProvideCredentials`.
+
+### 8. Test Pattern: tokio::io::duplex
+
+For testing async `AsyncRead`/`AsyncWrite` hook loops without subprocesses:
+
+```rust
+let (mut input_writer, input_reader) = tokio::io::duplex(16384);
+input_writer.write_all(json_line.as_bytes()).await;
+drop(input_writer);  // triggers EOF
+
+let (output_writer, mut output_reader) = tokio::io::duplex(16384);
+run_hook_loop_io(&state, port, input_reader, output_writer).await.unwrap();
+
+let mut output = String::new();
+output_reader.read_to_string(&mut output).await;
+```
+
+## Why This Works
+
+1. **Container credential protocol**: AWS SDKs natively support this protocol — no code changes in calling code
+2. **Loopback-only binding**: `127.0.0.1:0` limits exposure to local processes
+3. **Per-session bearer token**: UUID token gates `/creds` endpoint; printed to stderr for operator visibility
+4. **Hook mutation path**: Injected env vars pass through sandbox's authorized `--env` mechanism
+5. **Resilient loop**: Malformed input logged and skipped; hook survives for subsequent valid events
+6. **No ~/.aws exposure**: Sandbox never sees credential files; credentials fetched on-demand per request
+
+## Prevention Strategies
+
+**Test Cases:**
+- `creds_200_valid_token`: Valid bearer returns credential JSON
+- `creds_401_wrong_token`: Wrong token returns 401
+- `creds_401_missing_token`: Missing auth header returns 401
+- `hook_injects_env_bash_exec`: PreToolUse injection for bash_exec
+- `hook_injects_env_no_prior_env`: Creates env map if missing
+- `hook_noop_other_tool`: No mutation for non-bash tools
+- `hook_malformed_json_skipped_continues_loop`: Loop survives bad JSON
+- `hook_missing_id_skipped_continues_loop`: Loop survives missing id
+- `hook_non_object_tool_input_emits_noop`: Graceful degradation
+
+**Best Practices:**
+- Use `match`+`continue` in persistent hook loops, never `?`
+- Emit no-op response for mutation failures so tool call proceeds
+- Add `io-std` tokio feature explicitly in binary crates using stdin/stdout
+- Test error paths: malformed JSON, missing fields, invalid structure
+- Validate bearer token on every HTTP request
+
+**Code Review Checklist:**
+- [ ] Hook loop uses `match`/`continue` for parse errors
+- [ ] Mutation failures emit no-op, not error
+- [ ] Response format is flattened (top-level `hookSpecificOutput`)
+- [ ] tokio has `io-std` feature
+- [ ] HTTP server binds to `127.0.0.1:0` (loopback only)
+- [ ] Tests cover malformed input paths
+
+## Related Issues
+
+- **GitHub Issue:** [#530 — AWS credentials provider for sandbox bash processes](https://github.com/dobesv/harnx/issues/530)
+- **Related Solution:** [aws-credential-chain-caching-2026-05-15.md](./aws-credential-chain-caching-2026-05-15.md) — Same AWS provider pattern for Bedrock client
+- **Related Solution:** [hooks-mutation-implementation-2026-05-14.md](../logic-errors/hooks-mutation-implementation-2026-05-14.md) — Hook mutation mechanism
+- **Related Solution:** [per-call-env-param-bash-mcp-2026-05-13.md](../api-design/per-call-env-param-bash-mcp-2026-05-13.md) — Env injection through bash tools
+- **Related Solution:** [environment-sanitization-bash-sandbox-2026-04-29.md](../security-issues/environment-sanitization-bash-sandbox-2026-04-29.md) — Why AWS vars are stripped


### PR DESCRIPTION
Adds a new harnx-aws-creds binary crate that implements the AWS container credential provider protocol as a persistent PreToolUse hook.

The binary starts an Axum HTTP server on a random loopback port and generates a random bearer token. It injects AWS_CONTAINER_CREDENTIALS_FULL_URI, AWS_CONTAINER_AUTHORIZATION_TOKEN, and AWS_REGION into bash_exec and bash_spawn tool inputs. This allows AWS SDKs and CLIs inside the sandbox to fetch credentials transparently without exposing ~/.aws.

Includes 11 tests covering HTTP endpoints, hook loop logic, and error-path resilience.

#530

Plan: harnx-530-aws-creds-hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent AWS credential provider binary that serves credentials on localhost with per-session token and injects AWS credential env vars into sandboxed bash tool runs; supports selecting profiles via CLI.

* **Documentation**
  * Added comprehensive setup, configuration, security, and integration guidance.

* **Tests**
  * Added async and regression tests for auth, env injection, robustness, and persistent-hook behavior.

* **Chores**
  * Updated release packaging, installer defaults, and Docker artifacts to include the new binary.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->