### PR TITLE
docs: list all installable binaries in README with per-binary docs

### DIFF
--- a/.changeset/readme-install-binaries.md
+++ b/.changeset/readme-install-binaries.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Fix README install instructions to list all installable binaries instead of only three, and link each binary to its documentation. Added per-crate READMEs for `harnx-serve`, `harnx-acp-server`, `harnx-mcp-fs`, `harnx-mcp-time`, `harnx-mcp-hooks-proxy`, `harnx-proxy-auth`, and `harnx-sandbox-exec` (in `harnx-sandbox-common`). Also wired the previously-omitted `harnx-k8s-creds` binary into the release workflow, Docker image, and `argc install` so it ships and installs alongside `harnx-aws-creds`, and added the missing `harnx-mcp-hooks-proxy` binary to the Docker image.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,7 +123,7 @@ jobs:
         $BUILD_CMD build --locked --release --target=${{ matrix.target }} ${{ matrix.cargo-flags }} \
           -p harnx -p harnx-serve -p harnx-acp-server \
           -p harnx-mcp-bash -p harnx-mcp-fs -p harnx-mcp-plans -p harnx-mcp-time \
-          -p harnx-aws-creds -p harnx-pkg -p harnx-proxy-auth -p harnx-mcp-hooks-proxy \
+          -p harnx-aws-creds -p harnx-k8s-creds -p harnx-pkg -p harnx-proxy-auth -p harnx-mcp-hooks-proxy \
           -p harnx-sandbox-run \
           -p harnx-sandbox-common
 
@@ -151,6 +151,7 @@ jobs:
           "harnx-mcp-plans:harnx-mcp-plans"
           "harnx-mcp-time:harnx-mcp-time"
           "harnx-aws-creds:harnx-aws-creds"
+          "harnx-k8s-creds:harnx-k8s-creds"
           "harnx-pkg:harnx-pkg"
           "harnx-proxy-auth:harnx-proxy-auth"
           "harnx-mcp-hooks-proxy:harnx-mcp-hooks-proxy"
@@ -249,6 +250,8 @@ jobs:
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-aws-creds-$V-x86_64-unknown-linux-musl.tar.gz" || true
           gh release download "$GITHUB_REF_NAME" \
+            --pattern "harnx-k8s-creds-$V-x86_64-unknown-linux-musl.tar.gz" || true
+          gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-pkg-$V-x86_64-unknown-linux-musl.tar.gz" || true
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-proxy-auth-$V-x86_64-unknown-linux-musl.tar.gz" || true
@@ -276,6 +279,8 @@ jobs:
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-aws-creds-$V-aarch64-unknown-linux-musl.tar.gz" || true
           gh release download "$GITHUB_REF_NAME" \
+            --pattern "harnx-k8s-creds-$V-aarch64-unknown-linux-musl.tar.gz" || true
+          gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-pkg-$V-aarch64-unknown-linux-musl.tar.gz" || true
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-proxy-auth-$V-aarch64-unknown-linux-musl.tar.gz" || true
@@ -300,7 +305,7 @@ jobs:
         run: |
           missing=0
           for dir in linux-amd64 linux-arm64; do
-            for bin in harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-bash-sandbox-run harnx-mcp-fs harnx-mcp-plans harnx-mcp-time harnx-aws-creds harnx-pkg harnx-proxy-auth harnx-mcp-hooks-proxy harnx-sandbox-run harnx-sandbox-exec; do
+            for bin in harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-bash-sandbox-run harnx-mcp-fs harnx-mcp-plans harnx-mcp-time harnx-aws-creds harnx-k8s-creds harnx-pkg harnx-proxy-auth harnx-mcp-hooks-proxy harnx-sandbox-run harnx-sandbox-exec; do
               if [ ! -f "$dir/$bin" ]; then
                 echo "ERROR: missing $dir/$bin"
                 missing=1

--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -9,11 +9,11 @@ set -e
 # rebuilds that `cargo install --path` does. Release profile by default; pass --debug for
 # a faster build with slower runtime.
 # @flag --debug Install debug build instead of the default release build
