### PR TITLE
Relocate .env files to XDG data directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,6 +3690,7 @@ dependencies = [
  "birdcage",
  "fancy-regex 0.18.0",
  "gix",
+ "harnx-core",
  "harnx-mcp",
  "harnx-mcp-history",
  "libc",

--- a/crates/harnx-core/src/config_paths.rs
+++ b/crates/harnx-core/src/config_paths.rs
@@ -28,6 +28,9 @@ pub const PACKAGE_METADATA_FILE_NAME: &str = "package.yaml";
 /// Shell env file loaded by `load_env_file`, relative to the config dir.
 pub const ENV_FILE_NAME: &str = ".env";
 
+/// Bash env file loaded by the bash MCP server.
+pub const BASH_ENV_FILE_NAME: &str = ".env.bash";
+
 /// Default name for the persisted "last messages" file.
 pub const MESSAGES_FILE_NAME: &str = "messages.md";
 
@@ -227,7 +230,15 @@ pub fn macro_file(name: &str) -> PathBuf {
 pub fn env_file() -> PathBuf {
     match env::var(get_env_name("env_file")) {
         Ok(value) if !value.is_empty() => PathBuf::from(value),
-        _ => local_path(ENV_FILE_NAME),
+        _ => data_path(ENV_FILE_NAME),
+    }
+}
+
+/// Path to the `.env.bash` file loaded by the bash MCP server. Overridable via `HARNX_BASH_ENV_FILE`.
+pub fn bash_env_file() -> PathBuf {
+    match env::var(get_env_name("bash_env_file")) {
+        Ok(value) if !value.is_empty() => PathBuf::from(value),
+        _ => data_path(BASH_ENV_FILE_NAME),
     }
 }
 
@@ -719,6 +730,76 @@ mod tests {
             got.ends_with("packages/mypkg.patch.yaml"),
             "package_patch_file('mypkg') should end with 'packages/mypkg.patch.yaml', got: {}",
             got.display()
+        );
+    }
+
+    #[test]
+    fn env_file_default_returns_data_dir_env() {
+        let test_dir = "/tmp/harnx_env_file_test_a1b2";
+        let got = with_envs(
+            &[("HARNX_ENV_FILE", None), ("HARNX_DATA_DIR", Some(test_dir))],
+            env_file,
+        );
+        assert_eq!(
+            got,
+            PathBuf::from(test_dir).join(".env"),
+            "env_file() should return data_dir().join('.env') when HARNX_ENV_FILE unset"
+        );
+    }
+
+    #[test]
+    fn env_file_override_works() {
+        let test_path = "/tmp/custom_env_file_c3d4";
+        let got = with_env("HARNX_ENV_FILE", test_path, env_file);
+        assert_eq!(
+            got,
+            PathBuf::from(test_path),
+            "env_file() should return the HARNX_ENV_FILE override"
+        );
+    }
+
+    #[test]
+    fn bash_env_file_default_returns_data_dir_env_bash() {
+        let test_dir = "/tmp/harnx_bash_env_file_test_e5f6";
+        let got = with_envs(
+            &[
+                ("HARNX_BASH_ENV_FILE", None),
+                ("HARNX_DATA_DIR", Some(test_dir)),
+            ],
+            bash_env_file,
+        );
+        assert_eq!(
+            got,
+            PathBuf::from(test_dir).join(".env.bash"),
+            "bash_env_file() should return data_dir().join('.env.bash') when unset"
+        );
+    }
+
+    #[test]
+    fn bash_env_file_override_works() {
+        let test_path = "/tmp/custom_bash_env_file_g7h8";
+        let got = with_env("HARNX_BASH_ENV_FILE", test_path, bash_env_file);
+        assert_eq!(
+            got,
+            PathBuf::from(test_path),
+            "bash_env_file() should return the HARNX_BASH_ENV_FILE override"
+        );
+    }
+
+    #[test]
+    fn bash_env_file_empty_falls_back_to_default() {
+        let test_dir = "/tmp/harnx_bash_env_empty_test_i9j0";
+        let got = with_envs(
+            &[
+                ("HARNX_BASH_ENV_FILE", Some("")),
+                ("HARNX_DATA_DIR", Some(test_dir)),
+            ],
+            bash_env_file,
+        );
+        assert_eq!(
+            got,
+            PathBuf::from(test_dir).join(".env.bash"),
+            "empty HARNX_BASH_ENV_FILE should fall back to default"
         );
     }
 }

