### PR TITLE
feat: Add hooks configuration to MCP server configs

### DIFF
--- a/.changesets/mcp-server-hooks.md
+++ b/.changesets/mcp-server-hooks.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+Add `hooks` configuration to MCP server config files. Hooks defined in a server's YAML file only apply to tool calls going to that specific server.

--- a/crates/harnx-acp/src/manager.rs
+++ b/crates/harnx-acp/src/manager.rs
@@ -230,6 +230,7 @@ fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
                 ..Default::default()
             },
             mcp_tool_name: Some("session_new".to_string()),
+            mcp_server_name: None,
             call_template: Some(session_new_call_template),
             result_template: None,
         },
@@ -266,6 +267,7 @@ fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
                 ..Default::default()
             },
             mcp_tool_name: Some("session_prompt".to_string()),
+            mcp_server_name: None,
             call_template: Some(session_prompt_call_template),
             result_template: None,
         },
@@ -290,6 +292,7 @@ fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
                 ..Default::default()
             },
             mcp_tool_name: Some("session_load".to_string()),
+            mcp_server_name: None,
             call_template: Some(session_load_call_template),
             result_template: None,
         },
@@ -314,6 +317,7 @@ fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
                 ..Default::default()
             },
             mcp_tool_name: Some("session_cancel".to_string()),
+            mcp_server_name: None,
             call_template: Some(session_cancel_call_template),
             result_template: None,
         },

--- a/crates/harnx-core/src/tool.rs
+++ b/crates/harnx-core/src/tool.rs
@@ -94,6 +94,8 @@ pub struct ToolDeclaration {
     #[serde(skip, default)]
     pub mcp_tool_name: Option<String>,
     #[serde(skip, default)]
+    pub mcp_server_name: Option<String>,
+    #[serde(skip, default)]
     pub call_template: Option<String>,
     #[serde(skip, default)]
     pub result_template: Option<String>,

--- a/crates/harnx-hooks/src/matcher.rs
+++ b/crates/harnx-hooks/src/matcher.rs
@@ -28,6 +28,16 @@ impl CompiledMatcher {
                 .unwrap_or(false),
         }
     }
