### PR TITLE
docs: clarify acli proxy-auth requires API-token auth, not OAuth

### DIFF
--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -417,7 +417,9 @@ hooks:
 
 ### Atlassian CLI (`acli`) Example
 
-`acli` (the Atlassian CLI for Jira, Confluence, etc.) stores API tokens in the OS keyring, which is inaccessible inside the sandboxed environment. `harnx-proxy-auth` solves this by automatically sourcing the token from your host OS keyring at startup. Once you have run `acli jira auth login` on the host, no further manual environment variables or `.env` entries are required.
+`acli` (the Atlassian CLI for Jira, Confluence, etc.) stores API tokens in the OS keyring, which is inaccessible inside the sandboxed environment. `harnx-proxy-auth` solves this by automatically sourcing the token from your host OS keyring at startup. Once you have logged in with an API token on the host, no further manual environment variables or `.env` entries are required.
+
+> **API-token auth only — OAuth is not supported.** This flow replays your stored credential as an HTTP Basic auth password, so `acli` must be authenticated with an **API token** (Step 1 below). It does **not** work if you logged in with OAuth (`acli jira auth login --web`): OAuth stores a short-lived, rotating bearer token as a compressed binary blob the proxy can neither read (it is not valid UTF-8, so it degrades to `null` and no synthetic config is injected) nor replay as Basic auth — sandboxed `acli` then fails with `unauthorized: use 'acli jira auth login' to authenticate`. If `acli jira auth status` reports `Authentication Type: oauth`, run `acli jira auth logout` and repeat Step 1 with an API token.
 
 #### Step 1 — Log in with your real token (once, on the host)
 
@@ -440,7 +442,7 @@ The same command applies to other `acli` products: replace `jira` with `confluen
 
 Add the following to your `config.yaml`. The proxy will self-source credentials from your host OS keyring using `--load-exec`. It injects a synthetic `jira_config.yaml` containing a sentinel token into the sandbox via `--fs`, and the `--hook` filter replaces that sentinel with the real token in outbound requests.
 
-No manual environment variables are required as long as you have run `acli jira auth login` on your host.
+No manual environment variables are required as long as you have logged in with an **API token** (Step 1) on your host — OAuth (`--web`) is not supported.
 
 ```yaml
 hooks:

