### PR TITLE
Replace gemini-3.1-flash-lite-preview with GA model

### DIFF
--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -4475,7 +4475,7 @@ mod tests {
         let agents_dir = temp.path().join("agents");
         std::fs::create_dir_all(&agents_dir).unwrap();
 
-        let agent_content = "---\nmodel: gemini:gemini-3.1-flash-lite-preview\n---\nYou are a specialized compaction agent. Produce a concise summary.\n";
+        let agent_content = "---\nmodel: gemini:gemini-3.1-flash-lite\n---\nYou are a specialized compaction agent. Produce a concise summary.\n";
         let mut f = std::fs::File::create(agents_dir.join("my-compactor.md")).unwrap();
         f.write_all(agent_content.as_bytes()).unwrap();
 
@@ -4483,12 +4483,9 @@ mod tests {
         // compaction_agent = "my-compactor".
         let mut main_agent = Agent::new(AgentConfig::from_markdown(
             "main",
-            "---\nmodel: gemini:gemini-3.1-flash-lite-preview\ncompaction_agent: my-compactor\n---\nYou are the main agent.",
+            "---\nmodel: gemini:gemini-3.1-flash-lite\ncompaction_agent: my-compactor\n---\nYou are the main agent.",
         ).unwrap());
-        main_agent.set_model(crate::client::Model::new(
-            "gemini",
-            "gemini-3.1-flash-lite-preview",
-        ));
+        main_agent.set_model(crate::client::Model::new("gemini", "gemini-3.1-flash-lite"));
 
         let mut config = Config {
             data: ConfigData {
@@ -4601,14 +4598,14 @@ mod tests {
 
         // Use /gemini (leading slash) to escape to top-level so the model
         // reference is not rewritten to mypkg/gemini by apply_package_agent_transforms.
-        let package_compactor = "---\nmodel: /gemini:gemini-3.1-flash-lite-preview\n---\nYou are the PACKAGE compactor. Produce a concise summary.\n";
+        let package_compactor = "---\nmodel: /gemini:gemini-3.1-flash-lite\n---\nYou are the PACKAGE compactor. Produce a concise summary.\n";
         let mut package_file =
             std::fs::File::create(package_agents_dir.join("compactor.md")).unwrap();
         package_file
             .write_all(package_compactor.as_bytes())
             .unwrap();
 
-        let top_level_compactor = "---\nmodel: gemini:gemini-3.1-flash-lite-preview\n---\nYou are the TOP-LEVEL compactor. Produce a concise summary.\n";
+        let top_level_compactor = "---\nmodel: gemini:gemini-3.1-flash-lite\n---\nYou are the TOP-LEVEL compactor. Produce a concise summary.\n";
         let mut top_level_file =
             std::fs::File::create(top_level_agents_dir.join("compactor.md")).unwrap();
         top_level_file
@@ -4618,15 +4615,12 @@ mod tests {
         let mut main_agent = Agent::new(
             AgentConfig::from_markdown(
                 "mypkg/main",
-                "---\nmodel: gemini:gemini-3.1-flash-lite-preview\n---\nYou are the main package agent.",
+                "---\nmodel: gemini:gemini-3.1-flash-lite\n---\nYou are the main package agent.",
             )
             .unwrap(),
         );
         main_agent.set_compaction_agent(Some("compactor".to_string()));
-        main_agent.set_model(crate::client::Model::new(
-            "gemini",
-            "gemini-3.1-flash-lite-preview",
-        ));
+        main_agent.set_model(crate::client::Model::new("gemini", "gemini-3.1-flash-lite"));
 
         let mut config = Config {
             data: ConfigData {

--- a/crates/harnx/models.yaml
+++ b/crates/harnx/models.yaml
@@ -145,7 +145,7 @@
       output_price: 1.5
       supports_vision: true
       supports_tool_use: true
-    - name: gemini-3.1-flash-lite-preview
+    - name: gemini-3.1-flash-lite
       max_input_tokens: 1048576
       supports_vision: true
       supports_tool_use: true
@@ -580,7 +580,7 @@
       output_price: 1.5
       supports_vision: true
       supports_tool_use: true
-    - name: gemini-3.1-flash-lite-preview
+    - name: gemini-3.1-flash-lite
       max_input_tokens: 1048576
       supports_vision: true
       supports_tool_use: true

--- a/packages/coding/agents/compact-coder.md
+++ b/packages/coding/agents/compact-coder.md
@@ -1,6 +1,6 @@
 ---
 role: compaction
-model: gemini:gemini-3.1-flash-lite-preview
+model: gemini:gemini-3.1-flash-lite
 version: '0.2.0'
 ---
 You are summarizing a conversation between a user and an AI coding assistant.

--- a/packages/pantheon/README.md
+++ b/packages/pantheon/README.md
@@ -46,7 +46,7 @@ results, and a multi-agent code review pipeline.
 ### Compaction Agents
 `compact-dev`, `compact-researcher`, `compact-planner`, `compact-reviewer`,
 `compact-argus`, `compact-mnemosyne`, `compact-reliability`, `compact-deploy` —
-lightweight context-compression agents (gemini-3.1-flash-lite-preview) used to keep
+lightweight context-compression agents (gemini-3.1-flash-lite) used to keep
 long conversations within token limits.
 
 ---

--- a/packages/pantheon/agents/compact-argus.md
+++ b/packages/pantheon/agents/compact-argus.md
@@ -1,6 +1,6 @@
 ---
 role: compaction
-model: gemini:gemini-3.1-flash-lite-preview
+model: gemini:gemini-3.1-flash-lite
 version: '0.2.0'
 ---
 You are summarizing a conversation between a user and an AI verification agent that checks whether tasks completed by other agents meet their requirements.

--- a/packages/pantheon/agents/compact-deploy.md
+++ b/packages/pantheon/agents/compact-deploy.md
@@ -1,6 +1,6 @@
 ---
 role: compaction
-model: gemini:gemini-3.1-flash-lite-preview
+model: gemini:gemini-3.1-flash-lite
 version: '0.2.0'
 ---
 You are summarizing a conversation between a user and an AI deployment verification agent that assesses deployment readiness and produces Go/No-Go checklists for pull requests.

--- a/packages/pantheon/agents/compact-dev.md
+++ b/packages/pantheon/agents/compact-dev.md
@@ -1,6 +1,6 @@
 ---
 role: compaction
-model: gemini:gemini-3.1-flash-lite-preview
+model: gemini:gemini-3.1-flash-lite
 version: '0.2.0'
 ---
 You are summarizing a conversation between a user and an AI coding agent that executes tasks, writes code, and delegates work to specialist agents.

--- a/packages/pantheon/agents/compact-mnemosyne.md
+++ b/packages/pantheon/agents/compact-mnemosyne.md
@@ -1,6 +1,6 @@
 ---
 role: compaction
-model: gemini:gemini-3.1-flash-lite-preview
+model: gemini:gemini-3.1-flash-lite
 version: '0.2.0'
 ---
 You are summarizing a conversation between a user and Mnemosyne, an AI agent that compounds engineering learnings into docs/solutions/ entries after work completes.

--- a/packages/pantheon/agents/compact-planner.md
+++ b/packages/pantheon/agents/compact-planner.md
@@ -1,6 +1,6 @@
 ---
 role: compaction
-model: gemini:gemini-3.1-flash-lite-preview
+model: gemini:gemini-3.1-flash-lite
 version: '0.2.0'
 ---
 You are summarizing a conversation between a user and an AI orchestrator agent that manages multi-step work plans and delegates tasks to sub-agents.

--- a/packages/pantheon/agents/compact-reliability.md
+++ b/packages/pantheon/agents/compact-reliability.md
@@ -1,6 +1,6 @@
 ---
 role: compaction
-model: gemini:gemini-3.1-flash-lite-preview
+model: gemini:gemini-3.1-flash-lite
 version: '0.2.0'
 ---
 You are summarizing a conversation between a user and an AI reliability review agent that analyzes pull requests and codebases for error handling, retry logic, timeouts, and resilience issues.

--- a/packages/pantheon/agents/compact-researcher.md
+++ b/packages/pantheon/agents/compact-researcher.md
@@ -1,6 +1,6 @@
 ---
 role: compaction
-model: gemini:gemini-3.1-flash-lite-preview
+model: gemini:gemini-3.1-flash-lite
 version: '0.2.0'
 ---
 You are summarizing a conversation between a user and an AI strategic planner that interviews users, researches codebases, and creates implementation plans.

--- a/packages/pantheon/agents/compact-reviewer.md
+++ b/packages/pantheon/agents/compact-reviewer.md
@@ -1,6 +1,6 @@
 ---
 role: compaction
-model: gemini:gemini-3.1-flash-lite-preview
+model: gemini:gemini-3.1-flash-lite
 version: '0.2.0'
 ---
 You are summarizing a conversation between a user and an AI code review agent that analyzes pull requests and codebases for quality, security, and correctness issues.


### PR DESCRIPTION
Replace deprecated  model references with the GA model  across the codebase.

Changes made:
-  — deduplicated preview entry to GA name (2 provider sections)
-  — 7 test fixture occurrences
-  — frontmatter model ref
-  — 8 compact agent frontmatter refs
-  — description text

Motivation:
 returns HTTP 404 NOT_FOUND from the Gemini API. GA model  already existed in models.yaml with full pricing metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model configurations across agents and system components to the latest stable version.
  * Updated corresponding documentation and test fixtures to reflect current configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/661?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->