### PR TITLE
fix(sandbox): harden default whitelist with least-privilege split

### DIFF
--- a/.changeset/sandbox-default-writable-hardening.md
+++ b/.changeset/sandbox-default-writable-hardening.md
@@ -1,0 +1,9 @@
+---
+harnx: minor
+---
+
+Harden the sandbox default whitelist: directories on `PATH` or holding host-executed binaries (`~/.nvm`, `~/.cargo/bin`, `~/.pyenv`, `~/.rye`, `~/.mono`, `~/.local/share/{claude,opencode,pipx}`) are now **read+execute only**, and package-manager caches (`~/.npm`, `~/.yarn`, `~/.cargo/registry`, `~/.cargo/git`, `~/.bun/install/cache`, `~/.local/share/{pnpm,uv}`) are **read+write only**. No `$HOME` directory is granted write+execute by default. This closes a sandbox-escape vector where a compromised sandboxed process could plant a malicious executable in a writable directory that the user later runs on the host.
+
+Privileged operations that install or self-update executables (`cargo install`, `nvm install`, `pyenv install`, `rye sync`, `pipx install`, `claude update`, `opencode` self-update) now require explicit write access — pass `--extra-rwx <path>` (or set `HARNX_BASH_EXTRA_RWX` for the bash MCP server), or run them outside the sandbox.
+
+A custom `CARGO_HOME` now also receives the same defaults as the standard `~/.cargo`: read access to its root (for `config.toml`/credentials), read+exec for `bin`, and read+write for the `registry` and `git` download caches.

--- a/crates/harnx-mcp-bash/src/server/tests.rs
+++ b/crates/harnx-mcp-bash/src/server/tests.rs
@@ -520,10 +520,19 @@ mod sandbox_args {
             assert_arg_pair_present(&pairs, "--exec", path_str(".local/bin"));
             assert_arg_pair_present(&pairs, "--read", path_str(".cache"));
             assert_arg_pair_present(&pairs, "--write", path_str(".cache"));
-            assert_arg_pair_present(&pairs, "--read", path_str(".pyenv"));
-            assert_arg_pair_present(&pairs, "--write", path_str(".pyenv"));
+            // .pyenv is exec-only (read+exec, no write): the EXEC defaults emit
+            // only --exec, so neither --read nor --write should be present.
+            assert_arg_pair_absent(&pairs, "--read", path_str(".pyenv"));
+            assert_arg_pair_absent(&pairs, "--write", path_str(".pyenv"));
             assert_arg_pair_present(&pairs, "--exec", path_str(".pyenv"));
             assert_arg_pair_present(&pairs, "--exec", path_str(".cargo/bin"));
+            assert_arg_pair_present(&pairs, "--read", path_str(".npm"));
+            assert_arg_pair_present(&pairs, "--write", path_str(".npm"));
+            assert_arg_pair_absent(&pairs, "--exec", path_str(".npm"));
+            // .local/share/claude is exec-only: --exec only, no --read/--write.
+            assert_arg_pair_absent(&pairs, "--read", path_str(".local/share/claude"));
+            assert_arg_pair_absent(&pairs, "--write", path_str(".local/share/claude"));
+            assert_arg_pair_present(&pairs, "--exec", path_str(".local/share/claude"));
         }
     }
 
@@ -543,7 +552,15 @@ mod sandbox_args {
             None,
         );
 
+        // Custom CARGO_HOME root is readable so config.toml/credentials work.
+        assert_arg_pair_present(&pairs, "--read", "/opt/cargo-custom");
         assert_arg_pair_present(&pairs, "--exec", "/opt/cargo-custom/bin");
+        // Custom CARGO_HOME keeps cache-write parity with the default ~/.cargo.
+        assert_arg_pair_present(&pairs, "--read", "/opt/cargo-custom/registry");
+        assert_arg_pair_present(&pairs, "--write", "/opt/cargo-custom/registry");
+        assert_arg_pair_absent(&pairs, "--exec", "/opt/cargo-custom/registry");
+        assert_arg_pair_present(&pairs, "--read", "/opt/cargo-custom/git");
+        assert_arg_pair_present(&pairs, "--write", "/opt/cargo-custom/git");
         assert_arg_pair_present(&pairs, "--exec", "/opt/go");
         assert_arg_pair_present(&pairs, "--exec", "/srv/go-workspace/bin");
         assert_arg_pair_present(&pairs, "--read", "/srv/go-workspace/pkg");

