### PR TITLE
Update agent git instructions to use origin/HEAD

### DIFF
--- a/docs/solutions/workflow-issues/git-branch-relative-diff-base-2026-05-24.md
+++ b/docs/solutions/workflow-issues/git-branch-relative-diff-base-2026-05-24.md
@@ -1,0 +1,124 @@
+---
+title: "Git branch-relative diff base: origin/HEAD not merge-base"
+date: 2026-05-24
+category: workflow-issues
+problem_type: logic_error
+component: pantheon-agents
+root_cause: incorrect git diff base selection for squash and review operations
+resolution_type: code_fix
+severity: medium
+tags:
+  - git
+  - squash
+  - diff-base
+  - agent-prompts
+  - origin-head
+plan_ref: fixup-git-instructions-issue-641
+---
+
+## Problem
+
+Agent prompts used incorrect git patterns for branch-relative operations: `git merge-base` was recommended as squash base, `<default-branch>` placeholders required manual detection, and `HEAD~1` fallbacks only captured the most recent commit instead of full branch history.
+
+## Symptoms
+
+- Squash operations missed commits when default branch was merged into feature branch
+- `git diff HEAD~1` showed only the latest commit, not full branch changes
+- Hardcoded `origin/main`/`origin/master` failed in repos with different default branch names
+- Agent instructions used confusing placeholder syntax like `<default-branch>`
+- Terminology error: prompts described `git diff --name-only` output as "commits" instead of "files"
+
+## Investigation Steps
+
+Issue #641 identified multiple stale git patterns across agent prompts:
+1. Searched for `origin/master`, `origin/main`, `HEAD~1`, `merge-base` in agent files
+2. Traced why `git merge-base` fails as squash base in merge-workflow teams
+3. Verified `origin/HEAD` behavior across clone types (full, shallow, fresh)
+4. Confirmed dot-syntax asymmetry: `git diff origin/HEAD...` (three-dot for cumulative diff) vs `git log origin/HEAD..` (two-dot for branch commits)
+
+Tested with `git symbolic-ref refs/remotes/origin/HEAD` in standard and shallow clones — shallow clones do NOT create this ref by default.
+
+## Root Cause
+
+**Squash base rule inversion**: `git merge-base HEAD origin/<default-branch>` returns the nearest common ancestor. When the default branch is merged INTO the feature branch (merge-workflow), the merge-base advances past that merge commit, causing squash to miss the merged-in commits. `origin/HEAD` always points to the tip of the remote's default branch, which is the correct boundary.
+
+**Dot syntax**: Git's three-dot diff (`A...B`) shows changes from merge base to B — correct for cumulative branch diff. Two-dot log (`A..B`) shows commits reachable from B but not A — correct for branch commit list. These must NOT be unified.
+
+**HEAD~1 fallback**: Only captures the most recent commit. Feature branches often have multiple commits; `HEAD~1` missed the full branch scope.
+
+## Solution
+
+### 1. Squash Base Rule
+
+Replace `git merge-base` with `origin/HEAD`:
+
+```bash
+# BEFORE (incorrect)
+git reset --soft $(git merge-base HEAD origin/<default-branch>)
+
+# AFTER (correct)
+git reset --soft origin/HEAD
+```
+
+Add prerequisite note for missing `origin/HEAD`:
+```bash
+git fetch origin                    # ensure freshness
+git remote set-head origin -a       # set if missing (shallow clones)
+```
+
+### 2. Dot-Syntax Asymmetry (Intentional)
+
+Keep these patterns distinct:
+- `git diff origin/HEAD...` — three-dot for cumulative branch diff
+- `git log origin/HEAD..` — two-dot for branch commits list
+
+Do NOT unify these to the same syntax.
+
+### 3. Replace HEAD~1 Fallbacks
+
+```bash
+# BEFORE (misses full branch history)
+git diff HEAD~1 --name-only
+
+# AFTER (full branch scope)
+git diff origin/HEAD... --name-only
+```
+
+### 4. Eliminate Default Branch Detection Logic
+
+Replace `origin/main`, `origin/master`, `<default-branch>` with `origin/HEAD`. No detection logic needed — git resolves automatically via remote HEAD.
+
+## Why This Works
+
+`origin/HEAD` is a symbolic ref that always points to the remote's default branch tip. Unlike `<default-branch>` placeholders, it:
+- Requires no branch-name detection
+- Works regardless of whether the repo uses `main`, `master`, or custom names
+- Self-resolves via git remote configuration
+
+The prerequisite is that `origin/HEAD` exists. Full clones create it automatically. Shallow clones and some CI environments may not, requiring the recovery commands above.
+
+## Prevention Strategies
+
+**Verification checklist for git instruction changes:**
+- [ ] All branch-relative diffs use `origin/HEAD...` (three-dot)
+- [ ] All branch commit logs use `origin/HEAD..` (two-dot)
+- [ ] No `HEAD~1`, `HEAD~N` as review-scope fallbacks
+- [ ] No `<default-branch>` placeholders
+- [ ] No `git merge-base` as squash base
+- [ ] Prerequisite note for `origin/HEAD` setup included
+
+**Smoke-test before merging:**
+```bash
+git rev-parse --verify origin/HEAD   # confirm ref exists
+git diff origin/HEAD... --name-only  # confirm syntax works
+git log --oneline origin/HEAD..     # confirm log works
+```
+
+**Terminology accuracy:**
+- `git diff --name-only` → lists changed files, NOT commits
+- `git log` → lists commits
+
+## Related Issues
+
+- GitHub Issue: #641 — Fix stale git patterns in agent prompts
+- Files changed: `packages/pantheon/agents/shared/clio.md`, `shared/pytheas.md`, `shared/mnemosyne.md`, `shared/aristarchus.md`, `shared/argus.md`, `shared/atlas.md`, `shared/quality-review.md`, `packages/pantheon/agents/clio.md`, `packages/pantheon/agents/mnemosyne.md`

