### PR TITLE
fix(tui): remove side borders from transcript detail viewer

### DIFF
--- a/.changeset/fix-detail-view-side-borders.md
+++ b/.changeset/fix-detail-view-side-borders.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Remove the left/right borders from the transcript detail viewer so copying multi-line content no longer captures vertical `|` border characters. The top and bottom borders are retained for the title and footer separation.

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -1188,8 +1188,17 @@ impl Tui {
                 (entries, title)
             };
 
-        // Create block with border and title
-        let block = Block::default().borders(Borders::ALL).title(title.as_str());
+        // Create block with horizontal (top + bottom) borders and a title.
+        //
+        // Left/right borders are intentionally omitted: terminal text selection
+        // of multi-line content would otherwise capture the vertical `|` border
+        // glyphs on every line, polluting copied text (issue #710). Horizontal
+        // borders are kept — the top border anchors the title and the bottom
+        // border separates the content from the footer — without affecting
+        // multi-line copy, since they never appear inside the selected lines.
+        let block = Block::default()
+            .borders(Borders::TOP | Borders::BOTTOM)
+            .title(title.as_str());
 
         // Get inner area for content
         let inner_area = block.inner(chunks[0]);

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -6189,6 +6189,46 @@ async fn test_detail_view_esc_closes_view_and_preserves_focus() {
     );
 }
 
+/// Regression test for issue #710: the detail viewer must not render vertical
+/// `│` side borders, otherwise terminal text selection of multi-line content
+/// captures the border glyphs and pollutes copied text. Top and bottom
+/// horizontal borders are still expected (title anchor + footer separation).
+#[tokio::test]
+async fn test_detail_view_has_no_vertical_side_borders() {
+    let mut harness = TuiTestHarness::with_size(40, 15).await;
+    harness.tui().app.transcript.clear();
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "first line\nsecond line\nthird line".to_string(),
+        seq: Some(1),
+        timestamp: None,
+    });
+    harness.tui().app.transcript_focus = Some(0);
+    harness.tui().app.detail_view_open = true;
+    harness.render();
+
+    let buffer = harness.terminal.backend().buffer();
+    let mut vertical_border_cells = 0;
+    let mut horizontal_border_cells = 0;
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            match buffer[(x, y)].symbol() {
+                "│" | "┌" | "┐" | "└" | "┘" => vertical_border_cells += 1,
+                "─" => horizontal_border_cells += 1,
+                _ => {}
+            }
+        }
+    }
+
+    assert_eq!(
+        vertical_border_cells, 0,
+        "detail view must not render vertical/corner border glyphs (issue #710)"
+    );
+    assert!(
+        horizontal_border_cells > 0,
+        "detail view should still render horizontal (top/bottom) borders"
+    );
+}
+
 #[tokio::test]
 async fn test_detail_view_mutation_shortcuts_work() {
     let mut harness = TuiTestHarness::new().await;

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -6207,10 +6207,20 @@ async fn test_detail_view_has_no_vertical_side_borders() {
     harness.render();
 
     let buffer = harness.terminal.backend().buffer();
+    // Scan only the detail-view region, not the whole buffer, so unrelated UI
+    // chrome can't affect the result. render_detail_view() clears the full
+    // terminal and splits it vertically into the bordered content area
+    // (chunks[0], all rows except the last) plus a single-row footer
+    // (chunks[1], the bottom row). The detail-view block therefore spans the
+    // full width and every row except the footer.
+    let detail_x_min = 0;
+    let detail_x_max = buffer.area.width;
+    let detail_y_min = 0;
+    let detail_y_max = buffer.area.height.saturating_sub(1); // exclude footer row
     let mut vertical_border_cells = 0;
     let mut horizontal_border_cells = 0;
-    for y in 0..buffer.area.height {
-        for x in 0..buffer.area.width {
+    for y in detail_y_min..detail_y_max {
+        for x in detail_x_min..detail_x_max {
             match buffer[(x, y)].symbol() {
                 "│" | "┌" | "┐" | "└" | "┘" => vertical_border_cells += 1,
                 "─" => horizontal_border_cells += 1,


### PR DESCRIPTION
The detail viewer used a full border box, so selecting and copying multi-line content in the terminal captured the vertical | border glyphs on every line, polluting copied text. Switch the block to top+bottom borders only — keeping the title anchor and footer separation while leaving copied multi-line content clean.

Adds a regression test asserting no vertical/corner border glyphs are rendered in the detail view.

Issue: #710
Closes #710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the transcript detail viewer to remove left and right borders, preventing vertical border characters from being included in multi-line copy operations.

* **Tests**
  * Added regression test to verify vertical borders are not rendered in the detail view while horizontal borders are preserved for visual separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->