### PR TITLE
fix(core): stop leaking unfiltered tool list into agent system prompt

### DIFF
--- a/.changesets/fix-unfiltered-tool-summary-in-prompt.md
+++ b/.changesets/fix-unfiltered-tool-summary-in-prompt.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Stopped appending a numbered tool summary to the agent system prompt. The summary was rendered from the agent's full, unfiltered tool set (`get_all_tools()` across every MCP server and package), so an agent in one package would have tools from other packages — e.g. `coding__*` tools listed for a `pantheon` agent — described in its prompt even though those tools were never offered to it. The list was also redundant: the model already receives every available tool as a structured definition via the API `tools` field, correctly filtered by `use_tools`.

--- a/crates/harnx-core/src/agent_config.rs
+++ b/crates/harnx-core/src/agent_config.rs
@@ -410,80 +410,38 @@ impl AgentConfig {
         self.session_variables = None;
     }
 
-    /// Compute the full system-message text (prompt + tools summary), matching
-    /// the logic in `build_messages` but without producing a User message.
+    /// Compute the system-message text from the agent's interpolated prompt.
     /// Used by `Session::build_messages` when `inject_system_prompt` is true.
+    ///
+    /// The agent's available tools are NOT summarized here: the model already
+    /// receives every available tool as a structured definition via the API
+    /// `tools` field (built, filtered by `use_tools`, in
+    /// `Config::tool_declarations_for_use_tools`). Appending an unfiltered
+    /// text list duplicated those definitions and leaked tools from other
+    /// packages into the prompt.
     pub fn system_text(&self) -> anyhow::Result<String> {
-        let prompt = self.interpolated_instructions()?;
-        let tools_text = self.tools_text();
-        Ok(match (&tools_text, prompt.is_empty()) {
-            (Some(tools), false) => format!("{prompt}\n\n{tools}"),
-            (Some(tools), true) => tools.clone(),
-            (None, false) => prompt,
-            (None, true) => String::new(),
-        })
+        self.interpolated_instructions()
     }
 
