### PR TITLE
feat(session-history): harnx_agent_session_history_read tool

### DIFF
--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -1180,6 +1180,12 @@ impl Config {
                 declarations.extend(handoff_declarations);
                 handoff_targets.extend(targets);
             }
+            if selectors.iter().any(|v| {
+                let v = v.trim();
+                v == crate::session_history::TOOL_NAME || v == "*"
+            }) {
+                declarations.push(crate::session_history::tool_declaration());
+            }
         }
 
         let mut seen = HashSet::new();

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -95,7 +95,10 @@ struct PendingToolCalls {
     timestamp: Option<chrono::DateTime<chrono::Utc>>,
 }
 
-pub(crate) fn collect_raw_log_entries(content: &str, name: &str) -> Result<Vec<(usize, SessionLogEntry)>> {
+pub(crate) fn collect_raw_log_entries(
+    content: &str,
+    name: &str,
+) -> Result<Vec<(usize, SessionLogEntry)>> {
     serde_yaml::Deserializer::from_str(content)
         .enumerate()
         .map(|(seq, document)| {

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -95,7 +95,7 @@ struct PendingToolCalls {
     timestamp: Option<chrono::DateTime<chrono::Utc>>,
 }
 
-fn collect_raw_log_entries(content: &str, name: &str) -> Result<Vec<(usize, SessionLogEntry)>> {
+pub(crate) fn collect_raw_log_entries(content: &str, name: &str) -> Result<Vec<(usize, SessionLogEntry)>> {
     serde_yaml::Deserializer::from_str(content)
         .enumerate()
         .map(|(seq, document)| {

--- a/crates/harnx-runtime/src/config/session_ops_split.rs
+++ b/crates/harnx-runtime/src/config/session_ops_split.rs
@@ -554,6 +554,7 @@ fn append_recovery_note(summary: String, covered: (Option<usize>, Option<usize>,
     };
     format!(
         "{summary}\n\n[Earlier conversation: {count} message(s){range} were summarized above. \
-The full pre-compaction transcript remains in this session's log on disk.]"
+The full pre-compaction transcript remains in this session's log; use the \
+`harnx_agent_session_history_read` tool to search it by entry index, type, tool name, or text.]"
     )
 }

--- a/crates/harnx-runtime/src/config/tests.rs
+++ b/crates/harnx-runtime/src/config/tests.rs
@@ -1391,3 +1391,89 @@ async fn use_agent_scopes_managers_to_package_for_delegation_tools() {
         "after use_agent, same-package ACP tools must NOT be `pantheon__`-prefixed; got {names:?}"
     );
 }
+
+// ── SessionHistoryProvider::call_tool end-to-end ─────────────────────────
+
+/// Exercises the full `call_tool` path of `SessionHistoryProvider`: build a
+/// real on-disk log, wire it up as the active session's `path`, then call
+/// through the provider and verify the envelope shape.
+#[tokio::test]
+async fn session_history_provider_call_tool_returns_message_entries() {
+    use crate::session_history::SessionHistoryProvider;
+    use harnx_core::abort::create_abort_signal;
+    use harnx_core::tool::ToolProvider as _;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+
+    // Build a minimal config with a session that has a real on-disk log.
+    let mut config = Config {
+        data: ConfigData {
+            stream: false,
+            save_session: Some(true),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut session = self::session::new(&config, "call-tool-test").unwrap();
+    session.set_sessions_dir(tmp.path().to_path_buf());
+
+    // Append a message entry so the log file is initialized and contains data.
+    let wrote = self::session::append_event(
+        &mut session,
+        &harnx_core::session::SessionLogEntry::Message {
+            role: crate::client::MessageRole::User,
+            content: crate::client::MessageContent::Text("what is 2+2?".to_string()),
+            timestamp: None,
+        },
+    );
+    assert!(wrote, "append_event must write the log file");
+
+    config.session = Some(session);
+    let global_config: GlobalConfig = Arc::new(RwLock::new(config));
+
+    let provider = SessionHistoryProvider::new(global_config.clone());
+    let abort = create_abort_signal();
+
+    // has_tool assertions
+    assert!(
+        provider.has_tool(crate::session_history::TOOL_NAME),
+        "provider must report the session-history tool as owned"
+    );
+    assert!(
+        !provider.has_tool("other_tool"),
+        "provider must not claim unrelated tools"
+    );
+
+    // call_tool with a type filter so only message entries come back.
+    let result = provider
+        .call_tool(
+            crate::session_history::TOOL_NAME,
+            serde_json::json!({"type": "message"}),
+            &abort,
+        )
+        .await
+        .map_err(|e| match e {
+            harnx_core::tool::ToolError::Recoverable(e) => e,
+            harnx_core::tool::ToolError::Fatal(e) => e,
+        })
+        .unwrap();
+
+    // Verify the content envelope: [{type:"text", text:"[...]"}]
+    let text = result["content"][0]["text"]
+        .as_str()
+        .expect("content[0].text must be a string");
+    assert_eq!(
+        result["content"][0]["type"], "text",
+        "content type must be 'text'"
+    );
+
+    // The text must deserialize as a JSON array containing at least one object
+    // with type == "message".
+    let rows: serde_json::Value =
+        serde_json::from_str(text).expect("content text must be valid JSON");
+    let arr = rows.as_array().expect("rows must be a JSON array");
+    assert!(
+        arr.iter().any(|r| r["type"] == "message"),
+        "at least one entry with type 'message' must be present; got: {arr:?}"
+    );
+}

--- a/crates/harnx-runtime/src/config/tests.rs
+++ b/crates/harnx-runtime/src/config/tests.rs
@@ -1087,6 +1087,34 @@ fn handoff_tool_declarations_are_package_aware_and_valid() {
 }
 
 #[test]
+fn session_history_tool_declaration_is_gated_by_use_tools() {
+    let config = Config::default();
+    let history_name = crate::session_history::TOOL_NAME;
+
+    let selected = config
+        .tool_declarations_for_use_tools(Some(history_name), None)
+        .0;
+    assert!(
+        selected.iter().any(|d| d.name == history_name),
+        "explicitly selecting the tool should include its declaration"
+    );
+
+    let unrelated = config
+        .tool_declarations_for_use_tools(Some("some_unrelated_tool"), None)
+        .0;
+    assert!(
+        !unrelated.iter().any(|d| d.name == history_name),
+        "an unrelated selector must not include the session-history declaration"
+    );
+
+    let wildcard = config.tool_declarations_for_use_tools(Some("*"), None).0;
+    assert!(
+        wildcard.iter().any(|d| d.name == history_name),
+        "a wildcard selector should include the session-history declaration"
+    );
+}
+
+#[test]
 fn dynamic_provider_model_init_sets_client_name_from_provider() {
     struct ProviderGuard(Option<std::ffi::OsString>);
     impl Drop for ProviderGuard {

--- a/crates/harnx-runtime/src/lib.rs
+++ b/crates/harnx-runtime/src/lib.rs
@@ -15,6 +15,7 @@ pub mod bootstrap;
 pub mod client;
 pub mod commands;
 pub mod config;
+pub mod session_history;
 pub mod test_utils;
 pub mod tool;
 pub mod utils;

--- a/crates/harnx-runtime/src/session_history.rs
+++ b/crates/harnx-runtime/src/session_history.rs
@@ -217,14 +217,10 @@ fn parse_query(arguments: &Value) -> HistoryQuery {
 
 /// `ToolProvider` for the session-history tool. Resolves the active session's
 /// on-disk log path from the captured config at call time (own session only).
-// `#[allow(dead_code)]`: the provider struct/impl are unused until the
-// registration task wires them into the tool-call loop. Removed in that task.
-#[allow(dead_code)]
 pub struct SessionHistoryProvider {
     config: GlobalConfig,
 }
 
-#[allow(dead_code)]
 impl SessionHistoryProvider {
     pub fn new(config: GlobalConfig) -> Self {
         Self { config }

--- a/crates/harnx-runtime/src/session_history.rs
+++ b/crates/harnx-runtime/src/session_history.rs
@@ -3,9 +3,13 @@
 //! dropped by compaction stays recoverable. Pure query core here; the
 //! `ToolProvider` wiring resolves the active session path and reads the file.
 
+use crate::config::GlobalConfig;
 use anyhow::Result;
+use async_trait::async_trait;
 use fancy_regex::Regex;
+use harnx_core::abort::AbortSignal;
 use harnx_core::session::SessionLogEntry;
+use harnx_core::tool::{JsonSchema, ToolDeclaration, ToolError, ToolProvider};
 use serde_json::{json, Value};
 
 /// The tool name exposed to agents.
@@ -46,8 +50,10 @@ fn entry_searchable_text(entry: &SessionLogEntry) -> String {
     match entry {
         SessionLogEntry::Message { content, .. } => content.to_text(),
         SessionLogEntry::ToolCalls { text, calls, .. } => {
-            let calls_text: Vec<String> =
-                calls.iter().map(|c| format!("{}({})", c.name, c.arguments)).collect();
+            let calls_text: Vec<String> = calls
+                .iter()
+                .map(|c| format!("{}({})", c.name, c.arguments))
+                .collect();
             format!("{text}\n{}", calls_text.join("\n"))
         }
         SessionLogEntry::ToolResults { results, .. } => results
@@ -65,7 +71,9 @@ fn entry_searchable_text(entry: &SessionLogEntry) -> String {
 fn entry_tool_names(entry: &SessionLogEntry) -> Vec<String> {
     match entry {
         SessionLogEntry::ToolCalls { calls, .. } => calls.iter().map(|c| c.name.clone()).collect(),
-        SessionLogEntry::ToolResults { results, .. } => results.iter().map(|r| r.name.clone()).collect(),
+        SessionLogEntry::ToolResults { results, .. } => {
+            results.iter().map(|r| r.name.clone()).collect()
+        }
         _ => Vec::new(),
     }
 }
@@ -153,6 +161,112 @@ pub fn query_log_content(content: &str, session_name: &str, query: &HistoryQuery
     query_entries_with_jaq(&entries, query)
 }
 
+/// Build the tool declaration (name, description, JSON-schema parameters).
+pub fn tool_declaration() -> ToolDeclaration {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "index_min": {"type": "integer", "description": "Minimum log entry seq (inclusive)."},
+            "index_max": {"type": "integer", "description": "Maximum log entry seq (inclusive)."},
+            "type": {"type": "string", "description": "Filter by entry type: message, tool_calls, tool_results, compress, header, data_urls, clear, edit_entries, rewind."},
+            "tool_name": {"type": "string", "description": "Keep only entries referencing this tool name."},
+            "text_regex": {"type": "string", "description": "Keep entries whose rendered text matches this regular expression."},
+            "limit": {"type": "integer", "description": "Maximum number of rows to return."},
+            "jaq": {"type": "string", "description": "Optional jq/jaq expression applied to the array of matched rows for arbitrary filtering or projection. Invalid expressions return an error."}
+        }
+    });
+    ToolDeclaration {
+        name: TOOL_NAME.to_string(),
+        description: "Search this session's own history log, including detail dropped by compaction. \
+Filter by entry index range, type, tool name, or a text regex; optionally refine with a jaq expression. \
+Returns a JSON array of matching log entries (seq, type, text, tool names)."
+            .to_string(),
+        parameters: serde_json::from_value::<JsonSchema>(schema)
+            .expect("session-history tool schema is valid"),
+        mcp_tool_name: None,
+        mcp_server_name: None,
+        call_template: None,
+        result_template: None,
+    }
+}
+
+/// Parse the tool-call arguments JSON into a `HistoryQuery`.
+fn parse_query(arguments: &Value) -> HistoryQuery {
+    let s = |k: &str| {
+        arguments
+            .get(k)
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+    };
+    let u = |k: &str| {
+        arguments
+            .get(k)
+            .and_then(|v| v.as_u64())
+            .map(|n| n as usize)
+    };
+    HistoryQuery {
+        index_min: u("index_min"),
+        index_max: u("index_max"),
+        entry_type: s("type"),
+        tool_name: s("tool_name"),
+        text_regex: s("text_regex"),
+        limit: u("limit"),
+        jaq: s("jaq"),
+    }
+}
+
+/// `ToolProvider` for the session-history tool. Resolves the active session's
+/// on-disk log path from the captured config at call time (own session only).
+// `#[allow(dead_code)]`: the provider struct/impl are unused until the
+// registration task wires them into the tool-call loop. Removed in that task.
+#[allow(dead_code)]
+pub struct SessionHistoryProvider {
+    config: GlobalConfig,
+}
+
+#[allow(dead_code)]
+impl SessionHistoryProvider {
+    pub fn new(config: GlobalConfig) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl ToolProvider for SessionHistoryProvider {
+    fn name(&self) -> &str {
+        "session_history"
+    }
+
+    fn has_tool(&self, tool_name: &str) -> bool {
+        tool_name == TOOL_NAME
+    }
+
+    async fn call_tool(
+        &self,
+        _tool_name: &str,
+        arguments: Value,
+        _abort: &AbortSignal,
+    ) -> Result<Value, ToolError> {
+        let (path, name) = {
+            let guard = self.config.read();
+            let session = guard
+                .session
+                .as_ref()
+                .ok_or_else(|| ToolError::Recoverable(anyhow::anyhow!("no active session")))?;
+            let path = session.path.clone().ok_or_else(|| {
+                ToolError::Recoverable(anyhow::anyhow!("session has not been saved yet"))
+            })?;
+            (path, session.id().to_string())
+        };
+        let content = std::fs::read_to_string(&path).map_err(|e| {
+            ToolError::Recoverable(anyhow::anyhow!("failed to read session log: {e}"))
+        })?;
+        let query = parse_query(&arguments);
+        let rows = query_log_content(&content, &name, &query).map_err(ToolError::Recoverable)?;
+        Ok(json!({ "content": [{ "type": "text", "text": rows.to_string() }] }))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -178,36 +292,58 @@ mod tests {
         use harnx_core::tool::ToolCall;
         use serde_json::json;
         vec![
-            (0, SessionLogEntry::Message {
-                role: MessageRole::User,
-                content: MessageContent::Text("please run the build".into()),
-                timestamp: None,
-            }),
-            (1, SessionLogEntry::ToolCalls {
-                text: "running it".into(),
-                thought: None,
-                calls: vec![ToolCall { name: "bash".into(), arguments: json!({"cmd":"make"}), id: Some("c1".into()), thought_signature: None }],
-                timestamp: None,
-            }),
-            (2, SessionLogEntry::ToolResults {
-                results: vec![harnx_core::session::ToolOutput {
-                    id: Some("c1".into()), name: "bash".into(),
-                    output: json!({"content":[{"type":"text","text":"build ok"}]}),
-                    content: vec![], switch_agent: None,
-                }],
-                timestamp: None,
-            }),
-            (3, SessionLogEntry::Message {
-                role: MessageRole::Assistant,
-                content: MessageContent::Text("the build passed".into()),
-                timestamp: None,
-            }),
+            (
+                0,
+                SessionLogEntry::Message {
+                    role: MessageRole::User,
+                    content: MessageContent::Text("please run the build".into()),
+                    timestamp: None,
+                },
+            ),
+            (
+                1,
+                SessionLogEntry::ToolCalls {
+                    text: "running it".into(),
+                    thought: None,
+                    calls: vec![ToolCall {
+                        name: "bash".into(),
+                        arguments: json!({"cmd":"make"}),
+                        id: Some("c1".into()),
+                        thought_signature: None,
+                    }],
+                    timestamp: None,
+                },
+            ),
+            (
+                2,
+                SessionLogEntry::ToolResults {
+                    results: vec![harnx_core::session::ToolOutput {
+                        id: Some("c1".into()),
+                        name: "bash".into(),
+                        output: json!({"content":[{"type":"text","text":"build ok"}]}),
+                        content: vec![],
+                        switch_agent: None,
+                    }],
+                    timestamp: None,
+                },
+            ),
+            (
+                3,
+                SessionLogEntry::Message {
+                    role: MessageRole::Assistant,
+                    content: MessageContent::Text("the build passed".into()),
+                    timestamp: None,
+                },
+            ),
         ]
     }
 
     #[test]
     fn query_filters_by_type() {
-        let q = HistoryQuery { entry_type: Some("message".into()), ..Default::default() };
+        let q = HistoryQuery {
+            entry_type: Some("message".into()),
+            ..Default::default()
+        };
         let rows = query_entries(&sample_entries(), &q).unwrap();
         let arr = rows.as_array().unwrap();
         assert_eq!(arr.len(), 2);
@@ -216,30 +352,52 @@ mod tests {
 
     #[test]
     fn query_filters_by_tool_name_and_index_range() {
-        let q = HistoryQuery { tool_name: Some("bash".into()), ..Default::default() };
+        let q = HistoryQuery {
+            tool_name: Some("bash".into()),
+            ..Default::default()
+        };
         let rows = query_entries(&sample_entries(), &q).unwrap();
         assert_eq!(rows.as_array().unwrap().len(), 2);
 
-        let q = HistoryQuery { index_min: Some(2), index_max: Some(3), ..Default::default() };
+        let q = HistoryQuery {
+            index_min: Some(2),
+            index_max: Some(3),
+            ..Default::default()
+        };
         let rows = query_entries(&sample_entries(), &q).unwrap();
-        let seqs: Vec<u64> = rows.as_array().unwrap().iter().map(|r| r["seq"].as_u64().unwrap()).collect();
+        let seqs: Vec<u64> = rows
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|r| r["seq"].as_u64().unwrap())
+            .collect();
         assert_eq!(seqs, vec![2, 3]);
     }
 
     #[test]
     fn query_filters_by_text_regex_and_limit() {
-        let q = HistoryQuery { text_regex: Some("build".into()), ..Default::default() };
+        let q = HistoryQuery {
+            text_regex: Some("build".into()),
+            ..Default::default()
+        };
         let rows = query_entries(&sample_entries(), &q).unwrap();
         assert_eq!(rows.as_array().unwrap().len(), 3);
 
-        let q = HistoryQuery { text_regex: Some("build".into()), limit: Some(1), ..Default::default() };
+        let q = HistoryQuery {
+            text_regex: Some("build".into()),
+            limit: Some(1),
+            ..Default::default()
+        };
         let rows = query_entries(&sample_entries(), &q).unwrap();
         assert_eq!(rows.as_array().unwrap().len(), 1);
     }
 
     #[test]
     fn query_applies_jaq_expression() {
-        let q = HistoryQuery { jaq: Some("map(select(.type == \"tool_results\"))".into()), ..Default::default() };
+        let q = HistoryQuery {
+            jaq: Some("map(select(.type == \"tool_results\"))".into()),
+            ..Default::default()
+        };
         let rows = query_entries_with_jaq(&sample_entries(), &q).unwrap();
         let arr = rows.as_array().unwrap();
         assert_eq!(arr.len(), 1);
@@ -248,15 +406,47 @@ mod tests {
 
     #[test]
     fn query_invalid_jaq_is_surfaced_as_error() {
-        let q = HistoryQuery { jaq: Some("this is (not valid jaq".into()), ..Default::default() };
+        let q = HistoryQuery {
+            jaq: Some("this is (not valid jaq".into()),
+            ..Default::default()
+        };
         let err = query_entries_with_jaq(&sample_entries(), &q).unwrap_err();
         assert!(err.to_string().contains("jaq"));
     }
 
     #[test]
+    fn tool_declaration_has_expected_name_and_params() {
+        let decl = tool_declaration();
+        assert_eq!(decl.name, TOOL_NAME);
+        let props = decl
+            .parameters
+            .properties
+            .as_ref()
+            .expect("schema has properties");
+        assert!(props.contains_key("jaq"));
+        assert!(props.contains_key("type"));
+        assert!(props.contains_key("tool_name"));
+    }
+
+    #[test]
+    fn parse_query_maps_arguments() {
+        let q = parse_query(&json!({"type": "message", "limit": 5, "index_min": 2}));
+        assert_eq!(q.entry_type.as_deref(), Some("message"));
+        assert_eq!(q.limit, Some(5));
+        assert_eq!(q.index_min, Some(2));
+        assert_eq!(q.index_max, None);
+        assert_eq!(q.tool_name, None);
+        assert_eq!(q.text_regex, None);
+        assert_eq!(q.jaq, None);
+    }
+
+    #[test]
     fn query_from_log_content_parses_and_filters() {
         let log = "type: header\nmodel: openai:gpt-4o\n---\ntype: message\nrole: user\ncontent: hello world\n";
-        let q = HistoryQuery { entry_type: Some("message".into()), ..Default::default() };
+        let q = HistoryQuery {
+            entry_type: Some("message".into()),
+            ..Default::default()
+        };
         let rows = query_log_content(log, "test", &q).unwrap();
         let arr = rows.as_array().unwrap();
         assert_eq!(arr.len(), 1);

--- a/crates/harnx-runtime/src/session_history.rs
+++ b/crates/harnx-runtime/src/session_history.rs
@@ -129,6 +129,30 @@ pub fn query_entries(entries: &[(usize, SessionLogEntry)], query: &HistoryQuery)
     Ok(Value::Array(rows))
 }
 
+/// Like `query_entries`, then apply the optional `jaq` expression over the
+/// matched-rows array. A broken jaq expression is surfaced as an error (rather
+/// than silently returning unfiltered rows) so the calling agent can fix or
+/// drop it instead of acting on results it wrongly believes were filtered.
+pub fn query_entries_with_jaq(
+    entries: &[(usize, SessionLogEntry)],
+    query: &HistoryQuery,
+) -> Result<Value> {
+    let rows = query_entries(entries, query)?;
+    let Some(expr) = &query.jaq else {
+        return Ok(rows);
+    };
+    // `eval_filter` returns `None` only on a parse/compile/runtime error; a
+    // legitimate empty result comes back as `Some([])`.
+    harnx_core::jaq::eval_filter(expr, rows)
+        .ok_or_else(|| anyhow::anyhow!("invalid jaq expression: {expr}"))
+}
+
+/// Parse a session log document string and run the full query against it.
+pub fn query_log_content(content: &str, session_name: &str, query: &HistoryQuery) -> Result<Value> {
+    let entries = crate::config::session::collect_raw_log_entries(content, session_name)?;
+    query_entries_with_jaq(&entries, query)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -211,5 +235,31 @@ mod tests {
         let q = HistoryQuery { text_regex: Some("build".into()), limit: Some(1), ..Default::default() };
         let rows = query_entries(&sample_entries(), &q).unwrap();
         assert_eq!(rows.as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn query_applies_jaq_expression() {
+        let q = HistoryQuery { jaq: Some("map(select(.type == \"tool_results\"))".into()), ..Default::default() };
+        let rows = query_entries_with_jaq(&sample_entries(), &q).unwrap();
+        let arr = rows.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["type"], "tool_results");
+    }
+
+    #[test]
+    fn query_invalid_jaq_is_surfaced_as_error() {
+        let q = HistoryQuery { jaq: Some("this is (not valid jaq".into()), ..Default::default() };
+        let err = query_entries_with_jaq(&sample_entries(), &q).unwrap_err();
+        assert!(err.to_string().contains("jaq"));
+    }
+
+    #[test]
+    fn query_from_log_content_parses_and_filters() {
+        let log = "type: header\nmodel: openai:gpt-4o\n---\ntype: message\nrole: user\ncontent: hello world\n";
+        let q = HistoryQuery { entry_type: Some("message".into()), ..Default::default() };
+        let rows = query_log_content(log, "test", &q).unwrap();
+        let arr = rows.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert!(arr[0]["text"].as_str().unwrap().contains("hello world"));
     }
 }

--- a/crates/harnx-runtime/src/session_history.rs
+++ b/crates/harnx-runtime/src/session_history.rs
@@ -3,7 +3,10 @@
 //! dropped by compaction stays recoverable. Pure query core here; the
 //! `ToolProvider` wiring resolves the active session path and reads the file.
 
+use anyhow::Result;
+use fancy_regex::Regex;
 use harnx_core::session::SessionLogEntry;
+use serde_json::{json, Value};
 
 /// The tool name exposed to agents.
 pub const TOOL_NAME: &str = "harnx_agent_session_history_read";
@@ -37,6 +40,95 @@ pub fn entry_type(entry: &SessionLogEntry) -> &'static str {
     }
 }
 
+/// Best-effort plain-text rendering of an entry, for `text_regex` matching and
+/// the row's `text` field. Bounded; images are already `cid:` refs.
+fn entry_searchable_text(entry: &SessionLogEntry) -> String {
+    match entry {
+        SessionLogEntry::Message { content, .. } => content.to_text(),
+        SessionLogEntry::ToolCalls { text, calls, .. } => {
+            let calls_text: Vec<String> =
+                calls.iter().map(|c| format!("{}({})", c.name, c.arguments)).collect();
+            format!("{text}\n{}", calls_text.join("\n"))
+        }
+        SessionLogEntry::ToolResults { results, .. } => results
+            .iter()
+            .map(|r| format!("{}: {}", r.name, r.output))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        SessionLogEntry::Compress { prompt } => prompt.clone(),
+        SessionLogEntry::Header { model_id, .. } => format!("model: {model_id}"),
+        _ => String::new(),
+    }
+}
+
+/// Tool names referenced by an entry (for `tool_name` filtering).
+fn entry_tool_names(entry: &SessionLogEntry) -> Vec<String> {
+    match entry {
+        SessionLogEntry::ToolCalls { calls, .. } => calls.iter().map(|c| c.name.clone()).collect(),
+        SessionLogEntry::ToolResults { results, .. } => results.iter().map(|r| r.name.clone()).collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Render one entry to a JSON row: `{ seq, type, text?, tool_names?, role? }`.
+fn entry_row(seq: usize, entry: &SessionLogEntry) -> Value {
+    let mut row = json!({ "seq": seq, "type": entry_type(entry) });
+    let text = entry_searchable_text(entry);
+    if !text.is_empty() {
+        row["text"] = json!(text);
+    }
+    let tools = entry_tool_names(entry);
+    if !tools.is_empty() {
+        row["tool_names"] = json!(tools);
+    }
+    if let SessionLogEntry::Message { role, .. } = entry {
+        row["role"] = json!(format!("{role:?}").to_lowercase());
+    }
+    row
+}
+
+/// Apply structured filters (index range, type, tool name, text regex, limit)
+/// to `entries`, returning a JSON array of matched rows. `jaq` is applied in a
+/// later layer, not here.
+pub fn query_entries(entries: &[(usize, SessionLogEntry)], query: &HistoryQuery) -> Result<Value> {
+    let regex = query
+        .text_regex
+        .as_deref()
+        .map(Regex::new)
+        .transpose()
+        .map_err(|e| anyhow::anyhow!("invalid text_regex: {e}"))?;
+
+    let mut rows: Vec<Value> = Vec::new();
+    for (seq, entry) in entries {
+        if query.index_min.is_some_and(|m| *seq < m) {
+            continue;
+        }
+        if query.index_max.is_some_and(|m| *seq > m) {
+            continue;
+        }
+        if let Some(t) = &query.entry_type {
+            if entry_type(entry) != t {
+                continue;
+            }
+        }
+        if let Some(tool) = &query.tool_name {
+            if !entry_tool_names(entry).iter().any(|n| n == tool) {
+                continue;
+            }
+        }
+        if let Some(re) = &regex {
+            if !re.is_match(&entry_searchable_text(entry)).unwrap_or(false) {
+                continue;
+            }
+        }
+        rows.push(entry_row(*seq, entry));
+    }
+    if let Some(limit) = query.limit {
+        rows.truncate(limit);
+    }
+    Ok(Value::Array(rows))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -56,5 +148,68 @@ mod tests {
             entry_type(&SessionLogEntry::Compress { prompt: "s".into() }),
             "compress"
         );
+    }
+
+    fn sample_entries() -> Vec<(usize, SessionLogEntry)> {
+        use harnx_core::tool::ToolCall;
+        use serde_json::json;
+        vec![
+            (0, SessionLogEntry::Message {
+                role: MessageRole::User,
+                content: MessageContent::Text("please run the build".into()),
+                timestamp: None,
+            }),
+            (1, SessionLogEntry::ToolCalls {
+                text: "running it".into(),
+                thought: None,
+                calls: vec![ToolCall { name: "bash".into(), arguments: json!({"cmd":"make"}), id: Some("c1".into()), thought_signature: None }],
+                timestamp: None,
+            }),
+            (2, SessionLogEntry::ToolResults {
+                results: vec![harnx_core::session::ToolOutput {
+                    id: Some("c1".into()), name: "bash".into(),
+                    output: json!({"content":[{"type":"text","text":"build ok"}]}),
+                    content: vec![], switch_agent: None,
+                }],
+                timestamp: None,
+            }),
+            (3, SessionLogEntry::Message {
+                role: MessageRole::Assistant,
+                content: MessageContent::Text("the build passed".into()),
+                timestamp: None,
+            }),
+        ]
+    }
+
+    #[test]
+    fn query_filters_by_type() {
+        let q = HistoryQuery { entry_type: Some("message".into()), ..Default::default() };
+        let rows = query_entries(&sample_entries(), &q).unwrap();
+        let arr = rows.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert!(arr.iter().all(|r| r["type"] == "message"));
+    }
+
+    #[test]
+    fn query_filters_by_tool_name_and_index_range() {
+        let q = HistoryQuery { tool_name: Some("bash".into()), ..Default::default() };
+        let rows = query_entries(&sample_entries(), &q).unwrap();
+        assert_eq!(rows.as_array().unwrap().len(), 2);
+
+        let q = HistoryQuery { index_min: Some(2), index_max: Some(3), ..Default::default() };
+        let rows = query_entries(&sample_entries(), &q).unwrap();
+        let seqs: Vec<u64> = rows.as_array().unwrap().iter().map(|r| r["seq"].as_u64().unwrap()).collect();
+        assert_eq!(seqs, vec![2, 3]);
+    }
+
+    #[test]
+    fn query_filters_by_text_regex_and_limit() {
+        let q = HistoryQuery { text_regex: Some("build".into()), ..Default::default() };
+        let rows = query_entries(&sample_entries(), &q).unwrap();
+        assert_eq!(rows.as_array().unwrap().len(), 3);
+
+        let q = HistoryQuery { text_regex: Some("build".into()), limit: Some(1), ..Default::default() };
+        let rows = query_entries(&sample_entries(), &q).unwrap();
+        assert_eq!(rows.as_array().unwrap().len(), 1);
     }
 }

--- a/crates/harnx-runtime/src/session_history.rs
+++ b/crates/harnx-runtime/src/session_history.rs
@@ -1,0 +1,60 @@
+//! The `harnx_agent_session_history_read` built-in tool: lets an agent search
+//! its own session's on-disk log (including pre-compaction entries) so detail
+//! dropped by compaction stays recoverable. Pure query core here; the
+//! `ToolProvider` wiring resolves the active session path and reads the file.
+
+use harnx_core::session::SessionLogEntry;
+
+/// The tool name exposed to agents.
+pub const TOOL_NAME: &str = "harnx_agent_session_history_read";
+
+/// Structured filters for a history query. All fields optional; absent = no
+/// constraint. `jaq` is applied (if present) to the array of matched rows.
+#[derive(Debug, Default, Clone)]
+pub struct HistoryQuery {
+    pub index_min: Option<usize>,
+    pub index_max: Option<usize>,
+    pub entry_type: Option<String>,
+    pub tool_name: Option<String>,
+    pub text_regex: Option<String>,
+    pub limit: Option<usize>,
+    pub jaq: Option<String>,
+}
+
+/// The log-entry `type` discriminant string (matches the YAML `type:` tag).
+pub fn entry_type(entry: &SessionLogEntry) -> &'static str {
+    match entry {
+        SessionLogEntry::Header { .. } => "header",
+        SessionLogEntry::Message { .. } => "message",
+        SessionLogEntry::ToolCalls { .. } => "tool_calls",
+        SessionLogEntry::ToolResults { .. } => "tool_results",
+        SessionLogEntry::DataUrls { .. } => "data_urls",
+        SessionLogEntry::Compress { .. } => "compress",
+        SessionLogEntry::Clear => "clear",
+        SessionLogEntry::EditEntries { .. } => "edit_entries",
+        SessionLogEntry::Rewind { .. } => "rewind",
+        SessionLogEntry::Unknown => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harnx_core::message::{MessageContent, MessageRole};
+
+    #[test]
+    fn entry_type_maps_variants() {
+        assert_eq!(
+            entry_type(&SessionLogEntry::Message {
+                role: MessageRole::User,
+                content: MessageContent::Text("hi".into()),
+                timestamp: None,
+            }),
+            "message"
+        );
+        assert_eq!(
+            entry_type(&SessionLogEntry::Compress { prompt: "s".into() }),
+            "compress"
+        );
+    }
+}

--- a/crates/harnx-runtime/src/session_history.rs
+++ b/crates/harnx-runtime/src/session_history.rs
@@ -149,8 +149,10 @@ pub fn query_entries_with_jaq(
     let Some(expr) = &query.jaq else {
         return Ok(rows);
     };
-    // `eval_filter` returns `None` only on a parse/compile/runtime error; a
-    // legitimate empty result comes back as `Some([])`.
+    // `eval_filter` returns `None` on a parse/compile/runtime error; surface
+    // that so the agent can fix or drop the expression. A filter that simply
+    // matches nothing does not return `None`, so this won't misfire on
+    // legitimately-empty results.
     harnx_core::jaq::eval_filter(expr, rows)
         .ok_or_else(|| anyhow::anyhow!("invalid jaq expression: {expr}"))
 }
@@ -447,5 +449,25 @@ mod tests {
         let arr = rows.as_array().unwrap();
         assert_eq!(arr.len(), 1);
         assert!(arr[0]["text"].as_str().unwrap().contains("hello world"));
+    }
+
+    #[test]
+    fn query_surfaces_entries_before_a_compress_boundary() {
+        let log = concat!(
+            "type: header\nmodel: openai:gpt-4o\n",
+            "---\ntype: message\nrole: user\ncontent: original question\n",
+            "---\ntype: compress\nprompt: summary so far\n",
+            "---\ntype: message\nrole: assistant\ncontent: recent answer\n",
+        );
+        let rows = query_log_content(log, "test", &HistoryQuery::default()).unwrap();
+        let arr = rows.as_array().unwrap();
+        // The pre-compaction "original question" entry is still surfaced.
+        assert!(arr.iter().any(|r| r["text"]
+            .as_str()
+            .is_some_and(|t| t.contains("original question"))));
+        assert!(arr.iter().any(|r| r["type"] == "compress"));
+        assert!(arr.iter().any(|r| r["text"]
+            .as_str()
+            .is_some_and(|t| t.contains("recent answer"))));
     }
 }

--- a/crates/harnx-runtime/src/tool.rs
+++ b/crates/harnx-runtime/src/tool.rs
@@ -262,6 +262,9 @@ pub fn build_tool_eval_context(
     if let Some(mcp) = mcp_manager {
         providers.push(mcp as Arc<dyn ToolProvider>);
     }
+    providers.push(Arc::new(crate::session_history::SessionHistoryProvider::new(
+        config.clone(),
+    )) as Arc<dyn ToolProvider>);
 
     let dispatch_hook_fn = build_dispatch_hook_fn(
         &hooks,

--- a/crates/harnx-runtime/src/tool.rs
+++ b/crates/harnx-runtime/src/tool.rs
@@ -262,9 +262,11 @@ pub fn build_tool_eval_context(
     if let Some(mcp) = mcp_manager {
         providers.push(mcp as Arc<dyn ToolProvider>);
     }
-    providers.push(Arc::new(crate::session_history::SessionHistoryProvider::new(
-        config.clone(),
-    )) as Arc<dyn ToolProvider>);
+    providers.push(
+        Arc::new(crate::session_history::SessionHistoryProvider::new(
+            config.clone(),
+        )) as Arc<dyn ToolProvider>,
+    );
 
     let dispatch_hook_fn = build_dispatch_hook_fn(
         &hooks,


### PR DESCRIPTION
## Summary

Adds a built-in agent tool, `harnx_agent_session_history_read`, that lets an agent search its **own** session's on-disk log — including detail dropped by compaction — so summarized context is recoverable. This is the third and final piece of the compaction overhaul (after attachment externalization #843 and the compaction redesign #846).

## What it does

The agent calls the tool with structured filters and gets back a JSON array of matching log entries:
- `index_min` / `index_max` — inclusive log-entry seq range
- `type` — `message`, `tool_calls`, `tool_results`, `compress`, `header`, …
- `tool_name` — entries referencing a given tool (matches both calls and results)
- `text_regex` — match against the entry's rendered text (`fancy-regex`)
- `limit` — cap the number of rows
- `jaq` — an optional jq/jaq expression over the matched rows for arbitrary filtering/projection (an invalid expression returns an error so the agent can fix it, rather than silently returning unfiltered rows)

The compaction recovery note (from #846) now points agents at this tool by name.

## Design

- New `crates/harnx-runtime/src/session_history.rs`: a pure query core (parse → structured filter → optional jaq) wrapped by a `ToolProvider` (`harnx_core`'s trait) that resolves the active session's `.yaml` path from a captured `GlobalConfig` and reads the file. Reuses `harnx_core::jaq::eval_filter` and the existing `collect_raw_log_entries` parser.
- **Own-session only:** the tool takes no path/session argument; the path comes solely from the active session, so it can't read other sessions or arbitrary files.
- **Recovers pre-compaction detail:** compaction is append-only + hard-cut, so the original entries remain in the log file; the tool reads the whole file and surfaces entries from before a `Compress` boundary.
- Declaration is gated by `use_tools` (opt-in, like handoff tools); the provider is registered alongside the acp/mcp providers — so agents that don't enable it are unaffected.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo nextest run --workspace` — 1518 tests pass
- Unit tests: entry-type classification; structured filters (type, tool name, index range, text regex, limit); jaq filtering + invalid-jaq-is-an-error; **entries before a `compress` boundary are surfaced**; log-content parse path; declaration gating (present for tool name / `*`, absent otherwise); and an end-to-end `call_tool` test (own-session resolution + result envelope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)