### PR TITLE
fix: add LLM read timeout so stalled requests fail clearly instead of…

### DIFF
--- a/.changeset/llm-read-timeout.md
+++ b/.changeset/llm-read-timeout.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Add a configurable read (inactivity) timeout for LLM provider HTTP requests so stalled responses fail with a clear error instead of hanging until the ACP idle timeout; raise the default ACP idle timeout to 600s as a backstop.

--- a/crates/harnx-acp/src/config.rs
+++ b/crates/harnx-acp/src/config.rs
@@ -6,7 +6,7 @@ fn default_true() -> bool {
 }
 
 fn default_idle_timeout() -> u64 {
-    300
+    600
 }
 
 fn default_operation_timeout() -> u64 {
@@ -26,6 +26,8 @@ pub struct AcpServerConfig {
     pub enabled: bool,
     #[serde(default)]
     pub description: Option<String>,
+    /// ACP subprocess idle backstop in seconds. LLM HTTP client read timeouts should
+    /// fail stalled requests first; this only catches fully silent subprocess hangs.
     #[serde(default = "default_idle_timeout")]
     pub idle_timeout_secs: u64,
     #[serde(default = "default_operation_timeout")]

--- a/crates/harnx-acp/src/manager.rs
+++ b/crates/harnx-acp/src/manager.rs
@@ -623,7 +623,7 @@ mod tests {
             env: HashMap::new(),
             enabled: true,
             description: None,
-            idle_timeout_secs: 300,
+            idle_timeout_secs: 600,
             operation_timeout_secs: 3600,
             package: None,
         }
@@ -671,7 +671,7 @@ command: agent
         assert!(config.env.is_empty());
         assert!(config.enabled);
         assert!(config.description.is_none());
-        assert_eq!(config.idle_timeout_secs, 300);
+        assert_eq!(config.idle_timeout_secs, 600);
         assert_eq!(config.operation_timeout_secs, 3600);
     }
 

--- a/crates/harnx-client/src/client.rs
+++ b/crates/harnx-client/src/client.rs
@@ -8,6 +8,9 @@ use serde_json::Value;
 use std::sync::LazyLock;
 use std::time::Duration;
 
+const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
+const DEFAULT_READ_TIMEOUT_SECS: u64 = 120;
+
 #[allow(unused_imports)]
 pub use harnx_core::api_types::{
     ChatCompletionsData, ChatCompletionsOutput, CompletionTokenUsage, EmbeddingsData,
@@ -166,6 +169,11 @@ fn set_proxy(mut builder: reqwest::ClientBuilder, proxy: &str) -> Result<reqwest
     Ok(builder)
 }
 
+fn resolve_timeout_secs(configured: Option<u64>, default: u64) -> u64 {
+    // reqwest treats 0 as infinite timeout; coerce it back to default so protections stay on.
+    configured.filter(|&secs| secs > 0).unwrap_or(default)
+}
+
 #[async_trait::async_trait]
 pub trait Client: Sync + Send {
     fn extra_config(&self) -> Option<&ExtraConfig>;
@@ -201,7 +209,14 @@ pub trait Client: Sync + Send {
     fn build_client(&self, ctx: &ClientCallContext<'_>) -> Result<ReqwestClient> {
         let mut builder = ReqwestClient::builder();
         let extra = self.extra_config();
-        let timeout = extra.and_then(|v| v.connect_timeout).unwrap_or(10);
+        let connect_timeout = resolve_timeout_secs(
+            extra.and_then(|v| v.connect_timeout),
+            DEFAULT_CONNECT_TIMEOUT_SECS,
+        );
+        let read_timeout = resolve_timeout_secs(
+            extra.and_then(|v| v.read_timeout),
+            DEFAULT_READ_TIMEOUT_SECS,
+        );
         if let Some(proxy) = extra.and_then(|v| v.proxy.as_deref()) {
             builder = set_proxy(builder, proxy)?;
         }
@@ -235,7 +250,8 @@ pub trait Client: Sync + Send {
             warn!("'client_key' is set but 'client_cert' is missing; mTLS identity will not be configured");
         }
         let client = builder
-            .connect_timeout(Duration::from_secs(timeout))
+            .connect_timeout(Duration::from_secs(connect_timeout))
+            .read_timeout(Duration::from_secs(read_timeout))
             .build()
             .with_context(|| "Failed to build client")?;
         Ok(client)
@@ -512,6 +528,7 @@ pub fn json_str_from_map<'a>(
 #[cfg(test)]
 mod request_data_tests {
     use super::RequestData;
+    use harnx_core::provider_config::openai::OpenAIConfig;
     use indexmap::IndexMap;
     use serde_json::json;
 
@@ -650,5 +667,41 @@ mod request_data_tests {
 
         assert_eq!(output["body"]["max_tokens"].as_i64(), Some(100));
         assert_eq!(output["body"]["temperature"].as_f64(), Some(0.5));
+    }
+
+    #[test]
+    fn extra_config_deserializes_read_timeout() {
+        let yaml = r#"
+type: openai
+extra:
+  connect_timeout: 7
+  read_timeout: 45
+"#;
+
+        let config: OpenAIConfig = serde_yaml::from_str(yaml).expect("parse OpenAI config");
+        let extra = config.extra.expect("extra config");
+
+        assert_eq!(extra.connect_timeout, Some(7));
+        assert_eq!(extra.read_timeout, Some(45));
+    }
+
+    #[test]
+    fn resolve_timeout_secs_coerces_zero_to_default() {
+        assert_eq!(
+            super::resolve_timeout_secs(Some(0), super::DEFAULT_CONNECT_TIMEOUT_SECS),
+            super::DEFAULT_CONNECT_TIMEOUT_SECS
+        );
+        assert_eq!(
+            super::resolve_timeout_secs(Some(0), super::DEFAULT_READ_TIMEOUT_SECS),
+            super::DEFAULT_READ_TIMEOUT_SECS
+        );
+        assert_eq!(
+            super::resolve_timeout_secs(Some(7), super::DEFAULT_CONNECT_TIMEOUT_SECS),
+            7
+        );
+        assert_eq!(
+            super::resolve_timeout_secs(None, super::DEFAULT_READ_TIMEOUT_SECS),
+            super::DEFAULT_READ_TIMEOUT_SECS
+        );
     }
 }

--- a/crates/harnx-core/src/api_types.rs
+++ b/crates/harnx-core/src/api_types.rs
@@ -12,6 +12,8 @@ use crate::tool::{ToolCall, ToolDeclaration};
 pub struct ExtraConfig {
     pub proxy: Option<String>,
     pub connect_timeout: Option<u64>,
+    /// Per-read inactivity timeout in seconds for provider HTTP responses.
+    pub read_timeout: Option<u64>,
     pub accept_invalid_certs: Option<bool>,
     pub ca_cert: Option<String>,
     pub client_cert: Option<String>,

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -75,10 +75,15 @@ For a complete list of supported providers and their specific configuration opti
 type: openai              # Provider type (openai, claude, gemini, etc.)
 api_key: sk-...           # Optional if <NAME>_API_KEY env var is set
 api_base: https://...     # Optional custom endpoint
+extra:
+  connect_timeout: 10     # seconds to establish TCP/TLS connection (default 10)
+  read_timeout: 120       # seconds of read inactivity before stalled response fails (default 120)
 patches:                  # Patch API requests using jq expressions
   chat_completions:
     - '.body.cache_control = {"type":"ephemeral"}'
 ```
+
+`extra.connect_timeout` sets how long Harnx waits to establish TCP/TLS connection before request fails. `extra.read_timeout` is per-read inactivity timeout, not cap on total stream duration, so long-but-progressing streaming responses are allowed to continue. Use it so stalled LLM provider surfaces clear error instead of hanging until ACP idle backstop fires.
 
 ### Per-Model Patches
 

--- a/docs/solutions/async-patterns/acp-idle-timeout-false-negative-2026-06-18.md
+++ b/docs/solutions/async-patterns/acp-idle-timeout-false-negative-2026-06-18.md
@@ -1,10 +1,11 @@
 ---
 title: "False-negative ACP idle timeout during long quiet remote work"
 date: 2026-06-18
+last_updated: 2026-06-19
 category: async-patterns
 problem_type: logic_error
-component: harnx-acp
-root_cause: "session_prompt idle timer reset only on session-matched session/update notifications; quiet long tool runs trip a spurious timeout"
+component: harnx-acp, harnx-client
+root_cause: "missing HTTP read_timeout caused LLM provider stalls to hang indefinitely, surfacing as misleading ACP idle timeout; prior liveness-sentinel fix addressed spurious timeouts during quiet-but-progressing work, but not the deeper transport-layer gap"
 resolution_type: code_fix
 severity: high
 tags:
@@ -15,6 +16,10 @@ tags:
   - acp
   - liveness
   - heartbeat
+  - reqwest
+  - http-client
+  - read-timeout
+  - layered-timeout
 plan_ref: acp-idle-timeout-874
 ---
 
@@ -123,6 +128,58 @@ session-matched updates.
 - Fire-and-forget cancellation stops abandoned remote work without making the
   caller wait a second timeout.
 
+
+## Follow-up: Deeper Root Cause — Missing HTTP Read Timeout
+
+The prior fix (liveness sentinel resetting the ACP idle timer on stderr/inbound-request heartbeats) addressed **spurious** idle timeouts during quiet-but-progressing work, but the issue recurred. Investigation revealed a deeper transport-layer gap.
+
+### Symptoms (Recurring)
+
+- ACP idle timeout fires even when the agent subprocess is healthy and making no requests.
+- No stderr activity, no session/update, no inbound requests — complete radio silence.
+- Liveness heartbeats never fire because the subprocess itself is stalled waiting on a hung LLM provider call.
+
+### Root Cause
+
+The LLM HTTP client (`crates/harnx-client/src/client.rs::build_client`) set **only** `connect_timeout` (10s) — **no read/overall timeout**. A stalled LLM provider (TCP/TLS connected but sending no bytes, common when streaming SSE hangs upstream) hangs **indefinitely**. The agent subprocess then goes fully silent (no stderr, no session/update, no inbound requests), so liveness heartbeats never fire and the parent's ACP idle timer trips with a misleading "idle timeout" error.
+
+**The idle timeout was the symptom; the missing LLM read timeout was the cause.**
+
+### Solution
+
+1. **Add `read_timeout` to HTTP client.** Added `read_timeout: Option<u64>` to `ExtraConfig` (harnx-core/src/api_types.rs); `build_client` applies reqwest `.read_timeout(120s default)`.
+
+2. **Correct timeout semantics.** reqwest `.read_timeout()` is a **per-read inactivity** timeout (fires only when no bytes arrive for the window), so it does **not** kill long-but-progressing streaming responses — only true stalls. This is why `.read_timeout()` is correct here and a total `.timeout()` would be **wrong** (it would kill healthy long generations).
+
+3. **Coerce zero to default.** `0` must be coerced to the default because reqwest treats a 0-duration timeout as infinite (silently disabling protection). Added a `resolve_timeout_secs` helper:
+
+   ```rust
+   fn resolve_timeout_secs(configured: Option<u64>, default: u64) -> u64 {
+       // reqwest treats 0 as infinite timeout; coerce it back to default.
+       configured.filter(|&secs| secs > 0).unwrap_or(default)
+   }
+   ```
+
+4. **Raise ACP backstop.** Raised ACP `idle_timeout_secs` default 300→600s, documented as a backstop now that the LLM layer fails fast.
+
+### Why This Works
+
+- Layered timeouts catch distinct failure modes:
+  - **HTTP read_timeout (120s)**: Primary — catches stalled provider reads, surfaces as provider/API error.
+  - **ACP idle_timeout (600s)**: Backstop — catches fully silent subprocess hangs (e.g., process wedged before making HTTP call).
+  - **operation_timeout (3600s)**: Hard ceiling — total session lifetime wall.
+
+- Per-read inactivity semantics ensure healthy long streams continue; only true dead air triggers.
+- Error attribution now distinguishes: "Failed to call chat-completions api ... operation timed out" vs "ACP server idle timeout".
+
+### Known Gap
+
+`LlamaServerClient` uses hyper over a Unix socket, bypassing reqwest, so it ignores `read_timeout`. A hung local llama-server still falls through to the ACP backstop. This is a known remaining gap and the subject of a follow-up issue.
+
+### Generalizable Lesson
+
+**Layered timeouts are essential.** A missing transport-layer timeout surfaces as a misleading higher-layer timeout. When diagnosing "misleading timeout" bugs, check each layer from bottom (transport) to top (process/application).
+
 ## Prevention Strategies
 
 **Code Review Checklist:**
@@ -131,12 +188,16 @@ session-matched updates.
 - [ ] Timeout branches that abandon remote work also request cancellation.
 - [ ] Cancellation on a timeout path is best-effort (no second blocking await).
 - [ ] Magic sentinels are named constants with a documented invariant.
+- [ ] All HTTP clients have both connect and read timeouts configured.
+- [ ] Read timeouts use per-read inactivity semantics (not total request deadline) for streaming workloads.
 
 **Testability:**
 - Extract `select!`-arm decision logic into pure functions and unit-test the
   truth table (matching id, sentinel, unrelated id, `Lagged`, `Closed`).
 - For the timeout path itself, inject a worker handle and a short timeout, then
   assert the error text and that a `CancelSession` command was enqueued.
+- For HTTP timeout configuration, verify deserialization and that zero values are
+  coerced to defaults (per `resolve_timeout_secs`).
 
 ## Related Issues
 


### PR DESCRIPTION
… false ACP idle timeout (#874)

LLM HTTP requests lacked a read timeout, causing stalled providers to hang silently until the ACP idle timer (300s) fired with a misleading "idle timeout" error.

This adds a per-read inactivity timeout to the LLM client (default 120s) for a clear, fast failure; raises the ACP idle default to 600s as a backstop; and documents the new configuration options.

Key changes:
- Add read_timeout to ExtraConfig in harnx-core
- Apply reqwest .read_timeout() in harnx-client (default 120s)
- Raise ACP idle default to 600s in harnx-acp
- Document connect_timeout and read_timeout in configuration-guide.md

Closes #874

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP requests no longer hang indefinitely on stalled responses
  * Increased default subprocess idle timeout to 600 seconds for improved stability

* **New Features**
  * Added configurable per-read inactivity timeout for LLM provider HTTP responses
  * Separate connect and read timeout settings for enhanced timeout control

* **Documentation**
  * Updated configuration guide with new timeout options under client settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->