### PR TITLE
fix(runtime): scope managers to package on async agent activation (#826)

### DIFF
--- a/.changeset/fix-package-agent-async-activation-scope.md
+++ b/.changeset/fix-package-agent-async-activation-scope.md
@@ -1,0 +1,22 @@
+---
+harnx: patch
+---
+Fix package agents losing their delegation tools when activated directly (#826).
+
+When a package agent (e.g. `pantheon/atlas`) was activated through the async
+`Config::use_agent` path — used by `--agent`, handoff `switch_agent`, and the
+ACP server — the MCP/ACP managers were never re-scoped to the agent's package.
+They stayed in the global scope left by `Config::init`, so every package server
+was emitted with a `<package>__` prefix. Two visible symptoms resulted:
+
+- The agent's own same-package ACP delegation tools were emitted as
+  `<package>__<peer>_session_prompt` instead of the bare `<peer>_session_prompt`
+  its `use_tools` allow-list references, so they were filtered out and the agent
+  could not delegate.
+- Same-package MCP tools leaked in under both `<package>__*` and sibling-package
+  namespaces (e.g. `coding__*`) instead of their bare same-package names.
+
+The intermittency depended on which activation path ran: the synchronous
+`use_agent_obj` path already scoped the managers, while the async `use_agent`
+path did not. `use_agent` now mirrors `use_agent_obj` and re-scopes the managers
+to the incoming agent's package before the agent's tools are snapshotted.

--- a/crates/harnx-runtime/src/config/agent_ops_split.rs
+++ b/crates/harnx-runtime/src/config/agent_ops_split.rs
@@ -79,19 +79,46 @@ impl Config {
         self.use_agent_obj(agent)
     }
 
+    /// Reinitialize the MCP/ACP managers so they are scoped to the package of
+    /// the agent named `agent_name` (or to the global, no-package view for a
+    /// top-level agent).
+    ///
+    /// This MUST run before the agent's tool declarations are read/snapshotted
+    /// (e.g. `agent::init` calls `mcp_manager.get_all_tools()`), otherwise the
+    /// agent inherits whatever scope the managers were last left in — typically
+    /// the global (`None`) scope from `Config::init`, which prefixes every
+    /// package server (`<pkg>__*`) and breaks same-package delegation and tool
+    /// naming (#826).
+    ///
+    /// Both agent-activation paths funnel their scoping decision through here so
+    /// the logic cannot drift between them again:
+    /// - the synchronous `use_agent_obj` path, and
+    /// - the asynchronous `use_agent` path.
+    pub(super) fn scope_managers_for_agent(&mut self, agent_name: &str) {
+        let agent_package =
+            harnx_core::package_namespace::pkg_from_qualified(agent_name).map(str::to_string);
+        self.reinit_managers_for_agent(agent_package.as_deref());
+    }
+
+    /// Install an already-built, already-scoped agent as the active agent.
+    ///
+    /// Assumes the managers have already been scoped for this agent via
+    /// [`scope_managers_for_agent`]. Use [`use_agent_obj`] when you have a
+    /// freshly built agent and still need the managers scoped.
+    pub(super) fn set_active_agent(&mut self, agent: Agent) {
+        self.agent = Some(agent);
+    }
+
     pub fn use_agent_obj(&mut self, agent: Agent) -> Result<()> {
         if self.agent.is_some() {
             self.exit_agent()?;
         }
 
-        // Reinitialize MCP/ACP managers scoped to the incoming agent's package
-        // (or None for top-level agents). This gives the agent a clean view:
-        // same-package MCP servers appear under their bare names, others prefixed.
-        let agent_package =
-            harnx_core::package_namespace::pkg_from_qualified(agent.name()).map(str::to_string);
-        self.reinit_managers_for_agent(agent_package.as_deref());
-
-        self.agent = Some(agent);
+        // Scope MCP/ACP managers to the incoming agent's package (or None for
+        // top-level agents) so same-package MCP servers appear under their bare
+        // names and others stay prefixed.
+        self.scope_managers_for_agent(agent.name());
+        self.set_active_agent(agent);
         Ok(())
     }
 
@@ -205,26 +232,20 @@ impl Config {
         }
         // Scope the MCP/ACP managers to the incoming agent's package BEFORE
         // `agent::init` snapshots the MCP tool declarations (it reads
-        // `mcp_manager.get_all_tools()` during init). Without this, a package
-        // agent activated through this async path inherits the global (`None`)
-        // manager scope left by `Config::init`, so every package server is
-        // prefixed: same-package MCP tools leak in under both `<pkg>__*` and
-        // sibling-package namespaces, and the agent's own ACP delegation tools
-        // are emitted as `<pkg>__<agent>_session_prompt` instead of the bare
-        // `<agent>_session_prompt` its `use_tools` allow-list references — so
-        // they are filtered out and the agent cannot delegate (#826).
+        // `mcp_manager.get_all_tools()` during init). Without this the agent
+        // would inherit the global (`None`) scope left by `Config::init` and
+        // its same-package tools would be wrongly prefixed (#826).
         //
-        // This mirrors the synchronous `use_agent_obj` path, which already
-        // scopes managers before the agent's tools are read.
-        let agent_package =
-            harnx_core::package_namespace::pkg_from_qualified(agent_name).map(str::to_string);
-        config
-            .write()
-            .reinit_managers_for_agent(agent_package.as_deref());
+        // Scoping + install go through the same `scope_managers_for_agent` /
+        // `set_active_agent` helpers as the synchronous `use_agent_obj` path, so
+        // the two activation paths cannot drift apart. We scope here (rather than
+        // letting `use_agent_obj` do it after the build) because the async build
+        // snapshots the agent's tools and must see the scoped managers.
+        config.write().scope_managers_for_agent(agent_name);
         let agent = self::agent::init(config, agent_name, abort_signal).await?;
         let session = session_name.map(|v| v.to_string());
         config.write().rag = agent.rag();
-        config.write().agent = Some(agent);
+        config.write().set_active_agent(agent);
         // Populate shared_variables from resolved file-backed defaults and
         // any --agent-variable overrides before any code path that renders
         // the template. session::new() -> set_agent() runs the template

--- a/crates/harnx-runtime/src/config/agent_ops_split.rs
+++ b/crates/harnx-runtime/src/config/agent_ops_split.rs
@@ -203,6 +203,24 @@ impl Config {
         if config.read().agent.is_some() {
             config.write().exit_agent()?;
         }
+        // Scope the MCP/ACP managers to the incoming agent's package BEFORE
+        // `agent::init` snapshots the MCP tool declarations (it reads
+        // `mcp_manager.get_all_tools()` during init). Without this, a package
+        // agent activated through this async path inherits the global (`None`)
+        // manager scope left by `Config::init`, so every package server is
+        // prefixed: same-package MCP tools leak in under both `<pkg>__*` and
+        // sibling-package namespaces, and the agent's own ACP delegation tools
+        // are emitted as `<pkg>__<agent>_session_prompt` instead of the bare
+        // `<agent>_session_prompt` its `use_tools` allow-list references — so
+        // they are filtered out and the agent cannot delegate (#826).
+        //
+        // This mirrors the synchronous `use_agent_obj` path, which already
+        // scopes managers before the agent's tools are read.
+        let agent_package =
+            harnx_core::package_namespace::pkg_from_qualified(agent_name).map(str::to_string);
+        config
+            .write()
+            .reinit_managers_for_agent(agent_package.as_deref());
         let agent = self::agent::init(config, agent_name, abort_signal).await?;
         let session = session_name.map(|v| v.to_string());
         config.write().rag = agent.rag();

--- a/crates/harnx-runtime/src/config/tests.rs
+++ b/crates/harnx-runtime/src/config/tests.rs
@@ -1095,3 +1095,230 @@ fn dynamic_provider_model_init_sets_client_name_from_provider() {
     assert_eq!(config.clients.len(), 1);
     assert_eq!(config.clients[0].effective_name(), "claude");
 }
+
+// ── Regression tests for #826: package agent delegation/MCP tools must be
+//    scoped to the active agent's package ───────────────────────────────────
+
+/// Build an ACP server config that came from package `pkg` (bare stem `name`),
+/// mirroring what `load_package_servers` produces on disk.
+fn make_package_acp_server(name: &str, pkg: &str) -> AcpServerConfig {
+    AcpServerConfig {
+        name: name.to_string(),
+        command: "echo".to_string(),
+        args: vec![],
+        env: HashMap::new(),
+        enabled: true,
+        description: None,
+        idle_timeout_secs: 300,
+        operation_timeout_secs: 3600,
+        package: Some(pkg.to_string()),
+    }
+}
+
+/// Build an MCP server config that came from package `pkg`.
+fn make_package_mcp_server(name: &str, pkg: &str) -> McpServerConfig {
+    let mut server = make_test_mcp_server(name);
+    server.package = Some(pkg.to_string());
+    server
+}
+
+/// #826 regression: when the active agent belongs to package `pantheon`, its
+/// own package ACP server (e.g. `pantheon/atlas`) must surface its delegation
+/// tool under the BARE name `atlas_session_prompt` — the name the agent's
+/// `use_tools` allow-list references. If the managers are left in the global
+/// (`None`) scope, the tool is emitted as `pantheon__atlas_session_prompt`,
+/// which does not match the allow-list and is filtered out, so the agent has
+/// NO delegation tools (the observed bug).
+#[test]
+fn package_agent_acp_delegation_tool_uses_bare_name_when_scoped() {
+    let mut config = Config {
+        acp_servers: vec![make_package_acp_server("atlas", "pantheon")],
+        ..Config::default()
+    };
+
+    // Scope managers to the active agent's package, as the agent-activation
+    // path must do before tools are read.
+    config.reinit_managers_for_agent(Some("pantheon"));
+
+    let manager = config
+        .acp_manager
+        .as_ref()
+        .expect("acp_manager should be initialized for a package ACP server");
+    let names: Vec<String> = manager
+        .get_all_tools_blocking()
+        .into_iter()
+        .map(|t| t.name)
+        .collect();
+
+    assert!(
+        names.contains(&"atlas_session_prompt".to_string()),
+        "same-package ACP server must surface bare `atlas_session_prompt`; got {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n.starts_with("pantheon__")),
+        "same-package ACP tools must NOT be prefixed with `pantheon__`; got {names:?}"
+    );
+}
+
+/// #826 regression: documents the BROKEN scope. When the managers are left in
+/// the global (`None`) scope — as the async `use_agent` path does, because it
+/// never calls `reinit_managers_for_agent` — a `pantheon` package ACP server is
+/// emitted under the prefixed name `pantheon__atlas_session_prompt`. This is the
+/// mismatch that makes delegation tools "disappear" for a package agent. This
+/// test pins the contrast so a future change that fixes the async path (by
+/// scoping the managers) is matched by the scoped-name assertion above.
+#[test]
+fn unscoped_managers_emit_prefixed_acp_tool_name() {
+    let mut config = Config {
+        acp_servers: vec![make_package_acp_server("atlas", "pantheon")],
+        ..Config::default()
+    };
+
+    // Global scope — exactly the state left by `Config::init` /
+    // `init_mcp_manager()` before any package-scoped reinit.
+    config.reinit_managers_for_agent(None);
+
+    let manager = config.acp_manager.as_ref().expect("acp_manager");
+    let names: Vec<String> = manager
+        .get_all_tools_blocking()
+        .into_iter()
+        .map(|t| t.name)
+        .collect();
+
+    assert!(
+        names.contains(&"pantheon__atlas_session_prompt".to_string()),
+        "unscoped managers prefix the package ACP tool; got {names:?}"
+    );
+    assert!(
+        !names.contains(&"atlas_session_prompt".to_string()),
+        "unscoped managers must NOT emit the bare name; got {names:?}"
+    );
+}
+
+/// #826 regression (MCP side): when scoped to the active agent's package,
+/// same-package MCP servers use bare names while OTHER packages stay prefixed.
+/// In the broken (`None`) scope every package server is prefixed, so the agent
+/// sees both `pantheon__*` AND `coding__*` namespaced tools instead of its bare
+/// same-package tools — the "extra tools that shouldn't be available" symptom.
+#[test]
+fn package_agent_mcp_tools_scoped_to_active_package() {
+    let mut config = Config {
+        mcp_servers: vec![
+            make_package_mcp_server("fs", "pantheon"),
+            make_package_mcp_server("db", "coding"),
+        ],
+        mcp_root: vec![],
+        ..Config::default()
+    };
+
+    // Active agent is in `pantheon`.
+    config.reinit_managers_for_agent(Some("pantheon"));
+    let manager = config.mcp_manager.as_ref().expect("mcp_manager");
+    let servers = manager.list_servers();
+
+    assert!(
+        servers.contains(&"fs".to_string()),
+        "same-package MCP server must use its bare name `fs`; got {servers:?}"
+    );
+    assert!(
+        servers.contains(&"coding__db".to_string()),
+        "other-package MCP server stays prefixed as `coding__db`; got {servers:?}"
+    );
+    assert!(
+        !servers.contains(&"pantheon__fs".to_string()),
+        "same-package MCP server must NOT be prefixed `pantheon__fs`; got {servers:?}"
+    );
+}
+
+/// #826 end-to-end regression: activating a package agent through the ASYNC
+/// `Config::use_agent` path (used by `--agent`, handoff `switch_agent`, and the
+/// ACP server) must scope the MCP/ACP managers to the agent's package, so the
+/// agent's own auto-registered ACP delegation tool is surfaced under the BARE
+/// name `atlas_session_prompt` (matching its `use_tools` allow-list) — not the
+/// `pantheon__atlas_session_prompt` form that gets filtered out, leaving the
+/// agent unable to delegate.
+///
+/// Before the fix, `use_agent` never called `reinit_managers_for_agent`, so the
+/// managers stayed in the global (`None`) scope left by `Config::init` and the
+/// tool was emitted prefixed.
+#[tokio::test]
+async fn use_agent_scopes_managers_to_package_for_delegation_tools() {
+    use crate::client::TestStateGuard;
+    use harnx_core::abort::create_abort_signal;
+
+    // Serialize on the shared test state lock (guards HARNX_* env vars).
+    let _guard = TestStateGuard::new(None).await;
+
+    let temp = tempfile::TempDir::new().unwrap();
+    // Package layout: packages/pantheon/agents/{atlas,hermes}.md
+    let pkg_agents = temp.path().join("packages/pantheon/agents");
+    std::fs::create_dir_all(&pkg_agents).unwrap();
+    std::fs::write(
+        pkg_agents.join("atlas.md"),
+        "---\nuse_tools: hermes_session_prompt\n---\nYou are Atlas. Delegate to hermes.\n",
+    )
+    .unwrap();
+    std::fs::write(pkg_agents.join("hermes.md"), "---\n---\nYou are Hermes.\n").unwrap();
+
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", temp.path());
+    let provider_prev = std::env::var_os("HARNX_PROVIDER");
+    // SAFETY: test-only; the shared test lock is held for the duration.
+    unsafe { std::env::set_var("HARNX_PROVIDER", "claude:some-model") };
+
+    let config = Config::init(WorkingMode::Cmd, false, vec![])
+        .await
+        .expect("config init");
+    let config = std::sync::Arc::new(parking_lot::RwLock::new(config));
+
+    // Sanity: the package agent was auto-registered as an ACP server, and at
+    // this point (no agent active) the managers are in the global scope so the
+    // tool name is prefixed.
+    {
+        let cfg = config.read();
+        let manager = cfg.acp_manager.as_ref().expect("acp_manager after init");
+        let names: Vec<String> = manager
+            .get_all_tools_blocking()
+            .into_iter()
+            .map(|t| t.name)
+            .collect();
+        assert!(
+            names.contains(&"pantheon__atlas_session_prompt".to_string()),
+            "pre-activation (global scope) should expose the prefixed tool; got {names:?}"
+        );
+    }
+
+    // Activate the package agent through the async path.
+    Config::use_agent(&config, "pantheon/atlas", None, create_abort_signal())
+        .await
+        .expect("use_agent should activate the package agent");
+
+    // After activation the managers must be scoped to `pantheon`, so the
+    // sibling `hermes` delegation tool is surfaced under its bare name.
+    let cfg = config.read();
+    let manager = cfg
+        .acp_manager
+        .as_ref()
+        .expect("acp_manager should remain initialized after use_agent");
+    let names: Vec<String> = manager
+        .get_all_tools_blocking()
+        .into_iter()
+        .map(|t| t.name)
+        .collect();
+
+    // SAFETY: test-only; restore provider env.
+    unsafe {
+        match &provider_prev {
+            Some(v) => std::env::set_var("HARNX_PROVIDER", v),
+            None => std::env::remove_var("HARNX_PROVIDER"),
+        }
+    }
+
+    assert!(
+        names.contains(&"hermes_session_prompt".to_string()),
+        "after use_agent, same-package delegation tool must be bare `hermes_session_prompt`; got {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n.starts_with("pantheon__")),
+        "after use_agent, same-package ACP tools must NOT be `pantheon__`-prefixed; got {names:?}"
+    );
+}

--- a/crates/harnx-runtime/src/config/tests.rs
+++ b/crates/harnx-runtime/src/config/tests.rs
@@ -1099,27 +1099,52 @@ fn dynamic_provider_model_init_sets_client_name_from_provider() {
 // ── Regression tests for #826: package agent delegation/MCP tools must be
 //    scoped to the active agent's package ───────────────────────────────────
 
-/// Build an ACP server config that came from package `pkg` (bare stem `name`),
-/// mirroring what `load_package_servers` produces on disk.
-fn make_package_acp_server(name: &str, pkg: &str) -> AcpServerConfig {
-    AcpServerConfig {
-        name: name.to_string(),
-        command: "echo".to_string(),
-        args: vec![],
-        env: HashMap::new(),
-        enabled: true,
-        description: None,
-        idle_timeout_secs: 300,
-        operation_timeout_secs: 3600,
-        package: Some(pkg.to_string()),
-    }
+/// A package-loaded server identity: the bare yaml stem plus the package it
+/// belongs to. Mirrors what `load_package_servers` records on disk.
+struct PackageServer<'a> {
+    stem: &'a str,
+    package: &'a str,
 }
 
-/// Build an MCP server config that came from package `pkg`.
-fn make_package_mcp_server(name: &str, pkg: &str) -> McpServerConfig {
-    let mut server = make_test_mcp_server(name);
-    server.package = Some(pkg.to_string());
-    server
+impl<'a> PackageServer<'a> {
+    fn new(stem: &'a str, package: &'a str) -> Self {
+        Self { stem, package }
+    }
+
+    /// Build an ACP server config for this package server.
+    fn into_acp(self) -> AcpServerConfig {
+        AcpServerConfig {
+            name: self.stem.to_string(),
+            command: "echo".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            enabled: true,
+            description: None,
+            idle_timeout_secs: 300,
+            operation_timeout_secs: 3600,
+            package: Some(self.package.to_string()),
+        }
+    }
+
+    /// Build an MCP server config for this package server.
+    ///
+    /// Built inline (rather than via the `#[cfg(unix)]` `make_test_mcp_server`
+    /// helper) so these regression tests compile on all platforms.
+    fn into_mcp(self) -> McpServerConfig {
+        McpServerConfig {
+            name: self.stem.to_string(),
+            command: "echo".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            roots: vec![],
+            enabled: true,
+            description: None,
+            rename_tools: HashMap::new(),
+            tool_templates: HashMap::new(),
+            hooks: None,
+            package: Some(self.package.to_string()),
+        }
+    }
 }
 
 /// #826 regression: when the active agent belongs to package `pantheon`, its
@@ -1132,7 +1157,7 @@ fn make_package_mcp_server(name: &str, pkg: &str) -> McpServerConfig {
 #[test]
 fn package_agent_acp_delegation_tool_uses_bare_name_when_scoped() {
     let mut config = Config {
-        acp_servers: vec![make_package_acp_server("atlas", "pantheon")],
+        acp_servers: vec![PackageServer::new("atlas", "pantheon").into_acp()],
         ..Config::default()
     };
 
@@ -1170,7 +1195,7 @@ fn package_agent_acp_delegation_tool_uses_bare_name_when_scoped() {
 #[test]
 fn unscoped_managers_emit_prefixed_acp_tool_name() {
     let mut config = Config {
-        acp_servers: vec![make_package_acp_server("atlas", "pantheon")],
+        acp_servers: vec![PackageServer::new("atlas", "pantheon").into_acp()],
         ..Config::default()
     };
 
@@ -1204,8 +1229,8 @@ fn unscoped_managers_emit_prefixed_acp_tool_name() {
 fn package_agent_mcp_tools_scoped_to_active_package() {
     let mut config = Config {
         mcp_servers: vec![
-            make_package_mcp_server("fs", "pantheon"),
-            make_package_mcp_server("db", "coding"),
+            PackageServer::new("fs", "pantheon").into_mcp(),
+            PackageServer::new("db", "coding").into_mcp(),
         ],
         mcp_root: vec![],
         ..Config::default()

--- a/crates/harnx/tests/tmux_e2e.rs
+++ b/crates/harnx/tests/tmux_e2e.rs
@@ -358,8 +358,15 @@ fn same_package_session_prompt_delegation_uses_qualified_spawn() -> Result<()> {
     // spawned ACP subagent could lose package prefix and fail once top-level agents
     // with same bare names were absent. This e2e test covers success path; exact
     // qualified spawn args are unit-covered in harnx-runtime package_loading tests.
+    //
+    // #826: once the same-package ACP delegation tool resolves under its bare
+    // name, the TUI renders the tool's `call_template` ("@ <peer> …") as the
+    // tool-call header instead of the raw `<peer>_session_prompt` name, so we
+    // assert on the rendered delegation header. (Before #826 was fixed the bare
+    // tool failed to resolve to a registered ACP server, so the raw name leaked
+    // through as a fallback header — that incidental display is no longer used.)
     assert!(
-        screen.contains(&format!("{}_session_prompt", PACKAGE_DELEGATION_PEER_NAME)),
+        screen.contains(&format!("@ {PACKAGE_DELEGATION_PEER_NAME}")),
         "same-package delegation tool call missing from TUI transcript:\n{screen}"
     );
     assert!(


### PR DESCRIPTION
## Summary
Fixes #826. Package agents activated through the **async** `Config::use_agent` path (`--agent`, handoff `switch_agent`, and the ACP server) never re-scoped the MCP/ACP managers to the agent's package. They stayed in the global scope left by `Config::init`, so every package server kept its `<package>__` prefix.

Two visible symptoms:
- Same-package ACP delegation tools were emitted as `<package>__<peer>_session_prompt` instead of the bare `<peer>_session_prompt` the agent's `use_tools` allow-list references → filtered out → **agent could not delegate** (no `*_session_prompt` tools).
- Same-package MCP tools leaked in under both `<package>__*` and sibling-package namespaces (e.g. `coding__*`) instead of bare same-package names → **extra tools that shouldn't be available**.

## Root cause
Order-of-operations divergence between two activation paths — not a true race:
- sync `use_agent_obj` already calls `reinit_managers_for_agent(Some(pkg))` before tools are read ✅
- async `use_agent` never did, and `agent::init` snapshots `mcp_manager.get_all_tools()` from the unscoped (`None`) manager ❌

Intermittency depended on which path applied the agent (interactive select vs direct launch/handoff).

## Fix
`use_agent` now mirrors `use_agent_obj`: it re-scopes the managers to the incoming agent's package (derived from `agent_name`) **before** `agent::init` snapshots the tools.

## Tests
- 3 unit tests: scoped vs unscoped ACP/MCP display names.
- 1 e2e test driving async `Config::use_agent` against an on-disk package — verified to **fail without the fix** (`pantheon__hermes_session_prompt`) and **pass with it** (`hermes_session_prompt`).
- Updated `tmux_e2e::same_package_session_prompt_delegation_uses_qualified_spawn`: the bare delegation tool now resolves, so the TUI renders the `call_template` header `@ <peer>` instead of the raw `<peer>_session_prompt` fallback. The peer-response assertion (the #804 proof) is unchanged.
- Changeset added (`harnx: patch`).

## Verification
- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — **1482 passed, 0 failed**, 3 skipped

## Note
This was investigated and implemented directly because the session running this work was itself hitting #826 (no `*_session_prompt` delegation tools, `coding__*` namespace leaking) — a live reproduction. The Aristarchus review gate could not be run for the same reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Package agents now correctly expose delegation tools when activated asynchronously
  * Tool names are properly scoped to prevent incorrect prefixes
  * Delegation tool calls in the TUI now display with correct agent information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->