### PR TITLE
Enable LLM vision for local media files via fs read tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3709,6 +3709,7 @@ name = "harnx-mcp-fs"
 version = "0.32.5"
 dependencies = [
  "anyhow",
+ "base64",
  "fancy-regex 0.18.0",
  "gix",
  "glob",
@@ -4734,9 +4735,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-core"
-version = "3.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7561783b20275a6c9cb576e39208b0c635f34ef14357f1f05a2927a774f3adec"
+checksum = "dca0f164c8e9c55fc5aefe60b371df735c719b09930dac185878f2f8c7ab6b68"
 dependencies = [
  "dyn-clone",
  "once_cell",
@@ -4767,9 +4768,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-json"
-version = "2.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ec9aaad7340e6990c6c1878ef3b46dbec624e535d7f786cc9ddcf94f773d33"
+checksum = "f5c5baabe63d1d72cde60ec7548a098036773e3541dbc65c6a44fb38e9cfb272"
 dependencies = [
  "bstr",
  "bytes",
@@ -4786,9 +4787,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-std"
-version = "3.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdc5a74b0feeb5e6a1dc2dd08c34280a61e37668d10a6a3b27ad69d0fb9ce2e"
+checksum = "2a11bb307027b20b3dc7b212ad687e7e410cbc43933eec5d498672ab2bc60666"
 dependencies = [
  "aho-corasick",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ which = "8.0.0"
 fuzzy-matcher = "0.3.7"
 terminal-colorsaurus = "1.0.3"
 duct = "1.0.0"
-rmcp = { version = "1.3.0", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "1.7", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server"] }
 process-wrap = { version = "9", features = ["tokio1"] }
 libc = "0.2"
 agent-client-protocol = { git = "https://github.com/agentclientprotocol/rust-sdk", rev = "81507b3912edce50c4e920b59ee861f63fdb1aef" }

--- a/crates/harnx-client/src/bedrock.rs
+++ b/crates/harnx-client/src/bedrock.rs
@@ -580,14 +580,32 @@ fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Resu
                                 "input": tool_result.call.arguments,
                             }
                         }));
+                        let mut tr_content = vec![json!({
+                            "json": tool_result.output,
+                        })];
+                        for part in &tool_result.content {
+                            if let MessageContentPart::ImageUrl {
+                                image_url: ImageUrl { url },
+                            } = part
+                            {
+                                if let Some((mime, data)) = url
+                                    .strip_prefix("data:")
+                                    .and_then(|v| v.split_once(";base64,"))
+                                {
+                                    let format = mime.strip_prefix("image/").unwrap_or(mime);
+                                    tr_content.push(json!({
+                                        "image": {
+                                            "format": format,
+                                            "source": { "bytes": data }
+                                        }
+                                    }));
+                                }
+                            }
+                        }
                         user_parts.push(json!({
                             "toolResult": {
                                 "toolUseId": tool_result.call.id,
-                                "content": [
-                                    {
-                                        "json": tool_result.output,
-                                    }
-                                ]
+                                "content": tr_content,
                             }
                         }));
                     }
@@ -1358,6 +1376,81 @@ mod tests {
         assert!(
             tool_calls.is_empty(),
             "no toolUse blocks were sent; tool_calls must stay empty"
+        );
+    }
+
+    #[test]
+    fn bedrock_tool_result_with_image_appends_image_block() {
+        use harnx_core::tool::ToolResult;
+        let model = Model::new("bedrock", "us.anthropic.claude-sonnet-4-6");
+        let tool_call = ToolCall {
+            id: Some("toolu_XYZ".to_string()),
+            name: "fs_read".to_string(),
+            arguments: json!({"path": "foo.png"}),
+            thought_signature: None,
+        };
+        let mut tool_result = ToolResult::new(tool_call, json!("output text"));
+        tool_result.content.push(MessageContentPart::ImageUrl {
+            image_url: crate::ImageUrl {
+                url: "data:image/png;base64,iVBORw0KGgo".to_string(),
+            },
+        });
+
+        let messages = vec![
+            Message::new(
+                MessageRole::User,
+                MessageContent::Text("Do something".to_string()),
+            ),
+            Message::new(
+                MessageRole::Tool,
+                MessageContent::ToolCalls(MessageContentToolCalls::new(
+                    vec![tool_result],
+                    "".to_string(),
+                    None,
+                )),
+            ),
+        ];
+
+        let body = build_chat_completions_body(
+            ChatCompletionsData {
+                messages,
+                temperature: None,
+                top_p: None,
+                functions: None,
+                stream: false,
+            },
+            &model,
+        )
+        .unwrap();
+
+        let user_msg = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| {
+                m["role"] == "user"
+                    && m["content"]
+                        .as_array()
+                        .is_some_and(|c| !c.is_empty() && c[0].get("toolResult").is_some())
+            })
+            .expect("must have a user toolResult turn");
+
+        let content = user_msg["content"]
+            .as_array()
+            .expect("user content array")[0]["toolResult"]["content"]
+            .as_array()
+            .expect("toolResult content array");
+
+        assert_eq!(content.len(), 2, "must have 2 blocks (json and image)");
+        assert_eq!(content[0], json!({"json": "output text"}));
+        assert_eq!(
+            content[1],
+            json!({
+                "image": {
+                    "format": "png",
+                    "source": { "bytes": "iVBORw0KGgo" }
+                }
+            })
         );
     }
 }

--- a/crates/harnx-client/src/claude.rs
+++ b/crates/harnx-client/src/claude.rs
@@ -369,10 +369,39 @@ pub fn claude_build_chat_completions_body(
                             "name": tool_result.call.name,
                             "input": tool_result.call.arguments,
                         }));
+                        let tr_content = if tool_result.content.is_empty() {
+                            json!(tool_result.output.to_string())
+                        } else {
+                            let mut blocks = vec![json!({
+                                "type": "text",
+                                "text": tool_result.output.to_string()
+                            })];
+                            for part in &tool_result.content {
+                                if let MessageContentPart::ImageUrl {
+                                    image_url: crate::ImageUrl { url },
+                                } = part
+                                {
+                                    if let Some((mime, data)) = url
+                                        .strip_prefix("data:")
+                                        .and_then(|v| v.split_once(";base64,"))
+                                    {
+                                        blocks.push(json!({
+                                            "type": "image",
+                                            "source": {
+                                                "type": "base64",
+                                                "media_type": mime,
+                                                "data": data,
+                                            }
+                                        }));
+                                    }
+                                }
+                            }
+                            json!(blocks)
+                        };
                         user_parts.push(json!({
                             "type": "tool_result",
                             "tool_use_id": tool_result.call.id,
-                            "content": tool_result.output.to_string(),
+                            "content": tr_content,
                         }));
                     }
                     vec![
@@ -1197,5 +1226,136 @@ system_prompt_prefix:
         unsafe { std::env::remove_var("CLAUDE_API_KEY") };
 
         assert_eq!(result.unwrap(), "test-key-bare");
+    }
+
+    /// When a ToolResult has image content, tool_result content should be an array
+    /// containing a text block and an image block with base64 data.
+    #[test]
+    fn claude_tool_result_with_image_emits_array_with_image_block() {
+        use harnx_core::tool::ToolResult;
+        let model = Model::new("claude", "claude-3-5-sonnet");
+        let tool_call = ToolCall {
+            id: Some("toolu_XYZ".to_string()),
+            name: "fs_read".to_string(),
+            arguments: json!({"path": "foo.png"}),
+            thought_signature: None,
+        };
+        let mut tool_result = ToolResult::new(tool_call, json!("output text"));
+        tool_result.content.push(MessageContentPart::ImageUrl {
+            image_url: crate::ImageUrl {
+                url: "data:image/png;base64,iVBORw0KGgo".to_string(),
+            },
+        });
+
+        let messages = vec![
+            Message::new(
+                MessageRole::User,
+                MessageContent::Text("Do something".to_string()),
+            ),
+            Message::new(
+                MessageRole::Tool,
+                MessageContent::ToolCalls(MessageContentToolCalls::new(
+                    vec![tool_result],
+                    "".to_string(),
+                    None,
+                )),
+            ),
+        ];
+
+        let body = claude_build_chat_completions_body(
+            ChatCompletionsData {
+                messages,
+                temperature: None,
+                top_p: None,
+                functions: None,
+                stream: false,
+            },
+            &model,
+        )
+        .unwrap();
+
+        let user_msg = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["role"] == "user" && m["content"].as_array().is_some_and(|c| !c.is_empty() && c[0].get("type").is_some_and(|t| t == "tool_result")))
+            .expect("must have a user tool_result turn");
+
+        let content = user_msg["content"]
+            .as_array()
+            .expect("user content array")[0]["content"]
+            .as_array()
+            .expect("tool_result content should be an array when images present");
+
+        assert_eq!(content.len(), 2, "must have 2 blocks (text and image)");
+        // tool_result.output.to_string() JSON-encodes the Value, so "output text" becomes "\"output text\""
+        assert_eq!(content[0], json!({"type": "text", "text": "\"output text\""}));
+        assert_eq!(
+            content[1],
+            json!({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "iVBORw0KGgo"
+                }
+            })
+        );
+    }
+
+    /// When a ToolResult has no content, tool_result content should be a string
+    /// (unchanged from prior behavior).
+    #[test]
+    fn claude_tool_result_without_image_emits_string() {
+        use harnx_core::tool::ToolResult;
+        let model = Model::new("claude", "claude-3-5-sonnet");
+        let tool_call = ToolCall {
+            id: Some("toolu_ABC".to_string()),
+            name: "fs_read".to_string(),
+            arguments: json!({"path": "foo.txt"}),
+            thought_signature: None,
+        };
+        let tool_result = ToolResult::new(tool_call, json!({"status": "ok"}));
+
+        let messages = vec![
+            Message::new(
+                MessageRole::User,
+                MessageContent::Text("Do something".to_string()),
+            ),
+            Message::new(
+                MessageRole::Tool,
+                MessageContent::ToolCalls(MessageContentToolCalls::new(
+                    vec![tool_result],
+                    "".to_string(),
+                    None,
+                )),
+            ),
+        ];
+
+        let body = claude_build_chat_completions_body(
+            ChatCompletionsData {
+                messages,
+                temperature: None,
+                top_p: None,
+                functions: None,
+                stream: false,
+            },
+            &model,
+        )
+        .unwrap();
+
+        let user_msg = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["role"] == "user" && m["content"].as_array().is_some_and(|c| !c.is_empty() && c[0].get("type").is_some_and(|t| t == "tool_result")))
+            .expect("must have a user tool_result turn");
+
+        let content = &user_msg["content"]
+            .as_array()
+            .expect("user content array")[0]["content"];
+
+        assert!(content.is_string(), "tool_result content should be a string when no images");
+        assert_eq!(content.as_str().unwrap(), "{\"status\":\"ok\"}");
     }
 }

