### PR TITLE
feat: add automatic cleanup of inactive sessions

### DIFF
--- a/.changeset/session-cleanup.md
+++ b/.changeset/session-cleanup.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+Add automatic cleanup of inactive sessions (#847). A new opt-in config key `cleanup_inactive_sessions_days` automatically deletes inactive session transcripts and their attachments after a configurable number of days. Activity is based on filesystem mtime; unset or 0 disables cleanup. Runs once at startup and hourly thereafter in all modes (TUI, CLI, serve); best-effort and fault-tolerant.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3917,6 +3917,7 @@ dependencies = [
  "dirs",
  "duct",
  "fancy-regex 0.18.0",
+ "filetime",
  "futures-util",
  "fuzzy-matcher",
  "globset",

--- a/crates/harnx-core/src/config_data.rs
+++ b/crates/harnx-core/src/config_data.rs
@@ -55,6 +55,7 @@ pub struct ConfigData {
     pub use_tools: Option<Vec<String>>,
 
     pub save_session: Option<bool>,
+    pub cleanup_inactive_sessions_days: Option<u64>,
     pub compress_threshold: usize,
 
     pub rag_embedding_model: Option<String>,
@@ -102,6 +103,7 @@ impl Default for ConfigData {
             use_tools: None,
 
             save_session: Some(true),
+            cleanup_inactive_sessions_days: None,
             compress_threshold: 180000,
 
             rag_embedding_model: None,

--- a/crates/harnx-runtime/Cargo.toml
+++ b/crates/harnx-runtime/Cargo.toml
@@ -72,6 +72,7 @@ libc = { workspace = true }
 arboard = { workspace = true }
 
 [dev-dependencies]
+filetime = "0.2"
 pretty_assertions = "1.4.0"
 tempfile = "3"
 tokio-test = "0.4"

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -31,6 +31,7 @@ pub use self::agent::{
     complete_agent_variables, list_agents, list_assistant_agents, Agent, AgentConfig,
     AgentVariables,
 };
+pub(crate) use self::attachments::attachments_dir_for;
 pub use self::input::Input;
 pub use self::patches_split::acp_server_display_name;
 pub use self::patches_split::mcp_server_display_name;

--- a/crates/harnx-runtime/src/lib.rs
+++ b/crates/harnx-runtime/src/lib.rs
@@ -15,6 +15,7 @@ pub mod bootstrap;
 pub mod client;
 pub mod commands;
 pub mod config;
+pub mod session_cleanup;
 pub mod session_history;
 pub mod test_utils;
 pub mod tool;

--- a/crates/harnx-runtime/src/session_cleanup.rs
+++ b/crates/harnx-runtime/src/session_cleanup.rs
@@ -1,0 +1,394 @@
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use tokio::fs;
+
+use crate::config::{attachments_dir_for, GlobalConfig};
+
+/// Convert byte count to human-readable string (e.g., "1.5 MB", "820 KB").
+/// Uses 1024-based scaling while keeping KB/MB/GB labels.
+pub fn humanize_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.0} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CleanupStats {
+    pub sessions_removed: u64,
+    pub bytes_freed: u64,
+}
+
+pub async fn run_cleanup(config: &GlobalConfig, days: u64) -> CleanupStats {
+    if days == 0 {
+        return CleanupStats::default();
+    }
+
+    let threshold = Duration::from_secs(days.saturating_mul(86_400));
+    let now = SystemTime::now();
+    let (sessions_dir, sessions) = {
+        let config = config.read();
+        (config.sessions_dir(), config.list_sessions_with_meta())
+    };
+
+    let mut stats = CleanupStats::default();
+
+    for session in sessions {
+        let Some(modified) = session.modified else {
+            continue;
+        };
+
+        let Ok(age) = now.duration_since(modified) else {
+            debug!("session cleanup skipped entry with future timestamp");
+            continue;
+        };
+
+        if age <= threshold {
+            continue;
+        }
+
+        let session_yaml_path = sessions_dir.join(format!("{}.yaml", session.id));
+        let attachments_dir = attachments_dir_for(&session_yaml_path);
+        let measured =
+            measure_path_size(&session_yaml_path).await + measure_path_size(&attachments_dir).await;
+
+        let attachments_removed =
+            remove_dir_best_effort(&attachments_dir, "attachments directory").await;
+        let session_removed =
+            remove_file_best_effort(&session_yaml_path, "session transcript").await;
+
+        if attachments_removed && session_removed {
+            stats.sessions_removed = stats.sessions_removed.saturating_add(1);
+            stats.bytes_freed = stats.bytes_freed.saturating_add(measured);
+        }
+    }
+
+    stats
+}
+
+async fn measure_path_size(path: &Path) -> u64 {
+    let metadata = match fs::symlink_metadata(path).await {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == ErrorKind::NotFound => return 0,
+        Err(err) => {
+            debug!("session cleanup failed to read metadata during size measurement: {err}");
+            return 0;
+        }
+    };
+
+    if metadata.is_file() {
+        return metadata.len();
+    }
+
+    if metadata.is_dir() {
+        return measure_dir_size(path.to_path_buf()).await;
+    }
+
+    0
+}
+
+async fn measure_dir_size(root: PathBuf) -> u64 {
+    let mut total = 0_u64;
+    let mut stack = vec![root];
+
+    while let Some(dir) = stack.pop() {
+        let mut entries = match fs::read_dir(&dir).await {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == ErrorKind::NotFound => continue,
+            Err(err) => {
+                debug!("session cleanup failed to read directory during size measurement: {err}");
+                continue;
+            }
+        };
+
+        loop {
+            match entries.next_entry().await {
+                Ok(Some(entry)) => {
+                    total = total.saturating_add(measure_dir_entry(entry, &mut stack).await);
+                }
+                Ok(None) => break,
+                Err(err) if err.kind() == ErrorKind::NotFound => break,
+                Err(err) => {
+                    debug!("session cleanup failed while iterating directory during size measurement: {err}");
+                    break;
+                }
+            }
+        }
+    }
+
+    total
+}
+
+async fn measure_dir_entry(entry: fs::DirEntry, stack: &mut Vec<PathBuf>) -> u64 {
+    let file_type = match entry.file_type().await {
+        Ok(file_type) => file_type,
+        Err(err) if err.kind() == ErrorKind::NotFound => return 0,
+        Err(err) => {
+            debug!("session cleanup failed to read entry type during size measurement: {err}");
+            return 0;
+        }
+    };
+
+    if file_type.is_dir() {
+        stack.push(entry.path());
+        return 0;
+    }
+
+    if !file_type.is_file() {
+        return 0;
+    }
+
+    match entry.metadata().await {
+        Ok(metadata) => metadata.len(),
+        Err(err) if err.kind() == ErrorKind::NotFound => 0,
+        Err(err) => {
+            debug!("session cleanup failed to read entry metadata during size measurement: {err}");
+            0
+        }
+    }
+}
+
+async fn remove_dir_best_effort(path: &Path, kind: &str) -> bool {
+    match fs::remove_dir_all(path).await {
+        Ok(()) => true,
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            debug!("session cleanup skipped missing {kind}");
+            true
+        }
+        Err(err) => {
+            warn!("session cleanup failed to remove {kind}: {err}");
+            false
+        }
+    }
+}
+
+async fn remove_file_best_effort(path: &Path, kind: &str) -> bool {
+    match fs::remove_file(path).await {
+        Ok(()) => true,
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            debug!("session cleanup skipped missing {kind}");
+            true
+        }
+        Err(err) => {
+            warn!("session cleanup failed to remove {kind}: {err}");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs as stdfs;
+    use std::sync::Arc;
+    use std::time::{Duration, SystemTime};
+
+    use filetime::{set_file_mtime, FileTime};
+    use parking_lot::RwLock;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::config::Config;
+
+    const SESSION_HEADER: &str =
+        "type: header\nmodel: test-model\nsession_id: sess-123\nworking_dir: /tmp/work\n";
+
+    #[test]
+    fn humanize_bytes_boundaries() {
+        // Bytes
+        assert_eq!(humanize_bytes(0), "0 B");
+        assert_eq!(humanize_bytes(1), "1 B");
+        assert_eq!(humanize_bytes(1023), "1023 B");
+
+        // KB boundaries
+        assert_eq!(humanize_bytes(1024), "1 KB");
+        assert_eq!(humanize_bytes(1536), "2 KB"); // 1.5 KB rounds to 2 KB
+        assert_eq!(humanize_bytes(1024 * 1023), "1023 KB");
+
+        // MB boundaries
+        assert_eq!(humanize_bytes(1024 * 1024), "1.0 MB");
+        assert_eq!(humanize_bytes(1024 * 1024 * 3 + 1024 * 512), "3.5 MB");
+        assert_eq!(humanize_bytes(1024 * 1024 * 1023), "1023.0 MB");
+
+        // GB boundaries
+        assert_eq!(humanize_bytes(1024 * 1024 * 1024), "1.0 GB");
+        assert_eq!(humanize_bytes(1024 * 1024 * 1024 * 5), "5.0 GB");
+    }
+
+    #[tokio::test]
+    async fn cleanup_disabled_when_days_zero_leaves_stale_sessions_on_disk() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let session =
+            create_session_fixture(tmp.path(), "stale-disabled", b"attachment-bytes").unwrap();
+        backdate_file_mtime(&session.yaml_path, Duration::from_secs(10 * 86_400)).unwrap();
+
+        let stats = run_cleanup(&config, 0).await;
+
+        assert_eq!(stats, CleanupStats::default());
+        assert!(session.yaml_path.exists());
+        assert!(session.attachments_dir.exists());
+        assert!(session.attachment_file.exists());
+    }
+
+    #[tokio::test]
+    async fn cleanup_removes_stale_session_yaml_and_attachments() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let days = 1_u64;
+        let session = create_session_fixture(tmp.path(), "stale", b"attached payload").unwrap();
+        backdate_file_mtime(&session.yaml_path, Duration::from_secs(days * 86_400 + 600)).unwrap();
+
+        let stats = run_cleanup(&config, days).await;
+
+        assert_eq!(stats.sessions_removed, 1);
+        assert!(stats.bytes_freed > 0);
+        assert!(!session.yaml_path.exists());
+        assert!(!session.attachments_dir.exists());
+        assert!(!session.attachment_file.exists());
+    }
+
+    #[tokio::test]
+    async fn cleanup_keeps_fresh_session() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let session = create_session_fixture(tmp.path(), "fresh", b"fresh attachment").unwrap();
+
+        let stats = run_cleanup(&config, 1).await;
+
+        assert_eq!(stats, CleanupStats::default());
+        assert!(session.yaml_path.exists());
+        assert!(session.attachments_dir.exists());
+        assert!(session.attachment_file.exists());
+    }
+
+    #[tokio::test]
+    async fn cleanup_uses_real_mtime_boundary_for_old_vs_recent_sessions() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let days = 1_u64;
+        let threshold = Duration::from_secs(days * 86_400);
+        let stale = create_session_fixture(tmp.path(), "stale-boundary", b"stale-bytes").unwrap();
+        let fresh = create_session_fixture(tmp.path(), "fresh-boundary", b"fresh-bytes").unwrap();
+
+        backdate_file_mtime(&stale.yaml_path, threshold + Duration::from_secs(180)).unwrap();
+        backdate_file_mtime(&fresh.yaml_path, threshold - Duration::from_secs(180)).unwrap();
+
+        let stats = run_cleanup(&config, days).await;
+
+        assert_eq!(stats.sessions_removed, 1);
+        assert!(stats.bytes_freed > 0);
+        assert!(!stale.yaml_path.exists());
+        assert!(!stale.attachments_dir.exists());
+        assert!(fresh.yaml_path.exists());
+        assert!(fresh.attachments_dir.exists());
+        assert!(fresh.attachment_file.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cleanup_does_not_follow_symlinked_attachments_contents() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let days = 1_u64;
+        let session = create_session_fixture(tmp.path(), "symlinked-attachments", b"tiny").unwrap();
+        let outside_dir = tmp.path().join("outside");
+        stdfs::create_dir_all(&outside_dir).unwrap();
+        let outside_file = outside_dir.join("outside.bin");
+        stdfs::write(&outside_file, vec![7_u8; 4096]).unwrap();
+        stdfs::remove_file(&session.attachment_file).unwrap();
+        symlink(&outside_file, &session.attachment_file).unwrap();
+        backdate_file_mtime(&session.yaml_path, Duration::from_secs(days * 86_400 + 600)).unwrap();
+
+        let expected = stdfs::metadata(&session.yaml_path).unwrap().len();
+        let stats = run_cleanup(&config, days).await;
+
+        assert_eq!(stats.sessions_removed, 1);
+        assert_eq!(stats.bytes_freed, expected);
+        assert!(!session.yaml_path.exists());
+        assert!(!session.attachments_dir.exists());
+        assert!(outside_file.exists());
+    }
+
+    #[tokio::test]
+    async fn cleanup_missing_sessions_dir_returns_empty_stats() {
+        let tmp = TempDir::new().unwrap();
+        let sessions_dir = tmp.path().join("missing-sessions-dir");
+        let config = test_config(&sessions_dir);
+
+        let stats = run_cleanup(&config, 1).await;
+
+        assert_eq!(stats, CleanupStats::default());
+        assert!(!sessions_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn cleanup_tolerates_missing_attachments_dir_for_stale_session() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let days = 1_u64;
+        let session =
+            create_session_fixture(tmp.path(), "missing-attachments", b"to-delete").unwrap();
+        stdfs::remove_dir_all(&session.attachments_dir).unwrap();
+        backdate_file_mtime(&session.yaml_path, Duration::from_secs(days * 86_400 + 600)).unwrap();
+
+        let stats = run_cleanup(&config, days).await;
+
+        assert_eq!(stats.sessions_removed, 1);
+        assert!(!session.yaml_path.exists());
+        assert!(!session.attachments_dir.exists());
+    }
+
+    fn test_config(sessions_dir: &Path) -> GlobalConfig {
+        let config = Config {
+            sessions_dir_override: Some(sessions_dir.to_path_buf()),
+            ..Config::default()
+        };
+        Arc::new(RwLock::new(config))
+    }
+
+    fn backdate_file_mtime(path: &Path, age: Duration) -> std::io::Result<()> {
+        let modified = SystemTime::now() - age;
+        set_file_mtime(path, FileTime::from_system_time(modified))
+    }
+
+    fn create_session_fixture(
+        sessions_dir: &Path,
+        id: &str,
+        attachment_contents: &[u8],
+    ) -> std::io::Result<SessionFixture> {
+        stdfs::create_dir_all(sessions_dir)?;
+
+        let yaml_path = sessions_dir.join(format!("{id}.yaml"));
+        stdfs::write(&yaml_path, SESSION_HEADER)?;
+
+        let attachments_dir = attachments_dir_for(&yaml_path);
+        stdfs::create_dir_all(&attachments_dir)?;
+        let attachment_file = attachments_dir.join("blob.bin");
+        stdfs::write(&attachment_file, attachment_contents)?;
+
+        Ok(SessionFixture {
+            yaml_path,
+            attachments_dir,
+            attachment_file,
+        })
+    }
+
+    struct SessionFixture {
+        yaml_path: PathBuf,
+        attachments_dir: PathBuf,
+        attachment_file: PathBuf,
+    }
+}

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -21,7 +21,7 @@ use crate::config::{
     WorkingMode,
 };
 use crate::tui::{TranscriptItem, Tui};
