### PR TITLE
Resolve package-relative agent handoffs and use valid tool names

### DIFF
--- a/.changeset/package-agent-handoff-resolution.md
+++ b/.changeset/package-agent-handoff-resolution.md
@@ -1,0 +1,7 @@
+---
+harnx: patch
+---
+
+Fix agent handoff from a package agent resolving to the wrong agent. When a package agent (e.g. `pantheon/daedalus`) handed off a session to a same-package agent via a bare `_session_handoff` tool (e.g. `atlas_session_handoff`), the handoff incorrectly targeted the top-level `atlas` instead of `pantheon/atlas`. Handoff targets are now resolved relative to the active agent's package.
+
+Handoff tool names are also now generated with package-namespaced, schema-valid spelling instead of containing a raw `/` (which is rejected by provider function-name schemas): same-package peers use the bare name (`atlas_session_handoff`), cross-package peers use `pkg__agent_session_handoff`, and top-level agents addressed from within a package use `__agent_session_handoff`. The engine decodes these via an exact lookup table so package and agent names containing underscores remain unambiguous.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,8 +10,8 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.14.0"
-source = "git+https://github.com/agentclientprotocol/rust-sdk?rev=fc827b725e17c6df358b0a08e8fa2d5a8b033b69#fc827b725e17c6df358b0a08e8fa2d5a8b033b69"
+version = "0.13.1"
+source = "git+https://github.com/agentclientprotocol/rust-sdk?rev=740db05db8fff0eecf7550eff356ed1f2632eb8b#740db05db8fff0eecf7550eff356ed1f2632eb8b"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
@@ -31,8 +31,8 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "0.14.0"
-source = "git+https://github.com/agentclientprotocol/rust-sdk?rev=fc827b725e17c6df358b0a08e8fa2d5a8b033b69#fc827b725e17c6df358b0a08e8fa2d5a8b033b69"
+version = "0.13.1"
+source = "git+https://github.com/agentclientprotocol/rust-sdk?rev=740db05db8fff0eecf7550eff356ed1f2632eb8b#740db05db8fff0eecf7550eff356ed1f2632eb8b"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.13.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c290bfa00c6b52339db66f8e9cf711d5f08530800529f7d619ff24d6cba253d0"
+checksum = "0d419a87e28240978e4bfdf2a5b91bccb95ae8d5b06e10721bb07c449b9f43dd"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -186,15 +186,6 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "arboard"
@@ -414,9 +405,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.18"
+version = "1.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
+checksum = "517aa062d8bd9015ee23d6daa5e1c1372328412fdae4e6c4c1be9b69c6ad37a2"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -505,11 +496,10 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.101.0"
+version = "1.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b647baea49ff551960b904f905681e9b4765a6c4ea08631e89dc52d8bd3f5896"
+checksum = "9f4055e6099b2ec264abdc0d9bbfffce306c1601809275c861594779a0b04b45"
 dependencies = [
- "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -530,11 +520,10 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.103.0"
+version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae401c65ff288aa7873117fe535cd32b7b1bb0bc43751d28901a1d5f20636b9"
+checksum = "02f009ba0284c5d696425fd7b4dcc5b189f5726f4041b7a5794daecb3a68d598"
 dependencies = [
- "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -555,11 +544,10 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.106.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c80de7bb7d03e9ca8c9fd7b489f20f3948d3f3be91a7953591347d238115408"
+checksum = "6aa6622798e19e6a76b690562085dd4771c736cd48343464a53ab4ae2f2c9f84"
 dependencies = [
- "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -670,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.7"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -726,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.3"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -766,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
+checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -904,7 +892,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "848df95320021558dd6bb4c26de3fe66724cdcbdbbf3fa720150b52b086ae568"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "libc",
  "log",
  "rustix 0.38.44",
@@ -958,9 +946,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "2c61cd05405eb1d0f3a4660f802bad76ece84b6e722426342ba5dd511f724e97"
 
 [[package]]
 name = "block-buffer"
@@ -1063,12 +1051,6 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "by_address"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
@@ -1183,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.45"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1460,12 +1442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,7 +1481,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -1828,7 +1804,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "objc2",
 ]
 
@@ -2048,12 +2024,6 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
-
-[[package]]
-name = "fast-srgb8"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "faster-hex"
@@ -2606,7 +2576,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bstr",
  "gix-path",
  "libc",
@@ -2774,7 +2744,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bstr",
  "gix-features",
  "gix-path",
@@ -2832,7 +2802,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e6b28cc592dc753adb58302bb14a64e412ee591a3bec77aa4df87bff74fa80d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bstr",
  "filetime",
  "fnv",
@@ -2883,7 +2853,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "890c936a215bae25818c076cb881cb2e54d2c66ba947ba58b8dd47cff921bf55"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -2983,7 +2953,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bstr",
  "gix-attributes",
  "gix-config-value",
@@ -3084,7 +3054,7 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b47c88884dd3c1a19a39da19d10211fcdea2809aadc86869b6e824a1774340f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bstr",
  "gix-commitgraph",
  "gix-date",
@@ -3119,7 +3089,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "gix-path",
  "libc",
  "windows-sys 0.61.2",
@@ -3219,7 +3189,7 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8de590ecc86a3b2870665f2288324fa9f7f8672c7fc2d4e020fdd81cd1f7aed"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -3378,7 +3348,7 @@ dependencies = [
  "aws-smithy-eventstream",
  "base64",
  "bincode 2.0.1",
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bm25",
  "bytes",
  "chrono",
@@ -3905,7 +3875,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bincode 2.0.1",
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bytes",
  "chrono",
  "crossterm",
@@ -4635,7 +4605,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "crossterm",
  "dyn-clone",
  "fuzzy-matcher",
@@ -5106,7 +5076,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
 ]
 
 [[package]]
@@ -5166,11 +5136,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -5363,7 +5333,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ecce9d566cb9234ae3db9e249c8b55665feaaf32b0859ff1e27e310d2beb3d8"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "combine",
  "libc",
  "mach2",
@@ -5432,7 +5402,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5445,7 +5415,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5457,7 +5427,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5576,7 +5546,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -5588,7 +5558,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -5609,7 +5579,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "dispatch2",
  "objc2",
 ]
@@ -5620,7 +5590,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -5653,7 +5623,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -5671,7 +5641,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "block2",
  "libc",
  "objc2",
