### PR TITLE
feat: support per-model GGUF configuration and HuggingFace auto-download

### DIFF
--- a/.changeset/llama-per-model-gguf.md
+++ b/.changeset/llama-per-model-gguf.md
@@ -1,0 +1,9 @@
+---
+harnx: minor
+---
+
+Updated `llama-server` provider to support per-model GGUF configuration and HuggingFace auto-download.
+- Models in `models[]` now specify their own `model_path`, `hf_repo`, and tuning knobs (`ctx_size`, `n_gpu_layers`, `threads`, `extra_args`, `socket_path`).
+- Added support for HuggingFace auto-download via the `-hf` flag in `llama-server`.
+- Model source resolution precedence: `model_path` (local) -> `hf_repo` (HuggingFace) -> model `name` as the HuggingFace repo spec.
+- Multi-model support: one provider config can now serve multiple models, each in its own lazily-spawned `llama-server` subprocess.

--- a/README.md
+++ b/README.md
@@ -179,16 +179,25 @@ AI Agent = Instructions (Prompt) + Tools (Function Callings) + Documents (RAG).
 
 ### Local LLM via llama-server
 
-Harnx can spawn and manage a local `llama-server` (from the [llama.cpp](https://github.com/ggml-org/llama.cpp) project) as a child process. It communicates over a high-performance **Unix domain socket**, serving OpenAI-compatible chat completions. This allows you to run local GGUF models with streaming and tool use support without heavy in-process builds or external TCP services.
+Harnx can spawn and manage local `llama-server` (from the [llama.cpp](https://github.com/ggml-org/llama.cpp) project) child processes. It communicates over high-performance **Unix domain sockets**, serving OpenAI-compatible chat completions. This allows you to run local GGUF models with streaming and tool use support without heavy in-process builds or external TCP services.
 
 - **Installation**: Install `llama-server` via [GitHub Releases](https://github.com/ggml-org/llama.cpp/releases) or `brew install llama.cpp`.
+- **Per-Model Config**: Each model entry in `models[]` specifies its own GGUF source and tuning knobs (`ctx_size`, `n_gpu_layers`, `threads`). One configuration file can serve multiple distinct models.
+- **Model Sources (Precedence)**:
+  1. `model_path`: Path to a local `.gguf` file (passes `-m`).
+  2. `hf_repo`: HuggingFace repo spec (passes `-hf`, e.g. `ggml-org/gemma-3-1b-it-GGUF`).
+  3. **Name as Source**: If both above are missing, the model `name` is used as the HuggingFace repo spec.
+- **HuggingFace Auto-Download**: When using an `hf_repo` (or a name-based HF spec), `llama-server` automatically downloads the GGUF to the standard HuggingFace cache on first use. No manual download is required.
+  - *Note*: Private or gated repos require the `HF_TOKEN` environment variable.
+  - *Note*: Auto-download requires a `llama-server` binary built with OpenSSL (included in official releases and `brew` installations).
+  - *Note*: First-run downloads can be large; initial readiness may take several minutes.
+- **Multi-Process Lifecycle**: Harnx lazily spawns up to one `llama-server` process per distinct runtime configuration. A configuration's identity includes the model source (local path or HF repo) **plus** its tuning parameters (`ctx_size`, `n_gpu_layers`, `threads`, `extra_args`, `socket_path`), so two models that differ only in tuning — even with the same HF repo spec — run as separate processes and are not shared. Only models you actually use will run. Each process holds its own model in RAM/VRAM. All processes are reaped when Harnx exits.
 - **Capability Matrix**: chat ✅, streaming ✅, tool calls ✅ (model-dependent), embeddings ❌, rerank ❌, vision ❌.
 - **Binary Discovery**: Harnx searches for the `llama-server` binary in this order:
   1. Config `binary_path`
   2. `HARNX_LLAMA_SERVER_BIN` environment variable
   3. System `PATH`
-- **Lifecycle**: One `llama-server` instance is lazily spawned per unique subprocess config on first request and reused. Matching configs share one process; different runtime knobs get distinct processes. All instances are killed when Harnx exits.
-- **Socket path**: defaults to `~/.local/share/harnx/llama-server-<pid>-<hash>.sock` (override with the `socket_path` config field).
+- **Socket Path**: Defaults to `~/.local/share/harnx/llama-server-<pid>-<hash>.sock` (override with the per-model `socket_path` field).
 - **Platform**: Unix-only (uses AF_UNIX sockets); not supported on Windows.
 
 See `example_config/clients/llama-server.yaml` for a configuration template.

--- a/crates/harnx-client/src/llama_server/client.rs
+++ b/crates/harnx-client/src/llama_server/client.rs
@@ -35,7 +35,7 @@ use hyperlocal::{UnixConnector, Uri as UnixUri};
 #[cfg(unix)]
 use serde_json::Value;
 #[cfg(unix)]
-use std::{path::PathBuf, time::Duration};
+use std::path::PathBuf;
 
 #[cfg(unix)]
 use log::debug;
@@ -59,19 +59,54 @@ impl crate::LlamaServerClient {
     /// Returns the socket path, spawning the server if necessary.
     ///
     /// Uses the global manager registry to ensure single-flight initialization.
+    /// Sources per-model fields from the selected model's `ModelData`.
     async fn get_socket_path(&self) -> Result<PathBuf> {
         use super::process::{get_or_create_manager, LlamaServerProcessConfig};
 
-        // Translate config fields to process config
+        let model_data = self.model.data();
+
+        // Resolve the model source from the selected model. Treat blank /
+        // whitespace-only values as absent so they don't win the precedence and
+        // forward an empty `-m ""` / `-hf ""` to llama-server.
+        let model_path = model_data
+            .model_path
+            .as_deref()
+            .map(str::trim)
+            .filter(|p| !p.is_empty());
+        let hf_repo = model_data
+            .hf_repo
+            .as_deref()
+            .map(str::trim)
+            .filter(|r| !r.is_empty());
+
+        use super::process::ModelSource;
+        use std::path::PathBuf;
+
+        let model_source = if let Some(p) = model_path {
+            ModelSource::LocalPath(PathBuf::from(p))
+        } else if let Some(repo) = hf_repo {
+            ModelSource::HfRepo(repo.to_string())
+        } else {
+            // No model_path or hf_repo: treat the model's name as a HuggingFace
+            // repo spec so `llama-server -hf <name>` can auto-download it.
+            let repo = self.model.real_name().to_string();
+            debug!(
+                "llama-server model '{}' has no model_path or hf_repo; using its name as a HuggingFace repo (-hf {repo})",
+                self.model.name()
+            );
+            ModelSource::HfRepo(repo)
+        };
+
+        // Translate model fields to process config
         let process_config = LlamaServerProcessConfig {
-            model_path: PathBuf::from(&self.config.model_path),
+            model_source,
             binary_path: self.config.binary_path.as_ref().map(PathBuf::from),
-            socket_path: self.config.socket_path.as_ref().map(PathBuf::from),
-            context_size: self.config.ctx_size,
-            gpu_layers: self.config.n_gpu_layers.map(|n| n as i32),
-            threads: self.config.threads,
-            extra_args: self.config.extra_args.clone().unwrap_or_default(),
-            ready_timeout: Duration::from_secs(5 * 60), // Default 5 min; configurable in future
+            socket_path: model_data.socket_path.as_ref().map(PathBuf::from),
+            context_size: model_data.ctx_size,
+            gpu_layers: model_data.n_gpu_layers.map(|n| n as i32),
+            threads: model_data.threads,
+            extra_args: model_data.extra_args.clone().unwrap_or_default(),
+            ready_timeout: super::process::DEFAULT_READY_TIMEOUT,
         };
 
         // Get or create manager from global registry

--- a/crates/harnx-client/src/llama_server/config_test.rs
+++ b/crates/harnx-client/src/llama_server/config_test.rs
@@ -3,17 +3,22 @@
 #[test]
 fn test_client_config_roundtrip_llama_server() {
     use crate::ClientConfig;
+    use harnx_core::model::ModelData;
     use harnx_core::provider_config::llama_server::LlamaServerConfig;
+
+    // Test config with per-model GGUF path and knobs
+    let model = ModelData::new("test-model")
+        .with_model_path("/path/to/model.gguf".to_string())
+        .with_ctx_size(2048)
+        .with_n_gpu_layers(4)
+        .with_threads(2)
+        .with_extra_args(vec!["--verbose".to_string()])
+        .with_socket_path("/tmp/llama.sock".to_string());
 
     let config = LlamaServerConfig {
         name: Some("test-llama-server".to_string()),
-        model_path: "/path/to/model.gguf".to_string(),
+        models: vec![model],
         binary_path: Some("/usr/local/bin/llama-server".to_string()),
-        socket_path: Some("/tmp/llama.sock".to_string()),
-        ctx_size: Some(2048),
-        n_gpu_layers: Some(4),
-        threads: Some(2),
-        extra_args: Some(vec!["--verbose".to_string()]),
         ..Default::default()
     };
 
@@ -23,26 +28,87 @@ fn test_client_config_roundtrip_llama_server() {
         json.contains(r#""type":"llama-server""#),
         "Serialized JSON should have type: llama-server"
     );
+    // Per-model model_path should appear in models array
+    assert!(
+        json.contains(r#""model_path":"/path/to/model.gguf""#),
+        "Serialized JSON should have per-model model_path"
+    );
 
     // Test deserialization from YAML
     let yaml = r#"
 type: llama-server
 name: test-llama-server
-model_path: /path/to/model.gguf
 binary_path: /usr/local/bin/llama-server
-socket_path: /tmp/llama.sock
-ctx_size: 2048
-n_gpu_layers: 4
-threads: 2
-extra_args:
-  - --verbose
+models:
+  - name: test-model
+    model_path: /path/to/model.gguf
+    ctx_size: 2048
+    n_gpu_layers: 4
+    threads: 2
+    extra_args:
+      - --verbose
+    socket_path: /tmp/llama.sock
 "#;
     let deserialized: ClientConfig = serde_yaml::from_str(yaml).unwrap();
     match deserialized {
         ClientConfig::LlamaServerConfig(c) => {
             assert_eq!(c.name, Some("test-llama-server".to_string()));
-            assert_eq!(c.model_path, "/path/to/model.gguf");
-            assert_eq!(c.ctx_size, Some(2048));
+            assert_eq!(c.models.len(), 1);
+            let m = &c.models[0];
+            assert_eq!(m.name, "test-model");
+            assert_eq!(m.model_path, Some("/path/to/model.gguf".to_string()));
+            assert_eq!(m.ctx_size, Some(2048));
+            assert_eq!(m.n_gpu_layers, Some(4));
+        }
+        _ => panic!("Expected LlamaServerConfig variant"),
+    }
+}
+
+/// Test that hf_repo field serializes/deserializes correctly.
+#[cfg(unix)]
+#[test]
+fn test_client_config_hf_repo() {
+    use crate::ClientConfig;
+    use harnx_core::model::ModelData;
+    use harnx_core::provider_config::llama_server::LlamaServerConfig;
+
+    // Test config with hf_repo instead of model_path
+    let model = ModelData::new("hf-model")
+        .with_hf_repo("unsloth/gemma-4-E4B-it-GGUF:UD-Q4_K_XL".to_string());
+
+    let config = LlamaServerConfig {
+        name: Some("test-hf".to_string()),
+        models: vec![model],
+        ..Default::default()
+    };
+
+    // Test serialization
+    let json = serde_json::to_string(&ClientConfig::LlamaServerConfig(config.clone())).unwrap();
+    assert!(
+        json.contains(r#""hf_repo":"unsloth/gemma-4-E4B-it-GGUF:UD-Q4_K_XL""#),
+        "Serialized JSON should have hf_repo"
+    );
+    assert!(
+        !json.contains("model_path"),
+        "Serialized JSON should not have model_path when unset"
+    );
+
+    // Test deserialization from YAML
+    let yaml = r#"
+type: llama-server
+name: test-hf
+models:
+  - name: hf-model
+    hf_repo: unsloth/gemma-4-E4B-it-GGUF:UD-Q4_K_XL
+"#;
+    let deserialized: ClientConfig = serde_yaml::from_str(yaml).unwrap();
+    match deserialized {
+        ClientConfig::LlamaServerConfig(c) => {
+            assert_eq!(c.models.len(), 1);
+            let m = &c.models[0];
+            assert_eq!(m.name, "hf-model");
+            assert_eq!(m.hf_repo, Some("unsloth/gemma-4-E4B-it-GGUF:UD-Q4_K_XL".to_string()));
+            assert_eq!(m.model_path, None);
         }
         _ => panic!("Expected LlamaServerConfig variant"),
     }

--- a/crates/harnx-client/src/llama_server/mod.rs
+++ b/crates/harnx-client/src/llama_server/mod.rs
@@ -16,6 +16,12 @@ pub mod process;
 pub mod process {
     use anyhow::{bail, Result};
 
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    pub enum ModelSource {
+        LocalPath(std::path::PathBuf),
+        HfRepo(String),
+    }
+
     #[derive(Debug, Clone)]
     pub struct LlamaServerProcessConfig;
 

--- a/crates/harnx-client/src/llama_server/process.rs
+++ b/crates/harnx-client/src/llama_server/process.rs
@@ -37,6 +37,29 @@ use tokio::{
     time::{sleep, Instant},
 };
 
+/// Represents the source of a model for llama-server.
+///
+/// Used to determine whether to pass `-m <path>` (local file) or `-hf <repo>`
+/// (HuggingFace auto-download) to llama-server.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ModelSource {
+    /// Local GGUF file path (passed via `-m`).
+    LocalPath(PathBuf),
+    /// HuggingFace repo spec (passed via `-hf`, e.g. `user/repo:quant`).
+    HfRepo(String),
+}
+
+impl ModelSource {
+    /// Stable string label used for identity/socket-hash keying. Distinct
+    /// prefixes ensure a local path and an HF repo spec never collide.
+    fn label(&self) -> String {
+        match self {
+            ModelSource::LocalPath(p) => format!("local:{}", p.display()),
+            ModelSource::HfRepo(r) => format!("hf:{r}"),
+        }
+    }
+}
+
 #[cfg(unix)]
 type HealthClient = Client<UnixConnector, Empty<Bytes>>;
 
@@ -49,8 +72,19 @@ const SOCKET_HASH_LEN: usize = 12;
 #[cfg(unix)]
 const LLAMA_SERVER_BIN_ENV: &str = "HARNX_LLAMA_SERVER_BIN";
 
+/// Default time to wait for `llama-server` to become ready. Generous because a
+/// first-run HuggingFace (`-hf`) download or a large local GGUF can take a while.
+pub const DEFAULT_READY_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
 /// Global registry of process managers, keyed by full process identity.
 /// Ensures one manager per unique llama-server subprocess config.
+///
+/// The registry deliberately holds a strong [`Arc`] so each spawned
+/// `llama-server` lives for the whole harnx process and is reused across
+/// requests (callers obtain the manager per request and drop their `Arc`
+/// immediately, so a `Weak` registry would tear the child down after every
+/// call and force a model reload on the next one). The child is reaped on
+/// process exit via `kill_on_drop(true)` on the spawned `Command`.
 #[cfg(unix)]
 static MANAGERS: OnceLock<std::sync::Mutex<HashMap<ProcessIdentity, Arc<LlamaServerProcessManager>>>> =
     OnceLock::new();
@@ -86,7 +120,7 @@ impl ProcessIdentity {
         let resolved_socket_path = resolve_socket_path_for_config(config)?;
 
         let canonical = [
-            format!("model_path={}", config.model_path.display()),
+            format!("model_source={}", config.model_source.label()),
             format!("binary_path={}", resolved_binary_path.display()),
             format!("socket_path={}", resolved_socket_path.display()),
             format!(
@@ -122,7 +156,7 @@ impl ProcessIdentity {
 #[cfg(unix)]
 #[derive(Debug, Clone)]
 pub struct LlamaServerProcessConfig {
-    pub model_path: PathBuf,
+    pub model_source: ModelSource,
     pub binary_path: Option<PathBuf>,
     pub socket_path: Option<PathBuf>,
     pub context_size: Option<u32>,
@@ -134,24 +168,29 @@ pub struct LlamaServerProcessConfig {
 
 #[cfg(unix)]
 impl LlamaServerProcessConfig {
-    pub fn new(model_path: impl Into<PathBuf>) -> Self {
+    pub fn new(model_source: ModelSource) -> Self {
         Self {
-            model_path: model_path.into(),
+            model_source,
             binary_path: None,
             socket_path: None,
             context_size: None,
             gpu_layers: None,
             threads: None,
             extra_args: Vec::new(),
-            ready_timeout: Duration::from_secs(5 * 60),
+            ready_timeout: DEFAULT_READY_TIMEOUT,
         }
+    }
+
+    /// Human-readable label for the model source (for logging).
+    fn model_source_label(&self) -> String {
+        self.model_source.label()
     }
 }
 
 #[cfg(unix)]
 impl Default for LlamaServerProcessConfig {
     fn default() -> Self {
-        Self::new("")
+        Self::new(ModelSource::LocalPath(PathBuf::new()))
     }
 }
 
@@ -169,8 +208,15 @@ impl LlamaServerProcessManager {
         if cfg!(windows) {
             bail!("llama-server provider requires a Unix platform (uses unix domain sockets)");
         }
-        if config.model_path.as_os_str().is_empty() {
-            bail!("llama-server model_path is required");
+        // Validate that the model source is non-empty
+        match &config.model_source {
+            ModelSource::LocalPath(p) if p.as_os_str().is_empty() => {
+                bail!("llama-server model_source LocalPath cannot be empty");
+            }
+            ModelSource::HfRepo(r) if r.trim().is_empty() => {
+                bail!("llama-server model_source HfRepo cannot be empty");
+            }
+            _ => {}
         }
         Ok(Self {
             config,
@@ -192,7 +238,7 @@ impl LlamaServerProcessManager {
             }
             warn!(
                 "llama-server process for {} exited after startup; respawning",
-                self.config.model_path.display()
+                self.config.model_source_label()
             );
             state.take();
         }
@@ -300,9 +346,8 @@ fn resolve_socket_path_for_config(config: &LlamaServerProcessConfig) -> Result<P
         return Ok(path.to_path_buf());
     }
 
-    let model_canonical = format!("model_path={}", config.model_path.display());
     let model_identity = ProcessIdentity {
-        canonical: model_canonical,
+        canonical: format!("model_source={}", config.model_source.label()),
     };
     Ok(default_socket_path(std::process::id(), &model_identity))
 }
@@ -322,11 +367,16 @@ async fn spawn_server(config: LlamaServerProcessConfig) -> Result<RunningServer>
     prepare_socket_path(&socket_path).await?;
 
     let mut command = Command::new(&binary_path);
-    command
-        .arg("-m")
-        .arg(&config.model_path)
-        .arg("--host")
-        .arg(&socket_path);
+    // Emit -m for local path or -hf for HuggingFace repo
+    match &config.model_source {
+        ModelSource::LocalPath(p) => {
+            command.arg("-m").arg(p);
+        }
+        ModelSource::HfRepo(r) => {
+            command.arg("-hf").arg(r);
+        }
+    }
+    command.arg("--host").arg(&socket_path);
 
     if let Some(context_size) = config.context_size {
         command.arg("-c").arg(context_size.to_string());
@@ -576,7 +626,20 @@ mod tests {
 
     fn test_config(model_path: &str) -> LlamaServerProcessConfig {
         LlamaServerProcessConfig {
-            model_path: PathBuf::from(model_path),
+            model_source: ModelSource::LocalPath(PathBuf::from(model_path)),
+            binary_path: Some(PathBuf::from("/bin/echo")),
+            socket_path: None,
+            context_size: Some(512),
+            gpu_layers: Some(0),
+            threads: Some(2),
+            extra_args: vec!["--alias".into(), "test".into()],
+            ready_timeout: Duration::from_secs(1),
+        }
+    }
+
+    fn test_config_hf(hf_repo: &str) -> LlamaServerProcessConfig {
+        LlamaServerProcessConfig {
+            model_source: ModelSource::HfRepo(hf_repo.to_string()),
             binary_path: Some(PathBuf::from("/bin/echo")),
             socket_path: None,
             context_size: Some(512),
@@ -651,6 +714,14 @@ mod tests {
         }
     }
 
+    #[test]
+    fn process_identity_differs_local_vs_hf() {
+        let local = ProcessIdentity::from_config(&test_config("/models/model.gguf")).unwrap();
+        let hf = ProcessIdentity::from_config(&test_config_hf("user/model:Q4_K_M")).unwrap();
+        // Different source types produce different identities
+        assert_ne!(local, hf);
+    }
+
     #[tokio::test]
     async fn discover_binary_path_reports_install_hint() {
         let temp = TempDir::new().unwrap();
@@ -719,12 +790,20 @@ mod tests {
         let err = get_or_create_manager(&LlamaServerProcessConfig::default()).unwrap_err();
         let message = err.to_string();
         assert!(
-            message.contains("llama-server model_path is required")
+            message.contains("llama-server model_source LocalPath cannot be empty")
                 || message.contains("Unable to find `llama-server`")
         );
 
         restore_env("PATH", old_path);
         restore_env(LLAMA_SERVER_BIN_ENV, old_env);
+    }
+
+    #[test]
+    fn manager_rejects_whitespace_only_hf_repo() {
+        let err = LlamaServerProcessManager::new(test_config_hf("   ")).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("llama-server model_source HfRepo cannot be empty"));
     }
 
     #[tokio::test]
@@ -740,14 +819,14 @@ mod tests {
             env::temp_dir().join(format!("harnx-llama-test-{}.sock", std::process::id()));
 
         let manager = LlamaServerProcessManager::new(LlamaServerProcessConfig {
-            model_path,
+            model_source: ModelSource::LocalPath(model_path),
             binary_path: Some(binary_path),
             socket_path: Some(socket_path.clone()),
             context_size: Some(512),
             gpu_layers: Some(0),
             threads: Some(2),
             extra_args: Vec::new(),
-            ready_timeout: Duration::from_secs(5 * 60),
+            ready_timeout: DEFAULT_READY_TIMEOUT,
         })?;
 
         let running = manager.ensure_ready().await?;
@@ -792,7 +871,7 @@ use std::{path::PathBuf, time::Duration};
 #[cfg(windows)]
 #[derive(Debug, Clone)]
 pub struct LlamaServerProcessConfig {
-    pub model_path: PathBuf,
+    pub model_source: ModelSource,
     pub binary_path: Option<PathBuf>,
     pub socket_path: Option<PathBuf>,
     pub context_size: Option<u32>,

--- a/crates/harnx-client/tests/llama_server_mock.rs
+++ b/crates/harnx-client/tests/llama_server_mock.rs
@@ -6,9 +6,12 @@ use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use harnx_client::client::{ChatCompletionsData, Client, Message, MessageContent, MessageRole};
-use harnx_client::llama_server::process::{LlamaServerProcessConfig, LlamaServerProcessManager};
+use harnx_client::llama_server::process::{
+    LlamaServerProcessConfig, LlamaServerProcessManager, ModelSource,
+};
 use harnx_client::{ClientConfig, LlamaServerClient, Model, SseEvent, SseHandler};
 use harnx_core::abort::create_abort_signal;
+use harnx_core::model::ModelData;
 use harnx_core::provider_config::llama_server::LlamaServerConfig;
 use harnx_core::tool::ToolDeclaration;
 use serde_json::json;
@@ -27,7 +30,7 @@ async fn llama_server_mock_e2e_lifecycle() -> Result<()> {
     std::fs::write(&model_path, b"mock model")?;
 
     let config = LlamaServerProcessConfig {
-        model_path: model_path.clone(),
+        model_source: ModelSource::LocalPath(model_path.clone()),
         binary_path: Some(binary_path),
         socket_path: Some(socket_path.clone()),
         context_size: Some(256),
@@ -124,26 +127,301 @@ async fn llama_server_mock_e2e_lifecycle() -> Result<()> {
     Ok(())
 }
 
-fn build_client(config: &LlamaServerProcessConfig, model_name: &str) -> Option<Box<dyn Client>> {
+/// Test multi-model support: one config with two models yields two distinct subprocesses.
+///
+/// Each model specifies its own socket_path and model_path, forcing distinct ProcessIdentity
+/// and thus distinct processes. The mock binary ignores -m (model_path), so we use distinct
+/// socket paths to isolate the processes. Each client drives a chat through its model's
+/// subprocess, and both sockets are cleaned up on drop.
+#[tokio::test]
+async fn llama_server_mock_multi_model_distinct_processes() -> Result<()> {
+    ensure_mock_binary_built()?;
+
+    let temp_dir = TempDir::new()?;
+    let binary_path = resolve_mock_binary_path()?;
+    let script_path = write_mock_script(temp_dir.path())?;
+
+    // Model A: distinct socket and dummy gguf path
+    let socket_a = temp_dir.path().join("model-a.sock");
+    let model_path_a = temp_dir.path().join("model-a.gguf");
+    std::fs::write(&model_path_a, b"mock model a")?;
+
+    // Model B: distinct socket and dummy gguf path
+    let socket_b = temp_dir.path().join("model-b.sock");
+    let model_path_b = temp_dir.path().join("model-b.gguf");
+    std::fs::write(&model_path_b, b"mock model b")?;
+
+    // Single provider config with two models, each with its own GGUF/socket
     let provider = LlamaServerConfig {
-        name: Some("llama-server".to_string()),
-        model_path: config.model_path.display().to_string(),
-        binary_path: config
-            .binary_path
-            .as_ref()
-            .map(|path| path.display().to_string()),
-        ctx_size: config.context_size,
-        n_gpu_layers: config.gpu_layers.map(|v| v as u32),
-        threads: config.threads,
-        extra_args: Some(config.extra_args.clone()),
-        socket_path: config
-            .socket_path
-            .as_ref()
-            .map(|path| path.display().to_string()),
+        name: Some("multi-llama".to_string()),
+        models: vec![
+            ModelData::new("model-a")
+                .with_model_path(model_path_a.display().to_string())
+                .with_socket_path(socket_a.display().to_string())
+                .with_ctx_size(256)
+                .with_threads(1)
+                .with_extra_args(vec![
+                    "--script".to_string(),
+                    script_path.display().to_string(),
+                ]),
+            ModelData::new("model-b")
+                .with_model_path(model_path_b.display().to_string())
+                .with_socket_path(socket_b.display().to_string())
+                .with_ctx_size(256)
+                .with_threads(1)
+                .with_extra_args(vec![
+                    "--script".to_string(),
+                    script_path.display().to_string(),
+                ]),
+        ],
+        binary_path: Some(binary_path.display().to_string()),
         ..Default::default()
     };
 
-    let model = Model::new("llama-server", model_name);
+    // Init client for model-a (use from_config to pick up the model's data)
+    let models_list = Model::from_config("multi-llama", &provider.models);
+    let model_a = models_list
+        .iter()
+        .find(|m| m.name() == "model-a")
+        .context("model-a not found")?
+        .clone();
+    let client_a = LlamaServerClient::init(
+        &[ClientConfig::LlamaServerConfig(provider.clone())],
+        &model_a,
+    )
+    .context("init client_a")?;
+
+    // Init client for model-b
+    let model_b = models_list
+        .iter()
+        .find(|m| m.name() == "model-b")
+        .context("model-b not found")?
+        .clone();
+    let client_b = LlamaServerClient::init(
+        &[ClientConfig::LlamaServerConfig(provider.clone())],
+        &model_b,
+    )
+    .context("init client_b")?;
+
+    let reqwest_client = reqwest::Client::new();
+
+    // Drive chat through model-a
+    let resp_a = client_a
+        .chat_completions_inner(
+            &reqwest_client,
+            ChatCompletionsData {
+                messages: vec![user_message("hello from a")],
+                temperature: None,
+                top_p: None,
+                functions: None,
+                stream: false,
+            },
+        )
+        .await?;
+    assert_eq!(resp_a.text, "mock non streaming reply");
+
+    // Drive chat through model-b
+    let resp_b = client_b
+        .chat_completions_inner(
+            &reqwest_client,
+            ChatCompletionsData {
+                messages: vec![user_message("hello from b")],
+                temperature: None,
+                top_p: None,
+                functions: None,
+                stream: false,
+            },
+        )
+        .await?;
+    assert_eq!(resp_b.text, "mock non streaming reply");
+
+    // Both sockets should exist (distinct processes spawned)
+    assert!(socket_a.exists(), "socket_a should exist");
+    assert!(socket_b.exists(), "socket_b should exist");
+
+    // Drop clients. The global MANAGERS registry holds Arc<LlamaServerProcessManager>,
+    // so dropping the client doesn't immediately drop the manager.
+    // Instead, we need to explicitly verify the processes by checking the registry behavior.
+    // For this test, we verify distinct processes via distinct sockets responding independently.
+    // Socket cleanup happens when the manager is dropped (on process exit or harnx shutdown).
+    // Drop clients to verify they work correctly
+    drop(client_a);
+    drop(client_b);
+
+    // Verify both sockets still exist (global registry holds managers alive)
+    assert!(
+        socket_a.exists(),
+        "socket_a should still exist (registry holds manager)"
+    );
+    assert!(
+        socket_b.exists(),
+        "socket_b should still exist (registry holds manager)"
+    );
+
+    // For this test, the key verification is that:
+    // 1. Both clients successfully communicated through distinct sockets
+    // 2. Two sockets exist (proving two distinct processes)
+    // The global registry deliberately keeps processes alive for reuse.
+    // Socket cleanup will happen on harnx exit.
+
+    Ok(())
+}
+
+/// Test HF repo-only model (no model_path, uses hf_repo field).
+/// The mock ignores -hf flag, so we can verify end-to-end flow.
+#[tokio::test]
+async fn llama_server_mock_hf_repo_only() -> Result<()> {
+    ensure_mock_binary_built()?;
+
+    let temp_dir = TempDir::new()?;
+    let socket_path = temp_dir.path().join("hf-model.sock");
+    let script_path = write_mock_script(temp_dir.path())?;
+    let binary_path = resolve_mock_binary_path()?;
+
+    // Model with hf_repo only (no model_path)
+    let model_data = ModelData::new("hf-test-model")
+        .with_hf_repo("unsloth/test-model:Q4_K_M".to_string())
+        .with_socket_path(socket_path.display().to_string())
+        .with_ctx_size(256)
+        .with_threads(1)
+        .with_extra_args(vec![
+            "--script".to_string(),
+            script_path.display().to_string(),
+        ]);
+
+    let provider = LlamaServerConfig {
+        name: Some("test-hf-provider".to_string()),
+        models: vec![model_data],
+        binary_path: Some(binary_path.display().to_string()),
+        ..Default::default()
+    };
+
+    let models_list = Model::from_config("test-hf-provider", &provider.models);
+    let model = models_list
+        .iter()
+        .find(|m| m.name() == "hf-test-model")
+        .context("hf-test-model not found")?
+        .clone();
+
+    let client = LlamaServerClient::init(&[ClientConfig::LlamaServerConfig(provider)], &model)
+        .context("init hf client")?;
+
+    let reqwest_client = reqwest::Client::new();
+    let resp = client
+        .chat_completions_inner(
+            &reqwest_client,
+            ChatCompletionsData {
+                messages: vec![user_message("test hf")],
+                temperature: None,
+                top_p: None,
+                functions: None,
+                stream: false,
+            },
+        )
+        .await?;
+
+    assert_eq!(resp.text, "mock non streaming reply");
+    assert!(socket_path.exists(), "socket should exist");
+
+    Ok(())
+}
+
+/// Test model with neither model_path nor hf_repo (name used as -hf argument).
+/// The mock ignores -hf flag, so we can verify end-to-end flow.
+#[tokio::test]
+async fn llama_server_mock_name_as_hf_repo() -> Result<()> {
+    ensure_mock_binary_built()?;
+
+    let temp_dir = TempDir::new()?;
+    // Use distinct socket to get a distinct process (prevents collision with other tests)
+    let socket_path = temp_dir.path().join("name-as-hf.sock");
+    let script_path = write_mock_script(temp_dir.path())?;
+    let binary_path = resolve_mock_binary_path()?;
+
+    // Model with neither model_path nor hf_repo - name will be used as HF repo
+    let model_data = ModelData::new("user/model-name:Q4_K_M")
+        .with_socket_path(socket_path.display().to_string())
+        .with_ctx_size(256)
+        .with_threads(1)
+        .with_extra_args(vec![
+            "--script".to_string(),
+            script_path.display().to_string(),
+        ]);
+
+    let provider = LlamaServerConfig {
+        name: Some("test-name-hf".to_string()),
+        models: vec![model_data],
+        binary_path: Some(binary_path.display().to_string()),
+        ..Default::default()
+    };
+
+    let models_list = Model::from_config("test-name-hf", &provider.models);
+    let model = models_list
+        .iter()
+        .find(|m| m.name() == "user/model-name:Q4_K_M")
+        .context("model not found")?
+        .clone();
+
+    let client = LlamaServerClient::init(&[ClientConfig::LlamaServerConfig(provider)], &model)
+        .context("init name-as-hf client")?;
+
+    let reqwest_client = reqwest::Client::new();
+    let resp = client
+        .chat_completions_inner(
+            &reqwest_client,
+            ChatCompletionsData {
+                messages: vec![user_message("test name as hf")],
+                temperature: None,
+                top_p: None,
+                functions: None,
+                stream: false,
+            },
+        )
+        .await?;
+
+    assert_eq!(resp.text, "mock non streaming reply");
+    assert!(socket_path.exists(), "socket should exist");
+
+    Ok(())
+}
+
+fn build_client(config: &LlamaServerProcessConfig, model_name: &str) -> Option<Box<dyn Client>> {
+    // Set the matching source field per variant: a local path → `model_path`,
+    // a HuggingFace repo → `hf_repo`. Leave the other unset (None) so we don't
+    // produce a misleading `model_path: Some("")`.
+    let mut model_data = ModelData::new(model_name);
+    match &config.model_source {
+        ModelSource::LocalPath(p) => {
+            model_data = model_data.with_model_path(p.display().to_string());
+        }
+        ModelSource::HfRepo(r) => {
+            model_data = model_data.with_hf_repo(r.clone());
+        }
+    }
+
+    let model_data = model_data
+        .with_socket_path(
+            config
+                .socket_path
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default(),
+        )
+        .with_ctx_size(config.context_size.unwrap_or(0))
+        .with_n_gpu_layers(config.gpu_layers.map(|v| v as u32).unwrap_or(0))
+        .with_threads(config.threads.unwrap_or(0))
+        .with_extra_args(config.extra_args.clone());
+
+    let provider = LlamaServerConfig {
+        name: Some("llama-server".to_string()),
+        models: vec![model_data],
+        binary_path: config.binary_path.as_ref().map(|p| p.display().to_string()),
+        ..Default::default()
+    };
+
+    // Use Model::from_config to get model with correct data from provider config
+    let models = Model::from_config("llama-server", &provider.models);
+    let model = models.into_iter().next()?;
     LlamaServerClient::init(&[ClientConfig::LlamaServerConfig(provider)], &model)
 }
 

--- a/crates/harnx-core/src/model.rs
+++ b/crates/harnx-core/src/model.rs
@@ -305,6 +305,39 @@ pub struct ModelData {
     pub default_chunk_size: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_batch_size: Option<usize>,
+
+    // llama-server local provider properties
+    /// Path to the GGUF model file (passed to llama-server via `-m`).
+    /// Optional; if unset, `hf_repo` or the model name is used as the source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_path: Option<String>,
+
+    /// HuggingFace repo spec for `-hf` auto-download (e.g. `unsloth/gemma-4-E4B-it-GGUF:UD-Q4_K_XL`).
+    /// Optional; used when `model_path` is unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hf_repo: Option<String>,
+
+    /// Context size in tokens (`-c` flag). Defaults to llama-server's default
+    /// (typically 512) if unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ctx_size: Option<u32>,
+
+    /// Number of GPU layers to offload (`-ngl` flag). Zero means CPU-only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub n_gpu_layers: Option<u32>,
+
+    /// Number of threads (`-t` flag). Defaults to llama-server's default if unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub threads: Option<u32>,
+
+    /// Raw passthrough arguments to llama-server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_args: Option<Vec<String>>,
+
+    /// Override Unix socket path. If unset, runtime uses
+    /// `~/.local/share/harnx/llama-server-<pid>-<hash>.sock`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub socket_path: Option<String>,
 }
 
 impl ModelData {
@@ -314,6 +347,42 @@ impl ModelData {
             model_type: default_model_type(),
             ..Default::default()
         }
+    }
+
+    // llama-server per-model builder methods
+    pub fn with_model_path(mut self, path: String) -> Self {
+        self.model_path = Some(path);
+        self
+    }
+
+    pub fn with_hf_repo(mut self, repo: String) -> Self {
+        self.hf_repo = Some(repo);
+        self
+    }
+
+    pub fn with_ctx_size(mut self, size: u32) -> Self {
+        self.ctx_size = Some(size);
+        self
+    }
+
+    pub fn with_n_gpu_layers(mut self, layers: u32) -> Self {
+        self.n_gpu_layers = Some(layers);
+        self
+    }
+
+    pub fn with_threads(mut self, threads: u32) -> Self {
+        self.threads = Some(threads);
+        self
+    }
+
+    pub fn with_extra_args(mut self, args: Vec<String>) -> Self {
+        self.extra_args = Some(args);
+        self
+    }
+
+    pub fn with_socket_path(mut self, path: String) -> Self {
+        self.socket_path = Some(path);
+        self
     }
 }
 

--- a/crates/harnx-core/src/provider_config/llama_server.rs
+++ b/crates/harnx-core/src/provider_config/llama_server.rs
@@ -1,6 +1,10 @@
 //! `LlamaServerConfig` — per-provider config for the llama-server subprocess
 //! provider. Manages a local `llama-server` (llama.cpp) child process listening
 //! on a Unix domain socket, serving OpenAI-compatible chat completions.
+//!
+//! Each model in `models[]` specifies its own GGUF path and tuning knobs,
+//! allowing one config to serve multiple local models. Selecting a model
+//! selects its corresponding subprocess (lazy spawn, reused, kill-on-drop).
 
 use serde::{Deserialize, Serialize};
 
@@ -11,6 +15,8 @@ use crate::model::{ModelData, RequestPatches};
 pub struct LlamaServerConfig {
     pub name: Option<String>,
 
+    /// Models served by this provider. Each model specifies its own
+    /// GGUF path and tuning knobs; selecting a model spawns its subprocess.
     #[serde(default)]
     pub models: Vec<ModelData>,
 
@@ -21,32 +27,10 @@ pub struct LlamaServerConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt_prefix: Option<Vec<String>>,
 
-    /// Path to the GGUF model file (passed to llama-server via `-m`).
-    pub model_path: String,
-
     /// Override path to the llama-server binary. If unset, the runtime
     /// searches PATH, then falls back to the `HARNX_LLAMA_SERVER_BIN` env var.
+    /// Shared across all models in this config (discovery is the same binary).
     pub binary_path: Option<String>,
-
-    /// Context size in tokens (`-c` flag). Defaults to llama-server's default
-    /// (typically 512) if unset.
-    #[serde(default)]
-    pub ctx_size: Option<u32>,
-
-    /// Number of GPU layers to offload (`-ngl` flag). Zero means CPU-only.
-    #[serde(default)]
-    pub n_gpu_layers: Option<u32>,
-
-    /// Number of threads (`-t` flag). Defaults to llama-server's default if unset.
-    #[serde(default)]
-    pub threads: Option<u32>,
-
-    /// Raw passthrough arguments to llama-server.
-    pub extra_args: Option<Vec<String>>,
-
-    /// Override Unix socket path. If unset, runtime uses
-    /// `~/.local/share/harnx/llama-server-<pid>-<hash>.sock`.
-    pub socket_path: Option<String>,
 
     /// Runtime-only: the package this client was loaded from, if any.
     /// Not persisted to YAML (serde skip).

--- a/crates/harnx-test-bins/src/bin/harnx-mock-llm/main.rs
+++ b/crates/harnx-test-bins/src/bin/harnx-mock-llm/main.rs
@@ -193,7 +193,7 @@ fn takes_value(flag: &str) -> bool {
     // Only the known llama-server value-flags consume the following argument.
     // Other unknown flags are treated as bare booleans and ignored, so a flag
     // like `--verbose` does not accidentally swallow the next argument.
-    matches!(flag, "-m" | "-c" | "-ngl" | "-t")
+    matches!(flag, "-m" | "-hf" | "-c" | "-ngl" | "-t")
 }
 
 fn print_help() {

--- a/docs/solutions/llama-server-subprocess.md
+++ b/docs/solutions/llama-server-subprocess.md
@@ -52,7 +52,7 @@ Since `reqwest` does not support Unix sockets natively, we implemented a custom 
 ## Why This Works
 
 - **Lean Binary**: The `harnx` binary stays small because it doesn't link `llama.cpp` directly.
-- **Zero Configuration**: If `llama-server` is in the `PATH`, the user only needs to provide a `model_path`.
+- **Zero Configuration**: If `llama-server` is in the `PATH`, the user only needs to provide a model name or source. GGUF models can be automatically downloaded from HuggingFace.
 - **Robustness**: The subprocess approach isolates the C++ memory management from the Rust runtime.
 - **Full Compatibility**: Supports streaming, tool calls (grammar-constrained), and all other standard chat completion features.
 
@@ -117,10 +117,10 @@ fn get_or_create_manager(config: &LlamaServerProcessConfig) -> Result<Arc<LlamaS
 
 ### 5. Registry Keying: Composite Identity Over ALL Process-Affecting Config
 
-**Problem** (from review): Keying by `model_path` alone silently reuses wrong subprocess or collides sockets.
+**Problem** (from review): Keying by model source alone silently reuses wrong subprocess or collides sockets.
 
 **Solution**: Key by composite identity including:
-- `model_path` (resolved)
+- `model_source` (Local path or HuggingFace repo)
 - `binary_path` (resolved)
 - `socket_path` (resolved)
 - `context_size`, `gpu_layers`, `threads`
@@ -128,7 +128,7 @@ fn get_or_create_manager(config: &LlamaServerProcessConfig) -> Result<Arc<LlamaS
 
 ```rust
 struct ProcessIdentity {
-    canonical: String,  // "model_path=...\nbinary_path=...\n..." 
+    canonical: String,  // "source=hf:unsloth/gemma-3\nbinary_path=...\n..." 
 }
 ```
 

--- a/example_config/clients/llama-server.yaml
+++ b/example_config/clients/llama-server.yaml
@@ -1,13 +1,29 @@
 type: llama-server
 name: local-llama
-model_path: /path/to/your/model.gguf  # REQUIRED: Path to your .gguf model file
-# binary_path: llama-server            # Optional: Path to llama-server binary
-# ctx_size: 2048                       # Optional: Context size (-c)
-# n_gpu_layers: 32                     # Optional: Number of GPU layers (-ngl)
-# threads: 8                           # Optional: Number of threads (-t)
-# socket_path: /tmp/llama.sock         # Optional: Override Unix socket path
-# extra_args: ["--flash-attn"]         # Optional: Raw passthrough arguments
+
+# binary_path: llama-server  # Optional: Shared binary path for all models below
+
 models:
-  - name: qwen2.5-7b-instruct
-    max_input_tokens: 32768
+  # 1. Local GGUF model with tuning knobs
+  - name: local-model
+    model_path: /path/to/your/model.gguf # Local path to .gguf file (-m)
+    ctx_size: 4096                       # Optional: Context size (-c)
+    n_gpu_layers: 32                     # Optional: Number of GPU layers to offload (-ngl)
+    threads: 8                           # Optional: Number of threads (-t)
+    max_input_tokens: 4096
+    supports_tool_use: true
+    # extra_args: ["--flash-attn"]       # Optional: Raw passthrough flags
+    # socket_path: /tmp/custom.sock      # Optional: Override Unix socket path
+
+  # 2. Explicit HuggingFace model (auto-download)
+  # llama-server will download the GGUF from HF on first use.
+  - name: gemma-3-1b
+    hf_repo: ggml-org/gemma-3-1b-it-GGUF  # Explicit HF repo spec (-hf)
+    max_input_tokens: 8192
+    supports_tool_use: true
+
+  # 3. "Name is the HF repo" (minimal config, auto-download)
+  # If model_path and hf_repo are both missing, 'name' is used as the HF repo spec.
+  - name: unsloth/gemma-4-E4B-it-GGUF:UD-Q4_K_XL
+    max_input_tokens: 8192
     supports_tool_use: true


### PR DESCRIPTION
Moves GGUF paths and per-process tuning knobs (ctx_size, n_gpu_layers, threads, extra_args, socket_path) from the llama-server provider top-level to individual model entries. This allows a single provider configuration to serve multiple models, each in its own lazily-spawned subprocess.

Adds support for HuggingFace auto-download via llama-server's -hf flag. Model source resolution follows a precedence of local model_path, then an explicit hf_repo, and finally the model name itself as a HuggingFace repository specification.

Includes updated documentation, example configurations, and an expanded test suite covering multi-model scenarios and auto-download resolution.

Plan: llama-per-model-gguf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-model support allowing multiple GGUF models in a single provider configuration
  * Added per-model tuning options including context size, GPU layers, thread count, and custom arguments
  * Added HuggingFace auto-download capability for models
  * Models now support flexible source specification: local path, HuggingFace repository, or model name as repository

* **Documentation**
  * Updated configuration examples and guide with new multi-model structure and available options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->