### PR TITLE
feat(mcp-plans): add automatic background cleanup of inactive plans

### DIFF
--- a/crates/harnx-mcp-plans/Cargo.toml
+++ b/crates/harnx-mcp-plans/Cargo.toml
@@ -14,7 +14,7 @@ rmcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-tokio = { workspace = true, features = ["fs"] }
+tokio = { workspace = true, features = ["fs", "time"] }
 schemars = { workspace = true }
 similar = { workspace = true }
 

--- a/crates/harnx-mcp-plans/README.md
+++ b/crates/harnx-mcp-plans/README.md
@@ -1,0 +1,36 @@
+# harnx-mcp-plans
+
+`harnx-mcp-plans` is an MCP server providing file-based management for plans, tasks, and notes. It stores data as YAML-frontmatter markdown files, making the storage human-readable and compatible with standard version control systems.
+
+## Overview
+
+The server organizes information into plans. Each plan is a directory containing:
+- `plan.md`: The main plan description and metadata.
+- `tasks/*.md`: Individual task files.
+- `notes/*.md`: Individual note files.
+
+## Usage
+
+Run the server as a subprocess in your MCP host (e.g., Claude Desktop).
+
+### CLI Options
+
+| Option | Short | Environment Variable | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `--dir <path>` | `-d` | `AGENT_PLANS_PATH` | `.agent/plans` | Path to the plans directory. |
+| `--retention-days <N>` | `-r` | `AGENT_PLANS_RETENTION_DAYS` | `14` | Retention period in days. |
+
+### Retention & Cleanup
+
+The server automatically cleans up inactive plans to manage disk space.
+
+- **Behavior**: On startup and every 24 hours thereafter, the server scans the plans directory. It deletes any plan directory where no file activity (`plan.md`, `tasks/*.md`, or `notes/*.md`) has occurred for longer than the retention period.
+- **Disabling Cleanup**: Set `--retention-days 0` or `AGENT_PLANS_RETENTION_DAYS=0` to disable the automatic cleanup process.
+
+## Tools
+
+The server provides a comprehensive set of tools for managing the lifecycle of plans and their components:
+
+- **Plans**: `list_plans`, `add_plan`, `get_plan`, `update_plan`, `delete_plan`
+- **Tasks**: `list_tasks`, `add_task`, `get_task`, `update_task`, `append_task`, `delete_task`
+- **Notes**: `list_notes`, `add_note`, `get_note`, `delete_note`

--- a/crates/harnx-mcp-plans/src/main.rs
+++ b/crates/harnx-mcp-plans/src/main.rs
@@ -14,10 +14,11 @@ mod server;
 use rmcp::ServiceExt;
 use server::PlansServer;
 use std::path::PathBuf;
