### PR TITLE
feat: improve bash exec output markdown formatting

### DIFF
--- a/.changeset/markdown-output-formatting.md
+++ b/.changeset/markdown-output-formatting.md
@@ -1,0 +1,5 @@
+---
+harnx: patch
+---
+
+Improve bash exec output formatting for markdown rendering in kagent (#713).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,6 +3672,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "tokio",
  "uuid",

--- a/crates/harnx-mcp-bash/Cargo.toml
+++ b/crates/harnx-mcp-bash/Cargo.toml
@@ -21,6 +21,7 @@ process-wrap = { workspace = true }
 rmcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 tempfile = "3"
 tokio = { workspace = true, features = ["fs"] }
 uuid = { workspace = true }

--- a/crates/harnx-mcp-bash/src/server/exec.rs
+++ b/crates/harnx-mcp-bash/src/server/exec.rs
@@ -341,10 +341,13 @@ impl BashServer {
     }
 
     pub(crate) fn build_success_result(
-        output: String,
+        mut output: String,
         summary: String,
         diff_parts: Vec<String>,
     ) -> CallToolResult {
+        if !output.ends_with('\n') {
+            output.push('\n');
+        }
         let mut contents = vec![
             Content::text(output).with_audience(vec![Role::Assistant]),
             Content::text(summary).with_audience(vec![Role::User]),

--- a/crates/harnx-mcp-bash/src/server/process.rs
+++ b/crates/harnx-mcp-bash/src/server/process.rs
@@ -233,10 +233,7 @@ impl BashServer {
                     "execution_id '{}' still running after {}s",
                     params.execution_id, timeout_secs
                 );
-                Ok(CallToolResult::success(vec![
-                    Content::text(output).with_audience(vec![Role::Assistant]),
-                    Content::text(summary).with_audience(vec![Role::User]),
-                ]))
+                Ok(Self::build_success_result(output, summary, vec![]))
             }
         }
     }
@@ -372,12 +369,9 @@ impl BashServer {
                 total_bytes: None,
             },
         );
-        let _ = write!(output, "signal: {}", signal);
+        let _ = write!(output, "\n\nsignal: {}", signal);
         let summary = format!("sent {} to {}", signal, execution_id);
-        CallToolResult::success(vec![
-            Content::text(output).with_audience(vec![Role::Assistant]),
-            Content::text(summary).with_audience(vec![Role::User]),
-        ])
+        Self::build_success_result(output, summary, vec![])
     }
 
     pub(crate) async fn build_wait_exit_result(
@@ -407,7 +401,6 @@ impl BashServer {
                 total_bytes: None,
             },
         );
-        output.pop();
         let summary = format!("spawned {}", ctx.execution_id);
         Self::build_success_result(output, summary, vec![])
     }

--- a/crates/harnx-mcp-bash/src/server/render.rs
+++ b/crates/harnx-mcp-bash/src/server/render.rs
@@ -197,7 +197,7 @@ pub(crate) fn count_lines(s: &str) -> usize {
     }
 }
 
-/// Render one stream's output block with `===== stdout =====` / `===== /stdout =====` markers.
+/// Render one stream's output block inside markdown fences with HTML markers.
 /// Each stream is truncated independently using `truncate_opts`.
 /// Returns the rendered block string (no trailing newline).
 pub(crate) fn render_stream_block(
@@ -207,12 +207,9 @@ pub(crate) fn render_stream_block(
     log_hint: Option<(&str, &Path)>, // (execution_id, log_path) for truncation hint
 ) -> String {
     let sanitized = sanitize_output_text(content);
-    if sanitized.is_empty() {
-        return format!("===== {name} (empty) =====");
-    }
     let truncated = truncate_output(&sanitized, truncate_opts);
     let was_truncated = truncated != sanitized;
-    let mut block = format!("===== {name} =====\n{truncated}");
+    let mut block = format!("<!-- start {name} -->\n```\n{truncated}");
     if was_truncated {
         if let Some((execution_id, log_path)) = log_hint {
             let _ = write!(
@@ -231,7 +228,9 @@ pub(crate) fn render_stream_block(
             );
         }
     }
-    let _ = write!(block, "\n===== /{name} =====");
+    // Known limitation: embedded ``` in stream content can break fence parsing;
+    // HTML comment markers provide structural fallback for downstream consumers.
+    let _ = write!(block, "\n```\n<!-- end {name} -->");
     block
 }
 
@@ -284,7 +283,7 @@ pub(crate) fn render_streams_block(
         Some((execution_id, stderr_log_path)),
     );
 
-    let rendered = format!("{stdout_block}\n{stderr_block}");
+    let rendered = format!("{stdout_block}\n\n{stderr_block}");
     (
         rendered,
         stdout_lines,
@@ -294,62 +293,50 @@ pub(crate) fn render_streams_block(
     )
 }
 
+#[derive(serde::Serialize)]
 pub(crate) struct MetadataHeader<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) execution_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) status: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) command: Option<&'a str>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_optional_path"
