### PR TITLE
fix(models): remove duplicate gemini-3.1-flash-lite entries in provid…

### DIFF
--- a/crates/harnx/models.yaml
+++ b/crates/harnx/models.yaml
@@ -145,10 +145,6 @@
       output_price: 1.5
       supports_vision: true
       supports_tool_use: true
-    - name: gemini-3.1-flash-lite
-      max_input_tokens: 1048576
-      supports_vision: true
-      supports_tool_use: true
     - name: gemini-3-flash-preview
       max_input_tokens: 1048576
       supports_vision: true
@@ -578,10 +574,6 @@
       max_output_tokens: 65536
       input_price: 0.25
       output_price: 1.5
-      supports_vision: true
-      supports_tool_use: true
-    - name: gemini-3.1-flash-lite
-      max_input_tokens: 1048576
       supports_vision: true
       supports_tool_use: true
     - name: gemini-3-flash-preview


### PR DESCRIPTION
…er catalogs

The previous rename of gemini-3.1-flash-lite-preview -> gemini-3.1-flash-lite created duplicate entries in both the gemini and vertexai provider sections. Each section already had a full-metadata entry (with max_output_tokens and pricing); the newly renamed entries were minimal (no pricing). Remove the redundant minimal rows so each model name appears exactly once per provider.