### PR TITLE
Implement find -exec syntax for hooks-proxy arguments

### DIFF
--- a/crates/harnx-mcp-hooks-proxy/README.md
+++ b/crates/harnx-mcp-hooks-proxy/README.md
@@ -1,14 +1,14 @@
 # harnx-mcp-hooks-proxy
 
-`harnx-mcp-hooks-proxy` is an MCP proxy that runs `harnx` hooks around tool calls made to an underlying MCP server. It allows users to wrap any existing MCP server with custom pre-tool and post-tool logic.
+`harnx-mcp-hooks-proxy` is an MCP proxy that runs `harnx` hooks around tool calls made to an underlying MCP server. It lets you wrap an existing MCP server with custom pre-tool and post-tool logic.
 
 ## Overview
 
-The proxy sits between an MCP host (like Claude Desktop) and a child MCP server process. It intercepts `tools/call` requests and responses, dispatching them to configured hooks before and after the child server handles the call.
+Proxy sits between an MCP host, such as Claude Desktop, and child MCP server process. It intercepts `tools/call` requests and responses, dispatching configured hooks before and after child server handles call.
 
 ## Installation
 
-To install `harnx-mcp-hooks-proxy` from the `harnx` workspace:
+To install `harnx-mcp-hooks-proxy` from `harnx` workspace:
 
 ```sh
 cargo install --path crates/harnx-mcp-hooks-proxy
@@ -16,27 +16,58 @@ cargo install --path crates/harnx-mcp-hooks-proxy
 
 ## Usage
 
-Run the proxy by specifying hooks and the child command to wrap, separated by `--`.
+Run proxy by declaring hook argv tokens directly, then terminate each hook with `;`. Use `--` to separate proxy flags from child command.
 
 ```sh
 harnx-mcp-hooks-proxy \