+
+    /// Match against an explicit text string instead of extracting from an event.
+    /// Used for server-scoped hooks where the matcher applies to the bare (unprefixed)
+    /// tool name rather than the display name carried in the event.
+    pub fn matches_str(&self, text: &str) -> bool {
+        match &self.regex {
+            None => true,
+            Some(regex) => regex.is_match(text).unwrap_or(false),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -35,6 +45,38 @@ mod tests {
     use super::CompiledMatcher;
     use crate::HookEvent;
     use serde_json::json;
+
+    // --- matches_str tests ---------------------------------------------------
+
+    #[test]
+    fn test_matches_str_no_pattern_matches_all() {
+        let matcher = CompiledMatcher::compile(&None).expect("compile empty matcher");
+        assert!(matcher.matches_str("anything"));
+        assert!(matcher.matches_str(""));
+    }
+
+    #[test]
+    fn test_matches_str_exact_match() {
+        let matcher = CompiledMatcher::compile(&Some("^exec$".to_string())).expect("compile regex");
+        assert!(matcher.matches_str("exec"));
+        assert!(!matcher.matches_str("bash_exec"));
+        assert!(!matcher.matches_str("exec_more"));
+    }
+
+    #[test]
+    fn test_matches_str_partial_pattern() {
+        let matcher = CompiledMatcher::compile(&Some("exec".to_string())).expect("compile regex");
+        // "exec" as a substring regex matches both
+        assert!(matcher.matches_str("exec"));
+        assert!(matcher.matches_str("bash_exec"));
+    }
+
+    #[test]
+    fn test_matches_str_no_match() {
+        let matcher = CompiledMatcher::compile(&Some("^list".to_string())).expect("compile regex");
+        assert!(!matcher.matches_str("exec"));
+        assert!(matcher.matches_str("list_files"));
+    }
 
     #[test]
     fn test_matcher_no_pattern() {

--- a/crates/harnx-mcp/src/client.rs
+++ b/crates/harnx-mcp/src/client.rs
@@ -158,6 +158,12 @@ impl McpClient {
         &self.name
     }
 
+    /// Returns the hooks configuration for this server, if any.
+    /// Used by the runtime to build per-server hook dispatch tables.
+    pub fn hooks(&self) -> Option<&harnx_core::hooks::HooksConfig> {
+        self.config.hooks.as_ref()
+    }
+
     pub fn is_connected(&self) -> bool {
         *self.connected.read()
     }
@@ -311,13 +317,15 @@ impl McpClient {
                     result_template,
                 };
 
-                mcp_tool_to_declaration(
+                let mut declaration = mcp_tool_to_declaration(
                     &final_name,
                     &server_tool_name,
                     tool.description.as_deref().unwrap_or_default(),
                     &input_schema,
                     templates,
-                )
+                )?;
+                declaration.mcp_server_name = Some(self.name.clone());
+                Ok(declaration)
             })
             .collect::<Result<Vec<_>>>()?;
 
@@ -566,6 +574,7 @@ mod tests {
             rename_tools: HashMap::new(),
             tool_templates: HashMap::new(),
             package: None,
+            hooks: None,
         }
     }
 

--- a/crates/harnx-mcp/src/config.rs
+++ b/crates/harnx-mcp/src/config.rs
@@ -1,3 +1,4 @@
+use harnx_core::hooks::HooksConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -35,6 +36,8 @@ pub struct McpServerConfig {
     /// Per-tool MiniJinja display templates. Overrides `_meta` templates from the MCP server.
     #[serde(default)]
     pub tool_templates: HashMap<String, ToolDisplayTemplates>,
+    #[serde(default)]
+    pub hooks: Option<HooksConfig>,
     /// The package this server belongs to, if it came from an installed package.
     /// Not serialized — set at runtime by the package loader.
     /// Used to present the server under its bare name when the active agent

--- a/crates/harnx-mcp/src/convert.rs
+++ b/crates/harnx-mcp/src/convert.rs
@@ -23,6 +23,7 @@ pub fn mcp_tool_to_declaration(
         description: tool_description.to_string(),
         parameters: convert_json_schema(input_schema)?,
         mcp_tool_name: Some(server_tool_name.to_string()),
+        mcp_server_name: None,
         call_template: templates.call_template,
         result_template: templates.result_template,
     })

--- a/crates/harnx-proxy-auth/tests/hook_e2e.rs
+++ b/crates/harnx-proxy-auth/tests/hook_e2e.rs
@@ -246,6 +246,7 @@ fn make_config(proxy_bin: PathBuf, bash_bin: PathBuf) -> GlobalConfig {
         rename_tools: HashMap::from([("exec".to_string(), "bash_exec".to_string())]),
         tool_templates: HashMap::new(),
         package: None,
+        hooks: None,
     }];
 
     config.init_mcp_manager();

--- a/crates/harnx-runtime/src/config/agent.rs
+++ b/crates/harnx-runtime/src/config/agent.rs
@@ -627,6 +627,7 @@ mod tests {
             description: description.to_string(),
             parameters: Default::default(),
             mcp_tool_name: None,
+            mcp_server_name: None,
             call_template: None,
             result_template: None,
         }

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -416,6 +416,7 @@ fn handoff_tool_declarations_for_agents() -> Vec<ToolDeclaration> {
                     ..Default::default()
                 },
                 mcp_tool_name: None,
+                mcp_server_name: None,
                 call_template: None,
                 result_template: None,
             }
@@ -4141,6 +4142,7 @@ mod tests {
             rename_tools: HashMap::new(),
             tool_templates: HashMap::new(),
             package: None,
+            hooks: None,
         };
         config.mcp_servers = vec![server];
         config.mcp_root = vec!["/extra".to_string()];

--- a/crates/harnx-runtime/src/tool.rs
+++ b/crates/harnx-runtime/src/tool.rs
@@ -3,6 +3,7 @@ use crate::{
     utils::*,
 };
 use anyhow::Result;
