### PR TITLE
feat(sandbox): support project-root pseudo-vars and tilde in paths

### DIFF
--- a/.changeset/sandbox-project-root-detection.md
+++ b/.changeset/sandbox-project-root-detection.md
@@ -1,0 +1,9 @@
+---
+harnx: minor
+---
+
+This release introduces project-root pseudo-variables for sandbox path configuration in `harnx-sandbox-run` and `harnx-mcp-bash`. You can now use `$GIT_ROOT`, `$GIT_COMMON_DIR`, `$NODE_PROJECT_ROOT`, `$CARGO_ROOT`, and `$GO_ROOT` in both CLI flags (`--extra-*`) and environment variables (`HARNX_BASH_EXTRA_*`).
+
+These variables are resolved at startup against the current working directory. If you are not inside a matching project (e.g., you use `$GIT_ROOT` while not in a git repository), the path is silently skipped. For security, any path that resolves to your home directory or an ancestor of it is also dropped.
+
+Additionally, `harnx-mcp-bash` now correctly applies the home-directory guard to all extra paths provided via flags or environment variables, matching the security behavior of `harnx-sandbox-run`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3934,6 +3934,7 @@ version = "0.32.3"
 dependencies = [
  "anyhow",
  "birdcage",
+ "gix",
  "log",
  "tempfile",
 ]

--- a/crates/harnx-mcp-bash/src/main.rs
+++ b/crates/harnx-mcp-bash/src/main.rs
@@ -1,4 +1,6 @@
 mod server;
+#[cfg(test)]
+mod test_support;
 
 use harnx_sandbox_common::SandboxConfig;
 use rmcp::ServiceExt;
@@ -51,12 +53,14 @@ async fn main() -> anyhow::Result<()> {
 }
 
 #[cfg(unix)]
