### PR TITLE
Add ~/.cargo to default exec path for sandbox

### DIFF
--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -516,7 +516,14 @@ impl BashServer {
     /// language version managers, locally-installed binaries).
     #[cfg(unix)]
     #[allow(dead_code)]
-    const HOME_EXEC_PATHS: &[&str] = &[".local/bin", ".local/lib", ".bun", ".asdf", "go/bin"];
+    const HOME_EXEC_PATHS: &[&str] = &[
+        ".local/bin",
+        ".local/lib",
+        ".bun",
+        ".asdf",
+        "go/bin",
+        ".cargo",
+    ];
 
     /// Read+write paths under `$HOME` for caches that hold data but should not
     /// be executable.

--- a/docs/bash-mcp-server.md
+++ b/docs/bash-mcp-server.md
@@ -97,7 +97,7 @@ On Linux and macOS, `harnx-mcp-bash` uses [birdcage](https://github.com/phylum-d
   - The path in the `$TMPDIR` environment variable, if set.
 - **Readable/Executable**:
   - Standard system directories required for bash and common utilities (e.g., `/usr/bin`, `/bin`, `/lib`).
-  - Tool installation directories under `$HOME`: `~/.local/bin`, `~/.local/lib`, `~/.bun`, `~/.asdf`, `~/go/bin`.
+  - Tool installation directories under `$HOME`: `~/.local/bin`, `~/.local/lib`, `~/.bun`, `~/.asdf`, `~/go/bin`, `~/.cargo`.
 - **Readable**:
   - System C/C++ header directories needed by `cc`, `bindgen`, and crates with native build scripts (Linux: `/usr/include`, `/usr/include/x86_64-linux-gnu`).
   - Common config files under `$HOME`: `~/.gitconfig`, `~/.gitignore`, `~/.gitignore_global`, `~/.tool-versions`.


### PR DESCRIPTION
There are some shared libraries in here that rust tools need in order to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the Unix sandbox default allowlist for executable paths to include the `.cargo` directory in `$HOME`, alongside existing tool installation directories such as `.local/bin`, `.bun`, `.asdf`, and `go/bin`.

* **Documentation**
  * Updated the bash MCP server filesystem sandbox documentation to reflect the expanded set of `$HOME`-relative directories granted default execution permissions within the sandbox environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->