### PR TITLE
Modify bash.yaml to include extra access arguments

### DIFF
--- a/packages/pantheon/mcp_servers/bash.yaml
+++ b/packages/pantheon/mcp_servers/bash.yaml
@@ -16,9 +16,17 @@ roots:
 # ~/.pyenv, ~/.rye (read+write+exec).
 
 args:
-  # Allow access to dev certificates
-  - --extra-read
-  - ~/dev_cert
+  # Allow access to detected project root (when run in a subdirectory) and git metadata (when in a git worktree)
+  - --extra-rwx
+  - $GIT_ROOT
+  - --extra-write
+  - $GIT_COMMON_DIR
+  - --extra-rwx
+  - $NODE_PROJECT_ROOT
+  - --extra-rwx
+  - $CARGO_ROOT
+  - --extra-rwx
+  - $GO_ROOT
   # Allow access to various config files
   - --extra-read
   - ~/.config/acli


### PR DESCRIPTION
Updated arguments to allow access to project root and git metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bash sandbox access configuration to remove developer certificate permissions and add read/write/execute access to project root directories for Git, Node, Cargo, and Go.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->