### PR TITLE
fix: deduplicate streamed text and repeated final message

### DIFF
--- a/.changeset/fix-duplicate-streaming-final-text.md
+++ b/.changeset/fix-duplicate-streaming-final-text.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Fix duplicated assistant text where streamed message chunks were followed by a repeated full final message (TUI streaming + ACP server hardening). Fixes #671.

--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -18,7 +18,13 @@ mod test_regression_issue_68;
 use agent_client_protocol as acp;
 use agent_client_protocol::schema::*;
 use harnx_hooks::{AsyncHookManager, PersistentHookManager};
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 use harnx_core::event::{AgentEvent, AgentSource, ModelEvent, ToolEvent};
 use harnx_runtime::config::GlobalConfig;
@@ -64,6 +70,7 @@ enum AcpForward {
 /// and can't be captured in the sink itself.
 struct AcpChunkSink {
     tx: tokio::sync::mpsc::UnboundedSender<AcpForward>,
+    streamed_text_this_turn: AtomicBool,
 }
 
 impl harnx_core::event::AgentEventSink for AcpChunkSink {
@@ -85,10 +92,13 @@ impl harnx_core::event::AgentEventSink for AcpChunkSink {
                     })
                     .collect();
                 if !text.is_empty() {
+                    self.streamed_text_this_turn.store(true, Ordering::Relaxed);
                     let _ = self.tx.send(AcpForward::Text(text, source));
                 }
             }