--- a/crates/harnx-sandbox-common/src/defaults.rs
+++ b/crates/harnx-sandbox-common/src/defaults.rs
@@ -59,6 +59,10 @@ pub const HOME_READ_PATHS: &[&str] = &[
 ];
 
 #[cfg(unix)]
+// Security hardening: writable + executable directories on PATH, or directories
+// that hold host-executed binaries, let sandboxed code plant trojans that user
+// may later run on host. Default to exec-only or write-only instead; users opt
+// into write with --extra-rwx/--extra-write for installs and self-updates.
 pub const HOME_EXEC_PATHS: &[&str] = &[
     ".local/bin",
     ".local/lib",
@@ -66,21 +70,9 @@ pub const HOME_EXEC_PATHS: &[&str] = &[
     ".asdf",
     "go/bin",
     ".cargo",
-];
-
-#[cfg(unix)]
-pub const HOME_WRITE_PATHS: &[&str] = &[".cache", "go/pkg"];
-
-#[cfg(unix)]
-pub const HOME_RWX_PATHS: &[&str] = &[
-    ".npm",
-    ".yarn",
     ".nvm",
     ".cargo/bin",
-    ".cargo/registry",
-    ".cargo/git",
     ".mono",
-    ".bun/install/cache",
     ".pyenv",
     ".rye",
     // AI coding agents whose self-updaters install versioned binaries under
@@ -89,9 +81,23 @@ pub const HOME_RWX_PATHS: &[&str] = &[
     ".local/share/opencode", // OpenCode
     // Python/JS package managers that install executables here:
     ".local/share/pipx", // pipx (installs aider, etc.)
+];
+
+#[cfg(unix)]
+pub const HOME_WRITE_PATHS: &[&str] = &[
+    ".cache",
+    "go/pkg",
+    ".npm",
+    ".yarn",
+    ".cargo/registry",
+    ".cargo/git",
+    ".bun/install/cache",
     ".local/share/pnpm", // pnpm store
     ".local/share/uv",   // uv (Python package manager)
 ];
+
+#[cfg(unix)]
+pub const HOME_RWX_PATHS: &[&str] = &[];
 
 #[cfg(unix)]
 pub fn push_home_relative_defaults(args: &mut Vec<OsString>, home: &Path) {
@@ -126,8 +132,23 @@ pub fn push_home_relative_defaults(args: &mut Vec<OsString>, home: &Path) {
 #[cfg(unix)]
 pub fn push_env_relative_defaults(args: &mut Vec<OsString>) {
     if let Some(cargo_home) = std::env::var_os("CARGO_HOME") {
+        let cargo_home = PathBuf::from(cargo_home);
+        // Root: read-only so config.toml / credentials are visible, matching the
+        // default ~/.cargo (which is in HOME_EXEC_PATHS and thus readable).
+        args.push(OsString::from("--read"));
+        args.push(cargo_home.clone().into_os_string());
+        // Binaries: read+exec only (same as the default ~/.cargo/bin).
         args.push(OsString::from("--exec"));
-        args.push(PathBuf::from(cargo_home).join("bin").into_os_string());
+        args.push(cargo_home.join("bin").into_os_string());
+        // Download caches: read+write (mirror the default ~/.cargo/registry and
+        // ~/.cargo/git so a custom CARGO_HOME keeps the same cache-write access).
+        for sub in ["registry", "git"] {
+            let path = cargo_home.join(sub);
+            args.push(OsString::from("--read"));
+            args.push(path.clone().into_os_string());
+            args.push(OsString::from("--write"));
+            args.push(path.into_os_string());
+        }
     }
     if let Some(goroot) = std::env::var_os("GOROOT") {
         args.push(OsString::from("--exec"));

--- a/crates/harnx-sandbox-run/src/sandbox.rs
+++ b/crates/harnx-sandbox-run/src/sandbox.rs
@@ -90,6 +90,10 @@ fn build_exec_args(cli: &Cli, all_env_keys: &[String], use_defaults: bool) -> Ve
             for sub in HOME_WRITE_PATHS {
                 let p = home.join(sub);
                 if p.exists() {
+                    // Emit --read alongside --write to match the shared default
+                    // logic in harnx-sandbox-common::push_home_relative_defaults.
+                    args.push("--read".into());
+                    args.push(p.clone().into_os_string());
                     args.push("--write".into());
                     args.push(p.into_os_string());
                 }
@@ -108,10 +112,29 @@ fn build_exec_args(cli: &Cli, all_env_keys: &[String], use_defaults: bool) -> Ve
         }
         // CARGO_HOME, GOROOT, GOPATH, GOBIN
         if let Some(cargo_home) = std::env::var_os("CARGO_HOME") {
-            let bin = std::path::PathBuf::from(cargo_home).join("bin");
+            let cargo_home = std::path::PathBuf::from(cargo_home);
+            // Root: read-only so config.toml / credentials are visible, matching
+            // the default ~/.cargo (readable via HOME_EXEC_PATHS).
+            if cargo_home.exists() {
+                args.push("--read".into());
+                args.push(cargo_home.clone().into_os_string());
+            }
+            // Binaries: read+exec only (same as the default ~/.cargo/bin).
+            let bin = cargo_home.join("bin");
             if bin.exists() {
                 args.push("--exec".into());
                 args.push(bin.into_os_string());
+            }
+            // Download caches: read+write (mirror the default ~/.cargo/registry
+            // and ~/.cargo/git so a custom CARGO_HOME keeps cache-write access).
+            for sub in ["registry", "git"] {
+                let path = cargo_home.join(sub);
+                if path.exists() {
+                    args.push("--read".into());
+                    args.push(path.clone().into_os_string());
+                    args.push("--write".into());
+                    args.push(path.into_os_string());
+                }
             }
         }
         if let Some(goroot) = std::env::var_os("GOROOT") {

--- a/docs/bash-mcp-server.md
+++ b/docs/bash-mcp-server.md
@@ -97,14 +97,14 @@ On Linux and macOS, `harnx-mcp-bash` uses [birdcage](https://github.com/phylum-d
   - The path in the `$TMPDIR` environment variable, if set.
 - **Readable/Executable**:
   - Standard system directories required for bash and common utilities (e.g., `/usr/bin`, `/bin`, `/lib`).
-  - Tool installation directories under `$HOME`: `~/.local/bin`, `~/.local/lib`, `~/.bun`, `~/.asdf`, `~/go/bin`, `~/.cargo`.
+  - Tool installation directories under `$HOME`: `~/.local/bin`, `~/.local/lib`, `~/.bun`, `~/.asdf`, `~/go/bin`, `~/.cargo`, `~/.nvm`, `~/.cargo/bin`, `~/.mono`, `~/.pyenv`, `~/.rye`, `~/.local/share/claude`, `~/.local/share/opencode`, `~/.local/share/pipx`.
 - **Readable**:
   - System C/C++ header directories needed by `cc`, `bindgen`, and crates with native build scripts (Linux: `/usr/include`, `/usr/include/x86_64-linux-gnu`).
   - Common config files under `$HOME`: `~/.gitconfig`, `~/.gitignore`, `~/.gitignore_global`, `~/.tool-versions`.
 - **Read+Write**:
-  - Cache and module directories under `$HOME`: `~/.cache`, `~/go/pkg`.
-- **Read+Write+Execute**:
-  - Package-manager and version-manager directories under `$HOME`: `~/.npm`, `~/.yarn`, `~/.nvm`, `~/.cargo/bin`, `~/.cargo/registry`, `~/.cargo/git`, `~/.mono`, `~/.bun/install/cache`, `~/.pyenv`, `~/.rye`.
+  - Cache and module directories under `$HOME`: `~/.cache`, `~/go/pkg`, `~/.npm`, `~/.yarn`, `~/.cargo/registry`, `~/.cargo/git`, `~/.bun/install/cache`, `~/.local/share/pnpm`, `~/.local/share/uv`.
+
+> **Security note:** Tool-install and self-update operations (such as `cargo install`, `nvm install`, `pyenv install`, `rye sync`, `pipx install`, `claude update`, or `opencode self-update`) require explicit write access because these directories are no longer writable by default. You can grant temporary write access using the `--extra-rwx` flag (or the `HARNX_BASH_EXTRA_RWX` environment variable for the bash MCP server), or perform these operations outside the sandbox.
 
 These `$HOME`-relative defaults exist regardless of whether the directory is present on the host (sandbox-run silently skips non-existent paths).
 
@@ -112,7 +112,7 @@ Toolchain-locating environment variables are honoured automatically when set:
 
 | Variable | Effect on sandbox |
 |----------|-------------------|
-| `CARGO_HOME` | `$CARGO_HOME/bin` added as executable. |
+| `CARGO_HOME` | `$CARGO_HOME` added as readable; `$CARGO_HOME/bin` added as executable; `$CARGO_HOME/registry` and `$CARGO_HOME/git` added as read+write. |
 | `GOROOT` | `$GOROOT` added as executable (Go install). |
 | `GOPATH` | `$GOPATH/bin` added as executable; `$GOPATH/pkg` added as read+write. |
 | `GOBIN` | `$GOBIN` added as executable. |
@@ -178,7 +178,7 @@ args: ["-e", "EDITOR=true"]
 
 Allow tools to use home-directory caches or persistent configuration:
 
-> **Note:** `~/.cargo/bin`, `~/.cargo/registry`, `~/.cargo/git`, and `~/.npm` are already included in the default allowlist with read+write+execute permissions. The examples below are only needed if you override the defaults or need additional paths.
+> **Note:** `~/.cargo/bin` is already included in the default allowlist with read+execute permissions, while `~/.cargo/registry`, `~/.cargo/git`, and `~/.npm` are included with read+write permissions. The examples below are only needed if you override the defaults, need additional paths, or require write access for tool installation.
 
 #### Allow pip to cache
 ```yaml
@@ -186,13 +186,13 @@ args: ["--extra-write", "~/.cache/pip"]
 ```
 
 #### Allow full cargo directory (non-default example)
-If you've removed the default cargo paths and want to grant broader access:
+If you need broader access than the defaults (e.g., for `cargo install` or updates):
 ```yaml
 args: ["--extra-rwx", "~/.cargo"]
 ```
 
 #### Allow full npm directory (non-default example)
-If you've removed the default npm path and want to grant broader access:
+If you need broader access than the default (e.g., for global installs or updates):
 ```yaml
 args: ["--extra-rwx", "~/.npm"]
 ```

--- a/docs/sandbox-run.md
+++ b/docs/sandbox-run.md
@@ -88,7 +88,7 @@ PATH="$({
 export PATH
 
 # shellcheck disable=SC2016 -- '$GIT_ROOT' style args are harnx-sandbox-run pseudo-vars; shell must pass them through literally.
-# Caches like ~/.npm, ~/.yarn, ~/.nvm, ~/.bun, ~/.cache, ~/.cargo, go/bin, go/pkg, and ~/.local/share/pnpm are pre-whitelisted.
+# Common tool and cache paths (like ~/.npm, ~/.cargo, ~/.cache) are pre-whitelisted.
 exec harnx-sandbox-run \
   --extra-rwx '$GIT_ROOT' \
   --extra-rwx '$NODE_PROJECT_ROOT' \
@@ -296,9 +296,10 @@ The `--working-dir <path>` flag changes where the sandboxed command starts, but 
 | Access | Paths |
 | :----- | :---- |
 | Read | `~/.gitconfig`, `~/.gitignore`, `~/.gitignore_global`, `~/.tool-versions` |
-| Read/Write | `~/.cache`, `~/go/pkg` |
-| Read/Write/Exec | `~/.npm`, `~/.yarn`, `~/.nvm`, `~/.cargo`, `~/.pyenv`, `~/.rye`, `~/.bun`, `~/.local/share/claude`, `~/.local/share/uv`, `~/.local/share/pnpm`, `~/.local/share/pipx`, `~/.local/share/opencode` |
-| Exec | `~/.local/bin`, `~/.local/lib`, `~/.asdf`, `~/.bun`, `~/go/bin` |
+| Read/Write | `~/.cache`, `~/go/pkg`, `~/.npm`, `~/.yarn`, `~/.cargo/registry`, `~/.cargo/git`, `~/.bun/install/cache`, `~/.local/share/pnpm`, `~/.local/share/uv` |
+| Exec | `~/.local/bin`, `~/.local/lib`, `~/.bun`, `~/.asdf`, `~/go/bin`, `~/.cargo`, `~/.nvm`, `~/.cargo/bin`, `~/.mono`, `~/.pyenv`, `~/.rye`, `~/.local/share/claude`, `~/.local/share/opencode`, `~/.local/share/pipx` |
+
+Tool-install and self-update operations (such as `cargo install`, `nvm install`, etc.) require explicit write access; grant with `--extra-rwx` or perform them outside the sandbox.
 
 Any other `$HOME` subdirectory (e.g. `~/.gemini`, `~/.config`, `~/.ssh`) is **blocked** unless you add it with `--extra-read`, `--extra-write`, or `--extra-rwx`. This is intentional — it prevents the sandboxed process from reading credentials or config files it doesn't need.
 

--- a/docs/solutions/security-issues/sandbox-writable-exec-path-escape-2026-06-04.md
+++ b/docs/solutions/security-issues/sandbox-writable-exec-path-escape-2026-06-04.md
@@ -1,0 +1,147 @@
+---
+title: "Sandbox Escape via Writable Executable Path Directories"
+date: 2026-06-04
+category: security-issues
+problem_type: security_issue
+component: harnx-sandbox-common
+root_cause: "Default whitelist granted write+exec to on-PATH tool directories, enabling trojan injection"
+resolution_type: code_fix
+severity: high
+tags:
+  - sandboxing
+  - privilege-escalation
+  - path-injection
+  - trojan
+  - least-privilege
+  - birdcage
+plan_ref: sandbox-default-writable-hardening
+---
+
+## Problem
+
+Sandbox default whitelist granted `read+write+exec` to many `$HOME` tool directories. Writable + executable + on-host-PATH = sandbox escape: a malicious sandboxed agent plants a trojan binary in such a directory; the user later runs that command on the HOST and executes it, bypassing the sandbox entirely.
+
+## Symptoms
+
+- Default sandbox configuration allowed write access to directories like `~/.cargo/bin`, `~/.nvm`, `~/.pyenv`, `~/.local/share/claude`, `~/.local/share/pipx`
+- These directories are commonly on `$PATH` or executed by shell initialization scripts
+- No explicit mechanism prevented a sandboxed process from modifying executables the host would later run
+- Attack vector: sandboxed agent writes malicious binary → user runs `cargo`/`node`/`python` on host → trojan executes with full user privileges
+
+## Investigation Steps
+
+Analyzed `crates/harnx-sandbox-common/src/defaults.rs` constants:
+
+- `HOME_RWX_PATHS` contained 15 paths with blanket `read+write+exec`
+- `HOME_EXEC_PATHS` and `HOME_WRITE_PATHS` had partial overlap
+- Checked which directories are on `$PATH` or commonly executed:
+  - `.nvm`, `.cargo/bin`, `.pyenv`, `.rye`, `.local/share/{claude,opencode,pipx}` — all on `$PATH` or shell init
+  - `.npm`, `.yarn`, `.cargo/registry`, `.cargo/git`, `.local/share/{pnpm,uv}` — pure caches, not on `$PATH`
+
+Verified two consumers of these constants:
+1. `defaults.rs::push_home_relative_defaults` → used by `args.rs` (bash MCP)
+2. `sandbox-run/src/sandbox.rs` lines 76-107 → own loops reading same constants
+
+Found divergence: `sandbox.rs` WRITE loop emitted only `--write` flag, while `args.rs` emitted `--read+--write`. Both paths map to `Exception::WriteAndRead` in `sandbox_exec.rs`, so divergence was cosmetic but required alignment for consistency.
+
+## Root Cause
+
+Security model violated the principle of least privilege. Default configuration prioritized convenience over security by granting `write+exec` to directories whose contents the host would execute. This created a privilege escalation path:
+
+```
+Sandboxed process writes trojan → ~/.cargo/bin/my_tool
+User runs my_tool on host → trojan executes outside sandbox
+```
+
+Threat model: compromised dependencies, prompt injection, or malicious agent code could plant backdoors that persist beyond sandbox lifecycle.
+
+## Solution
+
+Least-privilege split in `crates/harnx-sandbox-common/src/defaults.rs`:
+
+**On-PATH/host-executed directories → read+exec only:**
+```rust
+pub const HOME_EXEC_PATHS: &[&str] = &[
+    ".local/bin", ".local/lib", ".bun", ".asdf", "go/bin", ".cargo",
+    ".nvm", ".cargo/bin", ".mono", ".pyenv", ".rye",
+    ".local/share/claude", ".local/share/opencode", ".local/share/pipx",
+];
+```
+
+**Pure caches → read+write only:**
+```rust
+pub const HOME_WRITE_PATHS: &[&str] = &[
+    ".cache", "go/pkg",
+    ".npm", ".yarn", ".cargo/registry", ".cargo/git",
+    ".bun/install/cache", ".local/share/pnpm", ".local/share/uv",
+];
+```
+
+**RWX paths → emptied:**
+```rust
+pub const HOME_RWX_PATHS: &[&str] = &[];
+```
+
+**Opt-in for privileged operations:**
+Users can grant write access to tool directories when needed:
+- CLI: `--extra-rwx ~/.cargo/bin`
+- Env: `HARNX_BASH_EXTRA_RWX=~/.cargo/bin`
+
+**Alignment fix in sandbox-run:**
+```rust
+// sandbox.rs WRITE loop now pushes both flags
+for path in HOME_WRITE_PATHS {
+    args.push(OsString::from("--read"));
+    args.push(expanded.clone());
+    args.push(OsString::from("--write"));
+    args.push(expanded);
+}
+```
+
+## Why This Works
+
+1. **Eliminates attack vector**: Directories on `$PATH` cannot be modified by sandboxed processes, preventing trojan injection.
+
+2. **Preserves normal workflows**:
+   - Networked builds/installations still work (caches keep write access)
+   - Tool execution works (exec paths keep read+exec)
+   - Self-updates and privileged installs require explicit opt-in
+
+3. **Defense in depth**: Even if a sandboxed process is compromised, it cannot plant persistent backdoors in commonly-executed directories.
+
+4. **Aligns with security principle**: "Never grant write to a directory whose contents the host will execute."
+
+## Prevention Strategies
+
+**Reusable heuristic:**
+Never grant `write` permission to directories whose contents the host will execute. Apply this rule to any sandbox/containment system that shares directories with the host.
+
+**Test Cases:**
+- Assert exec-only paths receive `--read+--exec`, not `--write`
+- Assert cache paths receive `--read+--write`, not `--exec`
+- Assert `HOME_RWX_PATHS` is empty
+
+**Best Practices:**
+- Classify directories by execution risk before granting permissions
+- Default to read-only for on-PATH directories
+- Require explicit opt-in for security-sensitive permissions
+- Audit default whitelists against `$PATH` and shell initialization
+
+**Code Review Checklist:**
+- [ ] Are on-PATH directories granted write access? (Should be exec-only)
+- [ ] Are cache directories granted exec access? (Should be write-only)
+- [ ] Is RWX empty or explicitly justified?
+- [ ] Do tests verify least-privilege splits?
+
+## Trade-offs
+
+1. **Install/self-update workflows require explicit opt-in**: Users running `cargo install` or `npm install -g` inside sandbox must use `--extra-rwx`. This is intentional friction for security-sensitive operations.
+
+2. **Normal builds still work**: Networked package downloads write to cache directories (`.npm`, `.cargo/registry`) which retain write access. Compilation happens in project directories or temp, not tool directories.
+
+3. **Redundant entries**: `.cargo` and `.cargo/bin` both appear in exec list. `.cargo` parent covers all subdirs for exec, but explicit entries document intent and handle edge cases.
+
+## Related Issues
+
+- **Related Solution:** [sandbox-home-exposure-ancestor-walk-2026-05-21.md](sandbox-home-exposure-ancestor-walk-2026-05-21.md) — Previous sandbox hardening for write-path ancestor walk vulnerability
+- **Plan:** sandbox-default-writable-hardening

--- a/example_config/mcp_servers/bash.yaml
+++ b/example_config/mcp_servers/bash.yaml
@@ -11,17 +11,20 @@ rename_tools:
 # NOTE: Many home-directory paths are already whitelisted by default and do NOT
 # need to be added here. See docs/bash-mcp-server.md for the full list, which
 # includes: ~/.gitconfig, ~/.gitignore, ~/.gitignore_global, ~/.tool-versions
-# (read), ~/.local/bin, ~/.local/lib, ~/.bun, ~/.asdf, ~/go/bin, ~/.cargo
-# (read+exec), ~/.cache, ~/go/pkg (read+write), ~/.npm, ~/.yarn, ~/.nvm,
-# ~/.cargo/bin, ~/.cargo/registry, ~/.cargo/git, ~/.mono, ~/.bun/install/cache,
-# ~/.pyenv, ~/.rye (read+write+exec).
+# (read), ~/.local/bin, ~/.local/lib, ~/.bun, ~/.asdf, ~/go/bin, ~/.cargo,
+# ~/.nvm, ~/.cargo/bin, ~/.pyenv, ~/.rye, ~/.local/share/claude (read+exec),
+# ~/.cache, ~/go/pkg, ~/.npm, ~/.yarn, ~/.cargo/registry, ~/.cargo/git,
+# ~/.bun/install/cache (read+write). Tool-install directories (~/.cargo/bin,
+# ~/.nvm, ~/.pyenv, ~/.rye, etc.) are read+exec only — use --extra-rwx to
+# grant write access for operations like cargo install, nvm install, pyenv
+# install, rye sync, or claude update.
 #
 args:
 #   - --no-sandbox                                          # Disable sandboxing entirely
   # Allow access to rustup-managed toolchains
   - --extra-exec
   - ~/.rustup
-  # Allow access to ruff's cache
+  # Allow ruff to write to its cache (not a default-writable path)
   - --extra-rwx
   - ~/.ruff_cache
   # Allow access to various config files
@@ -33,6 +36,7 @@ args:
   - ~/.config/dcg
   - --extra-read
   - ~/.config/git
+  # Allow go to write to its config dir (not a default-writable path)
   - --extra-rwx
   - ~/.config/go
   - --extra-read


### PR DESCRIPTION
Splits the default $HOME whitelist into exec-capable tool directories and write-capable cache directories. Host-executed directories like ~/.cargo/bin and ~/.pyenv are now read+exec only, while package manager caches like ~/.npm and ~/.cargo/registry are read+write only.

Empties HOME_RWX_PATHS to prevent sandbox escapes via planted binaries in writable-on-host directories. Aligns harnx-sandbox-run and harnx-sandbox-common for consistency and adds parity for custom CARGO_HOME defaults (read root, read+exec bin, read+write caches). Updates tests, documentation, and example configurations to reflect the hardened posture.

Plan: sandbox-default-writable-hardening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Sandbox filesystem permissions hardened: PATH directories now exec-only; package manager caches are read+write only; $HOME no longer writable by default.
  * Tool installation and self-update commands now require explicit write access flag to operate.

* **Documentation**
  * Updated sandbox configuration guides reflecting new default permission model.
  * Added security issue documentation with remediation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->