-fn parse_env_paths(var_name: &str) -> Vec<PathBuf> {
+fn parse_env_paths(var_name: &str, cwd: &Path) -> Vec<PathBuf> {
     std::env::var_os(var_name)
         .map(|value| {
             std::env::split_paths(&value)
                 .filter(|path| !path.as_os_str().is_empty())
-                .map(|path| PathBuf::from(expand_tilde(&path.to_string_lossy())))
+                .filter_map(|path| {
+                    harnx_sandbox_common::expand_path_var(&path.to_string_lossy(), cwd)
+                })
                 .collect()
         })
         .unwrap_or_default()
@@ -82,27 +86,8 @@ fn path_is_executable(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn expand_tilde(raw: &str) -> String {
-    if !raw.starts_with('~') {
-        return raw.to_string();
-    }
-
-    let home = match std::env::var("HOME") {
-        Ok(home) => home,
-        Err(_) => return raw.to_string(),
-    };
-
-    if raw == "~" {
-        home
-    } else if let Some(suffix) = raw.strip_prefix("~/") {
-        format!("{home}/{suffix}")
-    } else {
-        raw.to_string()
-    }
-}
-
 fn push_root(roots: &mut Vec<PathBuf>, raw: &str) {
-    let raw = expand_tilde(raw);
+    let raw = harnx_sandbox_common::expand_tilde(raw);
     let path = PathBuf::from(&raw);
     if path.exists() {
         match path.canonicalize() {
@@ -119,14 +104,15 @@ fn push_root(roots: &mut Vec<PathBuf>, raw: &str) {
 #[cfg(unix)]
 fn parse_args() -> anyhow::Result<(Vec<PathBuf>, SandboxConfig)> {
     let args: Vec<String> = std::env::args().collect();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let mut roots = Vec::new();
     let mut sandbox_enabled = true;
     let mut sandbox_config = SandboxConfig {
         enabled: true,
-        extra_exec: parse_env_paths("HARNX_BASH_EXTRA_EXEC"),
-        extra_readable: parse_env_paths("HARNX_BASH_EXTRA_READABLE"),
-        extra_writable: parse_env_paths("HARNX_BASH_EXTRA_WRITABLE"),
-        extra_rwx: parse_env_paths("HARNX_BASH_EXTRA_RWX"),
+        extra_exec: parse_env_paths("HARNX_BASH_EXTRA_EXEC", &cwd),
+        extra_readable: parse_env_paths("HARNX_BASH_EXTRA_READABLE", &cwd),
+        extra_writable: parse_env_paths("HARNX_BASH_EXTRA_WRITABLE", &cwd),
+        extra_rwx: parse_env_paths("HARNX_BASH_EXTRA_RWX", &cwd),
         sandbox_run_path: PathBuf::from("harnx-sandbox-exec"),
         extra_env_passthrough: parse_env_passthrough(),
         env_overrides: vec![],
@@ -152,9 +138,9 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, SandboxConfig)> {
             }
             "--extra-read" => {
                 if i + 1 < args.len() {
-                    sandbox_config
-                        .extra_readable
-                        .push(PathBuf::from(expand_tilde(&args[i + 1])));
+                    if let Some(path) = harnx_sandbox_common::expand_path_var(&args[i + 1], &cwd) {
+                        sandbox_config.extra_readable.push(path);
+                    }
                     i += 2;
                 } else {
                     eprintln!("harnx-mcp-bash: --extra-read requires a path argument");
@@ -163,9 +149,9 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, SandboxConfig)> {
             }
             "--extra-exec" => {
                 if i + 1 < args.len() {
-                    sandbox_config
-                        .extra_exec
-                        .push(PathBuf::from(expand_tilde(&args[i + 1])));
+                    if let Some(path) = harnx_sandbox_common::expand_path_var(&args[i + 1], &cwd) {
+                        sandbox_config.extra_exec.push(path);
+                    }
                     i += 2;
                 } else {
                     eprintln!("harnx-mcp-bash: --extra-exec requires a path argument");
@@ -174,9 +160,9 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, SandboxConfig)> {
             }
             "--extra-write" => {
                 if i + 1 < args.len() {
-                    sandbox_config
-                        .extra_writable
-                        .push(PathBuf::from(expand_tilde(&args[i + 1])));
+                    if let Some(path) = harnx_sandbox_common::expand_path_var(&args[i + 1], &cwd) {
+                        sandbox_config.extra_writable.push(path);
+                    }
                     i += 2;
                 } else {
                     eprintln!("harnx-mcp-bash: --extra-write requires a path argument");
@@ -185,9 +171,9 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, SandboxConfig)> {
             }
             "--extra-rwx" => {
                 if i + 1 < args.len() {
-                    sandbox_config
-                        .extra_rwx
-                        .push(PathBuf::from(expand_tilde(&args[i + 1])));
+                    if let Some(path) = harnx_sandbox_common::expand_path_var(&args[i + 1], &cwd) {
+                        sandbox_config.extra_rwx.push(path);
+                    }
                     i += 2;
                 } else {
                     eprintln!("harnx-mcp-bash: --extra-rwx requires a path argument");
@@ -196,7 +182,9 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, SandboxConfig)> {
             }
             "--sandbox-run" => {
                 if i + 1 < args.len() {
-                    sandbox_run_override = Some(PathBuf::from(expand_tilde(&args[i + 1])));
+                    sandbox_run_override = Some(PathBuf::from(harnx_sandbox_common::expand_tilde(
+                        &args[i + 1],
+                    )));
                     i += 2;
                 } else {
                     eprintln!("harnx-mcp-bash: --sandbox-run requires a path argument");
@@ -262,6 +250,8 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, SandboxConfig)> {
                 eprintln!(
                     "  HARNX_BASH_ENV_PASSTHROUGH  Comma-separated extra env var names to pass through"
                 );
+                eprintln!();
+                eprintln!("  $GIT_ROOT, $GIT_COMMON_DIR, $NODE_PROJECT_ROOT, $CARGO_ROOT, $GO_ROOT supported; resolved vs cwd, dropped if absent");
                 eprintln!();
                 eprintln!("Sandboxing is enabled by default on Unix. Use --no-sandbox to disable it explicitly.");
                 eprintln!("The server communicates via stdio using the MCP protocol.");
@@ -453,52 +443,93 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, SandboxConfig)> {
 
 #[cfg(test)]
 mod tests {
-    use super::expand_tilde;
-    use std::ffi::{OsStr, OsString};
-    use std::sync::{Mutex, MutexGuard, OnceLock};
-
-    fn env_lock() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        match LOCK.get_or_init(|| Mutex::new(())).lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        }
-    }
-
-    struct EnvVar {
-        key: String,
-        prev: Option<OsString>,
-    }
-
-    impl EnvVar {
-        fn set(key: &str, value: impl AsRef<OsStr>) -> Self {
-            let prev = std::env::var_os(key);
-            unsafe { std::env::set_var(key, value.as_ref()) };
-            Self {
-                key: key.to_string(),
-                prev,
-            }
-        }
-    }
-
-    impl Drop for EnvVar {
-        fn drop(&mut self) {
-            unsafe {
-                match self.prev.take() {
-                    Some(value) => std::env::set_var(&self.key, value),
-                    None => std::env::remove_var(&self.key),
-                }
-            }
-        }
-    }
+    #[cfg(unix)]
+    use super::*;
+    #[cfg(unix)]
+    use crate::test_support::CwdGuard;
+    use crate::test_support::{env_lock, EnvVar};
 
     #[test]
     fn test_expand_tilde_replaces_prefix() {
         let _env_guard = env_lock();
         let _home = EnvVar::set("HOME", "/tmp/test-home");
 
-        assert_eq!(expand_tilde("~/foo"), "/tmp/test-home/foo");
-        assert_eq!(expand_tilde("~"), "/tmp/test-home");
-        assert_eq!(expand_tilde("/abs/path"), "/abs/path");
+        assert_eq!(
+            harnx_sandbox_common::expand_tilde("~/foo"),
+            "/tmp/test-home/foo"
+        );
+        assert_eq!(harnx_sandbox_common::expand_tilde("~"), "/tmp/test-home");
+        assert_eq!(harnx_sandbox_common::expand_tilde("/abs/path"), "/abs/path");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn env_extra_rwx_git_root_resolves_inside_repo() {
+        let _env_guard = env_lock();
+        let _clear_read = EnvVar::unset("HARNX_BASH_EXTRA_READABLE");
+        let _clear_write = EnvVar::unset("HARNX_BASH_EXTRA_WRITABLE");
+        let _clear_exec = EnvVar::unset("HARNX_BASH_EXTRA_EXEC");
+        let _clear_rwx = EnvVar::unset("HARNX_BASH_EXTRA_RWX");
+        let manifest_dir =
+            PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("manifest dir"));
+        let _cwd = CwdGuard::set(&manifest_dir);
+        let _extra = EnvVar::set("HARNX_BASH_EXTRA_RWX", "$GIT_ROOT");
+        let repo_root = harnx_sandbox_common::detect_project_root(
+            harnx_sandbox_common::RootKind::GitRoot,
+            &manifest_dir,
+        )
+        .expect("git root");
+
+        assert_eq!(
+            parse_env_paths("HARNX_BASH_EXTRA_RWX", &manifest_dir),
+            vec![repo_root]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn env_extra_git_root_is_dropped_outside_repo() {
+        let _env_guard = env_lock();
+        let _clear_read = EnvVar::unset("HARNX_BASH_EXTRA_READABLE");
+        let _clear_write = EnvVar::unset("HARNX_BASH_EXTRA_WRITABLE");
+        let _clear_exec = EnvVar::unset("HARNX_BASH_EXTRA_EXEC");
+        let _clear_rwx = EnvVar::unset("HARNX_BASH_EXTRA_RWX");
+        let temp = tempfile::tempdir().expect("tempdir");
+        if harnx_sandbox_common::detect_project_root(
+            harnx_sandbox_common::RootKind::GitRoot,
+            temp.path().parent().unwrap_or(temp.path()),
+        )
+        .is_some()
+        {
+            return;
+        }
+        let _cwd = CwdGuard::set(temp.path());
+        let _extra = EnvVar::set("HARNX_BASH_EXTRA_RWX", "$GIT_ROOT");
+
+        assert!(parse_env_paths("HARNX_BASH_EXTRA_RWX", temp.path()).is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn env_extra_paths_keep_tilde_and_literal_behavior() {
+        let _env_guard = env_lock();
+        let _clear_read = EnvVar::unset("HARNX_BASH_EXTRA_READABLE");
+        let _clear_write = EnvVar::unset("HARNX_BASH_EXTRA_WRITABLE");
+        let _clear_exec = EnvVar::unset("HARNX_BASH_EXTRA_EXEC");
+        let _clear_rwx = EnvVar::unset("HARNX_BASH_EXTRA_RWX");
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        std::fs::create_dir_all(&home).expect("create home");
+        let _cwd = CwdGuard::set(temp.path());
+        let _home = EnvVar::set("HOME", &home);
+        let _read = EnvVar::set(
+            "HARNX_BASH_EXTRA_READABLE",
+            std::ffi::OsString::from(format!("{}:{}", "~/foo", "/abs")),
+        );
+
+        assert_eq!(
+            parse_env_paths("HARNX_BASH_EXTRA_READABLE", temp.path()),
+            vec![home.join("foo"), PathBuf::from("/abs")]
+        );
     }
 }

--- a/crates/harnx-mcp-bash/src/server/tests.rs
+++ b/crates/harnx-mcp-bash/src/server/tests.rs
@@ -1,9 +1,7 @@
 use super::*;
 
 #[cfg(unix)]
-use std::ffi::{OsStr, OsString};
-#[cfg(unix)]
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::ffi::OsString;
 
 use rmcp::handler::client::ClientHandler;
 use rmcp::model::{ClientCapabilities, InitializeRequestParams, ListRootsResult, Root};
@@ -230,52 +228,7 @@ fn collect_arg_pairs(args: &[OsString]) -> Vec<(String, String)> {
 }
 
 #[cfg(unix)]
-fn env_lock() -> MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    match LOCK.get_or_init(|| Mutex::new(())).lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    }
-}
-
-#[cfg(unix)]
-struct EnvVar {
-    key: String,
-    prev: Option<OsString>,
-}
-
-#[cfg(unix)]
-impl EnvVar {
-    fn set(key: &str, value: impl AsRef<OsStr>) -> Self {
-        let prev = std::env::var_os(key);
-        unsafe { std::env::set_var(key, value.as_ref()) };
-        Self {
-            key: key.to_string(),
-            prev,
-        }
-    }
-
-    fn unset(key: &str) -> Self {
-        let prev = std::env::var_os(key);
-        unsafe { std::env::remove_var(key) };
-        Self {
-            key: key.to_string(),
-            prev,
-        }
-    }
-}
-
-#[cfg(unix)]
-impl Drop for EnvVar {
-    fn drop(&mut self) {
-        unsafe {
-            match self.prev.take() {
-                Some(value) => std::env::set_var(&self.key, value),
-                None => std::env::remove_var(&self.key),
-            }
-        }
-    }
-}
+use crate::test_support::{env_lock, EnvVar};
 
 #[cfg(unix)]
 fn enabled_sandbox_config() -> SandboxConfig {
@@ -547,6 +500,9 @@ mod sandbox_args {
     #[cfg(unix)]
     #[test]
     fn test_sandbox_args_defaults() {
+        // Reads process-global $HOME to derive expected home-relative defaults,
+        // so serialize against tests that mutate HOME via the shared env lock.
+        let _env_guard = env_lock();
         let root = Path::new("/test/root");
         let pairs = sandbox_arg_pairs(root, Path::new("/test/root/workdir"), None, None);
 

--- a/crates/harnx-mcp-bash/src/test_support.rs
+++ b/crates/harnx-mcp-bash/src/test_support.rs
@@ -1,0 +1,91 @@
+#[cfg(test)]
+use std::ffi::{OsStr, OsString};
+#[cfg(all(test, unix))]
+use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+#[cfg(test)]
+pub(crate) fn env_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    match LOCK.get_or_init(|| Mutex::new(())).lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct EnvVar {
+    key: String,
+    prev: Option<OsString>,
+}
+
+#[cfg(test)]
+impl EnvVar {
+    pub(crate) fn set(key: &str, value: impl AsRef<OsStr>) -> Self {
+        let prev = std::env::var_os(key);
+        // SAFETY: mutates process-global env. Tests that mutate env hold the
+        // process-global `env_lock()` mutex, so access is serialized and no
+        // other thread reads/writes the environment concurrently.
+        unsafe { std::env::set_var(key, value.as_ref()) };
+        Self {
+            key: key.to_string(),
+            prev,
+        }
+    }
+
+    // Only used by Unix-gated tests; avoids dead-code warnings on Windows.
+    #[cfg(unix)]
+    pub(crate) fn unset(key: &str) -> Self {
+        let prev = std::env::var_os(key);
+        // SAFETY: see `set` — serialized by the process-global `env_lock()`.
+        unsafe { std::env::remove_var(key) };
+        Self {
+            key: key.to_string(),
+            prev,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for EnvVar {
+    fn drop(&mut self) {
+        // SAFETY: mutates process-global env to restore the prior value. The
+        // guard is created and dropped while the owning test holds the
+        // process-global `env_lock()`, so env access stays serialized.
+        unsafe {
+            match self.prev.take() {
+                Some(value) => std::env::set_var(&self.key, value),
+                None => std::env::remove_var(&self.key),
+            }
+        }
+    }
+}
+
+// Only used by Unix-gated tests; gating avoids dead-code warnings on Windows.
+#[cfg(all(test, unix))]
+pub(crate) struct CwdGuard {
+    prev: PathBuf,
+}
+
+#[cfg(all(test, unix))]
+impl CwdGuard {
+    pub(crate) fn set(path: &Path) -> Self {
+        let prev = std::env::current_dir().expect("current_dir");
+        std::env::set_current_dir(path).expect("set_current_dir");
+        Self { prev }
+    }
+}
+
+#[cfg(all(test, unix))]
+impl Drop for CwdGuard {
+    fn drop(&mut self) {
+        // Non-panicking: log restoration failures rather than silencing them.
+        if let Err(e) = std::env::set_current_dir(&self.prev) {
+            eprintln!(
+                "test_support: restoring working directory to {} failed: {e}",
+                self.prev.display()
+            );
+        }
+    }
+}

--- a/crates/harnx-sandbox-common/Cargo.toml
+++ b/crates/harnx-sandbox-common/Cargo.toml
@@ -13,6 +13,7 @@ log = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 birdcage = { workspace = true }
+gix = { workspace = true }
 tempfile = "3"
 
 [[bin]]

--- a/crates/harnx-sandbox-common/src/args.rs
+++ b/crates/harnx-sandbox-common/src/args.rs
@@ -16,10 +16,25 @@ fn push_flagged_path(args: &mut Vec<OsString>, flag: &str, path: &Path) {
     args.push(path.as_os_str().to_os_string());
 }
 
+/// Best-effort name of the running executable, for use in warning messages.
+/// Falls back to a generic name when argv[0] is unavailable.
+#[cfg(unix)]
+fn program_name() -> String {
+    std::env::args()
+        .next()
+        .and_then(|p| {
+            Path::new(&p)
+                .file_name()
+                .and_then(|s| s.to_str().map(|s| s.to_owned()))
+        })
+        .unwrap_or_else(|| "harnx-sandbox".to_string())
+}
+
 pub fn build_default_sandbox_args(config: &SandboxConfig) -> Vec<OsString> {
     #[cfg(unix)]
     {
         let mut args = Vec::new();
+        let prog = program_name();
         for path in SYSTEM_EXEC_PATHS {
             args.push(OsString::from("--exec"));
             args.push(OsString::from(path));
@@ -36,15 +51,43 @@ pub fn build_default_sandbox_args(config: &SandboxConfig) -> Vec<OsString> {
         }
         push_env_relative_defaults(&mut args);
         for path in &config.extra_exec {
+            if crate::is_home_or_ancestor(path) {
+                eprintln!(
+                    "{prog}: warning: ignoring --extra-exec {}: would expose home directory",
+                    path.display()
+                );
+                continue;
+            }
             push_flagged_path(&mut args, "--exec", path);
         }
         for path in &config.extra_readable {
+            if crate::is_home_or_ancestor(path) {
+                eprintln!(
+                    "{prog}: warning: ignoring --extra-read {}: would expose home directory",
+                    path.display()
+                );
+                continue;
+            }
             push_flagged_path(&mut args, "--read", path);
         }
         for path in &config.extra_writable {
+            if crate::is_home_or_ancestor(path) {
+                eprintln!(
+                    "{prog}: warning: ignoring --extra-write {}: would expose home directory",
+                    path.display()
+                );
+                continue;
+            }
             push_flagged_path(&mut args, "--write", path);
         }
         for path in &config.extra_rwx {
+            if crate::is_home_or_ancestor(path) {
+                eprintln!(
+                    "{prog}: warning: ignoring --extra-rwx {}: would expose home directory",
+                    path.display()
+                );
+                continue;
+            }
             push_flagged_path(&mut args, "--read", path);
             push_flagged_path(&mut args, "--write", path);
             push_flagged_path(&mut args, "--exec", path);
@@ -61,6 +104,7 @@ pub fn build_default_sandbox_args(config: &SandboxConfig) -> Vec<OsString> {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+    use crate::test_support::{env_lock, EnvGuard};
     use anyhow::Result;
     use std::path::PathBuf;
 
@@ -97,5 +141,40 @@ mod tests {
         assert!(args.windows(2).any(|w| w == ["--read", "/rwx"]));
         assert!(args.windows(2).any(|w| w == ["--write", "/rwx"]));
         assert!(args.windows(2).any(|w| w == ["--exec", "/rwx"]));
+    }
+
+    #[test]
+    fn drops_home_extra_writable_and_rwx_paths() {
+        let _lock = env_lock();
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        std::fs::create_dir_all(&home).expect("create home");
+        unsafe { std::env::set_var("HOME", &home) };
+
+        let rwx = home.clone();
+        let writable = home.clone();
+        let config = SandboxConfig {
+            enabled: true,
+            extra_exec: Vec::new(),
+            extra_readable: Vec::new(),
+            extra_writable: vec![writable.clone()],
+            extra_rwx: vec![rwx.clone()],
+            extra_env_passthrough: Vec::new(),
+            env_overrides: Vec::new(),
+            sandbox_run_path: PathBuf::from("sandbox-run"),
+        };
+
+        let args: Vec<String> = build_default_sandbox_args(&config)
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        let writable = writable.to_string_lossy().into_owned();
+        let rwx = rwx.to_string_lossy().into_owned();
+
+        assert!(!args.windows(2).any(|w| w == ["--write", writable.as_str()]));
+        assert!(!args.windows(2).any(|w| w == ["--read", rwx.as_str()]));
+        assert!(!args.windows(2).any(|w| w == ["--write", rwx.as_str()]));
+        assert!(!args.windows(2).any(|w| w == ["--exec", rwx.as_str()]));
     }
 }

--- a/crates/harnx-sandbox-common/src/home_guard.rs
+++ b/crates/harnx-sandbox-common/src/home_guard.rs
@@ -46,45 +46,11 @@ pub fn is_home_or_ancestor(path: &Path) -> bool {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
-    use std::sync::{Mutex, OnceLock};
-
-    /// Serialise all tests that mutate process-global HOME / cwd.
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
-    /// RAII guard: snapshots HOME and cwd on creation, restores both on drop.
-    struct EnvGuard {
-        saved_home: Option<std::ffi::OsString>,
-        saved_cwd: PathBuf,
-    }
-
-    impl EnvGuard {
-        fn new() -> Self {
-            Self {
-                saved_home: std::env::var_os("HOME"),
-                saved_cwd: std::env::current_dir().expect("current_dir"),
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            // Restore cwd first so that any relative-path lookups during HOME
-            // restoration happen against the original directory.
-            let _ = std::env::set_current_dir(&self.saved_cwd);
-            match &self.saved_home {
-                Some(h) => unsafe { std::env::set_var("HOME", h) },
-                None => unsafe { std::env::remove_var("HOME") },
-            }
-        }
-    }
+    use crate::test_support::{env_lock, EnvGuard};
 
     #[test]
     fn home_path_matches() {
-        let _lock = env_lock().lock().expect("lock poisoned");
+        let _lock = env_lock();
         let _env = EnvGuard::new();
         let temp = tempfile::tempdir().expect("tempdir");
         let home = temp.path().join("home");
@@ -96,7 +62,7 @@ mod tests {
 
     #[test]
     fn ancestor_of_home_matches() {
-        let _lock = env_lock().lock().expect("lock poisoned");
+        let _lock = env_lock();
         let _env = EnvGuard::new();
         let temp = tempfile::tempdir().expect("tempdir");
         let parent = temp.path().join("parent");
@@ -109,7 +75,7 @@ mod tests {
 
     #[test]
     fn child_of_home_does_not_match() {
-        let _lock = env_lock().lock().expect("lock poisoned");
+        let _lock = env_lock();
         let _env = EnvGuard::new();
         let temp = tempfile::tempdir().expect("tempdir");
         let home = temp.path().join("home");
@@ -122,7 +88,7 @@ mod tests {
 
     #[test]
     fn relative_path_resolves_against_cwd() {
-        let _lock = env_lock().lock().expect("lock poisoned");
+        let _lock = env_lock();
         let _env = EnvGuard::new(); // restores HOME and cwd on drop
         let temp = tempfile::tempdir().expect("tempdir");
         let cwd = temp.path().join("cwd");

--- a/crates/harnx-sandbox-common/src/lib.rs
+++ b/crates/harnx-sandbox-common/src/lib.rs
@@ -4,6 +4,11 @@ pub mod config;
 pub mod defaults;
 #[cfg(unix)]
 pub mod home_guard;
+pub mod path_expand;
+#[cfg(unix)]
+pub mod root_detection;
+#[cfg(all(test, unix))]
+pub(crate) mod test_support;
 
 pub use args::build_default_sandbox_args;
 pub use config::SandboxConfig;
@@ -16,3 +21,6 @@ pub use defaults::{
 };
 #[cfg(unix)]
 pub use home_guard::{is_home_or_ancestor, resolve_path};
+pub use path_expand::{expand_path_var, expand_tilde};
+#[cfg(unix)]
+pub use root_detection::{detect_project_root, RootKind};

--- a/crates/harnx-sandbox-common/src/path_expand.rs
+++ b/crates/harnx-sandbox-common/src/path_expand.rs
@@ -1,0 +1,184 @@
+use std::path::{Path, PathBuf};
+
+pub fn expand_tilde(raw: &str) -> String {
+    if !raw.starts_with('~') {
+        return raw.to_string();
+    }
+
+    let home = match std::env::var("HOME") {
+        Ok(home) => home,
+        Err(_) => return raw.to_string(),
+    };
+
+    if raw == "~" {
+        home
+    } else if let Some(suffix) = raw.strip_prefix("~/") {
+        format!("{home}/{suffix}")
+    } else {
+        raw.to_string()
+    }
+}
+
+#[cfg(unix)]
+/// Expand raw path string for sandbox flags.
+/// 1. If it begins with known pseudo-var (`$GIT_ROOT`, `$GIT_COMMON_DIR`,
+///    `$NODE_PROJECT_ROOT`, `$CARGO_ROOT`, `$GO_ROOT`) at a prefix boundary
+///    (`$VAR` or `$VAR/...`), run project-root detection against `cwd`.
+///    - detection `Some(root)` joins any relative remainder onto `root`.
+///    - detection `None` returns `None`, so caller silently skips path.
+/// 2. Else apply `expand_tilde` and return resulting `PathBuf`.
+pub fn expand_path_var(raw: &str, cwd: &Path) -> Option<PathBuf> {
+    let pseudo_var = [
+        ("$GIT_ROOT", crate::RootKind::GitRoot),
+        ("$GIT_COMMON_DIR", crate::RootKind::GitCommonDir),
+        ("$NODE_PROJECT_ROOT", crate::RootKind::NodeProjectRoot),
+        ("$CARGO_ROOT", crate::RootKind::CargoRoot),
+        ("$GO_ROOT", crate::RootKind::GoRoot),
+    ]
+    .into_iter()
+    .find(|(prefix, _)| {
+        raw == *prefix
+            || raw
+                .strip_prefix(prefix)
+                .is_some_and(|rest| rest.starts_with('/'))
+    });
+
+    if let Some((prefix, kind)) = pseudo_var {
+        let root = crate::detect_project_root(kind, cwd)?;
+        let remainder = raw.strip_prefix(prefix).expect("matched prefix");
+        return Some(match remainder.strip_prefix('/') {
+            Some(relative) => root.join(relative),
+            None => root,
+        });
+    }
+
+    Some(PathBuf::from(expand_tilde(raw)))
+}
+
+#[cfg(not(unix))]
+pub fn expand_path_var(raw: &str, _cwd: &Path) -> Option<PathBuf> {
+    Some(PathBuf::from(raw))
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::detect_project_root;
+    use crate::test_support::{env_lock, EnvGuard};
+    use crate::RootKind;
+    use std::path::PathBuf;
+
+    fn touch(path: &Path) {
+        std::fs::write(path, "marker").expect("write marker");
+    }
+
+    #[test]
+    fn git_root_pseudo_var_expands_to_repo_root() {
+        let manifest_dir =
+            PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+        let expected = detect_project_root(RootKind::GitRoot, &manifest_dir).expect("git root");
+
+        assert_eq!(expand_path_var("$GIT_ROOT", &manifest_dir), Some(expected));
+    }
+
+    #[test]
+    fn git_root_pseudo_var_joins_suffix() {
+        let manifest_dir =
+            PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+        let expected = detect_project_root(RootKind::GitRoot, &manifest_dir)
+            .expect("git root")
+            .join("sub");
+
+        assert_eq!(
+            expand_path_var("$GIT_ROOT/sub", &manifest_dir),
+            Some(expected)
+        );
+    }
+
+    #[test]
+    fn git_root_pseudo_var_returns_none_outside_repo() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        if detect_project_root(
+            RootKind::GitRoot,
+            temp.path().parent().unwrap_or(temp.path()),
+        )
+        .is_some()
+        {
+            return;
+        }
+
+        assert_eq!(expand_path_var("$GIT_ROOT", temp.path()), None);
+    }
+
+    #[test]
+    fn node_project_root_pseudo_var_joins_suffix() {
+        let _lock = env_lock();
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("workspace");
+        let nested = root.join("apps/web/src");
+        std::fs::create_dir_all(&nested).expect("create nested");
+        touch(&root.join("package.json"));
+
+        assert_eq!(
+            expand_path_var("$NODE_PROJECT_ROOT/foo", &nested),
+            Some(root.join("foo"))
+        );
+    }
+
+    #[test]
+    fn pseudo_var_prefix_collisions_are_literal() {
+        let cwd = Path::new("/");
+
+        assert_eq!(
+            expand_path_var("$GIT_ROOTX", cwd),
+            Some(PathBuf::from("$GIT_ROOTX"))
+        );
+        assert_eq!(
+            expand_path_var("pre$GIT_ROOT", cwd),
+            Some(PathBuf::from("pre$GIT_ROOT"))
+        );
+    }
+
+    #[test]
+    fn tilde_and_absolute_paths_expand_without_pseudo_var_detection() {
+        let _lock = env_lock();
+        let _env = EnvGuard::new();
+        unsafe { std::env::set_var("HOME", "/tmp/test-home") };
+
+        assert_eq!(
+            expand_path_var("~/x", Path::new("/")),
+            Some(PathBuf::from("/tmp/test-home/x"))
+        );
+        assert_eq!(
+            expand_path_var("/abs/path", Path::new("/")),
+            Some(PathBuf::from("/abs/path"))
+        );
+    }
+
+    #[test]
+    fn pseudo_var_resolving_to_home_is_rejected() {
+        let _lock = env_lock();
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let nested = home.join("project/src");
+        std::fs::create_dir_all(&nested).expect("create nested");
+        touch(&home.join("package.json"));
+        unsafe { std::env::set_var("HOME", &home) };
+
+        assert_eq!(expand_path_var("$NODE_PROJECT_ROOT", &nested), None);
+    }
+
+    #[test]
+    fn expand_tilde_matches_existing_behavior() {
+        let _lock = env_lock();
+        let _env = EnvGuard::new();
+        unsafe { std::env::set_var("HOME", "/tmp/test-home") };
+
+        assert_eq!(expand_tilde("~/foo"), "/tmp/test-home/foo");
+        assert_eq!(expand_tilde("~"), "/tmp/test-home");
+        assert_eq!(expand_tilde("~user/foo"), "~user/foo");
+        assert_eq!(expand_tilde("/abs/path"), "/abs/path");
+    }
+}

--- a/crates/harnx-sandbox-common/src/root_detection.rs
+++ b/crates/harnx-sandbox-common/src/root_detection.rs
@@ -1,0 +1,296 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootKind {
+    GitRoot,
+    GitCommonDir,
+    NodeProjectRoot,
+    CargoRoot,
+    GoRoot,
+}
+
+/// Detect project root of `kind` starting from `cwd`.
+///
+/// Returns `None` if no matching root is found or if detected path resolves to
+/// `$HOME` or an ancestor of `$HOME`.
+///
+/// `NodeProjectRoot` returns highest ancestor containing `package.json` so
+/// monorepos resolve to workspace root instead of nested package root.
+/// `CargoRoot` returns highest ancestor containing `Cargo.toml` so monorepo
+/// crates resolve to workspace root that owns shared `target/` and `Cargo.lock`.
+/// `GoRoot` returns nearest ancestor containing `go.mod` because nested modules
+/// are independent roots.
+pub fn detect_project_root(kind: RootKind, cwd: &Path) -> Option<PathBuf> {
+    let root = match kind {
+        RootKind::GitRoot => gix::discover(cwd).ok()?.workdir()?.to_path_buf(),
+        RootKind::GitCommonDir => gix::discover(cwd).ok()?.common_dir().to_path_buf(),
+        RootKind::NodeProjectRoot => {
+            detect_marker_root(cwd, "package.json", WalkStrategy::Highest)?
+        }
+        RootKind::CargoRoot => detect_marker_root(cwd, "Cargo.toml", WalkStrategy::Highest)?,
+        RootKind::GoRoot => detect_marker_root(cwd, "go.mod", WalkStrategy::Nearest)?,
+    };
+
+    if crate::is_home_or_ancestor(&root) {
+        return None;
+    }
+
+    Some(root)
+}
+
+#[derive(Clone, Copy)]
+enum WalkStrategy {
+    Highest,
+    Nearest,
+}
+
+fn detect_marker_root(cwd: &Path, marker: &str, strategy: WalkStrategy) -> Option<PathBuf> {
+    let mut current = if cwd.is_dir() {
+        cwd.to_path_buf()
+    } else {
+        cwd.parent()?.to_path_buf()
+    };
+    let mut found = None;
+
+    loop {
+        if current.join(marker).exists() {
+            match strategy {
+                WalkStrategy::Nearest => return guard_candidate(current),
+                WalkStrategy::Highest => found = Some(current.clone()),
+            }
+        }
+
+        // Stops at the home boundary: is_home_or_ancestor canonicalizes and
+        // returns true when `current` is $HOME itself or an ancestor of it, so
+        // a separate raw-equality check against $HOME would be redundant.
+        if crate::is_home_or_ancestor(&current) {
+            break;
+        }
+
+        let Some(parent) = current.parent() else {
+            break;
+        };
+        current = parent.to_path_buf();
+    }
+
+    found.and_then(guard_candidate)
+}
+
+fn guard_candidate(path: PathBuf) -> Option<PathBuf> {
+    if crate::is_home_or_ancestor(&path) {
+        None
+    } else {
+        Some(path)
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::test_support::{env_lock, EnvGuard};
+
+    fn touch(path: &Path) {
+        std::fs::write(path, "marker").expect("write marker");
+    }
+
+    #[test]
+    fn detects_node_cargo_and_go_roots_from_nested_directory() {
+        let _lock = env_lock();
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("workspace");
+        let nested = root.join("apps/api/src");
+        std::fs::create_dir_all(&nested).expect("create nested");
+        touch(&root.join("package.json"));
+        touch(&root.join("Cargo.toml"));
+        touch(&root.join("go.mod"));
+
+        assert_eq!(
+            detect_project_root(RootKind::NodeProjectRoot, &nested),
+            Some(root.clone())
+        );
+        assert_eq!(
+            detect_project_root(RootKind::CargoRoot, &nested),
+            Some(root.clone())
+        );
+        assert_eq!(detect_project_root(RootKind::GoRoot, &nested), Some(root));
+    }
+
+    #[test]
+    fn returns_none_when_no_marker_present() {
+        let _lock = env_lock();
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let nested = temp.path().join("workspace/subdir");
+        std::fs::create_dir_all(&nested).expect("create nested");
+
+        assert_eq!(
+            detect_project_root(RootKind::NodeProjectRoot, &nested),
+            None
+        );
+        assert_eq!(detect_project_root(RootKind::CargoRoot, &nested), None);
+        assert_eq!(detect_project_root(RootKind::GoRoot, &nested), None);
+    }
+
+    #[test]
+    fn returns_none_when_detected_root_is_home() {
+        let _lock = env_lock();
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let nested = home.join("project/src");
+        std::fs::create_dir_all(&nested).expect("create nested");
+        touch(&home.join("package.json"));
+        touch(&home.join("Cargo.toml"));
+        touch(&home.join("go.mod"));
+        unsafe { std::env::set_var("HOME", &home) };
+
+        assert_eq!(
+            detect_project_root(RootKind::NodeProjectRoot, &nested),
+            None
+        );
+        assert_eq!(detect_project_root(RootKind::CargoRoot, &nested), None);
+        assert_eq!(detect_project_root(RootKind::GoRoot, &nested), None);
+    }
+
+    #[test]
+    fn detects_git_root_from_manifest_dir() {
+        let manifest_dir =
+            PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+
+        assert!(detect_project_root(RootKind::GitRoot, &manifest_dir).is_some());
+    }
+
+    #[test]
+    fn distinguishes_git_root_from_git_common_dir_in_linked_worktree() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let primary = temp.path().join("primary");
+        let linked = temp.path().join("linked-worktree");
+        std::fs::create_dir_all(&primary).expect("create primary");
+
+        let run_git = |args: &[&str], dir: &Path| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .output()
+                .expect("run git command")
+        };
+
+        let init = run_git(&["init", "--initial-branch=main"], &primary);
+        assert!(
+            init.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&init.stderr)
+        );
+
+        let config_name = run_git(&["config", "user.name", "Test User"], &primary);
+        assert!(
+            config_name.status.success(),
+            "git config user.name failed: {}",
+            String::from_utf8_lossy(&config_name.stderr)
+        );
+
+        let config_email = run_git(&["config", "user.email", "test@example.com"], &primary);
+        assert!(
+            config_email.status.success(),
+            "git config user.email failed: {}",
+            String::from_utf8_lossy(&config_email.stderr)
+        );
+
+        std::fs::write(primary.join("README.md"), "hello\n").expect("write readme");
+        let add = run_git(&["add", "README.md"], &primary);
+        assert!(
+            add.status.success(),
+            "git add failed: {}",
+            String::from_utf8_lossy(&add.stderr)
+        );
+
+        let commit = run_git(&["commit", "-m", "initial"], &primary);
+        assert!(
+            commit.status.success(),
+            "git commit failed: {}",
+            String::from_utf8_lossy(&commit.stderr)
+        );
+
+        let worktree = run_git(
+            &[
+                "worktree",
+                "add",
+                linked.to_str().expect("utf8 linked path"),
+            ],
+            &primary,
+        );
+        assert!(
+            worktree.status.success(),
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&worktree.stderr)
+        );
+
+        let expected_common_dir = primary.join(".git");
+        let detected_git_root = detect_project_root(RootKind::GitRoot, &linked).expect("git root");
+        let detected_common_dir =
+            detect_project_root(RootKind::GitCommonDir, &linked).expect("git common dir");
+
+        assert_eq!(
+            std::fs::canonicalize(detected_git_root).expect("canonical git root"),
+            std::fs::canonicalize(&linked).expect("canonical linked worktree")
+        );
+        assert_eq!(
+            std::fs::canonicalize(detected_common_dir).expect("canonical common dir"),
+            std::fs::canonicalize(expected_common_dir).expect("canonical expected common dir")
+        );
+    }
+
+    #[test]
+    fn symlink_target_in_home_is_rejected() {
+        let _lock = env_lock();
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let link_parent = temp.path().join("outside");
+        let symlink_root = link_parent.join("link-to-home");
+        let nested = symlink_root.join("deep/src");
+        std::fs::create_dir_all(&home).expect("create home");
+        std::fs::create_dir_all(&link_parent).expect("create link parent");
+        touch(&home.join("package.json"));
+        touch(&home.join("Cargo.toml"));
+        touch(&home.join("go.mod"));
+        std::os::unix::fs::symlink(&home, &symlink_root).expect("symlink home");
+        std::fs::create_dir_all(&nested).expect("create nested via symlink");
+        unsafe { std::env::set_var("HOME", &home) };
+
+        assert_eq!(
+            detect_project_root(RootKind::NodeProjectRoot, &nested),
+            None
+        );
+        assert_eq!(detect_project_root(RootKind::CargoRoot, &nested), None);
+        assert_eq!(detect_project_root(RootKind::GoRoot, &nested), None);
+    }
+
+    #[test]
+    fn highest_vs_nearest_marker_selection() {
+        let _lock = env_lock();
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let top = temp.path().join("workspace");
+        let middle = top.join("apps/service");
+        let nested = middle.join("src/bin");
+        std::fs::create_dir_all(&nested).expect("create nested");
+        touch(&top.join("package.json"));
+        touch(&middle.join("package.json"));
+        touch(&top.join("Cargo.toml"));
+        touch(&middle.join("Cargo.toml"));
+        touch(&top.join("go.mod"));
+        touch(&middle.join("go.mod"));
+
+        assert_eq!(
+            detect_project_root(RootKind::NodeProjectRoot, &nested),
+            Some(top.clone())
+        );
+        assert_eq!(
+            detect_project_root(RootKind::CargoRoot, &nested),
+            Some(top.clone())
+        );
+        assert_eq!(detect_project_root(RootKind::GoRoot, &nested), Some(middle));
+    }
+}

--- a/crates/harnx-sandbox-common/src/test_support.rs
+++ b/crates/harnx-sandbox-common/src/test_support.rs
@@ -1,0 +1,49 @@
+#[cfg(all(test, unix))]
+use std::path::PathBuf;
+#[cfg(all(test, unix))]
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+#[cfg(all(test, unix))]
+pub(crate) fn env_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    match LOCK.get_or_init(|| Mutex::new(())).lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[cfg(all(test, unix))]
+pub(crate) struct EnvGuard {
+    saved_home: Option<std::ffi::OsString>,
+    saved_cwd: PathBuf,
+}
+
+#[cfg(all(test, unix))]
+impl EnvGuard {
+    pub(crate) fn new() -> Self {
+        Self {
+            saved_home: std::env::var_os("HOME"),
+            saved_cwd: std::env::current_dir().expect("current_dir"),
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // Non-panicking: log restoration failures rather than silencing them.
+        if let Err(e) = std::env::set_current_dir(&self.saved_cwd) {
+            eprintln!(
+                "test_support: restoring working directory to {} failed: {e}",
+                self.saved_cwd.display()
+            );
+        }
+        // SAFETY: mutates process-global env (HOME) to restore the prior value.
+        // EnvGuard is only constructed in tests holding the process-global
+        // `env_lock()` mutex, so environment access is serialized.
+        match &self.saved_home {
+            Some(home) => unsafe { std::env::set_var("HOME", home) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+    }
+}

--- a/crates/harnx-sandbox-run/src/cli.rs
+++ b/crates/harnx-sandbox-run/src/cli.rs
@@ -83,19 +83,19 @@ pub fn pre_parse_hooks(raw: Vec<String>) -> anyhow::Result<(Vec<HookDef>, Vec<St
 #[command(name = "harnx-sandbox-run")]
 #[command(about = "Run commands inside the birdcage sandbox with hook support")]
 pub struct Cli {
-    /// Add sandbox read-only path (may be repeated).
+    /// Add sandbox read-only path (may be repeated). Supports project-root pseudo-vars like $GIT_ROOT (see docs).
     #[arg(long, value_name = "path")]
     pub extra_read: Vec<PathBuf>,
 
-    /// Add sandbox writable path (may be repeated).
+    /// Add sandbox writable path (may be repeated). Supports project-root pseudo-vars like $GIT_ROOT (see docs).
     #[arg(long, value_name = "path")]
     pub extra_write: Vec<PathBuf>,
 
-    /// Add sandbox execute path (may be repeated).
+    /// Add sandbox execute path (may be repeated). Supports project-root pseudo-vars like $GIT_ROOT (see docs).
     #[arg(long, value_name = "path")]
     pub extra_exec: Vec<PathBuf>,
 
-    /// Add sandbox read/write/exec path (may be repeated).
+    /// Add sandbox read/write/exec path (may be repeated). Supports project-root pseudo-vars like $GIT_ROOT (see docs).
     #[arg(long, value_name = "path")]
     pub extra_rwx: Vec<PathBuf>,
 

--- a/crates/harnx-sandbox-run/src/main.rs
+++ b/crates/harnx-sandbox-run/src/main.rs
@@ -30,33 +30,13 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 
-/// Expand a leading `~` to `$HOME`. Matches the behaviour in `harnx-mcp-bash`.
-#[cfg(unix)]
-fn expand_tilde(raw: &str) -> String {
-    if !raw.starts_with('~') {
-        return raw.to_string();
-    }
-    let home = match std::env::var("HOME") {
-        Ok(h) => h,
-        Err(_) => return raw.to_string(),
-    };
-    if raw == "~" {
-        home
-    } else if let Some(suffix) = raw.strip_prefix("~/") {
-        format!("{home}/{suffix}")
-    } else {
-        raw.to_string()
-    }
-}
-
-/// Read a colon-separated path list from an env var, expanding tildes.
+/// Read a colon-separated path list from an env var.
 #[cfg(unix)]
 fn env_paths(var: &str) -> Vec<PathBuf> {
     std::env::var_os(var)
         .map(|val| {
             std::env::split_paths(&val)
                 .filter(|p| !p.as_os_str().is_empty())
-                .map(|p| PathBuf::from(expand_tilde(&p.to_string_lossy())))
                 .collect()
         })
         .unwrap_or_default()

--- a/crates/harnx-sandbox-run/src/sandbox.rs
+++ b/crates/harnx-sandbox-run/src/sandbox.rs
@@ -42,11 +42,12 @@ fn find_sandbox_exec() -> PathBuf {
 #[cfg(unix)]
 fn build_exec_args(cli: &Cli, all_env_keys: &[String], use_defaults: bool) -> Vec<OsString> {
     use harnx_sandbox_common::{
-        is_home_or_ancestor, resolve_path, system_writable_paths, HOME_EXEC_PATHS, HOME_READ_PATHS,
-        HOME_RWX_PATHS, HOME_WRITE_PATHS, SYSTEM_EXEC_PATHS, SYSTEM_READ_PATHS,
+        expand_path_var, is_home_or_ancestor, resolve_path, system_writable_paths, HOME_EXEC_PATHS,
+        HOME_READ_PATHS, HOME_RWX_PATHS, HOME_WRITE_PATHS, SYSTEM_EXEC_PATHS, SYSTEM_READ_PATHS,
     };
 
     let mut args: Vec<OsString> = Vec::new();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
     // Default whitelist — same paths that harnx-mcp-bash uses
     if use_defaults {
@@ -146,7 +147,11 @@ fn build_exec_args(cli: &Cli, all_env_keys: &[String], use_defaults: bool) -> Ve
 
     // CLI-provided extra paths
     for path in &cli.extra_read {
-        let resolved = resolve_path(path);
+        let raw = path.to_string_lossy();
+        let Some(expanded) = expand_path_var(&raw, &cwd) else {
+            continue;
+        };
+        let resolved = resolve_path(&expanded);
         if is_home_or_ancestor(&resolved) {
             eprintln!(
                 "harnx-sandbox-run: warning: ignoring --extra-read {}: would expose home directory",
@@ -158,7 +163,11 @@ fn build_exec_args(cli: &Cli, all_env_keys: &[String], use_defaults: bool) -> Ve
         args.push(resolved.into_os_string());
     }
     for path in &cli.extra_write {
-        let resolved = resolve_path(path);
+        let raw = path.to_string_lossy();
+        let Some(expanded) = expand_path_var(&raw, &cwd) else {
+            continue;
+        };
+        let resolved = resolve_path(&expanded);
         if is_home_or_ancestor(&resolved) {
             eprintln!(
                 "harnx-sandbox-run: warning: ignoring --extra-write {}: would expose home directory",
@@ -170,7 +179,11 @@ fn build_exec_args(cli: &Cli, all_env_keys: &[String], use_defaults: bool) -> Ve
         args.push(resolved.into_os_string());
     }
     for path in &cli.extra_exec {
-        let resolved = resolve_path(path);
+        let raw = path.to_string_lossy();
+        let Some(expanded) = expand_path_var(&raw, &cwd) else {
+            continue;
+        };
+        let resolved = resolve_path(&expanded);
         if is_home_or_ancestor(&resolved) {
             eprintln!(
                 "harnx-sandbox-run: warning: ignoring --extra-exec {}: would expose home directory",
@@ -182,7 +195,11 @@ fn build_exec_args(cli: &Cli, all_env_keys: &[String], use_defaults: bool) -> Ve
         args.push(resolved.into_os_string());
     }
     for path in &cli.extra_rwx {
-        let resolved = resolve_path(path);
+        let raw = path.to_string_lossy();
+        let Some(expanded) = expand_path_var(&raw, &cwd) else {
+            continue;
+        };
+        let resolved = resolve_path(&expanded);
         if is_home_or_ancestor(&resolved) {
             eprintln!(
                 "harnx-sandbox-run: warning: ignoring --extra-rwx {}: would expose home directory",
@@ -306,6 +323,36 @@ pub fn setup_and_spawn(
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvGuard {
+        saved_home: Option<std::ffi::OsString>,
+        saved_cwd: PathBuf,
+    }
+
+    impl EnvGuard {
+        fn new() -> Self {
+            Self {
+                saved_home: std::env::var_os("HOME"),
+                saved_cwd: std::env::current_dir().expect("current_dir"),
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.saved_cwd);
+            match &self.saved_home {
+                Some(home) => unsafe { std::env::set_var("HOME", home) },
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+        }
+    }
 
     #[test]
     fn collect_env_hook_overrides_cli() {
@@ -350,6 +397,8 @@ mod tests {
 
     #[test]
     fn build_exec_args_filters_home_and_resolves_allowed_paths() {
+        let _lock = env_lock().lock().expect("lock poisoned");
+        let _env = EnvGuard::new();
         let temp = tempfile::tempdir().expect("tempdir");
         let cwd = temp.path().join("cwd");
         let home = temp.path().join("home");
@@ -357,7 +406,6 @@ mod tests {
         std::fs::create_dir_all(&cwd).expect("create cwd");
         std::fs::create_dir_all(&child).expect("create child");
 
-        let old_cwd = std::env::current_dir().expect("current_dir");
         std::env::set_current_dir(&cwd).expect("set cwd");
         unsafe { std::env::set_var("HOME", &home) };
 
@@ -401,7 +449,87 @@ mod tests {
                 "--".to_string(),
             ]
         );
+    }
 
-        std::env::set_current_dir(old_cwd).expect("restore cwd");
+    #[test]
+    fn build_exec_args_expands_git_root_rwx_inside_repo() {
+        let _lock = env_lock().lock().expect("lock poisoned");
+        let _env = EnvGuard::new();
+        let manifest_dir =
+            PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+        std::env::set_current_dir(&manifest_dir).expect("set cwd");
+        let repo_root = harnx_sandbox_common::detect_project_root(
+            harnx_sandbox_common::RootKind::GitRoot,
+            &manifest_dir,
+        )
+        .expect("git root");
+        let expected = harnx_sandbox_common::resolve_path(&repo_root)
+            .to_string_lossy()
+            .into_owned();
+
+        let cli = Cli {
+            env_vars: vec![],
+            extra_read: vec![],
+            extra_write: vec![],
+            extra_exec: vec![],
+            extra_rwx: vec![PathBuf::from("$GIT_ROOT")],
+            no_network: false,
+            working_dir: None,
+            no_defaults: false,
+            command: vec![],
+        };
+
+        let args: Vec<String> = build_exec_args(&cli, &[], false)
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            args,
+            vec![
+                "--read".to_string(),
+                expected.clone(),
+                "--write".to_string(),
+                expected.clone(),
+                "--exec".to_string(),
+                expected,
+                "--".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_exec_args_skips_git_root_rwx_outside_repo() {
+        let _lock = env_lock().lock().expect("lock poisoned");
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        if harnx_sandbox_common::detect_project_root(
+            harnx_sandbox_common::RootKind::GitRoot,
+            temp.path().parent().unwrap_or(temp.path()),
+        )
+        .is_some()
+        {
+            return;
+        }
+        std::env::set_current_dir(temp.path()).expect("set cwd");
+
+        let cli = Cli {
+            env_vars: vec![],
+            extra_read: vec![],
+            extra_write: vec![],
+            extra_exec: vec![],
+            extra_rwx: vec![PathBuf::from("$GIT_ROOT")],
+            no_network: false,
+            working_dir: None,
+            no_defaults: false,
+            command: vec![],
+        };
+
+        let args: Vec<String> = build_exec_args(&cli, &[], false)
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(args, vec!["--".to_string()]);
     }
 }

--- a/docs/bash-mcp-server.md
+++ b/docs/bash-mcp-server.md
@@ -132,6 +132,7 @@ You can grant additional filesystem access using CLI flags or environment variab
 **Notes:**
 - CLI flags can be repeated to add multiple paths.
 - Environment variables accept a colon-separated list of paths (e.g., `HARNX_BASH_EXTRA_RWX=/path/one:/path/two`). This applies to all `HARNX_BASH_EXTRA_*` variables.
+- All path flags and environment variables support **project-root pseudo-variables** (e.g., `$GIT_ROOT`, `$GIT_COMMON_DIR`, `$NODE_PROJECT_ROOT`, `$CARGO_ROOT`, `$GO_ROOT`). These are resolved at startup against the current working directory and are silently dropped if the current directory is not in a matching project, or if they would expose your home directory. See the [harnx-sandbox-run documentation](sandbox-run.md#project-root-pseudo-variables) for the full list of variables and their semantics.
 
 ### Disabling Sandboxing
 

--- a/docs/sandbox-run.md
+++ b/docs/sandbox-run.md
@@ -155,7 +155,7 @@ These match the `harnx-mcp-bash` environment variables, so the same shell profil
 | `HARNX_BASH_EXTRA_RWX` | Colon-separated paths | Extra sandbox read/write/exec paths |
 | `HARNX_BASH_ENV_PASSTHROUGH` | Comma-separated names | Extra host env var names to pass through |
 
-Paths support `~` expansion. CLI flags and env vars both accumulate — they are not mutually exclusive.
+Paths support `~` expansion and project-root pseudo-variables. CLI flags and env vars both accumulate — they are not mutually exclusive.
 
 > **Note:** The `<COMMAND>` must come after `--` or at the very end of the arguments.
 
@@ -328,6 +328,35 @@ If a tool needs access to paths not in the default whitelist, use the access fla
 
 ```bash
 harnx-sandbox-run --extra-rwx ~/.custom-tool-cache -- my-tool
+```
+
+## Project-Root Pseudo-Variables
+
+Sandbox path flags (`--extra-read/-write/-exec/-rwx`) and environment variables (`HARNX_BASH_EXTRA_READABLE/EXEC/WRITABLE/RWX`) accept project-root pseudo-variables. These are resolved at startup against the current working directory:
+
+| Pseudo-variable | Resolves to |
+| :--- | :--- |
+| `$GIT_ROOT` | git worktree root (`gix discover` workdir) |
+| `$GIT_COMMON_DIR` | primary worktree's `.git` data dir (handles linked worktrees) |
+| `$NODE_PROJECT_ROOT` | highest ancestor containing `package.json` (workspace root) |
+| `$CARGO_ROOT` | highest ancestor containing `Cargo.toml` (workspace root) |
+| `$GO_ROOT` | nearest ancestor containing `go.mod` |
+
+### Semantics
+
+- **Silent skip**: If the current directory is not inside a matching project, the path is silently dropped. This allows you to set global environment variables like `HARNX_BASH_EXTRA_RWX='$GIT_ROOT'` that only take effect when you are actually in a git repository.
+- **Security**: Any pseudo-variable that resolves to `$HOME` or an ancestor of `$HOME` is dropped. The sandbox never grants access to your entire home directory via root detection.
+- **Prefix match**: A pseudo-variable only triggers on an exact prefix-boundary match. `$GIT_ROOT` or `$GIT_ROOT/subdir` will be expanded, but `$GIT_ROOTX` or `/foo/$GIT_ROOT` will be treated as literal strings.
+- **No escaping**: There is no mechanism to escape these variables. A directory literally named `$GIT_ROOT` cannot be targeted.
+- **Shell quoting**: Use single quotes in your shell (e.g., `'$GIT_ROOT'`) to prevent the shell from attempting to expand them as shell variables.
+- **Unix-only**: Project-root detection is currently supported on Unix systems only. On other platforms, these strings are ignored.
+
+### Linked Worktrees
+
+`$GIT_COMMON_DIR` is particularly useful for git history in linked worktrees. It resolves to the primary worktree's `.git` data directory, which is required for many git operations to function correctly from a linked worktree.
+
+```bash
+harnx-sandbox-run --extra-rwx '$GIT_ROOT' --extra-rwx '$GIT_COMMON_DIR' -- yarn install
 ```
 
 ## Network Access

--- a/docs/solutions/workflow-issues/sandbox-project-root-pseudo-vars-2026-06-02.md
+++ b/docs/solutions/workflow-issues/sandbox-project-root-pseudo-vars-2026-06-02.md
@@ -1,0 +1,189 @@
+---
+title: "Sandbox Project-Root Autodetection via Pseudo-Variable Path Syntax"
+date: 2026-06-02
+category: workflow-issues
+problem_type: workflow_issue
+component: harnx-sandbox-common
+root_cause: "Hardcoded sandbox paths did not adapt to project context; linked git worktrees lacked access to primary .git; HOME guard missing from harnx-mcp-bash extra paths"
+resolution_type: code_fix
+severity: medium
+tags:
+  - sandboxing
+  - path-resolution
+  - git-worktree
+  - cross-platform
+  - testing
+  - security-invariant
+plan_ref: sandbox-project-root-detection
+---
+  
+## Problem
+
+Sandboxing development tools (yarn, cargo, go) required manually specifying project paths. Users in git linked worktrees could not access the primary `.git` data directory (history, hooks). `harnx-mcp-bash` did not apply the `is_home_or_ancestor` security guard to `--extra-*` paths, allowing accidental HOME exposure.
+
+## Symptoms
+
+- `harnx-sandbox-run --extra-rwx '$GIT_ROOT' -- cargo build` failed or required manual path calculation
+- Linked worktree users: git history commands failed inside sandbox (no access to primary `.git`)
+- `harnx-mcp-bash`: `HARNX_BASH_EXTRA_RWX=$HOME` granted full home access (defect)
+- Monorepos: user had to determine correct workspace root manually
+
+## Investigation Steps
+
+1. Identified that `harnx-sandbox-run` and `harnx-mcp-bash` each had their own `expand_tilde` implementations — code duplication
+2. Traced `harnx-mcp-bash` extra path handling: no `is_home_or_ancestor` check (defect from tilde-expansion PR)
+3. Evaluated git library options: `gix` already a workspace dep (used by `harnx-mcp-history`), no subprocess
+4. Tested `gix::Repository::common_dir()` for linked worktrees: returns non-normalized path (`.git/worktrees/<name>/../..`), but canonicalizes correctly through `is_home_or_ancestor`
+5. Designed marker-fs walk-up: Node/Cargo = highest ancestor (monorepo hoisted deps), Go = nearest (independent modules)
+6. Hit flaky test failures under `cargo test`: env-mutating tests across modules in single binary used independent `OnceLock<Mutex>` locks — does NOT serialize. Single `OnceLock<Mutex<()>>` per *binary* required
+
+## Root Cause
+
+**No shared path resolution**: Each binary had its own `expand_tilde`, no project-root detection. Users hardcoded paths or wrote wrapper scripts.
+
+**Missing HOME guard**: `harnx-mcp-bash` extra paths bypassed `is_home_or_ancestor` check introduced for security incident #619.
+
+**Test isolation bug**: `OnceLock<Mutex<()>>` declared per-module. Under `cargo test` (single process, threads), per-module locks do NOT serialize against each other. Only `nextest` masks this (process isolation per test).
+
+## Solution
+
+Added project-root pseudo-variables to sandbox path flags, shared in `harnx-sandbox-common`.
+
+### New Modules
+
+**`root_detection.rs`** — detects project roots via `gix` and marker-fs walk-up:
+```rust
+pub enum RootKind {
+    GitRoot,         // gix::discover(cwd).workdir()
+    GitCommonDir,    // gix::discover(cwd).common_dir()
+    NodeProjectRoot, // walk up for package.json (highest)
+    CargoRoot,       // walk up for Cargo.toml (highest)
+    GoRoot,          // walk up for go.mod (nearest)
+}
+
+pub fn detect_project_root(kind: RootKind, cwd: &Path) -> Option<PathBuf> {
+    let root = match kind { /* ... */ };
+    if crate::is_home_or_ancestor(&root) {
+        return None;  // Security invariant: never allow HOME/ancestor
+    }
+    Some(root)
+}
+```
+
+**`path_expand.rs`** — shared path expansion:
+```rust
+#[cfg(unix)]
+pub fn expand_path_var(raw: &str, cwd: &Path) -> Option<PathBuf> {
+    // Match pseudo-var at exact prefix-boundary only
+    let pseudo_var = [
+        ("$GIT_ROOT", RootKind::GitRoot),
+        ("$GIT_COMMON_DIR", RootKind::GitCommonDir),
+        // ...
+    ].into_iter().find(|(prefix, _)| {
+        raw == *prefix || raw.strip_prefix(prefix).is_some_and(|r| r.starts_with('/'))
+    });
+    
+    if let Some((prefix, kind)) = pseudo_var {
+        let root = detect_project_root(kind, cwd)?;
+        let remainder = raw.strip_prefix(prefix).expect("matched");
+        return Some(match remainder.strip_prefix('/') {
+            Some(relative) => root.join(relative),
+            None => root,
+        });
+    }
+    
+    Some(PathBuf::from(expand_tilde(raw)))
+}
+
+#[cfg(not(unix))]
+pub fn expand_path_var(raw: &str, _cwd: &Path) -> Option<PathBuf> {
+    Some(PathBuf::from(raw))  // consume-and-ignore
+}
+```
+
+**`test_support.rs`** — single process-wide env lock per crate:
+```rust
+pub(crate) fn env_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    // Recover from poisoning: a panicking test still leaves the lock usable for
+    // the next one, which only needs serialized access (not invariant integrity).
+    match LOCK.get_or_init(|| Mutex::new(())).lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+pub(crate) struct EnvGuard {
+    saved_home: Option<OsString>,
+    saved_cwd: PathBuf,
+}
+// RAII: restores HOME/cwd on drop
+```
+
+### Home Guard Fix
+
+Added `is_home_or_ancestor` check to `harnx-mcp-bash` extra paths in `args.rs`:
+```rust
+for path in extra_paths {
+    #[cfg(unix)]
+    if is_home_or_ancestor(&path) {
+        eprintln!("harnx-mcp-bash: dropping --extra-* path resolving to $HOME or ancestor");
+        continue;
+    }
+    // ... add to sandbox args
+}
+```
+
+### Test Isolation Fix
+
+Consolidated `OnceLock<Mutex<()>>` into single `test_support.rs` per crate. All test modules in that crate import from same location:
+- `harnx-sandbox-common/src/test_support.rs` — used by `home_guard`, `root_detection`, `path_expand`, `args` test modules
+- `harnx-mcp-bash/src/test_support.rs` — used by `main.rs` tests and `server/tests.rs`
+
+## Why This Works
+
+**Security invariant reused**: `is_home_or_ancestor` from prior incident (#619) guards every detected root. Canonicalizes both HOME and candidate, checks `home.starts_with(&candidate)`. Symlink-to-HOME resolved via canonicalization. Child of `$HOME` allowed; `$HOME` or ancestor blocked.
+
+**`common_dir()` handles linked worktrees**: `gix::Repository::common_dir()` returns primary `.git` path (even from linked worktree). Returns non-normalized path with `../..` segments, but `is_home_or_ancestor` canonicalizes internally, defeating this gotcha. `workdir()` returns linked worktree root.
+
+**Highest vs Nearest semantics**: Node/Cargo walk to highest ancestor with marker — enables monorepo workspace root (shared `node_modules`, shared `target/`). Go walks to nearest `go.mod` — nested modules are independent.
+
+**Prefix-boundary matching**: `$GIT_ROOT` matches, `$GIT_ROOTX` literal (prefix not followed by `/` or end). Remainder joined relative: strip leading `/` so `join()` appends to root.
+
+**`Option<PathBuf>` return**: Silent-skip-on-miss for pseudo-vars (no git repo → no path). Literal/tilde always `Some`.
+
+**Cross-platform**: `#[cfg(unix)]` detection; non-Unix `expand_path_var` returns raw path unchanged. Symbol exists on both, compiles.
+
+**Single env lock per binary**: `OnceLock<Mutex<()>>` is process-global. Multiple declarations in different modules = multiple locks = does NOT serialize. Single `test_support.rs` with `pub(crate)` lock used by all modules in same binary. `cargo test` runs tests in single process; `nextest` isolates per test.
+
+## Prevention Strategies
+
+**Test Cases:**
+- Pseudo-var expands in git repo, drops outside repo
+- `$GIT_COMMON_DIR` resolves to primary `.git` from linked worktree (real `git worktree add` test)
+- Symlink pointing to `$HOME` dropped by guard
+- `$GIT_ROOTX` literal, `/foo/$VAR` literal (no expansion mid-path)
+- HOME/cwd mutation tests serialize on shared env lock
+
+**Best Practices:**
+- Every path added to sandbox MUST pass `is_home_or_ancestor`
+- Adding new pseudo-var? Update array in `path_expand.rs`, add `RootKind` variant
+- Marker-fs detection: mono-root tools (Node, Cargo) = highest; independent modules (Go) = nearest
+- `gix` paths may be non-normalized; canonicalize before string comparison
+
+**Code Review Checklist:**
+- [ ] New sandbox path sources apply `is_home_or_ancestor`?
+- [ ] Path expansion called at both CLI and env-var entry points?
+- [ ] Non-Unix compile passes (consume-and-ignore)?
+- [ ] env-mutating tests use SINGLE shared `OnceLock<Mutex<()>>` per crate?
+
+**Test Isolation Rule:**
+`OnceLock<Mutex<()>>` must be declared exactly ONCE per test binary. If crate has no lib.rs (bin with `mod server`), inline tests and `server/tests.rs` share one binary. Put lock in `test_support.rs`, use `pub(crate)`.
+
+## Related Issues
+
+- **GitHub Issue:** [#575 — Sandbox project-root autodetection via pseudo-variable path syntax](https://github.com/dobesv/harnx/issues/575)
+- **Plan:** sandbox-project-root-detection
+- **Commits:** a5e2c22b1e, 99c0d39370, 832d688829, 985c0f2090, b827d23178, 358b02f7ff, 6b7f0141b4
+- **Related Solution:** [../security-issues/sandbox-home-exposure-ancestor-walk-2026-05-21.md](../security-issues/sandbox-home-exposure-ancestor-walk-2026-05-21.md) — HOME guard invariant (reused)
+- **Related Solution:** [sandbox-path-tilde-expansion-cross-platform-2026-04-29.md](sandbox-path-tilde-expansion-cross-platform-2026-04-29.md) — Tilde expansion, env lock pattern


### PR DESCRIPTION
Introduces project-root autodetection via pseudo-variables ($GIT_ROOT, $GIT_COMMON_DIR, $NODE_PROJECT_ROOT, $CARGO_ROOT, $GO_ROOT) in path-related flags for harnx-sandbox-run and harnx-mcp-bash.

- Consolidates path expansion (tilde and pseudo-vars) into harnx-sandbox-common.
- Implements RootKind detection for Git, Node, Cargo, and Go projects.
- $GIT_COMMON_DIR correctly resolves to the primary .git directory even when working in a linked git worktree.
- Applies the home-guard security check to all expanded paths in harnx-mcp-bash and harnx-sandbox-run to prevent accidental HOME exposure.
- Unifies test environment locking across crate modules to prevent race conditions during parallel test execution.
- Includes comprehensive documentation for the new pseudo-variables and a detailed solution entry.

#575

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for project-root pseudo-variables ($GIT_ROOT, $GIT_COMMON_DIR, $NODE_PROJECT_ROOT, $CARGO_ROOT, $GO_ROOT) in sandbox path configuration flags and environment variables.

* **Bug Fixes**
  * Applied consistent home directory protection to all extra paths in bash-mcp-server to prevent unintended home directory exposure.

* **Documentation**
  * Updated sandbox-run and bash-mcp-server documentation with pseudo-variable support details and expansion semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->