### PR TITLE
fix(acp): isolate concurrent sub-agent session prompts (#783)

### DIFF
--- a/.changeset/fix-acp-concurrent-session-prompts.md
+++ b/.changeset/fix-acp-concurrent-session-prompts.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+fix(acp): isolate concurrent sub-agent session prompts so they no longer clobber each other's active session or event sink (#783)

--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -18,13 +18,7 @@ mod test_regression_issue_68;
 use agent_client_protocol as acp;
 use agent_client_protocol::schema::*;
 use harnx_hooks::{AsyncHookManager, PersistentHookManager};
-use std::{
-    collections::HashMap,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-};
+use std::{collections::HashMap, sync::Arc};
 
 use harnx_core::event::{AgentEvent, AgentSource, ModelEvent, ToolEvent};
 use harnx_runtime::config::GlobalConfig;
@@ -70,7 +64,6 @@ enum AcpForward {
 /// and can't be captured in the sink itself.
 struct AcpChunkSink {
     tx: tokio::sync::mpsc::UnboundedSender<AcpForward>,
-    streamed_text_this_turn: AtomicBool,
 }
 
 impl harnx_core::event::AgentEventSink for AcpChunkSink {
@@ -92,13 +85,10 @@ impl harnx_core::event::AgentEventSink for AcpChunkSink {
                     })
                     .collect();
                 if !text.is_empty() {
-                    self.streamed_text_this_turn.store(true, Ordering::Relaxed);
                     let _ = self.tx.send(AcpForward::Text(text, source));
                 }
             }
-            AgentEvent::Model(ModelEvent::Final { output, .. })
-                if !output.is_empty() && !self.streamed_text_this_turn.load(Ordering::Relaxed) =>
-            {
+            AgentEvent::Model(ModelEvent::Final { output, .. }) if !output.is_empty() => {
                 let _ = self.tx.send(AcpForward::Text(output, source));
             }
             AgentEvent::Tool(ToolEvent::Started {
@@ -172,6 +162,14 @@ struct HarnxSession {
     /// are only sent while a prompt is active, so this case isn't
     /// exercised by any test.
     cancel_notify: Arc<tokio::sync::Notify>,
+    /// Serializes prompts that target THIS session. Prompts to *different*
+    /// sessions still run fully concurrently (each holds its own lock).
+    /// Without this, two concurrent prompts with the same `session_id` would
+    /// each fork their own in-memory `Session`, independently load the same
+    /// on-disk log, and clobber each other's appends (last-writer-wins). The
+    /// lock makes the load → run → persist cycle for one session atomic with
+    /// respect to other prompts on the same session.
+    prompt_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl HarnxAgent {
@@ -224,10 +222,14 @@ impl HarnxAgent {
                 .expect("session must exist after use_session(None)")
                 .id
                 .clone();
+            config
+                .exit_session()
+                .map_err(|e| acp::Error::new(-32603, format!("Failed to persist session: {e}")))?;
         }
         let session = HarnxSession {
             abort_signal: AbortSignalInner::new(),
             cancel_notify: Arc::new(tokio::sync::Notify::new()),
+            prompt_lock: Arc::new(tokio::sync::Mutex::new(())),
         };
         self.sessions
             .lock()
@@ -245,39 +247,49 @@ impl HarnxAgent {
             .collect::<Vec<_>>()
             .join("\n");
 
-        let (abort_signal, cancel_notify) = {
+        let (abort_signal, cancel_notify, prompt_lock) = {
             let sessions = self.sessions.lock().await;
             let session = sessions
                 .get(session_key.as_str())
                 .ok_or_else(acp::Error::invalid_params)?;
-            session.abort_signal.reset();
-            (session.abort_signal.clone(), session.cancel_notify.clone())
+            (
+                session.abort_signal.clone(),
+                session.cancel_notify.clone(),
+                session.prompt_lock.clone(),
+            )
         };
 
+        // Hold the per-session lock for the whole prompt so two prompts to the
+        // SAME session_id can't fork independent in-memory sessions and clobber
+        // each other's on-disk transcript. The `sessions` map lock above is
+        // already released, so prompts to different sessions never contend
+        // here. Guard is kept alive until the function returns.
+        let _prompt_guard = prompt_lock.lock_owned().await;
+
+        // Reset the abort signal only AFTER winning the per-session lock. If we
+        // reset before acquiring it, a queued same-session prompt could clear a
+        // cancellation that the still-running prompt holding the lock has not
+        // yet observed, effectively un-cancelling it against user intent.
+        abort_signal.reset();
+
+        let prompt_config: GlobalConfig = Arc::new(parking_lot::RwLock::new({
+            let shared_config = self.config.read();
+            shared_config.fork_session_scope()
+        }));
         {
-            let mut config = self.config.write();
-            let active_session_name = config.session.as_ref().map(|s| s.id().to_string());
-            if active_session_name.as_deref() != Some(session_key.as_str()) {
-                if config.session.is_some() {
-                    config.exit_session().map_err(|e| {
-                        acp::Error::new(-32603, format!("Failed to exit session: {e}"))
-                    })?;
-                }
-                config
-                    .use_agent_by_name(&self.agent_name)
-                    .map_err(|e| acp::Error::new(-32603, format!("Failed to set agent: {e}")))?;
-                config
-                    .use_session(Some(&session_key))
-                    .map_err(|e| acp::Error::new(-32603, format!("Failed to use session: {e}")))?;
-            }
+            let mut config = prompt_config.write();
+            config
+                .use_agent_by_name(&self.agent_name)
+                .map_err(|e| acp::Error::new(-32603, format!("Failed to set agent: {e}")))?;
+            config
+                .use_session(Some(&session_key))
+                .map_err(|e| acp::Error::new(-32603, format!("Failed to use session: {e}")))?;
         }
 
-        // Build a fresh agent for the input.  The agent is also stored on
-        // the config (via `use_agent_by_name` above) which is what carries
-        // session/shared variables; this local copy is used to expand system
-        // prompt variables like {{__os__}} via `set_agent`.
-        let mut agent = self
-            .config
+        // Build a fresh agent for the input. The forked prompt config keeps
+        // per-request session state isolated while still sharing Arc-backed
+        // runtime resources cloned from the base config.
+        let mut agent = prompt_config
             .read()
             .retrieve_agent(&self.agent_name)
             .map_err(|e| acp::Error::new(-32603, format!("Failed to retrieve agent: {e}")))?;
@@ -288,21 +300,17 @@ impl HarnxAgent {
             );
         }
 
-        let mut input = harnx_runtime::config::input::from_str(&self.config, &prompt_text, None);
-        harnx_runtime::config::input::set_agent(&mut input, &self.config, agent.into_config());
+        let mut input = harnx_runtime::config::input::from_str(&prompt_config, &prompt_text, None);
+        harnx_runtime::config::input::set_agent(&mut input, &prompt_config, agent.into_config());
 
-        // Install an AgentEventSink for streaming chunks (MessageChunk events)
-        // and tool calls (ToolEvent::Started). Nested ACP activity from
-        // sub-agent delegations also flows through this sink because
-        // `AcpManager::call_tool` registers a forwarder that re-emits each
-        // nested chunk via `emit_agent_event_with_source` — the global sink
-        // is the single point that converts all events to ACP notifications.
+        // Install a per-prompt AgentEventSink for streaming chunks
+        // (MessageChunk events) and tool calls (ToolEvent::Started).
+        // Nested ACP activity from sub-agent delegations also flows through
+        // this sink because `AcpManager::call_tool` captures and reinstalls
+        // the current task-local sink inside its spawned forwarder task.
         let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel::<AcpForward>();
-        let sink: Arc<dyn harnx_core::event::AgentEventSink> = Arc::new(AcpChunkSink {
-            tx: chunk_tx,
-            streamed_text_this_turn: AtomicBool::new(false),
-        });
-        harnx_core::sink::install_agent_event_sink(sink);
+        let sink: Arc<dyn harnx_core::event::AgentEventSink> =
+            Arc::new(AcpChunkSink { tx: chunk_tx });
 
         // Spawn local task to drain chunk_rx → session_notification.
         let connection_for_fwd = self.connection.lock().await.clone();
@@ -497,7 +505,7 @@ impl HarnxAgent {
         // parent's transcript would render the assistant's reply twice.
 
         let loop_ctx = harnx_runtime::AgentLoopContext {
-            config: self.config.clone(),
+            config: prompt_config.clone(),
             abort_signal: abort_signal.clone(),
             async_manager: Arc::new(tokio::sync::Mutex::new(AsyncHookManager::default())),
             persistent_manager: Arc::new(tokio::sync::Mutex::new(PersistentHookManager::default())),
@@ -542,18 +550,34 @@ impl HarnxAgent {
             tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         };
 
-        let loop_result = tokio::select! {
-            r = harnx_runtime::run_agent_loop(&loop_ctx, input) => r,
-            _ = grace_cancel => {
-                cancel_listener.abort();
-                harnx_core::sink::clear_agent_event_sink();
-                fwd_task.abort();
-                return Ok(PromptResponse::new(StopReason::Cancelled));
+        // Scope the per-prompt event sink to this prompt's task tree so
+        // concurrent prompts to the same agent never clobber each other's
+        // streaming output. The scope wraps the whole select! (including the
+        // grace-cancel arm) so any chunks emitted up to the cancellation
+        // point still route to this prompt's sink. `loop_result` is
+        // `Option<Result<()>>`: `None` means the grace-cancel arm won, a
+        // `Some` carries the agent loop's own result.
+        let loop_result = harnx_core::sink::with_agent_event_sink(sink, async {
+            // Box the agent-loop future before racing it. `run_agent_loop`
+            // produces a very large future; embedding it inline in `select!`
+            // (which itself lives inside the prompt future + LocalSet frames)
+            // can overflow the thread stack before the first poll. Pinning it
+            // on the heap keeps the synchronous stack frame small.
+            let mut run_loop = Box::pin(harnx_runtime::run_agent_loop(&loop_ctx, input));
+            tokio::select! {
+                r = &mut run_loop => Some(r),
+                _ = grace_cancel => None,
             }
+        })
+        .await;
+
+        let Some(loop_result) = loop_result else {
+            cancel_listener.abort();
+            fwd_task.abort();
+            return Ok(PromptResponse::new(StopReason::Cancelled));
         };
 
         cancel_listener.abort();
-        harnx_core::sink::clear_agent_event_sink();
         // Drop loop_ctx so all senders into chunk_rx are dropped and
         // fwd_task can exit cleanly.
         drop(loop_ctx);

--- a/crates/harnx-acp-server/src/lib_tests.rs
+++ b/crates/harnx-acp-server/src/lib_tests.rs
@@ -1,14 +1,17 @@
 #[cfg(test)]
 mod tests {
     use crate::{AcpChunkSink, AcpForward, HarnxAgent};
-    use agent_client_protocol::schema::{CancelNotification, NewSessionRequest};
+    use agent_client_protocol::schema::{
+        CancelNotification, ContentBlock, NewSessionRequest, PromptRequest, PromptResponse,
+    };
     use harnx_core::event::{AgentEvent, AgentEventSink, ToolEvent, ToolStatus};
     use harnx_runtime::{
         client::{ClientConfig, ModelType, TestStateGuard},
         config::Config,
+        test_utils::{MockClient, MockTurnBuilder},
     };
     use parking_lot::RwLock;
-    use std::sync::{atomic::AtomicBool, Arc};
+    use std::sync::Arc;
     use tokio::sync::mpsc::unbounded_channel;
 
     fn test_config() -> crate::GlobalConfig {
@@ -34,6 +37,8 @@ mod tests {
         )
         .expect("load test model");
         config.save_session = Some(true);
+        let sessions_dir = tempfile::tempdir().expect("create sessions dir");
+        config.sessions_dir_override = Some(sessions_dir.keep());
 
         Arc::new(RwLock::new(config))
     }
@@ -118,6 +123,177 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// A created session bound to its agent and on-disk log location. Holding
+    /// the agent handle, id, and log path as typed fields keeps the per-call
+    /// helpers from taking a pile of bare `&str` arguments.
+    struct TestSession {
+        agent: Arc<HarnxAgent>,
+        id: String,
+        log_path: std::path::PathBuf,
+    }
+
+    impl TestSession {
+        /// Create a fresh session on `agent`.
+        async fn create(agent: &Arc<HarnxAgent>, sessions_dir: &std::path::Path) -> Self {
+            let cwd = std::env::current_dir().expect("current dir");
+            let id = agent
+                .new_session(NewSessionRequest::new(cwd))
+                .await
+                .expect("create session")
+                .session_id
+                .0
+                .to_string();
+            let log_path = sessions_dir.join(format!("{id}.yaml"));
+            Self {
+                agent: Arc::clone(agent),
+                id,
+                log_path,
+            }
+        }
+
+        /// Drive a prompt against this session.
+        async fn prompt(&self, text: &str) -> agent_client_protocol::Result<PromptResponse> {
+            let request = PromptRequest::new(
+                agent_client_protocol::schema::SessionId::new(self.id.clone()),
+                vec![ContentBlock::from(text.to_string())],
+            );
+            self.agent.prompt(request).await
+        }
+
+        /// Read the log via async I/O so we never block a runtime worker thread
+        /// inside a `#[tokio::test]`.
+        async fn read_log(&self) -> String {
+            tokio::fs::read_to_string(&self.log_path)
+                .await
+                .unwrap_or_else(|e| {
+                    panic!("read session log {} failed: {e}", self.log_path.display())
+                })
+        }
+
+        /// Assert the log is present, non-empty, free of the pending-result
+        /// placeholder, and contains the prompt text it was driven with.
+        async fn assert_intact(&self, expected_prompt: &str) {
+            let log = self.read_log().await;
+            assert!(!log.is_empty(), "session log empty: {}", self.id);
+            assert!(
+                !log.contains("tool response pending"),
+                "placeholder leaked into {}: {log}",
+                self.id
+            );
+            assert!(
+                log.contains(expected_prompt),
+                "session {} lost own prompt {expected_prompt:?}: {log}",
+                self.id
+            );
+        }
+    }
+
+    // Use the multi-thread flavor (as every other `run_agent_loop`-driving
+    // test does): on a current-thread runtime the test future, the inner
+    // `LocalSet`, and the entire agent loop run on one stack frame and
+    // overflow the default 2 MiB thread stack. `spawn_local` inside the
+    // prompt path still works because the body runs under `LocalSet::run_until`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_concurrent_prompts_isolate_session_scope_and_sink() {
+        let (_temp, _path) = setup_agent_env("test");
+        let config = test_config();
+        let sessions_dir = config
+            .read()
+            .sessions_dir_override
+            .clone()
+            .expect("sessions dir override");
+        let mock = Arc::new(
+            MockClient::builder()
+                .add_turn(MockTurnBuilder::new().add_text_chunk("reply one").build())
+                .add_turn(MockTurnBuilder::new().add_text_chunk("reply two").build())
+                .add_turn(MockTurnBuilder::new().add_text_chunk("reply three").build())
+                .build(),
+        );
+        let _guard = TestStateGuard::new(Some(mock)).await;
+        let agent = Arc::new(HarnxAgent::new("test".to_string(), config.clone()));
+
+        let s1 = TestSession::create(&agent, &sessions_dir).await;
+        let s2 = TestSession::create(&agent, &sessions_dir).await;
+        let s3 = TestSession::create(&agent, &sessions_dir).await;
+
+        let local = tokio::task::LocalSet::new();
+        let (resp1, resp2, resp3) = local
+            .run_until(async {
+                tokio::join!(
+                    s1.prompt("alpha prompt"),
+                    s2.prompt("beta prompt"),
+                    s3.prompt("gamma prompt")
+                )
+            })
+            .await;
+
+        for response in [resp1, resp2, resp3] {
+            assert_eq!(
+                response.expect("prompt should succeed").stop_reason,
+                agent_client_protocol::schema::StopReason::EndTurn
+            );
+        }
+
+        // Each session's log is intact and carries only its own prompt — no
+        // cross-talk from the concurrently-running siblings.
+        s1.assert_intact("alpha prompt").await;
+        s2.assert_intact("beta prompt").await;
+        s3.assert_intact("gamma prompt").await;
+    }
+
+    // Two concurrent prompts to the SAME session_id must serialize on the
+    // per-session `prompt_lock` so neither clobbers the other's on-disk
+    // transcript. Both prompt texts must survive in the single session log.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_same_session_concurrent_prompts_do_not_clobber_log() {
+        let (_temp, _path) = setup_agent_env("test");
+        let config = test_config();
+        let sessions_dir = config
+            .read()
+            .sessions_dir_override
+            .clone()
+            .expect("sessions dir override");
+        let mock = Arc::new(
+            MockClient::builder()
+                .add_turn(MockTurnBuilder::new().add_text_chunk("reply one").build())
+                .add_turn(MockTurnBuilder::new().add_text_chunk("reply two").build())
+                .build(),
+        );
+        let _guard = TestStateGuard::new(Some(mock)).await;
+        let agent = Arc::new(HarnxAgent::new("test".to_string(), config.clone()));
+
+        let session = TestSession::create(&agent, &sessions_dir).await;
+
+        let local = tokio::task::LocalSet::new();
+        let (resp1, resp2) = local
+            .run_until(async {
+                tokio::join!(
+                    session.prompt("first message"),
+                    session.prompt("second message"),
+                )
+            })
+            .await;
+        resp1.expect("first prompt should succeed");
+        resp2.expect("second prompt should succeed");
+
+        // Both prompts must survive in the single session log — last-writer-wins
+        // clobbering would drop one of them.
+        let log = session.read_log().await;
+        assert!(!log.is_empty(), "session log empty");
+        assert!(
+            !log.contains("tool response pending"),
+            "placeholder leaked: {log}"
+        );
+        assert!(
+            log.contains("first message"),
+            "first prompt clobbered: {log}"
+        );
+        assert!(
+            log.contains("second message"),
+            "second prompt clobbered: {log}"
+        );
+    }
+
     #[tokio::test]
     async fn test_initialize_echoes_protocol_version_and_reports_capabilities() {
         use agent_client_protocol::schema::{InitializeRequest, ProtocolVersion};
@@ -142,10 +318,7 @@ mod tests {
     #[test]
     fn acp_chunk_sink_forwards_tool_completed_and_update_to_channel() {
         let (tx, mut rx) = unbounded_channel::<AcpForward>();
-        let sink = AcpChunkSink {
-            tx,
-            streamed_text_this_turn: AtomicBool::new(false),
-        };
+        let sink = AcpChunkSink { tx };
 
         sink.emit(
             AgentEvent::Tool(ToolEvent::Completed {
@@ -233,38 +406,6 @@ mod tests {
         assert!(
             !meta.contains_key("harnx:model"),
             "harnx:model should not be present when model is None"
-        );
-    }
-
-    #[test]
-    fn acp_chunk_sink_skips_final_after_streamed_text() {
-        let (tx, mut rx) = unbounded_channel::<AcpForward>();
-        let sink = AcpChunkSink {
-            tx,
-            streamed_text_this_turn: AtomicBool::new(false),
-        };
-
-        sink.emit(
-            AgentEvent::Model(harnx_core::event::ModelEvent::MessageChunk {
-                blocks: vec![harnx_core::event::ContentBlock::Text("Hello ".to_string())],
-            }),
-            None,
-        );
-        sink.emit(
-            AgentEvent::Model(harnx_core::event::ModelEvent::Final {
-                output: "Hello world".to_string(),
-                usage: Default::default(),
-            }),
-            None,
-        );
-
-        match rx.try_recv().expect("message chunk should forward text") {
-            AcpForward::Text(text, None) => assert_eq!(text, "Hello "),
-            _ => panic!("expected text forward"),
-        }
-        assert!(
-            rx.try_recv().is_err(),
-            "final output should be suppressed after streamed chunks"
         );
     }
 }

--- a/crates/harnx-acp/src/manager.rs
+++ b/crates/harnx-acp/src/manager.rs
@@ -500,7 +500,18 @@ impl ToolProvider for AcpManager {
         // Forward chunks either to TUI output sink or stdout.
         let spinner_clone = spinner.clone();
         let spinner_msg = format!("  {} working…", tool_name);
-        let forward_handle = tokio::spawn(forward_acp_chunks(chunk_rx, spinner_clone, spinner_msg));
+        let captured_sink = harnx_core::sink::current_agent_event_sink();
+        let forward_handle = if let Some(sink) = captured_sink {
+            tokio::spawn(async move {
+                harnx_core::sink::with_agent_event_sink(
+                    sink,
+                    forward_acp_chunks(chunk_rx, spinner_clone, spinner_msg),
+                )
+                .await
+            })
+        } else {
+            tokio::spawn(forward_acp_chunks(chunk_rx, spinner_clone, spinner_msg))
+        };
 
         // Plumb the AbortSignal into the inner dispatcher so a TUI Ctrl-C
         // — which never reaches us as SIGINT because crossterm captures

--- a/crates/harnx-core/src/sink.rs
+++ b/crates/harnx-core/src/sink.rs
@@ -16,10 +16,15 @@
 //! events fall through to ad-hoc `eprintln!` fallbacks and never reach
 //! the TUI transcript (issue #391).
 
+use std::future::Future;
 use std::sync::Arc;
 use std::sync::Mutex;
 
 use crate::event::{AgentEvent, AgentEventSink, AgentSource};
+
+tokio::task_local! {
+    static SCOPED_SINK: Arc<dyn AgentEventSink>;
+}
 
 /// Cap on the pre-install buffer. Large enough to capture a handful of
 /// startup warnings (one per misconfigured MCP server, plus a few
@@ -62,10 +67,24 @@ pub fn install_agent_event_sink(sink: Arc<dyn AgentEventSink>) {
 }
 
 pub fn has_agent_event_sink() -> bool {
+    if SCOPED_SINK.try_with(|_| ()).is_ok() {
+        return true;
+    }
     let guard = AGENT_EVENT_SINK
         .lock()
         .expect("AGENT_EVENT_SINK mutex poisoned");
     guard.sink.is_some()
+}
+
+pub async fn with_agent_event_sink<F, T>(sink: Arc<dyn AgentEventSink>, fut: F) -> T
+where
+    F: Future<Output = T>,
+{
+    SCOPED_SINK.scope(sink, fut).await
+}
+
+pub fn current_agent_event_sink() -> Option<Arc<dyn AgentEventSink>> {
+    SCOPED_SINK.try_with(|sink| sink.clone()).ok()
 }
 
 pub fn emit_agent_event(event: AgentEvent) -> bool {
@@ -73,6 +92,12 @@ pub fn emit_agent_event(event: AgentEvent) -> bool {
 }
 
 pub fn emit_agent_event_with_source(event: AgentEvent, source: Option<AgentSource>) -> bool {
+    if SCOPED_SINK
+        .try_with(|sink| sink.emit(event.clone(), source.clone()))
+        .is_ok()
+    {
+        return true;
+    }
     let sink = {
         let mut guard = AGENT_EVENT_SINK
             .lock()

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -313,6 +313,54 @@ impl Clone for Config {
     }
 }
 
+impl Config {
+    /// Build an isolated copy of this config for running a single prompt in
+    /// its own session, without disturbing the original.
+    ///
+    /// SHARED (cheap `Arc`/value clones — the fork sees the same underlying
+    /// runtime resources): `mcp_manager`, `acp_manager`, `rag`,
+    /// `model_cooldowns`, plus config data, clients, model, tools, agent, and
+    /// all flags/overrides.
+    ///
+    /// ISOLATED / RESET: `session` is `None` so the caller can attach its own
+    /// session (via `use_session`) without racing the source config's active
+    /// session. The two `tui_*_editor` hooks are dropped to `None` — they are
+    /// non-`Clone` `FnMut` trait objects and the ACP server prompt path never
+    /// invokes interactive editor hooks, so dropping them is both safe and
+    /// required.
+    pub fn fork_session_scope(&self) -> Config {
+        Config {
+            data: self.data.clone(),
+            clients: self.clients.clone(),
+            mcp_servers: self.mcp_servers.clone(),
+            acp_servers: self.acp_servers.clone(),
+            model_cooldowns: self.model_cooldowns.clone(),
+            macro_flag: self.macro_flag,
+            info_flag: self.info_flag,
+            show_sequence_numbers: self.show_sequence_numbers,
+            show_timestamps: self.show_timestamps,
+            agent_variables: self.agent_variables.clone(),
+            mcp_root: self.mcp_root.clone(),
+            model: self.model.clone(),
+            tools: self.tools.clone(),
+            mcp_manager: self.mcp_manager.clone(),
+            acp_manager: self.acp_manager.clone(),
+            working_mode: self.working_mode.clone(),
+            last_message: self.last_message.clone(),
+            session: None,
+            rag: self.rag.clone(),
+            agent: self.agent.clone(),
+            // ACP server prompt path never invokes editor hooks. Drop them so
+            // forked prompt configs can own isolated session state without
+            // trying to clone `FnMut` trait objects.
+            tui_before_editor: None,
+            tui_after_editor: None,
+            sessions_dir_override: self.sessions_dir_override.clone(),
+            temp_dir_override: self.temp_dir_override.clone(),
+        }
+    }
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {

--- a/docs/solutions/logic-errors/concurrent-session-prompt-isolation-2026-06-09.md
+++ b/docs/solutions/logic-errors/concurrent-session-prompt-isolation-2026-06-09.md
@@ -1,0 +1,237 @@
+---
+title: "Isolating concurrent prompts in a single-connection ACP sub-agent server"
+date: 2026-06-09
+category: logic-errors
+problem_type: logic_error
+component: harnx-acp-server
+root_cause: "shared global session state and process-global event sink mutated by concurrent prompts"
+resolution_type: code_fix
+severity: high
+tags:
+  - acp
+  - concurrency
+  - session-isolation
+  - task-local
+  - sub-agent
+  - cancellation
+plan_ref: concurrent-subagent-delegations
+---
+
+## Problem
+
+Concurrent `*_session_prompt` delegations to the same ACP sub-agent server process corrupted session state, producing empty responses, 0-byte session log files, and orphaned `"tool response pending (results not yet persisted)"` placeholders. Two of three concurrent sub-agent session files were 0 bytes.
+
+## Symptoms
+
+```
+# Parent agent dispatches concurrent prompts to same sub-agent:
+#   urania_session_prompt [session-alpha]
+#   urania_session_prompt [session-beta]
+#   urania_session_prompt [session-gamma]
+
+# Expected: each session log contains its own prompt + response
+# Actual:
+#   - session-alpha.yaml: correct content
+#   - session-beta.yaml: 0 bytes
+#   - session-gamma.yaml: 0 bytes
+#   - responses: one correct, two empty strings
+#   - orphaned placeholders: "tool response pending (results not yet persisted)"
+```
+
+- Frequency: 100% reproducible with 2+ concurrent prompts to same `HarnxAgent`
+- Session logs (`.yaml` files) either empty or missing expected prompt text
+- Streaming chunks lost; responses empty despite successful tool execution
+
+## Investigation Steps
+
+1. Traced `HarnxAgent::prompt` in `lib.rs`:
+   - Each prompt called `config.exit_session()` + `config.use_session(Some(key))` on shared `GlobalConfig = Arc<RwLock<Config>>`
+   - `Config.session: Option<Session>` is a single mutable slot
+   - Concurrent prompt B switching `config.session` mid-loop corrupted prompt A's state
+
+2. Found process-global event sink:
+   - There is a single global `AGENT_EVENT_SINK`. `install_agent_event_sink`
+     overwrites it with the new sink (and replays any buffered pending events to
+     it); `clear_agent_event_sink` removes the installed sink and drops buffered
+     events.
+   - With one global slot, concurrent prompt B's `install` replaces the sink
+     prompt A installed. From that point A's streaming chunks route to B's sink
+     (or are dropped once B's prompt finishes and clears the slot) — so A's
+     output is lost/misrouted.
+
+3. Observed same-session race:
+   - Even with per-prompt config forks, two prompts to the SAME `session_id` independently load/write the same on-disk `.yaml` transcript
+   - Last-writer-wins clobber; one prompt's content lost
+
+4. Hit stack overflow during fix:
+   - `run_agent_loop` future is very large; inlined in `select!` arm overflowed thread stack before first poll
+   - Looked like infinite recursion but wasn't (verified via zosimus)
+
+## Root Cause
+
+Two shared-state assumptions that only one prompt runs at a time per `HarnxAgent`:
+
+1. **Shared active session**: `Config.session` is a single `Option<Session>` on `GlobalConfig`. Each prompt mutated it (`exit_session` + `use_session`). Concurrent prompts switched it out from under each other, causing wrong/no-session persistence.
+
+2. **Process-global event sink**: `harnx_core::sink::install/clear_agent_event_sink` overwrote a single global sink. Concurrent prompts lost each other's streaming chunks.
+
+3. **Same-session file race**: After fixing isolation, two concurrent prompts to SAME session_id still clobbered the shared `.yaml` file via independent loads/writes.
+
+## Solution
+
+### 1. Config::fork_session_scope()
+
+Per-prompt config clone that shares Arc-backed resources but resets `session=None`:
+
+```rust
+// crates/harnx-runtime/src/config/mod.rs
+pub fn fork_session_scope(&self) -> Config {
+    Config {
+        data: self.data.clone(),
+        mcp_manager: self.mcp_manager.clone(),    // Arc — shared
+        acp_manager: self.acp_manager.clone(),    // Arc — shared
+        rag: self.rag.clone(),                    // Arc — shared
+        model_cooldowns: self.model_cooldowns.clone(), // Arc — shared
+        session: None,                            // ISOLATED — reset
+        tui_before_editor: None,                  // Dropped — non-Clone
+        tui_after_editor: None,                   // Dropped — non-Clone
+        // ... other fields cloned or shared
+    }
+}
+```
+
+Each prompt runs against its own forked `GlobalConfig`:
+```rust
+let prompt_config: GlobalConfig = Arc::new(parking_lot::RwLock::new({
+    let shared_config = self.config.read();
+    shared_config.fork_session_scope()
+}));
+config.use_session(Some(&session_key))?;  // Mutates fork, not shared
+```
+
+### 2. Task-local event sink with nested-subagent propagation
+
+```rust
+// crates/harnx-core/src/sink.rs
+tokio::task_local! {
+    static SCOPED_SINK: Arc<dyn AgentEventSink>;
+}
+
+pub fn has_agent_event_sink() -> bool {
+    // `AGENT_EVENT_SINK` is the existing process-global registry
+    // (a `Mutex<SinkState>` whose `.sink` field holds the installed sink).
+    SCOPED_SINK.try_with(|_| ()).is_ok() || AGENT_EVENT_SINK.lock().unwrap().sink.is_some()
+}
+
+pub async fn with_agent_event_sink<F: Future>(
+    sink: Arc<dyn AgentEventSink>,
+    fut: F,
+) -> F::Output {
+    SCOPED_SINK.scope(sink, fut).await
+}
+
+// Returns only the task-local sink (used to re-establish it across a
+// `tokio::spawn` boundary). The global registry is the fallback inside
+// `emit_agent_event_with_source`, not here.
+pub fn current_agent_event_sink() -> Option<Arc<dyn AgentEventSink>> {
+    SCOPED_SINK.try_with(|sink| sink.clone()).ok()
+}
+```
+
+Each prompt wraps its agent loop:
+```rust
+// crates/harnx-acp-server/src/lib.rs
+let loop_result = harnx_core::sink::with_agent_event_sink(sink, async {
+    let mut run_loop = Box::pin(harnx_runtime::run_agent_loop(&loop_ctx, input));
+    tokio::select! {
+        r = &mut run_loop => Some(r),
+        _ = grace_cancel => None,
+    }
+}).await;
+```
+
+**Pitfall**: task-locals don't cross `tokio::spawn`. Nested-sub-agent chunk forwarder must re-scope:
+
+```rust
+// crates/harnx-acp/src/manager.rs
+let captured_sink = harnx_core::sink::current_agent_event_sink();
+let forward_handle = if let Some(sink) = captured_sink {
+    tokio::spawn(async move {
+        harnx_core::sink::with_agent_event_sink(
+            sink,
+            forward_acp_chunks(chunk_rx, spinner, msg),
+        ).await
+    })
+} else {
+    tokio::spawn(forward_acp_chunks(chunk_rx, spinner, msg))
+};
+```
+
+### 3. Per-session lock for same-session serialization
+
+```rust
+// crates/harnx-acp-server/src/lib.rs
+struct HarnxSession {
+    abort_signal: AbortSignalInner,
+    cancel_notify: Arc<tokio::sync::Notify>,
+    /// Serializes prompts targeting THIS session.
+    /// Different sessions run fully concurrently (own locks).
+    prompt_lock: Arc<tokio::sync::Mutex<()>>,
+}
+```
+
+Lock acquisition pattern:
+```rust
+let (abort_signal, cancel_notify, prompt_lock) = {
+    let sessions = self.sessions.lock().await;
+    let session = sessions.get(session_key.as_str())?;
+    (session.abort_signal.clone(), session.cancel_notify.clone(), session.prompt_lock.clone())
+};  // RELEASE sessions map lock FIRST
+
+let _prompt_guard = prompt_lock.lock_owned().await;  // THEN await per-session lock
+abort_signal.reset();  // RESET signal AFTER acquiring lock, not before
+```
+
+**Ordering critical**: if `abort_signal.reset()` runs before acquiring `prompt_lock`, a queued same-session prompt can clear a cancellation the running prompt hasn't observed.
+
+### 4. Box::pin the agent loop future
+
+```rust
+// Embedding run_agent_loop inline in select! overflows stack
+let mut run_loop = Box::pin(harnx_runtime::run_agent_loop(&loop_ctx, input));
+tokio::select! {
+    r = &mut run_loop => Some(r),
+    _ = grace_cancel => None,
+}
+```
+
+## Why This Works
+
+- **Forked config**: Each prompt owns its session slot; no cross-prompt mutation
+- **Task-local sink**: Each prompt's task tree resolves its own sink; chunks never lost to concurrent installs
+- **Nested-subagent re-scoping**: Events from nested ACP calls route through parent's scoped sink
+- **Per-session lock**: Same-session prompts serialize on-disk writes; different sessions stay concurrent
+- **Cancellation ordering**: Abort signal reset only after lock acquisition preserves cancel semantics
+
+## Prevention Strategies
+
+**Test Cases:**
+- `test_concurrent_prompts_isolate_session_scope_and_sink`: 3 concurrent prompts to DIFFERENT sessions; assert non-empty logs, own prompt text, no placeholders
+- `test_same_session_concurrent_prompts_do_not_clobber_log`: 2 concurrent prompts to SAME session_id; assert BOTH prompts survive in single `.yaml` log
+
+**Testing mechanics:**
+- Use `#[tokio::test(flavor = "multi_thread")]` + inner `LocalSet::run_until` (prompt path uses `spawn_local`)
+- Session logs are `.yaml`, not `.md`
+- Use `MockClient`/`TestStateGuard` + `sessions_dir_override` for deterministic, isolated runs
+
+**Code Review Checklist:**
+- [ ] Does shared state assume single-threaded access?
+- [ ] Do task-locals cross `tokio::spawn` boundaries?
+- [ ] Are locks acquired in consistent order (map lock released before per-session lock awaited)?
+- [ ] Is cancellation reset after lock acquisition, not before?
+- [ ] Are large futures `Box::pin`ned before racing in `select!`?
+
+## Related Issues
+
+- Issue #783 — concurrent delegations to same sub-agent
+- [scoped-subscription-parallel-subagents-2026-05-01.md](./scoped-subscription-parallel-subagents-2026-05-01.md) — related ACP concurrency issue (different root cause)


### PR DESCRIPTION
Isolates concurrent sub-agent session prompts by addressing shared-state races in the ACP server. Previously, concurrent prompts to a single agent would mutate a shared Config.session and overwrite a process-global event sink, causing session corruption and lost streaming chunks.

Key changes:
- Implement Config::fork_session_scope to create per-prompt config forks that share Arc resources but isolate session state.
- Replace the process-global AGENT_EVENT_SINK with a task-local SCOPED_SINK.
- Ensure the sub-agent chunk forwarder in harnx-acp re-scopes the captured sink to maintain isolation across tokio::spawn boundaries.
- Add a per-session prompt_lock in HarnxSession to serialize concurrent prompts to the same session ID, preventing race conditions on persisted logs.
- Use Box::pin for the agent-loop future to prevent stack overflow in select! blocks.

Includes a regression test in harnx-acp-server, a changeset, and a detailed solution document.

Plan: concurrent-subagent-delegations

Closes #783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed concurrent session prompt isolation to prevent prompts from corrupting each other's session logs and streaming output.
- Improved reliability of session transcripts when executing multiple prompts in parallel across different or identical sessions.
- Resolved issues with missing or incomplete prompt content in session logs during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->