+use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let (plans_dir, retention_days) = parse_args();
+    let (plans_dir, retention_days) = parse_args()?;
 
     eprintln!(
         "harnx-mcp-plans v{}: starting (dir: {}, retention: {} days)",
@@ -38,6 +39,13 @@ async fn main() -> anyhow::Result<()> {
         let mut cleanup_handle = tokio::spawn(server::cleanup_loop(plans_dir, retention_days));
         let service_handle = tokio::spawn(async move { service.waiting().await });
         tokio::pin!(service_handle);
+
+        // Exponential backoff state for cleanup task restarts.
+        // Reset to base on a clean exit; doubles on each panic up to MAX_BACKOFF.
+        const BASE_BACKOFF: Duration = Duration::from_secs(1);
+        const MAX_BACKOFF: Duration = Duration::from_secs(300); // 5 min cap
+        let mut backoff = BASE_BACKOFF;
+
         loop {
             tokio::select! {
                 result = &mut *service_handle => {
@@ -46,11 +54,18 @@ async fn main() -> anyhow::Result<()> {
                     break;
                 }
                 result = &mut cleanup_handle => {
-                    // Cleanup task exited (e.g. panicked) — log and restart
-                    if let Err(e) = result {
-                        eprintln!("[cleanup] task failed: {e}");
+                    match result {
+                        Err(e) => {
+                            // Task panicked — log, back off, restart
+                            eprintln!("[cleanup] task failed: {e}");
+                            tokio::time::sleep(backoff).await;
+                            backoff = (backoff * 2).min(MAX_BACKOFF);
+                        }
+                        Ok(()) => {
+                            // Clean exit (shouldn't happen in normal operation) — restart immediately
+                            backoff = BASE_BACKOFF;
+                        }
                     }
-                    // Restart cleanup loop so periodic cleanup continues
                     cleanup_handle = tokio::spawn(server::cleanup_loop(cleanup_dir.clone(), retention_days));
                 }
             }
@@ -60,7 +75,7 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn parse_args() -> (PathBuf, u64) {
+fn parse_args() -> anyhow::Result<(PathBuf, u64)> {
     let args: Vec<String> = std::env::args().collect();
     let mut plans_dir: Option<PathBuf> = None;
     let mut retention_days: Option<u64> = None;
@@ -73,8 +88,7 @@ fn parse_args() -> (PathBuf, u64) {
                     plans_dir = Some(PathBuf::from(&args[i + 1]));
                     i += 2;
                 } else {
-                    eprintln!("harnx-mcp-plans: --dir requires a path argument");
-                    std::process::exit(1);
+                    anyhow::bail!("harnx-mcp-plans: --dir requires a path argument");
                 }
             }
             "--retention-days" | "-r" => {
@@ -85,16 +99,14 @@ fn parse_args() -> (PathBuf, u64) {
                             i += 2;
                         }
                         Err(_) => {
-                            eprintln!(
+                            anyhow::bail!(
                                 "harnx-mcp-plans: --retention-days requires a non-negative integer (got: {})",
                                 args[i + 1]
                             );
-                            std::process::exit(1);
                         }
                     }
                 } else {
-                    eprintln!("harnx-mcp-plans: --retention-days requires a number argument");
-                    std::process::exit(1);
+                    anyhow::bail!("harnx-mcp-plans: --retention-days requires a number argument");
                 }
             }
             "--help" | "-h" => {
@@ -117,9 +129,9 @@ fn parse_args() -> (PathBuf, u64) {
                 std::process::exit(0);
             }
             other => {
-                eprintln!("harnx-mcp-plans: unknown argument: {}", other);
-                eprintln!("Try: harnx-mcp-plans --help");
-                std::process::exit(1);
+                anyhow::bail!(
+                    "harnx-mcp-plans: unknown argument: {other}\nTry: harnx-mcp-plans --help"
+                );
             }
         }
     }
@@ -131,11 +143,10 @@ fn parse_args() -> (PathBuf, u64) {
         match env_days.trim().parse::<u64>() {
             Ok(days) => days,
             Err(_) => {
-                eprintln!(
+                anyhow::bail!(
                     "harnx-mcp-plans: AGENT_PLANS_RETENTION_DAYS must be a non-negative integer (got: {})",
                     env_days.trim()
                 );
-                std::process::exit(1);
             }
         }
     } else {
@@ -155,5 +166,5 @@ fn parse_args() -> (PathBuf, u64) {
         PathBuf::from(".agent/plans")
     };
 
-    (plans_dir, retention_days)
+    Ok((plans_dir, retention_days))
 }

--- a/crates/harnx-mcp-plans/src/main.rs
+++ b/crates/harnx-mcp-plans/src/main.rs
@@ -17,25 +17,53 @@ use std::path::PathBuf;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let plans_dir = parse_args();
+    let (plans_dir, retention_days) = parse_args();
 
     eprintln!(
-        "harnx-mcp-plans v{}: starting (dir: {})",
+        "harnx-mcp-plans v{}: starting (dir: {}, retention: {} days)",
         env!("CARGO_PKG_VERSION"),
-        plans_dir.display()
+        plans_dir.display(),
+        retention_days
     );
 
-    let server = PlansServer::new(plans_dir);
+    let server = PlansServer::new(plans_dir.clone());
     let transport = rmcp::transport::stdio();
     let service = server.serve(transport).await?;
-    service.waiting().await?;
+
+    if retention_days == 0 {
+        eprintln!("[cleanup] retention disabled");
+        service.waiting().await?;
+    } else {
+        let cleanup_dir = plans_dir.clone();
+        let mut cleanup_handle = tokio::spawn(server::cleanup_loop(plans_dir, retention_days));
+        let service_handle = tokio::spawn(async move { service.waiting().await });
+        tokio::pin!(service_handle);
+        loop {
+            tokio::select! {
+                result = &mut *service_handle => {
+                    // MCP service exited — normal shutdown
+                    result??;
+                    break;
+                }
+                result = &mut cleanup_handle => {
+                    // Cleanup task exited (e.g. panicked) — log and restart
+                    if let Err(e) = result {
+                        eprintln!("[cleanup] task failed: {e}");
+                    }
+                    // Restart cleanup loop so periodic cleanup continues
+                    cleanup_handle = tokio::spawn(server::cleanup_loop(cleanup_dir.clone(), retention_days));
+                }
+            }
+        }
+    }
 
     Ok(())
 }
 
-fn parse_args() -> PathBuf {
+fn parse_args() -> (PathBuf, u64) {
     let args: Vec<String> = std::env::args().collect();
     let mut plans_dir: Option<PathBuf> = None;
+    let mut retention_days: Option<u64> = None;
     let mut i = 1;
 
     while i < args.len() {
@@ -49,16 +77,43 @@ fn parse_args() -> PathBuf {
                     std::process::exit(1);
                 }
             }
+            "--retention-days" | "-r" => {
+                if i + 1 < args.len() {
+                    match args[i + 1].parse::<u64>() {
+                        Ok(days) => {
+                            retention_days = Some(days);
+                            i += 2;
+                        }
+                        Err(_) => {
+                            eprintln!(
+                                "harnx-mcp-plans: --retention-days requires a non-negative integer (got: {})",
+                                args[i + 1]
+                            );
+                            std::process::exit(1);
+                        }
+                    }
+                } else {
+                    eprintln!("harnx-mcp-plans: --retention-days requires a number argument");
+                    std::process::exit(1);
+                }
+            }
             "--help" | "-h" => {
                 eprintln!("harnx-mcp-plans: File-based todo/plan management MCP server");
                 eprintln!();
                 eprintln!("Usage: harnx-mcp-plans [OPTIONS]");
                 eprintln!();
                 eprintln!("Options:");
-                eprintln!("  --dir, -d <path>  Set the plans directory (default: .agent/plans)");
-                eprintln!("  --help, -h        Show this help message");
+                eprintln!(
+                    "  --dir, -d <path>           Set the plans directory (default: .agent/plans)"
+                );
+                eprintln!(
+                    "  --retention-days, -r <N>   Set retention period in days (default: 14)"
+                );
+                eprintln!("  --help, -h                 Show this help message");
                 eprintln!();
-                eprintln!("Env: AGENT_PLANS_PATH overrides the default directory.");
+                eprintln!("Env:");
+                eprintln!("  AGENT_PLANS_PATH         Overrides the default directory.");
+                eprintln!("  AGENT_PLANS_RETENTION_DAYS  Overrides the default retention days.");
                 std::process::exit(0);
             }
             other => {
@@ -69,15 +124,36 @@ fn parse_args() -> PathBuf {
         }
     }
 
-    if let Some(dir) = plans_dir {
-        return dir;
-    }
-
-    if let Ok(env_path) = std::env::var("AGENT_PLANS_PATH") {
-        if !env_path.trim().is_empty() {
-            return PathBuf::from(env_path.trim());
+    // Resolve retention_days: CLI flag > env var > default (14)
+    let retention_days = if let Some(days) = retention_days {
+        days
+    } else if let Ok(env_days) = std::env::var("AGENT_PLANS_RETENTION_DAYS") {
+        match env_days.trim().parse::<u64>() {
+            Ok(days) => days,
+            Err(_) => {
+                eprintln!(
+                    "harnx-mcp-plans: AGENT_PLANS_RETENTION_DAYS must be a non-negative integer (got: {})",
+                    env_days.trim()
+                );
+                std::process::exit(1);
+            }
         }
-    }
+    } else {
+        14
+    };
 
-    PathBuf::from(".agent/plans")
+    // Resolve plans_dir: CLI flag > env var > default
+    let plans_dir = if let Some(dir) = plans_dir {
+        dir
+    } else if let Ok(env_path) = std::env::var("AGENT_PLANS_PATH") {
+        if !env_path.trim().is_empty() {
+            PathBuf::from(env_path.trim())
+        } else {
+            PathBuf::from(".agent/plans")
+        }
+    } else {
+        PathBuf::from(".agent/plans")
+    };
+
+    (plans_dir, retention_days)
 }

--- a/crates/harnx-mcp-plans/src/server.rs
+++ b/crates/harnx-mcp-plans/src/server.rs
@@ -1984,7 +1984,16 @@ fn plan_last_activity(plan_dir: &Path) -> std::io::Result<std::time::SystemTime>
 }
 
 async fn run_cleanup_pass(dir: &Path, retention: Duration) {
-    for plan_dir in plan_dirs(dir) {
+    let dir_owned = dir.to_owned();
+    let dirs = match tokio::task::spawn_blocking(move || plan_dirs(&dir_owned)).await {
+        Ok(dirs) => dirs,
+        Err(e) => {
+            eprintln!("[cleanup] error listing plans: {e}");
+            return;
+        }
+    };
+
+    for plan_dir in dirs {
         let name = plan_dir
             .file_name()
             .unwrap_or_default()

--- a/crates/harnx-mcp-plans/src/server.rs
+++ b/crates/harnx-mcp-plans/src/server.rs
@@ -17,6 +17,7 @@ use similar::{ChangeTag, TextDiff};
 use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct TaskFrontMatter {
@@ -1948,6 +1949,100 @@ fn plan_dirs(dir: &Path) -> Vec<PathBuf> {
     dirs
 }
 
+fn plan_last_activity(plan_dir: &Path) -> std::io::Result<std::time::SystemTime> {
+    let mut latest = None;
+
+    let plan_file = plan_dir.join("plan.md");
+    if let Ok(metadata) = std::fs::metadata(&plan_file) {
+        latest = Some(metadata.modified()?);
+    }
+
+    for subdir in ["tasks", "notes"] {
+        let dir = plan_dir.join(subdir);
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+
+        for entry in entries {
+            let path = entry?.path();
+            if !path.is_file() || path.extension().and_then(OsStr::to_str) != Some("md") {
+                continue;
+            }
+
+            let modified = std::fs::metadata(&path)?.modified()?;
+            latest = Some(match latest {
+                Some(current) => current.max(modified),
+                None => modified,
+            });
+        }
+    }
+
+    match latest {
+        Some(modified) => Ok(modified),
+        None => plan_dir.metadata()?.modified(),
+    }
+}
+
+async fn run_cleanup_pass(dir: &Path, retention: Duration) {
+    for plan_dir in plan_dirs(dir) {
+        let name = plan_dir
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned();
+        let plan_dir_for_activity = plan_dir.clone();
+        let last_activity =
+            match tokio::task::spawn_blocking(move || plan_last_activity(&plan_dir_for_activity))
+                .await
+            {
+                Ok(Ok(last_activity)) => last_activity,
+                Ok(Err(e)) => {
+                    eprintln!("[cleanup] error checking plan {name}: {e}");
+                    continue;
+                }
+                Err(e) => {
+                    eprintln!("[cleanup] error checking plan {name}: {e}");
+                    continue;
+                }
+            };
+
+        let age = std::time::SystemTime::now()
+            .duration_since(last_activity)
+            .unwrap_or_default();
+        if age <= retention {
+            continue;
+        }
+
+        let plan_dir_for_delete = plan_dir.clone();
+        match tokio::task::spawn_blocking(move || std::fs::remove_dir_all(plan_dir_for_delete))
+            .await
+        {
+            Ok(Ok(())) => {
+                eprintln!(
+                    "[cleanup] deleted inactive plan {name} (inactive for {} days)",
+                    age.as_secs() / 86_400
+                );
+            }
+            Ok(Err(e)) => eprintln!("[cleanup] error deleting plan {name}: {e}"),
+            Err(e) => eprintln!("[cleanup] error deleting plan {name}: {e}"),
+        }
+    }
+}
+
+pub async fn cleanup_loop(dir: PathBuf, retention_days: u64) {
+    let retention = Duration::from_secs(retention_days.saturating_mul(86_400));
+
+    run_cleanup_pass(&dir, retention).await;
+
+    let mut interval = tokio::time::interval(Duration::from_secs(86_400));
+    interval.tick().await;
+
+    loop {
+        interval.tick().await;
+        run_cleanup_pass(&dir, retention).await;
+    }
+}
+
 fn list_note_ids(dir: &Path, plan_name: &str) -> Vec<String> {
     let notes = notes_dir(dir, plan_name);
     let Ok(entries) = std::fs::read_dir(notes) else {
@@ -1992,13 +2087,16 @@ impl ServerHandler for PlansServer {
                     .with_meta(Meta(json!({"call_template": "list plans", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("add_plan", "Create a new plan with optional metadata. Keep body content under 1000 words per call; use update_plan with replace_in_content for targeted edits.", Map::new())
                     .with_input_schema::<AddPlanParams>()
-                    .with_meta(Meta(json!({"call_template": "create plan {{ args.name }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.git_branch %} [{{ args.git_branch }}]{% endif %}{% if args.github_owner_repo %} ({{ args.github_owner_repo }}){% endif %}{% if args.body %}\n{{ args.body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(Meta(json!({"call_template": "create plan {{ args.name }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.git_branch %} [{{ args.git_branch }}]{% endif %}{% if args.github_owner_repo %} ({{ args.github_owner_repo }}){% endif %}{% if args.body %}
+{{ args.body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("get_plan", "Read plan metadata, body, and list task/note IDs.", Map::new())
                     .with_input_schema::<GetPlanParams>()
                     .with_meta(Meta(json!({"call_template": "read plan {{ args.name }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("update_plan", "Update plan body and metadata. Creates plan if it doesn't exist. Use replace_content to rewrite body, append_content to extend it, or replace_in_content for surgical edits. Optionally batch-create tasks. Keep each write under 1000 words.", Map::new())
                     .with_input_schema::<UpdatePlanParams>()
-                    .with_meta(Meta(json!({"call_template": "update plan {{ args.name }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.git_branch %} [{{ args.git_branch }}]{% endif %}{% if args.github_owner_repo %} ({{ args.github_owner_repo }}){% endif %}{% if args.tasks %} [{{ args.tasks | length }} tasks]{% endif %}{% if args.replace_content %}\n{{ args.replace_content | truncate(80) }}{% endif %}{% if args.append_content %}\n+{{ args.append_content | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(Meta(json!({"call_template": "update plan {{ args.name }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.git_branch %} [{{ args.git_branch }}]{% endif %}{% if args.github_owner_repo %} ({{ args.github_owner_repo }}){% endif %}{% if args.tasks %} [{{ args.tasks | length }} tasks]{% endif %}{% if args.replace_content %}
+{{ args.replace_content | truncate(80) }}{% endif %}{% if args.append_content %}
++{{ args.append_content | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("delete_plan", "Delete an entire plan and all its tasks and notes.", Map::new())
                     .with_input_schema::<DeletePlanParams>()
                     .with_meta(Meta(json!({"call_template": "delete plan {{ args.name }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
@@ -2007,13 +2105,16 @@ impl ServerHandler for PlansServer {
                     .with_meta(Meta(json!({"call_template": "list tasks {{ args.plan }}{% if args.filter and args.filter != 'open' %} [{{ args.filter }}]{% endif %}{% if args.tag %} #{{ args.tag }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("add_task", "Create a task in a plan. Keep body under 1000 words; use update_task with replace_in_body for targeted edits.", Map::new())
                     .with_input_schema::<AddTaskParams>()
-                    .with_meta(Meta(json!({"call_template": "create task {{ args.plan }}/{{ args.title }}{% if args.status %} [{{ args.status }}]{% endif %}{% if args.assignee %} @{{ args.assignee }}{% endif %}{% if args.executor %} ▶{{ args.executor }}{% endif %}{% if args.tags %} #{{ args.tags | join(' #') }}{% endif %}{% if args.body %}\n{{ args.body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(Meta(json!({"call_template": "create task {{ args.plan }}/{{ args.title }}{% if args.status %} [{{ args.status }}]{% endif %}{% if args.assignee %} @{{ args.assignee }}{% endif %}{% if args.executor %} ▶{{ args.executor }}{% endif %}{% if args.tags %} #{{ args.tags | join(' #') }}{% endif %}{% if args.body %}
+{{ args.body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("get_task", "Read a task by ID within a plan.", Map::new())
                     .with_input_schema::<GetTaskParams>()
                     .with_meta(Meta(json!({"call_template": "read task {{ args.plan }}/{{ args.id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("update_task", "Update a task within its plan. Use replace_body to rewrite body, append_body to extend it, or replace_in_body for surgical edits. Keep each write under 1000 words.", Map::new())
                     .with_input_schema::<UpdateTaskParams>()
-                    .with_meta(Meta(json!({"call_template": "update task {{ args.plan }}/{{ args.id }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.status %} [{{ args.status }}]{% endif %}{% if args.assignee %} @{{ args.assignee }}{% endif %}{% if args.executor %} ▶{{ args.executor }}{% endif %}{% if args.tags %} #{{ args.tags | join(' #') }}{% endif %}{% if args.replace_body %}\n{{ args.replace_body | truncate(80) }}{% endif %}{% if args.append_body %}\n+{{ args.append_body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(Meta(json!({"call_template": "update task {{ args.plan }}/{{ args.id }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.status %} [{{ args.status }}]{% endif %}{% if args.assignee %} @{{ args.assignee }}{% endif %}{% if args.executor %} ▶{{ args.executor }}{% endif %}{% if args.tags %} #{{ args.tags | join(' #') }}{% endif %}{% if args.replace_body %}
+{{ args.replace_body | truncate(80) }}{% endif %}{% if args.append_body %}
++{{ args.append_body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("delete_task", "Delete a task by ID.", Map::new())
                     .with_input_schema::<DeleteTaskParams>()
                     .with_meta(Meta(json!({"call_template": "delete task {{ args.plan }}/{{ args.id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
@@ -2022,7 +2123,8 @@ impl ServerHandler for PlansServer {
                     .with_meta(Meta(json!({"call_template": "list notes {{ args.plan }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("add_note", "Add a note to a plan. Keep body under 1000 words; use update_note with replace_in_body for targeted edits.", Map::new())
                     .with_input_schema::<AddNoteParams>()
-                    .with_meta(Meta(json!({"call_template": "add note {{ args.plan }}{% if args.summary %} — {{ args.summary | truncate(60) }}{% endif %}{% if args.author %} by {{ args.author }}{% endif %}{% if args.body %}\n{{ args.body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(Meta(json!({"call_template": "add note {{ args.plan }}{% if args.summary %} — {{ args.summary | truncate(60) }}{% endif %}{% if args.author %} by {{ args.author }}{% endif %}{% if args.body %}
+{{ args.body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("get_note", "Read a note from a plan.", Map::new())
                     .with_input_schema::<GetNoteParams>()
                     .with_meta(Meta(json!({"call_template": "read note {{ args.plan }}/{{ args.note_id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
@@ -2118,6 +2220,7 @@ mod tests {
     use super::*;
     use serde_json::Value;
     use std::fs;
+    use std::time::Duration;
 
     fn temp_test_dir(label: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!("harnx-mcp-plans-{}-{}", label, gen_id()));
@@ -2135,6 +2238,62 @@ mod tests {
 
     fn extract_id(summary: &str) -> String {
         summary.split_whitespace().nth(2).unwrap().to_string()
+    }
+
+    #[test]
+    fn plan_last_activity_uses_latest_file_mtime_not_dir_mtime() {
+        let dir = temp_test_dir("plan-last-activity-latest-file");
+        let plan_dir = dir.join("plan-a");
+        fs::create_dir_all(&plan_dir).unwrap();
+
+        let dir_mtime = plan_dir.metadata().unwrap().modified().unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        fs::write(plan_dir.join("plan.md"), "plan").unwrap();
+        let plan_mtime = plan_dir
+            .join("plan.md")
+            .metadata()
+            .unwrap()
+            .modified()
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        fs::create_dir_all(plan_dir.join("tasks")).unwrap();
+        fs::write(plan_dir.join("tasks/task-1.md"), "task").unwrap();
+        let task_mtime = plan_dir
+            .join("tasks/task-1.md")
+            .metadata()
+            .unwrap()
+            .modified()
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        fs::create_dir_all(plan_dir.join("notes")).unwrap();
+        fs::write(plan_dir.join("notes/note-1.md"), "note").unwrap();
+        let note_mtime = plan_dir
+            .join("notes/note-1.md")
+            .metadata()
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        let actual = plan_last_activity(&plan_dir).unwrap();
+        let expected = plan_mtime.max(task_mtime).max(note_mtime);
+
+        assert_eq!(actual, expected);
+        assert!(actual > dir_mtime);
+    }
+
+    #[test]
+    fn plan_last_activity_falls_back_to_dir_mtime_for_empty_plan() {
+        let dir = temp_test_dir("plan-last-activity-empty-plan");
+        let plan_dir = dir.join("plan-a");
+        fs::create_dir_all(&plan_dir).unwrap();
+
+        let expected = plan_dir.metadata().unwrap().modified().unwrap();
+        let actual = plan_last_activity(&plan_dir).unwrap();
+
+        assert_eq!(actual, expected);
     }
 
     #[tokio::test]
@@ -4081,6 +4240,24 @@ line2"
             "expected 'not found' in: {}",
             err.message
         );
+    }
+
+    #[tokio::test]
+    async fn cleanup_deletes_stale_plan_but_keeps_fresh_plan() {
+        let dir = temp_test_dir("cleanup-stale-plan");
+        let stale_plan = dir.join("stale-plan");
+        let fresh_plan = dir.join("fresh-plan");
+
+        fs::create_dir_all(&stale_plan).unwrap();
+        fs::write(stale_plan.join("plan.md"), "stale").unwrap();
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        fs::create_dir_all(&fresh_plan).unwrap();
+        fs::write(fresh_plan.join("plan.md"), "fresh").unwrap();
+
+        run_cleanup_pass(&dir, Duration::from_millis(10)).await;
+
+        assert!(!stale_plan.exists(), "stale plan should be deleted");
+        assert!(fresh_plan.exists(), "fresh plan should be kept");
     }
 
     #[test]

--- a/docs/solutions/async-patterns/mcp-server-background-task-supervision-2026-05-25.md
+++ b/docs/solutions/async-patterns/mcp-server-background-task-supervision-2026-05-25.md
@@ -1,0 +1,155 @@
+---
+title: "MCP server background task supervision with restart semantics"
+date: 2026-05-25
+category: async-patterns
+problem_type: logic_error
+component: harnx-mcp-plans
+root_cause: "RunningService::waiting consumes self, preventing direct select! alongside background task"
+resolution_type: code_fix
+severity: medium
+tags:
+  - tokio
+  - spawn
+  - JoinHandle
+  - select!
+  - supervision
+  - mcp
+  - rmcp
+  - restart
+plan_ref: harnx-mcp-plans-auto-cleanup
+---
+
+## Problem
+
+rmcp's `RunningService::waiting(self)` consumes the service, making it impossible to `select!` directly on both the service future and a background task. Naive patterns either drop the background task JoinHandle (silent failures) or terminate the server when background task exits.
+
+## Symptoms
+
+- Background cleanup task failure takes down entire MCP server
+- Double execution at startup (e.g., cleanup runs twice immediately)
+- `dead_code` warnings during incremental feature development
+- Nested async functions inaccessible from test module
+
+## Investigation Steps
+
+1. Attempted direct `select!` on `service.waiting()` and cleanup JoinHandle — compiler error: `waiting` consumes `self`, can't await twice
+2. Tried spawning service.waiting() in task, keeping cleanup Handle — realized both needed to be JoinHandles for select! symmetry
+3. Discovered `tokio::time::interval()` fires immediately on first `.tick().await`
+4. Hit test visibility issue: async fn nested inside async fn invisible to `#[cfg(test)]` module
+
+## Root Cause
+
+**Pattern 1: Service consumption.** rmcp's `RunningService::waiting(self)` takes ownership. Pattern that works:
+
+1. Spawn `service.waiting()` as its own task, returning a JoinHandle
+2. Spawn cleanup task, returning another JoinHandle
+3. Use `tokio::pin!` + loop + `select!` on both handles
+4. When cleanup exits/panics: log error, spawn fresh cleanup task with cloned config
+5. When service exits: break from loop, normal shutdown
+
+**Pattern 2: Interval first tick.** `tokio::time::interval()` first tick is immediate. To run startup pass + subsequent periodic passes without duplication:
+
+```rust
+run_cleanup_pass(&dir, retention).await;  // startup pass
+let mut interval = tokio::time::interval(period);
+interval.tick().await;  // consume immediate tick
+loop {
+    interval.tick().await;
+    run_cleanup_pass(&dir, retention).await;
+}
+```
+
+**Pattern 3: spawn_blocking for fs I/O.** Walking directories and computing mtime inside `tokio::task::spawn_blocking` prevents blocking the async runtime.
+
+**Pattern 4: Nested async fn visibility.** Extract them as top-level free functions for test access.
+
+## Solution
+
+**Main.rs supervision loop:**
+
+```rust
+let cleanup_dir = plans_dir.clone();
+let mut cleanup_handle = tokio::spawn(server::cleanup_loop(plans_dir, retention_days));
+let service_handle = tokio::spawn(async move { service.waiting().await });
+tokio::pin!(service_handle);
+
+loop {
+    tokio::select! {
+        result = &mut *service_handle => {
+            result??;
+            break;
+        }
+        result = &mut cleanup_handle => {
+            if let Err(e) = result {
+                eprintln!("[cleanup] task failed: {e}");
+            }
+            cleanup_handle = tokio::spawn(server::cleanup_loop(cleanup_dir.clone(), retention_days));
+        }
+    }
+}
+```
+
+**Cleanup loop with correct interval handling:**
+
+```rust
+pub async fn cleanup_loop(dir: PathBuf, retention_days: u64) {
+    let retention = Duration::from_secs(retention_days.saturating_mul(86_400));
+    
+    run_cleanup_pass(&dir, retention).await;
+    
+    let mut interval = tokio::time::interval(Duration::from_secs(86_400));
+    interval.tick().await;
+    
+    loop {
+        interval.tick().await;
+        run_cleanup_pass(&dir, retention).await;
+    }
+}
+
+async fn run_cleanup_pass(dir: &Path, retention: Duration) {
+    for plan_dir in plan_dirs(dir) {
+        let last_activity = tokio::task::spawn_blocking(move || {
+            plan_last_activity(&plan_dir)
+        }).await;
+        // ... process ...
+    }
+}
+```
+
+## Why This Works
+
+1. **Both tasks spawned**: `service.waiting()` wrapped in spawn returns a handle, enabling `select!` alongside cleanup handle.
+
+2. **`tokio::pin!`**: Allows borrowing the JoinHandle mutably in select! after moving it into the pinned pointer.
+
+3. **Loop with restart**: When cleanup panics/exits, spawn fresh task with cloned config. Server continues serving MCP requests.
+
+4. **First tick consumption**: Immediate tick consumed before loop, preventing duplicate startup execution.
+
+5. **Top-level async functions**: Extracted from nesting ensures `#[cfg(test)]` module can call them.
+
+## Prevention Strategies
+
+**Code Review Checklist:**
+- [ ] `RunningService::waiting()` spawned into its own task
+- [ ] Background task JoinHandle kept and supervised via `select!`
+- [ ] Task failure logs error but continues service (unless explicit exit desired)
+- [ ] `tokio::time::interval()` first tick consumed if startup pass runs separately
+- [ ] Blocking fs I/O wrapped in `spawn_blocking`
+- [ ] Async helper functions extracted to top-level for test visibility
+
+**Best Practices:**
+- Clone config/data before spawning background tasks that may need restart
+- Use `tokio::pin!` for JoinHandles that need to be replaced in a loop
+- Document intentional task detachment with `// fire-and-forget` comment
+- Accept `dead_code` warnings when building incrementally — disappear once wired
+
+**Test Cases:**
+- Force cleanup task failure, verify server continues serving
+- Add stale and fresh test data, run one pass, assert only stale deleted
+- Verify only one startup pass when interval loop begins
+
+## Related Issues
+
+- **Related Solution:** [acp-io-task-supervision-2026-05-07.md](../async-patterns/acp-io-task-supervision-2026-05-07.md) — JoinHandle supervision in LocalSet command loop
+- **GitHub:** [issue #652](https://github.com/dobesv/harnx/issues/652) — Plan cleanup background task


### PR DESCRIPTION
Adds automatic background cleanup of inactive plans to harnx-mcp-plans with a configurable retention period. Cleanup is performed daily in the background.

Key changes:
- Add --retention-days CLI flag and AGENT_PLANS_RETENTION_DAYS env var (default 14 days)
- Implement supervised background task that restarts on panic
- Add unit tests for deletion logic

#652

Plan: harnx-mcp-plans-auto-cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic cleanup of inactive plans with configurable retention period
  * Added `--retention-days` command-line option and environment variable support for retention configuration
  * Background cleanup task supervision with automatic restart capability

* **Documentation**
  * Added README documenting the plans management server and available tools
  * Added solution guide for async task supervision patterns

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->