### PR TITLE
fix(packages): list individual tools instead of toolset aliases and w…

### DIFF
--- a/.changesets/package-agent-tool-cleanup.md
+++ b/.changesets/package-agent-tool-cleanup.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Package agents (pantheon, coding) now list individual tool names instead of the `fs_read_tools` / `fs_write_tools` toolset aliases (which were only defined in `example_config/config.yaml`) and the `bash_*` wildcard, so they work regardless of the user's own `toolsets:` configuration. Pytheas and Zosimus now explicitly default to the current working directory as the repository under investigation rather than asking the user.

--- a/packages/coding/agents/coder.md
+++ b/packages/coding/agents/coder.md
@@ -8,9 +8,19 @@ model_fallbacks:
 
 use_tools:
   - bash_exec
-  - bash_*
-  - fs_read_tools
-  - fs_write_tools
+  - bash_read_exec_log
+  - bash_spawn
+  - bash_wait
+  - bash_terminate
+  - fs_read
+  - fs_ls
+  - fs_grep
+  - fs_find
+  - fs_write
+  - fs_edit
+  - fs_insert
+  - fs_re_replace
+  - fs_rollback_file
   - fetch_fetch_markdown
   - fetch_fetch_readable
   - exa_web_search_exa
@@ -32,9 +42,10 @@ use_tools:
   - plans_update_note
   - plans_update_plan
   - plans_update_task
+  - time_convert_time
   - time_get_current_time
   - time_wait
-
+  - time_wait_until
 description: >
   Full-stack coding assistant — reads code, writes code, runs tests, searches
   the web for docs, and manages local plans to track multi-step tasks.
@@ -54,7 +65,7 @@ searching for information as needed. You persist until the task is done.
 Before writing code:
 1. **Read `AGENTS.md`** at the repo root (if present) — it contains project-specific rules, validation commands, and conventions for AI agents.
 2. **Read `README.md`** for project overview and structure.
-3. **Explore the relevant code** using `fs_read_tools` before making changes — never modify files you haven't read.
+3. **Explore the relevant code** using `fs_read`, `fs_ls`, `fs_grep`, and `fs_find` before making changes — never modify files you haven't read.
 4. **Search for prior art** using `bash_exec` with `rg` or `sg` (ast-grep) before writing new code.
 
 When implementing:
@@ -65,7 +76,7 @@ When implementing:
 
 ## Tool Usage
 
-**File system**: Use `fs_read_tools` to read, `fs_write_tools` to write. Prefer `fs_edit` for targeted edits over rewriting whole files.
+**File system**: Use `fs_read`, `fs_ls`, `fs_grep`, and `fs_find` to read. Use `fs_write`, `fs_edit`, `fs_insert`, and `fs_re_replace` to modify. Prefer `fs_edit` for targeted edits over rewriting whole files.
 
 **Shell**: Use `bash_exec` for git, tests, linters, package managers, and any CLI operations.
 

--- a/packages/pantheon/README.md
+++ b/packages/pantheon/README.md
@@ -245,7 +245,3 @@ Available fields you can set per server with jq:
 | `.roots += [...]` | Append to the roots list |
 | `.roots` | Replace the roots list entirely |
 
-### Optional / advanced
-
-`tmux_*` and `trigger_agent` tools in `sisyphus.md` are harnx built-ins for
-TUI/tmux workflow features — no separate server config needed.

--- a/packages/pantheon/agents/aeacus.md
+++ b/packages/pantheon/agents/aeacus.md
@@ -4,8 +4,14 @@ model: openai:gpt-5.4
 compaction_agent: compact-reviewer
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - plans_add_note
 - plans_get_note
 - plans_get_plan
@@ -14,7 +20,6 @@ use_tools:
 - plans_list_tasks
 - plans_update_note
 - fs_rollback_file
-
 description: "Pragmatic engineer \u2014 evaluates code review findings through the\
   \ lens of real-world production impact, blast radius, and failure modes. Named after\
   \ Aeacus (EE-uh-kus), keeper of the Underworld's records who ensured completeness.\n"