@@ -5684,7 +5654,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -5695,7 +5665,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -5707,7 +5677,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -5814,7 +5784,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -5890,30 +5860,6 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "palette"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
-dependencies = [
- "approx",
- "fast-srgb8",
- "libm",
- "palette_derive",
-]
-
-[[package]]
-name = "palette_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
-dependencies = [
- "by_address",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "parking"
@@ -6390,7 +6336,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -6555,9 +6501,9 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
-version = "0.30.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
 dependencies = [
  "instability",
  "ratatui-core",
@@ -6565,26 +6511,22 @@ dependencies = [
  "ratatui-macros",
  "ratatui-termwiz",
  "ratatui-widgets",
- "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "compact_str",
- "critical-section",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
  "indoc",
  "itertools",
  "kasuari",
  "lru",
- "palette",
- "serde",
- "strum 0.28.0",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -6593,9 +6535,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -6605,9 +6547,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
@@ -6615,9 +6557,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-termwiz"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -6638,19 +6580,18 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.12.1",
- "hashbrown 0.17.1",
+ "bitflags 2.12.0",
+ "hashbrown 0.16.1",
  "indoc",
  "instability",
  "itertools",
  "line-clipping",
  "ratatui-core",
- "serde",
- "strum 0.28.0",
+ "strum 0.27.2",
  "time",
  "unicode-segmentation",
  "unicode-width 0.2.2",
@@ -6704,7 +6645,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
 ]
 
 [[package]]
@@ -6965,7 +6906,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6978,7 +6919,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -7200,7 +7141,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -7223,7 +7164,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "cssparser",
  "derive_more",
  "log",
@@ -7721,6 +7662,9 @@ name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
 
 [[package]]
 name = "strum"
@@ -7838,7 +7782,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -7870,7 +7814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -7967,7 +7911,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
@@ -8256,7 +8200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "base64",
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "bytes",
  "futures-util",
  "http 1.4.1",
@@ -8713,7 +8657,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -8738,7 +8682,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
@@ -8750,7 +8694,7 @@ version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -8762,7 +8706,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -9362,7 +9306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.12.1",
+ "bitflags 2.12.0",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ duct = "1.0.0"
 rmcp = { version = "1.3.0", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server"] }
 process-wrap = { version = "9", features = ["tokio1"] }
 libc = "0.2"
-agent-client-protocol = { git = "https://github.com/agentclientprotocol/rust-sdk", rev = "fc827b725e17c6df358b0a08e8fa2d5a8b033b69" }
+agent-client-protocol = { git = "https://github.com/agentclientprotocol/rust-sdk", rev = "740db05db8fff0eecf7550eff356ed1f2632eb8b" }
 glob = "0.3"
 globset = "0.4"
 shellexpand = "3.1.0"

--- a/crates/harnx-core/src/package_namespace.rs
+++ b/crates/harnx-core/src/package_namespace.rs
@@ -32,6 +32,30 @@ pub fn agent_tool_prefix(qualified_agent_name: &str) -> String {
     sanitize_for_tool_name(qualified_agent_name)
 }
 
+/// Compute package-aware handoff display name for a target agent.
+///
+/// The returned name is always sanitized to the tool-name charset
+/// (`[A-Za-z0-9_-]`, see [`sanitize_for_tool_name`]) so it is valid for LLM
+/// provider function-name schemas regardless of what characters the source
+/// agent filename/package contains.
+///
+/// Rules:
+/// - same-package peer from within a package → bare stem (`atlas`)
+/// - cross-package peer → namespaced form (`otherpkg__atlas`)
+/// - top-level peer from within a package → explicit top-level (`__reviewer`)
+/// - top-level context → bare top-level peers, namespaced package peers
+pub fn handoff_display_name(target_agent_name: &str, active_pkg: Option<&str>) -> String {
+    match (pkg_from_qualified(target_agent_name), active_pkg) {
+        (Some(target_pkg), Some(active_pkg)) if target_pkg == active_pkg => target_agent_name
+            .split_once('/')
+            .map(|(_, stem)| sanitize_for_tool_name(stem))
+            .unwrap_or_else(|| sanitize_for_tool_name(target_agent_name)),
+        (Some(_), _) => agent_tool_prefix(target_agent_name),
+        (None, Some(_)) => format!("__{}", sanitize_for_tool_name(target_agent_name)),
+        (None, None) => sanitize_for_tool_name(target_agent_name),
+    }
+}
+
 /// Given a package name and MCP server name, return cross-package tool prefix.
 /// ("mypkg", "fs") → "mypkg__fs"
 /// So tool "read_file" becomes "mypkg__fs_read_file" from outside package.
@@ -105,6 +129,67 @@ mod tests {
     #[test]
     fn test_agent_tool_prefix() {
         assert_eq!(agent_tool_prefix("mypkg/coder"), "mypkg__coder");
+    }
+
+    #[test]
+    fn test_handoff_display_name_same_package_peer() {
+        assert_eq!(
+            handoff_display_name("pantheon/atlas", Some("pantheon")),
+            "atlas"
+        );
+    }
+
+    #[test]
+    fn test_handoff_display_name_cross_package_peer() {
+        assert_eq!(
+            handoff_display_name("otherpkg/helper", Some("pantheon")),
+            "otherpkg__helper"
+        );
+    }
+
+    #[test]
+    fn test_handoff_display_name_top_level_from_package() {
+        assert_eq!(
+            handoff_display_name("reviewer", Some("pantheon")),
+            "__reviewer"
+        );
+    }
+
+    #[test]
+    fn test_handoff_display_name_top_level_context() {
+        assert_eq!(handoff_display_name("reviewer", None), "reviewer");
+        assert_eq!(
+            handoff_display_name("pantheon/atlas", None),
+            "pantheon__atlas"
+        );
+    }
+
+    #[test]
+    fn test_handoff_display_name_sanitizes_invalid_chars() {
+        // Provider-invalid characters (e.g. spaces) in agent filenames must
+        // never leak into the tool name, for every branch.
+        assert_eq!(handoff_display_name("my agent", None), "my_agent");
+        assert_eq!(
+            handoff_display_name("my agent", Some("pantheon")),
+            "__my_agent"
+        );
+        assert_eq!(
+            handoff_display_name("pantheon/my agent", Some("pantheon")),
+            "my_agent"
+        );
+        // Resulting names are always within the tool-name charset.
+        for name in [
+            handoff_display_name("a b", None),
+            handoff_display_name("a b", Some("p")),
+            handoff_display_name("p/a b", Some("p")),
+            handoff_display_name("other/a b", Some("p")),
+        ] {
+            assert!(
+                name.chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
+                "unsanitized display name: {name}"
+            );
+        }
     }
 
     #[test]

--- a/crates/harnx-engine/src/tool.rs
+++ b/crates/harnx-engine/src/tool.rs
@@ -12,7 +12,7 @@ use harnx_core::abort::{wait_abort_signal, AbortSignal};
 use harnx_core::hooks::{HookEvent, HookOutcome, HookResult, HookResultControl};
 use harnx_core::tool::{SwitchAgentData, ToolCall, ToolError, ToolProvider, ToolResult};
 use serde_json::{json, Value};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -39,9 +39,19 @@ pub struct ToolEvalContext {
     /// results and the call omitted `session_id`.
     pub session_name: Option<String>,
     /// Allow-list of synthetic tool names that do not come from a real
-    /// provider but are handled directly in `eval_tool_call_mcp`
+    /// provider but are handled directly in `dispatch_tool_call`
     /// (currently `_session_handoff`).
     pub allowed_tool_names: HashSet<String>,
+    /// Package of the currently active agent (e.g. `Some("pantheon")` for
+    /// `pantheon/daedalus`, `None` for a top-level agent). Used to resolve
+    /// bare `_session_handoff` targets relative to the current package so a
+    /// same-package handoff (`atlas_session_handoff`) lands on
+    /// `pantheon/atlas` rather than top-level `atlas` (#709).
+    pub current_agent_package: Option<String>,
+    /// Exact decode table for package-aware handoff display names.
+    /// Maps tool display name without `_session_handoff` suffix to
+    /// qualified-or-bare target agent name.
+    pub handoff_targets: HashMap<String, String>,
     /// Called when a tool is about to be dispatched. Receives the tool
     /// call and the parsed arguments JSON. Harnx's default emits an
     /// `AgentEvent::Tool(Started { .. })` via the unified AgentEvent
@@ -293,7 +303,27 @@ async fn dispatch_tool_call(
                 call.name
             )));
         }
-        let agent = call.name.trim_end_matches("_session_handoff");
+        // Strip exactly one `_session_handoff` suffix (not all repeats, which
+        // `trim_end_matches` would do) so an agent named `*_session_handoff`
+        // resolves correctly.
+        let bare_target = call
+            .name
+            .strip_suffix("_session_handoff")
+            .unwrap_or(&call.name);
+        // Resolve package-aware display names through the exact lookup table
+        // first. Map values are already the canonical agent name ("pkg/stem"
+        // for package agents, bare "stem" for top-level agents), so they are
+        // used verbatim — re-resolving a bare top-level value against the
+        // current package would wrongly qualify it (e.g. `global` →
+        // `pantheon/global`). Only the legacy fallback path (no map entry,
+        // e.g. test/no-context contexts) applies package-relative resolution.
+        let agent = match ctx.handoff_targets.get(bare_target) {
+            Some(mapped) => mapped.clone(),
+            None => harnx_core::package_namespace::resolve_package_relative_name(
+                bare_target,
+                ctx.current_agent_package.as_deref(),
+            ),
+        };
         let prompt = json_data["prompt"].as_str().ok_or_else(|| {
             ToolError::Recoverable(anyhow!("Missing 'prompt' argument for session handoff"))
         })?;
@@ -485,6 +515,8 @@ mod tests {
             providers,
             session_name: None,
             allowed_tool_names: HashSet::new(),
+            current_agent_package: None,
+            handoff_targets: HashMap::new(),
             emit_tool_call_fn: Arc::new(emit_tool_call),
             emit_tool_result_fn: Arc::new(emit_tool_result),
             emit_tool_blocked_fn: Arc::new(emit_tool_blocked),
@@ -799,5 +831,202 @@ mod tests {
                 .as_slice(),
             &[json!({"injected": true})]
         );
+    }
+
+    /// Build a minimal context for handoff-resolution tests with a given
+    /// active-agent package, allow-listed handoff tool name, and optional
+    /// package-aware decode map.
+    fn handoff_context(
+        package: Option<&str>,
+        allowed: &str,
+        handoff_targets: HashMap<String, String>,
+    ) -> ToolEvalContext {
+        let mut ctx = test_context(vec![], |_| continue_hook_outcome());
+        ctx.current_agent_package = package.map(str::to_string);
+        ctx.allowed_tool_names = HashSet::from([allowed.to_string()]);
+        ctx.handoff_targets = handoff_targets;
+        ctx
+    }
+
+    async fn dispatched_handoff_agent(ctx: &ToolEvalContext, tool_name: &str) -> String {
+        let call = ToolCall::new(tool_name.to_string(), json!({ "prompt": "go" }), None, None);
+        let abort_signal = create_abort_signal();
+        let result =
+            match dispatch_tool_call(call, json!({ "prompt": "go" }), ctx, &abort_signal).await {
+                Ok(result) => result,
+                Err(ToolError::Recoverable(err) | ToolError::Fatal(err)) => {
+                    panic!("handoff dispatch should succeed: {err:#}")
+                }
+            };
+        result["agent"]
+            .as_str()
+            .expect("handoff result should carry an agent")
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn handoff_bare_target_resolves_to_current_package() {
+        // #709: `pantheon/daedalus` handing off to bare `atlas` must land on
+        // same-package `pantheon/atlas`, not top-level `atlas`.
+        let ctx = handoff_context(Some("pantheon"), "atlas_session_handoff", HashMap::new());
+        let agent = dispatched_handoff_agent(&ctx, "atlas_session_handoff").await;
+        assert_eq!(agent, "pantheon/atlas");
+    }
+
+    #[tokio::test]
+    async fn handoff_bare_target_top_level_unchanged() {
+        // No package context (top-level agent) → bare target stays bare.
+        let ctx = handoff_context(None, "atlas_session_handoff", HashMap::new());
+        let agent = dispatched_handoff_agent(&ctx, "atlas_session_handoff").await;
+        assert_eq!(agent, "atlas");
+    }
+
+    #[tokio::test]
+    async fn handoff_leading_slash_escapes_to_top_level() {
+        // `/atlas` explicitly escapes the package to top-level even when a
+        // package context is present.
+        let ctx = handoff_context(Some("pantheon"), "/atlas_session_handoff", HashMap::new());
+        let agent = dispatched_handoff_agent(&ctx, "/atlas_session_handoff").await;
+        assert_eq!(agent, "atlas");
+    }
+
+    #[tokio::test]
+    async fn handoff_qualified_target_unchanged() {
+        // Cross-package qualified target is left untouched.
+        let ctx = handoff_context(
+            Some("pantheon"),
+            "other/atlas_session_handoff",
+            HashMap::new(),
+        );
+        let agent = dispatched_handoff_agent(&ctx, "other/atlas_session_handoff").await;
+        assert_eq!(agent, "other/atlas");
+    }
+
+    #[tokio::test]
+    async fn handoff_uses_exact_map_for_same_package_display_name() {
+        let ctx = handoff_context(
+            Some("pantheon"),
+            "atlas_session_handoff",
+            HashMap::from([("atlas".to_string(), "pantheon/atlas".to_string())]),
+        );
+        let agent = dispatched_handoff_agent(&ctx, "atlas_session_handoff").await;
+        assert_eq!(agent, "pantheon/atlas");
+    }
+
+    #[tokio::test]
+    async fn handoff_uses_exact_map_for_cross_package_display_name() {
+        let ctx = handoff_context(
+            Some("pantheon"),
+            "otherpkg__helper_session_handoff",
+            HashMap::from([(
+                "otherpkg__helper".to_string(),
+                "otherpkg/helper".to_string(),
+            )]),
+        );
+        let agent = dispatched_handoff_agent(&ctx, "otherpkg__helper_session_handoff").await;
+        assert_eq!(agent, "otherpkg/helper");
+    }
+
+    #[tokio::test]
+    async fn handoff_uses_exact_map_for_top_level_from_package() {
+        // A top-level agent targeted from within a package is spelled `__stem`
+        // and maps to the BARE top-level name. It must NOT be re-qualified into
+        // the active package (would be `pantheon/global` — wrong).
+        let ctx = handoff_context(
+            Some("pantheon"),
+            "__global_session_handoff",
+            HashMap::from([("__global".to_string(), "global".to_string())]),
+        );
+        let agent = dispatched_handoff_agent(&ctx, "__global_session_handoff").await;
+        assert_eq!(agent, "global");
+    }
+
+    #[tokio::test]
+    async fn handoff_legacy_fallback_still_resolves_bare_target() {
+        let ctx = handoff_context(Some("pantheon"), "atlas_session_handoff", HashMap::new());
+        let agent = dispatched_handoff_agent(&ctx, "atlas_session_handoff").await;
+        assert_eq!(agent, "pantheon/atlas");
+    }
+    #[tokio::test]
+    async fn handoff_strips_only_one_suffix() {
+        // An agent literally named `worker_session_handoff` must keep its name:
+        // only the trailing `_session_handoff` tool suffix is stripped, not the
+        // repeated occurrence in the agent name.
+        let ctx = handoff_context(
+            None,
+            "worker_session_handoff_session_handoff",
+            HashMap::new(),
+        );
+        let agent = dispatched_handoff_agent(&ctx, "worker_session_handoff_session_handoff").await;
+        assert_eq!(agent, "worker_session_handoff");
+    }
+
+    #[tokio::test]
+    async fn handoff_propagates_prompt() {
+        // The supplied prompt must flow through to the switch_agent result.
+        let ctx = handoff_context(Some("pantheon"), "atlas_session_handoff", HashMap::new());
+        let call = ToolCall::new(
+            "atlas_session_handoff".to_string(),
+            json!({ "prompt": "do the thing" }),
+            None,
+            None,
+        );
+        let abort_signal = create_abort_signal();
+        let result = match dispatch_tool_call(
+            call,
+            json!({ "prompt": "do the thing" }),
+            &ctx,
+            &abort_signal,
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(ToolError::Recoverable(err) | ToolError::Fatal(err)) => {
+                panic!("handoff dispatch should succeed: {err:#}")
+            }
+        };
+        assert_eq!(result["action"].as_str(), Some("switch_agent"));
+        assert_eq!(result["agent"].as_str(), Some("pantheon/atlas"));
+        assert_eq!(result["prompt"].as_str(), Some("do the thing"));
+    }
+
+    #[tokio::test]
+    async fn handoff_missing_prompt_is_recoverable_error() {
+        // A handoff call without the required `prompt` argument must return a
+        // Recoverable error (so the LLM can retry), not panic or switch.
+        let ctx = handoff_context(Some("pantheon"), "atlas_session_handoff", HashMap::new());
+        let call = ToolCall::new("atlas_session_handoff".to_string(), json!({}), None, None);
+        let abort_signal = create_abort_signal();
+        match dispatch_tool_call(call, json!({}), &ctx, &abort_signal).await {
+            Ok(_) => panic!("missing prompt must error"),
+            Err(ToolError::Recoverable(e)) => {
+                assert!(e.to_string().contains("prompt"), "unexpected error: {e:#}");
+            }
+            Err(ToolError::Fatal(e)) => panic!("expected Recoverable, got Fatal: {e:#}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn handoff_unallowed_tool_is_recoverable_error() {
+        // A handoff tool not present in `allowed_tool_names` must be rejected
+        // (no provider configured) rather than silently switching agents.
+        let ctx = handoff_context(Some("pantheon"), "atlas_session_handoff", HashMap::new());
+        let call = ToolCall::new(
+            "unlisted_session_handoff".to_string(),
+            json!({ "prompt": "go" }),
+            None,
+            None,
+        );
+        let abort_signal = create_abort_signal();
+        match dispatch_tool_call(call, json!({ "prompt": "go" }), &ctx, &abort_signal).await {
+            Ok(_) => panic!("unallowed handoff tool must error"),
+            Err(ToolError::Recoverable(e)) => {
+                assert!(
+                    e.to_string().contains("unlisted_session_handoff"),
+                    "unexpected error: {e:#}"
+                );
+            }
+            Err(ToolError::Fatal(e)) => panic!("expected Recoverable, got Fatal: {e:#}"),
+        }
     }
 }

--- a/crates/harnx-proxy-auth/tests/hook_e2e.rs
+++ b/crates/harnx-proxy-auth/tests/hook_e2e.rs
@@ -243,7 +243,7 @@ async fn hook_injected_env_reaches_bash_exec_command() {
     let persistent_manager = Arc::new(Mutex::new(PersistentHookManager::new()));
     // Pass Some("*") so tool_declarations_for_use_tools connects to MCP servers
     // and populates their tool lists; None skips MCP entirely.
-    let ctx = build_tool_eval_context(&config, Some("*"), &persistent_manager);
+    let ctx = build_tool_eval_context(&config, Some("*"), None, &persistent_manager);
 
     // Skip if the MCP server failed to connect (e.g. sandbox execution restrictions).
     if !ctx.allowed_tool_names.contains("bash_exec") {

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -180,7 +180,12 @@ pub async fn run_command_with_output(
                 }
                 Some("tools") => {
                     let conf = config.read();
-                    let declarations = conf.tool_declarations_for_use_tools(Some("*"));
+                    // Spell handoff tool names relative to the active agent's
+                    // package so they match the active-tool whitelist below and
+                    // what the agent actually sees (#709).
+                    let active_pkg = conf.active_package();
+                    let (declarations, _) =
+                        conf.tool_declarations_for_use_tools(Some("*"), active_pkg.as_deref());
                     let active_tools = conf.active_tool_names();
                     if declarations.is_empty() {
                         writeln!(output, "No tools available")?;

--- a/crates/harnx-runtime/src/config/completion_split.rs
+++ b/crates/harnx-runtime/src/config/completion_split.rs
@@ -92,9 +92,13 @@ impl Config {
                         values.push("*".to_string());
                     }
                     values.extend(
-                        self.tool_declarations_for_use_tools(Some("*"))
-                            .iter()
-                            .map(|v| v.name.clone()),
+                        self.tool_declarations_for_use_tools(
+                            Some("*"),
+                            self.active_package().as_deref(),
+                        )
+                        .0
+                        .iter()
+                        .map(|v| v.name.clone()),
                     );
                     values.extend(self.toolsets.keys().map(|v| v.to_string()));
                     values
@@ -121,7 +125,8 @@ impl Config {
             values = candidates.into_iter().map(|v| (v, None)).collect();
         } else if cmd == ".use" && args.len() == 2 && args[0] == "tool" {
             let mut candidates: Vec<String> = self
-                .tool_declarations_for_use_tools(Some("*"))
+                .tool_declarations_for_use_tools(Some("*"), self.active_package().as_deref())
+                .0
                 .iter()
                 .map(|v| v.name.clone())
                 .collect();

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -153,10 +153,17 @@ fn matches_tool_glob(pattern: &str, name: &str) -> bool {
 
 /// Extract a valid package name from a directory path entry.
 /// Returns None for non-directories and hidden directories (starting with '.').
-fn handoff_tool_declarations_for_agents() -> Vec<ToolDeclaration> {
-    crate::config::agent::list_agents()
+fn handoff_tool_declarations_for_agents(
+    active_pkg: Option<&str>,
+) -> (Vec<ToolDeclaration>, HashMap<String, String>) {
+    let mut handoff_targets = HashMap::new();
+    let declarations = crate::config::agent::list_agents()
         .into_iter()
         .map(|agent_name| {
+            let display_name =
+                harnx_core::package_namespace::handoff_display_name(&agent_name, active_pkg);
+            handoff_targets.insert(display_name.clone(), agent_name.clone());
+
             let mut properties = IndexMap::new();
             properties.insert(
                 "prompt".to_string(),
@@ -177,7 +184,7 @@ fn handoff_tool_declarations_for_agents() -> Vec<ToolDeclaration> {
                 },
             );
             ToolDeclaration {
-                name: format!("{agent_name}_session_handoff"),
+                name: format!("{display_name}_session_handoff"),
                 description: format!(
                     "Exit the current interactive agent session and hand off to the '{agent_name}' agent. Resolves the target session internally (reusing session_id when provided, otherwise the current session), then continues interaction in that agent session with the supplied prompt."
                 ),
@@ -193,7 +200,9 @@ fn handoff_tool_declarations_for_agents() -> Vec<ToolDeclaration> {
                 result_template: None,
             }
         })
-        .collect()
+        .collect();
+
+    (declarations, handoff_targets)
 }
 
 pub struct Config {
@@ -476,6 +485,16 @@ impl Config {
         }
     }
 
+    /// Package of the currently active agent (e.g. `Some("pantheon")` for
+    /// `pantheon/daedalus`, `None` for a top-level agent). Used to spell
+    /// package-aware handoff tool declarations consistently across the engine
+    /// allow-list, the tool list sent to the LLM, CLI listings, and shell
+    /// completion (#709).
+    pub fn active_package(&self) -> Option<String> {
+        harnx_core::package_namespace::pkg_from_qualified(self.extract_agent().name())
+            .map(str::to_string)
+    }
+
     pub fn resolved_hooks(&self) -> HooksConfig {
         let global = self.hooks.clone().unwrap_or_default();
         if let Some(agent) = &self.agent {
@@ -680,7 +699,13 @@ impl Config {
             None => return HashSet::new(),
         };
         let use_tools_str = use_tools.join(",");
-        let declarations = self.tool_declarations_for_use_tools(Some(&use_tools_str));
+        // Generate handoff declarations relative to the active agent's package
+        // so their names match the package-aware spelling exposed to the agent
+        // and decoded by the engine (#709).
+        let active_pkg =
+            harnx_core::package_namespace::pkg_from_qualified(agent.name()).map(str::to_string);
+        let (declarations, _) =
+            self.tool_declarations_for_use_tools(Some(&use_tools_str), active_pkg.as_deref());
         let declaration_names: HashSet<String> =
             declarations.iter().map(|d| d.name.clone()).collect();
         let mut names = HashSet::new();
@@ -721,7 +746,13 @@ impl Config {
         }
         let use_tools = agent.use_tools()?;
         let use_tools_str = use_tools.join(",");
-        let declarations = self.tool_declarations_for_use_tools(Some(&use_tools_str));
+        // Handoff declarations must be spelled relative to this agent's package
+        // so the tool names sent to the LLM match what the engine can decode
+        // and what `build_tool_eval_context` allow-lists (#709).
+        let active_pkg =
+            harnx_core::package_namespace::pkg_from_qualified(agent.name()).map(str::to_string);
+        let (declarations, _) =
+            self.tool_declarations_for_use_tools(Some(&use_tools_str), active_pkg.as_deref());
         let tool_names = self.collect_selected_tool_names(&use_tools, &declarations);
 
         let mut functions: Vec<ToolDeclaration> = declarations
@@ -1050,8 +1081,13 @@ impl Config {
         Ok(())
     }
 
-    pub fn tool_declarations_for_use_tools(&self, use_tools: Option<&str>) -> Vec<ToolDeclaration> {
+    pub fn tool_declarations_for_use_tools(
+        &self,
+        use_tools: Option<&str>,
+        active_pkg: Option<&str>,
+    ) -> (Vec<ToolDeclaration>, HashMap<String, String>) {
         let mut declarations = self.tools.declarations();
+        let mut handoff_targets = HashMap::new();
         if let Some(use_tools) = use_tools {
             if self.needs_mcp_tools() {
                 if let Some(manager) = &self.mcp_manager {
@@ -1069,13 +1105,16 @@ impl Config {
                 let v = v.trim();
                 v.ends_with("_session_handoff") || v == "*"
             }) {
-                declarations.extend(handoff_tool_declarations_for_agents());
+                let (handoff_declarations, targets) =
+                    handoff_tool_declarations_for_agents(active_pkg);
+                declarations.extend(handoff_declarations);
+                handoff_targets.extend(targets);
             }
         }
 
         let mut seen = HashSet::new();
         declarations.retain(|declaration| seen.insert(declaration.name.clone()));
-        declarations
+        (declarations, handoff_targets)
     }
 }
 

--- a/crates/harnx-runtime/src/config/settings_split.rs
+++ b/crates/harnx-runtime/src/config/settings_split.rs
@@ -160,7 +160,8 @@ impl Config {
         if value
             && config
                 .read()
-                .tool_declarations_for_use_tools(Some("*"))
+                .tool_declarations_for_use_tools(Some("*"), None)
+                .0
                 .is_empty()
         {
             bail!("Tool use cannot be enabled because no tools are installed.")

--- a/crates/harnx-runtime/src/config/tests.rs
+++ b/crates/harnx-runtime/src/config/tests.rs
@@ -981,3 +981,55 @@ fn apply_client_patch_with_invalid_jq_expression_returns_err() {
     assert!(result.is_err());
     assert_eq!(before, after);
 }
+
+#[test]
+fn handoff_tool_declarations_are_package_aware_and_valid() {
+    let fixture_agents = [
+        "pantheon/atlas".to_string(),
+        "otherpkg/helper".to_string(),
+        "global".to_string(),
+    ];
+
+    let declarations = fixture_agents
+        .iter()
+        .map(|agent_name| {
+            let display_name =
+                harnx_core::package_namespace::handoff_display_name(agent_name, Some("pantheon"));
+            (
+                format!("{display_name}_session_handoff"),
+                display_name,
+                agent_name.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let declaration_names: std::collections::HashSet<String> = declarations
+        .iter()
+        .map(|(name, _, _)| name.clone())
+        .collect();
+    let handoff_targets: std::collections::HashMap<String, String> = declarations
+        .iter()
+        .map(|(_, display_name, agent_name)| (display_name.clone(), agent_name.clone()))
+        .collect();
+
+    assert!(declaration_names.iter().all(|name| !name.contains('/')));
+    assert!(declaration_names.iter().all(|name| name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')));
+
+    assert!(declaration_names.contains("atlas_session_handoff"));
+    assert!(declaration_names.contains("otherpkg__helper_session_handoff"));
+    assert!(declaration_names.contains("__global_session_handoff"));
+
+    assert_eq!(
+        handoff_targets.get("atlas").map(String::as_str),
+        Some("pantheon/atlas")
+    );
+    assert_eq!(
+        handoff_targets.get("otherpkg__helper").map(String::as_str),
+        Some("otherpkg/helper")
+    );
+    assert_eq!(
+        handoff_targets.get("__global").map(String::as_str),
+        Some("global")
+    );
+}

--- a/crates/harnx-runtime/src/tool.rs
+++ b/crates/harnx-runtime/src/tool.rs
@@ -53,7 +53,16 @@ pub async fn execute_tool_round(
         )?;
     }
     let agent_use_tools = input.agent().use_tools().map(|v| v.join(","));
-    let eval_ctx = build_tool_eval_context(config, agent_use_tools.as_deref(), persistent_manager);
+    // Derive the active agent's package (e.g. `pantheon` for `pantheon/daedalus`)
+    // so bare `_session_handoff` targets resolve to the same package (#709).
+    let current_agent_package =
+        harnx_core::package_namespace::pkg_from_qualified(input.agent().name()).map(str::to_string);
+    let eval_ctx = build_tool_eval_context(
+        config,
+        agent_use_tools.as_deref(),
+        current_agent_package,
+        persistent_manager,
+    );
     let results = match eval_tool_calls(&eval_ctx, tool_calls.clone(), abort_signal).await {
         Ok(results) => results,
         Err(err) => {
@@ -194,12 +203,14 @@ fn build_emit_fns(
 pub fn build_tool_eval_context(
     config: &GlobalConfig,
     agent_use_tools: Option<&str>,
+    current_agent_package: Option<String>,
     persistent_manager: &std::sync::Arc<tokio::sync::Mutex<PersistentHookManager>>,
 ) -> ToolEvalContext {
     let guard = config.read();
+    let (tool_declarations, handoff_targets) =
+        guard.tool_declarations_for_use_tools(agent_use_tools, current_agent_package.as_deref());
     let decl_map: Arc<HashMap<String, ToolDeclaration>> = Arc::new(
-        guard
-            .tool_declarations_for_use_tools(agent_use_tools)
+        tool_declarations
             .into_iter()
             .map(|d| (d.name.clone(), d))
             .collect(),
@@ -264,6 +275,8 @@ pub fn build_tool_eval_context(
         providers,
         session_name,
         allowed_tool_names,
+        current_agent_package,
+        handoff_targets,
         emit_tool_call_fn,
         emit_tool_result_fn,
         emit_tool_blocked_fn,
@@ -480,7 +493,7 @@ mod tests {
             harnx_hooks::PersistentHookManager::new(),
         ));
         let result = eval_tool_calls(
-            &build_tool_eval_context(&config, None, &persistent_manager),
+            &build_tool_eval_context(&config, None, None, &persistent_manager),
             calls,
             &abort_signal,
         )
@@ -494,6 +507,32 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("No tool provider configured"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn build_tool_eval_context_stores_current_agent_package() {
+        // The package derived from a qualified agent name in `execute_tool_round`
+        // must be threaded into `ToolEvalContext` so the engine can resolve
+        // same-package handoff targets (#709).
+        let _guard = crate::client::TestStateGuard::new(None).await;
+        let config = Arc::new(RwLock::new(Config::default()));
+        let persistent_manager = std::sync::Arc::new(tokio::sync::Mutex::new(
+            harnx_hooks::PersistentHookManager::new(),
+        ));
+
+        // Mirror the derivation done in `execute_tool_round`.
+        let pkg = harnx_core::package_namespace::pkg_from_qualified("pantheon/daedalus")
+            .map(str::to_string);
+        assert_eq!(pkg.as_deref(), Some("pantheon"));
+        let ctx = build_tool_eval_context(&config, None, pkg, &persistent_manager);
+        assert_eq!(ctx.current_agent_package.as_deref(), Some("pantheon"));
+
+        // A bare (top-level) agent name yields no package context.
+        let bare =
+            harnx_core::package_namespace::pkg_from_qualified("daedalus").map(str::to_string);
+        assert_eq!(bare, None);
+        let ctx = build_tool_eval_context(&config, None, bare, &persistent_manager);
+        assert_eq!(ctx.current_agent_package, None);
     }
 
     #[test]

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -502,8 +502,12 @@ pub(crate) fn session_history_transcript_items(config: &GlobalConfig) -> Vec<Tra
         Some(s) if !s.is_empty() => s,
         _ => return vec![],
     };
-    let decl_map: HashMap<String, ToolDeclaration> = cfg
-        .tool_declarations_for_use_tools(Some("*"))
+    // Spell handoff tool declaration names relative to the active agent's
+    // package so the transcript matches what the agent actually saw (#709).
+    let active_pkg = cfg.active_package();
+    let (declarations, _handoff_targets) =
+        cfg.tool_declarations_for_use_tools(Some("*"), active_pkg.as_deref());
+    let decl_map: HashMap<String, ToolDeclaration> = declarations
         .into_iter()
         .map(|d| (d.name.clone(), d))
         .collect();

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -2054,7 +2054,7 @@ async fn test_tool_result_switch_agent_parsing() {
         harnx_hooks::PersistentHookManager::new(),
     ));
     let mut results = eval_tool_calls(
-        &harnx_runtime::tool::build_tool_eval_context(&config, None, &pm),
+        &harnx_runtime::tool::build_tool_eval_context(&config, None, None, &pm),
         vec![call],
         &abort_signal,
     )

--- a/docs/solutions/logic-errors/package-relative-agent-handoff-2026-06-04.md
+++ b/docs/solutions/logic-errors/package-relative-agent-handoff-2026-06-04.md
@@ -1,0 +1,199 @@
+---
+title: "Package-relative agent handoff resolution for _session_handoff"
+date: 2026-06-04
+category: logic-errors
+problem_type: logic_error
+component: harnx-engine
+root_cause: missing-package-context-in-synthetic-tool-dispatch
+resolution_type: code_fix
+severity: medium
+tags:
+  - session-handoff
+  - packages
+  - namespacing
+  - agent-resolution
+plan_ref: issue-709-package-handoff
+---
+
+## Problem
+
+A package agent (`pantheon/daedalus`) using a bare `_session_handoff` tool (`atlas_session_handoff`) to hand off to a same-package agent resolved the target to top-level `atlas` instead of `pantheon/atlas`. The synthetic handoff dispatch had no awareness of the active agent's package.
+
+## Symptoms
+
+- Package agent calls `atlas_session_handoff`, expecting `pantheon/atlas`
+- Handoff lands on top-level `atlas` if it exists, or fails if only `pantheon/atlas` exists
+- Confusing behavior: same tool call produces different results from package vs top-level agents
+- Issue #709: explicit bug report for same-package handoff misresolution
+
+## Investigation Steps
+
+1. Traced handoff dispatch in `crates/harnx-engine/src/tool.rs`: the `_session_handoff` branch extracted the agent name by trimming the `_session_handoff` suffix and emitted `switch_agent { agent }` verbatim.
+
+2. Verified downstream `Config::use_agent` → `agent::init` → `Config::agent_file` resolution rules:
+   - Name containing `/` → `packages/<pkg>/agents/<stem>.md`
+   - Bare name → `agents/<name>.md`
+
+3. Confirmed bare names always resolved top-level regardless of calling agent's package.
+
+4. Found existing helper `harnx_core::package_namespace::resolve_package_relative_name()` implementing exactly the needed resolution semantics:
+   - `/foo` → `foo` (top-level escape)
+   - `other/foo` → `other/foo` (cross-package)
+   - `foo` + `Some(pkg)` → `pkg/foo` (same-package)
+   - `foo` + `None` → `foo` (top-level context)
+
+5. Verified the package context lives on `Input.agent().name()` per-prompt, NOT global Config — ACP server path may target different agents per prompt.
+
+## Root Cause
+
+The `_session_handoff` dispatch in `dispatch_tool_call` extracted the agent name from the tool name and passed it directly to the result without package-relative transformation. The dispatcher had no access to the active agent's package context.
+
+**Data flow gap:**
+
+```
+Input.agent().name() → "pantheon/daedalus"  (package info here)
+    ↓
+execute_tool_round → ToolEvalContext built without package field
+    ↓
+dispatch_tool_call → _session_handoff branch sees only bare "atlas"
+    ↓
+switch_agent result → "atlas" (wrong, should be "pantheon/atlas")
+```
+
+## Solution
+
+### 1. Added Package Context to ToolEvalContext
+
+In `crates/harnx-engine/src/tool.rs`:
+
+```rust
+pub struct ToolEvalContext {
+    // ... existing fields ...
+    /// Package of the currently active agent (e.g. `Some("pantheon")` for
+    /// `pantheon/daedalus`, `None` for a top-level agent). Used to resolve
+    /// bare `_session_handoff` targets relative to the current package.
+    pub current_agent_package: Option<String>,
+}
+```
+
+### 2. Derived Package Context at Runtime Layer
+
+In `crates/harnx-runtime/src/tool.rs`:
+
+```rust
+// In execute_tool_round:
+let current_agent_package =
+    harnx_core::package_namespace::pkg_from_qualified(input.agent().name())
+        .map(str::to_string);
+
+let eval_ctx = build_tool_eval_context(
+    config,
+    agent_use_tools.as_deref(),
+    current_agent_package,  // new parameter
+    persistent_manager,
+);
+```
+
+### 3. Applied Resolution in Handoff Dispatch
+
+In `crates/harnx-engine/src/tool.rs`:
+
+```rust
+if call.name.ends_with("_session_handoff") {
+    // Strip exactly one suffix (not all repeats)
+    let bare_target = call.name
+        .strip_suffix("_session_handoff")
+        .unwrap_or(&call.name);
+
+    // Resolve relative to current package
+    let agent = harnx_core::package_namespace::resolve_package_relative_name(
+        bare_target,
+        ctx.current_agent_package.as_deref(),
+    );
+
+    // ... rest of handoff logic uses resolved `agent`
+}
+```
+
+### 4. Layering Preserved
+
+- `harnx-runtime`: derives package context from `Input`, passes to context builder
+- `harnx-engine`: consumes context, applies resolution via shared helper
+- `harnx-core`: pure resolution logic, no I/O dependency
+
+Dependency direction runtime → engine → core maintained correctly.
+
+## Why This Works
+
+The `resolve_package_relative_name()` helper encapsulates the four resolution rules already used for compaction agent and client/model resolution (documented in [package-scoped-name-resolution-2026-05-17.md](./package-scoped-name-resolution-2026-05-17.md)). By threading the active agent's package through `ToolEvalContext`, the handoff dispatcher can apply the same rules:
+
+| Tool Call | From Agent | Package Context | Resolved Target |
+|-----------|------------|-----------------|-----------------|
+| `atlas_session_handoff` | `pantheon/daedalus` | `Some("pantheon")` | `pantheon/atlas` |
+| `atlas_session_handoff` | `atlas` (top-level) | `None` | `atlas` |
+| `/atlas_session_handoff` | `pantheon/daedalus` | `Some("pantheon")` | `atlas` (escape) |
+| `other/atlas_session_handoff` | `pantheon/daedalus` | `Some("pantheon")` | `other/atlas` |
+
+The `strip_suffix()` call removes exactly one `_session_handoff` suffix, preventing misresolution of edge-case agent names ending with `_session_handoff` (unlike `trim_end_matches()` which greedily removes repeated suffixes).
+
+## Prevention Strategies
+
+### Test Cases
+
+Added 6 unit tests in `crates/harnx-engine/src/tool.rs`:
+
+- `handoff_bare_target_resolves_to_current_package` — main fix verification
+- `handoff_bare_target_top_level_unchaved` — `None` package context (regression guard)
+- `handoff_leading_slash_escapes_to_top_level` — `/` escape hatch
+- `handoff_qualified_target_unchanged` — cross-package pass-through
+- `handoff_strips_only_one_suffix` — edge case: agent named `*_session_handoff`
+- `handoff_propagates_prompt` — contract verification: prompt flows through
+
+### Code Review Checklist
+
+- [ ] Does synthetic tool dispatch account for package context where relevant?
+- [ ] When extending `ToolEvalContext`, update all `build_tool_eval_context` call sites
+- [ ] Use `strip_suffix()` for single-suffix removal, not `trim_end_matches()`
+- [ ] Package context derives from `Input.agent().name()` per-prompt, not global config
+
+### Key Gotchas
+
+1. **`strip_suffix` vs `trim_end_matches`**: `trim_end_matches` removes *all* trailing matches of the pattern. For `_session_handoff`, this could misresolve an agent literally named `atlas_session_handoff` (tool `atlas_session_handoff_session_handoff` would resolve to `atlas` instead of `atlas_session_handoff`). Use `strip_suffix()` for exact single-suffix removal.
+
+2. **Package context from Input, not Config**: The active agent is per-prompt (`input.agent().name()`), not global. ACP server paths may target different agents for different prompts. Mirror this in any similar context derivation.
+
+3. **Declarations were also wrong (invalid tool names)**: The initial fix corrected *resolution* but left the declaration layer emitting `format!("{agent_name}_session_handoff")` from `list_agents()` — which returns `pkg/stem`. That produced literal `pantheon/atlas_session_handoff` tool names containing a `/`, which is **invalid** for OpenAI/Anthropic function-name schemas (`^[a-zA-Z0-9_-]+$`) and harnx does no client-side sanitization. See the follow-up below.
+
+## Follow-up: package-aware handoff tool-name spelling
+
+### Why string-munging the name is unsafe
+`validate_package_name` allows `[a-zA-Z0-9_-]`, so **package names may contain `_`**, and agent stems may too. Decoding a display name like `a__b__c` back to `pkg/stem` by splitting on `__` is therefore ambiguous. The decode **must** use an exact lookup map, never string parsing.
+
+### Spelling scheme (LLM-visible display name, relative to the active agent's package)
+All names are slash-free and match `[A-Za-z0-9_-]`:
+
+| Target (from active package `P`) | Display name | Decodes to |
+|---|---|---|
+| Same-package peer `P/atlas` | `atlas` | `P/atlas` |
+| Cross-package peer `other/helper` | `other__helper` | `other/helper` |
+| Top-level agent `global` | `__global` | `global` |
+| (active agent is top-level) package peer `P/atlas` | `P__atlas` | `P/atlas` |
+| (active agent is top-level) top-level peer `global` | `global` | `global` |
+
+Helper: `harnx_core::package_namespace::handoff_display_name(target, active_pkg)`.
+
+### Decode (engine): map value is canonical — use it VERBATIM
+`ToolEvalContext.handoff_targets: HashMap<String,String>` maps display-name → qualified-or-bare agent name. The engine does an exact lookup and uses the value **as-is**. Do NOT re-run `resolve_package_relative_name` on a map hit: a top-level value like bare `global` would be wrongly qualified to `P/global`. Re-resolution applies only on the fallback path (empty map / legacy / test contexts).
+
+### The trap: declaration generation and tool selection must use the SAME package context
+The handoff declaration names are generated in three places that all feed the LLM or the engine allow-list:
+- `build_tool_eval_context` → the engine's `allowed_tool_names` + `handoff_targets`.
+- `select_tools(agent)` (via `config/input.rs`) → the function list **sent to the LLM**.
+- `active_tool_names()` → UI/whitelist display.
+
+If any of these passes `None` for the package while another passes the real package, the LLM sees one spelling (e.g. `P__atlas_session_handoff`) while the engine allow-lists another (bare `atlas_session_handoff`) → the call fails the `allowed_tool_names` gate. **All declaration-generation call sites must derive the active agent's package** via `pkg_from_qualified(agent.name())`.
+
+## Related Issues
+
+- **GitHub Issue:** [#709](https://github.com/dobesv/harnx/issues/709) — Agent handoff from package agent goes to non-package agent
+- **Prior Solution:** [package-scoped-name-resolution-2026-05-17.md](./package-scoped-name-resolution-2026-05-17.md) — Same resolution helper applied to compaction agents and client/model references


### PR DESCRIPTION
Bare/same-package handoff targets now resolve relative to the active agent's package. Handoff tool declaration names are generated with package-namespaced, slash-free spelling (same-pkg bare, cross-pkg pkg__agent, top-level-from-package __agent) and decoded via an exact lookup map to ensure underscores in package or agent names remain unambiguous. Tool names are sanitized to the provider function-name charset.

Closes #709

Plan: issue-709-package-handoff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent handoff resolution when a package agent hands off to a peer agent within the same package using bare session handoff calls.

* **Improvements**
  * Tool declarations and tab-completion now correctly scope to the active agent's package context.
  * Agent handoff tool names are now package-namespaced with improved naming to prevent ambiguity and ensure correct target resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->