--- a/packages/pantheon/agents/clio.md
+++ b/packages/pantheon/agents/clio.md
@@ -24,7 +24,7 @@ use_tools:
 - plans_list_tasks
 - plans_update_note
 description: |
-  Git operations agent — handles commits, squash, rebase, and push. Squashes branches into a single clean commit, rebases on origin/master, and pushes to remote. Named after Clio (KLEE-oh), the Muse of history.
+  Git operations agent — handles commits, squash, rebase, and push. Squashes branches into a single clean commit, rebases on origin/HEAD, and pushes to remote. Named after Clio (KLEE-oh), the Muse of history.
 version: "1"
 variables:
 - name: clio_core

--- a/packages/pantheon/agents/mnemosyne.md
+++ b/packages/pantheon/agents/mnemosyne.md
@@ -45,7 +45,7 @@ You work locally. Use `fs_read` tools to inspect changes via git history,
 `fs_write` for solution docs, and `bash_exec` for git and date commands.
 
 - Retrieve today's date: `bash_exec("date +%Y-%m-%d")`
-- Inspect recent changes: `bash_exec("git diff HEAD~1")`, `bash_exec("git log --oneline -5")`
+- Inspect recent changes: `bash_exec("git diff origin/HEAD...")`, `bash_exec("git log --oneline origin/HEAD..")`
 - Create solution directories: `bash_exec("mkdir -p docs/solutions/<category>")`
 - Write new solution docs: `fs_write` tool
 - Update existing docs: `fs_edit` or `fs_write` tool

--- a/packages/pantheon/agents/shared/argus.md
+++ b/packages/pantheon/agents/shared/argus.md
@@ -26,8 +26,8 @@ For every verification request, execute ALL applicable steps:
 ### 1. Detect Working Tree State
 Before reading files, check whether changes are committed or still in the working tree:
 - Run `git status --short` to see if there are unstaged or staged changes
