### PR TITLE
fix(acp): preserve whitespace-only streaming chunks

### DIFF
--- a/crates/harnx-acp/src/client.rs
+++ b/crates/harnx-acp/src/client.rs
@@ -137,7 +137,12 @@ impl AcpNotificationClient {
         let event: Option<AgentEvent> = match args.update {
             SessionUpdate::AgentMessageChunk(chunk) => {
                 let text = chunk_text(&chunk.content);
-                if text.trim().is_empty() {
+                // Only drop genuinely empty chunks. Whitespace-only chunks
+                // (e.g. a lone "\n" between streamed list items or paragraphs)
+                // are meaningful: stripping them concatenates adjacent chunks
+                // and corrupts the rendered markdown (see issue #862, where
+                // "1. Confirm\n2. Confirm" rendered as "1. Confirm2. Confirm").
+                if text.is_empty() {
                     None
                 } else {
                     message_text = Some(text.clone());
@@ -148,7 +153,9 @@ impl AcpNotificationClient {
             }
             SessionUpdate::AgentThoughtChunk(chunk) => {
                 let text = chunk_text(&chunk.content);
-                if text.trim().is_empty() {
+                // See AgentMessageChunk above: preserve whitespace-only chunks
+                // so streamed thoughts keep their newlines/spacing.
+                if text.is_empty() {
                     None
                 } else {
                     Some(AgentEvent::Model(ModelEvent::ThoughtChunk {
@@ -1548,5 +1555,166 @@ mod tests {
             }
             other => panic!("unexpected forwarded event: {other:?}"),
         }
+    }
+
+    /// Regression test for issue #862: whitespace-only message chunks (e.g. a
+    /// lone "\n" streamed between list items) must NOT be dropped. Dropping them
+    /// concatenated adjacent chunks, rendering "1. Confirm\n2. Confirm" as
+    /// "1. Confirm2. Confirm" in the TUI.
+    #[tokio::test]
+    async fn whitespace_only_message_chunk_is_forwarded_not_stripped() {
+        let sessions = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let chunk_forwarder = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel();
+        chunk_forwarder.write().await.insert(1, chunk_tx);
+        let (activity_tx, _) = tokio::sync::broadcast::channel(8);
+        let client = AcpNotificationClient::new(
+            "working".to_string(),
+            sessions.clone(),
+            chunk_forwarder,
+            activity_tx,
+        );
+
+        // Stream chunks the way an agent emits a numbered list: text, then
+        // standalone whitespace separators (newline, spaces, mixed), then more
+        // text. Every whitespace-only chunk must survive so spacing is intact.
+        let pieces = ["1. Confirm", "\n", "2. Confirm", " ", "(tab\t)", "\n \t "];
+        for piece in pieces {
+            let notification = SessionNotification::new(
+                SessionId::new("outer-session"),
+                SessionUpdate::AgentMessageChunk(ContentChunk::new(piece.into())),
+            );
+            client.session_notification(notification).await.unwrap();
+        }
+
+        let mut received = String::new();
+        for _ in 0..pieces.len() {
+            let forwarded = chunk_rx.recv().await.expect("forwarded chunk");
+            match forwarded {
+                NestedAcpEvent::Agent(
+                    AgentEvent::Model(ModelEvent::MessageChunk { blocks }),
+                    _,
+                ) => {
+                    for b in &blocks {
+                        if let ContentBlock::Text(t) = b {
+                            received.push_str(t);
+                        }
+                    }
+                }
+                other => panic!("unexpected nested ACP event: {other:?}"),
+            }
+        }
+
+        // All whitespace (newline, spaces, tab) must be preserved verbatim so
+        // markdown renders the two list items on separate lines.
+        let expected = "1. Confirm\n2. Confirm (tab\t)\n \t ";
+        assert_eq!(received, expected);
+
+        // The accumulated response_text must also retain the whitespace.
+        let sessions = sessions.read().await;
+        let state = sessions
+            .get("outer-session")
+            .expect("session state recorded");
+        assert_eq!(state.response_text, expected);
+    }
+
+    /// Regression test for issue #862, thought-chunk path: whitespace-only
+    /// `AgentThoughtChunk`s (e.g. a lone "\n" between streamed thought lines)
+    /// must NOT be dropped, otherwise thoughts concatenate the same way.
+    #[tokio::test]
+    async fn whitespace_only_thought_chunk_is_forwarded_not_stripped() {
+        let sessions = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let chunk_forwarder = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel();
+        chunk_forwarder.write().await.insert(1, chunk_tx);
+        let (activity_tx, _) = tokio::sync::broadcast::channel(8);
+        let client = AcpNotificationClient::new(
+            "working".to_string(),
+            sessions,
+            chunk_forwarder,
+            activity_tx,
+        );
+
+        for piece in ["Step one", "\n", "Step two"] {
+            let notification = SessionNotification::new(
+                SessionId::new("outer-session"),
+                SessionUpdate::AgentThoughtChunk(ContentChunk::new(piece.into())),
+            );
+            client.session_notification(notification).await.unwrap();
+        }
+
+        let mut received = String::new();
+        for _ in 0..3 {
+            let forwarded = chunk_rx.recv().await.expect("forwarded thought chunk");
+            match forwarded {
+                NestedAcpEvent::Agent(
+                    AgentEvent::Model(ModelEvent::ThoughtChunk { blocks }),
+                    _,
+                ) => {
+                    for b in &blocks {
+                        if let ContentBlock::Text(t) = b {
+                            received.push_str(t);
+                        }
+                    }
+                }
+                other => panic!("unexpected nested ACP event: {other:?}"),
+            }
+        }
+
+        assert_eq!(received, "Step one\nStep two");
+    }
+
+    /// A genuinely empty thought chunk ("") is still dropped.
+    #[tokio::test]
+    async fn empty_thought_chunk_is_dropped() {
+        let sessions = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let chunk_forwarder = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel();
+        chunk_forwarder.write().await.insert(1, chunk_tx);
+        let (activity_tx, _) = tokio::sync::broadcast::channel(8);
+        let client = AcpNotificationClient::new(
+            "working".to_string(),
+            sessions,
+            chunk_forwarder,
+            activity_tx,
+        );
+
+        let notification = SessionNotification::new(
+            SessionId::new("outer-session"),
+            SessionUpdate::AgentThoughtChunk(ContentChunk::new("".into())),
+        );
+        client.session_notification(notification).await.unwrap();
+
+        assert!(
+            chunk_rx.try_recv().is_err(),
+            "empty thought chunk should not be forwarded"
+        );
+    }
+
+    /// A genuinely empty chunk ("") carries no content and is still dropped.
+    #[tokio::test]
+    async fn empty_message_chunk_is_dropped() {
+        let sessions = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let chunk_forwarder = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel();
+        chunk_forwarder.write().await.insert(1, chunk_tx);
+        let (activity_tx, _) = tokio::sync::broadcast::channel(8);
+        let client = AcpNotificationClient::new(
+            "working".to_string(),
+            sessions,
+            chunk_forwarder,
+            activity_tx,
+        );
+
+        let notification = SessionNotification::new(
+            SessionId::new("outer-session"),
+            SessionUpdate::AgentMessageChunk(ContentChunk::new("".into())),
+        );
+        client.session_notification(notification).await.unwrap();
+
+        assert!(
+            chunk_rx.try_recv().is_err(),
+            "empty chunk should not be forwarded"
+        );
     }
 }

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1147,7 +1147,12 @@ impl Tui {
                     .trim_start_matches("<think>")
                     .trim_end_matches("</think>")
                     .to_string();
-                if clean.trim().is_empty() {
+                // Only skip genuinely empty chunks (e.g. a chunk that was just a
+                // `<think>` tag). Whitespace-only chunks (a lone "\n" between
+                // streamed thought lines) must be preserved so the accumulated
+                // thought keeps its line breaks — same class of bug as #862 in
+                // the ACP client's message/thought chunk handling.
+                if clean.is_empty() {
                     vec![]
                 } else {
                     if self.app.pending_thought_source != source {

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -1178,6 +1178,52 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
 }
 
 #[tokio::test]
+async fn whitespace_only_thought_chunk_is_preserved_in_tui() {
+    let config = test_config();
+    let persistent = std::sync::Arc::new(tokio::sync::Mutex::new(
+        harnx_hooks::PersistentHookManager::new(),
+    ));
+    let mut tui = Tui::init(&config, harnx_hooks::AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    // Send a thought chunk with only a newline
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Model(ModelEvent::ThoughtChunk {
+            blocks: vec![ContentBlock::Text("\n".to_string())],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    assert_eq!(tui.app.pending_thought_text, "\n");
+}
+
+#[tokio::test]
+async fn thought_chunk_with_think_tags_is_stripped_and_dropped_if_empty() {
+    let config = test_config();
+    let persistent = std::sync::Arc::new(tokio::sync::Mutex::new(
+        harnx_hooks::PersistentHookManager::new(),
+    ));
+    let mut tui = Tui::init(&config, harnx_hooks::AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    // Send a thought chunk with only <think> tags
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Model(ModelEvent::ThoughtChunk {
+            blocks: vec![ContentBlock::Text("<think></think>".to_string())],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    assert!(tui.app.pending_thought_text.is_empty());
+}
+
+#[tokio::test]
 async fn llm_multiline_text_renders_without_extra_blank_lines() {
     let config = test_config();
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));

--- a/docs/solutions/logic-errors/streaming-whitespace-chunk-handling-2026-06-16.md
+++ b/docs/solutions/logic-errors/streaming-whitespace-chunk-handling-2026-06-16.md
@@ -1,0 +1,103 @@
+---
+title: "Preserve whitespace-only chunks in streaming deltas"
+date: 2026-06-16
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-acp-client"
+root_cause: "incorrect empty-string guard trimming whitespace before filtering"
+resolution_type: code_fix
+severity: medium
+tags:
+  - streaming
+  - whitespace
+  - markdown
+  - acp
+  - chunks
+plan_ref: "issue-862-whitespace-streaming"
+---
+
+## Problem
+
+Streamed markdown numbered lists rendered run-together in the TUI, e.g. "1. Confirm2. Confirm3. Reject...Key practical call:" with no line breaks between items.
+
+## Symptoms
+
+- TUI displayed concatenated list items during streaming: "1. Item1. Item2. Item"
+- Issue #862: Is whitespace being stripped in streaming output?
+- Only affected ACP sub-agent streaming through the `AcpNotificationClient` receive path
+- ACP server send-side and CLI sink rendered correctly
+
+## Investigation Steps
+
+1. Reproduced by running a sub-agent that streams numbered lists — items concatenated without separators
+2. Traced streaming path: `AcpNotificationClient::session_notification` handles `AgentMessageChunk` and `AgentThoughtChunk`
+3. Found the guard: `if text.trim().is_empty() { None }` — discards chunks where trimmed text is empty
+4. Identified that ACP sub-agents stream newline/space separators as standalone whitespace-only chunks
+5. Compared with ACP server (`harnx-acp-server/src/lib.rs`) and CLI sink (`harnx/src/cli_event_sink.rs`) — both used `is_empty()` not `trim().is_empty()`
+6. Root cause isolated to client receive-side only
+
+## Root Cause
+
+The `AcpNotificationClient::session_notification` method filtered streaming chunks with:
+
+```rust
+if text.trim().is_empty() { None }
+```
+
+ACP sub-agents stream the newline/space separators between list items as standalone whitespace-only content chunks (e.g., a single `"\n"`). The `trim().is_empty()` guard discarded these chunks entirely, causing adjacent text chunks to concatenate with no separator. This also corrupted `response_text` accumulated for parent agent next-turn input.
+
+## Solution
+
+Changed the guard to preserve whitespace-only chunks:
+
+**Before:**
+```rust
+if text.trim().is_empty() { None }
+```
+
+**After:**
+```rust
+if text.is_empty() { None }
+```
+
+File: `crates/harnx-acp/src/client.rs` in `AcpNotificationClient::session_notification`
+
+The same anti-pattern existed in the TUI thought-chunk handler
+(`crates/harnx-tui/src/input.rs`, the `ModelEvent::ThoughtChunk` arm): after
+stripping `<think>`/`</think>` tags it used `clean.trim().is_empty()`, which
+dropped whitespace-only thought chunks and concatenated streamed thought lines.
+Changed to `clean.is_empty()` so pure-tag/empty chunks are still skipped while
+whitespace separators are preserved. (`flush_pending_thought` still `.trim()`s
+the fully accumulated thought, so leading/trailing whitespace is not shown.)
+
+This matches the existing behavior in:
+- ACP server send-side (`harnx-acp-server/src/lib.rs`)
+- CLI event sink (`harnx/src/cli_event_sink.rs`)
+- TUI message-chunk handler (`harnx-tui/src/input.rs`, already `is_empty()`)
+
+## Why This Works
+
+When filtering streaming deltas/chunks, only genuinely empty chunks (zero-length strings) should be dropped. Whitespace-only chunks (lone `"\n"`, `" "`, etc.) carry semantically significant inter-token whitespace for markdown rendering and text reconstruction.
+
+Using `is_empty()` checks for zero-length content. Using `trim().is_empty()` incorrectly treats `" "` and `"\n"` as "empty" when they are structural separators in markdown.
+
+## Prevention Strategies
+
+**Test Cases:**
+- `whitespace_only_message_chunk_is_forwarded_not_stripped` — verifies lone newline preserved
+- `empty_message_chunk_is_dropped` — verifies genuinely empty chunk filtered out
+
+**Best Practices:**
+- When filtering streaming deltas, use `text.is_empty()` not `text.trim().is_empty()`
+- Inter-token whitespace (newlines, spaces) is semantically significant in streamed markdown
+- Audit all chunk-filtering guards for this pattern
+
+**Code Review Checklist:**
+- [ ] Does streaming chunk filter use `is_empty()` not `trim().is_empty()`?
+- [ ] Are there tests for whitespace-only chunk handling?
+- [ ] Is filtering behavior consistent across send-side and receive-side?
+
+## Related Issues
+
+- **Issue:** #862 — "Is whitespace being stripped in streaming output?"
+- **Related Solution:** [logic-errors/streaming-final-deduplication-2026-06-09.md](streaming-final-deduplication-2026-06-09.md) — ACP chunk handling for Final vs streamed text


### PR DESCRIPTION
The ACP client and TUI thought-chunk handler were dropping whitespace-only streamed chunks (like \n) via trim().is_empty(), causing concatenation of markdown list items (e.g. "1. Confirm2. Confirm"). Changed the guard to is_empty() so only genuinely empty chunks are dropped.

Added regression tests in harnx-acp and harnx-tui. Includes a documentation entry in docs/solutions.

#862

Plan: issue-862-whitespace-streaming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed whitespace-only chunks being incorrectly discarded during streaming, which corrupted markdown list formatting and thought content display.

* **Tests**
  * Added regression tests to verify whitespace-only chunks are properly preserved and genuinely empty chunks are discarded.

* **Documentation**
  * Added documentation detailing the streaming whitespace handling fix and prevention checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->