+    )]
     pub(crate) working_dir: Option<&'a Path>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_optional_path"
+    )]
     pub(crate) stdout_log_path: Option<&'a Path>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_optional_path"
+    )]
     pub(crate) stderr_log_path: Option<&'a Path>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) total_lines: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) total_bytes: Option<usize>,
 }
 
-pub(crate) fn render_metadata_header(output: &mut String, metadata: MetadataHeader<'_>) {
-    let MetadataHeader {
-        execution_id,
-        status,
-        exit_code,
-        command,
-        working_dir,
-        stdout_log_path,
-        stderr_log_path,
-        total_lines,
-        total_bytes,
-    } = metadata;
+fn serialize_optional_path<S>(path: &Option<&Path>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match path {
+        Some(path) => serializer.serialize_str(&path.display().to_string()),
+        None => serializer.serialize_none(),
+    }
+}
 
-    if let Some(execution_id) = execution_id {
-        let _ = writeln!(output, "execution_id: {execution_id}");
-    }
-    if let Some(status) = status {
-        let _ = writeln!(output, "status: {status}");
-    }
-    if let Some(exit_code) = exit_code {
-        let _ = writeln!(output, "exit_code: {exit_code}");
-    }
-    if let Some(command) = command {
-        let _ = writeln!(output, "command: {command}");
-    }
-    if let Some(working_dir) = working_dir {
-        let _ = writeln!(output, "working_dir: {}", working_dir.display());
-    }
-    if let Some(stdout_log_path) = stdout_log_path {
-        let _ = writeln!(output, "stdout_log_path: {}", stdout_log_path.display());
-    }
-    if let Some(stderr_log_path) = stderr_log_path {
-        let _ = writeln!(output, "stderr_log_path: {}", stderr_log_path.display());
-    }
-    if let Some(total_lines) = total_lines {
-        let _ = writeln!(output, "total_lines: {total_lines}");
-    }
-    if let Some(total_bytes) = total_bytes {
-        let _ = writeln!(
-            output,
-            "total_bytes: {total_bytes} ({})",
-            format_size(total_bytes)
-        );
-    }
+pub(crate) fn render_metadata_header(output: &mut String, metadata: MetadataHeader<'_>) {
+    let yaml = serde_yaml::to_string(&metadata).expect("MetadataHeader should serialize to YAML");
+    let _ = write!(output, "```yaml\n{yaml}```");
 }
 
 pub(crate) struct TimeoutRenderContext<'a> {

--- a/crates/harnx-mcp-bash/src/server/tests.rs
+++ b/crates/harnx-mcp-bash/src/server/tests.rs
@@ -1762,6 +1762,17 @@ async fn test_spawn_and_terminate() {
         &text,
         &["status: terminated", "command: sleep 30", "signal: SIGTERM"],
     );
+    // The YAML metadata fence must close on its own line, followed by a blank
+    // line, then the `signal:` line as plain text. Guards against the closing
+    // fence and signal text being mashed onto the same line (e.g. "```signal:").
+    assert!(
+        text.contains("```\n\nsignal: SIGTERM"),
+        "terminate output must separate the closing yaml fence from the signal line: {text:?}"
+    );
+    assert!(
+        !text.contains("```signal:"),
+        "signal line must not be mashed onto the closing yaml fence: {text:?}"
+    );
 }
 
 #[tokio::test]