-- If there are uncommitted changes: the working tree IS the source of truth. Use `git diff --name-only` (unstaged) and `git diff --cached --name-only` (staged) to identify changed files — do NOT rely on `git log` or `git diff HEAD~1` which will miss uncommitted work entirely.
-- If the working tree is clean: use `git diff HEAD~1 --name-only` or the delegate's claimed file list.
+- If there are uncommitted changes: the working tree IS the source of truth. Use `git diff --name-only` (unstaged) and `git diff --cached --name-only` (staged) to identify changed files — do NOT rely on `git log` or `git diff origin/HEAD...` which will miss uncommitted work entirely.
+- If the working tree is clean: use `git diff origin/HEAD... --name-only` to list all branch changes relative to the default branch, or fall back to the delegate's claimed file list.
 
 ### 2. Read Changed Files
 Use `Read` to inspect every file the delegate reports modifying.

--- a/packages/pantheon/agents/shared/aristarchus.md
+++ b/packages/pantheon/agents/shared/aristarchus.md
@@ -60,7 +60,7 @@ Each Judge independently reviews ALL Muse findings and renders per-finding verdi
 
 ## Input Modes
 Aristarchus handles two review modes, both running the full pipeline:
-- **Local review**: The working directory is the repository. Pytheas detects the working tree state (`git status`, `git diff`, `git diff --cached`), identifies changed files, and computes the merge base via `git merge-base HEAD origin/<default-branch>`. Diff analysis is relative to that merge base. Issue tracker references are inferred from the branch name, commit messages, or user input.
+- **Local review**: The working directory is the repository. Pytheas detects the working tree state (`git status`, `git diff`, `git diff --cached`), identifies changed files via `git diff origin/HEAD... --name-only`, and uses `origin/HEAD` as the diff base. Issue tracker references are inferred from the branch name, commit messages, or user input.
 - **PR review**: Caller provides a PR number (or URL). Pytheas fetches PR metadata, changed files, and the merge-base SHA via `gh` and the GitHub compare API. Diff analysis uses that merge base — not the live tip of the base branch — to avoid flagging changes that landed on the base branch after the PR was created. Existing PR reviews and comments are also fetched.
 
 ## Task-Driven Review Pipeline
@@ -69,13 +69,13 @@ Five phases, tracked in the plan. Each phase is a task. Plans are kept for futur
 ### Phase 1: Context Assembly (task: `context-assembly`)
 - Create a plan for each review with tasks for each process phase, muse, and judge.
 - **Delegate context fetching to Pytheas.** Provide the plan ID. The Pytheas delegation covers exactly these tasks — nothing more:
-  - **Local review**: detect working tree state; identify changed files via `git diff --name-only` and `git diff --cached --name-only`; compute merge base via `git merge-base HEAD origin/<default-branch>`.
+  - **Local review**: detect working tree state; identify changed files via `git diff --name-only` and `git diff --cached --name-only`; use `origin/HEAD` as the diff base (e.g. `git diff origin/HEAD... --name-only` for branch-scoped changed files).
   - **PR review**: fetch PR metadata, changed files, and merge-base SHA via `gh` and the GitHub compare API (`merge_base_commit.sha`).
   - For both modes: search for issue tracker references in the branch name, PR title/description, or commit messages — detect the tracker from `AGENTS.md`/`README.md` first — and fetch ticket details and acceptance criteria (if no issue is found, extract goals from the PR description or commit messages instead); check for a plan reference in commit trailers and read the linked plan for implementation context if present.
-  - Save all findings as plan notes: `metadata`, `merge-base`, `changed-files`, `issue-context`, `existing-reviews`, `implementation-plan`.
+  - Save all findings as plan notes: `metadata`, `changed-files`, `issue-context`, `existing-reviews`, `implementation-plan`.
   - Muse selection and review scope are not part of this delegation — those are Aristarchus's responsibilities, handled after Pytheas returns.
 - After Pytheas returns, read the plan notes to verify context was gathered. If gaps exist, delegate back to Pytheas to fill them.