--- a/crates/harnx-client/src/openai.rs
+++ b/crates/harnx-client/src/openai.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-use harnx_core::text::strip_think_tag;
+use harnx_core::{message::MessageContentPart, text::strip_think_tag, tool::ToolResult};
 
 use anyhow::{bail, Context, Result};
 use reqwest::RequestBuilder;
@@ -8,6 +8,37 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 
 const API_BASE: &str = "https://api.openai.com/v1";
+
+
+fn openai_collect_tool_result_images(tool_results: &[ToolResult]) -> Vec<Value> {
+    tool_results
+        .iter()
+        .flat_map(|tool_result| tool_result.content.iter())
+        .filter_map(|part| match part {
+            MessageContentPart::ImageUrl { image_url } => Some(json!({
+                "type": "image_url",
+                "image_url": { "url": image_url.url },
+            })),
+            MessageContentPart::Text { .. } => None,
+        })
+        .collect()
+}
+
+fn openai_tool_message_content(tool_result: &ToolResult) -> String {
+    let output = tool_result.output.to_string();
+    if tool_result
+        .content
+        .iter()
+        .any(|part| matches!(part, MessageContentPart::ImageUrl { .. }))
+    {
+        format!(
+            "{output}\n[Tool {} returned image(s): see next message]",
+            tool_result.call.name
+        )
+    } else {
+        output
+    }
+}
 
 impl OpenAIClient {
     config_get_fn!(api_key, get_api_key);
@@ -309,6 +340,7 @@ pub fn openai_build_chat_completions_body(data: ChatCompletionsData, model: &Mod
                     thought: _,
                     sequence,
                 }) => {
+                    let trailing_image_parts = openai_collect_tool_result_images(&tool_results);
                     if !sequence {
                         let tool_calls: Vec<_> = tool_results
                             .iter()
@@ -326,38 +358,53 @@ pub fn openai_build_chat_completions_body(data: ChatCompletionsData, model: &Mod
                         let mut messages = vec![
                             json!({ "role": MessageRole::Assistant, "tool_calls": tool_calls }),
                         ];
-                        for tool_result in tool_results {
+                        for tool_result in &tool_results {
                             messages.push(json!({
                                 "role": "tool",
-                                "content": tool_result.output.to_string(),
+                                "content": openai_tool_message_content(tool_result),
                                 "tool_call_id": tool_result.call.id,
+                            }));
+                        }
+                        if !trailing_image_parts.is_empty() {
+                            messages.push(json!({
+                                "role": MessageRole::User,
+                                "content": trailing_image_parts,
                             }));
                         }
                         messages
                     } else {
-                        tool_results.into_iter().flat_map(|tool_result| {
-                            vec![
-                                json!({
-                                    "role": MessageRole::Assistant,
-                                    "tool_calls": [
-                                        {
-                                            "id": tool_result.call.id,
-                                            "type": "function",
-                                            "function": {
-                                                "name": tool_result.call.name,
-                                                "arguments": tool_result.call.arguments.to_string(),
-                                            },
-                                        }
-                                    ]
-                                }),
-                                json!({
-                                    "role": "tool",
-                                    "content": tool_result.output.to_string(),
-                                    "tool_call_id": tool_result.call.id,
-                                })
-                            ]
-
-                        }).collect()
+                        let mut messages: Vec<_> = tool_results
+                            .into_iter()
+                            .flat_map(|tool_result| {
+                                vec![
+                                    json!({
+                                        "role": MessageRole::Assistant,
+                                        "tool_calls": [
+                                            {
+                                                "id": tool_result.call.id,
+                                                "type": "function",
+                                                "function": {
+                                                    "name": tool_result.call.name,
+                                                    "arguments": tool_result.call.arguments.to_string(),
+                                                },
+                                            }
+                                        ]
+                                    }),
+                                    json!({
+                                        "role": "tool",
+                                        "content": openai_tool_message_content(&tool_result),
+                                        "tool_call_id": tool_result.call.id,
+                                    })
+                                ]
+                            })
+                            .collect();
+                        if !trailing_image_parts.is_empty() {
+                            messages.push(json!({
+                                "role": MessageRole::User,
+                                "content": trailing_image_parts,
+                            }));
+                        }
+                        messages
                     }
                 }
                 MessageContent::Text(text) if role.is_assistant() && i != messages_len - 1 => {
@@ -486,6 +533,45 @@ fn normalize_function_id(value: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use harnx_core::{
+        message::{ImageUrl, Message, MessageContent, MessageContentPart, MessageContentToolCalls, MessageRole},
+        tool::{ToolCall, ToolResult},
+    };
+
+    fn test_tool_result(id: &str, name: &str, output: Value) -> ToolResult {
+        ToolResult::new(
+            ToolCall::new(name.to_string(), json!({"arg": id}), Some(id.to_string()), None),
+            output,
+        )
+    }
+
+    fn image_part(url: &str) -> MessageContentPart {
+        MessageContentPart::ImageUrl {
+            image_url: ImageUrl {
+                url: url.to_string(),
+            },
+        }
+    }
+
+    fn build_tool_calls_body(tool_results: Vec<ToolResult>, sequence: bool) -> Value {
+        let mut tool_calls = MessageContentToolCalls::new(tool_results, String::new(), None);
+        tool_calls.sequence = sequence;
+        let data = ChatCompletionsData {
+            messages: vec![Message {
+                role: MessageRole::Assistant,
+                content: MessageContent::ToolCalls(tool_calls),
+                ..Default::default()
+            }],
+            temperature: None,
+            top_p: None,
+            functions: None,
+            stream: false,
+        };
+        let model = harnx_core::model::Model::new("openai", "gpt-4o");
+        openai_build_chat_completions_body(data, &model)
+    }
+
     use harnx_core::abort::create_abort_signal;
     use tokio::sync::mpsc::unbounded_channel;
 
@@ -554,6 +640,146 @@ mod tests {
         model.set_max_tokens(Some(1024), true);
         model.data_mut().patches = Some(patches.into_iter().map(String::from).collect());
         model
+    }
+
+
+    #[test]
+    fn tool_calls_with_images_emit_single_trailing_user_message_in_normal_mode() {
+        let mut first = test_tool_result("call_1", "read_file", json!({"ok": true, "idx": 1}));
+        first.content.push(image_part("data:image/png;base64,AAAA"));
+        let mut second = test_tool_result("call_2", "inspect_file", json!({"ok": true, "idx": 2}));
+        second.content.push(image_part("data:image/jpeg;base64,BBBB"));
+
+        let body = build_tool_calls_body(vec![first.clone(), second.clone()], false);
+        let messages = body["messages"].as_array().expect("messages array");
+
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0]["role"], json!("assistant"));
+        assert_eq!(messages[0]["tool_calls"][0]["id"], json!("call_1"));
+        assert_eq!(messages[0]["tool_calls"][1]["id"], json!("call_2"));
+
+        assert_eq!(messages[1]["role"], json!("tool"));
+        assert_eq!(messages[1]["tool_call_id"], json!("call_1"));
+        assert_eq!(
+            messages[1]["content"],
+            json!(format!(
+                "{}\n[Tool {} returned image(s): see next message]",
+                first.output, first.call.name
+            ))
+        );
+
+        assert_eq!(messages[2]["role"], json!("tool"));
+        assert_eq!(messages[2]["tool_call_id"], json!("call_2"));
+        assert_eq!(
+            messages[2]["content"],
+            json!(format!(
+                "{}\n[Tool {} returned image(s): see next message]",
+                second.output, second.call.name
+            ))
+        );
+
+        assert_eq!(messages[3]["role"], json!("user"));
+        assert_eq!(
+            messages[3]["content"],
+            json!([
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+                {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,BBBB"}},
+            ])
+        );
+    }
+
+    #[test]
+    fn tool_calls_with_single_image_emit_trailing_user_message_in_sequence_mode() {
+        let mut first = test_tool_result("call_1", "read_file", json!("preview"));
+        first.content.push(image_part("data:image/png;base64,AAAA"));
+        let second = test_tool_result("call_2", "list_dir", json!("no image"));
+
+        let body = build_tool_calls_body(vec![first.clone(), second.clone()], true);
+        let messages = body["messages"].as_array().expect("messages array");
+
+        assert_eq!(messages.len(), 5);
+        assert_eq!(messages[0]["role"], json!("assistant"));
+        assert_eq!(messages[0]["tool_calls"][0]["id"], json!("call_1"));
+        assert_eq!(messages[1]["role"], json!("tool"));
+        assert_eq!(messages[1]["tool_call_id"], json!("call_1"));
+        assert_eq!(
+            messages[1]["content"],
+            json!(format!(
+                "{}\n[Tool {} returned image(s): see next message]",
+                first.output, first.call.name
+            ))
+        );
+        assert_eq!(messages[2]["role"], json!("assistant"));
+        assert_eq!(messages[2]["tool_calls"][0]["id"], json!("call_2"));
+        assert_eq!(messages[3]["role"], json!("tool"));
+        assert_eq!(messages[3]["tool_call_id"], json!("call_2"));
+        assert_eq!(messages[3]["content"], json!(second.output.to_string()));
+        assert_eq!(messages[4]["role"], json!("user"));
+        assert_eq!(
+            messages[4]["content"],
+            json!([
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ])
+        );
+    }
+
+    #[test]
+    fn tool_calls_without_images_match_legacy_output() {
+        let first = test_tool_result("call_1", "read_file", json!("first"));
+        let second = test_tool_result("call_2", "list_dir", json!({"ok": true}));
+
+        let normal_body = build_tool_calls_body(vec![first.clone(), second.clone()], false);
+        assert_eq!(
+            normal_body["messages"],
+            json!([
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "read_file", "arguments": "{\"arg\":\"call_1\"}"}
+                        },
+                        {
+                            "id": "call_2",
+                            "type": "function",
+                            "function": {"name": "list_dir", "arguments": "{\"arg\":\"call_2\"}"}
+                        }
+                    ]
+                },
+                {"role": "tool", "content": "\"first\"", "tool_call_id": "call_1"},
+                {"role": "tool", "content": "{\"ok\":true}", "tool_call_id": "call_2"}
+            ])
+        );
+
+        let sequence_body = build_tool_calls_body(vec![first, second], true);
+        assert_eq!(
+            sequence_body["messages"],
+            json!([
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "read_file", "arguments": "{\"arg\":\"call_1\"}"}
+                        }
+                    ]
+                },
+                {"role": "tool", "content": "\"first\"", "tool_call_id": "call_1"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_2",
+                            "type": "function",
+                            "function": {"name": "list_dir", "arguments": "{\"arg\":\"call_2\"}"}
+                        }
+                    ]
+                },
+                {"role": "tool", "content": "{\"ok\":true}", "tool_call_id": "call_2"}
+            ])
+        );
     }
 
     #[test]

