### PR TITLE
Add tool confirmation guide and animated demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Harnx supports custom dark and light themes, which highlight response text and c
 - [RAG Guide](docs/rag-guide.md)
 - [Environment Variables](docs/environment-variables.md)
 - [Configuration Guide](docs/configuration-guide.md)
+- [Tool Confirmation Guide](docs/tool-confirmation-guide.md)
 - [Custom Theme](docs/custom-theme.md)
 - [FAQ](docs/faq.md)
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -16,14 +16,19 @@ Two pipelines:
 ```
 demos/
 ├── agent.tape                  TUI tape — agent demo
+├── tool-confirm.tape           TUI tape — tool confirmation demo
 ├── render.sh                   TUI orchestrator: mock-llm → vhs → cleanup
 ├── render-web.sh               Web orchestrator: mock-llm → harnx --serve → playwright → ffmpeg
 ├── config/                     Self-contained HARNX_CONFIG_DIR (shared by both)
 │   ├── config.yaml
 │   ├── agents/demo-agent.md
+│   ├── agents/tool-confirm-agent.md
+│   ├── ask-confirm-hook.sh     Hook script returning "ask" for all tools
+│   ├── mcp_servers/time.yaml   Time MCP server (used by tool-confirm demo)
 │   └── clients/mock.yaml       openai-compatible client pointed at :3829
 ├── scripts/                    Mock-LLM response scripts (one entry per request)
 │   ├── agent-flow.yaml
+│   ├── tool-confirm-flow.yaml
 │   ├── playground-flow.yaml
 │   └── arena-flow.yaml
 ├── web/                        Playwright scripts
@@ -76,6 +81,7 @@ palette filter for size + colour quality. Everything is torn down on exit.
 | README image            | Pipeline      | Script                           |
 |-------------------------|---------------|----------------------------------|
 | `harnx-agent`           | TUI           | `demos/agent.tape`               |
+| `harnx-tool-confirm`    | TUI           | `demos/tool-confirm.tape`        |
 | `harnx-llm-playground`  | Web           | `demos/web/playground.mjs`       |
 | `harnx-llm-arena`       | Web           | `demos/web/arena.mjs`            |
 | `harnx-themes`          | TUI (no demo yet) | swap in custom `.tmTheme` files; see `docs/custom-theme.md` |

--- a/demos/config/agents/tool-confirm-agent.md
+++ b/demos/config/agents/tool-confirm-agent.md
@@ -1,0 +1,13 @@
+---
+model: mock:mock-llm
+description: Demo agent for tool confirmation recording.
+use_tools:
+  - time_get_current_time
+hooks:
+  entries:
+    - event: PreToolUse
+      type: claude-command
+      command: "bash demos/config/ask-confirm-hook.sh"
+---
+
+You are a helpful assistant. When asked about the time, use the time tool to check it.

--- a/demos/config/ask-confirm-hook.sh
+++ b/demos/config/ask-confirm-hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Hook script that requires manual confirmation for every tool call.
+# Used by the tool-confirm demo and as a reference for docs.
+#
+# Input: JSON payload on stdin (from harnx PreToolUse event)
+# Output: JSON response requesting user confirmation
+
+# Read and discard stdin (required by protocol)
+cat > /dev/null
+
+# Return "ask" permission decision
+printf '%s\n' '{"hookSpecificOutput":{"permissionDecision":"ask","permissionDecisionReason":"Manual approval required"}}'

--- a/demos/config/mcp_servers/time.yaml
+++ b/demos/config/mcp_servers/time.yaml
@@ -1,0 +1,3 @@
+command: harnx-mcp-time
+description: >-
+  Allow the agent to check the time or wait for a period of time

--- a/demos/scripts/tool-confirm-flow.yaml
+++ b/demos/scripts/tool-confirm-flow.yaml
@@ -1,0 +1,22 @@
+chunk_delay_ms: 35
+turns:
+  - text_chunks:
+      - "I'll check the current time in UTC for you now."
+    tool_calls:
+      - id: call_utc_time
+        name: time_get_current_time
+        arguments:
+          timezone: UTC
+  - text_chunks:
+      - "Time retrieved successfully after approval. "
+      - "I was able to run the UTC time tool and get current time."
+  - text_chunks:
+      - "I'll check the current time in New York next."
+    tool_calls:
+      - id: call_new_york_time
+        name: time_get_current_time
+        arguments:
+          timezone: America/New_York
+  - text_chunks:
+      - "No problem — tool use was denied, so I didn't check New York time."
+fallback_text: "(demo complete)"

--- a/demos/tool-confirm.tape
+++ b/demos/tool-confirm.tape
@@ -1,0 +1,59 @@
+# VHS tape for the harnx tool confirmation demo.
+#
+# Render with:   ./demos/render.sh tool-confirm
+# (which starts harnx-mock-llm, points HARNX_CONFIG_DIR at demos/config, runs
+# `vhs demos/tool-confirm.tape`, then cleans up.)
+#
+# To render this tape standalone (mock-llm already running on :3829):
+#   HARNX_CONFIG_DIR=demos/config vhs demos/tool-confirm.tape
+
+Output demos/out/tool-confirm.gif
+
+# render.sh points HOME at an empty tmpdir so the user's shell init (jetbrains
+# hooks, git-aware prompts, etc.) stays out of the recording.
+Set Shell    bash
+Set FontSize 16
+Set Width    1100
+Set Height   600
+Set Theme    "Catppuccin Mocha"
+Set TypingSpeed 60ms
+Set PlaybackSpeed 1.0
+
+# Launch harnx into the TUI. HARNX_CONFIG_DIR is exported by render.sh; if
+# you're invoking vhs directly, export it yourself first.
+#
+# Hide/Show keeps the bare-prompt frame from appearing in the GIF — recording
+# only resumes once harnx has painted its first screen.
+Hide
+# --session demo bypasses the "Select Session" picker that would otherwise
+# eat the first keystrokes; --empty-session forces a fresh history each run.
+Type "harnx -a tool-confirm-agent --session demo --empty-session"
+Enter
+Sleep 3s
+Show
+
+# First turn: ask about the time. The mock LLM will call time_get_current_time,
+# which triggers the PreToolUse "ask" hook and shows a confirmation prompt.
+Type "What time is it in UTC?"
+Sleep 400ms
+Enter
+Sleep 4s
+
+# The confirmation prompt appears. Approve the tool call by typing 'y'.
+Type "y"
+Enter
+Sleep 5s
+
+# Second turn: ask about New York time. Another tool call + confirmation prompt.
+Type "What about in New York?"
+Sleep 400ms
+Enter
+Sleep 4s
+
+# This time deny the tool call (default is No, so just press Enter).
+Enter
+Sleep 4s
+
+# Ctrl+D exits the TUI.
+Ctrl+D
+Sleep 500ms

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -229,7 +229,42 @@ hooks:
       status_message: "Blocking bash_exec for safety"
 ```
 