--- a/docs/sandbox-run.md
+++ b/docs/sandbox-run.md
@@ -198,7 +198,7 @@ exec harnx-sandbox-run \
 **Key points:**
 - Replace `my-profile` with your AWS profile name (omit `--hook ... harnx-aws-creds ...` entirely if you don't need AWS). Project access now uses harnx-sandbox-run pseudo-vars, so current git root / node project root / git common dir are granted automatically when present; add `--extra-rwx /path` for any extra directories the agent should access.
 - The `--env` and `--fs` scripts inject fake sentinel tokens into the sandbox (e.g. `ghp_<random>` for GitHub, or a synthetic `jira_config.yaml` for Atlassian) so tools like `gh` or `acli` consider themselves authenticated. The real tokens never enter the sandbox — `harnx-proxy-auth` reads them from the host (environment or OS keyring) and injects them into outbound HTTP headers.
-- The Atlassian flow self-sources credentials from your host OS keyring (Linux Secret Service or macOS Keychain) using `--load-exec`. As long as you have run `acli jira auth login` on your host, it works automatically with no manual environment variables required.
+- The Atlassian flow self-sources credentials from your host OS keyring (Linux Secret Service or macOS Keychain) using `--load-exec`. **It works only when `acli` is authenticated with an API token, not OAuth** — see the Atlassian example below. As long as you have logged in with an API token on your host, it works automatically with no manual environment variables required.
 - macOS users: change the `--load-exec` command for `atlassian_token` to use `security find-generic-password -s acli -a "jira:$p" -w`.
 - Remove the Atlassian block if you don't use Jira/Confluence.
 - `if COND then EXPR end` — omitting `else` passes the input through unchanged (jaq default).
@@ -397,6 +397,15 @@ The hooks match the *exact* sentinel values injected by `--env` — `basic("x-ac
 
 ### Example: Atlassian (Jira / Confluence) with `harnx-proxy-auth`
 
+> **API-token auth only — OAuth is not supported.** This flow replays your stored credential as an HTTP Basic auth password, so `acli` must be logged in with an **API token**. It does **not** work if you authenticated with OAuth (`acli jira auth login --web`): OAuth stores a short-lived, rotating bearer token as a compressed binary blob, which the proxy can neither read (it is not valid UTF-8) nor replay as Basic auth — sandboxed `acli` then fails with `unauthorized: use 'acli jira auth login' to authenticate`. If `acli jira auth status` reports `Authentication Type: oauth`, switch to an API token:
+>
+> ```sh
+> acli jira auth logout
+> echo '<your-api-token>' | acli jira auth login --site "<your-site>.atlassian.net" --email "<your-email>" --token
+> ```
+>
+> Create an API token at <https://id.atlassian.com/manage-profile/security/api-tokens>.
+
 Atlassian's REST API uses HTTP Basic auth with your email as the username and an API token as the password.
 
 ```bash
@@ -422,7 +431,7 @@ harnx-sandbox-run \
   -- acli jira workitem search --jql "assignee = currentUser() AND resolution = Unresolved"
 ```
 
-The proxy automatically sources your real credentials from the host OS keyring using `--load-exec`. It injects a synthetic `jira_config.yaml` containing a sentinel token into the sandbox via `--fs`, and the `--hook` filter replaces that sentinel with the real token in outbound requests. No manual environment variables are required as long as you have run `acli jira auth login` on your host.
+The proxy automatically sources your real credentials from the host OS keyring using `--load-exec`. It injects a synthetic `jira_config.yaml` containing a sentinel token into the sandbox via `--fs`, and the `--hook` filter replaces that sentinel with the real token in outbound requests. No manual environment variables are required as long as you have logged in with an **API token** (`acli jira auth login --site … --email … --token`) on your host. OAuth logins (`--web`) are not supported — see the warning above.
 
 ### Combining multiple hooks in one `harnx-proxy-auth` invocation
 

--- a/docs/solutions/integration-issues/atlassian-cli-proxy-auth-2026-05-20.md
+++ b/docs/solutions/integration-issues/atlassian-cli-proxy-auth-2026-05-20.md
@@ -23,6 +23,8 @@ plan_ref: acli-sandbox-credential-isolation
 
 > **Superseded (2026-06):** The previous workaround (injecting headers via proxy and allowing `~/.config/acli` read access) was incomplete. Research revealed that `acli` performs a keyring lookup *before* making any HTTP requests. If the keyring is inaccessible (e.g., due to sandbox isolation), `acli` fails locally with an "unauthorized" error and never attempts a network connection, preventing the proxy from intervening. Additionally, a major security gap was discovered where sandboxed processes could access the host's DBus session bus to read all OS keyring secrets. This document has been updated to reflect the comprehensive fix.
 
+> **Applies to API-token auth only — not OAuth.** The flow replays the credential as HTTP Basic auth, so it works only when `acli` is authenticated with an **API token** (`acli jira auth login … --token`). An OAuth login (`acli jira auth login --web`) stores a short-lived, rotating bearer token as a gzip-compressed binary blob: the `--load-exec` capture cannot read it (it is not valid UTF-8, so `$atlassian_token` degrades to `null` and the `if $p and $atlassian_token` guards all skip — no synthetic config, no `ACLI_CONFIG_DIR`, no header rewrite), and it could not be replayed as a Basic-auth password even if it could be read. Sandboxed `acli` then fails locally with `unauthorized: use 'acli jira auth login' to authenticate`.
+
 ## Problem
 
 Atlassian CLI (`acli`) stores API tokens in the OS keyring (Secret Service/libsecret on Linux). Historically, providing these credentials to sandboxed agents required either granting the sandbox access to the host DBus session (a severe security risk) or finding a way to bypass the local check.
@@ -140,7 +142,7 @@ By providing a valid `SecretStore` blob (a sentinel token) in a private `jira_co
 
 ### Configuration Checklist
 
--   [x] `acli auth login` run on host to generate `~/.config/acli/jira_config.yaml`.
+-   [x] `acli auth login` run on host **with an API token** (`--token`, not `--web`/OAuth) to generate `~/.config/acli/jira_config.yaml`.
 -   [x] `harnx-proxy-auth` configured with `--load-yaml`, `--load-exec`, `--fs`, and the Atlassian `--hook`.
 -   [x] `~/.config/acli` removed from sandbox `--extra-read` paths.
 -   [x] `XDG_RUNTIME_DIR` confirmed as excluded from sandbox environment (blocking DBus).


### PR DESCRIPTION
## What

Clarify across the docs that the `harnx-proxy-auth` Atlassian / `acli` credential-injection flow works **only with API-token auth**, not OAuth.

- **`docs/sandbox-run.md`** — inline caveat in the `claude` shim "Key points", a prominent callout above the standalone Atlassian example (OAuth failure symptom + exact switch-to-API-token commands), and a clarified closing note.
- **`docs/hooks-guide.md`** — a callout before Step 1 and a clarified Step 2 note.
- **`docs/solutions/integration-issues/atlassian-cli-proxy-auth-2026-05-20.md`** — an "API-token only" note after the Superseded banner and an updated config-checklist item.

## Why

The flow replays the stored credential as an **HTTP Basic auth** password, so it requires an API token. If a user runs `acli jira auth login --web` (OAuth), `acli` stores a short-lived, rotating bearer token as a gzip-compressed binary blob. The proxy's `--load-exec` capture reads keyring output via `String::from_utf8`, which fails on the non-UTF-8 blob and degrades `$atlassian_token` to `null` — so the `if $p and $atlassian_token` guards all skip, no synthetic config / `ACLI_CONFIG_DIR` / header rewrite is applied, and sandboxed `acli` fails locally with `unauthorized: use 'acli jira auth login' to authenticate`. (Even if it were captured, an OAuth bearer token can't be replayed as a Basic-auth password.)

Docs-only change — no Rust touched, so the cargo verification pipeline doesn't apply; CI has no markdown lint. Relates to #801, which tracks the proxy-side fix (clear warning on a non-UTF-8 secret) and the OAuth-support feasibility analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Atlassian CLI authentication documentation to clarify that only API-token authentication is supported for proxy integration; OAuth login is explicitly not supported.
  * Added detailed warnings explaining why OAuth authentication fails and provided enhanced setup instructions for proper API token configuration across multiple guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->