### PR TITLE
fix(runtime): resolve package-relative agent delegation naming

### DIFF
--- a/.changeset/package-agent-delegation-resolution.md
+++ b/.changeset/package-agent-delegation-resolution.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Fix package-relative agent resolution for delegation tools (`_session_prompt`, etc.); tool names now match the slash-free, package-relative scheme used for handoffs. Fixes #709.

--- a/crates/harnx-acp/src/manager.rs
+++ b/crates/harnx-acp/src/manager.rs
@@ -745,6 +745,104 @@ enabled: false
     }
 
     #[test]
+    fn test_generate_acp_tools_namespaced_server_name_is_slash_free() {
+        let tools = generate_acp_tools("other__helper");
+        let tool_names: Vec<_> = tools.iter().map(|tool| tool.name.as_str()).collect();
+
+        assert_eq!(
+            tool_names,
+            vec![
+                "other__helper_session_new",
+                "other__helper_session_prompt",
+                "other__helper_session_load",
+                "other__helper_session_cancel",
+            ]
+        );
+        assert!(tool_names.iter().all(|name| !name.contains('/')));
+    }
+
+    #[test]
+    fn test_find_client_for_tool_round_trips_namespaced_server_methods() {
+        let manager = AcpManager::new();
+        manager.initialize(vec![test_config("other__helper")]);
+
+        for expected_method in [
+            "session_new",
+            "session_prompt",
+            "session_load",
+            "session_cancel",
+        ] {
+            let tool_name = format!("other__helper_{expected_method}");
+            let (client, method) = manager
+                .find_client_for_tool(&tool_name)
+                .expect("matched client for namespaced tool");
+            assert_eq!(client.name(), "other__helper");
+            assert_eq!(method, expected_method);
+        }
+    }
+
+    #[test]
+    fn test_generate_acp_tools_global_server_name_round_trips() {
+        let tools = generate_acp_tools("__global");
+        let tool_names: Vec<_> = tools.iter().map(|tool| tool.name.as_str()).collect();
+
+        assert_eq!(
+            tool_names,
+            vec![
+                "__global_session_new",
+                "__global_session_prompt",
+                "__global_session_load",
+                "__global_session_cancel",
+            ]
+        );
+        assert!(tool_names.iter().all(|name| !name.contains('/')));
+
+        let manager = AcpManager::new();
+        manager.initialize(vec![test_config("__global")]);
+
+        let (client, method) = manager
+            .find_client_for_tool("__global_session_prompt")
+            .expect("matched client for global tool");
+        assert_eq!(client.name(), "__global");
+        assert_eq!(method, "session_prompt");
+    }
+
+    #[test]
+    fn test_find_client_for_tool_round_trips_server_name_with_underscore() {
+        let tools = generate_acp_tools("my_agent");
+        let tool_names: Vec<_> = tools.iter().map(|tool| tool.name.as_str()).collect();
+        assert_eq!(
+            tool_names,
+            vec![
+                "my_agent_session_new",
+                "my_agent_session_prompt",
+                "my_agent_session_load",
+                "my_agent_session_cancel",
+            ]
+        );
+        assert!(tool_names.iter().all(|name| !name.contains('/')));
+
+        let manager = AcpManager::new();
+        manager.initialize(vec![test_config("my_agent")]);
+
+        let (client, method) = manager
+            .find_client_for_tool("my_agent_session_prompt")
+            .expect("matched client for underscore tool");
+        assert_eq!(client.name(), "my_agent");
+        assert_eq!(method, "session_prompt");
+    }
+
+    #[test]
+    fn test_find_client_for_tool_rejects_unknown_namespaced_method() {
+        let manager = AcpManager::new();
+        manager.initialize(vec![test_config("other__helper")]);
+
+        assert!(manager
+            .find_client_for_tool("other__helper_session_bogus")
+            .is_none());
+    }
+
+    #[test]
     fn test_find_client_for_tool_no_match() {
         let manager = AcpManager::new();
         manager.initialize(vec![]);

--- a/crates/harnx-runtime/src/config/patches_split.rs
+++ b/crates/harnx-runtime/src/config/patches_split.rs
@@ -2,6 +2,7 @@
 use crate::client::ClientConfig;
 use anyhow::{Context, Result};
 use harnx_acp::AcpServerConfig;
+use harnx_core::package_namespace::{handoff_display_name, pkg_from_qualified, qualify_agent_name};
 use harnx_mcp::McpServerConfig;
 
 /// Extract a valid package name from a directory path entry.
@@ -77,6 +78,22 @@ pub(super) fn apply_client_patch(client: &mut ClientConfig, patches: &[String]) 
     Ok(())
 }
 
