### PR TITLE
feat(tui): view compaction result details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -177,7 +177,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1818,7 +1818,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1977,7 +1977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2822,7 +2822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -4714,7 +4714,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5505,7 +5505,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5893,7 +5893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6636,9 +6636,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-textarea"
-version = "0.9.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c78d5ba0f26f97baed69a4c479f268a31c7b5b89d68ab939842152e383d6e73"
+checksum = "2950274c0e155944158cf766848dd87bd6db6dad27da1c23ee4a7c8de71dbf1f"
 dependencies = [
  "ratatui-core",
  "ratatui-crossterm",
@@ -6993,7 +6993,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7061,7 +7061,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7635,7 +7635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7884,7 +7884,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8968,7 +8968,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1,3 +1,4 @@
+use crate::lifecycle::session_history_transcript_items;
 use crate::render_helpers::{render_status_line, render_usage_line};
 use crate::strip_ansi;
 use crate::types::Tui;
@@ -159,6 +160,34 @@ fn tool_completed_to_transcript_items(
 }
 
 impl Tui {
+    fn open_detail_view_for_focused_item(&mut self) {
+        self.app.detail_view_scroll = {
+            let mut s = ratatui_widget_scrolling::ScrollState::new();
+            s.follow = false;
+            s
+        };
+        let focused_item = self
+            .app
+            .transcript_focus
+            .and_then(|focus| self.app.transcript.get(focus));
+        match focused_item {
+            Some(TranscriptItem::CompactionMarker { detail_text, .. }) => {
+                // The detail view always renders detail_text for a compaction
+                // marker (see render_detail_view), so a raw-YAML lookup here
+                // would be computed but never displayed. Skip it.
+                self.app.detail_view_text = Some(detail_text.clone());
+                self.app.detail_view_raw_yaml = None;
+            }
+            _ => {
+                self.app.detail_view_text = None;
+                self.app.detail_view_raw_yaml = self
+                    .selected_seq_range()
+                    .and_then(|(from, to)| self.config.read().get_message_range_yaml(from, to));
+            }
+        }
+        self.app.detail_view_open = true;
+    }
+
     async fn handle_detail_view_key(&mut self, key: KeyEvent) -> Result<()> {
         match (key.code, key.modifiers) {
             (KeyCode::Esc, KeyModifiers::NONE) => {
@@ -197,16 +226,7 @@ impl Tui {
                         self.app.transcript_focus = Some(focus_idx);
                         self.app.transcript_selection_anchor = None;
                         self.app.transcript_browsing = prior_browsing;
-                        self.app.detail_view_scroll = {
-                            let mut s = ratatui_widget_scrolling::ScrollState::new();
-                            s.follow = false;
-                            s
-                        };
-                        self.app.detail_view_raw_yaml =
-                            self.selected_seq_range().and_then(|(from, to)| {
-                                self.config.read().get_message_range_yaml(from, to)
-                            });
-                        self.app.detail_view_open = true;
+                        self.open_detail_view_for_focused_item();
                     }
                 }
             }
@@ -245,15 +265,7 @@ impl Tui {
             }
             (KeyCode::Enter, KeyModifiers::NONE) => {
                 // Open detail view for current focused item
-                self.app.detail_view_scroll = {
-                    let mut s = ratatui_widget_scrolling::ScrollState::new();
-                    s.follow = false;
-                    s
-                };
-                self.app.detail_view_raw_yaml = self
-                    .selected_seq_range()
-                    .and_then(|(from, to)| self.config.read().get_message_range_yaml(from, to));
-                self.app.detail_view_open = true;
+                self.open_detail_view_for_focused_item();
             }
             (KeyCode::Char('e'), KeyModifiers::NONE) => {
                 self.handle_transcript_edit().await?;
@@ -400,16 +412,7 @@ impl Tui {
                 self.handle_transcript_rewind();
             }
             (KeyCode::Enter, KeyModifiers::NONE) if self.app.transcript_focus.is_some() => {
-                self.app.detail_view_scroll = {
-                    let mut s = ratatui_widget_scrolling::ScrollState::new();
-                    s.follow = false;
-                    s
-                };
-                // Pre-load raw session YAML (same content .edit message would open).
-                self.app.detail_view_raw_yaml = self
-                    .selected_seq_range()
-                    .and_then(|(from, to)| self.config.read().get_message_range_yaml(from, to));
-                self.app.detail_view_open = true;
+                self.open_detail_view_for_focused_item();
             }
             (KeyCode::Enter, KeyModifiers::NONE) => {
                 if self.try_handle_attach_command().await {
@@ -1211,7 +1214,27 @@ impl Tui {
                 )]
             }
             AgentEvent::Session(SessionEvent::CompactingCompleted) => {
-                vec![TranscriptItem::SystemText("Session compacted.".to_string())]
+                self.app.transcript = session_history_transcript_items(&self.config);
+                self.app.streaming_assistant_idx = None;
+                // A compaction can land mid-turn after some assistant text has
+                // already streamed. The rebuild drops that streamed row, so the
+                // per-turn flag must also reset — otherwise the next
+                // ModelEvent::Final sees streamed_text_this_turn == true and
+                // skips rendering the final assistant row.
+                self.app.streamed_text_this_turn = false;
+                // The rebuild drops all SourceHeading entries, so the next
+                // output must re-emit its heading even if it shares the prior
+                // source. Without this, the first post-compaction message would
+                // render without an agent label.
+                self.app.last_ui_output_source = None;
+                self.clear_usage_tracking();
+                // The transcript is entirely rebuilt, so any prior focus/anchor
+                // indices reference now-different items even when still in
+                // bounds. Clear selection/detail state unconditionally.
+                self.app.transcript_focus = None;
+                self.app.transcript_selection_anchor = None;
+                self.pin_transcript_to_bottom();
+                vec![]
             }
             AgentEvent::Session(SessionEvent::CompactingFailed(err)) => {
                 vec![TranscriptItem::ErrorText(format!(
@@ -2341,6 +2364,7 @@ impl Tui {
                     self.run_command(&cmd).await?;
                     self.app.detail_view_open = false;
                     self.app.detail_view_raw_yaml = None;
+                    self.app.detail_view_text = None;
                     self.app.transcript_browsing = false;
                     self.app.transcript_focus = None;
                     self.app.transcript_selection_anchor = None;
@@ -2365,6 +2389,7 @@ impl Tui {
                     }
                     self.app.detail_view_open = false;
                     self.app.detail_view_raw_yaml = None;
+                    self.app.detail_view_text = None;
                     self.app.transcript_browsing = false;
                     self.app.transcript_focus = None;
                     self.app.transcript_selection_anchor = None;
@@ -2410,6 +2435,7 @@ impl Tui {
         match item {
             TranscriptItem::UserText { text, .. } => Some(text.clone()),
             TranscriptItem::AssistantText { text, .. } => Some(text.clone()),
+            TranscriptItem::CompactionMarker { detail_text, .. } => Some(detail_text.clone()),
             TranscriptItem::ToolCall {
                 tool_name,
                 body: Some(crate::types::ToolCallBody::Yaml(body)),

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -129,6 +129,7 @@ impl Tui {
             },
             detail_view_open: false,
             detail_view_raw_yaml: None,
+            detail_view_text: None,
             transcript_browsing: false,
             browsing_view_scroll: {
                 let mut s = ratatui_widget_scrolling::ScrollState::new();
@@ -497,6 +498,110 @@ pub(crate) fn messages_to_transcript_items(
     items
 }
 
+fn flatten_transcript_item_to_compaction_lines(item: &TranscriptItem, lines: &mut Vec<String>) {
+    match item {
+        TranscriptItem::UserText { text, .. }
+        | TranscriptItem::AssistantText { text, .. }
+        | TranscriptItem::SystemText(text)
+        | TranscriptItem::ErrorText(text)
+        | TranscriptItem::ThoughtText(text)
+        | TranscriptItem::StatusLine(text)
+        | TranscriptItem::UsageLine(text)
+        | TranscriptItem::AttachmentHeader(text)
+        | TranscriptItem::AttachmentItem(text)
+        | TranscriptItem::AttachmentPreviewLine(text)
+        | TranscriptItem::MutationNotice(text) => lines.extend(text.lines().map(str::to_string)),
+        TranscriptItem::ToolCall {
+            tool_name, body, ..
+        } => {
+            lines.push(format!("name: {tool_name}"));
+            match body {
+                Some(crate::types::ToolCallBody::Yaml(body))
+                | Some(crate::types::ToolCallBody::Markdown(body)) => {
+                    lines.extend(body.lines().map(str::to_string));
+                }
+                None => {}
+            }
+        }
+        TranscriptItem::ToolResultMarkdown { text, .. } => {
+            lines.extend(text.lines().map(str::to_string));
+        }
+        TranscriptItem::Plan(entries) => {
+            for entry in entries {
+                lines.push(format!("- [{}] {}", entry.status, entry.content));
+            }
+        }
+        TranscriptItem::SourceHeading(source) => {
+            lines.push(crate::render_helpers::source_heading(source));
+        }
+        TranscriptItem::CompactionMarker { text, .. } => lines.push(text.clone()),
+    }
+}
+
+fn compaction_section_label(item: &TranscriptItem) -> Option<String> {
+    match item {
+        TranscriptItem::UserText { .. } => Some("── user ──".to_string()),
+        TranscriptItem::AssistantText { .. } => Some("── assistant ──".to_string()),
+        TranscriptItem::ToolCall { tool_name, .. } => Some(format!("── tool call: {tool_name} ──")),
+        TranscriptItem::ToolResultMarkdown { .. } => Some("── tool result ──".to_string()),
+        TranscriptItem::ThoughtText(_) => Some("── thinking ──".to_string()),
+        _ => None,
+    }
+}
+
+fn append_message_compaction_detail_sections(
+    detail_sections: &mut Vec<String>,
+    message: &Message,
+    decl_map: &HashMap<String, ToolDeclaration>,
+) {
+    use harnx_core::message::MessageRole;
+
+    if message.role == MessageRole::System {
+        let text = message.content.to_text();
+        if !text.is_empty() {
+            detail_sections.push(format!(
+                "── system ──
+{text}"
+            ));
+        }
+        return;
+    }
+
+    for item in messages_to_transcript_items(std::slice::from_ref(message), decl_map) {
+        if let Some(label) = compaction_section_label(&item) {
+            let mut section_lines = vec![label];
+            flatten_transcript_item_to_compaction_lines(&item, &mut section_lines);
+            detail_sections.push(section_lines.join(
+                "
+",
+            ));
+        }
+    }
+}
+
+fn build_compaction_marker(
+    messages: &[Message],
+    decl_map: &HashMap<String, ToolDeclaration>,
+) -> TranscriptItem {
+    let from_seq = messages.iter().filter_map(|msg| msg.log_seq).min();
+    let to_seq = messages.iter().filter_map(|msg| msg.log_seq).max();
+    let mut detail_sections = Vec::new();
+    for message in messages {
+        append_message_compaction_detail_sections(&mut detail_sections, message, decl_map);
+    }
+    let detail_text = detail_sections.join(
+        "
+
+",
+    );
+    TranscriptItem::CompactionMarker {
+        text: "─── session compacted ───".to_string(),
+        from_seq,
+        to_seq,
+        detail_text,
+    }
+}
+
 pub(crate) fn session_history_transcript_items(config: &GlobalConfig) -> Vec<TranscriptItem> {
     let cfg = config.read();
     let session = match cfg.session.as_ref() {
@@ -514,12 +619,9 @@ pub(crate) fn session_history_transcript_items(config: &GlobalConfig) -> Vec<Tra
         .collect();
     let mut items = Vec::new();
     if !session.compressed_messages.is_empty() {
-        items.extend(messages_to_transcript_items(
+        items.push(build_compaction_marker(
             &session.compressed_messages,
             &decl_map,
-        ));
-        items.push(TranscriptItem::SystemText(
-            "─── session compacted ───".to_string(),
         ));
     }
     items.extend(messages_to_transcript_items(&session.messages, &decl_map));

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -136,6 +136,17 @@ impl Tui {
                 );
                 RenderedEntry::from_lines(lines, width)
             }
+            TranscriptItem::CompactionMarker { text, .. } => {
+                let lines = Self::render_text_entry(
+                    "",
+                    text,
+                    Style::default()
+                        .fg(Color::DarkGray)
+                        .add_modifier(Modifier::DIM),
+                    false,
+                );
+                RenderedEntry::from_lines(lines, width)
+            }
             TranscriptItem::SystemText(text) => {
                 let lines = Self::render_text_entry(
                     "",
@@ -1054,6 +1065,24 @@ impl Tui {
                 lines.push(Line::from(Span::styled("── source ──", label_style)));
                 push_field!("source", &crate::render_helpers::source_heading(source));
             }
+            TranscriptItem::CompactionMarker {
+                text,
+                from_seq,
+                to_seq,
+                detail_text,
+            } => {
+                lines.push(Line::from(Span::styled(
+                    "── compacted session ──",
+                    label_style,
+                )));
+                push_field!("text", text);
+                let seq_range = match (from_seq, to_seq) {
+                    (Some(from), Some(to)) => format!("{from}–{to}"),
+                    _ => "n/a".to_string(),
+                };
+                push_field!("seq_range", seq_range);
+                push_field!("detail", detail_text);
+            }
             TranscriptItem::SystemText(text) => {
                 lines.push(Line::from(Span::styled("── system ──", label_style)));
                 push_field!("text", text);
@@ -1132,7 +1161,13 @@ impl Tui {
         // Fallback: render_entry_detail() for items that have no seq number or
         // when no session is active.
         let (entries_as_vec, title): (Vec<Vec<Line<'static>>>, String) =
-            if let Some(yaml) = &self.app.detail_view_raw_yaml {
+            if let Some(text) = &self.app.detail_view_text {
+                let entries = vec![text
+                    .lines()
+                    .map(|line| Line::from(Span::raw(line.to_string())))
+                    .collect()];
+                (entries, "Compacted session".to_string())
+            } else if let Some(yaml) = &self.app.detail_view_raw_yaml {
                 // Split on the same separator edit_message_range joins with.
                 let docs: Vec<&str> = yaml.split("\n---\n").collect();
                 let doc_count = docs.len();

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -67,6 +67,47 @@ fn test_config_with_mock_client_and_agent(
     config
 }
 
+fn make_compacted_message(
+    role: harnx_core::message::MessageRole,
+    content: harnx_core::message::MessageContent,
+    log_seq: usize,
+) -> harnx_core::message::Message {
+    harnx_core::message::Message {
+        role,
+        content,
+        log_seq: Some(log_seq),
+        log_timestamp: None,
+    }
+}
+
+fn seed_compressed_session(config: &GlobalConfig) {
+    let mut guard = config.write();
+    let mut session = harnx_runtime::config::session::new(&guard, "compacted").unwrap();
+    session.compressed_messages = vec![
+        make_compacted_message(
+            harnx_core::message::MessageRole::System,
+            harnx_core::message::MessageContent::Text("Old system note".to_string()),
+            0,
+        ),
+        make_compacted_message(
+            harnx_core::message::MessageRole::User,
+            harnx_core::message::MessageContent::Text("Old question".to_string()),
+            1,
+        ),
+        make_compacted_message(
+            harnx_core::message::MessageRole::Assistant,
+            harnx_core::message::MessageContent::Text("Old answer".to_string()),
+            2,
+        ),
+    ];
+    session.messages = vec![make_compacted_message(
+        harnx_core::message::MessageRole::User,
+        harnx_core::message::MessageContent::Text("Current question".to_string()),
+        3,
+    )];
+    guard.session = Some(session);
+}
+
 fn normalize_screen(contents: &str) -> String {
     let trimmed = contents
         .lines()
@@ -7741,14 +7782,41 @@ async fn render_agent_event_compacting_started_produces_transcript_entry() {
 }
 
 #[tokio::test]
-async fn render_agent_event_compacting_completed_produces_transcript_entry() {
-    let config = test_config();
+async fn render_agent_event_compacting_completed_reconciles_live_transcript() {
+    let config = test_config_with_mock_client_and_agent("test-agent", None);
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
     let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
         .await
         .unwrap();
 
-    // First emit CompactingStarted
+    tui.app.transcript = vec![
+        TranscriptItem::UserText {
+            text: "Old question".to_string(),
+            seq: Some(1),
+            timestamp: None,
+        },
+        TranscriptItem::AssistantText {
+            text: "Old answer".to_string(),
+            seq: Some(2),
+            timestamp: None,
+            rendered_cache: None,
+        },
+        TranscriptItem::UserText {
+            text: "Current question".to_string(),
+            seq: Some(3),
+            timestamp: None,
+        },
+    ];
+    tui.app.streaming_assistant_idx = Some(1);
+    tui.app.last_usage_transcript_idx = Some(2);
+    tui.app.last_usage_source = Some(AgentSource {
+        agent: "primary".to_string(),
+        session_id: None,
+        model: None,
+    });
+    tui.app.transcript_focus = Some(99);
+    tui.app.transcript_selection_anchor = Some(88);
+
     tui.handle_tui_event(TuiEvent::Agent(
         AgentEvent::Session(SessionEvent::CompactingStarted),
         None,
@@ -7756,7 +7824,8 @@ async fn render_agent_event_compacting_completed_produces_transcript_entry() {
     .await
     .unwrap();
 
-    // Then emit CompactingCompleted
+    seed_compressed_session(&config);
+
     tui.handle_tui_event(TuiEvent::Agent(
         AgentEvent::Session(SessionEvent::CompactingCompleted),
         None,
@@ -7764,25 +7833,86 @@ async fn render_agent_event_compacting_completed_produces_transcript_entry() {
     .await
     .unwrap();
 
-    // Should have both transcript items
-    let items: Vec<_> = tui
+    assert_eq!(
+        tui.app
+            .transcript
+            .iter()
+            .filter(|item| matches!(item, TranscriptItem::CompactionMarker { .. }))
+            .count(),
+        1
+    );
+    assert_eq!(
+        tui.app
+            .transcript
+            .iter()
+            .filter(|item| matches!(item, TranscriptItem::SystemText(text) if text == "Compacting session…"))
+            .count(),
+        0
+    );
+    assert_eq!(
+        tui.app
+            .transcript
+            .iter()
+            .filter(|item| matches!(item, TranscriptItem::UserText { text, .. } if text == "Old question"))
+            .count(),
+        0
+    );
+    assert_eq!(
+        tui.app
+            .transcript
+            .iter()
+            .filter(|item| matches!(item, TranscriptItem::AssistantText { text, .. } if text == "Old answer"))
+            .count(),
+        0
+    );
+    assert_eq!(
+        tui.app
+            .transcript
+            .iter()
+            .filter(|item| matches!(item, TranscriptItem::UserText { text, .. } if text == "Current question"))
+            .count(),
+        1
+    );
+    // seed_compressed_session assigns log_seq 0,1,2 to the compressed
+    // messages, so the marker must span that full range.
+    assert!(matches!(
+        tui.app.transcript.first(),
+        Some(TranscriptItem::CompactionMarker { text, detail_text, from_seq, to_seq })
+            if text == "─── session compacted ───"
+                && detail_text.contains("Old question")
+                && detail_text.contains("Old answer")
+                && *from_seq == Some(0)
+                && *to_seq == Some(2)
+    ));
+    assert!(tui.app.transcript[0].is_navigable());
+    assert_eq!(tui.app.streaming_assistant_idx, None);
+    assert_eq!(tui.app.last_usage_transcript_idx, None);
+    assert_eq!(tui.app.last_usage_source, None);
+    assert_eq!(tui.app.transcript_focus, None);
+    assert_eq!(tui.app.transcript_selection_anchor, None);
+}
+
+#[tokio::test]
+async fn session_history_compaction_detail_includes_system_messages() {
+    let config = test_config_with_mock_client_and_agent("test-agent", None);
+    seed_compressed_session(&config);
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    let marker = tui
         .app
         .transcript
         .iter()
-        .filter_map(|item| match item {
-            TranscriptItem::SystemText(text) => Some(text.clone()),
+        .find_map(|item| match item {
+            TranscriptItem::CompactionMarker { detail_text, .. } => Some(detail_text),
             _ => None,
         })
-        .collect();
+        .expect("expected compaction marker");
 
-    assert!(
-        items.contains(&"Compacting session…".to_string()),
-        "Expected 'Compacting session…' in transcript"
-    );
-    assert!(
-        items.contains(&"Session compacted.".to_string()),
-        "Expected 'Session compacted.' in transcript"
-    );
+    assert!(marker.contains("── system ──"));
+    assert!(marker.contains("Old system note"));
 }
 
 #[tokio::test]
@@ -7831,4 +7961,96 @@ async fn render_agent_event_compacting_failed_produces_error_transcript_entry() 
             .any(|s| s.contains("Compaction failed: test error")),
         "Expected 'Compaction failed: test error' in transcript"
     );
+}
+
+#[tokio::test]
+async fn session_history_compaction_is_single_navigable_item() {
+    let config = test_config();
+    seed_compressed_session(&config);
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    let compaction_items: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .filter(|item| matches!(item, TranscriptItem::CompactionMarker { .. }))
+        .collect();
+    assert_eq!(compaction_items.len(), 1);
+    assert!(compaction_items[0].is_navigable());
+    assert!(!tui.app.transcript.iter().any(|item| {
+        matches!(item, TranscriptItem::UserText { text, .. } if text == "Old question")
+            || matches!(item, TranscriptItem::AssistantText { text, .. } if text == "Old answer")
+    }));
+}
+
+#[tokio::test]
+async fn transcript_navigation_can_focus_compaction_marker() {
+    let config = test_config();
+    seed_compressed_session(&config);
+    let mut harness = TuiTestHarness::with_config(config).await;
+
+    // Locate indices dynamically so the test does not depend on the exact
+    // bootstrap transcript ordering.
+    let marker_idx = harness
+        .tui()
+        .app
+        .transcript
+        .iter()
+        .position(|item| matches!(item, TranscriptItem::CompactionMarker { .. }))
+        .expect("compaction marker present");
+    // The navigable item immediately after the marker (e.g. "Current question").
+    let after_marker_idx = (marker_idx + 1..harness.tui().app.transcript.len())
+        .find(|&i| harness.tui().app.transcript[i].is_navigable())
+        .expect("navigable item after marker");
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+        .await
+        .unwrap();
+    assert_eq!(harness.tui().app.transcript_focus, Some(after_marker_idx));
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+        .await
+        .unwrap();
+    assert_eq!(harness.tui().app.transcript_focus, Some(marker_idx));
+    assert!(matches!(
+        harness.tui().app.transcript.get(marker_idx),
+        Some(TranscriptItem::CompactionMarker { .. })
+    ));
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+        .await
+        .unwrap();
+    assert_eq!(harness.tui().app.transcript_focus, Some(after_marker_idx));
+}
+
+#[tokio::test]
+async fn enter_on_compaction_marker_opens_full_detail_view() {
+    let config = test_config();
+    seed_compressed_session(&config);
+    let mut harness = TuiTestHarness::with_config(config).await;
+    harness.tui().app.transcript_focus = Some(1);
+
+    harness
+        .tui()
+        .handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert!(harness.tui().app.detail_view_open);
+    let detail = harness.tui().app.detail_view_text.clone();
+    assert!(detail.as_deref().is_some_and(|text| {
+        text.contains("── user ──")
+            && text.contains("Old question")
+            && text.contains("── assistant ──")
+            && text.contains("Old answer")
+    }));
 }

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -111,6 +111,7 @@ pub(super) struct App {
     /// detail_view_open is set.  None when no session is active or the item
     /// has no sequence number.
     pub(super) detail_view_raw_yaml: Option<String>,
+    pub(super) detail_view_text: Option<String>,
     /// True when the user is browsing history in fullscreen mode.
     /// Distinct from detail_view_open which shows raw YAML.
     pub(super) transcript_browsing: bool,
@@ -238,6 +239,12 @@ pub enum TranscriptItem {
         rendered_cache: RenderedCache,
     },
     StatusLine(String),
+    CompactionMarker {
+        text: String,
+        from_seq: Option<usize>,
+        to_seq: Option<usize>,
+        detail_text: String,
+    },
     Plan(Vec<PlanEntry>),
     UsageLine(String),
     ToolCall {
@@ -276,6 +283,7 @@ impl TranscriptItem {
             TranscriptItem::UserText { .. }
                 | TranscriptItem::AssistantText { .. }
                 | TranscriptItem::ToolCall { .. }
+                | TranscriptItem::CompactionMarker { .. }
         )
     }
 }

--- a/docs/solutions/integration-issues/tui-compaction-marker-detail-view-2026-06-12.md
+++ b/docs/solutions/integration-issues/tui-compaction-marker-detail-view-2026-06-12.md
@@ -1,0 +1,216 @@
+---
+title: "TUI compaction marker as single navigable event with detail view"
+date: 2026-06-12
+category: integration-issues
+problem_type: integration_issue
+component: "harnx-tui"
+root_cause: "aggregated transcript items were rendered as non-navigable SystemText, preventing users from viewing compacted content as one event"
+resolution_type: code_fix
+severity: medium
+tags:
+  - tui
+  - ratatui
+  - transcript
+  - compaction
+  - navigation
+  - detail-view
+plan_ref: view-compaction-details
+---
+
+## Problem
+
+After session compaction, the TUI transcript showed a `─── session compacted ───` marker as a plain non-navigable `TranscriptItem::SystemText`. Compacted messages expanded into individual transcript items. Pressing UP highlighted individual lines and ENTER showed just one message — users couldn't view the full compacted output as one navigable event.
+
+## Symptoms
+
+- Compaction marker appeared as dim text, not selectable via UP/DOWN
+- Compacted messages rendered as separate transcript lines
+- ENTER on any compacted line showed only that single message
+- No way to view the complete compacted session as one coherent event
+
+## Investigation Steps
+
+1. Examined `TranscriptItem` enum in `types.rs` — only `UserText`, `AssistantText`, `ToolCall` had `seq()` returning `Some`, making them navigable
+2. Traced `session_history_transcript_items()` in `lifecycle.rs` — expanded `compressed_messages` into individual `TranscriptItem`s with a trailing `SystemText` marker
+3. Reviewed `is_navigable()` — `SystemText` returns `false`, so marker wasn't focusable
+4. Identified that `messages_to_transcript_items()` skips `MessageRole::System`, omitting system messages from detail text
+5. Found live `CompactingCompleted` event handler appended markers but didn't rebuild transcript, leaving stale items visible
+
+## Root Cause
+
+Three design gaps:
+
+1. **String-matching for marker type**: Using `SystemText` prevented type-specific behavior and required fragile string matching to detect compaction markers
+2. **No navigable aggregate pattern**: Transcript items without message seq couldn't be focused, even when they represent viewable aggregate events
+3. **Live/reload path divergence**: History rebuild (clean slate) vs. live event append (accumulates) produced different transcript states
+
+## Solution
+
+### 1. Dedicated transcript item variant
+
+Added `TranscriptItem::CompactionMarker { text, from_seq, to_seq, detail_text }` in `types.rs`:
+
+```rust
+pub enum TranscriptItem {
+    // ... existing variants ...
+    CompactionMarker {
+        text: String,           // "─── session compacted ───"
+        from_seq: Option<usize>,
+        to_seq: Option<usize>,
+        detail_text: String,    // Pre-rendered human-readable content
+    },
+}
+```
+
+**Key design:** `is_navigable()` returns `true` for `CompactionMarker`, but `seq()` returns `None`. This makes the marker focusable for viewing while keeping edit/delete/rewind operations message-only.
+
+### 2. Navigation model
+
+In `types.rs`:
+
+```rust
+impl TranscriptItem {
+    pub fn is_navigable(&self) -> bool {
+        matches!(self, Self::UserText { .. } | Self::AssistantText { .. } 
+                     | Self::ToolCall { .. } | Self::CompactionMarker { .. })
+    }
+    
+    pub fn seq(&self) -> Option<usize> {
+        match self {
+            Self::UserText { seq, .. } => Some(*seq),
+            Self::AssistantText { seq, .. } => Some(*seq),
+            Self::ToolCall { seq, .. } => Some(*seq),
+            _ => None,  // CompactionMarker intentionally excluded
+        }
+    }
+}
+```
+
+Adding navigable items without seq is the right pattern for view-only aggregate events.
+
+### 3. Detail view dual-state pattern
+
+Added `detail_view_text: Option<String>` to `App` struct alongside existing `detail_view_raw_yaml`:
+
+```rust
+pub struct App {
+    // ... existing fields ...
+    pub detail_view_raw_yaml: Option<String>,  // YAML for seq-based messages
+    pub detail_view_text: Option<String>,      // Plain text for CompactionMarker
+}
+```
+
+Render priority in `render.rs`:
+
+```rust
+fn render_detail_view(...) {
+    if let Some(text) = &app.detail_view_text {
+        // Render plain text with title "Compacted session"
+    } else if let Some(yaml) = &app.detail_view_raw_yaml {
+        // Render YAML documents
+    } else {
+        // Fallback: render_entry_detail()
+    }
+}
+```
+
+### 4. Detail text construction
+
+In `lifecycle.rs`, `build_compaction_marker()` prefetches `detail_text` by flattening compressed messages:
+
+```rust
+fn build_compaction_marker(messages: &[Message], config: &GlobalConfig) -> TranscriptItem {
+    let detail_text = messages_to_transcript_items(messages, config)
+        .into_iter()
+        .flat_map(|item| flatten_transcript_item_to_compaction_lines(item))
+        .collect::<Vec<_>>()
+        .join("\n");
+    
+    TranscriptItem::CompactionMarker {
+        text: "─── session compacted ───".into(),
+        from_seq: min_seq,
+        to_seq: max_seq,
+        detail_text,
+    }
+}
+```
+
+**Critical:** Include `MessageRole::System` in `messages_to_transcript_items` and add `compaction_section_label` arm for system messages (`── system ──`). System messages contribute to token usage and belong in the compacted view.
+
+### 5. Live event handler MUST rebuild
+
+**CRITICAL gotcha:** The live `CompactingCompleted` event handler must REBUILD the transcript from `session_history_transcript_items(&config)`, NOT append a marker:
+
+```rust
+SessionEvent::CompactingCompleted => {
+    // WRONG: self.app.transcript.push(marker);
+    // RIGHT:
+    self.app.transcript = Self::session_history_transcript_items(&self.config);
+    
+    // Reset transcript-index-dependent state:
+    self.app.streaming_assistant_idx = None;
+    self.reset_usage_tracking();
+    self.app.transcript_focus = None;  // Or clamp to valid range
+    self.app.transcript_selection_anchor = None;
+    self.app.last_ui_output_source = None;  // Else next same-source output skips SourceHeading
+}
+```
+
+**Why:** Without rebuild, just-compacted messages remain visible (duplication), and cumulative `compressed_messages` produce overlapping markers on repeated compactions.
+
+### 6. Centralized detail-open helper
+
+In `input.rs`, unify ENTER handling across modes:
+
+```rust
+fn open_detail_view_for_focused_item(&mut self) {
+    let focused = self.app.transcript.get(focus_idx);
+    match focused {
+        Some(TranscriptItem::CompactionMarker { detail_text, .. }) => {
+            // The detail view always renders detail_text for a marker, so a
+            // seq-based YAML lookup here would be computed but never shown.
+            // Use the precomputed detail_text exclusively and leave raw_yaml None.
+            self.app.detail_view_text = Some(detail_text.clone());
+            self.app.detail_view_raw_yaml = None;
+        }
+        Some(other) if other.seq().is_some() => {
+            self.app.detail_view_text = None;  // Clear for normal messages
+            // ... populate detail_view_raw_yaml from seq range ...
+        }
+        _ => {}
+    }
+    self.app.detail_view_open = true;
+}
+```
+
+## Why This Works
+
+1. **Dedicated variant**: Localizes behavior, carries data needed (detail_text + optional seq range), avoids string-matching
+2. **seq() returns None**: Edit/delete/rewind (via `selected_seq_range()`) operate only on messages, not aggregate markers
+3. **`is_navigable()` controls arrow-key focus**: Marker participates in UP/DOWN navigation and ENTER detail view
+4. **Rebuild on live event**: Ensures live and reload paths converge, removing stale items and preventing cumulative marker bugs
+5. **Prefetched detail_text**: Avoids computing seq-based YAML for items that always render plain text
+6. **Dual-state render priority**: `detail_view_text` first (for markers), `detail_view_raw_yaml` second (for messages)
+
+## Prevention Strategies
+
+**Test Cases:**
+- History reload: single navigable marker, no expanded compressed items
+- Navigation: UP/DOWN focuses marker
+- ENTER: opens detail view showing full `detail_text`
+- Live `CompactingCompleted`: assert transcript equals `session_history_transcript_items()` output
+- Multiple compactions: one marker after N compactions, no duplicates
+- System messages: included in compacted detail text
+
+**Code Review Checklist:**
+- [ ] Does new `TranscriptItem` variant need `is_navigable()`?
+- [ ] Should edit/delete/rewind operate on this item? If not, `seq()` returns `None`
+- [ ] Do live event and reload paths converge? (Both call same builder)
+- [ ] Is transcript-index-dependent state reset on rebuild?
+- [ ] Is `detail_view_text` cleared when opening normal message detail?
+
+## Related Issues
+
+- **Plan:** view-compaction-details (GH-562)
+- **Related Solution:** [tui-compaction-spinner-corruption-2026-06-08.md](tui-compaction-spinner-corruption-2026-06-08.md) — AgentEvent-based compaction progress
+- **Related Solution:** [tui-transcript-focus-navigation-2026-05-01.md](tui-transcript-focus-navigation-2026-05-01.md) — Focus state model


### PR DESCRIPTION
Compaction now renders as one navigable transcript event. ENTER opens a detail view showing the full compacted session output (including system messages). Live CompactingCompleted rebuilds the transcript to match the history-reload path, fixing duplication and overlapping markers. Copy and insert operations now work on the marker.

Issue: #562

Plan: view-compaction-details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compacted sessions now appear as a single navigable item with a dedicated detail view showing the full compacted content.
  * Users can navigate to and open compaction markers to review compacted conversation history.

* **Bug Fixes**
  * Session compaction now properly rebuilds the transcript instead of incorrectly appending multiple items.
  * Compaction markers are now correctly treated as navigable elements in the interface.

* **Documentation**
  * Added integration issue documentation detailing session compaction marker improvements and prevention guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->