### PR TITLE
feat(proxy-auth): add --env sentinel env vars for bash tool calls

### DIFF
--- a/.changesets/632-sentinel-env-vars.md
+++ b/.changesets/632-sentinel-env-vars.md
@@ -1,0 +1,41 @@
+---
+harnx-proxy-auth: minor
+---
+Add `--env` flag to `harnx-proxy-auth` for sentinel credential injection.
+
+The new `--env '<jaq-script>'` flag generates session-unique fake credential
+tokens at startup and injects them into bash tool calls. Hook scripts can then
+match on those sentinel values and replace them with real credentials, keeping
+real tokens out of tool call arguments, logs, and process listings.
+
+`--env` scripts now receive `{}` as input, so field assignment patterns like
+`.GITHUB_TOKEN = "ghs_\($fake_base64_key)"` work directly.
+
+Hook filters can also use sentinel jaq variables directly:
+- `$fake_uuid_key`
+- `$fake_base64_key`
+- `$fake_url_base64_key`
+- `$fake_hex_key`
+- `$fake_email`
+
+**New jaq helpers** usable in both `--env` and `--hook` scripts:
+- `bearer(token)` — returns `"Bearer <token>"`
+- `basic(user; pass)` — returns `"Basic <base64(user:pass)>"`
+
+Example — GitHub token injection:
+```sh
+harnx-proxy-auth \
+  --env 'if (env.GITHUB_TOKEN // env.GH_TOKEN) then .GITHUB_TOKEN = "ghs_\($fake_base64_key)" else . end' \
+  --hook 'if (.host == "api.github.com") and (.headers.authorization == "Bearer ghs_\($fake_base64_key)")
+      then .headers.authorization = bearer(env.GITHUB_TOKEN // env.GH_TOKEN)
+      else . end'
+```
+
+Example — Atlassian Basic auth:
+```sh
+harnx-proxy-auth \
+  --env 'if (env.ATLASSIAN_API_TOKEN and env.ATLASSIAN_EMAIL) then .ATLASSIAN_API_TOKEN = $fake_uuid_key | .ATLASSIAN_EMAIL = $fake_email else . end' \
+  --hook 'if (.host | endswith(".atlassian.net")) and .headers.authorization == "Basic \([$fake_email, $fake_uuid_key] | join(":") | @base64)"
+      then .headers.authorization = basic(env.ATLASSIAN_EMAIL; env.ATLASSIAN_API_TOKEN)
+      else . end'
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,6 +3803,8 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "jaq-all",
+ "jaq-core",
+ "jaq-std",
  "parking_lot",
  "rcgen",
  "reqwest",
@@ -3814,6 +3816,7 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/harnx-proxy-auth/Cargo.toml
+++ b/crates/harnx-proxy-auth/Cargo.toml
@@ -30,7 +30,10 @@ tempfile.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
+uuid.workspace = true
 jaq-all.workspace = true
+jaq-core.workspace = true
+jaq-std.workspace = true
 
 [dev-dependencies]
 harnx-core = { path = "../harnx-core" }

--- a/crates/harnx-proxy-auth/src/cli.rs
+++ b/crates/harnx-proxy-auth/src/cli.rs
@@ -18,6 +18,14 @@ pub struct Args {
     /// without exposing full tokens.
     #[arg(long, value_name = "PATH")]
     pub log_file: Option<std::path::PathBuf>,
+
+    /// jq/jaq filter that receives sentinel values as jaq variables:
+    /// `$fake_uuid_key`, `$fake_base64_key`, `$fake_url_base64_key`,
+    /// `$fake_hex_key`, `$fake_email`. Must output a JSON object.
+    /// Multiple `--env` flags run in order and merge (later keys win).
+    /// Error aborts startup.
+    #[arg(long, value_name = "JQ_FILTER")]
+    pub env: Vec<String>,
 }
 
 impl Args {
@@ -40,6 +48,7 @@ mod tests {
         let args = Args {
             hook: Vec::new(),
             log_file: None,
+            env: Vec::new(),
         };
         assert_eq!(args.combined_filter(), ".");
     }
@@ -49,6 +58,7 @@ mod tests {
         let args = Args {
             hook: vec![".foo = 1".into(), ".bar = 2".into()],
             log_file: None,
+            env: Vec::new(),
         };
         assert_eq!(args.combined_filter(), ".foo = 1 | .bar = 2");
     }

--- a/crates/harnx-proxy-auth/src/filter.rs
+++ b/crates/harnx-proxy-auth/src/filter.rs
@@ -1,21 +1,42 @@
-use anyhow::{anyhow, Result};
-use jaq_all::{data, fmts, json};
+use anyhow::{anyhow, bail, Result};
+use jaq_all::{compile_with, data, defs, fmts, jaq_core::Vars, json};
+use jaq_core::native::{bome, run, unary, v};
+use jaq_std::ValT as _;
 use serde_json::Value;
 
 pub struct CompiledFilter(data::Filter);
 
+const ENV_SCRIPT_VAR_NAMES: [&str; 5] = [
+    "fake_uuid_key",
+    "fake_base64_key",
+    "fake_url_base64_key",
+    "fake_hex_key",
+    "fake_email",
+];
+
 pub fn compile(expr: &str) -> Result<CompiledFilter> {
-    data::compile(expr)
+    let var_names = ENV_SCRIPT_VAR_NAMES.map(str::to_owned);
+    compile_with(expr, defs(), data::funs().chain(auth_funs()), &var_names)
         .map(CompiledFilter)
         .map_err(|errors| anyhow!("jaq filter compile error: {errors:?}"))
 }
 
-pub fn apply_filter(filter: &CompiledFilter, req_json: Value) -> Result<Value> {
+pub fn apply_filter(
+    filter: &CompiledFilter,
+    req_json: Value,
+    sentinels: &crate::sentinel::Sentinels,
+) -> Result<Value> {
     let input = fmts::read::json::parse_single(req_json.to_string().as_bytes())
         .map_err(|error| anyhow!("input conversion: {error}"))?;
 
     let runner = data::Runner::default();
-    let vars = Default::default();
+    let vars = Vars::new([
+        sentinel_string_to_jaq_value(&sentinels.uuid_key)?,
+        sentinel_string_to_jaq_value(&sentinels.base64_key)?,
+        sentinel_string_to_jaq_value(&sentinels.url_base64_key)?,
+        sentinel_string_to_jaq_value(&sentinels.hex_key)?,
+        sentinel_string_to_jaq_value(&sentinels.email)?,
+    ]);
     let mut output = None;
 
     data::run(
@@ -23,18 +44,128 @@ pub fn apply_filter(filter: &CompiledFilter, req_json: Value) -> Result<Value> {
         &filter.0,
         vars,
         std::iter::once(Ok::<_, String>(input)),
-        |error| anyhow!(error),
-        |value| {
-            output = Some(value);
+        |value| Ok::<_, String>(Some(value)),
+        |result| {
+            output = Some(result);
             Ok(())
         },
-    )?;
+    )
+    .map_err(|error| anyhow!("jaq filter execution failed: {error:?}"))?;
 
     match output {
         Some(Ok(value)) => jaq_value_to_json(value),
-        Some(Err(error)) => Err(anyhow!(error.to_string())),
+        Some(Err(error)) => bail!("jaq filter runtime error: {error}"),
         None => Ok(req_json),
     }
+}
+
+/// Compile and run `--env` jaq scripts, injecting sentinel variables.
+/// Each script receives {} as input and sentinel values as jaq variables.
+/// Scripts must output JSON objects; outputs are merged (later keys win).
+/// Returns error if any script fails to compile, errors at runtime, outputs non-object, or
+/// produces any non-string value (env vars must be strings for MCP tool compatibility).
+pub fn eval_env_scripts(
+    scripts: &[String],
+    sentinels: &crate::sentinel::Sentinels,
+) -> anyhow::Result<serde_json::Map<String, Value>> {
+    let mut merged = serde_json::Map::new();
+
+    for script in scripts {
+        let output = run_env_script(script, sentinels)?;
+        merged.extend(output);
+    }
+
+    Ok(merged)
+}
+
+fn run_env_script(
+    script: &str,
+    sentinels: &crate::sentinel::Sentinels,
+) -> Result<serde_json::Map<String, Value>> {
+    let var_names = ENV_SCRIPT_VAR_NAMES.map(str::to_owned);
+    let filter = compile_with(script, defs(), data::funs().chain(auth_funs()), &var_names)
+        .map_err(|errors| anyhow!("jaq env script compile error: {errors:?}"))?;
+
+    let vars = Vars::new([
+        sentinel_string_to_jaq_value(&sentinels.uuid_key)?,
+        sentinel_string_to_jaq_value(&sentinels.base64_key)?,
+        sentinel_string_to_jaq_value(&sentinels.url_base64_key)?,
+        sentinel_string_to_jaq_value(&sentinels.hex_key)?,
+        sentinel_string_to_jaq_value(&sentinels.email)?,
+    ]);
+    let input = fmts::read::json::parse_single(b"{}")
+        .map_err(|error| anyhow!("env script input conversion: {error}"))?;
+    let runner = data::Runner::default();
+    let mut output = None;
+
+    data::run(
+        &runner,
+        &filter,
+        vars,
+        std::iter::once(Ok::<_, String>(input)),
+        |value| Ok::<_, String>(Some(value)),
+        |result| {
+            output = Some(result);
+            Ok(())
+        },
+    )
+    .map_err(|error| anyhow!("jaq env script execution failed: {error:?}"))?;
+
+    let value = match output {
+        Some(Ok(value)) => jaq_value_to_json(value)?,
+        Some(Err(error)) => bail!("jaq env script runtime error: {error}"),
+        None => Value::Null,
+    };
+    let object = value
+        .as_object()
+        .cloned()
+        .ok_or_else(|| anyhow!("jaq env script must output object, got {value}"))?;
+
+    for (key, val) in &object {
+        if !val.is_string() {
+            bail!("jaq env script output value for key {key:?} must be a string, got {val}");
+        }
+    }
+
+    Ok(object)
+}
+
+fn auth_funs() -> impl Iterator<Item = jaq_core::native::Fun<data::DataKind>> {
+    use base64::Engine as _;
+
+    fn bearer(cv: jaq_core::Cv<'_, data::DataKind>) -> jaq_core::ValXs<'_, json::Val> {
+        unary(cv, |_input, token| {
+            let token = token.try_as_bytes()?;
+            Ok(json::Val::from_utf8_bytes(
+                format!("Bearer {}", String::from_utf8_lossy(token)).into_bytes(),
+            ))
+        })
+    }
+
+    fn basic(mut cv: jaq_core::Cv<'_, data::DataKind>) -> jaq_core::ValXs<'_, json::Val> {
+        let pass = cv.0.pop_var();
+        let user = cv.0.pop_var();
+        bome((|| {
+            let user = user.try_as_bytes()?;
+            let pass = pass.try_as_bytes()?;
+            let encoded =
+                base64::engine::general_purpose::STANDARD.encode([user, b":", pass].concat());
+            Ok(json::Val::from_utf8_bytes(
+                format!("Basic {encoded}").into_bytes(),
+            ))
+        })())
+    }
+
+    [
+        run::<data::DataKind>(("bearer", v(1), bearer)),
+        run::<data::DataKind>(("basic", v(2), basic)),
+    ]
+    .into_iter()
+}
+
+fn sentinel_string_to_jaq_value(value: &str) -> Result<json::Val> {
+    fmts::read::json::parse_single(format!("{value:?}").as_bytes())
+        .map_err(|error| anyhow!("sentinel conversion: {error}"))
 }
 
 fn jaq_value_to_json(value: json::Val) -> Result<Value> {
@@ -70,24 +201,42 @@ fn jaq_value_to_json(value: json::Val) -> Result<Value> {
 
 #[cfg(test)]
 mod tests {
+    use super::{apply_filter, compile, eval_env_scripts};
+    use crate::sentinel::Sentinels;
     use serde_json::json;
-
-    use super::{apply_filter, compile};
 
     fn request_json() -> serde_json::Value {
         json!({
             "method": "GET",
             "host": "github.com",
-            "path": "/repos/foo/bar",
+            "path": "/login",
             "headers": {
-                "content-type": "application/json"
+                "user-agent": "curl/8.0"
             }
         })
     }
 
+    fn test_sentinels() -> Sentinels {
+        Sentinels {
+            uuid_key: "11111111-2222-3333-4444-555555555555".to_owned(),
+            base64_key: "QUJDREVGR0hJSktMTU5PUA==".to_owned(),
+            url_base64_key: "QUJDREVGR0hJSktMTU5PUA".to_owned(),
+            hex_key: "00112233445566778899aabbccddeeff".to_owned(),
+            email: "fake@example.com".to_owned(),
+        }
+    }
+
     #[test]
-    fn compile_identity_filter() {
-        compile(".").expect("identity filter compiles");
+    fn compile_rejects_invalid_jq() {
+        let err = compile(".").expect("identity filter compiles");
+        let output =
+            apply_filter(&err, request_json(), &test_sentinels()).expect("identity filter applies");
+        assert_eq!(output["host"], "github.com");
+
+        let err = compile("if . then")
+            .err()
+            .expect("invalid filter should error");
+        assert!(err.to_string().contains("compile error"));
     }
 
     #[test]
@@ -95,7 +244,8 @@ mod tests {
         let filter = compile(".headers.authorization = \"Bearer test\"")
             .expect("header assignment compiles");
 
-        let output = apply_filter(&filter, request_json()).expect("filter applies");
+        let output =
+            apply_filter(&filter, request_json(), &test_sentinels()).expect("filter applies");
         assert_eq!(output["headers"]["authorization"], "Bearer test");
     }
 
@@ -103,7 +253,8 @@ mod tests {
     fn identity_filter_returns_same_object() {
         let filter = compile(".").expect("identity filter compiles");
         let input = request_json();
-        let output = apply_filter(&filter, input.clone()).expect("filter applies");
+        let output =
+            apply_filter(&filter, input.clone(), &test_sentinels()).expect("filter applies");
         assert_eq!(output, input);
     }
 
@@ -112,7 +263,8 @@ mod tests {
         // implicit `else .` — non-matching input returns unchanged
         let filter = compile("if .host == \"evil.com\" then .block = true end")
             .expect("if-without-else compiles");
-        let output = apply_filter(&filter, request_json()).expect("filter applies");
+        let output =
+            apply_filter(&filter, request_json(), &test_sentinels()).expect("filter applies");
         assert_eq!(output, request_json()); // github.com — passes through unchanged
     }
 
@@ -120,7 +272,8 @@ mod tests {
     fn block_true_sets_block_field() {
         let filter = compile("if .host == \"evil.com\" then .block = true else . end")
             .expect("block filter compiles");
-        let blocked = apply_filter(&filter, request_json()).expect("filter applies");
+        let blocked =
+            apply_filter(&filter, request_json(), &test_sentinels()).expect("filter applies");
         // github.com is not evil.com — no block field
         assert!(blocked.get("block").is_none());
 
@@ -130,7 +283,7 @@ mod tests {
             "path": "/",
             "headers": {}
         });
-        let blocked = apply_filter(&filter, evil).expect("filter applies");
+        let blocked = apply_filter(&filter, evil, &test_sentinels()).expect("filter applies");
         assert_eq!(blocked["block"], true);
     }
 
@@ -144,7 +297,7 @@ mod tests {
             "path": "/",
             "headers": {}
         });
-        let result = apply_filter(&filter, evil).expect("filter applies");
+        let result = apply_filter(&filter, evil, &test_sentinels()).expect("filter applies");
         assert_eq!(result["block"], "not allowed");
     }
 
@@ -159,7 +312,150 @@ mod tests {
         )
         .expect("github auth filter compiles");
 
-        let output = apply_filter(&filter, request_json()).expect("filter applies");
+        let output =
+            apply_filter(&filter, request_json(), &test_sentinels()).expect("filter applies");
         assert_eq!(output["headers"]["authorization"], "Bearer test-token");
+    }
+
+    #[test]
+    fn eval_env_scripts_returns_literal_object() {
+        let output = eval_env_scripts(&[r#"{"FOO": "bar"}"#.to_owned()], &test_sentinels())
+            .expect("env scripts eval");
+
+        assert_eq!(output.get("FOO"), Some(&json!("bar")));
+    }
+
+    #[test]
+    fn eval_env_scripts_supports_field_assignment_pattern() {
+        // The primary intended usage: .REAL_VAR = "sentinel_value"
+        // This only works if the script input is {} (object), not null.
+        let sentinels = test_sentinels();
+        let output = eval_env_scripts(
+            &[r#"if true then .GITHUB_TOKEN = "ghs_test" else . end"#.to_owned()],
+            &sentinels,
+        )
+        .expect("field assignment pattern should work with {} input");
+
+        assert_eq!(output.get("GITHUB_TOKEN"), Some(&json!("ghs_test")));
+    }
+
+    #[test]
+    fn eval_env_scripts_injects_sentinel_variables() {
+        let sentinels = test_sentinels();
+        let output = eval_env_scripts(&[r#"{"K": $fake_uuid_key}"#.to_owned()], &sentinels)
+            .expect("env scripts eval");
+
+        assert_eq!(output.get("K"), Some(&json!(sentinels.uuid_key)));
+    }
+
+    #[test]
+    fn eval_env_scripts_later_scripts_overwrite_keys() {
+        let output = eval_env_scripts(
+            &[
+                r#"{"K": "first", "A": "alpha"}"#.to_owned(),
+                r#"{"K": "second"}"#.to_owned(),
+            ],
+            &test_sentinels(),
+        )
+        .expect("env scripts eval");
+
+        assert_eq!(output.get("K"), Some(&json!("second")));
+        assert_eq!(output.get("A"), Some(&json!("alpha")));
+    }
+
+    #[test]
+    fn bearer_formats_authorization_header() {
+        let output = apply_filter(
+            &compile("bearer(\"abc\")").expect("bearer compiles"),
+            json!(null),
+            &test_sentinels(),
+        )
+        .expect("bearer applies");
+
+        assert_eq!(output, json!("Bearer abc"));
+    }
+
+    #[test]
+    fn basic_formats_authorization_header() {
+        let output = apply_filter(
+            &compile("basic(\"user\"; \"pass\")").expect("basic compiles"),
+            json!(null),
+            &test_sentinels(),
+        )
+        .expect("basic applies");
+
+        assert_eq!(output, json!("Basic dXNlcjpwYXNz"));
+    }
+
+    #[test]
+    fn basic_supports_empty_password() {
+        let output = apply_filter(
+            &compile("basic(\"u\"; \"\")").expect("basic compiles"),
+            json!(null),
+            &test_sentinels(),
+        )
+        .expect("basic applies");
+
+        assert_eq!(output, json!("Basic dTo="));
+    }
+
+    #[test]
+    fn hook_filter_interpolates_fake_base64_key() {
+        let output = apply_filter(
+            &compile(r#""ghs_\($fake_base64_key)""#).expect("hook compiles"),
+            json!(null),
+            &test_sentinels(),
+        )
+        .expect("hook applies");
+
+        assert_eq!(output, json!("ghs_QUJDREVGR0hJSktMTU5PUA=="));
+    }
+
+    #[test]
+    fn hook_filter_condition_uses_fake_uuid_key() {
+        let filter = compile(
+            r#"if .headers.authorization == "Bearer \($fake_uuid_key)" then .matched = true else . end"#,
+        )
+        .expect("hook compiles");
+        let input = json!({
+            "headers": {
+                "authorization": "Bearer 11111111-2222-3333-4444-555555555555"
+            }
+        });
+
+        let output = apply_filter(&filter, input, &test_sentinels()).expect("hook applies");
+
+        assert_eq!(output["matched"], true);
+    }
+
+    #[test]
+    fn eval_env_scripts_errors_on_syntax_error() {
+        let err = eval_env_scripts(&["{".to_owned()], &test_sentinels())
+            .expect_err("invalid script should error");
+
+        assert!(err.to_string().contains("compile error"));
+    }
+
+    #[test]
+    fn eval_env_scripts_errors_on_non_object_output() {
+        let err = eval_env_scripts(&["42".to_owned()], &test_sentinels())
+            .expect_err("non-object output should error");
+
+        assert!(err.to_string().contains("must output object"));
+    }
+
+    #[test]
+    fn eval_env_scripts_errors_on_non_string_value() {
+        let err = eval_env_scripts(&[r#"{"PORT": 8080}"#.to_owned()], &test_sentinels())
+            .expect_err("non-string value should error");
+
+        assert!(err.to_string().contains("must be a string"));
+    }
+
+    #[test]
+    fn eval_env_scripts_empty_list_returns_empty_map() {
+        let output = eval_env_scripts(&[], &test_sentinels()).expect("empty env scripts eval");
+
+        assert!(output.is_empty());
     }
 }

--- a/crates/harnx-proxy-auth/src/hook.rs
+++ b/crates/harnx-proxy-auth/src/hook.rs
@@ -28,7 +28,11 @@ struct HookSpecificOutput {
     tool_input: Value,
 }
 
-pub async fn run_jsonl_loop(proxy_port: u16, ca_cert_path: PathBuf) -> Result<()> {
+pub async fn run_jsonl_loop(
+    proxy_port: u16,
+    ca_cert_path: PathBuf,
+    extra_env: Map<String, Value>,
+) -> Result<()> {
     let stdin = io::stdin();
     let stdout = io::stdout();
     let mut lines = BufReader::new(stdin).lines();
@@ -54,7 +58,12 @@ pub async fn run_jsonl_loop(proxy_port: u16, ca_cert_path: PathBuf) -> Result<()
             HookResponse {
                 id: request.id,
                 hook_specific_output: Some(HookSpecificOutput {
-                    tool_input: augment_tool_input(request.tool_input, proxy_port, &ca_cert_path),
+                    tool_input: augment_tool_input(
+                        request.tool_input,
+                        proxy_port,
+                        &ca_cert_path,
+                        &extra_env,
+                    ),
                 }),
             }
         } else {
@@ -73,7 +82,12 @@ pub async fn run_jsonl_loop(proxy_port: u16, ca_cert_path: PathBuf) -> Result<()
     Ok(())
 }
 
-fn augment_tool_input(tool_input: Option<Value>, proxy_port: u16, ca_cert_path: &str) -> Value {
+fn augment_tool_input(
+    tool_input: Option<Value>,
+    proxy_port: u16,
+    ca_cert_path: &str,
+    extra_env: &Map<String, Value>,
+) -> Value {
     let mut tool_input = match tool_input {
         Some(Value::Object(map)) => map,
         _ => Map::new(),
@@ -83,6 +97,10 @@ fn augment_tool_input(tool_input: Option<Value>, proxy_port: u16, ca_cert_path: 
         Some(Value::Object(map)) => map,
         _ => Map::new(),
     };
+
+    for (key, value) in extra_env {
+        env.entry(key.clone()).or_insert_with(|| value.clone());
+    }
 
     for (key, value) in [
         ("HTTP_PROXY", format!("http://127.0.0.1:{proxy_port}")),
@@ -124,7 +142,7 @@ mod tests {
     fn bash_exec_injects_proxy_env_vars() {
         let input = Some(json!({"command": "echo hi", "env": {"FOO": "bar"}}));
 
-        let actual = augment_tool_input(input, PROXY_PORT, CA_CERT_PATH);
+        let actual = augment_tool_input(input, PROXY_PORT, CA_CERT_PATH, &Map::new());
 
         assert_eq!(
             actual,
@@ -148,7 +166,7 @@ mod tests {
     fn bash_spawn_injects_proxy_env_vars() {
         let input = Some(json!({"command": "sleep 1", "inputs": ["/tmp/in"]}));
 
-        let actual = augment_tool_input(input, PROXY_PORT, CA_CERT_PATH);
+        let actual = augment_tool_input(input, PROXY_PORT, CA_CERT_PATH, &Map::new());
 
         assert_eq!(
             actual,
@@ -183,7 +201,7 @@ mod tests {
             }
         }));
 
-        let actual = augment_tool_input(input, PROXY_PORT, CA_CERT_PATH);
+        let actual = augment_tool_input(input, PROXY_PORT, CA_CERT_PATH, &Map::new());
 
         assert_eq!(
             actual["env"]["HTTPS_PROXY"],
@@ -197,9 +215,58 @@ mod tests {
     fn missing_env_field_creates_env_with_proxy_vars() {
         let input = Some(json!({"command": "git fetch"}));
 
-        let actual = augment_tool_input(input, PROXY_PORT, CA_CERT_PATH);
+        let actual = augment_tool_input(input, PROXY_PORT, CA_CERT_PATH, &Map::new());
 
         assert_eq!(actual["env"], expected_proxy_env());
+    }
+
+    #[test]
+    fn extra_env_is_injected_when_missing_from_tool_input_env() {
+        let input = Some(json!({"command": "echo hi"}));
+        let extra_env = Map::from_iter([(String::from("FOO"), json!("from-script"))]);
+
+        let actual = augment_tool_input(input, PROXY_PORT, CA_CERT_PATH, &extra_env);
+
+        assert_eq!(actual["env"]["FOO"], json!("from-script"));
+        assert_eq!(
+            actual["env"]["HTTPS_PROXY"],
+            json!(format!("http://127.0.0.1:{PROXY_PORT}"))
+        );
+    }
+
+    #[test]
+    fn tool_input_env_takes_precedence_over_extra_env() {
+        let input = Some(json!({
+            "command": "echo hi",
+            "env": {
+                "FOO": "from-user"
+            }
+        }));
+        let extra_env = Map::from_iter([(String::from("FOO"), json!("from-script"))]);
+
+        let actual = augment_tool_input(input, PROXY_PORT, CA_CERT_PATH, &extra_env);
+
+        assert_eq!(actual["env"]["FOO"], json!("from-user"));
+    }
+
+    #[test]
+    fn extra_env_takes_precedence_over_proxy_defaults() {
+        let input = Some(json!({"command": "echo hi"}));
+        let extra_env = Map::from_iter([(
+            String::from("HTTPS_PROXY"),
+            json!("http://script-proxy:7777"),
+        )]);
+
+        let actual = augment_tool_input(input, PROXY_PORT, CA_CERT_PATH, &extra_env);
+
+        assert_eq!(
+            actual["env"]["HTTPS_PROXY"],
+            json!("http://script-proxy:7777")
+        );
+        assert_eq!(
+            actual["env"]["HTTP_PROXY"],
+            json!(format!("http://127.0.0.1:{PROXY_PORT}"))
+        );
     }
 
     #[test]
@@ -210,7 +277,12 @@ mod tests {
         let response = HookResponse {
             id: request.id,
             hook_specific_output: Some(HookSpecificOutput {
-                tool_input: augment_tool_input(request.tool_input, PROXY_PORT, CA_CERT_PATH),
+                tool_input: augment_tool_input(
+                    request.tool_input,
+                    PROXY_PORT,
+                    CA_CERT_PATH,
+                    &Map::new(),
+                ),
             }),
         };
 

--- a/crates/harnx-proxy-auth/src/lib.rs
+++ b/crates/harnx-proxy-auth/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cli;
 pub mod filter;
 pub mod hook;
 pub mod proxy;
+pub mod sentinel;
 
 /// Decode a standard base64 string to bytes.
 /// Used by integration tests to decode the CA cert from the `CA_CERT_PEM_B64` readiness line.

--- a/crates/harnx-proxy-auth/src/main.rs
+++ b/crates/harnx-proxy-auth/src/main.rs
@@ -1,9 +1,10 @@
 use std::io::Write;
+use std::sync::Arc;
 
 use anyhow::Result;
 use clap::Parser;
 
-use harnx_proxy_auth::{ca, cli, filter, hook, proxy};
+use harnx_proxy_auth::{ca, cli, filter, hook, proxy, sentinel};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -16,11 +17,13 @@ async fn main() -> Result<()> {
     let args = <cli::Args as Parser>::parse();
     let filter_expr = args.combined_filter();
     let filter = filter::compile(&filter_expr)?;
+    let sentinels = Arc::new(sentinel::Sentinels::generate());
+    let extra_env = filter::eval_env_scripts(&args.env, &sentinels)?;
 
     let (ca_setup, _ca_temp_dir) = ca::setup()?;
     let ca_cert_path = ca_setup.cert_pem_path.clone();
     let ca_cert_pem = std::fs::read_to_string(&ca_cert_path)?;
-    let port = proxy::start_proxy_with_log(filter, ca_setup, args.log_file).await?;
+    let port = proxy::start_proxy_with_log(filter, ca_setup, sentinels, args.log_file).await?;
 
     // Write readiness lines then explicitly drop the lock before entering the
     // async JSONL loop. Holding a std::io::StdoutLock across an .await would
@@ -36,5 +39,5 @@ async fn main() -> Result<()> {
         stdout.flush()?;
     } // lock dropped here
 
-    hook::run_jsonl_loop(port, ca_cert_path).await
+    hook::run_jsonl_loop(port, ca_cert_path, extra_env).await
 }

--- a/crates/harnx-proxy-auth/src/proxy.rs
+++ b/crates/harnx-proxy-auth/src/proxy.rs
@@ -26,6 +26,7 @@ use crate::filter::{self, CompiledFilter};
 #[derive(Clone)]
 struct AuthHandler {
     filter: Arc<CompiledFilter>,
+    sentinels: Arc<crate::sentinel::Sentinels>,
     log_file: Option<PathBuf>,
 }
 
@@ -37,7 +38,7 @@ impl HttpHandler for AuthHandler {
     ) -> RequestOrResponse {
         let req_json = request_json(&req);
 
-        match filter::apply_filter(&self.filter, req_json.clone()) {
+        match filter::apply_filter(&self.filter, req_json.clone(), &self.sentinels) {
             Ok(result) => {
                 // If the filter sets `.block` to a truthy value, return a 403 response
                 // instead of forwarding the request.
@@ -220,16 +221,39 @@ fn replace_headers(headers: &mut http::HeaderMap, new_headers: &Map<String, Valu
     changed
 }
 
-pub async fn start_proxy(filter: CompiledFilter, ca: CaSetup) -> Result<u16> {
-    start_proxy_inner(filter, ca, None, false).await
+pub async fn start_proxy(
+    filter: CompiledFilter,
+    ca: CaSetup,
+    sentinels: Arc<crate::sentinel::Sentinels>,
+) -> Result<u16> {
+    start_proxy_inner(
+        filter,
+        ProxyConfig {
+            ca,
+            sentinels,
+            log_file: None,
+            danger_accept_invalid_certs: false,
+        },
+    )
+    .await
 }
 
 pub async fn start_proxy_with_log(
     filter: CompiledFilter,
     ca: CaSetup,
+    sentinels: Arc<crate::sentinel::Sentinels>,
     log_file: Option<PathBuf>,
 ) -> Result<u16> {
-    start_proxy_inner(filter, ca, log_file, false).await
+    start_proxy_inner(
+        filter,
+        ProxyConfig {
+            ca,
+            sentinels,
+            log_file,
+            danger_accept_invalid_certs: false,
+        },
+    )
+    .await
 }
 
 /// Like [`start_proxy`] but skips TLS certificate verification for upstream
@@ -238,8 +262,25 @@ pub async fn start_proxy_with_log(
 pub async fn start_proxy_danger_accept_invalid_certs(
     filter: CompiledFilter,
     ca: CaSetup,
+    sentinels: Arc<crate::sentinel::Sentinels>,
 ) -> Result<u16> {
-    start_proxy_inner(filter, ca, None, true).await
+    start_proxy_inner(
+        filter,
+        ProxyConfig {
+            ca,
+            sentinels,
+            log_file: None,
+            danger_accept_invalid_certs: true,
+        },
+    )
+    .await
+}
+
+struct ProxyConfig {
+    ca: CaSetup,
+    sentinels: Arc<crate::sentinel::Sentinels>,
+    log_file: Option<PathBuf>,
+    danger_accept_invalid_certs: bool,
 }
 
 fn build_danger_https_connector() -> Result<hyper_rustls::HttpsConnector<HttpConnector>> {
@@ -300,12 +341,13 @@ fn build_danger_https_connector() -> Result<hyper_rustls::HttpsConnector<HttpCon
         .wrap_connector(http))
 }
 
-async fn start_proxy_inner(
-    filter: CompiledFilter,
-    ca: CaSetup,
-    log_file: Option<PathBuf>,
-    danger_accept_invalid_certs: bool,
-) -> Result<u16> {
+async fn start_proxy_inner(filter: CompiledFilter, config: ProxyConfig) -> Result<u16> {
+    let ProxyConfig {
+        ca,
+        sentinels,
+        log_file,
+        danger_accept_invalid_certs,
+    } = config;
     let issuer = Issuer::from_ca_cert_pem(&ca.cert.pem(), ca.key_pair)?;
     let issuer = RcgenAuthority::new(issuer, 256, aws_lc_rs::default_provider());
 
@@ -314,6 +356,7 @@ async fn start_proxy_inner(
 
     let handler = AuthHandler {
         filter: Arc::new(filter),
+        sentinels,
         log_file,
     };
 

--- a/crates/harnx-proxy-auth/src/sentinel.rs
+++ b/crates/harnx-proxy-auth/src/sentinel.rs
@@ -1,0 +1,83 @@
+use base64::Engine as _;
+use uuid::Uuid;
+
+pub struct Sentinels {
+    pub uuid_key: String,
+    pub base64_key: String,
+    pub url_base64_key: String,
+    pub hex_key: String,
+    pub email: String,
+}
+
+impl Sentinels {
+    pub fn generate() -> Self {
+        let uuid = Uuid::new_v4();
+        let uuid_key = uuid.hyphenated().to_string();
+
+        Self {
+            hex_key: uuid.simple().to_string(),
+            base64_key: base64::engine::general_purpose::STANDARD.encode(uuid.as_bytes()),
+            url_base64_key: base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .encode(uuid.as_bytes()),
+            email: uuid_key.replacen('-', "@", 1),
+            uuid_key,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Sentinels;
+    use base64::Engine as _;
+
+    #[test]
+    fn generate_populates_all_fields() {
+        let sentinels = Sentinels::generate();
+
+        assert!(!sentinels.uuid_key.is_empty());
+        assert!(!sentinels.base64_key.is_empty());
+        assert!(!sentinels.url_base64_key.is_empty());
+        assert!(!sentinels.hex_key.is_empty());
+        assert!(!sentinels.email.is_empty());
+    }
+
+    #[test]
+    fn generate_hex_key_has_expected_length() {
+        let sentinels = Sentinels::generate();
+
+        assert_eq!(sentinels.hex_key.len(), 32);
+    }
+
+    #[test]
+    fn generate_email_contains_at_sign() {
+        let sentinels = Sentinels::generate();
+
+        assert!(sentinels.email.contains('@'));
+    }
+
+    #[test]
+    fn generate_base64_key_decodes() {
+        let sentinels = Sentinels::generate();
+
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&sentinels.base64_key)
+            .unwrap();
+
+        assert!(!decoded.is_empty());
+    }
+
+    #[test]
+    fn generate_base64_variants_round_trip_to_same_bytes() {
+        let sentinels = Sentinels::generate();
+
+        let standard = base64::engine::general_purpose::STANDARD
+            .decode(&sentinels.base64_key)
+            .unwrap();
+        let url_safe = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(&sentinels.url_base64_key)
+            .unwrap();
+
+        assert_eq!(standard.len(), 16);
+        assert_eq!(standard, url_safe);
+    }
+}

--- a/crates/harnx-proxy-auth/tests/hook_e2e.rs
+++ b/crates/harnx-proxy-auth/tests/hook_e2e.rs
@@ -107,11 +107,95 @@ async fn hook_dispatch_does_not_mutate_non_bash_tools() {
     );
 }
 
+/// Verify that `--env` sentinel variables are injected into bash tool call env maps.
+///
+/// This test uses the `--env` flag to pass a custom environment variable template
+/// with a sentinel value, and verifies that the resulting env map contains the
+/// resolved sentinel variable.
+#[tokio::test(flavor = "multi_thread")]
+async fn hook_env_sentinel_is_injected_into_bash_tool_input() {
+    let Some(proxy_bin) = proxy_binary_path() else {
+        eprintln!(
+            "SKIP hook_env_sentinel_is_injected_into_bash_tool_input: harnx-proxy-auth not found"
+        );
+        return;
+    };
+
+    // The --env arg contains JSON with a sentinel variable using jaq string interpolation.
+    // The jaq `\($fake_base64_key)` is literal inside the shell single-quoted string.
+    let env_arg = r#"{"FAKE_TOKEN": "ghs_\($fake_base64_key)"}"#;
+
+    let outcome = dispatch_one_hook_with_env(
+        &proxy_bin,
+        Some(env_arg),
+        HookEvent::PreToolUse {
+            tool_name: "bash_exec".to_string(),
+            tool_input: json!({ "command": "echo hi" }),
+            tool_use_id: "toolu_hook_e2e_env".to_string(),
+        },
+    )
+    .await;
+
+    assert!(
+        matches!(outcome.control, HookResultControl::Continue),
+        "hook should continue, not block"
+    );
+
+    let mutated = outcome
+        .result
+        .mutated_tool_input
+        .expect("persistent hook must mutate tool_input for bash_exec");
+    let env = mutated
+        .get("env")
+        .and_then(Value::as_object)
+        .expect("mutated tool_input must contain an 'env' object");
+
+    let fake_token = env
+        .get("FAKE_TOKEN")
+        .and_then(Value::as_str)
+        .expect("FAKE_TOKEN must be injected");
+
+    assert!(
+        fake_token.starts_with("ghs_"),
+        "FAKE_TOKEN should start with sentinel prefix 'ghs_', got: {fake_token}"
+    );
+    // Verify jaq interpolation actually resolved: no raw template markers should remain.
+    assert!(
+        !fake_token.contains("($") && !fake_token.contains('$'),
+        "FAKE_TOKEN contains unresolved jaq template marker, interpolation failed: {fake_token}"
+    );
+    // The suffix should be base64 characters only (the fake_base64_key encoding).
+    let suffix = fake_token.trim_start_matches("ghs_");
+    assert!(
+        !suffix.is_empty()
+            && suffix
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '='),
+        "FAKE_TOKEN suffix is not valid base64, got: {suffix}"
+    );
+}
+
 async fn dispatch_one_hook(proxy_bin: &Path, event: HookEvent) -> HookOutcome {
+    dispatch_one_hook_with_env(proxy_bin, None, event).await
+}
+
+async fn dispatch_one_hook_with_env(
+    proxy_bin: &Path,
+    env_arg: Option<&str>,
+    event: HookEvent,
+) -> HookOutcome {
+    let command = match env_arg {
+        Some(env) => format!(
+            r#"{} --env '{}' --hook '.'"#,
+            shell_escape_path(proxy_bin),
+            env
+        ),
+        None => format!("{} --hook '.'", shell_escape_path(proxy_bin)),
+    };
     let hooks = vec![HookConfig {
         event: "PreToolUse".to_string(),
         matcher: Some("bash_exec".to_string()),
-        command: format!("{} --hook '.'", shell_escape_path(proxy_bin)),
+        command,
         timeout: None, // use framework default (30s); proxy startup can be slow on CI
         status_message: None,
         async_hook: None,

--- a/crates/harnx-proxy-auth/tests/https_connect.rs
+++ b/crates/harnx-proxy-auth/tests/https_connect.rs
@@ -115,12 +115,14 @@ async fn header_injection_works_through_https_connect_tunnel() {
         let filter_expr =
             r#"if .host == "localhost" then .headers["x-test-header"] = "hello-world" end"#;
         let compiled = filter::compile(filter_expr).expect("compile filter");
+        let sentinels = Arc::new(harnx_proxy_auth::sentinel::Sentinels::generate());
 
         // Start the proxy with danger_accept_invalid_certs so it can connect
         // upstream to our self-signed test server.
-        let proxy_port = proxy::start_proxy_danger_accept_invalid_certs(compiled, ca_setup)
-            .await
-            .expect("start proxy");
+        let proxy_port =
+            proxy::start_proxy_danger_accept_invalid_certs(compiled, ca_setup, sentinels)
+                .await
+                .expect("start proxy");
 
         sleep(Duration::from_millis(100)).await;
 
@@ -162,6 +164,95 @@ async fn header_injection_works_through_https_connect_tunnel() {
             Some("hello-world"),
             "proxy did not inject x-test-header for tunnelled HTTPS — \
              host was not resolved from Host header. Full echoed headers: {body}"
+        );
+    })
+    .await
+    .expect("test timed out");
+}
+
+/// Test that hook filters can use sentinel jaq variables directly.
+///
+/// This covers hook-side sentinel interpolation without exporting sentinels into
+/// process env. The filter matches a sentinel-backed Authorization header and
+/// replaces it before forwarding request upstream.
+#[tokio::test]
+async fn hook_filter_can_use_sentinel_variables() {
+    use harnx_proxy_auth::sentinel::Sentinels;
+
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    timeout(Duration::from_secs(20), async {
+        // Set up the proxy CA — keep the TempDir alive for the duration.
+        let (ca_setup, _ca_temp_dir) = ca::setup().expect("proxy CA setup");
+        let ca_cert_pem =
+            std::fs::read_to_string(&ca_setup.cert_pem_path).expect("read CA cert PEM");
+
+        // Generate a self-signed server cert for "localhost".
+        let server_cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("gen server cert");
+        let server_cert_der = server_cert.cert.der().to_vec();
+        let server_key_der = server_cert.signing_key.serialize_der();
+
+        // Spawn an HTTPS server using the self-signed cert.
+        let (server_port, _server_shutdown) = spawn_https_server(server_cert_der, server_key_der)
+            .await
+            .expect("spawn HTTPS server");
+
+        // Generate sentinels and pre-compute the sentinel-backed header value.
+        let sentinels = Arc::new(Sentinels::generate());
+        let sentinel_value = format!("ghs_{}", sentinels.base64_key);
+
+        // Compile the jq filter that checks the sentinel jaq variable directly.
+        let filter_expr =
+            r#"if .headers.authorization == "Bearer ghs_\($fake_base64_key)" then .headers.authorization = "Bearer real_token_from_env" else . end"#;
+        let compiled = filter::compile(filter_expr).expect("compile filter");
+
+        // Start the proxy with danger_accept_invalid_certs so it can connect
+        // upstream to our self-signed test server.
+        let proxy_port =
+            proxy::start_proxy_danger_accept_invalid_certs(compiled, ca_setup, sentinels.clone())
+            .await
+            .expect("start proxy");
+
+        sleep(Duration::from_millis(100)).await;
+
+        // Build a reqwest client that routes HTTPS through the proxy (CONNECT
+        // tunnel). `danger_accept_invalid_certs` is required because the
+        // MITM leaf certs hudsucker generates have no Extended Key Usage.
+        let proxy_ca = reqwest::tls::Certificate::from_pem(ca_cert_pem.as_bytes())
+            .expect("parse proxy CA cert");
+
+        let client = reqwest::Client::builder()
+            .proxy(
+                reqwest::Proxy::https(format!("http://127.0.0.1:{proxy_port}"))
+                    .expect("build proxy"),
+            )
+            .add_root_certificate(proxy_ca)
+            .danger_accept_invalid_certs(true)
+            .build()
+            .expect("build reqwest client");
+
+        // Send a request with the sentinel token in Authorization header.
+        let response = client
+            .get(format!("https://localhost:{server_port}/"))
+            .header("Authorization", format!("Bearer {sentinel_value}"))
+            .send()
+            .await
+            .expect("send request");
+
+        assert!(
+            response.status().is_success(),
+            "expected 200, got {}",
+            response.status()
+        );
+
+        let body: Value = response.json().await.expect("parse JSON body");
+
+        // The proxy filter should have replaced the sentinel token with the real token.
+        assert_eq!(
+            body.get("authorization").and_then(Value::as_str),
+            Some("Bearer real_token_from_env"),
+            "proxy did not replace sentinel token via $fake_base64_key. Full echoed headers: {body}"
         );
     })
     .await

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -323,6 +323,80 @@ hooks:
           end'
 ```
 