-- All Muses and Judges use the `merge-base` plan note as the diff base (e.g. `git diff <merge_base_sha> HEAD`). If the note is absent, note the limitation and proceed with the best available diff base.
+- All Muses and Judges use `origin/HEAD` as the diff base (e.g. `git diff origin/HEAD...`). For PR reviews, the merge-base SHA from the GitHub compare API may also be used if available in plan notes.
 - Determine review scope (which Muses to include). Mark task done.
 
 ### Phase 2: Specialist Reviews (tasks: `review-MUSE-NAME`)

--- a/packages/pantheon/agents/shared/atlas.md
+++ b/packages/pantheon/agents/shared/atlas.md
@@ -288,7 +288,7 @@ After all implementation work is complete and individually verified by Argus:
    - **Whether changes are committed or uncommitted** — if there are unstaged/staged
      changes, explicitly state: "Changes are uncommitted in the working tree. Use
      `git diff` and `git diff --cached` to see the changes under review, not
-     `git log` or `git diff HEAD~1`."
+     `git log` or `git diff origin/HEAD...`."
 4. Handle the review outcome by verdict:
    - **APPROVE**: Work is complete. Proceed to final reporting and git operations (clio).
    - **REQUEST_CHANGES**: Aristarchus has identified **blocker** findings that must

--- a/packages/pantheon/agents/shared/clio.md
+++ b/packages/pantheon/agents/shared/clio.md
@@ -62,24 +62,24 @@ Adds retry logic for 401 responses during the refresh window.
 
 ## Squash Base Rule
 
-**Always use `git merge-base` as the squash base — NEVER the default branch directly.**
+**Always use `origin/HEAD` as the squash base — NEVER `git merge-base`.**
 
-When squashing commits before a push, the base must be the point where the branch actually
-diverged from the default branch — not the current tip of the default branch. When a branch
-hasn't been rebased recently, those two are different commits. Using the branch tip as the
-base bundles all of master's advancement (potentially thousands of unrelated files) into the
-squashed commit.
+When squashing commits before a push, use `origin/HEAD` as the base. It always resolves to
+the current tip of the default branch on the remote, which is the correct boundary for what
+belongs in this PR.
+
+> **Prerequisite**: `origin/HEAD` must be set. If in doubt, run `git fetch origin` before
+> squashing. If `origin/HEAD` is not set (rare in some shallow clones), set it explicitly:
+> `git remote set-head origin -a`.
+
+Using `git merge-base` is unreliable: when the default branch has been merged *into* the
+feature branch (common in merge-workflow teams), the merge-base drifts forward and captures
+too little history — the squash misses commits that should be included.
 
 **Correct:**
 ```
-git reset --soft $(git merge-base HEAD origin/<default-branch>)
+git reset --soft origin/HEAD
 git commit -m "..."
-```
-
-**Never:**
-```
-git reset --soft origin/<default-branch>   # WRONG — picks up all master advancement
-git rebase -i origin/<default-branch>      # WRONG — same problem
 ```
 
 ### Mandatory File-Count Sanity Check
@@ -87,16 +87,16 @@ git rebase -i origin/<default-branch>      # WRONG — same problem
 After squashing and before rebasing or pushing, verify the squash captured only this PR's changes:
 
 ```
-git diff $(git merge-base HEAD origin/<default-branch>)..HEAD --name-only | wc -l
+git diff origin/HEAD... --name-only | wc -l
 ```
 
 **If the count exceeds 200 files, STOP immediately.** Do NOT rebase or push.
-This almost certainly means the wrong squash base was used — the squash captured
-master's advancement in addition to the PR's actual changes.
+This almost certainly means something is wrong with the squash — verify the branch is
+not accidentally including unrelated commits.
 
 Report to the caller:
 - The file count observed
-- That the squash base appears incorrect
+- That the squash result appears incorrect
 - That they should investigate and retry
 
 Only proceed with rebase and push if the file count is plausible for the PR.
@@ -111,7 +111,7 @@ When asked to squash without pushing, perform only up through the squash step.
 
 ## Branch Management
 
