### PR TITLE
feat(acp)!: extract ACP server and fix same-package delegation

### DIFF
--- a/.changeset/acp-server-extraction-and-package-delegation.md
+++ b/.changeset/acp-server-extraction-and-package-delegation.md
@@ -1,0 +1,7 @@
+---
+harnx: major
+---
+Move ACP support out of the `harnx` binary and fix same-package pantheon delegation.
+
+- **Breaking:** The `harnx --acp <agent>` flag has been removed (no backward compatibility). Serving an agent over ACP is now done with the standalone `harnx-acp-server <agent>` binary. Internally generated ACP subagent servers are auto-registered to spawn `harnx-acp-server <agent>` instead of `harnx --acp <agent>`; the server binary is resolved as a sibling of the running `harnx` executable, falling back to `harnx-acp-server` on `PATH` (#550).
+- **Fix:** Same-package pantheon delegation no longer drops the package prefix on spawn. Auto-registered ACP servers now keep the package-qualified spawn target (e.g. `pantheon/aristarchus`) in their `args`, independent of the per-agent display-name rewrite that exposes same-package peers under their bare name. Package-loaded `acp_servers/*.yaml` whose `args` reference the bare server stem are normalized to the qualified `<package>/<name>` target. This fixes delegation between two agents in the same package once same-named top-level agents are removed (#804).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,7 +3392,6 @@ dependencies = [
  "glob",
  "globset",
  "harnx-acp",
- "harnx-acp-server",
  "harnx-client",
  "harnx-core",
  "harnx-engine",

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ what you need:
 
 | Binary | What it does | Docs |
 |---|---|---|
-| `harnx` | Full CLI — TUI + Cmd + HTTP (`--serve`) + ACP (`--acp=<agent>`) | [Command-Line Guide](docs/command-line-guide.md) |
+| `harnx` | Full CLI — TUI + Cmd + HTTP (`--serve`); ACP via `harnx-acp-server <agent>` | [Command-Line Guide](docs/command-line-guide.md) |
 | `harnx-serve` | HTTP-only server, no TUI deps | [README](crates/harnx-serve/README.md) |
 | `harnx-acp-server` | ACP-only headless agent over stdio, no TUI deps | [README](crates/harnx-acp-server/README.md) |
 | `harnx-pkg` | Package manager for harnx agent configurations | [Package System](docs/packages.md) |

--- a/crates/harnx-acp-server/src/bin/harnx-acp-server.rs
+++ b/crates/harnx-acp-server/src/bin/harnx-acp-server.rs
@@ -2,8 +2,8 @@
 //! that don't need the TUI or HTTP server. Speaks the ACP protocol over
 //! stdin/stdout to a host coordinator (Zed, Superpowers, etc.).
 //!
-//! All advanced features (session management, macros, model picker, etc.)
-//! remain available through the primary `harnx --acp=<name>` path.
+//! Run as `harnx-acp-server <agent>` to serve an agent with full
+//! session management, macros, model picker, and other runtime features.
 
 use anyhow::{Context, Result};
 use clap::Parser;

--- a/crates/harnx-runtime/src/config/loader_split.rs
+++ b/crates/harnx-runtime/src/config/loader_split.rs
@@ -169,7 +169,7 @@ impl Config {
             .iter()
             .map(|server| server.name.clone())
             .collect();
-        let current_exe = std::env::current_exe()?.to_string_lossy().to_string();
+        let command = harnx_acp_server_command();
         for agent_name in list_agents() {
             if !existing_names.contains(&agent_name) {
                 // Extract the package for package agents (e.g. "mypkg/coder" → Some("mypkg")).
@@ -178,8 +178,8 @@ impl Config {
                     .map(str::to_string);
                 acp_servers.push(AcpServerConfig {
                     name: agent_name.clone(),
-                    command: current_exe.clone(),
-                    args: vec!["--acp".to_string(), agent_name],
+                    command: command.clone(),
+                    args: vec![agent_name.clone()],
                     env: Default::default(),
                     enabled: true,
                     description: None,
@@ -279,6 +279,48 @@ impl Config {
     }
 }
 
+fn harnx_acp_server_command() -> String {
+    std::env::current_exe()
+        .map(|current_exe| harnx_acp_server_command_from_current_exe(&current_exe))
+        .unwrap_or_else(|_| fallback_harnx_acp_server_command())
+}
+
+fn harnx_acp_server_command_from_current_exe(current_exe: &Path) -> String {
+    harnx_acp_server_command_from_parent(current_exe.parent(), current_exe.is_absolute())
+}
+
+fn harnx_acp_server_command_from_parent(
+    parent_dir: Option<&Path>,
+    current_exe_is_absolute: bool,
+) -> String {
+    let Some(parent_dir) = parent_dir else {
+        return fallback_harnx_acp_server_command();
+    };
+    if !current_exe_is_absolute {
+        return fallback_harnx_acp_server_command();
+    }
+    let sibling = parent_dir.join(harnx_acp_server_binary_name());
+    if sibling.is_file() {
+        sibling.to_string_lossy().to_string()
+    } else {
+        fallback_harnx_acp_server_command()
+    }
+}
+
+#[cfg(windows)]
+fn harnx_acp_server_binary_name() -> &'static str {
+    "harnx-acp-server.exe"
+}
+
+#[cfg(not(windows))]
+fn harnx_acp_server_binary_name() -> &'static str {
+    "harnx-acp-server"
+}
+
+fn fallback_harnx_acp_server_command() -> String {
+    String::from("harnx-acp-server")
+}
+
 async fn create_config_file(config_path: &Path) -> Result<()> {
     let ans = Confirm::new("No config file, create a new one?")
         .with_default(true)
@@ -336,4 +378,77 @@ async fn create_config_file(config_path: &Path) -> Result<()> {
     ));
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::harnx_acp_server_command_from_current_exe;
+    use std::{fs, path::PathBuf};
+
+    #[test]
+    fn harnx_acp_server_command_uses_existing_sibling_binary() {
+        let temp_dir = unique_temp_dir("harnx-acp-server-sibling-present");
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        let current_exe = temp_dir.join(current_exe_name());
+        fs::write(&current_exe, b"").unwrap();
+
+        let sibling = temp_dir.join(harnx_acp_server_binary_name());
+        fs::write(&sibling, b"").unwrap();
+
+        assert_eq!(
+            harnx_acp_server_command_from_current_exe(&current_exe),
+            sibling.to_string_lossy().to_string()
+        );
+
+        fs::remove_dir_all(&temp_dir).unwrap();
+    }
+
+    #[test]
+    fn harnx_acp_server_command_falls_back_when_sibling_missing() {
+        let temp_dir = unique_temp_dir("harnx-acp-server-sibling-missing");
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        let current_exe = temp_dir.join(current_exe_name());
+        fs::write(&current_exe, b"").unwrap();
+
+        assert_eq!(
+            harnx_acp_server_command_from_current_exe(&current_exe),
+            "harnx-acp-server"
+        );
+
+        fs::remove_dir_all(&temp_dir).unwrap();
+    }
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let unique = format!(
+            "{prefix}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        std::env::temp_dir().join(unique)
+    }
+
+    #[cfg(windows)]
+    fn current_exe_name() -> &'static str {
+        "harnx-runtime-test.exe"
+    }
+
+    #[cfg(not(windows))]
+    fn current_exe_name() -> &'static str {
+        "harnx-runtime-test"
+    }
+
+    #[cfg(windows)]
+    fn harnx_acp_server_binary_name() -> &'static str {
+        "harnx-acp-server.exe"
+    }
+
+    #[cfg(not(windows))]
+    fn harnx_acp_server_binary_name() -> &'static str {
+        "harnx-acp-server"
+    }
 }

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -30,10 +30,10 @@ pub use self::agent::{
     AgentVariables,
 };
 pub use self::input::Input;
