### PR TITLE
fix(mcp): don't request roots from clients lacking the capability

### DIFF
--- a/.changeset/690-no-roots-without-capability.md
+++ b/.changeset/690-no-roots-without-capability.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+MCP servers (`harnx-mcp-fs`, `harnx-mcp-bash`) no longer send `roots/list` requests to clients that did not advertise the `roots` capability (#690). Such clients can't answer the request, so the servers now keep their CLI-provided roots instead.

--- a/crates/harnx-mcp-bash/src/server.rs
+++ b/crates/harnx-mcp-bash/src/server.rs
@@ -5,6 +5,7 @@ use harnx_mcp::safety::{
 
 use fancy_regex::Regex;
 use gix::ObjectId;
+use harnx_mcp::peer::peer_supports_roots;
 use harnx_mcp::schema::object_schema_with_desc;
 use harnx_mcp_history::classify::{classify_command, SnapshotDecision};
 use harnx_mcp_history::HistoryManager;
@@ -734,6 +735,14 @@ impl BashServer {
     }
 
     async fn refresh_roots(&self, peer: &rmcp::service::Peer<RoleServer>) -> Result<(), ErrorData> {
+        if !peer_supports_roots(peer) {
+            // The client never advertised the `roots` capability, so it can't
+            // answer a `roots/list` request. Keep the CLI-provided roots and
+            // mark initialization done so we don't keep retrying.
+            self.inner.roots_initialized.store(true, Ordering::SeqCst);
+            return Ok(());
+        }
+
         let result = peer.list_roots().await.map_err(|err| {
             ErrorData::internal_error(format!("failed to fetch roots from peer: {err}"), None)
         })?;
@@ -2952,6 +2961,76 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    /// A client that does NOT advertise the `roots` capability.
+    #[derive(Clone)]
+    struct NoRootsClientHandler {
+        list_roots_called: Arc<AtomicBool>,
+    }
+
+    impl ClientHandler for NoRootsClientHandler {
+        fn get_info(&self) -> InitializeRequestParams {
+            // Deliberately no `.enable_roots()` — this client cannot answer
+            // a `roots/list` request.
+            InitializeRequestParams::new(
+                ClientCapabilities::builder().build(),
+                Implementation::new("test-no-roots", "0.1"),
+            )
+        }
+
+        async fn list_roots(
+            &self,
+            _cx: RequestContext<RoleClient>,
+        ) -> Result<ListRootsResult, ErrorData> {
+            self.list_roots_called.store(true, Ordering::SeqCst);
+            Ok(ListRootsResult::new(vec![]))
+        }
+    }
+
+    /// When the client never advertised `roots`, the server must not send it
+    /// a `roots/list` request; it keeps the CLI-provided roots instead.
+    #[tokio::test]
+    async fn does_not_request_roots_when_client_lacks_capability() {
+        let temp_dir = TestDir::new();
+        let initial_root = temp_dir.path().to_path_buf();
+        let server = BashServer::new(vec![initial_root.clone()]);
+        let server_clone = server.clone();
+
+        let (client_transport, server_transport) = duplex(65_536);
+        let list_roots_called = Arc::new(AtomicBool::new(false));
+        let client_handler = NoRootsClientHandler {
+            list_roots_called: list_roots_called.clone(),
+        };
+        let server_fut = serve_server(server, server_transport);
+        let client_fut = serve_client(client_handler, client_transport);
+        let (server_res, client_res) = tokio::join!(server_fut, client_fut);
+        let server_service = server_res.unwrap();
+        let client_service = client_res.unwrap();
+
+        let server_peer = server_service.peer().clone();
+        let _client_task = tokio::spawn(async move {
+            let _ = client_service.waiting().await;
+        });
+
+        server_clone
+            .ensure_roots_initialized(&server_peer)
+            .await
+            .expect("initialization succeeds without roots support");
+
+        assert!(
+            !list_roots_called.load(Ordering::SeqCst),
+            "server must not request roots from a client lacking the roots capability"
+        );
+        assert_eq!(
+            *server_clone.inner.roots.read().await,
+            vec![initial_root],
+            "CLI-provided roots must be retained"
+        );
+        assert!(
+            server_clone.inner.roots_initialized.load(Ordering::SeqCst),
+            "roots should be marked initialized so we don't retry every tool call"
+        );
     }
 
     #[tokio::test]

--- a/crates/harnx-mcp-fs/src/server.rs
+++ b/crates/harnx-mcp-fs/src/server.rs
@@ -3,6 +3,7 @@ use crate::summary::{
     SearchTruncation,
 };
 
+use harnx_mcp::peer::peer_supports_roots;
 use harnx_mcp::safety::{
     file_uri_to_path, format_size, is_binary_content, sanitize_output_text, truncate_line,
     validate_path, validate_write_path, DEFAULT_FIND_LIMIT, DEFAULT_GREP_LIMIT, DEFAULT_LS_LIMIT,
@@ -378,6 +379,14 @@ impl FsServer {
     }
 
     async fn refresh_roots(&self, peer: &rmcp::service::Peer<RoleServer>) -> Result<(), ErrorData> {
+        if !peer_supports_roots(peer) {
+            // The client never advertised the `roots` capability, so it can't
+            // answer a `roots/list` request. Keep the CLI-provided roots and
+            // mark initialization done so we don't keep retrying.
+            self.roots_initialized.store(true, Ordering::SeqCst);
+            return Ok(());
+        }
+
         let result = peer.list_roots().await.map_err(|err| {
             ErrorData::internal_error(format!("failed to fetch roots from peer: {err}"), None)
         })?;
@@ -2042,6 +2051,76 @@ mod tests {
             texts.len()
         );
         assert!(texts[1].contains("-old value"), "diff missing: {texts:?}");
+    }
+
+    /// A client that does NOT advertise the `roots` capability.
+    #[derive(Clone)]
+    struct NoRootsClientHandler {
+        list_roots_called: Arc<AtomicBool>,
+    }
+
+    impl ClientHandler for NoRootsClientHandler {
+        fn get_info(&self) -> InitializeRequestParams {
+            // Deliberately no `.enable_roots()` — this client cannot answer
+            // a `roots/list` request.
+            InitializeRequestParams::new(
+                ClientCapabilities::builder().build(),
+                Implementation::new("test-no-roots", "0.1"),
+            )
+        }
+
+        async fn list_roots(
+            &self,
+            _cx: RequestContext<RoleClient>,
+        ) -> Result<ListRootsResult, ErrorData> {
+            self.list_roots_called.store(true, Ordering::SeqCst);
+            Ok(ListRootsResult::new(vec![]))
+        }
+    }
+
+    /// When the client never advertised `roots`, the server must not send it
+    /// a `roots/list` request; it keeps the CLI-provided roots instead.
+    #[tokio::test]
+    async fn does_not_request_roots_when_client_lacks_capability() {
+        let temp_dir = TestDir::new();
+        let initial_root = temp_dir.path().to_path_buf();
+        let server = FsServer::new(vec![initial_root.clone()]);
+        let server_clone = server.clone();
+
+        let (client_transport, server_transport) = duplex(65_536);
+        let list_roots_called = Arc::new(AtomicBool::new(false));
+        let client_handler = NoRootsClientHandler {
+            list_roots_called: list_roots_called.clone(),
+        };
+        let server_fut = serve_server(server, server_transport);
+        let client_fut = serve_client(client_handler, client_transport);
+        let (server_res, client_res) = tokio::join!(server_fut, client_fut);
+        let server_service = server_res.unwrap();
+        let client_service = client_res.unwrap();
+
+        let server_peer = server_service.peer().clone();
+        let _client_task = tokio::spawn(async move {
+            let _ = client_service.waiting().await;
+        });
+
+        server_clone
+            .ensure_roots_initialized(&server_peer)
+            .await
+            .expect("initialization succeeds without roots support");
+
+        assert!(
+            !list_roots_called.load(Ordering::SeqCst),
+            "server must not request roots from a client lacking the roots capability"
+        );
+        assert_eq!(
+            *server_clone.roots.read().await,
+            vec![initial_root],
+            "CLI-provided roots must be retained"
+        );
+        assert!(
+            server_clone.roots_initialized.load(Ordering::SeqCst),
+            "roots should be marked initialized so we don't retry every tool call"
+        );
     }
 
     #[tokio::test]

--- a/crates/harnx-mcp/src/lib.rs
+++ b/crates/harnx-mcp/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod client;
 pub mod config;
 pub mod convert;
+pub mod peer;
 pub mod safety;
 pub mod schema;
 

--- a/crates/harnx-mcp/src/peer.rs
+++ b/crates/harnx-mcp/src/peer.rs
@@ -1,0 +1,17 @@
+//! Helpers for inspecting the connected MCP peer (client) from a server.
+
+use rmcp::service::Peer;
+use rmcp::RoleServer;
+
+/// Returns `true` when the connected client advertised support for the
+/// `roots` capability during initialization.
+///
+/// MCP servers must only send `roots/list` requests to clients that
+/// declared the `roots` capability. Calling `list_roots` against a client
+/// that never advertised it yields a protocol error, so callers use this
+/// to decide whether to fall back to their CLI-provided roots instead.
+pub fn peer_supports_roots(peer: &Peer<RoleServer>) -> bool {
+    peer.peer_info()
+        .map(|info| info.capabilities.roots.is_some())
+        .unwrap_or(false)
+}


### PR DESCRIPTION
## Summary

Closes #690.

`harnx-mcp-fs` and `harnx-mcp-bash` sent a `roots/list` request to the connected client on the first tool call, even when the client never advertised the `roots` capability during initialization. Those clients can't answer the request, so it produced a needless protocol error before the servers fell back to their CLI-provided roots.

This change checks the client's advertised capabilities (via `peer.peer_info()`) before requesting roots:

- New shared helper `harnx_mcp::peer::peer_supports_roots()` inspects the connected client's capabilities.
- `refresh_roots()` in both servers short-circuits when the client lacks the `roots` capability: it keeps the CLI-provided roots and marks initialization done so it doesn't retry on every tool call.

### Side note
The `harnx-mcp-hooks-proxy` advertises `ClientCapabilities::default()` (no roots) and carries a `list_roots`-returns-error workaround so child servers fall back to CLI roots. With this fix the children no longer request roots from it at all, making that workaround redundant — it's left in place (harmless) to keep this change focused.

## Tests

- Added `does_not_request_roots_when_client_lacks_capability` to both servers, using a client handler that does not advertise roots and a flag that trips if `list_roots` is ever invoked. Verifies no request is sent, CLI roots are retained, and roots are marked initialized.

## Verification

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run -p harnx-mcp -p harnx-mcp-fs -p harnx-mcp-bash -p harnx-mcp-hooks-proxy --stress-count=5` — 158 tests, 5/5 iterations passed
- `cs delta` — Code Health unchanged (bash 2.76→2.76, fs 3.60→3.60)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP servers (harnx-mcp-fs and harnx-mcp-bash) now gracefully handle clients that don't support the roots capability—they retain CLI-provided roots instead of attempting failed root synchronization requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->