### PR TITLE
feat(agents): grant session-history tool to compaction-enabled agents

### DIFF
--- a/.changeset/compaction-agents-session-history-tool.md
+++ b/.changeset/compaction-agents-session-history-tool.md
@@ -1,0 +1,6 @@
+---
+harnx: patch
+pantheon: patch
+coding: patch
+---
+Grant the `harnx_agent_session_history_read` tool to every bundled agent configured with a `compaction_agent`, so they can search their pre-compaction session history after a compaction.

--- a/example_config/agents/example-agent.md
+++ b/example_config/agents/example-agent.md
@@ -12,6 +12,7 @@ use_tools:                       # Which MCP tools to allow
   - ListDirectory
   - Read
   - Write
+  - harnx_agent_session_history_read
 description: ""                  # Short description of the agent
 version: ""                      # Agent version string
 compaction_agent: example-compaction-agent  # Agent to use for context compression (uses its model/system prompt)

--- a/packages/coding/agents/coder.md
+++ b/packages/coding/agents/coder.md
@@ -46,6 +46,7 @@ use_tools:
   - time_get_current_time
   - time_wait
   - time_wait_until
+  - harnx_agent_session_history_read
 description: >
   Full-stack coding assistant — reads code, writes code, runs tests, searches
   the web for docs, and manages local plans to track multi-step tasks.

--- a/packages/pantheon/agents/aeacus.md
+++ b/packages/pantheon/agents/aeacus.md
@@ -20,6 +20,7 @@ use_tools:
 - plans_list_tasks
 - plans_update_note
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Pragmatic engineer \u2014 evaluates code review findings through the\
   \ lens of real-world production impact, blast radius, and failure modes. Named after\
   \ Aeacus (EE-uh-kus), keeper of the Underworld's records who ensured completeness.\n"

--- a/packages/pantheon/agents/apollo.md
+++ b/packages/pantheon/agents/apollo.md
@@ -27,6 +27,7 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
+- harnx_agent_session_history_read
 description: "Creative coding and innovative solutions specialist — provides the creative spark for novel UX and 'out-of-the-box' logic. Named after Apollo (uh-POL-oh), God of the Arts.\n"
 version: '0.2.4'
 variables:

--- a/packages/pantheon/agents/argus.md
+++ b/packages/pantheon/agents/argus.md
@@ -20,6 +20,7 @@ use_tools:
 - plans_list_tasks
 - plans_update_note
 - plans_update_task
+- harnx_agent_session_history_read
 description: "Task verification agent — independently verifies work completed by other agents by reading changed files, running tests and diagnostics, and cross-checking claims against actual results. Returns structured PASS/FAIL verdicts with evidence. Named after Argus (AR-gus) Panoptes, the hundred-eyed giant who never slept.\n"
 version: '0.2.4'
 variables:

--- a/packages/pantheon/agents/aristarchus.md
+++ b/packages/pantheon/agents/aristarchus.md
@@ -46,6 +46,7 @@ use_tools:
   - thalia_session_prompt
   - tyche_session_prompt
   - urania_session_prompt
+  - harnx_agent_session_history_read
 description: "Code review coordinator \u2014 orchestrates multi-agent code review\
   \ of pull requests and codebases, aggregating specialist findings into structured\
   \ verdicts. Named after Aristarchus (ar-ih-STAR-kus) of Samothrace, the greatest\

--- a/packages/pantheon/agents/athena.md
+++ b/packages/pantheon/agents/athena.md
@@ -26,6 +26,7 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
+- harnx_agent_session_history_read
 description: "Complex multi-faceted strategy and execution specialist — commands the field when a high-effort task is too complex for a specialist. Named after Athena (uh-THEE-nuh), Goddess of Strategic Warfare.\n"
 version: '0.2.4'
 variables:

--- a/packages/pantheon/agents/atlas.md
+++ b/packages/pantheon/agents/atlas.md
@@ -55,6 +55,7 @@ use_tools:
 - time_wait
 - time_wait_until
 - zosimus_session_prompt
+- harnx_agent_session_history_read
 description: "Plan execution orchestrator \u2014 manages plans and todos in local,\
   \ distributes tasks to Pantheon specialist agents, and shares context via plan notes.\
   \ Verifies every delegation independently. Named after Atlas (AT-lus), the Titan\

--- a/packages/pantheon/agents/calliope.md
+++ b/packages/pantheon/agents/calliope.md
@@ -18,6 +18,7 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Code quality specialist — identifies code smells, DRY violations, complexity issues, naming problems, and SOLID principle adherence. Named after Calliope (kuh-LY-uh-pee), the Muse of epic poetry and eloquence.\n"
 version: '0.2.4'
 variables:

