### PR TITLE
fix: suppress noisy sandbox-run log for non-existent paths

### DIFF
--- a/crates/harnx-mcp-bash/src/bin/sandbox_run.rs
+++ b/crates/harnx-mcp-bash/src/bin/sandbox_run.rs
@@ -137,10 +137,6 @@ fn add_path_exception(
     make_exception: fn(PathBuf) -> Exception,
 ) -> Result<(), String> {
     if !path.exists() {
-        eprintln!(
-            "sandbox-run: skipping non-existent path: {}",
-            path.display()
-        );
         return Ok(());
     }
 
@@ -307,7 +303,7 @@ mod tests {
         );
         // If the ancestor walk were still present, $HOME would have been added.
         // We can't inspect Birdcage internals, but if it didn't add it the function
-        // must have taken the early-return path (the warning + Ok(()) branch).
+        // must have taken the early-return path (the Ok(()) branch).
         // The test above verifies that the function returns Ok without erroring,
         // which is the correct post-fix behavior (previously it would walk to $HOME).
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary warning messages when non-existent paths are provided during sandbox configuration, streamlining the user experience by handling missing paths gracefully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->