--- a/packages/pantheon/agents/apollo.md
+++ b/packages/pantheon/agents/apollo.md
@@ -4,9 +4,19 @@ model: gemini:gemini-3.1-pro-preview
 compaction_agent: compact-dev
 use_tools:
 - bash_exec
-- bash_*
-- fs_write_tools
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_write
+- fs_edit
+- fs_insert
+- fs_re_replace
+- fs_rollback_file
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - fetch_fetch_markdown
 - plans_add_note
 - plans_get_note
@@ -17,7 +27,6 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
-
 description: "Creative coding and innovative solutions specialist — provides the creative spark for novel UX and 'out-of-the-box' logic. Named after Apollo (uh-POL-oh), God of the Arts.\n"
 version: '1'
 variables:

--- a/packages/pantheon/agents/argus.md
+++ b/packages/pantheon/agents/argus.md
@@ -3,8 +3,15 @@ role: subagent
 model: gemini:gemini-3-flash-preview
 compaction_agent: compact-argus
 use_tools:
-- bash_*
-- fs_read_tools
+- bash_exec
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - plans_add_note
 - plans_get_note
 - plans_get_plan
@@ -13,7 +20,6 @@ use_tools:
 - plans_list_tasks
 - plans_update_note
 - plans_update_task
-
 description: "Task verification agent — independently verifies work completed by other agents by reading changed files, running tests and diagnostics, and cross-checking claims against actual results. Returns structured PASS/FAIL verdicts with evidence. Named after Argus (AR-gus) Panoptes, the hundred-eyed giant who never slept.\n"
 version: '1'
 variables:

--- a/packages/pantheon/agents/aristarchus.md
+++ b/packages/pantheon/agents/aristarchus.md
@@ -3,13 +3,23 @@ model: openai:gpt-5.4
 compaction_agent: compact-reviewer
 use_tools:
   - aeacus_session_prompt
-  - bash_*
   - bash_exec
+  - bash_read_exec_log
+  - bash_spawn
+  - bash_wait
+  - bash_terminate
   - calliope_session_prompt
   - erato_session_prompt
   - euterpe_session_prompt
-  - fs_read_tools
-  - fs_write_tools
+  - fs_read
+  - fs_ls
+  - fs_grep
+  - fs_find
+  - fs_write
+  - fs_edit
+  - fs_insert
+  - fs_re_replace
+  - fs_rollback_file
   - librarian_session_prompt
   - melpomene_session_prompt
   - minos_session_prompt
@@ -36,7 +46,6 @@ use_tools:
   - thalia_session_prompt
   - tyche_session_prompt
   - urania_session_prompt
-
 description: "Code review coordinator \u2014 orchestrates multi-agent code review\
   \ of pull requests and codebases, aggregating specialist findings into structured\
   \ verdicts. Named after Aristarchus (ar-ih-STAR-kus) of Samothrace, the greatest\

--- a/packages/pantheon/agents/athena.md
+++ b/packages/pantheon/agents/athena.md
@@ -4,9 +4,19 @@ model: bedrock:zai.glm-5
 compaction_agent: compact-dev
 use_tools:
 - bash_exec
-- bash_*
-- fs_write_tools
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_write
+- fs_edit
+- fs_insert
+- fs_re_replace
+- fs_rollback_file
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - fetch_fetch_markdown
 - plans_add_note
 - plans_get_note
@@ -16,7 +26,6 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
-
 description: "Complex multi-faceted strategy and execution specialist — commands the field when a high-effort task is too complex for a specialist. Named after Athena (uh-THEE-nuh), Goddess of Strategic Warfare.\n"
 version: '1'
 variables:

--- a/packages/pantheon/agents/atlas.md
+++ b/packages/pantheon/agents/atlas.md
@@ -7,9 +7,19 @@ model_fallbacks:
 compaction_agent: compact-planner
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
-- fs_write_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
+- fs_write
+- fs_edit
+- fs_insert
+- fs_re_replace
+- fs_rollback_file
 - apollo_session_prompt
 - argus_session_prompt
 - aristarchus_session_prompt
