### PR TITLE
fix: agent picker and variable completion now include package agents; add harnx-pkg to install and Docker

### DIFF
--- a/.changesets/fix-569-picker-package-agents.md
+++ b/.changesets/fix-569-picker-package-agents.md
@@ -1,0 +1,12 @@
+---
+harnx: minor
+---
+Fix agent picker and tab completion not showing agents from packages.
+
+Agents installed in `packages/<pkg>/agents/` now appear in the TUI agent
+picker and `.agent` tab completion (they were only loadable by explicit
+`harnx -a pkg/name` before). Variable completion for package agents
+(`pkg/name VAR=`) also now resolves the correct file.
+
+The `harnx-pkg` binary is now included in the default `argc install` set
+and in the Docker image.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,7 +123,7 @@ jobs:
         $BUILD_CMD build --locked --release --target=${{ matrix.target }} ${{ matrix.cargo-flags }} \
           -p harnx -p harnx-serve -p harnx-acp-server \
           -p harnx-mcp-bash -p harnx-mcp-fs -p harnx-mcp-plans -p harnx-mcp-time \
-          -p harnx-aws-creds
+          -p harnx-aws-creds -p harnx-pkg
 
     - name: Build Archives
       shell: bash
@@ -149,6 +149,7 @@ jobs:
           "harnx-mcp-plans:harnx-mcp-plans"
           "harnx-mcp-time:harnx-mcp-time"
           "harnx-aws-creds:harnx-aws-creds"
+          "harnx-pkg:harnx-pkg"
         )
 
         archives=()
@@ -241,6 +242,8 @@ jobs:
             --pattern "harnx-mcp-time-$V-x86_64-unknown-linux-musl.tar.gz" || true
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-aws-creds-$V-x86_64-unknown-linux-musl.tar.gz" || true
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern "harnx-pkg-$V-x86_64-unknown-linux-musl.tar.gz" || true
           # Download aarch64 (arm64) archives
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-$V-aarch64-unknown-linux-musl.tar.gz" || true
@@ -258,6 +261,8 @@ jobs:
             --pattern "harnx-mcp-time-$V-aarch64-unknown-linux-musl.tar.gz" || true
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-aws-creds-$V-aarch64-unknown-linux-musl.tar.gz" || true
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern "harnx-pkg-$V-aarch64-unknown-linux-musl.tar.gz" || true
 
       - name: Extract archives
         run: |
@@ -273,7 +278,7 @@ jobs:
         run: |
           missing=0
           for dir in linux-amd64 linux-arm64; do
-            for bin in harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-bash-sandbox-run harnx-mcp-fs harnx-mcp-plans harnx-mcp-time harnx-aws-creds; do
+            for bin in harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-bash-sandbox-run harnx-mcp-fs harnx-mcp-plans harnx-mcp-time harnx-aws-creds harnx-pkg; do
               if [ ! -f "$dir/$bin" ]; then
                 echo "ERROR: missing $dir/$bin"
                 missing=1

--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -9,11 +9,11 @@ set -e
 # rebuilds that `cargo install --path` does. Release profile by default; pass --debug for
 # a faster build with slower runtime.
 # @flag --debug Install debug build instead of the default release build
