### PR TITLE
Implement package-relative resolution for compaction agents and models

### DIFF
--- a/.changesets/package-scoped-resolution.md
+++ b/.changesets/package-scoped-resolution.md
@@ -1,0 +1,38 @@
+---
+harnx: major
+---
+**Breaking change**: bare `compaction_agent` and `model`/client names in package agents now resolve within the same package by default.
+
+## What changed
+
+Packaged agents now use package-relative name resolution for `compaction_agent` references (#586) and `model`/client references (#585), matching the existing MCP/ACP server namespacing behaviour.
+
+| Reference in a package agent | Resolves to |
+|---|---|
+| `foo` | `pkg/foo` (same package) |
+| `other/foo` | `other/foo` (explicit cross-package, unchanged) |
+| `/foo` | `foo` (top-level, leading slash stripped) |
+
+- **`compaction_agent`**: Resolved at call time in `compact_session()`. A bare name is qualified with the active agent's package prefix before looking up the agent.
+- **`model` / client name**: Resolved at load time in `apply_package_agent_transforms()`. The client-name part of a model string (e.g. `openai` in `openai:gpt-4o`) is qualified. Package clients themselves are also renamed from `openai` to `pkg/openai` when loaded from a package directory.
+
+## Why
+
+Prevents name collisions between packages and makes packages self-contained — a package can define its own client named `openai` without conflicting with a top-level client of the same name, and an agent inside the package will use that package-local client by default.
+
+## Migration
+
+Any package agent that previously relied on a bare name resolving to a top-level resource must be updated:
+
+- Prefix with `/` to escape to the top-level namespace:
+  ```yaml
+  compaction_agent: /my-global-compactor
+  model: /openai:gpt-4o
+  ```
+- Cross-package references use `other_pkg/name` syntax (unchanged):
+  ```yaml
+  compaction_agent: shared-tools/summarizer
+  model: shared-tools/openai:gpt-4o
+  ```
+
+Top-level agents (not inside a package) are **not affected** — their bare name references still resolve globally.

--- a/crates/harnx-client/src/bedrock.rs
+++ b/crates/harnx-client/src/bedrock.rs
@@ -938,6 +938,7 @@ mod tests {
             patches: None,
             extra: None,
             system_prompt_prefix: None,
+            package: None,
         }
     }
 

--- a/crates/harnx-client/src/lib.rs
+++ b/crates/harnx-client/src/lib.rs
@@ -76,3 +76,79 @@ register_client!(
     (vertexai, "vertexai", VertexAIConfig, VertexAIClient),
     (bedrock, "bedrock", BedrockConfig, BedrockClient),
 );
+
+impl ClientConfig {
+    /// Returns the client's configured name (the `name` field of the inner config),
+    /// or `None` for `Unknown` variants.
+    pub fn inner_name(&self) -> Option<&str> {
+        match self {
+            ClientConfig::OpenAIConfig(c) => c.name.as_deref(),
+            ClientConfig::OpenAICompatibleConfig(c) => c.name.as_deref(),
+            ClientConfig::GeminiConfig(c) => c.name.as_deref(),
+            ClientConfig::ClaudeConfig(c) => c.name.as_deref(),
+            ClientConfig::CohereConfig(c) => c.name.as_deref(),
+            ClientConfig::AzureOpenAIConfig(c) => c.name.as_deref(),
+            ClientConfig::VertexAIConfig(c) => c.name.as_deref(),
+            ClientConfig::BedrockConfig(c) => c.name.as_deref(),
+            ClientConfig::Unknown => None,
+        }
+    }
+
+    /// Returns the effective name used to identify this client.
+    /// This is the explicit `name` field if set, or the provider's default name.
+    pub fn effective_name(&self) -> &str {
+        match self {
+            ClientConfig::OpenAIConfig(c) => c.name.as_deref().unwrap_or("openai"),
+            ClientConfig::OpenAICompatibleConfig(c) => {
+                c.name.as_deref().unwrap_or("openai-compatible")
+            }
+            ClientConfig::GeminiConfig(c) => c.name.as_deref().unwrap_or("gemini"),
+            ClientConfig::ClaudeConfig(c) => c.name.as_deref().unwrap_or("claude"),
+            ClientConfig::CohereConfig(c) => c.name.as_deref().unwrap_or("cohere"),
+            ClientConfig::AzureOpenAIConfig(c) => c.name.as_deref().unwrap_or("azure-openai"),
+            ClientConfig::VertexAIConfig(c) => c.name.as_deref().unwrap_or("vertexai"),
+            ClientConfig::BedrockConfig(c) => c.name.as_deref().unwrap_or("bedrock"),
+            ClientConfig::Unknown => "unknown",
+        }
+    }
+
+    /// Sets the `name` and `package` fields on the inner config struct.
+    /// Used at load time to qualify package clients.
+    pub fn set_name_and_package(&mut self, name: String, package: String) {
+        match self {
+            ClientConfig::OpenAIConfig(c) => {
+                c.name = Some(name);
+                c.package = Some(package);
+            }
+            ClientConfig::OpenAICompatibleConfig(c) => {
+                c.name = Some(name);
+                c.package = Some(package);
+            }
+            ClientConfig::GeminiConfig(c) => {
+                c.name = Some(name);
+                c.package = Some(package);
+            }
+            ClientConfig::ClaudeConfig(c) => {
+                c.name = Some(name);
+                c.package = Some(package);
+            }
+            ClientConfig::CohereConfig(c) => {
+                c.name = Some(name);
+                c.package = Some(package);
+            }
+            ClientConfig::AzureOpenAIConfig(c) => {
+                c.name = Some(name);
+                c.package = Some(package);
+            }
+            ClientConfig::VertexAIConfig(c) => {
+                c.name = Some(name);
+                c.package = Some(package);
+            }
+            ClientConfig::BedrockConfig(c) => {
+                c.name = Some(name);
+                c.package = Some(package);
+            }
+            ClientConfig::Unknown => {}
+        }
+    }
+}