+/// Reconstruct the target's qualified name (`pkg/agent`) from a server config.
+///
+/// Auto-registered package agents already carry a qualified `server.name`, so it
+/// is returned as-is. Manual package servers carry a bare stem and are qualified
+/// against their package. Top-level servers (no package) stay bare.
+fn server_target_qualified(name: &str, package: Option<&str>) -> String {
+    if pkg_from_qualified(name).is_some() {
+        name.to_string()
+    } else if let Some(pkg) = package {
+        qualify_agent_name(pkg, name)
+    } else {
+        name.to_string()
+    }
+}
+
+/// Compute display name for MCP server given active agent package.
 ///
 /// - Top-level servers (`package == None`): unchanged name.
 /// - Same-package servers: bare name (the yaml stem, e.g. `fs`).
@@ -95,10 +112,156 @@ pub(super) fn acp_server_display_name(
     server: &AcpServerConfig,
     agent_package: Option<&str>,
 ) -> String {
-    use harnx_core::package_namespace::sanitize_for_tool_name;
-    match (&server.package, agent_package) {
-        (None, _) => server.name.clone(),
-        (Some(pkg), Some(active_package)) if pkg == active_package => server.name.clone(),
-        (Some(pkg), _) => format!("{}__{}", sanitize_for_tool_name(pkg), server.name),
+    handoff_display_name(
+        &server_target_qualified(&server.name, server.package.as_deref()),
+        agent_package,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{acp_server_display_name, mcp_server_display_name, server_target_qualified};
+    use harnx_acp::AcpServerConfig;
+    use harnx_core::package_namespace::handoff_display_name;
+    use harnx_mcp::McpServerConfig;
+    use std::collections::HashMap;
+
+    fn acp_server(name: &str, package: Option<&str>) -> AcpServerConfig {
+        AcpServerConfig {
+            name: name.to_string(),
+            command: "acp-server".to_string(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            enabled: true,
+            description: None,
+            idle_timeout_secs: 300,
+            operation_timeout_secs: 3600,
+            package: package.map(str::to_string),
+        }
+    }
+
+    fn mcp_server(name: &str, package: Option<&str>) -> McpServerConfig {
+        McpServerConfig {
+            name: name.to_string(),
+            command: "mcp-server".to_string(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            roots: Vec::new(),
+            enabled: true,
+            description: None,
+            rename_tools: HashMap::new(),
+            tool_templates: HashMap::new(),
+            hooks: None,
+            package: package.map(str::to_string),
+        }
+    }
+
+    fn assert_display_name_matches_handoff(
+        target_qualified: &str,
+        active_pkg: Option<&str>,
+        actual: &str,
+    ) {
+        assert_eq!(actual, handoff_display_name(target_qualified, active_pkg));
+        assert!(
+            !actual.contains('/'),
+            "display name leaked slash for {target_qualified}: {actual}"
+        );
+    }
+
+    #[test]
+    fn acp_auto_registered_same_package_uses_bare_stem() {
+        let server = acp_server("pantheon/atlas", Some("pantheon"));
+        let actual = acp_server_display_name(&server, Some("pantheon"));
+
+        assert_eq!(actual, "atlas");
+        assert_display_name_matches_handoff(
+            &server_target_qualified(&server.name, server.package.as_deref()),
+            Some("pantheon"),
+            &actual,
+        );
+    }
+
+    #[test]
+    fn acp_cross_package_uses_namespaced_display() {
+        let server = acp_server("other/helper", Some("other"));
+        let actual = acp_server_display_name(&server, Some("pantheon"));
+
+        assert_eq!(actual, "other__helper");
+        assert_display_name_matches_handoff(
+            &server_target_qualified(&server.name, server.package.as_deref()),
+            Some("pantheon"),
+            &actual,
+        );
+    }
+
+    #[test]
+    fn acp_top_level_from_package_gets_explicit_prefix() {
+        let server = acp_server("global", None);
+        let actual = acp_server_display_name(&server, Some("pantheon"));
+
+        assert_eq!(actual, "__global");
+        assert_display_name_matches_handoff(
+            &server_target_qualified(&server.name, server.package.as_deref()),
+            Some("pantheon"),
+            &actual,
+        );
+    }
+
+    #[test]
+    fn acp_manual_same_package_bare_name_stays_bare() {
+        let server = acp_server("fs", Some("pantheon"));
+        let actual = acp_server_display_name(&server, Some("pantheon"));
+
+        assert_eq!(actual, "fs");
+        assert_display_name_matches_handoff(
+            &server_target_qualified(&server.name, server.package.as_deref()),
+            Some("pantheon"),
+            &actual,
+        );
+    }
+
+    #[test]
+    fn acp_manual_top_level_bare_name_stays_bare_at_top_level() {
+        let server = acp_server("fs", None);
+        let actual = acp_server_display_name(&server, None);
+
+        assert_eq!(actual, "fs");
+        assert_display_name_matches_handoff(
+            &server_target_qualified(&server.name, server.package.as_deref()),
+            None,
+            &actual,
+        );
+    }
+
+    #[test]
+    fn mcp_same_package_uses_bare_name() {
+        let server = mcp_server("fs", Some("pantheon"));
+        let actual = mcp_server_display_name(&server, Some("pantheon"));
+
+        assert_eq!(actual, "fs");
+    }
+
+    #[test]
+    fn mcp_cross_package_uses_namespaced_display() {
+        let server = mcp_server("db", Some("otherpkg"));
+        let actual = mcp_server_display_name(&server, Some("pantheon"));
+
+        assert_eq!(actual, "otherpkg__db");
+    }
+
+    #[test]
+    fn mcp_top_level_from_package_stays_bare() {
+        let server = mcp_server("bash", None);
+        let actual = mcp_server_display_name(&server, Some("pantheon"));
+
+        assert_eq!(actual, "bash");
+    }
+
+    #[test]
+    fn mcp_same_package_with_no_active_package_uses_namespaced_display() {
+        let server = mcp_server("fs", Some("mypkg"));
+        let actual = mcp_server_display_name(&server, None);
+
+        assert_eq!(actual, "mypkg__fs");
     }
 }

--- a/docs/solutions/logic-errors/package-relative-agent-delegation-2026-06-09.md
+++ b/docs/solutions/logic-errors/package-relative-agent-delegation-2026-06-09.md
@@ -1,0 +1,70 @@
+---
+title: "Package-relative agent delegation resolution for _session_*"
+date: 2026-06-09
+category: logic-errors
+problem_type: logic_error
+component: harnx-runtime
+root_cause: qualified-server-name-in-acp-display-name
+resolution_type: code_fix
+severity: medium
+tags:
+  - session-delegation
+  - packages
+  - namespacing
+  - agent-resolution
+plan_ref: issue-709-package-delegation
+---
+
+## Problem
+
+Agent delegation tools (e.g., `_session_prompt`, `_session_new`) did not resolve package-relative targets when called from within a package. Furthermore, the fully-qualified agent names (e.g., `pkg/agent`) leaked into the LLM function names, violating function-naming schemas (which typically forbid `/`) and preventing same-package peers from addressing each other by bare name.
+
+## Symptoms
+
+- A package agent `pantheon/daedalus` saw delegation tools like `pantheon/atlas_session_prompt` instead of the expected `atlas_session_prompt`.
+- LLM calls failed due to invalid function names containing slashes.
+- Delegation failed to resolve targets correctly because the display names did not match the expected relative-naming convention.
+
+## Root Cause
+
+Auto-registered package agents populate `AcpServerConfig.name` with a fully-qualified name (`pkg/agent`). However, `acp_server_display_name` in `crates/harnx-runtime/src/config/patches_split.rs` assumed `server.name` was always a bare stem. This resulted in slashes leaking into the display names used for tool generation and dispatch.
+
+## Fix
+
+The fix establishes `acp_server_display_name` as the lean, single source of truth for delegation tool naming. It now reconstructs the target's qualified name based on the server configuration and delegates formatting to the shared `harnx_core::package_namespace::handoff_display_name` helper.
+
+Because delegation tool generation (`harnx-acp::generate_acp_tools`) and dispatch (`find_client_for_tool`) both key off the `AcpManager.clients` display-name keys, fixing this single function ensures consistency across the entire delegation flow without requiring an additional engine-level mapping.
+
+### Why MCP was left unchanged
+
+The `mcp_server_display_name` function was deliberately left with its original logic. MCP tool resolution uses a different mechanism (`namespace_use_tools_entry`), where top-level MCP servers (e.g., `bash`) are expected to remain bare rather than using the `__` prefix used by the agent handoff/delegation scheme. Reusing the handoff scheme for MCP would have regressed existing contracts (e.g., `package_loading_test_mcp_server_display_names_for_agent`).
+
+## Resolution Table
+
+From the perspective of an active package `P`, delegation tool prefixes now match the handoff scheme:
+
+| Target | Display tool prefix | Example tool |
+|---|---|---|
+| Same-package peer `P/atlas` | `atlas` | `atlas_session_prompt` |
+| Cross-package peer `other/helper` | `other__helper` | `other__helper_session_prompt` |
+| Top-level agent `global` (in pkg) | `__global` | `__global_session_prompt` |
+| (Active top-level) package peer `P/atlas` | `P__atlas` | `P__atlas_session_prompt` |
+| (Active top-level) top-level peer `global` | `global` | `global_session_prompt` |
+
+No tool names contain `/`.
+
+## Key Gotchas
+
+1. **`strip_suffix` vs `trim_end_matches`**: Always use `strip_suffix` for exact single-pattern removal. `trim_end_matches` is greedy and may over-trim agent names that happen to end with the pattern.
+2. **Ambiguous Decoding**: Package and agent names may contain underscores (`_`), so decoding by splitting on `__` is unreliable. This implementation avoids the need for decoding by ensuring that both tool generation and dispatch use the same computed key.
+3. **Dispatch Logic**: The dispatch prefix-match logic remains unchanged; it simply benefits from the corrected keys in the client map.
+
+## Tests Added
+
+- **Unit tests for name resolution**: Added 8 tests to `patches_split.rs` covering 4 ACP scenarios (same-pkg, cross-pkg, top-level-from-pkg, top-level-context) and 4 MCP scenarios.
+- **Round-trip verification**: Added tests in `harnx-acp/src/manager.rs` to ensure that generated tool names correctly dispatch back to the intended client keys, covering namespaced (`other__helper`), top-level (`__global`), and underscore-containing stems (`my_agent`).
+
+## Related Issues
+
+- **GitHub Issue:** [#709](https://github.com/dobesv/harnx/issues/709) — Agent handoff from package agent goes to non-package agent (delegation follow-up)
+- **Sibling Resolution:** [Package-relative agent handoff resolution for _session_handoff](./package-relative-agent-handoff-2026-06-04.md)


### PR DESCRIPTION
Updates acp_server_display_name to correctly resolve package-relative target agents for delegation tools (_session_*). Previously, qualified names like "pkg/agent" leaked into LLM function names, violating naming schemas and preventing relative addressing.

The fix ensures consistency with the handoff resolution scheme:
- Same-package peers use bare names.
- Cross-package peers use "pkg__agent" syntax.
- Top-level agents from within a package use the "__global" prefix.

Includes unit tests for resolution logic and round-trip tool-to-client dispatch verification.

Closes #709

Plan: issue-709-package-delegation