+### Sentinel Environment Variable Injection (`--env`)
+
+The `--env '<jaq-script>'` flag allows you to generate fake "sentinel" credentials at startup and inject them into bash tool calls. Hook scripts can then match on those sentinel values and replace them with real credentials — keeping real tokens out of tool call arguments entirely.
+
+#### Purpose
+
+When an agent uses a tool like `curl` or `git`, any credentials passed as arguments (e.g., `-H "Authorization: Bearer $TOKEN"`) are visible in the process list and logs. By using sentinels, you can provide the tool with a unique, session-specific "fake" token. The `harnx-proxy-auth` hook recognizes this fake token as it passes through the proxy and swaps it for the real one just before the request leaves the machine.
+
+#### Execution Model
+
+1. **Startup**: The `--env` script receives `{}` as input and must output a JSON object where keys are environment variable names and values are their sentinel values. **All values must be strings** — non-string values (numbers, booleans, objects) are rejected at startup.
+2. **Order**: Multiple `--env` flags run in order; later keys overwrite earlier ones.
+3. **Validation**: Any compilation, runtime, or type error in an `--env` script will abort startup.
+4. **Precedence**: Injection follows this order (highest priority wins):
+    - `tool_input.env` (user-provided keys always win)
+    - **Sentinel environment variables** (from `--env` flags)
+    - Proxy variables (`HTTP_PROXY`, etc.)
+
+#### Available Sentinel Variables
+
+The following jaq variables are available to each `--env` script to help generate unique keys:
+
+| Variable | Description | Example |
+| :--- | :--- | :--- |
+| `$fake_uuid_key` | UUID string with dashes | `550e8400-e29b-41d4-a716-446655440000` |
+| `$fake_base64_key` | Standard Base64 of the UUID bytes | `VQ6EANKbQdSnbEVmVESAAA==` |
+| `$fake_url_base64_key` | URL-safe no-pad Base64 of the UUID bytes | `VQ6EANKbQdSnbEVmVESAAA` |
+| `$fake_hex_key` | Lowercase hex (32 characters) | `550e8400e29b41d4a716446655440000` |
+| `$fake_email` | UUID with first `-` replaced by `@` | `550e8400@e29b-41d4-a716-446655440000` |
+
+#### Helper Functions
+
+Two helper functions are provided for formatting authentication headers:
+
+- **`bearer(token)`**: Returns `"Bearer <token>"`.
+- **`basic(user; pass)`**: Returns `"Basic <base64(user:pass)>"`.
+
+#### Worked Examples
+
+##### 1. GitHub Token Injection
+
+The `--env` script overrides `GITHUB_TOKEN` in the bash tool's environment with a session-unique sentinel value. The tool sends that sentinel in the `Authorization` header. The `--hook` script sees the sentinel value in the outbound request and swaps in the real `GITHUB_TOKEN` (still in the proxy's own environment) before the request leaves the machine.
+
+```yaml
+hooks:
+  entries:
+  - event: PreToolUse
+    type: claude-command-persistent
+    matcher: "bash_exec|bash_spawn"
+    command: >-
+      harnx-proxy-auth
+      --env 'if (env.GITHUB_TOKEN // env.GH_TOKEN) then .GITHUB_TOKEN = "ghs_\($fake_base64_key)" else . end'
+      --hook 'if (.host == "api.github.com") and (.headers.authorization == "Bearer ghs_\($fake_base64_key)")
+          then .headers.authorization = bearer(env.GITHUB_TOKEN // env.GH_TOKEN)
+          else . end'
+```
+
+##### 2. Atlassian/Jira Basic Auth
+
+```yaml
+hooks:
+  entries:
+  - event: PreToolUse
+    type: claude-command-persistent
+    matcher: "bash_exec|bash_spawn"
+    command: >-
+      harnx-proxy-auth
+      --env 'if (env.ATLASSIAN_API_TOKEN and env.ATLASSIAN_EMAIL) then .ATLASSIAN_API_TOKEN = $fake_uuid_key | .ATLASSIAN_EMAIL = $fake_email else . end'
+      --hook 'if (.host | endswith(".atlassian.net")) and .headers.authorization == "Basic \([$fake_email, $fake_uuid_key] | join(":") | @base64)"
+          then .headers.authorization = basic(env.ATLASSIAN_EMAIL; env.ATLASSIAN_API_TOKEN)
+          else . end'
+
+```
+
 ### Atlassian CLI (`acli`) Example
 
 `acli` (the Atlassian CLI for Jira, Confluence, etc.) stores API tokens in the OS keyring, which may not be accessible inside the bash birdcage. The solution is to set up `acli` on the host once, then use `harnx-proxy-auth` to transparently replace the `Authorization: Basic` header on every request to `*.atlassian.net` with credentials from environment variables.
