### PR TITLE
fix(release): extract knope sync command to a shell script

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -44,19 +44,11 @@ type = "PrepareRelease"
 
 # Sync the `version:` field in all agent .md frontmatter to match the
 # package version that PrepareRelease just wrote to each package.yaml.
+# Logic lives in a shell script because knope's Command step execs argv
+# directly without a shell — multi-line `for` loops here fail with ENOENT.
 [[workflows.steps]]
 type = "Command"
-command = """
-for pkg in pantheon coding; do
-  dir="packages/$pkg"
-  [ -f "$dir/package.yaml" ] || continue
-  ver=$(grep -m1 '^version:' "$dir/package.yaml" | sed "s/version: v//")
-  [ -n "$ver" ] || continue
-  find "$dir/agents" -maxdepth 1 -name "*.md" | while read f; do
-    sed -i "s/^version: .*/version: '$ver'/" "$f"
-  done
-done
-"""
+command = "bash scripts/sync-package-versions.sh"
 
 # `PrepareRelease` deletes the consumed changeset files from disk but
 # (in our setup) doesn't always stage those deletions. Force-stage

--- a/packages/coding/agents/compact-coder.md
+++ b/packages/coding/agents/compact-coder.md
@@ -1,6 +1,7 @@
 ---
 role: compaction
 model: gemini:gemini-3.1-flash-lite-preview
+version: '0.1.0'
 ---
 You are summarizing a conversation between a user and an AI coding assistant.
 

--- a/packages/pantheon/agents/compact-argus.md
+++ b/packages/pantheon/agents/compact-argus.md
@@ -1,6 +1,7 @@
 ---
 role: compaction
 model: gemini:gemini-3.1-flash-lite-preview
+version: '0.1.0'
 ---
 You are summarizing a conversation between a user and an AI verification agent that checks whether tasks completed by other agents meet their requirements.
 

--- a/packages/pantheon/agents/compact-deploy.md
+++ b/packages/pantheon/agents/compact-deploy.md
@@ -1,6 +1,7 @@
 ---
 role: compaction
 model: gemini:gemini-3.1-flash-lite-preview
+version: '0.1.0'
 ---
 You are summarizing a conversation between a user and an AI deployment verification agent that assesses deployment readiness and produces Go/No-Go checklists for pull requests.
 

--- a/packages/pantheon/agents/compact-dev.md
+++ b/packages/pantheon/agents/compact-dev.md
@@ -1,6 +1,7 @@
 ---
 role: compaction
 model: gemini:gemini-3.1-flash-lite-preview
+version: '0.1.0'
 ---
 You are summarizing a conversation between a user and an AI coding agent that executes tasks, writes code, and delegates work to specialist agents.
 

--- a/packages/pantheon/agents/compact-mnemosyne.md
+++ b/packages/pantheon/agents/compact-mnemosyne.md
@@ -1,6 +1,7 @@
 ---
 role: compaction
 model: gemini:gemini-3.1-flash-lite-preview
+version: '0.1.0'
 ---
 You are summarizing a conversation between a user and Mnemosyne, an AI agent that compounds engineering learnings into docs/solutions/ entries after work completes.
 

--- a/packages/pantheon/agents/compact-planner.md
+++ b/packages/pantheon/agents/compact-planner.md
@@ -1,6 +1,7 @@
 ---
 role: compaction
 model: gemini:gemini-3.1-flash-lite-preview
+version: '0.1.0'
 ---
 You are summarizing a conversation between a user and an AI orchestrator agent that manages multi-step work plans and delegates tasks to sub-agents.
 

--- a/packages/pantheon/agents/compact-reliability.md
+++ b/packages/pantheon/agents/compact-reliability.md
@@ -1,6 +1,7 @@
 ---
 role: compaction
 model: gemini:gemini-3.1-flash-lite-preview
+version: '0.1.0'
 ---
 You are summarizing a conversation between a user and an AI reliability review agent that analyzes pull requests and codebases for error handling, retry logic, timeouts, and resilience issues.
 

--- a/packages/pantheon/agents/compact-researcher.md
+++ b/packages/pantheon/agents/compact-researcher.md
@@ -1,6 +1,7 @@
 ---
 role: compaction
 model: gemini:gemini-3.1-flash-lite-preview
+version: '0.1.0'
 ---
 You are summarizing a conversation between a user and an AI strategic planner that interviews users, researches codebases, and creates implementation plans.
 

--- a/packages/pantheon/agents/compact-reviewer.md
+++ b/packages/pantheon/agents/compact-reviewer.md
@@ -1,6 +1,7 @@
 ---
 role: compaction
 model: gemini:gemini-3.1-flash-lite-preview
+version: '0.1.0'
 ---
 You are summarizing a conversation between a user and an AI code review agent that analyzes pull requests and codebases for quality, security, and correctness issues.
 

--- a/scripts/sync-package-versions.sh
+++ b/scripts/sync-package-versions.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Sync the `version:` field in each agent .md frontmatter to match the
+# package version in its package.yaml. Run by knope's release workflow
+# between `PrepareRelease` and the lockfile-refresh commit.
+#
+# Knope's Command step execs argv directly (no shell), so multi-line
+# `for` loops in knope.toml fail with ENOENT — keep the loop here.
+set -euo pipefail
+
+for pkg in pantheon coding; do
+  dir="packages/$pkg"
+  [ -f "$dir/package.yaml" ] || continue
+  ver=$(grep -m1 '^version:' "$dir/package.yaml" | sed 's/version: v//')
+  [ -n "$ver" ] || continue
+  find "$dir/agents" -maxdepth 1 -name '*.md' | while read -r f; do
+    sed -i "s/^version: .*/version: '$ver'/" "$f"
+  done
+done


### PR DESCRIPTION
## Summary

The Prepare Release workflow [failed](https://github.com/dobesv/harnx/actions/runs/26376054116/job/77636391866) with:

```
Error: command::io
  × I/O error: No such file or directory (os error 2)
```

**Root cause:** knope's `Command` step execs argv directly via `execvp` — it does not invoke a shell. PR #547 added a multi-line `for pkg in pantheon coding; do ... done` block as a Command step in `knope.toml`. `for` is a shell builtin, not a binary, so knope's first-token exec fails with `ENOENT`. `knope release --dry-run` passes because it only prints commands; only the real release tries to exec them.

**Fix:** Move the loop into `scripts/sync-package-versions.sh` and invoke it as a single argv (`bash scripts/sync-package-versions.sh`).

**Also:** add `version: '0.1.0'` frontmatter to the nine compaction agent files (`compact-argus.md`, `compact-coder.md`, `compact-dev.md`, etc.) that previously had no `version:` field, so the sync script has something to act on for every agent. The 35 agents that already had `version: '1'` will get normalized to the bumped version on the next release run (the sync script overwrites them).

## Test plan

- [x] Verified locally with `knope release --dry-run` — now shows `Would run bash scripts/sync-package-versions.sh`
- [x] Reproduced the original failure with a minimal knope.toml using a `for` loop in a Command step, confirmed `bash -c ...` / wrapper script avoids it
- [x] Simulated end-to-end: bumped `packages/pantheon/package.yaml` to `v0.2.0`, ran `scripts/sync-package-versions.sh`, confirmed all pantheon agent `.md` frontmatter updated to `'0.2.0'` while coding agents stayed at `'0.1.0'`, then reverted
- [x] `cargo build --workspace` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo nextest run --workspace` — 1160/1160 pass
- [ ] After merge: re-run **Actions → Prepare Release → Run workflow**

🤖 Generated with [Claude Code](https://claude.com/claude-code)