@@ -40,10 +50,11 @@ use_tools:
 - plans_update_task
 - plato_session_prompt
 - pytheas_session_prompt
+- time_convert_time
+- time_get_current_time
 - time_wait
 - time_wait_until
 - zosimus_session_prompt
-
 description: "Plan execution orchestrator \u2014 manages plans and todos in local,\
   \ distributes tasks to Pantheon specialist agents, and shares context via plan notes.\
   \ Verifies every delegation independently. Named after Atlas (AT-lus), the Titan\

--- a/packages/pantheon/agents/calliope.md
+++ b/packages/pantheon/agents/calliope.md
@@ -4,15 +4,20 @@ model: gemini:gemini-3-flash-preview
 compaction_agent: compact-reviewer
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - plans_add_note
 - plans_get_note
 - plans_get_plan
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
-
 description: "Code quality specialist — identifies code smells, DRY violations, complexity issues, naming problems, and SOLID principle adherence. Named after Calliope (kuh-LY-uh-pee), the Muse of epic poetry and eloquence.\n"
 version: '1'
 variables:

--- a/packages/pantheon/agents/clio.md
+++ b/packages/pantheon/agents/clio.md
@@ -4,16 +4,25 @@ model: gemini:gemini-3-flash-preview
 compaction_agent: compact-dev
 use_tools:
 - bash_exec
-- bash_*
-- fs_write_tools
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_write
+- fs_edit
+- fs_insert
+- fs_re_replace
+- fs_rollback_file
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - plans_add_note
 - plans_get_note
 - plans_get_plan
 - plans_list_notes
 - plans_list_tasks
 - plans_update_note
-
 description: |
   Git operations agent — handles commits, squash, rebase, and push. Squashes branches into a single clean commit, rebases on origin/master, and pushes to remote. Named after Clio (KLEE-oh), the Muse of history.
 version: "1"
@@ -33,7 +42,7 @@ variables:
 
 ## Local environment Workflow
 Use `bash_exec` to run local git commands (`git status`, `git add`, `git commit`, `git push`).
-Use `fs_read_tools` or `plans_get_plan` to inspect plan notes for JIRA ticket context when needed.
+Use the filesystem read tools (`fs_read`, `fs_ls`, `fs_grep`, `fs_find`) or `plans_get_plan` to inspect plan notes for JIRA ticket context when needed.
 
 {{repo_docs}}
 

--- a/packages/pantheon/agents/erato.md
+++ b/packages/pantheon/agents/erato.md
@@ -4,15 +4,20 @@ model: gemini:gemini-3-flash-preview
 compaction_agent: compact-reviewer
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - plans_add_note
 - plans_get_note
 - plans_get_plan
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
-
 description: "UI/UX and accessibility specialist — evaluates design system compliance, responsive design, WCAG accessibility, ARIA usage, keyboard navigation, and user experience patterns. Named after Erato (EH-ruh-toh), the Muse of love poetry — ensuring the UI is lovable and accessible to all.\n"
 version: '1'
 variables:

--- a/packages/pantheon/agents/euterpe.md
+++ b/packages/pantheon/agents/euterpe.md
@@ -4,15 +4,20 @@ model: gemini:gemini-3-flash-preview
 compaction_agent: compact-reviewer
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - plans_add_note
 - plans_get_note
 - plans_get_plan
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
-
 description: "Coding conventions specialist — validates adherence to project patterns, naming conventions, file organization, import ordering, type safety, and documentation standards. Named after Euterpe (yoo-TUR-pee), the Muse of music and harmony.\n"
 version: '1'
 variables:

--- a/packages/pantheon/agents/hephaestus.md
+++ b/packages/pantheon/agents/hephaestus.md
@@ -4,9 +4,19 @@ model: openai:gpt-5.4
 compaction_agent: compact-dev
 use_tools:
 - bash_exec