-    pub fn tools_text(&self) -> Option<String> {
-        let declarations = self.tools.declarations();
-        if declarations.is_empty() {
-            return None;
-        }
-        let tools = declarations
-            .iter()
-            .enumerate()
-            .map(|(i, v)| {
-                let description = match v.description.split_once('\n') {
-                    Some((first_line, _)) => first_line,
-                    None => &v.description,
-                };
-                format!("{}. {}: {description}", i + 1, v.name)
-            })
-            .collect::<Vec<String>>()
-            .join("\n");
-        Some(tools)
-    }
-
-    /// Build the messages for a one-shot LLM call using this agent's prompt +
-    /// tools and the user-side `input`. Assembles a System message (prompt +
-    /// tool summary, if any) followed by a User message with the input's
-    /// content, optionally appending an Assistant continuation message if
-    /// `input.continue_output()` is set.
+    /// Build the messages for a one-shot LLM call using this agent's prompt and
+    /// the user-side `input`. Assembles a System message (the prompt) followed
+    /// by a User message with the input's content, optionally appending an
+    /// Assistant continuation message if `input.continue_output()` is set.
     pub fn build_messages(
         &self,
         input: &crate::input::Input,
     ) -> anyhow::Result<Vec<crate::message::Message>> {
         use crate::message::{Message, MessageContent, MessageRole};
         let prompt = self.interpolated_instructions()?;
-        let tools_text = self.tools_text();
         let content = input.message_content();
-        let mut messages = if prompt.is_empty() {
-            let mut messages = vec![];
-            if let Some(tools_text) = &tools_text {
-                messages.push(Message::new(
-                    MessageRole::System,
-                    MessageContent::Text(tools_text.clone()),
-                ));
-            }
-            messages.push(Message::new(MessageRole::User, content));
-            messages
-        } else {
-            let mut messages = vec![];
-            let system_text = match (&tools_text, prompt.is_empty()) {
-                (Some(tools), false) => format!("{prompt}\n\n{tools}"),
-                (Some(tools), true) => tools.clone(),
-                (None, false) => prompt.to_string(),
-                (None, true) => String::new(),
-            };
-            if !system_text.is_empty() {
-                messages.push(Message::new(
-                    MessageRole::System,
-                    MessageContent::Text(system_text),
-                ));
-            }
-            messages.push(Message::new(MessageRole::User, content));
-            messages
-        };
+        let mut messages = vec![];
+        if !prompt.is_empty() {
+            messages.push(Message::new(
+                MessageRole::System,
+                MessageContent::Text(prompt),
+            ));
+        }
+        messages.push(Message::new(MessageRole::User, content));
         if let Some(text) = input.continue_output() {
             messages.push(Message::new(
                 MessageRole::Assistant,
@@ -493,23 +451,16 @@ impl AgentConfig {
         Ok(messages)
     }
 
-    /// Render the prompt + tools-summary + input markdown for the echo-mode
-    /// (`.echo`) command. Companion of `build_messages`.
+    /// Render the prompt + input markdown for the echo-mode (`.echo`) command.
+    /// Companion of `build_messages`.
     pub fn echo_messages(&self, input: &crate::input::Input) -> anyhow::Result<String> {
         let prompt = self.interpolated_instructions()?;
-        let tools_text = self.tools_text();
         let input_markdown = input.render();
 
         if prompt.is_empty() {
-            if let Some(tools) = &tools_text {
-                Ok(format!("{tools}\n\n{input_markdown}"))
-            } else {
-                Ok(input_markdown)
-            }
-        } else if let Some(tools) = &tools_text {
-            Ok(format!("{prompt}\n\n{tools}\n\n{input_markdown}"))
+            Ok(input_markdown)
         } else {
-            Ok(format!("{}\n\n{}", prompt, input_markdown))
+            Ok(format!("{prompt}\n\n{input_markdown}"))
         }
     }
 }

--- a/crates/harnx-runtime/src/config/agent_tests.rs
+++ b/crates/harnx-runtime/src/config/agent_tests.rs
@@ -261,44 +261,44 @@ fn test_agent_compaction_agent_roundtrip() {
     assert_eq!(reparsed.model_id(), Some("openai:gpt-4o"));
 }
 
+/// The system prompt must NOT enumerate the agent's tools. The model receives
+/// tool definitions via the API `tools` field (filtered by `use_tools` in
+/// `Config::tool_declarations_for_use_tools`); rendering an unfiltered text
+/// list here duplicated those definitions and leaked tools from other packages
+/// into the prompt.
 #[test]
-fn test_tools_text_with_tools() {
+fn test_system_text_excludes_tool_summary() {
     let agent = make_agent_with_tools(
-        "prompt",
+        "You are a helpful assistant.",
         vec![
             make_tool_declaration("tool_a", "Description A"),
             make_tool_declaration("tool_b", "Description B"),
         ],
     );
 
-    let text = agent.tools_text();
+    let text = agent.system_text().unwrap();
 
-    assert_eq!(
-        text,
-        Some("1. tool_a: Description A\n2. tool_b: Description B".to_string())
-    );
+    assert_eq!(text, "You are a helpful assistant.");
+    assert!(!text.contains("tool_a"));
+    assert!(!text.contains("Description A"));
 }
 
 #[test]
-fn test_tools_text_without_tools() {
-    let agent = make_agent_with_tools("prompt", vec![]);
-
-    assert_eq!(agent.tools_text(), None);
-}
-
-#[test]
-fn test_tools_text_multiline_description() {
+fn test_build_messages_excludes_tool_summary() {
+    let config = GlobalConfig::default();
     let agent = make_agent_with_tools(
-        "prompt",
-        vec![make_tool_declaration(
-            "tool_x",
-            "First line\nSecond line\nThird line",
-        )],
+        "System prompt.",
+        vec![make_tool_declaration("tool_a", "Description A")],
     );
+    let input = crate::config::input::from_str(&config, "Real input", Some(agent));
 
-    let text = agent.tools_text();
+    let messages = input.agent().build_messages(&input).unwrap();
 
-    assert_eq!(text, Some("1. tool_x: First line".to_string()));
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0].role, MessageRole::System);
+    assert_eq!(messages[0].content.to_text(), "System prompt.");
+    assert!(!messages[0].content.to_text().contains("tool_a"));
+    assert_eq!(messages[1].content.to_text(), "Real input");
 }
 
 #[test]


### PR DESCRIPTION
## Problem

A `pantheon/atlas` session showed `coding__`-prefixed tools (plus a duplicate unprefixed list) described in its system prompt — tools that belong to the `coding` package and are never offered to that agent as callable definitions.

Root cause: two independent code paths disagreed about which tools the agent has.

- **Tools the model actually receives** — `Config::tool_declarations_for_use_tools()` (`harnx-runtime/src/config/mod.rs`): expands the agent's `use_tools` selectors, filters via `get_tools_for_selectors`, scoped to the active package. Correct.
- **The text list in the prompt (the bug)** — `agent::init()` set the agent's tool set to `manager.get_all_tools()` (every tool from every MCP server across all packages, no `use_tools`, no package scoping). `AgentConfig::tools_text()` numbered that whole set and `build_messages`/`system_text` appended it to the system prompt with no heading.

The summary was also redundant: the model already receives every available tool as a structured definition via the API `tools` field.

## Fix

- `system_text()`, `build_messages()`, `echo_messages()` no longer append the tool list — the system message is just the interpolated prompt.
- Deleted the now-dead `tools_text()` method.
- **Kept** the agent's `tools` field: `merge_agent_owned_tools` still consumes it, but there it is filtered through the `tool_names` whitelist, so it doesn't leak.

## Tests

Replaced the three `tools_text` unit tests with `test_system_text_excludes_tool_summary` and `test_build_messages_excludes_tool_summary`, asserting the prompt contains the agent prompt but none of the tool names/descriptions even when the agent has tools set.

## Verification

`cargo build`, `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo nextest run -p harnx-core -p harnx-runtime` (421/421) all pass.

Note: this affects newly created sessions; sessions whose turn-1 system message already baked in the bad list are not changed retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)