-use harnx_core::event::AgentSource;
+use harnx_core::event::{AgentEvent, AgentSource, NoticeEvent};
 use harnx_hooks::{
     dispatch_hooks_with_count_and_manager, dispatch_hooks_with_managers, drain_async_results,
     inject_pending_async_context, AsyncHookManager, HookEvent, HookResultControl,
@@ -34,6 +34,9 @@ use anyhow::{bail, Result};
 use clap::Parser;
 use parking_lot::RwLock;
 use std::{env, path::PathBuf, sync::Arc, time::Duration};
+
+use harnx_core::sink::emit_agent_event;
+use harnx_runtime::session_cleanup::{humanize_bytes, run_cleanup, CleanupStats};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -197,6 +200,27 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
         println!("{info}");
         return Ok(());
     }
+
+    // Spawn session cleanup background task if enabled.
+    // MUST run before the serve branch so cleanup runs in ALL modes (TUI, CLI, Serve).
+    // The task is best-effort and never panics; deletions are fault-tolerant.
+    let cleanup_days = config.read().cleanup_inactive_sessions_days;
+    if let Some(days) = cleanup_days {
+        if days > 0 {
+            let config_clone = Arc::clone(&config);
+            tokio::spawn(async move {
+                // tokio::time::interval fires its first tick immediately, so cleanup runs
+                // once at startup and then every hour thereafter.
+                let mut interval = tokio::time::interval(Duration::from_secs(3600));
+                loop {
+                    interval.tick().await;
+                    let stats = run_cleanup(&config_clone, days).await;
+                    emit_cleanup_summary(stats);
+                }
+            });
+        }
+    }
+
     if let Some(addr) = cli.serve {
         return serve::run(config, addr).await;
     }
