### PR TITLE
feat: support client patching from packages

### DIFF
--- a/.changesets/package-client-patch.md
+++ b/.changesets/package-client-patch.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+Implement support for loading and patching client configurations from packages.

--- a/crates/harnx-client/src/macros.rs
+++ b/crates/harnx-client/src/macros.rs
@@ -10,7 +10,7 @@ macro_rules! register_client {
             use harnx_core::provider_config::$module::$config;
         )+
 
-        #[derive(Debug, Clone, serde::Deserialize)]
+        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
         #[serde(tag = "type")]
         pub enum ClientConfig {
             $(

--- a/crates/harnx-core/src/api_types.rs
+++ b/crates/harnx-core/src/api_types.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::message::Message;
 use crate::tool::{ToolCall, ToolDeclaration};
 
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ExtraConfig {
     pub proxy: Option<String>,
     pub connect_timeout: Option<u64>,

--- a/crates/harnx-core/src/provider_config/azure_openai.rs
+++ b/crates/harnx-core/src/provider_config/azure_openai.rs
@@ -1,11 +1,11 @@
 //! `AzureOpenAIConfig` — per-provider config for Azure-hosted OpenAI.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::api_types::ExtraConfig;
 use crate::model::{ModelData, RequestPatches};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AzureOpenAIConfig {
     pub name: Option<String>,
     pub api_base: Option<String>,

--- a/crates/harnx-core/src/provider_config/bedrock.rs
+++ b/crates/harnx-core/src/provider_config/bedrock.rs
@@ -1,11 +1,11 @@
 //! `BedrockConfig` — per-provider config for AWS Bedrock.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::api_types::ExtraConfig;
 use crate::model::{ModelData, RequestPatches};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BedrockConfig {
     pub name: Option<String>,
     pub access_key_id: Option<String>,

--- a/crates/harnx-core/src/provider_config/claude.rs
+++ b/crates/harnx-core/src/provider_config/claude.rs
@@ -1,11 +1,11 @@
 //! `ClaudeConfig` — per-provider config for Anthropic Claude.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::api_types::ExtraConfig;
 use crate::model::{ModelData, RequestPatches};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClaudeConfig {
     pub name: Option<String>,
     pub api_key: Option<String>,

--- a/crates/harnx-core/src/provider_config/cohere.rs
+++ b/crates/harnx-core/src/provider_config/cohere.rs
@@ -1,11 +1,11 @@
 //! `CohereConfig` — per-provider config for Cohere.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::api_types::ExtraConfig;
 use crate::model::{ModelData, RequestPatches};
 
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CohereConfig {
     pub name: Option<String>,
     pub api_key: Option<String>,

--- a/crates/harnx-core/src/provider_config/gemini.rs
+++ b/crates/harnx-core/src/provider_config/gemini.rs
@@ -1,11 +1,11 @@
 //! `GeminiConfig` — per-provider config for Google Gemini.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::api_types::ExtraConfig;
 use crate::model::{ModelData, RequestPatches};
 
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct GeminiConfig {
     pub name: Option<String>,
     pub api_key: Option<String>,

--- a/crates/harnx-core/src/provider_config/openai.rs
+++ b/crates/harnx-core/src/provider_config/openai.rs
@@ -1,11 +1,11 @@
 //! `OpenAIConfig` — per-provider config for the OpenAI client.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::api_types::ExtraConfig;
 use crate::model::{ModelData, RequestPatches};
 
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct OpenAIConfig {
     pub name: Option<String>,
     pub api_key: Option<String>,

--- a/crates/harnx-core/src/provider_config/openai_compatible.rs
+++ b/crates/harnx-core/src/provider_config/openai_compatible.rs
@@ -1,12 +1,12 @@
 //! `OpenAICompatibleConfig` — per-provider config for the generic
 //! OpenAI-compatible client (used by xAI, Groq, Mistral, DeepSeek, etc.).
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::api_types::ExtraConfig;
 use crate::model::{ModelData, RequestPatches};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OpenAICompatibleConfig {
     pub name: Option<String>,
     pub api_base: Option<String>,

--- a/crates/harnx-core/src/provider_config/vertexai.rs
+++ b/crates/harnx-core/src/provider_config/vertexai.rs
@@ -1,11 +1,11 @@
 //! `VertexAIConfig` — per-provider config for Google Vertex AI.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::api_types::ExtraConfig;
 use crate::model::{ModelData, RequestPatches};
 
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct VertexAIConfig {
     pub name: Option<String>,
     pub project_id: Option<String>,

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -341,6 +341,26 @@ fn apply_mcp_server_patch(server: &mut McpServerConfig, patches: &[String]) {
     }
 }
 
+fn apply_client_patch(client: &mut ClientConfig, patches: &[String]) {
+    if patches.is_empty() {
+        return;
+    }
+    let input = match serde_json::to_value(&*client) {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!("Failed to serialize ClientConfig for jaq patch: {e}");
+            return;
+        }
+    };
+    let output = harnx_core::jaq::eval_filters(patches, input);
+    match serde_json::from_value(output) {
+        Ok(patched) => {
+            *client = patched;
+        }
+        Err(e) => log::warn!("Failed to deserialize ClientConfig after jaq patch: {e}"),
+    }
+}
+
 ///
 /// - Top-level servers (`package == None`): unchanged name.
 /// - Same-package servers: bare name (the yaml stem, e.g. `fs`).
@@ -2945,9 +2965,11 @@ impl Config {
     /// — bare or prefixed — is decided at `init_mcp_manager_for_agent` time
     /// based on which agent is active.
     fn load_package_servers(config: &mut Config, pkg_path: &Path, pkg_name: &str) {
+        // Load the patch file once — shared by MCP servers and clients.
+        let patch = load_package_mcp_patch(pkg_name);
+
         let pkg_mcp_dir = pkg_path.join(paths::MCP_SERVERS_DIR_NAME);
         if pkg_mcp_dir.is_dir() {
-            let patch = load_package_mcp_patch(pkg_name);
             for mut server in Self::load_mcp_servers_from_dir(&pkg_mcp_dir).unwrap_or_default() {
                 server.package = Some(pkg_name.to_string());
                 if let Some(patch) = &patch {
@@ -2964,6 +2986,32 @@ impl Config {
                 config.acp_servers.push(server);
             }
         }
+
+        config.clients.extend(Self::load_package_clients(
+            pkg_path,
+            pkg_name,
+            patch.as_ref(),
+        ));
+    }
+
+    /// Load clients from a single package directory, applying any patch expressions.
+    fn load_package_clients(
+        pkg_path: &Path,
+        pkg_name: &str,
+        patch: Option<&harnx_core::package::PackagePatch>,
+    ) -> Vec<ClientConfig> {
+        let _ = pkg_name;
+        let pkg_clients_dir = pkg_path.join(paths::CLIENTS_DIR_NAME);
+        if !pkg_clients_dir.is_dir() {
+            return vec![];
+        }
+        let mut clients = Self::load_clients_from_dir(&pkg_clients_dir).unwrap_or_default();
+        if let Some(patch) = patch {
+            for client in &mut clients {
+                apply_client_patch(client, &patch.clients);
+            }
+        }
+        clients
     }
 
     fn load_clients_from_dir(dir: &Path) -> Result<Vec<ClientConfig>> {
@@ -4631,5 +4679,55 @@ mod mcp_patch_tests {
         // The package field should be preserved even though it has #[serde(skip)]
         assert_eq!(server.package, Some("mypkg".to_string()));
         assert_eq!(server.description, Some("Updated description".to_string()));
+    }
+}
+
+#[cfg(test)]
+mod client_patch_tests {
+    use super::apply_client_patch;
+    use harnx_client::ClientConfig;
+
+    fn make_openai_client() -> ClientConfig {
+        serde_yaml::from_str("type: openai\napi_key: sk-original\n")
+            .expect("should parse openai client config")
+    }
+
+    #[test]
+    fn apply_client_patch_with_identity_expression_leaves_config_unchanged() {
+        let mut client = make_openai_client();
+        let before = serde_json::to_value(&client).expect("serialize");
+        apply_client_patch(&mut client, &[".".to_string()]);
+        let after = serde_json::to_value(&client).expect("serialize");
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn apply_client_patch_with_empty_patches_is_noop() {
+        let mut client = make_openai_client();
+        let before = serde_json::to_value(&client).expect("serialize");
+        apply_client_patch(&mut client, &[]);
+        let after = serde_json::to_value(&client).expect("serialize");
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn apply_client_patch_sets_field_via_jq_expression() {
+        let mut client = make_openai_client();
+        apply_client_patch(&mut client, &[r#".api_key = "sk-patched""#.to_string()]);
+        if let ClientConfig::OpenAIConfig(c) = &client {
+            assert_eq!(c.api_key.as_deref(), Some("sk-patched"));
+        } else {
+            panic!("expected OpenAI client, got: {client:?}");
+        }
+    }
+
+    #[test]
+    fn apply_client_patch_with_invalid_jq_expression_leaves_config_unchanged() {
+        let mut client = make_openai_client();
+        let before = serde_json::to_value(&client).expect("serialize");
+        // Unclosed string — jaq will skip this expression
+        apply_client_patch(&mut client, &[r#".api_key = "unclosed"#.to_string()]);
+        let after = serde_json::to_value(&client).expect("serialize");
+        assert_eq!(before, after);
     }
 }

--- a/docs/solutions/integration-issues/jaq-expression-patching-yaml-to-jq-migration-2026-05-16.md
+++ b/docs/solutions/integration-issues/jaq-expression-patching-yaml-to-jq-migration-2026-05-16.md
@@ -14,7 +14,10 @@ tags:
   - serde
   - json-round-trip
   - yaml-migration
+  - client-config
+  - package-patching
 plan_ref: "jaq-patch-dsl"
+last_updated: 2026-05-16
 ---
 
 ## Problem
@@ -180,6 +183,77 @@ patches:
 ## Related Issues
 
 - **GitHub:** #565 — Replace YAML DSL patches with jq/jaq expressions
+- **GitHub:** #581 — Enable client config patching from packages (`PackagePatch.clients`)
 - **Plan:** `jaq-patch-dsl`
+- **Plan:** `patch-clients-from-packages`
 - **Changeset:** `.changesets/jaq-patch-expressions.md`
 - **Migration targets:** `models.yaml` (25 entries), `example_config/clients/*.yaml`, `packages/*/clients/*.yaml`
+
+---
+
+## Addendum: Client Config Patching (#581)
+
+### Problem Extension
+
+`PackagePatch.clients` existed in the schema as "dead surface" — the field was defined but never applied at runtime. Package authors could not ship `clients/` subdirectories with configs that get patched via `<pkg>.patches.yaml`.
+
+### Key Insight: Serialize Must Be Derived Alongside Deserialize
+
+Provider config structs (`OpenAIConfig`, `ClaudeConfig`, etc.) and `ExtraConfig` only derived `Deserialize`. The jaq patch system serializes configs to JSON, applies jq filters, then deserializes back. `Serialize` had to be added to:
+- All provider config structs in `harnx-client`
+- `ExtraConfig` struct
+- The `ClientConfig` enum in the `register_client!` macro
+
+Without `Serialize`, `serde_json::to_value(&client)` fails at runtime.
+
+### No skip Fields in ClientConfig
+
+Unlike `McpServerConfig` which has `package: Option<String>` marked `#[serde(skip)]`, `ClientConfig` has no skip fields. This means `apply_client_patch`:
+
+```rust
+fn apply_client_patch(client: &mut ClientConfig, patches: &[String]) {
+    if patches.is_empty() { return; }
+    let input = match serde_json::to_value(&*client) {
+        Ok(v) => v,
+        Err(e) => { log::warn!("Failed to serialize ClientConfig for jaq patch: {e}"); return; }
+    };
+    let output = harnx_core::jaq::eval_filters(patches, input);
+    match serde_json::from_value(output) {
+        Ok(patched) => { *client = patched; }
+        Err(e) => log::warn!("Failed to deserialize ClientConfig after jaq patch: {e}"),
+    }
+}
+```
+
+No save/restore logic needed — JSON round-trip is lossless for `ClientConfig`.
+
+### Package Loading Integration
+
+In `load_package_servers`, the same pattern used for MCP/ACP servers applies to clients:
+
+```rust
+let pkg_clients_dir = pkg_path.join(paths::CLIENTS_DIR_NAME);
+if pkg_clients_dir.is_dir() {
+    let patch = load_package_mcp_patch(pkg_name);  // loads full PackagePatch
+    for mut client in Self::load_clients_from_dir(&pkg_clients_dir).unwrap_or_default() {
+        if let Some(patch) = &patch {
+            apply_client_patch(&mut client, &patch.clients);
+        }
+        config.clients.push(client);
+    }
+}
+```
+
+Note: `load_package_mcp_patch()` loads the full `PackagePatch` (not just MCP). The misleading name is a known non-blocker.
+
+### Design Gap: ClientConfig Lacks Package Attribution
+
+MCP/ACP server configs have `package: Option<String>` (runtime-only, skip-serialized) for origin tracking. `ClientConfig` lacks this field. Clients loaded from packages are anonymous re: their origin. Not a bug, but a design asymmetry to be aware of for future work.
+
+### Tests
+
+`client_patch_tests` module verifies:
+- Identity expression leaves config unchanged
+- Empty patches no-op
+- Field setting via jq (e.g., `.api_key = "sk-patched"`)
+- Invalid jq expressions fail gracefully (log warning, config unchanged)


### PR DESCRIPTION
Implements support for loading and patching client configurations from packages. Adds jq-based patching for ClientConfig enums and integrates it into the package loading pipeline.

[#581]

Plan: patch-clients-from-packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading and patching client configurations from packages, enabling dynamic configuration modifications.

* **Documentation**
  * Updated documentation with details on client configuration patching behavior and jq/jaq expression usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->