-  --pre-tool-use "claude-command my-pre-hook" \
-  --post-tool-use "claude-command my-post-hook" \
-  -- child-mcp-server --arg1
+  --pre-tool-use claude-command --matcher '^exec$' /path/to/pre-hook.sh --log /tmp/pre.log \; \
+  --post-tool-use claude-command /path/to/post-hook.sh done \; \
+  -- post-child-mcp-server --arg1
 ```
+
+Each hook uses `find -exec` style syntax: one flag, followed by multiple argv tokens, terminated by `;`.
 
 ## CLI Options
 
 | Option | Description |
 | :--- | :--- |
-| `--pre-tool-use <SPEC>` | Hook to run before a tool call. |
-| `--post-tool-use <SPEC>` | Hook to run after a successful tool call. |
-| `--post-tool-use-failure <SPEC>` | Hook to run after a tool call failure. |
-| `--` | Separator between proxy flags and the child command to execute. |
+| `--pre-tool-use <TYPE> [--async] [--matcher <REGEX>] <CMD> [ARGS...] ;` | Hook to run before tool call. |
+| `--post-tool-use <TYPE> [--async] [--matcher <REGEX>] <CMD> [ARGS...] ;` | Hook to run after successful tool call. |
+| `--post-tool-use-failure <TYPE> [--async] [--matcher <REGEX>] <CMD> [ARGS...] ;` | Hook to run after tool call failure. |
+| `--` | Separator between proxy flags and child command to execute. |
 
-### Hook Specification
+## Hook Specification
 
-A `<SPEC>` follows the format: `claude-command [--async] [--matcher <REGEX>] <COMMAND>`
+Hook grammar per event flag:
 
-- `--async`: Run the hook asynchronously (do not wait for completion).
-- `--matcher <REGEX>`: Only run the hook if the tool name matches the regex.
+```text
+--pre-tool-use <TYPE> [--async] [--matcher <REGEX>] <CMD> [ARGS...] ;
+--post-tool-use <TYPE> [--async] [--matcher <REGEX>] <CMD> [ARGS...] ;
+--post-tool-use-failure <TYPE> [--async] [--matcher <REGEX>] <CMD> [ARGS...] ;
+```
+
+Rules:
+
+- First token after event flag is hook type, such as `claude-command`.
+- `--async` marks hook as asynchronous.
+- `--matcher <REGEX>` limits hook to matching tool names.
+- First non-option token after type and optional flags is command.
+- Remaining tokens become command arguments.
+- Hook ends at literal `;`. In many shells, write that as `\;` so shell passes terminator through unchanged.
+- No inner quoting layer needed for hook command parsing. Pass command and each argument as separate argv tokens.
+
+Examples:
+
+```sh
+harnx-mcp-hooks-proxy \
+  --pre-tool-use claude-command /usr/local/bin/audit-hook --phase before \; \
+  -- post-child-mcp-server
+```
+
+```sh
+harnx-mcp-hooks-proxy \
+  --post-tool-use claude-command --async --matcher '^exec$' python3 /opt/hooks/notify.py success webhook \; \
+  -- child-mcp-server --stdio
+```
+
+Proxy shell-quotes hook command and args internally when building `HookConfig.command`, so tokens with spaces or quotes are preserved correctly without requiring you to pack whole hook into one quoted string.

--- a/crates/harnx-mcp-hooks-proxy/src/cli.rs
+++ b/crates/harnx-mcp-hooks-proxy/src/cli.rs
@@ -5,6 +5,33 @@ pub fn parse_args() -> Result<(HooksConfig, Vec<String>)> {
     parse_args_from(std::env::args().skip(1))
 }
 
+fn collect_hook_tokens<I>(iter: &mut I, flag: &str) -> Result<Vec<String>>
+where
+    I: Iterator<Item = String>,
+{
+    let mut tokens = Vec::new();
+    for token in iter.by_ref() {
+        if token == ";" || token == "\\;" {
+            return Ok(tokens);
+        }
+        tokens.push(token);
+    }
+    bail!("unterminated {flag} (missing ';')")
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn build_hook_command(command: &str, args: &[String]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 1);
+    parts.push(shell_quote(command));
+    for arg in args {
+        parts.push(shell_quote(arg));
+    }
+    parts.join(" ")
+}
+
 fn parse_args_from<I>(args: I) -> Result<(HooksConfig, Vec<String>)>
 where
     I: IntoIterator<Item = String>,
@@ -31,66 +58,63 @@ where
                     child_cmd_args,
                 ));
             }
-            "--pre-tool-use" => hooks.push(parse_hook_flag("PreToolUse", &mut iter)?),
-            "--post-tool-use" => hooks.push(parse_hook_flag("PostToolUse", &mut iter)?),
+            "--pre-tool-use" => hooks.push(parse_hook_flag("PreToolUse", &arg, &mut iter)?),
+            "--post-tool-use" => hooks.push(parse_hook_flag("PostToolUse", &arg, &mut iter)?),
             "--post-tool-use-failure" => {
-                hooks.push(parse_hook_flag("PostToolUseFailure", &mut iter)?)
+                hooks.push(parse_hook_flag("PostToolUseFailure", &arg, &mut iter)?)
             }
-            other => bail!("unknown argument: {other}"),
+            other => bail!("unexpected argument before `--`: {other}"),
         }
     }
 }
 
-fn parse_hook_flag<I>(event: &str, iter: &mut I) -> Result<HookConfig>
+fn parse_hook_flag<I>(event: &str, flag: &str, iter: &mut I) -> Result<HookConfig>
 where
     I: Iterator<Item = String>,
 {
-    let value = iter
-        .next()
-        .with_context(|| format!("missing value for flag corresponding to {event}"))?;
-    parse_hook_spec(event, &value)
+    let hook_tokens = collect_hook_tokens(iter, flag)?;
+    parse_hook_tokens(event, flag, hook_tokens)
 }
 
-fn parse_hook_spec(event: &str, spec: &str) -> Result<HookConfig> {
-    let tokens: Vec<&str> = spec.split_whitespace().collect();
-    if tokens.is_empty() {
-        bail!("empty hook specification for {event}");
-    }
+fn parse_hook_tokens(event: &str, flag: &str, tokens: Vec<String>) -> Result<HookConfig> {
+    let mut iter = tokens.into_iter();
 
-    let hook_type = tokens[0].to_string();
+    let hook_type = iter
+        .next()
+        .with_context(|| format!("{flag} requires a TYPE before command"))?;
+
     let mut async_hook = None;
     let mut matcher = None;
-    let mut command_tokens = Vec::new();
-    let mut index = 1;
+    let mut command = None;
+    let mut args = Vec::new();
 
-    while index < tokens.len() {
-        match tokens[index] {
-            "--async" => {
+    while let Some(token) = iter.next() {
+        match token.as_str() {
+            "--async" if command.is_none() => {
                 async_hook = Some(true);
-                index += 1;
             }
-            "--matcher" => {
-                let regex = tokens
-                    .get(index + 1)
-                    .ok_or_else(|| anyhow!("missing regex after --matcher in {event}"))?;
-                matcher = Some((*regex).to_string());
-                index += 2;
+            "--matcher" if command.is_none() => {
+                let regex = iter
+                    .next()
+                    .ok_or_else(|| anyhow!("{flag} --matcher requires a REGEX"))?;
+                matcher = Some(regex);
             }
             _ => {
-                command_tokens.extend(tokens[index..].iter().copied());
+                command = Some(token);
+                args.extend(iter);
                 break;
             }
         }
     }
 
-    if command_tokens.is_empty() {
-        bail!("missing hook command for {event}");
-    }
+    let command =
+        command.ok_or_else(|| anyhow!("{flag} requires a command after TYPE and options"))?;
+    let command = build_hook_command(&command, &args);
 
     Ok(HookConfig {
         event: event.to_string(),
         matcher,
-        command: command_tokens.join(" "),
+        command,
         timeout: Some(30),
         status_message: None,
         async_hook,
@@ -100,13 +124,15 @@ fn parse_hook_spec(event: &str, spec: &str) -> Result<HookConfig> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_args_from;
+    use super::*;
 
     #[test]
-    fn parses_basic_hook_and_child_command() {
+    fn parses_single_hook_and_child_command() {
         let (hooks, child) = parse_args_from(vec![
             "--pre-tool-use".to_string(),
-            "claude-command my-hook-script".to_string(),
+            "claude-command".to_string(),
+            "my-hook-script".to_string(),
+            ";".to_string(),
             "--".to_string(),
             "child-bin".to_string(),
             "--flag".to_string(),
@@ -117,7 +143,7 @@ mod tests {
         let hook = &hooks.entries[0];
         assert_eq!(hook.event, "PreToolUse");
         assert_eq!(hook.hook_type, "claude-command");
-        assert_eq!(hook.command, "my-hook-script");
+        assert_eq!(hook.command, "'my-hook-script'");
         assert_eq!(child, vec!["child-bin", "--flag"]);
     }
 
@@ -125,7 +151,12 @@ mod tests {
     fn parses_hook_with_matcher_and_async_flags() {
         let (hooks, child) = parse_args_from(vec![
             "--pre-tool-use".to_string(),
-            "claude-command --async --matcher bash.* my-script".to_string(),
+            "claude-command".to_string(),
+            "--async".to_string(),
+            "--matcher".to_string(),
+            "bash.*".to_string(),
+            "my-script".to_string(),
+            ";".to_string(),
             "--".to_string(),
             "child".to_string(),
         ])
@@ -136,19 +167,62 @@ mod tests {
         assert_eq!(hook.event, "PreToolUse");
         assert_eq!(hook.matcher.as_deref(), Some("bash.*"));
         assert_eq!(hook.async_hook, Some(true));
-        assert_eq!(hook.command, "my-script");
+        assert_eq!(hook.command, "'my-script'");
         assert_eq!(child, vec!["child"]);
+    }
+
+    #[test]
+    fn accepts_escaped_semicolon_terminator() {
+        let (hooks, child) = parse_args_from(vec![
+            "--pre-tool-use".to_string(),
+            "claude-command".to_string(),
+            "my-script".to_string(),
+            "\\;".to_string(),
+            "--".to_string(),
+            "child".to_string(),
+        ])
+        .expect("parse succeeds");
+
+        assert_eq!(hooks.entries.len(), 1);
+        assert_eq!(hooks.entries[0].command, "'my-script'");
+        assert_eq!(child, vec!["child"]);
+    }
+
+    #[test]
+    fn preserves_and_quotes_multiple_args() {
+        let (hooks, _) = parse_args_from(vec![
+            "--pre-tool-use".to_string(),
+            "claude-command".to_string(),
+            "hook script".to_string(),
+            "arg with spaces".to_string(),
+            "it's-fine".to_string(),
+            ";".to_string(),
+            "--".to_string(),
+            "child".to_string(),
+        ])
+        .expect("parse succeeds");
+
+        assert_eq!(
+            hooks.entries[0].command,
+            "'hook script' 'arg with spaces' 'it'\\''s-fine'"
+        );
     }
 
     #[test]
     fn parses_multiple_hooks_of_different_events() {
         let (hooks, child) = parse_args_from(vec![
             "--pre-tool-use".to_string(),
-            "claude-command pre-script".to_string(),
+            "claude-command".to_string(),
+            "pre-script".to_string(),
+            ";".to_string(),
             "--post-tool-use".to_string(),
-            "claude-command post-script".to_string(),
+            "claude-command".to_string(),
+            "post-script".to_string(),
+            ";".to_string(),
             "--post-tool-use-failure".to_string(),
-            "claude-command fail-script".to_string(),
+            "claude-command".to_string(),
+            "fail-script".to_string(),
+            ";".to_string(),
             "--".to_string(),
             "child".to_string(),
         ])
@@ -156,19 +230,54 @@ mod tests {
 
         assert_eq!(hooks.entries.len(), 3);
         assert_eq!(hooks.entries[0].event, "PreToolUse");
-        assert_eq!(hooks.entries[0].command, "pre-script");
+        assert_eq!(hooks.entries[0].command, "'pre-script'");
         assert_eq!(hooks.entries[1].event, "PostToolUse");
-        assert_eq!(hooks.entries[1].command, "post-script");
+        assert_eq!(hooks.entries[1].command, "'post-script'");
         assert_eq!(hooks.entries[2].event, "PostToolUseFailure");
-        assert_eq!(hooks.entries[2].command, "fail-script");
+        assert_eq!(hooks.entries[2].command, "'fail-script'");
         assert_eq!(child, vec!["child"]);
+    }
+
+    #[test]
+    fn error_on_unterminated_hook() {
+        let result = parse_args_from(vec![
+            "--pre-tool-use".to_string(),
+            "claude-command".to_string(),
+            "script".to_string(),
+        ]);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "unterminated --pre-tool-use (missing ';')"
+        );
+    }
+
+    #[test]
+    fn error_on_missing_command() {
+        let result = parse_args_from(vec![
+            "--pre-tool-use".to_string(),
+            "claude-command".to_string(),
+            "--async".to_string(),
+            "--matcher".to_string(),
+            "bash.*".to_string(),
+            ";".to_string(),
+            "--".to_string(),
+            "child".to_string(),
+        ]);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "--pre-tool-use requires a command after TYPE and options"
+        );
     }
 
     #[test]
     fn error_on_missing_separator() {
         let result = parse_args_from(vec![
             "--pre-tool-use".to_string(),
-            "claude-command script".to_string(),
+            "claude-command".to_string(),
+            "script".to_string(),
+            ";".to_string(),
         ]);
         assert!(result.is_err());
     }
@@ -177,9 +286,59 @@ mod tests {
     fn error_on_empty_child_command() {
         let result = parse_args_from(vec![
             "--pre-tool-use".to_string(),
-            "claude-command script".to_string(),
+            "claude-command".to_string(),
+            "script".to_string(),
+            ";".to_string(),
             "--".to_string(),
         ]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn error_on_unexpected_arg_before_separator() {
+        let result = parse_args_from(vec![
+            "--bogus".to_string(),
+            "--pre-tool-use".to_string(),
+            "claude-command".to_string(),
+            "script".to_string(),
+            ";".to_string(),
+            "--".to_string(),
+            "child".to_string(),
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn error_on_matcher_without_regex() {
+        let result = parse_args_from(vec![
+            "--pre-tool-use".to_string(),
+            "claude-command".to_string(),
+            "--matcher".to_string(),
+            ";".to_string(),
+            "--".to_string(),
+            "child".to_string(),
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn option_like_tokens_after_command_are_literal_args() {
+        let (hooks, child) = parse_args_from(vec![
+            "--pre-tool-use".to_string(),
+            "claude-command".to_string(),
+            "my-cmd".to_string(),
+            "--async".to_string(),
+            ";".to_string(),
+            "--".to_string(),
+            "child".to_string(),
+        ])
+        .expect("parse succeeds");
+
+        assert_eq!(hooks.entries.len(), 1);
+        let hook = &hooks.entries[0];
+        assert_eq!(hook.event, "PreToolUse");
+        assert_eq!(hook.async_hook, None);
+        assert!(hook.command.contains("--async"));
+        assert_eq!(child, vec!["child"]);
     }
 }

--- a/crates/harnx-mcp-hooks-proxy/tests/proxy_e2e.rs
+++ b/crates/harnx-mcp-hooks-proxy/tests/proxy_e2e.rs
@@ -119,13 +119,13 @@ async fn pre_tool_use_block() {
     .expect("write hook script");
     chmod_script(&script_path);
 
-    let hook_arg = format!("claude-command {}", shell_escape_path(&script_path));
     let repo_root = repo_root();
+    let script_path_str = script_path.to_str().expect("utf-8 script path");
     let service = spawn_proxy(
         &proxy_bin,
         &bash_bin,
         &repo_root,
-        &[("--pre-tool-use", hook_arg.as_str())],
+        &[&["--pre-tool-use", "claude-command", script_path_str, ";"]],
     )
     .await
     .expect("spawn proxy with blocking hook and connect MCP client");
@@ -177,12 +177,12 @@ async fn run_mutation_test(test_name: &str, tc: MutationTestCase<'_>) {
     std::fs::write(&script_path, tc.hook_script).expect("write hook script");
     chmod_script(&script_path);
 
-    let hook_arg = format!("claude-command {}", shell_escape_path(&script_path));
+    let script_path_str = script_path.to_str().expect("utf-8 script path");
     let service = spawn_proxy(
         &proxy_bin,
         &bash_bin,
         &repo_root,
-        &[(tc.hook_flag, hook_arg.as_str())],
+        &[&[tc.hook_flag, "claude-command", script_path_str, ";"]],
     )
     .await
     .expect("spawn proxy with mutation hook and connect MCP client");
@@ -286,12 +286,17 @@ async fn post_tool_use_failure() {
     .expect("write failure hook script");
     chmod_script(&script_path);
 
-    let hook_arg = format!("claude-command {}", shell_escape_path(&script_path));
+    let script_path_str = script_path.to_str().expect("utf-8 script path");
     let service = spawn_proxy(
         &proxy_bin,
         &bash_bin,
         &repo_root,
-        &[("--post-tool-use-failure", hook_arg.as_str())],
+        &[&[
+            "--post-tool-use-failure",
+            "claude-command",
+            script_path_str,
+            ";",
+        ]],
     )
     .await
     .expect("spawn proxy with failure hook");
@@ -327,11 +332,13 @@ async fn spawn_proxy(
     proxy_bin: &Path,
     bash_bin: &Path,
     repo_root: &Path,
-    hook_args: &[(&str, &str)],
+    hook_args: &[&[&str]],
 ) -> anyhow::Result<rmcp::service::RunningService<RoleClient, TestClientHandler>> {
     let mut command = tokio::process::Command::new(proxy_bin);
-    for (flag, value) in hook_args {
-        command.arg(flag).arg(value);
+    for hook_group in hook_args {
+        for token in *hook_group {
+            command.arg(token);
+        }
     }
     command.arg("--");
     command.arg(bash_bin);
@@ -410,11 +417,6 @@ fn binary_name(base: &str) -> String {
     } else {
         base.to_string()
     }
-}
-
-fn shell_escape_path(path: &Path) -> String {
-    let s = path.to_string_lossy();
-    format!("'{}'", s.replace('\'', "'\\''"))
 }
 
 fn chmod_script(path: &Path) {

--- a/docs/solutions/integration-issues/hooks-proxy-exec-syntax-2026-06-10.md
+++ b/docs/solutions/integration-issues/hooks-proxy-exec-syntax-2026-06-10.md
@@ -1,0 +1,134 @@
+---
+title: "find -exec Style Hook CLI Syntax for MCP Hooks Proxy"
+date: 2026-06-10
+category: integration-issues
+problem_type: integration_issue
+component: harnx-mcp-hooks-proxy
+root_cause: "Shell-quoting complexity in hook command arguments motivated find -exec style argv token syntax"
+resolution_type: code_fix
+severity: medium
+tags:
+  - cli-parsing
+  - hooks
+  - argument-handling
+  - shell-semantics
+  - code-reuse
+plan_ref: hooks-proxy-exec-syntax-673
+---
+
+## Problem
+
+Users had to shell-quote hook commands within a single string argument, e.g. `--hook "echo 'hello world'"`. This is error-prone and differs from how `find -exec` handles commands cleanly as separate argv tokens. GitHub issue #673 requested `find -exec` style syntax: `--hook <TYPE> <CMD> [ARGS...] ;` with each token as a separate argv element, eliminating inner shell-quoting.
+
+## Symptoms
+
+- Users struggled with nested quoting: `--hook "sh -c 'echo $VAR'"`
+- Inconsistent UX across workspace crates for hook specification
+- No unified pattern for passing multi-token commands to hooks
+
+## Investigation Steps
+
+1. Reviewed existing `harnx-sandbox-run` crate — already implements `find -exec` syntax
+2. Located reference implementation: `crates/harnx-sandbox-run/src/cli.rs` (`pre_parse_hooks` + `collect_hook_tokens`)
+3. Found `build_hook_command` + `shell_quote` in `crates/harnx-sandbox-run/src/hooks.rs`
+4. Verified pattern: pre-parse argv collecting tokens until `;` or `\;` terminator **before** clap sees args
+5. Noted workspace-wide duplication: same `shell_quote` and `build_hook_command` exist in harnx-mcp-hooks-proxy, harnx-sandbox-run, harnx-hooks — candidate for extraction into harnx-core
+
+## Root Cause
+
+Traditional single-string hook args require users to mentally model shell quoting rules. The `find -exec` pattern solves this by treating each argv token as a literal until the terminator, then shell-quoting programmatically at dispatch time.
+
+## Solution
+
+Mirror the proven pattern from `harnx-sandbox-run`:
+
+**Pre-parse loop** (`collect_hook_tokens`):
+
+```rust
+fn collect_hook_tokens<I>(iter: &mut I, flag: &str) -> Result<Vec<String>>
+where
+    I: Iterator<Item = String>,
+{
+    let mut tokens = Vec::new();
+    for token in iter.by_ref() {
+        if token == ";" || token == "\\;" {
+            return Ok(tokens);
+        }
+        tokens.push(token);
+    }
+    bail!("unterminated {flag} (missing ';')")
+}
+```
+
+**Shell-quoting** (`shell_quote`):
+
+```rust
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn build_hook_command(command: &str, args: &[String]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 1);
+    parts.push(shell_quote(command));
+    for arg in args {
+        parts.push(shell_quote(arg));
+    }
+    parts.join(" ")
+}
+```
+
+**Option parsing guard** (key design detail):
+
+```rust
+while let Some(token) = iter.next() {
+    match token.as_str() {
+        "--async" if command.is_none() => { async_hook = Some(true); }
+        "--matcher" if command.is_none() => { matcher = Some(iter.next().context("--matcher requires REGEX")?); }
+        _ => {
+            command = Some(token);  // First non-option is the command
+            args.extend(iter);       // Rest are args
+            break;
+        }
+    }
+}
+```
+
+The `if command.is_none()` guard ensures `--async`/`--matcher` are only consumed BEFORE the first command token. Same flags appearing after the command are treated as literal args.
+
+**CLI usage**:
+
+```bash
+harnx-mcp-hooks-proxy \
+  --pre-tool-use claude-command --async --matcher "bash_exec" /usr/bin/env-logger arg1 arg2 ';' \
+  --post-tool-use claude-command /usr/bin/cleanup ';' \
+  -- child-command --with --args
+```
+
+## Why This Works
+
+1. **Pre-parsing before clap**: Raw argv is walked once, collecting hook tokens until `;`. Remaining args go to clap. This avoids clap trying to parse `--async` within hook definitions as its own flags.
+2. **Per-token shell-quoting**: Each token is quoted individually and joined into a single `HookConfig.command` string, executed via `sh -c` downstream. Users don't need to quote.
+3. **Option guard**: `--async`/`--matcher` only recognized before the command token — prevents accidental interception if a wrapped command uses the same flag names.
+4. **Reused proven pattern**: harnx-sandbox-run already validated this approach — mirroring reduces risk and maintains workspace consistency.
+
+## Prevention Strategies
+
+**Code Review Checklist**:
+- [ ] Does new hook CLI syntax mirror harnx-sandbox-run's `pre_parse_hooks` + `collect_hook_tokens`?
+- [ ] Are options guarded with `if command.is_none()`?
+- [ ] Is `shell_quote` used for each token (not the whole string)?
+
+**Future Consolidation**:
+- Extract `shell_quote` and `build_hook_command` into `harnx-core` to eliminate duplication across harnx-mcp-hooks-proxy, harnx-sandbox-run, harnx-hooks.
+
+**Test Cases**:
+- Hook with `--async` before command → recognized
+- Hook with `--async` after command → treated as literal arg
+- Hook with spaces in args → no quoting issues
+- Unterminated hook definition → clear error message
+
+## Related Issues
+
+- **GitHub:** [#673](https://github.com/example/harnx/issues/673) — find -exec style hook args
+- **Reference Implementation:** `crates/harnx-sandbox-run/src/cli.rs` — `pre_parse_hooks` + `collect_hook_tokens`
+- **Related Solution:** [cli-hook-pre-parse-separator-2026-05-28.md](./cli-hook-pre-parse-separator-2026-05-28.md) — `--` separator boundary handling


### PR DESCRIPTION
Changes harnx-mcp-hooks-proxy hook argument syntax to find -exec style (--<event> <TYPE> [--async] [--matcher <REGEX>] <CMD> [ARGS...] ;, terminated by ;/\;), removing the need for inner shell-quoting. Updates unit and e2e tests and the crate README. Adds a docs/solutions entry for the new syntax.

Closes #673

Plan: hooks-proxy-exec-syntax-673