@@ -1006,4 +1030,30 @@ mod resume_tests {
             "harnx -a 'my agent' -s 'my session'"
         );
     }
+}
+
+/// Emit cleanup summary if sessions were removed.
+/// In TUI/CLI mode, `emit_agent_event` buffers the event until a sink is installed,
+/// then replays it to the transcript.
+///
+/// In serve mode there is no interactive transcript sink. The event will be buffered
+/// but never delivered to a user-visible destination. For serve mode visibility,
+/// we log the summary directly using `log::info!`. This dual-path ensures the message
+/// appears in user-facing transcripts (TUI/CLI) AND in server logs (serve mode).
+fn emit_cleanup_summary(stats: CleanupStats) {
+    if stats.sessions_removed == 0 {
+        return;
+    }
+    let msg = format!(
+        "Note: cleaned up {} old sessions, {} disk freed",
+        stats.sessions_removed,
+        humanize_bytes(stats.bytes_freed)
+    );
+    // Always emit via agent event sink for TUI/CLI visibility.
+    // The function returns true if the event was delivered or buffered.
+    emit_agent_event(AgentEvent::Notice(NoticeEvent::Info(msg.clone())));
+    // Also log for serve mode visibility, since serve has no transcript sink.
+    // In TUI/CLI this creates a minor duplication (transcript + log), but the
+    // log is typically suppressed at INFO level in interactive use anyway.
+    log::info!("{msg}");
 }

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -49,6 +49,7 @@ The `config.yaml` file contains global behavior and appearance settings.
 
 - **stream**: Whether to use streaming for responses. (`true`/`false`)
 - **save_session**: Whether to save session history. (`true`/`false`)
