### PR TITLE
docs: rewrite AI agent wrapper scripts as PATH shim-dir recipe

### DIFF
--- a/.changeset/sandbox-shim-dir-recipe.md
+++ b/.changeset/sandbox-shim-dir-recipe.md
@@ -1,0 +1,5 @@
+---
+harnx: patch
+---
+
+Rewrite the "AI Agent Wrapper Scripts" section of `docs/sandbox-run.md` to use a PATH-prepended shim directory (`${XDG_DATA_HOME:-$HOME/.local/share}/harnx/sandbox-bin`). The shims are named after the real commands (`claude`, `gemini`, `node`/`yarn`/`npm`/`npx`/`pnpm`), each stripping its own directory from `PATH` before exec'ing the real tool inside a tailored birdcage sandbox, using the project-root pseudo-variables. Replaces the old `claude-sb`/`gemini-sb` recipe (#575).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "agent-client-protocol"
 version = "0.13.1"
-source = "git+https://github.com/agentclientprotocol/rust-sdk?rev=6b099b97f6a26686195e82802b87042ab74dc8b1#6b099b97f6a26686195e82802b87042ab74dc8b1"
+source = "git+https://github.com/agentclientprotocol/rust-sdk?rev=740db05db8fff0eecf7550eff356ed1f2632eb8b#740db05db8fff0eecf7550eff356ed1f2632eb8b"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "agent-client-protocol-derive"
 version = "0.13.1"
-source = "git+https://github.com/agentclientprotocol/rust-sdk?rev=6b099b97f6a26686195e82802b87042ab74dc8b1#6b099b97f6a26686195e82802b87042ab74dc8b1"
+source = "git+https://github.com/agentclientprotocol/rust-sdk?rev=740db05db8fff0eecf7550eff356ed1f2632eb8b#740db05db8fff0eecf7550eff356ed1f2632eb8b"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -167,7 +167,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -178,7 +178,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -405,9 +405,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.18"
+version = "1.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
+checksum = "517aa062d8bd9015ee23d6daa5e1c1372328412fdae4e6c4c1be9b69c6ad37a2"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -496,11 +496,10 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.101.0"
+version = "1.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b647baea49ff551960b904f905681e9b4765a6c4ea08631e89dc52d8bd3f5896"
+checksum = "9f4055e6099b2ec264abdc0d9bbfffce306c1601809275c861594779a0b04b45"
 dependencies = [
- "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -521,11 +520,10 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.103.0"
+version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae401c65ff288aa7873117fe535cd32b7b1bb0bc43751d28901a1d5f20636b9"
+checksum = "02f009ba0284c5d696425fd7b4dcc5b189f5726f4041b7a5794daecb3a68d598"
 dependencies = [
- "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -546,11 +544,10 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.106.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c80de7bb7d03e9ca8c9fd7b489f20f3948d3f3be91a7953591347d238115408"
+checksum = "6aa6622798e19e6a76b690562085dd4771c736cd48343464a53ab4ae2f2c9f84"
 dependencies = [
- "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -661,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.7"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -717,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.3"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -757,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
+checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -895,7 +892,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "848df95320021558dd6bb4c26de3fe66724cdcbdbbf3fa720150b52b086ae568"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "libc",
  "log",
  "rustix 0.38.44",
@@ -949,9 +946,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "2c61cd05405eb1d0f3a4660f802bad76ece84b6e722426342ba5dd511f724e97"
 
 [[package]]
 name = "block-buffer"
@@ -1168,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.45"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1484,7 +1481,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -1798,7 +1795,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1807,7 +1804,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "objc2",
 ]
 
@@ -1957,7 +1954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2579,7 +2576,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bstr",
  "gix-path",
  "libc",
@@ -2747,7 +2744,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bstr",
  "gix-features",
  "gix-path",
@@ -2805,7 +2802,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e6b28cc592dc753adb58302bb14a64e412ee591a3bec77aa4df87bff74fa80d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bstr",
  "filetime",
  "fnv",
@@ -2856,7 +2853,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "890c936a215bae25818c076cb881cb2e54d2c66ba947ba58b8dd47cff921bf55"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -2956,7 +2953,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bstr",
  "gix-attributes",
  "gix-config-value",
@@ -3057,7 +3054,7 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b47c88884dd3c1a19a39da19d10211fcdea2809aadc86869b6e824a1774340f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bstr",
  "gix-commitgraph",
  "gix-date",
@@ -3092,7 +3089,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "gix-path",
  "libc",
  "windows-sys 0.61.2",
@@ -3192,7 +3189,7 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8de590ecc86a3b2870665f2288324fa9f7f8672c7fc2d4e020fdd81cd1f7aed"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -3351,7 +3348,7 @@ dependencies = [
  "aws-smithy-eventstream",
  "base64",
  "bincode 2.0.1",
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bm25",
  "bytes",
  "chrono",
@@ -3878,7 +3875,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bincode 2.0.1",
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bytes",
  "chrono",
  "crossterm",
@@ -4608,7 +4605,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "crossterm",
  "dyn-clone",
  "fuzzy-matcher",
@@ -4666,7 +4663,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5079,7 +5076,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
 ]
 
 [[package]]
@@ -5117,9 +5114,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "loom"
@@ -5336,7 +5333,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ecce9d566cb9234ae3db9e249c8b55665feaaf32b0859ff1e27e310d2beb3d8"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "combine",
  "libc",
  "mach2",
@@ -5405,7 +5402,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5418,7 +5415,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5430,7 +5427,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5467,7 +5464,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5549,7 +5546,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -5561,7 +5558,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -5582,7 +5579,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "dispatch2",
  "objc2",
 ]
