### PR TITLE
refactor(bash): remove inputs/outputs sandbox-narrowing params from b…

### DIFF
--- a/.changeset/remove-bash-inputs-outputs-params.md
+++ b/.changeset/remove-bash-inputs-outputs-params.md
@@ -1,0 +1,5 @@
+---
+harnx: patch
+---
+
+Remove the `inputs`/`outputs` parameters from the bash MCP tools (`bash_exec`/`bash_spawn`). The sandbox no longer narrows project roots per call — roots always get read+write+exec — fixing `cargo` build failures in sub-agents (#850). Legacy calls that still pass `inputs`/`outputs` are accepted and ignored.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Harnx ships with several built-in MCP servers ready to enable in your config. Se
     *   Path validation against allowed roots; smart output truncation; binary detection.
     *   [Local history snapshots](docs/local-history-guide.md) before and after every mutation.
 *   **`harnx-mcp-bash`** — Bash command execution (`exec`, `spawn`, `wait`, `terminate`, `read_exec_log`)
-    *   **Filesystem sandboxing via [birdcage](https://crates.io/crates/birdcage)** (Linux/macOS) — write access limited to roots by default; per-call `inputs`/`outputs` overrides.
+    *   **Filesystem sandboxing via [birdcage](https://crates.io/crates/birdcage)** (Linux/macOS) — commands run with read+write+exec access to the project roots plus default system/cache allow-lists.
     *   Process group management (kill-on-drop) and background `spawn` + `wait` pattern.
     *   Path validation and history snapshots around mutating commands.
 *   **`harnx-mcp-time`** — Time and timezone utilities (`get_current_time`, `convert_time`, `wait`).

--- a/crates/harnx-core/src/tool.rs
+++ b/crates/harnx-core/src/tool.rs
@@ -722,7 +722,7 @@ mod tests {
     #[test]
     fn test_bash_exec_call_template_fence_closes_on_own_line() {
         // This is the actual template used by the bash exec tool.
-        let template = "```sh\n$ {{ args.command }}\n```{% if args.working_dir or args.timeout_secs or args.head_lines or args.tail_lines or args.max_output_bytes or args.inputs or args.outputs %}\n{% if args.working_dir %}({{ args.working_dir }}) {% endif %}{% if args.timeout_secs %}[{{ args.timeout_secs }}s] {% endif %}{% if args.head_lines is not none %}[head:{{ args.head_lines }}] {% endif %}{% if args.tail_lines is not none %}[tail_lines:{{ args.tail_lines }}] {% endif %}{% if args.max_output_bytes is not none %}[:{{ args.max_output_bytes }}b] {% endif %}{% if args.inputs %}[<{{ args.inputs | length }}] {% endif %}{% if args.outputs %}[>{{ args.outputs | length }}]{% endif %}{% endif %}";
+        let template = "```sh\n$ {{ args.command }}\n```{% if args.working_dir or args.timeout_secs or args.head_lines or args.tail_lines or args.max_output_bytes %}\n{% if args.working_dir %}({{ args.working_dir }}) {% endif %}{% if args.timeout_secs %}[{{ args.timeout_secs }}s] {% endif %}{% if args.head_lines is not none %}[head:{{ args.head_lines }}] {% endif %}{% if args.tail_lines is not none %}[tail_lines:{{ args.tail_lines }}] {% endif %}{% if args.max_output_bytes is not none %}[:{{ args.max_output_bytes }}b] {% endif %}{% endif %}";
 
         // No extras — bare fence, closing ``` is the last line.
         let out =
@@ -788,9 +788,7 @@ mod tests {
                 "command": "ls",
                 "head_lines": 5,
                 "tail_lines": 2,
-                "max_output_bytes": 1024,
-                "inputs": ["in.txt"],
-                "outputs": ["out.txt"]
+                "max_output_bytes": 1024
             }),
             "",
         )
@@ -810,14 +808,6 @@ mod tests {
         assert!(
             out.contains("[:1024b]"),
             "max_output_bytes in extended output: {out:?}"
-        );
-        assert!(
-            out.contains("[<1]"),
-            "inputs count in extended output: {out:?}"
-        );
-        assert!(
-            out.contains("[>1]"),
-            "outputs count in extended output: {out:?}"
         );
     }
 

--- a/crates/harnx-mcp-bash/src/server/command.rs
+++ b/crates/harnx-mcp-bash/src/server/command.rs
@@ -6,21 +6,13 @@ impl BashServer {
     pub(crate) fn build_sandbox_args(
         &self,
         working_dir: &Path,
-        inputs: Option<&[PathBuf]>,
-        outputs: Option<&[PathBuf]>,
         roots: &[PathBuf],
     ) -> Vec<OsString> {
-        let inputs_explicit_empty = matches!(inputs, Some([]));
         let mut acc = SandboxAcc::new(build_default_sandbox_args(&self.inner.sandbox_config));
 
-        acc.apply_outputs(outputs, roots, inputs_explicit_empty);
-
-        if let Some(paths) = inputs.filter(|paths| !paths.is_empty()) {
-            acc.add_reads(paths);
-        }
-
-        if !inputs_explicit_empty {
-            acc.ensure_working_dir_readable(working_dir);
+        acc.ensure_working_dir_readable(working_dir);
+        for root in roots {
+            push_root_write_exec(root, &mut acc.args, &mut acc.writable);
         }
 
         let mut args = acc.into_args();
@@ -63,12 +55,10 @@ impl BashServer {
             working_dir,
             exec_dir,
             command,
-            inputs,
-            outputs,
             roots,
             extra_env,
         } = spec;
-        let mut sb_args = self.build_sandbox_args(working_dir, inputs, outputs, roots);
+        let mut sb_args = self.build_sandbox_args(working_dir, roots);
         sb_args.push(OsString::from("--working-dir"));
         sb_args.push(working_dir.as_os_str().to_owned());
         if let Some(extra_env) = extra_env {
@@ -165,16 +155,12 @@ impl BashServer {
             #[cfg(unix)]
             {
                 let roots_guard = self.inner.roots.read().await;
-                let inputs = parse_input_path_list(ctx.inputs, &roots_guard, ctx.working_dir)?;
-                let outputs = parse_output_path_list(ctx.outputs, &roots_guard, ctx.working_dir)?;
                 let command = self
                     .build_sandbox_command(
                         SandboxCommandSpec {
                             working_dir: ctx.working_dir,
                             exec_dir: ctx.exec_dir,
                             command: ctx.command,
-                            inputs: inputs.as_deref(),
-                            outputs: outputs.as_deref(),
                             roots: &roots_guard,
                             extra_env: ctx.env,
                         },

--- a/crates/harnx-mcp-bash/src/server/exec.rs
+++ b/crates/harnx-mcp-bash/src/server/exec.rs
@@ -13,7 +13,6 @@ impl BashServer {
             .prepare_exec(
                 &params.command,
                 params.working_dir.as_deref(),
-                params.outputs.as_ref(),
                 params.env.as_ref(),
                 "before exec",
             )
@@ -46,10 +45,6 @@ impl BashServer {
                     command: &params.command,
                     working_dir: &working_dir,
                     exec_dir: &exec_dir,
-                    #[cfg(unix)]
-                    inputs: &params.inputs,
-                    #[cfg(unix)]
-                    outputs: &params.outputs,
                     env: params.env.as_ref(),
                 },
                 Stdio::piped(),
@@ -161,7 +156,6 @@ impl BashServer {
         &self,
         command: &str,
         working_dir: Option<&str>,
-        outputs: Option<&Vec<String>>,
         extra_env: Option<&HashMap<String, String>>,
         snapshot_label: &str,
     ) -> Result<ExecPreparation, ErrorData> {
@@ -173,9 +167,7 @@ impl BashServer {
         }
 
         let working_dir = self.resolve_working_dir(working_dir).await?;
-        let output_paths = self.resolve_output_paths(&working_dir, outputs).await?;
-        let snapshot_decision =
-            Self::snapshot_decision_from_output_paths(command, &working_dir, output_paths.as_ref());
+        let snapshot_decision = Self::snapshot_decision_for_command(command, &working_dir);
         let before_snap_ids = self
             .take_snapshots(&snapshot_decision, &working_dir, snapshot_label)
             .await;
@@ -187,28 +179,11 @@ impl BashServer {
         })
     }
 
-    pub(crate) async fn resolve_output_paths(
-        &self,
-        working_dir: &Path,
-        outputs: Option<&Vec<String>>,
-    ) -> Result<Option<Vec<PathBuf>>, ErrorData> {
-        let roots_guard = self.inner.roots.read().await;
-        let owned_outputs = outputs.cloned();
-        let output_paths = parse_output_path_list(&owned_outputs, &roots_guard, working_dir)?;
-        drop(roots_guard);
-        Ok(output_paths)
-    }
-
-    pub(crate) fn snapshot_decision_from_output_paths(
+    pub(crate) fn snapshot_decision_for_command(
         command: &str,
         working_dir: &Path,
-        output_paths: Option<&Vec<PathBuf>>,
     ) -> SnapshotDecision {
-        match output_paths {
-            None => classify_command(command, working_dir),
-            Some(paths) if paths.is_empty() => SnapshotDecision::ReadOnly,
-            Some(paths) => SnapshotDecision::Targeted(paths.clone()),
-        }
+        classify_command(command, working_dir)
     }
 
     pub(crate) async fn take_snapshots(

--- a/crates/harnx-mcp-bash/src/server/handler.rs
+++ b/crates/harnx-mcp-bash/src/server/handler.rs
@@ -28,7 +28,7 @@ impl ServerHandler for BashServer {
                 )
                 .with_input_schema::<ExecCommandParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "```{{ args.command | shebang_lang }}\n$ {{ args.command | strip_shebang }}\n```{% if args.working_dir or args.timeout_secs or args.head_lines or args.tail_lines or args.max_output_bytes or args.inputs or args.outputs %}\n{% if args.working_dir %}({{ args.working_dir }}) {% endif %}{% if args.timeout_secs %}[{{ args.timeout_secs }}s] {% endif %}{% if args.head_lines is not none %}[head:{{ args.head_lines }}] {% endif %}{% if args.tail_lines is not none %}[tail_lines:{{ args.tail_lines }}] {% endif %}{% if args.max_output_bytes is not none %}[:{{ args.max_output_bytes }}b] {% endif %}{% if args.inputs %}[<{{ args.inputs | length }}] {% endif %}{% if args.outputs %}[>{{ args.outputs | length }}]{% endif %}{% endif %}",
+                    "call_template": "```{{ args.command | shebang_lang }}\n$ {{ args.command | strip_shebang }}\n```{% if args.working_dir or args.timeout_secs or args.head_lines or args.tail_lines or args.max_output_bytes %}\n{% if args.working_dir %}({{ args.working_dir }}) {% endif %}{% if args.timeout_secs %}[{{ args.timeout_secs }}s] {% endif %}{% if args.head_lines is not none %}[head:{{ args.head_lines }}] {% endif %}{% if args.tail_lines is not none %}[tail_lines:{{ args.tail_lines }}] {% endif %}{% if args.max_output_bytes is not none %}[:{{ args.max_output_bytes }}b] {% endif %}{% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "read_exec_log",
@@ -46,7 +46,7 @@ impl ServerHandler for BashServer {
                 )
                 .with_input_schema::<SpawnCommandParams>()
                 .with_meta(Meta(json!({
-                    "call_template": "```{{ args.command | shebang_lang }}\n$ {{ args.command | strip_shebang }} &\n```{% if args.working_dir or args.inputs or args.outputs %}\n{% if args.working_dir %}({{ args.working_dir }}) {% endif %}{% if args.inputs %}[<{{ args.inputs | length }}] {% endif %}{% if args.outputs %}[>{{ args.outputs | length }}]{% endif %}{% endif %}",
+                    "call_template": "```{{ args.command | shebang_lang }}\n$ {{ args.command | strip_shebang }} &\n```{% if args.working_dir %}\n({{ args.working_dir }}) {% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
                     "wait",

--- a/crates/harnx-mcp-bash/src/server/handlers.rs
+++ b/crates/harnx-mcp-bash/src/server/handlers.rs
@@ -1,12 +1,11 @@
 // Auto-split from server.rs for cohesion. See server/mod.rs.
 use super::*;
 
-/// Accumulator for sandbox CLI args plus the readable/writable path sets used
-/// to decide whether the working directory still needs an explicit `--read`.
+/// Accumulator for sandbox CLI args plus the writable path set used to decide
+/// whether the working directory still needs an explicit `--read`.
 #[cfg(unix)]
 pub(crate) struct SandboxAcc {
     pub(crate) args: Vec<OsString>,
-    pub(crate) readable: Vec<PathBuf>,
     pub(crate) writable: Vec<PathBuf>,
 }
 
@@ -15,7 +14,6 @@ impl SandboxAcc {
     pub(crate) fn new(args: Vec<OsString>) -> Self {
         Self {
             args,
-            readable: Vec::new(),
             writable: Vec::new(),
         }
     }
@@ -24,51 +22,10 @@ impl SandboxAcc {
         self.args
     }
 
-    pub(crate) fn add_reads(&mut self, paths: &[PathBuf]) {
-        for path in paths {
-            self.args.push(OsString::from("--read"));
-            self.args.push(path.clone().into_os_string());
-            self.readable.push(path.clone());
-        }
-    }
-
-    pub(crate) fn apply_outputs(
-        &mut self,
-        outputs: Option<&[PathBuf]>,
-        roots: &[PathBuf],
-        inputs_explicit_empty: bool,
-    ) {
-        match outputs {
-            None => {
-                for root in roots {
-                    push_root_write_exec(root, &mut self.args, &mut self.writable);
-                }
-            }
-            Some([]) => {
-                if !inputs_explicit_empty {
-                    for root in roots {
-                        push_root_read_exec(root, &mut self.args, &mut self.readable);
-                    }
-                }
-            }
-            Some(paths) => {
-                for path in paths {
-                    self.args.push(OsString::from("--write"));
-                    self.args.push(path.clone().into_os_string());
-                    self.writable.push(path.clone());
-                }
-                for root in roots {
-                    push_root_exec_only(root, &mut self.args);
-                }
-            }
-        }
-    }
-
     pub(crate) fn ensure_working_dir_readable(&mut self, working_dir: &Path) {
         let covered = self
             .writable
             .iter()
-            .chain(self.readable.iter())
             .any(|path| working_dir.starts_with(path));
         if !covered {
             self.args.push(OsString::from("--read"));
@@ -84,8 +41,6 @@ pub(crate) struct SandboxCommandSpec<'a> {
     pub(crate) working_dir: &'a Path,
     pub(crate) exec_dir: &'a Path,
     pub(crate) command: &'a str,
-    pub(crate) inputs: Option<&'a [PathBuf]>,
-    pub(crate) outputs: Option<&'a [PathBuf]>,
     pub(crate) roots: &'a [PathBuf],
     pub(crate) extra_env: Option<&'a HashMap<String, String>>,
 }
@@ -144,10 +99,6 @@ pub(crate) struct CommandBuildCtx<'a> {
     pub(crate) command: &'a str,
     pub(crate) working_dir: &'a Path,
     pub(crate) exec_dir: &'a Path,
-    #[cfg(unix)]
-    pub(crate) inputs: &'a Option<Vec<String>>,
-    #[cfg(unix)]
-    pub(crate) outputs: &'a Option<Vec<String>>,
     pub(crate) env: Option<&'a HashMap<String, String>>,
 }
 

--- a/crates/harnx-mcp-bash/src/server/mod.rs
+++ b/crates/harnx-mcp-bash/src/server/mod.rs
@@ -1,6 +1,6 @@
 use harnx_mcp::safety::{
     file_uri_to_path, format_size, sanitize_output_text, truncate_output, validate_path,
-    validate_write_path, TruncateOpts,
+    TruncateOpts,
 };
 
 use fancy_regex::Regex;
@@ -77,9 +77,6 @@ pub(crate) struct SpawnedProcess {
     stderr_log_path: PathBuf,
     before_snap_ids: Vec<(PathBuf, gix::ObjectId)>,
     snapshot_decision: SnapshotDecision,
-    /// Resolved output paths from params.outputs; drives history snapshot in wait_impl.
-    /// None = use snapshot_decision (classifier); Some([]) = ReadOnly; Some(paths) = Targeted.
-    output_paths: Option<Vec<PathBuf>>,
 }
 
 struct BashServerInner {

--- a/crates/harnx-mcp-bash/src/server/params.rs
+++ b/crates/harnx-mcp-bash/src/server/params.rs
@@ -16,10 +16,6 @@ pub(crate) struct ExecCommandParams {
     #[serde(default)]
     pub(crate) max_output_bytes: Option<usize>,
     #[serde(default)]
-    pub(crate) inputs: Option<Vec<String>>,
-    #[serde(default)]
-    pub(crate) outputs: Option<Vec<String>>,
-    #[serde(default)]
     pub(crate) env: Option<HashMap<String, String>>,
 }
 
@@ -35,8 +31,6 @@ impl JsonSchema for ExecCommandParams {
         let head_lines = generator.subschema_for::<Option<usize>>();
         let tail_lines = generator.subschema_for::<Option<usize>>();
         let max_output_bytes = generator.subschema_for::<Option<usize>>();
-        let inputs = generator.subschema_for::<Option<Vec<String>>>();
-        let outputs = generator.subschema_for::<Option<Vec<String>>>();
         let env = generator.subschema_for::<Option<HashMap<String, String>>>();
         object_schema_with_desc(
             vec![
@@ -46,8 +40,6 @@ impl JsonSchema for ExecCommandParams {
                 ("head_lines", "Return only the first N lines of combined output. Prefer this over `| head -N` in the command.", head_lines),
                 ("tail_lines", "Return only the last N lines of combined output. Prefer this over `| tail -N` in the command.", tail_lines),
                 ("max_output_bytes", "Truncate output to this many bytes. Prefer this over `| head -c N` in the command.", max_output_bytes),
-                ("inputs", "Paths that the command will read (for sandbox allow-listing).", inputs),
-                ("outputs", "Paths that the command will write (triggers history snapshot).", outputs),
                 ("env", "Additional environment variables for the command. Merged on top of the server's environment; per-call overrides only.", env),
             ],
             &["command"],
@@ -126,10 +118,6 @@ pub(crate) struct SpawnCommandParams {
     #[serde(default)]
     pub(crate) working_dir: Option<String>,
     #[serde(default)]
-    pub(crate) inputs: Option<Vec<String>>,
-    #[serde(default)]
-    pub(crate) outputs: Option<Vec<String>>,
-    #[serde(default)]
     pub(crate) env: Option<HashMap<String, String>>,
 }
 
@@ -141,8 +129,6 @@ impl JsonSchema for SpawnCommandParams {
     fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         let command = generator.subschema_for::<String>();
         let working_dir = generator.subschema_for::<Option<String>>();
-        let inputs = generator.subschema_for::<Option<Vec<String>>>();
-        let outputs = generator.subschema_for::<Option<Vec<String>>>();
         let env = generator.subschema_for::<Option<HashMap<String, String>>>();
         object_schema_with_desc(
             vec![
@@ -151,12 +137,6 @@ impl JsonSchema for SpawnCommandParams {
                     "working_dir",
                     "Working directory. Defaults to the project root.",
                     working_dir,
-                ),
-                ("inputs", "Paths the command will read.", inputs),
-                (
-                    "outputs",
-                    "Paths the command will write (triggers history snapshot on wait).",
-                    outputs,
                 ),
                 (
                     "env",

--- a/crates/harnx-mcp-bash/src/server/process.rs
+++ b/crates/harnx-mcp-bash/src/server/process.rs
@@ -14,7 +14,6 @@ impl BashServer {
             .prepare_exec(
                 &params.command,
                 params.working_dir.as_deref(),
-                params.outputs.as_ref(),
                 params.env.as_ref(),
                 "before spawn",
             )
@@ -24,10 +23,6 @@ impl BashServer {
             snapshot_decision,
             before_snap_ids,
         } = prepared;
-        let output_paths = self
-            .resolve_output_paths(&working_dir, params.outputs.as_ref())
-            .await?;
-
         self.ensure_log_dir().await?;
 
         let exec_dir = self.next_exec_dir()?.keep();
@@ -54,10 +49,6 @@ impl BashServer {
                     command: &params.command,
                     working_dir: &working_dir,
                     exec_dir: &exec_dir,
-                    #[cfg(unix)]
-                    inputs: &params.inputs,
-                    #[cfg(unix)]
-                    outputs: &params.outputs,
                     env: params.env.as_ref(),
                 },
                 Stdio::from(stdout_file),
@@ -81,7 +72,6 @@ impl BashServer {
             stderr_log_path: stderr_log_path.clone(),
             before_snap_ids,
             snapshot_decision: snapshot_decision.clone(),
-            output_paths,
         };
 
         self.store_spawned_process(execution_id.clone(), entry)
@@ -116,7 +106,6 @@ impl BashServer {
             stderr_log_path,
             before_snap_ids,
             snapshot_decision,
-            output_paths,
         ) = {
             let mut map = self.inner.spawned.lock().await;
             let entry = map.remove(&params.execution_id).ok_or_else(|| {
@@ -136,14 +125,7 @@ impl BashServer {
                 entry.stderr_log_path,
                 entry.before_snap_ids,
                 entry.snapshot_decision,
-                entry.output_paths,
             )
-        };
-
-        let snapshot_decision = match &output_paths {
-            None => snapshot_decision,
-            Some(paths) if paths.is_empty() => SnapshotDecision::ReadOnly,
-            Some(paths) => SnapshotDecision::Targeted(paths.clone()),
         };
 
         let timeout = Duration::from_secs(timeout_secs);
@@ -209,7 +191,6 @@ impl BashServer {
                         stderr_log_path: stderr_log_path.clone(),
                         before_snap_ids,
                         snapshot_decision,
-                        output_paths,
                     },
                 );
 

--- a/crates/harnx-mcp-bash/src/server/render.rs
+++ b/crates/harnx-mcp-bash/src/server/render.rs
@@ -78,54 +78,6 @@ pub(crate) fn sandbox_run_test_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/debug/harnx-sandbox-exec")
 }
 
-#[cfg(unix)]
-pub(crate) fn parse_input_path_list(
-    list: &Option<Vec<String>>,
-    roots: &[PathBuf],
-    working_dir: &Path,
-) -> Result<Option<Vec<PathBuf>>, ErrorData> {
-    parse_validated_path_list(list, roots, working_dir, validate_path)
-}
-
-pub(crate) fn parse_output_path_list(
-    list: &Option<Vec<String>>,
-    roots: &[PathBuf],
-    working_dir: &Path,
-) -> Result<Option<Vec<PathBuf>>, ErrorData> {
-    parse_validated_path_list(list, roots, working_dir, validate_write_path)
-}
-
-pub(crate) fn parse_validated_path_list(
-    list: &Option<Vec<String>>,
-    roots: &[PathBuf],
-    working_dir: &Path,
-    validator: fn(&str, &[PathBuf]) -> Result<PathBuf, String>,
-) -> Result<Option<Vec<PathBuf>>, ErrorData> {
-    match list {
-        None => Ok(None),
-        Some(strs) => {
-            let mut out = Vec::with_capacity(strs.len());
-            for raw in strs {
-                if raw.trim().is_empty() {
-                    return Err(ErrorData::invalid_params(
-                        "path list contains empty string",
-                        None,
-                    ));
-                }
-                let resolved = if Path::new(raw).is_relative() {
-                    working_dir.join(raw)
-                } else {
-                    PathBuf::from(raw)
-                };
-                let validated = validator(&resolved.to_string_lossy(), roots)
-                    .map_err(|err| ErrorData::invalid_params(err, None))?;
-                out.push(validated);
-            }
-            Ok(Some(out))
-        }
-    }
-}
-
 pub(crate) fn load_bash_env_file() -> Vec<(String, String)> {
     let env_file = harnx_core::config_paths::bash_env_file();
     let Ok(contents) = std::fs::read_to_string(&env_file) else {

--- a/crates/harnx-mcp-bash/src/server/sandbox.rs
+++ b/crates/harnx-mcp-bash/src/server/sandbox.rs
@@ -35,30 +35,3 @@ pub(crate) fn push_root_write_exec(
     args.push(root.as_os_str().to_os_string());
     writable.push(root.to_path_buf());
 }
-
-/// Push `--read` and `--exec` args for `root`, unless it is `$HOME` or an ancestor.
-#[cfg(unix)]
-pub(crate) fn push_root_read_exec(
-    root: &Path,
-    args: &mut Vec<OsString>,
-    readable: &mut Vec<PathBuf>,
-) {
-    if is_home_or_ancestor(root) {
-        return;
-    }
-    args.push(OsString::from("--read"));
-    args.push(root.as_os_str().to_os_string());
-    args.push(OsString::from("--exec"));
-    args.push(root.as_os_str().to_os_string());
-    readable.push(root.to_path_buf());
-}
-
-/// Push `--exec` arg for `root`, unless it is `$HOME` or an ancestor.
-#[cfg(unix)]
-pub(crate) fn push_root_exec_only(root: &Path, args: &mut Vec<OsString>) {
-    if is_home_or_ancestor(root) {
-        return;
-    }
-    args.push(OsString::from("--exec"));
-    args.push(root.as_os_str().to_os_string());
-}

--- a/crates/harnx-mcp-bash/src/server/tests.rs
+++ b/crates/harnx-mcp-bash/src/server/tests.rs
@@ -342,19 +342,9 @@ fn sandbox_server(root: impl Into<PathBuf>) -> BashServer {
 }
 
 #[cfg(unix)]
-fn sandbox_arg_pairs(
-    root: &Path,
-    working_dir: &Path,
-    inputs: Option<Vec<PathBuf>>,
-    outputs: Option<Vec<PathBuf>>,
-) -> Vec<(String, String)> {
+fn sandbox_arg_pairs(root: &Path, working_dir: &Path) -> Vec<(String, String)> {
     let server = sandbox_server(root.to_path_buf());
-    let args = server.build_sandbox_args(
-        working_dir,
-        inputs.as_deref(),
-        outputs.as_deref(),
-        &[root.to_path_buf()],
-    );
+    let args = server.build_sandbox_args(working_dir, &[root.to_path_buf()]);
     collect_arg_pairs(&args)
 }
 
@@ -384,8 +374,6 @@ fn exec_params(command: impl Into<String>, working_dir: &Path) -> ExecCommandPar
         head_lines: None,
         tail_lines: None,
         max_output_bytes: None,
-        inputs: None,
-        outputs: None,
         env: None,
     }
 }
@@ -394,8 +382,6 @@ fn spawn_params(command: impl Into<String>, working_dir: &Path) -> SpawnCommandP
     SpawnCommandParams {
         command: command.into(),
         working_dir: Some(working_dir.to_string_lossy().to_string()),
-        inputs: None,
-        outputs: None,
         env: None,
     }
 }
@@ -429,6 +415,14 @@ fn assert_text_contains_all(text: &str, needles: &[&str]) {
     for needle in needles {
         assert!(text.contains(needle), "missing {needle:?} in text: {text}");
     }
+}
+
+#[test]
+fn test_exec_params_ignores_legacy_inputs_outputs() {
+    let json = r#"{"command":"echo hi","inputs":["/tmp/in"],"outputs":["/tmp/out"]}"#;
+    let parsed: ExecCommandParams =
+        serde_json::from_str(json).expect("legacy payload must deserialize");
+    assert_eq!(parsed.command, "echo hi");
 }
 
 fn assert_execution_metadata_fields(text: &str) {
@@ -469,31 +463,6 @@ fn extract_field(text: &str, field: &str) -> String {
         .to_string()
 }
 
-async fn git(args: &[&str], cwd: &Path) {
-    let status = tokio::process::Command::new("git")
-        .args(args)
-        .current_dir(cwd)
-        .status()
-        .await
-        .unwrap();
-    assert!(
-        status.success(),
-        "git command failed: git {}",
-        args.join(" ")
-    );
-}
-
-async fn init_git_repo(root: &Path) {
-    tokio::fs::write(root.join("tracked.txt"), "baseline\n")
-        .await
-        .unwrap();
-    git(&["init"], root).await;
-    git(&["config", "user.name", "Test User"], root).await;
-    git(&["config", "user.email", "test@example.com"], root).await;
-    git(&["add", "tracked.txt"], root).await;
-    git(&["commit", "-m", "initial"], root).await;
-}
-
 mod sandbox_args {
     use super::*;
 
@@ -504,7 +473,7 @@ mod sandbox_args {
         // so serialize against tests that mutate HOME via the shared env lock.
         let _env_guard = env_lock();
         let root = Path::new("/test/root");
-        let pairs = sandbox_arg_pairs(root, Path::new("/test/root/workdir"), None, None);
+        let pairs = sandbox_arg_pairs(root, Path::new("/test/root/workdir"));
 
         assert_arg_pair_present(&pairs, "--write", "/test/root");
         assert_arg_pair_present(&pairs, "--exec", "/usr/bin");
@@ -545,12 +514,7 @@ mod sandbox_args {
         let _gopath = EnvVar::set("GOPATH", "/srv/go-workspace");
         let _gobin = EnvVar::set("GOBIN", "/srv/go-workspace/installed");
 
-        let pairs = sandbox_arg_pairs(
-            Path::new("/test/root"),
-            Path::new("/test/root/workdir"),
-            None,
-            None,
-        );
+        let pairs = sandbox_arg_pairs(Path::new("/test/root"), Path::new("/test/root/workdir"));
 
         // Custom CARGO_HOME root is readable so config.toml/credentials work.
         assert_arg_pair_present(&pairs, "--read", "/opt/cargo-custom");
@@ -575,12 +539,7 @@ mod sandbox_args {
         let _gomodcache = EnvVar::set("GOMODCACHE", "/srv/go-mod-cache");
         let _gocache = EnvVar::set("GOCACHE", "/srv/go-build-cache");
 
-        let pairs = sandbox_arg_pairs(
-            Path::new("/test/root"),
-            Path::new("/test/root/workdir"),
-            None,
-            None,
-        );
+        let pairs = sandbox_arg_pairs(Path::new("/test/root"), Path::new("/test/root/workdir"));
 
         assert_arg_pair_present(&pairs, "--read", "/srv/go-mod-cache");
         assert_arg_pair_present(&pairs, "--write", "/srv/go-mod-cache");
@@ -596,12 +555,7 @@ mod sandbox_args {
         let _env_guard = env_lock();
         let _homebrew = EnvVar::set("HOMEBREW_PREFIX", "/custom/homebrew");
 
-        let pairs = sandbox_arg_pairs(
-            Path::new("/test/root"),
-            Path::new("/test/root/workdir"),
-            None,
-            None,
-        );
+        let pairs = sandbox_arg_pairs(Path::new("/test/root"), Path::new("/test/root/workdir"));
 
         // The Homebrew prefix is granted read+execute (exec implies read).
         assert_arg_pair_present(&pairs, "--exec", "/custom/homebrew");
@@ -616,12 +570,7 @@ mod sandbox_args {
         let _env_guard = env_lock();
         let _homebrew = EnvVar::unset("HOMEBREW_PREFIX");
 
-        let pairs = sandbox_arg_pairs(
-            Path::new("/test/root"),
-            Path::new("/test/root/workdir"),
-            None,
-            None,
-        );
+        let pairs = sandbox_arg_pairs(Path::new("/test/root"), Path::new("/test/root/workdir"));
 
         // With HOMEBREW_PREFIX unset, the macOS compile-time default applies.
         assert_arg_pair_present(&pairs, "--exec", "/opt/homebrew");
@@ -634,12 +583,7 @@ mod sandbox_args {
         let _env_guard = env_lock();
         let _homebrew = EnvVar::unset("HOMEBREW_PREFIX");
 
-        let pairs = sandbox_arg_pairs(
-            Path::new("/test/root"),
-            Path::new("/test/root/workdir"),
-            None,
-            None,
-        );
+        let pairs = sandbox_arg_pairs(Path::new("/test/root"), Path::new("/test/root/workdir"));
 
         // With HOMEBREW_PREFIX unset, the Linux compile-time default applies.
         assert_arg_pair_present(&pairs, "--exec", "/home/linuxbrew/.linuxbrew");
@@ -648,50 +592,41 @@ mod sandbox_args {
 
     #[cfg(unix)]
     #[test]
-    fn test_sandbox_args_empty_outputs() {
-        let pairs = sandbox_arg_pairs(
-            Path::new("/test/root"),
-            Path::new("/test/root/workdir"),
-            None,
-            Some(vec![]),
-        );
+    fn test_sandbox_args_root_write_exec_workdir_inside_root() {
+        let pairs = sandbox_arg_pairs(Path::new("/test/root"), Path::new("/test/root/workdir"));
 
-        assert_arg_pair_present(&pairs, "--read", "/test/root");
-        assert_arg_pair_absent(&pairs, "--write", "/test/root");
+        assert_arg_pair_present(&pairs, "--write", "/test/root");
+        assert_arg_pair_present(&pairs, "--exec", "/test/root");
     }
 
     #[cfg(unix)]
     #[test]
-    fn test_sandbox_args_custom_outputs() {
-        let pairs = sandbox_arg_pairs(
-            Path::new("/test/root"),
-            Path::new("/custom/out/workdir"),
-            None,
-            Some(vec![PathBuf::from("/custom/out")]),
-        );
+    fn test_sandbox_args_root_write_exec_workdir_outside_root() {
+        let pairs = sandbox_arg_pairs(Path::new("/test/root"), Path::new("/custom/out/workdir"));
 
-        assert_arg_pair_present(&pairs, "--write", "/custom/out");
-        assert_arg_pair_absent(&pairs, "--write", "/test/root");
-        assert_arg_pair_absent(&pairs, "--read", "/test/root");
+        assert_arg_pair_present(&pairs, "--write", "/test/root");
+        assert_arg_pair_present(&pairs, "--exec", "/test/root");
     }
 
     #[cfg(unix)]
     #[test]
-    fn test_sandbox_args_empty_inputs_empty_outputs() {
+    fn test_sandbox_args_root_write_exec_tmp_workdir() {
         let working_dir = Path::new("/tmp/test_wd_xxx");
-        let pairs = sandbox_arg_pairs(
-            Path::new("/test/root"),
-            working_dir,
-            Some(vec![]),
-            Some(vec![]),
-        );
+        let pairs = sandbox_arg_pairs(Path::new("/test/root"), working_dir);
 
-        assert_arg_pair_absent(&pairs, "--write", "/test/root");
-        assert_arg_pair_absent(&pairs, "--read", "/test/root");
-        assert_arg_pair_absent(&pairs, "--read", "/tmp/test_wd_xxx");
+        assert_arg_pair_present(&pairs, "--write", "/test/root");
+        assert_arg_pair_present(&pairs, "--exec", "/test/root");
     }
 
     #[cfg(unix)]
+    #[test]
+    fn test_roots_always_writable_and_executable() {
+        let root = tempfile::tempdir().unwrap();
+        let pairs = sandbox_arg_pairs(root.path(), root.path());
+
+        assert_arg_pair_present(&pairs, "--write", root.path().to_string_lossy());
+        assert_arg_pair_present(&pairs, "--exec", root.path().to_string_lossy());
+    }
     #[test]
     fn test_sandbox_args_extra_writable() {
         let mut config = enabled_sandbox_config();
@@ -701,8 +636,6 @@ mod sandbox_args {
         let server = BashServer::new_with_sandbox(vec![PathBuf::from("/test/root")], config);
         let args = server.build_sandbox_args(
             Path::new("/custom/writable/workdir"),
-            None,
-            None,
             &[PathBuf::from("/test/root")],
         );
         let pairs = collect_arg_pairs(&args);
@@ -718,8 +651,6 @@ mod sandbox_args {
         let server = BashServer::new_with_sandbox(vec![PathBuf::from("/test/root")], config);
         let args = server.build_sandbox_args(
             Path::new("/custom/rwx/workdir"),
-            None,
-            None,
             &[PathBuf::from("/test/root")],
         );
         let pairs = collect_arg_pairs(&args);
@@ -734,7 +665,7 @@ mod sandbox_args {
     fn test_sandbox_args_roots_get_exec() {
         let root = PathBuf::from("/test/root");
         let server = BashServer::new_with_sandbox(vec![root.clone()], enabled_sandbox_config());
-        let args = server.build_sandbox_args(Path::new("/test/root/workdir"), None, None, &[root]);
+        let args = server.build_sandbox_args(Path::new("/test/root/workdir"), &[root]);
         let pairs = collect_arg_pairs(&args);
 
         assert!(pairs.contains(&("--write".into(), "/test/root".into())));
@@ -750,8 +681,6 @@ mod sandbox_args {
         );
         let args = server.build_sandbox_args(
             Path::new("/test/root/workdir"),
-            None,
-            None,
             &[PathBuf::from("/test/root")],
         );
         let pairs = collect_arg_pairs(&args);
@@ -771,8 +700,6 @@ mod sandbox_args {
         );
         let args = server.build_sandbox_args(
             Path::new("/test/root/workdir"),
-            None,
-            None,
             &[PathBuf::from("/test/root")],
         );
         let pairs = collect_arg_pairs(&args);
@@ -975,78 +902,8 @@ fn env_bash_dotfile_loaded() {
 }
 
 #[cfg(unix)]
-#[tokio::test]
-async fn test_inputs_validation_rejects_paths_outside_roots() {
-    let root = TestDir::new();
-    let server =
-        BashServer::new_with_sandbox(vec![root.path().to_path_buf()], enabled_sandbox_config());
-
-    let result = server
-        .exec_command_impl(ExecCommandParams {
-            inputs: Some(vec!["/etc".into()]),
-            ..exec_params("cat /etc/passwd", root.path())
-        })
-        .await;
-
-    let err = result.unwrap_err();
-    assert_eq!(err.code.0, -32602);
-    assert!(
-        err.message.contains("outside allowed roots")
-            || err.message.contains("not under allowed roots")
-    );
-}
-
 #[cfg(unix)]
-#[tokio::test]
-async fn test_outputs_validation_rejects_paths_outside_roots() {
-    let root = TestDir::new();
-    let server =
-        BashServer::new_with_sandbox(vec![root.path().to_path_buf()], enabled_sandbox_config());
-
-    let result = server
-        .exec_command_impl(ExecCommandParams {
-            outputs: Some(vec!["/etc".into()]),
-            ..exec_params("echo hi", root.path())
-        })
-        .await;
-
-    let err = result.unwrap_err();
-    assert_eq!(err.code.0, -32602);
-    assert!(
-        err.message.contains("outside allowed roots")
-            || err.message.contains("not under allowed roots")
-    );
-}
-
 #[cfg(unix)]
-#[tokio::test]
-async fn test_inputs_relative_paths_resolved_against_working_dir() {
-    // Verifies that a relative `inputs` path is resolved against the
-    // tool's `working_dir` at validation time (not the server's CWD).
-    // We don't run bash here — that's a separate concern covered by the
-    // Linux-only sandbox-runtime tests below; we just check that
-    // validation accepts the relative path.
-    let root = TestDir::new();
-    std::fs::create_dir(root.path().join("subdir")).unwrap();
-    let roots = vec![root.path().to_path_buf()];
-
-    let validated = parse_input_path_list(&Some(vec!["subdir".to_string()]), &roots, root.path())
-        .expect("relative input path under working_dir must validate");
-
-    let paths = validated.expect("Some(_) when input list provided");
-    assert_eq!(paths.len(), 1);
-    assert!(
-        paths[0].ends_with("subdir"),
-        "validated path should canonicalize to .../subdir, got {}",
-        paths[0].display()
-    );
-    assert!(
-        paths[0].starts_with(root.path().canonicalize().unwrap()),
-        "validated path should be under root, got {}",
-        paths[0].display()
-    );
-}
-
 #[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_sandbox_exec_write_allowed() {
@@ -1064,8 +921,6 @@ async fn test_sandbox_exec_write_allowed() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -1101,8 +956,6 @@ async fn test_sandbox_exec_write_denied_outside_root() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: Some(vec![]),
             env: None,
         })
         .await
@@ -1128,72 +981,6 @@ async fn test_sandbox_exec_write_denied_outside_root() {
 
 #[cfg(target_os = "linux")]
 #[tokio::test]
-async fn test_sandbox_exec_custom_outputs() {
-    if !sandbox_runtime_works() {
-        return;
-    }
-    let root = TestDir::new();
-    let other = TestDir::new();
-    let server = sandboxed_server(vec![root.path().to_path_buf(), other.path().to_path_buf()]);
-    let outputs = vec![other.path().to_string_lossy().to_string()];
-
-    let fail_result = server
-        .exec_command_impl(ExecCommandParams {
-            command: "echo hi > in_root.txt".to_string(),
-            working_dir: Some(root.path().to_string_lossy().to_string()),
-            timeout_secs: Some(15),
-            head_lines: None,
-            tail_lines: None,
-            max_output_bytes: None,
-            inputs: None,
-            outputs: Some(outputs.clone()),
-            env: None,
-        })
-        .await
-        .unwrap();
-    let fail_text = text_content(&fail_result);
-    eprintln!(
-        "sandbox custom outputs fail output:
-{fail_text}"
-    );
-    let fail_exit_code = extract_field(&fail_text, "exit_code")
-        .parse::<i32>()
-        .unwrap();
-    assert_ne!(
-        fail_exit_code, 0,
-        "expected root write failure, got:
-{fail_text}"
-    );
-    assert!(!root.path().join("in_root.txt").exists());
-
-    let success_result = server
-        .exec_command_impl(ExecCommandParams {
-            command: format!("echo bye > {}", other.path().join("in_other.txt").display()),
-            working_dir: Some(root.path().to_string_lossy().to_string()),
-            timeout_secs: Some(15),
-            head_lines: None,
-            tail_lines: None,
-            max_output_bytes: None,
-            inputs: None,
-            outputs: Some(outputs),
-            env: None,
-        })
-        .await
-        .unwrap();
-    let success_text = text_content(&success_result);
-    eprintln!(
-        "sandbox custom outputs success output:
-{success_text}"
-    );
-    assert_eq!(extract_field(&success_text, "exit_code"), "0");
-    assert_eq!(
-        std::fs::read_to_string(other.path().join("in_other.txt")).unwrap(),
-        "bye
-"
-    );
-}
-
-#[tokio::test]
 async fn test_working_dir_rejected_outside_roots() {
     let allowed = TestDir::new();
     let outside = TestDir::new();
@@ -1207,8 +994,6 @@ async fn test_working_dir_rejected_outside_roots() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await;
@@ -1233,8 +1018,6 @@ async fn test_exec_rejects_empty_command() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await;
@@ -1258,8 +1041,6 @@ async fn test_exec_rejects_invalid_env_keys() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: Some(bad_env),
         })
         .await;
@@ -1276,8 +1057,6 @@ async fn test_exec_rejects_invalid_env_keys() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: Some(bad_env2),
         })
         .await;
@@ -1294,8 +1073,6 @@ async fn test_exec_rejects_invalid_env_keys() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: Some(bad_env3),
         })
         .await;
@@ -1333,8 +1110,6 @@ async fn test_exec_basic_command() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -1385,8 +1160,6 @@ async fn test_exec_per_call_env_vars() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: Some(extra_env),
         })
         .await
@@ -1411,8 +1184,6 @@ async fn test_spawn_per_call_env_vars() {
         .spawn_impl(SpawnCommandParams {
             command: "echo $MY_SPAWN_VAR".to_string(),
             working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
-            inputs: None,
-            outputs: None,
             env: Some(extra_env),
         })
         .await
@@ -1463,8 +1234,6 @@ async fn test_sandbox_exec_per_call_env_vars() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: Some(extra_env),
         })
         .await
@@ -1496,8 +1265,6 @@ async fn test_sandbox_spawn_per_call_env_vars() {
         .spawn_impl(SpawnCommandParams {
             command: "echo $MY_SANDBOX_SPAWN_VAR".to_string(),
             working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
-            inputs: None,
-            outputs: None,
             env: Some(extra_env),
         })
         .await
@@ -1544,8 +1311,6 @@ async fn env_secret_not_leaked_to_child() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -1574,8 +1339,6 @@ async fn test_exec_timeout() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -1605,8 +1368,6 @@ async fn test_exec_truncation_mentions_log_paths_and_read_exec_log_works() {
             head_lines: Some(1),
             tail_lines: Some(1),
             max_output_bytes: Some(16),
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -1694,8 +1455,6 @@ async fn test_cleanup_log_dir_removes_temp_logs() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -1719,8 +1478,6 @@ async fn test_spawn_and_wait() {
         .spawn_impl(SpawnCommandParams {
             command: "echo background && sleep 1".to_string(),
             working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -1763,8 +1520,6 @@ async fn test_spawn_wait_timeout() {
         .spawn_impl(SpawnCommandParams {
             command: "sleep 5".to_string(),
             working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -1869,8 +1624,6 @@ async fn test_spawn_with_output() {
         .spawn_impl(SpawnCommandParams {
             command: "for i in 1 2 3; do echo line$i; done".to_string(),
             working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -1899,112 +1652,6 @@ async fn test_spawn_with_output() {
 }
 
 #[tokio::test]
-async fn test_exec_with_outputs_uses_targeted_snapshot() {
-    let temp_dir = TestDir::new();
-    init_git_repo(temp_dir.path()).await;
-    let server = BashServer::new(vec![temp_dir.path().to_path_buf()]);
-
-    let result = server
-        .exec_command_impl(ExecCommandParams {
-            command: "printf 'one\n' > specific_file.txt && printf 'two\n' > other_file.txt"
-                .to_string(),
-            working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
-            timeout_secs: Some(5),
-            head_lines: None,
-            tail_lines: Some(20),
-            max_output_bytes: None,
-            inputs: None,
-            outputs: Some(vec!["specific_file.txt".to_string()]),
-            env: None,
-        })
-        .await
-        .unwrap();
-
-    let text = text_content(&result);
-    assert!(text.contains("exit_code: 0"));
-    assert!(text.contains("status: exited"));
-    assert!(text.contains("diff --git"));
-    assert!(text.contains("specific_file.txt"));
-    assert!(!text.contains("diff --git a/other_file.txt b/other_file.txt"));
-}
-
-#[tokio::test]
-async fn test_exec_with_empty_outputs_skips_snapshot() {
-    let temp_dir = TestDir::new();
-    init_git_repo(temp_dir.path()).await;
-    let server = BashServer::new(vec![temp_dir.path().to_path_buf()]);
-
-    let result = server
-        .exec_command_impl(ExecCommandParams {
-            command: "printf 'one\n' > specific_file.txt && printf 'two\n' > other_file.txt"
-                .to_string(),
-            working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
-            timeout_secs: Some(5),
-            head_lines: None,
-            tail_lines: Some(20),
-            max_output_bytes: None,
-            inputs: None,
-            outputs: Some(vec![]),
-            env: None,
-        })
-        .await
-        .unwrap();
-
-    let text = text_content(&result);
-    assert!(text.contains("exit_code: 0"));
-    assert!(text.contains("status: exited"));
-    assert!(!text.contains("diff --git"));
-}
-
-#[tokio::test]
-async fn test_spawn_wait_with_outputs_uses_targeted_snapshot() {
-    let temp_dir = TestDir::new();
-    init_git_repo(temp_dir.path()).await;
-    let server = BashServer::new(vec![temp_dir.path().to_path_buf()]);
-
-    let result = server
-        .spawn_impl(SpawnCommandParams {
-            command: "printf 'one\n' > out.txt && printf 'two\n' > other.txt".to_string(),
-            working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
-            inputs: None,
-            outputs: Some(vec!["out.txt".to_string()]),
-            env: None,
-        })
-        .await
-        .unwrap();
-
-    let text = text_content(&result);
-    let execution_id = extract_field(&text, "execution_id");
-
-    let result = server
-        .wait_impl(WaitParams {
-            execution_id,
-            timeout_secs: Some(5),
-            head_lines: None,
-            tail_lines: Some(20),
-            max_output_bytes: None,
-            grep: None,
-        })
-        .await
-        .unwrap();
-
-    let text = text_content(&result);
-    let diff_text = result
-        .content
-        .iter()
-        .skip(2)
-        .filter_map(|content| match &content.raw {
-            rmcp::model::RawContent::Text(text) => Some(text.text.as_str()),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    assert!(text.contains("exit_code: 0"));
-    assert!(diff_text.contains("out.txt"));
-    assert!(!diff_text.contains("other.txt"));
-}
-
-#[tokio::test]
 async fn test_exec_env_special_chars_and_override() {
     let temp_dir = TestDir::new();
     let server = BashServer::new(vec![temp_dir.path().to_path_buf()]);
@@ -2024,8 +1671,6 @@ async fn test_exec_env_special_chars_and_override() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: Some(extra_env),
         })
         .await
@@ -2070,8 +1715,6 @@ async fn test_sandbox_exec_env_special_chars_and_override() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: Some(extra_env),
         })
         .await
@@ -2164,8 +1807,6 @@ mod home_filtering {
             BashServer::new_with_sandbox(vec![home_root.clone()], enabled_sandbox_config());
         let args = server.build_sandbox_args(
             std::path::Path::new("/tmp/harnx-test-sandbox-home/work"),
-            None,
-            None,
             &[home_root],
         );
         let pairs = collect_arg_pairs(&args);
@@ -2193,8 +1834,6 @@ mod home_filtering {
             BashServer::new_with_sandbox(vec![subdir_root.clone()], enabled_sandbox_config());
         let args = server.build_sandbox_args(
             std::path::Path::new("/tmp/harnx-test-sandbox-home2/projects"),
-            None,
-            None,
             &[subdir_root],
         );
         let pairs = collect_arg_pairs(&args);
@@ -2240,8 +1879,6 @@ async fn test_exec_python_shebang() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -2272,8 +1909,6 @@ async fn test_exec_node_shebang() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -2300,8 +1935,6 @@ async fn test_spawn_python_shebang() {
         .spawn_impl(SpawnCommandParams {
             command: "#!/usr/bin/env python3\nprint(\"hello from spawn python\")".to_string(),
             working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -2421,8 +2054,6 @@ async fn test_sandbox_exec_python_shebang() {
             head_lines: None,
             tail_lines: None,
             max_output_bytes: None,
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -2453,8 +2084,6 @@ async fn test_wait_grep_filters_per_stream() {
             command: "printf 'keep-out\\ndrop-out\\n'; printf 'keep-err\\ndrop-err\\n' >&2"
                 .to_string(),
             working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -2501,8 +2130,6 @@ async fn test_wait_truncation_triggers_and_mentions_log_path() {
         .spawn_impl(SpawnCommandParams {
             command: "for i in $(seq 1 200); do echo \"stdout-line-$i\"; done".to_string(),
             working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -2545,8 +2172,6 @@ async fn test_wait_max_output_bytes_truncates() {
         .spawn_impl(SpawnCommandParams {
             command: "for i in $(seq 1 200); do echo \"line-$i\"; done".to_string(),
             working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -2584,8 +2209,6 @@ async fn test_wait_stream_markers() {
         .spawn_impl(SpawnCommandParams {
             command: "echo only-stdout".to_string(),
             working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await
@@ -2637,15 +2260,11 @@ async fn test_concurrent_execution_log_isolation() {
         server.spawn_impl(SpawnCommandParams {
             command: "echo alpha-out; echo alpha-err >&2; sleep 0.3".to_string(),
             working_dir: Some(wd.clone()),
-            inputs: None,
-            outputs: None,
             env: None,
         }),
         server.spawn_impl(SpawnCommandParams {
             command: "echo bravo-out; echo bravo-err >&2; sleep 0.3".to_string(),
             working_dir: Some(wd.clone()),
-            inputs: None,
-            outputs: None,
             env: None,
         }),
     );
@@ -2715,8 +2334,6 @@ async fn test_spawn_wait_read_exec_log_returns_full_output() {
         .spawn_impl(SpawnCommandParams {
             command: "printf 'out1\\nout2\\nout3\\n'; printf 'err1\\nerr2\\n' >&2".to_string(),
             working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
-            inputs: None,
-            outputs: None,
             env: None,
         })
         .await

--- a/crates/harnx-proxy-auth/src/hook.rs
+++ b/crates/harnx-proxy-auth/src/hook.rs
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn bash_spawn_injects_proxy_env_vars() {
-        let input = Some(json!({"command": "sleep 1", "inputs": ["/tmp/in"]}));
+        let input = Some(json!({"command": "sleep 1", "working_dir": "/tmp"}));
 
         let actual = augment_tool_input(input, PROXY_PORT, CA_CERT_PATH, &Map::new());
 
@@ -169,7 +169,7 @@ mod tests {
             actual,
             json!({
                 "command": "sleep 1",
-                "inputs": ["/tmp/in"],
+                "working_dir": "/tmp",
                 "env": expected_proxy_env(),
             })
         );

--- a/docs/bash-mcp-server.md
+++ b/docs/bash-mcp-server.md
@@ -176,6 +176,8 @@ args: ["-e", "EDITOR=true"]
 
 ### Sandbox Configuration
 
+
+The bash MCP sandbox grants project roots read+write+exec access by default. Commands are NOT narrowed by per-call paths; the `bash_exec` and `bash_spawn` tools do not have `inputs` or `outputs` parameters.
 Allow tools to use home-directory caches or persistent configuration:
 
 > **Note:** `~/.cargo/bin` is already included in the default allowlist with read+execute permissions, while `~/.cargo/registry`, `~/.cargo/git`, and `~/.npm` are included with read+write permissions. The examples below are only needed if you override the defaults, need additional paths, or require write access for tool installation.

--- a/docs/solutions/integration-issues/bash-inputs-outputs-sandbox-narrowing-2026-06-15.md
+++ b/docs/solutions/integration-issues/bash-inputs-outputs-sandbox-narrowing-2026-06-15.md
@@ -1,0 +1,62 @@
+---
+title: "Fix: Cargo build failures in sub-agents due to bash sandbox narrowing"
+date: 2026-06-15
+category: integration-issues
+problem_type: bug
+component: harnx-mcp-bash
+root_cause: "Per-call 'outputs' parameter narrowed project roots to exec-only, breaking cargo crate detection"
+resolution_type: code_fix
+severity: high
+tags:
+  - sandbox
+  - birdcage
+  - bash
+  - cargo
+  - mcp
+plan_ref: harnx-850-bash-inputs-outputs
+---
+
+## Problem
+
+Sub-agents attempting to run `cargo` commands (like `cargo build` or `cargo test`) frequently failed with `error[E0463]: can't find crate` even when the dependencies were present. This occurred because the `bash_exec` tool's `outputs` parameter was used to narrow filesystem access, but the narrowing logic was too restrictive for Rust's compilation model.
+
+## Root Cause
+
+The `harnx-mcp-bash` tools (`bash_exec`/`bash_spawn`) previously allowed agents to specify `inputs` and `outputs` paths. If provided, these paths narrowed the sandbox's access to the project roots.
+
+When `outputs` were specified:
+1. The listed paths were granted read+write+exec access.
+2. The project roots (which are normally read+write+exec) were downgraded to **exec-only** if they were not explicitly listed in `outputs`.
+
+This broke `cargo` because it needs to read metadata and lockfiles from the project root even when it is only writing to `target/`. When the project root became exec-only, `cargo` could no longer "see" the crate structure or its dependencies, leading to "can't find crate" errors.
+
+## Solution
+
+The `inputs` and `outputs` parameters were removed from the `bash_exec` and `bash_spawn` tool definitions.
+
+- **Unconditional Root Access:** Project roots now always receive read+write+exec access in the sandbox.
+- **Removed Narrowing:** The per-call narrowing logic was deleted.
+- **Legacy Compatibility:** The tools still accept `inputs` and `outputs` arguments from legacy callers to avoid breaking existing agents, but these arguments are ignored.
+- **History Snapshots:** Command classification is now used exclusively to determine when to take history snapshots, rather than relying on the presence of `outputs`.
+
+## Symptoms Before Fix
+
+```text
+error[E0463]: can't find crate for `harnx_core`
+  --> src/main.rs:1:1
+   |
+ 1 | extern crate harnx_core;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ can't find crate
+```
+
+## Prevention Strategies
+
+- **Avoid Per-Call Narrowing of Primary Roots:** Primary project roots should maintain consistent permissions to ensure toolchain stability.
+- **Use Command Classification for Side Effects:** Use AST or pattern-based command classification to detect mutations rather than relying on agent-supplied path hints.
+- **Verify Toolchain Requirements:** When implementing sandboxing, verify that common toolchains (Cargo, NPM, Go) can still access necessary metadata files in the project structure.
+
+## Related Issues
+
+- **GitHub Issue:** [#850](https://github.com/dobesv/harnx/issues/850)
+- **Plan:** harnx-850-bash-inputs-outputs
+- **Supersedes:** [cli-wrapper-sandboxing-for-tokio-servers-2026-04-28.md](./cli-wrapper-sandboxing-for-tokio-servers-2026-04-28.md) (in part)

--- a/docs/solutions/integration-issues/cli-wrapper-sandboxing-for-tokio-servers-2026-04-28.md
+++ b/docs/solutions/integration-issues/cli-wrapper-sandboxing-for-tokio-servers-2026-04-28.md
@@ -16,6 +16,8 @@ tags:
 plan_ref: bash-sandboxing-birdcage
 ---
 
+
+> **Superseded (#850):** The per-call `inputs`/`outputs` params described below were removed from the bash MCP tools. Project roots now always get read+write+exec and snapshots are always classifier-based. This doc is retained for historical context.
 ## Problem
 
 Birdcage, a Rust sandboxing crate, requires a single-threaded execution context to activate its sandbox. Tokio's multi-threaded runtime (the default with `#[tokio::main]`) spawns the server across multiple threads, making direct in-process sandbox activation impossible.

--- a/docs/solutions/workflow-issues/go-cache-whitelist-var-expansion-2026-06-10.md
+++ b/docs/solutions/workflow-issues/go-cache-whitelist-var-expansion-2026-06-10.md
@@ -185,7 +185,11 @@ Ensures sandboxed `go` process sees custom cache locations matching whitelisted 
 
 ## Scope Limitation
 
-`$VAR` expansion applies to CLI `--extra-*` flags, environment variable whitelist paths, and default toolchain paths. MCP per-call tool `inputs`/`outputs` parameters do NOT expand `$VAR` — those are literal paths validated against the working directory. Follow-up work could extend expansion to MCP tool params or narrow help text wording.
+`$VAR` expansion applies to CLI `--extra-*` flags, environment variable whitelist paths, and default toolchain paths.
+
+> **Note (#850):** The per-call tool `inputs`/`outputs` parameters described below were removed from the bash MCP tools; this paragraph is retained for historical context only.
+
+The (now removed) MCP per-call `inputs`/`outputs` parameters did NOT expand `$VAR` — they were literal paths validated against the working directory. `$VAR` expansion remains relevant only for the CLI `--extra-*` flags and toolchain paths noted above.
 
 ## Related Issues
 


### PR DESCRIPTION
…ash MCP

Removes the LLM-facing inputs and outputs parameters from the bash_exec and bash_spawn tools in harnx-mcp-bash. These parameters previously narrowed the birdcage sandbox for project roots, which caused build failures (e.g., Cargo unable to find crates) when the actual build target directory didn't match the narrowed allow-list.

Project roots now always receive write+exec access, matching the main-agent behavior. History snapshots now consistently use the command-classifier-based approach instead of targeted snapshots. Legacy payloads containing these fields are tolerated and ignored to ensure backward compatibility with existing agent prompts.

Includes a knope changeset, updated documentation, and a solution doc detailing the change.

Refs #850

Plan: harnx-850-bash-inputs-outputs