### PR TITLE
feat(session): externalize image attachments to content-addressed files (cid refs)

### DIFF
--- a/crates/harnx-core/src/session.rs
+++ b/crates/harnx-core/src/session.rs
@@ -178,6 +178,9 @@ pub struct Session {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub compressed_messages: Vec<Message>,
     pub messages: Vec<Message>,
+    /// Maps an attachment reference (`cid:<sha256>`) to the relative filename
+    /// of the blob stored under the session's `{id}.attachments/` directory.
+    /// (Historically this mapped `sha256(data_uri)` to a source file path.)
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub data_urls: HashMap<String, String>,
 

--- a/crates/harnx-runtime/src/config/attachments.rs
+++ b/crates/harnx-runtime/src/config/attachments.rs
@@ -188,6 +188,21 @@ pub fn expand_parts(
     Ok(())
 }
 
+/// Remove a session's attachments directory if it exists. Safe to call when
+/// the directory was never created.
+pub fn remove_attachments_dir(session_yaml_path: &Path) -> Result<()> {
+    let dir = attachments_dir_for(session_yaml_path);
+    match std::fs::remove_dir_all(&dir) {
+        Ok(()) => Ok(()),
+        // No directory means there was nothing to clean up — a success, and
+        // race-free (no exists()-then-remove gap).
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => {
+            Err(err).with_context(|| format!("Failed to remove attachments dir {}", dir.display()))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -246,6 +261,21 @@ mod tests {
         assert_eq!(cid, cid2);
         let count = std::fs::read_dir(&dir).unwrap().flatten().count();
         assert_eq!(count, 1, "duplicate blob does not create a second file");
+    }
+
+    #[test]
+    fn remove_attachments_dir_is_idempotent() {
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let yaml = tmp.path().join("abc.yaml");
+        let dir = attachments_dir_for(&yaml);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("x.png"), b"x").unwrap();
+
+        remove_attachments_dir(&yaml).unwrap();
+        assert!(!dir.exists());
+        // Second call is a no-op, not an error.
+        remove_attachments_dir(&yaml).unwrap();
     }
 
     #[test]

--- a/crates/harnx-runtime/src/config/attachments.rs
+++ b/crates/harnx-runtime/src/config/attachments.rs
@@ -159,14 +159,16 @@ pub fn externalize_parts(
     map: &mut HashMap<String, String>,
 ) -> Result<()> {
     for part in parts.iter_mut() {
-        if let MessageContentPart::ImageUrl { image_url } = part {
-            if image_url.url.starts_with("data:") {
-                let filename = attachment_filename(&image_url.url);
-                let cid = write_attachment(dir, &image_url.url)?;
-                map.insert(cid.clone(), filename);
-                image_url.url = cid;
-            }
+        let MessageContentPart::ImageUrl { image_url } = part else {
+            continue;
+        };
+        if !image_url.url.starts_with("data:") {
+            continue;
         }
+        let filename = attachment_filename(&image_url.url);
+        let cid = write_attachment(dir, &image_url.url)?;
+        map.insert(cid.clone(), filename);
+        image_url.url = cid;
     }
     Ok(())
 }
@@ -179,21 +181,23 @@ pub fn expand_parts(
     parts: &mut [MessageContentPart],
 ) -> Result<()> {
     for part in parts.iter_mut() {
-        if let MessageContentPart::ImageUrl { image_url } = part {
-            if image_url.url.starts_with(CID_PREFIX) {
-                match encoder.expand(dir, &image_url.url) {
-                    Ok(url) => image_url.url = url,
-                    Err(err) => {
-                        // Never send a raw `cid:` ref to the model (it would be
-                        // rejected) and never fail the whole turn over one lost
-                        // blob: drop the unresolvable image to a text
-                        // placeholder and keep going with the rest.
-                        log::warn!("dropping unresolvable attachment {}: {err}", image_url.url);
-                        *part = MessageContentPart::Text {
-                            text: format!("[unavailable image attachment: {}]", image_url.url),
-                        };
-                    }
-                }
+        let MessageContentPart::ImageUrl { image_url } = part else {
+            continue;
+        };
+        if !image_url.url.starts_with(CID_PREFIX) {
+            continue;
+        }
+        match encoder.expand(dir, &image_url.url) {
+            Ok(url) => image_url.url = url,
+            Err(err) => {
+                // Never send a raw `cid:` ref to the model (it would be
+                // rejected) and never fail the whole turn over one lost blob:
+                // drop the unresolvable image to a text placeholder and keep
+                // going with the rest.
+                log::warn!("dropping unresolvable attachment {}: {err}", image_url.url);
+                *part = MessageContentPart::Text {
+                    text: format!("[unavailable image attachment: {}]", image_url.url),
+                };
             }
         }
     }

--- a/crates/harnx-runtime/src/config/attachments.rs
+++ b/crates/harnx-runtime/src/config/attachments.rs
@@ -1,0 +1,76 @@
+//! Content-addressed storage for image/binary attachments referenced from
+//! session transcripts. Blobs live in a per-session `{id}.attachments/`
+//! directory and are referenced from message content as `cid:<sha256>`,
+//! keeping multi-megabyte base64 out of the transcript and out of memory at
+//! rest. The wire encoding is pluggable (`AttachmentEncoder`); only the
+//! base64 backend ships today, with provider upload-API backends to follow.
+
+use std::path::{Path, PathBuf};
+
+use harnx_core::crypto::sha256;
+
+/// Prefix marking a content reference in `ImageUrl.url`.
+pub const CID_PREFIX: &str = "cid:";
+
+/// Compute the content id for an inline `data:` URI. The id is the SHA-256
+/// of the full data URI string (consistent with the existing `data_urls`
+/// keying), so identical blobs collapse to one id.
+pub fn cid_for_data_url(data_url: &str) -> String {
+    format!("{CID_PREFIX}{}", sha256(data_url))
+}
+
+/// Map a data URI's MIME type to a file extension. Defaults to `bin` for
+/// unrecognised types.
+pub fn extension_for_data_url(data_url: &str) -> &'static str {
+    let mime = data_url
+        .strip_prefix("data:")
+        .and_then(|rest| rest.split(';').next())
+        .unwrap_or("");
+    match mime {
+        "image/png" => "png",
+        "image/jpeg" => "jpg",
+        "image/webp" => "webp",
+        "image/gif" => "gif",
+        _ => "bin",
+    }
+}
+
+/// The attachments directory for a session given its `.yaml` transcript path:
+/// `<dir>/<stem>.attachments/`.
+pub fn attachments_dir_for(session_yaml_path: &Path) -> PathBuf {
+    let stem = session_yaml_path
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let parent = session_yaml_path.parent().unwrap_or_else(|| Path::new("."));
+    parent.join(format!("{stem}.attachments"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cid_is_stable_and_prefixed() {
+        let url = "data:image/png;base64,QUJD";
+        let cid = cid_for_data_url(url);
+        assert!(cid.starts_with(CID_PREFIX));
+        assert_eq!(cid, cid_for_data_url(url), "cid must be deterministic");
+    }
+
+    #[test]
+    fn extension_is_derived_from_mime() {
+        assert_eq!(extension_for_data_url("data:image/png;base64,AA"), "png");
+        assert_eq!(extension_for_data_url("data:image/jpeg;base64,AA"), "jpg");
+        assert_eq!(extension_for_data_url("data:application/x;base64,AA"), "bin");
+    }
+
+    #[test]
+    fn attachments_dir_is_sibling_of_transcript() {
+        let p = std::path::Path::new("/tmp/sessions/agent/abc123.yaml");
+        assert_eq!(
+            attachments_dir_for(p),
+            std::path::PathBuf::from("/tmp/sessions/agent/abc123.attachments")
+        );
+    }
+}

--- a/crates/harnx-runtime/src/config/attachments.rs
+++ b/crates/harnx-runtime/src/config/attachments.rs
@@ -5,10 +5,12 @@
 //! rest. The wire encoding is pluggable (`AttachmentEncoder`); only the
 //! base64 backend ships today, with provider upload-API backends to follow.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use harnx_core::crypto::{base64_decode, base64_encode, sha256};
+use harnx_core::message::MessageContentPart;
 
 /// Prefix marking a content reference in `ImageUrl.url`.
 pub const CID_PREFIX: &str = "cid:";
@@ -47,6 +49,13 @@ pub fn attachments_dir_for(session_yaml_path: &Path) -> PathBuf {
     parent.join(format!("{stem}.attachments"))
 }
 
+/// The content-addressed filename (`<sha256>.<ext>`) for an inline `data:`
+/// URI. Single source of truth shared by the writer and the `cid -> filename`
+/// map, so the recorded filename can never drift from the file on disk.
+fn attachment_filename(data_url: &str) -> String {
+    format!("{}.{}", sha256(data_url), extension_for_data_url(data_url))
+}
+
 /// Split a `data:<mime>;base64,<payload>` URI into (mime, payload).
 fn split_data_url(data_url: &str) -> Option<(&str, &str)> {
     let rest = data_url.strip_prefix("data:")?;
@@ -69,19 +78,17 @@ pub fn write_attachment(dir: &Path, data_url: &str) -> Result<String> {
         return Ok(data_url.to_string());
     }
     let cid = cid_for_data_url(data_url);
-    let hash = cid.strip_prefix(CID_PREFIX).unwrap_or(&cid);
-    let ext = extension_for_data_url(data_url);
     std::fs::create_dir_all(dir)
         .with_context(|| format!("Failed to create attachments dir {}", dir.display()))?;
-    let file_path = dir.join(format!("{hash}.{ext}"));
+    let file_path = dir.join(attachment_filename(data_url));
     match std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
         .open(&file_path)
     {
         Ok(mut file) => {
-            let (_mime, payload) = split_data_url(data_url)
-                .ok_or_else(|| anyhow::anyhow!("malformed data URI"))?;
+            let (_mime, payload) =
+                split_data_url(data_url).ok_or_else(|| anyhow::anyhow!("malformed data URI"))?;
             let bytes = base64_decode(payload).context("failed to decode attachment base64")?;
             file.write_all(&bytes)
                 .with_context(|| format!("Failed to write attachment {}", file_path.display()))?;
@@ -143,6 +150,44 @@ impl AttachmentEncoder for Base64Encoder {
     }
 }
 
+/// Rewrite every inline-`data:` image part in `parts` to a `cid:` reference,
+/// writing the bytes to `dir` and recording `cid -> filename` in `map`.
+/// Parts already holding a `cid:`/external URL are left unchanged.
+pub fn externalize_parts(
+    dir: &Path,
+    parts: &mut [MessageContentPart],
+    map: &mut HashMap<String, String>,
+) -> Result<()> {
+    for part in parts.iter_mut() {
+        if let MessageContentPart::ImageUrl { image_url } = part {
+            if image_url.url.starts_with("data:") {
+                let filename = attachment_filename(&image_url.url);
+                let cid = write_attachment(dir, &image_url.url)?;
+                map.insert(cid.clone(), filename);
+                image_url.url = cid;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Replace every `cid:` image reference in `parts` with its inline `data:`
+/// URI for transmission. Used on the send path only.
+pub fn expand_parts(
+    encoder: &dyn AttachmentEncoder,
+    dir: &Path,
+    parts: &mut [MessageContentPart],
+) -> Result<()> {
+    for part in parts.iter_mut() {
+        if let MessageContentPart::ImageUrl { image_url } = part {
+            if image_url.url.starts_with(CID_PREFIX) {
+                image_url.url = encoder.expand(dir, &image_url.url)?;
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -159,7 +204,10 @@ mod tests {
     fn extension_is_derived_from_mime() {
         assert_eq!(extension_for_data_url("data:image/png;base64,AA"), "png");
         assert_eq!(extension_for_data_url("data:image/jpeg;base64,AA"), "jpg");
-        assert_eq!(extension_for_data_url("data:application/x;base64,AA"), "bin");
+        assert_eq!(
+            extension_for_data_url("data:application/x;base64,AA"),
+            "bin"
+        );
     }
 
     #[test]
@@ -188,12 +236,64 @@ mod tests {
 
         let encoder = Base64Encoder;
         let restored = encoder.expand(&dir, &cid).unwrap();
-        assert_eq!(restored, data_url, "expand reproduces the original data URI");
+        assert_eq!(
+            restored, data_url,
+            "expand reproduces the original data URI"
+        );
 
         // Writing the same blob again is idempotent (no duplicate file).
         let cid2 = write_attachment(&dir, &data_url).unwrap();
         assert_eq!(cid, cid2);
         let count = std::fs::read_dir(&dir).unwrap().flatten().count();
         assert_eq!(count, 1, "duplicate blob does not create a second file");
+    }
+
+    #[test]
+    fn externalize_then_expand_parts_round_trips() {
+        use harnx_core::message::{ImageUrl, MessageContentPart};
+        use std::collections::HashMap;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("s.attachments");
+        let data_url = "data:image/png;base64,QUJD".to_string();
+        let mut parts = vec![
+            MessageContentPart::Text { text: "hi".into() },
+            MessageContentPart::ImageUrl {
+                image_url: ImageUrl {
+                    url: data_url.clone(),
+                },
+            },
+        ];
+
+        let mut map = HashMap::new();
+        externalize_parts(&dir, &mut parts, &mut map).unwrap();
+
+        // The image part now holds a cid: reference, not the base64.
+        match &parts[1] {
+            MessageContentPart::ImageUrl { image_url } => {
+                assert!(image_url.url.starts_with(CID_PREFIX));
+                assert!(!image_url.url.contains("QUJD"));
+            }
+            other => panic!("expected ImageUrl, got {other:#?}"),
+        }
+        assert_eq!(map.len(), 1, "cid -> filename recorded");
+        assert!(
+            map.values().next().unwrap().ends_with(".png"),
+            "recorded filename carries the image extension"
+        );
+
+        // Expansion restores the data URI in-place.
+        let encoder = Base64Encoder;
+        expand_parts(&encoder, &dir, &mut parts).unwrap();
+        match &parts[1] {
+            MessageContentPart::ImageUrl { image_url } => assert_eq!(image_url.url, data_url),
+            other => panic!("expected ImageUrl, got {other:#?}"),
+        }
+        // Non-image parts are left untouched throughout.
+        match &parts[0] {
+            MessageContentPart::Text { text } => assert_eq!(text, "hi"),
+            other => panic!("expected Text, got {other:#?}"),
+        }
     }
 }

--- a/crates/harnx-runtime/src/config/attachments.rs
+++ b/crates/harnx-runtime/src/config/attachments.rs
@@ -181,7 +181,19 @@ pub fn expand_parts(
     for part in parts.iter_mut() {
         if let MessageContentPart::ImageUrl { image_url } = part {
             if image_url.url.starts_with(CID_PREFIX) {
-                image_url.url = encoder.expand(dir, &image_url.url)?;
+                match encoder.expand(dir, &image_url.url) {
+                    Ok(url) => image_url.url = url,
+                    Err(err) => {
+                        // Never send a raw `cid:` ref to the model (it would be
+                        // rejected) and never fail the whole turn over one lost
+                        // blob: drop the unresolvable image to a text
+                        // placeholder and keep going with the rest.
+                        log::warn!("dropping unresolvable attachment {}: {err}", image_url.url);
+                        *part = MessageContentPart::Text {
+                            text: format!("[unavailable image attachment: {}]", image_url.url),
+                        };
+                    }
+                }
             }
         }
     }
@@ -276,6 +288,25 @@ mod tests {
         assert!(!dir.exists());
         // Second call is a no-op, not an error.
         remove_attachments_dir(&yaml).unwrap();
+    }
+
+    #[test]
+    fn expand_parts_drops_unresolvable_cid() {
+        use harnx_core::message::{ImageUrl, MessageContentPart};
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("missing.attachments"); // never created
+        let mut parts = vec![MessageContentPart::ImageUrl {
+            image_url: ImageUrl {
+                url: "cid:deadbeef".into(),
+            },
+        }];
+        let encoder = Base64Encoder;
+        expand_parts(&encoder, &dir, &mut parts).unwrap();
+        match &parts[0] {
+            MessageContentPart::Text { text } => assert!(text.contains("unavailable")),
+            other => panic!("expected Text placeholder, got {other:#?}"),
+        }
     }
 
     #[test]

--- a/crates/harnx-runtime/src/config/attachments.rs
+++ b/crates/harnx-runtime/src/config/attachments.rs
@@ -7,7 +7,8 @@
 
 use std::path::{Path, PathBuf};
 
-use harnx_core::crypto::sha256;
+use anyhow::{Context, Result};
+use harnx_core::crypto::{base64_decode, base64_encode, sha256};
 
 /// Prefix marking a content reference in `ImageUrl.url`.
 pub const CID_PREFIX: &str = "cid:";
@@ -46,6 +47,102 @@ pub fn attachments_dir_for(session_yaml_path: &Path) -> PathBuf {
     parent.join(format!("{stem}.attachments"))
 }
 
+/// Split a `data:<mime>;base64,<payload>` URI into (mime, payload).
+fn split_data_url(data_url: &str) -> Option<(&str, &str)> {
+    let rest = data_url.strip_prefix("data:")?;
+    let (meta, payload) = rest.split_once(',')?;
+    let mime = meta.split(';').next().unwrap_or("");
+    Some((mime, payload))
+}
+
+/// Write the decoded bytes of an inline `data:` URI to the attachments dir as
+/// `<sha256>.<ext>` and return the `cid:<sha256>` reference. Idempotent:
+/// because the filename is the content hash, an identical blob maps to the
+/// same path. The write uses `create_new` so concurrent callers can't race on
+/// the same path — `AlreadyExists` means the (byte-identical) blob is already
+/// stored, so it is a successful no-op. Non-`data:` URLs are returned
+/// unchanged as their own reference (they are already external).
+pub fn write_attachment(dir: &Path, data_url: &str) -> Result<String> {
+    use std::io::Write;
+
+    if !data_url.starts_with("data:") {
+        return Ok(data_url.to_string());
+    }
+    let cid = cid_for_data_url(data_url);
+    let hash = cid.strip_prefix(CID_PREFIX).unwrap_or(&cid);
+    let ext = extension_for_data_url(data_url);
+    std::fs::create_dir_all(dir)
+        .with_context(|| format!("Failed to create attachments dir {}", dir.display()))?;
+    let file_path = dir.join(format!("{hash}.{ext}"));
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&file_path)
+    {
+        Ok(mut file) => {
+            let (_mime, payload) = split_data_url(data_url)
+                .ok_or_else(|| anyhow::anyhow!("malformed data URI"))?;
+            let bytes = base64_decode(payload).context("failed to decode attachment base64")?;
+            file.write_all(&bytes)
+                .with_context(|| format!("Failed to write attachment {}", file_path.display()))?;
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("Failed to create attachment {}", file_path.display()));
+        }
+    }
+    Ok(cid)
+}
+
+/// Produces the on-the-wire representation of a `cid:` reference for an LLM
+/// request. The base64 backend ships today; provider upload-API backends
+/// (Anthropic Files, Gemini File API, …) are a planned follow-up.
+pub trait AttachmentEncoder {
+    /// Resolve a reference (`cid:<hash>`, an inline `data:` URI, or an external
+    /// URL) into the value to send to the model.
+    fn expand(&self, dir: &Path, reference: &str) -> Result<String>;
+}
+
+/// Re-inlines attachment bytes as a `data:` URI. Transient — the result is
+/// placed in the outgoing request only, never re-stored.
+pub struct Base64Encoder;
+
+impl AttachmentEncoder for Base64Encoder {
+    fn expand(&self, dir: &Path, reference: &str) -> Result<String> {
+        let Some(hash) = reference.strip_prefix(CID_PREFIX) else {
+            // Inline data URI or external URL — already wire-ready.
+            return Ok(reference.to_string());
+        };
+        // Find the single file whose stem matches the hash.
+        let entry = std::fs::read_dir(dir)
+            .with_context(|| format!("attachments dir missing: {}", dir.display()))?
+            .flatten()
+            .find(|e| {
+                e.path()
+                    .file_stem()
+                    .map(|s| s.to_string_lossy() == *hash)
+                    .unwrap_or(false)
+            })
+            .ok_or_else(|| anyhow::anyhow!("attachment not found for {reference}"))?;
+        let path = entry.path();
+        let ext = path
+            .extension()
+            .map(|e| e.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let mime = match ext.as_str() {
+            "png" => "image/png",
+            "jpg" | "jpeg" => "image/jpeg",
+            "webp" => "image/webp",
+            "gif" => "image/gif",
+            _ => "application/octet-stream",
+        };
+        let bytes = std::fs::read(&path)
+            .with_context(|| format!("Failed to read attachment {}", path.display()))?;
+        Ok(format!("data:{mime};base64,{}", base64_encode(bytes)))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -72,5 +169,31 @@ mod tests {
             attachments_dir_for(p),
             std::path::PathBuf::from("/tmp/sessions/agent/abc123.attachments")
         );
+    }
+
+    #[test]
+    fn write_then_base64_expand_round_trips() {
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("s.attachments");
+        // 3 bytes "ABC" base64 == "QUJD"
+        let data_url = "data:image/png;base64,QUJD".to_string();
+
+        let cid = write_attachment(&dir, &data_url).unwrap();
+        assert!(cid.starts_with(CID_PREFIX));
+        // The file is named <sha256>.<ext> inside the dir.
+        let entries: Vec<_> = std::fs::read_dir(&dir).unwrap().flatten().collect();
+        assert_eq!(entries.len(), 1, "exactly one attachment file written");
+        assert!(entries[0].file_name().to_string_lossy().ends_with(".png"));
+
+        let encoder = Base64Encoder;
+        let restored = encoder.expand(&dir, &cid).unwrap();
+        assert_eq!(restored, data_url, "expand reproduces the original data URI");
+
+        // Writing the same blob again is idempotent (no duplicate file).
+        let cid2 = write_attachment(&dir, &data_url).unwrap();
+        assert_eq!(cid, cid2);
+        let count = std::fs::read_dir(&dir).unwrap().flatten().count();
+        assert_eq!(count, 1, "duplicate blob does not create a second file");
     }
 }

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 mod agent_ops_split;
+mod attachments;
 mod completion_split;
 mod env_split;
 pub mod input;

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -718,6 +718,11 @@ impl Config {
         match file_ext {
             Some(ext) => {
                 let path = dir.join(format!("{name}{ext}"));
+                if kind == "session" {
+                    if let Err(err) = crate::config::attachments::remove_attachments_dir(&path) {
+                        log::warn!("failed to remove attachments for session '{name}': {err}");
+                    }
+                }
                 remove_file(&path).with_context(|| fail(&path))
             }
             None => {

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -702,17 +702,7 @@ pub fn save(
     // first-turn images persisted before incremental externalization, or
     // legacy sessions loaded with inline base64) so the rewritten transcript
     // never carries inline base64. Idempotent: existing cid refs are skipped.
-    {
-        let dir = crate::config::attachments::attachments_dir_for(session_path);
-        let mut map = std::collections::HashMap::new();
-        for msg in session.compressed_messages.iter_mut() {
-            externalize_message(&dir, &mut msg.content, &mut map);
-        }
-        for msg in session.messages.iter_mut() {
-            externalize_message(&dir, &mut msg.content, &mut map);
-        }
-        session.data_urls.extend(map);
-    }
+    externalize_persisted_messages(session, session_path);
 
     // Write in the new log format.
     let mut content = serde_yaml::to_string(&session.build_header_entry())
@@ -981,15 +971,11 @@ pub fn add_tool_results(session: &mut Session, results: &[crate::tool::ToolResul
     // the cid -> filename map is logged as a DataUrls entry after the
     // ToolResults entry (below) so the ToolCalls/ToolResults pairing on replay
     // is not split.
-    if let Some(dir) = attachments_dir.as_ref() {
-        for slot in pending.tool_results.iter_mut() {
-            if let Err(err) =
-                crate::config::attachments::externalize_parts(dir, &mut slot.content, &mut cid_urls)
-            {
-                log::warn!("tool-result attachment externalization failed: {err}");
-            }
-        }
-    }
+    externalize_tool_result_content(
+        attachments_dir.as_deref(),
+        &mut pending.tool_results,
+        &mut cid_urls,
+    );
 
     let log_results: Vec<harnx_core::session::ToolOutput> = pending
         .tool_results
@@ -1013,16 +999,8 @@ pub fn add_tool_results(session: &mut Session, results: &[crate::tool::ToolResul
     if !appended {
         session.dirty = true;
     }
-    if !cid_urls.is_empty() {
-        if !append_event(
-            session,
-            &SessionLogEntry::DataUrls {
-                urls: cid_urls.clone(),
-            },
-        ) {
-            session.dirty = true;
-        }
-        session.data_urls.extend(cid_urls);
+    if !record_externalized(session, cid_urls) {
+        session.dirty = true;
     }
     session.update_tokens();
     Ok(())
@@ -1093,6 +1071,61 @@ fn externalize_content(
     map
 }
 
+/// Externalize inline image data URIs across a slice of tool results into
+/// `cid:` references, recording `cid -> filename` in `map`. No-op when the
+/// session has no attachments dir yet.
+fn externalize_tool_result_content(
+    dir: Option<&std::path::Path>,
+    results: &mut [crate::tool::ToolResult],
+    map: &mut std::collections::HashMap<String, String>,
+) {
+    let Some(dir) = dir else {
+        return;
+    };
+    for slot in results.iter_mut() {
+        if let Err(err) = crate::config::attachments::externalize_parts(dir, &mut slot.content, map)
+        {
+            log::warn!("tool-result attachment externalization failed: {err}");
+        }
+    }
+}
+
+/// Externalize still-inline image content across every stored message
+/// (compressed + active) into the session's attachments dir, merging the new
+/// `cid -> filename` mappings into the session map. Idempotent — used by the
+/// full-rewrite `save()` to migrate first-turn/legacy inline blobs.
+fn externalize_persisted_messages(session: &mut Session, session_path: &std::path::Path) {
+    let dir = crate::config::attachments::attachments_dir_for(session_path);
+    let mut map = std::collections::HashMap::new();
+    for msg in session.compressed_messages.iter_mut() {
+        externalize_message(&dir, &mut msg.content, &mut map);
+    }
+    for msg in session.messages.iter_mut() {
+        externalize_message(&dir, &mut msg.content, &mut map);
+    }
+    session.data_urls.extend(map);
+}
+
+/// Record freshly externalized `cid -> filename` mappings: append a `DataUrls`
+/// log entry and merge them into the session map. No-op when empty. Returns
+/// whether the append (if any) succeeded.
+fn record_externalized(
+    session: &mut Session,
+    cid_urls: std::collections::HashMap<String, String>,
+) -> bool {
+    if cid_urls.is_empty() {
+        return true;
+    }
+    let appended = append_event(
+        session,
+        &SessionLogEntry::DataUrls {
+            urls: cid_urls.clone(),
+        },
+    );
+    session.data_urls.extend(cid_urls);
+    appended
+}
+
 /// Shared round-opening setup used by both `add_assistant_text` and
 /// `add_tool_calls`: first-turn agent-message injection, user-message
 /// push (skipped on continuation rounds), data-URL persistence, and
@@ -1121,15 +1154,7 @@ fn begin_turn(session: &mut Session, input: &Input, _output: &str) -> Result<boo
         }
         // Seq-less metadata record for the cids written above; appended after
         // the messages so message log_seqs are unaffected.
-        if !cid_urls.is_empty() {
-            all_appended &= append_event(
-                session,
-                &SessionLogEntry::DataUrls {
-                    urls: cid_urls.clone(),
-                },
-            );
-            session.data_urls.extend(cid_urls);
-        }
+        all_appended &= record_externalized(session, cid_urls);
     } else if !is_continuation {
         // `seq` is the message's log-document index. `externalize_content` only
         // writes attachment files + rewrites `content` in memory (it takes
@@ -1151,15 +1176,7 @@ fn begin_turn(session: &mut Session, input: &Input, _output: &str) -> Result<boo
         );
         session.messages.push(user_msg);
         emit_agent_event(AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }));
-        if !cid_urls.is_empty() {
-            all_appended &= append_event(
-                session,
-                &SessionLogEntry::DataUrls {
-                    urls: cid_urls.clone(),
-                },
-            );
-            session.data_urls.extend(cid_urls);
-        }
+        all_appended &= record_externalized(session, cid_urls);
     }
     let new_data_urls = input.data_urls();
     if !new_data_urls.is_empty() {
@@ -1217,6 +1234,35 @@ pub fn build_messages(session: &Session, input: &Input) -> Result<Vec<Message>> 
     Ok(messages)
 }
 
+/// Expand the `cid:` image references in a single message's content — both
+/// plain content arrays and tool-result content — to inline `data:` URIs.
+fn expand_message(
+    encoder: &dyn crate::config::attachments::AttachmentEncoder,
+    dir: &std::path::Path,
+    content: &mut MessageContent,
+) {
+    let result = match content {
+        MessageContent::Array(parts) => {
+            crate::config::attachments::expand_parts(encoder, dir, parts)
+        }
+        MessageContent::ToolCalls(tool_calls) => {
+            let mut res = Ok(());
+            for tool_result in tool_calls.tool_results.iter_mut() {
+                if let Err(err) =
+                    crate::config::attachments::expand_parts(encoder, dir, &mut tool_result.content)
+                {
+                    res = Err(err);
+                }
+            }
+            res
+        }
+        MessageContent::Text(_) => Ok(()),
+    };
+    if let Err(err) = result {
+        log::warn!("attachment expansion failed: {err}");
+    }
+}
+
 /// Replace `cid:` image references in outgoing messages with inline `data:`
 /// URIs (base64 backend). Walks both plain content arrays and tool-result
 /// content. No-op when the session has no attachments dir / no cid refs.
@@ -1229,25 +1275,7 @@ fn expand_message_attachments(session: &Session, messages: &mut [Message]) {
     let dir = crate::config::attachments::attachments_dir_for(std::path::Path::new(path));
     let encoder = crate::config::attachments::Base64Encoder;
     for message in messages.iter_mut() {
-        match &mut message.content {
-            MessageContent::Array(parts) => {
-                if let Err(err) = crate::config::attachments::expand_parts(&encoder, &dir, parts) {
-                    log::warn!("attachment expansion failed: {err}");
-                }
-            }
-            MessageContent::ToolCalls(tool_calls) => {
-                for result in tool_calls.tool_results.iter_mut() {
-                    if let Err(err) = crate::config::attachments::expand_parts(
-                        &encoder,
-                        &dir,
-                        &mut result.content,
-                    ) {
-                        log::warn!("attachment expansion failed: {err}");
-                    }
-                }
-            }
-            MessageContent::Text(_) => {}
-        }
+        expand_message(&encoder, &dir, &mut message.content);
     }
 }
 

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -920,6 +920,14 @@ pub fn add_tool_calls(
 /// Matches each result to its call by id (or by position when the id
 /// is absent).
 pub fn add_tool_results(session: &mut Session, results: &[crate::tool::ToolResult]) -> Result<()> {
+    // Resolve the attachments dir up front so we don't need to borrow `session`
+    // again while the `pending` mutable borrow below is live.
+    let attachments_dir = session
+        .path
+        .as_deref()
+        .map(|p| crate::config::attachments::attachments_dir_for(std::path::Path::new(p)));
+    let mut cid_urls = std::collections::HashMap::new();
+
     let Some(last) = session.messages.last_mut() else {
         anyhow::bail!("add_tool_results called on empty session");
     };
@@ -952,6 +960,21 @@ pub fn add_tool_results(session: &mut Session, results: &[crate::tool::ToolResul
         }
     }
 
+    // Externalize inline image data URIs in tool-result content to cid refs
+    // before persisting, freeing the in-memory base64. Files are written now;
+    // the cid -> filename map is logged as a DataUrls entry after the
+    // ToolResults entry (below) so the ToolCalls/ToolResults pairing on replay
+    // is not split.
+    if let Some(dir) = attachments_dir.as_ref() {
+        for slot in pending.tool_results.iter_mut() {
+            if let Err(err) =
+                crate::config::attachments::externalize_parts(dir, &mut slot.content, &mut cid_urls)
+            {
+                log::warn!("tool-result attachment externalization failed: {err}");
+            }
+        }
+    }
+
     let log_results: Vec<harnx_core::session::ToolOutput> = pending
         .tool_results
         .iter()
@@ -973,6 +996,17 @@ pub fn add_tool_results(session: &mut Session, results: &[crate::tool::ToolResul
     );
     if !appended {
         session.dirty = true;
+    }
+    if !cid_urls.is_empty() {
+        if !append_event(
+            session,
+            &SessionLogEntry::DataUrls {
+                urls: cid_urls.clone(),
+            },
+        ) {
+            session.dirty = true;
+        }
+        session.data_urls.extend(cid_urls);
     }
     session.update_tokens();
     Ok(())
@@ -1118,7 +1152,52 @@ pub fn echo_messages(session: &Session, input: &Input) -> String {
     serde_yaml::to_string(&messages).unwrap_or_else(|_| "Unable to echo message".into())
 }
 
+/// Build the outgoing message list and expand any `cid:` attachment references
+/// back into inline `data:` URIs for transmission. Expansion is transient —
+/// it affects only the returned messages, never the stored session.
 pub fn build_messages(session: &Session, input: &Input) -> Result<Vec<Message>> {
+    let mut messages = build_messages_inner(session, input)?;
+    expand_message_attachments(session, &mut messages);
+    Ok(messages)
+}
+
+/// Replace `cid:` image references in outgoing messages with inline `data:`
+/// URIs (base64 backend). Walks both plain content arrays and tool-result
+/// content. No-op when the session has no attachments dir / no cid refs.
+fn expand_message_attachments(session: &Session, messages: &mut [Message]) {
+    // A `cid:` ref only ever enters a message via the externalize-on-save path,
+    // which requires a session path — so no path means no refs to expand.
+    let Some(path) = session.path.as_ref() else {
+        return;
+    };
+    let dir = crate::config::attachments::attachments_dir_for(std::path::Path::new(path));
+    let encoder = crate::config::attachments::Base64Encoder;
+    for message in messages.iter_mut() {
+        match &mut message.content {
+            MessageContent::Array(parts) => {
+                if let Err(err) =
+                    crate::config::attachments::expand_parts(&encoder, &dir, parts)
+                {
+                    log::warn!("attachment expansion failed: {err}");
+                }
+            }
+            MessageContent::ToolCalls(tool_calls) => {
+                for result in tool_calls.tool_results.iter_mut() {
+                    if let Err(err) = crate::config::attachments::expand_parts(
+                        &encoder,
+                        &dir,
+                        &mut result.content,
+                    ) {
+                        log::warn!("attachment expansion failed: {err}");
+                    }
+                }
+            }
+            MessageContent::Text(_) => {}
+        }
+    }
+}
+
+fn build_messages_inner(session: &Session, input: &Input) -> Result<Vec<Message>> {
     let mut messages = session.messages.clone();
     if input.continue_output().is_some() {
         return Ok(messages);
@@ -2020,10 +2099,15 @@ results:
 
         let persisted = std::fs::read_to_string(session.path.as_ref().unwrap()).unwrap();
         assert!(persisted.contains("<image: image/png,"));
+        assert!(persisted.contains("cid:"), "tool-result image is referenced by cid");
         assert!(
-            persisted.contains(&data_uri),
-            "persisted session should inline tool result data URI in content"
+            !persisted.contains(&base64_payload),
+            "tool-result base64 must not be inlined in the transcript"
         );
+        let dir = crate::config::attachments::attachments_dir_for(std::path::Path::new(
+            session.path.as_ref().unwrap(),
+        ));
+        assert_eq!(std::fs::read_dir(&dir).unwrap().flatten().count(), 1);
 
         let reloaded = super::load_from_log_for_test(&persisted);
         let MessageContent::ToolCalls(tool_calls) = &reloaded
@@ -2038,7 +2122,9 @@ results:
         assert_eq!(tool_calls.tool_results.len(), 1);
         assert_eq!(tool_calls.tool_results[0].content.len(), 1);
         match &tool_calls.tool_results[0].content[0] {
-            MessageContentPart::ImageUrl { image_url } => assert_eq!(image_url.url, data_uri),
+            MessageContentPart::ImageUrl { image_url } => {
+                assert!(image_url.url.starts_with("cid:"), "reloaded content keeps cid ref");
+            }
             other => panic!("expected ImageUrl content part, got {other:#?}"),
         }
         assert_eq!(tool_calls.tool_results[0].output, redacted_output);

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -991,6 +991,33 @@ fn is_tool_continuation(input: &Input, messages: &[Message]) -> bool {
     input.tool_calls.is_some() && messages.last().is_some_and(|m| m.role == MessageRole::Tool)
 }
 
+/// Rewrite inline image data URIs in `content` to `cid:` references in place,
+/// writing the bytes to the session's attachments dir. Returns the
+/// `cid -> filename` map of newly externalized blobs (empty when there are
+/// none, or when the session has no saved path yet — in which case the blob
+/// stays inline and is externalized on a later save).
+fn externalize_content(
+    session: &Session,
+    content: &mut MessageContent,
+) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+    let Some(path) = session.path.as_ref() else {
+        return map;
+    };
+    let MessageContent::Array(parts) = content else {
+        return map;
+    };
+    let dir = crate::config::attachments::attachments_dir_for(std::path::Path::new(path));
+    if let Err(err) = crate::config::attachments::externalize_parts(&dir, parts, &mut map) {
+        // On partial failure, keep the map entries for blobs that were already
+        // written and rewritten in `content`: their files are on disk and their
+        // `cid:` refs are now in `content`, so the caller must still record them
+        // in a DataUrls entry. Any remaining parts stay inline.
+        log::warn!("attachment externalization failed: {err}");
+    }
+    map
+}
+
 /// Shared round-opening setup used by both `add_assistant_text` and
 /// `add_tool_calls`: first-turn agent-message injection, user-message
 /// push (skipped on continuation rounds), data-URL persistence, and
@@ -1014,8 +1041,16 @@ fn begin_turn(session: &mut Session, input: &Input, _output: &str) -> Result<boo
             session.messages.push(msg.with_log_seq(seq));
         }
     } else if !is_continuation {
+        // `seq` is the message's log-document index. `externalize_content` only
+        // writes attachment files + rewrites `content` in memory (it takes
+        // `&Session`, so it cannot append), so nothing must be appended between
+        // here and the Message append below or `seq` would be off by one. The
+        // cid DataUrls entry is a seq-less metadata record appended *after* the
+        // message.
         let seq = session.next_seq();
-        let user_msg = Message::new(MessageRole::User, input.message_content()).with_log_seq(seq);
+        let mut content = input.message_content();
+        let cid_urls = externalize_content(session, &mut content);
+        let user_msg = Message::new(MessageRole::User, content).with_log_seq(seq);
         all_appended &= append_event(
             session,
             &SessionLogEntry::Message {
@@ -1026,6 +1061,15 @@ fn begin_turn(session: &mut Session, input: &Input, _output: &str) -> Result<boo
         );
         session.messages.push(user_msg);
         emit_agent_event(AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }));
+        if !cid_urls.is_empty() {
+            all_appended &= append_event(
+                session,
+                &SessionLogEntry::DataUrls {
+                    urls: cid_urls.clone(),
+                },
+            );
+            session.data_urls.extend(cid_urls);
+        }
     }
     let new_data_urls = input.data_urls();
     if !new_data_urls.is_empty() {
@@ -2606,5 +2650,49 @@ content: second
              the user re-asked and loops on 'Let me look at the current state…'. \
              messages: {messages:#?}"
         );
+    }
+
+    #[test]
+    fn externalize_content_rewrites_image_to_cid_and_writes_file() {
+        use harnx_core::message::{ImageUrl, MessageContent, MessageContentPart};
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let mut session = test_session();
+        session.set_sessions_dir(tmp.path().to_path_buf());
+        super::ensure_log_file(&mut session);
+        assert!(session.path.is_some(), "ensure_log_file should set a path");
+
+        let base64_payload = "QUJDREVG".repeat(64);
+        let data_uri = format!("data:image/png;base64,{base64_payload}");
+        let mut content = MessageContent::Array(vec![
+            MessageContentPart::Text { text: "look".into() },
+            MessageContentPart::ImageUrl {
+                image_url: ImageUrl { url: data_uri },
+            },
+        ]);
+
+        let map = super::externalize_content(&session, &mut content);
+        assert_eq!(map.len(), 1, "one cid recorded");
+        assert!(
+            map.keys().next().unwrap().starts_with("cid:"),
+            "map is keyed by the cid reference"
+        );
+
+        match &content {
+            MessageContent::Array(parts) => match &parts[1] {
+                MessageContentPart::ImageUrl { image_url } => {
+                    assert!(image_url.url.starts_with("cid:"));
+                    assert!(!image_url.url.contains(&base64_payload));
+                }
+                other => panic!("expected ImageUrl, got {other:#?}"),
+            },
+            other => panic!("expected Array, got {other:#?}"),
+        }
+
+        let dir = crate::config::attachments::attachments_dir_for(std::path::Path::new(
+            session.path.as_ref().unwrap(),
+        ));
+        assert_eq!(std::fs::read_dir(&dir).unwrap().flatten().count(), 1);
     }
 }

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -698,6 +698,22 @@ pub fn save(
 
     session.path = Some(session_path.display().to_string());
 
+    // Externalize any still-inline image data URIs across all messages (e.g.
+    // first-turn images persisted before incremental externalization, or
+    // legacy sessions loaded with inline base64) so the rewritten transcript
+    // never carries inline base64. Idempotent: existing cid refs are skipped.
+    {
+        let dir = crate::config::attachments::attachments_dir_for(session_path);
+        let mut map = std::collections::HashMap::new();
+        for msg in session.compressed_messages.iter_mut() {
+            externalize_message(&dir, &mut msg.content, &mut map);
+        }
+        for msg in session.messages.iter_mut() {
+            externalize_message(&dir, &mut msg.content, &mut map);
+        }
+        session.data_urls.extend(map);
+    }
+
     // Write in the new log format.
     let mut content = serde_yaml::to_string(&session.build_header_entry())
         .with_context(|| format!("Failed to serialize session header for '{}'", session.id))?;
@@ -1025,6 +1041,40 @@ fn is_tool_continuation(input: &Input, messages: &[Message]) -> bool {
     input.tool_calls.is_some() && messages.last().is_some_and(|m| m.role == MessageRole::Tool)
 }
 
+/// Externalize inline image data URIs in a single message's content — both
+/// plain content arrays and tool-result content — into `cid:` references,
+/// writing files to `dir` and recording `cid -> filename` in `map`. On partial
+/// failure, keeps whatever was already externalized (those files are on disk
+/// and their refs are already in `content`).
+fn externalize_message(
+    dir: &std::path::Path,
+    content: &mut MessageContent,
+    map: &mut std::collections::HashMap<String, String>,
+) {
+    let result = match content {
+        MessageContent::Array(parts) => {
+            crate::config::attachments::externalize_parts(dir, parts, map)
+        }
+        MessageContent::ToolCalls(tool_calls) => {
+            let mut res = Ok(());
+            for tool_result in tool_calls.tool_results.iter_mut() {
+                if let Err(err) = crate::config::attachments::externalize_parts(
+                    dir,
+                    &mut tool_result.content,
+                    map,
+                ) {
+                    res = Err(err);
+                }
+            }
+            res
+        }
+        MessageContent::Text(_) => Ok(()),
+    };
+    if let Err(err) = result {
+        log::warn!("attachment externalization failed: {err}");
+    }
+}
+
 /// Rewrite inline image data URIs in `content` to `cid:` references in place,
 /// writing the bytes to the session's attachments dir. Returns the
 /// `cid -> filename` map of newly externalized blobs (empty when there are
@@ -1035,20 +1085,11 @@ fn externalize_content(
     content: &mut MessageContent,
 ) -> std::collections::HashMap<String, String> {
     let mut map = std::collections::HashMap::new();
-    let Some(path) = session.path.as_ref() else {
-        return map;
-    };
-    let MessageContent::Array(parts) = content else {
+    let Some(path) = session.path.as_deref() else {
         return map;
     };
     let dir = crate::config::attachments::attachments_dir_for(std::path::Path::new(path));
-    if let Err(err) = crate::config::attachments::externalize_parts(&dir, parts, &mut map) {
-        // On partial failure, keep the map entries for blobs that were already
-        // written and rewritten in `content`: their files are on disk and their
-        // `cid:` refs are now in `content`, so the caller must still record them
-        // in a DataUrls entry. Any remaining parts stay inline.
-        log::warn!("attachment externalization failed: {err}");
-    }
+    externalize_message(&dir, content, &mut map);
     map
 }
 
@@ -1062,8 +1103,12 @@ fn begin_turn(session: &mut Session, input: &Input, _output: &str) -> Result<boo
     let is_continuation = is_tool_continuation(input, &session.messages);
     if session.messages.is_empty() {
         let agent_messages = input.agent().build_messages(input)?;
-        for msg in agent_messages {
+        let mut cid_urls = std::collections::HashMap::new();
+        for mut msg in agent_messages {
+            // `externalize_content` only writes files + rewrites `content` in
+            // memory (takes `&Session`, cannot append), so `seq` stays correct.
             let seq = session.next_seq();
+            cid_urls.extend(externalize_content(session, &mut msg.content));
             all_appended &= append_event(
                 session,
                 &SessionLogEntry::Message {
@@ -1073,6 +1118,17 @@ fn begin_turn(session: &mut Session, input: &Input, _output: &str) -> Result<boo
                 },
             );
             session.messages.push(msg.with_log_seq(seq));
+        }
+        // Seq-less metadata record for the cids written above; appended after
+        // the messages so message log_seqs are unaffected.
+        if !cid_urls.is_empty() {
+            all_appended &= append_event(
+                session,
+                &SessionLogEntry::DataUrls {
+                    urls: cid_urls.clone(),
+                },
+            );
+            session.data_urls.extend(cid_urls);
         }
     } else if !is_continuation {
         // `seq` is the message's log-document index. `externalize_content` only
@@ -1175,9 +1231,7 @@ fn expand_message_attachments(session: &Session, messages: &mut [Message]) {
     for message in messages.iter_mut() {
         match &mut message.content {
             MessageContent::Array(parts) => {
-                if let Err(err) =
-                    crate::config::attachments::expand_parts(&encoder, &dir, parts)
-                {
+                if let Err(err) = crate::config::attachments::expand_parts(&encoder, &dir, parts) {
                     log::warn!("attachment expansion failed: {err}");
                 }
             }
@@ -2099,7 +2153,10 @@ results:
 
         let persisted = std::fs::read_to_string(session.path.as_ref().unwrap()).unwrap();
         assert!(persisted.contains("<image: image/png,"));
-        assert!(persisted.contains("cid:"), "tool-result image is referenced by cid");
+        assert!(
+            persisted.contains("cid:"),
+            "tool-result image is referenced by cid"
+        );
         assert!(
             !persisted.contains(&base64_payload),
             "tool-result base64 must not be inlined in the transcript"
@@ -2123,7 +2180,10 @@ results:
         assert_eq!(tool_calls.tool_results[0].content.len(), 1);
         match &tool_calls.tool_results[0].content[0] {
             MessageContentPart::ImageUrl { image_url } => {
-                assert!(image_url.url.starts_with("cid:"), "reloaded content keeps cid ref");
+                assert!(
+                    image_url.url.starts_with("cid:"),
+                    "reloaded content keeps cid ref"
+                );
             }
             other => panic!("expected ImageUrl content part, got {other:#?}"),
         }
@@ -2739,6 +2799,40 @@ content: second
     }
 
     #[test]
+    fn save_externalizes_inline_image_content() {
+        use harnx_core::message::{ImageUrl, MessageContent, MessageContentPart};
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let mut session = test_session();
+        session.set_sessions_dir(tmp.path().to_path_buf());
+
+        let base64_payload = "QUJDREVG".repeat(64);
+        let data_uri = format!("data:image/png;base64,{base64_payload}");
+        session.messages.push(Message::new(
+            MessageRole::User,
+            MessageContent::Array(vec![MessageContentPart::ImageUrl {
+                image_url: ImageUrl { url: data_uri },
+            }]),
+        ));
+
+        let path = tmp.path().join("s1.yaml");
+        super::save(&mut session, "s1", &path, false).unwrap();
+
+        let persisted = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            persisted.contains("cid:"),
+            "saved transcript references a cid"
+        );
+        assert!(
+            !persisted.contains(&base64_payload),
+            "no inline base64 in saved transcript"
+        );
+        let dir = crate::config::attachments::attachments_dir_for(&path);
+        assert_eq!(std::fs::read_dir(&dir).unwrap().flatten().count(), 1);
+    }
+
+    #[test]
     fn externalize_content_rewrites_image_to_cid_and_writes_file() {
         use harnx_core::message::{ImageUrl, MessageContent, MessageContentPart};
         use tempfile::TempDir;
@@ -2752,7 +2846,9 @@ content: second
         let base64_payload = "QUJDREVG".repeat(64);
         let data_uri = format!("data:image/png;base64,{base64_payload}");
         let mut content = MessageContent::Array(vec![
-            MessageContentPart::Text { text: "look".into() },
+            MessageContentPart::Text {
+                text: "look".into(),
+            },
             MessageContentPart::ImageUrl {
                 image_url: ImageUrl { url: data_uri },
             },

--- a/crates/harnx-runtime/src/config/session_ops_split.rs
+++ b/crates/harnx-runtime/src/config/session_ops_split.rs
@@ -333,6 +333,13 @@ impl Config {
             // is preserved across agent changes, not the conversation history.
             let session_path = self.session_file(&name);
             if session_path.exists() {
+                if let Err(err) = crate::config::attachments::remove_attachments_dir(&session_path)
+                {
+                    log::warn!(
+                        "failed to remove attachments for '{}' during reset: {err}",
+                        session_path.display()
+                    );
+                }
                 remove_file(&session_path).with_context(|| {
                     format!("Failed to remove session file '{}'", session_path.display())
                 })?;


### PR DESCRIPTION
## Summary

Image/binary attachments were stored as inline `data:…base64` blobs inside session-transcript message content — in memory and in the YAML log. Loading a transcript materialized every image as a multi-megabyte string, and this was a major contributor to runaway memory use. This PR moves attachments out of the transcript into content-addressed files and references them by `cid:<sha256>`.

This is **step 1** of a broader compaction pass. It fixes the at-rest / load-time and live-session memory growth from inline base64. The remaining piece of the OOM-during-compaction fix (keeping base64 out of the compaction *request* itself) lands in a follow-up that reworks compaction to a flattened-text summarizer (will also pick up #820 and #838); a session-history search tool (#819) is a further follow-up.

## What changed

- **New `attachments` module** (`crates/harnx-runtime/src/config/attachments.rs`): content-addressing (`cid:<sha256>`), per-session `{id}.attachments/<sha256>.<ext>` storage, race-free idempotent writes, and a pluggable `AttachmentEncoder` (base64 backend only for now).
- **Store on save:** user messages (first turn + later turns) and tool-result content have inline `data:` image URIs rewritten to `cid:` refs and the bytes written to disk, freeing the in-memory base64. The `cid → filename` map persists via the existing `DataUrls` log entry. A full `save()` also externalizes any still-inline content (migrating legacy transcripts).
- **Expand on send:** `build_messages` transiently re-expands `cid:` refs back to `data:` URIs for the LLM request (covering both plain content and tool-result content); a missing blob degrades to a text placeholder rather than failing the turn. Expansion is never written back to the session.
- **Cleanup:** the two explicit session-deletion paths (`.delete` command and `reset_session`) now remove the `{id}.attachments/` directory alongside the transcript. (harnx has no automatic session GC.)

Provider upload/Files-API encoder backends (Anthropic Files, Gemini File API, …) are intentionally deferred — tracked in #841. The base64 encoder is the universal default and always remains as a fallback.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo nextest run --workspace --stress-count=5` — 1493 tests pass, 5/5 stress iterations
- New unit/integration tests cover: content-addressing + write/expand round-trip, idempotent writes, externalize/expand of content parts, user-message & tool-result externalization on save (cid in transcript, no inline base64, attachment file written), `cid:` re-expansion on the send path (tool-result round-trip reproduces the original data URI), graceful drop of an unresolvable attachment, and attachments-dir removal on delete/reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now store image attachments on disk rather than embedding them inline. Attachment directories are automatically cleaned up when sessions are deleted or reset. Image references are transparently expanded when communicating with models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->