@@ -5593,7 +5590,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -5626,7 +5623,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -5644,7 +5641,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "block2",
  "libc",
  "objc2",
@@ -5657,7 +5654,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -5668,7 +5665,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -5680,7 +5677,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -5787,7 +5784,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -5855,7 +5852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6339,7 +6336,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -6522,7 +6519,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
@@ -6587,7 +6584,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -6648,7 +6645,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
 ]
 
 [[package]]
@@ -6909,7 +6906,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6922,11 +6919,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6994,7 +6991,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7144,7 +7141,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -7167,7 +7164,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "cssparser",
  "derive_more",
  "log",
@@ -7568,7 +7565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7785,7 +7782,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -7817,10 +7814,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7914,7 +7911,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
@@ -8203,7 +8200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "base64",
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bytes",
  "futures-util",
  "http 1.4.1",
@@ -8660,7 +8657,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -8685,7 +8682,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
@@ -8697,7 +8694,7 @@ version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -8709,7 +8706,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -8904,7 +8901,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9309,7 +9306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ duct = "1.0.0"
 rmcp = { version = "1.3.0", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server"] }
 process-wrap = { version = "9", features = ["tokio1"] }
 libc = "0.2"
-agent-client-protocol = { git = "https://github.com/agentclientprotocol/rust-sdk", rev = "6b099b97f6a26686195e82802b87042ab74dc8b1" }
+agent-client-protocol = { git = "https://github.com/agentclientprotocol/rust-sdk", rev = "740db05db8fff0eecf7550eff356ed1f2632eb8b" }
 glob = "0.3"
 globset = "0.4"
 shellexpand = "3.1.0"

--- a/docs/sandbox-run.md
+++ b/docs/sandbox-run.md
@@ -28,34 +28,129 @@ harnx-sandbox-run -- bash -c "echo hello"
 
 The primary use case for `harnx-sandbox-run` is running AI coding agents with bypassed permissions. Since the sandbox provides the actual safety boundary (preventing writes outside the project, network calls to unexpected hosts, etc.), the agent's own interactive permission prompts become redundant.
 
-### Claude Code (`claude-sb`)
+You can transparently sandbox your existing tools with a "shim directory." You place scripts named after the real commands (`claude`, `gemini`, `node`, `yarn`, …) in a directory that is first on your `PATH`, so typing the normal command runs it inside the sandbox — no need to remember a special wrapper name.
 
-Create a script named `claude-sb`. This example shows the full setup with AWS credentials, GitHub auth (git over HTTPS + API), and Atlassian (Jira/Confluence) — remove any sections you don't need:
+### Shim directory setup
 
 ```bash
+# Create the shim directory
+mkdir -p "${XDG_DATA_HOME:-$HOME/.local/share}/harnx/sandbox-bin"
+```
+
+Prepend this directory to your `PATH` in your shell profile (e.g., `~/.bashrc`, `~/.zshrc`):
+
+```bash
+export PATH="${XDG_DATA_HOME:-$HOME/.local/share}/harnx/sandbox-bin:$PATH"
+```
+
+The shim directory must be **first** on your `PATH` so the shims shadow the real tools. For the installation commands below, we'll use a `SHIM_DIR` variable:
+
+```bash
+SHIM_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/harnx/sandbox-bin"
+```
+
+### How the shims work
+
+Each shim script identifies its own location and strips that directory from the `PATH` before executing the real tool inside the sandbox. This is necessary because `harnx-sandbox-run` passes your `PATH` through to the sandboxed process, and `birdcage` resolves the target command against that `PATH`. If the shim directory remained first, the shim would re-invoke itself and recurse on the host. Stripping the directory (and the fact that the shim directory is not on the sandbox's execution whitelist) prevents this.
+
+For project access, the shims use [Project-Root Pseudo-Variables](#project-root-pseudo-variables) like `$GIT_ROOT` to automatically grant access to the current project's roots. These are silently skipped if you are not in a matching project.
+
+### Node, Yarn, npm, npx, pnpm (`node`)
+
+A single dispatcher script can handle the entire Node family by detecting which name it was called with. Common Node caches are already whitelisted by default, and project roots are granted automatically.
+```bash
 #!/usr/bin/env bash
-# claude-sb — run Claude Code inside the birdcage sandbox
+set -euo pipefail
+
+# Node-family sandbox shim.
+# Save this file as "node", then symlink or copy it to yarn, npm, npx, and pnpm.
+# It detects which real tool to run from its own basename, so one script covers all five.
+# Common Node caches are already in harnx-sandbox-run's default whitelist, so no extra cache flags are needed.
+# Project roots are auto-detected by harnx-sandbox-run's pseudo-vars and silently skipped when absent.
+
+tool="$(basename "$0")"
+self_dir="$(cd "$(dirname "$0")" && pwd -P)"
+PATH="$({
+  old_ifs=$IFS
+  IFS=:
+  for path_entry in $PATH; do
+    if [ "$path_entry" != "$self_dir" ]; then
+      if [ -n "${new_path-}" ]; then
+        new_path="${new_path}:$path_entry"
+      else
+        new_path="$path_entry"
+      fi
+    fi
+  done
+  IFS=$old_ifs
+  printf '%s' "${new_path-}"
+})" # Drop shim dir from PATH by exact element match to prevent harnx-sandbox-run -- "$tool" from resolving back to shim and recursing.
+export PATH
+
+# shellcheck disable=SC2016 -- '$GIT_ROOT' style args are harnx-sandbox-run pseudo-vars; shell must pass them through literally.
+# Caches like ~/.npm, ~/.yarn, ~/.nvm, ~/.bun, ~/.cache, ~/.cargo, go/bin, go/pkg, and ~/.local/share/pnpm are pre-whitelisted.
+exec harnx-sandbox-run \
+  --extra-rwx '$GIT_ROOT' \
+  --extra-rwx '$NODE_PROJECT_ROOT' \
+  --extra-rwx '$GIT_COMMON_DIR' \
+  -- "$tool" "$@"
+```
+Installation:
+
+```bash
+SHIM_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/harnx/sandbox-bin"
+# Save the script above as "$SHIM_DIR/node", then:
+chmod +x "$SHIM_DIR/node"
+for t in yarn npm npx pnpm; do ln -sf node "$SHIM_DIR/$t"; done
+```
+
+### Claude Code (`claude`)
+
+Claude Code requires access to its own configuration and credentials, along with credential hooks for AWS, GitHub, and Atlassian.
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# claude — run Claude Code inside birdcage sandbox
 #
 # --dangerously-skip-permissions bypasses Claude's own permission prompts;
-# the sandbox is the actual safety boundary.
+# sandbox is actual safety boundary.
 #
-# Credentials are injected via hooks — real tokens never enter the sandbox:
-#   - harnx-aws-creds: resolves AWS credentials from the host and exposes
-#     them via the container credentials protocol (no raw keys in env)
+# Credentials are injected via hooks — real tokens never enter sandbox:
+#   - harnx-aws-creds: resolves AWS credentials from host and exposes
+#     them via container credentials protocol (no raw keys in env)
 #   - harnx-proxy-auth: HTTPS MITM proxy that intercepts outbound requests
 #     and injects auth headers; --env scripts put fake sentinel tokens into
-#     the sandbox env so the LLM never sees real credentials
+#     sandbox env so LLM never sees real credentials
+
+self_dir="$(cd "$(dirname "$0")" && pwd -P)"
+PATH="$({
+  old_ifs=$IFS
+  IFS=:
+  for path_entry in $PATH; do
+    if [ "$path_entry" != "$self_dir" ]; then
+      if [ -n "${new_path-}" ]; then
+        new_path="${new_path}:$path_entry"
+      else
+        new_path="$path_entry"
+      fi
+    fi
+  done
+  IFS=$old_ifs
+  printf '%s' "${new_path-}"
+})" # Drop shim dir from PATH by exact element match to prevent harnx-sandbox-run -- claude from resolving back to shim and recursing.
+export PATH
+
+# shellcheck disable=SC2016 -- '$GIT_ROOT' style args are harnx-sandbox-run pseudo-vars; shell must pass them through literally.
+# ~/.local/share/claude is already default-whitelisted, so intentionally not listed here.
 exec harnx-sandbox-run \
-  \
-  --extra-rwx ~/projects \
-  \
+  --extra-rwx '$GIT_ROOT' \
+  --extra-rwx '$NODE_PROJECT_ROOT' \
+  --extra-rwx '$GIT_COMMON_DIR' \
   --extra-rwx ~/.claude \
-  --extra-rwx ~/.local/share/claude \
   --extra-write ~/.claude.json \
-  \
   --env "EDITOR=true" \
   --env "PUPPETEER_NO_SANDBOX=1" \
-  \
   --hook claude-command-persistent harnx-aws-creds --profile my-profile \; \
   \
   --hook claude-command-persistent harnx-proxy-auth \
@@ -81,52 +176,69 @@ exec harnx-sandbox-run \
         then .headers.authorization = basic(env.ATLASSIAN_EMAIL; env.ATLASSIAN_API_TOKEN)
         end' \
   \; \
-  \
-  -- \
-  claude --dangerously-skip-permissions "$@"
+  -- claude --dangerously-skip-permissions "$@"
 ```
-
 **Key points:**
-- Replace `~/projects` with a folder where you have files the agent needs to work on, and `my-profile` with your AWS profile name (omit `--hook ... harnx-aws-creds ...` entirely if you don't need AWS).
+- Replace `my-profile` with your AWS profile name (omit `--hook ... harnx-aws-creds ...` entirely if you don't need AWS). Project access now uses harnx-sandbox-run pseudo-vars, so current git root / node project root / git common dir are granted automatically when present; add `--extra-rwx /path` for any extra directories the agent should access.
 - The `--env` scripts inject fake sentinel tokens (e.g. `ghp_<random>`) into the sandbox so `gh` sees `GITHUB_TOKEN` set and considers itself authenticated. The real token never enters the sandbox — `harnx-proxy-auth` reads it from the host env and injects it into outbound HTTP headers.
 - Remove the Atlassian block if you don't use Jira/Confluence.
 - `if COND then EXPR end` — omitting `else` passes the input through unchanged (jaq default).
 
-### Gemini CLI (`gemini-sb`)
-
-Create a script named `gemini-sb`:
-
+### Gemini CLI (`gemini`)
 ```bash
 #!/usr/bin/env bash
-# gemini-sb — run Gemini CLI inside the birdcage sandbox
+set -euo pipefail
+
+# gemini — run Gemini CLI inside birdcage sandbox
 #
 # --yolo bypasses Gemini's own permission prompts;
-# the sandbox is the actual safety boundary.
+# sandbox is actual safety boundary.
 #
 # ~/.gemini        — global settings, OAuth credentials, commands, skills
 # ~/.config/gemini — XDG config fallback (used on some systems)
-# .                — the project directory you want the agent to work in
-#                    (the sandbox does NOT whitelist the current directory
-#                    automatically — you must grant access explicitly;
-#                    passing . is safe: harnx-sandbox-run resolves it and
-#                    refuses to grant access if it would expose $HOME)
+# Project roots are auto-detected via $GIT_ROOT / $NODE_PROJECT_ROOT /
+# $GIT_COMMON_DIR and silently skipped when absent.
+
+self_dir="$(cd "$(dirname "$0")" && pwd -P)"
+PATH="$({
+  old_ifs=$IFS
+  IFS=:
+  for path_entry in $PATH; do
+    if [ "$path_entry" != "$self_dir" ]; then
+      if [ -n "${new_path-}" ]; then
+        new_path="${new_path}:$path_entry"
+      else
+        new_path="$path_entry"
+      fi
+    fi
+  done
+  IFS=$old_ifs
+  printf '%s' "${new_path-}"
+})" # Drop shim dir from PATH by exact element match to prevent harnx-sandbox-run -- gemini from resolving back to shim and recursing.
+export PATH
+
+# shellcheck disable=SC2016 -- '$GIT_ROOT' style args are harnx-sandbox-run pseudo-vars; shell must pass them through literally.
 exec harnx-sandbox-run \
   --extra-rwx ~/.gemini \
   --extra-rwx ~/.config/gemini \