@@ -371,9 +445,9 @@ The harnx `.env` file uses plain `KEY=value` lines (no `export`). See [Environme
 
 #### Step 3 — Configure the proxy hook
 
-Add the following to your `config.yaml`. The filter builds the correct `Basic` header from `ATLASSIAN_EMAIL` and `ATLASSIAN_API_TOKEN`, then injects it on any request to `*.atlassian.net`.
+Add the following to your `config.yaml`. The `--env` script emits sentinel placeholders for both the email and API token. The hook only rewrites requests whose `Authorization` header exactly matches that sentinel-derived `Basic` value.
 
-> **If either variable is unset**, the filter produces `Authorization: Basic Og==` (base64 of `:`), which is invalid and will be rejected with `401 Unauthorized`. Set both variables before running harnx.
+> **If either variable is unset**, the `--env` script returns `.`, so no Atlassian sentinel vars are injected and the hook condition never matches.
 
 ```yaml
 hooks:
@@ -383,14 +457,15 @@ hooks:
     matcher: "bash_exec|bash_spawn"
     command: >-
       harnx-proxy-auth
-      --hook 'if (.host | endswith(".atlassian.net"))
-          then .headers.authorization = "Basic \([(env.ATLASSIAN_EMAIL // ""), (env.ATLASSIAN_API_TOKEN // "")] | join(":") | @base64)"
-          end'
+      --env 'if (env.ATLASSIAN_API_TOKEN and env.ATLASSIAN_EMAIL) then .ATLASSIAN_API_TOKEN = $fake_uuid_key | .ATLASSIAN_EMAIL = $fake_email else . end'
+      --hook 'if (.host | endswith(".atlassian.net")) and .headers.authorization == "Basic \([$fake_email, $fake_uuid_key] | join(":") | @base64)"
+          then .headers.authorization = basic(env.ATLASSIAN_EMAIL; env.ATLASSIAN_API_TOKEN)
+          else . end'
 ```
 
 > **Security note:** `endswith(".atlassian.net")` prevents DNS-level spoofing — `"evilatlassian.net"` does not match because of the leading dot. However, credentials will be forwarded to **any** `*.atlassian.net` tenant, including ones owned by third parties. To scope injection to your own workspace only, use explicit equality: `.host == "mysite.atlassian.net"`.
 
-You can combine Atlassian and GitHub auth in a single `harnx-proxy-auth` invocation using multiple `--hook` flags:
+You can combine Atlassian and GitHub auth in a single `harnx-proxy-auth` invocation using multiple `--env` and `--hook` flags:
 
 ```yaml
 hooks:
@@ -400,12 +475,14 @@ hooks:
     matcher: "bash_exec|bash_spawn"
     command: >-
       harnx-proxy-auth
-      --hook 'if (.host == "github.com" or .host == "api.github.com" or .host == "uploads.github.com" or .host == "objects.githubusercontent.com")
-          then .headers.authorization = "Bearer \(env.GITHUB_TOKEN // env.GH_TOKEN)"
-          end'
-      --hook 'if (.host | endswith(".atlassian.net"))
-          then .headers.authorization = "Basic \([(env.ATLASSIAN_EMAIL // ""), (env.ATLASSIAN_API_TOKEN // "")] | join(":") | @base64)"
-          end'
+      --env 'if (env.GITHUB_TOKEN // env.GH_TOKEN) then .GITHUB_TOKEN = "ghs_\($fake_base64_key)" else . end'
+      --hook 'if (.host == "api.github.com") and (.headers.authorization == "Bearer ghs_\($fake_base64_key)")
+          then .headers.authorization = bearer(env.GITHUB_TOKEN // env.GH_TOKEN)
+          else . end'
+      --env 'if (env.ATLASSIAN_API_TOKEN and env.ATLASSIAN_EMAIL) then .ATLASSIAN_API_TOKEN = $fake_uuid_key | .ATLASSIAN_EMAIL = $fake_email else . end'
+      --hook 'if (.host | endswith(".atlassian.net")) and .headers.authorization == "Basic \([$fake_email, $fake_uuid_key] | join(":") | @base64)"
+          then .headers.authorization = basic(env.ATLASSIAN_EMAIL; env.ATLASSIAN_API_TOKEN)
+          else . end'
 ```
 
 ### Injected Environment Variables

--- a/docs/solutions/integration-issues/sentinel-env-vars-proxy-injection-2026-05-27.md
+++ b/docs/solutions/integration-issues/sentinel-env-vars-proxy-injection-2026-05-27.md
@@ -1,0 +1,197 @@
+---
+title: "Sentinel env vars for hook scripts: two-process env gap and jaq variable injection"
+date: 2026-05-27
+category: "integration-issues"
+problem_type: integration_issue
+component: "harnx-proxy-auth"
+root_cause: "process boundary env isolation and jaq API contract mismatch"
+resolution_type: code_fix
+severity: high
+tags:
+  - jaq
+  - proxy
+  - environment-variables
+  - hooks
+  - sentinel
+  - process-isolation
+plan_ref: "harnx-issue-632-sentinel-env-vars"
+---
+
+## Problem
+
+`harnx-proxy-auth`'s `--env '<jaq-script>'` flag generates session-unique UUID sentinel values and injects them into bash tool call environments, enabling hook scripts to match sentinel values and replace them with real credentials. However, hook jaq filters evaluating `env.SENTINEL_VAR` saw `null` instead of the sentinel values because the proxy process's own environment was not updated — creating a two-process env gap.
+
+Additionally, jaq's variable injection API requires specific patterns that differ from typical jq usage.
+
+## Symptoms
+
+- Hook filters reading `env.GITHUB_TOKEN_FAKE` returned `null` even though `--env` scripts executed successfully
+- Sentinel values appeared in bash tool environments but not in HTTPS request modification hooks
+- Non-string values from `--env` scripts caused MCP deserialization failures downstream in `harnx-mcp-bash`
+- Attempting to inject variables into jaq scripts failed with compile errors or runtime `null` values
+
+## Investigation Steps
+
+1. Traced `--env` script evaluation through `filter::eval_env_scripts` — confirmed scripts executed and produced correct output
+2. Verified `extra_env` map passed to `hook::run_jsonl_loop` — confirmed values present
+3. Added debug logging to hook filter execution — `env.VAR` returned `null`
+4. Examined jaq's `env` implementation — reads from `std::env::var` at runtime, not from injected context
+5. Identified process boundary: bash tool env injection (one process) vs. MITM proxy filter evaluation (another logical flow in same process, but reading from OS env)
+6. Traced jaq-all `compile_with` API — variable names passed without `$` prefix, values supplied positionally via `Vars::new`
+
+## Root Cause
+
+### Two-Process Env Gap
+
+`harnx-proxy-auth` runs two separate logical flows in the same process:
+1. **JSONL loop**: Injects env vars into bash tool calls via `extra_env` parameter
+2. **HTTPS MITM proxy**: Applies jaq filters to outbound requests; `env.VAR` reads from proxy process's own OS environment via `std::env::var`
+
+The `extra_env` map is only passed to bash tool call augmentation — it never touches the proxy process's own environment. Hook filters executing at request time call `std::env::var` directly, bypassing `extra_env` entirely.
+
+### jaq Variable Injection API
+
+`jaq_all::compile_with(code, defs, funs, &var_names)` expects variable names without `$` prefix. At runtime, `jaq_core::Vars::new([val1, val2, ...])` positionally maps values to those names. Omitting either step causes compile errors or runtime `null`.
+
+### String-Only Env Var Contract
+
+`harnx-mcp-bash` expects `HashMap<String, String>` for env vars. Non-string values cause deserialization failures. Validation at injection time is too late — must validate at `eval_env_scripts` output time.
+
+## Solution
+
+### Export Sentinel Vars to Proxy Process Environment
+
+After `eval_env_scripts`, call `std::env::set_var` for each key-value pair:
+
+```rust
+// main.rs
+let extra_env = filter::eval_env_scripts(&args.env, &sentinels)?;
+
+// Export sentinel env vars into this process's own environment so that
+// --hook jaq filters can read them via env.VARNAME at request time.
+// Without this, jaq's `env.VAR` reads from the proxy process environment,
+// not from `extra_env` which is only passed to bash tool calls.
+// `eval_env_scripts` guarantees all values are strings; unwrap is safe.
+for (key, value) in &extra_env {
+    std::env::set_var(key, value.as_str().unwrap_or_default());
+}
+```
+
+### Jaq Variable Injection Pattern
+
+```rust
+// filter.rs
+const ENV_SCRIPT_VAR_NAMES: [&str; 5] = [
+    "fake_uuid_key",
+    "fake_base64_key",
+    "fake_url_base64_key",
+    "fake_hex_key",
+    "fake_email",
+];
+
+fn run_env_script(script: &str, sentinels: &Sentinels) -> Result<Map<String, Value>> {
+    let var_names = ENV_SCRIPT_VAR_NAMES.map(str::to_owned);
+    let filter = compile_with(script, defs(), data::funs().chain(auth_funs()), &var_names)
+        .map_err(|errors| anyhow!("jaq env script compile error: {errors:?}"))?;
+
+    let vars = Vars::new([
+        sentinel_string_to_jaq_value(&sentinels.uuid_key)?,
+        sentinel_string_to_jaq_value(&sentinels.base64_key)?,
+        sentinel_string_to_jaq_value(&sentinels.url_base64_key)?,
+        sentinel_string_to_jaq_value(&sentinels.hex_key)?,
+        sentinel_string_to_jaq_value(&sentinels.email)?,
+    ]);
+    // ... execute filter with vars
+}
+```
+
+### Native Jaq Helper Functions
+
+Pattern for adding native jaq functions:
+
+```rust
+fn auth_funs() -> impl Iterator<Item = jaq_core::native::Fun<data::DataKind>> {
+    // 1-arg function using unary helper
+    fn bearer(cv: jaq_core::Cv<'_, data::DataKind>) -> jaq_core::ValXs<'_, json::Val> {
+        unary(cv, |_input, token| {
+            let token = token.try_as_bytes()?;
+            Ok(json::Val::from_utf8_bytes(
+                format!("Bearer {}", String::from_utf8_lossy(token)).into_bytes(),
+            ))
+        })
+    }
+
+    // 2-arg function using pop_var twice (last pop = first arg)
+    fn basic(mut cv: jaq_core::Cv<'_, data::DataKind>) -> jaq_core::ValXs<'_, json::Val> {
+        let pass = cv.0.pop_var();
+        let user = cv.0.pop_var();
+        bome((|| {
+            let user = user.try_as_bytes()?;
+            let pass = pass.try_as_bytes()?;
+            let encoded = base64::engine::general_purpose::STANDARD
+                .encode([user, b":", pass].concat());
+            Ok(json::Val::from_utf8_bytes(
+                format!("Basic {encoded}").into_bytes(),
+            ))
+        })())
+    }
+
+    [
+        run::<data::DataKind>(("bearer", v(1), bearer)),
+        run::<data::DataKind>(("basic", v(2), basic)),
+    ]
+    .into_iter()
+}
+```
+
+Key patterns:
+- `v(n)` specifies number of filter arguments
+- `unary(cv, |input, arg1| ...)` for single-arg helpers
+- For multi-arg: `cv.0.pop_var()` repeatedly — last pop is first argument
+- `Val::from_utf8_bytes(bytes)` constructs string values
+- `val.try_as_bytes()` extracts bytes from input values
+
+### String Validation at Script Output Time
+
+```rust
+// filter.rs - eval_env_scripts validates all values are strings
+for (key, val) in &object {
+    if !val.is_string() {
+        return Err(anyhow!(
+            "jaq env script output value for key {key:?} must be a string, got {val}"
+        ));
+    }
+}
+```
+
+## Why This Works
+
+**Env export**: `std::env::set_var` modifies the process's OS environment, which jaq's `env.VAR` reads from at runtime. This bridges the gap between the `extra_env` map (bash tool injection) and the proxy's actual environment (hook filter evaluation).
+
+**Variable injection**: jaq's `compile_with` requires variable names at compile time (without `$` prefix) and values at runtime (positionally via `Vars::new`). Both must match in order and count.
+
+**String validation**: Validating at `eval_env_scripts` time fails fast before any injection attempt, providing clear error messages about which key produced a non-string value. This prevents confusing MCP deserialization errors downstream.
+
+## Prevention Strategies
+
+**Test Cases:**
+- Add E2E test proving hook filter can read sentinel values via `env.SENTINEL_VAR`
+- Test that `eval_env_scripts` rejects non-string values with specific error message
+- Test variable injection round-trip: define variable, reference in script, verify output
+
+**Best Practices:**
+- When spawning background processes that read env vars, distinguish between "env map passed to subprocess" and "current process's OS env"
+- For jaq variable injection: compile with names (no `$`), run with `Vars::new([values...])`
+- Validate env var values are strings immediately after script output, not at injection time
+
+**Code Review Checklist:**
+- [ ] Does the proxy process export env vars it needs for filter execution?
+- [ ] Are jaq variables passed without `$` prefix to `compile_with`?
+- [ ] Are variable values positionally matched to names in `Vars::new`?
+- [ ] Are all env var values validated as strings before injection?
+
+## Related Issues
+
+- **Issue:** #632 — Add `--env` sentinel env vars feature
+- **Solution:** [integration-issues/atlassian-cli-proxy-auth-2026-05-20.md](../integration-issues/atlassian-cli-proxy-auth-2026-05-20.md) — Similar pattern of env var injection in hook filters
+- **Solution:** [security-issues/environment-sanitization-bash-sandbox-2026-04-29.md](../security-issues/environment-sanitization-bash-sandbox-2026-04-29.md) — Env var precedence and injection patterns

--- a/example_config/config.yaml
+++ b/example_config/config.yaml
@@ -51,9 +51,11 @@ toolsets:
 #
 # PreToolUse hooks can return hookSpecificOutput.toolInput to mutate tool arguments.
 # PostToolUse hooks can return hookSpecificOutput.toolResponse to mutate the tool response.
-# Example: Inject GitHub auth headers for HTTPS requests via the harnx-proxy-auth hook.
-# This is a persistent hook process that acts as an HTTPS MITM proxy, injecting auth
-# headers based on URL-matcher rules. It runs once and handles all bash_exec/bash_spawn events.
+#
+# Example: Inject GitHub auth headers via harnx-proxy-auth using --env sentinel technique.
+# The --env script emits real variable names with fake sentinel values. The hook matches
+# the sentinel in outbound requests and replaces it with the real token from the environment.
+# This prevents the real token from appearing in logs or process listings.
 #
 # hooks:
 #   entries:
@@ -62,6 +64,21 @@ toolsets:
 #     matcher: "bash_exec|bash_spawn"
 #     command: >-
 #       harnx-proxy-auth
-#       --hook 'if (.host == "github.com" or .host == "api.github.com" or .host == "uploads.github.com" or .host == "objects.githubusercontent.com")
-#           then .headers.authorization = "Bearer \(env.GITHUB_TOKEN // env.GH_TOKEN)"
+#       --env 'if (env.GITHUB_TOKEN // env.GH_TOKEN) then .GITHUB_TOKEN = "ghs_\($fake_base64_key)" else . end'
+#       --hook 'if (.host == "api.github.com") and (.headers.authorization == "Bearer ghs_\($fake_base64_key)")
+#           then .headers.authorization = bearer(env.GITHUB_TOKEN // env.GH_TOKEN)
+#           else . end'
+#
+# Example: Inject Atlassian Basic auth using sentinel email + UUID placeholders.
+#
+# hooks:
+#   entries:
+#   - event: PreToolUse
+#     type: claude-command-persistent
+#     matcher: "bash_exec|bash_spawn"
+#     command: >-
+#       harnx-proxy-auth
+#       --env 'if (env.ATLASSIAN_API_TOKEN and env.ATLASSIAN_EMAIL) then .ATLASSIAN_API_TOKEN = $fake_uuid_key | .ATLASSIAN_EMAIL = $fake_email else . end'
+#       --hook 'if (.host | endswith(".atlassian.net")) and .headers.authorization == "Basic \([$fake_email, $fake_uuid_key] | join(":") | @base64)"
+#           then .headers.authorization = basic(env.ATLASSIAN_EMAIL; env.ATLASSIAN_API_TOKEN)
 #           else . end'


### PR DESCRIPTION
Adds a new --env flag to harnx-proxy-auth that generates session-unique UUID sentinels and injects them into bash_exec/bash_spawn tool calls. This enables hook scripts to conditionally replace fake tokens with real credentials without exposing them in process lists or logs.

The feature generates five sentinel encodings ($fake_uuid_key, $fake_base64_key, $fake_url_base64_key, $fake_hex_key, $fake_email) available as jaq variables in both --env and --hook scripts. It also introduces bearer(token) and basic(user; pass) jaq helpers for common authentication patterns.

#632

Plan: harnx-issue-632-sentinel-env-vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--env` flag to generate session-unique sentinel credentials and inject them into bash tool environments
  * New helpers for credential formatting: `bearer()` and `basic()`
  * Hooks can match sentinel values and rewrite them with real credentials

* **Documentation**
  * Expanded hooks guide with `--env` examples for GitHub and Atlassian
  * Added integration troubleshooting page describing env injection semantics

* **Tests**
  * Added unit and integration tests covering env scripts, sentinel injection, and hook behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->