+use harnx_core::hooks::HookConfig;
 use harnx_hooks::{HookEvent, PersistentHookManager};
 
 use serde_json::Value;
@@ -97,6 +98,10 @@ pub async fn execute_tool_round(
 /// manager so `ToolEvalContext` can fire PreToolUse/PostToolUse hooks.
 fn build_dispatch_hook_fn(
     hooks: &harnx_hooks::HooksConfig,
+    // Value is (bare_server_tool_name, hook_entries). The matcher in each entry is
+    // evaluated against the bare name, not the prefixed display name, so renaming
+    // an MCP server doesn't require updating hook matchers.
+    per_tool_hooks: HashMap<String, (String, Vec<HookConfig>)>,
     session_name: Option<&str>,
     persistent_manager: &std::sync::Arc<tokio::sync::Mutex<PersistentHookManager>>,
 ) -> Arc<DispatchHookFn> {
@@ -106,13 +111,49 @@ fn build_dispatch_hook_fn(
     let persistent_manager = persistent_manager.clone();
     Arc::new(move |event: HookEvent| {
         let hooks_entries = hooks_entries.clone();
+        let per_tool_hooks = per_tool_hooks.clone();
         let session_id = session_id.clone();
         let cwd = cwd.clone();
         let persistent_manager = persistent_manager.clone();
         Box::pin(async move {
+            let display_tool_name = match &event {
+                HookEvent::PreToolUse { tool_name, .. }
+                | HookEvent::PostToolUse { tool_name, .. }
+                | HookEvent::PostToolUseFailure { tool_name, .. } => Some(tool_name.as_str()),
+                _ => None,
+            };
+
+            // For server-scoped hooks, match the hook's `matcher` against the bare
+            // (unprefixed) tool name. Strip the matcher from entries we add to the
+            // merged list so the global dispatcher doesn't re-check against the
+            // prefixed display name and accidentally reject them.
+            let mut merged_entries: Vec<HookConfig> = if let Some(display_name) = display_tool_name
+            {
+                per_tool_hooks
+                    .get(display_name)
+                    .map(|(bare_name, entries)| {
+                        entries
+                            .iter()
+                            .filter(|hook| {
+                                harnx_hooks::CompiledMatcher::compile(&hook.matcher)
+                                    .map(|m| m.matches_str(bare_name))
+                                    .unwrap_or(false)
+                            })
+                            .map(|hook| HookConfig {
+                                matcher: None,
+                                ..hook.clone()
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+            merged_entries.extend(hooks_entries.clone());
+
             harnx_hooks::dispatch::dispatch_hooks_with_count_and_manager(
                 &event,
-                &hooks_entries,
+                &merged_entries,
                 &session_id,
                 &cwd,
                 0,
@@ -167,6 +208,37 @@ pub fn build_tool_eval_context(
     let hooks = guard.resolved_hooks();
     let acp_manager = guard.acp_manager.clone();
     let mcp_manager = guard.mcp_manager.clone();
+    // Build a map from display tool name → (bare_tool_name, server_hook_entries).
+    // Look up hooks via the McpManager (which stores clients keyed by display name),
+    // so packaged/prefixed servers are found correctly. Server hooks are filtered to
+    // only tool-use events; their matchers are evaluated against the bare name so
+    // renaming a server doesn't require updating hook matchers.
+    let per_tool_hooks: HashMap<String, (String, Vec<HookConfig>)> = decl_map
+        .iter()
+        .filter_map(|(tool_name, decl)| {
+            let server_name = decl.mcp_server_name.as_ref()?;
+            let bare_name = decl
+                .mcp_tool_name
+                .clone()
+                .unwrap_or_else(|| tool_name.clone());
+            let server_hooks = mcp_manager
+                .as_ref()?
+                .get_client(server_name)
+                .and_then(|client| client.hooks().cloned())?;
+            let hook_entries = server_hooks
+                .entries
+                .iter()
+                .filter(|hook| {
+                    matches!(
+                        hook.event.as_str(),
+                        "PreToolUse" | "PostToolUse" | "PostToolUseFailure"
+                    )
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            (!hook_entries.is_empty()).then(|| (tool_name.clone(), (bare_name, hook_entries)))
+        })
+        .collect();
     let session_name = guard.session.as_ref().map(|s| s.id().to_string());
     drop(guard);
 
@@ -180,8 +252,12 @@ pub fn build_tool_eval_context(
         providers.push(mcp as Arc<dyn ToolProvider>);
     }
 
-    let dispatch_hook_fn =
-        build_dispatch_hook_fn(&hooks, session_name.as_deref(), persistent_manager);
+    let dispatch_hook_fn = build_dispatch_hook_fn(
+        &hooks,
+        per_tool_hooks,
+        session_name.as_deref(),
+        persistent_manager,
+    );
     let (emit_tool_call_fn, emit_tool_result_fn, emit_tool_blocked_fn) = build_emit_fns(&decl_map);
 
     ToolEvalContext {
@@ -508,6 +584,7 @@ mod tests {
             description: String::new(),
             parameters: Default::default(),
             mcp_tool_name: Some(name.to_string()),
+            mcp_server_name: None,
             call_template: call_template.map(String::from),
             result_template: result_template.map(String::from),
         }
@@ -652,6 +729,191 @@ mod tests {
         let result_val = json!({"output": "file.txt"});
         let result = render_result_for_display(&call, &result_val, "raw fallback", &decl_map);
         assert!(result.is_none(), "no result_template => should return None");
+    }
+
+    // --- Server-scoped hook dispatch tests -----------------------------------
+    //
+    // These tests exercise `build_dispatch_hook_fn` directly to verify that
+    // per-server hooks use bare-name matching and are correctly merged with
+    // global hooks.
+
+    fn make_hook_config(event: &str, matcher: Option<&str>, command: &str) -> HookConfig {
+        HookConfig {
+            event: event.to_string(),
+            matcher: matcher.map(|s| s.to_string()),
+            command: command.to_string(),
+            timeout: Some(5),
+            status_message: None,
+            async_hook: None,
+            hook_type: "claude-command".to_string(),
+        }
+    }
+
+    #[cfg(unix)]
+    fn pre_tool_use_event_with_name(tool_name: &str) -> HookEvent {
+        HookEvent::PreToolUse {
+            tool_name: tool_name.to_string(),
+            tool_input: serde_json::json!({}),
+            tool_use_id: "test-id".to_string(),
+        }
+    }
+
+    fn session_start_event() -> HookEvent {
+        HookEvent::SessionStart {
+            source: "test".to_string(),
+            model: "test-model".to_string(),
+        }
+    }
+
+    fn make_per_tool_hooks(
+        display_name: &str,
+        bare_name: &str,
+        hooks: Vec<HookConfig>,
+    ) -> HashMap<String, (String, Vec<HookConfig>)> {
+        let mut map = HashMap::new();
+        map.insert(display_name.to_string(), (bare_name.to_string(), hooks));
+        map
+    }
+
+    async fn dispatch_and_collect_context(
+        global_hooks: Vec<HookConfig>,
+        per_tool_hooks: HashMap<String, (String, Vec<HookConfig>)>,
+        event: HookEvent,
+    ) -> harnx_hooks::HookOutcome {
+        use harnx_hooks::HooksConfig;
+
+        let hooks_config = HooksConfig {
+            max_resume: None,
+            entries: global_hooks,
+        };
+        let pm = Arc::new(tokio::sync::Mutex::new(
+            harnx_hooks::PersistentHookManager::new(),
+        ));
+        let dispatch_fn = build_dispatch_hook_fn(&hooks_config, per_tool_hooks, None, &pm);
+        (dispatch_fn)(event).await
+    }
+
+    /// A no-matcher server hook applies to all tools on that server.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn server_hook_no_matcher_matches_any_tool() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script_path = dir.path().join("hook.sh");
+        let mut f = std::fs::File::create(&script_path).expect("create script");
+        writeln!(f, "#!/bin/sh").unwrap();
+        writeln!(f, "cat > /dev/null").unwrap();
+        writeln!(f, "echo '{{\"additionalContext\":\"server-hook-ran\"}}'").unwrap();
+        drop(f);
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let server_hook = make_hook_config(
+            "PreToolUse",
+            None, // no matcher — should match all tools
+            script_path.to_str().unwrap(),
+        );
+        let per_tool = make_per_tool_hooks(
+            "myserver_exec", // display name
+            "exec",          // bare name
+            vec![server_hook],
+        );
+        let outcome = dispatch_and_collect_context(
+            vec![],
+            per_tool,
+            pre_tool_use_event_with_name("myserver_exec"),
+        )
+        .await;
+        assert!(
+            outcome.result.additional_context.as_deref() == Some("server-hook-ran"),
+            "no-matcher server hook should run for any tool on the server, got: {:?}",
+            outcome.result.additional_context
+        );
+    }
+
+    /// A server hook with `matcher: "exec"` matches the bare name `exec`,
+    /// NOT the prefixed display name `myserver_exec`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn server_hook_matcher_uses_bare_name_not_display_name() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script_path = dir.path().join("hook.sh");
+        let mut f = std::fs::File::create(&script_path).expect("create script");
+        writeln!(f, "#!/bin/sh").unwrap();
+        writeln!(f, "cat > /dev/null").unwrap();
+        writeln!(f, "echo '{{\"additionalContext\":\"bare-match\"}}'").unwrap();
+        drop(f);
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // matcher = "^exec$" — matches bare name "exec" but NOT "myserver_exec"
+        let server_hook =
+            make_hook_config("PreToolUse", Some("^exec$"), script_path.to_str().unwrap());
+        let per_tool = make_per_tool_hooks(
+            "myserver_exec", // display name (what the event carries)
+            "exec",          // bare name (what the matcher runs against)
+            vec![server_hook],
+        );
+        let outcome = dispatch_and_collect_context(
+            vec![],
+            per_tool,
+            pre_tool_use_event_with_name("myserver_exec"),
+        )
+        .await;
+        assert_eq!(
+            outcome.result.additional_context.as_deref(),
+            Some("bare-match"),
+            "matcher 'exec' should match bare name 'exec', even though display name is 'myserver_exec'"
+        );
+    }
+
+    /// A server hook whose matcher doesn't match the bare name is excluded.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn server_hook_matcher_excludes_non_matching_bare_name() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script_path = dir.path().join("hook.sh");
+        let mut f = std::fs::File::create(&script_path).expect("create script");
+        writeln!(f, "#!/bin/sh").unwrap();
+        writeln!(f, "cat > /dev/null").unwrap();
+        writeln!(f, "echo '{{\"additionalContext\":\"should-not-run\"}}'").unwrap();
+        drop(f);
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // matcher = "^list$" does NOT match bare name "exec"
+        let server_hook =
+            make_hook_config("PreToolUse", Some("^list$"), script_path.to_str().unwrap());
+        let per_tool = make_per_tool_hooks("myserver_exec", "exec", vec![server_hook]);
+        let outcome = dispatch_and_collect_context(
+            vec![],
+            per_tool,
+            pre_tool_use_event_with_name("myserver_exec"),
+        )
+        .await;
+        assert!(
+            outcome.result.additional_context.is_none(),
+            "hook with matcher '^list$' should not run for bare name 'exec'"
+        );
+    }
+
+    /// Non-tool events (e.g. SessionStart) don't pick up server hooks
+    /// because `per_tool_hooks` is keyed by display tool name.
+    #[tokio::test]
+    async fn server_hooks_not_applied_to_non_tool_events() {
+        // No script needed — we just verify the hook doesn't fire.
+        // A hook entry that would normally match is in per_tool_hooks, but
+        // the event is SessionStart which yields no display_tool_name.
+        let server_hook = make_hook_config("SessionStart", None, "echo hi");
+        let per_tool = make_per_tool_hooks("myserver_exec", "exec", vec![server_hook]);
+        let outcome = dispatch_and_collect_context(vec![], per_tool, session_start_event()).await;
+        // SessionStart is not in the filtered tool-use events list so it
+        // would have been stripped at build_tool_eval_context time, but
+        // even if it were present, display_tool_name is None for non-tool
+        // events so no per_tool_hooks lookup happens.
+        assert!(outcome.result.additional_context.is_none());
     }
 
     #[test]

--- a/crates/harnx-runtime/tests/package_loading.rs
+++ b/crates/harnx-runtime/tests/package_loading.rs
@@ -288,6 +288,7 @@ fn package_loading_test_mcp_server_display_names_for_agent() {
         rename_tools: Default::default(),
         tool_templates: Default::default(),
         package: Some("mypkg".to_string()),
+        hooks: None,
     };
 
     // Construct a different-package server

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -533,6 +533,7 @@ mod tests {
             description: String::new(),
             parameters: Default::default(),
             mcp_tool_name: Some("bash_exec".to_string()),
+            mcp_server_name: None,
             call_template: Some("${{ args.command }}".to_string()),
             result_template: None,
         };
@@ -586,6 +587,7 @@ mod tests {
             description: String::new(),
             parameters: Default::default(),
             mcp_tool_name: Some("no_template_tool".to_string()),
+            mcp_server_name: None,
             call_template: None,
             result_template: None,
         };

--- a/crates/harnx/tests/tmux_e2e.rs
+++ b/crates/harnx/tests/tmux_e2e.rs
@@ -697,6 +697,7 @@ fn write_fixture_files(paths: &TestPaths) -> Result<()> {
         rename_tools: Default::default(),
         tool_templates: Default::default(),
         package: None,
+        hooks: None,
     };
     std::fs::write(
         mcp_servers_dir.join("repro249.yaml"),

--- a/docs/solutions/api-design/per-mcp-server-hook-config-2026-05-16.md
+++ b/docs/solutions/api-design/per-mcp-server-hook-config-2026-05-16.md
@@ -1,0 +1,158 @@
+---
+title: "Per-MCP-server hook configuration"
+date: 2026-05-16
+category: "api-design"
+problem_type: integration_issue
+component: "harnx-runtime"
+root_cause: "missing scope isolation for hook definitions"
+resolution_type: code_fix
+severity: medium
+tags:
+  - hooks
+  - mcp
+  - scoping
+  - configuration
+plan_ref: "per-mcp-server-hooks"
+---
+
+## Problem
+
+Hook definitions lived only in the global `config.yaml`, making it impossible to scope hooks to a specific MCP server. Users could not define hooks inside a per-server YAML file that applied only to tool calls targeting that server.
+
+## Symptoms
+
+- Hooks in global config applied to all tool calls regardless of origin
+- No mechanism for package authors to ship server-scoped hooks
+- Renaming MCP servers (prefixing for packages) would require updating all hook matchers
+
+## Investigation Steps
+
+1. Traced the hook dispatch flow: `build_tool_eval_context` builds the `DispatchHookFn` closure over `hooks.entries`
+2. Identified that `McpManager` stores clients keyed by **display name** (e.g., `pkg__bash`), not original config name
+3. Found that `ToolDeclaration.mcp_server_name` is set to `self.name` in `McpClient::list_tools` — also the display name
+4. Realized direct lookup via `Config.mcp_servers` (which has original names) would fail silently for packaged servers
+
+## Root Cause
+
+Hook configuration was monolithic. The dispatch closure had no visibility into which MCP server a tool call originated from, and there was no mechanism to scope hook definitions to a per-server context.
+
+## Solution
+
+Extended `McpServerConfig` with an optional `hooks` field and implemented server-scoped hook dispatch:
+
+**1. Added hooks field to McpServerConfig (`crates/harnx-mcp/src/config.rs`):**
+
+```rust
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct McpServerConfig {
+    // ... other fields ...
+    #[serde(default)]
+    pub hooks: Option<HooksConfig>,
+}
+```
+
+**2. Added mcp_server_name to ToolDeclaration (`crates/harnx-core/src/tool.rs`):**
+
+```rust
+pub struct ToolDeclaration {
+    // ... other fields ...
+    #[serde(skip, default)]
+    pub mcp_server_name: Option<String>,
+}
+```
+
+**3. Added matches_str to CompiledMatcher (`crates/harnx-hooks/src/matcher.rs`):**
+
+```rust
+impl CompiledMatcher {
+    /// Match against an explicit text string instead of extracting from an event.
+    /// Used for server-scoped hooks where the matcher applies to the bare (unprefixed)
+    /// tool name rather than the display name carried in the event.
+    pub fn matches_str(&self, text: &str) -> bool {
+        match self {
+            CompiledMatcher::Regex(re) => re.is_match(text),
+            CompiledMatcher::Glob(pat) => pat.matches(text),
+        }
+    }
+}
+```
+
+**4. Build per-tool hooks map and merge at dispatch (`crates/harnx-runtime/src/tool.rs`):**
+
+```rust
+// Build map from display tool name → (bare_tool_name, server_hook_entries)
+let per_tool_hooks: HashMap<String, (String, Vec<HookConfig>)> = decl_map
+    .iter()
+    .filter_map(|(tool_name, decl)| {
+        let server_name = decl.mcp_server_name.as_ref()?;
+        let bare_name = decl.mcp_tool_name.clone()
+            .unwrap_or_else(|| tool_name.clone());
+        let server_hooks = mcp_manager
+            .as_ref()?
+            .get_client(server_name)
+            .and_then(|client| client.hooks().cloned())?;
+        let hook_entries = server_hooks.entries.iter()
+            .filter(|hook| matches!(hook.event.as_str(), "PreToolUse" | "PostToolUse" | "PostToolUseFailure"))
+            .cloned()
+            .collect::<Vec<_>>();
+        (!hook_entries.is_empty()).then(|| (tool_name.clone(), (bare_name, hook_entries)))
+    })
+    .collect();
+
+// In dispatch closure: match vs bare name, strip matcher before merge
+let mut merged_entries: Vec<HookConfig> = if let Some(display_name) = display_tool_name {
+    per_tool_hooks.get(display_name)
+        .map(|(bare_name, entries)| {
+            entries.iter()
+                .filter(|hook| {
+                    harnx_hooks::CompiledMatcher::compile(&hook.matcher)
+                        .map(|m| m.matches_str(bare_name))
+                        .unwrap_or(false)
+                })
+                .map(|hook| HookConfig { matcher: None, ..hook.clone() })
+                .collect()
+        })
+        .unwrap_or_default()
+} else { Vec::new() };
+merged_entries.extend(hooks_entries.clone());
+```
+
+## Why This Works
+
+**Server name identity via McpManager**: MCP servers get prefixed names (e.g., `bash` → `pkg__bash`) in `reinit_managers_for_agent`. `McpManager` stores clients by this display name, and `ToolDeclaration.mcp_server_name` matches it. Hook lookup via `mcp_manager.get_client(server_name)` finds packaged servers correctly; direct `Config.mcp_servers` lookup would silently fail.
+
+**Bare-name matcher semantics**: Server hook matchers evaluate against the bare tool name (`exec`) not the display name (`bash_exec`). Hook configs remain portable — renaming the MCP server doesn't require updating matchers. Implementation calls `CompiledMatcher::matches_str(bare_name)` instead of `matcher.matches(event)`.
+
+**Matcher stripping trick**: After filtering, the `matcher` field is cleared before adding to the merged list. This prevents the global dispatcher from re-running the matcher against the prefixed display name (which would fail for matchers like `^exec$` when event's tool_name is `bash_exec`).
+
+**Event type filtering**: Server hooks are filtered to only `PreToolUse`, `PostToolUse`, `PostToolUseFailure` at context build time. Other events (`SessionStart`, `Stop`, etc.) are silently ignored.
+
+**Merge order**: Server-specific hook entries prepend to global entries, ensuring they run first and can block before global hooks see the event.
+
+## Prevention Strategies
+
+**Test Cases:**
+- Verify server hooks run before global hooks
+- Test that matcher `^exec$` matches `exec` but not `bash_exec` when defined in server config
+- Confirm packaged servers (`pkg__server`) hooks dispatch correctly
+- Assert non-tool events (`SessionStart`, `Stop`) are ignored in server hooks
+
+**Best Practices:**
+- Use bare tool names in server hook matchers for portability
+- Filter server hooks to tool-use events only (others ignored anyway)
+- Prefer server-scoped hooks for package-provided blocking logic
+
+**Code Review Checklist:**
+- [ ] Is server hook lookup going through `McpManager`, not raw `Config.mcp_servers`?
+- [ ] Are matchers evaluated against bare names, then stripped before merge?
+- [ ] Are non-tool events filtered out of server hook entries?
+- [ ] Is merge order correct (server hooks first)?
+
+## Related Issues
+
+- **Files Changed:**
+  - `crates/harnx-mcp/src/config.rs` — `hooks: Option<HooksConfig>` on `McpServerConfig`
+  - `crates/harnx-mcp/src/client.rs` — set `mcp_server_name` on tool declarations; expose `hooks()` accessor
+  - `crates/harnx-core/src/tool.rs` — `mcp_server_name: Option<String>` on `ToolDeclaration` (serde skip)
+  - `crates/harnx-hooks/src/matcher.rs` — `matches_str(&self, text: &str) -> bool` on `CompiledMatcher`
+  - `crates/harnx-runtime/src/tool.rs` — `build_tool_eval_context` and `build_dispatch_hook_fn` extended

--- a/example_config/mcp_servers/bash.yaml
+++ b/example_config/mcp_servers/bash.yaml
@@ -83,3 +83,11 @@ args:
 #   HARNX_BASH_EXTRA_READABLE: /opt/sdk      # Extra readable path via environment
 #   HARNX_BASH_EXTRA_EXEC: /opt/tools/bin    # Extra executable path via environment
 #   HARNX_BASH_ENV_PASSTHROUGH: GITHUB_TOKEN,SSH_AUTH_SOCK  # Comma-separated list to pass through
+# hooks:
+#   entries:
+#   - event: PreToolUse
+#     type: claude-command
+#     command: /path/to/my-bash-hook.sh
+#     # matcher applies to the bare (server-side) tool name, e.g. "exec" not "bash_exec".
+#     # This means renaming the server doesn't require updating hook matchers.
+#     # matcher: "exec"


### PR DESCRIPTION
Adds `hooks` configuration to `McpServerConfig` so hooks can be defined per-MCP-server and only apply to tool calls going to that specific server. Server hook matchers apply to the bare (unprefixed) tool name so renaming the server doesn't require updating hook matchers. Only tool-use events are supported for server-level hooks.

Closes #572

## Changes

- `McpServerConfig` gains a `hooks: Option<HooksConfig>` field (serde default, backward-compatible)
- `ToolDeclaration` gains `mcp_server_name: Option<String>` (runtime-only, serde skip) set when tools are loaded from an MCP client
- `McpClient` exposes a `hooks()` accessor for the runtime to retrieve server hook config
- `CompiledMatcher` gains `matches_str(text)` for explicit-string matching (used for bare-name evaluation)
- `build_tool_eval_context` builds a per-tool hook map via `McpManager.get_client()` (display-name keyed, works for prefixed/packaged servers)
- Server hooks are filtered to tool-use events only, matched against the bare tool name, and prepended before global hooks at dispatch time
- Example config (`mcp_servers/bash.yaml`) updated with commented-out example and explanation of bare-name matcher semantics

## Matcher semantics

```yaml
hooks:
  entries:
  - event: PreToolUse
    type: claude-command
    command: /path/to/hook.sh
    matcher: "^exec$"   # matches bare name "exec", not prefixed "bash_exec"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for configuring hooks per MCP server so hook behavior can be scoped to individual servers.

* **Documentation**
  * Added design docs explaining per-server hook configuration and matching semantics.
  * Updated example MCP server config with guidance (commented) on defining hooks.

* **Tests**
  * Test suites updated to cover matcher behavior and server-scoped hook dispatch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->