--- a/packages/pantheon/agents/clio.md
+++ b/packages/pantheon/agents/clio.md
@@ -23,6 +23,7 @@ use_tools:
 - plans_list_notes
 - plans_list_tasks
 - plans_update_note
+- harnx_agent_session_history_read
 description: |
   Git operations agent — handles commits, squash, rebase, and push. Squashes branches into a single clean commit, rebases on origin/HEAD, and pushes to remote. Named after Clio (KLEE-oh), the Muse of history.
 version: '0.2.4'

--- a/packages/pantheon/agents/daedalus.md
+++ b/packages/pantheon/agents/daedalus.md
@@ -25,6 +25,7 @@ use_tools:
 - plans_update_task
 - pytheas_session_prompt
 - zosimus_session_prompt
+- harnx_agent_session_history_read
 description: "Strategic planner \u2014 interviews users, delegates pre-analysis to\
   \ Metis, research to Explore/Librarian/Oracle, produces plans reviewed by Momus,\
   \ then hands off to Atlas for execution. Named after Daedalus (DED-uh-lus), the\

--- a/packages/pantheon/agents/erato.md
+++ b/packages/pantheon/agents/erato.md
@@ -18,6 +18,7 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "UI/UX and accessibility specialist — evaluates design system compliance, responsive design, WCAG accessibility, ARIA usage, keyboard navigation, and user experience patterns. Named after Erato (EH-ruh-toh), the Muse of love poetry — ensuring the UI is lovable and accessible to all.\n"
 version: '0.2.4'
 variables:

--- a/packages/pantheon/agents/euterpe.md
+++ b/packages/pantheon/agents/euterpe.md
@@ -18,6 +18,7 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Coding conventions specialist — validates adherence to project patterns, naming conventions, file organization, import ordering, type safety, and documentation standards. Named after Euterpe (yoo-TUR-pee), the Muse of music and harmony.\n"
 version: '0.2.4'
 variables:

--- a/packages/pantheon/agents/hephaestus.md
+++ b/packages/pantheon/agents/hephaestus.md
@@ -26,6 +26,7 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
+- harnx_agent_session_history_read
 description: "Deep work and complex refactoring specialist — grinds through autonomous, heavy-duty problem-solving at the forge. Named after Hephaestus (heh-FES-tus), the Divine Blacksmith.\n"
 version: '0.2.4'
 variables:

--- a/packages/pantheon/agents/hermes.md
+++ b/packages/pantheon/agents/hermes.md
@@ -26,6 +26,7 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
+- harnx_agent_session_history_read
 description: "Quick tasks and minor bugs specialist — handles the small, fast, 'blink-and-you-miss-it' fixes with rapid turnaround. Named after Hermes (HER-meez), the Winged Messenger.\n"
 version: '0.2.4'
 variables:

--- a/packages/pantheon/agents/hestia.md
+++ b/packages/pantheon/agents/hestia.md
@@ -26,6 +26,7 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
+- harnx_agent_session_history_read
 description: "Maintenance, stability, and routine tasks specialist — keeps the codebase warm, clean, and stable for day-to-day operations. Named after Hestia (HES-tee-uh), Guardian of the Hearth.\n"
 version: '0.2.4'
 variables:

--- a/packages/pantheon/agents/iris.md
+++ b/packages/pantheon/agents/iris.md
@@ -26,6 +26,7 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
+- harnx_agent_session_history_read
 description: "Visual engineering, frontend, and UI/UX specialist — bridges the gap between the invisible code and the visible UI. Named after Iris (EYE-ris), Goddess of the Rainbow.\n"
 version: '0.2.4'
 variables:

--- a/packages/pantheon/agents/librarian.md
+++ b/packages/pantheon/agents/librarian.md
@@ -8,6 +8,7 @@ use_tools:
 - exa_web_search_exa
 - fetch_fetch_markdown
 - grep_grep_query
+- harnx_agent_session_history_read
 description: "External knowledge researcher \u2014 searches the web, library documentation,\
   \ and public GitHub repositories to find best practices, patterns, API references,\
   \ and solutions to technical questions.\n"

--- a/packages/pantheon/agents/melpomene.md
+++ b/packages/pantheon/agents/melpomene.md
@@ -20,6 +20,7 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Security vulnerability specialist \u2014 identifies injection risks,\
   \ authentication flaws, authorization gaps, secrets exposure, input validation issues,\
   \ and supply chain risks. Named after Melpomene (mel-POM-uh-nee), the Muse of tragedy\