-**NEVER commit to main or master.** Before any commit, verify you are
+**NEVER commit to the default branch.** Before any commit, verify you are
 on a feature branch. If you are on the default branch or in a detached
 HEAD state, STOP and ask the caller how to proceed.
 

--- a/packages/pantheon/agents/shared/mnemosyne.md
+++ b/packages/pantheon/agents/shared/mnemosyne.md
@@ -61,7 +61,7 @@ It is bad to stop at "I found some learnings" without actually deciding whether 
 
 ### Phase 1: Analysis
 1. Read plan notes with `plan_get_notes` and extract notes of type: learnings, decisions, problems, and verification.
-2. Inspect recent changes by running `git diff HEAD~1` and `git log --oneline -5` to understand what changed.
+2. Inspect recent changes by running `git diff origin/HEAD...` and `git log --oneline origin/HEAD..` to understand what changed on this branch.
 3. Identify:
    - What problem was solved?
    - What approach was taken?

--- a/packages/pantheon/agents/shared/pytheas.md
+++ b/packages/pantheon/agents/shared/pytheas.md
@@ -84,7 +84,7 @@ Use these command-line tools for powerful code analysis:
 
 ### Working Tree State Detection
 
-**For reviews of uncommitted local changes**, always detect the working tree state before identifying changed files. Changes under review may be uncommitted or unstaged — `git log` and `git diff HEAD~1` will miss them entirely.
+**For reviews of uncommitted local changes**, always detect the working tree state before identifying changed files. Changes under review may be uncommitted or unstaged — `git log` and `git diff origin/HEAD...` applied to committed history will miss them entirely.
 
 Run these commands early in your exploration:
 1. `git status --short` — overview of working tree state (modified, staged, untracked files)
@@ -95,7 +95,8 @@ Run these commands early in your exploration:
 
 **Determining the changed-files list for local reviews:**
 - If there are unstaged or staged changes: these ARE the changes under review. Use the combined output of `git diff --name-only` and `git diff --cached --name-only` as the changed-files list.
-- If the working tree is clean (no uncommitted changes): fall back to `git diff HEAD~1 --name-only` or analyze the most recent commits.
+- If the working tree is clean (no uncommitted changes): fall back to `git diff origin/HEAD... --name-only` to list all changed files on this branch relative to the default branch.
+  - If `origin/HEAD` is not set (e.g. shallow clone), run `git fetch origin` first, or `git remote set-head origin -a` to set it.
 - Save the working tree state as a plan note (`working-tree-state`) so Aristarchus and the Muses know the review scope.
 
 Save the working tree state as a plan note (type: `working-tree-state`) so Aristarchus and the Muses know the review scope. Include: list of unstaged modified files, staged files, and untracked files. Note whether changes are in the working tree vs committed history.

--- a/packages/pantheon/agents/shared/quality-review.md
+++ b/packages/pantheon/agents/shared/quality-review.md
@@ -21,7 +21,7 @@ After all implementation work is complete and individually verified by Argus:
    - **Whether changes are committed or uncommitted** — if there are unstaged/staged
      changes, explicitly state: "Changes are uncommitted in the working tree. Use
      `git diff` and `git diff --cached` to see the changes under review, not
-     `git log` or `git diff HEAD~1`."
+     `git log` or `git diff origin/HEAD...`."
 4. Handle the review outcome by verdict:
    - **APPROVE**: Work is complete. Proceed to final reporting and git operations (clio).
    - **REQUEST_CHANGES**: Aristarchus has identified **blocker** findings that must


### PR DESCRIPTION
Updates multiple agent prompts and documentation to use origin/HEAD instead of hardcoded default branch names (main/master) or merge-base detection. Reverses the Squash Base Rule in Clio's instructions to favor origin/HEAD, which remains reliable when the default branch has been merged into a feature branch.

Consistent dot-syntax is applied across all agents: three-dot diff (origin/HEAD...) for cumulative branch changes and two-dot log (origin/HEAD..) for identifying new commits. Adds a solution document recording the branch-relative diff base pattern.

#641

Plan: fixup-git-instructions-issue-641