### PR TITLE
refactor(tui): simplify streamed-assistant-text accumulation

### DIFF
--- a/.changeset/tui-streaming-run-accumulation.md
+++ b/.changeset/tui-streaming-run-accumulation.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Simplify TUI streamed-assistant-text accumulation. Streamed text now coalesces into a single transcript block per unbroken run; an interleaving item (tool call, tool result, notice, source heading) ends the run so the following text starts a fresh block below it. This replaces the previous per-line splitting and the index-based bookkeeping (`streaming_assistant_idx`) with a single open/closed flag and a "look at the trailing item" rule, removing a fragile multi-branch loop.

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -767,7 +767,7 @@ impl Tui {
                 // Reset streaming index so the next LLM turn creates a fresh
                 // AssistantText item instead of appending to the previous one.
                 // This keeps tool-call rows visually between the two turns.
-                self.app.streaming_assistant_idx = None;
+                self.app.streaming_open = false;
                 self.pin_transcript_to_bottom();
             }
             TuiEvent::PendingMessageConsumed(pending) => {
@@ -911,25 +911,12 @@ impl Tui {
 
         let is_thought = matches!(&event, AgentEvent::Model(ModelEvent::ThoughtChunk { .. }));
         let is_usage = matches!(&event, AgentEvent::Model(ModelEvent::Usage { .. }));
-        // Tool calls (and plan updates) from sub-agents represent a turn-like
-        // boundary in the sub-agent's output: text streamed *before* the tool
-        // call belongs visually above it, text streamed *after* belongs
-        // visually below.  Reset the streaming-assistant index here so a
-        // subsequent MessageChunk starts a fresh AssistantText rather than
-        // being appended to the text that preceded the tool call.  We
-        // deliberately do NOT reset for display-only events (Notice::Info,
-        // Tool::Completed, Model::Usage, Tool::Update) so that LLM text
-        // chunks with trailing-newline completion still coalesce correctly
-        // across those events.
-        let is_turn_boundary = matches!(
-            &event,
-            AgentEvent::Tool(ToolEvent::Started { .. })
-                | AgentEvent::Tool(ToolEvent::Blocked { .. })
-                | AgentEvent::Plan { .. }
-        );
-        if is_turn_boundary {
-            self.app.streaming_assistant_idx = None;
-        }
+        // No streaming-run bookkeeping is needed here: any event that renders a
+        // visible transcript item (tool call, tool result, notice, plan, …)
+        // becomes the trailing item, which ends the open streaming run on its
+        // own — the next MessageChunk sees a non-AssistantText tail and starts
+        // a fresh block. See `append_streaming_assistant_chunk`.
+        //
         // Handle LogSeqAssigned before any heading/thought side-effects — it
         // is a pure seq-assignment event and should not create stray headings
         // or flush pending thoughts.
@@ -1058,63 +1045,45 @@ impl Tui {
                 *self.shared_pending_message.lock().await = None;
                 self.app.last_ui_output_source = None;
                 let usage_str = format_usage(&usage);
-                if !output.is_empty() && !self.app.streamed_text_this_turn {
-                    if let Some(idx) = self.app.streaming_assistant_idx {
-                        match self.app.transcript.get_mut(idx) {
-                            Some(TranscriptItem::AssistantText {
-                                text: existing,
+                if !output.is_empty() {
+                    if self.app.streamed_text_this_turn {
+                        // We streamed this turn, so the streamed run is the
+                        // trailing block of AssistantText items. Replace it
+                        // with the model's canonical final `output` (collapsing
+                        // any trailing run to a single block) so streamed text
+                        // is never duplicated by the final message.
+                        let tail_start = self
+                            .app
+                            .transcript
+                            .iter()
+                            .rposition(|item| !matches!(item, TranscriptItem::AssistantText { .. }))
+                            .map_or(0, |idx| idx + 1);
+
+                        if tail_start < self.app.transcript.len() {
+                            let mut tail = self.app.transcript.split_off(tail_start);
+                            if let Some(TranscriptItem::AssistantText {
+                                text,
                                 rendered_cache,
                                 ..
-                            }) if !existing.is_empty() => {
-                                if existing != &output {
-                                    *existing = output;
-                                    // Invalidate cached render so the updated text is re-rendered.
-                                    *rendered_cache = None;
-                                }
+                            }) = tail.first_mut()
+                            {
+                                *text = output;
+                                *rendered_cache = None;
                             }
-                            _ => {
-                                self.app.transcript.push(TranscriptItem::AssistantText {
-                                    text: output,
-                                    seq: None,
-                                    timestamp: Some(chrono::Utc::now()),
-                                    rendered_cache: None,
-                                });
-                                self.app.streaming_assistant_idx =
-                                    Some(self.app.transcript.len() - 1);
-                            }
+                            tail.truncate(1);
+                            self.app.transcript.extend(tail);
+                        } else {
+                            self.app.transcript.push(TranscriptItem::AssistantText {
+                                text: output,
+                                seq: None,
+                                timestamp: Some(chrono::Utc::now()),
+                                rendered_cache: None,
+                            });
                         }
                     } else {
-                        self.app.transcript.push(TranscriptItem::AssistantText {
-                            text: output,
-                            seq: None,
-                            timestamp: Some(chrono::Utc::now()),
-                            rendered_cache: None,
-                        });
-                        self.app.streaming_assistant_idx = Some(self.app.transcript.len() - 1);
-                    }
-                    self.pin_transcript_to_bottom();
-                } else if !output.is_empty() {
-                    let tail_start = self
-                        .app
-                        .transcript
-                        .iter()
-                        .rposition(|item| !matches!(item, TranscriptItem::AssistantText { .. }))
-                        .map_or(0, |idx| idx + 1);
-
-                    if tail_start < self.app.transcript.len() {
-                        let mut tail = self.app.transcript.split_off(tail_start);
-                        if let Some(TranscriptItem::AssistantText {
-                            text,
-                            rendered_cache,
-                            ..
-                        }) = tail.first_mut()
-                        {
-                            *text = output;
-                            *rendered_cache = None;
-                        }
-                        tail.truncate(1);
-                        self.app.transcript.extend(tail);
-                    } else {
+                        // Nothing streamed this turn (non-streaming client, or
+                        // an empty stream): append the final text as a fresh
+                        // block.
                         self.app.transcript.push(TranscriptItem::AssistantText {
                             text: output,
                             seq: None,
@@ -1124,7 +1093,7 @@ impl Tui {
                     }
                     self.pin_transcript_to_bottom();
                 }
-                self.app.streaming_assistant_idx = None;
+                self.app.streaming_open = false;
                 self.app.streamed_text_this_turn = false;
                 if !usage_str.is_empty() {
                     self.app
@@ -1152,7 +1121,7 @@ impl Tui {
                 // channel so its content can't leak into the next task.
                 self.current_prompt_abort = None;
                 *self.shared_pending_message.lock().await = None;
-                self.app.streaming_assistant_idx = None;
+                self.app.streaming_open = false;
                 // Symmetric with the Final handler: reset the per-turn
                 // streamed-text flag so a streamed chunk before an error
                 // can't suppress a later turn's final text.
@@ -1270,7 +1239,7 @@ impl Tui {
             }
             AgentEvent::Session(SessionEvent::CompactingCompleted) => {
                 self.app.transcript = session_history_transcript_items(&self.config);
-                self.app.streaming_assistant_idx = None;
+                self.app.streaming_open = false;
                 // A compaction can land mid-turn after some assistant text has
                 // already streamed. The rebuild drops that streamed row, so the
                 // per-turn flag must also reset — otherwise the next
@@ -1332,7 +1301,7 @@ impl Tui {
             // chunks get concatenated onto the parent's AssistantText,
             // producing a single run-on paragraph that mixes content from
             // multiple agents on the top-level row.
-            self.app.streaming_assistant_idx = None;
+            self.app.streaming_open = false;
         }
         if !is_usage {
             self.clear_usage_tracking();
@@ -1385,7 +1354,7 @@ impl Tui {
         self.current_prompt_abort = Some(new_abort.clone());
 
         self.app.llm_busy = true;
-        self.app.streaming_assistant_idx = None;
+        self.app.streaming_open = false;
         self.app.streamed_text_this_turn = false;
 
         let event_tx = self.event_tx.clone();
@@ -1971,7 +1940,7 @@ impl Tui {
         }
 
         self.app.transcript.clear();
-        self.app.streaming_assistant_idx = None;
+        self.app.streaming_open = false;
         self.app.streamed_text_this_turn = false;
         // Reset scroll state so the widget doesn't subtract-overflow when
         // the rebuilt transcript is shorter than the previous one.

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -98,7 +98,7 @@ impl Tui {
             should_quit: false,
             llm_busy: false,
             scroll_state: ratatui_widget_scrolling::ScrollState::new(),
-            streaming_assistant_idx: None,
+            streaming_open: false,
             streamed_text_this_turn: false,
             cache_valid_width: None,
             last_ui_output_source: None,

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -630,56 +630,37 @@ impl Tui {
         total as u16
     }
 
+    /// Append a streamed assistant text chunk to the open streaming run,
+    /// which is always the trailing `AssistantText` transcript item. If no
+    /// run is open — at turn start, or because an interleaving item (tool
+    /// call, tool result, notice, source heading, …) became the trailing
+    /// item — a fresh `AssistantText` is started. An interleaving item thus
+    /// breaks the surrounding text into separate blocks for free, with no
+    /// per-event bookkeeping.
     pub(super) fn append_streaming_assistant_chunk(&mut self, chunk: &str) {
-        let mut remainder = chunk;
-        while !remainder.is_empty() {
-            if let Some(idx) = self.app.streaming_assistant_idx {
-                match self.app.transcript.get_mut(idx) {
-                    Some(TranscriptItem::AssistantText { text: existing, .. }) => {
-                        if existing.is_empty() {
-                            if let Some(split_at) = remainder.find('\n') {
-                                let (segment, rest) = remainder.split_at(split_at + 1);
-                                existing.push_str(segment);
-                                remainder = rest;
-                                self.app.streaming_assistant_idx = None;
-                            } else {
-                                existing.push_str(remainder);
-                                break;
-                            }
-                        } else if let Some(last_newline) = existing.rfind('\n') {
-                            let tail = &existing[last_newline + 1..];
-                            if tail.is_empty() {
-                                self.app.streaming_assistant_idx = None;
-                            } else if let Some(split_at) = remainder.find('\n') {
-                                let (segment, rest) = remainder.split_at(split_at + 1);
-                                existing.push_str(segment);
-                                remainder = rest;
-                                self.app.streaming_assistant_idx = None;
-                            } else {
-                                existing.push_str(remainder);
-                                break;
-                            }
-                        } else if let Some(split_at) = remainder.find('\n') {
-                            let (segment, rest) = remainder.split_at(split_at + 1);
-                            existing.push_str(segment);
-                            remainder = rest;
-                            self.app.streaming_assistant_idx = None;
-                        } else {
-                            existing.push_str(remainder);
-                            break;
-                        }
-                    }
-                    _ => self.app.streaming_assistant_idx = None,
-                }
-            } else {
-                self.app.transcript.push(TranscriptItem::AssistantText {
-                    text: String::new(),
-                    seq: None,
-                    timestamp: Some(chrono::Utc::now()),
-                    rendered_cache: None,
-                });
-                self.app.streaming_assistant_idx = Some(self.app.transcript.len() - 1);
-            }
+        let open = self.app.streaming_open
+            && matches!(
+                self.app.transcript.last(),
+                Some(TranscriptItem::AssistantText { .. })
+            );
+        if !open {
+            self.app.transcript.push(TranscriptItem::AssistantText {
+                text: String::new(),
+                seq: None,
+                timestamp: Some(chrono::Utc::now()),
+                rendered_cache: None,
+            });
+            self.app.streaming_open = true;
+        }
+        if let Some(TranscriptItem::AssistantText {
+            text,
+            rendered_cache,
+            ..
+        }) = self.app.transcript.last_mut()
+        {
+            text.push_str(chunk);
+            // Invalidate the cached render so the appended text repaints.
+            *rendered_cache = None;
         }
     }
 
@@ -691,7 +672,7 @@ impl Tui {
     pub(crate) fn clear_transcript(&mut self) {
         self.app.transcript.clear();
         self.app.scroll_state = ratatui_widget_scrolling::ScrollState::new();
-        self.app.streaming_assistant_idx = None;
+        self.app.streaming_open = false;
         self.app.streamed_text_this_turn = false;
     }
 
@@ -1391,7 +1372,13 @@ impl Tui {
             )];
         }
 
-        let streaming_idx = self.app.streaming_assistant_idx;
+        // The open streaming run is always the trailing item; skip its render
+        // cache so in-progress text repaints each frame.
+        let streaming_idx = self
+            .app
+            .streaming_open
+            .then(|| self.app.transcript.len().checked_sub(1))
+            .flatten();
         self.app
             .transcript
             .iter_mut()

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -471,7 +471,9 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
             _ => None,
         })
         .collect();
-    assert_eq!(assistant_entries, vec!["Hello\n", "world\n", "Again"]);
+    // A streamed run accumulates verbatim until an interleaving item (here the
+    // "tool output" notice) ends it; the next chunk starts a fresh block below.
+    assert_eq!(assistant_entries, vec!["Hello\nworld", "\nAgain"]);
     assert!(tui
         .app
         .transcript
@@ -633,9 +635,11 @@ async fn final_only_coalesces_trailing_streamed_run_after_interruption() {
             _ => None,
         })
         .collect();
+    // The pre-interruption run accumulated verbatim into one block; the notice
+    // ended it; Final coalesces only the trailing run into the canonical block.
     assert_eq!(
         assistant_entries,
-        vec!["```rust\n", "fn first() {}\n", full_block]
+        vec!["```rust\nfn first() {}\n", full_block]
     );
     assert!(transcript
         .iter()
@@ -7925,7 +7929,7 @@ async fn render_agent_event_compacting_completed_reconciles_live_transcript() {
             timestamp: None,
         },
     ];
-    tui.app.streaming_assistant_idx = Some(1);
+    tui.app.streaming_open = true;
     tui.app.last_usage_transcript_idx = Some(2);
     tui.app.last_usage_source = Some(AgentSource {
         agent: "primary".to_string(),
@@ -8003,7 +8007,7 @@ async fn render_agent_event_compacting_completed_reconciles_live_transcript() {
                 && *to_seq == Some(2)
     ));
     assert!(tui.app.transcript[0].is_navigable());
-    assert_eq!(tui.app.streaming_assistant_idx, None);
+    assert!(!tui.app.streaming_open);
     assert_eq!(tui.app.last_usage_transcript_idx, None);
     assert_eq!(tui.app.last_usage_source, None);
     assert_eq!(tui.app.transcript_focus, None);

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -71,7 +71,13 @@ pub(super) struct App {
     pub(super) should_quit: bool,
     pub(super) llm_busy: bool,
     pub(super) scroll_state: ratatui_widget_scrolling::ScrollState,
-    pub(super) streaming_assistant_idx: Option<usize>,
+    /// True while the trailing `AssistantText` transcript item is an open
+    /// streaming run that subsequent `MessageChunk`s should be appended to.
+    /// Set false at every turn boundary (Final, Error, new prompt) so a
+    /// finalized message — or the startup banner — is never appended to.
+    /// Interleaving items (tool calls, notices, headings, …) end a run
+    /// implicitly by becoming the trailing item themselves.
+    pub(super) streaming_open: bool,
     pub(super) streamed_text_this_turn: bool,
     pub(super) cache_valid_width: Option<u16>,
     pub(super) last_ui_output_source: Option<AgentSource>,


### PR DESCRIPTION
## What

Rewrites `append_streaming_assistant_chunk` (TUI) from a multi-branch `while`-loop over a `remainder` slice — splitting streamed text into one transcript item per line — into a flat accumulator:

- Streamed text coalesces into a **single trailing `AssistantText` block** per unbroken run.
- An **interleaving item** (tool call, tool result, notice, source heading, usage line, the next user message) becomes the trailing transcript item and thereby ends the run — the next chunk sees a non-`AssistantText` tail and starts a fresh block below it. No per-event reset bookkeeping.

State change: `streaming_assistant_idx: Option<usize>` → `streaming_open: bool`. The open run is always the last transcript item, so the index was redundant as a position — and could go stale when the transcript is rebuilt (e.g. after compaction). The `is_turn_boundary` special-casing is removed; the `Final` handler keeps coalescing the trailing streamed run into the model's canonical output.

## Why

Investigating the intermittent OOM (#842), this function was the one loop-shaped piece of code in the "final response / waiting for input" path. I traced the old version as terminating, so **this is a robustness/clarity fix, not a confirmed fix for #842** — the leak is still more consistent with a stream that never closes or a recent dependency bump. But the old code had three branches that neither advanced `remainder` nor broke, relying on subtle one-step convergence; the new code is trivially bounded and drops the stale-index hazard.

## Behavior change

Streamed text now renders as accumulated blocks broken by interleaving events, rather than one item per line. Example: chunks `"Hello\nworld"`, a tool-output notice, then `"\nAgain"` now yield blocks `["Hello\nworld", "\nAgain"]` instead of `["Hello\n", "world\n", "Again"]`.

## Testing

- `cargo build --workspace`, `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 1543 passed, 3 skipped

Tests updated to assert run-accumulation rather than per-line splitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)