### PR TITLE
fix(tui): show session compaction in transcript instead of stdout spinner

### DIFF
--- a/.changeset/compaction-transcript-feedback.md
+++ b/.changeset/compaction-transcript-feedback.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Show session compaction in the transcript instead of a stdout spinner. Previously, triggering compaction (the `.compact session` command or automatic compaction) drew a spinner directly to stdout, which corrupted the TUI input area and left an uncleared line. Compaction now emits `CompactingStarted` / `CompactingCompleted` / `CompactingFailed` session events that the TUI renders as transcript entries and the CLI renders via a managed spinner. Manual compaction also guards against running concurrently with automatic compaction.

--- a/crates/harnx-core/src/event.rs
+++ b/crates/harnx-core/src/event.rs
@@ -117,6 +117,8 @@ pub enum SessionEvent {
         path: PathBuf,
     },
     CompactingStarted,
+    CompactingCompleted,
+    CompactingFailed(String),
     AgentInitializing {
         agent: String,
     },

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use crate::config::{macro_execute, AgentVariables, Config, GlobalConfig, Input, LastMessage};
-use crate::utils::{abortable_run_with_spinner, dimmed_text, set_text, AbortSignal};
+use crate::utils::{dimmed_text, set_text, AbortSignal};
 use harnx_hooks::{
     dispatch_hooks_with_managers, AsyncHookManager, HookEvent, HookResultControl,
     PersistentHookManager,
@@ -343,13 +343,74 @@ pub async fn run_command_with_output(
             }
             ".compact" => match args {
                 Some("session") => {
-                    abortable_run_with_spinner(
-                        Config::compact_session(config),
-                        "Compacting",
-                        abort_signal.clone(),
-                    )
-                    .await?;
-                    writeln!(output, "✓ Successfully compacted the session.")?;
+                    // Atomically guard against concurrent compaction (auto or
+                    // manual) and claim the compacting flag under a single write
+                    // lock. The agent loop and auto-compaction both consult
+                    // `is_compacting_session()` (the `compressing` flag), so we
+                    // must set it here for the duration of the manual run.
+                    enum Claim {
+                        Claimed,
+                        AlreadyCompacting,
+                        NoSession,
+                    }
+                    let claim = {
+                        let mut cfg = config.write();
+                        match cfg.session.as_mut() {
+                            None => Claim::NoSession,
+                            Some(session) if session.compressing() => Claim::AlreadyCompacting,
+                            Some(session) => {
+                                session.set_compressing(true);
+                                Claim::Claimed
+                            }
+                        }
+                    };
+                    match claim {
+                        Claim::NoSession => {
+                            writeln!(output, "No active session to compact.")?;
+                            return Ok(CommandOutcome::Continue);
+                        }
+                        Claim::AlreadyCompacting => {
+                            writeln!(output, "Compaction already in progress.")?;
+                            return Ok(CommandOutcome::Continue);
+                        }
+                        Claim::Claimed => {}
+                    }
+                    // Emit start event, run compaction, then emit completion or
+                    // failure. Always clear the compacting flag afterwards. All
+                    // user-visible feedback flows through the SessionEvents
+                    // (rendered by the TUI transcript / CLI spinner sink) so we
+                    // do NOT also write to `output` — that would double-render
+                    // the message in the TUI/CLI.
+                    harnx_core::sink::emit_agent_event(
+                        harnx_core::event::AgentEvent::Session(
+                            harnx_core::event::SessionEvent::CompactingStarted,
+                        ),
+                    );
+                    let result = Config::compact_session(config).await;
+                    if let Some(session) = config.write().session.as_mut() {
+                        session.set_compressing(false);
+                    }
+                    match result {
+                        Ok(()) => {
+                            harnx_core::sink::emit_agent_event(
+                                harnx_core::event::AgentEvent::Session(
+                                    harnx_core::event::SessionEvent::CompactingCompleted,
+                                ),
+                            );
+                        }
+                        Err(err) => {
+                            // Emit the failure event only. Do NOT propagate the
+                            // error or write to `output` — either would render
+                            // the failure a second time.
+                            harnx_core::sink::emit_agent_event(
+                                harnx_core::event::AgentEvent::Session(
+                                    harnx_core::event::SessionEvent::CompactingFailed(
+                                        err.to_string(),
+                                    ),
+                                ),
+                            );
+                        }
+                    }
                 }
                 _ => writeln!(output, r#"Usage: .compact session"#)?,
             },

--- a/crates/harnx-runtime/src/config/session_ops_split.rs
+++ b/crates/harnx-runtime/src/config/session_ops_split.rs
@@ -408,21 +408,28 @@ impl Config {
         if !need_compact {
             return;
         }
-        let color = if config.read().light_theme() {
-            nu_ansi_term::Color::LightGray
-        } else {
-            nu_ansi_term::Color::DarkGray
-        };
-        crate::utils::emit_info(format!(
-            "📢 {}",
-            color.italic().paint("Compacting the session.")
+        // Use SessionEvent for consistent TUI/CLI handling.
+        // The TUI will render CompactingStarted/CompactingCompleted as transcript items.
+        harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
+            harnx_core::event::SessionEvent::CompactingStarted,
         ));
         tokio::spawn(async move {
-            if let Err(err) = Config::compact_session(&config).await {
-                warn!("Failed to compact the session: {err}");
-            }
+            let result = Config::compact_session(&config).await;
             if let Some(session) = config.write().session.as_mut() {
                 session.set_compressing(false);
+            }
+            match &result {
+                Ok(()) => {
+                    harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
+                        harnx_core::event::SessionEvent::CompactingCompleted,
+                    ));
+                }
+                Err(err) => {
+                    warn!("Failed to compact the session: {err}");
+                    harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
+                        harnx_core::event::SessionEvent::CompactingFailed(err.to_string()),
+                    ));
+                }
             }
         });
     }

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1199,8 +1199,19 @@ impl Tui {
                     rendered_cache: None,
                 }]
             }
