### PR TITLE
feat(tui): instrument the intermittent OOM (#842) with a memory watchdog

### DIFF
--- a/.changeset/tui-memory-watchdog-instrumentation.md
+++ b/.changeset/tui-memory-watchdog-instrumentation.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Add diagnostic instrumentation for the intermittent out-of-memory crash (#842). The TUI event loop now runs a low-overhead memory watchdog that, once per second, logs (at `warn`) a snapshot of process RSS, transcript item count and text size, and the event-channel backlog whenever RSS crosses a doubling threshold — plus a warning when a single tick drains an abnormal number of events (a flooding producer). Compaction now logs when it starts and finishes (with duration) and flags a compaction triggered while another is still running. These surface in the harnx log file, so the next occurrence shows whether the growth is in the transcript/event path or elsewhere. Enable logging (set a non-`off` log level; `info` captures compaction detail) to collect it.

--- a/crates/harnx-runtime/src/config/session_ops_split.rs
+++ b/crates/harnx-runtime/src/config/session_ops_split.rs
@@ -411,11 +411,20 @@ impl Config {
 
     pub fn maybe_compact_session(config: GlobalConfig) {
         let mut need_compact = false;
+        // Instrumentation for the intermittent OOM (#842), which the user has
+        // seen correlate with compaction at the end of a turn. Record the
+        // session size at trigger time and flag a re-entrant trigger (a fresh
+        // compaction starting while a previous one is still running), which
+        // would point at overlapping compaction tasks as the memory source.
+        let mut msg_count = 0usize;
+        let mut already_compacting = false;
         {
             let mut config = config.write();
             let compress_threshold = config.compress_threshold;
             if let Some(session) = config.session.as_mut() {
                 if session.need_compress(compress_threshold) {
+                    already_compacting = session.compressing();
+                    msg_count = session.messages.len();
                     session.set_compressing(true);
                     need_compact = true;
                 }
@@ -424,6 +433,14 @@ impl Config {
         if !need_compact {
             return;
         }
+        if already_compacting {
+            log::warn!(
+                "compaction: triggered while a previous compaction is still in \
+                 progress (messages={msg_count}) — overlapping compaction tasks"
+            );
+        }
+        log::info!("compaction: started (messages={msg_count})");
+        let started = std::time::Instant::now();
         // Use SessionEvent for consistent TUI/CLI handling.
         // The TUI will render CompactingStarted/CompactingCompleted as transcript items.
         harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
@@ -436,12 +453,19 @@ impl Config {
             }
             match &result {
                 Ok(()) => {
+                    log::info!(
+                        "compaction: completed in {:?} (messages_before={msg_count})",
+                        started.elapsed()
+                    );
                     harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
                         harnx_core::event::SessionEvent::CompactingCompleted,
                     ));
                 }
                 Err(err) => {
-                    warn!("Failed to compact the session: {err}");
+                    warn!(
+                        "Failed to compact the session after {:?}: {err}",
+                        started.elapsed()
+                    );
                     harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
                         harnx_core::event::SessionEvent::CompactingFailed(err.to_string()),
                     ));

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -22,14 +22,72 @@ use harnx_runtime::config::{
 };
 use harnx_runtime::tool::ToolDeclaration;
 use harnx_runtime::utils::create_abort_signal;
+use log::warn;
 use ratatui::Terminal;
 #[cfg(test)]
 use ratatui_textarea::Input as TextInput;
 use std::collections::HashMap;
 use std::io::{self, Write};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, Mutex};
+
+/// How often the memory watchdog samples RSS. Cheap; only logs on threshold
+/// crossings.
+const WATCHDOG_INTERVAL: Duration = Duration::from_secs(1);
+/// First RSS threshold (bytes) the watchdog warns at; it then doubles on each
+/// crossing. 512 MiB sits above normal sessions so quiet runs log nothing.
+const WATCHDOG_RSS_FLOOR: u64 = 512 * 1024 * 1024;
+/// Draining at least this many events from `event_rx` in a single tick is
+/// treated as a producer flooding the channel and is logged.
+const WATCHDOG_EVENT_DRAIN: usize = 2_000;
+
+/// Best-effort resident-set size of this process in bytes (Linux only).
+/// Returns `None` on other platforms or if `/proc` is unreadable. Used purely
+/// by the memory watchdog to localize the #842 OOM: if RSS climbs while the
+/// transcript stays small, the leak is outside the transcript.
+#[cfg(target_os = "linux")]
+fn process_rss_bytes() -> Option<u64> {
+    // /proc/self/statm field 2 (0-indexed 1) is resident pages. Page size is
+    // assumed 4 KiB — fine for an order-of-magnitude diagnostic.
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let resident_pages: u64 = statm.split_whitespace().nth(1)?.parse().ok()?;
+    Some(resident_pages.saturating_mul(4096))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_rss_bytes() -> Option<u64> {
+    None
+}
+
+/// (item count, summed text bytes) for the transcript — a coarse proxy for how
+/// much of the process's memory lives in transcript items. Ignores cached
+/// renders and tool-call bodies; the text fields dominate.
+fn transcript_footprint(items: &[TranscriptItem]) -> (usize, usize) {
+    let bytes = items
+        .iter()
+        .map(|item| match item {
+            TranscriptItem::SystemText(s)
+            | TranscriptItem::ErrorText(s)
+            | TranscriptItem::ThoughtText(s)
+            | TranscriptItem::StatusLine(s)
+            | TranscriptItem::UsageLine(s)
+            | TranscriptItem::AttachmentHeader(s)
+            | TranscriptItem::AttachmentItem(s)
+            | TranscriptItem::AttachmentPreviewLine(s)
+            | TranscriptItem::MutationNotice(s) => s.len(),
+            TranscriptItem::UserText { text, .. }
+            | TranscriptItem::AssistantText { text, .. }
+            | TranscriptItem::ToolResultMarkdown { text, .. } => text.len(),
+            TranscriptItem::CompactionMarker {
+                text, detail_text, ..
+            } => text.len() + detail_text.len(),
+            TranscriptItem::ToolCall { tool_name, .. } => tool_name.len(),
+            TranscriptItem::Plan(_) | TranscriptItem::SourceHeading(_) => 0,
+        })
+        .sum();
+    (items.len(), bytes)
+}
 
 impl Tui {
     #[cfg(test)]
@@ -284,6 +342,15 @@ impl Tui {
         self.install_external_editor_bridge();
         self.install_tool_confirm_bridge();
         let mut last_tick = Instant::now();
+        // Memory watchdog for the intermittent OOM (#842). Cheap in the common
+        // case: once a second we read RSS and only emit a (warn-level) line
+        // when it crosses the next doubling threshold, so normal sessions log
+        // nothing. When it does fire it records whether the growth is in the
+        // transcript / event channel (the render path) or elsewhere
+        // (compaction task, streaming buffers), which is what we can't tell
+        // from the OOM alone.
+        let mut last_watchdog = Instant::now();
+        let mut rss_warn_threshold: u64 = WATCHDOG_RSS_FLOOR;
         loop {
             // After an external editor exits, the terminal buffer is stale.
             // Clear it to force ratatui to repaint every cell from scratch.
@@ -318,8 +385,47 @@ impl Tui {
                 }
             }
 
+            let mut drained = 0usize;
             while let Ok(evt) = self.event_rx.try_recv() {
                 self.handle_tui_event(evt).await?;
+                drained += 1;
+            }
+            if drained >= WATCHDOG_EVENT_DRAIN {
+                // A single tick draining this many events means a producer is
+                // flooding the channel faster than the UI consumes it — the
+                // prime suspect for unbounded transcript growth.
+                warn!(
+                    "tui-watchdog: drained {drained} events in one tick; \
+                     event_rx_backlog={} transcript_items={} llm_busy={} compacting={}",
+                    self.event_rx.len(),
+                    self.app.transcript.len(),
+                    self.app.llm_busy,
+                    self.config.read().is_compacting_session(),
+                );
+            }
+
+            if last_watchdog.elapsed() >= WATCHDOG_INTERVAL {
+                last_watchdog = Instant::now();
+                if let Some(rss) = process_rss_bytes() {
+                    if rss >= rss_warn_threshold {
+                        let (items, text_bytes) = transcript_footprint(&self.app.transcript);
+                        warn!(
+                            "tui-watchdog: RSS={}MiB transcript_items={items} \
+                             transcript_text={}MiB event_rx_backlog={} \
+                             llm_busy={} compacting={}",
+                            rss / (1024 * 1024),
+                            text_bytes / (1024 * 1024),
+                            self.event_rx.len(),
+                            self.app.llm_busy,
+                            self.config.read().is_compacting_session(),
+                        );
+                        // Raise the bar past current RSS so we log the climb
+                        // (one line per doubling) rather than every second.
+                        while rss_warn_threshold <= rss {
+                            rss_warn_threshold = rss_warn_threshold.saturating_mul(2);
+                        }
+                    }
+                }
             }
 
             if last_tick.elapsed() >= TICK_RATE {


### PR DESCRIPTION
## Context

Follow-up to #854. The streaming-accumulation simplification did **not** stop the intermittent OOM (#842) — the user has now seen it recur on the final message, possibly correlated with compaction. Rather than guess again, this adds diagnostics that survive an OOM-kill (simplelog's `WriteLogger` writes straight to the log file) so the next occurrence localizes the growth.

## What it logs

**TUI event loop (memory watchdog).** Once per second it samples process RSS (Linux `/proc/self/statm`) and, only when RSS crosses the next doubling threshold (512 MiB floor), emits a `warn` line:

```
tui-watchdog: RSS=…MiB transcript_items=… transcript_text=…MiB event_rx_backlog=… llm_busy=… compacting=…
```

Quiet sessions log nothing. The point is to tell apart the two failure modes the OOM alone can't:
- RSS tracks `transcript_text` / `event_rx_backlog` → growth is in the transcript / event path.
- RSS climbs while those stay flat → growth is elsewhere (compaction task, streaming buffers, leaked tasks).

It also warns when a single tick drains ≥2000 events — a producer flooding the channel.

**Compaction.** Logs start/finish with duration and message count, and warns if a compaction is triggered while a previous one is still running (overlapping tasks). Pure instrumentation — **no behavior change** to the compaction path.

## Using it

Enable logging (set a non-`off` log level; `info` also captures compaction start/finish detail). The watchdog lines are `warn`-level so they appear at any enabled level.

## Testing

- `cargo build --workspace`, `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 1540 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added memory watchdog diagnostics to monitor and log memory usage patterns, helping identify out-of-memory issues.
  * Logs memory metrics and transcript footprint when usage crosses thresholds.
  * Enhanced compaction tracking with duration logging and conflict detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->