--- a/crates/harnx-client/src/vertexai.rs
+++ b/crates/harnx-client/src/vertexai.rs
@@ -2,6 +2,7 @@ use crate::access_token::*;
 use crate::claude::*;
 use crate::openai::*;
 use crate::*;
+use harnx_core::tool::ToolCall;
 
 use anyhow::{anyhow, bail, Context, Result};
 use chrono::{Duration, Utc};
@@ -386,7 +387,7 @@ pub fn gemini_build_chat_completions_body(
                                 MessageContentPart::Text { text } => json!({"text": text}),
                                 MessageContentPart::ImageUrl { image_url: ImageUrl { url } } => {
                                     if let Some((mime_type, data)) = url.strip_prefix("data:").and_then(|v| v.split_once(";base64,")) {
-                                        json!({ "inline_data": { "mime_type": mime_type, "data": data } })
+                                        json!({ "inlineData": { "mimeType": mime_type, "data": data } })
                                     } else {
                                         network_image_urls.push(url.clone());
                                         json!({ "url": url })
@@ -425,20 +426,40 @@ pub fn gemini_build_chat_completions_body(
                             }
                             model_parts.push(part_obj);
                         }
-                        let function_parts: Vec<Value> = tool_results.into_iter().map(|tool_result| {
-                            json!({
-                                "functionResponse": {
-                                    "name": tool_result.call.name,
-                                    "response": {
-                                        "name": tool_result.call.name,
-                                        "content": tool_result.output,
-                                    }
-                                }
-                            })
-                        }).collect();
-                        vec![
-                            json!({ "role": "model", "parts": model_parts }),
-                            json!({ "role": "function", "parts": function_parts }),
+                        let mut function_parts: Vec<Value> = Vec::new();
+                for tool_result in &tool_results {
+                    function_parts.push(json!({
+                        "functionResponse": {
+                            "name": tool_result.call.name,
+                            "response": {
+                                "name": tool_result.call.name,
+                                "content": tool_result.output,
+                            }
+                        }
+                    }));
+                }
+                for tool_result in &tool_results {
+                    for part in &tool_result.content {
+                        if let MessageContentPart::ImageUrl {
+                            image_url: ImageUrl { url },
+                        } = part
+                        {
+                            if let Some((mime_type, data)) =
+                                url.strip_prefix("data:").and_then(|v| v.split_once(";base64,"))
+                            {
+                                function_parts.push(
+                                    json!({ "text": format!("[Tool {} returned image]", tool_result.call.name) }),
+                                );
+                                function_parts.push(json!({
+                                    "inlineData": { "mimeType": mime_type, "data": data }
+                                }));
+                            }
+                        }
+                    }
+                }
+                vec![
+                    json!({ "role": "model", "parts": model_parts }),
+                    json!({ "role": "function", "parts": function_parts }),
                         ]
                     }
                 }
@@ -608,8 +629,119 @@ fn strip_model_version(name: &str) -> &str {
     }
 }
 
+
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn gemini_serializer_appends_tool_images_after_function_responses() {
+        let mut first_tool_call = ToolCall::new(
+            "first_tool".to_string(),
+            json!({"arg": 1}),
+            Some("call_1".to_string()),
+            None,
+        );
+        first_tool_call.thought_signature = Some("sig_1".to_string());
+        let mut first_tool_result = harnx_core::tool::ToolResult::new(first_tool_call, json!({"status": "ok"}));
+        first_tool_result.content = vec![MessageContentPart::ImageUrl {
+            image_url: ImageUrl {
+                url: "data:image/png;base64,aGVsbG8=".to_string(),
+            },
+        }];
+
+        let second_tool_call = ToolCall::new(
+            "second_tool".to_string(),
+            json!({"arg": 2}),
+            Some("call_2".to_string()),
+            None,
+        );
+        let second_tool_result = harnx_core::tool::ToolResult::new(second_tool_call, json!({"status": "ok2"}));
+
+        let messages = vec![
+            Message::new(
+                MessageRole::User,
+                MessageContent::Text("Run tools".to_string()),
+            ),
+            Message::new(
+                MessageRole::Tool,
+                MessageContent::ToolCalls(MessageContentToolCalls::new(
+                    vec![first_tool_result, second_tool_result],
+                    "Calling tools".to_string(),
+                    None,
+                )),
+            ),
+        ];
+        let body = gemini_build_chat_completions_body(
+            ChatCompletionsData {
+                messages,
+                temperature: None,
+                top_p: None,
+                functions: None,
+                stream: true,
+            },
+            &Model::new("gemini", "gemini-2.5-pro"),
+        )
+        .unwrap();
+
+        let contents = body["contents"].as_array().unwrap();
+        let function_turn = contents
+            .iter()
+            .find(|content| content["role"] == "function")
+            .expect("tool results must serialize to function turn");
+        let parts = function_turn["parts"].as_array().unwrap();
+        assert_eq!(parts.len(), 4);
+        assert_eq!(parts[0]["functionResponse"]["name"], "first_tool");
+        assert_eq!(parts[1]["functionResponse"]["name"], "second_tool");
+        assert_eq!(parts[2]["text"], "[Tool first_tool returned image]");
+        assert_eq!(parts[3]["inlineData"]["mimeType"], "image/png");
+        assert_eq!(parts[3]["inlineData"]["data"], "aGVsbG8=");
+    }
+
+    #[test]
+    fn gemini_serializer_leaves_no_image_tool_turn_unchanged() {
+        let tool_call = ToolCall::new(
+            "plain_tool".to_string(),
+            json!({"arg": 1}),
+            Some("call_plain".to_string()),
+            None,
+        );
+        let tool_result = harnx_core::tool::ToolResult::new(tool_call, json!({"status": "ok"}));
+        let messages = vec![
+            Message::new(
+                MessageRole::User,
+                MessageContent::Text("Run tool".to_string()),
+            ),
+            Message::new(
+                MessageRole::Tool,
+                MessageContent::ToolCalls(MessageContentToolCalls::new(
+                    vec![tool_result],
+                    "Calling tool".to_string(),
+                    None,
+                )),
+            ),
+        ];
+        let body = gemini_build_chat_completions_body(
+            ChatCompletionsData {
+                messages,
+                temperature: None,
+                top_p: None,
+                functions: None,
+                stream: true,
+            },
+            &Model::new("gemini", "gemini-2.5-pro"),
+        )
+        .unwrap();
+
+        let contents = body["contents"].as_array().unwrap();
+        let function_turn = contents
+            .iter()
+            .find(|content| content["role"] == "function")
+            .expect("tool results must serialize to function turn");
+        let parts = function_turn["parts"].as_array().unwrap();
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0]["functionResponse"]["name"], "plain_tool");
+        assert!(parts[0]["inlineData"].is_null());
+    }
+
     use super::*;
     use harnx_core::abort::create_abort_signal;
     use tokio::sync::mpsc::unbounded_channel;

--- a/crates/harnx-core/src/model.rs
+++ b/crates/harnx-core/src/model.rs
@@ -149,6 +149,22 @@ impl Model {
         self.data.no_system_message
     }
 
+    pub fn supports_vision(&self) -> bool {
+        self.data.supports_vision
+    }
+
+    pub fn supports_tool_use(&self) -> bool {
+        self.data.supports_tool_use
+    }
+
+    pub fn input_price(&self) -> Option<f64> {
+        self.data.input_price
+    }
+
+    pub fn output_price(&self) -> Option<f64> {
+        self.data.output_price
+    }
+
     pub fn system_prompt_prefix(&self) -> Option<&[String]> {
         self.data.system_prompt_prefix.as_deref()
     }

--- a/crates/harnx-core/src/session.rs
+++ b/crates/harnx-core/src/session.rs
@@ -129,6 +129,8 @@ pub struct ToolOutput {
     pub id: Option<String>,
     pub name: String,
     pub output: Value,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub content: Vec<crate::message::MessageContentPart>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub switch_agent: Option<SwitchAgentData>,
 }

--- a/crates/harnx-core/src/tool.rs
+++ b/crates/harnx-core/src/tool.rs
@@ -5,6 +5,7 @@
 //! crate that needs to speak the schema.
 
 use crate::abort::AbortSignal;
+use crate::message::MessageContentPart;
 use async_trait::async_trait;
 use indexmap::IndexMap;
 use minijinja::{Environment, Error, UndefinedBehavior};
@@ -16,6 +17,8 @@ use std::collections::HashSet;
 pub struct ToolResult {
     pub call: ToolCall,
     pub output: Value,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub content: Vec<MessageContentPart>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub switch_agent: Option<SwitchAgentData>,
 }
@@ -33,8 +36,21 @@ impl ToolResult {
         Self {
             call,
             output,
+            content: Vec::new(),
             switch_agent: None,
         }
+    }
+
+    /// Returns true if this result has media content (images, etc.).
+    pub fn has_media(&self) -> bool {
+        !self.content.is_empty()
+    }
+
+    /// Returns an iterator over image content parts in this result.
+    pub fn images(&self) -> impl Iterator<Item = &MessageContentPart> {
+        self.content
+            .iter()
+            .filter(|part| matches!(part, MessageContentPart::ImageUrl { .. }))
     }
 }
 

--- a/crates/harnx-engine/src/lib.rs
+++ b/crates/harnx-engine/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod chat_completions;
 pub mod engine;
 pub mod input;
+pub mod media;
 pub mod retry;
 pub mod tool;
 