--- a/packages/pantheon/agents/metis.md
+++ b/packages/pantheon/agents/metis.md
@@ -15,6 +15,7 @@ use_tools:
 - librarian_session_prompt
 - pytheas_session_prompt
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Pre-planning consultant \u2014 analyzes user requests before Daedalus\
   \ generates plans, identifying hidden intentions, ambiguities, and AI failure points.\
   \ Produces directives that guide the planner. Named after Metis (MEE-tis), the Greek\

--- a/packages/pantheon/agents/minos.md
+++ b/packages/pantheon/agents/minos.md
@@ -18,6 +18,7 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Methodical auditor \u2014 systematically verifies code review findings\
   \ by tracing evidence chains, checking cited code, and rendering verdicts. Named\
   \ after Minos (MY-nos), judge of the Underworld who weighed the deeds of the deceased.\n"

--- a/packages/pantheon/agents/mnemosyne.md
+++ b/packages/pantheon/agents/mnemosyne.md
@@ -23,6 +23,7 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - time_get_current_time
+- harnx_agent_session_history_read
 description: "Knowledge compounding specialist \u2014 captures learnings, decisions,\
   \ and solutions from completed tasks into structured docs/solutions/ entries for\
   \ future reference. Named after Mnemosyne (neh-MOZ-ih-nee), Titan of Memory and\

--- a/packages/pantheon/agents/momus.md
+++ b/packages/pantheon/agents/momus.md
@@ -20,6 +20,7 @@ use_tools:
 - plans_list_tasks
 - plans_update_note
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Plan reviewer \u2014 verifies that implementation plans are executable\
   \ and that file references are valid. Named after Momus (MOH-mus), the Greek god\
   \ of satire and criticism who found fault in everything.\n"

--- a/packages/pantheon/agents/nemesis.md
+++ b/packages/pantheon/agents/nemesis.md
@@ -18,6 +18,7 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Reliability specialist \u2014 reviews error handling, retry logic, circuit\
   \ breakers, timeouts, health checks, graceful degradation, and async handler safety.\
   \ Named after Nemesis (NEM-uh-sis), goddess of retribution who ensures hubris does\

--- a/packages/pantheon/agents/oracle.md
+++ b/packages/pantheon/agents/oracle.md
@@ -4,6 +4,7 @@ compaction_agent: compact-researcher
 use_tools:
 - exa_web_search_exa
 - fetch_fetch_markdown
+- harnx_agent_session_history_read
 description: "Architecture and strategy consultant \u2014 provides deep analysis of\
   \ technology trade-offs, scalability concerns, and long-term architectural implications.\
   \ Like consulting the Oracle (OR-uh-kul) at Delphi for complex technical decisions.\n"

--- a/packages/pantheon/agents/peitho.md
+++ b/packages/pantheon/agents/peitho.md
@@ -26,6 +26,7 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
+- harnx_agent_session_history_read
 description: "Peitho (PY-thoh) - Goddess of Persuasion. She turns technical jargon into eloquent, human-readable documentation. Specialist in documentation, release notes, and user communication.\n"
 version: '0.2.4'
 variables:

--- a/packages/pantheon/agents/plato.md
+++ b/packages/pantheon/agents/plato.md
@@ -26,6 +26,7 @@ use_tools:
 - plans_update_note
 - plans_update_task
 - pytheas_session_prompt
+- harnx_agent_session_history_read
 description: "High-level system design and architecture specialist — designs the perfect architecture that other agents try to replicate. Named after Plato (PLAY-toh), the Master of Ideal Forms.\n"
 version: '0.2.4'
 variables:

--- a/packages/pantheon/agents/polyhymnia.md
+++ b/packages/pantheon/agents/polyhymnia.md
@@ -19,6 +19,7 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Privacy and compliance specialist \u2014 evaluates PII handling, data\
   \ protection patterns, consent flows, data retention, logging practices, and regulatory\
   \ compliance. Named after Polyhymnia (pol-ee-HIM-nee-uh), the Muse of sacred poetry\

--- a/packages/pantheon/agents/pytheas.md
+++ b/packages/pantheon/agents/pytheas.md
@@ -21,6 +21,7 @@ use_tools:
 - plans_list_tasks
 - plans_update_note
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Reconnaissance and research agent — explores codebases, fetches GitHub PR/issue context (Jira and GitHub Issues), and caches findings as plan notes for other agents. Performs fast code analysis using ripgrep, ast-grep, and file inspection. Named after Pytheas (pih-THEE-us) of Massalia, the Greek explorer who sailed beyond the known world.\n"
 version: '0.2.4'
 variables:

--- a/packages/pantheon/agents/rhadamanthus.md
+++ b/packages/pantheon/agents/rhadamanthus.md
@@ -18,6 +18,7 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Skeptical investigator \u2014 pressure-tests code review findings by\
   \ challenging assumptions, searching for mitigating factors, and catching false\
   \ positives. Named after Rhadamanthus (rad-uh-MAN-thus), the strictest judge of\

--- a/packages/pantheon/agents/sisyphus.md
+++ b/packages/pantheon/agents/sisyphus.md
@@ -54,6 +54,7 @@ use_tools:
 - time_wait
 - time_wait_until
 - zosimus_session_prompt
+- harnx_agent_session_history_read
 description: "Task executor \u2014 handles tasks from users. For complex work,\
   \ creates local plans and executes them directly or delegates to Pantheon specialists.\
   \ Writes code directly in the project directory. Named after Sisyphus (SIS-ih-fus).\n"

--- a/packages/pantheon/agents/terpsichore.md
+++ b/packages/pantheon/agents/terpsichore.md
@@ -18,6 +18,7 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Refactoring and completeness specialist — identifies missed simplification opportunities, partial fixes, incomplete implementations, and unaddressed edge cases. Named after Terpsichore (turp-SIK-uh-ree), the Muse of dance — ensuring code moves elegantly.\n"
 version: '0.2.4'
 variables:

--- a/packages/pantheon/agents/thalia.md
+++ b/packages/pantheon/agents/thalia.md
@@ -18,6 +18,7 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Testing adequacy specialist — evaluates test coverage, edge case handling, assertion quality, test isolation, and identifies untested code paths. Named after Thalia (thuh-LY-uh), the Muse of comedy — finding what's absurdly untested.\n"
 version: '0.2.4'
 variables:

--- a/packages/pantheon/agents/tyche.md
+++ b/packages/pantheon/agents/tyche.md
@@ -18,6 +18,7 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Deployment verification specialist \u2014 produces Go/No-Go deployment\
   \ checklists with pre-deployment checks, migration verification, rollback procedures,\
   \ and monitoring plans. Named after Tyche (TY-kee), goddess of fortune who determines\

--- a/packages/pantheon/agents/urania.md
+++ b/packages/pantheon/agents/urania.md
@@ -20,6 +20,7 @@ use_tools:
 - plans_update_note
 - pytheas_session_prompt
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Architecture and big picture specialist \u2014 evaluates cross-cutting\
   \ concerns, dependency direction, design pattern adherence, API contract consistency,\
   \ and system-wide impact. Named after Urania (yoo-RAY-nee-uh), the Muse of astronomy\

--- a/packages/pantheon/agents/zosimus.md
+++ b/packages/pantheon/agents/zosimus.md
@@ -21,6 +21,7 @@ use_tools:
 - plans_list_notes
 - plans_update_note
 - fs_rollback_file
+- harnx_agent_session_history_read
 description: "Deep investigation agent — performs multi-step code analysis, reproduces bugs, validates hypotheses, and caches findings as plan notes for other agents. Executes targeted diagnostics and probe scripts without modifying repository source files. Named after Zosimus, the careful investigator.\n"
 version: '0.2.4'
 variables:


### PR DESCRIPTION
## What

Adds `harnx_agent_session_history_read` to the `use_tools` list of every bundled agent that has a `compaction_agent` configured (36 agents across `example_config`, `packages/coding`, and `packages/pantheon`).

## Why

The session-history search tool (issue #819, implemented in #851) lets an agent grep its own pre-compaction session transcript to recover context that summarization may have dropped. But the tool is gated by `use_tools` — it's only offered to an agent that lists it explicitly or uses a `*` wildcard (see `config/mod.rs` and the `session_history_tool_declaration_is_gated_by_use_tools` test).

None of the bundled compaction-enabled agents used a wildcard, so the tool the compaction flow points them at (`session_ops_split.rs`) was never actually callable. This grants it to exactly the agents that undergo compaction.

## Scope

- Targeted agents are those with a `compaction_agent:` field — i.e. agents that *get* compacted.
- `role: compaction` summarizer agents and `shared/` prompt fragments are intentionally excluded; they don't need to search their own history.
- The tool is inserted as the last `use_tools` entry in each file, matching each file's existing indentation.

## Verification

- YAML frontmatter re-parses for all 36 files, with the tool present in `use_tools`.
- No bundled compaction agent is left without the tool.
- `cargo nextest -p harnx-runtime` agent/config/compaction-loading tests: 62 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents configured with compaction can now access their pre-compaction session history after a compaction event, enabling better continuity in agent operations.

* **Chores**
  * Updated multiple agent configurations to enable the new session history reading capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->