### PR TITLE
feat(sandbox): add harnx-sandbox-run standalone CLI with credential injection

### DIFF
--- a/.changesets/harnx-sandbox-run.md
+++ b/.changesets/harnx-sandbox-run.md
@@ -1,0 +1,5 @@
+---
+harnx: minor
+---
+
+New `harnx-sandbox-run` binary: run arbitrary commands inside the birdcage sandbox with hook support for credential injection. Supports interactive TTY, all sandbox flags from `harnx-mcp-bash`, and both one-shot and persistent hooks via `--hook` syntax.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,7 +123,9 @@ jobs:
         $BUILD_CMD build --locked --release --target=${{ matrix.target }} ${{ matrix.cargo-flags }} \
           -p harnx -p harnx-serve -p harnx-acp-server \
           -p harnx-mcp-bash -p harnx-mcp-fs -p harnx-mcp-plans -p harnx-mcp-time \
-          -p harnx-aws-creds -p harnx-pkg -p harnx-proxy-auth -p harnx-mcp-hooks-proxy
+          -p harnx-aws-creds -p harnx-pkg -p harnx-proxy-auth -p harnx-mcp-hooks-proxy \
+          -p harnx-sandbox-run \
+          -p harnx-sandbox-common
 
     - name: Build Archives
       shell: bash
@@ -152,6 +154,8 @@ jobs:
           "harnx-pkg:harnx-pkg"
           "harnx-proxy-auth:harnx-proxy-auth"
           "harnx-mcp-hooks-proxy:harnx-mcp-hooks-proxy"
+          "harnx-sandbox-run:harnx-sandbox-run"
+          "harnx-sandbox-exec:harnx-sandbox-exec"
         )
 
         archives=()
@@ -250,6 +254,10 @@ jobs:
             --pattern "harnx-proxy-auth-$V-x86_64-unknown-linux-musl.tar.gz" || true
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-mcp-hooks-proxy-$V-x86_64-unknown-linux-musl.tar.gz" || true
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern "harnx-sandbox-run-$V-x86_64-unknown-linux-musl.tar.gz" || true
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern "harnx-sandbox-exec-$V-x86_64-unknown-linux-musl.tar.gz" || true
           # Download aarch64 (arm64) archives
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-$V-aarch64-unknown-linux-musl.tar.gz" || true
@@ -273,6 +281,10 @@ jobs:
             --pattern "harnx-proxy-auth-$V-aarch64-unknown-linux-musl.tar.gz" || true
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-mcp-hooks-proxy-$V-aarch64-unknown-linux-musl.tar.gz" || true
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern "harnx-sandbox-run-$V-aarch64-unknown-linux-musl.tar.gz" || true
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern "harnx-sandbox-exec-$V-aarch64-unknown-linux-musl.tar.gz" || true
 
       - name: Extract archives
         run: |
@@ -288,7 +300,7 @@ jobs:
         run: |
           missing=0
           for dir in linux-amd64 linux-arm64; do
-            for bin in harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-bash-sandbox-run harnx-mcp-fs harnx-mcp-plans harnx-mcp-time harnx-aws-creds harnx-pkg harnx-proxy-auth harnx-mcp-hooks-proxy; do
+            for bin in harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-bash-sandbox-run harnx-mcp-fs harnx-mcp-plans harnx-mcp-time harnx-aws-creds harnx-pkg harnx-proxy-auth harnx-mcp-hooks-proxy harnx-sandbox-run harnx-sandbox-exec; do
               if [ ! -f "$dir/$bin" ]; then
                 echo "ERROR: missing $dir/$bin"
                 missing=1

--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -9,11 +9,11 @@ set -e
 # rebuilds that `cargo install --path` does. Release profile by default; pass --debug for
 # a faster build with slower runtime.
 # @flag --debug Install debug build instead of the default release build