--- a/crates/harnx-engine/src/media.rs
+++ b/crates/harnx-engine/src/media.rs
@@ -1,0 +1,207 @@
+use harnx_core::message::{ImageUrl, MessageContentPart};
+use serde_json::Value;
+
+/// Walk output["content"][] for image blocks, returning each as a data-URI ImageUrl part.
+/// Non-image results / missing content → empty Vec.
+pub fn extract_image_parts(output: &Value) -> Vec<MessageContentPart> {
+    let Some(content) = output.get("content").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    content
+        .iter()
+        .filter_map(|block| {
+            if block.get("type").and_then(Value::as_str) != Some("image") {
+                return None;
+            }
+
+            let data = block.get("data").and_then(Value::as_str)?;
+            let mime = block
+                .get("mimeType")
+                .or_else(|| block.get("mime_type"))
+                .and_then(Value::as_str)?;
+
+            Some(MessageContentPart::ImageUrl {
+                image_url: ImageUrl {
+                    url: format!("data:{mime};base64,{data}"),
+                },
+            })
+        })
+        .collect()
+}
+
+/// Replace heavy base64 `data` of image blocks in output["content"][] with a short
+/// placeholder so output.to_string() (session logs, OpenAI tool text) stays small.
+/// Text blocks untouched. Mutates in place.
+pub fn redact_image_data(output: &mut Value) {
+    let Some(content) = output.get_mut("content").and_then(Value::as_array_mut) else {
+        return;
+    };
+
+    for block in content {
+        if block.get("type").and_then(Value::as_str) != Some("image") {
+            continue;
+        }
+
+        let Some(data) = block.get("data").and_then(Value::as_str) else {
+            continue;
+        };
+
+        let mime = block
+            .get("mimeType")
+            .or_else(|| block.get("mime_type"))
+            .and_then(Value::as_str)
+            .unwrap_or("image");
+        let placeholder = format!("<image: {mime}, {} base64 chars>", data.chars().count());
+
+        if let Some(object) = block.as_object_mut() {
+            object.insert("data".to_string(), Value::String(placeholder));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_image_parts, redact_image_data};
+    use harnx_core::message::MessageContentPart;
+    use serde_json::json;
+
+    fn image_urls(parts: Vec<MessageContentPart>) -> Vec<String> {
+        parts
+            .into_iter()
+            .filter_map(|part| match part {
+                MessageContentPart::ImageUrl { image_url } => Some(image_url.url),
+                MessageContentPart::Text { .. } => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn extract_image_parts_returns_data_uri_for_camel_case_mime() {
+        let data = "aGVsbG8=";
+        let output = json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": "caption"
+                },
+                {
+                    "type": "image",
+                    "data": data,
+                    "mimeType": "image/png"
+                }
+            ]
+        });
+
+        let parts = extract_image_parts(&output);
+        assert_eq!(
+            image_urls(parts),
+            vec![format!("data:image/png;base64,{data}")]
+        );
+    }
+
+    #[test]
+    fn extract_image_parts_accepts_snake_case_mime() {
+        let data = "aGVsbG8=";
+        let output = json!({
+            "content": [
+                {
+                    "type": "image",
+                    "data": data,
+                    "mime_type": "image/jpeg"
+                }
+            ]
+        });
+
+        let parts = extract_image_parts(&output);
+        assert_eq!(
+            image_urls(parts),
+            vec![format!("data:image/jpeg;base64,{data}")]
+        );
+    }
+
+    #[test]
+    fn extract_image_parts_returns_empty_for_non_image_or_missing_content() {
+        let text_only = json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": "only text"
+                }
+            ]
+        });
+        let missing_content = json!({"result": "ok"});
+
+        assert!(extract_image_parts(&text_only).is_empty());
+        assert!(extract_image_parts(&missing_content).is_empty());
+    }
+
+    #[test]
+    fn extract_image_parts_skips_image_blocks_missing_mime() {
+        let output = json!({
+            "content": [
+                {
+                    "type": "image",
+                    "data": "aGVsbG8="
+                }
+            ]
+        });
+
+        assert!(extract_image_parts(&output).is_empty());
+    }
+
+    #[test]
+    fn redact_image_data_replaces_payload_and_preserves_text_type_and_mime() {
+        let data = "aGVsbG8=";
+        let text = "caption";
+        let mut output = json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": text
+                },
+                {
+                    "type": "image",
+                    "data": data,
+                    "mimeType": "image/png"
+                }
+            ]
+        });
+
+        redact_image_data(&mut output);
+
+        let serialized = output.to_string();
+        assert!(!serialized.contains(data));
+        assert!(serialized.contains(text));
+
+        let image_block = &output["content"][1];
+        assert_eq!(image_block["type"], "image");
+        assert_eq!(image_block["mimeType"], "image/png");
+        assert_eq!(image_block["data"], "<image: image/png, 8 base64 chars>");
+    }
+
+    #[test]
+    fn extract_then_redact_keeps_extracted_parts_owned() {
+        let data = "aGVsbG8=";
+        let mut output = json!({
+            "content": [
+                {
+                    "type": "image",
+                    "data": data,
+                    "mimeType": "image/png"
+                }
+            ]
+        });
+
+        let parts = extract_image_parts(&output);
+        redact_image_data(&mut output);
+        assert_eq!(
+            image_urls(parts),
+            vec![format!("data:image/png;base64,{data}")]
+        );
+        assert_eq!(
+            output["content"][0]["data"],
+            "<image: image/png, 8 base64 chars>"
+        );
+    }
+}

--- a/crates/harnx-engine/src/tool.rs
+++ b/crates/harnx-engine/src/tool.rs
@@ -205,6 +205,10 @@ pub async fn eval_tool_calls(
                 if let Some(mutated_response) = post_outcome.result.mutated_tool_response {
                     result = mutated_response;
                 }
+                let images = crate::media::extract_image_parts(&result);
+                if !images.is_empty() {
+                    crate::media::redact_image_data(&mut result);
+                }
                 (ctx.emit_tool_result_fn)(&call, &result);
                 if !result.is_null() {
                     is_all_null = false;
@@ -212,6 +216,7 @@ pub async fn eval_tool_calls(
                     result = json!("DONE");
                 }
                 let mut result_obj = ToolResult::new(call, result);
+                result_obj.content = images;
                 result_obj.switch_agent = detect_switch_agent(&result_obj.output);
                 output.push(result_obj);
             }
@@ -785,6 +790,67 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].output, json!({"mutated": true}));
+    }
+
+    #[tokio::test]
+    async fn successful_tool_result_populates_image_content_parts() {
+        let image_data = "Zm9v";
+        let emitted_results = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let emitted_results_clone = Arc::clone(&emitted_results);
+        let ctx = test_context_with_emitters(
+            vec![Arc::new(MockToolProvider::ok(
+                "tool_a",
+                Duration::ZERO,
+                json!({
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "caption"
+                        },
+                        {
+                            "type": "image",
+                            "mimeType": "image/png",
+                            "data": image_data
+                        }
+                    ]
+                }),
+            ))],
+            |_| continue_hook_outcome(),
+            |_, _| {},
+            move |_, value| {
+                emitted_results_clone
+                    .lock()
+                    .expect("lock emitted results")
+                    .push(value.clone());
+            },
+            |_, _| {},
+        );
+        let abort_signal = create_abort_signal();
+
+        let result = eval_tool_calls(&ctx, vec![test_call("tool_a")], &abort_signal)
+            .await
+            .expect("tool call should succeed");
+
+        let emitted_results = emitted_results.lock().expect("lock emitted results");
+        assert_eq!(emitted_results.len(), 1);
+        let emitted_output = emitted_results[0].to_string();
+        assert!(!emitted_output.contains(image_data));
+        assert!(emitted_output.contains("caption"));
+        assert!(emitted_output.contains("<image: image/png, 4 base64 chars>"));
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].content.len(), 1);
+        match &result[0].content[0] {
+            harnx_core::message::MessageContentPart::ImageUrl { image_url } => {
+                assert_eq!(image_url.url, format!("data:image/png;base64,{image_data}"));
+            }
+            other => panic!("expected image content part, got {other:?}"),
+        }
+
+        let serialized_output = result[0].output.to_string();
+        assert!(!serialized_output.contains(image_data));
+        assert!(serialized_output.contains("caption"));
+        assert!(serialized_output.contains("<image: image/png, 4 base64 chars>"));
     }
 
     #[tokio::test]

--- a/crates/harnx-mcp-fs/Cargo.toml
+++ b/crates/harnx-mcp-fs/Cargo.toml
@@ -17,6 +17,7 @@ harnx-mcp-history = { workspace = true }
 log = { workspace = true }
 rmcp = { workspace = true }
 serde = { workspace = true }
+base64 = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 

--- a/crates/harnx-mcp-fs/src/server/handler.rs
+++ b/crates/harnx-mcp-fs/src/server/handler.rs
@@ -9,7 +9,7 @@ impl ServerHandler for FsServer {
                 env!("CARGO_PKG_VERSION"),
             ))
             .with_instructions(
-                "Filesystem MCP server with read, write, edit, insert, re_replace, listing, grep, and glob tools.",
+                "Filesystem MCP server with read (text and local images), write, edit, insert, re_replace, listing, grep, and glob tools.",
             )
     }
 
