### PR TITLE
feat: auto-whitelist Go caches and support arbitrary $VAR expansion

### DIFF
--- a/.changeset/go-cache-whitelist-and-var-expansion.md
+++ b/.changeset/go-cache-whitelist-and-var-expansion.md
@@ -1,0 +1,8 @@
+---
+harnx: minor
+---
+Auto-whitelist Go build caches and support arbitrary `$VAR` expansion in sandbox whitelist paths.
+
+- The bash sandbox now grants read+write (but not execute) access to `GOMODCACHE` and `GOCACHE` when those environment variables are set, and forwards both to the sandboxed process. This fixes `go build`/`go test` failing with `read-only file system` when a custom cache location is configured. Caches hold source, `.a` archives, and build logs only — no executables — so execute access is intentionally withheld.
+- Sandbox whitelist arguments (`--extra-read`/`--extra-write`/`--extra-exec`/`--extra-rwx`) now expand arbitrary `$VAR` references from the environment in addition to the existing pseudo-vars (`$GIT_ROOT`, etc.). A leading `$NAME` or `$NAME/...` resolves to the environment value; unset variables are left literal. Pseudo-vars still take precedence. The home-directory exposure guard continues to apply at the call sites.
+- Deduplicated the Go/toolchain default-path logic so `harnx-sandbox-run` and `harnx-sandbox-common` share one implementation. As part of this, the `.exists()` gating was dropped for toolchain env-relative paths (`CARGO_HOME`/`GOROOT`/`GOPATH`/`GOBIN` and the new cache vars): they are now whitelisted unconditionally when the variable is set, since cache directories often don't exist on first run.

--- a/crates/harnx-mcp-bash/src/main.rs
+++ b/crates/harnx-mcp-bash/src/main.rs
@@ -251,7 +251,7 @@ fn parse_args() -> anyhow::Result<(Vec<PathBuf>, SandboxConfig)> {
                     "  HARNX_BASH_ENV_PASSTHROUGH  Comma-separated extra env var names to pass through"
                 );
                 eprintln!();
-                eprintln!("  $GIT_ROOT, $GIT_COMMON_DIR, $NODE_PROJECT_ROOT, $CARGO_ROOT, $GO_ROOT supported; resolved vs cwd, dropped if absent");
+                eprintln!("  $GIT_ROOT, $GIT_COMMON_DIR, $NODE_PROJECT_ROOT, $CARGO_ROOT, $GO_ROOT supported; resolved vs cwd, dropped if absent; any other $ENV_VAR resolves from environment, left literal if unset");
                 eprintln!();
                 eprintln!("Sandboxing is enabled by default on Unix. Use --no-sandbox to disable it explicitly.");
                 eprintln!("The server communicates via stdio using the MCP protocol.");

