### PR TITLE
fix(tui): detail view shows full tool output when browsing history

### DIFF
--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -893,25 +893,46 @@ impl Tui {
         // is a pure seq-assignment event and should not create stray headings
         // or flush pending thoughts.
         if let AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }) = event {
+            // Try to backfill the seq into the most recent unsequenced transcript
+            // item (UserText, AssistantText, or ToolCall). If an item is found and
+            // patched, the seq has been consumed — clear pending_tool_seq.  If no
+            // item is found yet (e.g. ToolEvent::Started arrives after this event),
+            // store seq in pending_tool_seq so the upcoming ToolCall can pick it up.
+            let mut backfilled = false;
             for item in self.app.transcript.iter_mut().rev() {
                 match item {
+                    // Only backfill "live" entries — items with a timestamp are
+                    // created during an active session.  The agent banner is
+                    // AssistantText { seq: None, timestamp: None } and must not
+                    // consume a seq that belongs to the first real message.
                     TranscriptItem::UserText {
                         seq: item_seq @ None,
+                        timestamp: Some(_),
                         ..
                     }
                     | TranscriptItem::AssistantText {
                         seq: item_seq @ None,
+                        timestamp: Some(_),
                         ..
                     }
                     | TranscriptItem::ToolCall {
                         seq: item_seq @ None,
+                        timestamp: Some(_),
                         ..
                     } => {
                         *item_seq = Some(seq);
+                        backfilled = true;
                         break;
                     }
                     _ => {}
                 }
+            }
+            if backfilled {
+                // Seq consumed by an existing item; clear any pending slot.
+                self.app.pending_tool_seq = None;
+            } else {
+                // No existing item to patch; save for the next ToolCall creation.
+                self.app.pending_tool_seq = Some(seq);
             }
             return;
         }