@@ -20,7 +20,7 @@ impl ServerHandler for FsServer {
     ) -> Result<ListToolsResult, ErrorData> {
         let read_only = ToolAnnotations::new().read_only(true);
         let tools = vec![
-                Tool::new("read", "Read a text file with line numbers, pagination, grep filtering, and smart truncation. Prefer this tool over shell commands like sed, cat, head, tail. Use offset+limit to read specific line ranges instead of sed -n.", Map::new())
+                Tool::new("read", "Read a text file with line numbers, pagination, grep filtering, and smart truncation. Prefer this tool over shell commands like sed, cat, head, tail. Use offset+limit to read specific line ranges instead of sed -n. Also reads local image files (PNG, JPEG, GIF, WebP, up to 5MB) and returns them as viewable images for vision-capable models — use this to view/inspect an image file by its path.", Map::new())
                     .with_input_schema::<ReadFileParams>()
                     .annotate(read_only.clone())
                     .with_meta(make_tool_meta("📖 {{ args.path }}{% if args.offset %} +{{ args.offset }}{% endif %}{% if args.limit is not none %} [:{{ args.limit }}]{% endif %}{% if args.tail is not none %} [tail:{{ args.tail }}]{% endif %}{% if args.grep %} /{{ args.grep }}/{% endif %}{% if args.head_lines is not none %} [head:{{ args.head_lines }}]{% endif %}{% if args.tail_lines is not none %} [tail_lines:{{ args.tail_lines }}]{% endif %}{% if args.max_output_bytes is not none %} [:{{ args.max_output_bytes }}b]{% endif %}")),

--- a/crates/harnx-mcp-fs/src/server/handlers.rs
+++ b/crates/harnx-mcp-fs/src/server/handlers.rs
@@ -1,3 +1,5 @@
+use base64::Engine;
+
 // Auto-split from server.rs for cohesion. See server/mod.rs.
 use super::*;
 
@@ -286,6 +288,76 @@ impl FsServer {
         }
     }
 
+    fn image_mime_from_magic(bytes: &[u8]) -> Option<&'static str> {
+        if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+            return Some("image/png");
+        }
+        if bytes.starts_with(b"\xFF\xD8\xFF") {
+            return Some("image/jpeg");
+        }
+        if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+            return Some("image/gif");
+        }
+        if Self::is_webp(bytes) {
+            return Some("image/webp");
+        }
+
+        None
+    }
+
+    fn is_webp(bytes: &[u8]) -> bool {
+        bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP"
+    }
+
+    fn image_mime_from_ext(path: &std::path::Path) -> Option<&'static str> {
+        let ext = path
+            .extension()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_ascii_lowercase())?;
+
+        match ext.as_str() {
+            "png" => Some("image/png"),
+            "jpg" | "jpeg" => Some("image/jpeg"),
+            "gif" => Some("image/gif"),
+            "webp" => Some("image/webp"),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn detect_image_mime(path: &std::path::Path, bytes: &[u8]) -> Option<&'static str> {
+        Self::image_mime_from_magic(bytes).or_else(|| Self::image_mime_from_ext(path))
+    }
+
+    fn try_read_image_content(
+        path: &std::path::Path,
+        bytes: &[u8],
+        params_path: &str,
+    ) -> Option<Result<CallToolResult, ErrorData>> {
+        const MAX_IMAGE_BYTES: usize = 5 * 1024 * 1024;
+        let mime = Self::detect_image_mime(path, bytes)?;
+
+        if bytes.len() > MAX_IMAGE_BYTES {
+            return Some(tool_error(format!(
+                "'{}' image too large ({} bytes, max {}).",
+                params_path,
+                bytes.len(),
+                MAX_IMAGE_BYTES
+            )));
+        }
+
+        let data = base64::engine::general_purpose::STANDARD.encode(bytes);
+        let summary = format!(
+            "Read image '{}' ({}, {} bytes)",
+            params_path,
+            mime,
+            bytes.len()
+        );
+
+        Some(Ok(CallToolResult::success(vec![
+            Content::image(data, mime.to_string()).with_audience(vec![Role::Assistant]),
+            Content::text(summary).with_audience(vec![Role::User]),
+        ])))
+    }
     pub(crate) async fn read_file_impl(
         &self,
         params: ReadFileParams,
@@ -321,6 +393,10 @@ impl FsServer {
 
         let bytes = std::fs::read(&path)
             .map_err(|err| internal_error(format!("failed to read '{}': {err}", params.path)))?;
+
+        if let Some(result) = Self::try_read_image_content(&path, &bytes, &params.path) {
+            return result;
+        }
 
         if is_binary_content(&bytes) {
             return tool_error(format!("'{}' appears to be a binary file.", params.path));

--- a/crates/harnx-mcp-fs/src/server/params.rs
+++ b/crates/harnx-mcp-fs/src/server/params.rs
@@ -107,7 +107,7 @@ impl JsonSchema for ReadFileParams {
         let max_output_bytes = generator.subschema_for::<Option<usize>>();
         object_schema_with_desc(
             vec![
-                ("path", "Absolute path to the file to read. Prefer this tool over shell commands like sed, cat, head, tail for reading files.", path),
+                ("path", "Absolute path to the file to read. Prefer this tool over shell commands like sed, cat, head, tail for reading files. If the path is an image file (PNG/JPEG/GIF/WebP), it is returned as viewable image content.", path),
                 ("offset", "Start reading at this line number (1-indexed). Use to read a specific line range instead of `sed -n 'N,Mp'`.", offset),
                 ("limit", "Maximum number of lines to return from offset. Combine with offset to read a range.", limit),
                 ("tail", "Return only the last N lines of the file.", tail),

--- a/crates/harnx-mcp-fs/src/server/tests.rs
+++ b/crates/harnx-mcp-fs/src/server/tests.rs
@@ -206,6 +206,21 @@ async fn test_fs_server_list_tools() {
             "rollback_file"
         ]
     );
+
+    // Verify read tool advertises image support in its description
+    let read_tool = tools
+        .tools
+        .iter()
+        .find(|t| t.name == "read")
+        .expect("read tool should exist");
+    let desc = read_tool
+        .description
+        .as_ref()
+        .expect("read tool should have description");
+    assert!(
+        desc.to_lowercase().contains("image"),
+        "read tool description should mention image support"
+    );
 }
 
 #[tokio::test]
@@ -610,6 +625,113 @@ async fn test_read_file_binary_detection() {
     assert!(text_content(&result).contains("appears to be a binary file"));
 }
 
+#[tokio::test]
+async fn test_read_file_image_png() {
+    let temp_dir = TestDir::new();
+    let file_path = temp_dir.path().join("test.png");
+    std::fs::write(&file_path, b"\x89PNG\r\n\x1a\n...fake...").unwrap();
+    let server = make_server(temp_dir.path());
+
+    let result = server
+        .read_file_impl(ReadFileParams {
+            path: path_string(&file_path),
+            offset: None,
+            limit: None,
+            tail: None,
+            grep: None,
+            head_lines: None,
+            tail_lines: None,
+            max_output_bytes: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.is_error, Some(false));
+    let mut found_image = false;
+    for content in result.content {
+        let v = serde_json::to_value(&content).unwrap();
+        if v["type"] == "image" {
+            found_image = true;
+            assert_eq!(v["mimeType"], "image/png");
+            assert!(!v["data"].as_str().unwrap().is_empty());
+        }
+    }
+    assert!(found_image, "expected to find an Image content block");
+}
+
+#[tokio::test]
+async fn test_read_file_image_oversized() {
+    let temp_dir = TestDir::new();
+    let file_path = temp_dir.path().join("big.jpg");
+    // > 5MB
+    let big_data = vec![0xFF, 0xD8, 0xFF, 0x00];
+    let mut file_data = big_data.clone();
+    file_data.resize(5 * 1024 * 1024 + 10, 0);
+    std::fs::write(&file_path, &file_data).unwrap();
+    let server = make_server(temp_dir.path());
+
+    let result = server
+        .read_file_impl(ReadFileParams {
+            path: path_string(&file_path),
+            offset: None,
+            limit: None,
+            tail: None,
+            grep: None,
+            head_lines: None,
+            tail_lines: None,
+            max_output_bytes: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.is_error, Some(true));
+    assert!(text_content(&result).contains("image too large"));
+}
+
+#[test]
+fn test_detect_image_mime_logic() {
+    let p = Path::new("test.txt");
+    assert_eq!(
+        FsServer::detect_image_mime(p, b"\x89PNG\r\n\x1a\n123"),
+        Some("image/png")
+    );
+    assert_eq!(
+        FsServer::detect_image_mime(p, b"\xFF\xD8\xFF123"),
+        Some("image/jpeg")
+    );
+    assert_eq!(
+        FsServer::detect_image_mime(p, b"GIF87a123"),
+        Some("image/gif")
+    );
+    assert_eq!(
+        FsServer::detect_image_mime(p, b"GIF89a123"),
+        Some("image/gif")
+    );
+    assert_eq!(
+        FsServer::detect_image_mime(p, b"RIFF1234WEBP123"),
+        Some("image/webp")
+    );
+
+    // Extension fallback
+    assert_eq!(
+        FsServer::detect_image_mime(Path::new("test.png"), b"random"),
+        Some("image/png")
+    );
+    assert_eq!(
+        FsServer::detect_image_mime(Path::new("TEST.JPG"), b"random"),
+        Some("image/jpeg")
+    );
+    assert_eq!(
+        FsServer::detect_image_mime(Path::new("file.webp"), b"random"),
+        Some("image/webp")
+    );
+
+    // Neither
+    assert_eq!(
+        FsServer::detect_image_mime(Path::new("test.txt"), b"random"),
+        None
+    );
+}
 #[tokio::test]
 async fn test_edit_file_unique_match() {
     let temp_dir = TestDir::new();

--- a/crates/harnx-runtime/src/client/message.rs
+++ b/crates/harnx-runtime/src/client/message.rs
@@ -51,6 +51,38 @@ pub fn render_message_input(
     }
 }
 
+fn strip_image_parts(messages: &mut [Message]) -> usize {
+    let mut stripped_images = 0usize;
+
+    for message in messages.iter_mut() {
+        match &mut message.content {
+            MessageContent::ToolCalls(tool_calls) => {
+                stripped_images += strip_tool_call_image_parts(tool_calls);
+            }
+            MessageContent::Array(parts) => {
+                stripped_images += strip_content_part_images(parts);
+            }
+            _ => {}
+        }
+    }
+
+    stripped_images
+}
+
+fn strip_tool_call_image_parts(tool_calls: &mut MessageContentToolCalls) -> usize {
+    tool_calls
+        .tool_results
+        .iter_mut()
+        .map(|tool_result| strip_content_part_images(&mut tool_result.content))
+        .sum()
+}
+
+fn strip_content_part_images(parts: &mut Vec<MessageContentPart>) -> usize {
+    let before = parts.len();
+    parts.retain(|part| !matches!(part, MessageContentPart::ImageUrl { .. }));
+    before - parts.len()
+}
+
 pub fn patch_messages(messages: &mut Vec<Message>, model: &Model) {
     if messages.is_empty() {
         return;
@@ -84,12 +116,40 @@ pub fn patch_messages(messages: &mut Vec<Message>, model: &Model) {
             message.merge_system(system);
         }
     }
+    if !model.supports_vision() {
+        let stripped_images = strip_image_parts(messages);
+        if stripped_images > 0 {
+            log::warn!(
+                "model '{}' lacks vision support; stripped {} image(s)",
+                model.id(),
+                stripped_images
+            );
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use harnx_core::message::extract_system_message;
+    use harnx_core::{
+        message::{extract_system_message, ImageUrl},
+        tool::{ToolCall, ToolResult},
+    };
+
+    fn tool_result_with_content(content: Vec<MessageContentPart>) -> ToolResult {
+        ToolResult {
+            call: ToolCall::new(
+                "read_media".to_string(),
+                json!({ "path": "image.png" }),
+                None,
+                None,
+            ),
+            output: json!({ "status": "ok" }),
+            content,
+            switch_agent: None,
+        }
+    }
+    use serde_json::json;
 
     #[test]
     fn extract_system_message_text_returns_vec() {
@@ -199,6 +259,166 @@ mod tests {
                 assert!(
                     matches!(&parts[2], MessageContentPart::Text { text } if text == "Be helpful")
                 );
+            }
+            other => panic!("Expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn patch_messages_strips_tool_result_images_for_non_vision_model() {
+        let mut messages = vec![Message::new(
+            MessageRole::Assistant,
+            MessageContent::ToolCalls(MessageContentToolCalls::new(
+                vec![tool_result_with_content(vec![
+                    MessageContentPart::ImageUrl {
+                        image_url: ImageUrl {
+                            url: "file:///image.png".to_string(),
+                        },
+                    },
+                ])],
+                "tool output".to_string(),
+                None,
+            )),
+        )];
+        let model = Model::new("test", "test-model");
+
+        patch_messages(&mut messages, &model);
+
+        match &messages[0].content {
+            MessageContent::ToolCalls(tool_calls) => {
+                assert!(tool_calls.tool_results[0].content.is_empty());
+            }
+            other => panic!("Expected ToolCalls, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn patch_messages_keeps_tool_result_images_for_vision_model() {
+        let mut messages = vec![Message::new(
+            MessageRole::Assistant,
+            MessageContent::ToolCalls(MessageContentToolCalls::new(
+                vec![tool_result_with_content(vec![
+                    MessageContentPart::ImageUrl {
+                        image_url: ImageUrl {
+                            url: "file:///image.png".to_string(),
+                        },
+                    },
+                ])],
+                "tool output".to_string(),
+                None,
+            )),
+        )];
+        let mut model = Model::new("test", "test-model");
+        model.data_mut().supports_vision = true;
+
+        patch_messages(&mut messages, &model);
+
+        match &messages[0].content {
+            MessageContent::ToolCalls(tool_calls) => {
+                assert_eq!(tool_calls.tool_results[0].content.len(), 1);
+                assert!(matches!(
+                    tool_calls.tool_results[0].content[0],
+                    MessageContentPart::ImageUrl { .. }
+                ));
+            }
+            other => panic!("Expected ToolCalls, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn patch_messages_strips_only_image_parts_for_non_vision_model() {
+        let mut messages = vec![Message::new(
+            MessageRole::Assistant,
+            MessageContent::ToolCalls(MessageContentToolCalls::new(
+                vec![tool_result_with_content(vec![
+                    MessageContentPart::Text {
+                        text: "caption".to_string(),
+                    },
+                    MessageContentPart::ImageUrl {
+                        image_url: ImageUrl {
+                            url: "file:///image.png".to_string(),
+                        },
+                    },
+                ])],
+                "tool output".to_string(),
+                None,
+            )),
+        )];
+        let model = Model::new("test", "test-model");
+
+        patch_messages(&mut messages, &model);
+
+        match &messages[0].content {
+            MessageContent::ToolCalls(tool_calls) => {
+                assert_eq!(tool_calls.tool_results[0].content.len(), 1);
+                assert!(matches!(
+                    &tool_calls.tool_results[0].content[0],
+                    MessageContentPart::Text { text } if text == "caption"
+                ));
+            }
+            other => panic!("Expected ToolCalls, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn patch_messages_strips_user_images_for_non_vision_model() {
+        let mut messages = vec![Message::new(
+            MessageRole::User,
+            MessageContent::Array(vec![
+                MessageContentPart::Text {
+                    text: "describe this".to_string(),
+                },
+                MessageContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: "file:///image.png".to_string(),
+                    },
+                },
+            ]),
+        )];
+        let model = Model::new("test", "test-model");
+
+        patch_messages(&mut messages, &model);
+
+        match &messages[0].content {
+            MessageContent::Array(parts) => {
+                assert_eq!(parts.len(), 1);
+                assert!(matches!(
+                    &parts[0],
+                    MessageContentPart::Text { text } if text == "describe this"
+                ));
+            }
+            other => panic!("Expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn patch_messages_keeps_user_images_for_vision_model() {
+        let mut messages = vec![Message::new(
+            MessageRole::User,
+            MessageContent::Array(vec![
+                MessageContentPart::Text {
+                    text: "describe this".to_string(),
+                },
+                MessageContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: "file:///image.png".to_string(),
+                    },
+                },
+            ]),
+        )];
+        let mut model = Model::new("test", "test-model");
+        model.data_mut().supports_vision = true;
+
+        patch_messages(&mut messages, &model);
+
+        match &messages[0].content {
+            MessageContent::Array(parts) => {
+                assert_eq!(parts.len(), 2);
+                assert!(matches!(
+                    &parts[0],
+                    MessageContentPart::Text { text } if text == "describe this"
+                ));
+                assert!(matches!(&parts[1], MessageContentPart::ImageUrl { .. }));
             }
             other => panic!("Expected Array, got {:?}", other),
         }

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -26,7 +26,7 @@ pub enum CommandOutcome {
     OpenSessionPicker,
 }
 
-pub static COMMANDS: LazyLock<[Command; 45]> = LazyLock::new(|| {
+pub static COMMANDS: LazyLock<[Command; 46]> = LazyLock::new(|| {
     [
         Command::new(".help", "Show this help guide"),
         Command::new(".info", "Show system info"),
@@ -53,6 +53,10 @@ pub static COMMANDS: LazyLock<[Command; 45]> = LazyLock::new(|| {
             "Compact session messages using configured compaction agent",
         ),
         Command::new(".info session", "Show session info"),
+        Command::new(
+            ".info model",
+            "Show active model details (id, client, pricing, vision/tool-use, catalog source)",
+        ),
         Command::new(".edit session", "Modify current session"),
         Command::new(
             ".edit message <n>",
@@ -169,6 +173,10 @@ pub async fn run_command_with_output(
                 Some("session") => {
                     let info = config.read().session_info()?;
                     write!(output, "{info}")?;
+                }
+                Some("model") => {
+                    let conf = config.read();
+                    write_model_info_block(output, &conf, conf.current_model())?;
                 }
                 Some("rag") => {
                     let info = config.read().rag_info()?;
@@ -943,6 +951,60 @@ fn split_first_arg(args: Option<&str>) -> Option<(&str, Option<&str>)> {
     })
 }
 
+fn model_source_label(conf: &Config, model: &crate::client::Model) -> &'static str {
+    if crate::client::list_all_models(&conf.clients)
+        .iter()
+        .any(|candidate| {
+            candidate.id() == model.id() && candidate.model_type() == model.model_type()
+        })
+    {
+        "catalog"
+    } else {
+        "fallback/default (not found in catalog — capabilities may be wrong!)"
+    }
+}
+
+fn format_option<T: std::fmt::Display>(value: Option<T>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "—".to_string())
+}
+
+fn write_model_info_block(
+    output: &mut (dyn Write + Send),
+    conf: &Config,
+    model: &crate::client::Model,
+) -> Result<()> {
+    writeln!(output, "model: {}", model.id())?;
+    writeln!(output, "client: {}", model.client_name())?;
+    writeln!(output, "real_name: {}", model.real_name())?;
+    writeln!(output, "type: {}", model.model_type())?;
+    writeln!(output, "source: {}", model_source_label(conf, model))?;
+    writeln!(output, "supports_vision: {}", model.supports_vision())?;
+    writeln!(output, "supports_tool_use: {}", model.supports_tool_use())?;
+    writeln!(
+        output,
+        "max_input_tokens: {}",
+        format_option(model.max_input_tokens())
+    )?;
+    writeln!(
+        output,
+        "max_output_tokens: {}",
+        format_option(model.max_output_tokens())
+    )?;
+    writeln!(
+        output,
+        "input_price: {}",
+        format_option(model.input_price())
+    )?;
+    writeln!(
+        output,
+        "output_price: {}",
+        format_option(model.output_price())
+    )?;
+    Ok(())
+}
+
 pub fn split_args_text(line: &str, is_win: bool) -> (Vec<String>, &str) {
     let mut words = Vec::new();
     let mut word = String::new();
@@ -1018,6 +1080,92 @@ pub fn split_args_text(line: &str, is_win: bool) -> (Vec<String>, &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{self, WorkingMode};
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn test_config_with_model(model: crate::client::Model) -> GlobalConfig {
+        let mut config = Config {
+            model,
+            working_mode: WorkingMode::Cmd,
+            ..Default::default()
+        };
+        config.session = Some(config::session::new(&config, "test").expect("test session"));
+        Arc::new(RwLock::new(config))
+    }
+
+    fn model_with_data(
+        client_name: &str,
+        name: &str,
+        supports_vision: bool,
+    ) -> crate::client::Model {
+        let mut model = crate::client::Model::new(client_name, name);
+        model.data_mut().supports_vision = supports_vision;
+        model
+    }
+
+    #[tokio::test]
+    async fn test_info_model_reports_catalog_model() {
+        let mut config = Config {
+            clients: vec![crate::client::ClientConfig::OpenAIConfig(Default::default())],
+            model: model_with_data("openai", "gpt-4o", true),
+            working_mode: WorkingMode::Cmd,
+            ..Default::default()
+        };
+        config.session = Some(config::session::new(&config, "test").expect("test session"));
+        let config = Arc::new(RwLock::new(config));
+        let mut output = Vec::new();
+        let abort_signal = crate::utils::create_abort_signal();
+        let mut async_manager = AsyncHookManager::default();
+        let persistent_manager = Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new()));
+        let mut pending_async_context = None;
+
+        let outcome = run_command_with_output(
+            &config,
+            abort_signal,
+            ".info model",
+            &mut async_manager,
+            &persistent_manager,
+            &mut pending_async_context,
+            &mut output,
+        )
+        .await
+        .expect("command succeeds");
+
+        assert_eq!(outcome, CommandOutcome::Continue);
+        let output = String::from_utf8(output).expect("utf8 output");
+        assert!(output.contains("model: openai:gpt-4o"));
+        assert!(output.contains("supports_vision: true"));
+        assert!(output.contains("source: catalog"));
+    }
+
+    #[tokio::test]
+    async fn test_info_model_reports_fallback_model() {
+        let config =
+            test_config_with_model(model_with_data("test-client", "fallback-model", false));
+        let mut output = Vec::new();
+        let abort_signal = crate::utils::create_abort_signal();
+        let mut async_manager = AsyncHookManager::default();
+        let persistent_manager = Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new()));
+        let mut pending_async_context = None;
+
+        run_command_with_output(
+            &config,
+            abort_signal,
+            ".info model",
+            &mut async_manager,
+            &persistent_manager,
+            &mut pending_async_context,
+            &mut output,
+        )
+        .await
+        .expect("command succeeds");
+
+        let output = String::from_utf8(output).expect("utf8 output");
+        assert!(output.contains("model: test-client:fallback-model"));
+        assert!(output.contains("supports_vision: false"));
+        assert!(output.contains("source: fallback/default"));
+    }
 
     #[test]
     fn test_process_command_line() {

--- a/crates/harnx-runtime/src/config/completion_split.rs
+++ b/crates/harnx-runtime/src/config/completion_split.rs
@@ -20,7 +20,7 @@ impl Config {
                 ".rag" => map_completion_values(Self::list_rags()),
                 ".agent" => map_completion_values(precomputed_agents),
                 ".macro" => map_completion_values(Self::list_macros()),
-                ".info" => map_completion_values(vec!["session", "agent", "rag", "tools"]),
+                ".info" => map_completion_values(vec!["session", "model", "agent", "rag", "tools"]),
                 ".mcp" => map_completion_values(vec![
                     "list",
                     "connect",

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -376,6 +376,7 @@ fn repair_orphan_tool_calls(pending: PendingToolCalls, _name: &str) -> Result<Me
         output: serde_json::json!({
             "error": "tool response lost (session was interrupted before results were persisted)"
         }),
+        content: Vec::new(),
         switch_agent: None,
     };
     // Fabricate one lost-response per call, matched by id/position.
@@ -422,6 +423,7 @@ fn assemble_tool_message(
                 Some(out) => ToolResult {
                     call,
                     output: out.output,
+                    content: out.content,
                     switch_agent: out.switch_agent,
                 },
                 None => ToolResult::new(
@@ -546,7 +548,14 @@ pub fn render(session: &Session) -> Result<String> {
         items.push(("path", path.to_string()));
     }
 
-    items.push(("model", session.model().id()));
+    items.push((
+        "model",
+        format!(
+            "{} (vision: {})",
+            session.model().id(),
+            session.model().supports_vision()
+        ),
+    ));
 
     if let Some(temperature) = session.temperature() {
         items.push(("temperature", temperature.to_string()));
@@ -646,6 +655,7 @@ fn append_message_entries(content: &mut String, msg: &Message, session_id: &str)
                     id: r.call.id.clone(),
                     name: r.call.name.clone(),
                     output: r.output.clone(),
+                    content: r.content.clone(),
                     switch_agent: r.switch_agent.clone(),
                 })
                 .collect();
@@ -937,6 +947,7 @@ pub fn add_tool_results(session: &mut Session, results: &[crate::tool::ToolResul
             .or_else(|| positional.next());
         if let Some(replacement) = replacement {
             slot.output = replacement.output;
+            slot.content = replacement.content;
             slot.switch_agent = replacement.switch_agent;
         }
     }
@@ -948,6 +959,7 @@ pub fn add_tool_results(session: &mut Session, results: &[crate::tool::ToolResul
             id: r.call.id.clone(),
             name: r.call.name.clone(),
             output: r.output.clone(),
+            content: r.content.clone(),
             switch_agent: r.switch_agent.clone(),
         })
         .collect();
@@ -1761,6 +1773,273 @@ content: second
             json!({"results": ["a", "b"]}),
             "reloaded tool output should match what we wrote"
         );
+    }
+
+    #[test]
+    fn legacy_tool_result_without_content_loads_with_empty_content() {
+        use serde_json::json;
+
+        let content = r#"---
+type: header
+model: test:model
+agent: default
+save_session: true
+---
+type: user
+text: find test
+---
+type: tool_calls
+text: searching...
+calls:
+  - name: search
+    arguments:
+      query: test
+    id: c1
+---
+type: tool_results
+results:
+  - id: c1
+    name: search
+    output:
+      results:
+        - a
+        - b
+"#;
+
+        let reloaded = super::load_from_log_for_test(content);
+        let tool_msg = reloaded
+            .messages
+            .iter()
+            .find(|m| m.role == MessageRole::Tool)
+            .expect("session should contain a Tool message");
+        let MessageContent::ToolCalls(tc) = &tool_msg.content else {
+            panic!("expected ToolCalls content on Tool message");
+        };
+
+        assert_eq!(tc.tool_results[0].output, json!({"results": ["a", "b"]}));
+        assert!(
+            tc.tool_results[0].content.is_empty(),
+            "legacy sessions without content field should load as empty Vec"
+        );
+    }
+
+    #[test]
+    fn session_serialization_omits_empty_tool_result_content() {
+        use crate::tool::{ToolCall, ToolResult};
+        use serde_json::json;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let mut session = test_session();
+        session.set_sessions_dir(tmp.path().to_path_buf());
+
+        let config = Config::default();
+        let agent = config.extract_agent();
+        let global_config = std::sync::Arc::new(parking_lot::RwLock::new(config.clone()));
+
+        let call = ToolCall {
+            name: "search".to_string(),
+            arguments: json!({"query": "test"}),
+            id: Some("c1".to_string()),
+            thought_signature: None,
+        };
+        let result = ToolResult::new(call.clone(), json!({"results": ["a", "b"]}));
+
+        let input = crate::config::input::from_str(&global_config, "find test", Some(agent));
+        super::add_tool_calls(&mut session, &input, "searching...", None, &[call]).unwrap();
+        super::add_tool_results(&mut session, &[result]).unwrap();
+
+        let serialized = std::fs::read_to_string(session.path.as_ref().unwrap()).unwrap();
+        let tool_results_doc = serialized
+            .split("---")
+            .find(|doc| doc.contains("type: tool_results"))
+            .expect("persisted session should contain tool_results document");
+        assert!(
+            !tool_results_doc.contains("content:"),
+            "empty tool result content should be omitted from persisted tool_results YAML"
+        );
+    }
+
+    #[test]
+    fn tool_result_image_content_survives_add_tool_results_and_build_messages() {
+        use crate::tool::{ToolCall, ToolResult};
+        use harnx_core::message::{ImageUrl, MessageContentPart};
+        use serde_json::json;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let mut session = test_session();
+        session.set_sessions_dir(tmp.path().to_path_buf());
+
+        let config = Config::default();
+        let agent = config.extract_agent();
+        let global_config = std::sync::Arc::new(parking_lot::RwLock::new(config.clone()));
+        let input = crate::config::input::from_str(&global_config, "inspect image", Some(agent));
+
+        let data_uri = "data:image/png;base64,AAAA".to_string();
+        let call = ToolCall {
+            name: "read".to_string(),
+            arguments: json!({"path": "chart.png"}),
+            id: Some("c1".to_string()),
+            thought_signature: None,
+        };
+        let result = ToolResult {
+            call: call.clone(),
+            output: json!({
+                "content": [{
+                    "type": "image",
+                    "mime_type": "image/png",
+                    "data": "<image: image/png, 4 base64 chars>"
+                }]
+            }),
+            content: vec![MessageContentPart::ImageUrl {
+                image_url: ImageUrl {
+                    url: data_uri.clone(),
+                },
+            }],
+            switch_agent: None,
+        };
+
+        super::add_tool_calls(&mut session, &input, "reading...", None, &[call]).unwrap();
+        super::add_tool_results(&mut session, &[result]).unwrap();
+
+        let messages = super::build_messages(&session, &input).unwrap();
+        let tool_message = messages
+            .iter()
+            .find(|message| message.role == MessageRole::Tool)
+            .expect("tool message should be present");
+        let MessageContent::ToolCalls(tool_calls) = &tool_message.content else {
+            panic!("expected tool-call message, got {tool_message:#?}");
+        };
+        assert_eq!(tool_calls.tool_results.len(), 1);
+        assert_eq!(tool_calls.tool_results[0].content.len(), 1);
+        match &tool_calls.tool_results[0].content[0] {
+            MessageContentPart::ImageUrl { image_url } => assert_eq!(image_url.url, data_uri),
+            other => panic!("expected ImageUrl content part, got {other:#?}"),
+        }
+        assert_eq!(
+            tool_calls.tool_results[0].output,
+            json!({
+                "content": [{
+                    "type": "image",
+                    "mime_type": "image/png",
+                    "data": "<image: image/png, 4 base64 chars>"
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn session_persistence_round_trips_tool_result_image_content_with_redacted_output() {
+        use crate::tool::{ToolCall, ToolResult};
+        use harnx_core::message::{ImageUrl, MessageContentPart};
+        use serde_json::json;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let mut session = test_session();
+        session.set_sessions_dir(tmp.path().to_path_buf());
+
+        let config = Config::default();
+        let agent = config.extract_agent();
+        let global_config = std::sync::Arc::new(parking_lot::RwLock::new(config.clone()));
+
+        let base64_payload = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".repeat(8);
+        let data_uri = format!("data:image/png;base64,{base64_payload}");
+        let call = ToolCall {
+            name: "read".to_string(),
+            arguments: json!({"path": "chart.png"}),
+            id: Some("c1".to_string()),
+            thought_signature: None,
+        };
+        let redacted_output = json!({
+            "content": [{
+                "type": "image",
+                "mime_type": "image/png",
+                "data": format!("<image: image/png, {} base64 chars>", base64_payload.len())
+            }]
+        });
+        let result = ToolResult {
+            call: call.clone(),
+            output: redacted_output.clone(),
+            content: vec![MessageContentPart::ImageUrl {
+                image_url: ImageUrl {
+                    url: data_uri.clone(),
+                },
+            }],
+            switch_agent: None,
+        };
+
+        let input = crate::config::input::from_str(&global_config, "inspect image", Some(agent));
+        super::add_tool_calls(&mut session, &input, "reading...", None, &[call]).unwrap();
+        super::add_tool_results(&mut session, &[result]).unwrap();
+
+        let persisted = std::fs::read_to_string(session.path.as_ref().unwrap()).unwrap();
+        assert!(persisted.contains("<image: image/png,"));
+        assert!(
+            persisted.contains(&data_uri),
+            "persisted session should inline tool result data URI in content"
+        );
+
+        let reloaded = super::load_from_log_for_test(&persisted);
+        let MessageContent::ToolCalls(tool_calls) = &reloaded
+            .messages
+            .iter()
+            .find(|message| message.role == MessageRole::Tool)
+            .expect("reloaded tool message should be present")
+            .content
+        else {
+            panic!("expected reloaded tool-call message");
+        };
+        assert_eq!(tool_calls.tool_results.len(), 1);
+        assert_eq!(tool_calls.tool_results[0].content.len(), 1);
+        match &tool_calls.tool_results[0].content[0] {
+            MessageContentPart::ImageUrl { image_url } => assert_eq!(image_url.url, data_uri),
+            other => panic!("expected ImageUrl content part, got {other:#?}"),
+        }
+        assert_eq!(tool_calls.tool_results[0].output, redacted_output);
+    }
+
+    #[test]
+    fn load_old_tool_results_without_content_defaults_to_empty_content() {
+        let content = r#"type: header
+model: test
+---
+type: message
+role: user
+content: inspect image
+---
+type: tool_calls
+text: reading...
+calls:
+  - name: read
+    arguments:
+      path: chart.png
+    id: c1
+---
+type: tool_results
+results:
+  - id: c1
+    name: read
+    output:
+      content:
+        - type: image
+          mime_type: image/png
+          data: "<image: image/png, 4 base64 chars>"
+"#;
+
+        let session = super::load_from_log_for_test(content);
+        let MessageContent::ToolCalls(tool_calls) = &session
+            .messages
+            .iter()
+            .find(|message| message.role == MessageRole::Tool)
+            .expect("tool message should load")
+            .content
+        else {
+            panic!("expected tool-call message");
+        };
+        assert_eq!(tool_calls.tool_results.len(), 1);
+        assert!(tool_calls.tool_results[0].content.is_empty());
     }
 
     #[test]

--- a/crates/harnx-runtime/src/config/session_edit_tests.rs
+++ b/crates/harnx-runtime/src/config/session_edit_tests.rs
@@ -44,6 +44,7 @@ fn tool_results_yaml_with_optional_ids(result_ids: &[Option<String>]) -> String 
                 id: id.clone(),
                 name: "bash_exec".to_string(),
                 output: serde_json::json!({"ok": true}),
+                content: Vec::new(),
                 switch_agent: None,
             })
             .collect(),
@@ -301,6 +302,7 @@ fn tool_results_entry(id: &str) -> SessionLogEntry {
             id: Some(id.to_string()),
             name: "bash_exec".to_string(),
             output: serde_json::json!("ok"),
+            content: Vec::new(),
             switch_agent: None,
         }],
     }

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__info_session_with_session_in_tui.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__info_session_with_session_in_tui.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/harnx-tui/src/tests.rs
-assertion_line: 652
+assertion_line: 731
 expression: rendered
 ---
 Welcome to harnx [VERSION]  •  Type .help for commands, Tab to
 complete.
 💬  info-session-with-session-test
-model               mock:mock-model
+model               mock:mock-model (vision: false)
 save_session        true
 tokens              0
 turns               0

--- a/docs/solutions/llm-view-local-media-images.md
+++ b/docs/solutions/llm-view-local-media-images.md
@@ -1,0 +1,136 @@
+---
+title: "LLM local image viewing via fs read tool"
+date: 2026-06-11
+category: "media"
+problem_type: integration_issue
+component: "harnx-engine"
+root_cause: "fs read tool rejected binary; tool images never surfaced as vision input"
+resolution_type: feature_implementation
+severity: high
+tags:
+  - media
+  - image
+  - fs
+  - mcp
+  - tool-result
+  - vision
+  - gemini
+  - camelCase
+plan_ref: "harnx-175-llm-view-local-media"
+last_updated: 2026-06-11
+---
+
+# LLM local image viewing via fs read tool
+
+## Problem
+
+The `fs` MCP `read` tool previously rejected binary files (triggering `is_binary_content` → `tool_error`), and MCP tool results flowed back as untyped `serde_json::Value` in `ToolResult.output`. Provider serializers embedded that output as JSON/string in tool-result blocks, meaning images were never surfaced as vision input even if a tool returned them.
+
+## Solution
+
+The "A-lite" approach adds a dedicated `content` field to `ToolResult` to carry image data while maintaining backward compatibility with existing session persistence and agent-switch detection logic.
+
+### 1. Additive ToolResult content
+
+`ToolResult` in `harnx-core` now includes an optional `content` field:
+
+```rust
+pub struct ToolResult {
+    pub output: Value,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub content: Vec<MessageContentPart>,
+}
+```
+
+This ensures that existing saved sessions (which lack this field) load correctly, and `output` remains the source of truth for text-based analysis.
+
+### 2. Pipeline: Extraction and Redaction
+
+When a tool returns an rmcp `CallToolResult` containing image blocks, `harnx-engine` processes it at the boundary:
+
+1. **Extraction**: `extract_image_parts` in `harnx-engine/src/media.rs` identifies `RawContent::Image` blocks and converts them to `MessageContentPart::ImageUrl` (base64 data URIs).
+2. **Redaction**: `redact_image_data` replaces the massive base64 string in the `output` field with a lightweight placeholder: `<image: {mime}, {n} base64 chars>`. This prevents session logs and OpenAI-style tool text from bloating.
+3. **Storage**: The full image data lives in `ToolResult.content` (a data URI). This is consumed by provider serializers **and** persisted in the session log (see "Persistence" below), so the image survives across turns and across interrupt/resume.
+
+**Critical ordering**: Redaction occurs *before* the emit callback (`emit_tool_result_fn`) to ensure UI/log/event sinks receive the redacted output, not raw base64.
+
+### 3. Per-Provider Implementation
+
+Different LLM providers handle images in tool results via diverse API shapes:
+
+- **Claude & Bedrock**: Support native image blocks directly inside the tool result content array.
+- **OpenAI / Azure / openai_compatible**: The `tool` role only accepts strings. The engine emits the tool message with the redacted text placeholder, followed by a trailing `user` message containing the `image_url` parts.
+- **Gemini / VertexAI**: Emits `functionResponse` parts first, followed by sibling `inlineData` parts in the same turn.
+
+### 4. Vision Gating
+
+To prevent API errors when using models without vision capabilities, `patch_messages` in `harnx-runtime` strips image parts from **all message origins** (tool results and user input) and logs a warning if `!model.supports_vision()`.
+
+## Why This Works
+
+- **Backward Compatibility**: `output` remains a `Value` and is preserved for tools and agent-switch logic.
+- **Memory Efficiency**: The base64 is stored exactly once — in `content` (as a data URI). `output` keeps only a small redacted placeholder, so `output.to_string()` paths (OpenAI tool text, display) stay small and the bytes are never duplicated.
+- **Provider Agnostic**: The engine handles the extraction, and specialized serializers adapt the output to the specific requirements of each LLM provider's API.
+
+## Key Decisions
+
+- **Images Only**: Support is limited to PNG, JPG, GIF, and WebP. Video and audio are deferred.
+- **Size Cap**: The `fs` read tool enforces a ~5MB cap per image. Oversized images return a text error instead of a vision block.
+- **No Resizing**: Images are passed through exactly as read from disk; no compression or resizing is performed by the engine.
+- **Engine-Core Separation**: Core remains RMCP-agnostic. All RMCP-specific parsing logic lives in `harnx-engine` and `harnx-mcp-fs`.
+
+## Persistence
+
+Tool-returned images are persisted in the session log, exactly like user-attached (`.attach`) images — the data URI is inlined in the `tool_results` entry. Mechanically: `harnx_core::session::ToolOutput` carries an additive `content: Vec<MessageContentPart>` field (same `#[serde(default, skip_serializing_if = "Vec::is_empty")]` pattern as `ToolResult.content`); `add_tool_results` copies `content` into both the in-memory message and the persisted log entry; and `assemble_tool_message` rehydrates it on load. As a result the image survives across turns in a live session **and** across interrupt/resume. `output` stays redacted (placeholder only), so the bytes are stored once.
+
+## Known Limitations
+
+- **TUI Rendering**: The terminal UI does not yet render the images returned by tools.
+
+## Gotchas / Lessons Learned
+
+### Gemini/VertexAI REST API Requires camelCase for Image Parts
+
+The Gemini and Vertex AI `generateContent` REST API requires **camelCase** JSON keys for image inline-data parts:
+
+- `inlineData` (not `inline_data`)
+- `mimeType` (not `mime_type`)
+
+**Trap**: Using snake_case keys (`inline_data`, `mime_type`) results in **silent failure** — the fields are treated as unknown and dropped by Google's API. The image never reaches the model, and no error is returned.
+
+This bug existed in the pre-implementation codebase for user-input images and was replicated in the new tool-result image path during initial implementation. Fixed by updating both request-body serializer sites in `vertexai.rs` to use camelCase.
+
+Verified against Google's official REST API documentation: [`inlineData` must use camelCase](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/GenerateContentRequest#inlineData).
+
+### Redaction Must Precede Emit Callback
+
+The redaction step (`redact_image_data`) must run **before** the tool-result emit callback (`emit_tool_result_fn`). If redaction runs after emit, raw base64 payloads leak to UI/log/event sinks. The implementation now extracts images and redacts `output` in the correct sequence before invoking the emit callback.
+
+### Tool Affordance: Describe the Image Capability or the Model Won't Use It
+
+Returning images from the `read` tool is necessary but **not sufficient**. The model decides whether to call a tool from its **description**, not its implementation. With `read` described only as "Read a text file...", agents (observed with Claude Opus 4.8) would refuse or skip reading an image path entirely — the vision pipeline never even ran. User-attached images (`.attach`, which flow through `MessageContent::Array`) worked fine, which isolated the problem to tool discoverability.
+
+Fix: keep overloading the normal filesystem `read` tool (consistent with Claude Code, opencode, Cline, Aider, Cursor — none expose a dedicated media tool) and **advertise image support in the model-facing metadata**: the tool description, the `path` parameter description, and the server instructions all state that `read` returns local image files (PNG/JPEG/GIF/WebP) as viewable content. A dedicated `read_media`/`view_image` tool was considered and rejected as inconsistent with prevailing harness conventions.
+
+### The Runtime Drops `content` Unless Every Hand-Off Copies It
+
+Populating `ToolResult.content` in the engine is not enough — the image is lost unless **every** layer that reconstructs a tool-result message also carries `content`. The original implementation missed `add_tool_results` in `harnx-runtime`, which rebuilds the in-memory session message copying only `output` and `switch_agent`. Result: the image was dropped on the **same turn** (not just on resume, as originally assumed), and `build_messages` sent empty content to the provider → the model hallucinated the image. The unit tests passed because they exercised the engine and provider serializers in isolation with synthetic `content`; none ran the real `add_tool_results → build_messages` path. **Lesson**: for a field that threads through multiple representations (live message, persisted log, rehydrated message, wire format), add an end-to-end integration test through the real assembly path, not just isolated unit tests of each stage.
+
+### Diagnosing Model Capability: `.info model`
+
+When images silently fail to reach a vision model, the usual cause is model resolution: an id that doesn't match the catalog falls back to `Model::new(...)` with `supports_vision = false`, and vision gating then strips the image. The `.info model` command surfaces the active model's `supports_vision`, `supports_tool_use`, pricing, token limits, and crucially its **source** (`catalog` vs `fallback/default`) so this footgun is visible. A `fallback/default` source is the tell that capabilities (including vision) may be wrong because the configured model id didn't match any catalog entry.
+
+## File Pointers
+
+- `crates/harnx-mcp-fs/src/server/handlers.rs`: Handler for `read` tool with `detect_image_mime` and 5MB cap.
+- `crates/harnx-engine/src/media.rs`: `extract_image_parts` and `redact_image_data` helpers.
+- `crates/harnx-engine/src/tool.rs`: Integration of extraction/redaction into the tool execution flow (extract → redact → emit).
+- `crates/harnx-client/src/claude.rs`: Native image blocks in tool results.
+- `crates/harnx-client/src/bedrock.rs`: Native image blocks in `toolResult.content`.
+- `crates/harnx-client/src/openai.rs`: Follow-up user message pattern for images.
+- `crates/harnx-client/src/vertexai.rs`: Sibling `inlineData` parts with camelCase keys.
+- `crates/harnx-runtime/src/client/message.rs`: `patch_messages` vision gating for both tool results and user input.
+- `crates/harnx-core/src/tool.rs`: Additive `content` field on `ToolResult`.
+- `crates/harnx-core/src/model.rs`: `supports_vision()` flag.
+- `crates/harnx-core/src/session.rs` & `crates/harnx-runtime/src/config/session.rs`: `ToolOutput.content` persistence; `add_tool_results` / `assemble_tool_message` carry image data URIs across turns and resume.
+- `crates/harnx-runtime/src/commands.rs`: `.info model` diagnostic (model id, client, source catalog/fallback, vision, tool-use, pricing, token limits).


### PR DESCRIPTION
Enhances the fs MCP read tool to return local image files (PNG, JPG, GIF, WebP) as viewable image content blocks. Updates the engine's ToolResult and ToolOutput types to carry image data URIs in an additive content field, which is persisted in the session log and durable across turns and resume.

Specialized serializers adapt the image blocks to specific provider requirements: native blocks for Claude and Bedrock, follow-up user messages for OpenAI, and sibling inlineData parts with camelCase keys for Gemini and Vertex AI.

Includes a vision gating mechanism to strip images for models without vision support and adds a .info model diagnostic command to surface active model metadata (ID, source, capabilities) for troubleshooting.

Issue: #175
Plan: harnx-175-llm-view-local-media

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool results can include inline images (data-URI) so vision-capable models can process them
  * Filesystem read now returns viewable local images (PNG/JPEG/GIF/WebP) with size limits
  * Added `.info model` command showing model capabilities, vision/tool support, and pricing

* **Documentation**
  * New guide on local-image handling, persistence, redaction, and provider-specific behavior

* **Chores**
  * Updated rmcp dependency to version 1.7
<!-- end of auto-generated comment: release notes by coderabbit.ai -->