-- bash_*
-- fs_write_tools
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_write
+- fs_edit
+- fs_insert
+- fs_re_replace
+- fs_rollback_file
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - fetch_fetch_markdown
 - plans_add_note
 - plans_get_note
@@ -16,7 +26,6 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
-
 description: "Deep work and complex refactoring specialist — grinds through autonomous, heavy-duty problem-solving at the forge. Named after Hephaestus (heh-FES-tus), the Divine Blacksmith.\n"
 version: '1'
 variables:

--- a/packages/pantheon/agents/hermes.md
+++ b/packages/pantheon/agents/hermes.md
@@ -4,9 +4,19 @@ model: bedrock:zai.glm-5
 compaction_agent: compact-dev
 use_tools:
 - bash_exec
-- bash_*
-- fs_write_tools
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_write
+- fs_edit
+- fs_insert
+- fs_re_replace
+- fs_rollback_file
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - fetch_fetch_markdown
 - plans_add_note
 - plans_get_note
@@ -16,7 +26,6 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
-
 description: "Quick tasks and minor bugs specialist — handles the small, fast, 'blink-and-you-miss-it' fixes with rapid turnaround. Named after Hermes (HER-meez), the Winged Messenger.\n"
 version: '1'
 variables:

--- a/packages/pantheon/agents/hestia.md
+++ b/packages/pantheon/agents/hestia.md
@@ -4,9 +4,19 @@ model: bedrock:zai.glm-5
 compaction_agent: compact-dev
 use_tools:
 - bash_exec
-- bash_*
-- fs_write_tools
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_write
+- fs_edit
+- fs_insert
+- fs_re_replace
+- fs_rollback_file
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - fetch_fetch_markdown
 - plans_add_note
 - plans_get_note
@@ -16,7 +26,6 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
-
 description: "Maintenance, stability, and routine tasks specialist — keeps the codebase warm, clean, and stable for day-to-day operations. Named after Hestia (HES-tee-uh), Guardian of the Hearth.\n"
 version: '1'
 variables:

--- a/packages/pantheon/agents/iris.md
+++ b/packages/pantheon/agents/iris.md
@@ -4,9 +4,19 @@ model: gemini:gemini-3.1-pro-preview
 compaction_agent: compact-dev
 use_tools:
 - bash_exec
-- bash_*
-- fs_write_tools
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_write
+- fs_edit
+- fs_insert
+- fs_re_replace
+- fs_rollback_file
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - fetch_fetch_markdown
 - plans_add_note
 - plans_get_note
@@ -16,7 +26,6 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
-
 description: "Visual engineering, frontend, and UI/UX specialist — bridges the gap between the invisible code and the visible UI. Named after Iris (EYE-ris), Goddess of the Rainbow.\n"
 version: '1'
 variables:

--- a/packages/pantheon/agents/melpomene.md
+++ b/packages/pantheon/agents/melpomene.md
@@ -4,8 +4,14 @@ model: openai:gpt-5.4
 compaction_agent: compact-reviewer
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - librarian_session_prompt
 - oracle_session_prompt
 - plans_add_note
@@ -14,7 +20,6 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
-
 description: "Security vulnerability specialist \u2014 identifies injection risks,\
   \ authentication flaws, authorization gaps, secrets exposure, input validation issues,\
   \ and supply chain risks. Named after Melpomene (mel-POM-uh-nee), the Muse of tragedy\

--- a/packages/pantheon/agents/metis.md
+++ b/packages/pantheon/agents/metis.md
@@ -4,12 +4,17 @@ model: bedrock:zai.glm-5
 compaction_agent: compact-planner
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - librarian_session_prompt
 - pytheas_session_prompt
 - fs_rollback_file
-
 description: "Pre-planning consultant \u2014 analyzes user requests before Daedalus\
   \ generates plans, identifying hidden intentions, ambiguities, and AI failure points.\
   \ Produces directives that guide the planner. Named after Metis (MEE-tis), the Greek\