@@ -1134,7 +1155,7 @@ impl Tui {
                 vec![TranscriptItem::ToolCall {
                     tool_name: name,
                     body: tool_call_body(markdown.as_deref(), &input),
-                    seq: None,
+                    seq: self.app.pending_tool_seq,
                     timestamp: Some(chrono::Utc::now()),
                     rendered_cache: None,
                 }]
@@ -1160,7 +1181,7 @@ impl Tui {
                 vec![TranscriptItem::ToolCall {
                     tool_name: name,
                     body,
-                    seq: None,
+                    seq: self.app.pending_tool_seq,
                     timestamp: Some(chrono::Utc::now()),
                     rendered_cache: None,
                 }]

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -102,6 +102,7 @@ impl Tui {
             last_usage_transcript_idx: None,
             pending_thought_source: None,
             pending_thought_text: String::new(),
+            pending_tool_seq: None,
             pending_message: None,
             completions: vec![],
             completion_index: 0,

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -1164,6 +1164,17 @@ impl Tui {
                     if i < self.app.transcript.len() {
                         let entry = &self.app.transcript[i];
                         entries.push(Self::render_entry_detail(entry));
+                        // When the selected range is a single ToolCall with no
+                        // adjacent result in the range, peek at the next item so
+                        // the fallback view includes the paired result.
+                        if matches!(entry, TranscriptItem::ToolCall { .. }) && i + 1 > to {
+                            if let Some(next) = self.app.transcript.get(i + 1) {
+                                if matches!(next, TranscriptItem::ToolResultMarkdown { .. }) {
+                                    entries.push(vec![Line::from("")]);
+                                    entries.push(Self::render_entry_detail(next));
+                                }
+                            }
+                        }
                         if i < to {
                             entries.push(vec![Line::from("")]);
                         }

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -1652,12 +1652,12 @@ async fn live_log_seq_assignment_patches_latest_unsequenced_transcript_items() {
     tui.app.show_sequence_numbers = true;
 
     tui.app.transcript.push(TranscriptItem::UserText {
-        timestamp: None,
+        timestamp: Some(chrono::Utc::now()),
         text: "older user".to_string(),
         seq: Some(1),
     });
     tui.app.transcript.push(TranscriptItem::UserText {
-        timestamp: None,
+        timestamp: Some(chrono::Utc::now()),
         text: "live user".to_string(),
         seq: None,
     });
@@ -1670,7 +1670,7 @@ async fn live_log_seq_assignment_patches_latest_unsequenced_transcript_items() {
     .unwrap();
 
     tui.app.transcript.push(TranscriptItem::AssistantText {
-        timestamp: None,
+        timestamp: Some(chrono::Utc::now()),
         text: "live assistant".to_string(),
         seq: None,
         rendered_cache: None,
@@ -1699,6 +1699,141 @@ async fn live_log_seq_assignment_patches_latest_unsequenced_transcript_items() {
         .collect();
 
     assert_eq!(pairs, vec![("user", Some(2)), ("assistant", Some(3))]);
+}
+
+#[tokio::test]
+async fn live_log_seq_assignment_applies_to_tool_calls_started_after_seq_event() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 5 }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Tool(ToolEvent::Started {
+            id: "call-1".into(),
+            name: "bash_exec".into(),
+            kind: ToolKind::Other,
+            markdown: None,
+            input: yaml_to_json("command: echo hi"),
+            locations: vec![],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let tool_call_idx = tui
+        .app
+        .transcript
+        .iter()
+        .position(|item| matches!(item, TranscriptItem::ToolCall { tool_name, .. } if tool_name == "bash_exec"))
+        .expect("expected ToolCall transcript item");
+
+    match &tui.app.transcript[tool_call_idx] {
+        TranscriptItem::ToolCall { seq, .. } => assert_eq!(*seq, Some(5)),
+        other => panic!("expected ToolCall transcript item, got {other:?}"),
+    }
+
+    // Verify pending_tool_seq is still set: multiple tool calls in the same round
+    // share the same log_seq, so we intentionally do NOT clear it after first use.
+    // It will be cleared when the next LogSeqAssigned arrives (for a different round)
+    // and successfully backfills a UserText or AssistantText item, or overwritten by
+    // the next tool round's LogSeqAssigned.
+    assert_eq!(
+        tui.app.pending_tool_seq,
+        Some(5),
+        "pending_tool_seq should remain set so subsequent ToolCalls in same round share seq"
+    );
+}
+
+#[tokio::test]
+async fn log_seq_backfill_clears_pending_tool_seq() {
+    // When LogSeqAssigned arrives and backfills an EXISTING transcript item,
+    // pending_tool_seq must be cleared (not left set for the next ToolCall).
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    // First add an AssistantText with seq=None so backfill can find it.
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Model(ModelEvent::MessageChunk {
+            blocks: vec![ContentBlock::Text("assistant reply".to_string())],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    // Now LogSeqAssigned should backfill the AssistantText and NOT set pending_tool_seq.
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 3 }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    // Backfill succeeded — pending should be None.
+    assert_eq!(
+        tui.app.pending_tool_seq, None,
+        "pending_tool_seq must be None after backfill consumed the seq"
+    );
+}
+
+#[tokio::test]
+async fn live_log_seq_assignment_applies_to_blocked_tool_calls() {
+    // ToolEvent::Blocked also uses pending_tool_seq, same as ToolEvent::Started.
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 7 }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Tool(ToolEvent::Blocked {
+            id: "call-2".into(),
+            name: "dangerous_tool".into(),
+            input: yaml_to_json("target: /etc"),
+            reason: "hook denied".into(),
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let blocked_call = tui
+        .app
+        .transcript
+        .iter()
+        .find(|item| matches!(item, TranscriptItem::ToolCall { tool_name, .. } if tool_name == "dangerous_tool"))
+        .expect("expected ToolCall for blocked tool");
+
+    match blocked_call {
+        TranscriptItem::ToolCall { seq, .. } => {
+            assert_eq!(
+                *seq,
+                Some(7),
+                "blocked ToolCall should inherit pending_tool_seq"
+            );
+        }
+        other => panic!("expected ToolCall, got {other:?}"),
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -76,6 +76,7 @@ pub(super) struct App {
     pub(super) last_usage_transcript_idx: Option<usize>,
     pub(super) pending_thought_source: Option<AgentSource>,
     pub(super) pending_thought_text: String,
+    pub(super) pending_tool_seq: Option<usize>,
     pub(super) pending_message: Option<PendingMessage>,
     pub(super) completions: Vec<(String, Option<String>)>,
     pub(super) completion_index: usize,

--- a/docs/solutions/logic-errors/tui-tool-call-seq-pending-slot-2026-05-27.md
+++ b/docs/solutions/logic-errors/tui-tool-call-seq-pending-slot-2026-05-27.md
@@ -1,0 +1,119 @@
+---
+title: "TUI tool call seq assignment via pending slot for inverted event ordering"
+date: 2026-05-27
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-tui"
+root_cause: "event ordering mismatch — log seq assigned before ToolCall transcript item created"
+resolution_type: code_fix
+severity: medium
+tags:
+  - tui
+  - event-ordering
+  - transcript
+  - tool-calls
+  - state-machine
+  - pending-slot
+plan_ref: "issue-626-detail-view-tool-output"
+---
+
+## Problem
+
+In the harnx TUI, pressing Enter on a ToolCall item in transcript browsing mode opened a detail view showing only the rendered markdown/yaml body — same as the main view — instead of the full raw session YAML with both tool call inputs AND outputs.
+
+## Symptoms
+
+- Detail view for live (non-history) tool calls showed `body (markdown): [command]` without result
+- `detail_view_raw_yaml` was `None` for live tool calls
+- History items loaded from session file worked correctly
+- Issue reproducible: any tool executed during live session, then viewed in browsing mode
+
+## Investigation Steps
+
+1. Traced `detail_view_raw_yaml` assignment in `input.rs:237-248` — depends on `selected_seq_range()` returning valid seq
+2. Checked `selected_seq_range()` — returns `None` when transcript item has `seq == None`
+3. Traced ToolCall creation in `input.rs:1134-1140` — `ToolEvent::Started` creates `TranscriptItem::ToolCall { seq: None }`
+4. Found `LogSeqAssigned` handler in `input.rs:895-916` — backfills seq onto most recent unsequenced item
+5. Discovered event ordering: `LogSeqAssigned` fires BEFORE `ToolEvent::Started` creates the ToolCall
+6. Backfill found no ToolCall to patch → seq lost
+7. History items work because `messages_to_transcript_items` reconstructs items with seq already set
+
+## Root Cause
+
+TUI event ordering for live tool calls is inverted:
+
+1. `LogSeqAssigned { seq }` fires before `ToolEvent::Started` creates the ToolCall transcript item
+2. Backfill handler tries to find most recent unsequenced item — no ToolCall exists yet
+3. `ToolEvent::Started` creates `TranscriptItem::ToolCall { seq: None }` — never backfilled
+4. `selected_seq_range()` returns `None` for seq-less items
+5. `get_message_range_yaml()` cannot fetch session content
+6. `detail_view_raw_yaml` stays `None` → fallback renderer used (no tool result shown)
+
+This contrasts with text items (UserText, AssistantText) where the transcript item is created before seq assignment arrives.
+
+**Key insight:** ToolCalls are unique in that persistence happens BEFORE the tool runs, so the seq is known before the UI event fires.
+
+## Solution
+
+Added `pending_tool_seq: Option<usize>` to the `App` struct to bridge the event ordering gap.
+
+**Lifecycle:**
+
+1. `LogSeqAssigned` arrives and no existing item to backfill → `pending_tool_seq = Some(seq)`
+2. `LogSeqAssigned` arrives and finds item to backfill → `pending_tool_seq = None` (seq consumed)
+3. `ToolEvent::Started` or `ToolEvent::Blocked` creates ToolCall → uses `pending_tool_seq` as seq
+4. `pending_tool_seq` NOT cleared after ToolCall creation — multiple tool calls in same round share same log_seq
+5. Overwritten by next `LogSeqAssigned` from next round
+
+**Code changes:**
+
+```rust
+// types.rs
+pub(super) pending_tool_seq: Option<usize>,
+
+// input.rs — LogSeqAssigned handler
+if backfilled {
+    self.app.pending_tool_seq = None;
+} else {
+    self.app.pending_tool_seq = Some(seq);
+}
+
+// input.rs — ToolEvent::Started handler
+AgentEvent::Tool(ToolEvent::Started { .. }) => {
+    vec![TranscriptItem::ToolCall {
+        seq: self.app.pending_tool_seq,  // Use pending slot
+        ..
+    }]
+}
+```
+
+Also improved fallback renderer in `render.rs` to peek at adjacent `ToolResultMarkdown` when selected item is a seq-less ToolCall at end of selection range.
+
+## Why This Works
+
+The pending slot decouples the seq assignment event from the ToolCall creation event. Since LogSeqAssigned arrives before ToolEvent::Started, we store the seq and retrieve it when the ToolCall is created. Multiple tools in the same round share the seq (one `ToolCalls` log entry covers all), so we intentionally don't clear it after first use.
+
+This pattern mirrors existing `pending_thought_text` and `pending_message` slots but handles the inverse ordering — those are for items created BEFORE seq assignment, ToolCalls are created AFTER.
+
+## Prevention Strategies
+
+**Test cases:**
+- `live_log_seq_assignment_applies_to_tool_calls_started_after_seq_event` — primary case: LogSeqAssigned then ToolEvent::Started
+- `log_seq_backfill_clears_pending_tool_seq` — backfill path clears pending
+- `live_log_seq_assignment_applies_to_blocked_tool_calls` — Blocked path uses same pattern
+
+**Best practices:**
+- Any TUI state set by one agent event and consumed by later event needs an intermediary "pending" slot
+- When event ordering differs between live and history replay, test both paths
+- Trace the full lifecycle: `LogSeqAssigned` → `TranscriptItem` creation → `selected_seq_range()` → `detail_view_raw_yaml`
+
+**Code review checklist:**
+- [ ] Does the item exist in transcript before seq assignment?
+- [ ] If not, does a pending slot capture the seq?
+- [ ] Is the pending slot cleared appropriately to avoid stale state?
+
+## Related Issues
+
+- **GitHub:** [#626](https://github.com/dobesv/harnx/issues/626) — Detail view not showing full tool output
+- **Related Solution:** [tui-browsing-full-transcript-render-2026-05-05.md](./tui-browsing-full-transcript-render-2026-05-05.md) — Browsing mode transcript view architecture
+- **Related Solution:** [tool-output-header-suppression-2026-05-02.md](./tool-output-header-suppression-2026-05-02.md) — Tool output display patterns


### PR DESCRIPTION
The detail view now shows full raw session YAML (tool call inputs + outputs) when pressing Enter on a ToolCall in browsing mode.

Root cause: LogSeqAssigned fires before ToolEvent::Started, leaving ToolCall with seq: None.
Fix: pending_tool_seq field in App to bridge the event ordering gap.
Also: fallback renderer improved to include adjacent ToolResultMarkdown.

Fixes #626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool-call entries now reliably show their sequence numbers and display their paired tool results in the detail view, even when events arrive out of order.
  * Multiple tool calls in the same round can correctly share the same sequence number.

* **Documentation**
  * Added explanation of the tool-call sequencing behavior and the lifecycle for pending sequence assignment.

* **Tests**
  * Added tests covering live sequence assignment, backfill clearing, and blocked/started tool-call behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->