### PR TITLE
fix: preserve package-scoped qualifier when loading agents from CLI

### DIFF
--- a/.changesets/582-package-scoped-agent-cli-fix.md
+++ b/.changesets/582-package-scoped-agent-cli-fix.md
@@ -1,0 +1,8 @@
+---
+harnx: patch
+---
+Fix `harnx -a <pkg>/<agent>` and `.agent <pkg>/<agent>` so they load the
+package-scoped agent. Previously the loader dropped the package qualifier and
+the agent reported its name as the bare stem, which meant the top-level agent
+of the same stem appeared to be selected and per-package patches and manager
+scoping were skipped.

--- a/crates/harnx-runtime/src/config/agent.rs
+++ b/crates/harnx-runtime/src/config/agent.rs
@@ -202,7 +202,7 @@ pub fn resolve_variables(agent: &mut Agent) -> Result<()> {
 pub async fn init(config: &GlobalConfig, name: &str, abort_signal: AbortSignal) -> Result<Agent> {
     let agent_file_path = Config::agent_file(name);
     let mut agent = if agent_file_path.exists() {
-        load(&agent_file_path)?
+        load_with_qualified_name(&agent_file_path, name)?
     } else {
         builtin(name)?
     };
@@ -507,7 +507,7 @@ pub async fn list_assistant_agents() -> Vec<String> {
 pub fn complete_agent_variables(agent_name: &str) -> Vec<(String, Option<String>)> {
     let markdown_path = Config::agent_file(agent_name);
     if markdown_path.exists() {
-        if let Ok(agent) = load(&markdown_path) {
+        if let Ok(agent) = load_with_qualified_name(&markdown_path, agent_name) {
             return agent
                 .defined_variables()
                 .iter()
@@ -1027,6 +1027,35 @@ You are a test agent.
             agent.defined_variables()[0].default.as_deref(),
             Some("Nested prompt")
         );
+    }
+
+    /// Regression for: `harnx -a pkg/agent` and `.agent pkg/agent` would load
+    /// the file at `packages/<pkg>/agents/<stem>.md` but call `load(path)` —
+    /// which derives the agent name from the file stem alone, dropping the
+    /// `<pkg>/` qualifier. As a result the loaded agent reported its name as
+    /// the bare stem (so it looked like a top-level agent had been selected),
+    /// `pkg_from_qualified(agent.name())` returned `None`, and the package
+    /// transforms (patches, namespaced managers) were never applied.
+    #[test]
+    fn test_init_preserves_qualified_name_for_package_agent() {
+        with_test_config_dir(|config_dir| {
+            let pkg_agents_dir = config_dir.join("packages/pantheon/agents");
+            fs::create_dir_all(&pkg_agents_dir)?;
+            fs::write(
+                pkg_agents_dir.join("sisyphus.md"),
+                "---\nrole: assistant\n---\nPackage-scoped agent.",
+            )?;
+            let config = GlobalConfig::default();
+            let runtime = tokio::runtime::Runtime::new()?;
+            let agent = runtime.block_on(super::init(
+                &config,
+                "pantheon/sisyphus",
+                create_abort_signal(),
+            ))?;
+            assert_eq!(agent.name(), "pantheon/sisyphus");
+            Ok(())
+        })
+        .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `harnx -a pantheon/sisyphus` and `.agent pantheon/sisyphus` now actually select the package-scoped agent. Previously both routed through `Config::use_agent` -> `agent::init`, which called `load(path)`. That helper derives the name from the file stem, so the agent loaded from `packages/pantheon/agents/sisyphus.md` reported its name as `sisyphus`. Since the package transforms (patches, namespaced manager scoping) only fire when the name contains `/`, they were silently skipped and the result looked like the top-level `sisyphus` agent had been selected.
- Switched `agent::init` and `complete_agent_variables` to `load_with_qualified_name(&path, name)` so the caller-supplied qualified name carries through to the loaded agent. The picker UI path already used `retrieve_agent` -> `load_with_qualified_name` and was unaffected.
- Added a regression test (`test_init_preserves_qualified_name_for_package_agent`) that creates a package-scoped agent file and asserts the loaded agent's `name()` retains the `pkg/stem` form.

Fixes #582

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace --stress-count=5` (1076 tests x 5 iterations, all passed)
- [x] `cs delta` (no issues found)
- [ ] Manual: `harnx -a pantheon/sisyphus` in a config with a `pantheon` package selects the package agent (not the top-level one)
- [ ] Manual: `.agent pantheon/sisyphus` from inside the TUI does the same