--- a/packages/pantheon/agents/minos.md
+++ b/packages/pantheon/agents/minos.md
@@ -4,15 +4,20 @@ model: gemini:gemini-3.1-pro-preview
 compaction_agent: compact-reviewer
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - plans_add_note
 - plans_get_note
 - plans_get_plan
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
-
 description: "Methodical auditor \u2014 systematically verifies code review findings\
   \ by tracing evidence chains, checking cited code, and rendering verdicts. Named\
   \ after Minos (MY-nos), judge of the Underworld who weighed the deeds of the deceased.\n"

--- a/packages/pantheon/agents/mnemosyne.md
+++ b/packages/pantheon/agents/mnemosyne.md
@@ -4,16 +4,25 @@ model: bedrock:zai.glm-5
 compaction_agent: compact-mnemosyne
 use_tools:
 - bash_exec
-- bash_*
-- fs_write_tools
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_write
+- fs_edit
+- fs_insert
+- fs_re_replace
+- fs_rollback_file
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - plans_add_note
 - plans_get_note
 - plans_get_plan
 - plans_list_notes
 - plans_update_note
 - time_get_current_time
-
 description: "Knowledge compounding specialist \u2014 captures learnings, decisions,\
   \ and solutions from completed tasks into structured docs/solutions/ entries for\
   \ future reference. Named after Mnemosyne (neh-MOZ-ih-nee), Titan of Memory and\

--- a/packages/pantheon/agents/momus.md
+++ b/packages/pantheon/agents/momus.md
@@ -4,8 +4,14 @@ model: openai:gpt-5.4
 compaction_agent: compact-planner
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - plans_get_note
 - plans_get_plan
 - plans_get_task
@@ -14,7 +20,6 @@ use_tools:
 - plans_list_tasks
 - plans_update_note
 - fs_rollback_file
-
 description: "Plan reviewer \u2014 verifies that implementation plans are executable\
   \ and that file references are valid. Named after Momus (MOH-mus), the Greek god\
   \ of satire and criticism who found fault in everything.\n"

--- a/packages/pantheon/agents/nemesis.md
+++ b/packages/pantheon/agents/nemesis.md
@@ -4,15 +4,20 @@ model: bedrock:zai.glm-5
 compaction_agent: compact-reliability
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - plans_add_note
 - plans_get_note
 - plans_get_plan
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
-
 description: "Reliability specialist \u2014 reviews error handling, retry logic, circuit\
   \ breakers, timeouts, health checks, graceful degradation, and async handler safety.\
   \ Named after Nemesis (NEM-uh-sis), goddess of retribution who ensures hubris does\

--- a/packages/pantheon/agents/peitho.md
+++ b/packages/pantheon/agents/peitho.md
@@ -4,9 +4,19 @@ model: gemini:gemini-3-flash-preview
 compaction_agent: compact-dev
 use_tools:
 - bash_exec
-- bash_*
-- fs_write_tools
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_write
+- fs_edit
+- fs_insert
+- fs_re_replace
+- fs_rollback_file
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - fetch_fetch_markdown
 - plans_add_note
 - plans_get_note
@@ -16,7 +26,6 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
-
 description: "Peitho (PY-thoh) - Goddess of Persuasion. She turns technical jargon into eloquent, human-readable documentation. Specialist in documentation, release notes, and user communication.\n"
 version: '1'
 variables:

--- a/packages/pantheon/agents/plato.md
+++ b/packages/pantheon/agents/plato.md
@@ -4,9 +4,19 @@ model: openai:gpt-5.4
 compaction_agent: compact-dev
 use_tools:
 - bash_exec
-- bash_*
-- fs_write_tools
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_write
+- fs_edit
+- fs_insert
+- fs_re_replace
+- fs_rollback_file
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - fetch_fetch_markdown
 - plans_add_note
 - plans_get_note
@@ -16,7 +26,6 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
-
 description: "High-level system design and architecture specialist — designs the perfect architecture that other agents try to replicate. Named after Plato (PLAY-toh), the Master of Ideal Forms.\n"
 version: '1'
 variables:

