### PR TITLE
feat(sandbox): auto-whitelist Homebrew prefix and fix /usr/local defaults

### DIFF
--- a/.changeset/homebrew-prefix-auto-whitelist.md
+++ b/.changeset/homebrew-prefix-auto-whitelist.md
@@ -1,0 +1,7 @@
+---
+harnx: minor
+---
+Auto-whitelist the Homebrew install prefix in the default sandbox allowlist so Homebrew-managed tools work without manual overrides.
+
+- The Homebrew prefix is granted read+execute (never write) by default. The location is resolved dynamically: `HOMEBREW_PREFIX` is honoured when set, otherwise a compile-time platform default is used (`/opt/homebrew` on macOS, `/home/linuxbrew/.linuxbrew` on Linux). No runtime OS detection is performed.
+- Fix a `/usr/local` static-path oversight: `/usr/local` is now readable on both Linux and macOS, and `/usr/local/lib` is now executable on Linux (macOS already had it) so dynamically linked binaries can load their dylibs (#818).

--- a/crates/harnx-mcp-bash/src/server/tests.rs
+++ b/crates/harnx-mcp-bash/src/server/tests.rs
@@ -592,6 +592,62 @@ mod sandbox_args {
 
     #[cfg(unix)]
     #[test]
+    fn test_sandbox_args_honours_homebrew_prefix_env_var() {
+        let _env_guard = env_lock();
+        let _homebrew = EnvVar::set("HOMEBREW_PREFIX", "/custom/homebrew");
+
+        let pairs = sandbox_arg_pairs(
+            Path::new("/test/root"),
+            Path::new("/test/root/workdir"),
+            None,
+            None,
+        );
+
+        // The Homebrew prefix is granted read+execute (exec implies read).
+        assert_arg_pair_present(&pairs, "--exec", "/custom/homebrew");
+        // Never writable: a writable+executable prefix would let sandboxed code
+        // plant binaries the host later runs (security precedent).
+        assert_arg_pair_absent(&pairs, "--write", "/custom/homebrew");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_sandbox_args_homebrew_prefix_macos_fallback() {
+        let _env_guard = env_lock();
+        let _homebrew = EnvVar::unset("HOMEBREW_PREFIX");
+
+        let pairs = sandbox_arg_pairs(
+            Path::new("/test/root"),
+            Path::new("/test/root/workdir"),
+            None,
+            None,
+        );
+
+        // With HOMEBREW_PREFIX unset, the macOS compile-time default applies.
+        assert_arg_pair_present(&pairs, "--exec", "/opt/homebrew");
+        assert_arg_pair_absent(&pairs, "--write", "/opt/homebrew");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_sandbox_args_homebrew_prefix_linux_fallback() {
+        let _env_guard = env_lock();
+        let _homebrew = EnvVar::unset("HOMEBREW_PREFIX");
+
+        let pairs = sandbox_arg_pairs(
+            Path::new("/test/root"),
+            Path::new("/test/root/workdir"),
+            None,
+            None,
+        );
+
+        // With HOMEBREW_PREFIX unset, the Linux compile-time default applies.
+        assert_arg_pair_present(&pairs, "--exec", "/home/linuxbrew/.linuxbrew");
+        assert_arg_pair_absent(&pairs, "--write", "/home/linuxbrew/.linuxbrew");
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn test_sandbox_args_empty_outputs() {
         let pairs = sandbox_arg_pairs(
             Path::new("/test/root"),

--- a/crates/harnx-sandbox-common/src/defaults.rs
+++ b/crates/harnx-sandbox-common/src/defaults.rs
@@ -23,6 +23,7 @@ pub const SYSTEM_EXEC_PATHS: &[&str] = &[
     "/usr/bin",
     "/bin",
     "/usr/local/bin",
+    "/usr/local/lib",
     "/usr/sbin",
     "/sbin",
     "/usr/lib",
@@ -64,9 +65,13 @@ pub const SYSTEM_EXEC_PATHS: &[&str] = &[
 pub const SYSTEM_EXEC_PATHS: &[&str] = &["/usr/bin", "/bin", "/tmp", "/etc"];
 
 #[cfg(target_os = "linux")]
-pub const SYSTEM_READ_PATHS: &[&str] = &["/usr/include", "/usr/include/x86_64-linux-gnu"];
+pub const SYSTEM_READ_PATHS: &[&str] = &[
+    "/usr/local",
+    "/usr/include",
+    "/usr/include/x86_64-linux-gnu",
+];
 #[cfg(target_os = "macos")]
-pub const SYSTEM_READ_PATHS: &[&str] = &[];
+pub const SYSTEM_READ_PATHS: &[&str] = &["/usr/local"];
 #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
 pub const SYSTEM_READ_PATHS: &[&str] = &["/usr/include"];
 
@@ -207,6 +212,51 @@ pub fn push_env_relative_defaults(args: &mut Vec<OsString>) {
         args.push(gocache.clone().into_os_string());
         args.push(OsString::from("--write"));
         args.push(gocache.into_os_string());
+    }
+    push_homebrew_defaults(args);
+}
+
+/// Compile-time default Homebrew install prefix for the current platform, used
+/// only when `HOMEBREW_PREFIX` is unset. Returns `None` on platforms without a
+/// conventional Homebrew location so nothing is granted there.
+///
+/// Selection is purely compile-time via `#[cfg(target_os)]` — no runtime OS
+/// detection (`uname`, `/etc/os-release`) is performed.
+#[cfg(unix)]
+fn default_homebrew_prefix() -> Option<&'static str> {
+    #[cfg(target_os = "macos")]
+    {
+        Some("/opt/homebrew")
+    }
+    #[cfg(target_os = "linux")]
+    {
+        Some("/home/linuxbrew/.linuxbrew")
+    }
+    #[cfg(all(unix, not(any(target_os = "macos", target_os = "linux"))))]
+    {
+        None
+    }
+}
+
+/// Grant the Homebrew install prefix read+execute access so sandboxed commands
+/// can run Homebrew-managed binaries and load their dylibs without manual
+/// overrides. The location varies per install, so it is resolved dynamically
+/// here rather than living in the static `SYSTEM_EXEC_PATHS` list.
+///
+/// Resolution order: honour `HOMEBREW_PREFIX` when set; otherwise fall back to
+/// the compile-time platform default. Emits `--exec` only (read + execute) —
+/// `--write` is never granted by default, matching the least-privilege
+/// precedent for exec paths (a writable+executable prefix would let sandboxed
+/// code plant binaries the host later runs).
+#[cfg(unix)]
+fn push_homebrew_defaults(args: &mut Vec<OsString>) {
+    let prefix = match std::env::var_os("HOMEBREW_PREFIX") {
+        Some(prefix) => Some(PathBuf::from(prefix)),
+        None => default_homebrew_prefix().map(PathBuf::from),
+    };
+    if let Some(prefix) = prefix {
+        args.push(OsString::from("--exec"));
+        args.push(prefix.into_os_string());
     }
 }
 


### PR DESCRIPTION

Add dynamic Homebrew prefix detection to the sandbox default allowlist via push_env_relative_defaults: honour HOMEBREW_PREFIX when set, else fall back to a compile-time platform default (/opt/homebrew on macOS, /home/linuxbrew/.linuxbrew on Linux). Granted read+execute only (never write), matching the least-privilege precedent for exec paths. Compile-time cfg!(target_os) only; no runtime OS detection.

Also fix a /usr/local static-path oversight: /usr/local is now readable on both platforms and /usr/local/lib is executable on Linux (macOS already had it).

Refs #818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox now automatically whitelists Homebrew installation prefix with read+execute access.

* **Bug Fixes**
  * Fixed `/usr/local` readability on Linux and macOS.
  * Fixed `/usr/local/lib` executability on Linux for dynamic library loading.

* **Tests**
  * Added sandbox behavior tests for Homebrew prefix handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->