-            // Not rendered by the TUI: Turn, Session, Status, Tool::Progress,
-            // Tool::Failed.
+            AgentEvent::Session(SessionEvent::CompactingStarted) => {
+                vec![TranscriptItem::SystemText(
+                    "Compacting session…".to_string(),
+                )]
+            }
+            AgentEvent::Session(SessionEvent::CompactingCompleted) => {
+                vec![TranscriptItem::SystemText("Session compacted.".to_string())]
+            }
+            AgentEvent::Session(SessionEvent::CompactingFailed(err)) => {
+                vec![TranscriptItem::ErrorText(format!(
+                    "Compaction failed: {err}"
+                ))]
+            }
             _ => vec![],
         };
 

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -7583,3 +7583,125 @@ async fn test_agent_command_leaves_tui_without_session_gap() {
         "Expected a picker to be open when session is missing!"
     );
 }
+
+#[tokio::test]
+async fn render_agent_event_compacting_started_produces_transcript_entry() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    // Emit CompactingStarted event
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::CompactingStarted),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    // Should produce a SystemText transcript item
+    let has_compacting_msg = tui.app.transcript.iter().any(|item| {
+        matches!(
+            item,
+            TranscriptItem::SystemText(text) if text == "Compacting session…"
+        )
+    });
+    assert!(
+        has_compacting_msg,
+        "Expected 'Compacting session…' in transcript after CompactingStarted event"
+    );
+}
+
+#[tokio::test]
+async fn render_agent_event_compacting_completed_produces_transcript_entry() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    // First emit CompactingStarted
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::CompactingStarted),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    // Then emit CompactingCompleted
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::CompactingCompleted),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    // Should have both transcript items
+    let items: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|item| match item {
+            TranscriptItem::SystemText(text) => Some(text.clone()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        items.contains(&"Compacting session…".to_string()),
+        "Expected 'Compacting session…' in transcript"
+    );
+    assert!(
+        items.contains(&"Session compacted.".to_string()),
+        "Expected 'Session compacted.' in transcript"
+    );
+}
+
+#[tokio::test]
+async fn render_agent_event_compacting_failed_produces_error_transcript_entry() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    // First emit CompactingStarted
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::CompactingStarted),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    // Then emit CompactingFailed
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::CompactingFailed("test error".to_string())),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    // Should have both transcript items
+    let items: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|item| match item {
+            TranscriptItem::SystemText(text) => Some(format!("SystemText: {text}")),
+            TranscriptItem::ErrorText(text) => Some(format!("ErrorText: {text}")),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        items.iter().any(|s| s.contains("Compacting session…")),
+        "Expected 'Compacting session…' in transcript"
+    );
+    assert!(
+        items
+            .iter()
+            .any(|s| s.contains("Compaction failed: test error")),
+        "Expected 'Compaction failed: test error' in transcript"
+    );
+}