--- a/packages/pantheon/agents/polyhymnia.md
+++ b/packages/pantheon/agents/polyhymnia.md
@@ -4,8 +4,14 @@ model: openai:gpt-5.4
 compaction_agent: compact-reviewer
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - librarian_session_prompt
 - plans_add_note
 - plans_get_note
@@ -13,7 +19,6 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
-
 description: "Privacy and compliance specialist \u2014 evaluates PII handling, data\
   \ protection patterns, consent flows, data retention, logging practices, and regulatory\
   \ compliance. Named after Polyhymnia (pol-ee-HIM-nee-uh), the Muse of sacred poetry\

--- a/packages/pantheon/agents/pytheas.md
+++ b/packages/pantheon/agents/pytheas.md
@@ -3,8 +3,14 @@ model: gemini:gemini-3-flash-preview
 compaction_agent: compact-researcher
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - fetch_fetch_markdown
 - grep_grep_query
 - plans_add_note
@@ -15,7 +21,6 @@ use_tools:
 - plans_list_tasks
 - plans_update_note
 - fs_rollback_file
-
 description: "Reconnaissance and research agent — explores codebases, fetches GitHub PR/issue context (Jira and GitHub Issues), and caches findings as plan notes for other agents. Performs fast code analysis using ripgrep, ast-grep, and file inspection. Named after Pytheas (pih-THEE-us) of Massalia, the Greek explorer who sailed beyond the known world.\n"
 version: '1'
 variables:
@@ -47,10 +52,10 @@ variables:
 
 ## Local environment Workflow
 
-You work locally using `fs_read_tools`, and `bash_exec` directly — no sandbox creation needed.
+You work locally using the filesystem read tools (`fs_read`, `fs_ls`, `fs_grep`, `fs_find`) and `bash_exec` directly. Assume the repository under investigation is the current working directory unless the user names a different path.
 
 1. **Read documentation**: Check for `AGENTS.md` and `README.md` in the repository root.
-2. **Explore the codebase**: Use `fs_read_tools` to map file structure, search patterns, and read file contents.
+2. **Explore the codebase**: Use `fs_ls`, `fs_find`, `fs_grep`, and `fs_read` to map file structure, search patterns, and read file contents.
 3. **Search code structurally**: Use `bash_exec` with `rg` for text search and `sg` (ast-grep) for structural code search.
 4. **Cache findings**: If a plan ID is provided, save key findings as plan notes via `plans_add_note`.
 5. **GitHub/Jira research**: Use `fetch_fetch_markdown` or web search tools to fetch PR data, issue context, and commit history.

--- a/packages/pantheon/agents/rhadamanthus.md
+++ b/packages/pantheon/agents/rhadamanthus.md
@@ -4,15 +4,20 @@ model: bedrock:zai.glm-5
 compaction_agent: compact-reviewer
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - plans_add_note
 - plans_get_note
 - plans_get_plan
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
-
 description: "Skeptical investigator \u2014 pressure-tests code review findings by\
   \ challenging assumptions, searching for mitigating factors, and catching false\
   \ positives. Named after Rhadamanthus (rad-uh-MAN-thus), the strictest judge of\

--- a/packages/pantheon/agents/shared/atlas.md
+++ b/packages/pantheon/agents/shared/atlas.md
@@ -349,11 +349,10 @@ When all tasks are done, provide a structured completion report:
 </rules>
 
 <instructions>
-## Default Repositories
+## Default Repository
 
-When the user or Daedalus does not specify a repository, ask them which repository to work in before proceeding.
+Assume the repository to work in is the current working directory. Do not scan parent directories, sibling paths, or other filesystem locations looking for a repo. Only switch to a different path if the user or Daedalus explicitly names one.
 
 All git operations should be performed using standard Bash commands.
 
-Do NOT guess repository names. If the user refers to a repository that is not one of the defaults
-and you are unsure, ask for the repository name or URL. Checking out the wrong repository wastes time.
+If the user names a repository you do not recognize and you are unsure how it relates to the current working directory, ask for the repository name or URL. Checking out the wrong repository wastes time.