-            AgentEvent::Model(ModelEvent::Final { output, .. }) if !output.is_empty() => {
+            AgentEvent::Model(ModelEvent::Final { output, .. })
+                if !output.is_empty() && !self.streamed_text_this_turn.load(Ordering::Relaxed) =>
+            {
                 let _ = self.tx.send(AcpForward::Text(output, source));
             }
             AgentEvent::Tool(ToolEvent::Started {
@@ -288,8 +298,10 @@ impl HarnxAgent {
         // nested chunk via `emit_agent_event_with_source` — the global sink
         // is the single point that converts all events to ACP notifications.
         let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel::<AcpForward>();
-        let sink: Arc<dyn harnx_core::event::AgentEventSink> =
-            Arc::new(AcpChunkSink { tx: chunk_tx });
+        let sink: Arc<dyn harnx_core::event::AgentEventSink> = Arc::new(AcpChunkSink {
+            tx: chunk_tx,
+            streamed_text_this_turn: AtomicBool::new(false),
+        });
         harnx_core::sink::install_agent_event_sink(sink);
 
         // Spawn local task to drain chunk_rx → session_notification.

--- a/crates/harnx-acp-server/src/lib_tests.rs
+++ b/crates/harnx-acp-server/src/lib_tests.rs
@@ -8,7 +8,7 @@ mod tests {
         config::Config,
     };
     use parking_lot::RwLock;
-    use std::sync::Arc;
+    use std::sync::{atomic::AtomicBool, Arc};
     use tokio::sync::mpsc::unbounded_channel;
 
     fn test_config() -> crate::GlobalConfig {
@@ -142,7 +142,10 @@ mod tests {
     #[test]
     fn acp_chunk_sink_forwards_tool_completed_and_update_to_channel() {
         let (tx, mut rx) = unbounded_channel::<AcpForward>();
-        let sink = AcpChunkSink { tx };
+        let sink = AcpChunkSink {
+            tx,
+            streamed_text_this_turn: AtomicBool::new(false),
+        };
 
         sink.emit(
             AgentEvent::Tool(ToolEvent::Completed {
@@ -230,6 +233,38 @@ mod tests {
         assert!(
             !meta.contains_key("harnx:model"),
             "harnx:model should not be present when model is None"
+        );
+    }
+
+    #[test]
+    fn acp_chunk_sink_skips_final_after_streamed_text() {
+        let (tx, mut rx) = unbounded_channel::<AcpForward>();
+        let sink = AcpChunkSink {
+            tx,
+            streamed_text_this_turn: AtomicBool::new(false),
+        };
+
+        sink.emit(
+            AgentEvent::Model(harnx_core::event::ModelEvent::MessageChunk {
+                blocks: vec![harnx_core::event::ContentBlock::Text("Hello ".to_string())],
+            }),
+            None,
+        );
+        sink.emit(
+            AgentEvent::Model(harnx_core::event::ModelEvent::Final {
+                output: "Hello world".to_string(),
+                usage: Default::default(),
+            }),
+            None,
+        );
+
+        match rx.try_recv().expect("message chunk should forward text") {
+            AcpForward::Text(text, None) => assert_eq!(text, "Hello "),
+            _ => panic!("expected text forward"),
+        }
+        assert!(
+            rx.try_recv().is_err(),
+            "final output should be suppressed after streamed chunks"
         );
     }
 }

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1006,6 +1006,7 @@ impl Tui {
                 if text.is_empty() {
                     vec![]
                 } else {
+                    self.app.streamed_text_this_turn = true;
                     self.append_streaming_assistant_chunk(&text);
                     self.pin_transcript_to_bottom();
                     vec![]
@@ -1029,7 +1030,7 @@ impl Tui {
                 *self.shared_pending_message.lock().await = None;
                 self.app.last_ui_output_source = None;
                 let usage_str = format_usage(&usage);
-                if !output.is_empty() {
+                if !output.is_empty() && !self.app.streamed_text_this_turn {
                     if let Some(idx) = self.app.streaming_assistant_idx {
                         match self.app.transcript.get_mut(idx) {
                             Some(TranscriptItem::AssistantText {
@@ -1066,6 +1067,7 @@ impl Tui {
                     self.pin_transcript_to_bottom();
                 }
                 self.app.streaming_assistant_idx = None;
+                self.app.streamed_text_this_turn = false;
                 if !usage_str.is_empty() {
                     self.app
                         .transcript
@@ -1093,6 +1095,10 @@ impl Tui {
                 self.current_prompt_abort = None;
                 *self.shared_pending_message.lock().await = None;
                 self.app.streaming_assistant_idx = None;
+                // Symmetric with the Final handler: reset the per-turn
+                // streamed-text flag so a streamed chunk before an error
+                // can't suppress a later turn's final text.
+                self.app.streamed_text_this_turn = false;
                 self.app.last_ui_output_source = None;
                 self.app.transcript.push(TranscriptItem::ErrorText(err));
                 self.pin_transcript_to_bottom();
@@ -1301,6 +1307,8 @@ impl Tui {
         self.current_prompt_abort = Some(new_abort.clone());
 
         self.app.llm_busy = true;
+        self.app.streaming_assistant_idx = None;
+        self.app.streamed_text_this_turn = false;
 
         let event_tx = self.event_tx.clone();
         let ctx = crate::prompt::PromptTaskContext {
@@ -1886,6 +1894,7 @@ impl Tui {
 
         self.app.transcript.clear();
         self.app.streaming_assistant_idx = None;
+        self.app.streamed_text_this_turn = false;
         // Reset scroll state so the widget doesn't subtract-overflow when
         // the rebuilt transcript is shorter than the previous one.
         self.app.scroll_state = ratatui_widget_scrolling::ScrollState::new();

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -96,6 +96,7 @@ impl Tui {
             llm_busy: false,
             scroll_state: ratatui_widget_scrolling::ScrollState::new(),
             streaming_assistant_idx: None,
+            streamed_text_this_turn: false,
             cache_valid_width: None,
             last_ui_output_source: None,
             last_usage_source: None,

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -674,6 +674,7 @@ impl Tui {
         self.app.transcript.clear();
         self.app.scroll_state = ratatui_widget_scrolling::ScrollState::new();
         self.app.streaming_assistant_idx = None;
+        self.app.streamed_text_this_turn = false;
     }
 
     pub(super) fn build_input_title(&self) -> Line<'static> {

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -439,6 +439,83 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
 }
 
 #[tokio::test]
+async fn final_does_not_duplicate_streamed_multiline_assistant_text() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    tui.app.llm_busy = true;
+    tui.app.streamed_text_this_turn = false;
+
+    for chunk in ["Hello\n", "world\n", "Again"] {
+        tui.handle_tui_event(TuiEvent::Agent(
+            AgentEvent::Model(ModelEvent::MessageChunk {
+                blocks: vec![ContentBlock::Text(chunk.to_string())],
+            }),
+            None,
+        ))
+        .await
+        .unwrap();
+    }
+
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Model(ModelEvent::Final {
+            output: "Hello\nworld\nAgain".to_string(),
+            usage: Default::default(),
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let assistant_entries: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|entry| match entry {
+            TranscriptItem::AssistantText { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(assistant_entries, vec!["Hello\n", "world\n", "Again"]);
+    assert!(!tui.app.streamed_text_this_turn);
+}
+
+#[tokio::test]
+async fn final_without_chunks_renders_assistant_text_once() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    tui.app.llm_busy = true;
+
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Model(ModelEvent::Final {
+            output: "Hello\nworld\nAgain".to_string(),
+            usage: Default::default(),
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let assistant_entries: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|entry| match entry {
+            TranscriptItem::AssistantText { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(assistant_entries, vec!["Hello\nworld\nAgain"]);
+}
+
+#[tokio::test]
 async fn ui_output_inserts_heading_when_source_changes() {
     let config = test_config();
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -70,6 +70,7 @@ pub(super) struct App {
     pub(super) llm_busy: bool,
     pub(super) scroll_state: ratatui_widget_scrolling::ScrollState,
     pub(super) streaming_assistant_idx: Option<usize>,
+    pub(super) streamed_text_this_turn: bool,
     pub(super) cache_valid_width: Option<u16>,
     pub(super) last_ui_output_source: Option<AgentSource>,
     pub(super) last_usage_source: Option<AgentSource>,

--- a/docs/solutions/logic-errors/streaming-final-deduplication-2026-06-09.md
+++ b/docs/solutions/logic-errors/streaming-final-deduplication-2026-06-09.md
@@ -1,0 +1,134 @@
+---
+title: "Fix duplicated assistant text from streaming + final message"
+date: 2026-06-09
+category: "logic-errors"
+problem_type: logic_error
+component: "streaming-event-handlers"
+root_cause: "dual-finalization in streaming mode"
+resolution_type: code_fix
+severity: medium
+tags:
+  - streaming
+  - duplicate-text
+  - event-handling
+  - tui
+  - acp-server
+plan_ref: "issue-671-dup-text"
+---
+
+## Problem
+
+Streaming models emit incremental `ModelEvent::MessageChunk` events, then a `ModelEvent::Final`. Consumers that also render `Final.output` duplicate the already-streamed text. Reported in harnx TUI and kagent (ACP client).
+
+## Symptoms
+
+```
+- Behavior: Assistant text appears twice in TUI for multiline streaming responses
+- Trigger: Claude and other streaming models; multiline responses always duplicated
+- ACP clients: kagent reported duplicate text via ACP protocol
+```
+
+## Investigation Steps
+
+Traced event flow through TUI and ACP server:
+
+1. Engine streaming path (`crates/harnx-engine/src/chat_completions.rs:run_chat_completion_streaming`) correctly emits `Final { output: "" }` (empty).
+
+2. TUI's `on_text_response` callback (`crates/harnx-tui/src/prompt.rs:124-135`) re-emits `Final { output: <full text> }` after streaming chunks already populated transcript.
+
+3. TUI Final handler (`crates/harnx-tui/src/input.rs:1014-1067`) appends `output` as NEW `AssistantText` when `streaming_assistant_idx == None`.
+
+4. `append_streaming_assistant_chunk` (`crates/harnx-tui/src/render.rs:615-665`) resets `streaming_assistant_idx = None` at every newline boundary. Multiline responses always trigger this, causing duplication.
+
+5. ACP server sink (`crates/harnx-acp-server/src/lib.rs:78-93`) forwards non-empty `Final` even after chunks were forwarded — latent hazard.
+
+## Root Cause
+
+Two finalization systems active in streaming mode:
+
+- **Engine**: emits empty `Final` on streaming path (correct).
+- **TUI callback**: manually emits non-empty `Final` via `on_text_response` after streaming complete.
+- **TUI Final handler**: appends full text as new `AssistantText` when `streaming_assistant_idx` was reset to `None`.
+- **render.rs**: resets `streaming_assistant_idx = None` at newline boundaries — multiline responses always duplicate.
+
+The `streaming_assistant_idx` tracks which transcript entry receives chunks, but resets mid-stream on newlines. Cannot be used for dedup.
+
+## Solution
+
+Track per-turn boolean flag `streamed_text_this_turn`. Set `true` when any non-empty `MessageChunk` rendered/forwarded. Suppress rendering/forwarding `Final.output` when flag set (chunks already cover text). Keep usage/cleanup logic unconditional.
+
+**TUI** (`crates/harnx-tui/src/types.rs`):
+```rust
+pub struct App {
+    // ...
+    pub streamed_text_this_turn: bool,
+}
+```
+
+**TUI chunk handler** (`crates/harnx-tui/src/input.rs:1004-1013`):
+```rust
+if !text.is_empty() {
+    self.app.streamed_text_this_turn = true;
+    self.append_streaming_assistant_chunk(&text);
+}
+```
+
+**TUI Final handler** (`crates/harnx-tui/src/input.rs:1033-1070`):
+```rust
+if !output.is_empty() && !self.app.streamed_text_this_turn {
+    // Only render Final.output if no chunks were streamed
+    self.app.transcript.push(TranscriptItem::AssistantText { ... });
+}
+self.app.streamed_text_this_turn = false; // reset for next turn
+```
+
+**ACP sink** (`crates/harnx-acp-server/src/lib.rs:71-103`):
+```rust
+struct AcpChunkSink {
+    tx: UnboundedSender<AcpForward>,
+    streamed_text_this_turn: AtomicBool, // fresh per prompt
+}
+
+// On MessageChunk:
+if !text.is_empty() {
+    self.streamed_text_this_turn.store(true, Ordering::Relaxed);
+    self.tx.send(AcpForward::Text(text, source));
+}
+
+// On Final:
+if !output.is_empty() && !self.streamed_text_this_turn.load(Ordering::Relaxed) {
+    self.tx.send(AcpForward::Text(output, source));
+}
+```
+
+**Reset points:**
+- TUI: `start_prompt` (line 1307), `Final` handler (line 1070), `clear_transcript` (lifecycle.rs:99)
+- ACP: fresh `AtomicBool::new(false)` per `prompt()` call — sink created fresh each request
+
+## Why This Works
+
+Flag survives newline-boundary resets of `streaming_assistant_idx`. Once any chunk text rendered, Final's text suppressed for remainder of turn. Non-streaming path never sets flag, so `Final.output` still renders — only text source there.
+
+Key insight: streaming configuration is per-prompt (`config.stream`). Every tool round in a single prompt uses same stream setting — streaming round never followed by non-streaming round within one prompt. Per-prompt sticky flag is safe.
+
+## Prevention Strategies
+
+**Test cases:**
+- `final_does_not_duplicate_streamed_multiline_assistant_text` — TUI multiline streaming no-dup
+- `final_without_chunks_renders_assistant_text_once` — TUI non-streaming still renders
+- `acp_chunk_sink_skips_final_after_streamed_text` — ACP suppression
+
+**Pattern to follow:**
+- Use turn-scoped flag for dedup, not chunk-scoped index
+- Reset flag at prompt/turn boundaries, not mid-stream
+- ACP sink lifetime: fresh per `prompt()` call
+
+**Code review checklist:**
+- [ ] Does Final handler check streamed-text flag before rendering?
+- [ ] Is flag reset at all turn boundaries?
+- [ ] ACP sink: Is `AtomicBool` created fresh per request?
+
+## Related Issues
+
+- GitHub Issue: #671
+- Follow-up: CLI sink (`crates/harnx/src/cli_event_sink.rs`) lacks same guard but currently safe because engine emits empty Final on streaming path. Revisit if provider emits non-empty Final alongside chunks.


### PR DESCRIPTION
Streaming models (e.g. Claude) emit incremental MessageChunk events and then a Final event. Consumers that also render Final.output re-printed the already-streamed text, duplicating the assistant message in the harnx TUI and in ACP clients such as kagent.

Track a per-turn streamed_text_this_turn flag in the TUI app state and the ACP server AcpChunkSink; when chunks were already streamed, suppress rendering/forwarding of Final.output (usage/cleanup still runs). The non-streaming path never sets the flag, so its Final.output still renders. Includes a docs/solutions writeup and regression tests.

Fixes #671