### PR TITLE
feat!: derive client name from filename stem and ignore in-file name field

### DIFF
--- a/.changeset/client-name-from-filename.md
+++ b/.changeset/client-name-from-filename.md
@@ -1,0 +1,8 @@
+---
+harnx: minor
+---
+Client names are now derived from the YAML filename stem instead of a `name:` field in the file contents.
+
+- A client defined in `clients/<name>.yaml` is named `<name>` (extension stripped, verbatim — no lowercasing). For package clients the name is `<package>/<stem>`.
+- A `name:` field inside a client spec is now ignored (silently skipped); the filename is the sole source of the client name. There is no migration — rename the file if you relied on a differing `name:` field. This mirrors how MCP/ACP server specs are already named (#823).
+- The provider-default fallback (e.g. defaulting an unnamed client to `openai`) has been removed; dynamic clients created from a `provider:model` selection are still named after their provider.

--- a/.changeset/client-name-from-filename.md
+++ b/.changeset/client-name-from-filename.md
@@ -1,5 +1,5 @@
 ---
-harnx: minor
+harnx: major
 ---
 Client names are now derived from the YAML filename stem instead of a `name:` field in the file contents.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,11 @@ cargo nextest run --workspace --stress-count=5                # Run all tests, r
 cs delta $(git merge-base HEAD origin/main)                   # Run CodeScene code quality analysis on current branch changes                                          
 ```
 
+**Use `cargo nextest`, never `cargo test`.** Tests rely on nextest's per-test
+process isolation; `cargo test` shares one process and produces spurious
+failures. The tmux/interrupt e2e tests guard against this and will panic with a
+redirect message if run under `cargo test` (via `harnx_core::require_nextest()`).
+
 **Do not skip any of these steps or you WILL miss problems**
 **Do not ignore clippy warnings.** CI sets `RUSTFLAGS=--deny warnings` and runs `cargo clippy -- -D warnings`, so any warning will fail the build.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -177,7 +177,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1818,7 +1818,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1977,7 +1977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2822,7 +2822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -4714,7 +4714,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5505,7 +5505,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5893,7 +5893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6636,9 +6636,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-textarea"
-version = "0.9.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c78d5ba0f26f97baed69a4c479f268a31c7b5b89d68ab939842152e383d6e73"
+checksum = "2950274c0e155944158cf766848dd87bd6db6dad27da1c23ee4a7c8de71dbf1f"
 dependencies = [
  "ratatui-core",
  "ratatui-crossterm",
@@ -6993,7 +6993,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7061,7 +7061,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7635,7 +7635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7884,7 +7884,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8968,7 +8968,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/harnx-acp-server/src/lib_tests.rs
+++ b/crates/harnx-acp-server/src/lib_tests.rs
@@ -28,8 +28,16 @@ mod tests {
         )
         .expect("parse test client config");
 
-        let mut config = Config::default();
-        config.clients = clients;
+        // Set the client name to match what the file loader would do for openai.yaml
+        let mut clients = clients;
+        if let Some(c) = clients.first_mut() {
+            c.set_name("openai".to_string());
+        }
+
+        let mut config = Config {
+            clients,
+            ..Default::default()
+        };
         config.model = harnx_runtime::client::retrieve_model(
             &config.clients,
             "openai:gpt-4o",

--- a/crates/harnx-client/src/bedrock.rs
+++ b/crates/harnx-client/src/bedrock.rs
@@ -946,7 +946,7 @@ mod tests {
         session_token: Option<&str>,
     ) -> BedrockConfig {
         BedrockConfig {
-            name: None,
+            name: String::new(),
             access_key_id: access_key_id.map(Into::into),
             secret_access_key: secret_access_key.map(Into::into),
             region: region.map(Into::into),

--- a/crates/harnx-client/src/claude.rs
+++ b/crates/harnx-client/src/claude.rs
@@ -1213,8 +1213,9 @@ system_prompt_prefix:
     /// CLAUDE_API_KEY, not the invalid PANTHEON/CLAUDE_API_KEY.
     #[test]
     fn package_client_uses_bare_name_for_env_var() {
-        let config: ClaudeConfig =
-            serde_yaml::from_str("name: \"pantheon/claude\"").expect("parse config");
+        let mut config: ClaudeConfig =
+            serde_yaml::from_str("type: claude").expect("parse config");
+        config.name = "pantheon/claude".to_string();
         let client = ClaudeClient {
             config,
             model: Model::new("pantheon/claude", "claude-3-5-sonnet"),

--- a/crates/harnx-client/src/lib.rs
+++ b/crates/harnx-client/src/lib.rs
@@ -84,82 +84,54 @@ register_client!(
 );
 
 impl ClientConfig {
-    /// Returns the client's configured name (the `name` field of the inner config),
-    /// or `None` for `Unknown` variants.
-    pub fn inner_name(&self) -> Option<&str> {
-        match self {
-            ClientConfig::OpenAIConfig(c) => c.name.as_deref(),
-            ClientConfig::OpenAICompatibleConfig(c) => c.name.as_deref(),
-            ClientConfig::GeminiConfig(c) => c.name.as_deref(),
-            ClientConfig::ClaudeConfig(c) => c.name.as_deref(),
-            ClientConfig::CohereConfig(c) => c.name.as_deref(),
-            ClientConfig::AzureOpenAIConfig(c) => c.name.as_deref(),
-            ClientConfig::VertexAIConfig(c) => c.name.as_deref(),
-            ClientConfig::BedrockConfig(c) => c.name.as_deref(),
-            ClientConfig::LlamaServerConfig(c) => c.name.as_deref(),
-            ClientConfig::Unknown => None,
-        }
-    }
-
     /// Returns the effective name used to identify this client.
-    /// This is the explicit `name` field if set, or the provider's default name.
+    /// This is the configured `name` field (filename-derived), or "unknown" for Unknown.
     pub fn effective_name(&self) -> &str {
         match self {
-            ClientConfig::OpenAIConfig(c) => c.name.as_deref().unwrap_or("openai"),
-            ClientConfig::OpenAICompatibleConfig(c) => {
-                c.name.as_deref().unwrap_or("openai-compatible")
-            }
-            ClientConfig::GeminiConfig(c) => c.name.as_deref().unwrap_or("gemini"),
-            ClientConfig::ClaudeConfig(c) => c.name.as_deref().unwrap_or("claude"),
-            ClientConfig::CohereConfig(c) => c.name.as_deref().unwrap_or("cohere"),
-            ClientConfig::AzureOpenAIConfig(c) => c.name.as_deref().unwrap_or("azure-openai"),
-            ClientConfig::VertexAIConfig(c) => c.name.as_deref().unwrap_or("vertexai"),
-            ClientConfig::BedrockConfig(c) => c.name.as_deref().unwrap_or("bedrock"),
-            ClientConfig::LlamaServerConfig(c) => c.name.as_deref().unwrap_or("llama-server"),
+            ClientConfig::OpenAIConfig(c) => &c.name,
+            ClientConfig::OpenAICompatibleConfig(c) => &c.name,
+            ClientConfig::GeminiConfig(c) => &c.name,
+            ClientConfig::ClaudeConfig(c) => &c.name,
+            ClientConfig::CohereConfig(c) => &c.name,
+            ClientConfig::AzureOpenAIConfig(c) => &c.name,
+            ClientConfig::VertexAIConfig(c) => &c.name,
+            ClientConfig::BedrockConfig(c) => &c.name,
+            ClientConfig::LlamaServerConfig(c) => &c.name,
             ClientConfig::Unknown => "unknown",
         }
     }
 
-    /// Sets the `name` and `package` fields on the inner config struct.
-    /// Used at load time to qualify package clients.
-    pub fn set_name_and_package(&mut self, name: String, package: String) {
+    /// Sets the `name` field on the inner config struct.
+    /// Used at load time to set the filename-derived name.
+    pub fn set_name(&mut self, name: String) {
+        debug_assert!(!name.is_empty());
         match self {
-            ClientConfig::OpenAIConfig(c) => {
-                c.name = Some(name);
-                c.package = Some(package);
-            }
-            ClientConfig::OpenAICompatibleConfig(c) => {
-                c.name = Some(name);
-                c.package = Some(package);
-            }
-            ClientConfig::GeminiConfig(c) => {
-                c.name = Some(name);
-                c.package = Some(package);
-            }
-            ClientConfig::ClaudeConfig(c) => {
-                c.name = Some(name);
-                c.package = Some(package);
-            }
-            ClientConfig::CohereConfig(c) => {
-                c.name = Some(name);
-                c.package = Some(package);
-            }
-            ClientConfig::AzureOpenAIConfig(c) => {
-                c.name = Some(name);
-                c.package = Some(package);
-            }
-            ClientConfig::VertexAIConfig(c) => {
-                c.name = Some(name);
-                c.package = Some(package);
-            }
-            ClientConfig::BedrockConfig(c) => {
-                c.name = Some(name);
-                c.package = Some(package);
-            }
-            ClientConfig::LlamaServerConfig(c) => {
-                c.name = Some(name);
-                c.package = Some(package);
-            }
+            ClientConfig::OpenAIConfig(c) => c.name = name,
+            ClientConfig::OpenAICompatibleConfig(c) => c.name = name,
+            ClientConfig::GeminiConfig(c) => c.name = name,
+            ClientConfig::ClaudeConfig(c) => c.name = name,
+            ClientConfig::CohereConfig(c) => c.name = name,
+            ClientConfig::AzureOpenAIConfig(c) => c.name = name,
+            ClientConfig::VertexAIConfig(c) => c.name = name,
+            ClientConfig::BedrockConfig(c) => c.name = name,
+            ClientConfig::LlamaServerConfig(c) => c.name = name,
+            ClientConfig::Unknown => {}
+        }
+    }
+
+    /// Sets the `package` field on the inner config struct.
+    /// Used at load time to set the package identifier.
+    pub fn set_package(&mut self, package: Option<String>) {
+        match self {
+            ClientConfig::OpenAIConfig(c) => c.package = package,
+            ClientConfig::OpenAICompatibleConfig(c) => c.package = package,
+            ClientConfig::GeminiConfig(c) => c.package = package,
+            ClientConfig::ClaudeConfig(c) => c.package = package,
+            ClientConfig::CohereConfig(c) => c.package = package,
+            ClientConfig::AzureOpenAIConfig(c) => c.package = package,
+            ClientConfig::VertexAIConfig(c) => c.package = package,
+            ClientConfig::BedrockConfig(c) => c.package = package,
+            ClientConfig::LlamaServerConfig(c) => c.package = package,
             ClientConfig::Unknown => {}
         }
     }

--- a/crates/harnx-client/src/llama_server/client.rs
+++ b/crates/harnx-client/src/llama_server/client.rs
@@ -294,7 +294,7 @@ impl crate::Client for crate::LlamaServerClient {
     }
 
     fn name(&self) -> &str {
-        self.config.name.as_deref().unwrap_or("llama-server")
+        &self.config.name
     }
 
     fn model(&self) -> &Model {

--- a/crates/harnx-client/src/llama_server/config_test.rs
+++ b/crates/harnx-client/src/llama_server/config_test.rs
@@ -101,9 +101,12 @@ models:
   - name: hf-model
     hf_repo: unsloth/gemma-4-E4B-it-GGUF:UD-Q4_K_XL
 "#;
-    let deserialized: ClientConfig = serde_yaml::from_str(yaml).unwrap();
+    let mut deserialized: ClientConfig = serde_yaml::from_str(yaml).unwrap();
+    // Set the name as the loader would (from the filename stem).
+    deserialized.set_name("test-hf".to_string());
     match deserialized {
         ClientConfig::LlamaServerConfig(c) => {
+            assert_eq!(c.name, "test-hf");
             assert_eq!(c.models.len(), 1);
             let m = &c.models[0];
             assert_eq!(m.name, "hf-model");

--- a/crates/harnx-client/src/llama_server/config_test.rs
+++ b/crates/harnx-client/src/llama_server/config_test.rs
@@ -16,7 +16,7 @@ fn test_client_config_roundtrip_llama_server() {
         .with_socket_path("/tmp/llama.sock".to_string());
 
     let config = LlamaServerConfig {
-        name: Some("test-llama-server".to_string()),
+        name: "test-llama-server".to_string(),
         models: vec![model],
         binary_path: Some("/usr/local/bin/llama-server".to_string()),
         ..Default::default()
@@ -37,7 +37,6 @@ fn test_client_config_roundtrip_llama_server() {
     // Test deserialization from YAML
     let yaml = r#"
 type: llama-server
-name: test-llama-server
 binary_path: /usr/local/bin/llama-server
 models:
   - name: test-model
@@ -49,10 +48,12 @@ models:
       - --verbose
     socket_path: /tmp/llama.sock
 "#;
-    let deserialized: ClientConfig = serde_yaml::from_str(yaml).unwrap();
+    let mut deserialized: ClientConfig = serde_yaml::from_str(yaml).unwrap();
+    // Set the name as the loader would
+    deserialized.set_name("test-llama-server".to_string());
     match deserialized {
         ClientConfig::LlamaServerConfig(c) => {
-            assert_eq!(c.name, Some("test-llama-server".to_string()));
+            assert_eq!(c.name, "test-llama-server");
             assert_eq!(c.models.len(), 1);
             let m = &c.models[0];
             assert_eq!(m.name, "test-model");
@@ -77,7 +78,7 @@ fn test_client_config_hf_repo() {
         .with_hf_repo("unsloth/gemma-4-E4B-it-GGUF:UD-Q4_K_XL".to_string());
 
     let config = LlamaServerConfig {
-        name: Some("test-hf".to_string()),
+        name: "test-hf".to_string(),
         models: vec![model],
         ..Default::default()
     };
@@ -96,7 +97,6 @@ fn test_client_config_hf_repo() {
     // Test deserialization from YAML
     let yaml = r#"
 type: llama-server
-name: test-hf
 models:
   - name: hf-model
     hf_repo: unsloth/gemma-4-E4B-it-GGUF:UD-Q4_K_XL
@@ -122,7 +122,6 @@ fn test_client_config_unknown_type() {
 
     let yaml = r#"
 type: unknown-provider
-name: test
 "#;
     let deserialized: ClientConfig = serde_yaml::from_str(yaml).unwrap();
     assert!(matches!(deserialized, ClientConfig::Unknown));

--- a/crates/harnx-client/src/macros.rs
+++ b/crates/harnx-client/src/macros.rs
@@ -53,7 +53,7 @@ macro_rules! register_client {
                         if let Some(v) = $crate::ALL_PROVIDER_MODELS.iter().find(|v| {
                             v.provider == $name ||
                                 ($name == OpenAICompatibleClient::NAME
-                                    && local_config.name.as_ref().map(|name| name.starts_with(&v.provider)).unwrap_or_default())
+                                    && local_config.name.starts_with(&v.provider))
                         }) {
                             Model::from_config(client_name, &v.models)
                         } else {
@@ -74,7 +74,7 @@ macro_rules! register_client {
                 }
 
                 pub fn name(local_config: &$config) -> &str {
-                    local_config.name.as_deref().unwrap_or(Self::NAME)
+                    &local_config.name
                 }
             }
 

--- a/crates/harnx-client/tests/llama_server_mock.rs
+++ b/crates/harnx-client/tests/llama_server_mock.rs
@@ -153,7 +153,7 @@ async fn llama_server_mock_multi_model_distinct_processes() -> Result<()> {
 
     // Single provider config with two models, each with its own GGUF/socket
     let provider = LlamaServerConfig {
-        name: Some("multi-llama".to_string()),
+        name: "multi-llama".to_string(),
         models: vec![
             ModelData::new("model-a")
                 .with_model_path(model_path_a.display().to_string())
@@ -290,7 +290,7 @@ async fn llama_server_mock_hf_repo_only() -> Result<()> {
         ]);
 
     let provider = LlamaServerConfig {
-        name: Some("test-hf-provider".to_string()),
+        name: "test-hf-provider".to_string(),
         models: vec![model_data],
         binary_path: Some(binary_path.display().to_string()),
         ..Default::default()
@@ -349,7 +349,7 @@ async fn llama_server_mock_name_as_hf_repo() -> Result<()> {
         ]);
 
     let provider = LlamaServerConfig {
-        name: Some("test-name-hf".to_string()),
+        name: "test-name-hf".to_string(),
         models: vec![model_data],
         binary_path: Some(binary_path.display().to_string()),
         ..Default::default()
@@ -413,7 +413,7 @@ fn build_client(config: &LlamaServerProcessConfig, model_name: &str) -> Option<B
         .with_extra_args(config.extra_args.clone());
 
     let provider = LlamaServerConfig {
-        name: Some("llama-server".to_string()),
+        name: "llama-server".to_string(),
         models: vec![model_data],
         binary_path: config.binary_path.as_ref().map(|p| p.display().to_string()),
         ..Default::default()

--- a/crates/harnx-core/src/lib.rs
+++ b/crates/harnx-core/src/lib.rs
@@ -33,3 +33,30 @@ pub mod tool;
 pub mod working_mode;
 
 pub mod jaq;
+
+/// Assert that the current test is running under `cargo nextest`, panicking with
+/// guidance otherwise.
+///
+/// Some tests rely on per-test process isolation because they mutate
+/// process-global state (environment variables, the shared model registry, tmux
+/// sessions, etc.). `cargo test` runs every test of a binary in a single process
+/// with shared threads, which makes these tests flaky and produces confusing
+/// failures. `cargo nextest` runs each test in its own process and is the
+/// supported runner.
+///
+/// Nextest sets `NEXTEST=1` in every test process; `cargo test` does not. Call
+/// this as the first line of a test that must not run under `cargo test`.
+#[track_caller]
+pub fn require_nextest() {
+    if std::env::var_os("NEXTEST").is_none() {
+        panic!(
+            "\n\n\
+             This test must be run with cargo-nextest, not `cargo test`.\n\
+             It mutates process-global state and needs nextest's per-test process isolation;\n\
+             `cargo test` shares one process across tests and produces spurious failures.\n\n\
+             Run instead:\n\
+             \tcargo nextest run --workspace\n\n\
+             See AGENTS.md (\"Verifying Changes\") for the full verification pipeline.\n"
+        );
+    }
+}

--- a/crates/harnx-core/src/provider_config/azure_openai.rs
+++ b/crates/harnx-core/src/provider_config/azure_openai.rs
@@ -7,7 +7,8 @@ use crate::model::{ModelData, RequestPatches};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AzureOpenAIConfig {
-    pub name: Option<String>,
+    #[serde(skip)]
+    pub name: String,
     pub api_base: Option<String>,
     pub api_key: Option<String>,
     #[serde(default)]

--- a/crates/harnx-core/src/provider_config/bedrock.rs
+++ b/crates/harnx-core/src/provider_config/bedrock.rs
@@ -7,7 +7,8 @@ use crate::model::{ModelData, RequestPatches};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BedrockConfig {
-    pub name: Option<String>,
+    #[serde(skip)]
+    pub name: String,
     pub access_key_id: Option<String>,
     pub secret_access_key: Option<String>,
     pub region: Option<String>,

--- a/crates/harnx-core/src/provider_config/claude.rs
+++ b/crates/harnx-core/src/provider_config/claude.rs
@@ -7,7 +7,8 @@ use crate::model::{ModelData, RequestPatches};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClaudeConfig {
-    pub name: Option<String>,
+    #[serde(skip)]
+    pub name: String,
     pub api_key: Option<String>,
     pub api_base: Option<String>,
     #[serde(default)]

--- a/crates/harnx-core/src/provider_config/cohere.rs
+++ b/crates/harnx-core/src/provider_config/cohere.rs
@@ -7,7 +7,8 @@ use crate::model::{ModelData, RequestPatches};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CohereConfig {
-    pub name: Option<String>,
+    #[serde(skip)]
+    pub name: String,
     pub api_key: Option<String>,
     pub api_base: Option<String>,
     #[serde(default)]

--- a/crates/harnx-core/src/provider_config/gemini.rs
+++ b/crates/harnx-core/src/provider_config/gemini.rs
@@ -7,7 +7,8 @@ use crate::model::{ModelData, RequestPatches};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct GeminiConfig {
-    pub name: Option<String>,
+    #[serde(skip)]
+    pub name: String,
     pub api_key: Option<String>,
     pub api_base: Option<String>,
     #[serde(default)]

--- a/crates/harnx-core/src/provider_config/llama_server.rs
+++ b/crates/harnx-core/src/provider_config/llama_server.rs
@@ -13,7 +13,8 @@ use crate::model::{ModelData, RequestPatches};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct LlamaServerConfig {
-    pub name: Option<String>,
+    #[serde(skip)]
+    pub name: String,
 
     /// Models served by this provider. Each model specifies its own
     /// GGUF path and tuning knobs; selecting a model spawns its subprocess.

--- a/crates/harnx-core/src/provider_config/openai.rs
+++ b/crates/harnx-core/src/provider_config/openai.rs
@@ -7,7 +7,8 @@ use crate::model::{ModelData, RequestPatches};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct OpenAIConfig {
-    pub name: Option<String>,
+    #[serde(skip)]
+    pub name: String,
     pub api_key: Option<String>,
     pub api_base: Option<String>,
     pub organization_id: Option<String>,

--- a/crates/harnx-core/src/provider_config/openai_compatible.rs
+++ b/crates/harnx-core/src/provider_config/openai_compatible.rs
@@ -8,7 +8,8 @@ use crate::model::{ModelData, RequestPatches};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OpenAICompatibleConfig {
-    pub name: Option<String>,
+    #[serde(skip)]
+    pub name: String,
     pub api_base: Option<String>,
     pub api_key: Option<String>,
     #[serde(default)]

--- a/crates/harnx-core/src/provider_config/vertexai.rs
+++ b/crates/harnx-core/src/provider_config/vertexai.rs
@@ -7,7 +7,8 @@ use crate::model::{ModelData, RequestPatches};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct VertexAIConfig {
-    pub name: Option<String>,
+    #[serde(skip)]
+    pub name: String,
     pub project_id: Option<String>,
     pub location: Option<String>,
     pub adc_file: Option<String>,

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -1106,8 +1106,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_info_model_reports_catalog_model() {
+        let mut openai_client = crate::client::ClientConfig::OpenAIConfig(Default::default());
+        openai_client.set_name("openai".to_string());
         let mut config = Config {
-            clients: vec![crate::client::ClientConfig::OpenAIConfig(Default::default())],
+            clients: vec![openai_client],
             model: model_with_data("openai", "gpt-4o", true),
             working_mode: WorkingMode::Cmd,
             ..Default::default()

--- a/crates/harnx-runtime/src/config/loader_split.rs
+++ b/crates/harnx-runtime/src/config/loader_split.rs
@@ -155,11 +155,19 @@ impl Config {
         }
         let mut clients = Vec::new();
         for path in Self::sorted_yaml_files(dir)? {
-            let stem = path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or_default()
-                .to_string();
+            // Derive the client name from the filename stem. Skip paths with a
+            // missing or empty stem (e.g. non-UTF-8 names) — an empty name would
+            // violate ClientConfig::set_name's debug_assert.
+            let stem = match path.file_stem().and_then(|s| s.to_str()) {
+                Some(stem) if !stem.is_empty() => stem.to_string(),
+                _ => {
+                    log::warn!(
+                        "Skipping client config with invalid filename stem: '{}'",
+                        path.display()
+                    );
+                    continue;
+                }
+            };
             let content = read_to_string(&path)
                 .with_context(|| format!("Failed to read client config '{}'", path.display()))?;
             let mut client: ClientConfig = serde_yaml::from_str(&content)

--- a/crates/harnx-runtime/src/config/loader_split.rs
+++ b/crates/harnx-runtime/src/config/loader_split.rs
@@ -136,15 +136,15 @@ impl Config {
         // Qualify client names with package prefix after patching.
         // Must be after patching because apply_client_patch round-trips through
         // serde_json and resets #[serde(skip)] fields like `package`.
-        // Always call set_name_and_package (not just for bare names) so the
-        // `package` field is restored even for explicitly-named clients whose
+        // Always restore `package` even for explicitly-named clients whose
         // name already contains '/'.
         for client in &mut clients {
             let resolved_name = harnx_core::package_namespace::resolve_package_relative_name(
                 client.effective_name(),
                 Some(pkg_name),
             );
-            client.set_name_and_package(resolved_name, pkg_name.to_string());
+            client.set_name(resolved_name);
+            client.set_package(Some(pkg_name.to_string()));
         }
         clients
     }
@@ -155,10 +155,16 @@ impl Config {
         }
         let mut clients = Vec::new();
         for path in Self::sorted_yaml_files(dir)? {
+            let stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default()
+                .to_string();
             let content = read_to_string(&path)
                 .with_context(|| format!("Failed to read client config '{}'", path.display()))?;
-            let client: ClientConfig = serde_yaml::from_str(&content)
+            let mut client: ClientConfig = serde_yaml::from_str(&content)
                 .with_context(|| format!("Failed to parse client config '{}'", path.display()))?;
+            client.set_name(stem);
             clients.push(client);
         }
         Ok(clients)
@@ -217,7 +223,7 @@ impl Config {
             .into_iter()
             .any(|(name, _)| provider == name);
         let client = if is_openai_compatible {
-            json!({ "type": "openai-compatible", "name": provider })
+            json!({ "type": "openai-compatible" })
         } else {
             json!({ "type": provider })
         };
@@ -233,8 +239,10 @@ impl Config {
             ..Self::default()
         };
 
-        config.clients =
-            vec![serde_json::from_value(client).context("Failed to parse client config")?];
+        let mut client: ClientConfig =
+            serde_json::from_value(client).context("Failed to parse client config")?;
+        client.set_name(provider.to_string());
+        config.clients = vec![client];
 
         let config_dir = Self::config_dir();
         config.mcp_servers =

--- a/crates/harnx-runtime/src/config/patches_split.rs
+++ b/crates/harnx-runtime/src/config/patches_split.rs
@@ -69,12 +69,48 @@ pub(super) fn apply_client_patch(client: &mut ClientConfig, patches: &[String]) 
     if patches.is_empty() {
         return Ok(());
     }
-    let input = serde_json::to_value(&*client)
+
+    let saved_name = match client {
+        ClientConfig::Unknown => None,
+        _ => Some(client.effective_name().to_string()),
+    };
+    let saved_package = match client {
+        ClientConfig::OpenAIConfig(c) => c.package.clone(),
+        ClientConfig::OpenAICompatibleConfig(c) => c.package.clone(),
+        ClientConfig::GeminiConfig(c) => c.package.clone(),
+        ClientConfig::ClaudeConfig(c) => c.package.clone(),
+        ClientConfig::CohereConfig(c) => c.package.clone(),
+        ClientConfig::AzureOpenAIConfig(c) => c.package.clone(),
+        ClientConfig::VertexAIConfig(c) => c.package.clone(),
+        ClientConfig::BedrockConfig(c) => c.package.clone(),
+        ClientConfig::LlamaServerConfig(c) => c.package.clone(),
+        ClientConfig::Unknown => None,
+    };
+
+    let mut input = serde_json::to_value(&*client)
         .with_context(|| "Failed to serialize ClientConfig for jaq patch")?;
+    if let (Some(name), serde_json::Value::Object(obj)) = (&saved_name, &mut input) {
+        obj.insert("name".to_string(), serde_json::Value::String(name.clone()));
+    }
+
     let output = harnx_core::jaq::eval_filters_strict(patches, input)
         .with_context(|| "jq patch expression failed for client config")?;
+
+    let patched_name = output
+        .as_object()
+        .and_then(|obj| obj.get("name"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string);
+
     *client = serde_json::from_value(output)
         .with_context(|| "Failed to deserialize ClientConfig after jaq patch")?;
+
+    if let Some(name) = patched_name.or(saved_name) {
+        client.set_name(name);
+    }
+    client.set_package(saved_package);
+
     Ok(())
 }
 

--- a/crates/harnx-runtime/src/config/session_edit_tests.rs
+++ b/crates/harnx-runtime/src/config/session_edit_tests.rs
@@ -199,7 +199,7 @@ fn edit_message_range_supports_reordering_plain_messages() {
             .clients
             .push(harnx_client::ClientConfig::OpenAICompatibleConfig(
                 harnx_core::provider_config::openai_compatible::OpenAICompatibleConfig {
-                    name: Some("test".to_string()),
+                    name: "test".to_string(),
                     api_base: None,
                     api_key: None,
                     models: vec![],

--- a/crates/harnx-runtime/src/config/tests.rs
+++ b/crates/harnx-runtime/src/config/tests.rs
@@ -1082,6 +1082,7 @@ fn dynamic_provider_model_init_sets_client_name_from_provider() {
         }
     }
 
+    #[cfg(unix)]
     let _lock = env_lock();
     let tmp = tempfile::tempdir().unwrap();
     let _config_dir = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());

--- a/crates/harnx-runtime/src/config/tests.rs
+++ b/crates/harnx-runtime/src/config/tests.rs
@@ -943,8 +943,17 @@ use super::apply_client_patch;
 use harnx_client::ClientConfig;
 
 fn make_openai_client() -> ClientConfig {
-    serde_yaml::from_str("type: openai\napi_key: sk-original\n")
-        .expect("should parse openai client config")
+    let mut client: ClientConfig = serde_yaml::from_str("type: openai\napi_key: sk-original\n")
+        .expect("should parse openai client config");
+    client.set_name("openai".to_string());
+    client
+}
+
+fn make_claude_client() -> ClientConfig {
+    let mut client: ClientConfig = serde_yaml::from_str("type: claude\napi_key: sk-original\n")
+        .expect("should parse claude client config");
+    client.set_name("claude".to_string());
+    client
 }
 
 #[test]
@@ -976,6 +985,26 @@ fn apply_client_patch_sets_field_via_jq_expression() {
         assert_eq!(c.api_key.as_deref(), Some("sk-patched"));
     } else {
         panic!("expected OpenAI client, got: {client:?}");
+    }
+}
+
+#[test]
+fn apply_client_patch_name_filter_matches_and_preserves_name() {
+    let mut client = make_claude_client();
+    client.set_package(Some("pkg".to_string()));
+
+    let result = apply_client_patch(
+        &mut client,
+        &[r#"if .name == "claude" then .api_key = "patched-key" else . end"#.to_string()],
+    );
+
+    assert!(result.is_ok());
+    assert_eq!(client.effective_name(), "claude");
+    if let ClientConfig::ClaudeConfig(c) = &client {
+        assert_eq!(c.api_key.as_deref(), Some("patched-key"));
+        assert_eq!(c.package.as_deref(), Some("pkg"));
+    } else {
+        panic!("expected Claude client, got: {client:?}");
     }
 }
 
@@ -1039,4 +1068,29 @@ fn handoff_tool_declarations_are_package_aware_and_valid() {
         handoff_targets.get("__global").map(String::as_str),
         Some("global")
     );
+}
+
+#[test]
+fn dynamic_provider_model_init_sets_client_name_from_provider() {
+    struct ProviderGuard(Option<std::ffi::OsString>);
+    impl Drop for ProviderGuard {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => unsafe { std::env::set_var("HARNX_PROVIDER", value) },
+                None => unsafe { std::env::remove_var("HARNX_PROVIDER") },
+            }
+        }
+    }
+
+    let _lock = env_lock();
+    let tmp = tempfile::tempdir().unwrap();
+    let _config_dir = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+    let _provider_guard = ProviderGuard(std::env::var_os("HARNX_PROVIDER"));
+    unsafe { std::env::set_var("HARNX_PROVIDER", "claude:some-model") };
+
+    let config = tokio_test::block_on(Config::init(WorkingMode::Cmd, false, vec![]))
+        .expect("dynamic config should load");
+
+    assert_eq!(config.clients.len(), 1);
+    assert_eq!(config.clients[0].effective_name(), "claude");
 }

--- a/crates/harnx-runtime/tests/package_loading.rs
+++ b/crates/harnx-runtime/tests/package_loading.rs
@@ -44,6 +44,67 @@ fn install_test_package(config_dir: &Path, pkg_name: &str, files: &[(&str, &str)
 }
 
 #[test]
+fn package_loading_test_package_client_patch_preserves_qualified_name() {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    install_test_package(
+        tmp.path(),
+        "mypkg",
+        &[
+            (
+                "clients/openai.yaml",
+                "type: openai
+api_key: sk-original
+",
+            ),
+            (
+                "agents/worker.md",
+                "---
+model: openai:gpt-4o
+---
+You work.",
+            ),
+        ],
+    );
+
+    // The package patch file is a SIBLING of the package directory:
+    // packages/<pkg>.patch.yaml (see harnx_core::config_paths::package_patch_file).
+    std::fs::write(
+        tmp.path().join("packages").join("mypkg.patch.yaml"),
+        "clients:
+  - 'if .name == \"openai\" then .api_key = \"patched-key\" else . end'
+",
+    )
+    .unwrap();
+
+    let config = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(Config::init(
+            harnx_runtime::config::WorkingMode::Cmd,
+            false,
+            vec![],
+        ))
+        .expect("config should load");
+
+    let client = config
+        .clients
+        .iter()
+        .find(|client| client.effective_name() == "mypkg/openai")
+        .expect("expected qualified package client named mypkg/openai");
+
+    assert_eq!(client.effective_name(), "mypkg/openai");
+    match client {
+        harnx_client::ClientConfig::OpenAIConfig(c) => {
+            assert_eq!(c.api_key.as_deref(), Some("patched-key"));
+            assert_eq!(c.package.as_deref(), Some("mypkg"));
+        }
+        _ => panic!("expected OpenAIConfig variant, got: {client:?}"),
+    }
+}
+
+#[test]
 fn package_loading_test_package_client_loaded_with_qualified_name() {
     let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
     let tmp = tempfile::TempDir::new().unwrap();
@@ -815,4 +876,55 @@ fn package_loading_test_package_explicit_yaml_acp_bare_arg_is_qualified_but_top_
         .find(|server| server.package.is_none() && server.name == "top")
         .expect("top-level acp server should load");
     assert_eq!(top_level_server.args, vec!["top".to_string()]);
+}
+
+/// Test that in-file `name:` is ignored and client name comes from filename.
+/// This directly verifies issue #823: client name should come from YAML filename stem,
+/// NOT from a `name:` field in file contents.
+#[test]
+fn package_loading_test_client_name_ignored_from_file_contents() {
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
+
+    // Create clients directory at root level
+    std::fs::create_dir_all(tmp.path().join("clients")).unwrap();
+
+    // Write a client file named "foo.yaml" but with `name: bar` inside
+    // The effective_name should be "foo" (from filename), NOT "bar" (from file contents)
+    std::fs::write(
+        tmp.path().join("clients/foo.yaml"),
+        "type: claude\nname: bar\n",
+    )
+    .unwrap();
+
+    let config = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(Config::init(
+            harnx_runtime::config::WorkingMode::Cmd,
+            false,
+            vec![],
+        ))
+        .expect("config should load");
+
+    // Find the client and verify its effective_name is "foo" (filename stem), not "bar"
+    let client = config
+        .clients
+        .iter()
+        .find(|c| c.effective_name() == "foo")
+        .expect("expected client named 'foo' from filename, not 'bar' from file contents");
+
+    // Also verify no client named "bar" exists (proving name: field was ignored)
+    assert!(
+        !config.clients.iter().any(|c| c.effective_name() == "bar"),
+        "client 'bar' should not exist - in-file name: field must be ignored"
+    );
+
+    // Verify the client is a ClaudeConfig variant (correct deserialization)
+    match client {
+        harnx_client::ClientConfig::ClaudeConfig(c) => {
+            assert_eq!(c.name, "foo");
+        }
+        _ => panic!("expected ClaudeConfig variant, got: {:?}", client),
+    }
 }

--- a/crates/harnx/src/test_utils/interrupt.rs
+++ b/crates/harnx/src/test_utils/interrupt.rs
@@ -472,6 +472,7 @@ pub fn spawn_oneshot(
     harnx_bin: &Path,
     prompt: &str,
 ) -> Result<std::process::Child> {
+    harnx_core::require_nextest();
     use std::process::{Command, Stdio};
     // --agent default is required since chat activity needs an active agent.
     // The "default" agent is written by write_minimal_config.
@@ -522,6 +523,7 @@ pub async fn spawn_acp_client(
     harnx_bin: &Path,
     agent: &str,
 ) -> Result<harnx_acp::AcpClient> {
+    harnx_core::require_nextest();
     let mut env = HashMap::new();
     env.insert(
         "HARNX_CONFIG_DIR".to_string(),

--- a/crates/harnx/src/test_utils/tmux_harness.rs
+++ b/crates/harnx/src/test_utils/tmux_harness.rs
@@ -37,6 +37,10 @@ impl TmuxHarness {
     /// variables needed by their test subject inside the pane (e.g., via `send_text`
     /// with `env VAR=val ...`).
     pub fn new(cwd: impl AsRef<Path>, cols: u16, rows: u16) -> Result<Self> {
+        // tmux-driven tests mutate global session/socket state and must run with
+        // per-test process isolation. Refuse to run under `cargo test`.
+        harnx_core::require_nextest();
+
         let session_name = unique_name("harnx-test");
         let socket_path = std::env::temp_dir().join(format!("{}.sock", unique_name("tmux")));
 

--- a/demos/config/clients/mock.yaml
+++ b/demos/config/clients/mock.yaml
@@ -1,5 +1,4 @@
 type: openai-compatible
-name: mock
 api_key: sk-mock
 api_base: http://127.0.0.1:3829/v1
 models:

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -66,13 +66,12 @@ Each LLM provider is configured in its own YAML file within the `clients/` direc
 
 For a complete list of supported providers and their specific configuration options, see the [**LLM Providers Reference**](providers.md).
 
-**Note:** The filename is for organization only. The client's ID used in `model` settings (e.g., `myclient:gpt-4`) is determined by the `name` field inside the configuration file.
+**Note:** The **filename** (without `.yaml`) is used as the client's ID in `model` settings (e.g., `openai:gpt-4`). Any `name` field inside the file is ignored.
 
 ### General Client Options
 
 ```yaml
 type: openai              # Provider type (openai, claude, gemini, etc.)
-name: my-openai           # Client ID for model strings (e.g., my-openai:gpt-4)
 api_key: sk-...           # Optional if <NAME>_API_KEY env var is set
 api_base: https://...     # Optional custom endpoint
 patches:                  # Patch API requests using jq expressions

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -77,6 +77,7 @@ api_base: https://...     # Optional custom endpoint
 patches:                  # Patch API requests using jq expressions
   chat_completions:
     - '.body.cache_control = {"type":"ephemeral"}'
+```
 
 ### Per-Model Patches
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -110,6 +110,16 @@ Package agents and servers are automatically namespaced to avoid collisions with
 
 The `/` in agent names is replaced with `__` in tool names.
 
+### Naming Convention
+
+The names of agents, servers, and clients are derived from their **filename stems** (extension stripped):
+
+- **Agents**: `agents/coder.md` becomes `coder`.
+- **MCP Servers**: `mcp_servers/fs.yaml` becomes `fs`.
+- **Clients**: `clients/openai.yaml` becomes `openai`.
+
+For package-provided entities, the name is prefixed with the package name: `<package>/<stem>`. For example, `my-pkg/openai`. Any `name:` field inside the configuration file is ignored.
+
 ### Within-package `use_tools` references
 
 When an agent inside a package references tools from the same package, write them exactly as you would for a top-level agent — using the bare server name:
@@ -155,7 +165,7 @@ mcp_servers:
 ```
 
 - **Matching**: Use `if .name == "..." then ... end` for exact matching, or `if (.name | test("...")) then ... end` for pattern matching. The `else .` (pass through unchanged) is implicit when omitted.
-- **Context**: Agent patches match against the bare agent name (stem), not the qualified `pkg/name` form.
+- **Context**: Patches match against the **bare name** (filename stem), not the qualified `pkg/name` form. This applies to agents, clients, and MCP servers.
 - **Chaining**: Filters are applied in sequence. If a filter fails, it is skipped with a warning.
 
 ## manifest.yaml schema

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -13,7 +13,7 @@ All clients support these common fields:
 | `system_prompt_prefix` | List of strings prepended to all system prompts for this client (each item is a separate paragraph). | N/A |
 | `models` | List of manual model definitions. | N/A |
 
-> **Note on Environment Variables:** The `{NAME}` prefix in environment variables is derived from the client's **filename stem** (uppercased). For example, a client defined in `clients/my-openai.yaml` will use `MY_OPENAI_API_KEY`. If the filename is just the provider type (e.g., `openai.yaml`), it defaults to `OPENAI_API_KEY`. Any `name` field in the file is ignored.
+> **Note on Environment Variables:** The `{NAME}` prefix in environment variables is the client's **filename stem, uppercased as-is** — env var names are built as `${NAME}_${FIELD}` with no character substitution. For example, a client defined in `clients/my_openai.yaml` uses `MY_OPENAI_API_KEY`. If the filename is just the provider type (e.g., `openai.yaml`), it defaults to `OPENAI_API_KEY`. Hyphens are **not** converted to underscores, so a stem with a hyphen produces a hyphen in the prefix (e.g., `clients/my-openai.yaml` → `MY-OPENAI_API_KEY`); prefer underscores in filenames if you intend to use env var overrides. Any `name` field in the file is ignored.
 
 ---
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -8,13 +8,12 @@ All clients support these common fields:
 
 | Field | Description | Env Var Override |
 |-------|-------------|------------------|
-| `name` | Unique ID for the client (used in model identifiers like `my-name:gpt-4`). Defaults to the provider type. | N/A |
 | `patch` | Regex-based patches for API requests (url, headers, body). | N/A |
 | `extra` | Provider-specific extra configuration. | N/A |
 | `system_prompt_prefix` | List of strings prepended to all system prompts for this client (each item is a separate paragraph). | N/A |
 | `models` | List of manual model definitions. | N/A |
 
-> **Note on Environment Variables:** The `{NAME}` prefix in environment variables is the `name` field of the client (uppercased). If `name` is not set, it defaults to the provider `type` (e.g., `OPENAI_API_KEY`).
+> **Note on Environment Variables:** The `{NAME}` prefix in environment variables is derived from the client's **filename stem** (uppercased). For example, a client defined in `clients/my-openai.yaml` will use `MY_OPENAI_API_KEY`. If the filename is just the provider type (e.g., `openai.yaml`), it defaults to `OPENAI_API_KEY`. Any `name` field in the file is ignored.
 
 ---
 
@@ -119,12 +118,12 @@ Integration for Azure-hosted OpenAI deployments.
 
 | Field | Description | Env Var Override |
 |-------|-------------|------------------|
-| `api_base` | **Required.** Format: `https://{RESOURCE}.openai.azure.com` | `AZURE-OPENAI_API_BASE` ¹ |
-| `api_key` | **Required.** Your Azure OpenAI API key. | `AZURE-OPENAI_API_KEY` ¹ |
+| `api_base` | **Required.** Format: `https://{RESOURCE}.openai.azure.com` | `AZURE_OPENAI_API_BASE` ¹ |
+| `api_key` | **Required.** Your Azure OpenAI API key. | `AZURE_OPENAI_API_KEY` ¹ |
 
 **Special Behavior:** Models must be listed manually in the `models` field, with `name` matching the Azure deployment name.
 
-> ¹ The env var names contain a hyphen (`AZURE-OPENAI_*`), which most shells do not allow in variable names. To use env var overrides for Azure OpenAI, set `name: azure_openai` (underscore) in your config file — this makes the env vars `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_API_BASE`, which are shell-safe.
+> ¹ The env var prefix is derived from the filename stem. To ensure env var names are shell-safe (no hyphens), name your configuration file `azure_openai.yaml` (with an underscore). This results in env vars like `AZURE_OPENAI_API_KEY`.
 
 **Example:**
 ```yaml
@@ -167,7 +166,6 @@ Used for any provider that implements the OpenAI API specification.
 **Example:**
 ```yaml
 type: openai-compatible
-name: my-provider
 api_base: "https://api.example.com/v1"
 api_key: "..."
 ```
@@ -181,13 +179,12 @@ Ollama provides a local OpenAI-compatible API.
 **Example:**
 ```yaml
 type: openai-compatible
-name: ollama
 api_base: "http://localhost:11434/v1"
 ```
 
 ### Named Shortcuts
 
-The following providers have pre-configured `api_base` URLs. Use `type: openai-compatible` with `name:` set to one of the names below, and harnx will fill in the correct `api_base` automatically (you can still override it explicitly). The env var prefix for the API key is the name uppercased.
+The following providers have pre-configured `api_base` URLs. Use `type: openai-compatible` and name the configuration file one of the names below (e.g., `clients/groq.yaml`), and harnx will fill in the correct `api_base` automatically (you can still override it explicitly). The env var prefix for the API key is the filename stem uppercased.
 
 | Name | API Base URL | Env Var Prefix |
 |------|--------------|----------------|
@@ -210,14 +207,13 @@ The following providers have pre-configured `api_base` URLs. Use `type: openai-c
 | `xai` | `https://api.x.ai/v1` | `XAI` |
 | `zhipuai` | `https://open.bigmodel.cn/api/paas/v4` | `ZHIPUAI` |
 
-**Example (using `type: openai-compatible` with `name:`):**
+**Example (using `type: openai-compatible` with the filename `groq.yaml`):**
 ```yaml
 type: openai-compatible
-name: groq
 api_base: https://api.groq.com/openai/v1
 # api_key: "..."   # or set GROQ_API_KEY
 ```
 
-> **Note:** The shorthand names (e.g., `groq`, `deepseek`, `xai`) are used as the `name` field, **not** the `type` field. The `type` must always be `openai-compatible`. The `api_base` is pre-configured by harnx when the name matches a known provider, so you can omit it if using a standard provider name.
+> **Note:** The shorthand names (e.g., `groq`, `deepseek`, `xai`) must be used as the **filename** (e.g., `groq.yaml`), not the `type` field. The `type` must always be `openai-compatible`. The `api_base` is pre-configured by harnx when the filename stem matches a known provider, so you can omit it if using a standard provider name.
 >
 > ² Cloudflare's URL contains a literal `{ACCOUNT_ID}` placeholder. You must supply the correct URL explicitly via `api_base` in your config file — the placeholder is not substituted automatically.

--- a/docs/solutions/logic-errors/serde-skip-patch-round-trip-2026-06-12.md
+++ b/docs/solutions/logic-errors/serde-skip-patch-round-trip-2026-06-12.md
@@ -29,7 +29,7 @@ When a Rust struct field is marked `#[serde(skip)]` and that struct is round-tri
 - Qualified names derived from the field become invalid (e.g. `pkg/` instead of `pkg/openai`)
 - Test fixtures that parse YAML directly via `serde_yaml::from_str` without going through the loader produce configs with empty identity fields
 
-```
+```yaml
 # Example: package patch filter stops matching after name becomes #[serde(skip)]
 patches:
   clients:

--- a/docs/solutions/logic-errors/serde-skip-patch-round-trip-2026-06-12.md
+++ b/docs/solutions/logic-errors/serde-skip-patch-round-trip-2026-06-12.md
@@ -1,0 +1,178 @@
+---
+title: "Serde skip fields lost during JSON round-trip for jaq/jq config patching"
+date: 2026-06-12
+category: "logic-errors"
+problem_type: logic_error
+component: "patch-layer"
+root_cause: "serde(skip) fields absent from JSON and reset to Default after deserialize"
+resolution_type: code_fix
+severity: high
+tags:
+  - serde
+  - jaq
+  - jq
+  - patching
+  - json-round-trip
+  - client-config
+  - mcp-server-config
+plan_ref: "client-name-from-filename"
+---
+
+## Problem
+
+When a Rust struct field is marked `#[serde(skip)]` and that struct is round-tripped through `serde_json::to_value` → jaq filter → `serde_json::from_value` for config patching, the skipped field is silently lost: absent from the JSON the filter sees, and reset to its `Default::default()` after deserialization. If the skipped field holds identity or runtime-critical data, downstream logic breaks.
+
+## Symptoms
+
+- Patch filters that key on the skipped field (e.g. `if .name == "claude" then ...`) silently stop matching
+- After patching, the field value becomes empty/None instead of its pre-patch value
+- Qualified names derived from the field become invalid (e.g. `pkg/` instead of `pkg/openai`)
+- Test fixtures that parse YAML directly via `serde_yaml::from_str` without going through the loader produce configs with empty identity fields
+
+```
+# Example: package patch filter stops matching after name becomes #[serde(skip)]
+patches:
+  clients:
+    - 'if .name == "claude" then .api_key = "sk-..." end'
+# Result: filter never matches, .name is absent from JSON input
+```
+
+## Investigation Steps
+
+1. Traced `apply_client_patch` in `crates/harnx-runtime/src/config/patches_split.rs` — found it serialize → jaq → deserialize without special handling for skipped fields
+2. Reviewed provider config structs — confirmed `#[serde(skip)] pub name: String` on all 9 client providers
+3. Compared with MCP server patch — `apply_mcp_server_patch` already saves/restores `package` (also skip), but only `package` because `McpServerConfig.name` uses `#[serde(default)]` (serialized)
+4. Identified two impacts: (a) `.name` filters don't match, (b) package client names become `pkg/` after patch qualification
+5. Found test helpers in `harnx-acp-server`, `harnx-client` tests that parse YAML directly without `set_name` calls — they produced empty-named configs
+
+## Root Cause
+
+`#[serde(skip)]` has two effects during round-trip:
+
+1. **Serialization omits the field**: `serde_json::to_value(&config)` produces JSON without that field
+2. **Deserialization uses Default**: `serde_json::from_value(json)` initializes the field via `Default::default()`
+
+For `String` fields, this means empty string `""`. The jaq filter sees JSON without the field, and after the filter runs, the field is reset.
+
+This is expected serde behavior, but problematic when:
+- The skipped field is runtime-derived (filename stem, dynamic provider)
+- The field is identity-critical (used for model resolution, env var construction)
+- Downstream code assumes the field was set by the loader
+
+## Solution
+
+### Pattern: Save-Inject-Restore
+
+Before the serde round-trip, save skipped fields. To enable filter matching, inject identity fields into the JSON. After `from_value`, restore the fields (preferring patched values if the filter set them).
+
+```rust
+pub(super) fn apply_client_patch(client: &mut ClientConfig, patches: &[String]) -> Result<()> {
+    if patches.is_empty() {
+        return Ok(());
+    }
+
+    // 1. Save skipped fields before serialization
+    let saved_name = match client {
+        ClientConfig::Unknown => None,
+        _ => Some(client.effective_name().to_string()),
+    };
+    let saved_package = /* match each variant for package */;
+
+    // 2. Serialize to JSON
+    let mut input = serde_json::to_value(&*client)?;
+
+    // 3. Inject saved name into JSON for filter visibility
+    if let (Some(name), serde_json::Value::Object(ref mut obj)) = (&saved_name, &mut input) {
+        obj.insert("name".to_string(), serde_json::Value::String(name.clone()));
+    }
+
+    // 4. Run jaq filters
+    let output = harnx_core::jaq::eval_filters_strict(patches, input)?;
+
+    // 5. Extract patched name if filter set one
+    let patched_name = output
+        .as_object()
+        .and_then(|obj| obj.get("name"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string);
+
+    // 6. Deserialize back
+    *client = serde_json::from_value(output)?;
+
+    // 7. Restore skipped fields (prefer patched, fallback to saved)
+    if let Some(name) = patched_name.or(saved_name) {
+        client.set_name(name);
+    }
+    client.set_package(saved_package);
+
+    Ok(())
+}
+```
+
+### Variant Differences
+
+| Config Type | `name` attribute | `package` attribute | Fields to save/restore |
+|-------------|------------------|---------------------|------------------------|
+| `McpServerConfig` | `#[serde(default)]` | `#[serde(skip)]` | `package` only |
+| `ClientConfig` | `#[serde(skip)]` | `#[serde(skip)]` | Both `name` and `package` |
+
+MCP servers use `#[serde(default)]` for name, so it serializes and filters can see `.name` naturally. Clients use `#[serde(skip)]` for name (preventing YAML re-serialization), requiring explicit injection.
+
+### Test Fixture Pattern
+
+Any test helper that constructs configs without the file loader must explicitly set the name field:
+
+```rust
+// BEFORE (broken after serde-skip change)
+let config: ClientConfig = serde_yaml::from_str(r#"
+type: claude
+api_key: sk-test
+"#)?;
+
+// AFTER (must set name explicitly)
+let mut config: ClientConfig = serde_yaml::from_str(r#"
+type: claude
+api_key: sk-test
+"#)?;
+config.set_name("test-client".to_string());  // Or client name matching test intent
+```
+
+## Why This Works
+
+1. **Save before serialize**: Captures runtime-derived values before they're lost
+2. **Inject for filters**: Makes identity fields visible to jaq expressions, preserving documented filter semantics
+3. **Restore after deserialize**: Ensures downstream code sees correctly populated fields
+4. **Prefer patched values**: Allows filters to intentionally modify identity (e.g., rename a client)
+
+The inject step is key for backward compatibility: it ensures documented patch examples like `if .name == "claude" then ...` continue working despite the field being skipped.
+
+## Prevention Strategies
+
+### Test Cases
+
+- Add regression test: patch filter matching on `.name` should work
+- Add regression test: qualified name preserved after patching (no `pkg/`)
+- Add test: patched name trumps saved name if filter sets one
+- Add test: direct YAML parse without `set_name` fails model resolution
+
+### Best Practices
+
+- Always save/restore `#[serde(skip)]` fields around serde round-trips
+- Inject identity fields into JSON so filters can match on them
+- Prefer `#[serde(skip)]` over `#[serde(default)]` when field should never serialize (prevents accidental YAML pollution)
+- Document that test helpers bypassing the loader must set skipped fields explicitly
+
+### Code Review Checklist
+
+- [ ] All `#[serde(skip)]` fields saved before `serde_json::to_value`?
+- [ ] Identity fields (name, id) injected into JSON for filter visibility?
+- [ ] Fields restored after `serde_json::from_value`?
+- [ ] Test helpers that parse YAML directly call `set_name`?
+- [ ] Patched values preferred over saved values (allow intentional modification)?
+
+## Related Issues
+
+- **Prior solution:** [jaq-expression-patching-yaml-to-jq-migration-2026-05-16](../integration-issues/jaq-expression-patching-yaml-to-jq-migration-2026-05-16.md) — MCP server `package` save/restore pattern
+- **Strict evaluation:** [strict-jaq-patch-evaluation-2026-05-24](../logic-errors/strict-jaq-patch-evaluation-2026-05-24.md) — error propagation for invalid patches
+- **Issue:** #823 — Client name derived from filename, mirrors MCP loader pattern

--- a/example_config/clients/azure_openai.yaml
+++ b/example_config/clients/azure_openai.yaml
@@ -2,7 +2,7 @@
 # Note: Azure OpenAI requires manual model listing as deployment names vary.
 
 type: azure-openai
-name: azure_openai   # Underscore keeps env var names shell-safe (AZURE_OPENAI_API_KEY)
+# Note: The filename 'azure_openai.yaml' ensures env var names are shell-safe (AZURE_OPENAI_API_KEY)
 
 # Required: The base URL of your Azure OpenAI resource
 # Format: https://{RESOURCE}.openai.azure.com

--- a/example_config/clients/bedrock.yaml
+++ b/example_config/clients/bedrock.yaml
@@ -4,7 +4,6 @@
 # (env vars AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, ~/.aws/config, IAM roles, etc.).
 
 type: bedrock
-name: bedrock             # Optional: defaults to "bedrock"
 
 # Required: AWS Region (e.g., us-east-1, us-west-2)
 region: us-east-1

--- a/example_config/clients/cohere.yaml
+++ b/example_config/clients/cohere.yaml
@@ -1,7 +1,6 @@
 # Cohere Configuration
 
 type: cohere
-name: cohere
 
 # Your Cohere API key
 api_key: "your-api-key"

--- a/example_config/clients/deepseek.yaml
+++ b/example_config/clients/deepseek.yaml
@@ -2,6 +2,5 @@
 # Env var: DEEPSEEK_API_KEY
 
 type: openai-compatible
-name: deepseek
 api_base: https://api.deepseek.com
 # api_key: "..."   # or set DEEPSEEK_API_KEY

--- a/example_config/clients/groq.yaml
+++ b/example_config/clients/groq.yaml
@@ -2,6 +2,5 @@
 # Env var: GROQ_API_KEY
 
 type: openai-compatible
-name: groq
 api_base: https://api.groq.com/openai/v1
 # api_key: "..."   # or set GROQ_API_KEY

--- a/example_config/clients/llama-server.yaml
+++ b/example_config/clients/llama-server.yaml
@@ -1,5 +1,4 @@
 type: llama-server
-name: local-llama
 
 # binary_path: llama-server  # Optional: Shared binary path for all models below
 

--- a/example_config/clients/ollama.yaml
+++ b/example_config/clients/ollama.yaml
@@ -1,5 +1,4 @@
 type: openai-compatible
-name: ollama
 api_base: http://localhost:11434/v1
 models:
   - name: llama3.1

--- a/example_config/clients/vertexai.yaml
+++ b/example_config/clients/vertexai.yaml
@@ -2,7 +2,6 @@
 # Vertex AI uses Google Application Default Credentials (ADC).
 
 type: vertexai
-name: vertexai
 
 # Required: Google Cloud Project ID
 project_id: "your-project-id"

--- a/example_config/clients/xai.yaml
+++ b/example_config/clients/xai.yaml
@@ -2,6 +2,5 @@
 # Env var: XAI_API_KEY
 
 type: openai-compatible
-name: xai
 api_base: https://api.x.ai/v1
 # api_key: "..."   # or set XAI_API_KEY

--- a/packages/pantheon/clients/bedrock.yaml
+++ b/packages/pantheon/clients/bedrock.yaml
@@ -1,5 +1,4 @@
 type: openai-compatible
-name: bedrock
 # AWS Bedrock OpenAI-compatible endpoint.
 # Change the region in api_base if you use a different one.
 api_base: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1


### PR DESCRIPTION
The client name is now authoritative from the YAML filename stem, mirroring the MCP server loader pattern. Top-level name fields in client YAML specifications are silently ignored. For package clients, names are automatically qualified with the package prefix (e.g., pkg/client-name).

Updated example_config and documentation to reflect filename-based naming. Renamed azure-openai.yaml to azure_openai.yaml to ensure shell-safe environment variable prefixes (e.g., AZURE_OPENAI_API_KEY). Preserves client name and package metadata during package patching round-trips by injecting the name before jaq evaluation and restoring it after deserialization. Removes provider-default fallback names (e.g., "openai"), requiring names to be set by the loader.

Refs #823

Plan: client-name-from-filename

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Client identifiers are now derived from YAML **filename stems** (e.g., `openai.yaml` → `openai`) instead of `name:` fields inside the file.
  * Environment variable prefixes are now based on **filenames** (uppercased) rather than configured client names.
  * Any `name:` field within client configuration files is now ignored.
  * Updated example configurations and documentation to reflect filename-based client naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->