-  --extra-rwx . \
-  -- \
-  gemini --yolo "$@"
+  --extra-rwx '$GIT_ROOT' \
+  --extra-rwx '$NODE_PROJECT_ROOT' \
+  --extra-rwx '$GIT_COMMON_DIR' \
+  -- gemini --yolo "$@"
+```
+If the agent needs access to additional directories, grant them with `--extra-rwx /path/to/dir` in the shim script.
+
+### Installing the shims
+
+Make all shims executable and verify that the shims appear first on your `PATH`:
+
+```bash
+chmod +x "$SHIM_DIR"/*
+command -v node      # should print the shim path under sandbox-bin
+which -a node         # confirm the shim appears before the real tool
 ```
 
-> **Note:** Pass `--extra-rwx` for each additional project directory you want Gemini to access. The sandbox restricts writes to only the paths you explicitly grant.
-
-### Installation
-
-1. Save the scripts to a directory in your `PATH` (e.g., `~/.local/bin/`).
-2. Make them executable:
-   ```bash
-   chmod +x ~/.local/bin/claude-sb ~/.local/bin/gemini-sb
-   ```
+*Note: This replaces the older `claude-sb` / `gemini-sb` scripts — users can delete those and use the shim directory instead.*
 
 ## CLI Reference
 
@@ -173,7 +285,7 @@ For the full list of default paths, see the [Bash MCP Server documentation](bash
 harnx-sandbox-run --extra-rwx . -- my-tool
 ```
 
-Passing `.` is safe: `harnx-sandbox-run` resolves it to an absolute path before use. If the resolved path is `$HOME` itself or an ancestor of `$HOME` (e.g. `/`), the path is silently skipped and a warning is printed to stderr — so running `gemini-sb` from your home directory won't accidentally expose all of `~`.
+Passing `.` is safe: `harnx-sandbox-run` resolves it to an absolute path before use. If the resolved path is `$HOME` itself or an ancestor of `$HOME` (e.g. `/`), the path is silently skipped and a warning is printed to stderr — so running the `gemini` shim from your home directory won't accidentally expose all of `~`.
 
 The `--working-dir <path>` flag changes where the sandboxed command starts, but it also does not automatically grant filesystem access to that path — you still need a matching `--extra-rwx` (or `--extra-read` / `--extra-write`) for it.
 
@@ -315,7 +427,7 @@ harnx-sandbox-run \
   -- my-tool
 ```
 
-See the `claude-sb` wrapper script above for a complete working example combining AWS credentials, GitHub, and Atlassian in one invocation.
+See the `claude` shim in [AI Agent Wrapper Scripts](#ai-agent-wrapper-scripts) above for a complete working example combining AWS credentials, GitHub, and Atlassian in one invocation.
 
 ## Extra Path Access
 

--- a/docs/solutions/integration-issues/path-shim-sandbox-recursion-prevention-2026-06-02.md
+++ b/docs/solutions/integration-issues/path-shim-sandbox-recursion-prevention-2026-06-02.md
@@ -1,0 +1,172 @@
+---
+title: "PATH Shim Directory Pattern for Transparent Sandbox Wrappers"
+date: 2026-06-02
+category: integration-issues
+problem_type: integration_issue
+component: harnx-sandbox-run
+root_cause: "Shim directory on PATH causes host-side recursion when sandbox passes PATH through and child resolves command[0] against that PATH"
+resolution_type: workflow_improvement
+severity: high
+tags:
+  - sandboxing
+  - birdcage
+  - path-manipulation
+  - recursion-prevention
+  - wrapper-scripts
+  - self-name-dispatch
+plan_ref: sandbox-shim-dir-recipe
+---
+
+## Problem
+
+When using a PATH-prepended "shim directory" to transparently sandbox CLI tools, `harnx-sandbox-run` passes `PATH` through to the sandboxed child (baseline env passthrough). Birdcage resolves the command (`command[0]`) against this inherited `PATH`. If the shim directory is still first on `PATH` inside the sandbox, `harnx-sandbox-run -- node` re-resolves to the shim script → infinite recursion on the host.
+
+## Symptoms
+
+```
+# Scenario: shim dir at /home/user/.local/share/harnx/sandbox-bin
+# User runs: node --version
+# Shim execs: harnx-sandbox-run -- node --version
+# Inside sandbox, PATH still starts with shim dir
+# Birdcage resolves "node" → shim script again → recursion
+
+# Eventually hits:
+bash: fork retry: Resource temporarily unavailable  # (process table exhausted)
+# OR (with defense-in-depth whitelist):
+Error: Permission denied (exec from non-whitelisted path)
+```
+
+## Investigation Steps
+
+1. Reviewed `harnx-sandbox-run` source (`crates/harnx-sandbox-run/src/sandbox.rs:246`) — confirmed `PATH` is in `DEFAULT_ENV_PASSTHROUGH` baseline env list.
+
+2. Traced sandbox behavior: birdcage inherits environment from parent process, including `PATH`. When child command is a bare name (not absolute path), birdcage resolves it via `PATH` lookup.
+
+3. Identified that the shim directory, being first on `PATH`, would be found first when resolving commands like `node`, `claude`, `gemini`.
+
+4. Recognized two defenses needed:
+   - Shim MUST strip its own directory from `PATH` before exec-ing `harnx-sandbox-run`
+   - Shim directory should NOT be on sandbox's exec whitelist (defense in depth)
+
+5. Tested PATH-strip pattern with exact element matching to ensure substring-similar paths (e.g., `/path/to/shim-extra`) are preserved.
+
+## Root Cause
+
+**Recursion mechanism**: Shim dir prepended to `PATH` → shim execs `harnx-sandbox-run -- tool` → sandbox passes `PATH` through → child process inherits `PATH` with shim dir still first → birdcage resolves bare command name against `PATH` → finds shim again → infinite loop.
+
+The recursion occurs on the HOST side (not inside the sandbox) because `harnx-sandbox-run` itself runs outside the sandbox and execs the shim again.
+
+## Solution
+
+### PATH-Strip Pattern
+
+Each shim strips its own directory from `PATH` before exec-ing `harnx-sandbox-run`:
+
+```bash
+# Resolve own directory (canonical path)
+self_dir="$(cd "$(dirname "$0")" && pwd -P)"
+
+# Strip self_dir from PATH by exact element match (not substring!)
+PATH="$({
+  old_ifs=$IFS
+  IFS=:
+  for path_entry in $PATH; do
+    if [ "$path_entry" != "$self_dir" ]; then
+      if [ -n "${new_path-}" ]; then
+        new_path="${new_path}:$path_entry"
+      else
+        new_path="$path_entry"
+      fi
+    fi
+  done
+  IFS=$old_ifs
+  printf '%s' "${new_path-}"
+})"
+export PATH
+```
+
+**Key details:**
+- Uses `IFS=:` to split on path separator
+- Exact element comparison (`[ "$path_entry" != "$self_dir" ]`) — not substring match
+- Rebuilds `PATH` preserving order of remaining elements
+- Handles empty `PATH` gracefully (`${new_path-}` syntax)
+
+### Self-Name Dispatch Pattern
+
+Single script handles multiple tools via `basename "$0"`:
+
+```bash
+tool="$(basename "$0")"
+# ... PATH strip ...
+exec harnx-sandbox-run -- "$tool" "$@"
+```
+
+Create symlinks for tool variants:
+```bash
+chmod +x "$SHIM_DIR/node"
+for t in yarn npm npx pnpm; do ln -sf node "$SHIM_DIR/$t"; done
+```
+
+This works when all symlinked tools have identical sandbox access rules (node-family: same caches, same project roots).
+
+### Defense-in-Depth: Exec Whitelist
+
+Document that shim directory is NOT on the sandbox's execution whitelist. Even if PATH-strip fails (e.g., symlinked PATH entry), birdcage blocks exec from shim dir inside sandbox, causing a clear "Permission denied" rather than silent recursion.
+
+## Why This Works
+
+1. **Exact-element strip prevents substring clobber**: `/path/to/shim-extra` is preserved when stripping `/path/to/shim`
+
+2. **Self-name dispatch reduces boilerplate**: One script, N symlinks, identical access profiles
+
+3. **Defense-in-depth fails safe**: Whitelist block produces visible error, not infinite loop
+
+4. **Canonical path resolution (`pwd -P`)**: Handles symlinks to shim dir at the script level (though see edge cases below)
+
+5. **Works with pseudo-vars**: `$GIT_ROOT`, `$NODE_PROJECT_ROOT`, `$GIT_COMMON_DIR` passed through literally (single-quoted) so `harnx-sandbox-run` resolves them inside sandbox context
+
+## Known Edge Cases
+
+1. **Symlinked PATH entry vs canonical `self_dir`**: If user's shell profile uses a symlinked path (e.g., `/links/me/.local/...`) while `pwd -P` resolves to canonical (e.g., `/nfs/users/me/.local/...`), exact match fails. Shim dir remains on `PATH`.
+
+   **Mitigation**: Document that users should use canonical paths in shell profile. Defense-in-depth whitelist still prevents recursion (fails with exec denial).
+
+2. **Trailing slash on PATH entry**: `/path/to/shim/` != `/path/to/shim`. Exact match fails.
+
+   **Mitigation**: Document: avoid trailing slashes in PATH exports. Shell profile templates in docs don't add them.
+
+3. **Empty PATH after strip**: If `PATH` contained only shim dir, result is empty string. Child process cannot resolve any commands — fails fast at exec.
+
+Both edge cases are narrow and result in clear failure, not silent security bypass.
+
+## Prevention Strategies
+
+**When to Use This Pattern:**
+- Transparent sandboxing of existing CLI tools
+- Multiple tools share identical sandbox access rules
+- Users want zero-config project access (pseudo-vars)
+
+**When to Create Separate Shims:**
+- Tools have different access profiles (e.g., `claude` needs `~/.claude` + hooks; `gemini` needs `~/.gemini`)
+- Per-tool hook configuration differs
+
+**Code Review Checklist:**
+- [ ] PATH strip uses exact element match (not substring)?
+- [ ] `IFS=:` used to split correctly?
+- [ ] `pwd -P` used for `self_dir` resolution?
+- [ ] Shim directory excluded from exec whitelist?
+- [ ] Pseudo-vars single-quoted to prevent host expansion?
+- [ ] `shellcheck disable=SC2016` for pseudo-var patterns?
+
+**Testing:**
+- Verify PATH strip removes shim dir while preserving similar paths
+- Run `which -a tool` to confirm shim appears before real tool
+- Test symlinked PATH entry scenario (should fail with exec denial, not recurse)
+
+## Related Issues
+
+- **GitHub Issue:** [#575 — Ability to use sandbox tooling as CLI wrappers](https://github.com/dobesv/harnx/issues/575)
+- **Plan:** sandbox-shim-dir-recipe
+- **Commits:** 25933701ee (shim-dir recipe), 8df2053917 (key points clarification)
+- **Related Solution:** [birdcage-env-passthrough-2026-05-28.md](birdcage-env-passthrough-2026-05-28.md) — Baseline env passthrough design
+- **Related Solution:** [sandbox-project-root-pseudo-vars-2026-06-02.md](../workflow-issues/sandbox-project-root-pseudo-vars-2026-06-02.md) — Pseudo-var syntax


### PR DESCRIPTION
Rewrites the "AI Agent Wrapper Scripts" section of `docs/sandbox-run.md` to replace the legacy `claude-sb` and `gemini-sb` scripts with a transparent PATH-prepended shim directory (`${XDG_DATA_HOME:-$HOME/.local/share}/harnx/sandbox-bin`).

The new recipe uses shims named after the real commands (`claude`, `gemini`, `node`, `yarn`, `npm`, `npx`, `pnpm`) that strip their own directory from `PATH` before executing the real tool inside a tailored birdcage sandbox. This approach leverages project-root pseudo-variables (`$GIT_ROOT`, `$GIT_COMMON_DIR`, `$NODE_PROJECT_ROOT`) to provide zero-config access to project files.

Includes:
- Detailed setup instructions for the shim directory and shell profile.
- Optimized shims for Claude, Gemini, and the Node.js tool family.
- A new solution document covering the PATH-strip mechanism to prevent infinite recursion.
- A `harnx: patch` changeset for the documentation update.

#575

Plan: sandbox-shim-dir-recipe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sandbox wrapper documentation with new shim directory workflow for AI agent tools.
  * Added comprehensive setup and configuration guidance for Claude and Gemini CLI integrations.
  * Added troubleshooting documentation for preventing recursion issues when using PATH-prepended shim directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->