### PR TITLE
feat(mcp-bash): add shebang support for non-bash interpreters

### DIFF
--- a/.changesets/shebang-support-bash-mcp.md
+++ b/.changesets/shebang-support-bash-mcp.md
@@ -1,0 +1,5 @@
+---
+harnx-core: minor
+harnx-mcp-bash: minor
+---
+Add shebang support to the bash MCP server. Scripts starting with `#!` (e.g., Python, Node, Ruby) are automatically written to temporary files and executed via the detected interpreter. Includes dynamic Markdown code-fence highlighting and automatic sandbox allowlisting for absolute interpreter paths.

--- a/crates/harnx-core/src/tool.rs
+++ b/crates/harnx-core/src/tool.rs
@@ -101,6 +101,66 @@ pub struct ToolDeclaration {
     pub result_template: Option<String>,
 }
 
+/// Map a shebang interpreter name to a Markdown code-fence language label.
+///
+/// Handles both `#!/usr/bin/env INTERP` and `#!/path/to/INTERP` forms.
+/// Returns `"sh"` for plain (non-shebang) commands and unknown interpreters.
+pub fn shebang_fence_lang(command: &str) -> &'static str {
+    let Some(shebang_line) = command
+        .strip_prefix("#!")
+        .and_then(|rest| rest.lines().next())
+    else {
+        return "sh";
+    };
+
+    let mut parts = shebang_line.split_whitespace();
+    let Some(first) = parts.next() else {
+        return "sh";
+    };
+
+    // Resolve `#!/usr/bin/env [flags...] INTERP` — the real interpreter is the
+    // first non-flag token after `env` (flags start with `-`).
+    let interp_name = if first == "/usr/bin/env" {
+        parts.find(|t| !t.starts_with('-')).unwrap_or("")
+    } else {
+        // Extract the last path component of a direct path.
+        first.rsplit('/').next().unwrap_or(first)
+    };
+
+    match interp_name {
+        "python" | "python3" => "python",
+        "node" | "nodejs" => "javascript",
+        "ruby" => "ruby",
+        "perl" => "perl",
+        "bash" => "bash",
+        "sh" => "sh",
+        "deno" => "typescript",
+        "bun" => "javascript",
+        "php" => "php",
+        _ => "sh",
+    }
+}
+
+/// Strip the shebang line (and any immediately following blank line) from a command string.
+///
+/// Returns the command unchanged if it does not start with `#!`.
+pub fn strip_shebang_line(command: &str) -> &str {
+    let Some(rest) = command.strip_prefix("#!") else {
+        return command;
+    };
+    // Skip the rest of the shebang line.
+    let after_shebang = match rest.find('\n') {
+        Some(pos) => &rest[pos + 1..],
+        None => return "",
+    };
+    // Also skip a single immediately-following blank line.
+    if let Some(stripped) = after_shebang.strip_prefix('\n') {
+        stripped
+    } else {
+        after_shebang
+    }
+}
+
 fn make_template_env<'a>() -> Environment<'a> {
     let mut env = Environment::new();
     env.set_undefined_behavior(UndefinedBehavior::Lenient);
@@ -125,6 +185,14 @@ fn make_template_env<'a>() -> Environment<'a> {
             }
         },
     );
+    // `shebang_lang`: maps a command string to the appropriate Markdown fence language.
+    env.add_filter("shebang_lang", |value: &str| -> &'static str {
+        shebang_fence_lang(value)
+    });
+    // `strip_shebang`: removes the leading shebang line from a command string.
+    env.add_filter("strip_shebang", |value: &str| -> String {
+        strip_shebang_line(value).to_string()
+    });
     env
 }
 
@@ -735,5 +803,90 @@ mod tests {
             out.contains("[>1]"),
             "outputs count in extended output: {out:?}"
         );