-### 4. Audit Logger (Async PostToolUse)
+### 4. Manual Tool Confirmation (Ask)
+
+Requires user approval before any tool runs. See the [Tool Confirmation Guide](tool-confirmation-guide.md) for a full walkthrough.
+
+```yaml
+hooks:
+  entries:
+    - event: PreToolUse
+      type: claude-command
+      command: >-
+        printf '%s\n' '{"hookSpecificOutput":{"permissionDecision":"ask","permissionDecisionReason":"Manual approval required"}}'
+```
+
+When the agent calls a tool, Harnx pauses and shows a confirmation prompt:
+
+```text
+Hook requires confirmation for tool 'bash_exec'
+Reason: Manual approval required
+Input: {
+  "command": "ls -la"
+}
+Allow this tool call? (y/N)
+```
+
+The default is **No** (deny). Use `matcher` to limit confirmation to specific tools:
+
+```yaml
+hooks:
+  entries:
+    - event: PreToolUse
+      type: claude-command
+      matcher: "bash_exec|bash_spawn"
+      command: "/path/to/ask-confirm.sh"
+```
+
+### 5. Audit Logger (Async PostToolUse)
 
 Logs all tool results to a file in the background.
 

--- a/docs/tool-confirmation-guide.md
+++ b/docs/tool-confirmation-guide.md
@@ -1,0 +1,156 @@
+# Tool Confirmation Guide
+
+Tool confirmation allows you to inspect and approve tool calls before they execute. This provides a safety layer for destructive operations, an audit trail for sensitive actions, and a way to learn how the agent interacts with your system.
+
+## 1. Quick Start
+
+The fastest way to enable manual confirmation for all tools is to add an inline hook to your `config.yaml`:
+
+```yaml
+hooks:
+  entries:
+    - event: PreToolUse
+      type: claude-command
+      command: >-
+        printf '%s\n' '{"hookSpecificOutput":{"permissionDecision":"ask","permissionDecisionReason":"Manual approval required"}}'
+```
+
+With this configuration, Harnx will pause and prompt you for every tool call.
+
+## 2. How It Works
+
+Harnx uses the **hooks system** to implement tool confirmation. When a `PreToolUse` hook returns a specific JSON response, the execution flow pauses:
+
+1.  **LLM requests a tool**: The agent decides to run a tool (e.g., `bash_exec`).
+2.  **Hook triggers**: Harnx runs your configured `PreToolUse` hook.
+3.  **Hook requests confirmation**: The hook returns `{"permissionDecision": "ask"}`.
+4.  **User prompted**: Harnx displays the tool name, arguments, and reason in the terminal.
+5.  **Execution or Denial**:
+    *   If you approve (**y**), the tool runs normally.
+    *   If you deny (**N**), the tool is blocked, and the agent receives a "Denied by user" error.
+
+## 3. Configuration Methods
+
+You can configure confirmation hooks globally in `config.yaml` or per-agent in front-matter.
+
+### Method A: External Script
+For more complex logic, move the hook to a script file:
+
+```yaml
+hooks:
+  entries:
+    - event: PreToolUse
+      type: claude-command
+      command: "/path/to/ask-confirm.sh"
+```
+
+**ask-confirm.sh** (see `demos/config/ask-confirm-hook.sh` for a working example):
+```bash
+#!/usr/bin/env bash
+# Consume stdin (tool payload) even if not used
+cat > /dev/null
+# Request confirmation
+printf '%s\n' '{"hookSpecificOutput":{"permissionDecision":"ask","permissionDecisionReason":"Manual approval required"}}'
+```
+
+### Method B: Selective Confirmation (Matcher)
+Use the `matcher` field to only require confirmation for specific tools:
+
+```yaml
+hooks:
+  entries:
+    - event: PreToolUse
+      type: claude-command
+      matcher: "bash_exec|bash_spawn"
+      command: "/path/to/ask-confirm.sh"
+```
+*The `matcher` uses a regex against the tool name.*
+
+### Method C: Per-Agent Hooks
+Enable confirmation only for specific agents by adding the hook to their Markdown front-matter:
+
+```yaml
+---
+model: openai:gpt-4o
+hooks:
+  entries:
+    - event: PreToolUse
+      type: claude-command
+      command: "/path/to/ask-confirm.sh"
+---
+
+You are a helpful assistant with manual tool oversight.
+```
+
+## 4. The Confirmation Prompt
+
+When a hook returns `"permissionDecision": "ask"`, you will see a prompt in your terminal:
+
+```text
+Hook requires confirmation for tool 'bash_exec'
+Reason: Manual approval required
+Input: {
+  "command": "rm -rf /tmp/test"
+}
+Allow this tool call? (y/N)
+```
+
+*   **Default Behavior**: The default choice is **No** (deny). You must explicitly type `y` to approve.
+*   **Agent Feedback**: If denied, the agent receives: `{"error": "Denied by user", "blocked_by_hook": true}`. The agent can then choose to try a different approach or ask you for clarification.
+*   **Non-interactive Mode**: If Harnx is running without a TUI/terminal (e.g., in CI or a pipe), tool calls requiring confirmation are **automatically denied**.
+
+## 5. Advanced: Conditional Confirmation
+
+You can write "smart" hooks that only ask for confirmation when operations appear dangerous.
+
+**smart-confirm.sh**:
+```bash
+#!/usr/bin/env bash
+input=$(cat)
+tool_name=$(echo "$input" | jq -r '.tool_name')
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+# Only inspect shell tools — let other tools proceed
+if [[ "$tool_name" != "bash_exec" && "$tool_name" != "bash_spawn" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+# Ask for commands that modify files
+if echo "$command" | grep -qE '(rm|mv|cp|chmod|chown|dd|mkfs)'; then
+  printf '%s\n' "{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"Command uses potentially destructive operation\"}}"
+else
+  echo '{}'
+fi
+```
+
+### Permission Decision Values
+Hooks can return these values in `hookSpecificOutput`:
+*   `"allow"`: Tool proceeds without prompting.
+*   `"deny"`: Tool is blocked immediately (agent gets error).
+*   `"ask"`: User is prompted to approve or deny.
+*   (Empty `{}`): Tool proceeds normally (default).
+
+**Important Notes:**
+*   **Exit Code Shorthand**: A hook script can exit with code `2` to immediately deny a tool call (equivalent to `permissionDecision: "deny"`).
+*   **Timeouts**: The hook execution timeout defaults to 30 seconds.
+*   **Payload**: Hook scripts receive the full tool call payload as a JSON object on `stdin`.
+*   **Chain of Command**: If multiple hooks are configured for the same event, any hook returning `"ask"` or `"deny"` will take precedence.
+
+## 6. Demo
+
+
+To see tool confirmation in action, render the demo recording:
+
+<img width="1100" height="600" alt="Image" src="https://github.com/user-attachments/assets/f7d6528f-5622-4848-893a-201c6dab538f" />
+
+```sh
+./demos/render.sh tool-confirm
+# → demos/out/tool-confirm.gif
+```
+
+The demo shows two tool calls: the first is approved, the second is denied.
+
+## 7. Related
+*   [Hooks Guide](hooks-guide.md) — Detailed reference for the hook system.
+*   [Configuration Guide](configuration-guide.md) — How to manage global and agent-level settings.


### PR DESCRIPTION
Add documentation for manual tool confirmation via hooks and an animated
TUI demo showcasing the feature.

Deliverables:
- New guide: docs/tool-confirmation-guide.md
- VHS demo: demos/tool-confirm.tape
- Mock LLM script: demos/scripts/tool-confirm-flow.yaml
- Hook and demo config: demos/config/ask-confirm-hook.sh,
  demos/config/agents/tool-confirm-agent.md,
  demos/config/mcp_servers/time.yaml
- Updated README.md, demos/README.md, and docs/hooks-guide.md
  with cross-links.

Plan: tool-confirmation-docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tool confirmation capability enabling manual approval before tool execution, supporting global and selective confirmation rules.

* **Documentation**
  * New comprehensive tool confirmation guide with configuration examples and advanced usage patterns.
  * Updated hooks documentation with confirmation workflows.
  * New interactive demo showcasing tool confirmation functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->