--- a/crates/harnx-core/src/package_namespace.rs
+++ b/crates/harnx-core/src/package_namespace.rs
@@ -60,6 +60,29 @@ pub fn namespace_use_tools_entry(pkg: &str, entry: &str) -> String {
     }
 }
 
+/// Resolves a potentially bare agent/client/model name relative to a package context.
+///
+/// Rules:
+///   - `/foo`        → `"foo"` (explicit top-level, strip leading slash)
+///   - `other/foo`   → `"other/foo"` (already qualified, unchanged)
+///   - `foo` + Some("pkg") → `"pkg/foo"` (relative to current package)
+///   - `foo` + None  → `"foo"` (top-level context, unchanged)
+pub fn resolve_package_relative_name(name: &str, pkg_context: Option<&str>) -> String {
+    if let Some(stripped) = name.strip_prefix('/') {
+        // Leading slash = explicit top-level escape
+        stripped.to_string()
+    } else if name.contains('/') {
+        // Already qualified (cross-package or explicit)
+        name.to_string()
+    } else if let Some(pkg) = pkg_context {
+        // Bare name in a package context → qualify it
+        format!("{pkg}/{name}")
+    } else {
+        // Bare name at top level → unchanged
+        name.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -116,6 +139,45 @@ mod tests {
         assert_eq!(
             namespace_use_tools_entry("mypkg", "fs_{read_file,write_file}"),
             "mypkg__fs_{read_file,write_file}"
+        );
+    }
+
+    #[test]
+    fn test_resolve_package_relative_bare_with_context() {
+        assert_eq!(
+            resolve_package_relative_name("foo", Some("mypkg")),
+            "mypkg/foo"
+        );
+    }
+
+    #[test]
+    fn test_resolve_package_relative_bare_no_context() {
+        assert_eq!(resolve_package_relative_name("foo", None), "foo");
+    }
+
+    #[test]
+    fn test_resolve_package_relative_leading_slash_with_context() {
+        assert_eq!(resolve_package_relative_name("/foo", Some("mypkg")), "foo");
+    }
+
+    #[test]
+    fn test_resolve_package_relative_leading_slash_no_context() {
+        assert_eq!(resolve_package_relative_name("/foo", None), "foo");
+    }
+
+    #[test]
+    fn test_resolve_package_relative_qualified_with_context() {
+        assert_eq!(
+            resolve_package_relative_name("other/foo", Some("mypkg")),
+            "other/foo"
+        );
+    }
+
+    #[test]
+    fn test_resolve_package_relative_qualified_no_context() {
+        assert_eq!(
+            resolve_package_relative_name("other/foo", None),
+            "other/foo"
         );
     }
 }

--- a/crates/harnx-core/src/provider_config/azure_openai.rs
+++ b/crates/harnx-core/src/provider_config/azure_openai.rs
@@ -16,4 +16,9 @@ pub struct AzureOpenAIConfig {
     pub extra: Option<ExtraConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt_prefix: Option<Vec<String>>,
+
+    /// Runtime-only: the package this client was loaded from, if any.
+    /// Not persisted to YAML (serde skip).
+    #[serde(skip)]
+    pub package: Option<String>,
 }

--- a/crates/harnx-core/src/provider_config/bedrock.rs
+++ b/crates/harnx-core/src/provider_config/bedrock.rs
@@ -19,4 +19,9 @@ pub struct BedrockConfig {
     pub extra: Option<ExtraConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt_prefix: Option<Vec<String>>,
+
+    /// Runtime-only: the package this client was loaded from, if any.
+    /// Not persisted to YAML (serde skip).
+    #[serde(skip)]
+    pub package: Option<String>,
 }

--- a/crates/harnx-core/src/provider_config/claude.rs
+++ b/crates/harnx-core/src/provider_config/claude.rs
@@ -16,4 +16,9 @@ pub struct ClaudeConfig {
     pub extra: Option<ExtraConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt_prefix: Option<Vec<String>>,
+
+    /// Runtime-only: the package this client was loaded from, if any.
+    /// Not persisted to YAML (serde skip).
+    #[serde(skip)]
+    pub package: Option<String>,
 }

--- a/crates/harnx-core/src/provider_config/cohere.rs
+++ b/crates/harnx-core/src/provider_config/cohere.rs
@@ -16,4 +16,9 @@ pub struct CohereConfig {
     pub extra: Option<ExtraConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt_prefix: Option<Vec<String>>,
+
+    /// Runtime-only: the package this client was loaded from, if any.
+    /// Not persisted to YAML (serde skip).
+    #[serde(skip)]
+    pub package: Option<String>,
 }

--- a/crates/harnx-core/src/provider_config/gemini.rs
+++ b/crates/harnx-core/src/provider_config/gemini.rs
@@ -16,4 +16,9 @@ pub struct GeminiConfig {
     pub extra: Option<ExtraConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt_prefix: Option<Vec<String>>,
+
+    /// Runtime-only: the package this client was loaded from, if any.
+    /// Not persisted to YAML (serde skip).
+    #[serde(skip)]
+    pub package: Option<String>,
 }

--- a/crates/harnx-core/src/provider_config/openai.rs
+++ b/crates/harnx-core/src/provider_config/openai.rs
@@ -17,4 +17,9 @@ pub struct OpenAIConfig {
     pub extra: Option<ExtraConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt_prefix: Option<Vec<String>>,
+
+    /// Runtime-only: the package this client was loaded from, if any.
+    /// Not persisted to YAML (serde skip).
+    #[serde(skip)]
+    pub package: Option<String>,
 }

--- a/crates/harnx-core/src/provider_config/openai_compatible.rs
+++ b/crates/harnx-core/src/provider_config/openai_compatible.rs
@@ -17,4 +17,9 @@ pub struct OpenAICompatibleConfig {
     pub extra: Option<ExtraConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt_prefix: Option<Vec<String>>,
+
+    /// Runtime-only: the package this client was loaded from, if any.
+    /// Not persisted to YAML (serde skip).
+    #[serde(skip)]
+    pub package: Option<String>,
 }

--- a/crates/harnx-core/src/provider_config/vertexai.rs
+++ b/crates/harnx-core/src/provider_config/vertexai.rs
@@ -17,4 +17,9 @@ pub struct VertexAIConfig {
     pub extra: Option<ExtraConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt_prefix: Option<Vec<String>>,
+
+    /// Runtime-only: the package this client was loaded from, if any.
+    /// Not persisted to YAML (serde skip).
+    #[serde(skip)]
+    pub package: Option<String>,
 }

--- a/crates/harnx-runtime/src/config/agent.rs
+++ b/crates/harnx-runtime/src/config/agent.rs
@@ -95,6 +95,45 @@ fn apply_package_agent_transforms(
     if let Some(patch) = load_package_patch_for(pkg_name)? {
         apply_agent_patch(config, agent_stem, &patch)?;
     }
+    // Rewrite model_id: resolve the client-name part relative to this package.
+    // Format is "client:model" or just "client". The leading-slash escape "/foo"
+    // resolves to top-level "foo"; "other/foo" passes through unchanged.
+    if let Some(model_id) = config.model_id().map(ToOwned::to_owned) {
+        let resolved = match model_id.split_once(':') {
+            Some((client_part, model_part)) => {
+                let resolved_client = harnx_core::package_namespace::resolve_package_relative_name(
+                    client_part,
+                    Some(pkg_name),
+                );
+                format!("{resolved_client}:{model_part}")
+            }
+            None => harnx_core::package_namespace::resolve_package_relative_name(
+                &model_id,
+                Some(pkg_name),
+            ),
+        };
+        config.set_model_id(Some(resolved));
+    }
+    // Rewrite model_fallbacks too
+    let resolved_fallbacks: Vec<String> = config
+        .model_fallbacks()
+        .iter()
+        .map(|fb| match fb.split_once(':') {
+            Some((client_part, model_part)) => {
+                let resolved_client = harnx_core::package_namespace::resolve_package_relative_name(
+                    client_part,
+                    Some(pkg_name),
+                );
+                format!("{resolved_client}:{model_part}")
+            }
+            None => {
+                harnx_core::package_namespace::resolve_package_relative_name(fb, Some(pkg_name))
+            }
+        })
+        .collect();
+    if !resolved_fallbacks.is_empty() {
+        config.set_model_fallbacks(resolved_fallbacks);
+    }
     Ok(())
 }
 

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -1956,6 +1956,8 @@ impl Config {
         }
 
         // Check if the current agent has a compaction_agent configured
+        let active_agent_name = config.read().extract_agent().name().to_string();
+        let active_pkg = harnx_core::package_namespace::pkg_from_qualified(&active_agent_name);
         let compaction_agent_name = config
             .read()
             .extract_agent()
@@ -1963,7 +1965,9 @@ impl Config {
             .map(str::to_owned);
 
         let (prompt, agent_override) = if let Some(name) = compaction_agent_name {
-            match config.read().retrieve_agent(&name) {
+            let resolved_name =
+                harnx_core::package_namespace::resolve_package_relative_name(&name, active_pkg);
+            match config.read().retrieve_agent(&resolved_name) {
                 Ok(mut compaction_agent) => {
                     if let Err(e) = self::agent::resolve_variables(&mut compaction_agent) {
                         warn!("Failed to resolve variables for compaction_agent '{name}': {e}");
@@ -3000,7 +3004,6 @@ impl Config {
         pkg_name: &str,
         patch: Option<&harnx_core::package::PackagePatch>,
     ) -> Vec<ClientConfig> {
-        let _ = pkg_name;
         let pkg_clients_dir = pkg_path.join(paths::CLIENTS_DIR_NAME);
         if !pkg_clients_dir.is_dir() {
             return vec![];
@@ -3009,6 +3012,16 @@ impl Config {
         if let Some(patch) = patch {
             for client in &mut clients {
                 apply_client_patch(client, &patch.clients);
+            }
+        }
+        // Qualify client names with package prefix after patching.
+        // Must be after patching because apply_client_patch round-trips through
+        // serde_json and resets #[serde(skip)] fields like `package`.
+        for client in &mut clients {
+            let bare_name = client.effective_name().to_string();
+            if !bare_name.contains('/') {
+                let qualified = format!("{pkg_name}/{bare_name}");
+                client.set_name_and_package(qualified, pkg_name.to_string());
             }
         }
         clients
@@ -3938,6 +3951,7 @@ mod tests {
                         patches: None,
                         extra: None,
                         system_prompt_prefix: None,
+                        package: None,
                     },
                 ));
             config.model = harnx_client::Model::new("test", "model");
@@ -4534,6 +4548,136 @@ mod tests {
         );
     }
 
+    /// compact_session with a package-scoped compaction_agent bare name must
+    /// resolve to the same-package compactor, not a top-level agent of the same name.
+    #[tokio::test]
+    async fn test_compact_session_package_bare_compaction_agent_resolves_within_package() {
+        use crate::client::TestStateGuard;
+        use crate::test_utils::{MockClient, MockTurnBuilder};
+        use std::io::Write as _;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let package_agents_dir = temp.path().join("packages/mypkg/agents");
+        std::fs::create_dir_all(&package_agents_dir).unwrap();
+        let top_level_agents_dir = temp.path().join("agents");
+        std::fs::create_dir_all(&top_level_agents_dir).unwrap();
+
+        std::fs::write(
+            temp.path().join("packages/mypkg/manifest.yaml"),
+            "name: mypkg\nsource:\n  type: git\n  url: file:///fake\n  tag: v1.0.0\n  commit: abc123\ninstalled_at: \"2025-01-01T00:00:00Z\"\n",
+        )
+        .unwrap();
+
+        // Use /gemini (leading slash) to escape to top-level so the model
+        // reference is not rewritten to mypkg/gemini by apply_package_agent_transforms.
+        let package_compactor = "---\nmodel: /gemini:gemini-3.1-flash-lite-preview\n---\nYou are the PACKAGE compactor. Produce a concise summary.\n";
+        let mut package_file =
+            std::fs::File::create(package_agents_dir.join("compactor.md")).unwrap();
+        package_file
+            .write_all(package_compactor.as_bytes())
+            .unwrap();
+
+        let top_level_compactor = "---\nmodel: gemini:gemini-3.1-flash-lite-preview\n---\nYou are the TOP-LEVEL compactor. Produce a concise summary.\n";
+        let mut top_level_file =
+            std::fs::File::create(top_level_agents_dir.join("compactor.md")).unwrap();
+        top_level_file
+            .write_all(top_level_compactor.as_bytes())
+            .unwrap();
+
+        let mut main_agent = Agent::new(
+            AgentConfig::from_markdown(
+                "mypkg/main",
+                "---\nmodel: gemini:gemini-3.1-flash-lite-preview\n---\nYou are the main package agent.",
+            )
+            .unwrap(),
+        );
+        main_agent.set_compaction_agent(Some("compactor".to_string()));
+        main_agent.set_model(crate::client::Model::new(
+            "gemini",
+            "gemini-3.1-flash-lite-preview",
+        ));
+
+        let mut config = Config {
+            data: ConfigData {
+                stream: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        struct EnvGuard {
+            key: &'static str,
+            prev: Option<std::ffi::OsString>,
+        }
+        impl EnvGuard {
+            fn new(key: &'static str, value: &std::path::Path) -> Self {
+                let prev = std::env::var_os(key);
+                unsafe { std::env::set_var(key, value) };
+                Self { key, prev }
+            }
+        }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.prev {
+                    Some(v) => unsafe { std::env::set_var(self.key, v) },
+                    None => unsafe { std::env::remove_var(self.key) },
+                }
+            }
+        }
+
+        config.agent = Some(main_agent);
+
+        let mut session = self::session::new(&config, "test-session").unwrap();
+        session.push_message_for_test(
+            MessageRole::User,
+            "Tell me about package-local compaction.".to_string(),
+        );
+        config.session = Some(session);
+        let config = Arc::new(RwLock::new(config));
+
+        let mock = Arc::new(
+            MockClient::builder()
+                .add_turn(MockTurnBuilder::new().add_text_chunk("Compacted.").build())
+                .build(),
+        );
+        let _guard = TestStateGuard::new(Some(mock.clone())).await;
+        let _env = EnvGuard::new("HARNX_CONFIG_DIR", temp.path());
+
+        Config::compact_session(&config).await.unwrap();
+
+        let history = mock.conversation_history();
+        assert_eq!(
+            history.conversation_history.len(),
+            1,
+            "expected exactly one LLM call"
+        );
+        let messages = &history.conversation_history[0].messages;
+
+        let has_package_system = messages.iter().any(|m| {
+            m.role == MessageRole::System
+                && if let MessageContent::Text(t) = &m.content {
+                    t.contains("PACKAGE compactor")
+                } else {
+                    false
+                }
+        });
+        assert!(
+            has_package_system,
+            "package compactor system prompt must be used; messages: {messages:?}"
+        );
+
+        let has_top_level_system = messages.iter().any(|m| {
+            m.role == MessageRole::System
+                && if let MessageContent::Text(t) = &m.content {
+                    t.contains("TOP-LEVEL compactor")
+                } else {
+                    false
+                }
+        });
+        assert!(
+            !has_top_level_system,
+            "top-level compactor system prompt must not be used; messages: {messages:?}"
+        );
+    }
     /// Regression test for the ACP-server failure where `use_agent_by_name`
     /// followed by `use_session` bailed with "agent variables are required"
     /// for an agent whose variables use `path:` (file-backed defaults).  The

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -3017,12 +3017,15 @@ impl Config {
         // Qualify client names with package prefix after patching.
         // Must be after patching because apply_client_patch round-trips through
         // serde_json and resets #[serde(skip)] fields like `package`.
+        // Always call set_name_and_package (not just for bare names) so the
+        // `package` field is restored even for explicitly-named clients whose
+        // name already contains '/'.
         for client in &mut clients {
-            let bare_name = client.effective_name().to_string();
-            if !bare_name.contains('/') {
-                let qualified = format!("{pkg_name}/{bare_name}");
-                client.set_name_and_package(qualified, pkg_name.to_string());
-            }
+            let resolved_name = harnx_core::package_namespace::resolve_package_relative_name(
+                client.effective_name(),
+                Some(pkg_name),
+            );
+            client.set_name_and_package(resolved_name, pkg_name.to_string());
         }
         clients
     }

--- a/crates/harnx-runtime/tests/package_loading.rs
+++ b/crates/harnx-runtime/tests/package_loading.rs
@@ -1,5 +1,6 @@
 use std::{ffi::OsString, path::Path, sync::Mutex};
 
+use harnx_core::package_namespace::resolve_package_relative_name;
 use harnx_runtime::config::{complete_agent_variables, list_agents, list_assistant_agents, Config};
 
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
@@ -40,6 +41,240 @@ fn install_test_package(config_dir: &Path, pkg_name: &str, files: &[(&str, &str)
         "name: {pkg_name}\nsource:\n  type: git\n  url: file:///fake\n  tag: v1.0.0\n  commit: abc123\ninstalled_at: \"2025-01-01T00:00:00Z\"\n"
     );
     std::fs::write(pkg_dir.join("manifest.yaml"), manifest).unwrap();
+}
+
+#[test]
+fn package_loading_test_package_client_loaded_with_qualified_name() {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    install_test_package(
+        tmp.path(),
+        "mypkg",
+        &[(
+            "clients/openai.yaml",
+            "type: openai
+",
+        )],
+    );
+
+    let config = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(Config::init(
+            harnx_runtime::config::WorkingMode::Cmd,
+            false,
+            vec![],
+        ))
+        .expect("config should load");
+
+    assert!(
+        config
+            .clients
+            .iter()
+            .any(|client| client.effective_name() == "mypkg/openai"),
+        "Expected qualified package client in config.clients, got: {:?}",
+        config
+            .clients
+            .iter()
+            .map(|client| client.effective_name().to_string())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn package_loading_test_package_agent_model_rewritten_to_qualified() {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    install_test_package(
+        tmp.path(),
+        "mypkg",
+        &[
+            (
+                "clients/openai.yaml",
+                "type: openai
+",
+            ),
+            (
+                "agents/worker.md",
+                "---
+model: openai:gpt-4o
+---
+You work.",
+            ),
+        ],
+    );
+
+    let config = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(Config::init(
+            harnx_runtime::config::WorkingMode::Cmd,
+            false,
+            vec![],
+        ))
+        .expect("config should load");
+    let agent = config.retrieve_agent("mypkg/worker").unwrap();
+
+    assert_eq!(agent.model_id(), Some("mypkg/openai:gpt-4o"));
+}
+
+#[test]
+fn package_loading_test_package_agent_model_leading_slash_rewritten_to_top_level() {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    std::fs::create_dir_all(tmp.path().join("clients")).unwrap();
+    std::fs::write(
+        tmp.path().join("clients/openai.yaml"),
+        "type: openai
+",
+    )
+    .unwrap();
+    install_test_package(
+        tmp.path(),
+        "mypkg",
+        &[(
+            "agents/worker.md",
+            "---
+model: /openai:gpt-4o
+---
+You work.",
+        )],
+    );
+
+    let config = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(Config::init(
+            harnx_runtime::config::WorkingMode::Cmd,
+            false,
+            vec![],
+        ))
+        .expect("config should load");
+    let agent = config.retrieve_agent("mypkg/worker").unwrap();
+
+    assert_eq!(agent.model_id(), Some("openai:gpt-4o"));
+}
+
+#[test]
+fn package_loading_test_package_agent_model_cross_package_unchanged() {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    install_test_package(
+        tmp.path(),
+        "other",
+        &[(
+            "clients/openai.yaml",
+            "type: openai
+",
+        )],
+    );
+    install_test_package(
+        tmp.path(),
+        "mypkg",
+        &[(
+            "agents/worker.md",
+            "---
+model: other/openai:gpt-4o
+---
+You work.",
+        )],
+    );
+
+    let config = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(Config::init(
+            harnx_runtime::config::WorkingMode::Cmd,
+            false,
+            vec![],
+        ))
+        .expect("config should load");
+    let agent = config.retrieve_agent("mypkg/worker").unwrap();
+
+    assert_eq!(agent.model_id(), Some("other/openai:gpt-4o"));
+}
+
+#[test]
+fn package_loading_test_package_clients_same_bare_name_do_not_collide() {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    install_test_package(
+        tmp.path(),
+        "pkg-a",
+        &[(
+            "clients/openai.yaml",
+            "type: openai
+",
+        )],
+    );
+    install_test_package(
+        tmp.path(),
+        "pkg-b",
+        &[(
+            "clients/openai.yaml",
+            "type: openai
+",
+        )],
+    );
+
+    let config = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(Config::init(
+            harnx_runtime::config::WorkingMode::Cmd,
+            false,
+            vec![],
+        ))
+        .expect("config should load");
+
+    let client_names = config
+        .clients
+        .iter()
+        .map(|client| client.effective_name().to_string())
+        .collect::<Vec<_>>();
+    assert!(client_names.contains(&"pkg-a/openai".to_string()));
+    assert!(client_names.contains(&"pkg-b/openai".to_string()));
+}
+
+#[test]
+fn package_loading_test_top_level_agent_model_stays_unchanged() {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    std::fs::create_dir_all(tmp.path().join("clients")).unwrap();
+    std::fs::write(
+        tmp.path().join("clients/openai.yaml"),
+        "type: openai
+",
+    )
+    .unwrap();
+    std::fs::create_dir_all(tmp.path().join("agents")).unwrap();
+    std::fs::write(
+        tmp.path().join("agents/worker.md"),
+        "---
+model: openai:gpt-4o
+---
+You work.",
+    )
+    .unwrap();
+
+    let config = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(Config::init(
+            harnx_runtime::config::WorkingMode::Cmd,
+            false,
+            vec![],
+        ))
+        .expect("config should load");
+    let agent = config.retrieve_agent("worker").unwrap();
+
+    assert_eq!(agent.model_id(), Some("openai:gpt-4o"));
 }
 
 #[test]
@@ -267,6 +502,95 @@ fn package_loading_test_package_agent_file_resolves_correctly() {
         path.exists(),
         "Expected resolved agent path to exist: {}",
         path.display()
+    );
+}
+
+#[test]
+fn package_loading_test_compaction_agent_bare_name_resolves_within_package() {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    install_test_package(
+        tmp.path(),
+        "mypkg",
+        &[
+            (
+                "agents/main.md",
+                "---\ncompaction_agent: compactor\n---\nYou are the main agent.",
+            ),
+            (
+                "agents/compactor.md",
+                "---\nrole: compaction\n---\nSummarize for mypkg.",
+            ),
+        ],
+    );
+
+    let agents_dir = tmp.path().join("agents");
+    std::fs::create_dir_all(&agents_dir).unwrap();
+    std::fs::write(
+        agents_dir.join("compactor.md"),
+        "---\nrole: compaction\n---\nTop-level summarizer.",
+    )
+    .unwrap();
+
+    let resolved = resolve_package_relative_name("compactor", Some("mypkg"));
+    assert_eq!(resolved, "mypkg/compactor");
+
+    let config = Config::default();
+    let package_compactor = config.retrieve_agent(&resolved).unwrap();
+    assert_eq!(package_compactor.name(), "mypkg/compactor");
+    let package_prompt = package_compactor.interpolated_instructions().unwrap();
+    assert!(
+        package_prompt.contains("mypkg"),
+        "Expected package-scoped compactor prompt, got: {:?}",
+        package_prompt
+    );
+
+    let top_level_compactor = config.retrieve_agent("compactor").unwrap();
+    assert_eq!(top_level_compactor.name(), "compactor");
+    let top_level_prompt = top_level_compactor.interpolated_instructions().unwrap();
+    assert!(
+        top_level_prompt.contains("Top-level"),
+        "Expected top-level compactor prompt, got: {:?}",
+        top_level_prompt
+    );
+}
+
+#[test]
+fn package_loading_test_compaction_agent_leading_slash_resolves_top_level() {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    install_test_package(
+        tmp.path(),
+        "mypkg",
+        &[(
+            "agents/main.md",
+            "---\ncompaction_agent: /compactor\n---\nYou are the main agent.",
+        )],
+    );
+
+    let agents_dir = tmp.path().join("agents");
+    std::fs::create_dir_all(&agents_dir).unwrap();
+    std::fs::write(
+        agents_dir.join("compactor.md"),
+        "---\nrole: compaction\n---\nTop-level summarizer.",
+    )
+    .unwrap();
+
+    let resolved = resolve_package_relative_name("/compactor", Some("mypkg"));
+    assert_eq!(resolved, "compactor");
+
+    let config = Config::default();
+    let top_level_compactor = config.retrieve_agent(&resolved).unwrap();
+    assert_eq!(top_level_compactor.name(), "compactor");
+    let top_level_prompt = top_level_compactor.interpolated_instructions().unwrap();
+    assert!(
+        top_level_prompt.contains("Top-level"),
+        "Expected top-level compactor prompt, got: {:?}",
+        top_level_prompt
     );
 }
 

--- a/docs/solutions/logic-errors/package-scoped-name-resolution-2026-05-17.md
+++ b/docs/solutions/logic-errors/package-scoped-name-resolution-2026-05-17.md
@@ -1,0 +1,215 @@
+---
+title: "Package-scoped name resolution for compaction agents and client/model references"
+date: 2026-05-17
+category: logic-errors
+problem_type: logic_error
+component: package-namespace
+root_cause: missing-package-context-resolution
+resolution_type: code_fix
+severity: medium
+tags:
+  - namespacing
+  - packages
+  - resolution
+  - compaction-agent
+  - client-config
+plan_ref: harnx-package-namespacing
+---
+
+## Problem
+
+Package agents referenced bare names (`compaction_agent: compactor`, `model: openai:gpt-4o`) that resolved globally against top-level resources, breaking package isolation. Two packages with identically-named clients or agents could collide, and agents within a package couldn't default to using resources defined in that same package.
+
+## Symptoms
+
+- Package agent with `compaction_agent: compactor` looked up `compactor` at top level instead of `mypkg/compactor`
+- Package agent with `model: openai:gpt-4o` used global `openai` client instead of `mypkg/openai`
+- Same-named clients in different packages collided on the global client list
+- No way to express "use the resource defined in my package" vs "use top-level resource"
+
+## Investigation Steps
+
+1. Reviewed existing MCP/ACP server namespacing precedent: servers loaded from a package are prefixed with `pkg/` on the global registry, and `reinit_managers_for_agent()` filters by package prefix.
+
+2. Identified two resolution sites:
+   - **Compaction agent**: `Config::compact_session()` reads `agent.compaction_agent()` and looks up the agent
+   - **Model/client**: `apply_package_agent_transforms()` processes `model_id` and `model_fallbacks` fields
+
+3. Designed resolution rules matching MCP/ACP convention:
+   - Bare `foo` → `pkg/foo` (package-relative)
+   - `/foo` → `foo` (top-level escape, leading slash stripped)
+   - `other/foo` → `other/foo` (already qualified, unchanged)
+
+4. Implemented shared helper `resolve_package_relative_name()` in `harnx-core`.
+
+5. Added `package: Option<String>` field to all 8 provider config structs for metadata tracking.
+
+## Root Cause
+
+The name resolution logic lacked awareness of package context. All bare names were resolved against the global namespace, violating the principle that packages should be self-contained.
+
+**Compaction agent path**: `compact_session()` extracted `compaction_agent` name and directly passed it to `retrieve_agent()` without any package-relative transformation.
+
+**Client/model path**: `apply_package_agent_transforms()` did not rewrite the client-name portion of model references, so `openai:gpt-4o` would match a top-level `openai` client instead of a package-local one.
+
+## Solution
+
+### Core Resolution Helper
+
+Added `resolve_package_relative_name()` in `crates/harnx-core/src/package_namespace.rs`:
+
+```rust
+pub fn resolve_package_relative_name(name: &str, pkg_context: Option<&str>) -> String {
+    if name.starts_with('/') {
+        // Leading slash escapes to top-level
+        name[1..].to_string()
+    } else if name.contains('/') {
+        // Already qualified, pass through
+        name.to_string()
+    } else if let Some(pkg) = pkg_context {
+        // Bare name in package context → qualify with package
+        format!("{pkg}/{name}")
+    } else {
+        // Bare name outside package context → unchanged
+        name.to_string()
+    }
+}
+```
+
+### Compaction Agent Resolution (call-time)
+
+In `crates/harnx-runtime/src/config/mod.rs`, modified `compact_session()`:
+
+```rust
+let active_agent_name = config.read().extract_agent().name().to_string();
+let active_pkg = harnx_core::package_namespace::pkg_from_qualified(&active_agent_name);
+let compaction_agent_name = config.read().extract_agent().compaction_agent().map(str::to_owned);
+
+if let Some(name) = compaction_agent_name {
+    let resolved_name = harnx_core::package_namespace::resolve_package_relative_name(&name, active_pkg);
+    match config.read().retrieve_agent(&resolved_name) {
+        // ...
+    }
+}
+```
+
+### Client/Model Resolution (load-time)
+
+In `crates/harnx-runtime/src/config/agent.rs`, `apply_package_agent_transforms()` rewrites model references:
+
+```rust
+if let Some(model_id) = config.model_id().map(ToOwned::to_owned) {
+    let resolved = match model_id.split_once(':') {
+        Some((client_part, model_part)) => {
+            let resolved_client = resolve_package_relative_name(client_part, Some(pkg_name));
+            format!("{resolved_client}:{model_part}")
+        }
+        None => resolve_package_relative_name(&model_id, Some(pkg_name)),
+    };
+    config.set_model_id(Some(resolved));
+}
+```
+
+### Client Name Qualification
+
+In `Config::load_package_clients()`, clients are renamed from bare `openai` to `mypkg/openai`:
+
+```rust
+for client in &mut clients {
+    let bare_name = client.effective_name().to_string();
+    if !bare_name.contains('/') {
+        let qualified = format!("{pkg_name}/{bare_name}");
+        client.set_name_and_package(qualified, pkg_name.to_string());
+    }
+}
+```
+
+## Why This Works
+
+- **Call-time vs load-time**: Compaction agent resolution happens at call-time because the active agent context isn't known until runtime. Client/model resolution happens at load-time because the package context is static once the agent is loaded.
+
+- **Shared helper**: Both paths use `resolve_package_relative_name()`, ensuring consistent semantics.
+
+- **Qualified names flow through existing caches**: Once a client is renamed to `mypkg/openai`, it works naturally with `OnceLock`-based global registries (`list_client_names()`, `list_all_models()`) without code changes.
+
+- **Escape syntax**: The leading-slash `/name` pattern provides an explicit way to reference top-level resources when needed.
+
+## Key Patterns Discovered
+
+### OnceLock Caching Hazard
+
+`list_client_names()` and `list_all_models()` in `harnx-client/src/macros.rs` use static `OnceLock` caches:
+
+```rust
+static ALL_CLIENT_NAMES: std::sync::OnceLock<Vec<String>> = OnceLock::new();
+static ALL_MODELS: std::sync::OnceLock<Vec<Model>> = OnceLock::new();
+```
+
+These caches populate on first call and never reset. Tests that need fresh client state must NOT use these functions — instead test directly on `Config.clients` vector:
+
+```rust
+assert!(
+    config.clients.iter().any(|client| client.effective_name() == "mypkg/openai"),
+);
+```
+
+### serde(skip) + jaq Patching
+
+Fields with `#[serde(skip)]` are reset to their `Default` value when config structs are round-tripped through `serde_json` during jaq patching (`apply_client_patch`). The `package` field must be set **after** patching, not before:
+
+```rust
+// Patching happens first
+for client in &mut clients {
+    apply_client_patch(client, &patch.clients);
+}
+// Qualification (which sets package) happens AFTER patching
+for client in &mut clients {
+    client.set_name_and_package(qualified, pkg_name.to_string());
+}
+```
+
+### Macro-generated Enum + Manual impl
+
+`ClientConfig` enum is generated by `register_client!` macro. To add methods that dispatch across all variants, add an explicit `impl ClientConfig` block after the macro invocation:
+
+```rust
+register_client!(OpenAIConfig, ...);
+
+impl ClientConfig {
+    pub fn set_name_and_package(&mut self, name: String, package: String) {
+        match self {
+            ClientConfig::OpenAIConfig(c) => { c.name = Some(name); c.package = Some(package); }
+            // ... other variants
+        }
+    }
+}
+```
+
+### Provider Config Struct Dispersion
+
+Each LLM provider (`openai.rs`, `claude.rs`, etc.) has its own struct in `crates/harnx-core/src/provider_config/`. Adding a field to all 8 requires touching all 8 files, plus any test initializers that construct them manually.
+
+## Prevention Strategies
+
+**Test Cases:**
+- Add integration tests for package-scoped resolution in `tests/package_loading.rs`
+- Test helper function `resolve_package_relative_name()` with all edge cases
+- Test that `compact_session()` resolves compaction agent within package
+- Test that package agent model references are rewritten correctly
+- Avoid `list_client_names()` / `list_all_models()` in tests — assert on `config.clients` directly
+
+**Best Practices:**
+- Use shared `resolve_package_relative_name()` helper for any new package-relative resolution
+- Set `#[serde(skip)]` fields after jaq patching, not before
+- Qualify package resources with `pkg/` prefix at load time to work with `OnceLock` caches
+
+**Code Review Checklist:**
+- [ ] Does the new entity reference need package-relative resolution?
+- [ ] Is resolution happening at the right time (load-time vs call-time)?
+- [ ] Are tests asserting on the right data (avoiding OnceLock caches)?
+
+## Related Issues
+
+- **GitHub Issue:** [#585](https://github.com/example/harnx/issues/585) — Agents in a package should use models/clients defined in that package by default
+- **GitHub Issue:** [#586](https://github.com/example/harnx/issues/586) — Compaction agent references in a packaged agent should resolve within the package by default
+- **Changeset:** `.changesets/package-scoped-resolution.md` — Breaking change documentation with migration guide

--- a/docs/solutions/logic-errors/package-scoped-name-resolution-2026-05-17.md
+++ b/docs/solutions/logic-errors/package-scoped-name-resolution-2026-05-17.md
@@ -210,6 +210,6 @@ Each LLM provider (`openai.rs`, `claude.rs`, etc.) has its own struct in `crates
 
 ## Related Issues
 
-- **GitHub Issue:** [#585](https://github.com/example/harnx/issues/585) — Agents in a package should use models/clients defined in that package by default
-- **GitHub Issue:** [#586](https://github.com/example/harnx/issues/586) — Compaction agent references in a packaged agent should resolve within the package by default
+- **GitHub Issue:** [#585](https://github.com/dobesv/harnx/issues/585) — Agents in a package should use models/clients defined in that package by default
+- **GitHub Issue:** [#586](https://github.com/dobesv/harnx/issues/586) — Compaction agent references in a packaged agent should resolve within the package by default
 - **Changeset:** `.changesets/package-scoped-resolution.md` — Breaking change documentation with migration guide


### PR DESCRIPTION
Resolves bare compaction_agent and model/client references within the package they belong to by default, matching existing MCP/ACP namespacing precedent. Introduces a /name syntax to explicitly escape to the top-level namespace. Cross-package references using pkg/name remain unchanged.

BREAKING CHANGE: Package agents that previously relied on bare names resolving to the top-level must be updated to use the /name syntax.

#585
#586

Plan: harnx-package-namespacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Package-scoped agent/client/model names now correctly resolve to package-local resources (including compaction agents) instead of falling back to top-level resources.

* **Breaking Changes**
  * Migration required: prefix names with `/` to force top-level resolution (e.g., `compaction_agent: /my-global-compactor`, `model: /openai:gpt-4o`).

* **Documentation**
  * Added migration guide and troubleshooting for package-scoped name resolution.

* **Tests**
  * Added comprehensive regression tests covering package loading and name qualification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->