+    }
+
+    #[test]
+    fn test_shebang_lang_filter_python() {
+        assert_eq!(
+            shebang_fence_lang("#!/usr/bin/env python3\nprint('hi')"),
+            "python"
+        );
+        assert_eq!(
+            shebang_fence_lang("#!/usr/bin/python3\nprint('hi')"),
+            "python"
+        );
+    }
+
+    #[test]
+    fn test_shebang_lang_filter_node() {
+        assert_eq!(
+            shebang_fence_lang("#!/usr/bin/env node\nconsole.log('hi')"),
+            "javascript"
+        );
+        assert_eq!(
+            shebang_fence_lang("#!/usr/bin/env bun\nconsole.log('hi')"),
+            "javascript"
+        );
+    }
+
+    #[test]
+    fn test_shebang_lang_filter_sh_fallback() {
+        assert_eq!(shebang_fence_lang("echo hello"), "sh");
+        assert_eq!(shebang_fence_lang("ls -la"), "sh");
+    }
+
+    #[test]
+    fn test_shebang_lang_filter_unknown_interp() {
+        assert_eq!(shebang_fence_lang("#!/usr/bin/env myweirdlang\ncode"), "sh");
+    }
+
+    #[test]
+    fn test_shebang_lang_known_interpreters() {
+        assert_eq!(shebang_fence_lang("#!/usr/bin/env ruby\nputs 1"), "ruby");
+        assert_eq!(shebang_fence_lang("#!/usr/bin/env perl\nprint 1"), "perl");
+        assert_eq!(shebang_fence_lang("#!/bin/bash\necho hi"), "bash");
+        assert_eq!(shebang_fence_lang("#!/bin/sh\necho hi"), "sh");
+        assert_eq!(shebang_fence_lang("#!/usr/bin/env deno\n"), "typescript");
+        assert_eq!(shebang_fence_lang("#!/usr/bin/env php\n"), "php");
+    }
+
+    #[test]
+    fn test_strip_shebang_filter() {
+        assert_eq!(
+            strip_shebang_line("#!/usr/bin/env python3\nprint('hi')"),
+            "print('hi')"
+        );
+        // blank line after shebang is also stripped
+        assert_eq!(
+            strip_shebang_line("#!/usr/bin/env python3\n\nprint('hi')"),
+            "print('hi')"
+        );
+    }
+
+    #[test]
+    fn test_strip_shebang_no_shebang() {
+        assert_eq!(strip_shebang_line("echo hello"), "echo hello");
+    }
+
+    #[test]
+    fn test_shebang_lang_env_s_flag() {
+        // #!/usr/bin/env -S python3 should still map to "python"
+        assert_eq!(
+            shebang_fence_lang("#!/usr/bin/env -S python3\nprint('hi')"),
+            "python"
+        );
+    }
+
+    #[test]
+    fn test_shebang_filters_via_template() {
+        // Verify both filters are actually registered and callable from MiniJinja.
+        let out = render_tool_call_template(
+            "```{{ args.command | shebang_lang }}\n$ {{ args.command | strip_shebang }}\n```",
+            &serde_json::json!({"command": "#!/usr/bin/env python3\nprint('hi')"}),
+            "",
+        )
+        .unwrap();
+        assert!(out.starts_with("```python\n"), "fence lang: {out:?}");
+        assert!(out.contains("print('hi')"), "body: {out:?}");
     }
 }

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -79,7 +79,7 @@ impl JsonSchema for ExecCommandParams {
         let env = generator.subschema_for::<Option<HashMap<String, String>>>();
         object_schema_with_desc(
             vec![
-                ("command", "Bash command to execute. Avoid shell pipes like | head, | tail, | grep — use head_lines, tail_lines, max_output_bytes instead.", command),
+                ("command", "Bash command to execute. Avoid shell pipes like | head, | tail, | grep — use head_lines, tail_lines, max_output_bytes instead. For multi-line Python/Node/Ruby/etc. scripts, start the command with a shebang line (e.g. #!/usr/bin/env python3) and write the script body on subsequent lines — the correct interpreter will be used automatically.", command),
                 ("working_dir", "Working directory for the command. Defaults to the project root.", working_dir),
                 ("timeout_secs", "Kill the command after this many seconds. Default: no timeout.", timeout_secs),
                 ("head_lines", "Return only the first N lines of combined output. Prefer this over `| head -N` in the command.", head_lines),
@@ -185,7 +185,7 @@ impl JsonSchema for SpawnCommandParams {
         let env = generator.subschema_for::<Option<HashMap<String, String>>>();
         object_schema_with_desc(
             vec![
-                ("command", "Bash command to run in the background.", command),
+                ("command", "Bash command to run in the background. Supports shebang lines: start the command with #!/usr/bin/env python3 (or node, ruby, etc.) to run a multi-line script with the correct interpreter instead of wrapping it in bash -c.", command),
                 (
                     "working_dir",
                     "Working directory. Defaults to the project root.",
@@ -1168,9 +1168,37 @@ impl BashServer {
                     }
                 }
                 sb_args.push(OsString::from("--"));
-                sb_args.push(OsString::from("bash"));
-                sb_args.push(OsString::from("-c"));
-                sb_args.push(OsString::from(&params.command));
+                if let Some((interp, shebang_args)) = parse_shebang(&params.command) {
+                    let ext = shebang_script_ext(&params.command);
+                    let script_path = exec_dir.join(format!("script.{ext}"));
+                    std::fs::write(&script_path, params.command.as_bytes())
+                        .map_err(|e| internal_error(format!("failed to write script file: {e}")))?;
+                    use std::os::unix::fs::PermissionsExt;
+                    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+                        .map_err(|e| internal_error(format!("failed to chmod script: {e}")))?;
+                    // If the interpreter is an absolute path outside SYSTEM_EXEC_PATHS, allow it.
+                    if interp.is_absolute() {
+                        if let Some(interp_dir) = interp.parent() {
+                            let dir_str = interp_dir.to_string_lossy();
+                            if !Self::SYSTEM_EXEC_PATHS
+                                .iter()
+                                .any(|p| *p == dir_str.as_ref())
+                            {
+                                sb_args.push(OsString::from("--exec"));
+                                sb_args.push(interp_dir.as_os_str().to_owned());
+                            }
+                        }
+                    }
+                    sb_args.push(interp.as_os_str().to_owned());
+                    for arg in shebang_args {
+                        sb_args.push(OsString::from(arg));
+                    }
+                    sb_args.push(script_path.as_os_str().to_owned());
+                } else {
+                    sb_args.push(OsString::from("bash"));
+                    sb_args.push(OsString::from("-c"));
+                    sb_args.push(OsString::from(&params.command));
+                }
                 drop(roots_guard);
                 let sandbox_run_path = self.inner.sandbox_config.sandbox_run_path.clone();
                 CommandWrap::with_new(sandbox_run_path, |command| {
@@ -1187,16 +1215,40 @@ impl BashServer {
         } else {
             let child_env = self.build_child_env();
             let extra_env = params.env.clone().unwrap_or_default();
-            CommandWrap::with_new("bash", |command| {
-                command
-                    .args(["-c", &params.command])
-                    .current_dir(&working_dir)
-                    .stdin(Stdio::null());
-                command.env_clear();
-                command.envs(child_env.iter().map(|(k, v)| (k, v)));
-                command.envs(extra_env.iter());
-                command.stdout(Stdio::piped()).stderr(Stdio::piped());
-            })
+            if let Some((interp, shebang_args)) = parse_shebang(&params.command) {
+                let ext = shebang_script_ext(&params.command);
+                let script_path = exec_dir.join(format!("script.{ext}"));
+                std::fs::write(&script_path, params.command.as_bytes())
+                    .map_err(|e| internal_error(format!("failed to write script file: {e}")))?;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+                        .map_err(|e| internal_error(format!("failed to chmod script: {e}")))?;
+                }
+                CommandWrap::with_new(&interp, |command| {
+                    command
+                        .args(&shebang_args)
+                        .arg(&script_path)
+                        .current_dir(&working_dir)
+                        .stdin(Stdio::null());
+                    command.env_clear();
+                    command.envs(child_env.iter().map(|(k, v)| (k, v)));
+                    command.envs(extra_env.iter());
+                    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+                })
+            } else {
+                CommandWrap::with_new("bash", |command| {
+                    command
+                        .args(["-c", &params.command])
+                        .current_dir(&working_dir)
+                        .stdin(Stdio::null());
+                    command.env_clear();
+                    command.envs(child_env.iter().map(|(k, v)| (k, v)));
+                    command.envs(extra_env.iter());
+                    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+                })
+            }
         };
         command.wrap(KillOnDrop);
         #[cfg(unix)]
@@ -1658,9 +1710,37 @@ impl BashServer {
                     }
                 }
                 sb_args.push(OsString::from("--"));
-                sb_args.push(OsString::from("bash"));
-                sb_args.push(OsString::from("-c"));
-                sb_args.push(OsString::from(&params.command));
+                if let Some((interp, shebang_args)) = parse_shebang(&params.command) {
+                    let ext = shebang_script_ext(&params.command);
+                    let script_path = exec_dir.join(format!("script.{ext}"));
+                    std::fs::write(&script_path, params.command.as_bytes())
+                        .map_err(|e| internal_error(format!("failed to write script file: {e}")))?;
+                    use std::os::unix::fs::PermissionsExt;
+                    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+                        .map_err(|e| internal_error(format!("failed to chmod script: {e}")))?;
+                    // If the interpreter is an absolute path outside SYSTEM_EXEC_PATHS, allow it.
+                    if interp.is_absolute() {
+                        if let Some(interp_dir) = interp.parent() {
+                            let dir_str = interp_dir.to_string_lossy();
+                            if !Self::SYSTEM_EXEC_PATHS
+                                .iter()
+                                .any(|p| *p == dir_str.as_ref())
+                            {
+                                sb_args.push(OsString::from("--exec"));
+                                sb_args.push(interp_dir.as_os_str().to_owned());
+                            }
+                        }
+                    }
+                    sb_args.push(interp.as_os_str().to_owned());
+                    for arg in shebang_args {
+                        sb_args.push(OsString::from(arg));
+                    }
+                    sb_args.push(script_path.as_os_str().to_owned());
+                } else {
+                    sb_args.push(OsString::from("bash"));
+                    sb_args.push(OsString::from("-c"));
+                    sb_args.push(OsString::from(&params.command));
+                }
                 drop(roots_guard);
                 let sandbox_run_path = self.inner.sandbox_config.sandbox_run_path.clone();
                 CommandWrap::with_new(sandbox_run_path, |command| {
@@ -1677,18 +1757,44 @@ impl BashServer {
         } else {
             let child_env = self.build_child_env();
             let extra_env = params.env.clone().unwrap_or_default();
-            CommandWrap::with_new("bash", |command| {
-                command
-                    .args(["-c", &params.command])
-                    .current_dir(&working_dir)
-                    .stdin(Stdio::null());
-                command.env_clear();
-                command.envs(child_env.iter().map(|(k, v)| (k, v)));
-                command.envs(extra_env.iter());
-                command
-                    .stdout(Stdio::from(stdout_file))
-                    .stderr(Stdio::from(stderr_file));
-            })
+            if let Some((interp, shebang_args)) = parse_shebang(&params.command) {
+                let ext = shebang_script_ext(&params.command);
+                let script_path = exec_dir.join(format!("script.{ext}"));
+                std::fs::write(&script_path, params.command.as_bytes())
+                    .map_err(|e| internal_error(format!("failed to write script file: {e}")))?;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+                        .map_err(|e| internal_error(format!("failed to chmod script: {e}")))?;
+                }
+                CommandWrap::with_new(&interp, |command| {
+                    command
+                        .args(&shebang_args)
+                        .arg(&script_path)
+                        .current_dir(&working_dir)
+                        .stdin(Stdio::null());
+                    command.env_clear();
+                    command.envs(child_env.iter().map(|(k, v)| (k, v)));
+                    command.envs(extra_env.iter());
+                    command
+                        .stdout(Stdio::from(stdout_file))
+                        .stderr(Stdio::from(stderr_file));
+                })
+            } else {
+                CommandWrap::with_new("bash", |command| {
+                    command
+                        .args(["-c", &params.command])
+                        .current_dir(&working_dir)
+                        .stdin(Stdio::null());
+                    command.env_clear();
+                    command.envs(child_env.iter().map(|(k, v)| (k, v)));
+                    command.envs(extra_env.iter());
+                    command
+                        .stdout(Stdio::from(stdout_file))
+                        .stderr(Stdio::from(stderr_file));
+                })
+            }
         };
         #[cfg(unix)]
         command.wrap(ProcessGroup::leader());
@@ -2190,12 +2296,12 @@ impl ServerHandler for BashServer {
             tools: vec![
                 Tool::new(
                     "exec",
-                    "Execute a local bash command and return truncated combined stdout/stderr. When output is cropped, stdout/stderr temp log files are included for later retrieval. Prefer head_lines/tail_lines/max_output_bytes params over piping to head/tail in the command string.",
+                    "Execute a local bash command and return truncated combined stdout/stderr. When output is cropped, stdout/stderr temp log files are included for later retrieval. Prefer head_lines/tail_lines/max_output_bytes params over piping to head/tail in the command string. Supports shebang lines: if the command starts with #!, the script is written to a temp file and executed with the named interpreter (python3, node, ruby, etc.) — prefer this over python3 -c or node -e for multi-line scripts.",
                     Map::new(),
                 )
                 .with_input_schema::<ExecCommandParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "```sh\n$ {{ args.command }}\n```{% if args.working_dir or args.timeout_secs or args.head_lines or args.tail_lines or args.max_output_bytes or args.inputs or args.outputs %}\n{% if args.working_dir %}({{ args.working_dir }}) {% endif %}{% if args.timeout_secs %}[{{ args.timeout_secs }}s] {% endif %}{% if args.head_lines is not none %}[head:{{ args.head_lines }}] {% endif %}{% if args.tail_lines is not none %}[tail_lines:{{ args.tail_lines }}] {% endif %}{% if args.max_output_bytes is not none %}[:{{ args.max_output_bytes }}b] {% endif %}{% if args.inputs %}[<{{ args.inputs | length }}] {% endif %}{% if args.outputs %}[>{{ args.outputs | length }}]{% endif %}{% endif %}",
+                    "call_template": "```{{ args.command | shebang_lang }}\n$ {{ args.command | strip_shebang }}\n```{% if args.working_dir or args.timeout_secs or args.head_lines or args.tail_lines or args.max_output_bytes or args.inputs or args.outputs %}\n{% if args.working_dir %}({{ args.working_dir }}) {% endif %}{% if args.timeout_secs %}[{{ args.timeout_secs }}s] {% endif %}{% if args.head_lines is not none %}[head:{{ args.head_lines }}] {% endif %}{% if args.tail_lines is not none %}[tail_lines:{{ args.tail_lines }}] {% endif %}{% if args.max_output_bytes is not none %}[:{{ args.max_output_bytes }}b] {% endif %}{% if args.inputs %}[<{{ args.inputs | length }}] {% endif %}{% if args.outputs %}[>{{ args.outputs | length }}]{% endif %}{% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "read_exec_log",
@@ -2208,12 +2314,12 @@ impl ServerHandler for BashServer {
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "spawn",
-                    "Spawn a background bash command. Returns an execution_id and log file paths immediately without waiting for the command to finish. Output is written to separate stdout.log and stderr.log files. Use 'wait' to check for completion and 'terminate' to stop it.",
+                    "Spawn a background bash command. Returns an execution_id and log file paths immediately without waiting for the command to finish. Output is written to separate stdout.log and stderr.log files. Use 'wait' to check for completion and 'terminate' to stop it. Supports shebang lines: if the command starts with #!, the script is executed with the named interpreter automatically.",
                     Map::new(),
                 )
                 .with_input_schema::<SpawnCommandParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "```sh\n$ {{ args.command }} &\n```{% if args.working_dir or args.inputs or args.outputs %}\n{% if args.working_dir %}({{ args.working_dir }}) {% endif %}{% if args.inputs %}[<{{ args.inputs | length }}] {% endif %}{% if args.outputs %}[>{{ args.outputs | length }}]{% endif %}{% endif %}",
+                    "call_template": "```{{ args.command | shebang_lang }}\n$ {{ args.command | strip_shebang }} &\n```{% if args.working_dir or args.inputs or args.outputs %}\n{% if args.working_dir %}({{ args.working_dir }}) {% endif %}{% if args.inputs %}[<{{ args.inputs | length }}] {% endif %}{% if args.outputs %}[>{{ args.outputs | length }}]{% endif %}{% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "wait",
@@ -2310,6 +2416,55 @@ impl ServerHandler for BashServer {
 // ---------------------------------------------------------------------------
 // Free functions
 // ---------------------------------------------------------------------------
+
+/// Parse a shebang line from the first line of `command`.
+///
+/// Returns `None` if the command does not start with `#!`.
+/// Returns `Some((interpreter_path, extra_args))` where:
+/// - `interpreter_path` is a bare name (for `#!/usr/bin/env INTERP`) or absolute path
+/// - `extra_args` are any additional arguments on the shebang line (e.g. `-u`)
+fn parse_shebang(command: &str) -> Option<(PathBuf, Vec<String>)> {
+    let first_line = command.lines().next()?;
+    let shebang_rest = first_line.strip_prefix("#!")?;
+
+    let mut parts = shebang_rest.split_whitespace();
+    let interpreter = parts.next()?;
+
+    if interpreter == "/usr/bin/env" {
+        // `#!/usr/bin/env [-flags...] INTERP [args...]` — skip any env flags (e.g. -S)
+        // and use the first non-flag token as the interpreter name.
+        let env_interp = parts.find(|t| !t.starts_with('-'))?;
+        // Remaining tokens after the interpreter are extra args.
+        let extra_args: Vec<String> = parts.map(str::to_string).collect();
+        Some((PathBuf::from(env_interp), extra_args))
+    } else {
+        // `#!/path/to/INTERP [args...]` — use literal path
+        Some((
+            PathBuf::from(interpreter),
+            parts.map(str::to_string).collect(),
+        ))
+    }
+}
+
+/// Return the file extension (without dot) for the temp script file based on the shebang interpreter.
+fn shebang_script_ext(command: &str) -> &'static str {
+    let Some((interp, _)) = parse_shebang(command) else {
+        return "sh";
+    };
+    match interp
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default()
+    {
+        "python" | "python3" => "py",
+        "node" | "nodejs" | "bun" => "js",
+        "ruby" => "rb",
+        "perl" => "pl",
+        "deno" => "ts",
+        "php" => "php",
+        _ => "sh",
+    }
+}
 
 fn parse_arguments<T: DeserializeOwned>(
     arguments: Option<Map<String, Value>>,
@@ -4693,6 +4848,235 @@ mod tests {
                 .any(|(flag, val)| flag == "--write"
                     && val == "/tmp/harnx-test-sandbox-home2/projects"),
             "$HOME/projects must appear as --write arg: {pairs:?}"
+        );
+    }
+
+    fn python3_available() -> bool {
+        std::process::Command::new("python3")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn node_available() -> bool {
+        std::process::Command::new("node")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    #[tokio::test]
+    async fn test_exec_python_shebang() {
+        if !python3_available() {
+            eprintln!("skipping: python3 not available");
+            return;
+        }
+        let temp_dir = TestDir::new();
+        let server = BashServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .exec_command_impl(ExecCommandParams {
+                command: "#!/usr/bin/env python3\nprint(\"hello from python\")".to_string(),
+                working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
+                timeout_secs: Some(10),
+                head_lines: None,
+                tail_lines: None,
+                max_output_bytes: None,
+                inputs: None,
+                outputs: None,
+                env: None,
+            })
+            .await
+            .unwrap();
+
+        let text = text_content(&result);
+        assert!(
+            text.contains("hello from python"),
+            "expected python output, got: {text:?}"
+        );
+        assert!(text.contains("exit_code: 0"), "expected success: {text:?}");
+    }
+
+    #[tokio::test]
+    async fn test_exec_node_shebang() {
+        if !node_available() {
+            eprintln!("skipping: node not available");
+            return;
+        }
+        let temp_dir = TestDir::new();
+        let server = BashServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let result = server
+            .exec_command_impl(ExecCommandParams {
+                command: "#!/usr/bin/env node\nconsole.log(\"hello from node\")".to_string(),
+                working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
+                timeout_secs: Some(10),
+                head_lines: None,
+                tail_lines: None,
+                max_output_bytes: None,
+                inputs: None,
+                outputs: None,
+                env: None,
+            })
+            .await
+            .unwrap();
+
+        let text = text_content(&result);
+        assert!(
+            text.contains("hello from node"),
+            "expected node output, got: {text:?}"
+        );
+        assert!(text.contains("exit_code: 0"), "expected success: {text:?}");
+    }
+
+    #[tokio::test]
+    async fn test_spawn_python_shebang() {
+        if !python3_available() {
+            eprintln!("skipping: python3 not available");
+            return;
+        }
+        let temp_dir = TestDir::new();
+        let server = BashServer::new(vec![temp_dir.path().to_path_buf()]);
+
+        let spawn_result = server
+            .spawn_impl(SpawnCommandParams {
+                command: "#!/usr/bin/env python3\nprint(\"hello from spawn python\")".to_string(),
+                working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
+                inputs: None,
+                outputs: None,
+                env: None,
+            })
+            .await
+            .unwrap();
+
+        let spawn_text = text_content(&spawn_result);
+        assert!(
+            spawn_text.contains("status: spawned"),
+            "expected spawned status: {spawn_text:?}"
+        );
+        let execution_id = extract_field(&spawn_text, "execution_id");
+
+        let wait_result = server
+            .wait_impl(WaitParams {
+                execution_id,
+                timeout_secs: Some(10),
+                head_lines: None,
+                tail_lines: Some(20),
+                max_output_bytes: None,
+                grep: None,
+            })
+            .await
+            .unwrap();
+
+        let wait_text = text_content(&wait_result);
+        assert!(
+            wait_text.contains("hello from spawn python"),
+            "expected python output in wait, got: {wait_text:?}"
+        );
+        assert!(
+            wait_text.contains("exit_code: 0"),
+            "expected success: {wait_text:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_shebang_none_for_plain_command() {
+        assert_eq!(parse_shebang("echo hello"), None);
+    }
+
+    #[test]
+    fn test_parse_shebang_env_python3() {
+        assert_eq!(
+            parse_shebang("#!/usr/bin/env python3\nprint(\"hi\")"),
+            Some((PathBuf::from("python3"), vec![]))
+        );
+    }
+
+    #[test]
+    fn test_parse_shebang_direct_path() {
+        assert_eq!(
+            parse_shebang("#!/usr/bin/python3\nprint(\"hi\")"),
+            Some((PathBuf::from("/usr/bin/python3"), vec![]))
+        );
+    }
+
+    #[test]
+    fn test_parse_shebang_with_args() {
+        assert_eq!(
+            parse_shebang("#!/usr/bin/python3 -u\nprint(\"hi\")"),
+            Some((PathBuf::from("/usr/bin/python3"), vec!["-u".to_string()]))
+        );
+    }
+
+    #[test]
+    fn test_parse_shebang_node() {
+        assert_eq!(
+            parse_shebang("#!/usr/bin/env node\nconsole.log(\"hi\")"),
+            Some((PathBuf::from("node"), vec![]))
+        );
+    }
+
+    #[test]
+    fn test_shebang_script_ext_values() {
+        assert_eq!(shebang_script_ext("#!/usr/bin/env python3\n"), "py");
+        assert_eq!(shebang_script_ext("#!/usr/bin/env node\n"), "js");
+        assert_eq!(shebang_script_ext("#!/usr/bin/env ruby\n"), "rb");
+        assert_eq!(shebang_script_ext("#!/usr/bin/env perl\n"), "pl");
+        assert_eq!(shebang_script_ext("#!/usr/bin/env deno\n"), "ts");
+        assert_eq!(shebang_script_ext("#!/usr/bin/env php\n"), "php");
+        assert_eq!(shebang_script_ext("echo hello"), "sh");
+    }
+
+    #[test]
+    fn test_parse_shebang_env_s_flag() {
+        // #!/usr/bin/env -S python3 -u should skip -S and use python3 as interpreter
+        assert_eq!(
+            parse_shebang("#!/usr/bin/env -S python3 -u\nprint(\"hi\")"),
+            Some((PathBuf::from("python3"), vec!["-u".to_string()]))
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn test_sandbox_exec_python_shebang() {
+        if !python3_available() {
+            eprintln!("skipping: python3 not available");
+            return;
+        }
+        let temp_dir = TestDir::new();
+        let server = sandboxed_server(vec![temp_dir.path().to_path_buf()]);
+
+        if !sandbox_runtime_works() {
+            eprintln!("skipping: sandbox runtime not available");
+            return;
+        }
+
+        let result = server
+            .exec_command_impl(ExecCommandParams {
+                command: "#!/usr/bin/env python3\nprint(\"hello from sandboxed python\")"
+                    .to_string(),
+                working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
+                timeout_secs: Some(10),
+                head_lines: None,
+                tail_lines: None,
+                max_output_bytes: None,
+                inputs: None,
+                outputs: None,
+                env: None,
+            })
+            .await
+            .unwrap();
+
+        let text = text_content(&result);
+        assert!(
+            text.contains("hello from sandboxed python"),
+            "expected python output in sandbox, got: {text:?}"
+        );
+        assert!(
+            text.contains("exit_code: 0"),
+            "expected success in sandbox: {text:?}"
         );
     }
 }

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -1171,11 +1171,16 @@ impl BashServer {
                 if let Some((interp, shebang_args)) = parse_shebang(&params.command) {
                     let ext = shebang_script_ext(&params.command);
                     let script_path = exec_dir.join(format!("script.{ext}"));
-                    std::fs::write(&script_path, params.command.as_bytes())
+                    tokio::fs::write(&script_path, params.command.as_bytes())
+                        .await
                         .map_err(|e| internal_error(format!("failed to write script file: {e}")))?;
                     use std::os::unix::fs::PermissionsExt;
-                    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
-                        .map_err(|e| internal_error(format!("failed to chmod script: {e}")))?;
+                    tokio::fs::set_permissions(
+                        &script_path,
+                        std::fs::Permissions::from_mode(0o755),
+                    )
+                    .await
+                    .map_err(|e| internal_error(format!("failed to chmod script: {e}")))?;
                     // If the interpreter is an absolute path outside SYSTEM_EXEC_PATHS, allow it.
                     if interp.is_absolute() {
                         if let Some(interp_dir) = interp.parent() {
@@ -1218,13 +1223,18 @@ impl BashServer {
             if let Some((interp, shebang_args)) = parse_shebang(&params.command) {
                 let ext = shebang_script_ext(&params.command);
                 let script_path = exec_dir.join(format!("script.{ext}"));
-                std::fs::write(&script_path, params.command.as_bytes())
+                tokio::fs::write(&script_path, params.command.as_bytes())
+                    .await
                     .map_err(|e| internal_error(format!("failed to write script file: {e}")))?;
                 #[cfg(unix)]
                 {
                     use std::os::unix::fs::PermissionsExt;
-                    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
-                        .map_err(|e| internal_error(format!("failed to chmod script: {e}")))?;
+                    tokio::fs::set_permissions(
+                        &script_path,
+                        std::fs::Permissions::from_mode(0o755),
+                    )
+                    .await
+                    .map_err(|e| internal_error(format!("failed to chmod script: {e}")))?;
                 }
                 CommandWrap::with_new(&interp, |command| {
                     command
@@ -1713,11 +1723,16 @@ impl BashServer {
                 if let Some((interp, shebang_args)) = parse_shebang(&params.command) {
                     let ext = shebang_script_ext(&params.command);
                     let script_path = exec_dir.join(format!("script.{ext}"));
-                    std::fs::write(&script_path, params.command.as_bytes())
+                    tokio::fs::write(&script_path, params.command.as_bytes())
+                        .await
                         .map_err(|e| internal_error(format!("failed to write script file: {e}")))?;
                     use std::os::unix::fs::PermissionsExt;
-                    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
-                        .map_err(|e| internal_error(format!("failed to chmod script: {e}")))?;
+                    tokio::fs::set_permissions(
+                        &script_path,
+                        std::fs::Permissions::from_mode(0o755),
+                    )
+                    .await
+                    .map_err(|e| internal_error(format!("failed to chmod script: {e}")))?;
                     // If the interpreter is an absolute path outside SYSTEM_EXEC_PATHS, allow it.
                     if interp.is_absolute() {
                         if let Some(interp_dir) = interp.parent() {
@@ -1760,13 +1775,18 @@ impl BashServer {
             if let Some((interp, shebang_args)) = parse_shebang(&params.command) {
                 let ext = shebang_script_ext(&params.command);
                 let script_path = exec_dir.join(format!("script.{ext}"));
-                std::fs::write(&script_path, params.command.as_bytes())
+                tokio::fs::write(&script_path, params.command.as_bytes())
+                    .await
                     .map_err(|e| internal_error(format!("failed to write script file: {e}")))?;
                 #[cfg(unix)]
                 {
                     use std::os::unix::fs::PermissionsExt;
-                    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
-                        .map_err(|e| internal_error(format!("failed to chmod script: {e}")))?;
+                    tokio::fs::set_permissions(
+                        &script_path,
+                        std::fs::Permissions::from_mode(0o755),
+                    )
+                    .await
+                    .map_err(|e| internal_error(format!("failed to chmod script: {e}")))?;
                 }
                 CommandWrap::with_new(&interp, |command| {
                     command

--- a/docs/solutions/logic-errors/shebang-interpreter-dispatch-2026-05-25.md
+++ b/docs/solutions/logic-errors/shebang-interpreter-dispatch-2026-05-25.md
@@ -1,0 +1,159 @@
+---
+title: "Shebang interpreter dispatch in bash MCP exec/spawn tools"
+date: 2026-05-25
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-mcp-bash"
+root_cause: "missing parser for shebang interpreter selection"
+resolution_type: code_fix
+severity: medium
+tags:
+  - shebang
+  - interpreter
+  - sandbox
+  - command-execution
+  - env-flags
+plan_ref: "shebang-support-bash-mcp"
+---
+
+## Problem
+
+The `harnx-mcp-bash` exec and spawn tools previously executed all commands via `bash -c`, even when the command string began with a shebang (`#!`) line indicating a different interpreter. Scripts with `#!/usr/bin/env python3` would fail because the Python shebang was ignored and bash attempted to interpret Python code.
+
+## Symptoms
+
+```
+- Behavior: Python/Node/Ruby scripts with shebangs fail with bash syntax errors
+- Error example: `syntax error near unexpected token 'print'` for `#!/usr/bin/env python3\nprint("hi")`
+- Impact: Feature request #655 — users could not pass multi-line scripts in different languages
+```
+
+## Investigation Steps
+
+Reviewed existing exec flow in `exec_command_impl` and `spawn_impl`. Both paths constructed `CommandWrap::with_new("bash", ...)` unconditionally. The `params.command` string was passed directly to `bash -c` without inspection.
+
+Traced the sandbox argument construction sequence: `sb_args.push("--")` separates sandbox options from the command, so interpreter and arguments must be appended after this separator.
+
+Noted that `exec_dir` (per-execution temp directory created via `next_exec_dir()`) already has sandbox write access, making it a suitable location for temp script files.
+
+## Root Cause
+
+Command execution path lacked shebang detection and interpreter dispatch logic. The `command` parameter was treated as opaque bash input regardless of `#!` prefix.
+
+Additionally, for `#!/usr/bin/env -S INTERP` forms, the parser initially treated `-S` as the interpreter name, causing execution failures for valid shebangs using the `-S` split-args flag.
+
+## Solution
+
+### 1. Shebang Parsing
+
+Added `parse_shebang(command)` function in `server.rs`:
+
+```rust
+fn parse_shebang(command: &str) -> Option<(PathBuf, Vec<String>)> {
+    let first_line = command.lines().next()?;
+    let shebang_rest = first_line.strip_prefix("#!")?;
+    let mut parts = shebang_rest.split_whitespace();
+    let interpreter = parts.next()?;
+
+    if interpreter == "/usr/bin/env" {
+        // Skip env flags (e.g. -S) before interpreter name
+        let env_interp = parts.find(|t| !t.starts_with('-'))?;
+        let extra_args: Vec<String> = parts.map(str::to_string).collect();
+        Some((PathBuf::from(env_interp), extra_args))
+    } else {
+        // Direct path interpreter
+        Some((PathBuf::from(interpreter), parts.map(str::to_string).collect()))
+    }
+}
+```
+
+Key pattern: `parts.find(|t| !t.starts_with('-'))` skips env flags like `-S` to find the actual interpreter name.
+
+### 2. Script File Creation
+
+For shebang commands, write to `exec_dir/script.<ext>` and set executable permissions:
+
+```rust
+if let Some((interp, shebang_args)) = parse_shebang(&params.command) {
+    let ext = shebang_script_ext(&params.command);
+    let script_path = exec_dir.join(format!("script.{ext}"));
+    std::fs::write(&script_path, params.command.as_bytes())?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&script_path, Permissions::from_mode(0o755))?;
+    // ... execute via interpreter
+}
+```
+
+File extension mapping: `python`/`python3` → `py`, `node`/`nodejs`/`bun` → `js`, `ruby` → `rb`, etc.
+
+### 3. Sandbox Interpreter Allowlisting
+
+For sandboxed execution with absolute interpreter paths outside `SYSTEM_EXEC_PATHS`:
+
+```rust
+if interp.is_absolute() {
+    if let Some(interp_dir) = interp.parent() {
+        if !Self::SYSTEM_EXEC_PATHS.iter().any(|p| *p == dir_str.as_ref()) {
+            sb_args.push(OsString::from("--exec"));
+            sb_args.push(interp_dir.as_os_str().to_owned());
+        }
+    }
+}
+sb_args.push(interp.as_os_str().to_owned());
+for arg in shebang_args {
+    sb_args.push(OsString::from(arg));
+}
+sb_args.push(script_path.as_os_str().to_owned());
+```
+
+**Important:** For `#!/usr/bin/env INTERP` (bare name), no `--exec` needed — env resolves via PATH, and sandbox already allows system exec paths.
+
+For absolute paths like `#!/opt/custom/bin/python3`, the parent directory is added to sandbox `--exec` allowlist.
+
+### 4. Cross-Crate Template Filters
+
+MiniJinja filters registered in `harnx-core/src/tool.rs`:
+
+- `shebang_lang`: Returns fence language for Markdown rendering (`python`, `javascript`, etc.)
+- `strip_shebang`: Removes shebang line from displayed command
+
+```rust
+env.add_filter("shebang_lang", |value: &str| shebang_fence_lang(value).to_string());
+env.add_filter("strip_shebang", |value: &str| strip_shebang_line(value).to_string());
+```
+
+Both crates share identical env-flag handling: `parts.find(|t| !t.starts_with('-'))`.
+
+## Why This Works
+
+1. **Argv-based execution:** Interpreter, shebang args, and script path passed as discrete `argv` entries — no shell interpolation, no command injection risk.
+
+2. **Sandbox-compatible:** Script lives in `exec_dir` (already writable). Absolute interpreter paths get parent-dir allowlisted via `--exec`. Env-style interpreters rely on `SYSTEM_EXEC_PATHS`.
+
+3. **No extra write args:** Since `exec_dir` is per-execution and sandbox-writable, temp script creation needs no additional `--write` flags.
+
+4. **Unified pattern:** Same logic for exec/spawn and sandbox/non-sandbox — four branches share identical shebang handling sequence.
+
+## Prevention Strategies
+
+**Test Coverage:**
+- `test_exec_python_shebang` — non-sandbox Python execution
+- `test_spawn_python_shebang` — spawn path with shebang
+- `test_sandbox_exec_python_shebang` — Linux sandbox integration
+- `test_parse_shebang_env_s_flag` — verifies `-S` flag skipping
+- `test_shebang_script_ext_values` — extension mapping verification
+
+**Code Review Checklist:**
+- [ ] Shebang detection happens before command execution
+- [ ] Script file written to `exec_dir` (sandbox-safe location)
+- [ ] Absolute interpreter paths outside system dirs get `--exec` added
+- [ ] Env-style interpreters don't get `--exec` (rely on PATH/system exec paths)
+- [ ] Env flags like `-S` skipped before interpreter extraction
+- [ ] Tests cover sandbox and non-sandbox paths on Linux
+
+## Related Issues
+
+- **GitHub Issue:** #655 — Original feature request
+- **Commits:**
+  - `0f9497c0` — Initial shebang support implementation
+  - `2a00c713` — Fix for `env -S` flag parsing + sandbox test

--- a/docs/solutions/logic-errors/shebang-interpreter-dispatch-2026-05-25.md
+++ b/docs/solutions/logic-errors/shebang-interpreter-dispatch-2026-05-25.md
@@ -22,7 +22,7 @@ The `harnx-mcp-bash` exec and spawn tools previously executed all commands via `
 
 ## Symptoms
 
-```
+```text
 - Behavior: Python/Node/Ruby scripts with shebangs fail with bash syntax errors
 - Error example: `syntax error near unexpected token 'print'` for `#!/usr/bin/env python3\nprint("hi")`
 - Impact: Feature request #655 — users could not pass multi-line scripts in different languages


### PR DESCRIPTION
Adds support for executing scripts with shebang lines (e.g., #!/usr/bin/env python3) in the exec and spawn tools of the bash MCP server.

Key changes:
- Implement parse_shebang to extract interpreter and arguments from command strings.
- Automatically write shebang commands to temporary script files in the execution directory and execute them via the detected interpreter.
- Update harnx-core with shebang_lang and strip_shebang MiniJinja filters for dynamic Markdown code-fence rendering and cleaner command display.
- Support sandboxed execution by automatically allowlisting absolute interpreter paths.
- Handle /usr/bin/env flags like -S during parsing.
- Add comprehensive unit and integration tests for shebang parsing, extension mapping, and sandboxed/non-sandboxed execution.

#655

Plan: shebang-support-bash-mcp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shebang support to bash MCP server—scripts can now be executed in any language (Python, Node.js, etc.) by specifying the interpreter in the shebang line.
  * Improved code-fence highlighting for multi-language scripts based on their detected interpreter.
  * Enhanced sandbox security with automatic allowlisting of interpreter paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->