### PR TITLE
feat: add gemini-3.5-flash and gemini-3.1-flash-lite to model registry

### DIFF
--- a/.changesets/611-add-gemini-3-5-flash.md
+++ b/.changesets/611-add-gemini-3-5-flash.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+Add `gemini-3.5-flash` and `gemini-3.1-flash-lite` to the built-in model list for the `gemini`, `vertexai`, and `openrouter` providers.

--- a/crates/harnx/models.yaml
+++ b/crates/harnx/models.yaml
@@ -106,6 +106,13 @@
 #  - https://ai.google.dev/api/rest/v1beta/models/streamGenerateContent
 - provider: gemini
   models:
+    - name: gemini-3.5-flash
+      max_input_tokens: 1048576
+      max_output_tokens: 65536
+      input_price: 1.5
+      output_price: 9
+      supports_vision: true
+      supports_tool_use: true
     - name: gemini-2.5-flash
       max_input_tokens: 1048576
       max_output_tokens: 65536
@@ -129,6 +136,13 @@
       supports_tool_use: true
     - name: gemini-3.1-pro-preview
       max_input_tokens: 1048576
+      supports_vision: true
+      supports_tool_use: true
+    - name: gemini-3.1-flash-lite
+      max_input_tokens: 1048576
+      max_output_tokens: 65536
+      input_price: 0.25
+      output_price: 1.5
       supports_vision: true
       supports_tool_use: true
     - name: gemini-3.1-flash-lite-preview
@@ -527,6 +541,13 @@
 #  - https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini
 - provider: vertexai
   models:
+    - name: gemini-3.5-flash
+      max_input_tokens: 1048576
+      max_output_tokens: 65536
+      input_price: 1.5
+      output_price: 9
+      supports_vision: true
+      supports_tool_use: true
     - name: gemini-2.5-flash
       max_input_tokens: 1048576
       max_output_tokens: 65536
@@ -550,6 +571,13 @@
       supports_tool_use: true
     - name: gemini-3.1-pro-preview
       max_input_tokens: 1048576
+      supports_vision: true
+      supports_tool_use: true
+    - name: gemini-3.1-flash-lite
+      max_input_tokens: 1048576
+      max_output_tokens: 65536
+      input_price: 0.25
+      output_price: 1.5
       supports_vision: true
       supports_tool_use: true
     - name: gemini-3.1-flash-lite-preview
@@ -1273,6 +1301,20 @@
       max_input_tokens: 131072
       input_price: 0.04
       output_price: 0.16
+      supports_tool_use: true
+    - name: google/gemini-3.5-flash
+      max_input_tokens: 1048576
+      max_output_tokens: 65536
+      input_price: 1.5
+      output_price: 9
+      supports_vision: true
+      supports_tool_use: true
+    - name: google/gemini-3.1-flash-lite
+      max_input_tokens: 1048576
+      max_output_tokens: 65536
+      input_price: 0.25
+      output_price: 1.5
+      supports_vision: true
       supports_tool_use: true
     - name: google/gemini-2.5-flash
       max_input_tokens: 1048576


### PR DESCRIPTION
Add two new Gemini models released at Google I/O 2026 (May 19, 2026) to the built-in model list across the gemini, vertexai, and openrouter providers:

- gemini-3.5-flash: 1M context, 65536 output, .5/ per M tokens
- gemini-3.1-flash-lite: stable release of the preview, bash.25/.5 per M

Closes #611

Plan: add-new-gemini-models-611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemini 3.5 Flash and Gemini 3.1 Flash Lite models to the available model catalog
  * Now accessible through Gemini, Vertex AI, and OpenRouter providers for enhanced flexibility
  * Both models include appropriate input/output token limits, vision support, and tool-use capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->