### PR TITLE
fix(client): strip package namespace prefix from env var lookup

### DIFF
--- a/crates/harnx-client/src/claude.rs
+++ b/crates/harnx-client/src/claude.rs
@@ -1179,4 +1179,23 @@ system_prompt_prefix:
         // saturating_add: overflow saturates to u64::MAX rather than panicking
         assert_eq!(add_opt_u64(Some(u64::MAX), Some(1)), Some(u64::MAX));
     }
+
+    /// Package-namespaced clients (e.g. "pantheon/claude") must look up
+    /// CLAUDE_API_KEY, not the invalid PANTHEON/CLAUDE_API_KEY.
+    #[test]
+    fn package_client_uses_bare_name_for_env_var() {
+        let config: ClaudeConfig =
+            serde_yaml::from_str("name: \"pantheon/claude\"").expect("parse config");
+        let client = ClaudeClient {
+            config,
+            model: Model::new("pantheon/claude", "claude-3-5-sonnet"),
+        };
+
+        // Set CLAUDE_API_KEY (bare name, no package prefix).
+        unsafe { std::env::set_var("CLAUDE_API_KEY", "test-key-bare") };
+        let result = client.get_api_key();
+        unsafe { std::env::remove_var("CLAUDE_API_KEY") };
+
+        assert_eq!(result.unwrap(), "test-key-bare");
+    }
 }

--- a/crates/harnx-client/src/macros.rs
+++ b/crates/harnx-client/src/macros.rs
@@ -230,7 +230,13 @@ macro_rules! impl_client_trait {
 macro_rules! config_get_fn {
     ($field_name:ident, $fn_name:ident) => {
         fn $fn_name(&self) -> anyhow::Result<String> {
-            let env_prefix = Self::name(&self.config);
+            let full_name = Self::name(&self.config);
+            // Strip package namespace prefix (e.g. "pantheon/claude" → "claude")
+            // so package clients look for the same env vars as root clients,
+            // e.g. CLAUDE_API_KEY rather than the invalid PANTHEON/CLAUDE_API_KEY.
+            let env_prefix = full_name
+                .rsplit_once('/')
+                .map_or(full_name, |(_, bare)| bare);
             let env_name =
                 format!("{}_{}", env_prefix, stringify!($field_name)).to_ascii_uppercase();
             std::env::var(&env_name)


### PR DESCRIPTION
Package clients get qualified names like "pantheon/claude" which caused config_get_fn! to look up "PANTHEON/CLAUDE_API_KEY" — an illegal env var name that never matches. Strip everything up to and including the last '/' so "pantheon/claude" looks for CLAUDE_API_KEY, same as a root client.

Fixes https://github.com/dobesv/harnx/issues/615

