### PR TITLE
Restore errored queued message as draft instead of auto-replaying

### DIFF
--- a/.changeset/tui-errored-message-retry-loop-fix.md
+++ b/.changeset/tui-errored-message-retry-loop-fix.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Fix an infinite retry loop in the TUI when a queued message failed to send. Errored messages are now restored as editable drafts instead of being automatically replayed.

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1128,17 +1128,23 @@ impl Tui {
                 self.app.streamed_text_this_turn = false;
                 self.app.last_ui_output_source = None;
                 self.app.transcript.push(TranscriptItem::ErrorText(err));
+
+                // Do NOT auto-replay the pending message on error. Replaying the
+                // exact input that just failed would loop forever for persistent
+                // failures (invalid input, repeated network errors). Instead,
+                // restore it as an editable draft so the user can review/edit and
+                // resubmit it with Enter, breaking the retry loop (issue #199).
+                if let Some(pending) = self.app.pending_message.take() {
+                    self.set_input_text(&pending.text);
+                    self.app.attachments = pending.attachments;
+                    self.app.attachment_dir = pending.attachment_dir;
+                    self.app.paste_count = pending.paste_count;
+                    self.app.transcript.push(TranscriptItem::SystemText(
+                        "Queued message not sent due to error. Press Enter to retry.".to_string(),
+                    ));
+                }
                 self.pin_transcript_to_bottom();
                 self.refresh_input_chrome();
-
-                if let Some(pending) = self.app.pending_message.take() {
-                    if let Err(err) = self.submit_pending_message(pending).await {
-                        self.app
-                            .transcript
-                            .push(TranscriptItem::ErrorText(pretty_error_string(&err)));
-                        self.pin_transcript_to_bottom();
-                    }
-                }
                 vec![]
             }
             AgentEvent::Model(ModelEvent::ThoughtChunk { blocks }) => {

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -2946,6 +2946,88 @@ async fn test_streaming_error_shows_full_cause_chain_in_transcript() {
     );
 }
 
+/// Regression test for issue #199: a pending (queued) message must NOT be
+/// auto-replayed when a ModelEvent::Error arrives. Auto-replaying the same
+/// input that just failed would loop forever for persistent failures. Instead
+/// the pending message is restored as an editable draft and the user is told to
+/// press Enter to retry.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pending_message_not_replayed_on_error() {
+    let config = test_config_with_mock_client_and_agent(
+        "test-agent",
+        Some("pending-replay-on-error-session"),
+    );
+    let mut harness = TuiTestHarness::with_config(config).await;
+    harness.tui().clear_transcript();
+
+    // Simulate a message queued mid-prompt, with a non-default paste_count so we
+    // can confirm the full draft state (not just text) is restored on error.
+    harness.tui().app.llm_busy = true;
+    harness.tui().app.paste_count = 3;
+    harness
+        .tui()
+        .queue_pending_message("retry me".to_string())
+        .await;
+    assert!(
+        harness.tui().app.pending_message.is_some(),
+        "precondition: a pending message should be queued"
+    );
+    // queue_pending_message snapshots paste_count into the pending message; reset
+    // the live value so the assertion below proves it was restored, not leftover.
+    harness.tui().app.paste_count = 0;
+
+    // Deliver an error for the in-flight prompt.
+    harness
+        .tui()
+        .event_tx
+        .send(TuiEvent::Agent(
+            AgentEvent::Model(ModelEvent::Error("boom".to_string())),
+            None,
+        ))
+        .unwrap();
+    harness.drain_and_settle().await.unwrap();
+
+    // The pending message must be cleared (not auto-replayed) and its shared
+    // copy must be cleared too, so it can't leak into a later task.
+    assert!(
+        harness.tui().app.pending_message.is_none(),
+        "pending message should be cleared after error, not auto-replayed"
+    );
+    assert!(
+        harness.tui().shared_pending_message.lock().await.is_none(),
+        "shared pending message should be cleared after error"
+    );
+
+    // The LLM-busy flag must be reset so the UI is unblocked for the retry.
+    assert!(
+        !harness.tui().app.llm_busy,
+        "llm_busy should be reset to false after error"
+    );
+
+    // The queued text is restored as an editable draft for the user.
+    assert_eq!(
+        harness.tui().app.input.lines().join("\n"),
+        "retry me",
+        "queued text should be restored to the input as a draft"
+    );
+
+    // Full draft state (not just text) is restored, e.g. paste_count.
+    assert_eq!(
+        harness.tui().app.paste_count,
+        3,
+        "paste_count should be restored from the pending message"
+    );
+
+    // A system notice instructs the user to press Enter to retry.
+    let has_retry_notice = harness.tui().app.transcript.iter().any(|entry| {
+        matches!(entry, TranscriptItem::SystemText(text) if text.contains("Press Enter to retry"))
+    });
+    assert!(
+        has_retry_notice,
+        "transcript should contain a 'Press Enter to retry' notice after error"
+    );
+}
+
 /// Test cancellation during tool call execution.
 /// When user presses Ctrl+C while a tool is executing, the tool should be aborted.
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
In the ModelEvent::Error handler, stop auto-replaying the queued pending message which caused an infinite retry loop for persistent failures. Restore the message as an editable draft (including text, attachments, attachment directory, and paste count) and push a system notice informing the user how to retry. Consolidates a redundant pin_transcript_to_bottom call.

Adds a regression test verifying that pending/shared state is cleared, llm_busy is reset, draft state is restored, and the retry notice is shown.

Closes #199

Plan-Id: pending-message-replay-loop-fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed an infinite retry loop when queued messages fail to send.
* Failed queued messages are now restored as editable drafts in the input (including attachments and paste count) instead of being automatically replayed.
* Added a system notice informing users: “Queued message not sent due to error. Press Enter to retry.”  
* Added a regression test to ensure pending messages are not replayed after a send error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->