### PR TITLE
feat: add opt-in Streamable HTTP transport for time and plans MCP ser…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,6 +3729,7 @@ name = "harnx-mcp-plans"
 version = "0.32.3"
 dependencies = [
  "anyhow",
+ "axum",
  "chrono",
  "rmcp",
  "schemars 1.2.1",
@@ -3737,6 +3738,8 @@ dependencies = [
  "serde_yaml",
  "similar 3.1.1",
  "tokio",
+ "tokio-util",
+ "tower",
 ]
 
 [[package]]
@@ -3744,6 +3747,7 @@ name = "harnx-mcp-time"
 version = "0.32.3"
 dependencies = [
  "anyhow",
+ "axum",
  "chrono",
  "chrono-tz",
  "iana-time-zone",
@@ -3752,6 +3756,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
+ "tower",
 ]
 
 [[package]]
@@ -6824,20 +6830,28 @@ checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64",
+ "bytes",
  "chrono",
  "futures",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
  "pastey",
  "pin-project-lite",
  "process-wrap",
+ "rand 0.10.1",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -7556,6 +7570,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8137,6 +8164,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,8 @@ serde_yaml = "0.9.17"
 tokio = { version = "1.48", features = ["rt", "time", "macros", "signal", "rt-multi-thread", "io-util", "process"] }
 tokio-graceful = "0.2.2"
 tokio-stream = { version = "0.1.15", default-features = false, features = ["sync"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+tower = { version = "0.5" }
 crossterm = "0.29"
 chrono = { version = "0.4.23", features = ["serde"] }
 chrono-tz = "0.10"
@@ -128,7 +130,7 @@ which = "8.0.0"
 fuzzy-matcher = "0.3.7"
 terminal-colorsaurus = "1.0.3"
 duct = "1.0.0"
-rmcp = { version = "1.3.0", features = ["client", "server", "transport-child-process", "transport-io"] }
+rmcp = { version = "1.3.0", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server"] }
 process-wrap = { version = "9", features = ["tokio1"] }
 libc = "0.2"
 agent-client-protocol = { git = "https://github.com/agentclientprotocol/rust-sdk", rev = "2e8c815284a27348f46306a8ffefa2b01e1bdb8d" }

--- a/crates/harnx-mcp-plans/Cargo.toml
+++ b/crates/harnx-mcp-plans/Cargo.toml
@@ -9,12 +9,15 @@ description = "MCP server that exposes a file-based plan/task/note management sy
 
 [dependencies]
 anyhow = { workspace = true }
+axum = { workspace = true }
 chrono = { workspace = true }
 rmcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true, features = ["fs", "time"] }
+tokio-util = { workspace = true }
+tower = { workspace = true }
 schemars = { workspace = true }
 similar = { workspace = true }
 

--- a/crates/harnx-mcp-plans/src/main.rs
+++ b/crates/harnx-mcp-plans/src/main.rs
@@ -11,76 +11,102 @@
 
 mod server;
 
+use anyhow::Context;
+use rmcp::transport::streamable_http_server::session::never::NeverSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 use rmcp::ServiceExt;
 use server::PlansServer;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+struct Args {
+    plans_dir: PathBuf,
+    retention_days: u64,
+    http: bool,
+    host: String,
+    port: u16,
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let (plans_dir, retention_days) = parse_args()?;
+    let Args {
+        plans_dir,
+        retention_days,
+        http,
+        host,
+        port,
+    } = parse_args()?;
 
-    eprintln!(
-        "harnx-mcp-plans v{}: starting (dir: {}, retention: {} days)",
-        env!("CARGO_PKG_VERSION"),
-        plans_dir.display(),
-        retention_days
-    );
-
-    let server = PlansServer::new(plans_dir.clone());
-    let transport = rmcp::transport::stdio();
-    let service = server.serve(transport).await?;
-
-    if retention_days == 0 {
-        eprintln!("[cleanup] retention disabled");
-        service.waiting().await?;
+    if http {
+        run_http(plans_dir, retention_days, host, port).await
     } else {
-        let cleanup_dir = plans_dir.clone();
-        let mut cleanup_handle = tokio::spawn(server::cleanup_loop(plans_dir, retention_days));
-        let service_handle = tokio::spawn(async move { service.waiting().await });
-        tokio::pin!(service_handle);
+        eprintln!(
+            "harnx-mcp-plans v{}: starting (dir: {}, retention: {} days)",
+            env!("CARGO_PKG_VERSION"),
+            plans_dir.display(),
+            retention_days
+        );
 
-        // Exponential backoff state for cleanup task restarts.
-        // Reset to base on a clean exit; doubles on each panic up to MAX_BACKOFF.
-        const BASE_BACKOFF: Duration = Duration::from_secs(1);
-        const MAX_BACKOFF: Duration = Duration::from_secs(300); // 5 min cap
-        let mut backoff = BASE_BACKOFF;
+        let server = PlansServer::new(plans_dir.clone());
+        let transport = rmcp::transport::stdio();
+        let service = server.serve(transport).await?;
 
-        loop {
-            tokio::select! {
-                result = &mut *service_handle => {
-                    // MCP service exited — normal shutdown
-                    result??;
-                    break;
-                }
-                result = &mut cleanup_handle => {
-                    match result {
-                        Err(e) => {
-                            // Task panicked — log, back off, restart
-                            eprintln!("[cleanup] task failed: {e}");
-                            tokio::time::sleep(backoff).await;
-                            backoff = (backoff * 2).min(MAX_BACKOFF);
-                        }
-                        Ok(()) => {
-                            // Clean exit (shouldn't happen in normal operation) — restart immediately
-                            backoff = BASE_BACKOFF;
-                        }
+        if retention_days == 0 {
+            eprintln!("[cleanup] retention disabled");
+            service.waiting().await?;
+        } else {
+            let cleanup_dir = plans_dir.clone();
+            let mut cleanup_handle = tokio::spawn(server::cleanup_loop(plans_dir, retention_days));
+            let service_handle = tokio::spawn(async move { service.waiting().await });
+            tokio::pin!(service_handle);
+
+            // Exponential backoff state for cleanup task restarts.
+            // Reset to base on a clean exit; doubles on each panic up to MAX_BACKOFF.
+            const BASE_BACKOFF: Duration = Duration::from_secs(1);
+            const MAX_BACKOFF: Duration = Duration::from_secs(300); // 5 min cap
+            let mut backoff = BASE_BACKOFF;
+
+            loop {
+                tokio::select! {
+                    result = &mut *service_handle => {
+                        // MCP service exited — normal shutdown
+                        result??;
+                        break;
                     }
-                    cleanup_handle = tokio::spawn(server::cleanup_loop(cleanup_dir.clone(), retention_days));
+                    result = &mut cleanup_handle => {
+                        match result {
+                            Err(e) => {
+                                // Task panicked — log, back off, restart
+                                eprintln!("[cleanup] task failed: {e}");
+                                tokio::time::sleep(backoff).await;
+                                backoff = (backoff * 2).min(MAX_BACKOFF);
+                            }
+                            Ok(()) => {
+                                // Clean exit (shouldn't happen in normal operation) — restart immediately
+                                backoff = BASE_BACKOFF;
+                            }
+                        }
+                        cleanup_handle = tokio::spawn(server::cleanup_loop(cleanup_dir.clone(), retention_days));
+                    }
                 }
             }
         }
-    }
 
-    Ok(())
+        Ok(())
+    }
 }
 
-fn parse_args() -> anyhow::Result<(PathBuf, u64)> {
+fn parse_args() -> anyhow::Result<Args> {
     let args: Vec<String> = std::env::args().collect();
     let mut plans_dir: Option<PathBuf> = None;
     let mut retention_days: Option<u64> = None;
-    let mut i = 1;
+    let mut http = false;
+    let mut host = None::<String>;
+    let mut port = None::<u16>;
 
+    let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
             "--dir" | "-d" => {
@@ -109,6 +135,36 @@ fn parse_args() -> anyhow::Result<(PathBuf, u64)> {
                     anyhow::bail!("harnx-mcp-plans: --retention-days requires a number argument");
                 }
             }
+            "--http" => {
+                http = true;
+                i += 1;
+            }
+            "--host" => {
+                if i + 1 < args.len() {
+                    host = Some(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    anyhow::bail!("harnx-mcp-plans: --host requires an address argument");
+                }
+            }
+            "--port" => {
+                if i + 1 < args.len() {
+                    match args[i + 1].parse::<u16>() {
+                        Ok(p) => {
+                            port = Some(p);
+                            i += 2;
+                        }
+                        Err(_) => {
+                            anyhow::bail!(
+                                "harnx-mcp-plans: --port requires a port number (got: {})",
+                                args[i + 1]
+                            );
+                        }
+                    }
+                } else {
+                    anyhow::bail!("harnx-mcp-plans: --port requires a number argument");
+                }
+            }
             "--help" | "-h" => {
                 eprintln!("harnx-mcp-plans: File-based todo/plan management MCP server");
                 eprintln!();
@@ -121,6 +177,11 @@ fn parse_args() -> anyhow::Result<(PathBuf, u64)> {
                 eprintln!(
                     "  --retention-days, -r <N>   Set retention period in days (default: 14)"
                 );
+                eprintln!("  --http                     Serve MCP over Streamable HTTP at /mcp");
+                eprintln!(
+                    "  --host <addr>              Bind address for HTTP mode (default: 0.0.0.0)"
+                );
+                eprintln!("  --port <N>                 Bind port for HTTP mode (default: 3000)");
                 eprintln!("  --help, -h                 Show this help message");
                 eprintln!();
                 eprintln!("Env:");
@@ -166,5 +227,126 @@ fn parse_args() -> anyhow::Result<(PathBuf, u64)> {
         PathBuf::from(".agent/plans")
     };
 
-    Ok((plans_dir, retention_days))
+    // Resolve HTTP options
+    let host = host.unwrap_or_else(|| "0.0.0.0".to_string());
+    let port = port.unwrap_or(3000);
+
+    Ok(Args {
+        plans_dir,
+        retention_days,
+        http,
+        host,
+        port,
+    })
+}
+
+async fn run_http(
+    plans_dir: PathBuf,
+    retention_days: u64,
+    host: String,
+    port: u16,
+) -> anyhow::Result<()> {
+    let ct = CancellationToken::new();
+    let factory_dir = plans_dir.clone();
+    let config = StreamableHttpServerConfig::default()
+        .with_stateful_mode(false)
+        .with_json_response(true)
+        .with_cancellation_token(ct.child_token())
+        // Empty allowlist = accept any Host header. Required so external
+        // (e.g. Kubernetes) Host values aren't rejected by rmcp's default
+        // loopback-only allowlist. Deploy behind a trusted ingress/network.
+        .disable_allowed_hosts();
+    let mcp_service = StreamableHttpService::new(
+        move || Ok(PlansServer::new(factory_dir.clone())),
+        Arc::new(NeverSessionManager::default()),
+        config,
+    );
+    let app = axum::Router::new().nest_service("/mcp", mcp_service);
+    let listener = tokio::net::TcpListener::bind((host.as_str(), port))
+        .await
+        .with_context(|| format!("harnx-mcp-plans: failed to bind {host}:{port}"))?;
+
+    spawn_shutdown_handler(ct.clone());
+
+    eprintln!(
+        "harnx-mcp-plans v{}: listening on http://{}:{}/mcp (dir: {}, retention: {} days)",
+        env!("CARGO_PKG_VERSION"),
+        host,
+        port,
+        plans_dir.display(),
+        retention_days,
+    );
+
+    let shutdown_ct = ct.clone();
+    let server_handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move { shutdown_ct.cancelled().await })
+            .await
+    });
+    tokio::pin!(server_handle);
+
+    if retention_days == 0 {
+        eprintln!("[cleanup] retention disabled");
+        (&mut server_handle).await??;
+    } else {
+        let cleanup_dir = plans_dir.clone();
+        let mut cleanup_handle =
+            tokio::spawn(server::cleanup_loop(cleanup_dir.clone(), retention_days));
+        const BASE_BACKOFF: Duration = Duration::from_secs(1);
+        const MAX_BACKOFF: Duration = Duration::from_secs(300);
+        let mut backoff = BASE_BACKOFF;
+
+        loop {
+            tokio::select! {
+                result = &mut *server_handle => {
+                    cleanup_handle.abort();
+                    result??;
+                    break;
+                }
+                result = &mut cleanup_handle => {
+                    match result {
+                        Err(e) => {
+                            eprintln!("[cleanup] task failed: {e}");
+                            tokio::time::sleep(backoff).await;
+                            backoff = (backoff * 2).min(MAX_BACKOFF);
+                        }
+                        Ok(()) => { backoff = BASE_BACKOFF; }
+                    }
+                    cleanup_handle = tokio::spawn(server::cleanup_loop(cleanup_dir.clone(), retention_days));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn spawn_shutdown_handler(ct: CancellationToken) {
+    tokio::spawn(async move {
+        #[cfg(unix)]
+        {
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(mut sigterm) => {
+                    tokio::select! {
+                        _ = tokio::signal::ctrl_c() => {}
+                        _ = sigterm.recv() => {}
+                    }
+                }
+                Err(e) => {
+                    eprintln!(
+                        "harnx-mcp-plans: failed to install SIGTERM handler ({e}); \
+                         falling back to Ctrl-C only"
+                    );
+                    let _ = tokio::signal::ctrl_c().await;
+                }
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+        }
+
+        ct.cancel();
+    });
 }

--- a/crates/harnx-mcp-time/Cargo.toml
+++ b/crates/harnx-mcp-time/Cargo.toml
@@ -9,6 +9,7 @@ description = "MCP server that exposes time and timezone utilities"
 
 [dependencies]
 anyhow = { workspace = true }
+axum = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
 iana-time-zone = { workspace = true }
@@ -17,6 +18,8 @@ rmcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
+tower = { workspace = true }
 
 [[bin]]
 name = "harnx-mcp-time"

--- a/crates/harnx-mcp-time/src/main.rs
+++ b/crates/harnx-mcp-time/src/main.rs
@@ -1,16 +1,166 @@
 mod server;
 
+use anyhow::Context;
+use rmcp::transport::streamable_http_server::session::never::NeverSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 use rmcp::ServiceExt;
 use server::TimeServer;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+struct Args {
+    http: bool,
+    host: String,
+    port: u16,
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    eprintln!("harnx-mcp-time v{}: starting", env!("CARGO_PKG_VERSION"),);
+    let args = parse_args()?;
 
-    let server = TimeServer::new();
-    let transport = rmcp::transport::stdio();
-    let service = server.serve(transport).await?;
-    service.waiting().await?;
+    if args.http {
+        run_http(args).await
+    } else {
+        eprintln!("harnx-mcp-time v{}: starting", env!("CARGO_PKG_VERSION"));
+
+        let server = TimeServer::new();
+        let service = server.serve(rmcp::transport::stdio()).await?;
+        service.waiting().await?;
+
+        Ok(())
+    }
+}
+
+fn parse_args() -> anyhow::Result<Args> {
+    let mut http = false;
+    let mut host = "0.0.0.0".to_string();
+    let mut port = 3000;
+
+    let args: Vec<String> = std::env::args().collect();
+    let mut i = 1;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            "--http" => {
+                http = true;
+                i += 1;
+            }
+            "--host" => {
+                if i + 1 >= args.len() {
+                    anyhow::bail!("harnx-mcp-time: --host requires an address argument");
+                }
+                host = args[i + 1].clone();
+                i += 2;
+            }
+            "--port" => {
+                if i + 1 >= args.len() {
+                    anyhow::bail!("harnx-mcp-time: --port requires a number argument");
+                }
+                match args[i + 1].parse::<u16>() {
+                    Ok(value) => {
+                        port = value;
+                        i += 2;
+                    }
+                    Err(_) => {
+                        anyhow::bail!(
+                            "harnx-mcp-time: --port requires a valid u16 port (got: {})",
+                            args[i + 1]
+                        );
+                    }
+                }
+            }
+            "--help" | "-h" => {
+                print_help();
+                std::process::exit(0);
+            }
+            other => {
+                anyhow::bail!(
+                    "harnx-mcp-time: unknown argument: {other}\nTry: harnx-mcp-time --help"
+                );
+            }
+        }
+    }
+
+    Ok(Args { http, host, port })
+}
+
+fn print_help() {
+    eprintln!("harnx-mcp-time: MCP time utilities server");
+    eprintln!();
+    eprintln!("Usage: harnx-mcp-time [OPTIONS]");
+    eprintln!();
+    eprintln!("Options:");
+    eprintln!("  --http              Serve MCP over Streamable HTTP at /mcp");
+    eprintln!("  --host <addr>       Bind address for HTTP mode (default: 0.0.0.0)");
+    eprintln!("  --port <N>          Bind port for HTTP mode (default: 3000)");
+    eprintln!("  --help, -h          Show this help message");
+}
+
+async fn run_http(args: Args) -> anyhow::Result<()> {
+    let Args { host, port, .. } = args;
+    let ct = CancellationToken::new();
+    let config = StreamableHttpServerConfig::default()
+        .with_stateful_mode(false)
+        .with_json_response(true)
+        .with_cancellation_token(ct.child_token())
+        // Empty allowlist = accept any Host header. Required so external
+        // (e.g. Kubernetes) Host values aren't rejected by rmcp's default
+        // loopback-only allowlist. Deploy behind a trusted ingress/network.
+        .disable_allowed_hosts();
+    let mcp_service = StreamableHttpService::new(
+        || Ok(TimeServer::new()),
+        Arc::new(NeverSessionManager::default()),
+        config,
+    );
+    let app = axum::Router::new().nest_service("/mcp", mcp_service);
+    let listener = tokio::net::TcpListener::bind((host.as_str(), port))
+        .await
+        .with_context(|| format!("harnx-mcp-time: failed to bind {host}:{port}"))?;
+
+    spawn_shutdown_handler(ct.clone());
+
+    eprintln!(
+        "harnx-mcp-time v{}: listening on http://{}:{}/mcp",
+        env!("CARGO_PKG_VERSION"),
+        host,
+        port
+    );
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            ct.cancelled().await;
+        })
+        .await?;
 
     Ok(())
+}
+
+fn spawn_shutdown_handler(ct: CancellationToken) {
+    tokio::spawn(async move {
+        #[cfg(unix)]
+        {
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(mut sigterm) => {
+                    tokio::select! {
+                        _ = tokio::signal::ctrl_c() => {}
+                        _ = sigterm.recv() => {}
+                    }
+                }
+                Err(e) => {
+                    eprintln!(
+                        "harnx-mcp-time: failed to install SIGTERM handler ({e}); \
+                         falling back to Ctrl-C only"
+                    );
+                    let _ = tokio::signal::ctrl_c().await;
+                }
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+        }
+
+        ct.cancel();
+    });
 }

--- a/docs/solutions/rmcp/streamable-http-server-setup-2026-05-29.md
+++ b/docs/solutions/rmcp/streamable-http-server-setup-2026-05-29.md
@@ -1,0 +1,229 @@
+---
+title: "rmcp Streamable HTTP server setup with graceful shutdown"
+date: 2026-05-29
+category: "rmcp"
+problem_type: integration_issue
+component: "rmcp-transport"
+root_cause: "non-obvious StreamableHttpServerConfig builder and WithGracefulShutdown select! incompatibility"
+resolution_type: code_fix
+severity: medium
+tags:
+  - mcp
+  - rmcp
+  - http
+  - axum
+  - graceful-shutdown
+  - tokio
+  - select!
+  - CancellationToken
+plan_ref: "harnx-mcp-http-transport"
+---
+
+## Problem
+
+Adding Streamable HTTP transport (MCP spec 2025-03-26) to an rmcp-based MCP server alongside existing stdio transport requires non-obvious builder patterns for `StreamableHttpServerConfig`, correct import paths for `NeverSessionManager`, and a spawned supervision pattern for `axum::serve` when background tasks must be supervised via `select!`.
+
+## Symptoms
+
+- **E0639**: Attempting struct literal initialization of `StreamableHttpServerConfig` fails: "cannot create non-exhaustive struct using struct literal"
+- **E0277**: `WithGracefulShutdown` does not implement `Future` — cannot use in `tokio::select!` even after `pin!`
+- **Host header rejected**: Kubernetes service DNS Host headers rejected by rmcp's default loopback-only allowlist
+- **SIGTERM handler panic**: `.expect()` on `signal(SignalKind::terminate())` panics in environments without UNIX signals
+
+## Investigation Steps
+
+1. Attempted direct struct literal for `StreamableHttpServerConfig` — rejected due to `#[non_exhaustive]`
+2. Tried `tokio::pin!` on `axum::serve(...).with_graceful_shutdown(...)` — compile error: `Future` not implemented
+3. Checked rmcp imports — `NeverSessionManager` lives at full path `rmcp::transport::streamable_http_server::session::never::NeverSessionManager`, not re-exported at crate root
+4. Tested with K8s deployment — default allowed_hosts (`["localhost","127.0.0.1","::1"]`) rejects external Host headers
+5. Reviewed rmcp source (`tower.rs`): empty `allowed_hosts` Vec means "accept all" (line ~252: `if allowed_hosts.is_empty() { return true }`)
+
+## Root Cause
+
+1. **`#[non_exhaustive]`**: rmcp marks config structs non-exhaustive to allow future field additions without breaking changes — requires builder pattern
+2. **`WithGracefulShutdown` type**: axum's `.with_graceful_shutdown()` returns a future-combinator struct, not a `Future` impl itself. The `.await` drives it, but you can't borrow it mutably for `select!`
+3. **DNS-rebinding protection**: rmcp's default Host allowlist is loopback-only for security; K8s/Docker deployments need explicit opt-out
+4. **Signal handler fragility**: `tokio::signal::unix::signal()` can fail in constrained environments; `.expect()` panics the spawned task
+
+## Solution
+
+### 1. Service setup with builder pattern
+
+```rust
+use anyhow::Context;
+use rmcp::transport::streamable_http_server::session::never::NeverSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+async fn run_http(host: String, port: u16) -> anyhow::Result<()> {
+    let ct = CancellationToken::new();
+    let config = StreamableHttpServerConfig::default()
+        .with_stateful_mode(false)      // Stateless for K8s horizontal scaling
+        .with_json_response(true)        // Streamable HTTP spec-recommended
+        .with_cancellation_token(ct.child_token())
+        // Empty allowlist = accept any Host header. Required so external
+        // (e.g. Kubernetes) Host values aren't rejected by rmcp's default
+        // loopback-only allowlist. Deploy behind a trusted ingress/network.
+        .disable_allowed_hosts();
+    
+    let mcp_service = StreamableHttpService::new(
+        || Ok(TimeServer::new()),                    // Factory closure
+        Arc::new(NeverSessionManager::default()),    // Session manager wrapped in Arc
+        config,
+    );
+    
+    let app = axum::Router::new().nest_service("/mcp", mcp_service);
+    let listener = tokio::net::TcpListener::bind((host.as_str(), port))
+        .await
+        .with_context(|| format!("failed to bind {host}:{port}"))?;
+    
+    spawn_shutdown_handler(ct.clone());
+    
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move { ct.cancelled().await })
+        .await?;
+    
+    Ok(())
+}
+```
+
+### 2. Factory closure for non-Clone servers
+
+When the server type isn't `Clone`, use `move` closure with cloned data:
+
+```rust
+let factory_dir = plans_dir.clone();
+let mcp_service = StreamableHttpService::new(
+    move || Ok(PlansServer::new(factory_dir.clone())),
+    Arc::new(NeverSessionManager::default()),
+    config,
+);
+```
+
+### 3. Spawned supervision for select! with background tasks
+
+`WithGracefulShutdown` cannot be pinned and used in `select!` directly. Wrap in `tokio::spawn`:
+
+```rust
+let shutdown_ct = ct.clone();
+let server_handle = tokio::spawn(async move {
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move { shutdown_ct.cancelled().await })
+        .await
+});
+tokio::pin!(server_handle);
+
+let mut cleanup_handle = tokio::spawn(cleanup_loop(dir.clone(), retention_days));
+let mut backoff = Duration::from_secs(1);
+const MAX_BACKOFF: Duration = Duration::from_secs(300);
+
+loop {
+    tokio::select! {
+        result = &mut *server_handle => {
+            cleanup_handle.abort();  // Don't let cleanup outlive server
+            result??;
+            break;
+        }
+        result = &mut cleanup_handle => {
+            match result {
+                Err(e) => {
+                    eprintln!("[cleanup] task failed: {e}");
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(MAX_BACKOFF);
+                }
+                Ok(()) => { backoff = Duration::from_secs(1); }
+            }
+            cleanup_handle = tokio::spawn(cleanup_loop(dir.clone(), retention_days));
+        }
+    }
+}
+```
+
+### 4. Graceful signal handler with fallback
+
+```rust
+fn spawn_shutdown_handler(ct: CancellationToken) {
+    tokio::spawn(async move {
+        #[cfg(unix)]
+        {
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(mut sigterm) => {
+                    tokio::select! {
+                        _ = tokio::signal::ctrl_c() => {}
+                        _ = sigterm.recv() => {}
+                    }
+                }
+                Err(e) => {
+                    eprintln!("failed to install SIGTERM handler ({e}); falling back to Ctrl-C only");
+                    let _ = tokio::signal::ctrl_c().await;
+                }
+            }
+        }
+        
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+        }
+        
+        ct.cancel();
+    });
+}
+```
+
+### 5. Preserving existing stdio path when adding HTTP mode
+
+Wrap the entire original stdio code path with minimal restructuring:
+
+```rust
+async fn main() -> anyhow::Result<()> {
+    let args = parse_args()?;
+    
+    if args.http {
+        run_http(args).await
+    } else {
+        // Original stdio code verbatim — only indentation changes
+        let server = PlansServer::new(plans_dir);
+        let transport = rmcp::transport::stdio();
+        let service = server.serve(transport).await?;
+        // ... rest of original code unchanged
+        Ok(())
+    }
+}
+```
+
+## Why This Works
+
+1. **Builder pattern**: `StreamableHttpServerConfig::default()` + `.with_*()` methods sidestep `#[non_exhaustive]` restriction
+2. **`tokio::spawn` wrapper**: Transforms `WithGracefulShutdown` into a `JoinHandle<Result<_>>` which IS a `Future` when polled via `&mut handle`
+3. **`disable_allowed_hosts()`**: rmcp's dedicated method (added in 1.7) makes intent explicit: empty Vec = accept any Host, appropriate when auth is network-based
+4. **`ct.child_token()` + parent `cancelled()`:** Parent cancellation cascades to child token registered with rmcp config, terminating the HTTP server gracefully
+5. **Graceful signal handler**: Degrading to Ctrl-C fallback avoids panic in environments without `/proc` or signal support
+
+## Prevention Strategies
+
+**Code Review Checklist:**
+- [ ] `StreamableHttpServerConfig` uses builder methods, not struct literal
+- [ ] `NeverSessionManager` imported from full path `rmcp::transport::streamable_http_server::session::never`
+- [ ] Session manager wrapped in `Arc::new(...)`
+- [ ] `axum::serve(...).with_graceful_shutdown(...)` wrapped in `tokio::spawn` before `select!`
+- [ ] `CancellationToken::child_token()` passed to rmcp config; parent waited in graceful shutdown
+- [ ] Signal handler degrades gracefully on UNIX signal install failure
+- [ ] Existing stdio code path wrapped in `if !http { ... }` with minimal restructuring
+
+**Best Practices:**
+- Use `.disable_allowed_hosts()` with comment explaining why (network-level auth)
+- Report HTTP startup with `eprintln!` showing version, host, port, endpoint
+- Enable rmcp feature `transport-streamable-http-server` + add `axum`, `tokio-util`, `tower` deps
+
+**Test Cases:**
+- Verify HTTP mode starts and responds to MCP initialize via curl
+- Verify stdio mode still works (no regression)
+- Verify graceful shutdown on SIGTERM (Unix) and Ctrl-C
+- Verify cleanup loop restarts on panic (plans server)
+
+## Related Issues
+
+- **GitHub:** [issue #686](https://github.com/dobesv/harnx/issues/686) — Add Streamable HTTP transport
+- **Related Solution:** [mcp-server-background-task-supervision-2026-05-25.md](../async-patterns/mcp-server-background-task-supervision-2026-05-25.md) — Supervision pattern for stdio servers
+- **MCP Spec:** Streamable HTTP Transport (2025-03-26 revision)


### PR DESCRIPTION
…vers

Adds support for the Streamable HTTP transport (MCP spec 2025-03-26) to the harnx-mcp-time and harnx-mcp-plans servers. Both servers now support a --http flag to switch from stdio to HTTP mode, with --port and --host flags for configuration.

Key changes:
- Add axum, tokio-util, and tower as workspace dependencies.
- Enable transport-streamable-http-server feature in the rmcp crate.
- Implement manual argument parsing for HTTP flags in both servers.
- Implement HTTP server logic with graceful shutdown and signal handling.
- Preserve existing stdio behavior as the default mode.
- Integrate the plans server's background cleanup loop with the HTTP server's supervision cycle.
- Document the Streamable HTTP server setup in docs/solutions/rmcp/.

Issue: #686
Closes #686

Plan: harnx-mcp-http-transport