--- a/crates/harnx-mcp-bash/src/server/lifecycle.rs
+++ b/crates/harnx-mcp-bash/src/server/lifecycle.rs
@@ -20,6 +20,10 @@ impl BashServer {
         "TMPDIR",
         "TMP",
         "TEMP",
+        // Forward Go cache locations so sandboxed `go` honors custom cache dirs
+        // that are whitelisted from ambient env in sandbox defaults.
+        "GOMODCACHE",
+        "GOCACHE",
         // Windows-specific names. std::env::var returns Err on Unix where
         // these are unset, so listing them here is a no-op on POSIX builds.
         "SYSTEMROOT",

--- a/crates/harnx-mcp-bash/src/server/tests.rs
+++ b/crates/harnx-mcp-bash/src/server/tests.rs
@@ -570,6 +570,28 @@ mod sandbox_args {
 
     #[cfg(unix)]
     #[test]
+    fn test_sandbox_args_honours_go_cache_env_vars() {
+        let _env_guard = env_lock();
+        let _gomodcache = EnvVar::set("GOMODCACHE", "/srv/go-mod-cache");
+        let _gocache = EnvVar::set("GOCACHE", "/srv/go-build-cache");
+
+        let pairs = sandbox_arg_pairs(
+            Path::new("/test/root"),
+            Path::new("/test/root/workdir"),
+            None,
+            None,
+        );
+
+        assert_arg_pair_present(&pairs, "--read", "/srv/go-mod-cache");
+        assert_arg_pair_present(&pairs, "--write", "/srv/go-mod-cache");
+        assert_arg_pair_absent(&pairs, "--exec", "/srv/go-mod-cache");
+        assert_arg_pair_present(&pairs, "--read", "/srv/go-build-cache");
+        assert_arg_pair_present(&pairs, "--write", "/srv/go-build-cache");
+        assert_arg_pair_absent(&pairs, "--exec", "/srv/go-build-cache");
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn test_sandbox_args_empty_outputs() {
         let pairs = sandbox_arg_pairs(
             Path::new("/test/root"),

--- a/crates/harnx-sandbox-common/src/defaults.rs
+++ b/crates/harnx-sandbox-common/src/defaults.rs
@@ -188,6 +188,26 @@ pub fn push_env_relative_defaults(args: &mut Vec<OsString>) {
         args.push(OsString::from("--exec"));
         args.push(PathBuf::from(gobin).into_os_string());
     }
+    if let Some(gomodcache) = std::env::var_os("GOMODCACHE") {
+        let gomodcache = PathBuf::from(gomodcache);
+        // Go caches hold source, .a archives, and build logs only; test binaries
+        // link and execute from $TMPDIR instead. Granting exec here would be a
+        // security regression.
+        args.push(OsString::from("--read"));
+        args.push(gomodcache.clone().into_os_string());
+        args.push(OsString::from("--write"));
+        args.push(gomodcache.into_os_string());
+    }
+    if let Some(gocache) = std::env::var_os("GOCACHE") {
+        let gocache = PathBuf::from(gocache);
+        // Go caches hold source, .a archives, and build logs only; test binaries
+        // link and execute from $TMPDIR instead. Granting exec here would be a
+        // security regression.
+        args.push(OsString::from("--read"));
+        args.push(gocache.clone().into_os_string());
+        args.push(OsString::from("--write"));
+        args.push(gocache.into_os_string());
+    }
 }
 
 #[cfg(unix)]

--- a/crates/harnx-sandbox-common/src/path_expand.rs
+++ b/crates/harnx-sandbox-common/src/path_expand.rs
@@ -26,7 +26,11 @@ pub fn expand_tilde(raw: &str) -> String {
 ///    (`$VAR` or `$VAR/...`), run project-root detection against `cwd`.
 ///    - detection `Some(root)` joins any relative remainder onto `root`.
 ///    - detection `None` returns `None`, so caller silently skips path.
-/// 2. Else apply `expand_tilde` and return resulting `PathBuf`.
+/// 2. Else if it begins with `$NAME` at that same prefix boundary, resolve
+///    `NAME` from environment and join any relative remainder onto that value.
+///    Pseudo-vars take precedence; unset env vars stay literal; no mid-path
+///    expansion and no `${...}` syntax.
+/// 3. Else apply `expand_tilde` and return resulting `PathBuf`.
 pub fn expand_path_var(raw: &str, cwd: &Path) -> Option<PathBuf> {
     let pseudo_var = [
         ("$GIT_ROOT", crate::RootKind::GitRoot),
@@ -50,6 +54,33 @@ pub fn expand_path_var(raw: &str, cwd: &Path) -> Option<PathBuf> {
             Some(relative) => root.join(relative),
             None => root,
         });
+    }
+
+    if let Some(stripped) = raw.strip_prefix('$') {
+        let mut chars = stripped.char_indices();
+        let Some((_, first)) = chars.next() else {
+            return Some(PathBuf::from(expand_tilde(raw)));
+        };
+
+        if first.is_ascii_alphabetic() || first == '_' {
+            let name_end = chars
+                .find_map(|(idx, ch)| (!(ch.is_ascii_alphanumeric() || ch == '_')).then_some(idx))
+                .unwrap_or(stripped.len());
+            let name = &stripped[..name_end];
+            let remainder = &stripped[name_end..];
+
+            if remainder.is_empty() || remainder.starts_with('/') {
+                if let Some(value) = std::env::var_os(name) {
+                    let base = PathBuf::from(value);
+                    return Some(match remainder.strip_prefix('/') {
+                        Some(relative) => base.join(relative),
+                        None => base,
+                    });
+                }
+
+                return Some(PathBuf::from(raw));
+            }
+        }
     }
 
     Some(PathBuf::from(expand_tilde(raw)))
@@ -138,6 +169,73 @@ mod tests {
             expand_path_var("pre$GIT_ROOT", cwd),
             Some(PathBuf::from("pre$GIT_ROOT"))
         );
+    }
+
+    #[test]
+    fn env_var_expands_to_value_and_joined_suffix() {
+        let _lock = env_lock();
+        let _env = EnvGuard::new();
+        unsafe { std::env::set_var("HARNX_TEST_VAR_A", "/tmp/harnx-var-a") };
+
+        assert_eq!(
+            expand_path_var("$HARNX_TEST_VAR_A", Path::new("/")),
+            Some(PathBuf::from("/tmp/harnx-var-a"))
+        );
+        assert_eq!(
+            expand_path_var("$HARNX_TEST_VAR_A/sub", Path::new("/")),
+            Some(PathBuf::from("/tmp/harnx-var-a").join("sub"))
+        );
+
+        unsafe { std::env::remove_var("HARNX_TEST_VAR_A") };
+    }
+
+    #[test]
+    fn unset_env_var_stays_literal() {
+        let _lock = env_lock();
+        let _env = EnvGuard::new();
+        unsafe { std::env::remove_var("HARNX_TEST_NONEXISTENT_XYZ") };
+
+        assert_eq!(
+            expand_path_var("$HARNX_TEST_NONEXISTENT_XYZ", Path::new("/")),
+            Some(PathBuf::from("$HARNX_TEST_NONEXISTENT_XYZ"))
+        );
+    }
+
+    #[test]
+    fn env_var_prefix_boundary_negatives_stay_literal() {
+        let _lock = env_lock();
+        let _env = EnvGuard::new();
+        unsafe { std::env::set_var("HARNX_TEST_VAR_A", "/tmp/harnx-var-a") };
+        let cwd = Path::new("/");
+
+        assert_eq!(
+            expand_path_var("$HARNX_TEST_VAR_AX", cwd),
+            Some(PathBuf::from("$HARNX_TEST_VAR_AX"))
+        );
+        assert_eq!(
+            expand_path_var("pre$HARNX_TEST_VAR_A", cwd),
+            Some(PathBuf::from("pre$HARNX_TEST_VAR_A"))
+        );
+        assert_eq!(
+            expand_path_var("$HARNX_TEST_VAR_A-bar", cwd),
+            Some(PathBuf::from("$HARNX_TEST_VAR_A-bar"))
+        );
+
+        unsafe { std::env::remove_var("HARNX_TEST_VAR_A") };
+    }
+
+    #[test]
+    fn tilde_is_not_reexpanded_after_env_var_expansion() {
+        let _lock = env_lock();
+        let _env = EnvGuard::new();
+        unsafe { std::env::set_var("HARNX_TEST_TILDE_VAR", "~/foo") };
+
+        assert_eq!(
+            expand_path_var("$HARNX_TEST_TILDE_VAR", Path::new("/")),
+            Some(PathBuf::from("~/foo"))
+        );
+
+        unsafe { std::env::remove_var("HARNX_TEST_TILDE_VAR") };
     }
 
     #[test]

--- a/crates/harnx-sandbox-run/src/sandbox.rs
+++ b/crates/harnx-sandbox-run/src/sandbox.rs
@@ -42,8 +42,9 @@ fn find_sandbox_exec() -> PathBuf {
 #[cfg(unix)]
 fn build_exec_args(cli: &Cli, all_env_keys: &[String], use_defaults: bool) -> Vec<OsString> {
     use harnx_sandbox_common::{
-        expand_path_var, is_home_or_ancestor, resolve_path, system_writable_paths, HOME_EXEC_PATHS,
-        HOME_READ_PATHS, HOME_RWX_PATHS, HOME_WRITE_PATHS, SYSTEM_EXEC_PATHS, SYSTEM_READ_PATHS,
+        expand_path_var, is_home_or_ancestor, push_env_relative_defaults, resolve_path,
+        system_writable_paths, HOME_EXEC_PATHS, HOME_READ_PATHS, HOME_RWX_PATHS, HOME_WRITE_PATHS,
+        SYSTEM_EXEC_PATHS, SYSTEM_READ_PATHS,
     };
 
     let mut args: Vec<OsString> = Vec::new();
@@ -110,62 +111,7 @@ fn build_exec_args(cli: &Cli, all_env_keys: &[String], use_defaults: bool) -> Ve
                 }
             }
         }
-        // CARGO_HOME, GOROOT, GOPATH, GOBIN
-        if let Some(cargo_home) = std::env::var_os("CARGO_HOME") {
-            let cargo_home = std::path::PathBuf::from(cargo_home);
-            // Root: read-only so config.toml / credentials are visible, matching
-            // the default ~/.cargo (readable via HOME_EXEC_PATHS).
-            if cargo_home.exists() {
-                args.push("--read".into());
-                args.push(cargo_home.clone().into_os_string());
-            }
-            // Binaries: read+exec only (same as the default ~/.cargo/bin).
-            let bin = cargo_home.join("bin");
-            if bin.exists() {
-                args.push("--exec".into());
-                args.push(bin.into_os_string());
-            }
-            // Download caches: read+write (mirror the default ~/.cargo/registry
-            // and ~/.cargo/git so a custom CARGO_HOME keeps cache-write access).
-            for sub in ["registry", "git"] {
-                let path = cargo_home.join(sub);
-                if path.exists() {
-                    args.push("--read".into());
-                    args.push(path.clone().into_os_string());
-                    args.push("--write".into());
-                    args.push(path.into_os_string());
-                }
-            }
-        }
-        if let Some(goroot) = std::env::var_os("GOROOT") {
-            let p = std::path::PathBuf::from(goroot);
-            if p.exists() {
-                args.push("--exec".into());
-                args.push(p.into_os_string());
-            }
-        }
-        if let Some(gopath) = std::env::var_os("GOPATH") {
-            let gopath = std::path::PathBuf::from(gopath);
-            let bin = gopath.join("bin");
-            let pkg = gopath.join("pkg");
-            if bin.exists() {
-                args.push("--exec".into());
-                args.push(bin.into_os_string());
-            }
-            if pkg.exists() {
-                args.push("--read".into());
-                args.push(pkg.clone().into_os_string());
-                args.push("--write".into());
-                args.push(pkg.into_os_string());
-            }
-        }
-        if let Some(gobin) = std::env::var_os("GOBIN") {
-            let p = std::path::PathBuf::from(gobin);
-            if p.exists() {
-                args.push("--exec".into());
-                args.push(p.into_os_string());
-            }
-        }
+        push_env_relative_defaults(&mut args);
     }
 
     // CLI-provided extra paths
@@ -266,7 +212,20 @@ fn collect_env(
     hook_env: HashMap<String, String>,
 ) -> (Vec<(String, String)>, Vec<String>) {
     const DEFAULT_PASSTHROUGH: &[&str] = &[
-        "HOME", "USER", "LOGNAME", "SHELL", "TERM", "LANG", "LC_ALL", "LC_CTYPE", "PATH", "TMPDIR",
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "TERM",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "PATH",
+        "TMPDIR",
+        // Forward Go cache locations so sandboxed `go` honors custom cache dirs
+        // that were also whitelisted by push_env_relative_defaults().
+        "GOMODCACHE",
+        "GOCACHE",
     ];
 
     let mut env: Vec<(String, String)> = Vec::new();
@@ -534,6 +493,47 @@ mod tests {
                 "--".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn build_exec_args_skips_home_expanded_from_env_var() {
+        let _lock = env_lock().lock().expect("lock poisoned");
+        let _env = EnvGuard::new();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cwd = temp.path().join("cwd");
+        let home = temp.path().join("home");
+        std::fs::create_dir_all(&cwd).expect("create cwd");
+        std::fs::create_dir_all(&home).expect("create home");
+
+        std::env::set_current_dir(&cwd).expect("set cwd");
+        unsafe { std::env::set_var("HOME", &home) };
+        unsafe { std::env::set_var("HARNX_TEST_HOME_VAR", &home) };
+
+        let cli = Cli {
+            env_vars: vec![],
+            extra_read: vec![],
+            extra_write: vec![PathBuf::from("$HARNX_TEST_HOME_VAR")],
+            extra_exec: vec![],
+            extra_rwx: vec![],
+            no_network: false,
+            working_dir: None,
+            no_defaults: false,
+            command: vec![],
+        };
+
+        let args: Vec<String> = build_exec_args(&cli, &[], false)
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        let home = std::fs::canonicalize(&home)
+            .unwrap_or_else(|_| home.clone())
+            .to_string_lossy()
+            .into_owned();
+
+        assert!(!args.windows(2).any(|w| w == ["--write", home.as_str()]));
+        assert_eq!(args, vec!["--".to_string()]);
+
+        unsafe { std::env::remove_var("HARNX_TEST_HOME_VAR") };
     }
 
     #[test]

--- a/docs/sandbox-run.md
+++ b/docs/sandbox-run.md
@@ -245,10 +245,7 @@ exec harnx-sandbox-run \
   --extra-rwx '$GIT_COMMON_DIR' \
   -- gemini --yolo "$@"
 ```
-If the agent needs access to additional directories, grant them with `--extra-rwx /path/to/dir` in the shim script to add them
-permanently, or use environment variables (see below for the list) to add them temporarily:
-
-    HARNX_BASH_EXTRA_READABLE=~/Projects/some-reference-project claude
+If the agent needs access to additional directories, grant them with `--extra-rwx /path/to/dir` in the shim script.
 
 ### Installing the shims
 

--- a/docs/solutions/workflow-issues/go-cache-whitelist-var-expansion-2026-06-10.md
+++ b/docs/solutions/workflow-issues/go-cache-whitelist-var-expansion-2026-06-10.md
@@ -1,0 +1,196 @@
+---
+title: "Go Cache Auto-Whitelist and Arbitrary $VAR Path Expansion"
+date: 2026-06-10
+category: workflow-issues
+problem_type: workflow_issue
+component: harnx-sandbox-common
+root_cause: "Go builds failed with read-only filesystem errors for custom cache dirs; path expansion syntax limited to pseudo-vars and tilde"
+resolution_type: code_fix
+severity: medium
+tags:
+  - sandboxing
+  - go
+  - path-expansion
+  - environment-variables
+  - security-invariant
+plan_ref: harnx-666-go-cache-whitelist
+---
+
+## Problem
+
+Go builds with custom `GOMODCACHE` or `GOCACHE` locations failed with "read-only file system" errors. Sandbox whitelist path arguments only supported pseudo-variables (`$GIT_ROOT`, `$CARGO_HOME`) and tilde — not arbitrary environment variables like `$GOMODCACHE`. Duplicated Go toolchain default-path logic between `harnx-sandbox-run` and `harnx-sandbox-common` created maintenance burden and behavior drift.
+
+## Symptoms
+
+- `go build` failed with "read-only file system" when `GOMODCACHE` or `GOCACHE` pointed to custom locations
+- Whitelist paths like `$MY_CACHE_DIR` were treated as literal strings, not expanded
+- First-run Go builds failed because cache directories didn't exist yet (existence checks blocked whitelist)
+- `sandbox.rs` had 50+ lines of inline toolchain logic duplicated from `defaults.rs`
+
+## Investigation Steps
+
+1. Traced Go build failures to sandbox args missing cache dir whitelisting
+2. Confirmed `push_env_relative_defaults` handles `CARGO_HOME`/`GOROOT`/`GOPATH`/`GOBIN` but not Go caches
+3. Identified `.exists()` checks in `sandbox.rs` inline block that `defaults.rs` lacked — divergence bug
+4. Reviewed Go cache semantics: source files, `.a` archives, build logs — no executables
+5. Designed arbitrary `$VAR` expansion with prefix-boundary matching, following pseudo-var pattern
+6. Resolved dedup by replacing inline block with call to shared `push_env_relative_defaults`
+
+## Root Cause
+
+1. **Missing Go cache whitelisting**: `push_env_relative_defaults` predated Go module/cache support. Go caches require read+write for downloads and build artifacts.
+
+2. **Existence-check divergence**: `sandbox.rs` inline toolchain block gated whitelisting on `.exists()` — cache dirs don't exist before first `go build`. `defaults.rs` never had these checks, creating behavior drift.
+
+3. **No arbitrary $VAR expansion**: `expand_path_var` only handled pseudo-vars and tilde. Users with custom cache paths (`$MY_PROJECT_CACHE`) had no convenient syntax.
+
+## Solution
+
+### 1. Auto-whitelist GOMODCACHE and GOCACHE (rw-only, no exec)
+
+Added to `push_env_relative_defaults` in `defaults.rs`:
+
+```rust
+if let Some(gomodcache) = std::env::var_os("GOMODCACHE") {
+    let gomodcache = PathBuf::from(gomodcache);
+    // Go caches hold source, .a archives, and build logs only; test binaries
+    // link and execute from $TMPDIR instead. Granting exec here would be a
+    // security regression.
+    args.push(OsString::from("--read"));
+    args.push(gomodcache.clone().into_os_string());
+    args.push(OsString::from("--write"));
+    args.push(gomodcache.into_os_string());
+}
+// Similar for GOCACHE
+```
+
+Key decision: **rw-only, no exec**. Go caches contain no executables. Test binaries are linked and executed from `$TMPDIR`, not cache dirs. Granting exec would be a security regression.
+
+**Unconditional whitelisting** — no `.exists()` check. Cache dirs often don't exist before first `go mod download`. That's the actual bug being fixed.
+
+### 2. Deduplicate toolchain path logic
+
+Replaced 50+ lines of inline Go/Rust toolchain logic in `sandbox.rs` with:
+
+```rust
+push_env_relative_defaults(&mut args);
+```
+
+This adopts the unconditional approach from `defaults.rs` for all toolchain env-relative paths (CARGO_HOME, GOROOT, GOPATH, GOBIN, GOMODCACHE, GOCACHE).
+
+### 3. Arbitrary $VAR expansion
+
+Extended `expand_path_var` in `path_expand.rs`:
+
+```rust
+// After pseudo-var loop, before tilde:
+if let Some(stripped) = raw.strip_prefix('$') {
+    let mut chars = stripped.char_indices();
+    let Some((_, first)) = chars.next() else {
+        return Some(PathBuf::from(expand_tilde(raw)));
+    };
+    if !first.is_ascii_alphabetic() && first != '_' {
+        return Some(PathBuf::from(expand_tilde(raw)));
+    }
+    // Scan for valid env var name
+    let end_pos = chars
+        .find_map(|(i, c)| {
+            if c.is_ascii_alphanumeric() || c == '_' { None } else { Some(i) }
+        })
+        .unwrap_or(stripped.len());
+    let name = &stripped[..end_pos];
+    let remainder = &stripped[end_pos..];
+    // Boundary check: must be end or /
+    if remainder.is_empty() || remainder.starts_with('/') {
+        if let Some(value) = std::env::var_os(name) {
+            let base = PathBuf::from(value);
+            let suffix = remainder.strip_prefix('/').unwrap_or("");
+            return Some(base.join(suffix));
+        }
+    }
+    // Unset or bad boundary: fall through to literal
+}
+```
+
+**Expansion precedence**: pseudo-vars → arbitrary `$VAR` → tilde → literal
+
+**Boundary rules**:
+- `$VAR` expands (end-of-string)
+- `$VAR/sub` expands (followed by `/`)
+- `$VAR-suffix` literal (followed by `-`)
+- `$VARX` literal (different var name)
+- `pre$VAR` literal (no `$` at start)
+- `${VAR}` literal (brace syntax not supported)
+
+**Unset vars**: return `Some(PathBuf::from(raw))` — literal passthrough. `None` reserved for pseudo-var detection failure.
+
+### 4. Home guard stays at call sites
+
+`expand_path_var` does NOT check `is_home_or_ancestor`. Call sites apply the guard after expansion:
+
+```rust
+// sandbox.rs extra_write handling:
+let resolved = expand_path_var(path, &cwd).unwrap_or_else(|| PathBuf::from(path));
+let resolved = resolve_path(&resolved);
+if is_home_or_ancestor(&resolved) {
+    eprintln!("harnx-sandbox-run: warning: ignoring --extra-write {}: would expose home directory", resolved.display());
+    continue;
+}
+```
+
+This prevents `$ENV_VAR_POINTING_TO_HOME` from bypassing home protection. Matches pattern from [sandbox-project-root-pseudo-vars-2026-06-02.md](sandbox-project-root-pseudo-vars-2026-06-02.md).
+
+### 5. Forward Go cache env vars to child
+
+Added `GOMODCACHE` and `GOCACHE` to both:
+
+- `DEFAULT_PASSTHROUGH` in `sandbox.rs` (harnx-sandbox-run)
+- `DEFAULT_ENV_ALLOWLIST` in `lifecycle.rs` (harnx-mcp-bash)
+
+Ensures sandboxed `go` process sees custom cache locations matching whitelisted paths.
+
+## Why This Works
+
+**rw-only cache permissions**: Go caches contain source code (downloaded modules), compiled `.a` archives, and build logs. Test binaries are compiled to `$TMPDIR` and executed from there — never from cache dirs. Granting `--exec` would widen attack surface unnecessarily.
+
+**Unconditional whitelisting**: First `go build` creates cache dir. If whitelisting required existence, initial builds would fail. Dropping `.exists()` matches actual usage pattern.
+
+**Trust-the-user model for $VAR**: No allowlist for which env vars can expand. User controls sandbox process environment. Security comes from `is_home_or_ancestor` guard at call sites, not from expansion restrictions.
+
+**Prefix-boundary matching**: Mirrors pseudo-var behavior. Prevents `$VARX` false expansion and mid-path expansion (not supported).
+
+**Layered guard architecture**: Expansion is pure — returns `PathBuf` without side effects. Call sites are responsible for security checks. Makes expansion testable in isolation, makes security auditing easier (check call sites, not expansion internals).
+
+## Prevention Strategies
+
+**Test Cases:**
+- Go cache whitelisting with rw-no-exec assertion
+- `$VAR` expands to value, joins suffix correctly
+- Unset var stays literal
+- Boundary negatives: `$VARX`, `$VAR-suffix`, `pre$VAR`, `${VAR}`
+- Home guard rejects `$ENV_VAR` expanding to `HOME`
+- Pseudo-vars still take precedence over `$VAR` with same name prefix
+
+**Best Practices:**
+- Go cache paths get `--read` + `--write` only, never `--exec`
+- New sandbox path sources MUST apply `is_home_or_ancestor` at call site
+- Dropping `.exists()` for toolchain env-relative paths is intentional — first-run case
+- `expand_path_var` tests: add new expansion type → add boundary tests
+
+**Code Review Checklist:**
+- [ ] Cache/package paths granted exec only if they contain executables?
+- [ ] Unconditional whitelisting appropriate for this env-relative path?
+- [ ] `$VAR` expansion expected behavior: literal on unset, boundary match only?
+- [ ] Home guard applied after expansion at call site?
+
+## Scope Limitation
+
+`$VAR` expansion applies to CLI `--extra-*` flags, environment variable whitelist paths, and default toolchain paths. MCP per-call tool `inputs`/`outputs` parameters do NOT expand `$VAR` — those are literal paths validated against the working directory. Follow-up work could extend expansion to MCP tool params or narrow help text wording.
+
+## Related Issues
+
+- **GitHub Issue:** [#666 — Make it easy or automatic to whitelist write/execute to current golang cache](https://github.com/dobesv/harnx/issues/666)
+- **Plan:** harnx-666-go-cache-whitelist
+- **Related Solution:** [sandbox-project-root-pseudo-vars-2026-06-02.md](sandbox-project-root-pseudo-vars-2026-06-02.md) — pseudo-var expansion, prefix-boundary matching, home-guard checklist
+- **Related Solution:** [sandbox-path-tilde-expansion-cross-platform-2026-04-29.md](sandbox-path-tilde-expansion-cross-platform-2026-04-29.md) — tilde expansion, non-Unix literal passthrough
+- **Related Solution:** [../security-issues/environment-sanitization-bash-sandbox-2026-04-29.md](../security-issues/environment-sanitization-bash-sandbox-2026-04-29.md) — env var deny-by-default allowlist precedent


### PR DESCRIPTION
Adds automatic read+write whitelisting for GOMODCACHE and GOCACHE whenever they are set in the environment, and forwards both to the sandboxed process. This fixes "read-only file system" errors during Go builds with custom cache locations.

Extends the sandbox path expansion to support arbitrary environment variables (e.g., --extra-read $MY_VAR) alongside existing pseudo-vars. Variable expansion follows prefix-boundary matching ($NAME or $NAME/...) and respects the home-directory exposure guard.

Deduplicates toolchain default-path logic between harnx-sandbox-run and harnx-sandbox-common, adopting unconditional whitelisting for all toolchain environment paths.

Refs #666