### PR TITLE
fix(xtask): install over running binaries without ETXTBSY

### DIFF
--- a/.changeset/xtask-install-busy-binary.md
+++ b/.changeset/xtask-install-busy-binary.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Fix `cargo xtask install` failing with "Text file busy" (ETXTBSY) when a target binary is currently running. The installer now copies to a temp file and atomically renames it over the destination, matching the old `cp -f` behaviour so install works without stopping existing harnx processes.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -99,13 +99,45 @@ fn install(args: InstallArgs) -> Result<()> {
         let source = target_dir.join(profile_dir).join(&executable_name);
         let destination = install_dir.join(&executable_name);
         println!("==> Installing {bin} -> {}", destination.display());
-        fs::copy(&source, &destination).with_context(|| {
+        install_binary(&source, &destination)?;
+    }
+
+    Ok(())
+}
+
+/// Copy `source` over `destination` without failing when the destination is a
+/// currently-running binary.
+///
+/// Writing directly to `destination` (as `fs::copy` does) fails with `ETXTBSY`
+/// ("Text file busy") on Linux when the target is being executed, because the
+/// open-for-truncate touches the in-use inode. Instead we copy to a sibling
+/// temp file and atomically `rename` it over the destination: the rename swaps
+/// the directory entry, leaving any running process pointing at the old, now
+/// unlinked inode. This mirrors the `cp -f` behaviour the old Argcfile task
+/// relied on, so `install` works without stopping existing harnx processes.
+fn install_binary(source: &PathBuf, destination: &PathBuf) -> Result<()> {
+    let file_name = destination.file_name().ok_or_else(|| {
+        anyhow!(
+            "install destination {} has no file name",
+            destination.display()
+        )
+    })?;
+    let mut tmp_name = OsString::from(".");
+    tmp_name.push(file_name);
+    tmp_name.push(".new");
+    let tmp = destination.with_file_name(tmp_name);
+
+    fs::copy(source, &tmp)
+        .with_context(|| format!("failed to copy {} to {}", source.display(), tmp.display()))?;
+    if let Err(err) = fs::rename(&tmp, destination) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err).with_context(|| {
             format!(
-                "failed to copy {} to {}",
-                source.display(),
+                "failed to install {} to {}",
+                tmp.display(),
                 destination.display()
             )
-        })?;
+        });
     }
 
     Ok(())


### PR DESCRIPTION
## Problem

`cargo xtask install` fails with:

```
Error: failed to copy .../target/release/harnx to ~/.cargo/bin/harnx: Text file busy (os error 26)
```

whenever a target binary is currently running (e.g. a `harnx` ACP/MCP server, a TUI session, or an editor that launched harnx as a backend).

## Cause

The installer used a bare `fs::copy(&source, &destination)`. `fs::copy` opens the destination for truncating write, which the kernel rejects with `ETXTBSY` while the file is being executed. This regressed in #795 (replacing the argc install task with the xtask) — the old `Argcfile.sh` used `cp -f`, and `--force` unlinks the busy destination and retries, sidestepping the error.

## Fix

Add an `install_binary()` helper that copies to a sibling temp file (`.<name>.new`) and **atomically renames** it over the destination. The rename swaps the directory entry, leaving any running process pointing at the old (now-unlinked) inode. This restores — and improves on — the old `cp -f` behaviour: install is now atomic and works without stopping existing harnx processes.

## Verification

Reproduced and fixed against a genuinely-running binary:

- With `harnx-mcp-time` running, a truncating write failed with `Text file busy` (reproducing the reported error), while `cargo xtask install` succeeded and swapped the inode atomically.
- `cargo build --workspace` ✅
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo nextest run --workspace --stress-count=5` ✅ (1400 tests, 5/5 iterations passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `cargo xtask install` failing when the destination binary is currently running. The installation process now succeeds without requiring you to stop existing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->