--- a/crates/harnx/src/cli_event_sink.rs
+++ b/crates/harnx/src/cli_event_sink.rs
@@ -10,8 +10,8 @@ use std::io::{stdout, Write};
 use std::sync::{Arc, Mutex};
 
 use harnx_core::event::{
-    AgentEvent, AgentEventSink, AgentSource, ContentBlock, ModelEvent, NoticeEvent, ToolEvent,
-    TurnEvent,
+    AgentEvent, AgentEventSink, AgentSource, ContentBlock, ModelEvent, NoticeEvent, SessionEvent,
+    ToolEvent, TurnEvent,
 };
 
 use harnx_render::{MarkdownRender, RenderOptions};
@@ -398,7 +398,31 @@ impl AgentEventSink for CliAgentEventSink {
             // Silent for Progress / Update — they are streamed mid-call
             // updates that would clutter stderr.
             AgentEvent::Tool(_) => {}
-            // Every other variant — Session, Status, Plan — still gets
+            // Compaction lifecycle: start spinner, stop it, or report failure.
+            AgentEvent::Session(SessionEvent::CompactingStarted) => {
+                if state.spinner.is_none() {
+                    state.spinner = Some(spawn_spinner("Compacting"));
+                }
+            }
+            AgentEvent::Session(SessionEvent::CompactingCompleted) => {
+                if let Err(err) = state.cleanup() {
+                    eprintln!(
+                        "{}",
+                        warning_text(&format!("cli-sink cleanup failed: {err}"))
+                    );
+                }
+                eprintln!("{}", dimmed_text("✓ Compacted the session."));
+            }
+            AgentEvent::Session(SessionEvent::CompactingFailed(err)) => {
+                if let Err(cleanup_err) = state.cleanup() {
+                    eprintln!(
+                        "{}",
+                        warning_text(&format!("cli-sink cleanup failed: {cleanup_err}"))
+                    );
+                }
+                eprintln!("{}", warning_text(&format!("compaction failed: {err}")));
+            }
+            // Every other variant — Session (other), Status, Plan — still gets
             // captured so nothing silently disappears. These receive dedicated
             // renderers in a future plan.
             other => eprintln!("{}", dimmed_text(&format!("[event] {other:?}"))),
@@ -878,5 +902,81 @@ mod tests {
             state.last_ui_output_source.is_some(),
             "source should still be set — cleanup must not run between same-source chunks"
         );
+    }
+
+    // ----------------------------------------------------------------
+    // Compaction event handling: CLI must handle Started/Completed/Failed
+    // without falling into the debug catch-all.
+    // ----------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn compacting_started_starts_spinner_without_panic() {
+        let sink = CliAgentEventSink::new(
+            false,
+            RenderOptions::default(),
+            harnx_core::abort::create_abort_signal(),
+        );
+        sink.emit(AgentEvent::Session(SessionEvent::CompactingStarted), None);
+        // cleanup to close spinner
+        sink.emit(AgentEvent::Session(SessionEvent::CompactingCompleted), None);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn compacting_completed_clears_spinner() {
+        let sink = CliAgentEventSink::new(
+            false,
+            RenderOptions::default(),
+            harnx_core::abort::create_abort_signal(),
+        );
+        // Start spinner first
+        sink.emit(AgentEvent::Turn(TurnEvent::Started), None);
+        {
+            let state = sink.state.lock().unwrap();
+            assert!(state.spinner.is_some(), "spinner should be started");
+        }
+        // CompactingStarted should NOT replace an existing spinner
+        sink.emit(AgentEvent::Session(SessionEvent::CompactingStarted), None);
+        {
+            let state = sink.state.lock().unwrap();
+            assert!(state.spinner.is_some(), "spinner should still exist");
+        }
+        // CompactingCompleted clears spinner
+        sink.emit(AgentEvent::Session(SessionEvent::CompactingCompleted), None);
+        {
+            let state = sink.state.lock().unwrap();
+            assert!(
+                state.spinner.is_none(),
+                "spinner should be cleared by Completed"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn compacting_failed_clears_spinner_and_reports_warning() {
+        let sink = CliAgentEventSink::new(
+            false,
+            RenderOptions::default(),
+            harnx_core::abort::create_abort_signal(),
+        );
+        // Start spinner
+        sink.emit(AgentEvent::Session(SessionEvent::CompactingStarted), None);
+        {
+            let state = sink.state.lock().unwrap();
+            assert!(state.spinner.is_some(), "spinner should be started");
+        }
+        // Failed clears spinner
+        sink.emit(
+            AgentEvent::Session(SessionEvent::CompactingFailed(
+                "something went wrong".to_string(),
+            )),
+            None,
+        );
+        {
+            let state = sink.state.lock().unwrap();
+            assert!(
+                state.spinner.is_none(),
+                "spinner should be cleared by Failed"
+            );
+        }
     }
 }

--- a/docs/solutions/integration-issues/tui-compaction-spinner-corruption-2026-06-08.md
+++ b/docs/solutions/integration-issues/tui-compaction-spinner-corruption-2026-06-08.md
@@ -1,0 +1,164 @@
+---
+title: "TUI compaction transcript via AgentEvent instead of stdout spinner"
+date: 2026-06-08
+category: integration-issues
+problem_type: integration_issue
+component: "harnx-runtime, harnx-tui, harnx-core"
+root_cause: "Direct stdout writes (crossterm spinner) bypassed ratatui's terminal state management, corrupting input area and leaving uncleared line"
+resolution_type: code_fix
+severity: medium
+tags:
+  - tui
+  - ratatui
+  - crossterm
+  - agent-event-sink
+  - transcript
+  - compaction
+plan_ref: compaction-transcript-711
+---
+
+## Problem
+
+Compaction in the TUI (`Cmd+. compact session`) drove a stdout spinner using `harnx-spinner` and crossterm escape sequences. These direct stdout writes corrupted the ratatui-managed input area and left an uncleared line after compaction finished.
+
+## Symptoms
+
+- Spinner text ("Compacting...") appeared in the TUI input area, overwriting the prompt
+- After compaction completed, a stray line remained visible in the terminal
+- TUI display state became inconsistent until next redraw
+
+## Investigation Steps
+
+1. Traced the `.compact session` path in `harnx-runtime/src/commands.rs` — used `abortable_run_with_spinner()` which writes directly to stdout via `crossterm`
+2. Confirmed harnx has a process-level `AgentEvent` sink system (`harnx_core::sink`) used for TUI/CLI/ACP frontends
+3. Found `harnx_core::sink::has_agent_event_sink()` predicate that returns `true` when a sink is installed
+4. Discovered `SessionEvent` variants are rendered in `harnx-tui/src/input.rs` via `render_agent_event()`
+5. Noted the catch-all `_ => vec![]` silently drops unhandled event variants — missing explicit arms
+
+## Root Cause
+
+Two issues combined:
+
+1. **Direct stdout writes corrupt ratatui**: `abortable_run_with_spinner()` uses `crossterm` to write spinner frames directly to stdout. Ratatui maintains its own terminal state via alternate screen buffer; direct writes bypass this and corrupt the display.
+
+2. **No event-based compaction path**: TUI mode had no way to render compaction progress as structured transcript entries instead of raw stdout.
+
+## Solution
+
+### 1. Emit lifecycle events unconditionally from the runtime
+
+In `crates/harnx-runtime/src/commands.rs`, the `.compact session` command always
+emits `SessionEvent`s — it does **not** branch on `has_agent_event_sink()`. (An
+earlier draft gated on that predicate, but it was removed: plain CLI also installs
+a sink, so the predicate is `true` in both CLI and TUI, making the gate dead code
+and routing CLI output into the sink's debug catch-all.) The command also claims
+the session's `compressing` flag atomically under a single write lock so manual
+compaction is visible to auto-compaction and the agent loop:
+
+```rust
+".compact" => match args {
+    Some("session") => {
+        // Atomic check-and-claim of the `compressing` flag under one write lock.
+        // (Distinguish NoSession / AlreadyCompacting / Claimed.)
+        // ... if not Claimed, print a message and return Ok(Continue) ...
+
+        harnx_core::sink::emit_agent_event(AgentEvent::Session(
+            SessionEvent::CompactingStarted,
+        ));
+        let result = Config::compact_session(config).await;
+        // Always clear the flag afterwards.
+        if let Some(session) = config.write().session.as_mut() {
+            session.set_compressing(false);
+        }
+        match result {
+            Ok(()) => emit(SessionEvent::CompactingCompleted),
+            // Emit failure event ONLY — do not also writeln! or propagate,
+            // or the failure renders twice.
+            Err(err) => emit(SessionEvent::CompactingFailed(err.to_string())),
+        }
+    }
+    _ => writeln!(output, r#"Usage: .compact session"#)?,
+},
+```
+
+Auto-compaction (`maybe_compact_session` in `config/session_ops_split.rs`) emits
+the same `CompactingStarted` → `CompactingCompleted`/`CompactingFailed` sequence.
+
+### 2. Add `SessionEvent` variants
+
+In `crates/harnx-core/src/event.rs`:
+
+```rust
+pub enum SessionEvent {
+    // ... existing variants
+    CompactingStarted,
+    CompactingCompleted,
+    CompactingFailed(String),
+}
+```
+
+### 3. Render events in each sink
+
+The runtime emits events unconditionally; each frontend's sink decides how to
+render them.
+
+TUI — `crates/harnx-tui/src/input.rs`, explicit arms in `render_agent_event()`:
+
+```rust
+AgentEvent::Session(SessionEvent::CompactingStarted) => {
+    vec![TranscriptItem::SystemText("Compacting session…".to_string())]
+}
+AgentEvent::Session(SessionEvent::CompactingCompleted) => {
+    vec![TranscriptItem::SystemText("Session compacted.".to_string())]
+}
+AgentEvent::Session(SessionEvent::CompactingFailed(err)) => {
+    vec![TranscriptItem::ErrorText(format!("Compaction failed: {err}"))]
+}
+```
+
+CLI — `crates/harnx/src/cli_event_sink.rs` adds arms that drive a managed
+spinner (start on `CompactingStarted`, `cleanup()` + "✓ Compacted the session."
+on `CompactingCompleted`, `cleanup()` + warning on `CompactingFailed`). This
+replaces the previous `[event] …` debug-catch-all fallback for these variants.
+
+### 4. Transcript reconciliation clears transient entries
+
+`reconcile_transcript_after_command()` clears and rebuilds the transcript for `.compact session`. The transient "Compacting session…" entry provides in-flight feedback; the final state comes from the rebuilt transcript (e.g., "─── session compacted ───" divider).
+
+## Why This Works
+
+**Process-level sink registry**: `harnx_core::sink` provides a global `AgentEventSink` registry. Frontends install their sink at startup, enabling any code (commands, runtime) to emit events without coupling to specific UIs.
+
+**Unconditional emission, sink-side rendering**: the runtime always emits the
+`SessionEvent`s; it does not gate on `has_agent_event_sink()`. Each installed
+sink renders them appropriately (TUI → transcript items, CLI → managed spinner +
+messages). `has_agent_event_sink()` is a poor branch point here because every
+frontend — including the plain CLI — installs a sink, so the predicate is almost
+always `true`; gating on it left the "no sink" branch dead and pushed CLI output
+into the sink's debug catch-all.
+
+**Ratatui owns terminal state**: Events rendered via `render_agent_event()` go through ratatui's widget pipeline. No raw stdout writes means no corruption.
+
+**Explicit match arms prevent silent drops**: Adding explicit arms for new `SessionEvent` variants ensures they're rendered. The catch-all `_ => vec![]` silently ignores unknown events — better to enumerate all handled variants.
+
+## Prevention Strategies
+
+**Test Cases:**
+- Add render tests for `CompactingStarted`/`CompactingCompleted`/`CompactingFailed` events (verify the TUI transcript contains the expected text / error item)
+- Verify the CLI event sink renders compaction events as a managed spinner (start) and clears it on completion/failure — not the `[event] …` debug fallback
+
+**Best Practices:**
+- Emit structured `SessionEvent`/`AgentEvent` lifecycle events; let sinks handle rendering for CLI vs TUI. Do not gate emission on `has_agent_event_sink()` — every frontend installs a sink.
+- Add explicit match arms in `render_agent_event()` (and the CLI sink's `emit`) for new `SessionEvent`/`AgentEvent` variants so the catch-all never silently drops or debug-prints them
+- Never write directly to stdout/stderr from code paths reachable in TUI mode — use the event sink
+
+**Code Review Checklist:**
+- [ ] Does this code write to stdout/stderr directly from a TUI-reachable path? Route it through the event sink instead.
+- [ ] Are new `AgentEvent`/`SessionEvent` variants handled by BOTH the TUI `render_agent_event()` and the CLI sink's `emit` (not just the catch-all)?
+- [ ] Does `reconcile_transcript_after_command()` need updating for new mutation commands?
+
+## Related Issues
+
+- **Issue:** [#711](https://github.com/dobesv/harnx/issues/711) — Compaction spinner corrupting TUI
+- **Prior Solution:** [tui-event-source-propagation-2026-05-26.md](./tui-event-source-propagation-2026-05-26.md) — Event source propagation pattern
+- **Prior Solution:** [non-interactive-safe-defaults-bash-children-2026-04-30.md](./non-interactive-safe-defaults-bash-children-2026-04-30.md) — Similar theme: preventing TUI corruption from child processes


### PR DESCRIPTION
Renders session compaction as transcript entries (TUI) or managed spinners (CLI) by emitting CompactingStarted, CompactingCompleted, and CompactingFailed session events from the runtime. This replaces direct stdout spinner writes that corrupted the TUI input line.

The manual `.compact session` command now atomically guards against concurrent auto-compaction using the session's compressing flag. Includes documentation of the TUI compaction spinner solution and a changeset for the user-visible fix.

[compaction-transcript-711]
#711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session compaction now displays progress through transcript events instead of stdout spinner, improving TUI stability.

* **Bug Fixes**
  * Resolved TUI corruption caused by spinner output interfering with terminal state.
  * Prevented concurrent manual and automatic session compaction.
  * Enhanced error messaging for failed compaction operations.
  * Improved attachment preview truncation using character-based limits.

* **Documentation**
  * Added integration issue documentation for TUI compaction stability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->