-# @arg bins*[harnx|harnx-serve|harnx-acp-server|harnx-mcp-bash|harnx-mcp-fs|harnx-mcp-time|harnx-mcp-plans|harnx-mcp-hooks-proxy|harnx-aws-creds|harnx-pkg|harnx-proxy-auth|harnx-sandbox-run|harnx-sandbox-exec] Restrict the install to one or more bins (default: all)
+# @arg bins*[harnx|harnx-serve|harnx-acp-server|harnx-mcp-bash|harnx-mcp-fs|harnx-mcp-time|harnx-mcp-plans|harnx-mcp-hooks-proxy|harnx-aws-creds|harnx-k8s-creds|harnx-pkg|harnx-proxy-auth|harnx-sandbox-run|harnx-sandbox-exec] Restrict the install to one or more bins (default: all)
 install() {
     bins=("${argc_bins[@]}")
     if [[ ${#bins[@]} -eq 0 ]]; then
-        bins=(harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-fs harnx-mcp-time harnx-mcp-plans harnx-mcp-hooks-proxy harnx-aws-creds harnx-pkg harnx-proxy-auth harnx-sandbox-run harnx-sandbox-exec)
+        bins=(harnx harnx-serve harnx-acp-server harnx-mcp-bash harnx-mcp-fs harnx-mcp-time harnx-mcp-plans harnx-mcp-hooks-proxy harnx-aws-creds harnx-k8s-creds harnx-pkg harnx-proxy-auth harnx-sandbox-run harnx-sandbox-exec)
     fi
 
     build_args=(--locked)

--- a/README.md
+++ b/README.md
@@ -8,18 +8,35 @@ usable with other harnesses.
 
 ## Install
 
-Harnx ships as three binaries, each installable independently:
+Harnx ships as a family of independently installable binaries. Each release
+publishes a separate archive per binary per target, so you can install only
+what you need:
 
-| Binary | What it does | Release size |
+| Binary | What it does | Docs |
 |---|---|---|
-| `harnx` | Full CLI — TUI + Cmd + HTTP (`--serve`) + ACP (`--acp=<agent>`) | ~18 MB |
-| `harnx-serve` | HTTP-only server, no TUI deps | ~10 MB |
-| `harnx-acp-server` | ACP-only headless agent over stdio, no TUI deps | ~11 MB |
-| `harnx-sandbox-run` | Standalone sandbox wrapper with hook support | ~10 MB |
+| `harnx` | Full CLI — TUI + Cmd + HTTP (`--serve`) + ACP (`--acp=<agent>`) | [Command-Line Guide](docs/command-line-guide.md) |
+| `harnx-serve` | HTTP-only server, no TUI deps | [README](crates/harnx-serve/README.md) |
+| `harnx-acp-server` | ACP-only headless agent over stdio, no TUI deps | [README](crates/harnx-acp-server/README.md) |
+| `harnx-pkg` | Package manager for harnx agent configurations | [Package System](docs/packages.md) |
+| `harnx-mcp-bash` | MCP server exposing bash/subprocess execution with safety guards | [Bash MCP Server](docs/bash-mcp-server.md) |
+| `harnx-mcp-fs` | MCP server exposing filesystem operations with safety guards | [README](crates/harnx-mcp-fs/README.md) |
+| `harnx-mcp-plans` | MCP server exposing file-based plan/task/note management | [README](crates/harnx-mcp-plans/README.md) |
+| `harnx-mcp-time` | MCP server exposing time and timezone utilities | [README](crates/harnx-mcp-time/README.md) |
+| `harnx-mcp-hooks-proxy` | MCP proxy that runs harnx hooks around every tool call | [README](crates/harnx-mcp-hooks-proxy/README.md) |
+| `harnx-sandbox-run` | Run commands inside the birdcage sandbox with hook support | [Sandbox Run](docs/sandbox-run.md) |
+| `harnx-sandbox-exec` | Low-level birdcage sandbox wrapper with explicit path allow-lists | [README](crates/harnx-sandbox-common/README.md) |
+| `harnx-aws-creds` | Bearer-protected helper that serves AWS credentials to tools | [AWS Creds](docs/aws-creds.md) |
+| `harnx-k8s-creds` | Persistent hook that injects scoped Kubernetes credentials into sandboxed tools | [README](crates/harnx-k8s-creds/README.md) |
+| `harnx-proxy-auth` | TLS-intercepting auth proxy that injects credentials and runs hooks | [README](crates/harnx-proxy-auth/README.md) |
+
+One helper binary ships bundled alongside its parent rather than as its own
+archive: `harnx-mcp-bash-sandbox-run` is included in the `harnx-mcp-bash`
+archive.
 
 Install whichever you need. Most users want just `harnx`; headless server
 deployments can skip the TUI deps by picking `harnx-serve` or
-`harnx-acp-server` directly.
+`harnx-acp-server` directly. The MCP server binaries (`harnx-mcp-*`) are only
+needed if you wire them up as external MCP servers.
 
 ### Install from Git (Rust developers)
 
@@ -39,13 +56,12 @@ track an in-progress branch.
 Clone the repo, then:
 
 ```sh
-# Install all three at once via the project's argc task runner:
+# Install all harnx binaries at once via the project's argc task runner:
 argc install
 
-# ...or pick one:
+# ...or pick one or more:
 argc install harnx
-argc install harnx-serve
-argc install harnx-acp-server
+argc install harnx-serve harnx-acp-server
 
 # Raw cargo also works:
 cargo install --path crates/harnx
@@ -54,8 +70,9 @@ cargo install --path crates/harnx-acp-server
 ```
 
 The `argc install` helper accepts `--debug` (build unoptimized for faster
-compile), `--force` (overwrite existing bins), and `--locked` (use the
-committed `Cargo.lock` for a reproducible install).
+compile) and an optional list of bin names to restrict the install. It always
+builds with the committed `Cargo.lock` for a reproducible result and overwrites
+any existing bins.
 
 ### Pre-built Binaries
 

--- a/crates/harnx-acp-server/README.md
+++ b/crates/harnx-acp-server/README.md
@@ -1,0 +1,24 @@
+# harnx-acp-server
+
+`harnx-acp-server` is a standalone ACP agent binary for headless deployments. It speaks the Agent Client Protocol (ACP) over stdio, allowing `harnx` agents to be integrated into host coordinators such as Zed or Superpowers without requiring the full `harnx` TUI.
+
+## Overview
+
+The server implements the `HarnxAgent` interface, binding the ACP protocol to the `harnx-runtime`. It handles session management, prompt execution, and tool calls while providing real-time event updates to the host.
+
+## Installation
+
+To install `harnx-acp-server` from the `harnx` workspace:
+
+```sh
+cargo install --path crates/harnx-acp-server
+```
+
+## CLI Options
+
+| Option | Short | Description |
+| :--- | :--- | :--- |
+| `<AGENT>` | | **Required**. The name of the agent to serve (must exist in `agents/`). |
+| `--model <MODEL>` | `-m` | Select a specific LLM model to use. |
+| `--dry-run` | | Echo prompts instead of sending them to the LLM. |
+| `--mcp-root <PATH>` | | Add one or more MCP roots (comma-separated). |

--- a/crates/harnx-mcp-fs/README.md
+++ b/crates/harnx-mcp-fs/README.md
@@ -1,0 +1,36 @@
+# harnx-mcp-fs
+
+`harnx-mcp-fs` is a high-performance MCP filesystem server that provides secure file and directory operations to LLM agents. It implements safety guards and supports dynamic MCP roots for restricted filesystem access.
+
+## Overview
+
+The server communicates via stdio using the Model Context Protocol (MCP). It restricts all filesystem operations to a set of allowed "roots." If no roots are specified via CLI or provided dynamically by the MCP client, all operations are denied.
+
+## Installation
+
+To install `harnx-mcp-fs` from the `harnx` workspace:
+
+```sh
+cargo install --path crates/harnx-mcp-fs
+```
+
+## CLI Options
+
+| Option | Short | Description |
+| :--- | :--- | :--- |
+| `--root <PATH>` | `-r` | Add an allowed root directory. This flag can be repeated to allow multiple roots. |
+| `--help` | `-h` | Show the help message. |
+
+## Tools
+
+The server exposes the following tools to the MCP client:
+
+- `read`: Read file contents with support for pagination, grep filtering, and truncation.
+- `write`: Create or overwrite a file with specified content.
+- `edit`: Perform exact-text replacement within a file.
+- `insert`: Insert text at a specific line and column.
+- `re_replace`: Replace text using regular expressions.
+- `ls`: List directory contents, optionally recursively.
+- `grep`: Search file contents with regex and optional context lines.
+- `find`: Find files by glob pattern.
+- `rollback_file`: Restore a repository to a prior harnx history snapshot.

--- a/crates/harnx-mcp-hooks-proxy/README.md
+++ b/crates/harnx-mcp-hooks-proxy/README.md
@@ -1,0 +1,42 @@
+# harnx-mcp-hooks-proxy
+
+`harnx-mcp-hooks-proxy` is an MCP proxy that runs `harnx` hooks around tool calls made to an underlying MCP server. It allows users to wrap any existing MCP server with custom pre-tool and post-tool logic.
+
+## Overview
+
+The proxy sits between an MCP host (like Claude Desktop) and a child MCP server process. It intercepts `tools/call` requests and responses, dispatching them to configured hooks before and after the child server handles the call.
+
+## Installation
+
+To install `harnx-mcp-hooks-proxy` from the `harnx` workspace:
+
+```sh
+cargo install --path crates/harnx-mcp-hooks-proxy
+```
+
+## Usage
+
+Run the proxy by specifying hooks and the child command to wrap, separated by `--`.
+
+```sh
+harnx-mcp-hooks-proxy \
+  --pre-tool-use "claude-command my-pre-hook" \
+  --post-tool-use "claude-command my-post-hook" \
+  -- child-mcp-server --arg1
+```
+
+## CLI Options
+
+| Option | Description |
+| :--- | :--- |
+| `--pre-tool-use <SPEC>` | Hook to run before a tool call. |
+| `--post-tool-use <SPEC>` | Hook to run after a successful tool call. |
+| `--post-tool-use-failure <SPEC>` | Hook to run after a tool call failure. |
+| `--` | Separator between proxy flags and the child command to execute. |
+
+### Hook Specification
+
+A `<SPEC>` follows the format: `claude-command [--async] [--matcher <REGEX>] <COMMAND>`
+
+- `--async`: Run the hook asynchronously (do not wait for completion).
+- `--matcher <REGEX>`: Only run the hook if the tool name matches the regex.

--- a/crates/harnx-mcp-plans/README.md
+++ b/crates/harnx-mcp-plans/README.md
@@ -32,5 +32,5 @@ The server automatically cleans up inactive plans to manage disk space.
 The server provides a comprehensive set of tools for managing the lifecycle of plans and their components:
 
 - **Plans**: `list_plans`, `add_plan`, `get_plan`, `update_plan`, `delete_plan`
-- **Tasks**: `list_tasks`, `add_task`, `get_task`, `update_task`, `append_task`, `delete_task`
-- **Notes**: `list_notes`, `add_note`, `get_note`, `delete_note`
+- **Tasks**: `list_tasks`, `add_task`, `get_task`, `update_task`, `delete_task`
+- **Notes**: `list_notes`, `add_note`, `get_note`, `update_note`, `delete_note`

--- a/crates/harnx-mcp-plans/src/main.rs
+++ b/crates/harnx-mcp-plans/src/main.rs
@@ -6,8 +6,8 @@
 //! Layout: `<dir>/<plan>/plan.md`, `<dir>/<plan>/tasks/<id>.md`, `<dir>/<plan>/notes/<id>.md`
 //!
 //! Provides: list_plans, add_plan, get_plan, update_plan, delete_plan,
-//! list_tasks, add_task, get_task, update_task, append_task, delete_task,
-//! list_notes, add_note, get_note, delete_note
+//! list_tasks, add_task, get_task, update_task, delete_task,
+//! list_notes, add_note, get_note, update_note, delete_note
 
 mod server;
 

--- a/crates/harnx-mcp-time/README.md
+++ b/crates/harnx-mcp-time/README.md
@@ -1,0 +1,24 @@
+# harnx-mcp-time
+
+`harnx-mcp-time` is an MCP server that provides time and timezone utilities to LLM agents. It allows agents to check the current time, convert between timezones, and perform timed waits.
+
+## Overview
+
+The server implements several tools for handling temporal data, using the Model Context Protocol (MCP) over stdio. It automatically detects the local timezone of the host system but allows overrides in tool calls.
+
+## Installation
+
+To install `harnx-mcp-time` from the `harnx` workspace:
+
+```sh
+cargo install --path crates/harnx-mcp-time
+```
+
+## Tools
+
+The server exposes the following tools:
+
+- `get_current_time`: Get the current time in a specific IANA timezone.
+- `convert_time`: Convert, offset, and reformat timestamps (ISO, Unix, or Epoch Millis).
+- `wait`: Pause execution for a specified number of seconds (max 3600).
+- `wait_until`: Pause execution until a specific target time (HH:MM or full ISO).

--- a/crates/harnx-proxy-auth/README.md
+++ b/crates/harnx-proxy-auth/README.md
@@ -1,0 +1,34 @@
+# harnx-proxy-auth
+
+`harnx-proxy-auth` is a TLS-intercepting authentication proxy designed to inject credentials and run hooks on outgoing HTTP requests. It is particularly useful for providing agents with secure access to protected APIs without exposing long-lived tokens to the agent's environment.
+
+## Overview
+
+The proxy generates a temporary Certificate Authority (CA) to intercept HTTPS traffic. It uses `jq` (via `jaq`) filters to mutate requests—such as adding `Authorization` headers—based on the request host, path, or method.
+
+## Installation
+
+To install `harnx-proxy-auth` from the `harnx` workspace:
+
+```sh
+cargo install --path crates/harnx-proxy-auth
+```
+
+## CLI Options
+
+| Option | Description |
+| :--- | :--- |
+| `--hook <JQ_FILTER>` | A `jaq` filter to apply to each request. Receives an object with `host`, `path`, `method`, and `headers`. Can be repeated to pipe multiple filters. |
+| `--env <JQ_FILTER>` | A `jaq` filter to generate extra environment variables for hooks, with access to generated sentinel values. |
+| `--log-file <PATH>` | Path to write a JSON log line for every proxied request (useful for debugging auth injection). |
+
+## Sentinel Values
+
+When using `--env`, the proxy provides several sentinel variables to the filter:
+- `$fake_uuid_key`
+- `$fake_base64_key`
+- `$fake_url_base64_key`
+- `$fake_hex_key`
+- `$fake_email`
+
+These can be used to populate headers or environment variables with temporary, session-specific values.

--- a/crates/harnx-sandbox-common/README.md
+++ b/crates/harnx-sandbox-common/README.md
@@ -1,0 +1,46 @@
+# harnx-sandbox-exec
+
+`harnx-sandbox-exec` is a low-level wrapper that runs a single command inside the
+[birdcage](https://github.com/phylum-dev/birdcage) filesystem sandbox with an
+explicit allow-list of paths. It is the primitive that higher-level tools such as
+`harnx-sandbox-run` and `harnx-mcp-bash` build on, and it ships in the
+`harnx-sandbox-common` crate.
+
+## Overview
+
+The binary configures a birdcage sandbox from the paths and options you pass on
+the command line, then execs the supplied command inside it. Unlike
+`harnx-sandbox-run`, it applies no default whitelist — you specify exactly which
+paths are readable, writable, and executable. Sandboxing is only available on
+Unix-like systems.
+
+For a higher-level wrapper with sensible defaults and hook support, see
+[`harnx-sandbox-run`](../harnx-sandbox-run/README.md).
+
+## Installation
+
+To install `harnx-sandbox-exec` from the `harnx` workspace:
+
+```sh
+cargo install --path crates/harnx-sandbox-common
+```
+
+## Usage
+
+```sh
+harnx-sandbox-exec [OPTIONS] -- <command> [args...]
+```
+
+Everything after `--` is the command to run inside the sandbox.
+
+## CLI Options
+
+| Option | Description |
+| :--- | :--- |
+| `--write <path>` | Allow read+write access to a path (repeatable). |
+| `--read <path>` | Allow read-only access to a path (repeatable). |
+| `--exec <path>` | Allow read+execute access to a path (repeatable). |
+| `--env VAR[=VALUE]` | Pass `VAR` from the host environment, or set it explicitly with `=VALUE` (repeatable). |
+| `--no-network` | Disable networking (networking is allowed by default). |
+| `--working-dir <path>` | Set the working directory of the spawned command. |
+| `--help`, `-h` | Print the help message. |

--- a/crates/harnx-serve/README.md
+++ b/crates/harnx-serve/README.md
@@ -1,0 +1,24 @@
+# harnx-serve
+
+`harnx-serve` is a standalone HTTP server binary for the `harnx` agent harness. It provides a headless deployment option that serves the same HTTP API as `harnx --serve` but with a smaller dependency footprint, omitting the TUI and terminal-related components.
+
+## Overview
+
+The server allows external clients (such as IDE plugins or web interfaces) to interact with `harnx` agents over HTTP. It supports agent execution, session management, and MCP tool orchestration.
+
+## Installation
+
+To install `harnx-serve` from the `harnx` workspace:
+
+```sh
+cargo install --path crates/harnx-serve
+```
+
+## CLI Options
+
+| Option | Short | Description |
+| :--- | :--- | :--- |
+| `--addr <ADDRESS>` | `-a` | Listen address (default from `config.yaml` or `127.0.0.1:8000`). |
+| `--model <MODEL>` | `-m` | Select a specific LLM model to use. |
+| `--dry-run` | | Echo prompts instead of sending them to the LLM. |
+| `--mcp-root <PATH>` | | Add one or more MCP roots (comma-separated). |

--- a/docker/harnx.Dockerfile
+++ b/docker/harnx.Dockerfile
@@ -15,7 +15,9 @@ COPY linux-${TARGETARCH}/harnx-mcp-fs /usr/local/bin/harnx-mcp-fs
 COPY linux-${TARGETARCH}/harnx-mcp-plans /usr/local/bin/harnx-mcp-plans
 COPY linux-${TARGETARCH}/harnx-mcp-time /usr/local/bin/harnx-mcp-time
 COPY linux-${TARGETARCH}/harnx-aws-creds /usr/local/bin/harnx-aws-creds
+COPY linux-${TARGETARCH}/harnx-k8s-creds /usr/local/bin/harnx-k8s-creds
 COPY linux-${TARGETARCH}/harnx-pkg /usr/local/bin/harnx-pkg
+COPY linux-${TARGETARCH}/harnx-mcp-hooks-proxy /usr/local/bin/harnx-mcp-hooks-proxy
 COPY linux-${TARGETARCH}/harnx-proxy-auth /usr/local/bin/harnx-proxy-auth
 COPY linux-${TARGETARCH}/harnx-sandbox-run /usr/local/bin/harnx-sandbox-run
 COPY linux-${TARGETARCH}/harnx-sandbox-exec /usr/local/bin/harnx-sandbox-exec


### PR DESCRIPTION
Expands README install table from 3 to all 14 released binaries with documentation links. Adds 7 new per-crate READMEs and fixes inaccurate tool names or flags in existing docs.

Wires previously-omitted harnx-k8s-creds binary into release.yaml, the Docker image, and Argcfile.sh. Adds missing harnx-mcp-hooks-proxy to the Docker image.

Closes #691

Plan: readme-binary-docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive per-binary README files for multiple harnx components
  * Updated main README with expanded installable binaries family and installation instructions

* **New Features**
  * `harnx-k8s-creds` and `harnx-mcp-hooks-proxy` now included in release builds and Docker image
  * Updated MCP server tool documentation and capabilities

* **Changes**
  * Modified default binary installation set to exclude one helper binary

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dobesv/harnx/pull/707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->