@@ -2415,7 +2426,7 @@ async fn test_wait_grep_filters_per_stream() {
     // the literal command (which contains "drop-*"), so assert against the
     // stdout/stderr block bodies, not the full text.
     let text = text_content(&result);
-    let blocks = &text[text.find("===== stdout =====").expect("stdout marker")..];
+    let blocks = &text[text.find("<!-- start stdout -->").expect("stdout marker")..];
     assert!(blocks.contains("keep-out"), "stdout match kept: {text}");
     assert!(blocks.contains("keep-err"), "stderr match kept: {text}");
     assert!(
@@ -2510,8 +2521,8 @@ async fn test_wait_max_output_bytes_truncates() {
     );
 }
 
-/// Stream markers appear in `wait` output: opening/closing markers for a
-/// non-empty stream, and the `(empty)` form for a stream with no output.
+/// Stream markers appear in `wait` output: opening/closing HTML-comment markers
+/// for streams. Empty streams emit start/end markers with an empty fenced code block.
 #[tokio::test]
 async fn test_wait_stream_markers() {
     let temp_dir = TestDir::new();
@@ -2544,17 +2555,21 @@ async fn test_wait_stream_markers() {
 
     let text = text_content(&result);
     assert!(
-        text.contains("===== stdout ====="),
+        text.contains("<!-- start stdout -->"),
         "stdout open marker: {text}"
     );
     assert!(
-        text.contains("===== /stdout ====="),
+        text.contains("<!-- end stdout -->"),
         "stdout close marker: {text}"
     );
     assert!(text.contains("only-stdout"));
     assert!(
-        text.contains("===== stderr (empty) ====="),
-        "empty stderr marker: {text}"
+        text.contains("<!-- start stderr -->"),
+        "empty stderr start marker: {text}"
+    );
+    assert!(
+        text.contains("<!-- end stderr -->"),
+        "empty stderr end marker: {text}"
     );
 }
 
@@ -2672,7 +2687,9 @@ async fn test_spawn_wait_read_exec_log_returns_full_output() {
     // Scope to the stdout block: the metadata header echoes the literal
     // command, which contains "out2".
     let wait_text = text_content(&result);
-    let wait_blocks = &wait_text[wait_text.find("===== stdout =====").expect("stdout marker")..];
+    let wait_blocks = &wait_text[wait_text
+        .find("<!-- start stdout -->")
+        .expect("stdout marker")..];
     assert!(wait_blocks.contains("out1"));
     assert!(
         !wait_blocks.contains("out2"),

--- a/docs/solutions/logic-errors/mcp-bash-markdown-output-formatting-2026-05-31.md
+++ b/docs/solutions/logic-errors/mcp-bash-markdown-output-formatting-2026-05-31.md
@@ -1,0 +1,195 @@
+---
+title: "MCP bash tool output markdown rendering in kagent"
+date: 2026-05-31
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-mcp-bash"
+root_cause: "hand-rolled key:value output with ad-hoc markers did not render correctly as markdown"
+resolution_type: code_fix
+severity: medium
+tags:
+  - markdown
+  - yaml
+  - serde_yaml
+  - mcp-tool-output
+  - html-comments
+plan_ref: "harnx-mcp-bash-markdown-output"
+---
+
+## Problem
+
+The `harnx-mcp-bash` exec tool output used hand-rolled `key: value` lines and `===== stdout =====` markers that rendered as unstyled text walls in kagent's markdown UI. Commands with colons, quotes, or newlines broke formatting due to lack of proper escaping.
+
+## Symptoms
+
+- Metadata rendered as plain `key: value` text instead of styled YAML block
+- Stream content had no code fencing — appeared as unformatted text
+- Commands like `echo "foo: bar"` broke YAML-parsing consumers due to unescaped colon
+- Empty streams emitted `(empty)` sentinel text, creating special-case handling
+
+## Investigation Steps
+
+1. Reviewed kagent markdown rendering behavior — it interprets MCP tool output as markdown
+2. Tested `serde_yaml::to_string` for metadata serialization — correctly handles quoting, multiline block scalars, special characters
+3. Evaluated options for stream block delimiters:
+   - Plain text markers: `===== stdout =====` — renders as plain text, no structure
+   - Backtick fences: ` ``` ` — renders as code but breaks if content contains triple-backticks
+   - HTML comments: `<!-- start stdout -->` — invisible in rendered markdown, survives nested backticks
+4. Decided on hybrid: HTML comment markers for structural fallback + backtick fences for visual rendering
+5. Found trailing-newline defect during review: `build_terminate_result` appended plaintext directly after fenced block output, mashing `signal: SIGTERM` onto the closing fence line
+
+## Root Cause
+
+Output formatting relied on manual string concatenation with ad-hoc marker syntax. No escaping for special characters. No consistent trailing-newline guarantee across code paths. Empty streams had a special sentinel branch instead of uniform treatment.
+
+## Solution
+
+### Metadata Header via serde_yaml
+
+```rust
+#[derive(serde::Serialize)]
+pub(crate) struct MetadataHeader<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) execution_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) status: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) command: Option<&'a str>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_optional_path"
+    )]
+    pub(crate) working_dir: Option<&'a Path>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_optional_path"
+    )]
+    pub(crate) stdout_log_path: Option<&'a Path>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_optional_path"
+    )]
+    pub(crate) stderr_log_path: Option<&'a Path>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) total_lines: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) total_bytes: Option<usize>,
+}
+
+fn serialize_optional_path<S>(path: &Option<&Path>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match path {
+        Some(path) => serializer.serialize_str(&path.display().to_string()),
+        None => serializer.serialize_none(),
+    }
+}
+
+pub(crate) fn render_metadata_header(output: &mut String, metadata: MetadataHeader<'_>) {
+    let yaml = serde_yaml::to_string(&metadata).expect("MetadataHeader should serialize to YAML");
+    let _ = write!(output, "```yaml\n{yaml}```");
+}
+```
+
+### Stream Blocks with HTML Comment Markers
+
+```rust
+pub(crate) fn render_stream_block(
+    name: &str,
+    content: &str,
+    truncate_opts: &TruncateOpts,
+    log_hint: Option<(&str, &Path)>,
+) -> String {
+    let sanitized = sanitize_output_text(content);
+    let truncated = truncate_output(&sanitized, truncate_opts);
+    let mut block = format!("<!-- start {name} -->\n```\n{truncated}");
+    // truncation hint appended inside fence if needed...
+    block.push_str("\n```\n<!-- end {name} -->");
+    block
+}
+```
+
+**New output shape:**
+
+~~~text
+```yaml
+execution_id: exec-...
+status: exited
+exit_code: 0
+command: echo test
+```
+
+<!-- start stdout -->
+```
+test
+```
+<!-- end stdout -->
+
+<!-- start stderr -->
+```
+```
+<!-- end stderr -->
+~~~
+
+### Trailing Newline Guarantee
+
+Centralized in `build_success_result`:
+
+```rust
+fn build_success_result(output: String, summary: String, annotations: Vec<Annotation>) -> CallToolResult {
+    // Ensure trailing newline for assistant-audience output
+    let output = if output.ends_with('\n') { output } else { format!("{output}\n") };
+    CallToolResult::success(vec![
+        Content::text(output).with_annotations(annotations),
+        Content::text(summary).with_audience(["user"]),
+    ])
+}
+```
+
+### Terminate Path Fix
+
+**Before (broken):**
+```rust
+let mut output = String::new();
+render_metadata_header(&mut output, metadata);
+write!(output, "signal: {signal}")?;  // Mashes onto closing fence line
+```
+
+**After (fixed):**
+```rust
+let mut output = String::new();
+render_metadata_header(&mut output, metadata);
+write!(output, "\n\nsignal: {signal}")?;  // Blank line separation
+build_success_result(output, summary, vec![])
+```
+
+## Why This Works
+
+1. **serde_yaml** handles YAML spec correctly — block scalars for multiline commands, proper quoting for colons/quotes, no `null` noise via `skip_serializing_if`.
+2. **HTML comment markers** are invisible in rendered markdown but survive even if stream content contains triple-backticks. LLM and downstream consumers can still locate block boundaries.
+3. **Empty streams** emit the same structure (start marker + empty fence + end marker) — no special-case branches, no `(empty)` sentinel.
+4. **Centralized trailing newline** ensures all assistant-audience code paths end cleanly.
+
+## Prevention Strategies
+
+**Test Cases:**
+- Assert metadata renders as valid YAML (`serde_yaml::from_str` roundtrips)
+- Assert commands with colons/quotes/newlines serialize correctly
+- Assert empty streams produce both start and end markers
+- Assert assistant output ends with `\n`
+
+**Code Review Checklist:**
+- [ ] When appending plaintext after a fenced block, insert `\n\n` separation
+- [ ] All paths building `CallToolResult` for assistant audience should go through `build_success_result`
+- [ ] `serde::Serialize` structs with `Option` fields should use `skip_serializing_if = "Option::is_none"`
+
+**Known Limitation:**
+- Triple-backticks in stream content break the plain fence rendering — accepted as low-probability edge case. HTML comment markers preserve structure for programmatic consumers.
+
+## Related Issues
+
+- **GitHub:** [#713](https://github.com/dobesv/harnx/issues/713) — Improve bash exec output markdown formatting
+- **Plan:** `harnx-mcp-bash-markdown-output`


### PR DESCRIPTION
Reformats harnx-mcp-bash execution output for proper markdown rendering in kagent. Uses serde_yaml to serialize metadata into a fenced yaml block, ensuring correct escaping for commands with special characters. Stream output (stdout/stderr) now uses HTML comment markers for structural parsing and backtick fences for code-block rendering. Ensures a trailing newline on all assistant-audience output and corrects blank-line separation in the termination result path.

Closes #713
Plan: harnx-mcp-bash-markdown-output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bash execution output formatting for markdown: metadata is emitted as a fenced YAML block, stdout/stderr are wrapped in fenced code blocks with preserved structural boundaries, and terminal output now reliably ends with a trailing newline to prevent fence concatenation.

* **Documentation**
  * Added a detailed guide describing the output formatting and markdown rendering fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->