--- a/packages/pantheon/agents/shared/metis.md
+++ b/packages/pantheon/agents/shared/metis.md
@@ -220,9 +220,9 @@ Rationale: [1-2 sentences explaining the classification]
 </rules>
 
 <instructions>
-## Default Repositories
+## Default Repository
 
-When the user or Daedalus does not specify a repository, ask them which repository to work in before proceeding.
+Assume the repository to work in is the current working directory. Do not scan parent directories, sibling paths, or other filesystem locations looking for a repo. Only switch to a different path if the user or Daedalus explicitly names one.
 
 ## Repository Documentation Discovery
 

--- a/packages/pantheon/agents/shared/pytheas.md
+++ b/packages/pantheon/agents/shared/pytheas.md
@@ -111,9 +111,9 @@ When a plan name (ID) is provided, cache findings as plan notes. Use descriptive
 
 Before adding notes, check existing notes first to avoid duplicating what's already cached.
 
-## Default Repositories
+## Default Repository
 
-Ask the user which repository to investigate when not specified.
+Assume the repository under investigation is the current working directory. Do not scan parent directories, sibling paths, or other filesystem locations looking for a repo. Only investigate a different path if the user explicitly names one.
 
 ## Output Format
 

--- a/packages/pantheon/agents/shared/sisyphus-default-repos.md
+++ b/packages/pantheon/agents/shared/sisyphus-default-repos.md
@@ -1,1 +1,1 @@
-When the user does not specify a repository, ask them which repository to work in before proceeding.
+Assume the repository to work in is the current working directory. Do not scan parent directories, sibling paths, or other filesystem locations looking for a repo. Only switch to a different path if the user explicitly names one.

--- a/packages/pantheon/agents/sisyphus.md
+++ b/packages/pantheon/agents/sisyphus.md
@@ -7,9 +7,19 @@ model_fallbacks:
 - openai:gpt-5.5
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
-- fs_write_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
+- fs_write
+- fs_edit
+- fs_insert
+- fs_re_replace
+- fs_rollback_file
 - apollo_session_prompt
 - argus_session_prompt
 - aristarchus_session_prompt
@@ -40,12 +50,11 @@ use_tools:
 - plans_update_task
 - plato_session_prompt
 - pytheas_session_prompt
+- time_convert_time
+- time_get_current_time
 - time_wait
 - time_wait_until
-- trigger_agent
-- tmux_*
 - zosimus_session_prompt
-
 description: "Task executor \u2014 handles tasks from users. For complex work,\
   \ creates local plans and executes them directly or delegates to Pantheon specialists.\
   \ Writes code directly in the project directory. Named after Sisyphus (SIS-ih-fus).\n"

--- a/packages/pantheon/agents/terpsichore.md
+++ b/packages/pantheon/agents/terpsichore.md
@@ -4,15 +4,20 @@ model: gemini:gemini-3-flash-preview
 compaction_agent: compact-reviewer
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - plans_add_note
 - plans_get_note
 - plans_get_plan
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
-
 description: "Refactoring and completeness specialist — identifies missed simplification opportunities, partial fixes, incomplete implementations, and unaddressed edge cases. Named after Terpsichore (turp-SIK-uh-ree), the Muse of dance — ensuring code moves elegantly.\n"
 version: '1'
 variables:

--- a/packages/pantheon/agents/thalia.md
+++ b/packages/pantheon/agents/thalia.md
@@ -4,15 +4,20 @@ model: gemini:gemini-3-flash-preview
 compaction_agent: compact-reviewer
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - plans_add_note
 - plans_get_note
 - plans_get_plan
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
-
 description: "Testing adequacy specialist — evaluates test coverage, edge case handling, assertion quality, test isolation, and identifies untested code paths. Named after Thalia (thuh-LY-uh), the Muse of comedy — finding what's absurdly untested.\n"
 version: '1'
 variables:

--- a/packages/pantheon/agents/tyche.md
+++ b/packages/pantheon/agents/tyche.md
@@ -4,15 +4,20 @@ model: bedrock:zai.glm-5
 compaction_agent: compact-deploy
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - plans_add_note
 - plans_get_note
 - plans_get_plan
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
-
 description: "Deployment verification specialist \u2014 produces Go/No-Go deployment\
   \ checklists with pre-deployment checks, migration verification, rollback procedures,\
   \ and monitoring plans. Named after Tyche (TY-kee), goddess of fortune who determines\

--- a/packages/pantheon/agents/urania.md
+++ b/packages/pantheon/agents/urania.md
@@ -4,8 +4,14 @@ model: bedrock:zai.glm-5
 compaction_agent: compact-reviewer
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - oracle_session_prompt
 - plans_add_note
 - plans_get_note
@@ -14,7 +20,6 @@ use_tools:
 - plans_update_note
 - pytheas_session_prompt
 - fs_rollback_file
-
 description: "Architecture and big picture specialist \u2014 evaluates cross-cutting\
   \ concerns, dependency direction, design pattern adherence, API contract consistency,\
   \ and system-wide impact. Named after Urania (yoo-RAY-nee-uh), the Muse of astronomy\

--- a/packages/pantheon/agents/zosimus.md
+++ b/packages/pantheon/agents/zosimus.md
@@ -4,8 +4,14 @@ model: openai:gpt-5.5
 compaction_agent: compact-researcher
 use_tools:
 - bash_exec
-- bash_*
-- fs_read_tools
+- bash_read_exec_log
+- bash_spawn
+- bash_wait
+- bash_terminate
+- fs_read
+- fs_ls
+- fs_grep
+- fs_find
 - fetch_fetch_markdown
 - grep_grep_query
 - plans_add_note
@@ -15,7 +21,6 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
-
 description: "Deep investigation agent — performs multi-step code analysis, reproduces bugs, validates hypotheses, and caches findings as plan notes for other agents. Executes targeted diagnostics and probe scripts without modifying repository source files. Named after Zosimus, the careful investigator.\n"
 version: '1'
 variables:
@@ -47,10 +52,10 @@ variables:
 
 ## Local environment Workflow
 
-You work locally using `fs_read_tools`, and `bash_exec` directly — no sandbox creation needed.
+You work locally using the filesystem read tools (`fs_read`, `fs_ls`, `fs_grep`, `fs_find`) and `bash_exec` directly. Assume the repository under investigation is the current working directory unless the user names a different path.
 
 1. **Read documentation**: Check for `AGENTS.md`, `README.md`, and local docs in area under investigation.
-2. **Map the codebase**: Use `fs_read_tools` to identify relevant paths and behaviors.
+2. **Map the codebase**: Use `fs_ls`, `fs_find`, `fs_grep`, and `fs_read` to identify relevant paths and behaviors.
 3. **Search deeply**: Use `bash_exec` with `rg` for text search and `sg` (ast-grep) for structural analysis.
 4. **Run investigations**: Execute diagnostics, tests, and minimal reproductions with `bash_exec`.
 5. **Write probe scripts when needed**: Use `bash_exec` with heredocs or write to `/tmp` — temporary scripts are allowed for investigation, but must not modify repository files.


### PR DESCRIPTION
…ildcards in package agents

Package agents now reference real tool names directly so they work regardless of the user's own `toolsets:` config. `fs_read_tools`/`fs_write_tools` (only defined in example_config) and the `bash_*` server wildcard are expanded; redundant `bash_exec` entries and unregistered `tmux_*`/`trigger_agent` references are removed. Pytheas, Zosimus, Sisyphus, Atlas, and Metis now treat the current working directory as the repository under investigation by default instead of asking the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Configuration & Documentation**
  * Updated agent tool permissions to use explicit tool listings for improved clarity and control.
  * Refined documentation to reflect updated tool naming conventions across agent guides.

* **Default Behavior**
  * Agent repository operations now default to the current working directory, eliminating the need for manual repository specification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->