### PR TITLE
Clarify session delegation and handoff tool descriptions

### DIFF
--- a/.changeset/session-tool-descriptions.md
+++ b/.changeset/session-tool-descriptions.md
@@ -1,0 +1,5 @@
+---
+harnx: patch
+---
+
+Clarify generated tool descriptions for session delegation and agent handoff so agents understand session context semantics (#837). The `session_prompt` ACP tool now states that continuing a prior conversation requires passing the `session_id` returned by an earlier prompt call, and that omitting it starts a new empty session with no prior context. The `handoff` tool description is corrected to reflect that the target agent always starts fresh — prior conversation history is intentionally cleared, and only the `prompt` argument carries context. Documentation-string changes only; no behavior changes.

--- a/crates/harnx-acp/src/manager.rs
+++ b/crates/harnx-acp/src/manager.rs
@@ -237,7 +237,7 @@ fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
         ToolDeclaration {
             name: format!("{server_name}_session_prompt"),
             description: format!(
-                "Send a prompt to the '{server_name}' ACP agent. Auto-creates a session if session_id is not provided.  Use the session_id from a prior prompt call to continue the same conversation."
+                "Send a prompt to the '{server_name}' ACP agent. To continue a prior conversation, you must pass the session_id returned by an earlier prompt call or by session_new; the remote agent keeps context under that session_id. If you omit session_id, this starts a new empty session with no prior context."
             ),
             parameters: JsonSchema {
                 type_value: Some("object".to_string()),
@@ -256,7 +256,7 @@ fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
                         JsonSchema {
                             type_value: Some("string".to_string()),
                             description: Some(
-                                "Session ID from a previous session_new call or a prior prompt call. If omitted, a new session is created automatically.".to_string(),
+                                "Session ID returned by a prior prompt call or by session_new. Pass it to preserve context from earlier turns; if omitted, a new empty session is created and no prior context is available.".to_string(),
                             ),
                             ..Default::default()
                         },
@@ -273,7 +273,7 @@ fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
         },
         ToolDeclaration {
             name: format!("{server_name}_session_load"),
-            description: format!("Load an existing session on the '{server_name}' ACP agent"),
+            description: format!("Load an existing session on the '{server_name}' ACP agent and resume its prior context"),
             parameters: JsonSchema {
                 type_value: Some("object".to_string()),
                 properties: Some({

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -183,7 +183,7 @@ fn handoff_tool_declarations_for_agents(
                 crate::tool::JsonSchema {
                     type_value: Some("string".to_string()),
                     description: Some(
-                        "Optional target session ID. If provided, the handoff reuses that session; if omitted, the current interactive session is reused.".to_string(),
+                        "Optional target session ID selecting which session the target agent starts under. Handoff clears conversation history, so even when a session is reused its prior messages are not visible to the target agent. Do not rely on earlier context being available — pass everything the target needs in `prompt`.".to_string(),
                     ),
                     ..Default::default()
                 },
@@ -191,7 +191,7 @@ fn handoff_tool_declarations_for_agents(
             ToolDeclaration {
                 name: format!("{display_name}_session_handoff"),
                 description: format!(
-                    "Exit the current interactive agent session and hand off to the '{agent_name}' agent. Resolves the target session internally (reusing session_id when provided, otherwise the current session), then continues interaction in that agent session with the supplied prompt."
+                    "Exit the current agent session and hand off to the '{agent_name}' agent, which starts fresh. Prior conversation history is not carried over — it is intentionally cleared on handoff. Only the `prompt` argument provides context to the target agent, so include everything it needs there."
                 ),
                 parameters: crate::tool::JsonSchema {
                     type_value: Some("object".to_string()),


### PR DESCRIPTION
Strengthens generated tool descriptions for ACP session prompt and agent handoff tools to ensure agents understand session context semantics. Specifies that continuing a conversation requires passing the returned session_id, and that handoff intentionally clears conversation history to start the target agent fresh.

#837
Plan-Id: harnx-837-session-tool-descriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified session tool descriptions: continuing a prior conversation requires providing the session ID, while omitting it starts a fresh session with no prior context.
  * Updated agent handoff documentation to explicitly state that prior conversation history is intentionally cleared, with only the new prompt carrying context to the target agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->