--- a/crates/harnx-mcp-bash/Cargo.toml
+++ b/crates/harnx-mcp-bash/Cargo.toml
@@ -11,6 +11,7 @@ description = "MCP server that exposes bash/subprocess execution with safety gua
 anyhow = { workspace = true }
 fancy-regex = { workspace = true }
 gix = { workspace = true }
+harnx-core = { path = "../harnx-core" }
 harnx-mcp = { path = "../harnx-mcp" }
 harnx-mcp-history = { workspace = true }
 libc = { workspace = true }

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -2377,24 +2377,15 @@ fn parse_validated_path_list(
 }
 
 fn load_bash_env_file() -> Vec<(String, String)> {
-    fn bash_config_dir() -> PathBuf {
-        if let Ok(v) = std::env::var("HARNX_CONFIG_DIR") {
-            return PathBuf::from(v);
-        }
-        if let Ok(v) = std::env::var("XDG_CONFIG_HOME") {
-            return PathBuf::from(v).join("harnx");
-        }
-        if let Ok(home) = std::env::var("HOME") {
-            return PathBuf::from(home).join(".config/harnx");
-        }
-        PathBuf::from(".config/harnx")
-    }
-
-    let env_file = bash_config_dir().join(".env.bash");
-    let Ok(contents) = std::fs::read_to_string(env_file) else {
+    let env_file = harnx_core::config_paths::bash_env_file();
+    let Ok(contents) = std::fs::read_to_string(&env_file) else {
         return vec![];
     };
-
+    #[cfg(unix)]
+    {
+        use std::os::unix::prelude::PermissionsExt;
+        let _ = std::fs::set_permissions(&env_file, std::fs::Permissions::from_mode(0o600));
+    }
     contents
         .lines()
         .filter_map(|line| {
@@ -3338,8 +3329,9 @@ mod tests {
 
         // .env.bash overrides NO_COLOR.
         let temp_dir = TestDir::new();
-        std::fs::write(temp_dir.path().join(".env.bash"), "NO_COLOR=0\n").unwrap();
-        let _config_dir = EnvVar::set("HARNX_CONFIG_DIR", temp_dir.path().as_os_str());
+        let env_file_path = temp_dir.path().join(".env.bash");
+        std::fs::write(&env_file_path, "NO_COLOR=0\n").unwrap();
+        let _bash_env_file = EnvVar::set("HARNX_BASH_ENV_FILE", env_file_path.as_os_str());
 
         // env_overrides wins for GIT_PAGER.
         let mut cfg = enabled_sandbox_config();
@@ -3383,12 +3375,9 @@ mod tests {
 
         // Point dotfile at a tempdir whose .env.bash sets a different value.
         let temp_dir = TestDir::new();
-        std::fs::write(
-            temp_dir.path().join(".env.bash"),
-            "HARNX_TEST_PRECEDENCE_VAR=from_dotfile\n",
-        )
-        .unwrap();
-        let _config_dir = EnvVar::set("HARNX_CONFIG_DIR", temp_dir.path().as_os_str());
+        let env_file_path = temp_dir.path().join(".env.bash");
+        std::fs::write(&env_file_path, "HARNX_TEST_PRECEDENCE_VAR=from_dotfile\n").unwrap();
+        let _bash_env_file = EnvVar::set("HARNX_BASH_ENV_FILE", env_file_path.as_os_str());
 
         // Case 1: dotfile only (no passthrough, no override).
         // Expect dotfile value to win over (absent) default allowlist value.
@@ -3427,12 +3416,13 @@ mod tests {
     fn env_bash_dotfile_loaded() {
         let _env_guard = env_lock();
         let temp_dir = TestDir::new();
+        let env_file_path = temp_dir.path().join(".env.bash");
         std::fs::write(
-            temp_dir.path().join(".env.bash"),
+            &env_file_path,
             "# comment line\n\nHARNX_TEST_INJECT_4_3=s3cr3t\nHARNX_TEST_INJECT_KV_4_3=a=b\n",
         )
         .unwrap();
-        let _config_dir = EnvVar::set("HARNX_CONFIG_DIR", temp_dir.path().as_os_str());
+        let _bash_env_file = EnvVar::set("HARNX_BASH_ENV_FILE", env_file_path.as_os_str());
 
         let env_vars = load_bash_env_file();
 

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -3550,14 +3550,22 @@ pub fn load_env_file() -> Result<()> {
         Err(_) => return Ok(()),
     };
     debug!("Use env file '{}'", env_file_path.display());
+    #[cfg(unix)]
+    {
+        use std::os::unix::prelude::PermissionsExt;
+        let _ = std::fs::set_permissions(&env_file_path, std::fs::Permissions::from_mode(0o600));
+    }
     for line in contents.lines() {
         let line = line.trim();
         if line.starts_with('#') || line.is_empty() {
             continue;
         }
         if let Some((key, value)) = line.split_once('=') {
-            unsafe {
-                env::set_var(key.trim(), value.trim());
+            let key = key.trim();
+            if !key.is_empty() {
+                unsafe {
+                    env::set_var(key, value.trim());
+                }
             }
         }
     }

--- a/docs/bash-mcp-server.md
+++ b/docs/bash-mcp-server.md
@@ -59,13 +59,13 @@ env:
 
 ### 3. Dotfile (`.env.bash`)
 
-You can create a `.env.bash` file in your Harnx configuration directory (typically `~/.config/harnx/.env.bash`). This file uses a plain `KEY=VALUE` format.
+You can create a `.env.bash` file in your Harnx data directory (typically `~/.local/share/harnx/.env.bash`). This path is overridable via the `HARNX_BASH_ENV_FILE` environment variable. This file uses a plain `KEY=VALUE` format.
 
 - `#` comments and blank lines are ignored.
 - The first `=` separates the key from the value (e.g., `KEY=a=b` produces value `a=b`).
 - No shell substitution is performed.
 
-**Example `~/.config/harnx/.env.bash`:**
+**Example `~/.local/share/harnx/.env.bash`:**
 
 ```text
 # GitHub Token
@@ -163,7 +163,7 @@ Pass `GH_TOKEN` or `GITHUB_TOKEN`:
 args: ["-e", "GITHUB_TOKEN"]
 ```
 
-Alternatively, you can persist these in `~/.config/harnx/.env.bash`.
+Alternatively, you can persist these in `~/.local/share/harnx/.env.bash`.
 
 #### Non-interactive Editor
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -2,7 +2,7 @@
 
 ## Env file
 
-Harnx can load environment variables from a `.env` file located in the configuration directory: `<harnx-config-dir>/.env`.
+Harnx can load environment variables from a `.env` file located in the data directory: `~/.local/share/harnx/.env`.
 
 ## Config-Related Envs
 
@@ -41,7 +41,8 @@ Harnx can load environment variables from a `.env` file located in the configura
 ## Files/Dirs Envs
 
 - **HARNX_CONFIG_DIR**: The directory for configuration files.
-- **HARNX_ENV_FILE**: The path to the environment file.
+- **HARNX_ENV_FILE**: Path to the `.env` credentials file. Defaults to `~/.local/share/harnx/.env`.
+- **HARNX_BASH_ENV_FILE**: Path to the `.env.bash` credentials file used by the bash MCP server. Defaults to `~/.local/share/harnx/.env.bash`.
 - **HARNX_CONFIG_FILE**: The path to the configuration file.
 - **HARNX_SESSIONS_DIR**: The directory for sessions.
 - **HARNX_RAGS_DIR**: The directory for RAG data.

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -350,21 +350,21 @@ Add your Atlassian credentials to the harnx `.env` file so they are available ev
 
 **Linux** (libsecret / `secret-tool`):
 ```sh
-echo "ATLASSIAN_API_TOKEN=$(secret-tool search service acli 2>/dev/null | awk '/^secret/{print $3}')" >> ~/.config/harnx/.env
-echo "ATLASSIAN_EMAIL=<your-email@example.com>" >> ~/.config/harnx/.env
+echo "ATLASSIAN_API_TOKEN=$(secret-tool search service acli 2>/dev/null | awk '/^secret/{print $3}')" >> ~/.local/share/harnx/.env
+echo "ATLASSIAN_EMAIL=<your-email@example.com>" >> ~/.local/share/harnx/.env
 ```
 
 **macOS** (Keychain / `security`):
 ```sh
-echo "ATLASSIAN_API_TOKEN=$(security find-generic-password -s acli -w)" >> ~/.config/harnx/.env
-echo "ATLASSIAN_EMAIL=<your-email@example.com>" >> ~/.config/harnx/.env
+echo "ATLASSIAN_API_TOKEN=$(security find-generic-password -s acli -w)" >> ~/.local/share/harnx/.env
+echo "ATLASSIAN_EMAIL=<your-email@example.com>" >> ~/.local/share/harnx/.env
 ```
 
 Or set them manually if you prefer:
 
 ```sh
-echo "ATLASSIAN_API_TOKEN=<your-real-api-token>" >> ~/.config/harnx/.env
-echo "ATLASSIAN_EMAIL=<your-email@example.com>" >> ~/.config/harnx/.env
+echo "ATLASSIAN_API_TOKEN=<your-real-api-token>" >> ~/.local/share/harnx/.env
+echo "ATLASSIAN_EMAIL=<your-email@example.com>" >> ~/.local/share/harnx/.env
 ```
 
 The harnx `.env` file uses plain `KEY=value` lines (no `export`). See [Environment Variables](environment-variables.md) for details.

--- a/docs/solutions/security-issues/credential-env-file-data-dir-relocation-2026-05-24.md
+++ b/docs/solutions/security-issues/credential-env-file-data-dir-relocation-2026-05-24.md
@@ -1,0 +1,179 @@
+---
+title: "Credential Env Files Relocated to XDG Data Directory"
+date: 2026-05-24
+category: security-issues
+problem_type: security_issue
+component: config-paths
+root_cause: "sensitive credential files stored in XDG config dir accessible to MCP servers"
+resolution_type: code_fix
+severity: medium
+tags:
+  - credentials
+  - xdg
+  - security
+  - permissions
+  - env-files
+plan_ref: "relocate-credential-env-files"
+---
+
+## Problem
+
+Credential env files (`.env`, `.env.bash`) were stored in the XDG config directory (`~/.config/harnx/`), making API keys accessible to agents with config-dir MCP server access. Agents could read `.env` files through config directory file access.
+
+## Symptoms
+
+- API keys stored in `~/.config/harnx/.env` and `~/.config/harnx/.env.bash`
+- Agents with MCP servers that have config directory access could read credential files
+- No permission enforcement on credential file access
+- Bash MCP server had duplicated XDG resolution logic for `.env.bash` path
+
+## Investigation Steps
+
+1. Reviewed prior art in `docs/solutions/logic-errors/xdg-directory-separation-2026-05-03.md` — established XDG data dir pattern for runtime data
+2. Identified credential files as security-sensitive data, not user-authored config
+3. Checked existing permission enforcement patterns in harnx-runtime — found silent `let _ =` pattern at line 3666
+4. Traced bash MCP server's `.env.bash` loading — found inline `bash_config_dir()` resolution logic
+5. Injected `KEY=value` parsing in `load_env_file()` — discovered panic on malformed `=VALUE` lines with empty key
+
+## Root Cause
+
+1. **Wrong directory**: Credential files were placed in `~/.config/harnx/` (XDG config dir) alongside user-authored config files. MCP servers with config-dir access could read these files.
+
+2. **Duplicated logic**: Bash MCP server had its own `bash_config_dir()` function for `.env.bash` resolution instead of using centralized `harnx-core::config_paths`.
+
+3. **No permission enforcement**: Credential files had no explicit `0600` permission enforcement, relying on user's umask.
+
+4. **Panic on malformed .env**: `load_env_file()` passed empty key to `env::set_var()` on lines like `=VALUE`, causing panic.
+
+## Solution
+
+### 1. Relocated credential files to XDG data directory
+
+Changed `env_file()` in `harnx-core/src/config_paths.rs`:
+
+```rust
+// BEFORE
+pub fn env_file() -> PathBuf {
+    match env::var(get_env_name("env_file")) {
+        Ok(value) if !value.is_empty() => PathBuf::from(value),
+        _ => local_path(ENV_FILE_NAME),  // ~/.config/harnx/.env
+    }
+}
+
+// AFTER
+pub fn env_file() -> PathBuf {
+    match env::var(get_env_name("env_file")) {
+        Ok(value) if !value.is_empty() => PathBuf::from(value),
+        _ => data_path(ENV_FILE_NAME),  // ~/.local/share/harnx/.env
+    }
+}
+```
+
+### 2. Added `bash_env_file()` with HARNX_BASH_ENV_FILE override
+
+Added centralized path resolution in `harnx-core/src/config_paths.rs`:
+
+```rust
+/// Bash env file loaded by the bash MCP server.
+pub const BASH_ENV_FILE_NAME: &str = ".env.bash";
+
+/// Path to the `.env.bash` file loaded by the bash MCP server. Overridable via `HARNX_BASH_ENV_FILE`.
+pub fn bash_env_file() -> PathBuf {
+    match env::var(get_env_name("bash_env_file")) {
+        Ok(value) if !value.is_empty() => PathBuf::from(value),
+        _ => data_path(BASH_ENV_FILE_NAME),
+    }
+}
+```
+
+Bash MCP server now imports from harnx-core:
+
+```rust
+// BEFORE: inline bash_config_dir() function
+let env_file = bash_config_dir().join(".env.bash");
+
+// AFTER: centralized resolution
+let env_file = harnx_core::config_paths::bash_env_file();
+```
+
+### 3. Added 0600 permission enforcement
+
+Enforced restrictive permissions after successful file read, using existing project patterns:
+
+```rust
+let env_file = harnx_core::config_paths::bash_env_file();
+let Ok(contents) = std::fs::read_to_string(&env_file) else {
+    return vec![];
+};
+#[cfg(unix)]
+{
+    use std::os::unix::prelude::PermissionsExt;
+    let _ = std::fs::set_permissions(&env_file, std::fs::Permissions::from_mode(0o600));
+}
+```
+
+Same pattern applied in `harnx-runtime/src/config/mod.rs:load_env_file()`.
+
+### 4. Fixed empty-key panic in .env parsing
+
+Added guard before `env::set_var()`:
+
+```rust
+// BEFORE
+if let Some((key, value)) = line.split_once('=') {
+    unsafe {
+        env::set_var(key.trim(), value.trim());
+    }
+}
+
+// AFTER
+if let Some((key, value)) = line.split_once('=') {
+    let key = key.trim();
+    if !key.is_empty() {
+        unsafe {
+            env::set_var(key, value.trim());
+        }
+    }
+}
+```
+
+## Why This Works
+
+1. **XDG separation**: Data directory (`~/.local/share/harnx/`) is for runtime data. Config directory (`~/.config/harnx/`) is for user-authored config. MCP servers with config-dir access no longer see credential files.
+
+2. **Centralized path resolution**: `bash_env_file()` in harnx-core eliminates duplicated XDG logic. Both `.env` and `.env.bash` follow same pattern with env var overrides (`HARNX_ENV_FILE`, `HARNX_BASH_ENV_FILE`).
+
+3. **Permission enforcement**: Silent `let _ =` matches existing project pattern. `#[cfg(unix)]` ensures Windows compatibility. Applies after successful read to avoid errors on missing files.
+
+4. **Empty-string guards**: Prior art from `xdg-directory-separation` established `!value.is_empty()` pattern for env var overrides. Applied same pattern to `HARNX_BASH_ENV_FILE`.
+
+## Prevention Strategies
+
+### Test Cases
+
+- `env_file_default_returns_data_dir_env` — verifies `.env` defaults to data dir
+- `bash_env_file_default_returns_data_dir_env_bash` — verifies `.env.bash` defaults to data dir
+- `bash_env_file_empty_falls_back_to_default` — verifies empty `HARNX_BASH_ENV_FILE` falls back to default
+- `harnx-mcp-bash::env_bash_dotfile_loaded` — verifies `.env.bash` loading works end-to-end
+
+### Best Practices
+
+- Store credentials in XDG data directory, not config directory
+- Always guard env var checks with `!value.is_empty()` before constructing paths
+- Use `#[cfg(unix)]` for permission enforcement to maintain Windows compatibility
+- Apply permissions after successful file read with silent `let _ =` error handling
+- Centralize path resolution in harnx-core to avoid duplication
+
+### Code Review Checklist
+
+- [ ] Are credential files in data directory, not config directory?
+- [ ] Does `load_*_env_file()` have `#[cfg(unix)]` permission enforcement?
+- [ ] Are env var overrides guarded with `!value.is_empty()`?
+- [ ] Is path resolution imported from `harnx_core::config_paths` rather than duplicated?
+- [ ] Do .env parsing loops handle empty keys gracefully?
+
+## Related Issues
+
+- **Prior Art:** [logic-errors/xdg-directory-separation-2026-05-03.md](../logic-errors/xdg-directory-separation-2026-05-03.md) — established XDG data dir pattern and empty-string guard pattern
+- **Issue:** #637 — original issue tracking credential file relocation
+- **Decision Note:** Plan note `4c50d3fa` — key decisions including no auto-migration, silent permission enforcement pattern

--- a/example_config/mcp_servers/exa.yaml
+++ b/example_config/mcp_servers/exa.yaml
@@ -1,4 +1,4 @@
-# Note: set EXA_API_KEY in .env in the config folder
+# Note: set EXA_API_KEY in ~/.local/share/harnx/.env
 command: npx
 args:
   - "-y"

--- a/packages/coding/README.md
+++ b/packages/coding/README.md
@@ -19,7 +19,7 @@ Install from GHCR (replace `v0.1.0` with the current release):
 harnx-pkg add ghcr.io/dobesv/harnx-packages/coding v0.1.0
 ```
 
-Set your API keys in `~/.config/harnx/.env`:
+Set your API keys in `~/.local/share/harnx/.env`:
 
 ```sh
 CLAUDE_API_KEY=sk-ant-...
@@ -91,7 +91,7 @@ or symlink anything.
 | `context7.yaml` | `context7_*` | Node.js / npx | Library docs lookup. No API key. |
 | `grep.yaml` | `grep_*` | uv / uvx | GitHub code search via grep.app. No API key. |
 
-Add your Exa key to `~/.config/harnx/.env`:
+Add your Exa key to `~/.local/share/harnx/.env`:
 
 ```sh
 EXA_API_KEY=...

--- a/packages/coding/mcp_servers/exa.yaml
+++ b/packages/coding/mcp_servers/exa.yaml
@@ -7,7 +7,7 @@ description: >-
   research and fact-finding.
 
 # Requires: Node.js / npx and an Exa API key.
-# Set EXA_API_KEY in ~/.config/harnx/.env
+# Set EXA_API_KEY in ~/.local/share/harnx/.env
 # Sign up at https://exa.ai to get a key.
 env:
   EXA_API_KEY: "$EXA_API_KEY"

--- a/packages/pantheon/README.md
+++ b/packages/pantheon/README.md
@@ -59,7 +59,7 @@ Install from GHCR (replace `v0.1.0` with the current release):
 harnx-pkg add ghcr.io/dobesv/harnx-packages/pantheon v0.1.0
 ```
 
-Then set your API keys in `~/.config/harnx/.env`:
+Then set your API keys in `~/.local/share/harnx/.env`:
 
 ```sh
 CLAUDE_API_KEY=sk-ant-...
@@ -93,7 +93,7 @@ The package ships four client configs:
 | `clients/gemini.yaml` | Google Gemini API | argus, clio, pytheas, compaction agents, … |
 | `clients/bedrock.yaml` | AWS Bedrock | hermes, hestia, athena, metis, oracle, mnemosyne, nemesis, rhadamanthus, tyche, urania |
 
-API keys are loaded from `~/.config/harnx/.env` (recommended) or from the
+API keys are loaded from `~/.local/share/harnx/.env` (recommended) or from the
 environment. Variable names: `CLAUDE_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `BEDROCK_API_KEY`.
 
 ---
@@ -138,7 +138,7 @@ Several agents (hermes, hestia, athena, metis, oracle, mnemosyne, nemesis,
 rhadamanthus, tyche, urania) use `bedrock:zai.glm-5`. The Bedrock client config
 is included in the package (`clients/bedrock.yaml`) — no manual setup needed.
 
-Set your Bedrock API key in `~/.config/harnx/.env`:
+Set your Bedrock API key in `~/.local/share/harnx/.env`:
 
 ```sh
 BEDROCK_API_KEY=...
@@ -206,7 +206,7 @@ or symlink anything.
 | `context7.yaml` | `context7_*` | Node.js / npx | Library docs lookup. No API key. |
 | `grep.yaml` | `grep_*` | uv / uvx | GitHub code search via grep.app. No API key. |
 
-Add your Exa key to `~/.config/harnx/.env`:
+Add your Exa key to `~/.local/share/harnx/.env`:
 
 ```sh
 EXA_API_KEY=...

--- a/packages/pantheon/clients/bedrock.yaml
+++ b/packages/pantheon/clients/bedrock.yaml
@@ -9,7 +9,7 @@ models:
     max_input_tokens: 200000
     max_output_tokens: 128000
 
-# Authentication: set BEDROCK_API_KEY in ~/.config/harnx/.env
+# Authentication: set BEDROCK_API_KEY in ~/.local/share/harnx/.env
 # This should be an AWS SigV4-signed token or API key configured for your
 # Bedrock endpoint. The standard AWS credential chain is not currently
 # supported — the key must be provided explicitly.

--- a/packages/pantheon/mcp_servers/exa.yaml
+++ b/packages/pantheon/mcp_servers/exa.yaml
@@ -7,7 +7,7 @@ description: >-
   research and fact-finding.
 
 # Requires: Node.js / npx and an Exa API key.
-# Set EXA_API_KEY in ~/.config/harnx/.env
+# Set EXA_API_KEY in ~/.local/share/harnx/.env
 # Sign up at https://exa.ai to get a key.
 env:
   EXA_API_KEY: "$EXA_API_KEY"


### PR DESCRIPTION
### Description

This pull request relocates `.env` and `.env.bash` files from the XDG configuration directory (`~/.config/harnx/`) to the XDG data directory (`~/.local/share/harnx/`). This enhances security by restricting access to sensitive credentials stored in these files. 

Key changes include:
- Centralization of path resolution for `.env` and `.env.bash` in `harnx-core/config_paths.rs`.
- Addition of the `HARNX_BASH_ENV_FILE` environment variable for custom `.env.bash` locations.
- Enforced 0600 permissions on credential files during load time on Unix-like systems.
- Documentation and README updates to reflect the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Relocated credential files from config directory to data directory for enhanced protection.
  * Enforced stricter file permissions on credential files.

* **New Features**
  * Added configurable environment file support for the bash MCP server with override capability.

* **Documentation**
  * Updated all configuration guides and examples to reflect new credential file storage locations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->