+- **cleanup_inactive_sessions_days**: Number of days of inactivity (filesystem mtime) after which a session's transcript (`{id}.yaml`) and its attachments directory (`{id}.attachments/`) are permanently deleted. Deletion is best-effort, permanent, and runs at startup and hourly thereafter in all modes. Set to `0` or leave unset to disable (default). (Example: `14`)
 - **keybindings**: Choose between `emacs` or `vi` style.
 - **editor**: Command used to edit input buffers.
 - **wrap**: Text wrapping behavior (`no`, `auto`, or a number).

--- a/docs/solutions/async-patterns/tokio-interval-spawn-single-point-2026-06-17.md
+++ b/docs/solutions/async-patterns/tokio-interval-spawn-single-point-2026-06-17.md
@@ -1,0 +1,147 @@
+---
+title: "Single spawn point for background tasks covering all modes (TUI, CLI, serve)"
+date: 2026-06-17
+category: async-patterns
+problem_type: logic_error
+component: harnx
+root_cause: "Background task spawn in mode-branch misses modes or duplicates execution"
+resolution_type: code_fix
+severity: medium
+tags:
+  - tokio
+  - spawn
+  - interval
+  - serve
+  - tui
+  - cli
+  - background-task
+plan_ref: harnx-session-cleanup
+---
+
+## Problem
+
+Background cleanup tasks were at risk of either missing execution in some modes (TUI/CLI/serve) or running multiple spawns if placed inside mode-specific branches. Additionally, `tokio::time::interval`'s first tick fires immediately, which can cause unintended double execution at startup if combined with an explicit pre-loop call.
+
+## Symptoms
+
+- Cleanup task only runs in TUI mode, not CLI or serve
+- Cleanup task spawns multiple times (once per mode branch)
+- Double execution at startup: explicit call + first interval tick both trigger cleanup
+- Trivial invocations (`--list-models`, `--info`) unnecessarily spawn background tasks
+
+## Investigation Steps
+
+1. Traced `main.rs` execution flow: early-return flags (`--list-models`, `--info`) exit before TUI/CLI/serve branches
+2. Identified mode divergence point: serve branch returns early at `serve::run()`, CLI branch installs event sink, TUI branch calls `start_interactive()`
+3. Noted existing pattern: SIGINT watcher spawned once (~line 82) before mode branches
+4. Investigated `tokio::time::interval` behavior: first `.tick().await` returns immediately (documented)
+5. Discovered serve mode has no interactive transcript sink — `emit_agent_event` buffers but never delivers
+
+## Root Cause
+
+**Pattern 1: Spawn location.** Placing background task spawn inside a mode branch (e.g., TUI block) excludes other modes. Placing it in multiple branches duplicates spawns.
+
+**Pattern 2: Interval first tick.** `tokio::time::interval().tick().await` fires immediately on first call. Combining an explicit startup call with `interval.tick().await` in a loop causes double execution at startup.
+
+**Pattern 3: Serve-mode visibility.** Serve mode runs without an interactive transcript sink. Events emitted via `emit_agent_event` are buffered but never reach user-visible output.
+
+## Solution
+
+**spawn placement:** Place single spawn AFTER early-return flags but BEFORE serve branch check:
+
+```rust
+// Early-return flags (exit without real work)
+if cli.list_models { /* ... */ return Ok(()); }
+if cli.info { /* ... */ return Ok(()); }
+
+// Single spawn covers TUI, CLI, AND serve
+let cleanup_days = config.read().cleanup_inactive_sessions_days;
+if let Some(days) = cleanup_days {
+    if days > 0 {
+        let config_clone = Arc::clone(&config);
+        tokio::spawn(async move {
+            // First tick fires immediately — cleanup runs at startup
+            let mut interval = tokio::time::interval(Duration::from_secs(3600));
+            loop {
+                interval.tick().await;
+                let stats = run_cleanup(&config_clone, days).await;
+                emit_cleanup_summary(stats);
+            }
+        });
+    }
+}
+
+// Mode branches diverge AFTER cleanup spawn
+if let Some(addr) = cli.serve {
+    return serve::run(config, addr).await;
+}
+// CLI branch...
+// TUI branch...
+```
+
+**Interval first tick:** Use the immediate first tick for startup execution instead of explicit pre-loop call:
+
+```rust
+// Before (double execution):
+run_cleanup(&config, days).await;  // Startup pass
+let mut interval = tokio::time::interval(Duration::from_secs(3600));
+loop {
+    interval.tick().await;  // Fires immediately!
+    run_cleanup(&config, days).await;  // Runs again
+}
+
+// After (single execution at startup):
+let mut interval = tokio::time::interval(Duration::from_secs(3600));
+loop {
+    interval.tick().await;  // Immediate first tick = startup pass
+    run_cleanup(&config, days).await;
+}
+```
+
+**Serve-mode dual-path emission:**
+
+```rust
+fn emit_cleanup_summary(stats: CleanupStats) {
+    if stats.sessions_removed == 0 { return; }
+    let msg = format!("Note: cleaned up {} old sessions, {} disk freed",
+        stats.sessions_removed, humanize_bytes(stats.bytes_freed));
+    // TUI/CLI visibility via agent event sink
+    emit_agent_event(AgentEvent::Notice(NoticeEvent::Info(msg.clone())));
+    // Serve visibility via log (no transcript sink in serve mode)
+    log::info!("{msg}");
+}
+```
+
+## Why This Works
+
+1. **Single spawn point before serve branch** ensures background task runs in all long-running modes (TUI, CLI, serve) while skipping trivial invocations that exit immediately via early-return flags.
+
+2. **Interval's immediate first tick** provides startup execution without redundant explicit call. Loop begins with `tick().await`, executing cleanup once at startup then hourly thereafter.
+
+3. **Dual-path emission** ensures cleanup summary reaches users in interactive modes (via buffered/flushed agent events) AND operators monitoring server logs in serve mode (via `log::info!`).
+
+4. **Idempotent cleanup** makes double-execution harmless; second pass finds nothing to delete. But avoiding it reduces wasted I/O.
+
+## Prevention Strategies
+
+**Code Review Checklist:**
+- [ ] Background task spawns placed BEFORE mode branches, AFTER early-return flags
+- [ ] Interval tick position documented if relying on immediate first tick for startup
+- [ ] Serve-mode output accounted for (log path or explicit suppression with comment)
+- [ ] Trivial invocations (`--list-*`, `--info`) do NOT trigger background tasks
+
+**Best Practices:**
+- Trace execution flow for new background tasks: early returns → spawn → mode branches
+- Document serve-mode visibility decisions inline (e.g., "serve has no transcript sink")
+- Rely on interval's first tick for startup pass rather than explicit pre-loop call
+
+**Test Cases:**
+- Spawn occurs when config `cleanup_inactive_sessions_days > 0`
+- Spawn skipped when config unset or `0`
+- Cleanup runs exactly once at startup (no double execution)
+- Trivial invocation (`--list-models`) exits without spawning
+
+## Related Issues
+
+- **Related Solution:** [mcp-server-background-task-supervision-2026-05-25.md](mcp-server-background-task-supervision-2026-05-25.md) — Interval first tick handling and supervision patterns for MCP server background tasks
+- **GitHub:** [issue #847](https://github.com/dobesv/harnx/issues/847) — Automatic session cleanup feature

--- a/example_config/config.yaml
+++ b/example_config/config.yaml
@@ -4,6 +4,10 @@ stream: true
 
 # ---- behavior ----
 save_session: true
+# Number of days of inactivity after which old sessions (transcript + attachments)
+# are automatically deleted. Unset or 0 disables cleanup. Cleanup runs at startup
+# and hourly in all modes. Activity is based on filesystem mtime.
+cleanup_inactive_sessions_days: 14
 keybindings: emacs
 
 # ---- tool-use ----


### PR DESCRIPTION
Adds a background task to automatically delete inactive session transcripts and their attachments after a configurable number of days of inactivity. Activity is determined by the filesystem mtime of the session transcript.

The cleanup task:
- Runs once at startup and hourly thereafter in all modes (TUI, CLI, serve).
- Is opt-in via the cleanup_inactive_sessions_days configuration option.
- Sums the disk space freed and emits a summary via agent events in interactive modes and logs in serve mode.
- Operates best-effort and is fault-tolerant against concurrent deletions or filesystem errors.

Includes a new solution document capturing the async background task pattern used for the implementation.

Closes #847

Plan: harnx-session-cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added best-effort automatic cleanup of inactive session transcripts and their attachments.
  * New `cleanup_inactive_sessions_days` configuration option in `config.yaml` controls retention (disabled if unset or `0`).
  * Cleanup runs at startup and hourly, and reports a summary of removed sessions.

* **Documentation**
  * Updated the configuration guide and example config to describe `cleanup_inactive_sessions_days`.

* **Tests**
  * Added coverage for cleanup behavior, including size reporting, stale vs. fresh sessions, and symlink-safe byte accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->