### PR TITLE
fix(mcp-plans): make cleanup test deterministic on Windows

### DIFF
--- a/.changeset/fix-windows-cleanup-test-flake.md
+++ b/.changeset/fix-windows-cleanup-test-flake.md
@@ -1,0 +1,5 @@
+---
+harnx: patch
+---
+
+Fix a Windows CI flake in the `harnx-mcp-plans` cleanup test. `cleanup_deletes_stale_plan_but_keeps_fresh_plan` relied on millisecond-scale sleeps finer than Windows filesystem timestamp resolution, causing the fresh plan to be deleted too. The test now sets the stale plan's mtime explicitly via `filetime` and uses a generous retention margin, making it deterministic across platforms.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,6 +3729,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "filetime",
  "rmcp",
  "schemars 1.2.1",
  "serde",

--- a/crates/harnx-mcp-plans/Cargo.toml
+++ b/crates/harnx-mcp-plans/Cargo.toml
@@ -21,6 +21,9 @@ tower = { workspace = true }
 schemars = { workspace = true }
 similar = { workspace = true }
 
+[dev-dependencies]
+filetime = "0.2"
+
 [[bin]]
 name = "harnx-mcp-plans"
 path = "src/main.rs"

--- a/crates/harnx-mcp-plans/src/server/tests.rs
+++ b/crates/harnx-mcp-plans/src/server/tests.rs
@@ -2025,17 +2025,27 @@ async fn delete_note_wrong_plan_fails() {
 
 #[tokio::test]
 async fn cleanup_deletes_stale_plan_but_keeps_fresh_plan() {
+    use filetime::set_file_mtime;
+    use std::time::SystemTime;
+
     let dir = temp_test_dir("cleanup-stale-plan");
     let stale_plan = dir.join("stale-plan");
     let fresh_plan = dir.join("fresh-plan");
 
+    // Create stale plan with mtime far in the past
     fs::create_dir_all(&stale_plan).unwrap();
-    fs::write(stale_plan.join("plan.md"), "stale").unwrap();
-    tokio::time::sleep(Duration::from_millis(25)).await;
+    let stale_plan_md = stale_plan.join("plan.md");
+    fs::write(&stale_plan_md, "stale").unwrap();
+    let stale_time =
+        filetime::FileTime::from_system_time(SystemTime::now() - Duration::from_secs(3600));
+    set_file_mtime(&stale_plan_md, stale_time).unwrap();
+
+    // Create fresh plan with mtime ~now
     fs::create_dir_all(&fresh_plan).unwrap();
     fs::write(fresh_plan.join("plan.md"), "fresh").unwrap();
 
-    run_cleanup_pass(&dir, Duration::from_millis(10)).await;
+    // Retention of 60s: stale (hour old) should be deleted, fresh should be kept
+    run_cleanup_pass(&dir, Duration::from_secs(60)).await;
 
     assert!(!stale_plan.exists(), "stale plan should be deleted");
     assert!(fresh_plan.exists(), "fresh plan should be kept");


### PR DESCRIPTION
The test relied on millisecond-scale sleeps finer than Windows FS timestamp resolution. Now sets stale mtime explicitly via filetime dev-dep with a 60s retention margin.

Plan: fix-windows-cleanup-test-flake

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent Windows CI test failures in cleanup operations. Enhanced test reliability through improved file timestamp handling and more deterministic test setup, ensuring consistent execution across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->