+pub use self::patches_split::acp_server_display_name;
 pub use self::patches_split::mcp_server_display_name;
 use self::patches_split::{
-    acp_server_display_name, apply_client_patch, apply_mcp_server_patch, load_package_mcp_patch,
-    package_dir_name,
+    apply_client_patch, apply_mcp_server_patch, load_package_mcp_patch, package_dir_name,
 };
 use self::session::Session;
 pub use self::session_meta::{

--- a/crates/harnx-runtime/src/config/patches_split.rs
+++ b/crates/harnx-runtime/src/config/patches_split.rs
@@ -108,10 +108,7 @@ pub fn mcp_server_display_name(server: &McpServerConfig, agent_package: Option<&
 }
 
 /// Compute display name for ACP server given active agent package.
-pub(super) fn acp_server_display_name(
-    server: &AcpServerConfig,
-    agent_package: Option<&str>,
-) -> String {
+pub fn acp_server_display_name(server: &AcpServerConfig, agent_package: Option<&str>) -> String {
     handoff_display_name(
         &server_target_qualified(&server.name, server.package.as_deref()),
         agent_package,

--- a/crates/harnx-runtime/src/config/servers_split.rs
+++ b/crates/harnx-runtime/src/config/servers_split.rs
@@ -1,6 +1,17 @@
 //! MCP/ACP server management extracted from config/mod.rs for code health.
 use super::*;
+use harnx_core::package_namespace::qualify_agent_name;
 use std::env;
+
+fn normalize_package_acp_server_args(server: &mut AcpServerConfig, pkg_name: &str) {
+    let stem = server.name.as_str();
+    let qualified = qualify_agent_name(pkg_name, stem);
+    for arg in &mut server.args {
+        if arg == stem {
+            *arg = qualified.clone();
+        }
+    }
+}
 
 impl Config {
     /// Load MCP and ACP servers from a single package directory.
@@ -34,6 +45,7 @@ impl Config {
         if pkg_acp_dir.is_dir() {
             for mut server in Self::load_acp_servers_from_dir(&pkg_acp_dir).unwrap_or_default() {
                 server.package = Some(pkg_name.to_string());
+                normalize_package_acp_server_args(&mut server, pkg_name);
                 config.acp_servers.push(server);
             }
         }

--- a/crates/harnx-runtime/src/lib.rs
+++ b/crates/harnx-runtime/src/lib.rs
@@ -23,5 +23,7 @@ pub use agent_loop::{
     run_agent_loop, AgentCallFn, AgentLoopContext, OnTextResponseFn, OnToolRoundFn,
 };
 
+/// Re-export for integration tests — verifies scoped-ACP display naming logic.
+pub use config::acp_server_display_name as acp_server_display_name_for_test;
 /// Re-export for integration tests — verifies the scoped-MCP naming logic.
 pub use config::mcp_server_display_name as mcp_server_display_name_for_test;

--- a/crates/harnx-runtime/tests/package_loading.rs
+++ b/crates/harnx-runtime/tests/package_loading.rs
@@ -659,3 +659,160 @@ fn package_loading_test_mcp_server_display_names_for_agent() {
         "mypkg__fs"
     );
 }
+
+#[test]
+fn package_loading_test_auto_registered_acp_servers_use_harnx_acp_server_command_and_qualified_args(
+) {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    std::fs::create_dir_all(tmp.path().join("clients")).unwrap();
+    std::fs::write(tmp.path().join("clients/openai.yaml"), "type: openai\n").unwrap();
+    std::fs::create_dir_all(tmp.path().join("agents")).unwrap();
+    std::fs::write(
+        tmp.path().join("agents").join("foo.md"),
+        "---\nmodel: openai:gpt-4o\n---\nTop-level agent.",
+    )
+    .unwrap();
+
+    install_test_package(
+        tmp.path(),
+        "pantheon",
+        &[(
+            "agents/aristarchus.md",
+            "---\nmodel: openai:gpt-4o\n---\nPackage agent.",
+        )],
+    );
+
+    let config = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(Config::init(
+            harnx_runtime::config::WorkingMode::Cmd,
+            false,
+            vec![],
+        ))
+        .expect("config should load");
+
+    let package_server = config
+        .acp_servers
+        .iter()
+        .find(|server| server.name == "pantheon/aristarchus")
+        .expect("package agent acp server should be auto-registered");
+    assert_eq!(
+        package_server.args,
+        vec!["pantheon/aristarchus".to_string()]
+    );
+    assert!(
+        package_server.command.ends_with("harnx-acp-server")
+            || package_server.command.ends_with("harnx-acp-server.exe"),
+        "expected harnx-acp-server command, got: {}",
+        package_server.command
+    );
+
+    let top_level_server = config
+        .acp_servers
+        .iter()
+        .find(|server| server.name == "foo")
+        .expect("top-level agent acp server should be auto-registered");
+    assert_eq!(top_level_server.args, vec!["foo".to_string()]);
+    assert!(
+        top_level_server.command.ends_with("harnx-acp-server")
+            || top_level_server.command.ends_with("harnx-acp-server.exe"),
+        "expected harnx-acp-server command, got: {}",
+        top_level_server.command
+    );
+}
+
+#[test]
+fn package_loading_test_reinit_acp_display_rewrite_keeps_spawn_target_qualified() {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    std::fs::create_dir_all(tmp.path().join("clients")).unwrap();
+    std::fs::write(tmp.path().join("clients/openai.yaml"), "type: openai\n").unwrap();
+    install_test_package(
+        tmp.path(),
+        "pantheon",
+        &[(
+            "agents/aristarchus.md",
+            "---\nmodel: openai:gpt-4o\n---\nPackage agent.",
+        )],
+    );
+
+    let config = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(Config::init(
+            harnx_runtime::config::WorkingMode::Cmd,
+            false,
+            vec![],
+        ))
+        .expect("config should load");
+
+    let original_server = config
+        .acp_servers
+        .iter()
+        .find(|server| server.name == "pantheon/aristarchus")
+        .expect("package agent acp server should be auto-registered");
+    assert_eq!(
+        original_server.args,
+        vec!["pantheon/aristarchus".to_string()]
+    );
+    // #804: same-package ACP display rewrite clones server and only rewrites display
+    // name, so bare display name + qualified source args proves spawn target stays qualified.
+    assert_eq!(
+        harnx_runtime::acp_server_display_name_for_test(original_server, Some("pantheon")),
+        "aristarchus"
+    );
+}
+
+#[test]
+fn package_loading_test_package_explicit_yaml_acp_bare_arg_is_qualified_but_top_level_stays_bare() {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    std::fs::create_dir_all(tmp.path().join("clients")).unwrap();
+    std::fs::write(tmp.path().join("clients/openai.yaml"), "type: openai\n").unwrap();
+    std::fs::create_dir_all(tmp.path().join("acp_servers")).unwrap();
+    std::fs::write(
+        tmp.path().join("acp_servers").join("top.yaml"),
+        "command: custom-top\nargs:\n  - top\n",
+    )
+    .unwrap();
+    install_test_package(
+        tmp.path(),
+        "momus",
+        &[(
+            "acp_servers/helper.yaml",
+            "command: custom-helper\nargs:\n  - helper\n  - --flag\n",
+        )],
+    );
+
+    let config = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(Config::init(
+            harnx_runtime::config::WorkingMode::Cmd,
+            false,
+            vec![],
+        ))
+        .expect("config should load");
+
+    let package_server = config
+        .acp_servers
+        .iter()
+        .find(|server| server.package.as_deref() == Some("momus") && server.name == "helper")
+        .expect("package acp server should load");
+    assert_eq!(
+        package_server.args,
+        vec!["momus/helper".to_string(), "--flag".to_string()]
+    );
+
+    let top_level_server = config
+        .acp_servers
+        .iter()
+        .find(|server| server.package.is_none() && server.name == "top")
+        .expect("top-level acp server should load");
+    assert_eq!(top_level_server.args, vec!["top".to_string()]);
+}

--- a/crates/harnx/Cargo.toml
+++ b/crates/harnx/Cargo.toml
@@ -76,7 +76,6 @@ agent-client-protocol = { workspace = true }
 glob = { workspace = true }
 globset = { workspace = true }
 harnx-acp = { workspace = true }
-harnx-acp-server = { workspace = true }
 harnx-client = { path = "../harnx-client" }
 harnx-core = { path = "../harnx-core" }
 harnx-engine = { path = "../harnx-engine" }

--- a/crates/harnx/src/cli.rs
+++ b/crates/harnx/src/cli.rs
@@ -39,9 +39,6 @@ pub struct Cli {
     /// Serve the LLM API and WebAPP
     #[clap(long, value_name = "ADDRESS")]
     pub serve: Option<Option<String>>,
-    /// Serve as an ACP agent over stdio
-    #[clap(long, value_name = "AGENT")]
-    pub acp: Option<String>,
     /// Include files, directories, or URLs
     #[clap(short = 'f', long, value_name = "FILE")]
     pub file: Vec<String>,
@@ -87,10 +84,6 @@ pub struct Cli {
 }
 
 impl Cli {
-    pub fn should_read_stdin(&self) -> bool {
-        self.acp.is_none()
-    }
-
     pub fn text(&self) -> Result<Option<String>> {
         let mut stdin_text = String::new();
         if !stdin().is_terminal() {
@@ -129,25 +122,5 @@ impl Cli {
                 }
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::Cli;
-    use clap::Parser;
-
-    #[test]
-    fn test_acp_mode_skips_stdin_reads() {
-        let cli = Cli::parse_from(["harnx", "--acp", "explore"]);
-
-        assert!(!cli.should_read_stdin());
-    }
-
-    #[test]
-    fn test_non_acp_mode_still_reads_stdin() {
-        let cli = Cli::parse_from(["harnx", "hello"]);
-
-        assert!(cli.should_read_stdin());
     }
 }

--- a/crates/harnx/src/lib.rs
+++ b/crates/harnx/src/lib.rs
@@ -11,7 +11,7 @@ pub use harnx_tui as tui;
 
 // Re-export the runtime bundle so `crate::config::X`, `crate::client::X`,
 // `crate::commands::X`, and `crate::tool::X` in harnx's remaining front-end
-// code (acp/, main.rs, agent_event_sink.rs, cli_event_sink.rs, test_utils/)
+// code (main.rs, agent_event_sink.rs, cli_event_sink.rs, test_utils/)
 // continue to resolve. After plan P46's extraction, these modules live in
 // harnx-runtime.
 pub use harnx_runtime::{client, commands, config, tool};

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -39,14 +39,8 @@ use std::{env, path::PathBuf, sync::Arc, time::Duration};
 async fn main() -> Result<()> {
     load_env_file()?;
     let cli = Cli::parse();
-    let text = if cli.should_read_stdin() {
-        cli.text()?
-    } else {
-        None
-    };
-    let working_mode = if let Some(ref agent_name) = cli.acp {
-        WorkingMode::Acp(agent_name.clone())
-    } else if cli.serve.is_some() {
+    let text = cli.text()?;
+    let working_mode = if cli.serve.is_some() {
         WorkingMode::Serve
     } else if text.is_none() && cli.file.is_empty() {
         WorkingMode::Tui
@@ -61,7 +55,7 @@ async fn main() -> Result<()> {
         || cli.list_rags
         || cli.list_macros
         || cli.list_sessions;
-    setup_logger(working_mode.is_serve() || working_mode.is_acp())?;
+    setup_logger(working_mode.is_serve())?;
     let config = Arc::new(RwLock::new(
         Config::init(working_mode, info_flag, cli.mcp_root.clone()).await?,
     ));
@@ -202,10 +196,6 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
         let info = config.read().info()?;
         println!("{info}");
         return Ok(());
-    }
-    let working_mode = config.read().working_mode.clone();
-    if let WorkingMode::Acp(agent_name) = working_mode {
-        return harnx_acp_server::run(config, agent_name).await;
     }
     if let Some(addr) = cli.serve {
         return serve::run(config, addr).await;

--- a/crates/harnx/src/test_utils/interrupt.rs
+++ b/crates/harnx/src/test_utils/interrupt.rs
@@ -11,6 +11,20 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+/// Locate the `harnx-acp-server` binary given the already-resolved `harnx`
+/// binary path.
+///
+/// The `harnx-acp-server` binary lives in its own crate, so
+/// `CARGO_BIN_EXE_harnx-acp-server` isn't visible from `harnx`'s test
+/// context. Because Cargo builds every workspace member into the same target
+/// dir, the binary sits next to the `harnx` binary. Callers are responsible
+/// for ensuring it has been built (e.g. via `cargo build --workspace` or
+/// `cargo nextest run --workspace`, which is what CI uses).
+pub fn harnx_acp_server_bin(harnx_bin: &Path) -> PathBuf {
+    let ext = std::env::consts::EXE_SUFFIX;
+    harnx_bin.with_file_name(format!("harnx-acp-server{ext}"))
+}
+
 /// Spinner frames used by the TUI when an LLM/tool/hook call is in flight.
 /// Mirrors `SPINNER_FRAMES` in `src/tui/types.rs`. Used to detect whether
 /// the TUI is currently busy.
@@ -366,10 +380,10 @@ pub fn script_call_sub_agent(agent_name: &str) -> MockOpenAiScript {
 /// Sets up two config dirs (child and parent) for a sub-agent delegation test.
 ///
 /// - Child dir: `dir/child` — minimal config pointing at `child_mock_url`,
-///   plus an agent file at `agents/child.md` (required by `harnx --acp child`).
+///   plus an agent file at `agents/child.md` (required by `harnx-acp-server child`).
 /// - Parent dir: `dir/parent` — minimal config pointing at `parent_mock_url`,
 ///   plus an `acp_servers/child.yaml` that spawns another harnx with
-///   `--acp child` and `HARNX_CONFIG_DIR` pointing at the child config dir.
+///   `harnx-acp-server child` and `HARNX_CONFIG_DIR` pointing at the child config dir.
 ///
 /// Returns the PARENT's `ConfigPaths` so `spawn_tui` launches the parent.
 pub fn write_with_sub_agent(
@@ -380,7 +394,7 @@ pub fn write_with_sub_agent(
 ) -> Result<ConfigPaths> {
     // Child config (lives in <dir>/child/harnx-config).
     let child_paths = write_minimal_config(&dir.join("child"), child_mock_url)?;
-    // The child needs an agent file matching the agent name passed to --acp.
+    // The child needs an agent file matching agent name passed to harnx-acp-server.
     std::fs::create_dir_all(child_paths.harnx_config_dir.join("agents"))?;
     std::fs::write(
         child_paths.harnx_config_dir.join("agents/child.md"),
@@ -390,7 +404,7 @@ pub fn write_with_sub_agent(
     // Parent config (lives in <dir>/parent/harnx-config).
     let parent_paths = write_minimal_config(&dir.join("parent"), parent_mock_url)?;
 
-    // ACP server entry on the parent — points at another harnx --acp child
+    // ACP server entry on parent — points at sibling harnx-acp-server child
     // with the child's HARNX_CONFIG_DIR.
     let acp_servers_dir = parent_paths.harnx_config_dir.join("acp_servers");
     std::fs::create_dir_all(&acp_servers_dir)?;
@@ -409,8 +423,10 @@ pub fn write_with_sub_agent(
     );
     let acp_server = AcpServerConfig {
         name: "child".to_string(),
-        command: harnx_bin.to_string_lossy().into_owned(),
-        args: vec!["--acp".to_string(), "child".to_string()],
+        command: harnx_acp_server_bin(harnx_bin)
+            .to_string_lossy()
+            .into_owned(),
+        args: vec!["child".to_string()],
         env,
         enabled: true,
         description: None,
@@ -487,7 +503,7 @@ pub fn send_sigint(child: &std::process::Child) -> Result<()> {
 
 /// Writes an agent markdown file under `<harnx_config_dir>/agents/<name>.md`
 /// pointing at the `mock-llm:test` model with `use_tools: '*'`. Required
-/// before launching `harnx --acp <name>`.
+/// before launching `harnx-acp-server <name>`.
 pub fn write_acp_agent(paths: &ConfigPaths, name: &str) -> Result<()> {
     let agents = paths.harnx_config_dir.join("agents");
     std::fs::create_dir_all(&agents).context("failed to create agents dir")?;
@@ -499,7 +515,7 @@ pub fn write_acp_agent(paths: &ConfigPaths, name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Builds a connected `AcpClient` against a `harnx --acp <agent>` child
+/// Builds connected `AcpClient` against `harnx-acp-server <agent>` child
 /// using the given config dir.
 pub async fn spawn_acp_client(
     paths: &ConfigPaths,
@@ -521,8 +537,10 @@ pub async fn spawn_acp_client(
     );
     let config = AcpServerConfig {
         name: format!("test-{agent}"),
-        command: harnx_bin.to_string_lossy().into_owned(),
-        args: vec!["--acp".to_string(), agent.to_string()],
+        command: harnx_acp_server_bin(harnx_bin)
+            .to_string_lossy()
+            .into_owned(),
+        args: vec![agent.to_string()],
         env,
         enabled: true,
         description: None,

--- a/crates/harnx/tests/interrupt_e2e.rs
+++ b/crates/harnx/tests/interrupt_e2e.rs
@@ -12,11 +12,11 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use harnx::test_utils::interrupt::{
-    script_call_sub_agent, script_call_trivial_tool, script_call_wait_tool, script_stall_streaming,
-    script_streaming_with_sentinel, send_sigint, spawn_acp_client, spawn_oneshot,
-    spawn_oneshot_in_tmux, spawn_tui, wait_for_cmd_exit, wait_for_exit, wait_for_prompt_return,
-    write_acp_agent, write_minimal_config, write_with_blocking_hook, write_with_sub_agent,
-    write_with_wait_tool,
+    harnx_acp_server_bin, script_call_sub_agent, script_call_trivial_tool, script_call_wait_tool,
+    script_stall_streaming, script_streaming_with_sentinel, send_sigint, spawn_acp_client,
+    spawn_oneshot, spawn_oneshot_in_tmux, spawn_tui, wait_for_cmd_exit, wait_for_exit,
+    wait_for_prompt_return, write_acp_agent, write_minimal_config, write_with_blocking_hook,
+    write_with_sub_agent, write_with_wait_tool,
 };
 use harnx::test_utils::mock_openai_server::MockOpenAiServer;
 use harnx::test_utils::tmux_harness::TmuxHarness;
@@ -500,14 +500,14 @@ fn interrupt_acp_sigint_cancels_and_exits() -> Result<()> {
     let mock = MockOpenAiServer::start(script_stall_streaming())?;
     let tmp = tempfile::tempdir()?;
     let paths = write_minimal_config(tmp.path(), &format!("http://127.0.0.1:{}/v1", mock.port()))?;
-    write_acp_agent(&paths, "default")?;
     let harnx_bin = PathBuf::from(env!("CARGO_BIN_EXE_harnx"));
+    write_acp_agent(&paths, "default")?;
+    let acp_server_bin = harnx_acp_server_bin(&harnx_bin);
 
-    // Spawn `harnx --acp default` with raw stdio. We don't need the
-    // RPC responses parsed — just need the child to be busy enough
+    // Spawn `harnx-acp-server default` with raw stdio. We don't need
+    // RPC responses parsed — just need child to be busy enough
     // that SIGINT is meaningful, and to confirm it then exits.
-    let mut child = Command::new(&harnx_bin)
-        .arg("--acp")
+    let mut child = Command::new(&acp_server_bin)
         .arg("default")
         .env("HARNX_CONFIG_DIR", &paths.harnx_config_dir)
         .stdin(Stdio::piped())

--- a/crates/harnx/tests/tmux_e2e.rs
+++ b/crates/harnx/tests/tmux_e2e.rs
@@ -8,6 +8,7 @@ use harnx_core::message::MessageRole;
 use harnx_core::session::SessionLogEntry;
 
 use anyhow::{Context, Result};
+use harnx::test_utils::interrupt::harnx_acp_server_bin;
 use insta::assert_snapshot;
 use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
@@ -18,6 +19,20 @@ const REPRO_249_MCP_TOOL_NAME: &str = "repro249_unique_mcp_tool";
 const REPRO_249_MCP_TOOL_RESPONSE: &str = "repro249 fixed tool response";
 const TEST_AGENT_NAME: &str = "test-agent";
 const TEST_SUB_AGENT_NAME: &str = "test-sub-agent";
+#[cfg(unix)]
+const PACKAGE_DELEGATION_PACKAGE_NAME: &str = "same-package-delegation";
+#[cfg(unix)]
+const PACKAGE_DELEGATION_CALLER_NAME: &str = "package-caller";
+#[cfg(unix)]
+const PACKAGE_DELEGATION_PEER_NAME: &str = "package-peer";
+#[cfg(unix)]
+const PACKAGE_DELEGATION_USER_PROMPT: &str = "delegate to your package peer";
+#[cfg(unix)]
+const PACKAGE_DELEGATION_PEER_RESPONSE: &str =
+    "Package peer response: same-package delegation succeeded.";
+#[cfg(unix)]
+const PACKAGE_DELEGATION_CALLER_RESPONSE: &str =
+    "Package caller final response: Package peer response: same-package delegation succeeded.";
 
 #[test]
 #[cfg(unix)]
@@ -261,6 +276,102 @@ fn repro_249_top_level_delegation_markers() -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+#[test]
+fn same_package_session_prompt_delegation_uses_qualified_spawn() -> Result<()> {
+    if option_env!("CARGO_BIN_NAME") == Some("harnx") {
+        eprintln!(
+            "skipping same_package_session_prompt_delegation_uses_qualified_spawn in binary test target"
+        );
+        return Ok(());
+    }
+    if !TmuxHarness::is_available() {
+        eprintln!("skipping same_package_session_prompt_delegation_uses_qualified_spawn: tmux is unavailable");
+        return Ok(());
+    }
+
+    let repo_root = repo_root()?;
+    let harnx_bin = PathBuf::from(env!("CARGO_BIN_EXE_harnx"));
+
+    let temp = TempDir::new().context("failed to create temp dir")?;
+    let mock = MockOpenAiServer::start(package_delegation_script())?;
+    let paths = TestPaths::new(temp.path(), mock.port())?;
+    write_same_package_delegation_fixture_files(&paths)?;
+
+    let path_env = format!(
+        "{}:{}",
+        harnx_bin
+            .parent()
+            .context("harnx binary missing parent directory")?
+            .display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let tmux = match TmuxHarness::new(&repo_root, 120, 35) {
+        Ok(tmux) => tmux,
+        Err(err) => {
+            eprintln!(
+                "skipping same_package_session_prompt_delegation_uses_qualified_spawn: \
+                 tmux is unavailable or unusable ({err:#})"
+            );
+            return Ok(());
+        }
+    };
+    tmux.send_keys(&["C-l"])?;
+
+    tmux.send_text(&format!(
+        "export HARNX_CONFIG_DIR={} HARNX_DATA_DIR={} HARNX_STATE_DIR={}",
+        shell_escape(paths.harnx_config_dir.to_string_lossy().as_ref()),
+        shell_escape(paths.harnx_data_dir.to_string_lossy().as_ref()),
+        shell_escape(paths.harnx_state_dir.to_string_lossy().as_ref())
+    ))?;
+    tmux.send_keys(&["Enter"])?;
+
+    tmux.send_text(&format!(
+        "export PATH={} && cd {}; printf '__PKG_DELEGATION_READY__\\n'",
+        shell_escape(&path_env),
+        shell_escape(repo_root.to_string_lossy().as_ref())
+    ))?;
+    tmux.send_keys(&["Enter"])?;
+    tmux.wait_for(Duration::from_secs(5), |screen| {
+        count_occurrences(screen, "__PKG_DELEGATION_READY__") >= 2
+    })?;
+
+    tmux.send_text(&format!(
+        "{} -a {PACKAGE_DELEGATION_PACKAGE_NAME}/{PACKAGE_DELEGATION_CALLER_NAME} --session || echo HARNX_EXIT:$?",
+        shell_escape(harnx_bin.to_string_lossy().as_ref()),
+    ))?;
+    tmux.send_keys(&["Enter"])?;
+
+    tmux.wait_for_contains("Welcome to harnx", Duration::from_secs(15))?;
+
+    tmux.send_text(PACKAGE_DELEGATION_USER_PROMPT)?;
+    tmux.send_keys(&["Enter"])?;
+
+    let screen = tmux.wait_for_stable(
+        Duration::from_secs(30),
+        Duration::from_millis(300),
+        |screen| screen.contains(PACKAGE_DELEGATION_PEER_RESPONSE),
+    )?;
+
+    // #804 regression repro: caller + peer exist only inside package. Before fix,
+    // spawned ACP subagent could lose package prefix and fail once top-level agents
+    // with same bare names were absent. This e2e test covers success path; exact
+    // qualified spawn args are unit-covered in harnx-runtime package_loading tests.
+    assert!(
+        screen.contains(&format!("{}_session_prompt", PACKAGE_DELEGATION_PEER_NAME)),
+        "same-package delegation tool call missing from TUI transcript:\n{screen}"
+    );
+    assert!(
+        screen.contains(PACKAGE_DELEGATION_PEER_RESPONSE),
+        "peer delegated response not visible in TUI transcript:\n{screen}"
+    );
+
+    drop(tmux);
+    drop(mock);
+    Ok(())
+}
+
 // Normalizes screen output for snapshot tests.
 fn normalize_screen(screen: &str) -> String {
     let trimmed = screen
@@ -459,6 +570,43 @@ fn repo_root() -> Result<PathBuf> {
         .context("failed to determine workspace root")
 }
 
+#[cfg(unix)]
+fn package_delegation_script() -> MockOpenAiScript {
+    // Turn order across caller + peer package agents:
+    //   Turn 0 (caller): delegate to same-package peer via bare tool name.
+    //   Turn 1 (peer)  : respond and end delegated session.
+    //   Turn 2 (caller): final summary after delegated session returns.
+    MockOpenAiScript {
+        turns: vec![
+            MockOpenAiTurn {
+                text_chunks: vec!["I'll delegate this to my package peer.".to_string()],
+                tool_calls: vec![MockOpenAiToolCall {
+                    name: format!("{}_session_prompt", PACKAGE_DELEGATION_PEER_NAME),
+                    arguments: json!({
+                        "message": "Explain whether same-package delegation succeeded."
+                    }),
+                    id: Some("call_package_peer_1".to_string()),
+                }],
+                error: None,
+                expect: None,
+            },
+            MockOpenAiTurn {
+                text_chunks: vec![PACKAGE_DELEGATION_PEER_RESPONSE.to_string()],
+                tool_calls: vec![],
+                error: None,
+                expect: None,
+            },
+            MockOpenAiTurn {
+                text_chunks: vec![PACKAGE_DELEGATION_CALLER_RESPONSE.to_string()],
+                tool_calls: vec![],
+                error: None,
+                expect: None,
+            },
+        ],
+        fallback_text: "No more scripted responses.".to_string(),
+        chunk_delay_ms: 0,
+    }
+}
 struct TestPaths {
     harnx_config_dir: PathBuf,
     harnx_data_dir: PathBuf,
@@ -631,7 +779,6 @@ fn write_mock_llm_client(config_dir: &Path, port: u16) -> Result<()> {
 
 fn write_fixture_files(paths: &TestPaths) -> Result<()> {
     std::fs::create_dir_all(&paths.harnx_config_dir)?;
-
     std::fs::write(&paths.config_path, "save: false\n")?;
 
     let clients_dir = paths.harnx_config_dir.join("clients");
@@ -720,6 +867,40 @@ fn write_fixture_files(paths: &TestPaths) -> Result<()> {
             TEST_SUB_AGENT_NAME
         ),
     )?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn write_same_package_delegation_fixture_files(paths: &TestPaths) -> Result<()> {
+    std::fs::create_dir_all(&paths.harnx_config_dir)?;
+    std::fs::write(&paths.config_path, "save: false\n")?;
+    write_mock_llm_client(&paths.harnx_config_dir, paths.port)?;
+
+    let package_agents_dir = paths
+        .harnx_config_dir
+        .join("packages")
+        .join(PACKAGE_DELEGATION_PACKAGE_NAME)
+        .join("agents");
+    std::fs::create_dir_all(&package_agents_dir)?;
+
+    std::fs::write(
+        package_agents_dir.join(format!("{PACKAGE_DELEGATION_CALLER_NAME}.md")),
+        format!(
+            "---\nname: {}\nmodel: /mock-llm:test\nuse_tools: {}_session_prompt\n---\nYou are {}. Delegate to {} in same package.\n",
+            PACKAGE_DELEGATION_CALLER_NAME,
+            PACKAGE_DELEGATION_PEER_NAME,
+            PACKAGE_DELEGATION_CALLER_NAME,
+            PACKAGE_DELEGATION_PEER_NAME,
+        ),
+    )?;
+    std::fs::write(
+        package_agents_dir.join(format!("{PACKAGE_DELEGATION_PEER_NAME}.md")),
+        format!(
+            "---\nname: {}\nmodel: /mock-llm:test\n---\nYou are {}. Answer delegated request.\n",
+            PACKAGE_DELEGATION_PEER_NAME, PACKAGE_DELEGATION_PEER_NAME,
+        ),
+    )?;
+
     Ok(())
 }
 
@@ -1108,16 +1289,21 @@ fn setup_handoff_tmux_session_with_script(
     let paths = TestPaths::new(temp.path(), mock.port())?;
     match (parent_use_tools, write_acp_server) {
         (Some(parent_use_tools), true) => {
-            write_handoff_fixture_files_with_parent_use_tools(&paths, parent_use_tools)?;
+            write_handoff_fixture_files_with_parent_use_tools(
+                &paths,
+                &harnx_bin,
+                parent_use_tools,
+            )?;
         }
         (Some(parent_use_tools), false) => {
             write_handoff_fixture_files_no_acp_server_with_parent_use_tools(
                 &paths,
+                &harnx_bin,
                 parent_use_tools,
             )?;
         }
-        (None, true) => write_handoff_fixture_files(&paths)?,
-        (None, false) => write_handoff_fixture_files_no_acp_server(&paths)?,
+        (None, true) => write_handoff_fixture_files(&paths, &harnx_bin)?,
+        (None, false) => write_handoff_fixture_files_no_acp_server(&paths, &harnx_bin)?,
     }
 
     let path_env = format!(
@@ -1288,42 +1474,45 @@ fn simple_handoff_script() -> MockOpenAiScript {
     }
 }
 
-fn write_handoff_fixture_files(paths: &TestPaths) -> Result<()> {
+fn write_handoff_fixture_files(paths: &TestPaths, harnx_bin: &Path) -> Result<()> {
     write_handoff_fixture_files_with_parent_use_tools(
         paths,
+        harnx_bin,
         &format!("{}_session_handoff", HANDOFF_SUB_AGENT_NAME),
     )
 }
 
-fn write_handoff_fixture_files_no_acp_server(paths: &TestPaths) -> Result<()> {
+fn write_handoff_fixture_files_no_acp_server(paths: &TestPaths, harnx_bin: &Path) -> Result<()> {
     write_handoff_fixture_files_no_acp_server_with_parent_use_tools(
         paths,
+        harnx_bin,
         &format!("{}_session_handoff", HANDOFF_SUB_AGENT_NAME),
     )
 }
 
 fn write_handoff_fixture_files_with_parent_use_tools(
     paths: &TestPaths,
+    harnx_bin: &Path,
     parent_use_tools: &str,
 ) -> Result<()> {
-    write_handoff_fixture_files_inner(paths, parent_use_tools, true)
+    write_handoff_fixture_files_inner(paths, harnx_bin, parent_use_tools, true)
 }
 
 fn write_handoff_fixture_files_no_acp_server_with_parent_use_tools(
     paths: &TestPaths,
+    harnx_bin: &Path,
     parent_use_tools: &str,
 ) -> Result<()> {
-    write_handoff_fixture_files_inner(paths, parent_use_tools, false)
+    write_handoff_fixture_files_inner(paths, harnx_bin, parent_use_tools, false)
 }
 
 fn write_handoff_fixture_files_inner(
     paths: &TestPaths,
+    harnx_bin: &Path,
     parent_use_tools: &str,
     write_acp_server: bool,
 ) -> Result<()> {
     std::fs::create_dir_all(&paths.harnx_config_dir)?;
-
-    let harnx_bin = PathBuf::from(env!("CARGO_BIN_EXE_harnx"));
 
     std::fs::write(&paths.config_path, "save: false\n")?;
 
@@ -1381,8 +1570,10 @@ fn write_handoff_fixture_files_inner(
         std::fs::create_dir_all(&acp_servers_dir)?;
         let acp_server = AcpServerConfig {
             name: HANDOFF_SUB_AGENT_NAME.to_string(),
-            command: harnx_bin.to_string_lossy().into_owned(),
-            args: vec!["--acp".to_string(), HANDOFF_SUB_AGENT_NAME.to_string()],
+            command: harnx_acp_server_bin(harnx_bin)
+                .to_string_lossy()
+                .into_owned(),
+            args: vec![HANDOFF_SUB_AGENT_NAME.to_string()],
             env: Default::default(),
             enabled: true,
             description: None,

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -133,8 +133,8 @@ All agents defined in the `agents/` directory are **automatically registered** a
 If you need to customize an agent's ACP settings (e.g., add environment variables or change timeouts), create a file in `acp_servers/` with the same name as the agent (e.g., `acp_servers/coder.yaml`).
 
 ```yaml
-command: harnx
-args: ["--acp", "coder"]
+command: harnx-acp-server
+args: ["coder"]
 env:
   DEBUG: "true"
 idle_timeout_secs: 600

--- a/docs/solutions/logic-errors/acp-server-extraction-delegation-fix-2026-06-11.md
+++ b/docs/solutions/logic-errors/acp-server-extraction-delegation-fix-2026-06-11.md
@@ -1,0 +1,192 @@
+---
+title: "ACP server extraction + package delegation #804 root-cause fix"
+date: 2026-06-11
+category: logic-errors
+problem_type: logic_error
+component: harnx-runtime
+root_cause: "name field conflated spawn-target and display-name identities"
+resolution_type: code_fix
+severity: high
+tags:
+  - acp
+  - package-delegation
+  - subprocess-spawn
+  - display-names
+  - binary-extraction
+  - test-harness
+plan_ref: acp-server-extraction-and-package-delegation-fix
+---
+
+## Problem
+
+`AcpServerConfig.name` field served dual roles:
+1. **Canonical SPAWN TARGET** — the package-qualified agent identifier used in subprocess args (e.g., `pantheon/aristarchus`)
+2. **LLM/tool DISPLAY NAME** — the bare name shown to the LLM (e.g., `aristarchus`)
+
+When `reinit_managers_for_agent` rewrote `s.name` to the bare display form for same-package peers, any code that derived spawn args from `name` would produce incorrect bare identifiers, breaking same-package delegation.
+
+## Symptoms
+
+- Same-package delegation (e.g., `pantheon/atlas` → `pantheon/aristarchus`) failed with "agent not found"
+- Spawn args contained bare `aristarchus` instead of qualified `pantheon/aristarchus`
+- Bug masked by same-named top-level agent (`agents/aristarchus.md`) until it was removed
+- `package_loading` integration tests flaked under `cargo test` due to shared global model catalog
+
+## Investigation Steps
+
+1. Traced `acp_server_display_name` in `servers_split.rs:196` — rewrites `s.name` per-agent context
+2. Verified `AcpManager` keys clients by rewritten `name` — correct for display
+3. Found ACP client spawns `config.command` + `config.args` verbatim at `harnx-acp/src/client.rs:613-625`
+4. Confirmed `auto_register_agents` already set `args = [agent_name.clone()]` with qualified names
+5. Identified gap: if any code derived spawn target from `name`, display rewrite would corrupt it
+6. Found package YAML configs in `packages/<pkg>/acp_servers/*.yaml` with bare args that needed qualification
+
+## Root Cause
+
+**Dual-identity conflation.** The `name` field held both the canonical identifier (used for dispatch) and the display name (shown to LLM). The display-rewrite cloned servers and mutated `name`, but any downstream code expecting `name` to be the spawn target would receive the wrong value.
+
+The fix separates concerns:
+- **Spawn target** lives in `args[0]` — never rewritten, always canonical
+- **Display name** computed on-demand via `acp_server_display_name()` — transient, not stored
+
+General lesson: when one field serves both a human/LLM-facing display role and a machine/spawn-target role, separate concerns so display rewrites cannot corrupt the spawn target.
+
+## Solution
+
+### 1. Auto-registration preserves qualified args at source
+
+```rust
+// crates/harnx-runtime/src/config/loader_split.rs:179-189
+acp_servers.push(AcpServerConfig {
+    name: agent_name.clone(),          // qualified: "pantheon/aristarchus"
+    command: command.clone(),
+    args: vec![agent_name.clone()],    // spawn target = qualified name
+    package: pkg,
+    ..
+});
+```
+
+`list_agents()` returns qualified names for package agents, so `args[0]` carries the canonical spawn target from the start.
+
+### 2. Display rewrite clones without touching args
+
+```rust
+// crates/harnx-runtime/src/config/servers_split.rs:191-199
+let acp_servers: Vec<AcpServerConfig> = self
+    .acp_servers
+    .iter()
+    .map(|s| {
+        let mut s = s.clone();
+        s.name = acp_server_display_name(&s, agent_package);  // rewrite display only
+        s  // args untouched
+    })
+    .collect();
+```
+
+### 3. Normalize package YAML bare args
+
+Package-loaded YAML servers with `args: [stem]` get qualified:
+
+```rust
+// crates/harnx-runtime/src/config/servers_split.rs:6-14
+fn normalize_package_acp_server_args(server: &mut AcpServerConfig, pkg_name: &str) {
+    let stem = server.name.as_str();
+    let qualified = qualify_agent_name(pkg_name, stem);
+    for arg in &mut server.args {
+        if arg == stem {
+            *arg = qualified.clone();
+        }
+    }
+}
+```
+
+### 4. Sibling-binary discovery helper
+
+```rust
+// crates/harnx-runtime/src/config/loader_split.rs:282-322
+fn harnx_acp_server_command() -> String {
+    std::env::current_exe()
+        .map(|exe| harnx_acp_server_command_from_current_exe(&exe))
+        .unwrap_or_else(|_| fallback_harnx_acp_server_command())
+}
+
+fn harnx_acp_server_command_from_parent(parent_dir: Option<&Path>, is_absolute: bool) -> String {
+    let Some(parent) = parent_dir else { return fallback() };
+    if !is_absolute { return fallback(); }
+    let sibling = parent.join(harnx_acp_server_binary_name());
+    if sibling.is_file() { sibling.to_string_lossy().to_string() }
+    else { fallback() }  // PATH lookup
+}
+```
+
+Cross-reference: [xtask-pattern-dynamic-bin-discovery-2026-06-10.md](../workflow-issues/xtask-pattern-dynamic-bin-discovery-2026-06-10.md) — same sibling-discovery pattern.
+
+## Why This Works
+
+- **Source of truth:** Spawn target is `args[0]`, set once at auto-registration, never derived from `name`
+- **Display isolation:** `s.name` rewrite clones `AcpServerConfig` but leaves `args` untouched
+- **YAML hardening:** Bare args in package YAML configs get normalized to qualified before display rewrite
+- **Binary discovery:** Sibling lookup works for workspace builds; PATH fallback for system installs
+
+## Test-Harness Gotchas
+
+### a) Integration tests flake under `cargo test`
+
+`package_loading` tests share a global model catalog (`harnx-client::ALL_PROVIDER_MODELS`). Parallel threads cause "Unknown chat model 'openai:gpt-4o'" panics that vary by run.
+
+**Fix:** Use `cargo nextest run` (per-process isolation). Documented in `AGENTS.md`.
+
+### b) Cannot test `pub(super)` from integration tests
+
+`reinit_managers_for_agent` is `pub(super)` — not callable from `tests/package_loading.rs`.
+
+**Workaround:** Assert the invariant via public test re-export:
+```rust
+// harnx-runtime/src/lib.rs re-exports for testing:
+pub fn acp_server_display_name_for_test(server: &AcpServerConfig, pkg: Option<&str>) -> String;
+
+// Test asserts display name is bare while source args stay qualified:
+assert_eq!(acp_server_display_name_for_test(original_server, Some("pantheon")), "aristarchus");
+assert_eq!(original_server.args, vec!["pantheon/aristarchus"]);
+```
+
+### c) Sibling binary resolution in tmux_e2e fixtures
+
+`harnx/tests/tmux_e2e.rs` resolves `harnx-acp-server` via `with_file_name`:
+
+```rust
+// crates/harnx/src/test_utils/interrupt.rs:23-26
+pub fn harnx_acp_server_bin(harnx_bin: &Path) -> PathBuf {
+    let ext = std::env::consts::EXE_SUFFIX;
+    harnx_bin.with_file_name(format!("harnx-acp-server{ext}"))
+}
+```
+
+No `CARGO_BIN_EXE` needed — workspace builds all members into same `target/<profile>/`.
+
+## Prevention Strategies
+
+**Test Cases:**
+- Unit tests for sibling discovery (present vs missing sibling)
+- Integration test: auto-registered ACP args stay qualified after display rewrite
+- Integration test: package YAML bare args normalized to qualified
+- E2E test: same-package delegation succeeds when no top-level agent masks
+
+**Best Practices:**
+- When a field serves both machine and human roles, separate concerns explicitly
+- Never derive machine-identifiers from display-rewriteable fields
+- Use `*_for_test` re-exports to verify invariants without testing private methods
+- Integration tests with shared state: run under `cargo nextest` with process isolation
+
+**Code Review Checklist:**
+- [ ] Does `AcpServerConfig.name` rewrite touch `args`? (should not)
+- [ ] Are package YAML bare args normalized before display rewrite?
+- [ ] Do integration tests isolate environment via `ENV_MUTEX` and `EnvGuard`?
+- [ ] Does spawn command derive target from `name` instead of `args`?
+
+## Related Issues
+
+- **GitHub:** [#550](https://github.com/dobesv/harnx/issues/550) — Move ACP support out of main harnx binary
+- **GitHub:** [#804](https://github.com/dobesv/harnx/issues/804) — Verify pantheon handoff/delegation within a package
+- **Prior Art:** [xtask-pattern-dynamic-bin-discovery-2026-06-10.md](../workflow-issues/xtask-pattern-dynamic-bin-discovery-2026-06-10.md) — sibling binary discovery pattern
+- **Related:** [package-relative-agent-delegation-2026-06-09.md](./package-relative-agent-delegation-2026-06-09.md) — display-name resolution for `_session_*`

--- a/example_config/acp_servers/README.md
+++ b/example_config/acp_servers/README.md
@@ -1,7 +1,7 @@
 # acp_servers/
 
 All agents defined in `agents/<name>.md` are **automatically registered** as ACP
-servers using the current `harnx` binary with `args: ["--acp", "<name>"]`.
+servers using `harnx-acp-server` with `args: ["<name>"]`.
 
 You only need to create files here when you want to **override** the default
 auto-registration — for example, to use a different binary, add environment
@@ -11,8 +11,8 @@ variables, or set a custom description.
 
 ```yaml
 # acp_servers/my-agent.yaml
-command: harnx
-args: ["--acp", "my-agent"]
+command: harnx-acp-server
+args: ["my-agent"]
 idle_timeout_secs: 600
 operation_timeout_secs: 7200
 description: "My custom agent with extended timeouts"
@@ -23,7 +23,7 @@ description: "My custom agent with extended timeouts"
 ```yaml
 # acp_servers/external.yaml
 command: /path/to/other-binary
-args: ["--acp-mode"]
+args: ["serve-stdio"]
 env:
   API_KEY: "your-key"
 enabled: true

--- a/scripts/completions/harnx.bash
+++ b/scripts/completions/harnx.bash
@@ -17,7 +17,7 @@ _harnx() {
 
     case "${cmd}" in
         harnx)
-            opts="-m -s -a -f -S -t -h -V --model --prompt --session --empty-session --save-session --agent --agent-variable --rag --rebuild-rag --macro --serve --acp --file --no-stream --dry-run --info --sync-models --list-models --list-sessions --list-agents --list-assistant-agents --list-rags --list-macros --mcp-root --tool --help --version"
+            opts="-m -s -a -f -S -t -h -V --model --prompt --session --empty-session --save-session --agent --agent-variable --rag --rebuild-rag --macro --serve --file --no-stream --dry-run --info --sync-models --list-models --list-sessions --list-agents --list-assistant-agents --list-rags --list-macros --mcp-root --tool --help --version"
             if [[ ${cur} == -* || ${cword} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -55,11 +55,6 @@ _harnx() {
                     ;;
                 --serve)
                     COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --acp)
-                    COMPREPLY=($(compgen -W "$("$1" --list-assistant-agents)" -- "${cur}"))
-                    __ltrim_colon_completions "$cur"
                     return 0
                     ;;
                 -f|--file)

--- a/scripts/completions/harnx.nu
+++ b/scripts/completions/harnx.nu
@@ -46,7 +46,6 @@ module completions {
     --rebuild-rag                                       # Rebuild the RAG to sync document changes
     --macro: string@"nu-complete harnx macro"          # Execute a macro
     --serve                                             # Serve the LLM API and WebAPP
-    --acp: string@"nu-complete harnx agent"            # Serve as an ACP agent over stdio
     --file(-f): string                                  # Include files, directories, or URLs
     --no-stream(-S)                                     # Turn off stream mode
     --dry-run                                           # Display the message without sending it

--- a/scripts/completions/harnx.ps1
+++ b/scripts/completions/harnx.ps1
@@ -34,7 +34,6 @@ Register-ArgumentCompleter -Native -CommandName 'harnx' -ScriptBlock {
             [CompletionResult]::new('--rebuild-rag', '--rebuild-rag', [CompletionResultType]::ParameterName, 'Rebuild the RAG to sync document changes')
             [CompletionResult]::new('--macro', '--macro', [CompletionResultType]::ParameterName, 'Execute a macro')
             [CompletionResult]::new('--serve', '--serve', [CompletionResultType]::ParameterName, 'Serve the LLM API and WebAPP')
-            [CompletionResult]::new('--acp', '--acp', [CompletionResultType]::ParameterName, 'Serve as an ACP agent over stdio')
             [CompletionResult]::new('-f', '-f', [CompletionResultType]::ParameterName, 'Include files, directories, or URLs')
             [CompletionResult]::new('--file', '--file', [CompletionResultType]::ParameterName, 'Include files, directories, or URLs')
             [CompletionResult]::new('-S', '-S', [CompletionResultType]::ParameterName, 'Turn off stream mode')
@@ -78,8 +77,6 @@ Register-ArgumentCompleter -Native -CommandName 'harnx' -ScriptBlock {
             $completions = Get-HarnxValues "--list-rags"
         } elseif ($flag -eq "--macro") {
             $completions = Get-HarnxValues "--list-macros"
-        } elseif ($flag -eq "--acp") {
-            $completions = Get-HarnxValues "--list-assistant-agents"
         } elseif ($flag -ceq "-f" -or $flag -eq "--file") {
             $completions = @()
         } elseif ($flag -eq "--mcp-root") {

--- a/scripts/completions/harnx.zsh
+++ b/scripts/completions/harnx.zsh
@@ -29,7 +29,6 @@ _harnx() {
 '--rebuild-rag[Rebuild the RAG to sync document changes]' \
 '--macro[Execute a macro]:MACRO:->macros' \
 '--serve[Serve the LLM API and WebAPP]:ADDRESS: ' \
-'--acp[Serve as an ACP agent over stdio]:AGENT:->agents' \
 '*-f[Include files, directories, or URLs]:FILE:_files' \
 '*--file[Include files, directories, or URLs]:FILE:_files' \
 '-S[Turn off stream mode]' \


### PR DESCRIPTION
Removes the --acp flag from the harnx binary and migrates all internally generated ACP subagent servers to use the new standalone harnx-acp-server binary. Resolves the server binary as a sibling of the running harnx executable with a PATH fallback.

Also fixes a delegation bug where same-package pantheon agents (e.g., pantheon/atlas delegating to aristarchus) would drop their package prefix on spawn, causing resolution failures once same-named top-level agents were removed. Auto-registered ACP servers now preserve the qualified spawn target in their args, decoupled from the display-name rewrite used for same-package peers. Normalizes package-loaded YAML configs to qualify bare agent arguments.

BREAKING CHANGE: The --acp <agent> flag has been removed from the harnx binary. Use the standalone harnx-acp-server <agent> binary instead.

Closes #550
Closes #804

Plan: acp-server-extraction-and-package-delegation-fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `--acp` flag from `harnx` command; use dedicated `harnx-acp-server <agent>` binary instead.

* **New Features**
  * Introduced `harnx-acp-server` standalone binary for serving agents over stdio.
  * Improved same-package agent delegation to preserve package-qualified agent names.

* **Documentation**
  * Updated configuration guides, examples, and shell completions to reflect new ACP server invocation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->