-# @arg bins*[harnx|harnx-serve|harnx-acp-server|harnx-mcp-bash|harnx-mcp-bash-sandbox-run|harnx-mcp-fs|harnx-mcp-time|harnx-mcp-plans|harnx-aws-creds] Restrict the install to one or more bins (default: all)
+# @arg bins*[harnx|harnx-serve|harnx-acp-server|harnx-mcp-bash|harnx-mcp-bash-sandbox-run|harnx-mcp-fs|harnx-mcp-time|harnx-mcp-plans|harnx-aws-creds|harnx-pkg] Restrict the install to one or more bins (default: all)
 install() {
     bins=("${argc_bins[@]}")
     if [[ ${#bins[@]} -eq 0 ]]; then
-        bins=(harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-fs harnx-mcp-time harnx-mcp-plans harnx-mcp-bash-sandbox-run harnx-aws-creds)
+        bins=(harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-fs harnx-mcp-time harnx-mcp-plans harnx-mcp-bash-sandbox-run harnx-aws-creds harnx-pkg)
     fi
 
     build_args=(--locked)

--- a/crates/harnx-runtime/src/config/agent.rs
+++ b/crates/harnx-runtime/src/config/agent.rs
@@ -445,35 +445,76 @@ pub fn list_agents() -> Vec<String> {
 /// Returns names of agents whose role is [`AgentRole::Assistant`].
 /// Unlike [`list_agents`], this reads and parses each agent file.
 /// Silently skips files that fail to parse.
+///
+/// Includes agents from the top-level `agents/` directory (bare names) and
+/// from `packages/<pkg>/agents/` directories (as `pkg/stem` qualified names).
 pub fn list_assistant_agents() -> Vec<String> {
     let agents_dir = Config::agents_config_dir();
-    let Ok(entries) = read_dir(&agents_dir) else {
-        return vec![];
-    };
-    let mut output: Vec<String> = entries
-        .filter_map(|e| e.ok())
-        .filter_map(|e| {
-            let path = e.path();
-            if path.extension().and_then(|x| x.to_str()) != Some("md") {
-                return None;
-            }
-            let name = path.file_stem()?.to_str()?.to_string();
-            let contents = read_to_string(&path).ok()?;
-            let config = AgentConfig::from_markdown(&name, &contents).ok()?;
-            if config.role == AgentRole::Assistant {
-                Some(name)
-            } else {
-                None
-            }
+    let mut output: Vec<String> = read_dir(&agents_dir)
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .filter_map(|e| {
+                    let path = e.path();
+                    if path.extension().and_then(|x| x.to_str()) != Some("md") {
+                        return None;
+                    }
+                    let name = path.file_stem()?.to_str()?.to_string();
+                    let contents = read_to_string(&path).ok()?;
+                    let config = AgentConfig::from_markdown(&name, &contents).ok()?;
+                    if config.role == AgentRole::Assistant {
+                        Some(name)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
         })
-        .collect();
+        .unwrap_or_default();
+
+    // Also include assistant agents from packages with qualified names (pkg/stem)
+    let packages_dir = harnx_core::config_paths::packages_dir();
+    if let Ok(pkg_entries) = read_dir(&packages_dir) {
+        for pkg_entry in pkg_entries.filter_map(|e| e.ok()) {
+            let pkg_path = pkg_entry.path();
+            if !pkg_path.is_dir() {
+                continue;
+            }
+            let pkg_name = match pkg_path.file_name().and_then(|n| n.to_str()) {
+                Some(n) if !n.starts_with('.') => n.to_string(),
+                _ => continue,
+            };
+            let agents_dir = pkg_path.join(harnx_core::config_paths::AGENTS_DIR_NAME);
+            if let Ok(agent_entries) = read_dir(&agents_dir) {
+                for agent_entry in agent_entries.filter_map(|e| e.ok()) {
+                    let path = agent_entry.path();
+                    if path.extension().and_then(|x| x.to_str()) != Some("md") {
+                        continue;
+                    }
+                    let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                        continue;
+                    };
+                    let Ok(contents) = read_to_string(&path) else {
+                        continue;
+                    };
+                    let qualified = format!("{pkg_name}/{stem}");
+                    if let Ok(config) = AgentConfig::from_markdown(&qualified, &contents) {
+                        if config.role == AgentRole::Assistant {
+                            output.push(qualified);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     output.sort();
     output.dedup();
     output
 }
 
 pub fn complete_agent_variables(agent_name: &str) -> Vec<(String, Option<String>)> {
-    let markdown_path = Config::agents_config_dir().join(format!("{agent_name}.md"));
+    let markdown_path = Config::agent_file(agent_name);
     if markdown_path.exists() {
         if let Ok(agent) = load(&markdown_path) {
             return agent

--- a/crates/harnx-runtime/tests/package_loading.rs
+++ b/crates/harnx-runtime/tests/package_loading.rs
@@ -1,6 +1,6 @@
 use std::{ffi::OsString, path::Path, sync::Mutex};
 
-use harnx_runtime::config::{list_agents, Config};
+use harnx_runtime::config::{complete_agent_variables, list_agents, list_assistant_agents, Config};
 
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
@@ -77,6 +77,129 @@ fn package_loading_test_package_agent_not_listed_bare() {
     assert!(
         !agents.contains(&"coder".to_string()),
         "Bare 'coder' should not be in agents list: {agents:?}"
+    );
+}
+
+#[test]
+fn package_loading_test_package_assistant_agent_appears_in_list_assistant_agents() {
+    // Regression test for issue #569: agent picker did not show agents from packages
+    // because list_assistant_agents() only scanned the top-level agents/ directory.
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    // An agent with default (Assistant) role
+    install_test_package(
+        tmp.path(),
+        "mypkg",
+        &[("agents/helper.md", "---\nmodel: test\n---\nI help.")],
+    );
+
+    let agents = list_assistant_agents();
+    assert!(
+        agents.contains(&"mypkg/helper".to_string()),
+        "Expected 'mypkg/helper' in list_assistant_agents, got: {agents:?}"
+    );
+}
+
+#[test]
+fn package_loading_test_package_subagent_not_in_list_assistant_agents() {
+    // Agents with role: subagent should NOT appear in the picker.
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    install_test_package(
+        tmp.path(),
+        "mypkg",
+        &[(
+            "agents/worker.md",
+            "---\nmodel: test\nrole: subagent\n---\nI work silently.",
+        )],
+    );
+
+    let agents = list_assistant_agents();
+    assert!(
+        !agents.contains(&"mypkg/worker".to_string()),
+        "Subagent 'mypkg/worker' should not appear in list_assistant_agents: {agents:?}"
+    );
+}
+
+#[test]
+fn package_loading_test_multiple_packages_assistant_sorted_deduped() {
+    // list_assistant_agents() across multiple packages must be sorted and deduplicated.
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    install_test_package(
+        tmp.path(),
+        "zeta",
+        &[("agents/assist.md", "---\nmodel: test\n---\nZeta assistant.")],
+    );
+    install_test_package(
+        tmp.path(),
+        "alpha",
+        &[(
+            "agents/assist.md",
+            "---\nmodel: test\n---\nAlpha assistant.",
+        )],
+    );
+
+    let agents = list_assistant_agents();
+    assert!(
+        agents.contains(&"alpha/assist".to_string()),
+        "Expected 'alpha/assist' in list_assistant_agents, got: {agents:?}"
+    );
+    assert!(
+        agents.contains(&"zeta/assist".to_string()),
+        "Expected 'zeta/assist' in list_assistant_agents, got: {agents:?}"
+    );
+    // Sorted: alpha before zeta
+    let alpha_pos = agents.iter().position(|s| s == "alpha/assist").unwrap();
+    let zeta_pos = agents.iter().position(|s| s == "zeta/assist").unwrap();
+    assert!(
+        alpha_pos < zeta_pos,
+        "Expected sorted order (alpha before zeta), got: {agents:?}"
+    );
+    // No duplicates
+    let deduped: Vec<_> = {
+        let mut v = agents.clone();
+        v.dedup();
+        v
+    };
+    assert_eq!(
+        agents, deduped,
+        "list_assistant_agents() must not contain duplicates"
+    );
+}
+
+#[test]
+fn package_loading_test_package_agent_variable_completion() {
+    // Regression test: complete_agent_variables() must resolve package agents via
+    // packages/<pkg>/agents/<stem>.md, not agents/<pkg>/<stem>.md.
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    install_test_package(
+        tmp.path(),
+        "mypkg",
+        &[(
+            "agents/helper.md",
+            "---\nmodel: test\nvariables:\n  - name: TARGET\n    description: The target to help with\n---\nI help with $TARGET.",
+        )],
+    );
+
+    let vars = complete_agent_variables("mypkg/helper");
+    assert!(
+        !vars.is_empty(),
+        "Expected variable completions for 'mypkg/helper', got none"
+    );
+    let names: Vec<&str> = vars.iter().map(|(k, _)| k.as_str()).collect();
+    assert!(
+        names.contains(&"TARGET="),
+        "Expected 'TARGET=' in completions, got: {names:?}"
     );
 }
 

--- a/docker/harnx.Dockerfile
+++ b/docker/harnx.Dockerfile
@@ -15,3 +15,4 @@ COPY linux-${TARGETARCH}/harnx-mcp-fs /usr/local/bin/harnx-mcp-fs
 COPY linux-${TARGETARCH}/harnx-mcp-plans /usr/local/bin/harnx-mcp-plans
 COPY linux-${TARGETARCH}/harnx-mcp-time /usr/local/bin/harnx-mcp-time
 COPY linux-${TARGETARCH}/harnx-aws-creds /usr/local/bin/harnx-aws-creds
+COPY linux-${TARGETARCH}/harnx-pkg /usr/local/bin/harnx-pkg

--- a/docs/solutions/logic-errors/package-agent-discovery-paths-2026-05-16.md
+++ b/docs/solutions/logic-errors/package-agent-discovery-paths-2026-05-16.md
@@ -1,0 +1,195 @@
+---
+title: "Package agent discovery for picker and variable completion"
+date: 2026-05-16
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-runtime, harnx-config"
+root_cause: "list_assistant_agents and complete_agent_variables only scanned top-level agents/ directory"
+resolution_type: code_fix
+severity: medium
+tags:
+  - package-agents
+  - agent-picker
+  - path-resolution
+  - completions
+plan_ref: "fix-agent-picker-packages-569"
+---
+
+## Problem
+
+Agents defined in `packages/<pkg>/agents/*.md` were invisible to the TUI agent picker and `.agent` tab completion. The functions `list_assistant_agents()` and `complete_agent_variables()` only scanned the top-level `agents/` directory, ignoring package-resident agents entirely.
+
+Related: variable completion for `.agent pkg/name VAR=` failed because `complete_agent_variables()` constructed paths incorrectly for qualified names.
+
+## Symptoms
+
+- Package agents (e.g., `mypkg/coder`) did not appear in TUI picker
+- Tab completion for `.agent` command excluded package agents
+- Variable completion (`.agent pkg/name VAR=`) returned no results for package agents
+- Workaround: direct invocation with `harnx -a pkg/name` worked correctly
+
+## Root Cause
+
+Two separate bugs:
+
+### 1. `list_assistant_agents()` incomplete scan
+
+Function only iterated `Config::agents_config_dir()` (top-level `agents/`), missing the package-scanning logic that `list_agents()` already had.
+
+### 2. `complete_agent_variables()` wrong path construction
+
+Function used manual string concatenation:
+
+```rust
+// Wrong: assumes flat agents/ directory
+let markdown_path = Config::agents_config_dir().join(format!("{agent_name}.md"));
+```
+
+For `agent_name = "pkg/name"`, this produced `agents/pkg/name.md` instead of `packages/pkg/agents/name.md`.
+
+## Solution
+
+### Fix 1: Mirror `list_agents()` package scanning in `list_assistant_agents()`
+
+Added package directory iteration after top-level scan (lines 475-509):
+
+```rust
+// Also include assistant agents from packages with qualified names (pkg/stem)
+let packages_dir = harnx_core::config_paths::packages_dir();
+if let Ok(pkg_entries) = read_dir(&packages_dir) {
+    for pkg_entry in pkg_entries.filter_map(|e| e.ok()) {
+        let pkg_path = pkg_entry.path();
+        if !pkg_path.is_dir() {
+            continue;
+        }
+        let pkg_name = match pkg_path.file_name().and_then(|n| n.to_str()) {
+            Some(n) if !n.starts_with('.') => n.to_string(),
+            _ => continue,
+        };
+        let agents_dir = pkg_path.join(harnx_core::config_paths::AGENTS_DIR_NAME);
+        if let Ok(agent_entries) = read_dir(&agents_dir) {
+            for agent_entry in agent_entries.filter_map(|e| e.ok()) {
+                let path = agent_entry.path();
+                if path.extension().and_then(|x| x.to_str()) != Some("md") {
+                    continue;
+                }
+                let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                    continue;
+                };
+                let Ok(contents) = read_to_string(&path) else {
+                    continue;
+                };
+                let qualified = format!("{pkg_name}/{stem}");
+                if let Ok(config) = AgentConfig::from_markdown(&qualified, &contents) {
+                    if config.role == AgentRole::Assistant {
+                        output.push(qualified);
+                    }
+                }
+            }
+        }
+    }
+}
+
+output.sort();
+output.dedup();
+```
+
+### Fix 2: Use `Config::agent_file()` for path resolution
+
+Changed from manual path construction to centralized resolver:
+
+```rust
+pub fn complete_agent_variables(agent_name: &str) -> Vec<(String, Option<String>)> {
+    let markdown_path = Config::agent_file(agent_name);  // ← correct
+    if markdown_path.exists() {
+        // ...
+    }
+}
+```
+
+`Config::agent_file()` correctly handles both cases:
+
+```rust
+pub fn agent_file(name: &str) -> PathBuf {
+    if let Some((pkg, stem)) = name.split_once('/') {
+        paths::package_dir(pkg)
+            .join(paths::AGENTS_DIR_NAME)
+            .join(format!("{stem}.md"))
+    } else {
+        paths::agents_config_dir().join(format!("{name}.md"))
+    }
+}
+```
+
+## Why This Works
+
+- **Package scanning**: Mirrors the existing pattern in `list_agents()` — iterates `packages_dir()`, skips hidden directories, finds `agents/` subdir, filters `.md` files, formats as `pkg/stem`
+- **Role filtering**: Parses frontmatter to check `config.role == AgentRole::Assistant` before including
+- **Graceful degradation**: Uses `if let Ok(...)` and `continue` to skip unreadable files/directories without failing the entire operation
+- **Centralized path resolution**: `Config::agent_file()` is the single source of truth for agent path resolution — any code that needs to open an agent file by name should use it
+
+## Prevention Strategies
+
+**Test isolation pattern (`ENV_MUTEX` + `EnvGuard`):**
+
+```rust
+use std::sync::LazyLock, Mutex;
+
+static ENV_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+#[test]
+fn test_package_agent_discovery() {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+    // ... test code ...
+}
+```
+
+**Test helper pattern (`install_test_package`):**
+
+```rust
+fn install_test_package(config_dir: &Path, pkg_name: &str, files: &[(&str, &str)]) {
+    let pkg_dir = config_dir.join("packages").join(pkg_name);
+    fs::create_dir_all(&pkg_dir).unwrap();
+    
+    let manifest = "name: ".to_string() + pkg_name;
+    fs::write(pkg_dir.join("manifest.yaml"), manifest).unwrap();
+    
+    for (path, content) in files {
+        fs::write(pkg_dir.join(path), content).unwrap();
+    }
+}
+```
+
+**Code review checklist:**
+
+- [ ] Any code that resolves agent file paths uses `Config::agent_file(name)`, not manual string concatenation
+- [ ] Functions that iterate agents check both top-level `agents/` and `packages/*/agents/`
+- [ ] New path logic tests use `ENV_MUTEX` to prevent parallel test interference
+- [ ] Qualified names (`pkg/stem`) handled consistently across discovery and resolution
+
+**Test coverage:**
+
+- `package_loading_test_package_assistant_agent_appears_in_list_assistant_agents` — package assistant appears in list
+- `package_loading_test_package_subagent_not_in_list_assistant_agents` — role filtering works
+- `package_loading_test_multiple_packages_assistant_sorted_deduped` — multi-package aggregation
+- `package_loading_test_package_agent_variable_completion` — `complete_agent_variables` resolves qualified names
+
+## Related Issues
+
+- **Issue:** [GH-569](https://github.com/SmartestEdu/harnx/issues/569) — Agent picker does not show agents from packages
+- **Related Solution:** [logic-errors/agent-role-filtering-completions-2026-05-04.md](agent-role-filtering-completions-2026-05-04.md) — AgentRole enum and list_assistant_agents() original implementation
+- **Related Solution:** [integration-issues/package-system-implementation-patterns-2026-05-07.md](../integration-issues/package-system-implementation-patterns-2026-05-07.md) — Package system patterns
+
+## Addition: harnx-pkg binary distribution
+
+As part of this fix, the `harnx-pkg` binary was added to distribution channels. Pattern for adding a new binary:
+
+1. **Argcfile.sh `install()`**: Add to `@arg bins` allowed values and default array
+2. **docker/harnx.Dockerfile**: Add `COPY --from=builder` line
+3. **.github/workflows/release.yaml**: Add to:
+   - Build matrix (`-p harnx-pkg`)
+   - `archive_specs` for each platform
+   - Docker download patterns (both architectures)
+   - Verify step


### PR DESCRIPTION
## Summary

Fixes two bugs where agents installed in `packages/` subdirectories were invisible to certain features, and adds `harnx-pkg` to all distribution channels.

## Changes

### Bug fixes (closes #569)

- **`list_assistant_agents()`** — extended to scan `packages/<pkg>/agents/*.md` and emit `pkg/stem` qualified names for assistant-role agents. Fixes the TUI agent picker and `.agent` tab completion not listing package agents.
- **`complete_agent_variables()`** — switched from manual path construction to `Config::agent_file(agent_name)`. For `pkg/name`, the old code produced `agents/pkg/name.md` (wrong); the new code produces `packages/pkg/agents/name.md` (correct). Fixes variable tab completion for package agents.

### harnx-pkg distribution

- `Argcfile.sh` `install()` — added to allowed bins list and default set
- `docker/harnx.Dockerfile` — `COPY` line added
- `.github/workflows/release.yaml` — build, archive_specs, Docker download (x86_64 + aarch64), and verify step all updated

## Tests

4 regression tests added to `crates/harnx-runtime/tests/package_loading.rs`:
1. Package assistant agent appears in `list_assistant_agents()`
2. Package subagent is excluded from picker
3. Multi-package result is sorted and deduplicated
4. `complete_agent_variables("pkg/name")` resolves the correct file

1034 tests, 5× stress run — all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agents installed in package directories now appear in the TUI agent picker and tab completion
  * Variable completion for package agents now resolves correctly

* **Chores**
  * Added `harnx-pkg` binary to default installation set and Docker image

* **Documentation**
  * Added documentation on agent discovery improvements and variable resolution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->