-# @arg bins*[harnx|harnx-serve|harnx-acp-server|harnx-mcp-bash|harnx-mcp-bash-sandbox-run|harnx-mcp-fs|harnx-mcp-time|harnx-mcp-plans|harnx-mcp-hooks-proxy|harnx-aws-creds|harnx-pkg|harnx-proxy-auth] Restrict the install to one or more bins (default: all)
+# @arg bins*[harnx|harnx-serve|harnx-acp-server|harnx-mcp-bash|harnx-mcp-fs|harnx-mcp-time|harnx-mcp-plans|harnx-mcp-hooks-proxy|harnx-aws-creds|harnx-pkg|harnx-proxy-auth|harnx-sandbox-run|harnx-sandbox-exec] Restrict the install to one or more bins (default: all)
 install() {
     bins=("${argc_bins[@]}")
     if [[ ${#bins[@]} -eq 0 ]]; then
-        bins=(harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-fs harnx-mcp-time harnx-mcp-plans harnx-mcp-bash-sandbox-run harnx-mcp-hooks-proxy harnx-aws-creds harnx-pkg harnx-proxy-auth)
+        bins=(harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-fs harnx-mcp-time harnx-mcp-plans harnx-mcp-hooks-proxy harnx-aws-creds harnx-pkg harnx-proxy-auth harnx-sandbox-run harnx-sandbox-exec)
     fi
 
     build_args=(--locked)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3665,6 +3665,7 @@ dependencies = [
  "harnx-core",
  "harnx-mcp",
  "harnx-mcp-history",
+ "harnx-sandbox-common",
  "libc",
  "log",
  "process-wrap",
@@ -3921,6 +3922,33 @@ dependencies = [
  "unicode-width 0.2.2",
  "uuid",
  "which",
+]
+
+[[package]]
+name = "harnx-sandbox-common"
+version = "0.32.2"
+dependencies = [
+ "anyhow",
+ "birdcage",
+ "log",
+ "tempfile",
+]
+
+[[package]]
+name = "harnx-sandbox-run"
+version = "0.32.2"
+dependencies = [
+ "anyhow",
+ "clap",
+ "env_logger",
+ "harnx-core",
+ "harnx-hooks",
+ "harnx-sandbox-common",
+ "log",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ members = [
     "crates/harnx-hooks",
     "crates/harnx-mcp",
     "crates/harnx-mcp-bash",
+    "crates/harnx-sandbox-common",
+    "crates/harnx-sandbox-run",
     "crates/harnx-mcp-hooks-proxy",
     "crates/harnx-mcp-fs",
     "crates/harnx-mcp-time",
@@ -144,6 +146,7 @@ harnx-acp = { path = "crates/harnx-acp" }
 harnx-acp-server = { path = "crates/harnx-acp-server" }
 minijinja = { version = "2.19.0", default-features = false, features = ["builtins", "debug", "serde"] }
 harnx-mcp-history = { path = "crates/harnx-mcp-history" }
+harnx-sandbox-common = { path = "crates/harnx-sandbox-common" }
 similar = "3"
 jaq-core = "3.0.0"
 jaq-std = "3.0.0"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Harnx ships as three binaries, each installable independently:
 | `harnx` | Full CLI — TUI + Cmd + HTTP (`--serve`) + ACP (`--acp=<agent>`) | ~18 MB |
 | `harnx-serve` | HTTP-only server, no TUI deps | ~10 MB |
 | `harnx-acp-server` | ACP-only headless agent over stdio, no TUI deps | ~11 MB |
+| `harnx-sandbox-run` | Standalone sandbox wrapper with hook support | ~10 MB |
 
 Install whichever you need. Most users want just `harnx`; headless server
 deployments can skip the TUI deps by picking `harnx-serve` or
@@ -26,6 +27,7 @@ deployments can skip the TUI deps by picking `harnx-serve` or
 cargo install --git https://github.com/dobesv/harnx harnx
 cargo install --git https://github.com/dobesv/harnx harnx-serve
 cargo install --git https://github.com/dobesv/harnx harnx-acp-server
+cargo install --git https://github.com/dobesv/harnx harnx-sandbox-run
 ```
 
 The package name after `--git <url>` picks which workspace member to install.

--- a/crates/harnx-aws-creds/src/main.rs
+++ b/crates/harnx-aws-creds/src/main.rs
@@ -141,12 +141,13 @@ fn handle_hook_line(line: &str, state: &AppState, port: u16) -> Option<Value> {
         }
     };
 
+    // Respond to any PreToolUse event with a tool_input — tool name filtering
+    // is the caller's responsibility (configured via the hook's matcher field).
     let response = match (
         request.get("hook_event_name").and_then(Value::as_str),
-        request.get("tool_name").and_then(Value::as_str),
         request.get("tool_input"),
     ) {
-        (Some("PreToolUse"), Some("bash_exec" | "bash_spawn"), Some(tool_input)) => {
+        (Some("PreToolUse"), Some(tool_input)) => {
             match mutate_tool_input(tool_input, state, port) {
                 Ok(mutated) => json!({
                     "id": id,
@@ -414,15 +415,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn hook_noop_other_tool() {
-        let output = run_hook_once(
-            "{\"id\":\"1\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"fs_read\",\"tool_input\":{\"path\":\"/tmp/file\"}}\n",
-            12345,
-        )
-        .await;
-
-        let response: Value = serde_json::from_str(output.trim()).unwrap();
-        assert_eq!(response, json!({ "id": "1" }));
+    async fn hook_injects_any_pretooluse_with_tool_input() {
+        // Tool name is ignored — caller is responsible for filtering via matcher.
+        // Any PreToolUse event with a tool_input gets credential injection.
+        let env = hook_injected_env(r#"{"command":"ls","env":{}}"#).await;
+        assert_eq!(env["AWS_REGION"], "us-east-1");
     }
 
     #[tokio::test]

--- a/crates/harnx-k8s-creds/src/main.rs
+++ b/crates/harnx-k8s-creds/src/main.rs
@@ -334,11 +334,10 @@ fn handle_hook_line(line: &str, kubeconfig_path: KubeconfigPath<'_>) -> Option<V
     let input: Value = serde_json::from_str(line).ok()?;
     let id = input.get("id")?.clone();
     let hook_event_name = input.get("hook_event_name").and_then(Value::as_str);
-    let tool_name = input.get("tool_name").and_then(Value::as_str);
 
-    if hook_event_name == Some("PreToolUse")
-        && matches!(tool_name, Some("bash_exec") | Some("bash_spawn"))
-    {
+    // Respond to any PreToolUse event with a tool_input — tool name filtering
+    // is the caller's responsibility (configured via the hook's matcher field).
+    if hook_event_name == Some("PreToolUse") {
         if let Some(tool_input) = input.get("tool_input") {
             if let Ok(tool_input) = mutate_tool_input(tool_input, kubeconfig_path) {
                 return Some(json!({
@@ -549,7 +548,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn hook_non_bash_tool_emits_noop() {
+    async fn hook_non_pretooluse_event_emits_noop() {
+        // PostToolUse events are always ignored regardless of tool name.
         assert_noop(
             &json!({"id":"1","hook_event_name":"PostToolUse","tool_name":"bash_exec","tool_input":{"command":"ls"}}),
             1,
@@ -591,7 +591,7 @@ mod tests {
     async fn hook_malformed_json_skipped_continues_loop() {
         assert_skipped_continues(
             "this is not json\n",
-            "{\"id\":\"2\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"fs_read\",\"tool_input\":{}}\n",
+            "{\"id\":\"2\",\"hook_event_name\":\"PostToolUse\",\"tool_name\":\"bash_exec\"}\n",
             2,
         )
         .await;

--- a/crates/harnx-mcp-bash/Cargo.toml
+++ b/crates/harnx-mcp-bash/Cargo.toml
@@ -14,6 +14,7 @@ gix = { workspace = true }
 harnx-core = { path = "../harnx-core" }
 harnx-mcp = { path = "../harnx-mcp" }
 harnx-mcp-history = { workspace = true }
+harnx-sandbox-common = { path = "../harnx-sandbox-common" }
 libc = { workspace = true }
 log = { workspace = true }
 process-wrap = { workspace = true }
@@ -31,6 +32,7 @@ birdcage = { workspace = true }
 name = "harnx-mcp-bash"
 path = "src/main.rs"
 
+# Kept for backward compatibility — now an alias; harnx-sandbox-exec is the canonical binary.
 [[bin]]
 name = "harnx-mcp-bash-sandbox-run"
 path = "src/bin/sandbox_run.rs"

--- a/crates/harnx-mcp-bash/src/main.rs
+++ b/crates/harnx-mcp-bash/src/main.rs
@@ -1,5 +1,6 @@
 mod server;
 
+use harnx_sandbox_common::SandboxConfig;
 use rmcp::ServiceExt;
 use server::BashServer;
 #[cfg(unix)]
@@ -116,17 +117,17 @@ fn push_root(roots: &mut Vec<PathBuf>, raw: &str) {
 }
 
 #[cfg(unix)]
-fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
+fn parse_args() -> anyhow::Result<(Vec<PathBuf>, SandboxConfig)> {
     let args: Vec<String> = std::env::args().collect();
     let mut roots = Vec::new();
     let mut sandbox_enabled = true;
-    let mut sandbox_config = server::SandboxConfig {
+    let mut sandbox_config = SandboxConfig {
         enabled: true,
         extra_exec: parse_env_paths("HARNX_BASH_EXTRA_EXEC"),
         extra_readable: parse_env_paths("HARNX_BASH_EXTRA_READABLE"),
         extra_writable: parse_env_paths("HARNX_BASH_EXTRA_WRITABLE"),
         extra_rwx: parse_env_paths("HARNX_BASH_EXTRA_RWX"),
-        sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
+        sandbox_run_path: PathBuf::from("harnx-sandbox-exec"),
         extra_env_passthrough: parse_env_passthrough(),
         env_overrides: vec![],
     };
@@ -277,15 +278,13 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
     }
 
     let resolved_sandbox_run_path = sandbox_run_override.clone().or_else(|| {
-        std::env::current_exe().ok().and_then(|path| {
-            path.parent()
-                .map(|dir| dir.join("harnx-mcp-bash-sandbox-run"))
-        })
+        std::env::current_exe()
+            .ok()
+            .and_then(|path| path.parent().map(|dir| dir.join("harnx-sandbox-exec")))
     });
 
     if sandbox_enabled {
-        let path = resolved_sandbox_run_path
-            .unwrap_or_else(|| PathBuf::from("harnx-mcp-bash-sandbox-run"));
+        let path = resolved_sandbox_run_path.unwrap_or_else(|| PathBuf::from("harnx-sandbox-exec"));
         if path_is_executable(&path) {
             sandbox_config.sandbox_run_path = path;
         } else if sandbox_run_override.is_some() {
@@ -295,14 +294,14 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
             );
         } else {
             anyhow::bail!(
-                "harnx-mcp-bash: error: sandbox helper at {} does not exist or is not executable; place harnx-mcp-bash-sandbox-run next to harnx-mcp-bash, use --sandbox-run <path>, or pass --no-sandbox to disable sandboxing explicitly",
+                "harnx-mcp-bash: error: sandbox helper at {} does not exist or is not executable; place harnx-sandbox-exec next to harnx-mcp-bash, use --sandbox-run <path>, or pass --no-sandbox to disable sandboxing explicitly",
                 path.display()
             );
         }
     } else {
         sandbox_config.enabled = false;
-        sandbox_config.sandbox_run_path = resolved_sandbox_run_path
-            .unwrap_or_else(|| PathBuf::from("harnx-mcp-bash-sandbox-run"));
+        sandbox_config.sandbox_run_path =
+            resolved_sandbox_run_path.unwrap_or_else(|| PathBuf::from("harnx-sandbox-exec"));
     }
 
     Ok((roots, sandbox_config))
@@ -320,17 +319,17 @@ fn parse_env_passthrough() -> Vec<String> {
 }
 
 #[cfg(not(unix))]
-fn parse_args() -> anyhow::Result<(Vec<PathBuf>, server::SandboxConfig)> {
+fn parse_args() -> anyhow::Result<(Vec<PathBuf>, SandboxConfig)> {
     let args: Vec<String> = std::env::args().collect();
     let mut roots = Vec::new();
-    let mut sandbox_config = server::SandboxConfig {
+    let mut sandbox_config = SandboxConfig {
         // Sandbox itself is Unix-only; on Windows these fields are unused.
         enabled: false,
         extra_exec: vec![],
         extra_readable: vec![],
         extra_writable: vec![],
         extra_rwx: vec![],
-        sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
+        sandbox_run_path: PathBuf::from("harnx-sandbox-exec"),
         extra_env_passthrough: parse_env_passthrough(),
         env_overrides: vec![],
     };

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -9,10 +9,10 @@ use harnx_mcp::schema::object_schema_with_desc;
 use harnx_mcp_history::classify::{classify_command, SnapshotDecision};
 use harnx_mcp_history::HistoryManager;
 #[cfg(unix)]
-use harnx_sandbox_common::SYSTEM_EXEC_PATHS;
-#[cfg(unix)]
 use harnx_sandbox_common::build_default_sandbox_args;
 use harnx_sandbox_common::SandboxConfig;
+#[cfg(unix)]
+use harnx_sandbox_common::SYSTEM_EXEC_PATHS;
 #[cfg(windows)]
 use process_wrap::tokio::JobObject;
 #[cfg(unix)]

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -8,6 +8,11 @@ use gix::ObjectId;
 use harnx_mcp::schema::object_schema_with_desc;
 use harnx_mcp_history::classify::{classify_command, SnapshotDecision};
 use harnx_mcp_history::HistoryManager;
+#[cfg(unix)]
+use harnx_sandbox_common::SYSTEM_EXEC_PATHS;
+#[cfg(unix)]
+use harnx_sandbox_common::build_default_sandbox_args;
+use harnx_sandbox_common::SandboxConfig;
 #[cfg(windows)]
 use process_wrap::tokio::JobObject;
 #[cfg(unix)]
@@ -331,35 +336,6 @@ struct SpawnedProcess {
     output_paths: Option<Vec<PathBuf>>,
 }
 
-/// Configuration for the bash MCP server's sandboxing and child env handling.
-///
-/// The sandboxing fields (`enabled`, `extra_exec`, `extra_readable`,
-/// `sandbox_run_path`) are honoured only on Unix; on other platforms they
-/// are accepted for API compatibility and ignored.
-///
-/// The env-control fields (`extra_env_passthrough`, `env_overrides`) are
-/// honoured on every platform — even when sandboxing is unavailable, the
-/// child bash process receives only the curated environment.
-#[derive(Clone, Debug)]
-pub struct SandboxConfig {
-    #[cfg_attr(not(unix), allow(dead_code))]
-    pub enabled: bool,
-    #[cfg_attr(not(unix), allow(dead_code))]
-    pub extra_exec: Vec<PathBuf>,
-    #[cfg_attr(not(unix), allow(dead_code))]
-    pub extra_readable: Vec<PathBuf>,
-    #[cfg_attr(not(unix), allow(dead_code))]
-    pub extra_writable: Vec<PathBuf>,
-    #[cfg_attr(not(unix), allow(dead_code))]
-    pub extra_rwx: Vec<PathBuf>,
-    /// Extra var names to pass through from host (allowlist additions).
-    pub extra_env_passthrough: Vec<String>,
-    /// Explicit overrides: KEY → VALUE (highest precedence).
-    pub env_overrides: Vec<(String, String)>,
-    #[cfg_attr(not(unix), allow(dead_code))]
-    pub sandbox_run_path: PathBuf,
-}
-
 struct BashServerInner {
     roots: RwLock<Vec<PathBuf>>,
     roots_initialized: AtomicBool,
@@ -384,15 +360,7 @@ struct BashServerInner {
 /// Used to prevent over-broad roots from granting sandbox write/exec access.
 #[cfg(unix)]
 fn is_home_or_ancestor(path: &Path) -> bool {
-    let home_os = match std::env::var_os("HOME") {
-        Some(h) => h,
-        None => return false,
-    };
-    let home = std::fs::canonicalize(&home_os)
-        .unwrap_or_else(|_| std::path::Path::new(&home_os).to_path_buf());
-    let candidate = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-    // path IS $HOME, or path is a strict ancestor of $HOME (home.starts_with(candidate))
-    home.starts_with(&candidate)
+    harnx_sandbox_common::is_home_or_ancestor(path)
 }
 
 // ---------------------------------------------------------------------------
@@ -445,200 +413,6 @@ pub struct BashServer {
 }
 
 impl BashServer {
-    #[cfg(target_os = "linux")]
-    #[allow(dead_code)]
-    const SYSTEM_EXEC_PATHS: &[&str] = &[
-        "/usr/bin",
-        "/bin",
-        "/usr/local/bin",
-        "/usr/sbin",
-        "/sbin",
-        "/usr/lib",
-        "/usr/lib64",
-        "/lib",
-        "/lib64",
-        "/usr/lib/x86_64-linux-gnu",
-        "/usr/libexec",
-        "/proc",
-        "/dev",
-        "/sys",
-        "/etc",
-        "/tmp",
-        "/run",
-        "/var/run",
-        "/usr/share",
-    ];
-    #[cfg(target_os = "macos")]
-    #[allow(dead_code)]
-    const SYSTEM_EXEC_PATHS: &[&str] = &[
-        "/usr/bin",
-        "/bin",
-        "/usr/local/bin",
-        "/usr/sbin",
-        "/sbin",
-        "/usr/lib",
-        "/usr/local/lib",
-        "/Library",
-        "/System",
-        "/private/tmp",
-        "/private/var",
-        "/dev",
-    ];
-    #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
-    #[allow(dead_code)]
-    const SYSTEM_EXEC_PATHS: &[&str] = &["/usr/bin", "/bin", "/tmp", "/etc"];
-
-    /// Read-only system paths needed for compiling C/C++ code (e.g. `cc`, `bindgen`,
-    /// crates with native build scripts like `onig_sys`). These hold headers, not
-    /// executables, so they are granted as `--read` rather than `--exec`.
-    #[cfg(target_os = "linux")]
-    #[allow(dead_code)]
-    const SYSTEM_READ_PATHS: &[&str] = &["/usr/include", "/usr/include/x86_64-linux-gnu"];
-    #[cfg(target_os = "macos")]
-    #[allow(dead_code)]
-    const SYSTEM_READ_PATHS: &[&str] = &[];
-    #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
-    #[allow(dead_code)]
-    const SYSTEM_READ_PATHS: &[&str] = &["/usr/include"];
-
-    /// Read-only paths under `$HOME` for git/tool-version configuration that
-    /// most commands consult but should never modify.
-    #[cfg(unix)]
-    #[allow(dead_code)]
-    const HOME_READ_PATHS: &[&str] = &[
-        ".gitconfig",
-        ".gitignore",
-        ".gitignore_global",
-        ".tool-versions",
-    ];
-
-    /// Read+execute paths under `$HOME` for tool installations (asdf, bun,
-    /// language version managers, locally-installed binaries).
-    #[cfg(unix)]
-    #[allow(dead_code)]
-    const HOME_EXEC_PATHS: &[&str] = &[
-        ".local/bin",
-        ".local/lib",
-        ".bun",
-        ".asdf",
-        "go/bin",
-        ".cargo",
-    ];
-
-    /// Read+write paths under `$HOME` for caches that hold data but should not
-    /// be executable.
-    #[cfg(unix)]
-    #[allow(dead_code)]
-    const HOME_WRITE_PATHS: &[&str] = &[".cache", "go/pkg"];
-
-    /// Read+write+execute paths under `$HOME` for tooling that installs and
-    /// runs binaries (npm, yarn, nvm, cargo, mono, bun cache, pyenv, rye).
-    /// `pyenv`/`rye` are Python version managers that install Pythons under
-    /// these directories and run them in place — needed for any project that
-    /// builds native Python packages outside the system Python.
-    #[cfg(unix)]
-    #[allow(dead_code)]
-    const HOME_RWX_PATHS: &[&str] = &[
-        ".npm",
-        ".yarn",
-        ".nvm",
-        ".cargo/bin",
-        ".cargo/registry",
-        ".cargo/git",
-        ".mono",
-        ".bun/install/cache",
-        ".pyenv",
-        ".rye",
-    ];
-
-    #[cfg(unix)]
-    fn push_home_relative_defaults(args: &mut Vec<OsString>, home: &Path) {
-        for sub in Self::HOME_READ_PATHS {
-            args.push(OsString::from("--read"));
-            args.push(home.join(sub).into_os_string());
-        }
-        for sub in Self::HOME_EXEC_PATHS {
-            args.push(OsString::from("--exec"));
-            args.push(home.join(sub).into_os_string());
-        }
-        for sub in Self::HOME_WRITE_PATHS {
-            let path = home.join(sub);
-            args.push(OsString::from("--read"));
-            args.push(path.clone().into_os_string());
-            args.push(OsString::from("--write"));
-            args.push(path.into_os_string());
-        }
-        for sub in Self::HOME_RWX_PATHS {
-            let path = home.join(sub);
-            args.push(OsString::from("--read"));
-            args.push(path.clone().into_os_string());
-            args.push(OsString::from("--write"));
-            args.push(path.clone().into_os_string());
-            args.push(OsString::from("--exec"));
-            args.push(path.into_os_string());
-        }
-    }
-
-    /// Honour toolchain-locating environment variables so users with non-default
-    /// install locations don't have to set `HARNX_BASH_EXTRA_*` themselves.
-    ///
-    /// - `CARGO_HOME` — Rust toolchain. Adds `$CARGO_HOME/bin` as exec.
-    /// - `GOROOT`     — Go installation. Adds `$GOROOT` as exec (toolchain binaries live in `$GOROOT/bin` and runtime in `$GOROOT/pkg`).
-    /// - `GOPATH`     — Go workspace. Adds `$GOPATH/bin` as exec and `$GOPATH/pkg` as read+write.
-    /// - `GOBIN`      — `go install` output dir. Adds `$GOBIN` as exec.
-    #[cfg(unix)]
-    fn push_env_relative_defaults(args: &mut Vec<OsString>) {
-        if let Some(cargo_home) = std::env::var_os("CARGO_HOME") {
-            args.push(OsString::from("--exec"));
-            args.push(PathBuf::from(cargo_home).join("bin").into_os_string());
-        }
-        if let Some(goroot) = std::env::var_os("GOROOT") {
-            args.push(OsString::from("--exec"));
-            args.push(PathBuf::from(goroot).into_os_string());
-        }
-        if let Some(gopath) = std::env::var_os("GOPATH") {
-            let gopath = PathBuf::from(gopath);
-            args.push(OsString::from("--exec"));
-            args.push(gopath.join("bin").into_os_string());
-            let pkg = gopath.join("pkg");
-            args.push(OsString::from("--read"));
-            args.push(pkg.clone().into_os_string());
-            args.push(OsString::from("--write"));
-            args.push(pkg.into_os_string());
-        }
-        if let Some(gobin) = std::env::var_os("GOBIN") {
-            args.push(OsString::from("--exec"));
-            args.push(PathBuf::from(gobin).into_os_string());
-        }
-    }
-
-    #[cfg(unix)]
-    fn system_writable_paths() -> Vec<PathBuf> {
-        #[cfg(target_os = "linux")]
-        {
-            // /dev/shm is a tmpfs used by Chrome/Puppeteer for inter-process
-            // shared memory.  Without write access the browser crashes on
-            // startup inside the sandbox (issue #528).  /tmp is included as
-            // the standard temporary-file directory.
-            vec![PathBuf::from("/tmp"), PathBuf::from("/dev/shm")]
-        }
-        #[cfg(target_os = "macos")]
-        {
-            let mut paths = vec![PathBuf::from("/private/tmp")];
-            if let Ok(tmpdir) = std::env::var("TMPDIR") {
-                let path = PathBuf::from(&tmpdir);
-                if path != Path::new("/private/tmp") {
-                    paths.push(path);
-                }
-            }
-            paths
-        }
-        #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
-        {
-            vec![PathBuf::from("/tmp")]
-        }
-    }
-
     /// Safe defaults for non-interactive child processes: (key, fallback).
     ///
     /// Each entry is seeded as the host-env value when set, otherwise the
@@ -710,7 +484,7 @@ impl BashServer {
                 extra_rwx: vec![],
                 extra_env_passthrough: vec![],
                 env_overrides: vec![],
-                sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
+                sandbox_run_path: PathBuf::from("harnx-sandbox-exec"),
             },
         )
     }
@@ -922,59 +696,10 @@ impl BashServer {
         outputs: Option<&[PathBuf]>,
         roots: &[PathBuf],
     ) -> Vec<OsString> {
-        let mut args = Vec::new();
+        let mut args = build_default_sandbox_args(&self.inner.sandbox_config);
         let mut readable_paths = Vec::new();
         let mut writable_paths = Vec::new();
         let inputs_explicit_empty = matches!(inputs, Some([]));
-
-        for path in Self::SYSTEM_EXEC_PATHS {
-            args.push(OsString::from("--exec"));
-            args.push(OsString::from(path));
-        }
-
-        for path in Self::SYSTEM_READ_PATHS {
-            args.push(OsString::from("--read"));
-            args.push(OsString::from(path));
-        }
-
-        for path in Self::system_writable_paths() {
-            args.push(OsString::from("--write"));
-            args.push(path.into_os_string());
-        }
-
-        if let Some(home) = std::env::var_os("HOME") {
-            Self::push_home_relative_defaults(&mut args, &PathBuf::from(home));
-        }
-
-        Self::push_env_relative_defaults(&mut args);
-
-        for path in &self.inner.sandbox_config.extra_exec {
-            args.push(OsString::from("--exec"));
-            args.push(path.clone().into_os_string());
-        }
-
-        for path in &self.inner.sandbox_config.extra_readable {
-            args.push(OsString::from("--read"));
-            args.push(path.clone().into_os_string());
-            readable_paths.push(path.clone());
-        }
-
-        for path in &self.inner.sandbox_config.extra_writable {
-            args.push(OsString::from("--write"));
-            args.push(path.clone().into_os_string());
-            writable_paths.push(path.clone());
-        }
-
-        for path in &self.inner.sandbox_config.extra_rwx {
-            args.push(OsString::from("--read"));
-            args.push(path.clone().into_os_string());
-            args.push(OsString::from("--write"));
-            args.push(path.clone().into_os_string());
-            args.push(OsString::from("--exec"));
-            args.push(path.clone().into_os_string());
-            readable_paths.push(path.clone());
-            writable_paths.push(path.clone());
-        }
 
         match outputs {
             None => {
@@ -1185,10 +910,7 @@ impl BashServer {
                     if interp.is_absolute() {
                         if let Some(interp_dir) = interp.parent() {
                             let dir_str = interp_dir.to_string_lossy();
-                            if !Self::SYSTEM_EXEC_PATHS
-                                .iter()
-                                .any(|p| *p == dir_str.as_ref())
-                            {
+                            if !SYSTEM_EXEC_PATHS.iter().any(|p| *p == dir_str.as_ref()) {
                                 sb_args.push(OsString::from("--exec"));
                                 sb_args.push(interp_dir.as_os_str().to_owned());
                             }
@@ -1737,10 +1459,7 @@ impl BashServer {
                     if interp.is_absolute() {
                         if let Some(interp_dir) = interp.parent() {
                             let dir_str = interp_dir.to_string_lossy();
-                            if !Self::SYSTEM_EXEC_PATHS
-                                .iter()
-                                .any(|p| *p == dir_str.as_ref())
-                            {
+                            if !SYSTEM_EXEC_PATHS.iter().any(|p| *p == dir_str.as_ref()) {
                                 sb_args.push(OsString::from("--exec"));
                                 sb_args.push(interp_dir.as_os_str().to_owned());
                             }
@@ -2507,7 +2226,7 @@ fn internal_error(msg: impl Into<Cow<'static, str>>) -> ErrorData {
 
 #[cfg(all(test, target_os = "linux"))]
 fn sandbox_run_test_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/debug/harnx-mcp-bash-sandbox-run")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/debug/harnx-sandbox-exec")
 }
 
 #[cfg(unix)]
@@ -3068,7 +2787,7 @@ mod tests {
             extra_rwx: vec![],
             extra_env_passthrough: vec![],
             env_overrides: vec![],
-            sandbox_run_path: PathBuf::from("harnx-mcp-bash-sandbox-run"),
+            sandbox_run_path: PathBuf::from("harnx-sandbox-exec"),
         }
     }
 

--- a/crates/harnx-proxy-auth/src/hook.rs
+++ b/crates/harnx-proxy-auth/src/hook.rs
@@ -9,8 +9,6 @@ use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
 struct HookRequest {
     id: String,
     #[serde(default)]
-    tool_name: Option<String>,
-    #[serde(default)]
     tool_input: Option<Value>,
 }
 
@@ -51,10 +49,9 @@ pub async fn run_jsonl_loop(
                 continue;
             }
         };
-        let response = if matches!(
-            request.tool_name.as_deref(),
-            Some("bash_exec") | Some("bash_spawn")
-        ) {
+        // Respond to any PreToolUse event with a tool_input — tool name filtering
+        // is the caller's responsibility (configured via the hook's matcher field).
+        let response = if request.tool_input.is_some() {
             HookResponse {
                 id: request.id,
                 hook_specific_output: Some(HookSpecificOutput {

--- a/crates/harnx-sandbox-common/Cargo.toml
+++ b/crates/harnx-sandbox-common/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "harnx-sandbox-common"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared sandbox configuration and default whitelist for harnx sandbox tools"
+
+[dependencies]
+anyhow = { workspace = true }
+log = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+birdcage = { workspace = true }
+tempfile = "3"
+
+[[bin]]
+name = "harnx-sandbox-exec"
+path = "src/bin/sandbox_exec.rs"

--- a/crates/harnx-sandbox-common/src/args.rs
+++ b/crates/harnx-sandbox-common/src/args.rs
@@ -82,6 +82,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn appends_extra_paths_to_defaults() {
         ensure_anyhow_is_linked().expect("anyhow helper should succeed");
 

--- a/crates/harnx-sandbox-common/src/args.rs
+++ b/crates/harnx-sandbox-common/src/args.rs
@@ -1,0 +1,101 @@
+use std::ffi::OsString;
+
+use crate::config::SandboxConfig;
+
+#[cfg(unix)]
+use crate::defaults::{
+    push_env_relative_defaults, push_home_relative_defaults, system_writable_paths,
+    SYSTEM_EXEC_PATHS, SYSTEM_READ_PATHS,
+};
+#[cfg(unix)]
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+fn push_flagged_path(args: &mut Vec<OsString>, flag: &str, path: &Path) {
+    args.push(OsString::from(flag));
+    args.push(path.as_os_str().to_os_string());
+}
+
+pub fn build_default_sandbox_args(config: &SandboxConfig) -> Vec<OsString> {
+    #[cfg(unix)]
+    {
+        let mut args = Vec::new();
+        for path in SYSTEM_EXEC_PATHS {
+            args.push(OsString::from("--exec"));
+            args.push(OsString::from(path));
+        }
+        for path in SYSTEM_READ_PATHS {
+            args.push(OsString::from("--read"));
+            args.push(OsString::from(path));
+        }
+        for path in system_writable_paths() {
+            push_flagged_path(&mut args, "--write", &path);
+        }
+        if let Some(home) = std::env::var_os("HOME") {
+            push_home_relative_defaults(&mut args, &PathBuf::from(home));
+        }
+        push_env_relative_defaults(&mut args);
+        for path in &config.extra_exec {
+            push_flagged_path(&mut args, "--exec", path);
+        }
+        for path in &config.extra_readable {
+            push_flagged_path(&mut args, "--read", path);
+        }
+        for path in &config.extra_writable {
+            push_flagged_path(&mut args, "--write", path);
+        }
+        for path in &config.extra_rwx {
+            push_flagged_path(&mut args, "--read", path);
+            push_flagged_path(&mut args, "--write", path);
+            push_flagged_path(&mut args, "--exec", path);
+        }
+        args
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = config;
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use std::path::PathBuf;
+
+    fn test_config() -> SandboxConfig {
+        SandboxConfig {
+            enabled: true,
+            extra_exec: vec![PathBuf::from("/exec")],
+            extra_readable: vec![PathBuf::from("/read")],
+            extra_writable: vec![PathBuf::from("/write")],
+            extra_rwx: vec![PathBuf::from("/rwx")],
+            extra_env_passthrough: Vec::new(),
+            env_overrides: Vec::new(),
+            sandbox_run_path: PathBuf::from("sandbox-run"),
+        }
+    }
+
+    fn ensure_anyhow_is_linked() -> Result<()> {
+        Ok(())
+    }
+
+    #[test]
+    fn appends_extra_paths_to_defaults() {
+        ensure_anyhow_is_linked().expect("anyhow helper should succeed");
+
+        let args = build_default_sandbox_args(&test_config());
+        let args: Vec<String> = args
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert!(args.windows(2).any(|w| w == ["--exec", "/exec"]));
+        assert!(args.windows(2).any(|w| w == ["--read", "/read"]));
+        assert!(args.windows(2).any(|w| w == ["--write", "/write"]));
+        assert!(args.windows(2).any(|w| w == ["--read", "/rwx"]));
+        assert!(args.windows(2).any(|w| w == ["--write", "/rwx"]));
+        assert!(args.windows(2).any(|w| w == ["--exec", "/rwx"]));
+    }
+}

--- a/crates/harnx-sandbox-common/src/args.rs
+++ b/crates/harnx-sandbox-common/src/args.rs
@@ -58,15 +58,12 @@ pub fn build_default_sandbox_args(config: &SandboxConfig) -> Vec<OsString> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
-    #[cfg(unix)]
     use anyhow::Result;
-    #[cfg(unix)]
     use std::path::PathBuf;
 
-    #[cfg(unix)]
     fn test_config() -> SandboxConfig {
         SandboxConfig {
             enabled: true,
@@ -80,13 +77,11 @@ mod tests {
         }
     }
 
-    #[cfg(unix)]
     fn ensure_anyhow_is_linked() -> Result<()> {
         Ok(())
     }
 
     #[test]
-    #[cfg(unix)]
     fn appends_extra_paths_to_defaults() {
         ensure_anyhow_is_linked().expect("anyhow helper should succeed");
 

--- a/crates/harnx-sandbox-common/src/args.rs
+++ b/crates/harnx-sandbox-common/src/args.rs
@@ -61,9 +61,12 @@ pub fn build_default_sandbox_args(config: &SandboxConfig) -> Vec<OsString> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use anyhow::Result;
+    #[cfg(unix)]
     use std::path::PathBuf;
 
+    #[cfg(unix)]
     fn test_config() -> SandboxConfig {
         SandboxConfig {
             enabled: true,
@@ -77,6 +80,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     fn ensure_anyhow_is_linked() -> Result<()> {
         Ok(())
     }

--- a/crates/harnx-sandbox-common/src/bin/sandbox_exec.rs
+++ b/crates/harnx-sandbox-common/src/bin/sandbox_exec.rs
@@ -1,0 +1,312 @@
+//! Sandbox execution CLI wrapper.
+//!
+//! Configures birdcage sandbox and spawns supplied command.
+
+#[cfg(unix)]
+use std::env;
+#[cfg(unix)]
+use std::ffi::{OsStr, OsString};
+#[cfg(unix)]
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::process;
+
+#[cfg(unix)]
+use birdcage::{process::Command, Birdcage, Exception, Sandbox};
+
+#[cfg(unix)]
+struct SandboxConfig {
+    exec_paths: Vec<PathBuf>,
+    write_paths: Vec<PathBuf>,
+    read_paths: Vec<PathBuf>,
+    env_vars: Vec<(String, String)>,
+    no_network: bool,
+    working_dir: Option<PathBuf>,
+    command: Vec<OsString>,
+}
+
+#[cfg(unix)]
+fn print_usage() {
+    println!(
+        "harnx-sandbox-exec [OPTIONS] -- <command> [args...]\n\nOptions:\n  --write <path>       Allow read+write (repeatable)\n  --read <path>        Allow read-only (repeatable)\n  --exec <path>        Allow read+execute (repeatable)\n  --env VAR[=VALUE]    Pass VAR from host env or set VALUE explicitly (repeatable)\n  --no-network         Disable networking (default: networking allowed)\n  --working-dir <path> Set working directory of spawned command\n  --help, -h           Print this help"
+    );
+}
+
+#[cfg(unix)]
+fn parse_path_arg<I>(args: &mut I, flag: &str) -> Result<PathBuf, String>
+where
+    I: Iterator<Item = OsString>,
+{
+    args.next()
+        .map(PathBuf::from)
+        .ok_or_else(|| format!("sandbox-exec: missing value for {flag}"))
+}
+
+#[cfg(unix)]
+fn parse_env_arg(raw: &OsStr) -> Result<(String, Option<String>), String> {
+    let s = raw
+        .to_str()
+        .ok_or_else(|| "sandbox-exec: --env value is not valid UTF-8".to_string())?;
+    if s.is_empty() {
+        return Err("sandbox-exec: --env requires a non-empty variable name".to_string());
+    }
+    match s.split_once('=') {
+        Some((key, value)) => {
+            if key.is_empty() {
+                return Err("sandbox-exec: --env requires a non-empty variable name".to_string());
+            }
+            Ok((key.to_string(), Some(value.to_string())))
+        }
+        None => Ok((s.to_string(), None)),
+    }
+}
+
+#[cfg(unix)]
+fn parse_args() -> Result<Option<SandboxConfig>, String> {
+    let mut args = env::args_os().skip(1);
+    let mut exec_paths = Vec::new();
+    let mut write_paths = Vec::new();
+    let mut read_paths = Vec::new();
+    let mut env_vars = Vec::new();
+    let mut no_network = false;
+    let mut working_dir = None;
+
+    while let Some(arg) = args.next() {
+        if arg == OsStr::new("--") {
+            let command: Vec<OsString> = args.collect();
+            if command.is_empty() {
+                return Err("sandbox-exec: missing command after --".to_string());
+            }
+            return Ok(Some(SandboxConfig {
+                exec_paths,
+                write_paths,
+                read_paths,
+                env_vars,
+                no_network,
+                working_dir,
+                command,
+            }));
+        }
+
+        match arg.as_os_str() {
+            flag if flag == OsStr::new("--write") => {
+                write_paths.push(parse_path_arg(&mut args, "--write")?);
+            }
+            flag if flag == OsStr::new("--read") => {
+                read_paths.push(parse_path_arg(&mut args, "--read")?);
+            }
+            flag if flag == OsStr::new("--exec") => {
+                exec_paths.push(parse_path_arg(&mut args, "--exec")?);
+            }
+            flag if flag == OsStr::new("--env") => {
+                let raw = args
+                    .next()
+                    .ok_or_else(|| "sandbox-exec: missing value for --env".to_string())?;
+                let (key, value) = parse_env_arg(&raw)?;
+                if let Some(value) = value {
+                    env_vars.push((key, value));
+                } else if let Ok(value) = env::var(&key) {
+                    env_vars.push((key, value));
+                }
+            }
+            flag if flag == OsStr::new("--working-dir") => {
+                working_dir = Some(parse_path_arg(&mut args, "--working-dir")?);
+            }
+            flag if flag == OsStr::new("--no-network") => {
+                no_network = true;
+            }
+            flag if flag == OsStr::new("--help") || flag == OsStr::new("-h") => {
+                return Ok(None);
+            }
+            _ => {
+                return Err(format!(
+                    "sandbox-exec: unexpected argument: {}",
+                    arg.to_string_lossy()
+                ));
+            }
+        }
+    }
+
+    Err("sandbox-exec: missing -- before command".to_string())
+}
+
+#[cfg(unix)]
+fn add_path_exception(
+    sandbox: &mut Birdcage,
+    path: &Path,
+    make_exception: fn(PathBuf) -> Exception,
+) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    sandbox
+        .add_exception(make_exception(path.to_path_buf()))
+        .map(|_| ())
+        .map_err(|error| {
+            format!(
+                "sandbox-exec: failed to add exception for {}: {error}",
+                path.display()
+            )
+        })
+}
+
+#[cfg(unix)]
+fn add_write_exception(sandbox: &mut Birdcage, path: &Path) -> Result<(), String> {
+    add_path_exception(sandbox, path, Exception::WriteAndRead)
+}
+
+#[cfg(unix)]
+fn run() -> Result<i32, String> {
+    let Some(config) = parse_args()? else {
+        print_usage();
+        return Ok(0);
+    };
+
+    let mut sandbox = Birdcage::new();
+
+    for path in &config.exec_paths {
+        add_path_exception(&mut sandbox, path, Exception::ExecuteAndRead)?;
+    }
+    for path in &config.write_paths {
+        add_write_exception(&mut sandbox, path)?;
+    }
+    for path in &config.read_paths {
+        add_path_exception(&mut sandbox, path, Exception::Read)?;
+    }
+    if !config.no_network {
+        sandbox
+            .add_exception(Exception::Networking)
+            .map_err(|error| {
+                format!("sandbox-exec: failed to add Networking exception: {error}")
+            })?;
+    }
+
+    for (key, value) in &config.env_vars {
+        // Ensure the value lives in the current process env so birdcage's
+        // restrict_env_variables() preserves it for the child.
+        //
+        // SAFETY: `env::set_var` is unsafe because it mutates process-global
+        // state and is not thread-safe. This binary is the `sandbox_run`
+        // helper, which runs single-threaded up to this point — `parse_args`
+        // and the sandbox setup never spawn threads, and we have not yet
+        // called `sandbox.spawn(...)`. No other code in the process can be
+        // observing the environment concurrently, so the call is sound. We
+        // must do this before `sandbox.spawn(...)` because birdcage's
+        // `restrict_env_variables()` (invoked from `Birdcage::lock` inside
+        // `spawn`) inspects `std::env::vars()` and removes any variable not
+        // listed via `Exception::Environment`.
+        unsafe { env::set_var(key, value) };
+        sandbox
+            .add_exception(Exception::Environment(key.clone()))
+            .map_err(|error| {
+                format!("sandbox-exec: failed to add env exception for {key}: {error}")
+            })?;
+    }
+
+    #[cfg(target_os = "macos")]
+    let mut command = {
+        let mut command = Command::new(&config.command[0]);
+        if let Some(working_dir) = &config.working_dir {
+            command.current_dir(working_dir);
+        }
+        command
+    };
+
+    #[cfg(not(target_os = "macos"))]
+    let mut command = if let Some(working_dir) = &config.working_dir {
+        // birdcage::process::Command on Linux lacks current_dir; rely on GNU env's
+        // --chdir extension for now. Known limitation on Alpine/Busybox systems.
+        let mut wrapped = Command::new("/usr/bin/env");
+        wrapped.arg("--chdir");
+        wrapped.arg(working_dir);
+        wrapped.arg(&config.command[0]);
+        wrapped
+    } else {
+        Command::new(&config.command[0])
+    };
+    command.args(&config.command[1..]);
+
+    let mut child = sandbox
+        .spawn(command)
+        .map_err(|error| format!("sandbox-exec: failed to spawn process: {error}"))?;
+    let status = child
+        .wait()
+        .map_err(|error| format!("sandbox-exec: failed to wait for child: {error}"))?;
+
+    Ok(status.code().unwrap_or(1))
+}
+
+#[cfg(unix)]
+fn main() {
+    match run() {
+        Ok(code) => process::exit(code),
+        Err(error) => {
+            eprintln!("{error}");
+            process::exit(127);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn main() {
+    eprintln!("sandbox-exec not supported on this platform");
+    std::process::exit(1);
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::env;
+
+    /// An existing path gets `Exception::WriteAndRead` added without error.
+    #[test]
+    fn test_write_exception_existing_path() {
+        let mut sandbox = Birdcage::new();
+        let path = std::env::temp_dir(); // always exists
+        let result = add_write_exception(&mut sandbox, &path);
+        assert!(
+            result.is_ok(),
+            "add_write_exception failed on existing path: {result:?}"
+        );
+    }
+
+    /// A non-existent path is silently skipped — `Ok(())` returned, no ancestor walked.
+    #[test]
+    fn test_write_exception_nonexistent_path() {
+        let mut sandbox = Birdcage::new();
+        let base = std::env::temp_dir();
+        let nonexistent = base.join("harnx-test-nonexistent-12345678");
+        // Make sure it really doesn't exist
+        assert!(!nonexistent.exists());
+        let result = add_write_exception(&mut sandbox, &nonexistent);
+        assert!(
+            result.is_ok(),
+            "add_write_exception should return Ok for non-existent paths, got: {result:?}"
+        );
+    }
+
+    /// When `$HOME/.pyenv` doesn't exist, `$HOME` must NOT appear as a sandbox exception.
+    /// This is the core regression test for issue #619.
+    #[test]
+    fn test_write_exception_nonexistent_nested_no_ancestor_walk() {
+        let home = env::var_os("HOME").expect("HOME must be set for this test");
+        let home_path = Path::new(&home);
+        // Construct a path like $HOME/.pyenv that is unlikely to exist
+        let fake_tool_path = home_path.join(".harnx-test-pyenv-NOTEXIST");
+        assert!(!fake_tool_path.exists(), "Test setup: path must not exist");
+
+        let mut sandbox = Birdcage::new();
+        // Must succeed (not error) without walking to $HOME
+        let result = add_write_exception(&mut sandbox, &fake_tool_path);
+        assert!(
+            result.is_ok(),
+            "add_write_exception should return Ok for non-existent $HOME child, got: {result:?}"
+        );
+        // If the ancestor walk were still present, $HOME would have been added.
+        // We can't inspect Birdcage internals, but if it didn't add it the function
+        // must have taken the early-return path (the Ok(()) branch).
+        // The test above verifies that the function returns Ok without erroring,
+        // which is the correct post-fix behavior (previously it would walk to $HOME).
+    }
+}

--- a/crates/harnx-sandbox-common/src/config.rs
+++ b/crates/harnx-sandbox-common/src/config.rs
@@ -1,0 +1,27 @@
+use std::path::PathBuf;
+
+/// Shared sandbox and child-env configuration.
+///
+/// Sandboxing fields are honoured only on Unix; on other platforms they are
+/// accepted for API compatibility and ignored.
+///
+/// Env-control fields are honoured on every platform.
+#[derive(Clone, Debug)]
+pub struct SandboxConfig {
+    #[cfg_attr(not(unix), allow(dead_code))]
+    pub enabled: bool,
+    #[cfg_attr(not(unix), allow(dead_code))]
+    pub extra_exec: Vec<PathBuf>,
+    #[cfg_attr(not(unix), allow(dead_code))]
+    pub extra_readable: Vec<PathBuf>,
+    #[cfg_attr(not(unix), allow(dead_code))]
+    pub extra_writable: Vec<PathBuf>,
+    #[cfg_attr(not(unix), allow(dead_code))]
+    pub extra_rwx: Vec<PathBuf>,
+    /// Extra var names to pass through from host (allowlist additions).
+    pub extra_env_passthrough: Vec<String>,
+    /// Explicit overrides: KEY → VALUE (highest precedence).
+    pub env_overrides: Vec<(String, String)>,
+    #[cfg_attr(not(unix), allow(dead_code))]
+    pub sandbox_run_path: PathBuf,
+}

--- a/crates/harnx-sandbox-common/src/defaults.rs
+++ b/crates/harnx-sandbox-common/src/defaults.rs
@@ -1,0 +1,173 @@
+#[cfg(unix)]
+use std::ffi::OsString;
+#[cfg(unix)]
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "linux")]
+pub const SYSTEM_EXEC_PATHS: &[&str] = &[
+    "/usr/bin",
+    "/bin",
+    "/usr/local/bin",
+    "/usr/sbin",
+    "/sbin",
+    "/usr/lib",
+    "/usr/lib64",
+    "/lib",
+    "/lib64",
+    "/usr/lib/x86_64-linux-gnu",
+    "/usr/libexec",
+    "/proc",
+    "/dev",
+    "/sys",
+    "/etc",
+    "/tmp",
+    "/run",
+    "/var/run",
+    "/usr/share",
+];
+#[cfg(target_os = "macos")]
+pub const SYSTEM_EXEC_PATHS: &[&str] = &[
+    "/usr/bin",
+    "/bin",
+    "/usr/local/bin",
+    "/usr/sbin",
+    "/sbin",
+    "/usr/lib",
+    "/usr/local/lib",
+    "/Library",
+    "/System",
+    "/private/tmp",
+    "/private/var",
+    "/dev",
+];
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+pub const SYSTEM_EXEC_PATHS: &[&str] = &["/usr/bin", "/bin", "/tmp", "/etc"];
+
+#[cfg(target_os = "linux")]
+pub const SYSTEM_READ_PATHS: &[&str] = &["/usr/include", "/usr/include/x86_64-linux-gnu"];
+#[cfg(target_os = "macos")]
+pub const SYSTEM_READ_PATHS: &[&str] = &[];
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+pub const SYSTEM_READ_PATHS: &[&str] = &["/usr/include"];
+
+#[cfg(unix)]
+pub const HOME_READ_PATHS: &[&str] = &[
+    ".gitconfig",
+    ".gitignore",
+    ".gitignore_global",
+    ".tool-versions",
+];
+
+#[cfg(unix)]
+pub const HOME_EXEC_PATHS: &[&str] = &[
+    ".local/bin",
+    ".local/lib",
+    ".bun",
+    ".asdf",
+    "go/bin",
+    ".cargo",
+];
+
+#[cfg(unix)]
+pub const HOME_WRITE_PATHS: &[&str] = &[".cache", "go/pkg"];
+
+#[cfg(unix)]
+pub const HOME_RWX_PATHS: &[&str] = &[
+    ".npm",
+    ".yarn",
+    ".nvm",
+    ".cargo/bin",
+    ".cargo/registry",
+    ".cargo/git",
+    ".mono",
+    ".bun/install/cache",
+    ".pyenv",
+    ".rye",
+    // AI coding agents whose self-updaters install versioned binaries under
+    // ~/.local/share/<name>/ and symlink them from ~/.local/bin/:
+    ".local/share/claude",   // Claude Code (`claude update`)
+    ".local/share/opencode", // OpenCode
+    // Python/JS package managers that install executables here:
+    ".local/share/pipx", // pipx (installs aider, etc.)
+    ".local/share/pnpm", // pnpm store
+    ".local/share/uv",   // uv (Python package manager)
+];
+
+#[cfg(unix)]
+pub fn push_home_relative_defaults(args: &mut Vec<OsString>, home: &Path) {
+    for sub in HOME_READ_PATHS {
+        args.push(OsString::from("--read"));
+        args.push(home.join(sub).into_os_string());
+    }
+    for sub in HOME_EXEC_PATHS {
+        args.push(OsString::from("--exec"));
+        args.push(home.join(sub).into_os_string());
+    }
+    for sub in HOME_WRITE_PATHS {
+        let path = home.join(sub);
+        args.push(OsString::from("--read"));
+        args.push(path.clone().into_os_string());
+        args.push(OsString::from("--write"));
+        args.push(path.into_os_string());
+    }
+    for sub in HOME_RWX_PATHS {
+        let path = home.join(sub);
+        args.push(OsString::from("--read"));
+        args.push(path.clone().into_os_string());
+        args.push(OsString::from("--write"));
+        args.push(path.clone().into_os_string());
+        args.push(OsString::from("--exec"));
+        args.push(path.into_os_string());
+    }
+}
+
+/// Honour toolchain-locating environment variables so users with non-default
+/// install locations don't have to set extra sandbox overrides themselves.
+#[cfg(unix)]
+pub fn push_env_relative_defaults(args: &mut Vec<OsString>) {
+    if let Some(cargo_home) = std::env::var_os("CARGO_HOME") {
+        args.push(OsString::from("--exec"));
+        args.push(PathBuf::from(cargo_home).join("bin").into_os_string());
+    }
+    if let Some(goroot) = std::env::var_os("GOROOT") {
+        args.push(OsString::from("--exec"));
+        args.push(PathBuf::from(goroot).into_os_string());
+    }
+    if let Some(gopath) = std::env::var_os("GOPATH") {
+        let gopath = PathBuf::from(gopath);
+        args.push(OsString::from("--exec"));
+        args.push(gopath.join("bin").into_os_string());
+        let pkg = gopath.join("pkg");
+        args.push(OsString::from("--read"));
+        args.push(pkg.clone().into_os_string());
+        args.push(OsString::from("--write"));
+        args.push(pkg.into_os_string());
+    }
+    if let Some(gobin) = std::env::var_os("GOBIN") {
+        args.push(OsString::from("--exec"));
+        args.push(PathBuf::from(gobin).into_os_string());
+    }
+}
+
+#[cfg(unix)]
+pub fn system_writable_paths() -> Vec<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        vec![PathBuf::from("/tmp"), PathBuf::from("/dev/shm")]
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let mut paths = vec![PathBuf::from("/private/tmp")];
+        if let Ok(tmpdir) = std::env::var("TMPDIR") {
+            let path = PathBuf::from(&tmpdir);
+            if path != Path::new("/private/tmp") {
+                paths.push(path);
+            }
+        }
+        paths
+    }
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+    {
+        vec![PathBuf::from("/tmp")]
+    }
+}

--- a/crates/harnx-sandbox-common/src/home_guard.rs
+++ b/crates/harnx-sandbox-common/src/home_guard.rs
@@ -1,0 +1,136 @@
+use std::path::{Path, PathBuf};
+
+/// Resolve `path` to canonical absolute form when possible.
+///
+/// If canonicalization fails (for example, path does not exist yet), fall back to
+/// joining relative paths against current working directory and returning an
+/// absolute path without resolving symlinks.
+#[cfg(unix)]
+pub fn resolve_path(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map(|cwd| cwd.join(path))
+                .unwrap_or_else(|_| path.to_path_buf())
+        }
+    })
+}
+
+/// Returns `true` if `path` is `$HOME` itself or an ancestor of `$HOME`
+/// (e.g. `/home` or `/`). Returns `false` when `$HOME` is unset or when
+/// `path` is a child of `$HOME` (e.g. `$HOME/projects`).
+///
+/// Used to prevent over-broad roots from granting sandbox write/exec access.
+#[cfg(unix)]
+pub fn is_home_or_ancestor(path: &Path) -> bool {
+    let home_os = match std::env::var_os("HOME") {
+        Some(h) => h,
+        None => return false,
+    };
+    let home = std::fs::canonicalize(&home_os).unwrap_or_else(|_| {
+        let home_path = Path::new(&home_os);
+        if home_path.is_absolute() {
+            home_path.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map(|cwd| cwd.join(home_path))
+                .unwrap_or_else(|_| home_path.to_path_buf())
+        }
+    });
+    let candidate = resolve_path(path);
+    home.starts_with(&candidate)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
+
+    /// Serialise all tests that mutate process-global HOME / cwd.
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    /// RAII guard: snapshots HOME and cwd on creation, restores both on drop.
+    struct EnvGuard {
+        saved_home: Option<std::ffi::OsString>,
+        saved_cwd: PathBuf,
+    }
+
+    impl EnvGuard {
+        fn new() -> Self {
+            Self {
+                saved_home: std::env::var_os("HOME"),
+                saved_cwd: std::env::current_dir().expect("current_dir"),
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // Restore cwd first so that any relative-path lookups during HOME
+            // restoration happen against the original directory.
+            let _ = std::env::set_current_dir(&self.saved_cwd);
+            match &self.saved_home {
+                Some(h) => unsafe { std::env::set_var("HOME", h) },
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+        }
+    }
+
+    #[test]
+    fn home_path_matches() {
+        let _lock = env_lock().lock().expect("lock poisoned");
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        std::fs::create_dir(&home).expect("create home");
+        unsafe { std::env::set_var("HOME", &home) };
+
+        assert!(is_home_or_ancestor(&home));
+    }
+
+    #[test]
+    fn ancestor_of_home_matches() {
+        let _lock = env_lock().lock().expect("lock poisoned");
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let parent = temp.path().join("parent");
+        let home = parent.join("home");
+        std::fs::create_dir_all(&home).expect("create home tree");
+        unsafe { std::env::set_var("HOME", &home) };
+
+        assert!(is_home_or_ancestor(&parent));
+    }
+
+    #[test]
+    fn child_of_home_does_not_match() {
+        let _lock = env_lock().lock().expect("lock poisoned");
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let child = home.join("projects");
+        std::fs::create_dir_all(&child).expect("create child");
+        unsafe { std::env::set_var("HOME", &home) };
+
+        assert!(!is_home_or_ancestor(&child));
+    }
+
+    #[test]
+    fn relative_path_resolves_against_cwd() {
+        let _lock = env_lock().lock().expect("lock poisoned");
+        let _env = EnvGuard::new(); // restores HOME and cwd on drop
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cwd = temp.path().join("cwd");
+        let home = cwd.join("home");
+        std::fs::create_dir_all(&home).expect("create cwd/home");
+        std::env::set_current_dir(&cwd).expect("set cwd");
+        unsafe { std::env::set_var("HOME", &home) };
+
+        assert!(is_home_or_ancestor(Path::new(".")));
+    }
+}

--- a/crates/harnx-sandbox-common/src/lib.rs
+++ b/crates/harnx-sandbox-common/src/lib.rs
@@ -1,0 +1,18 @@
+pub mod args;
+pub mod config;
+#[cfg(unix)]
+pub mod defaults;
+#[cfg(unix)]
+pub mod home_guard;
+
+pub use args::build_default_sandbox_args;
+pub use config::SandboxConfig;
+
+#[cfg(unix)]
+pub use defaults::{
+    push_env_relative_defaults, push_home_relative_defaults, system_writable_paths,
+    HOME_EXEC_PATHS, HOME_READ_PATHS, HOME_RWX_PATHS, HOME_WRITE_PATHS, SYSTEM_EXEC_PATHS,
+    SYSTEM_READ_PATHS,
+};
+#[cfg(unix)]
+pub use home_guard::{is_home_or_ancestor, resolve_path};

--- a/crates/harnx-sandbox-run/Cargo.toml
+++ b/crates/harnx-sandbox-run/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "harnx-sandbox-run"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Run commands inside the birdcage sandbox with hook support"
+
+[dependencies]
+harnx-sandbox-common = { path = "../harnx-sandbox-common" }
+harnx-hooks = { path = "../harnx-hooks" }
+harnx-core = { path = "../harnx-core" }
+clap = { workspace = true, features = ["derive"] }
+anyhow = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }
+log = { workspace = true }
+env_logger = "0.11"
+serde_json = { workspace = true }
+uuid = { workspace = true }
+
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[[bin]]
+name = "harnx-sandbox-run"
+path = "src/main.rs"

--- a/crates/harnx-sandbox-run/README.md
+++ b/crates/harnx-sandbox-run/README.md
@@ -1,0 +1,112 @@
+# harnx-sandbox-run
+
+[See the full documentation](../../docs/sandbox-run.md) for more examples and details.
+
+`harnx-sandbox-run` is a standalone utility to run arbitrary commands inside the [birdcage](https://github.com/phylum-dev/birdcage) sandbox. It provides the same sandboxing defaults and configuration as `harnx-mcp-bash` but can be used as a general-purpose wrapper for any CLI tool.
+
+It also supports **hooks** for credential injection, allowing you to securely provide environment variables or files to the sandboxed process without exposing them to the host environment permanently.
+
+## Installation
+
+```bash
+cargo install harnx-sandbox-run
+```
+
+## Usage Examples
+
+### Basic usage
+Run an interactive bash session in the sandbox:
+```bash
+harnx-sandbox-run -- bash
+```
+
+### AI Agent Wrappers (Primary Use Case)
+
+Running AI coding agents safely with permissions bypassed (the sandbox provides the actual safety boundary):
+
+#### Claude Code (`claude-sb`)
+```bash
+#!/usr/bin/env bash
+exec harnx-sandbox-run \
+  --hook claude-command-persistent harnx-aws-creds \; \
+  -- \
+  claude --dangerously-skip-permissions "$@"
+```
+
+#### Gemini CLI (`gemini-sb`)
+```bash
+#!/usr/bin/env bash
+exec harnx-sandbox-run \
+  -- \
+  gemini --yolo "$@"
+```
+
+### With AWS credential hooks
+Uses `harnx-aws-creds` to inject AWS credentials before running `claude`:
+```bash
+harnx-sandbox-run --hook claude-command-persistent harnx-aws-creds --profile my-profile \; -- claude
+```
+
+### Granting extra permissions
+Give the sandbox full RWX access to a specific directory. Use `.` to grant access to the current directory:
+```bash
+harnx-sandbox-run --extra-rwx . --extra-rwx ~/.npm -- npm install
+```
+
+If `.` resolves to `$HOME` or an ancestor, `harnx-sandbox-run` prints a warning and ignores it rather than exposing your entire home directory.
+
+### Disabling network
+```bash
+harnx-sandbox-run --no-network -- curl google.com
+```
+
+## CLI Reference
+
+```text
+Usage: harnx-sandbox-run [OPTIONS] -- <COMMAND>...
+
+Arguments:
+  <COMMAND>...  Command to run (required, must come after `--` or at end)
+
+Options:
+      --extra-read <path>          Add sandbox read-only path (may be repeated)
+      --extra-write <path>         Add sandbox writable path (may be repeated)
+      --extra-exec <path>          Add sandbox execute path (may be repeated)
+      --extra-rwx <path>           Add sandbox read/write/exec path (may be repeated)
+      --env <VAR[=VALUE]>          Set environment variable (VAR=VALUE); if VALUE omitted, inherit from host
+      --no-network                 Disable network access
+      --working-dir <path>         Working directory for the command
+      --no-defaults                Skip default whitelist (system paths, home paths, env-relative paths)
+      --hook <TYPE> <CMD> [ARGS...] \;
+                                   Pre-run hook for credential injection or env mutation
+  -h, --help                       Print help
+
+Environment:
+  HARNX_BASH_EXTRA_READABLE   Colon-separated extra sandbox read-only paths
+  HARNX_BASH_EXTRA_EXEC       Colon-separated extra sandbox execute paths
+  HARNX_BASH_EXTRA_WRITABLE   Colon-separated extra sandbox writable paths
+  HARNX_BASH_EXTRA_RWX        Colon-separated extra sandbox read/write/exec paths
+  HARNX_BASH_ENV_PASSTHROUGH  Comma-separated extra env var names to pass through
+```
+
+## How Hooks Work
+
+Hooks allow you to run a command before the main sandboxed process starts. These hooks can mutate the environment variables that will be passed to the sandboxed process.
+
+Syntax: `--hook TYPE CMD ARGS... \;`
+
+- **TYPE**: Currently supports `claude-command` (one-shot) or `claude-command-persistent`.
+- **CMD ARGS...**: The command to execute and its arguments.
+- **`\;`**: Terminates the hook definition (can also be a plain `;` if escaped from the shell).
+
+`harnx-sandbox-run` sends a `PreToolUse` event to each hook command before spawning the sandboxed process. Hook commands respond by returning environment-variable mutations, which `harnx-sandbox-run` collects and applies to the environment of the spawned process.
+
+## Platform Support
+
+`harnx-sandbox-run` relies on `birdcage` for sandboxing, which currently supports **Unix-like** systems:
+- Linux
+- macOS
+
+## Relationship to `harnx-mcp-bash`
+
+This binary uses the shared `harnx-sandbox-common` crate, ensuring that it uses the exact same default sandbox policies (whitelisted system paths, etc.) as the `harnx-mcp-bash` MCP server. It is essentially the standalone, non-MCP version of the same sandboxing logic.

--- a/crates/harnx-sandbox-run/src/cli.rs
+++ b/crates/harnx-sandbox-run/src/cli.rs
@@ -1,0 +1,239 @@
+//! CLI parsing with pre-parse hook extraction.
+//!
+//! The `--hook` flag uses a novel syntax that requires special parsing before clap:
+//! `--hook <TYPE> <CMD> [ARGS...] \;`
+//!
+//! This module extracts hook definitions first, then passes remaining args to clap.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+/// Parsed hook definition from `--hook TYPE CMD [ARGS...] ;` syntax.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookDef {
+    /// Hook type: "claude-command" or "claude-command-persistent".
+    pub hook_type: String,
+    /// Command to execute (first token after type).
+    pub command: String,
+    /// Arguments to pass to the command.
+    pub args: Vec<String>,
+}
+
+/// Consume tokens from `iter` until `;` or `\;` and return them.
+///
+/// # Errors
+///
+/// Returns an error if the iterator is exhausted without seeing a terminator.
+fn collect_hook_tokens(iter: &mut impl Iterator<Item = String>) -> anyhow::Result<Vec<String>> {
+    let mut tokens = Vec::new();
+    for token in iter.by_ref() {
+        if token == ";" || token == "\\;" {
+            return Ok(tokens);
+        }
+        tokens.push(token);
+    }
+    anyhow::bail!("harnx-sandbox-run: unterminated --hook (missing ';')")
+}
+
+/// Pre-parse `--hook` groups from raw arguments before clap.
+///
+/// Walks tokens; on `--hook` collects until `;` or `\;`. Returns the extracted
+/// hook definitions and remaining arguments for clap.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - A `--hook` is not terminated with `;` or `\;`
+/// - A `--hook` has fewer than 2 tokens (need type + command)
+pub fn pre_parse_hooks(raw: Vec<String>) -> anyhow::Result<(Vec<HookDef>, Vec<String>)> {
+    let mut hooks = Vec::new();
+    let mut remaining = Vec::new();
+    let mut tokens = raw.into_iter().peekable();
+
+    while let Some(token) = tokens.next() {
+        if token == "--" {
+            remaining.push(token);
+            remaining.extend(tokens);
+            break;
+        } else if token == "--hook" {
+            let hook_tokens = collect_hook_tokens(&mut tokens)?;
+
+            if hook_tokens.len() < 2 {
+                anyhow::bail!(
+                    "harnx-sandbox-run: --hook requires at least TYPE and COMMAND (got {} tokens)",
+                    hook_tokens.len()
+                );
+            }
+
+            hooks.push(HookDef {
+                hook_type: hook_tokens[0].clone(),
+                command: hook_tokens[1].clone(),
+                args: hook_tokens[2..].to_vec(),
+            });
+        } else {
+            remaining.push(token);
+        }
+    }
+
+    Ok((hooks, remaining))
+}
+
+/// Parsed CLI arguments for harnx-sandbox-run.
+#[derive(Debug, clap::Parser)]
+#[command(name = "harnx-sandbox-run")]
+#[command(about = "Run commands inside the birdcage sandbox with hook support")]
+pub struct Cli {
+    /// Add sandbox read-only path (may be repeated).
+    #[arg(long, value_name = "path")]
+    pub extra_read: Vec<PathBuf>,
+
+    /// Add sandbox writable path (may be repeated).
+    #[arg(long, value_name = "path")]
+    pub extra_write: Vec<PathBuf>,
+
+    /// Add sandbox execute path (may be repeated).
+    #[arg(long, value_name = "path")]
+    pub extra_exec: Vec<PathBuf>,
+
+    /// Add sandbox read/write/exec path (may be repeated).
+    #[arg(long, value_name = "path")]
+    pub extra_rwx: Vec<PathBuf>,
+
+    /// Set environment variable (VAR=VALUE); if VALUE omitted, inherit from host.
+    #[arg(long = "env", value_name = "VAR[=VALUE]")]
+    pub env_vars: Vec<String>,
+
+    /// Disable network access.
+    #[arg(long)]
+    pub no_network: bool,
+
+    /// Working directory for the command.
+    #[arg(long)]
+    pub working_dir: Option<PathBuf>,
+
+    /// Skip default whitelist (system paths, home paths, env-relative paths).
+    #[arg(long)]
+    pub no_defaults: bool,
+
+    /// Command to run (required, must come after `--` or at end).
+    #[arg(last = true, required = true)]
+    pub command: Vec<OsString>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_hook_with_args() {
+        let raw = vec![
+            "--hook".to_string(),
+            "claude-command".to_string(),
+            "echo".to_string(),
+            "hello".to_string(),
+            ";".to_string(),
+            "--".to_string(),
+            "bash".to_string(),
+        ];
+        let (hooks, remaining) = pre_parse_hooks(raw).expect("parse");
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0].hook_type, "claude-command");
+        assert_eq!(hooks[0].command, "echo");
+        assert_eq!(hooks[0].args, vec!["hello"]);
+        assert_eq!(remaining, vec!["--", "bash"]);
+    }
+
+    #[test]
+    fn extracts_hook_without_args() {
+        let raw = vec![
+            "--hook".to_string(),
+            "claude-command".to_string(),
+            "/bin/true".to_string(),
+            ";".to_string(),
+            "--".to_string(),
+            "ls".to_string(),
+        ];
+        let (hooks, remaining) = pre_parse_hooks(raw).expect("parse");
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0].command, "/bin/true");
+        assert!(hooks[0].args.is_empty());
+        assert_eq!(remaining, vec!["--", "ls"]);
+    }
+
+    #[test]
+    fn accepts_escaped_semicolon() {
+        let raw = vec![
+            "--hook".to_string(),
+            "claude-command".to_string(),
+            "cat".to_string(),
+            "\\;".to_string(),
+            "--".to_string(),
+            "ls".to_string(),
+        ];
+        let (hooks, _) = pre_parse_hooks(raw).expect("parse");
+        assert_eq!(hooks.len(), 1);
+    }
+
+    #[test]
+    fn rejects_unterminated_hook() {
+        let raw = vec![
+            "--hook".to_string(),
+            "claude-command".to_string(),
+            "echo".to_string(),
+        ];
+        let result = pre_parse_hooks(raw);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_hook_missing_command() {
+        let raw = vec![
+            "--hook".to_string(),
+            "claude-command".to_string(),
+            ";".to_string(),
+        ];
+        let result = pre_parse_hooks(raw);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn extracts_multiple_hooks() {
+        let raw = vec![
+            "--hook".to_string(),
+            "claude-command".to_string(),
+            "a".to_string(),
+            ";".to_string(),
+            "--hook".to_string(),
+            "claude-command-persistent".to_string(),
+            "b".to_string(),
+            ";".to_string(),
+            "--".to_string(),
+            "cmd".to_string(),
+        ];
+        let (hooks, _) = pre_parse_hooks(raw).expect("parse");
+        assert_eq!(hooks.len(), 2);
+        assert_eq!(hooks[0].command, "a");
+        assert_eq!(hooks[1].command, "b");
+    }
+
+    #[test]
+    fn handles_no_hooks() {
+        let raw = vec!["--".to_string(), "ls".to_string(), "-la".to_string()];
+        let (hooks, remaining) = pre_parse_hooks(raw).expect("parse");
+        assert!(hooks.is_empty());
+        assert_eq!(remaining, vec!["--", "ls", "-la"]);
+    }
+
+    #[test]
+    fn stops_hook_scanning_after_separator() {
+        let raw = vec![
+            "--".to_string(),
+            "my-tool".to_string(),
+            "--hook".to_string(),
+            "something".to_string(),
+        ];
+        let (hooks, remaining) = pre_parse_hooks(raw).expect("parse");
+        assert!(hooks.is_empty());
+        assert_eq!(remaining, vec!["--", "my-tool", "--hook", "something"]);
+    }
+}

--- a/crates/harnx-sandbox-run/src/hooks.rs
+++ b/crates/harnx-sandbox-run/src/hooks.rs
@@ -1,0 +1,222 @@
+//! Hook execution for harnx-sandbox-run.
+//!
+//! Converts CLI hook definitions into `HookConfig` and dispatches them via
+//! the harnx-hooks crate. Extracts environment mutations from hook output.
+//!
+//! The `PersistentHookManager` is returned alongside the env map so the caller
+//! can keep sidecar processes (e.g. harnx-proxy-auth) alive for the duration
+//! of the sandboxed command. The caller must drop the manager (and the tokio
+//! runtime) only after the child process has exited.
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{bail, Result};
+use harnx_core::hooks::{HookConfig, HookEvent, HookOutcome, HookResultControl};
+use harnx_hooks::{dispatch_hooks_with_managers, PersistentHookManager};
+use serde_json::json;
+use tokio::sync::Mutex as TokioMutex;
+
+use crate::cli::HookDef;
+
+/// Result of hook dispatch: env mutations plus the live persistent manager.
+///
+/// The manager must be kept alive (not dropped) for the entire duration of the
+/// sandboxed child process — sidecar hooks like `harnx-proxy-auth` run inside
+/// it. Drop the manager (and the tokio runtime) only after the child exits.
+pub struct HookResult {
+    /// Environment variable mutations to apply to the sandbox.
+    pub env: HashMap<String, String>,
+    /// Live persistent hook manager — drop this after the child exits.
+    pub manager: Arc<TokioMutex<PersistentHookManager>>,
+}
+
+/// Start persistent hooks, dispatch one PreToolUse event to collect env
+/// mutations, and return both the env map and the live manager.
+///
+/// The manager is NOT shut down here — the caller keeps it alive.
+pub async fn run_hooks(
+    hook_defs: &[HookDef],
+    session_id: &str,
+    cwd: &Path,
+    command: &[OsString],
+) -> Result<HookResult> {
+    if hook_defs.is_empty() {
+        return Ok(HookResult {
+            env: HashMap::new(),
+            manager: Arc::new(TokioMutex::new(PersistentHookManager::new())),
+        });
+    }
+
+    // Convert HookDefs to HookConfigs
+    let hooks: Vec<HookConfig> = hook_defs
+        .iter()
+        .map(|def| {
+            let full_command = build_hook_command(&def.command, &def.args);
+            HookConfig {
+                event: "PreToolUse".to_string(),
+                matcher: None,
+                command: full_command,
+                timeout: Some(30),
+                status_message: None,
+                async_hook: Some(false),
+                hook_type: def.hook_type.clone(),
+            }
+        })
+        .collect();
+
+    let command_str: String = command
+        .iter()
+        .map(|s| s.to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let tool_use_id = uuid::Uuid::new_v4().to_string();
+
+    let event = HookEvent::PreToolUse {
+        tool_name: "exec".to_string(),
+        tool_use_id,
+        tool_input: json!({
+            "command": command_str,
+            "env": {},
+        }),
+    };
+
+    let persistent_manager = Arc::new(TokioMutex::new(PersistentHookManager::new()));
+
+    let outcome = dispatch_hooks_with_managers(
+        &event,
+        &hooks,
+        session_id,
+        cwd,
+        None,
+        Some(&persistent_manager),
+    )
+    .await;
+
+    // Check for block — shut down before bailing
+    if matches!(outcome.control, HookResultControl::Block { .. }) {
+        persistent_manager.lock().await.shutdown();
+        bail!(
+            "hook blocked execution: {}",
+            outcome
+                .result
+                .additional_context
+                .as_deref()
+                .unwrap_or("no reason")
+        );
+    }
+
+    let env = extract_hook_env(&outcome);
+
+    // Return the manager alive — caller keeps it until the child exits.
+    Ok(HookResult {
+        env,
+        manager: persistent_manager,
+    })
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn build_hook_command(command: &str, args: &[String]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 1);
+    parts.push(shell_quote(command));
+    for arg in args {
+        parts.push(shell_quote(arg));
+    }
+    parts.join(" ")
+}
+
+fn extract_env_from_value(env: &mut HashMap<String, String>, value: &serde_json::Value) {
+    if let Some(env_map) = value.get("env").and_then(|env_obj| env_obj.as_object()) {
+        for (key, value) in env_map {
+            if let Some(value) = value.as_str() {
+                env.insert(key.clone(), value.to_string());
+            }
+        }
+    }
+}
+
+pub(crate) fn extract_hook_env(outcome: &HookOutcome) -> HashMap<String, String> {
+    let mut env = HashMap::new();
+
+    if let Some(hso) = &outcome.result.hook_specific_output {
+        if let Some(tool_input) = &hso.tool_input {
+            extract_env_from_value(&mut env, tool_input);
+        }
+    }
+
+    if let Some(tool_input) = &outcome.result.mutated_tool_input {
+        extract_env_from_value(&mut env, tool_input);
+    }
+
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harnx_core::hooks::{HookOutcome, HookResult, HookSpecificOutput};
+    use serde_json::json;
+
+    #[test]
+    fn shell_quotes_hook_command_and_args() {
+        assert_eq!(
+            build_hook_command(
+                "/tmp/hook script",
+                &["arg with spaces".to_string(), "it's fine".to_string()]
+            ),
+            "'/tmp/hook script' 'arg with spaces' 'it'\\''s fine'"
+        );
+    }
+
+    #[test]
+    fn extracts_env_from_hook_specific_output() {
+        let outcome = HookOutcome {
+            control: HookResultControl::Continue,
+            result: HookResult {
+                hook_specific_output: Some(HookSpecificOutput {
+                    tool_input: Some(json!({
+                        "command": "env",
+                        "env": {
+                            "HOOK_TEST_VAR": "from_hook"
+                        }
+                    })),
+                    ..HookSpecificOutput::default()
+                }),
+                ..HookResult::default()
+            },
+        };
+
+        let env = extract_hook_env(&outcome);
+        assert_eq!(
+            env.get("HOOK_TEST_VAR").map(String::as_str),
+            Some("from_hook")
+        );
+    }
+
+    #[test]
+    fn mutated_tool_input_overrides_hook_specific_output_env() {
+        let outcome = HookOutcome {
+            control: HookResultControl::Continue,
+            result: HookResult {
+                hook_specific_output: Some(HookSpecificOutput {
+                    tool_input: Some(json!({"env": {"HOOK_TEST_VAR": "old"}})),
+                    ..HookSpecificOutput::default()
+                }),
+                mutated_tool_input: Some(
+                    json!({"env": {"HOOK_TEST_VAR": "new", "OTHER": "value"}}),
+                ),
+                ..HookResult::default()
+            },
+        };
+
+        let env = extract_hook_env(&outcome);
+        assert_eq!(env.get("HOOK_TEST_VAR").map(String::as_str), Some("new"));
+        assert_eq!(env.get("OTHER").map(String::as_str), Some("value"));
+    }
+}

--- a/crates/harnx-sandbox-run/src/main.rs
+++ b/crates/harnx-sandbox-run/src/main.rs
@@ -1,0 +1,138 @@
+//! `harnx-sandbox-run`: A standalone utility to run commands inside a birdcage sandbox with hook support.
+//!
+//! This binary provides a way to run arbitrary commands with the same sandboxing defaults and
+//! credential injection hooks used by `harnx-mcp-bash`. It is useful for testing hooks,
+//! running tools securely, or as a building block for other agentic workflows.
+//!
+//! Sandboxing is delegated to `harnx-sandbox-exec`, which runs as a subprocess. This allows
+//! the parent process to keep its tokio runtime alive — and with it, any sidecar hook processes
+//! such as `harnx-proxy-auth` — for the full lifetime of the sandboxed command.
+//!
+//! ## Environment variables
+//!
+//! In addition to CLI flags, the following environment variables are supported (matching
+//! `harnx-mcp-bash`):
+//!
+//! | Variable | Format | Effect |
+//! |---|---|---|
+//! | `HARNX_BASH_EXTRA_READABLE` | Colon-separated paths | Extra sandbox read-only paths |
+//! | `HARNX_BASH_EXTRA_EXEC` | Colon-separated paths | Extra sandbox execute paths |
+//! | `HARNX_BASH_EXTRA_WRITABLE` | Colon-separated paths | Extra sandbox writable paths |
+//! | `HARNX_BASH_EXTRA_RWX` | Colon-separated paths | Extra sandbox read/write/exec paths |
+//! | `HARNX_BASH_ENV_PASSTHROUGH` | Comma-separated names | Extra host env var names to pass through |
+
+mod cli;
+mod hooks;
+mod sandbox;
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+/// Expand a leading `~` to `$HOME`. Matches the behaviour in `harnx-mcp-bash`.
+fn expand_tilde(raw: &str) -> String {
+    if !raw.starts_with('~') {
+        return raw.to_string();
+    }
+    let home = match std::env::var("HOME") {
+        Ok(h) => h,
+        Err(_) => return raw.to_string(),
+    };
+    if raw == "~" {
+        home
+    } else if let Some(suffix) = raw.strip_prefix("~/") {
+        format!("{home}/{suffix}")
+    } else {
+        raw.to_string()
+    }
+}
+
+/// Read a colon-separated path list from an env var, expanding tildes.
+#[cfg(unix)]
+fn env_paths(var: &str) -> Vec<PathBuf> {
+    std::env::var_os(var)
+        .map(|val| {
+            std::env::split_paths(&val)
+                .filter(|p| !p.as_os_str().is_empty())
+                .map(|p| PathBuf::from(expand_tilde(&p.to_string_lossy())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Read a comma-separated list of env var names from `HARNX_BASH_ENV_PASSTHROUGH`.
+fn env_passthrough_names() -> Vec<String> {
+    std::env::var("HARNX_BASH_ENV_PASSTHROUGH")
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    // Raw args (skip program name)
+    let raw: Vec<String> = std::env::args().skip(1).collect();
+
+    // Pre-parse --hook groups before clap
+    let (hook_defs, remaining) = cli::pre_parse_hooks(raw)?;
+
+    // Re-add program name for clap parsing
+    let mut clap_args = vec!["harnx-sandbox-run".to_string()];
+    clap_args.extend(remaining);
+
+    // Parse remaining args with clap
+    let mut cli = <cli::Cli as clap::Parser>::parse_from(&clap_args);
+
+    // Merge env var overrides (matching harnx-mcp-bash behaviour).
+    #[cfg(unix)]
+    {
+        cli.extra_read
+            .extend(env_paths("HARNX_BASH_EXTRA_READABLE"));
+        cli.extra_write
+            .extend(env_paths("HARNX_BASH_EXTRA_WRITABLE"));
+        cli.extra_exec.extend(env_paths("HARNX_BASH_EXTRA_EXEC"));
+        cli.extra_rwx.extend(env_paths("HARNX_BASH_EXTRA_RWX"));
+    }
+
+    // Extra env var names to pass through from host.
+    for name in env_passthrough_names() {
+        if let Ok(value) = std::env::var(&name) {
+            cli.env_vars.push(format!("{name}={value}"));
+        }
+    }
+
+    // Run hooks if any, keeping the tokio runtime (and all sidecar processes,
+    // e.g. harnx-proxy-auth) alive for the full duration of the child.
+    let (hook_env, _rt, _manager) = if !hook_defs.is_empty() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        let cwd = std::env::current_dir()?;
+        let session_id = uuid::Uuid::new_v4().to_string();
+        let result = rt.block_on(hooks::run_hooks(
+            &hook_defs,
+            &session_id,
+            &cwd,
+            &cli.command,
+        ))?;
+        // Keep rt and manager alive (bound to these variables) until after
+        // setup_and_spawn returns — this keeps harnx-proxy-auth running.
+        (result.env, Some(rt), Some(result.manager))
+    } else {
+        (std::collections::HashMap::new(), None, None)
+    };
+
+    // Delegate sandbox setup and spawn to harnx-sandbox-exec subprocess.
+    // The tokio runtime and hook manager stay alive (via _rt and _manager above)
+    // until this returns.
+    let use_defaults = !cli.no_defaults;
+    let exit_code = sandbox::setup_and_spawn(&cli, hook_env, use_defaults)?;
+
+    // _rt and _manager drop here, shutting down harnx-proxy-auth after child exits.
+
+    std::process::exit(exit_code);
+}

--- a/crates/harnx-sandbox-run/src/main.rs
+++ b/crates/harnx-sandbox-run/src/main.rs
@@ -25,11 +25,13 @@ mod cli;
 mod hooks;
 mod sandbox;
 
+#[cfg(unix)]
 use std::path::PathBuf;
 
 use anyhow::Result;
 
 /// Expand a leading `~` to `$HOME`. Matches the behaviour in `harnx-mcp-bash`.
+#[cfg(unix)]
 fn expand_tilde(raw: &str) -> String {
     if !raw.starts_with('~') {
         return raw.to_string();

--- a/crates/harnx-sandbox-run/src/sandbox.rs
+++ b/crates/harnx-sandbox-run/src/sandbox.rs
@@ -1,0 +1,406 @@
+//! Sandbox setup delegated to `harnx-sandbox-exec`.
+//!
+//! Instead of calling birdcage directly (which requires single-threaded context),
+//! this module spawns `harnx-sandbox-exec` as a subprocess. This allows the parent
+//! process to keep the tokio runtime — and sidecar hooks like `harnx-proxy-auth` —
+//! alive for the full duration of the sandboxed command.
+//!
+//! ## Env var protocol
+//!
+//! All env vars (defaults, CLI `--env`, hook-injected) are set on the **ambient
+//! environment** of the `harnx-sandbox-exec` subprocess via `std::process::Command::env()`.
+//! The CLI args to `harnx-sandbox-exec` only carry `--env VAR` (name-only) entries
+//! to tell it which vars to whitelist into the sandbox. Values never appear in the
+//! process argument list, preventing secrets from leaking into `ps`/`/proc`.
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+use crate::cli::Cli;
+
+/// Find `harnx-sandbox-exec` next to the current executable, falling back to PATH.
+fn find_sandbox_exec() -> PathBuf {
+    if let Ok(current) = std::env::current_exe() {
+        if let Some(dir) = current.parent() {
+            let candidate = dir.join("harnx-sandbox-exec");
+            if candidate.exists() {
+                return candidate;
+            }
+        }
+    }
+    PathBuf::from("harnx-sandbox-exec")
+}
+
+/// Build the argv for `harnx-sandbox-exec` from CLI flags and the default whitelist.
+///
+/// Env var *names* are passed as `--env VAR` (no value — `harnx-sandbox-exec` reads
+/// them from its ambient environment, which the caller sets via `.env()`).
+#[cfg(unix)]
+fn build_exec_args(cli: &Cli, all_env_keys: &[String], use_defaults: bool) -> Vec<OsString> {
+    use harnx_sandbox_common::{
+        is_home_or_ancestor, resolve_path, system_writable_paths, HOME_EXEC_PATHS, HOME_READ_PATHS,
+        HOME_RWX_PATHS, HOME_WRITE_PATHS, SYSTEM_EXEC_PATHS, SYSTEM_READ_PATHS,
+    };
+
+    let mut args: Vec<OsString> = Vec::new();
+
+    // Default whitelist — same paths that harnx-mcp-bash uses
+    if use_defaults {
+        for path in SYSTEM_EXEC_PATHS {
+            let p = std::path::PathBuf::from(path);
+            if p.exists() {
+                args.push("--exec".into());
+                args.push(p.into_os_string());
+            }
+        }
+        for path in SYSTEM_READ_PATHS {
+            let p = std::path::PathBuf::from(path);
+            if p.exists() {
+                args.push("--read".into());
+                args.push(p.into_os_string());
+            }
+        }
+        for p in system_writable_paths() {
+            if p.exists() {
+                args.push("--write".into());
+                args.push(p.into_os_string());
+            }
+        }
+        if let Some(home) = std::env::var_os("HOME") {
+            let home = std::path::PathBuf::from(home);
+            for sub in HOME_READ_PATHS {
+                let p = home.join(sub);
+                if p.exists() {
+                    args.push("--read".into());
+                    args.push(p.into_os_string());
+                }
+            }
+            for sub in HOME_EXEC_PATHS {
+                let p = home.join(sub);
+                if p.exists() {
+                    args.push("--exec".into());
+                    args.push(p.into_os_string());
+                }
+            }
+            for sub in HOME_WRITE_PATHS {
+                let p = home.join(sub);
+                if p.exists() {
+                    args.push("--write".into());
+                    args.push(p.into_os_string());
+                }
+            }
+            for sub in HOME_RWX_PATHS {
+                let p = home.join(sub);
+                if p.exists() {
+                    args.push("--read".into());
+                    args.push(p.clone().into_os_string());
+                    args.push("--write".into());
+                    args.push(p.clone().into_os_string());
+                    args.push("--exec".into());
+                    args.push(p.into_os_string());
+                }
+            }
+        }
+        // CARGO_HOME, GOROOT, GOPATH, GOBIN
+        if let Some(cargo_home) = std::env::var_os("CARGO_HOME") {
+            let bin = std::path::PathBuf::from(cargo_home).join("bin");
+            if bin.exists() {
+                args.push("--exec".into());
+                args.push(bin.into_os_string());
+            }
+        }
+        if let Some(goroot) = std::env::var_os("GOROOT") {
+            let p = std::path::PathBuf::from(goroot);
+            if p.exists() {
+                args.push("--exec".into());
+                args.push(p.into_os_string());
+            }
+        }
+        if let Some(gopath) = std::env::var_os("GOPATH") {
+            let gopath = std::path::PathBuf::from(gopath);
+            let bin = gopath.join("bin");
+            let pkg = gopath.join("pkg");
+            if bin.exists() {
+                args.push("--exec".into());
+                args.push(bin.into_os_string());
+            }
+            if pkg.exists() {
+                args.push("--read".into());
+                args.push(pkg.clone().into_os_string());
+                args.push("--write".into());
+                args.push(pkg.into_os_string());
+            }
+        }
+        if let Some(gobin) = std::env::var_os("GOBIN") {
+            let p = std::path::PathBuf::from(gobin);
+            if p.exists() {
+                args.push("--exec".into());
+                args.push(p.into_os_string());
+            }
+        }
+    }
+
+    // CLI-provided extra paths
+    for path in &cli.extra_read {
+        let resolved = resolve_path(path);
+        if is_home_or_ancestor(&resolved) {
+            eprintln!(
+                "harnx-sandbox-run: warning: ignoring --extra-read {}: would expose home directory",
+                path.display()
+            );
+            continue;
+        }
+        args.push("--read".into());
+        args.push(resolved.into_os_string());
+    }
+    for path in &cli.extra_write {
+        let resolved = resolve_path(path);
+        if is_home_or_ancestor(&resolved) {
+            eprintln!(
+                "harnx-sandbox-run: warning: ignoring --extra-write {}: would expose home directory",
+                path.display()
+            );
+            continue;
+        }
+        args.push("--write".into());
+        args.push(resolved.into_os_string());
+    }
+    for path in &cli.extra_exec {
+        let resolved = resolve_path(path);
+        if is_home_or_ancestor(&resolved) {
+            eprintln!(
+                "harnx-sandbox-run: warning: ignoring --extra-exec {}: would expose home directory",
+                path.display()
+            );
+            continue;
+        }
+        args.push("--exec".into());
+        args.push(resolved.into_os_string());
+    }
+    for path in &cli.extra_rwx {
+        let resolved = resolve_path(path);
+        if is_home_or_ancestor(&resolved) {
+            eprintln!(
+                "harnx-sandbox-run: warning: ignoring --extra-rwx {}: would expose home directory",
+                path.display()
+            );
+            continue;
+        }
+        args.push("--read".into());
+        args.push(resolved.clone().into_os_string());
+        args.push("--write".into());
+        args.push(resolved.clone().into_os_string());
+        args.push("--exec".into());
+        args.push(resolved.into_os_string());
+    }
+
+    if cli.no_network {
+        args.push("--no-network".into());
+    }
+
+    if let Some(dir) = &cli.working_dir {
+        args.push("--working-dir".into());
+        args.push(dir.clone().into_os_string());
+    }
+
+    // Env var names — values are in the ambient env, not in args
+    for key in all_env_keys {
+        args.push("--env".into());
+        args.push(key.clone().into());
+    }
+
+    args.push("--".into());
+    args.extend(cli.command.iter().cloned());
+
+    args
+}
+
+/// Collect all env vars to pass through, returning (key, value) pairs for the
+/// ambient environment and the list of key names for `--env` args.
+fn collect_env(
+    cli: &Cli,
+    hook_env: HashMap<String, String>,
+) -> (Vec<(String, String)>, Vec<String>) {
+    const DEFAULT_PASSTHROUGH: &[&str] = &[
+        "HOME", "USER", "LOGNAME", "SHELL", "TERM", "LANG", "LC_ALL", "LC_CTYPE", "PATH", "TMPDIR",
+    ];
+
+    let mut env: Vec<(String, String)> = Vec::new();
+
+    // 1. Baseline passthrough
+    for name in DEFAULT_PASSTHROUGH {
+        if let Ok(value) = std::env::var(name) {
+            env.push((name.to_string(), value));
+        }
+    }
+    // XDG_*
+    for (name, value) in std::env::vars() {
+        if name.starts_with("XDG_") && !env.iter().any(|(k, _)| k == &name) {
+            env.push((name, value));
+        }
+    }
+
+    // 2. CLI --env (override defaults)
+    for raw in &cli.env_vars {
+        if let Some((key, value)) = raw.split_once('=') {
+            env.retain(|(k, _)| k != key);
+            env.push((key.to_string(), value.to_string()));
+        } else if let Ok(value) = std::env::var(raw) {
+            env.retain(|(k, _)| k != raw.as_str());
+            env.push((raw.clone(), value));
+        }
+    }
+
+    // 3. Hook env (highest priority — never appears in args)
+    for (key, value) in hook_env {
+        env.retain(|(k, _)| k != &key);
+        env.push((key, value));
+    }
+
+    let keys: Vec<String> = env.iter().map(|(k, _)| k.clone()).collect();
+    (env, keys)
+}
+
+/// Spawn `harnx-sandbox-exec` and wait for it to exit.
+pub fn setup_and_spawn(
+    cli: &Cli,
+    hook_env: HashMap<String, String>,
+    use_defaults: bool,
+) -> Result<i32> {
+    let sandbox_exec = find_sandbox_exec();
+
+    let (env_pairs, env_keys) = collect_env(cli, hook_env);
+
+    #[cfg(unix)]
+    let exec_args = build_exec_args(cli, &env_keys, use_defaults);
+
+    #[cfg(not(unix))]
+    {
+        let _ = (env_keys, use_defaults);
+        anyhow::bail!("harnx-sandbox-run is only supported on Unix platforms");
+    }
+
+    #[cfg(unix)]
+    {
+        let status = std::process::Command::new(&sandbox_exec)
+            .args(&exec_args)
+            // Set all env vars as ambient environment — values never in args
+            .env_clear()
+            .envs(env_pairs.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+            .status()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to spawn {}: {e} — is harnx-sandbox-exec installed?",
+                    sandbox_exec.display()
+                )
+            })?;
+
+        Ok(status.code().unwrap_or(1))
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collect_env_hook_overrides_cli() {
+        let cli = Cli {
+            env_vars: vec!["MYVAR=from_cli".to_string()],
+            extra_read: vec![],
+            extra_write: vec![],
+            extra_exec: vec![],
+            extra_rwx: vec![],
+            no_network: false,
+            working_dir: None,
+            no_defaults: false,
+            command: vec![],
+        };
+        let hook_env = HashMap::from([("MYVAR".to_string(), "from_hook".to_string())]);
+        let (env, keys) = collect_env(&cli, hook_env);
+        let val = env
+            .iter()
+            .find(|(k, _)| k == "MYVAR")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(val, Some("from_hook"));
+        assert!(keys.contains(&"MYVAR".to_string()));
+    }
+
+    #[test]
+    fn collect_env_no_values_in_keys_only() {
+        // Keys list must contain the key name — the test just checks it's present
+        let cli = Cli {
+            env_vars: vec!["HOME".to_string()],
+            extra_read: vec![],
+            extra_write: vec![],
+            extra_exec: vec![],
+            extra_rwx: vec![],
+            no_network: false,
+            working_dir: None,
+            no_defaults: false,
+            command: vec![],
+        };
+        let (_, keys) = collect_env(&cli, HashMap::new());
+        assert!(keys.contains(&"HOME".to_string()));
+    }
+
+    #[test]
+    fn build_exec_args_filters_home_and_resolves_allowed_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cwd = temp.path().join("cwd");
+        let home = temp.path().join("home");
+        let child = home.join("projects");
+        std::fs::create_dir_all(&cwd).expect("create cwd");
+        std::fs::create_dir_all(&child).expect("create child");
+
+        let old_cwd = std::env::current_dir().expect("current_dir");
+        std::env::set_current_dir(&cwd).expect("set cwd");
+        unsafe { std::env::set_var("HOME", &home) };
+
+        let cli = Cli {
+            env_vars: vec![],
+            extra_read: vec![PathBuf::from(".")],
+            extra_write: vec![home.clone()],
+            extra_exec: vec![PathBuf::from("/")],
+            extra_rwx: vec![child.clone()],
+            no_network: false,
+            working_dir: None,
+            no_defaults: false,
+            command: vec![],
+        };
+
+        let args = build_exec_args(&cli, &[], false);
+        let args: Vec<String> = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        // Use canonicalize for expected paths: on macOS /var/… resolves to
+        // /private/var/… through a symlink, matching what resolve_path returns.
+        let canon = |p: &std::path::Path| {
+            std::fs::canonicalize(p)
+                .unwrap_or_else(|_| p.to_path_buf())
+                .to_string_lossy()
+                .into_owned()
+        };
+        assert_eq!(
+            args,
+            vec![
+                "--read".to_string(),
+                canon(&cwd),
+                "--read".to_string(),
+                canon(&child),
+                "--write".to_string(),
+                canon(&child),
+                "--exec".to_string(),
+                canon(&child),
+                "--".to_string(),
+            ]
+        );
+
+        std::env::set_current_dir(old_cwd).expect("restore cwd");
+    }
+}

--- a/crates/harnx-sandbox-run/src/sandbox.rs
+++ b/crates/harnx-sandbox-run/src/sandbox.rs
@@ -14,7 +14,9 @@
 //! process argument list, preventing secrets from leaking into `ps`/`/proc`.
 
 use std::collections::HashMap;
+#[cfg(unix)]
 use std::ffi::OsString;
+#[cfg(unix)]
 use std::path::PathBuf;
 
 use anyhow::Result;
@@ -279,7 +281,7 @@ pub fn setup_and_spawn(
 
     #[cfg(not(unix))]
     {
-        let _ = (env_keys, use_defaults);
+        let _ = (sandbox_exec, env_pairs, env_keys, use_defaults);
         anyhow::bail!("harnx-sandbox-run is only supported on Unix platforms");
     }
 

--- a/crates/harnx-sandbox-run/src/sandbox.rs
+++ b/crates/harnx-sandbox-run/src/sandbox.rs
@@ -16,7 +16,6 @@
 use std::collections::HashMap;
 #[cfg(unix)]
 use std::ffi::OsString;
-#[cfg(unix)]
 use std::path::PathBuf;
 
 use anyhow::Result;

--- a/crates/harnx-sandbox-run/tests/cli_parsing.rs
+++ b/crates/harnx-sandbox-run/tests/cli_parsing.rs
@@ -1,0 +1,210 @@
+//! CLI parsing unit tests.
+//!
+//! These tests exercise `pre_parse_hooks` edge cases and `Cli` struct parsing
+//! via clap's `try_parse_from`. They run without spawning the sandbox.
+
+use std::path::PathBuf;
+
+// Access Cli and pre_parse_hooks via the crate's public API.
+// Since this is a binary crate, we need to test via the test helper module.
+// For binary crates, integration tests in `tests/` cannot directly import from
+// `main.rs`. We use a #[path] include to access the cli module directly.
+#[path = "../src/cli.rs"]
+mod cli;
+
+use cli::{pre_parse_hooks, Cli};
+
+// === pre_parse_hooks tests ===
+
+#[test]
+fn test_hook_passthrough_to_clap() {
+    // Hook group is removed; remaining args have normal flags
+    let raw = vec![
+        "--hook".to_string(),
+        "claude-command".to_string(),
+        "echo".to_string(),
+        ";".to_string(),
+        "--no-network".to_string(),
+        "--".to_string(),
+        "ls".to_string(),
+    ];
+    let (hooks, remaining) = pre_parse_hooks(raw).expect("parse");
+    assert_eq!(hooks.len(), 1);
+    assert_eq!(remaining, vec!["--no-network", "--", "ls"]);
+}
+
+#[test]
+fn test_handles_no_hooks_passthrough() {
+    // No hooks, args pass through unchanged
+    let raw = vec![
+        "--no-network".to_string(),
+        "--".to_string(),
+        "echo".to_string(),
+        "hello".to_string(),
+    ];
+    let (hooks, remaining) = pre_parse_hooks(raw).expect("parse");
+    assert!(hooks.is_empty());
+    assert_eq!(remaining, vec!["--no-network", "--", "echo", "hello"]);
+}
+
+// === Cli parsing tests via clap ===
+
+#[test]
+fn test_parse_env_var_format() {
+    // --env VAR=value parses correctly
+    let cli = <Cli as clap::Parser>::try_parse_from([
+        "harnx-sandbox-run",
+        "--env",
+        "TEST_VAR=hello",
+        "--",
+        "echo",
+        "test",
+    ])
+    .expect("parse should succeed");
+    assert!(cli.env_vars.contains(&"TEST_VAR=hello".to_string()));
+    assert_eq!(cli.command.len(), 2);
+}
+
+#[test]
+fn test_parse_env_var_inherit() {
+    // --env VAR (no value) parses correctly
+    let cli =
+        <Cli as clap::Parser>::try_parse_from(["harnx-sandbox-run", "--env", "HOME", "--", "bash"])
+            .expect("parse should succeed");
+    assert!(cli.env_vars.contains(&"HOME".to_string()));
+}
+
+#[test]
+fn test_parse_no_network() {
+    // --no-network flag parses correctly
+    let cli = <Cli as clap::Parser>::try_parse_from([
+        "harnx-sandbox-run",
+        "--no-network",
+        "--",
+        "curl",
+        "https://example.com",
+    ])
+    .expect("parse should succeed");
+    assert!(cli.no_network);
+}
+
+#[test]
+fn test_parse_working_dir() {
+    // --working-dir /tmp parses correctly
+    let cli = <Cli as clap::Parser>::try_parse_from([
+        "harnx-sandbox-run",
+        "--working-dir",
+        "/tmp",
+        "--",
+        "ls",
+    ])
+    .expect("parse should succeed");
+    assert_eq!(cli.working_dir, Some(PathBuf::from("/tmp")));
+}
+
+#[test]
+fn test_parse_command_after_double_dash() {
+    // -- echo hello becomes the command
+    let cli = <Cli as clap::Parser>::try_parse_from([
+        "harnx-sandbox-run",
+        "--",
+        "echo",
+        "hello",
+        "world",
+    ])
+    .expect("parse should succeed");
+    assert_eq!(cli.command.len(), 3);
+    assert_eq!(cli.command[0].to_string_lossy(), "echo");
+    assert_eq!(cli.command[1].to_string_lossy(), "hello");
+    assert_eq!(cli.command[2].to_string_lossy(), "world");
+}
+
+#[test]
+fn test_parse_multiple_path_flags() {
+    // --extra-read /a --extra-write /b --extra-exec /c all parsed
+    let cli = <Cli as clap::Parser>::try_parse_from([
+        "harnx-sandbox-run",
+        "--extra-read",
+        "/a",
+        "--extra-write",
+        "/b",
+        "--extra-exec",
+        "/c",
+        "--",
+        "cmd",
+    ])
+    .expect("parse should succeed");
+    assert!(cli.extra_read.contains(&PathBuf::from("/a")));
+    assert!(cli.extra_write.contains(&PathBuf::from("/b")));
+    assert!(cli.extra_exec.contains(&PathBuf::from("/c")));
+}
+
+#[test]
+fn test_parse_repeated_path_flags() {
+    // Multiple --extra-read flags accumulate
+    let cli = <Cli as clap::Parser>::try_parse_from([
+        "harnx-sandbox-run",
+        "--extra-read",
+        "/a",
+        "--extra-read",
+        "/b",
+        "--extra-read",
+        "/c",
+        "--",
+        "cmd",
+    ])
+    .expect("parse should succeed");
+    assert_eq!(cli.extra_read.len(), 3);
+    assert!(cli.extra_read.contains(&PathBuf::from("/a")));
+    assert!(cli.extra_read.contains(&PathBuf::from("/b")));
+    assert!(cli.extra_read.contains(&PathBuf::from("/c")));
+}
+
+#[test]
+fn test_parse_extra_rwx() {
+    // --extra-rwx /tmp parses correctly
+    let cli = <Cli as clap::Parser>::try_parse_from([
+        "harnx-sandbox-run",
+        "--extra-rwx",
+        "/tmp",
+        "--",
+        "cmd",
+    ])
+    .expect("parse should succeed");
+    assert!(cli.extra_rwx.contains(&PathBuf::from("/tmp")));
+}
+
+#[test]
+fn test_parse_no_defaults() {
+    // --no-defaults flag parses correctly
+    let cli =
+        <Cli as clap::Parser>::try_parse_from(["harnx-sandbox-run", "--no-defaults", "--", "cmd"])
+            .expect("parse should succeed");
+    assert!(cli.no_defaults);
+}
+
+#[test]
+fn test_parse_missing_command_errors() {
+    // Missing command after -- should error
+    let result = <Cli as clap::Parser>::try_parse_from(["harnx-sandbox-run", "--"]);
+    assert!(result.is_err(), "expected error when command is missing");
+}
+
+#[test]
+fn test_parse_no_double_dash_errors() {
+    // clap's `last = true` requires `--` before the command
+    // Without it, the command is treated as an unknown argument
+    let result = <Cli as clap::Parser>::try_parse_from(["harnx-sandbox-run", "echo", "hello"]);
+    assert!(
+        result.is_err(),
+        "expected error when -- is missing before command"
+    );
+}
+
+#[test]
+fn test_parse_unknown_flag_errors() {
+    // Unknown flag should cause clap error
+    let result =
+        <Cli as clap::Parser>::try_parse_from(["harnx-sandbox-run", "--unknown-flag", "--", "cmd"]);
+    assert!(result.is_err(), "expected error for unknown flag");
+}

--- a/crates/harnx-sandbox-run/tests/integration.rs
+++ b/crates/harnx-sandbox-run/tests/integration.rs
@@ -7,8 +7,10 @@
 //! containers without unprivileged user namespaces), tests gracefully
 //! skip rather than fail.
 
+#[cfg(unix)]
 use std::fs;
 use std::process::Command;
+#[cfg(unix)]
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Path to the sandbox binary, set by cargo's CARGO_BIN_EXE_ env var.

--- a/crates/harnx-sandbox-run/tests/integration.rs
+++ b/crates/harnx-sandbox-run/tests/integration.rs
@@ -16,6 +16,7 @@ fn binary_path() -> std::path::PathBuf {
     std::path::PathBuf::from(env!("CARGO_BIN_EXE_harnx-sandbox-run"))
 }
 
+#[cfg(unix)]
 fn temp_test_dir(name: &str) -> std::path::PathBuf {
     let suffix = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/crates/harnx-sandbox-run/tests/integration.rs
+++ b/crates/harnx-sandbox-run/tests/integration.rs
@@ -1,0 +1,441 @@
+//! Integration tests for harnx-sandbox-run binary.
+//!
+//! These tests run the actual sandbox binary as a subprocess. They are
+//! `#[cfg(unix)]` gated since birdcage is Unix-only.
+//!
+//! On environments where birdcage cannot initialize (e.g., restricted
+//! containers without unprivileged user namespaces), tests gracefully
+//! skip rather than fail.
+
+use std::fs;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Path to the sandbox binary, set by cargo's CARGO_BIN_EXE_ env var.
+fn binary_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_harnx-sandbox-run"))
+}
+
+fn temp_test_dir(name: &str) -> std::path::PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("unix epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("harnx-sandbox-run-{name}-{suffix}"));
+    fs::create_dir_all(&dir).expect("create temp test dir");
+    dir
+}
+
+#[cfg(unix)]
+fn make_unix_script(path: &std::path::Path, body: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::write(path, body).expect("write script");
+    let mut perms = fs::metadata(path).expect("script metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).expect("chmod script");
+}
+
+/// Probe whether the birdcage sandbox can actually initialize in the
+/// current environment.
+///
+/// GitHub Actions Ubuntu runners and other restricted Linux environments
+/// commonly disallow unprivileged user namespaces, which causes
+/// `Sandbox::spawn()` to fail with EPERM at runtime.
+///
+/// If this returns false, tests should skip gracefully.
+#[cfg(unix)]
+fn sandbox_runtime_works() -> bool {
+    // Try a minimal sandbox invocation
+    let result = Command::new(binary_path())
+        .args([
+            "--exec",
+            "/bin",
+            "--exec",
+            "/usr",
+            "--exec",
+            "/lib",
+            "--exec",
+            "/lib64",
+            "--exec",
+            "/usr/lib",
+            "--exec",
+            "/usr/lib64",
+            "--exec",
+            "/tmp",
+            "--working-dir",
+            "/tmp",
+            "--",
+            "true",
+        ])
+        .status();
+
+    match result {
+        Ok(status) if status.success() => true,
+        Ok(status) => {
+            eprintln!(
+                "sandbox runtime probe: birdcage cannot initialize here (exit={:?}) — skipping",
+                status.code()
+            );
+            false
+        }
+        Err(err) => {
+            eprintln!("sandbox runtime probe: failed to spawn binary: {err} — skipping");
+            false
+        }
+    }
+}
+
+// === Unix-only sandbox tests ===
+// These require birdcage to initialize successfully
+
+#[cfg(unix)]
+#[test]
+fn test_basic_echo() {
+    if !sandbox_runtime_works() {
+        eprintln!("skipping: sandbox runtime not available");
+        return;
+    }
+
+    let output = Command::new(binary_path())
+        .args([
+            "--exec",
+            "/bin",
+            "--exec",
+            "/usr",
+            "--working-dir",
+            "/tmp",
+            "--",
+            "echo",
+            "hello",
+        ])
+        .output()
+        .expect("failed to spawn sandbox");
+
+    assert!(output.status.success(), "sandbox should exit successfully");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("hello"),
+        "output should contain 'hello', got: {stdout:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_exit_code_propagation() {
+    if !sandbox_runtime_works() {
+        eprintln!("skipping: sandbox runtime not available");
+        return;
+    }
+
+    let output = Command::new(binary_path())
+        .args([
+            "--exec",
+            "/bin",
+            "--exec",
+            "/usr",
+            "--working-dir",
+            "/tmp",
+            "--",
+            "bash",
+            "-c",
+            "exit 42",
+        ])
+        .output()
+        .expect("failed to spawn sandbox");
+
+    let code = output.status.code().unwrap_or(-1);
+    assert_eq!(
+        code, 42,
+        "sandbox should propagate exit code 42, got: {code}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_env_var_passthrough() {
+    if !sandbox_runtime_works() {
+        eprintln!("skipping: sandbox runtime not available");
+        return;
+    }
+
+    let output = Command::new(binary_path())
+        .args([
+            "--exec",
+            "/bin",
+            "--exec",
+            "/usr",
+            "--working-dir",
+            "/tmp",
+            "--env",
+            "TEST_VAR=hello_sandbox",
+            "--",
+            "bash",
+            "-c",
+            "echo \"$TEST_VAR\"",
+        ])
+        .output()
+        .expect("failed to spawn sandbox");
+
+    assert!(output.status.success(), "sandbox should exit successfully");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("hello_sandbox"),
+        "output should contain 'hello_sandbox', got: {stdout:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_no_network_flag() {
+    if !sandbox_runtime_works() {
+        eprintln!("skipping: sandbox runtime not available");
+        return;
+    }
+
+    // With --no-network, network access should be blocked
+    // We test that the flag is accepted and the binary runs
+    let output = Command::new(binary_path())
+        .args([
+            "--no-network",
+            "--exec",
+            "/bin",
+            "--exec",
+            "/usr",
+            "--working-dir",
+            "/tmp",
+            "--",
+            "echo",
+            "isolated",
+        ])
+        .output()
+        .expect("failed to spawn sandbox");
+
+    assert!(
+        output.status.success(),
+        "sandbox should exit successfully with --no-network"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("isolated"),
+        "output should contain 'isolated', got: {stdout:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_working_dir_option() {
+    if !sandbox_runtime_works() {
+        eprintln!("skipping: sandbox runtime not available");
+        return;
+    }
+
+    let output = Command::new(binary_path())
+        .args([
+            "--exec",
+            "/bin",
+            "--exec",
+            "/usr",
+            "--working-dir",
+            "/tmp",
+            "--",
+            "bash",
+            "-c",
+            "pwd",
+        ])
+        .output()
+        .expect("failed to spawn sandbox");
+
+    assert!(output.status.success(), "sandbox should exit successfully");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("/tmp"),
+        "working dir should be /tmp, got: {stdout:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_hook_cli_injects_env() {
+    if !sandbox_runtime_works() {
+        eprintln!("skipping: sandbox runtime not available");
+        return;
+    }
+
+    let dir = temp_test_dir("hook-env");
+    let hook_path = dir.join("hook.sh");
+    make_unix_script(
+        &hook_path,
+        r#"#!/bin/sh
+cat >/dev/null
+printf '%s' '{"hookSpecificOutput":{"toolInput":{"command":"env","env":{"HOOK_TEST_VAR":"from_hook"}}}}'
+"#,
+    );
+
+    let output = Command::new(binary_path())
+        .args([
+            "--hook",
+            "claude-command",
+            hook_path.to_str().expect("utf8 hook path"),
+            ";",
+            "--exec",
+            "/bin",
+            "--exec",
+            "/usr",
+            "--working-dir",
+            "/tmp",
+            "--",
+            "env",
+        ])
+        .output()
+        .expect("failed to spawn sandbox");
+
+    assert!(
+        output.status.success(),
+        "sandbox should exit successfully with hook, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.lines().any(|line| line == "HOOK_TEST_VAR=from_hook"),
+        "hook-injected env var missing from output: {stdout:?}"
+    );
+}
+
+// === Tests that don't require sandbox runtime ===
+
+#[test]
+fn test_help_flag() {
+    // --help should work without sandbox
+    let output = Command::new(binary_path())
+        .arg("--help")
+        .output()
+        .expect("failed to spawn sandbox --help");
+
+    assert!(output.status.success(), "--help should exit successfully");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("sandbox"),
+        "help output should mention 'sandbox', got: {stdout:?}"
+    );
+}
+
+#[test]
+fn test_missing_command_errors() {
+    // Running without a command should error
+    let output = Command::new(binary_path())
+        .output()
+        .expect("failed to spawn sandbox");
+
+    // Should not succeed - clap requires the command
+    assert!(
+        !output.status.success(),
+        "missing command should cause non-zero exit"
+    );
+}
+
+#[test]
+fn test_invalid_flag_errors() {
+    // Invalid flag should error
+    let output = Command::new(binary_path())
+        .args(["--invalid-flag-that-does-not-exist", "--", "cmd"])
+        .output()
+        .expect("failed to spawn sandbox");
+
+    assert!(
+        !output.status.success(),
+        "invalid flag should cause non-zero exit"
+    );
+}
+
+// === Additional Unix-specific tests ===
+
+#[cfg(unix)]
+#[test]
+fn test_path_exceptions() {
+    if !sandbox_runtime_works() {
+        eprintln!("skipping: sandbox runtime not available");
+        return;
+    }
+
+    // Test that --read, --write, --exec flags are accepted
+    let output = Command::new(binary_path())
+        .args([
+            "--read",
+            "/tmp",
+            "--write",
+            "/tmp",
+            "--exec",
+            "/bin",
+            "--exec",
+            "/usr",
+            "--working-dir",
+            "/tmp",
+            "--",
+            "true",
+        ])
+        .output()
+        .expect("failed to spawn sandbox");
+
+    assert!(
+        output.status.success(),
+        "sandbox should exit successfully with path exceptions"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_extra_rwx_flag() {
+    if !sandbox_runtime_works() {
+        eprintln!("skipping: sandbox runtime not available");
+        return;
+    }
+
+    // Test that --extra-rwx flag is accepted
+    let output = Command::new(binary_path())
+        .args(["--extra-rwx", "/tmp", "--working-dir", "/tmp", "--", "true"])
+        .output()
+        .expect("failed to spawn sandbox");
+
+    assert!(
+        output.status.success(),
+        "sandbox should exit successfully with --extra-rwx"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_no_defaults_flag() {
+    if !sandbox_runtime_works() {
+        eprintln!("skipping: sandbox runtime not available");
+        return;
+    }
+
+    // Test that --no-defaults flag is accepted (will fail without explicit paths)
+    // but we give it explicit paths for execution
+    let output = Command::new(binary_path())
+        .args([
+            "--no-defaults",
+            "--exec",
+            "/bin",
+            "--exec",
+            "/usr",
+            "--exec",
+            "/lib",
+            "--read",
+            "/tmp",
+            "--write",
+            "/tmp",
+            "--working-dir",
+            "/tmp",
+            "--",
+            "true",
+        ])
+        .output()
+        .expect("failed to spawn sandbox");
+
+    assert!(
+        output.status.success(),
+        "sandbox should exit successfully with --no-defaults and explicit paths"
+    );
+}

--- a/docker/harnx.Dockerfile
+++ b/docker/harnx.Dockerfile
@@ -17,3 +17,5 @@ COPY linux-${TARGETARCH}/harnx-mcp-time /usr/local/bin/harnx-mcp-time
 COPY linux-${TARGETARCH}/harnx-aws-creds /usr/local/bin/harnx-aws-creds
 COPY linux-${TARGETARCH}/harnx-pkg /usr/local/bin/harnx-pkg
 COPY linux-${TARGETARCH}/harnx-proxy-auth /usr/local/bin/harnx-proxy-auth
+COPY linux-${TARGETARCH}/harnx-sandbox-run /usr/local/bin/harnx-sandbox-run
+COPY linux-${TARGETARCH}/harnx-sandbox-exec /usr/local/bin/harnx-sandbox-exec

--- a/docs/aws-creds.md
+++ b/docs/aws-creds.md
@@ -1,0 +1,90 @@
+# harnx-aws-creds
+
+`harnx-aws-creds` is a persistent hook that injects AWS credentials into sandboxed processes. It runs as a sidecar alongside `harnx-mcp-bash` or `harnx-sandbox-run`, resolving credentials from the host and making them available inside the sandbox without mounting `~/.aws` or leaking raw key material.
+
+## The Problem It Solves
+
+The birdcage sandbox blocks access to `~/.aws`, and the bash MCP server strips `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` from the child environment by default (they're not in the allowlist). Without `harnx-aws-creds`, any AWS CLI or SDK call inside the sandbox fails with "no credentials found".
+
+## How It Works
+
+1. **Resolves credentials on the host** using the standard [AWS credential chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html): environment variables → `~/.aws/credentials` → `~/.aws/config` profiles → IAM instance role → SSO → etc.
+2. **Starts a local HTTP server** on `127.0.0.1:<random-port>` implementing the [AWS container credentials protocol](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html). This is a standard protocol all AWS SDKs support natively.
+3. **Injects three environment variables** into every `bash_exec`/`bash_spawn` tool call via the hook's `PreToolUse` mutation:
+   - `AWS_CONTAINER_CREDENTIALS_FULL_URI` — URL of the local server (`http://127.0.0.1:<port>/creds`)
+   - `AWS_CONTAINER_AUTHORIZATION_TOKEN` — a per-session UUID bearer token
+   - `AWS_REGION` — the region resolved from config
+
+When the sandboxed process calls any AWS SDK, the SDK fetches credentials from the local server. The sandbox process never sees `~/.aws` or raw `AWS_ACCESS_KEY_ID` values — it only knows the loopback URL.
+
+## Installation
+
+```bash
+cargo install harnx-aws-creds
+```
+
+## Usage
+
+### With `harnx-sandbox-run`
+
+```bash
+# Default credential chain (env vars, ~/.aws default profile, IAM role, SSO, etc.)
+harnx-sandbox-run --hook claude-command-persistent harnx-aws-creds \; -- aws s3 ls
+
+# Specific named profile from ~/.aws/config
+harnx-sandbox-run --hook claude-command-persistent harnx-aws-creds --profile my-profile \; -- aws s3 ls
+```
+
+### With `harnx-mcp-bash` (via agent config)
+
+In your agent's YAML config:
+
+```yaml
+hooks:
+  - event: PreToolUse
+    type: claude-command-persistent
+    command: "harnx-aws-creds"
+```
+
+With a specific profile:
+
+```yaml
+hooks:
+  - event: PreToolUse
+    type: claude-command-persistent
+    command: "harnx-aws-creds --profile my-profile"
+```
+
+## CLI Reference
+
+```text
+harnx-aws-creds [OPTIONS]
+
+Options:
+  --profile <PROFILE>  AWS profile name to use (default: standard credential chain)
+  -h, --help           Print help
+```
+
+### `--profile`
+
+Selects a named profile from `~/.aws/config` or `~/.aws/credentials`. Equivalent to setting `AWS_PROFILE=<name>` on the host before running the hook, but scoped to this hook process only.
+
+If omitted, the AWS SDK default credential chain applies:
+1. `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` env vars on the host
+2. `[default]` profile in `~/.aws/credentials` and `~/.aws/config`
+3. IAM instance/task/pod role (EC2, ECS, EKS)
+4. AWS SSO (`aws sso login`)
+5. Process credentials provider
+6. Web identity token
+
+## Security Notes
+
+- The HTTP server binds to **loopback only** (`127.0.0.1`), never to `0.0.0.0`
+- The bearer token is a **random UUID generated per session** — it changes every time `harnx-aws-creds` starts
+- The token is printed to stderr so operators can see it: `harnx-aws-creds: authorization token: <uuid>`
+- Credentials are fetched on-demand from the provider, so short-lived credentials (STS, SSO) are refreshed automatically
+- `~/.aws` is never mounted into the sandbox — the credential files remain inaccessible to the sandboxed process
+
+## Relationship to `harnx-mcp-bash`
+
+When `harnx-mcp-bash` runs a command in the sandbox, it strips most environment variables (including `AWS_*`) from the child process to prevent accidental credential leakage. `harnx-aws-creds` is the approved re-injection path: it uses the hook mechanism to add only the container credential protocol variables, which point to a localhost proxy rather than exposing raw keys.

--- a/docs/sandbox-run.md
+++ b/docs/sandbox-run.md
@@ -1,0 +1,347 @@
+# harnx-sandbox-run
+
+## Overview
+
+`harnx-sandbox-run` is a standalone utility to run arbitrary commands inside the [birdcage](https://github.com/phylum-dev/birdcage) filesystem sandbox. It provides the same sandboxing defaults and configuration as `harnx-mcp-bash`, but as a general-purpose wrapper for any CLI tool.
+
+This is particularly useful for running AI coding agents (like Claude Code or the Gemini CLI) safely. By running them inside the sandbox, you can bypass their internal permission prompts while maintaining a strict, verifiable safety boundary at the OS level.
+
+## Installation
+
+```bash
+cargo install harnx-sandbox-run
+```
+
+## Basic Usage
+
+Run an interactive bash session in the sandbox:
+```bash
+harnx-sandbox-run -- bash
+```
+
+Run a non-interactive command:
+```bash
+harnx-sandbox-run -- bash -c "echo hello"
+```
+
+## AI Agent Wrapper Scripts
+
+The primary use case for `harnx-sandbox-run` is running AI coding agents with bypassed permissions. Since the sandbox provides the actual safety boundary (preventing writes outside the project, network calls to unexpected hosts, etc.), the agent's own interactive permission prompts become redundant.
+
+### Claude Code (`claude-sb`)
+
+Create a script named `claude-sb`. This example shows the full setup with AWS credentials, GitHub auth (git over HTTPS + API), and Atlassian (Jira/Confluence) — remove any sections you don't need:
+
+```bash
+#!/usr/bin/env bash
+# claude-sb — run Claude Code inside the birdcage sandbox
+#
+# --dangerously-skip-permissions bypasses Claude's own permission prompts;
+# the sandbox is the actual safety boundary.
+#
+# Credentials are injected via hooks — real tokens never enter the sandbox:
+#   - harnx-aws-creds: resolves AWS credentials from the host and exposes
+#     them via the container credentials protocol (no raw keys in env)
+#   - harnx-proxy-auth: HTTPS MITM proxy that intercepts outbound requests
+#     and injects auth headers; --env scripts put fake sentinel tokens into
+#     the sandbox env so the LLM never sees real credentials
+exec harnx-sandbox-run \
+  \
+  --extra-rwx ~/projects \
+  \
+  --extra-rwx ~/.claude \
+  --extra-rwx ~/.local/share/claude \
+  --extra-write ~/.claude.json \
+  \
+  --env "EDITOR=true" \
+  --env "PUPPETEER_NO_SANDBOX=1" \
+  \
+  --hook claude-command-persistent harnx-aws-creds --profile my-profile \; \
+  \
+  --hook claude-command-persistent harnx-proxy-auth \
+    --env 'if env.GITHUB_TOKEN
+        then .GITHUB_TOKEN = "ghp_\($fake_base64_key)"
+        end' \
+    --hook 'if .host == "github.com"
+            and .headers.authorization == basic("x-access-token"; "ghp_\($fake_base64_key)")
+        then .headers.authorization = basic("x-access-token"; env.GITHUB_TOKEN)
+        end' \
+    --hook 'if (.host == "api.github.com"
+                or .host == "uploads.github.com"
+                or .host == "objects.githubusercontent.com")
+            and (.headers.authorization == bearer("ghp_\($fake_base64_key)")
+                 or .headers.authorization == "token ghp_\($fake_base64_key)")
+        then .headers.authorization = bearer(env.GITHUB_TOKEN)
+        end' \
+    --env 'if env.ATLASSIAN_API_TOKEN and env.ATLASSIAN_EMAIL
+        then .ATLASSIAN_API_TOKEN = $fake_uuid_key | .ATLASSIAN_EMAIL = $fake_email
+        end' \
+    --hook 'if (.host | endswith(".atlassian.net"))
+            and .headers.authorization == basic($fake_email; $fake_uuid_key)
+        then .headers.authorization = basic(env.ATLASSIAN_EMAIL; env.ATLASSIAN_API_TOKEN)
+        end' \
+  \; \
+  \
+  -- \
+  claude --dangerously-skip-permissions "$@"
+```
+
+**Key points:**
+- Replace `~/projects` with a folder where you have files the agent needs to work on, and `my-profile` with your AWS profile name (omit `--hook ... harnx-aws-creds ...` entirely if you don't need AWS).
+- The `--env` scripts inject fake sentinel tokens (e.g. `ghp_<random>`) into the sandbox so `gh` sees `GITHUB_TOKEN` set and considers itself authenticated. The real token never enters the sandbox — `harnx-proxy-auth` reads it from the host env and injects it into outbound HTTP headers.
+- Remove the Atlassian block if you don't use Jira/Confluence.
+- `if COND then EXPR end` — omitting `else` passes the input through unchanged (jaq default).
+
+### Gemini CLI (`gemini-sb`)
+
+Create a script named `gemini-sb`:
+
+```bash
+#!/usr/bin/env bash
+# gemini-sb — run Gemini CLI inside the birdcage sandbox
+#
+# --yolo bypasses Gemini's own permission prompts;
+# the sandbox is the actual safety boundary.
+#
+# ~/.gemini        — global settings, OAuth credentials, commands, skills
+# ~/.config/gemini — XDG config fallback (used on some systems)
+# .                — the project directory you want the agent to work in
+#                    (the sandbox does NOT whitelist the current directory
+#                    automatically — you must grant access explicitly;
+#                    passing . is safe: harnx-sandbox-run resolves it and
+#                    refuses to grant access if it would expose $HOME)
+exec harnx-sandbox-run \
+  --extra-rwx ~/.gemini \
+  --extra-rwx ~/.config/gemini \
+  --extra-rwx . \
+  -- \
+  gemini --yolo "$@"
+```
+
+> **Note:** Pass `--extra-rwx` for each additional project directory you want Gemini to access. The sandbox restricts writes to only the paths you explicitly grant.
+
+### Installation
+
+1. Save the scripts to a directory in your `PATH` (e.g., `~/.local/bin/`).
+2. Make them executable:
+   ```bash
+   chmod +x ~/.local/bin/claude-sb ~/.local/bin/gemini-sb
+   ```
+
+## CLI Reference
+
+| Option | Description |
+| :--- | :--- |
+| `--extra-read <path>` | Add sandbox read-only path (may be repeated) |
+| `--extra-write <path>` | Add sandbox writable path (may be repeated) |
+| `--extra-exec <path>` | Add sandbox execute path (may be repeated) |
+| `--extra-rwx <PATH>` | Add full rwx access for path (may be repeated) |
+| `--env <VAR[=VALUE]>` | Set environment variable; if VALUE omitted, inherit from host |
+| `--no-network` | Disable network access |
+| `--working-dir <DIR>` | Working directory for the command |
+| `--no-defaults` | Skip default whitelist (system paths, home paths, etc.) |
+| `--hook <TYPE> <CMD> [ARGS...] \;` | Pre-run hook for credential injection |
+| `-h, --help` | Print help |
+
+## Environment Variables
+
+These match the `harnx-mcp-bash` environment variables, so the same shell profile settings work for both:
+
+| Variable | Format | Effect |
+| :--- | :--- | :--- |
+| `HARNX_BASH_EXTRA_READABLE` | Colon-separated paths | Extra sandbox read-only paths |
+| `HARNX_BASH_EXTRA_EXEC` | Colon-separated paths | Extra sandbox execute paths |
+| `HARNX_BASH_EXTRA_WRITABLE` | Colon-separated paths | Extra sandbox writable paths |
+| `HARNX_BASH_EXTRA_RWX` | Colon-separated paths | Extra sandbox read/write/exec paths |
+| `HARNX_BASH_ENV_PASSTHROUGH` | Comma-separated names | Extra host env var names to pass through |
+
+Paths support `~` expansion. CLI flags and env vars both accumulate — they are not mutually exclusive.
+
+> **Note:** The `<COMMAND>` must come after `--` or at the very end of the arguments.
+
+## Default Whitelist
+
+By default, `harnx-sandbox-run` grants access to a curated set of system paths and common developer tools (like `cargo`, `npm`, and `git`).
+
+For the full list of default paths, see the [Bash MCP Server documentation](bash-mcp-server.md#default-environment-allowlist).
+
+### Current directory
+
+**The current working directory is NOT whitelisted automatically.** birdcage inherits the process's cwd so the command starts in the right place, but the sandbox blocks all reads and writes there unless you explicitly grant access:
+
+```bash
+harnx-sandbox-run --extra-rwx . -- my-tool
+```
+
+Passing `.` is safe: `harnx-sandbox-run` resolves it to an absolute path before use. If the resolved path is `$HOME` itself or an ancestor of `$HOME` (e.g. `/`), the path is silently skipped and a warning is printed to stderr — so running `gemini-sb` from your home directory won't accidentally expose all of `~`.
+
+The `--working-dir <path>` flag changes where the sandboxed command starts, but it also does not automatically grant filesystem access to that path — you still need a matching `--extra-rwx` (or `--extra-read` / `--extra-write`) for it.
+
+### Home directory
+
+**`$HOME` itself is NOT whitelisted.** Only specific subdirectories are granted access by default, covering common developer toolchains and dotfiles:
+
+| Access | Paths |
+| :----- | :---- |
+| Read | `~/.gitconfig`, `~/.gitignore`, `~/.gitignore_global`, `~/.tool-versions` |
+| Read/Write | `~/.cache`, `~/go/pkg` |
+| Read/Write/Exec | `~/.npm`, `~/.yarn`, `~/.nvm`, `~/.cargo`, `~/.pyenv`, `~/.rye`, `~/.bun`, `~/.local/share/claude`, `~/.local/share/uv`, `~/.local/share/pnpm`, `~/.local/share/pipx`, `~/.local/share/opencode` |
+| Exec | `~/.local/bin`, `~/.local/lib`, `~/.asdf`, `~/.bun`, `~/go/bin` |
+
+Any other `$HOME` subdirectory (e.g. `~/.gemini`, `~/.config`, `~/.ssh`) is **blocked** unless you add it with `--extra-read`, `--extra-write`, or `--extra-rwx`. This is intentional — it prevents the sandboxed process from reading credentials or config files it doesn't need.
+
+## Hooks
+
+Hooks allow you to run a command before the main process starts to inject credentials or mutate the environment.
+
+**Syntax:** `--hook TYPE CMD ARGS... \;`
+
+- **TYPE**: Currently supports `claude-command` (one-shot) or `claude-command-persistent`.
+- **CMD ARGS...**: The command to execute and its arguments.
+- **`\;`**: Terminates the hook definition (the backslash is required in most shells to prevent the `;` from being interpreted as a command separator).
+
+### Example: AWS Credentials with `harnx-aws-creds`
+
+`harnx-aws-creds` is a purpose-built persistent hook that makes AWS credentials available inside the sandbox without mounting `~/.aws` or exposing raw key material as plain environment variables.
+
+**How it works:**
+
+1. On startup, it resolves credentials from the host using the standard AWS credential chain (env vars → `~/.aws/credentials` → IAM instance role → SSO → etc.)
+2. It starts a local HTTP server on `127.0.0.1:<random-port>` implementing the [AWS container credentials protocol](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html)
+3. For every `bash_exec`/`bash_spawn` tool call it injects three env vars into the sandboxed process:
+   - `AWS_CONTAINER_CREDENTIALS_FULL_URI` — points to the local server
+   - `AWS_CONTAINER_AUTHORIZATION_TOKEN` — a per-session bearer token
+   - `AWS_REGION` — resolved from config
+
+The AWS SDK inside the sandbox calls back to the local server to fetch credentials on demand. The sandbox process never sees `~/.aws` or raw `AWS_ACCESS_KEY_ID` values. See [harnx-aws-creds documentation](aws-creds.md) for full details.
+
+```bash
+# Use the default credential chain (env vars, ~/.aws default profile, IAM role, etc.)
+harnx-sandbox-run --hook claude-command-persistent harnx-aws-creds \; -- claude
+
+# Use a specific named profile from ~/.aws/config
+harnx-sandbox-run --hook claude-command-persistent harnx-aws-creds --profile my-profile \; -- claude
+```
+
+### Example: GitHub credentials with `harnx-proxy-auth`
+
+The sandbox strips `GITHUB_TOKEN` from the child environment by default. `harnx-proxy-auth` is an HTTPS MITM proxy hook that intercepts outbound requests and injects auth headers, so the real token never has to enter the sandbox directly.
+
+**How it works:**
+
+1. An `--env` script runs on startup, reads `GITHUB_TOKEN` from the host env, and injects a fake sentinel token (e.g. `ghp_<random>`) into the sandbox's environment. Tools like `gh` see a non-empty `GITHUB_TOKEN` and consider themselves authenticated.
+2. `--hook` jaq filters run on every outbound HTTPS request. When they see a request carrying the sentinel token, they replace it with `bearer(env.GITHUB_TOKEN)` (the real token, read from the host-side proxy process).
+
+The real token never crosses into the sandbox — it only appears in HTTP headers on the wire.
+
+Available jaq helpers: `bearer(token)` → `"Bearer <token>"`, `basic(user; pass)` → `"Basic <base64(user:pass)>"`.
+
+```bash
+harnx-sandbox-run \
+  --hook claude-command-persistent harnx-proxy-auth \
+    --env 'if env.GITHUB_TOKEN
+        then .GITHUB_TOKEN = "ghp_\($fake_base64_key)"
+        end' \
+    --hook 'if .host == "github.com"
+            and .headers.authorization == basic("x-access-token"; "ghp_\($fake_base64_key)")
+        then .headers.authorization = basic("x-access-token"; env.GITHUB_TOKEN)
+        end' \
+    --hook 'if (.host == "api.github.com"
+                or .host == "uploads.github.com"
+                or .host == "objects.githubusercontent.com")
+            and (.headers.authorization == bearer("ghp_\($fake_base64_key)")
+                 or .headers.authorization == "token ghp_\($fake_base64_key)")
+        then .headers.authorization = bearer(env.GITHUB_TOKEN)
+        end' \
+  \; \
+  -- gh api user
+```
+
+Three hooks are needed because GitHub uses different auth schemes per endpoint:
+- `github.com` — git over HTTPS uses `Basic x-access-token:<token>`
+- `api.github.com`, `uploads.github.com`, `objects.githubusercontent.com` — REST/GraphQL APIs use `Bearer <token>` (curl, SDKs) or `token <token>` (`gh` CLI)
+
+The hooks match the *exact* sentinel values injected by `--env` — `basic("x-access-token"; "ghp_\($fake_base64_key)")`, `bearer("ghp_\($fake_base64_key)")`, and `"token ghp_\($fake_base64_key)"` — so they only fire on requests carrying the fake credential, never on a real token the user might have set independently.
+
+`if COND then EXPR end` — omitting `else` passes the request through unchanged when the condition is false.
+
+### Example: Atlassian (Jira / Confluence) with `harnx-proxy-auth`
+
+Atlassian's REST API uses HTTP Basic auth with your email as the username and an API token as the password.
+
+```bash
+harnx-sandbox-run \
+  --hook claude-command-persistent harnx-proxy-auth \
+    --env 'if env.ATLASSIAN_API_TOKEN and env.ATLASSIAN_EMAIL
+        then .ATLASSIAN_API_TOKEN = $fake_uuid_key | .ATLASSIAN_EMAIL = $fake_email
+        end' \
+    --hook 'if (.host | endswith(".atlassian.net"))
+            and .headers.authorization == basic($fake_email; $fake_uuid_key)
+        then .headers.authorization = basic(env.ATLASSIAN_EMAIL; env.ATLASSIAN_API_TOKEN)
+        end' \
+  \; \
+  -- acli jira workitem search --jql "assignee = currentUser() AND resolution = Unresolved"
+```
+
+The `--env` script injects fake sentinel values (`$fake_uuid_key` for the token, `$fake_email` for the email) into the sandbox. The `--hook` filter matches requests carrying those sentinels and replaces them with the real credentials from the host env. Set `ATLASSIAN_EMAIL` and `ATLASSIAN_API_TOKEN` in your host shell before running.
+
+### Combining multiple hooks in one `harnx-proxy-auth` invocation
+
+All `--env` and `--hook` flags for a single `harnx-proxy-auth` instance accumulate — you don't need separate hook invocations for GitHub and Atlassian:
+
+```bash
+harnx-sandbox-run \
+  --hook claude-command-persistent harnx-proxy-auth \
+    --env 'if env.GITHUB_TOKEN
+        then .GITHUB_TOKEN = "ghp_\($fake_base64_key)"
+        end' \
+    --hook 'if (.host == "api.github.com" or .host == "uploads.github.com" or .host == "objects.githubusercontent.com")
+            and (.headers.authorization == bearer("ghp_\($fake_base64_key)")
+                 or .headers.authorization == "token ghp_\($fake_base64_key)")
+        then .headers.authorization = bearer(env.GITHUB_TOKEN)
+        end' \
+    --hook 'if .host == "github.com"
+            and .headers.authorization == basic("x-access-token"; "ghp_\($fake_base64_key)")
+        then .headers.authorization = basic("x-access-token"; env.GITHUB_TOKEN)
+        end' \
+    --env 'if env.ATLASSIAN_API_TOKEN and env.ATLASSIAN_EMAIL
+        then .ATLASSIAN_API_TOKEN = $fake_uuid_key | .ATLASSIAN_EMAIL = $fake_email
+        end' \
+    --hook 'if (.host | endswith(".atlassian.net"))
+            and .headers.authorization == basic($fake_email; $fake_uuid_key)
+        then .headers.authorization = basic(env.ATLASSIAN_EMAIL; env.ATLASSIAN_API_TOKEN)
+        end' \
+  \; \
+  -- my-tool
+```
+
+See the `claude-sb` wrapper script above for a complete working example combining AWS credentials, GitHub, and Atlassian in one invocation.
+
+## Extra Path Access
+
+If a tool needs access to paths not in the default whitelist, use the access flags:
+
+- `--extra-read`: Read-only access (e.g., for config files)
+- `--extra-write`: Write access (e.g., for log files)
+- `--extra-exec`: Execution access (e.g., for binaries)
+- `--extra-rwx`: Full read, write, and execute access
+
+```bash
+harnx-sandbox-run --extra-rwx ~/.custom-tool-cache -- my-tool
+```
+
+## Network Access
+
+Network access is enabled by default. To run a command in a fully network-isolated environment:
+
+```bash
+harnx-sandbox-run --no-network -- cargo test
+```
+
+## Platform Support
+
+`harnx-sandbox-run` relies on `birdcage`, which currently supports:
+- **Linux**
+- **macOS**
+
+Windows is currently not supported for filesystem sandboxing.

--- a/docs/solutions/integration-issues/birdcage-env-passthrough-2026-05-28.md
+++ b/docs/solutions/integration-issues/birdcage-env-passthrough-2026-05-28.md
@@ -1,0 +1,143 @@
+---
+title: "Birdcage Environment Variable Passthrough for Interactive Sandboxes"
+date: 2026-05-28
+category: integration-issues
+problem_type: integration_issue
+component: harnx-sandbox-run
+root_cause: "Birdcage Exception::Environment only allows explicitly whitelisted vars; default environment wiped without explicit passthrough list"
+resolution_type: code_fix
+severity: high
+tags:
+  - sandboxing
+  - birdcage
+  - environment-variables
+  - interactive-shell
+  - security
+plan_ref: harnx-sandbox-run
+---
+
+## Problem
+
+Birdcage sandbox starts with empty environment unless variables are explicitly added via `Exception::Environment`. A standalone sandbox wrapper that doesn't inherit baseline `PATH`, `HOME`, `TERM`, etc. breaks interactive shell use.
+
+## Symptoms
+
+- `harnx-sandbox-run -- bash` fails with "bash: command not found" (no `PATH`)
+- Shell startup files fail to find `HOME`
+- Terminal features missing (no `TERM`)
+- XDG tools cannot locate config directories
+
+## Investigation Steps
+
+1. Tested `harnx-sandbox-run -- env` — output was empty except explicit `--env` vars
+2. Reviewed `harnx-mcp-bash/server.rs` — uses `DEFAULT_ENV_ALLOWLIST` for baseline vars
+3. Checked birdcage docs — `Exception::Environment` is whitelist, not passthrough
+4. Compared MCP server (curated env) vs standalone runner (intended parity)
+
+## Root Cause
+
+Birdcage's `restrict_env_variables()` blocks all environment variables except those explicitly added:
+
+```rust
+// In birdcage internals:
+fn restrict_env_variables() {
+    for (key, _) in std::env::vars() {
+        if !allowed.contains(&key) {
+            std::env::remove_var(&key);
+        }
+    }
+}
+```
+
+The `harnx-sandbox-run` initial implementation added only:
+1. CLI `--env KEY=VALUE` args
+2. Hook-provided env mutations
+
+No baseline vars (`HOME`, `PATH`, `TERM`) were inherited, breaking shell ergonomics.
+
+## Solution
+
+Define a default passthrough list and apply before CLI/hook overrides:
+
+```rust
+#[cfg(unix)]
+const DEFAULT_ENV_PASSTHROUGH: &[&str] = &[
+    "HOME", "USER", "LOGNAME", "SHELL", "TERM",
+    "LANG", "LC_ALL", "LC_CTYPE", "PATH", "TMPDIR",
+];
+
+// Apply baseline env
+let mut all_env: Vec<(String, String)> = Vec::new();
+
+for name in DEFAULT_ENV_PASSTHROUGH {
+    if let Ok(value) = env::var(name) {
+        all_env.push((name.to_string(), value));
+    }
+}
+
+// XDG_* convention: passthrough all XDG-prefixed vars
+for (name, value) in env::vars() {
+    if name.starts_with("XDG_") && !all_env.iter().any(|(k, _)| k == &name) {
+        all_env.push((name, value));
+    }
+}
+
+// CLI --env (overwrites baseline)
+for raw in &cli.env_vars {
+    // parse KEY=VALUE and push
+}
+
+// Hook-provided env (highest precedence)
+for (key, value) in hook_env {
+    all_env.push((key, value));
+}
+
+// Apply to sandbox
+for (key, value) in all_env {
+    sandbox.add_exception(Exception::Environment(key.into()))?;
+    env::set_var(&key, &value);
+}
+```
+
+**Precedence order** (low to high):
+1. `DEFAULT_ENV_PASSTHROUGH` baseline
+2. `XDG_*` automatic passthrough
+3. CLI `--env KEY=VALUE`
+4. Hook-injected env
+
+## Why This Works
+
+1. **Shell usability**: `PATH` allows finding commands, `HOME` allows `~` expansion, `TERM` enables colors/paging
+2. **Tool compatibility**: XDG vars (`XDG_CONFIG_HOME`, `XDG_DATA_HOME`) are standard for Linux desktop tools
+3. **Security maintained**: Explicit list prevents leaking secrets like `AWS_SECRET_ACCESS_KEY`
+4. **Override capability**: CLI and hooks can still override any value (precedence)
+
+This mirrors the `DEFAULT_ENV_ALLOWLIST` in `harnx-mcp-bash` while keeping separate constants (standalone use has slightly different ergonomics).
+
+## Prevention Strategies
+
+**Test Cases:**
+- Assert `PATH`, `HOME`, `TERM` present in sandboxed child
+- Assert `XDG_*` vars passed through
+- Assert CLI `--env` overwrites baseline
+- Assert hook env overwrites CLI and baseline
+
+**Best Practices:**
+- Always define baseline env passthrough for interactive sandboxes
+- Document precedence order explicitly
+- Test both with and without hooks (different code paths)
+- Use `Exception::Environment` + `set_var` before `spawn()` — birdcage inspects current process env
+
+**Code Review Checklist:**
+- [ ] Is baseline env defined and applied before sandbox spawn?
+- [ ] Are XDG vars handled?
+- [ ] Is precedence documented and tested?
+- [ ] Are secrets excluded from default list?
+
+## Related Issues
+
+- **GitHub Issue:** [#575 — Standalone CLI Sandbox Wrapper](https://github.com/dobesv/harnx/issues/575)
+- **Plan:** harnx-sandbox-run
+- **Related Solution:** [../security-issues/environment-sanitization-bash-sandbox-2026-04-29.md](../security-issues/environment-sanitization-bash-sandbox-2026-04-29.md) — Full environment curation pattern
+- **Related Solution:** [per-call-env-param-bash-mcp-2026-05-13.md](per-call-env-param-bash-mcp-2026-05-13.md) — Per-call env override pattern
+- **Related Solution:** [../security-issues/sandbox-home-exposure-ancestor-walk-2026-05-21.md](../security-issues/sandbox-home-exposure-ancestor-walk-2026-05-21.md) — Path exception safety

--- a/docs/solutions/integration-issues/cli-hook-pre-parse-separator-2026-05-28.md
+++ b/docs/solutions/integration-issues/cli-hook-pre-parse-separator-2026-05-28.md
@@ -1,0 +1,139 @@
+---
+title: "Pre-Parsing Hook Definitions with -- Separator Boundary"
+date: 2026-05-28
+category: integration-issues
+problem_type: integration_issue
+component: harnx-sandbox-run
+root_cause: "Hook pre-parser continued past -- separator, intercepting --hook flags intended for wrapped command"
+resolution_type: code_fix
+severity: high
+tags:
+  - cli-parsing
+  - hooks
+  - argument-handling
+  - separator
+  - shell-semantics
+plan_ref: harnx-sandbox-run
+---
+
+## Problem
+
+The `--hook TYPE CMD ARGS \;` syntax requires custom pre-parsing before clap. Without proper boundary handling, `--hook` tokens after `--` separator were intercepted as hook definitions, preventing wrapped commands from using literal `--hook` flags.
+
+## Symptoms
+
+- `harnx-sandbox-run -- my-tool --hook config` panics with "unterminated --hook"
+- Wrapped tools cannot accept `--hook` as legitimate argument
+- CLI parser violates standard `--` separator contract (everything after `--` is literal)
+
+## Investigation Steps
+
+1. Reviewed `pre_parse_hooks()` implementation — iterated all tokens without `--` check
+2. Tested `harnx-sandbox-run -- /bin/echo --hook test` — parse error
+3. Traced origin: hook collection loop consumed all tokens
+4. Confirmed standard CLI convention: `--` terminates flag processing
+
+## Root Cause
+
+Pre-parse loop iterated over entire arg list:
+
+**before** (broken):
+```rust
+while let Some(token) = tokens.next() {
+    if token == "--hook" {
+        // collect until ; or \;
+        // PROBLEM: continues even after --
+    }
+    // ...
+}
+```
+
+The `--` separator is standard CLI convention meaning "all following tokens are positional args, not flags." The hook parser violated this by continuing to intercept `--hook` after `--`.
+
+## Solution
+
+Break hook scanning at `--` and collect remaining tokens literally:
+
+```rust
+pub fn pre_parse_hooks(raw: Vec<String>) -> Result<(Vec<HookDef>, Vec<String>)> {
+    let mut hooks = Vec::new();
+    let mut remaining = Vec::new();
+    let mut tokens = raw.into_iter().peekable();
+
+    while let Some(token) = tokens.next() {
+        if token == "--" {
+            // Stop hook scanning; collect all remaining tokens as-is
+            remaining.push(token);
+            remaining.extend(tokens);  // drains iterator
+            break;
+        } else if token == "--hook" {
+            // Collect hook tokens until ; or \;
+            let mut hook_tokens = Vec::new();
+            let mut terminated = false;
+
+            for token in tokens.by_ref() {
+                if token == ";" || token == "\\;" {
+                    terminated = true;
+                    break;
+                }
+                hook_tokens.push(token);
+            }
+
+            if !terminated {
+                anyhow::bail!("unterminated --hook (missing ';')");
+            }
+
+            if hook_tokens.len() < 2 {
+                anyhow::bail!("--hook requires TYPE and COMMAND");
+            }
+
+            hooks.push(HookDef {
+                hook_type: hook_tokens[0].clone(),
+                command: hook_tokens[1].clone(),
+                args: hook_tokens[2..].to_vec(),
+            });
+        } else {
+            remaining.push(token);
+        }
+    }
+
+    Ok((hooks, remaining))
+}
+```
+
+**Key insight**: `remaining.extend(tokens)` drains the iterator without further inspection, guaranteeing `--hook` after `--` reaches clap unchanged.
+
+## Why This Works
+
+1. **Standard contract honored**: Everything after `--` is positional
+2. **No ambiguity**: Wrapped tool receives `--hook` as literal argument
+3. **Termination before clap**: Hook extraction completes, then `remaining` goes to clap
+4. **Composable**: Multiple `--` tokens work correctly (standard Unix behavior)
+
+The pattern generalizes to any CLI with custom pre-parse requirements:
+1. Pre-parse extracts special forms
+2. Stop at `--`, collect rest verbatim
+3. Pass remaining to standard parser
+
+## Prevention Strategies
+
+**Test Cases:**
+- `--hook type cmd ; -- wrapped-tool --hook config` → hook extracted, `--hook config` passed through
+- `-- --hook literal` → no hooks, `--hook literal` in remaining
+- Multiple hooks before `--` → all extracted
+
+**Best Practices:**
+- Always respect `--` separator in custom CLI parsing
+- `extend(tokens)` pattern is idiomatic for "collect rest verbatim"
+- Document the `--` boundary behavior explicitly
+
+**Code Review Checklist:**
+- [ ] Does pre-parse stop at `--`?
+- [ ] Are remaining tokens after `--` passed unchanged?
+- [ ] Is there a regression test for `--hook` after `--`?
+
+## Related Issues
+
+- **GitHub Issue:** [#575 — Standalone CLI Sandbox Wrapper](https://github.com/dobesv/harnx/issues/575)
+- **Plan:** harnx-sandbox-run
+- **Related Solution:** [per-call-env-param-bash-mcp-2026-05-13.md](per-call-env-param-bash-mcp-2026-05-13.md) — `--env` before `--` separator pattern

--- a/docs/solutions/integration-issues/tokio-birdcage-runtime-lifecycle-2026-05-28.md
+++ b/docs/solutions/integration-issues/tokio-birdcage-runtime-lifecycle-2026-05-28.md
@@ -1,0 +1,125 @@
+---
+title: "Tokio Runtime Lifecycle for Birdcage Sandbox Activation"
+date: 2026-05-28
+category: integration-issues
+problem_type: integration_issue
+component: harnx-sandbox-run
+root_cause: "Birdcage sandbox requires single-threaded context; tokio async runtime conflicts with namespace setup"
+resolution_type: code_fix
+severity: high
+tags:
+  - sandboxing
+  - birdcage
+  - tokio
+  - runtime-lifecycle
+  - namespaces
+  - process-isolation
+plan_ref: harnx-sandbox-run
+---
+
+## Problem
+
+Birdcage sandbox uses Linux namespaces (user, mount, PID) that must be activated from a single-threaded context. A tokio multi-threaded runtime prevents proper namespace setup, causing sandbox activation to fail or behave incorrectly.
+
+## Symptoms
+
+- Sandbox activation panics or returns thread-safety errors when called from within async context
+- Spawning sandboxed child processes hangs or returns `EPERM`/`EACCES`
+- Namespace isolation incomplete — sandboxed process can see host filesystem
+
+## Investigation Steps
+
+1. Reviewed birdcage crate documentation — requires `fork()`-like semantics in single-threaded context
+2. Tested `#[tokio::main]` pattern — runtime blocks namespace creation
+3. Tested `current_thread` runtime dropped before birdcage setup — works
+4. Separated concerns: hook dispatch needs async, sandbox activation does not
+
+## Root Cause
+
+Birdcage's `Sandbox::spawn()` internally calls `clone()` with namespace flags (`CLONE_NEWUSER`, `CLONE_NEWNS`, `CLONE_NEWPID`). The kernel's namespace implementation requires:
+
+1. Single-threaded process at namespace creation time
+2. No other threads holding references to resources being namespaced
+
+A tokio runtime (even `current_thread`) creates internal state that conflicts with namespace setup. The runtime must be fully dropped before birdcage operations.
+
+## Solution
+
+Use a short-lived `current_thread` tokio runtime for async work, then drop it before sandbox setup:
+
+**before** (broken):
+```rust
+#[tokio::main]
+async fn main() -> Result<()> {
+    let hook_env = hooks::run_hooks(&hook_defs, ...).await?;
+    sandbox::setup_and_spawn(&cli, hook_env)?;  // FAILS: runtime still active
+    Ok(())
+}
+```
+
+**after** (correct):
+```rust
+fn main() -> Result<()> {
+    let hook_env = if !hook_defs.is_empty() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        let env = rt.block_on(hooks::run_hooks(&hook_defs, ...))?;
+        drop(rt);  // CRITICAL: drop runtime before birdcage
+        env
+    } else {
+        HashMap::new()
+    };
+    
+    // Now safe: no tokio runtime active
+    sandbox::setup_and_spawn(&cli, hook_env)?;
+    Ok(())
+}
+```
+
+**Key pattern**: 
+1. Sync `main()` — no `#[tokio::main]`
+2. Create `current_thread` runtime only when needed (hooks)
+3. `rt.block_on()` for async work
+4. `drop(rt)` before any birdcage call
+5. Remaining execution is fully synchronous
+
+## Why This Works
+
+1. **Explicit runtime lifecycle**: `new_current_thread()` creates minimal async support without thread-pool overhead
+2. **Clean state**: `drop(rt)` ensures all tokio internals (wakers, task queues) are released
+3. **Namespace isolation**: Birdcage's `clone()` runs in pristine single-threaded process
+4. **No contention**: Hook async work completes before sandbox setup begins
+
+This pattern is appropriate when:
+- Async work is bounded (hooks, I/O setup) and completes before sandbox lock
+- Remaining execution is synchronous process management
+- Multiple sandboxed children aren't spawned concurrently
+
+For concurrent sandboxed spawns, use the **subprocess pattern** instead (see `cli-wrapper-sandboxing-for-tokio-servers-2026-04-28.md`).
+
+## Prevention Strategies
+
+**Test Cases:**
+- Verify sandbox activation succeeds after hook runtime drop
+- Test with both empty hooks (no runtime) and populated hooks (runtime created + dropped)
+- Assert sandboxed child cannot access paths outside whitelist
+
+**Best Practices:**
+- When integrating sandbox crates with tokio, check if crate requires single-threaded context
+- Prefer `current_thread` runtime when async work is preparatory, not ongoing
+- Explicitly drop runtimes before calling into sandboxing layer
+- Document the runtime lifecycle requirement at module boundary
+
+**Code Review Checklist:**
+- [ ] Is birdcage/spawn called after runtime drop?
+- [ ] Is `current_thread` runtime used instead of multi-threaded?
+- [ ] Is hook dispatch bounded (no post-sandbox async work)?
+- [ ] Are tests present for both hook and non-hook paths?
+
+## Related Issues
+
+- **GitHub Issue:** [#575 — Standalone CLI Sandbox Wrapper](https://github.com/dobesv/harnx/issues/575)
+- **Plan:** harnx-sandbox-run
+- **Related Solution:** [cli-wrapper-sandboxing-for-tokio-servers-2026-04-28.md](cli-wrapper-sandboxing-for-tokio-servers-2026-04-28.md) — Subprocess wrapper pattern for tokio servers
+- **Related Solution:** [../security-issues/environment-sanitization-bash-sandbox-2026-04-29.md](../security-issues/environment-sanitization-bash-sandbox-2026-04-29.md) — Environment control for sandboxed processes

--- a/example_config/config.yaml
+++ b/example_config/config.yaml
@@ -52,10 +52,28 @@ toolsets:
 # PreToolUse hooks can return hookSpecificOutput.toolInput to mutate tool arguments.
 # PostToolUse hooks can return hookSpecificOutput.toolResponse to mutate the tool response.
 #
-# Example: Inject GitHub auth headers via harnx-proxy-auth using --env sentinel technique.
-# The --env script emits real variable names with fake sentinel values. The hook matches
-# the sentinel in outbound requests and replaces it with the real token from the environment.
-# This prevents the real token from appearing in logs or process listings.
+# ---- harnx-proxy-auth: credential injection via HTTPS MITM proxy ----
+#
+# harnx-proxy-auth intercepts outbound HTTPS requests and injects auth headers.
+# It uses a sentinel technique: --env scripts inject fake placeholder tokens into
+# the child bash environment (so the LLM never sees real credentials), then --hook
+# filters match those sentinels in outgoing requests and replace them with real tokens.
+#
+# Available jaq helpers in --hook filters:
+#   bearer(token)         =>  "Bearer <token>"
+#   basic(user; password) =>  "Basic <base64(user:password)>"
+#
+# Available sentinel variables in --env and --hook scripts:
+#   $fake_uuid_key        random UUID (matches typical API key format)
+#   $fake_base64_key      random base64 string
+#   $fake_url_base64_key  random URL-safe base64 string
+#   $fake_hex_key         random 32-char hex string
+#   $fake_email           random fake email address
+#
+# `if COND then EXPR end` — omitting `else` passes the input through unchanged when
+# the condition is false (equivalent to `else .` in jaq but cleaner).
+#
+# Example: GitHub auth injection (git over HTTPS + GitHub API + uploads)
 #
 # hooks:
 #   entries:
@@ -64,12 +82,23 @@ toolsets:
 #     matcher: "bash_exec|bash_spawn"
 #     command: >-
 #       harnx-proxy-auth
-#       --env 'if (env.GITHUB_TOKEN // env.GH_TOKEN) then .GITHUB_TOKEN = "ghs_\($fake_base64_key)" else . end'
-#       --hook 'if (.host == "api.github.com") and (.headers.authorization == "Bearer ghs_\($fake_base64_key)")
-#           then .headers.authorization = bearer(env.GITHUB_TOKEN // env.GH_TOKEN)
-#           else . end'
+#       --env 'if env.GITHUB_TOKEN then .GITHUB_TOKEN = "ghp_\($fake_base64_key)" end'
+#       --hook 'if .host == "github.com"
+#               and .headers.authorization == basic("x-access-token"; "ghp_\($fake_base64_key)")
+#           then .headers.authorization = basic("x-access-token"; env.GITHUB_TOKEN)
+#           end'
+#       --hook 'if (.host == "api.github.com" or .host == "uploads.github.com" or .host == "objects.githubusercontent.com")
+#               and (.headers.authorization == bearer("ghp_\($fake_base64_key)")
+#                    or .headers.authorization == "token ghp_\($fake_base64_key)")
+#           then .headers.authorization = bearer(env.GITHUB_TOKEN)
+#           end'
 #
-# Example: Inject Atlassian Basic auth using sentinel email + UUID placeholders.
+# The --env script injects a fake ghp_<sentinel> token into the sandbox so tools
+# like `gh` see GITHUB_TOKEN set and consider themselves authenticated. The real
+# token never enters the sandbox — harnx-proxy-auth reads it from the host env
+# and injects it into outbound HTTP auth headers.
+#
+# Example: Atlassian (Jira/Confluence) auth injection
 #
 # hooks:
 #   entries:
@@ -78,7 +107,14 @@ toolsets:
 #     matcher: "bash_exec|bash_spawn"
 #     command: >-
 #       harnx-proxy-auth
-#       --env 'if (env.ATLASSIAN_API_TOKEN and env.ATLASSIAN_EMAIL) then .ATLASSIAN_API_TOKEN = $fake_uuid_key | .ATLASSIAN_EMAIL = $fake_email else . end'
-#       --hook 'if (.host | endswith(".atlassian.net")) and .headers.authorization == "Basic \([$fake_email, $fake_uuid_key] | join(":") | @base64)"
+#       --env 'if env.ATLASSIAN_API_TOKEN and env.ATLASSIAN_EMAIL
+#           then .ATLASSIAN_API_TOKEN = $fake_uuid_key | .ATLASSIAN_EMAIL = $fake_email
+#           end'
+#       --hook 'if (.host | endswith(".atlassian.net"))
+#               and .headers.authorization == basic($fake_email; $fake_uuid_key)
 #           then .headers.authorization = basic(env.ATLASSIAN_EMAIL; env.ATLASSIAN_API_TOKEN)
-#           else . end'
+#           end'
+#
+# Both can be combined into a single harnx-proxy-auth invocation with multiple
+# --env and --hook flags. See docs/sandbox-run.md for full claude-sb / gemini-sb
+# wrapper script examples.


### PR DESCRIPTION
Closes #575

## Summary

Adds `harnx-sandbox-run`, a standalone CLI for running arbitrary commands inside the birdcage filesystem sandbox with full hook and credential-injection support. Extracts shared sandbox configuration into a new `harnx-sandbox-common` crate and renames the sandbox exec helper from `harnx-mcp-bash-sandbox-run` → `harnx-sandbox-exec`.

## New crates

### `harnx-sandbox-run`
Standalone CLI mirroring `harnx-mcp-bash`'s sandbox behaviour, usable outside of MCP:
- Birdcage filesystem sandboxing with the same default whitelist as `harnx-mcp-bash`
- `--extra-read`, `--extra-write`, `--extra-exec`, `--extra-rwx` path access flags
- `--no-network` for fully network-isolated runs
- `--hook` support: one-shot and persistent hooks (e.g. `claude-command-persistent harnx-proxy-auth`) with `--env` and `--hook` sub-flags for credential injection
- Interactive TTY passthrough
- Full test suite: CLI parsing + integration tests (441 lines)
- `README.md` + `docs/sandbox-run.md` with worked examples (GitHub, AWS, Atlassian)

### `harnx-sandbox-common`
Shared crate extracted from `harnx-mcp-bash`:
- `SandboxConfig` struct (previously private to `harnx-mcp-bash`)
- Default path whitelist logic (prevents configuration drift between `harnx-mcp-bash` and `harnx-sandbox-run`)
- `harnx-sandbox-exec` binary (renamed from `harnx-mcp-bash-sandbox-run`, moved here)

## Changes to existing crates

### `harnx-mcp-bash`
- Uses `harnx-sandbox-common::SandboxConfig` instead of its own private struct
- Looks for `harnx-sandbox-exec` by default (replaces all `harnx-mcp-bash-sandbox-run` references)
- `server.rs` trimmed of ~260 lines of sandbox code now living in `harnx-sandbox-common`

### `harnx-aws-creds`
- Hook handler now responds to any `PreToolUse` event; tool-name filtering delegated to the caller's hook matcher config (removes hard-coded `bash_exec`/`bash_spawn` check)

### `harnx-proxy-auth`
- Minor hook improvements

## Architecture notes

**Process lifecycle fix**: previously `harnx-mcp-bash` called birdcage directly in a single-threaded context, forcing the tokio runtime (and `harnx-proxy-auth`) to be dropped before the sandboxed child started. Fixed by delegating sandbox setup + exec to `harnx-sandbox-exec` as a subprocess; the parent runtime stays alive for the full child lifetime.

**No secrets in process listing**: environment variable values are passed via `Command::env()` (ambient environment), never as CLI arguments. `ps`/`/proc/*/cmdline` never expose credentials.

## Infrastructure

- `release.yaml`: build, archive, docker download, and verify steps for `harnx-sandbox-exec` and `harnx-sandbox-run`
- `harnx.Dockerfile`: `COPY` line for `harnx-sandbox-exec`
- `Argcfile.sh`: `harnx-sandbox-exec` added to bin list and default install array
- `example_config/config.yaml`: updated with `harnx-sandbox-run` examples
- `docs/aws-creds.md`: new doc for AWS credential injection pattern
- Three `docs/solutions/` entries: birdcage env passthrough, CLI hook pre-parse separator, tokio–birdcage runtime lifecycle

## Testing

1264 tests pass across 54 binaries (including 5 stress iterations). Clippy `-D warnings` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds harnx-sandbox-run CLI and companion sandbox helper to run arbitrary commands inside a filesystem sandbox with interactive TTY, hook-based credential injection, env passthrough, network isolation, and support for persistent/one-shot hooks.

* **Improvements**
  * Shared sandbox defaults, safer HOME/path handling, and clearer env precedence (CLI → passthrough → hooks).
  * Packaging/workflow and install docs updated; extensive user docs and examples added.

* **Bug Fixes**
  * Fixed CLI hook pre-parse boundary and improved runtime lifecycle for reliable sandbox activation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->