### PR TITLE
feat: add high-availability NATS-backed distributed agent execution

### DIFF
--- a/.changeset/harnx-nats-ha.md
+++ b/.changeset/harnx-nats-ha.md
@@ -1,0 +1,14 @@
+---
+harnx: minor
+---
+
+High-availability distributed agent execution backed by NATS JetStream.
+
+This feature enables a distributed mode where thin clients (TUI, CLI, ACP) communicate with backend workers over NATS. Key capabilities include:
+- **Durable Persistence**: Session logs are stored as append-only streams in NATS JetStream.
+- **High Availability**: Multiple workers can provide failover, using a NATS KV-based lease for single-active-worker mutual exclusion and fence tokens to prevent stale writes.
+- **Thin Client Driver**: Automatic routing for `agent@cluster` agent references, separating client-side UI/tooling from backend execution.
+- **Live Event Fan-out**: Real-time streaming of model chunks and status updates to multiple connected clients for multiplayer visibility.
+- **Control Plane**: Remote cancellation and pending message management across the NATS cluster.
+- **Security**: Support for NATS token authentication and mTLS.
+- **Operations**: New `harnx worker` command, session management tools, and comprehensive HA documentation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ version = "0.14.0"
 source = "git+https://github.com/agentclientprotocol/rust-sdk?rev=5ce2e5d40fac5bf2596dfba1b8e4d562defff177#5ce2e5d40fac5bf2596dfba1b8e4d562defff177"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -83,9 +83,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -242,15 +242,15 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -270,7 +270,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -282,7 +282,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -339,6 +339,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-nats"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f6da6d49a956424ca4e28fe93656f790d748b469eaccbc7488fec545315180"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "pin-project",
+ "portable-atomic",
+ "rand 0.8.6",
+ "regex",
+ "ring",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile",
+ "rustls-webpki 0.102.8",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "tryhard",
+ "url",
+]
+
+[[package]]
 name = "async-process"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,7 +400,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -399,7 +435,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -419,9 +455,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
@@ -491,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.4"
+version = "1.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
+checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -516,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.101.0"
+version = "1.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b647baea49ff551960b904f905681e9b4765a6c4ea08631e89dc52d8bd3f5896"
+checksum = "8c82b3ac19f1431854f7ace3a7531674633e286bfdde21976893bfee36fd493b"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -541,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.103.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae401c65ff288aa7873117fe535cd32b7b1bb0bc43751d28901a1d5f20636b9"
+checksum = "321000d2b4c5519ee573f73167f612efd7329322d9b26969ad1979f0427f1913"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -566,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.106.0"
+version = "1.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c80de7bb7d03e9ca8c9fd7b489f20f3948d3f3be91a7953591347d238115408"
+checksum = "3d0d328ba962af23ecfa3c9f23b98d3d35e325fa218d7f13d17a6bf522f8a560"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -592,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -657,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -671,7 +707,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.4",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -761,7 +797,7 @@ checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -891,6 +927,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -1030,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1041,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1071,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "by_address"
@@ -1098,6 +1140,9 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -1111,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "bytesize"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
 
 [[package]]
 name = "cached"
@@ -1139,7 +1184,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1159,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1263,7 +1308,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1301,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "codesnake"
@@ -1329,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -1383,6 +1428,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -1415,6 +1466,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1556,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -1593,7 +1654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1603,6 +1664,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1636,7 +1723,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1649,7 +1736,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1660,7 +1747,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1671,14 +1758,14 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1714,7 +1801,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1731,6 +1818,17 @@ name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "der-parser"
@@ -1773,7 +1871,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1783,7 +1881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1805,7 +1903,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -1837,9 +1935,9 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
- "const-oid",
- "crypto-common 0.2.1",
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -1876,13 +1974,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1946,6 +2044,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2 0.10.9",
+ "signature",
+ "subtle",
+]
+
+[[package]]
 name = "ego-tree"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,9 +2073,9 @@ checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -1990,7 +2110,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2121,6 +2241,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -2311,7 +2437,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2328,9 +2454,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -2369,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2440,28 +2566,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
 name = "getset"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2907,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3bc074e5723027b482dcd9ab99d95804a53742f6de812d0172fbba4a186c1"
+checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -3229,9 +3352,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "23.0.0"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691ea1e31435c7e7d4d04705ec9d1c0d9482c46b2acf512bc723939d8f0af7fb"
+checksum = "6ef60812443484e67bf84e444cc71b4c78ae62deb822221774a4fa0c57fdb17f"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -3398,9 +3521,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3970,6 +4093,7 @@ version = "0.33.1"
 dependencies = [
  "anyhow",
  "arboard",
+ "async-nats",
  "async-recursion",
  "async-trait",
  "base64",
@@ -4009,6 +4133,7 @@ dependencies = [
  "pretty_assertions",
  "reqwest",
  "reqwest-eventsource",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4296,7 +4421,7 @@ dependencies = [
  "markup5ever 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4473,11 +4598,11 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.4",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -4653,12 +4778,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4754,7 +4873,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4912,7 +5031,7 @@ checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4957,7 +5076,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4976,7 +5095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4991,13 +5110,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -5153,12 +5271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5172,9 +5284,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -5343,20 +5455,20 @@ checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -5426,9 +5538,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -5476,7 +5588,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5543,6 +5655,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nkeys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
+dependencies = [
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "log",
+ "rand 0.8.6",
+ "signatory",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5583,6 +5710,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5606,7 +5742,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5917,6 +6053,12 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -5997,7 +6139,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6031,9 +6173,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "path-absolutize"
@@ -6061,6 +6203,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -6099,7 +6250,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6203,7 +6354,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6216,7 +6367,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6263,7 +6414,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6287,6 +6438,16 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -6404,16 +6565,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6432,7 +6583,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6499,9 +6650,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -6519,9 +6670,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -6555,9 +6706,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -6580,6 +6731,8 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -6589,7 +6742,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -6600,8 +6753,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6831,14 +6994,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6871,9 +7034,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "registry-testkit"
@@ -7018,7 +7181,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7065,7 +7228,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7083,30 +7246,43 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -7134,16 +7310,16 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.4",
  "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
+ "rustls-webpki 0.103.13",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -7154,6 +7330,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "rustls-pki-types",
+ "untrusted 0.9.0",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -7242,7 +7428,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7292,12 +7478,25 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -7404,7 +7603,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7415,7 +7614,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7433,6 +7632,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7441,6 +7649,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7457,9 +7676,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",
@@ -7477,14 +7696,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7595,9 +7814,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sigchld"
@@ -7652,11 +7871,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -7722,24 +7954,34 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smawk"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -7855,7 +8097,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7867,7 +8109,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7889,9 +8131,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7915,7 +8157,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7985,7 +8227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -8166,7 +8408,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8177,7 +8419,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8284,7 +8526,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8351,6 +8593,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.2",
+ "httparse",
+ "rand 0.8.6",
+ "ring",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "toml-span"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8378,9 +8641,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "base64",
  "bitflags 2.13.0",
@@ -8429,7 +8692,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8489,6 +8752,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8515,9 +8788,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -8669,7 +8942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "atomic",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -8728,27 +9001,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8759,9 +9023,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8769,9 +9033,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8779,46 +9043,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -8832,18 +9074,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]
@@ -8873,9 +9103,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.12"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
  "bitflags 2.13.0",
  "wayland-backend",
@@ -8918,9 +9148,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8938,9 +9168,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
@@ -8950,9 +9180,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8963,14 +9193,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -9155,7 +9385,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9166,7 +9396,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9208,6 +9438,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -9427,97 +9666,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "wl-clipboard-rs"
@@ -9638,9 +9789,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -9655,28 +9806,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9696,28 +9847,28 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9750,14 +9901,14 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ rmcp = { version = "1.7", features = ["client", "server", "transport-child-proce
 process-wrap = { version = "9", features = ["tokio1"] }
 libc = "0.2"
 agent-client-protocol = { git = "https://github.com/agentclientprotocol/rust-sdk", rev = "5ce2e5d40fac5bf2596dfba1b8e4d562defff177" }
+async-nats = { version = "0.42", default-features = false, features = ["server_2_10", "server_2_11", "ring"] }
 glob = "0.3"
 globset = "0.4"
 shellexpand = "3.1.0"

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Harnx supports custom dark and light themes, which highlight response text and c
 - [Macro Guide](docs/macro-guide.md)
 - [RAG Guide](docs/rag-guide.md)
 - [Environment Variables](docs/environment-variables.md)
+- [NATS HA Deployment Guide](docs/nats-ha.md)
 - [Configuration Guide](docs/configuration-guide.md)
 - [Tool Confirmation Guide](docs/tool-confirmation-guide.md)
 - [Custom Theme](docs/custom-theme.md)

--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -185,6 +185,45 @@ impl HarnxAgent {
     pub async fn set_connection(&self, conn: acp::ConnectionTo<acp::Client>) {
         *self.connection.lock().await = Some(conn);
     }
+
+    /// Build the local-agent turn input: select the agent + session on the
+    /// forked prompt config, resolve agent variables, and construct the `Input`
+    /// from the user's prompt text. Only used for local agent refs (remote
+    /// thin-client mode drives the turn over NATS instead).
+    fn build_local_input(
+        &self,
+        prompt_config: &GlobalConfig,
+        session_key: &str,
+        prompt_text: &str,
+    ) -> acp::Result<harnx_runtime::config::Input> {
+        {
+            let mut config = prompt_config.write();
+            config
+                .use_agent_by_name(&self.agent_name)
+                .map_err(|e| acp::Error::new(-32603, format!("Failed to set agent: {e}")))?;
+            config
+                .use_session(Some(session_key))
+                .map_err(|e| acp::Error::new(-32603, format!("Failed to use session: {e}")))?;
+        }
+
+        // Build a fresh agent for the input. The forked prompt config keeps
+        // per-request session state isolated while still sharing Arc-backed
+        // runtime resources cloned from the base config.
+        let mut agent = prompt_config
+            .read()
+            .retrieve_agent(&self.agent_name)
+            .map_err(|e| acp::Error::new(-32603, format!("Failed to retrieve agent: {e}")))?;
+        if let Err(e) = harnx_runtime::config::agent::resolve_variables(&mut agent) {
+            warn!(
+                "Failed to resolve variables for agent '{}': {e}",
+                self.agent_name
+            );
+        }
+
+        let mut input = harnx_runtime::config::input::from_str(prompt_config, prompt_text, None);
+        harnx_runtime::config::input::set_agent(&mut input, prompt_config, agent.into_config());
+        Ok(input)
+    }
 }
 
 impl HarnxAgent {
@@ -240,12 +279,7 @@ impl HarnxAgent {
 
     async fn prompt(&self, args: PromptRequest) -> acp::Result<PromptResponse> {
         let session_key = args.session_id.0.to_string();
-        let prompt_text: String = args
-            .prompt
-            .iter()
-            .map(content_block_to_text)
-            .collect::<Vec<_>>()
-            .join("\n");
+        let prompt_text = prompt_blocks_to_text(&args.prompt);
 
         let (abort_signal, cancel_notify, prompt_lock) = {
             let sessions = self.sessions.lock().await;
@@ -272,36 +306,23 @@ impl HarnxAgent {
         // yet observed, effectively un-cancelling it against user intent.
         abort_signal.reset();
 
+        // P4.2: remote agents (`agent@cluster`) run in thin-client mode — the
+        // turn is driven over NATS by a worker daemon, not by a local agent
+        // loop. Detect from the configured agent name; local refs are unchanged.
+        let remote_agent = parse_remote_agent(&self.agent_name);
+
         let prompt_config: GlobalConfig = Arc::new(parking_lot::RwLock::new({
             let shared_config = self.config.read();
             shared_config.fork_session_scope()
         }));
-        {
-            let mut config = prompt_config.write();
-            config
-                .use_agent_by_name(&self.agent_name)
-                .map_err(|e| acp::Error::new(-32603, format!("Failed to set agent: {e}")))?;
-            config
-                .use_session(Some(&session_key))
-                .map_err(|e| acp::Error::new(-32603, format!("Failed to use session: {e}")))?;
-        }
-
-        // Build a fresh agent for the input. The forked prompt config keeps
-        // per-request session state isolated while still sharing Arc-backed
-        // runtime resources cloned from the base config.
-        let mut agent = prompt_config
-            .read()
-            .retrieve_agent(&self.agent_name)
-            .map_err(|e| acp::Error::new(-32603, format!("Failed to retrieve agent: {e}")))?;
-        if let Err(e) = harnx_runtime::config::agent::resolve_variables(&mut agent) {
-            warn!(
-                "Failed to resolve variables for agent '{}': {e}",
-                self.agent_name
-            );
-        }
-
-        let mut input = harnx_runtime::config::input::from_str(&prompt_config, &prompt_text, None);
-        harnx_runtime::config::input::set_agent(&mut input, &prompt_config, agent.into_config());
+        // Local-agent setup (agent resolution + input building) only applies to
+        // local refs. For remote thin-client mode the worker resolves the agent
+        // and the input is the user's prompt text posted to the NATS log.
+        let input = if remote_agent.is_none() {
+            Some(self.build_local_input(&prompt_config, &session_key, &prompt_text)?)
+        } else {
+            None
+        };
 
         // Install a per-prompt AgentEventSink for streaming chunks
         // (MessageChunk events) and tool calls (ToolEvent::Started).
@@ -557,16 +578,51 @@ impl HarnxAgent {
         // point still route to this prompt's sink. `loop_result` is
         // `Option<Result<()>>`: `None` means the grace-cancel arm won, a
         // `Some` carries the agent loop's own result.
+        // Clone the sink for the remote driver before `sink` is moved into the
+        // scoped-sink wrapper used by the local path.
+        let remote_sink = sink.clone();
         let loop_result = harnx_core::sink::with_agent_event_sink(sink, async {
-            // Box the agent-loop future before racing it. `run_agent_loop`
-            // produces a very large future; embedding it inline in `select!`
-            // (which itself lives inside the prompt future + LocalSet frames)
-            // can overflow the thread stack before the first poll. Pinning it
-            // on the heap keeps the synchronous stack frame small.
-            let mut run_loop = Box::pin(harnx_runtime::run_agent_loop(&loop_ctx, input));
-            tokio::select! {
-                r = &mut run_loop => Some(r),
-                _ = grace_cancel => None,
+            match &remote_agent {
+                // Remote thin-client mode (P4.2): drive the turn over NATS via a
+                // worker daemon. Events render through the same `remote_sink`
+                // (an AcpChunkSink), so chunks reach the parent identically.
+                Some((agent, cluster)) => {
+                    let thin_cfg = harnx_runtime::ThinClientConfig {
+                        cluster: cluster.clone(),
+                        agent: agent.clone(),
+                        session_id: Some(session_key.clone()),
+                    };
+                    let mut run_remote = Box::pin(async {
+                        let session = harnx_runtime::ThinClientSession::from_global_config(
+                            thin_cfg,
+                            &prompt_config,
+                            abort_signal.clone(),
+                        )
+                        .await?;
+                        session
+                            .run_turn(&prompt_text, remote_sink, None)
+                            .await
+                            .map(|_| ())
+                    });
+                    tokio::select! {
+                        r = &mut run_remote => Some(r),
+                        _ = grace_cancel => None,
+                    }
+                }
+                // Local mode: run the agent loop in-process.
+                None => {
+                    // Box the agent-loop future before racing it. `run_agent_loop`
+                    // produces a very large future; embedding it inline in `select!`
+                    // (which itself lives inside the prompt future + LocalSet frames)
+                    // can overflow the thread stack before the first poll. Pinning it
+                    // on the heap keeps the synchronous stack frame small.
+                    let input = input.expect("local mode always builds input");
+                    let mut run_loop = Box::pin(harnx_runtime::run_agent_loop(&loop_ctx, input));
+                    tokio::select! {
+                        r = &mut run_loop => Some(r),
+                        _ = grace_cancel => None,
+                    }
+                }
             }
         })
         .await;
@@ -583,11 +639,7 @@ impl HarnxAgent {
         drop(loop_ctx);
         let _ = fwd_task.await;
 
-        match loop_result {
-            Ok(()) => Ok(PromptResponse::new(StopReason::EndTurn)),
-            Err(_e) if abort_signal.aborted() => Ok(PromptResponse::new(StopReason::Cancelled)),
-            Err(e) => Err(acp::Error::new(-32603, format!("Agent loop error: {e:#}"))),
-        }
+        prompt_stop_response(loop_result, &abort_signal)
     }
 
     async fn cancel(&self, args: CancelNotification) -> acp::Result<()> {
@@ -625,6 +677,39 @@ fn meta_from_source(source: &AgentSource) -> Option<serde_json::Map<String, serd
         );
     }
     Some(map)
+}
+
+/// Map a completed agent-loop result to the ACP prompt response, treating
+/// errors that coincide with an aborted signal as a cancellation.
+fn prompt_stop_response(
+    loop_result: anyhow::Result<()>,
+    abort_signal: &AbortSignal,
+) -> acp::Result<PromptResponse> {
+    match loop_result {
+        Ok(()) => Ok(PromptResponse::new(StopReason::EndTurn)),
+        Err(_e) if abort_signal.aborted() => Ok(PromptResponse::new(StopReason::Cancelled)),
+        Err(e) => Err(acp::Error::new(-32603, format!("Agent loop error: {e:#}"))),
+    }
+}
+
+/// Join the text of all ACP prompt content blocks into a single string.
+fn prompt_blocks_to_text(blocks: &[ContentBlock]) -> String {
+    blocks
+        .iter()
+        .map(content_block_to_text)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Detect a remote (`agent@cluster`) thin-client ref, returning the owned
+/// `(agent, cluster)` pair. Local refs return `None`.
+fn parse_remote_agent(agent_name: &str) -> Option<(String, String)> {
+    match harnx_core::agent_ref::AgentRef::parse(agent_name) {
+        harnx_core::agent_ref::AgentRef::Remote { agent, cluster } => {
+            Some((agent.into_owned(), cluster.into_owned()))
+        }
+        harnx_core::agent_ref::AgentRef::Local(_) => None,
+    }
 }
 
 fn content_block_to_text(content: &ContentBlock) -> String {

--- a/crates/harnx-acp/src/manager.rs
+++ b/crates/harnx-acp/src/manager.rs
@@ -233,95 +233,103 @@ fn generate_acp_tools(server_name: &str) -> Vec<ToolDeclaration> {
             mcp_server_name: None,
             call_template: Some(session_new_call_template),
             result_template: None,
+            idempotent_hint: None,
+            read_only_hint: None,
         },
-        ToolDeclaration {
-            name: format!("{server_name}_session_prompt"),
-            description: format!(
-                "Send a prompt to the '{server_name}' ACP agent. To continue a prior conversation, you must pass the session_id returned by an earlier prompt call or by session_new; the remote agent keeps context under that session_id. If you omit session_id, this starts a new empty session with no prior context."
-            ),
-            parameters: JsonSchema {
-                type_value: Some("object".to_string()),
-                properties: Some({
-                    let mut props = IndexMap::new();
-                    props.insert(
-                        "message".to_string(),
-                        JsonSchema {
-                            type_value: Some("string".to_string()),
-                            description: Some("The prompt message to send to the agent".to_string()),
-                            ..Default::default()
-                        },
-                    );
-                    props.insert(
-                        "session_id".to_string(),
-                        JsonSchema {
-                            type_value: Some("string".to_string()),
-                            description: Some(
-                                "Session ID returned by a prior prompt call or by session_new. Pass it to preserve context from earlier turns; if omitted, a new empty session is created and no prior context is available.".to_string(),
-                            ),
-                            ..Default::default()
-                        },
-                    );
-                    props
-                }),
-                required: Some(vec!["message".to_string()]),
-                ..Default::default()
+        acp_session_prompt_tool(server_name, session_prompt_call_template),
+        acp_session_id_tool(
+            AcpSessionIdTool {
+                name: &format!("{server_name}_session_load"),
+                description: &format!(
+                    "Load an existing session on the '{server_name}' ACP agent and resume its prior context"
+                ),
+                session_id_desc: "The session ID to load",
+                mcp_tool_name: "session_load",
+                call_template: session_load_call_template,
             },
-            mcp_tool_name: Some("session_prompt".to_string()),
-            mcp_server_name: None,
-            call_template: Some(session_prompt_call_template),
-            result_template: None,
-        },
-        ToolDeclaration {
-            name: format!("{server_name}_session_load"),
-            description: format!("Load an existing session on the '{server_name}' ACP agent and resume its prior context"),
-            parameters: JsonSchema {
-                type_value: Some("object".to_string()),
-                properties: Some({
-                    let mut props = IndexMap::new();
-                    props.insert(
-                        "session_id".to_string(),
-                        JsonSchema {
-                            type_value: Some("string".to_string()),
-                            description: Some("The session ID to load".to_string()),
-                            ..Default::default()
-                        },
-                    );
-                    props
-                }),
-                required: Some(vec!["session_id".to_string()]),
-                ..Default::default()
-            },
-            mcp_tool_name: Some("session_load".to_string()),
-            mcp_server_name: None,
-            call_template: Some(session_load_call_template),
-            result_template: None,
-        },
-        ToolDeclaration {
-            name: format!("{server_name}_session_cancel"),
-            description: format!("Cancel a running prompt on the '{server_name}' ACP agent"),
-            parameters: JsonSchema {
-                type_value: Some("object".to_string()),
-                properties: Some({
-                    let mut props = IndexMap::new();
-                    props.insert(
-                        "session_id".to_string(),
-                        JsonSchema {
-                            type_value: Some("string".to_string()),
-                            description: Some("The session ID to cancel".to_string()),
-                            ..Default::default()
-                        },
-                    );
-                    props
-                }),
-                required: Some(vec!["session_id".to_string()]),
-                ..Default::default()
-            },
-            mcp_tool_name: Some("session_cancel".to_string()),
-            mcp_server_name: None,
-            call_template: Some(session_cancel_call_template),
-            result_template: None,
-        },
+        ),
+        acp_session_id_tool(AcpSessionIdTool {
+            name: &format!("{server_name}_session_cancel"),
+            description: &format!("Cancel a running prompt on the '{server_name}' ACP agent"),
+            session_id_desc: "The session ID to cancel",
+            mcp_tool_name: "session_cancel",
+            call_template: session_cancel_call_template,
+        }),
     ]
+}
+
+/// Build a single object property of type `string` with the given description.
+fn string_prop(description: &str) -> JsonSchema {
+    JsonSchema {
+        type_value: Some("string".to_string()),
+        description: Some(description.to_string()),
+        ..Default::default()
+    }
+}
+
+/// The `session_prompt` ACP tool declaration (message + optional session_id).
+fn acp_session_prompt_tool(server_name: &str, call_template: String) -> ToolDeclaration {
+    let mut props = IndexMap::new();
+    props.insert(
+        "message".to_string(),
+        string_prop("The prompt message to send to the agent"),
+    );
+    props.insert(
+        "session_id".to_string(),
+        string_prop(
+            "Session ID returned by a prior prompt call or by session_new. Pass it to preserve context from earlier turns; if omitted, a new empty session is created and no prior context is available.",
+        ),
+    );
+    ToolDeclaration {
+        name: format!("{server_name}_session_prompt"),
+        description: format!(
+            "Send a prompt to the '{server_name}' ACP agent. To continue a prior conversation, you must pass the session_id returned by an earlier prompt call or by session_new; the remote agent keeps context under that session_id. If you omit session_id, this starts a new empty session with no prior context."
+        ),
+        parameters: JsonSchema {
+            type_value: Some("object".to_string()),
+            properties: Some(props),
+            required: Some(vec!["message".to_string()]),
+            ..Default::default()
+        },
+        mcp_tool_name: Some("session_prompt".to_string()),
+        mcp_server_name: None,
+        call_template: Some(call_template),
+        result_template: None,
+        idempotent_hint: None,
+        read_only_hint: None,
+    }
+}
+
+/// Parameters for [`acp_session_id_tool`].
+struct AcpSessionIdTool<'a> {
+    name: &'a str,
+    description: &'a str,
+    session_id_desc: &'a str,
+    mcp_tool_name: &'a str,
+    call_template: String,
+}
+
+/// Build an ACP tool that takes a single required `session_id` string
+/// parameter (used by `session_load` and `session_cancel`).
+fn acp_session_id_tool(tool: AcpSessionIdTool<'_>) -> ToolDeclaration {
+    let mut props = IndexMap::new();
+    props.insert("session_id".to_string(), string_prop(tool.session_id_desc));
+    ToolDeclaration {
+        name: tool.name.to_string(),
+        description: tool.description.to_string(),
+        parameters: JsonSchema {
+            type_value: Some("object".to_string()),
+            properties: Some(props),
+            required: Some(vec!["session_id".to_string()]),
+            ..Default::default()
+        },
+        mcp_tool_name: Some(tool.mcp_tool_name.to_string()),
+        mcp_server_name: None,
+        call_template: Some(tool.call_template),
+        result_template: None,
+        idempotent_hint: None,
+        read_only_hint: None,
+    }
 }
 
 pub async fn session_prompt_with_abort<Fut>(

--- a/crates/harnx-client/src/llama_server/client.rs
+++ b/crates/harnx-client/src/llama_server/client.rs
@@ -457,6 +457,8 @@ mod tests {
                 mcp_server_name: None,
                 call_template: None,
                 result_template: None,
+                idempotent_hint: None,
+                read_only_hint: None,
             }]),
             stream: false,
             attachments_dir: None,

--- a/crates/harnx-client/tests/llama_server_mock.rs
+++ b/crates/harnx-client/tests/llama_server_mock.rs
@@ -473,6 +473,8 @@ fn tool_declaration() -> ToolDeclaration {
         mcp_server_name: None,
         call_template: None,
         result_template: None,
+        idempotent_hint: None,
+        read_only_hint: None,
     }
 }
 

--- a/crates/harnx-core/src/agent_ref.rs
+++ b/crates/harnx-core/src/agent_ref.rs
@@ -1,0 +1,75 @@
+use std::borrow::Cow;
+
+/// Parsed agent selector from CLI/config surfaces.
+///
+/// `agent@cluster` selects a remote agent routed through cluster `cluster`.
+/// Parsing splits once on the LAST `@`, so `team@agent@prod` becomes
+/// `Remote { agent: "team@agent", cluster: "prod" }`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentRef<'a> {
+    Local(Cow<'a, str>),
+    Remote {
+        agent: Cow<'a, str>,
+        cluster: Cow<'a, str>,
+    },
+}
+
+impl<'a> AgentRef<'a> {
+    /// Parse raw `-a/--agent` value before any sanitization.
+    pub fn parse(raw: &'a str) -> Self {
+        match raw.rsplit_once('@') {
+            Some((agent, cluster)) => Self::Remote {
+                agent: Cow::Borrowed(agent),
+                cluster: Cow::Borrowed(cluster),
+            },
+            None => Self::Local(Cow::Borrowed(raw)),
+        }
+    }
+
+    pub fn local_name(&self) -> Option<&str> {
+        match self {
+            Self::Local(name) => Some(name.as_ref()),
+            Self::Remote { .. } => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AgentRef;
+
+    #[test]
+    fn parse_local_bare_name() {
+        assert_eq!(AgentRef::parse("foo"), AgentRef::Local("foo".into()));
+    }
+
+    #[test]
+    fn parse_local_package_name() {
+        assert_eq!(
+            AgentRef::parse("pkg/bar"),
+            AgentRef::Local("pkg/bar".into())
+        );
+    }
+
+    #[test]
+    fn parse_remote_name() {
+        assert_eq!(
+            AgentRef::parse("bar@foo"),
+            AgentRef::Remote {
+                agent: "bar".into(),
+                cluster: "foo".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_remote_splits_on_last_at() {
+        assert_eq!(
+            AgentRef::parse("team@agent@prod"),
+            AgentRef::Remote {
+                agent: "team@agent".into(),
+                cluster: "prod".into(),
+            }
+        );
+    }
+}

--- a/crates/harnx-core/src/config_paths.rs
+++ b/crates/harnx-core/src/config_paths.rs
@@ -46,6 +46,9 @@ pub const AGENTS_DIR_NAME: &str = "agents";
 /// Subdirectory holding per-client YAML files.
 pub const CLIENTS_DIR_NAME: &str = "clients";
 
+/// Subdirectory holding per-cluster NATS server configs.
+pub const NATS_SERVERS_DIR_NAME: &str = "nats_servers";
+
 /// Subdirectory holding per-MCP-server YAML files.
 pub const MCP_SERVERS_DIR_NAME: &str = "mcp_servers";
 
@@ -181,6 +184,11 @@ pub fn clients_dir() -> PathBuf {
     config_dir_path().join(CLIENTS_DIR_NAME)
 }
 
+/// Subdirectory holding per-cluster NATS server YAML files.
+pub fn nats_servers_dir() -> PathBuf {
+    config_dir_path().join(NATS_SERVERS_DIR_NAME)
+}
+
 /// Subdirectory holding per-MCP-server YAML files.
 pub fn mcp_servers_dir() -> PathBuf {
     config_dir_path().join(MCP_SERVERS_DIR_NAME)
@@ -224,6 +232,11 @@ pub fn package_patch_file(name: &str) -> PathBuf {
 /// Path to a specific macro file by name (extension `.yaml`).
 pub fn macro_file(name: &str) -> PathBuf {
     macros_dir().join(format!("{name}.yaml"))
+}
+
+/// Per-cluster NATS server config file under [`nats_servers_dir()`].
+pub fn nats_server_file(name: &str) -> PathBuf {
+    nats_servers_dir().join(format!("{name}.yaml"))
 }
 
 /// Path to the `.env` file loaded at startup. Overridable via `HARNX_ENV_FILE`.
@@ -442,6 +455,21 @@ mod tests {
         assert_eq!(
             got.file_name().and_then(|s| s.to_str()),
             Some("some_macro.yaml")
+        );
+    }
+
+    #[test]
+    fn nats_server_file_uses_nats_servers_dir_and_yaml_extension() {
+        let got = nats_server_file("foo");
+        let tail: Vec<_> = got
+            .iter()
+            .rev()
+            .take(2)
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            tail,
+            vec!["foo.yaml".to_string(), NATS_SERVERS_DIR_NAME.to_string()]
         );
     }
 

--- a/crates/harnx-core/src/input.rs
+++ b/crates/harnx-core/src/input.rs
@@ -38,6 +38,16 @@ pub struct Input {
     /// mid-tool-loop).  Appended as a trailing User message in
     /// `build_messages()`.
     pub injected_user_text: Option<String>,
+    /// When true, `begin_turn` must NOT append the turn's user message to the
+    /// session log. Used by the NATS HA worker: in distributed mode clients
+    /// append user `Message` entries to the durable log themselves, and the
+    /// worker derives its turn input by reading those already-logged messages.
+    /// Re-appending them would duplicate the user message AND reorder the
+    /// assistant barrier past any concurrently-arrived messages (burying them
+    /// before the barrier so they are never answered). The user messages are
+    /// already present in the loaded `session.messages`, so the LLM still sees
+    /// them; only the redundant durable append is suppressed.
+    pub skip_user_log_append: bool,
 }
 
 impl Input {
@@ -62,6 +72,7 @@ impl Input {
             with_agent: false,
             inject_system_prompt: false,
             injected_user_text: None,
+            skip_user_log_append: false,
         }
     }
 

--- a/crates/harnx-core/src/lib.rs
+++ b/crates/harnx-core/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod abort;
 pub mod agent_config;
+pub mod agent_ref;
 pub mod alloc_guard;
 pub mod api_types;
 pub mod attachments;
@@ -28,6 +29,8 @@ pub mod path;
 pub mod provider_config;
 pub mod retry_config;
 pub mod session;
+pub mod session_log;
+pub mod session_reconstruct;
 pub mod sink;
 pub mod system_vars;
 pub mod text;

--- a/crates/harnx-core/src/package_namespace.rs
+++ b/crates/harnx-core/src/package_namespace.rs
@@ -1,14 +1,20 @@
 /// Sanitize a string for use in tool name generation.
-/// Replaces `/` with `__` and any other non-alphanumeric-or-hyphen char with `_`.
+///
+/// Forward-only, lossy mapping. `/` becomes `__`, `@` becomes `__at__`, and any
+/// other non-alphanumeric-or-hyphen char becomes `_`. Like `/`, `@` mapping is
+/// not round-trippable and must not be used to reconstruct higher-level meaning.
 /// Examples:
 ///   "my-pkg"      → "my-pkg"
 ///   "org/my-pkg"  → "org__my-pkg"
+///   "foo@bar"     → "foo__at__bar"
 ///   "foo bar"     → "foo_bar"
 pub fn sanitize_for_tool_name(s: &str) -> String {
-    let mut result = String::with_capacity(s.len() + 2);
+    let mut result = String::with_capacity(s.len() + 8);
     for ch in s.chars() {
         if ch == '/' {
             result.push_str("__");
+        } else if ch == '@' {
+            result.push_str("__at__");
         } else if ch.is_alphanumeric() || ch == '-' || ch == '_' {
             result.push(ch);
         } else {
@@ -119,6 +125,11 @@ mod tests {
     #[test]
     fn test_sanitize_clean() {
         assert_eq!(sanitize_for_tool_name("mypkg"), "mypkg");
+    }
+
+    #[test]
+    fn test_sanitize_at_sign() {
+        assert_eq!(sanitize_for_tool_name("foo@bar"), "foo__at__bar");
     }
 
     #[test]

--- a/crates/harnx-core/src/session.rs
+++ b/crates/harnx-core/src/session.rs
@@ -67,10 +67,14 @@ pub enum SessionLogEntry {
     },
     #[serde(rename = "message")]
     Message {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
         role: MessageRole,
         content: MessageContent,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         timestamp: Option<DateTime<Utc>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        fence_token: Option<u64>,
     },
     /// Assistant turn that issued tool calls. The text/thought are the
     /// LLM's prose preceding the calls. This entry is written
@@ -88,7 +92,11 @@ pub enum SessionLogEntry {
         calls: Vec<ToolCall>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         timestamp: Option<DateTime<Utc>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        fence_token: Option<u64>,
     },
+    #[serde(rename = "cancel")]
+    Cancel { fence_token: u64 },
     /// Results for the immediately preceding `ToolCalls` entry.
     #[serde(rename = "tool_results")]
     ToolResults {
@@ -118,6 +126,43 @@ pub enum SessionLogEntry {
     },
     #[serde(other)]
     Unknown,
+}
+
+impl SessionLogEntry {
+    /// Stamp the fence token on worker-originated entries that carry one
+    /// (`Message`, `ToolCalls`). Other variants are left unchanged: `Cancel`
+    /// carries its fence at construction (control plane), and client-originated
+    /// entries (`UserMessage`) are intentionally unfenced.
+    pub fn set_fence_token(&mut self, fence: u64) {
+        match self {
+            SessionLogEntry::Message { fence_token, .. }
+            | SessionLogEntry::ToolCalls { fence_token, .. } => {
+                *fence_token = Some(fence);
+            }
+            _ => {}
+        }
+    }
+
+    /// Fence token carried by this entry, if any. `Message`/`ToolCalls` carry an
+    /// optional fence; `Cancel` always carries one. All other variants are
+    /// unfenced and return `None`.
+    pub fn fence_token(&self) -> Option<u64> {
+        match self {
+            SessionLogEntry::Message { fence_token, .. }
+            | SessionLogEntry::ToolCalls { fence_token, .. } => *fence_token,
+            SessionLogEntry::Cancel { fence_token } => Some(*fence_token),
+            _ => None,
+        }
+    }
+}
+
+/// Highest fence token stamped on any worker-originated entry in the slice.
+///
+/// Used on resume to fail-safe: if a worker observes a fence greater than the
+/// KV revision it currently holds, a newer worker has taken over and the
+/// resuming worker must abort before writing.
+pub fn max_worker_fence_token(entries: &[SessionLogEntry]) -> Option<u64> {
+    entries.iter().filter_map(|e| e.fence_token()).max()
 }
 
 /// A single tool-call result as persisted in the session log. Matches
@@ -206,6 +251,8 @@ pub struct Session {
     pub tokens: usize,
     #[serde(skip)]
     pub completion_usage: CompletionTokenUsage,
+    #[serde(skip)]
+    pub runtime: Option<std::sync::Arc<dyn std::any::Any + Send + Sync>>,
 }
 
 impl Session {
@@ -533,9 +580,11 @@ mod tests {
     #[test]
     fn session_log_entry_message_timestamp_serde_round_trip() {
         let entry = SessionLogEntry::Message {
+            id: None,
             role: MessageRole::User,
             content: MessageContent::Text("hello".to_string()),
             timestamp: Some(Utc::now()),
+            fence_token: None,
         };
 
         let yaml = serde_yaml::to_string(&entry).unwrap();
@@ -549,6 +598,7 @@ mod tests {
                 role,
                 content,
                 timestamp,
+                ..
             } => {
                 assert_eq!(role, MessageRole::User);
                 assert!(timestamp.is_some());
@@ -572,6 +622,7 @@ mod tests {
                 role,
                 content,
                 timestamp,
+                ..
             } => {
                 assert_eq!(role, MessageRole::User);
                 assert!(timestamp.is_none());
@@ -591,6 +642,7 @@ mod tests {
             thought: None,
             calls: vec![],
             timestamp: Some(Utc::now()),
+            fence_token: None,
         };
 
         let yaml = serde_yaml::to_string(&entry).unwrap();
@@ -709,6 +761,112 @@ content: replacement two
             SessionLogEntry::Rewind { after_seq } => assert_eq!(after_seq, 7),
             other => panic!("expected rewind, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn session_log_entry_removed_set_pending_message_deserializes_as_unknown() {
+        let yaml = "type: set_pending_message\ntext: pending assistant text\n";
+        let round_tripped: SessionLogEntry = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(round_tripped, SessionLogEntry::Unknown));
+    }
+
+    #[test]
+    fn session_log_entry_cancel_serde_round_trip() {
+        let entry = SessionLogEntry::Cancel { fence_token: 42 };
+
+        let yaml = serde_yaml::to_string(&entry).unwrap();
+        let round_tripped: SessionLogEntry = serde_yaml::from_str(&yaml).unwrap();
+
+        assert_eq!(yaml, "type: cancel\nfence_token: 42\n");
+        match round_tripped {
+            SessionLogEntry::Cancel { fence_token } => {
+                assert_eq!(fence_token, 42);
+            }
+            other => panic!("expected cancel, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_log_entry_none_fence_token_is_not_serialized() {
+        let assistant_message = SessionLogEntry::Message {
+            id: None,
+            role: MessageRole::Assistant,
+            content: MessageContent::Text("hello".to_string()),
+            timestamp: None,
+            fence_token: None,
+        };
+        let tool_calls = SessionLogEntry::ToolCalls {
+            text: "working".to_string(),
+            thought: None,
+            calls: vec![],
+            timestamp: None,
+            fence_token: None,
+        };
+
+        let assistant_yaml = serde_yaml::to_string(&assistant_message).unwrap();
+        let tool_calls_yaml = serde_yaml::to_string(&tool_calls).unwrap();
+
+        assert!(!assistant_yaml.contains("fence_token:"));
+        assert!(!tool_calls_yaml.contains("fence_token:"));
+    }
+
+    #[test]
+    fn set_fence_token_stamps_only_message_and_tool_calls() {
+        let mut msg = SessionLogEntry::Message {
+            id: None,
+            role: MessageRole::Assistant,
+            content: MessageContent::Text("x".to_string()),
+            timestamp: None,
+            fence_token: None,
+        };
+        msg.set_fence_token(7);
+        assert_eq!(msg.fence_token(), Some(7));
+
+        let mut calls = SessionLogEntry::ToolCalls {
+            text: String::new(),
+            thought: None,
+            calls: vec![],
+            timestamp: None,
+            fence_token: None,
+        };
+        calls.set_fence_token(9);
+        assert_eq!(calls.fence_token(), Some(9));
+    }
+
+    #[test]
+    fn cancel_entry_reports_its_fence_token() {
+        let cancel = SessionLogEntry::Cancel { fence_token: 5 };
+        assert_eq!(cancel.fence_token(), Some(5));
+    }
+
+    #[test]
+    fn max_worker_fence_token_finds_highest() {
+        let entries = vec![
+            SessionLogEntry::Message {
+                id: None,
+                role: MessageRole::User,
+                content: MessageContent::Text("u".to_string()),
+                timestamp: None,
+                fence_token: None,
+            },
+            SessionLogEntry::Message {
+                id: None,
+                role: MessageRole::Assistant,
+                content: MessageContent::Text("a".to_string()),
+                timestamp: None,
+                fence_token: Some(3),
+            },
+            SessionLogEntry::ToolCalls {
+                text: String::new(),
+                thought: None,
+                calls: vec![],
+                timestamp: None,
+                fence_token: Some(8),
+            },
+            SessionLogEntry::Cancel { fence_token: 6 },
+        ];
+        assert_eq!(max_worker_fence_token(&entries), Some(8));
+        assert_eq!(max_worker_fence_token(&[]), None);
     }
 
     #[test]

--- a/crates/harnx-core/src/session_log.rs
+++ b/crates/harnx-core/src/session_log.rs
@@ -1,0 +1,9 @@
+use crate::session::SessionLogEntry;
+
+use anyhow::Result;
+
+pub trait SessionLog {
+    fn append_event(&mut self, entry: &SessionLogEntry) -> Result<u64>;
+    fn load_events(&self) -> Result<Vec<(u64, SessionLogEntry)>>;
+    fn replay_from(&self, seq: u64) -> Result<Vec<SessionLogEntry>>;
+}

--- a/crates/harnx-core/src/session_reconstruct.rs
+++ b/crates/harnx-core/src/session_reconstruct.rs
@@ -1,0 +1,874 @@
+use crate::message::{Message, MessageRole};
+use crate::session::{SessionLogEntry, ToolOutput};
+use crate::tool::ToolCall;
+
+/// Apply mutation entries (EditEntries, Rewind) to build the effective entry stream.
+///
+/// This is the canonical resolver for mutation semantics:
+/// - `EditEntries { from, to, replacements: [] }` deletes entries in [from, to]
+/// - `EditEntries { from, to, replacements: [yaml, ...] }` replaces with parsed entries
+/// - `Rewind { after_seq }` truncates effective entries to <= after_seq
+///
+/// Invalid/malformed mutations are skipped with warnings (logged via the `log` crate).
+/// Replacements inherit the mutation's seq number for future addressing.
+pub fn apply_log_mutations(
+    raw_entries: &[(usize, SessionLogEntry)],
+) -> Vec<(usize, SessionLogEntry)> {
+    apply_log_mutations_with_name(raw_entries, "session")
+}
+
+/// Variant that accepts a session name for logging context.
+pub fn apply_log_mutations_with_name(
+    raw_entries: &[(usize, SessionLogEntry)],
+    name: &str,
+) -> Vec<(usize, SessionLogEntry)> {
+    let mut effective_entries = Vec::new();
+
+    for (seq, entry) in raw_entries {
+        match entry {
+            SessionLogEntry::Rewind { after_seq } => {
+                // Rewind can only reference entries that come before it in the log
+                if !effective_entries
+                    .iter()
+                    .any(|(existing_seq, _)| existing_seq == after_seq)
+                {
+                    log::warn!(
+                        "Skipping rewind entry #{seq} in session {name}: after_seq {after_seq} not present in replay state"
+                    );
+                    continue;
+                }
+                effective_entries.retain(|(existing_seq, _)| *existing_seq <= *after_seq);
+            }
+            SessionLogEntry::EditEntries {
+                from,
+                to,
+                replacements,
+            } => {
+                if from > to {
+                    log::warn!(
+                        "Skipping edit_entries entry #{seq} in session {name}: invalid range [{from}, {to}]"
+                    );
+                    continue;
+                }
+                // Note: to >= seq check is SKIPPED intentionally for NATS sequences
+                // which start at 1 (not 0). The validation that from/to reference
+                // earlier entries is done by checking they exist in effective_entries.
+
+                let Some(start_idx) = effective_entries
+                    .iter()
+                    .position(|(existing_seq, _)| existing_seq == from)
+                else {
+                    log::warn!(
+                        "Skipping edit_entries entry #{seq} in session {name}: from seq {from} not present in replay state"
+                    );
+                    continue;
+                };
+                let Some(end_idx) = effective_entries
+                    .iter()
+                    .rposition(|(existing_seq, _)| existing_seq == to)
+                else {
+                    log::warn!(
+                        "Skipping edit_entries entry #{seq} in session {name}: to seq {to} not present in replay state"
+                    );
+                    continue;
+                };
+                if start_idx > end_idx {
+                    log::warn!(
+                        "Skipping edit_entries entry #{seq} in session {name}: range [{from}, {to}] not in replay order"
+                    );
+                    continue;
+                }
+
+                let parsed_replacements: Vec<_> = replacements
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(replacement_idx, replacement)| {
+                        match serde_yaml::from_str::<SessionLogEntry>(replacement) {
+                            Ok(parsed) => {
+                                // Replacements inherit EditEntries seq because originals are
+                                // logically removed from effective stream. Future rewind/edit
+                                // operations must target mutation seq, not replaced seqs.
+                                Some((*seq, parsed))
+                            }
+                            Err(err) => {
+                                log::warn!(
+                                    "Skipping replacement #{replacement_idx} in edit_entries entry #{seq} for session {name}: {err}"
+                                );
+                                None
+                            }
+                        }
+                    })
+                    .collect();
+
+                effective_entries.splice(start_idx..=end_idx, parsed_replacements);
+            }
+            SessionLogEntry::Unknown => {}
+            _ => effective_entries.push((*seq, entry.clone())),
+        }
+    }
+
+    effective_entries
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TurnStatus {
+    Idle,
+    InFlightResumable,
+    InFlightCancelled,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReconstructedState {
+    pub turn_status: TurnStatus,
+    pub next_turn_messages: Vec<Message>,
+    pub resumable_ctx: Option<ResumableCtx>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResumableCtx {
+    pub last_user: Option<Message>,
+    pub last_assistant: Option<AssistantTurn>,
+    pub pending_tool_results: Vec<ToolOutput>,
+    pub fence_token: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub enum AssistantTurn {
+    Message(Message),
+    ToolCalls {
+        text: String,
+        thought: Option<String>,
+        calls: Vec<ToolCall>,
+    },
+}
+
+/// Reconstruct session state from raw log entries.
+///
+/// This function applies mutation entries (EditEntries, Rewind) automatically
+/// before reconstruction, so retract/edit operations are honored.
+///
+/// For direct control over mutation resolution, use `apply_log_mutations` then
+/// `reconstruct_state_effective`.
+pub fn reconstruct_state(entries: &[SessionLogEntry]) -> ReconstructedState {
+    // Apply mutations first: convert raw entries to effective entries
+    // Use 0-based indexing for local entries
+    let raw_with_seq: Vec<_> = entries
+        .iter()
+        .enumerate()
+        .map(|(i, e)| (i, e.clone()))
+        .collect();
+    let effective_entries = apply_log_mutations(&raw_with_seq);
+
+    // Convert to the format expected by reconstruct_state_with_seq
+    reconstruct_state_effective(&effective_entries)
+}
+
+/// Reconstruct session state from entries with NATS JetStream sequence numbers.
+///
+/// This function applies mutation entries (EditEntries, Rewind) automatically
+/// before reconstruction, so retract/edit operations are honored.
+///
+/// NATS sequences start at 1, not 0.
+pub fn reconstruct_state_from_nats(entries: &[(u64, SessionLogEntry)]) -> ReconstructedState {
+    // Convert u64 seq to usize and apply mutations
+    let raw_with_seq: Vec<_> = entries
+        .iter()
+        .map(|(seq, e)| (*seq as usize, e.clone()))
+        .collect();
+    let effective_entries = apply_log_mutations(&raw_with_seq);
+    reconstruct_state_effective(&effective_entries)
+}
+
+/// Reconstruct from pre-resolved effective entries (mutations already applied).
+pub fn reconstruct_state_effective(entries: &[(usize, SessionLogEntry)]) -> ReconstructedState {
+    let with_seq: Vec<_> = entries
+        .iter()
+        .map(|(seq, e)| (Some(*seq), e.clone()))
+        .collect();
+    reconstruct_state_with_seq(&with_seq)
+}
+
+/// Variant that accepts entries with JetStream sequence numbers attached.
+///
+/// IMPORTANT: Callers should use `reconstruct_state` or ensure they pass
+/// already-resolved entries. This function does NOT apply mutations.
+pub fn reconstruct_state_with_seq(
+    entries: &[(Option<usize>, SessionLogEntry)],
+) -> ReconstructedState {
+    let tail_indices = entries_after_last_barrier_with_seq(entries);
+    let mut replay = ReplayAccumulator::default();
+
+    for (idx, entry) in tail_indices {
+        replay.apply_entry_with_seq(idx, entry);
+    }
+
+    replay.finish()
+}
+
+#[derive(Debug, Default)]
+struct ReplayAccumulator {
+    next_turn_messages: Vec<Message>,
+    resumable_last_user: Option<Message>,
+    resumable_last_assistant: Option<AssistantTurn>,
+    pending_tool_results: Vec<ToolOutput>,
+    active_fence_token: Option<u64>,
+    cancel_fence_token: Option<u64>,
+}
+
+impl ReplayAccumulator {
+    #[allow(dead_code)]
+    fn apply_entry(&mut self, entry: &SessionLogEntry) {
+        self.apply_entry_with_seq(None, entry);
+    }
+
+    fn apply_entry_with_seq(&mut self, log_seq: Option<usize>, entry: &SessionLogEntry) {
+        match entry {
+            SessionLogEntry::Cancel { fence_token } => self.on_cancel(*fence_token),
+            SessionLogEntry::Message { role, .. } if role.is_user() => {
+                self.on_user_message_with_seq(log_seq, entry)
+            }
+            SessionLogEntry::Message { role, .. } if role.is_assistant() => {
+                self.on_assistant_message(entry)
+            }
+            SessionLogEntry::ToolCalls { .. } => self.on_tool_calls(entry),
+            SessionLogEntry::ToolResults { results, .. } => self.on_tool_results(results),
+            _ => {}
+        }
+    }
+
+    fn finish(self) -> ReconstructedState {
+        let is_resumable = matches!(
+            self.resumable_last_assistant,
+            Some(AssistantTurn::ToolCalls { .. })
+        );
+
+        if let Some(fence_token) = self.cancel_fence_token {
+            return ReconstructedState {
+                turn_status: TurnStatus::InFlightCancelled,
+                next_turn_messages: Vec::new(),
+                resumable_ctx: Some(ResumableCtx {
+                    last_user: None,
+                    last_assistant: None,
+                    pending_tool_results: Vec::new(),
+                    fence_token: Some(fence_token),
+                }),
+            };
+        }
+
+        if !self.next_turn_messages.is_empty() && !is_resumable {
+            return ReconstructedState {
+                turn_status: TurnStatus::Idle,
+                next_turn_messages: self.next_turn_messages,
+                resumable_ctx: None,
+            };
+        }
+
+        let next_turn_messages = self.next_turn_messages;
+        ReconstructedState {
+            turn_status: if is_resumable {
+                TurnStatus::InFlightResumable
+            } else {
+                TurnStatus::Idle
+            },
+            next_turn_messages: if is_resumable {
+                next_turn_messages
+            } else {
+                Vec::new()
+            },
+            resumable_ctx: is_resumable.then_some(ResumableCtx {
+                last_user: self.resumable_last_user,
+                last_assistant: self.resumable_last_assistant,
+                pending_tool_results: self.pending_tool_results,
+                fence_token: self.active_fence_token,
+            }),
+        }
+    }
+
+    fn on_cancel(&mut self, fence_token: u64) {
+        self.cancel_fence_token = Some(fence_token);
+        self.resumable_last_user = None;
+        self.resumable_last_assistant = None;
+        self.pending_tool_results.clear();
+        self.active_fence_token = None;
+    }
+
+    #[allow(dead_code)]
+    fn on_user_message(&mut self, entry: &SessionLogEntry) {
+        self.on_user_message_with_seq(None, entry);
+    }
+
+    fn on_user_message_with_seq(&mut self, log_seq: Option<usize>, entry: &SessionLogEntry) {
+        let Some(mut message) = cloned_message(entry) else {
+            return;
+        };
+        // Attach log_seq if provided
+        if let Some(seq) = log_seq {
+            message.log_seq = Some(seq);
+        }
+
+        if self.cancel_fence_token.is_some() {
+            self.cancel_fence_token = None;
+            self.next_turn_messages.clear();
+        }
+
+        if matches!(
+            self.resumable_last_assistant,
+            Some(AssistantTurn::ToolCalls { .. })
+        ) {
+            self.next_turn_messages.push(message);
+            return;
+        }
+
+        self.next_turn_messages.push(message.clone());
+        self.resumable_last_user = None;
+        self.resumable_last_assistant = None;
+        self.pending_tool_results.clear();
+        self.active_fence_token = None;
+    }
+
+    fn on_assistant_message(&mut self, _entry: &SessionLogEntry) {
+        self.next_turn_messages.clear();
+        self.resumable_last_user = None;
+        self.resumable_last_assistant = None;
+        self.pending_tool_results.clear();
+        self.active_fence_token = None;
+        self.cancel_fence_token = None;
+    }
+
+    fn on_tool_calls(&mut self, entry: &SessionLogEntry) {
+        if self.cancel_fence_token.is_some() {
+            return;
+        }
+
+        let SessionLogEntry::ToolCalls {
+            text,
+            thought,
+            calls,
+            fence_token,
+            ..
+        } = entry
+        else {
+            return;
+        };
+
+        self.resumable_last_user = self.next_turn_messages.last().cloned();
+        self.next_turn_messages.clear();
+        self.resumable_last_assistant = Some(AssistantTurn::ToolCalls {
+            text: text.clone(),
+            thought: thought.clone(),
+            calls: calls.clone(),
+        });
+        self.pending_tool_results.clear();
+        self.active_fence_token = *fence_token;
+    }
+
+    fn on_tool_results(&mut self, results: &[ToolOutput]) {
+        if self.cancel_fence_token.is_none()
+            && matches!(
+                self.resumable_last_assistant,
+                Some(AssistantTurn::ToolCalls { .. })
+            )
+        {
+            self.pending_tool_results = results.to_vec();
+        }
+    }
+}
+
+fn cloned_message(entry: &SessionLogEntry) -> Option<Message> {
+    let SessionLogEntry::Message {
+        role,
+        content,
+        timestamp,
+        ..
+    } = entry
+    else {
+        return None;
+    };
+
+    Some(Message {
+        role: *role,
+        content: content.clone(),
+        log_seq: None,
+        log_timestamp: *timestamp,
+    })
+}
+
+#[allow(dead_code)]
+fn entries_after_last_barrier(entries: &[SessionLogEntry]) -> &[SessionLogEntry] {
+    let last_barrier = entries
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(index, entry)| is_final_assistant_message(entry).then_some(index));
+
+    last_barrier.map_or(entries, |index| &entries[index + 1..])
+}
+
+fn entries_after_last_barrier_with_seq(
+    entries: &[(Option<usize>, SessionLogEntry)],
+) -> Vec<(Option<usize>, &SessionLogEntry)> {
+    let last_barrier = entries
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(index, (_, entry))| is_final_assistant_message(entry).then_some(index));
+
+    last_barrier.map_or_else(
+        || entries.iter().map(|(seq, e)| (*seq, e)).collect(),
+        |index| {
+            entries[index + 1..]
+                .iter()
+                .map(|(seq, e)| (*seq, e))
+                .collect()
+        },
+    )
+}
+
+fn is_final_assistant_message(entry: &SessionLogEntry) -> bool {
+    // A barrier is any final assistant text Message. Tool calls live in separate
+    // `ToolCalls` entries, so an assistant `Message` always marks the end of a
+    // completed turn. The fence_token is `Some(..)` for worker-originated (NATS HA)
+    // turns and `None` for local-mode turns — BOTH are barriers. The client-side
+    // `id` is irrelevant to barrier detection.
+    matches!(
+        entry,
+        SessionLogEntry::Message {
+            role: MessageRole::Assistant,
+            ..
+        }
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::MessageContent;
+    use serde_json::json;
+
+    #[test]
+    fn empty_log_is_idle_with_no_next_turn_messages() {
+        assert_case(
+            vec![],
+            ExpectedState::Idle {
+                next_turn_messages: &[],
+            },
+        );
+    }
+
+    #[test]
+    fn barrier_only_is_idle_with_no_next_turn_messages() {
+        assert_case(
+            vec![final_assistant("done")],
+            ExpectedState::Idle {
+                next_turn_messages: &[],
+            },
+        );
+    }
+
+    #[test]
+    fn post_barrier_single_user_folds_into_next_turn_messages() {
+        assert_case(
+            vec![final_assistant("done"), user_message("u1")],
+            ExpectedState::Idle {
+                next_turn_messages: &["u1"],
+            },
+        );
+    }
+
+    #[test]
+    fn post_barrier_multiple_users_fold_in_order() {
+        assert_case(
+            vec![
+                final_assistant("done"),
+                user_message("u1"),
+                user_message("u2"),
+                user_message("u3"),
+            ],
+            ExpectedState::Idle {
+                next_turn_messages: &["u1", "u2", "u3"],
+            },
+        );
+    }
+
+    #[test]
+    fn tool_calls_after_post_barrier_user_are_resumable() {
+        assert_case(
+            vec![
+                final_assistant("done"),
+                user_message("u1"),
+                tool_calls_assistant(7),
+            ],
+            ExpectedState::Resumable {
+                fence_token: Some(7),
+                last_user: Some("u1"),
+                assistant: ExpectedAssistant::ToolCalls,
+                pending_tool_results_len: 0,
+                next_turn_messages: &[],
+            },
+        );
+    }
+
+    #[test]
+    fn users_after_tool_calls_queue_for_next_turn() {
+        assert_case(
+            vec![
+                final_assistant("done"),
+                user_message("u1"),
+                tool_calls_assistant(7),
+                user_message("u2"),
+            ],
+            ExpectedState::Resumable {
+                fence_token: Some(7),
+                last_user: Some("u1"),
+                assistant: ExpectedAssistant::ToolCalls,
+                pending_tool_results_len: 0,
+                next_turn_messages: &["u2"],
+            },
+        );
+    }
+
+    #[test]
+    fn tool_results_without_matching_tool_calls_are_ignored() {
+        assert_case(
+            vec![final_assistant("done"), tool_results("tool-a")],
+            ExpectedState::Idle {
+                next_turn_messages: &[],
+            },
+        );
+    }
+
+    #[test]
+    fn tool_results_attach_to_resumable_ctx_but_keep_queued_users() {
+        assert_case(
+            vec![
+                final_assistant("done"),
+                user_message("u1"),
+                tool_calls_assistant(7),
+                user_message("u2"),
+                tool_results("tool-a"),
+            ],
+            ExpectedState::Resumable {
+                fence_token: Some(7),
+                last_user: Some("u1"),
+                assistant: ExpectedAssistant::ToolCalls,
+                pending_tool_results_len: 1,
+                next_turn_messages: &["u2"],
+            },
+        );
+    }
+
+    #[test]
+    fn cancel_after_tool_calls_marks_inflight_cancelled() {
+        assert_case(
+            vec![
+                final_assistant("done"),
+                user_message("u1"),
+                tool_calls_assistant(7),
+                cancel(7),
+            ],
+            ExpectedState::Cancelled {
+                fence_token: Some(7),
+            },
+        );
+    }
+
+    #[test]
+    fn user_after_cancel_starts_next_turn_and_clears_tombstone() {
+        assert_case(
+            vec![
+                final_assistant("done"),
+                user_message("u1"),
+                tool_calls_assistant(7),
+                cancel(7),
+                user_message("u2"),
+            ],
+            ExpectedState::Idle {
+                next_turn_messages: &["u2"],
+            },
+        );
+    }
+
+    #[test]
+    fn latest_cancel_tombstone_wins() {
+        assert_case(
+            vec![
+                final_assistant("done"),
+                user_message("u1"),
+                tool_calls_assistant(7),
+                cancel(7),
+                cancel(8),
+            ],
+            ExpectedState::Cancelled {
+                fence_token: Some(8),
+            },
+        );
+    }
+
+    #[test]
+    fn cancel_without_barrier_is_cancelled() {
+        assert_case(
+            vec![cancel(9)],
+            ExpectedState::Cancelled {
+                fence_token: Some(9),
+            },
+        );
+    }
+
+    #[test]
+    fn tool_results_without_tool_calls_after_barrier_stay_idle() {
+        assert_case(
+            vec![final_assistant("done"), tool_results("tool-a")],
+            ExpectedState::Idle {
+                next_turn_messages: &[],
+            },
+        );
+    }
+
+    #[test]
+    fn final_assistant_message_is_barrier_even_after_cancelled_tail() {
+        assert_case(
+            vec![cancel(3), final_assistant("done")],
+            ExpectedState::Idle {
+                next_turn_messages: &[],
+            },
+        );
+    }
+
+    #[test]
+    fn fenced_final_assistant_is_a_barrier() {
+        // Worker-originated (NATS HA) final assistant messages carry a fence_token.
+        // They MUST still be recognized as turn barriers, otherwise the worker
+        // re-folds already-answered user messages and re-runs completed turns.
+        assert_case(
+            vec![user_message("u1"), fenced_final_assistant("done", 5)],
+            ExpectedState::Idle {
+                next_turn_messages: &[],
+            },
+        );
+    }
+
+    #[test]
+    fn edit_entries_replacement_yaml_is_applied() {
+        let replacement = serde_yaml::to_string(&SessionLogEntry::Message {
+            id: Some("edited-id".to_string()),
+            role: MessageRole::User,
+            content: MessageContent::Text("edited".to_string()),
+            timestamp: None,
+            fence_token: None,
+        })
+        .expect("serialize replacement");
+
+        let effective = apply_log_mutations(&[
+            (1, user_message("original")),
+            (
+                2,
+                SessionLogEntry::EditEntries {
+                    from: 1,
+                    to: 1,
+                    replacements: vec![replacement],
+                },
+            ),
+        ]);
+
+        assert_eq!(effective.len(), 1);
+        assert_eq!(effective[0].0, 2);
+        assert_eq!(message_text(&entry_as_message(&effective[0].1)), "edited");
+    }
+
+    #[test]
+    fn rewind_truncates_effective_entries_after_prior_edit() {
+        let replacement = serde_yaml::to_string(&SessionLogEntry::Message {
+            id: Some("edited-id".to_string()),
+            role: MessageRole::User,
+            content: MessageContent::Text("edited".to_string()),
+            timestamp: None,
+            fence_token: None,
+        })
+        .expect("serialize replacement");
+
+        let effective = apply_log_mutations(&[
+            (1, user_message("original")),
+            (
+                2,
+                SessionLogEntry::EditEntries {
+                    from: 1,
+                    to: 1,
+                    replacements: vec![replacement],
+                },
+            ),
+            (3, final_assistant("done")),
+            (4, SessionLogEntry::Rewind { after_seq: 2 }),
+        ]);
+
+        assert_eq!(effective.len(), 1);
+        assert_eq!(effective[0].0, 2);
+        assert_eq!(message_text(&entry_as_message(&effective[0].1)), "edited");
+    }
+
+    #[test]
+    fn post_fenced_barrier_user_folds_into_next_turn() {
+        assert_case(
+            vec![
+                user_message("u1"),
+                fenced_final_assistant("answer1", 5),
+                user_message("u2"),
+            ],
+            ExpectedState::Idle {
+                next_turn_messages: &["u2"],
+            },
+        );
+    }
+
+    enum ExpectedState<'a> {
+        Idle {
+            next_turn_messages: &'a [&'a str],
+        },
+        Resumable {
+            fence_token: Option<u64>,
+            last_user: Option<&'a str>,
+            assistant: ExpectedAssistant,
+            pending_tool_results_len: usize,
+            next_turn_messages: &'a [&'a str],
+        },
+        Cancelled {
+            fence_token: Option<u64>,
+        },
+    }
+
+    enum ExpectedAssistant {
+        ToolCalls,
+    }
+
+    fn assert_case(entries: Vec<SessionLogEntry>, expected: ExpectedState<'_>) {
+        let state = reconstruct_state(&entries);
+        match expected {
+            ExpectedState::Idle { next_turn_messages } => {
+                assert_eq!(state.turn_status, TurnStatus::Idle);
+                assert_next_turn_messages(&state.next_turn_messages, next_turn_messages);
+                assert!(state.resumable_ctx.is_none());
+            }
+            ExpectedState::Resumable {
+                fence_token,
+                last_user,
+                assistant,
+                pending_tool_results_len,
+                next_turn_messages,
+            } => {
+                assert_eq!(state.turn_status, TurnStatus::InFlightResumable);
+                assert_next_turn_messages(&state.next_turn_messages, next_turn_messages);
+                let ctx = state.resumable_ctx.expect("resumable ctx");
+                assert_eq!(ctx.fence_token, fence_token);
+                assert_eq!(
+                    ctx.last_user.as_ref().map(message_text).as_deref(),
+                    last_user
+                );
+                match assistant {
+                    ExpectedAssistant::ToolCalls => {
+                        assert!(matches!(
+                            ctx.last_assistant,
+                            Some(AssistantTurn::ToolCalls { .. })
+                        ));
+                    }
+                }
+                assert_eq!(ctx.pending_tool_results.len(), pending_tool_results_len);
+            }
+            ExpectedState::Cancelled { fence_token } => {
+                assert_eq!(state.turn_status, TurnStatus::InFlightCancelled);
+                assert!(state.next_turn_messages.is_empty());
+                let ctx = state.resumable_ctx.expect("cancel ctx");
+                assert_eq!(ctx.fence_token, fence_token);
+                assert!(ctx.last_user.is_none());
+                assert!(ctx.last_assistant.is_none());
+                assert!(ctx.pending_tool_results.is_empty());
+            }
+        }
+    }
+
+    fn assert_next_turn_messages(messages: &[Message], expected: &[&str]) {
+        let actual: Vec<_> = messages.iter().map(message_text).collect();
+        assert_eq!(actual, expected);
+    }
+
+    fn message_text(message: &Message) -> String {
+        message.content.to_text()
+    }
+
+    fn final_assistant(text: &str) -> SessionLogEntry {
+        SessionLogEntry::Message {
+            id: None,
+            role: MessageRole::Assistant,
+            content: MessageContent::Text(text.to_string()),
+            timestamp: None,
+            fence_token: None,
+        }
+    }
+
+    fn entry_as_message(entry: &SessionLogEntry) -> Message {
+        match entry {
+            SessionLogEntry::Message {
+                role,
+                content,
+                timestamp,
+                ..
+            } => Message {
+                role: *role,
+                content: content.clone(),
+                log_seq: None,
+                log_timestamp: *timestamp,
+            },
+            other => panic!("expected message entry, got {other:?}"),
+        }
+    }
+
+    fn fenced_final_assistant(text: &str, fence_token: u64) -> SessionLogEntry {
+        SessionLogEntry::Message {
+            id: None,
+            role: MessageRole::Assistant,
+            content: MessageContent::Text(text.to_string()),
+            timestamp: None,
+            fence_token: Some(fence_token),
+        }
+    }
+
+    fn user_message(text: &str) -> SessionLogEntry {
+        SessionLogEntry::Message {
+            id: None,
+            role: MessageRole::User,
+            content: MessageContent::Text(text.to_string()),
+            timestamp: None,
+            fence_token: None,
+        }
+    }
+
+    fn tool_calls_assistant(fence_token: u64) -> SessionLogEntry {
+        SessionLogEntry::ToolCalls {
+            text: "working".to_string(),
+            thought: Some("thinking".to_string()),
+            calls: vec![ToolCall::new(
+                "tool-a".to_string(),
+                json!({"arg": 1}),
+                Some("call-1".to_string()),
+                None,
+            )],
+            timestamp: None,
+            fence_token: Some(fence_token),
+        }
+    }
+
+    fn tool_results(name: &str) -> SessionLogEntry {
+        SessionLogEntry::ToolResults {
+            results: vec![ToolOutput {
+                id: Some("call-1".to_string()),
+                name: name.to_string(),
+                output: json!({"ok": true}),
+                content: vec![],
+                switch_agent: None,
+            }],
+            timestamp: None,
+        }
+    }
+
+    fn cancel(fence_token: u64) -> SessionLogEntry {
+        SessionLogEntry::Cancel { fence_token }
+    }
+}

--- a/crates/harnx-core/src/tool.rs
+++ b/crates/harnx-core/src/tool.rs
@@ -115,6 +115,14 @@ pub struct ToolDeclaration {
     pub call_template: Option<String>,
     #[serde(skip, default)]
     pub result_template: Option<String>,
+    /// MCP tool annotation: if true, calling this tool repeatedly with the same
+    /// arguments has no additional effect. Runtime metadata only (not persisted).
+    #[serde(skip, default)]
+    pub idempotent_hint: Option<bool>,
+    /// MCP tool annotation: if true, the tool does not modify its environment.
+    /// Runtime metadata only (not persisted).
+    #[serde(skip, default)]
+    pub read_only_hint: Option<bool>,
 }
 
 /// Map a shebang interpreter name to a Markdown code-fence language label.

--- a/crates/harnx-mcp/src/client.rs
+++ b/crates/harnx-mcp/src/client.rs
@@ -279,55 +279,7 @@ impl McpClient {
         let functions = tools_result
             .tools
             .into_iter()
-            .map(|tool| {
-                let input_schema = Value::Object((*tool.input_schema).clone());
-                let server_tool_name = tool.name.to_string();
-                let final_name = if let Some(renamed) =
-                    self.config.rename_tools.get(server_tool_name.as_str())
-                {
-                    renamed.clone()
-                } else {
-                    format!("{}_{}", self.name, server_tool_name)
-                };
-
-                // Extract _meta templates (server-provided)
-                let meta_call_tmpl = tool
-                    .meta
-                    .as_ref()
-                    .and_then(|m| m.0.get("call_template"))
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
-                let meta_result_tmpl = tool
-                    .meta
-                    .as_ref()
-                    .and_then(|m| m.0.get("result_template"))
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
-
-                // Apply config override (higher precedence)
-                let cfg_templates: Option<&ToolDisplayTemplates> =
-                    self.config.tool_templates.get(&server_tool_name);
-                let call_template = cfg_templates
-                    .and_then(|t| t.call_template.clone())
-                    .or(meta_call_tmpl);
-                let result_template = cfg_templates
-                    .and_then(|t| t.result_template.clone())
-                    .or(meta_result_tmpl);
-                let templates = ToolTemplates {
-                    call_template,
-                    result_template,
-                };
-
-                let mut declaration = mcp_tool_to_declaration(
-                    &final_name,
-                    &server_tool_name,
-                    tool.description.as_deref().unwrap_or_default(),
-                    &input_schema,
-                    templates,
-                )?;
-                declaration.mcp_server_name = Some(self.name.clone());
-                Ok(declaration)
-            })
+            .map(|tool| self.build_tool_declaration(tool))
             .collect::<Result<Vec<_>>>()?;
 
         *self.tools.write() = functions;
@@ -335,6 +287,59 @@ impl McpClient {
         *self.service.write() = Some(service);
 
         Ok(())
+    }
+
+    /// Convert a single MCP `Tool` advertised by the server into a harnx
+    /// `ToolDeclaration`, applying tool renames and call/result display
+    /// templates (server `_meta` overridden by local config).
+    fn build_tool_declaration(&self, tool: rmcp::model::Tool) -> Result<ToolDeclaration> {
+        let input_schema = Value::Object((*tool.input_schema).clone());
+        let server_tool_name = tool.name.to_string();
+        let final_name =
+            if let Some(renamed) = self.config.rename_tools.get(server_tool_name.as_str()) {
+                renamed.clone()
+            } else {
+                format!("{}_{}", self.name, server_tool_name)
+            };
+
+        // Extract _meta templates (server-provided)
+        let meta_call_tmpl = tool
+            .meta
+            .as_ref()
+            .and_then(|m| m.0.get("call_template"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let meta_result_tmpl = tool
+            .meta
+            .as_ref()
+            .and_then(|m| m.0.get("result_template"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        // Apply config override (higher precedence)
+        let cfg_templates: Option<&ToolDisplayTemplates> =
+            self.config.tool_templates.get(&server_tool_name);
+        let call_template = cfg_templates
+            .and_then(|t| t.call_template.clone())
+            .or(meta_call_tmpl);
+        let result_template = cfg_templates
+            .and_then(|t| t.result_template.clone())
+            .or(meta_result_tmpl);
+        let templates = ToolTemplates {
+            call_template,
+            result_template,
+        };
+
+        let mut declaration = mcp_tool_to_declaration(
+            &final_name,
+            &server_tool_name,
+            tool.description.as_deref().unwrap_or_default(),
+            &input_schema,
+            templates,
+            tool.annotations.as_ref(),
+        )?;
+        declaration.mcp_server_name = Some(self.name.clone());
+        Ok(declaration)
     }
 
     pub async fn disconnect(&self) -> Result<()> {
@@ -718,6 +723,7 @@ mod tests {
                 "Read",
                 &json!({}),
                 ToolTemplates::default(),
+                None,
             )
             .unwrap(),
             mcp_tool_to_declaration(
@@ -726,6 +732,7 @@ mod tests {
                 "Write",
                 &json!({}),
                 ToolTemplates::default(),
+                None,
             )
             .unwrap(),
         ];
@@ -754,6 +761,7 @@ mod tests {
                     "desc",
                     &json!({}),
                     ToolTemplates::default(),
+                    None,
                 )
                 .unwrap()
             })
@@ -834,6 +842,7 @@ mod tests {
             "desc",
             &json!({}),
             ToolTemplates::default(),
+            None,
         )
         .unwrap()];
         *client.connection_failed.write() = true;
@@ -880,6 +889,7 @@ mod tests {
             "Read mock file contents.",
             &json!({}),
             ToolTemplates::default(),
+            None,
         )
         .unwrap()];
         *client.service.write() = Some(client_service);

--- a/crates/harnx-mcp/src/convert.rs
+++ b/crates/harnx-mcp/src/convert.rs
@@ -4,6 +4,8 @@ use anyhow::{anyhow, Result};
 use indexmap::IndexMap;
 use serde_json::Value;
 
+use rmcp::model::ToolAnnotations;
+
 /// Bundle of display templates for a tool.
 #[derive(Debug, Clone, Default)]
 pub struct ToolTemplates {
@@ -17,6 +19,7 @@ pub fn mcp_tool_to_declaration(
     tool_description: &str,
     input_schema: &Value,
     templates: ToolTemplates,
+    annotations: Option<&ToolAnnotations>,
 ) -> Result<ToolDeclaration> {
     Ok(ToolDeclaration {
         name: display_name.to_string(),
@@ -26,6 +29,8 @@ pub fn mcp_tool_to_declaration(
         mcp_server_name: None,
         call_template: templates.call_template,
         result_template: templates.result_template,
+        idempotent_hint: annotations.and_then(|a| a.idempotent_hint),
+        read_only_hint: annotations.and_then(|a| a.read_only_hint),
     })
 }
 
@@ -225,6 +230,7 @@ mod tests {
             "Read a file from disk",
             &schema,
             ToolTemplates::default(),
+            None,
         )
         .expect("convert tool");
 

--- a/crates/harnx-runtime/Cargo.toml
+++ b/crates/harnx-runtime/Cargo.toml
@@ -14,6 +14,7 @@ keywords.workspace = true
 anyhow = { workspace = true }
 async-recursion = { workspace = true }
 async-trait = { workspace = true }
+async-nats = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true }
 bitflags = { workspace = true }
@@ -47,6 +48,7 @@ parking_lot = { workspace = true }
 path-absolutize = { workspace = true }
 reqwest = { workspace = true }
 reqwest-eventsource = { workspace = true }
+rustls-pemfile = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/harnx-runtime/src/async_session_log.rs
+++ b/crates/harnx-runtime/src/async_session_log.rs
@@ -1,0 +1,46 @@
+//! Async session log persistence for NATS-backed sessions.
+//!
+//! See the worker entrypoint in `nats_worker.rs` for orchestration.
+
+use anyhow::Result;
+use async_nats::jetstream;
+use harnx_core::session::SessionLogEntry;
+
+/// NATS JetStream-backed async session log.
+///
+/// Wraps `NatsSessionLog` async methods for use in the NATS worker.
+/// Unlike the sync `SessionLog` trait, these methods are designed for
+/// async contexts (Tokio runtime).
+pub struct AsyncSessionLog {
+    inner: crate::nats_session_log::NatsSessionLog,
+}
+
+impl AsyncSessionLog {
+    /// Create a new async session log backed by NATS JetStream.
+    pub fn new(jetstream: jetstream::Context, session_id: impl Into<String>) -> Self {
+        Self {
+            inner: crate::nats_session_log::NatsSessionLog::new(jetstream, session_id),
+        }
+    }
+
+    /// Append an entry to the log, returning the JetStream sequence number.
+    pub async fn append_event(&self, entry: &SessionLogEntry) -> Result<u64> {
+        self.inner.append_event_async(entry).await
+    }
+
+    /// Load all entries from the session log.
+    pub async fn load_events(&self) -> Result<Vec<(u64, SessionLogEntry)>> {
+        self.inner.load_events_async().await
+    }
+
+    /// Replay entries from the given sequence number.
+    pub async fn replay_from(&self, seq: u64) -> Result<Vec<SessionLogEntry>> {
+        self.inner.replay_from_async(seq).await
+    }
+
+    /// Load and replay the session into an in-memory `Session`.
+    pub async fn load_session(&self, name: &str) -> Result<harnx_core::session::Session> {
+        let entries = self.load_events().await?;
+        crate::nats_session_log::load_session_from_entries(&entries, name)
+    }
+}

--- a/crates/harnx-runtime/src/config/agent_dump_tests.rs
+++ b/crates/harnx-runtime/src/config/agent_dump_tests.rs
@@ -116,6 +116,8 @@ fn make_tool_declaration(name: &str, description: &str) -> crate::tool::ToolDecl
         mcp_server_name: None,
         call_template: None,
         result_template: None,
+        idempotent_hint: None,
+        read_only_hint: None,
     }
 }
 

--- a/crates/harnx-runtime/src/config/agent_ops_split.rs
+++ b/crates/harnx-runtime/src/config/agent_ops_split.rs
@@ -1,6 +1,16 @@
 //! Agent lifecycle methods extracted from config/mod.rs for code health.
 use super::*;
 
+struct UseRemoteAgentParams<'a> {
+    config: &'a GlobalConfig,
+    agent: &'a str,
+    cluster: &'a str,
+    session_name: Option<&'a str>,
+    _abort_signal: AbortSignal,
+}
+
+use harnx_core::agent_ref::AgentRef;
+
 impl Config {
     pub fn use_prompt(&mut self, prompt: &str) -> Result<()> {
         let mut agent = Agent::new(AgentConfig::from_prompt(prompt));
@@ -224,6 +234,64 @@ impl Config {
         session_name: Option<&str>,
         abort_signal: AbortSignal,
     ) -> Result<()> {
+        match AgentRef::parse(agent_name) {
+            AgentRef::Local(agent_name) => {
+                Self::use_local_agent(config, agent_name.as_ref(), session_name, abort_signal).await
+            }
+            AgentRef::Remote { agent, cluster } => {
+                Self::use_remote_agent(UseRemoteAgentParams {
+                    config,
+                    agent: &agent,
+                    cluster: &cluster,
+                    session_name,
+                    _abort_signal: abort_signal,
+                })
+                .await
+            }
+        }
+    }
+
+    /// Activate a remote agent through NATS thin-client mode.
+    ///
+    /// This sets up the session for remote execution. The actual turn is driven
+    /// by the frontend calling `run_remote_agent_turn` when user input arrives.
+    async fn use_remote_agent(params: UseRemoteAgentParams<'_>) -> Result<()> {
+        let UseRemoteAgentParams {
+            config,
+            agent,
+            cluster,
+            session_name,
+            _abort_signal,
+        } = params;
+        // For now, remote agents are activated lazily when the first prompt arrives.
+        // We just validate the cluster exists and prepare metadata.
+        {
+            let cfg = config.read();
+            // Validate cluster exists
+            cfg.nats_server(cluster)
+                .map_err(|e| anyhow::anyhow!("remote agent validation failed: {e}"))?;
+        }
+
+        // Store remote agent metadata in config for use during prompt processing
+        // The actual ThinClientSession is created when the user sends a prompt
+        config
+            .write()
+            .set_remote_agent(agent.to_string(), cluster.to_string());
+
+        // If a session name was provided, set it (this is for future resume/attach)
+        if let Some(session) = session_name {
+            config.write().use_session(Some(session))?;
+        }
+
+        Ok(())
+    }
+
+    async fn use_local_agent(
+        config: &GlobalConfig,
+        agent_name: &str,
+        session_name: Option<&str>,
+        abort_signal: AbortSignal,
+    ) -> Result<()> {
         if !config.read().tool_use {
             bail!("Please enable tool use before using the agent.");
         }
@@ -284,6 +352,8 @@ impl Config {
             // Restore global (no-agent) manager view: all package servers prefixed.
             self.reinit_managers_for_agent(None);
         }
+        // Clear remote agent metadata too
+        self.remote_agent.take();
         Ok(())
     }
 }

--- a/crates/harnx-runtime/src/config/agent_tests.rs
+++ b/crates/harnx-runtime/src/config/agent_tests.rs
@@ -96,6 +96,8 @@ fn make_tool_declaration(name: &str, description: &str) -> crate::tool::ToolDecl
         mcp_server_name: None,
         call_template: None,
         result_template: None,
+        idempotent_hint: None,
+        read_only_hint: None,
     }
 }
 

--- a/crates/harnx-runtime/src/config/compaction_tests.rs
+++ b/crates/harnx-runtime/src/config/compaction_tests.rs
@@ -304,3 +304,48 @@ async fn test_compact_session_honors_compaction_keep_recent_turns() {
         "expected the summary plus the one kept turn (2 messages)"
     );
 }
+
+#[tokio::test]
+async fn test_apply_compaction_summary_skips_swapped_session() {
+    let config = with_session(
+        Config {
+            data: ConfigData {
+                stream: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        vec![
+            (MessageRole::User, "first prompt".to_string()),
+            (MessageRole::Assistant, "first reply".to_string()),
+            (MessageRole::User, "second prompt".to_string()),
+            (MessageRole::Assistant, "second reply".to_string()),
+        ],
+    );
+    let original_session = config.read().session.as_ref().unwrap().clone();
+    let original_id = original_session.id.clone();
+    let original_message_len = original_session.messages.len();
+    let original_continuous = config
+        .read()
+        .last_message
+        .as_ref()
+        .map(|last| last.continuous);
+    let split = 2;
+
+    let mut swapped_session = original_session.clone();
+    swapped_session.id = "swapped-session".to_string();
+    config.write().session = Some(swapped_session);
+
+    let applied =
+        Config::apply_compaction_summary(&config, &original_id, "summary".to_string(), split);
+
+    let guard = config.read();
+    let active = guard.session.as_ref().unwrap();
+    assert!(!applied, "session swap must skip stale compaction result");
+    assert_eq!(active.id, "swapped-session");
+    assert_eq!(active.messages.len(), original_message_len);
+    assert_eq!(
+        guard.last_message.as_ref().map(|last| last.continuous),
+        original_continuous
+    );
+}

--- a/crates/harnx-runtime/src/config/loader_split.rs
+++ b/crates/harnx-runtime/src/config/loader_split.rs
@@ -65,7 +65,7 @@ impl Config {
         Ok(config)
     }
 
-    pub(super) fn load_from_file(config_path: &Path) -> Result<Self> {
+    pub(crate) fn load_from_file(config_path: &Path) -> Result<Self> {
         let err = || format!("Failed to load config at '{}'", config_path.display());
         let data: ConfigData = if config_path.exists() {
             let content = read_to_string(config_path).with_context(err)?;
@@ -83,6 +83,8 @@ impl Config {
         };
         let config_dir = config_path.parent().unwrap_or(config_path);
         config.clients = Self::load_clients_from_dir(&config_dir.join(paths::CLIENTS_DIR_NAME))?;
+        config.nats_servers =
+            Self::load_nats_servers_from_dir(&config_dir.join(paths::NATS_SERVERS_DIR_NAME))?;
         config.mcp_servers =
             Self::load_mcp_servers_from_dir(&config_dir.join(paths::MCP_SERVERS_DIR_NAME))?;
         config.acp_servers =
@@ -253,6 +255,8 @@ impl Config {
         config.clients = vec![client];
 
         let config_dir = Self::config_dir();
+        config.nats_servers =
+            Self::load_nats_servers_from_dir(&config_dir.join(paths::NATS_SERVERS_DIR_NAME))?;
         config.mcp_servers =
             Self::load_mcp_servers_from_dir(&config_dir.join(paths::MCP_SERVERS_DIR_NAME))?;
         config.acp_servers =

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -7,6 +7,7 @@ mod env_split;
 pub mod input;
 mod loader_split;
 mod macros_split;
+mod nats_split;
 mod patches_split;
 mod paths_split;
 mod persistence_split;
@@ -14,13 +15,16 @@ mod rag_split;
 mod servers_split;
 pub mod session;
 mod session_dump;
+mod session_externalize;
 mod session_log_split;
 pub mod session_meta;
+mod session_ops_compaction;
 mod session_ops_split;
 mod settings_split;
 
 pub use self::env_split::load_env_file;
 pub use self::macros_split::macro_execute;
+pub use self::nats_split::NatsServerConfig;
 pub(crate) use self::persistence_split::collect_tool_calls;
 pub use self::session_dump::render_session_dump;
 pub(crate) use self::session_log_split::{
@@ -205,6 +209,8 @@ fn handoff_tool_declarations_for_agents(
                 mcp_server_name: None,
                 call_template: None,
                 result_template: None,
+                idempotent_hint: None,
+                read_only_hint: None,
             }
         })
         .collect();
@@ -218,6 +224,7 @@ pub struct Config {
     // Server-config vectors (types live in dependent crates — stay here,
     // not in ConfigData, to avoid reverse deps from harnx-core).
     pub clients: Vec<ClientConfig>,
+    pub nats_servers: Vec<NatsServerConfig>,
     pub mcp_servers: Vec<McpServerConfig>,
     pub acp_servers: Vec<AcpServerConfig>,
 
@@ -240,6 +247,10 @@ pub struct Config {
     pub session: Option<Session>,
     pub rag: Option<Arc<Rag>>,
     pub agent: Option<Agent>,
+    /// Remote agent metadata for NATS thin-client mode.
+    /// When set, the agent runs on a remote worker and this client
+    /// drives the turn via `ThinClientSession`.
+    pub remote_agent: Option<(String, String)>, // (agent_name, cluster)
     pub tui_before_editor: Option<Box<dyn FnMut() + Send + Sync>>,
     pub tui_after_editor: Option<Box<dyn FnMut() + Send + Sync>>,
     /// Runtime-only override for tool-use confirmation prompts. When set (the
@@ -300,6 +311,7 @@ impl Clone for Config {
         Self {
             data: self.data.clone(),
             clients: self.clients.clone(),
+            nats_servers: self.nats_servers.clone(),
             mcp_servers: self.mcp_servers.clone(),
             acp_servers: self.acp_servers.clone(),
             model_cooldowns: self.model_cooldowns.clone(),
@@ -318,6 +330,7 @@ impl Clone for Config {
             session: self.session.clone(),
             rag: self.rag.clone(),
             agent: self.agent.clone(),
+            remote_agent: self.remote_agent.clone(),
             tui_before_editor: None,
             tui_after_editor: None,
             tui_confirm_tool_use: None,
@@ -346,6 +359,7 @@ impl Config {
         Config {
             data: self.data.clone(),
             clients: self.clients.clone(),
+            nats_servers: self.nats_servers.clone(),
             mcp_servers: self.mcp_servers.clone(),
             acp_servers: self.acp_servers.clone(),
             model_cooldowns: self.model_cooldowns.clone(),
@@ -364,6 +378,7 @@ impl Config {
             session: None,
             rag: self.rag.clone(),
             agent: self.agent.clone(),
+            remote_agent: self.remote_agent.clone(),
             // ACP server prompt path never invokes editor hooks. Drop them so
             // forked prompt configs can own isolated session state without
             // trying to clone `FnMut` trait objects.
@@ -382,6 +397,7 @@ impl Default for Config {
             data: ConfigData::default(),
 
             clients: vec![],
+            nats_servers: vec![],
             mcp_servers: vec![],
             acp_servers: vec![],
 
@@ -403,6 +419,7 @@ impl Default for Config {
             session: None,
             rag: None,
             agent: None,
+            remote_agent: None,
             tui_before_editor: None,
             tui_after_editor: None,
             tui_confirm_tool_use: None,
@@ -429,6 +446,16 @@ pub(super) fn path_is_home_or_ancestor(path: &Path) -> bool {
 }
 
 impl Config {
+    /// Set remote agent metadata for NATS thin-client mode.
+    pub fn set_remote_agent(&mut self, agent: String, cluster: String) {
+        self.remote_agent = Some((agent, cluster));
+    }
+
+    /// Check if this config is running in remote-agent mode.
+    pub fn is_remote_agent(&self) -> bool {
+        self.remote_agent.is_some()
+    }
+
     pub fn state(&self) -> StateFlags {
         let mut flags = StateFlags::empty();
         if let Some(session) = &self.session {
@@ -1362,3 +1389,5 @@ mod session_edit_tests;
 mod test_support;
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_extra;

--- a/crates/harnx-runtime/src/config/nats_split.rs
+++ b/crates/harnx-runtime/src/config/nats_split.rs
@@ -1,0 +1,374 @@
+//! NATS cluster config loading and connection helpers.
+use super::*;
+use anyhow::{bail, Context, Result};
+use async_nats::{jetstream, ConnectOptions};
+use serde::{Deserialize, Serialize};
+use std::{
+    io::BufReader,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NatsServerConfig {
+    #[serde(default)]
+    pub name: String,
+    pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tls: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tls_cert: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tls_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tls_ca: Option<String>,
+}
+
+impl NatsServerConfig {
+    pub fn set_name(&mut self, name: impl Into<String>) {
+        self.name = name.into();
+    }
+}
+
+impl Config {
+    pub fn load_nats_servers_from_dir(dir: &Path) -> Result<Vec<NatsServerConfig>> {
+        if !dir.exists() {
+            return Ok(vec![]);
+        }
+
+        let mut servers = Vec::new();
+        for path in Self::sorted_yaml_files(dir)? {
+            let stem = match path.file_stem().and_then(|s| s.to_str()) {
+                Some(stem) if !stem.is_empty() => stem.to_string(),
+                _ => continue,
+            };
+
+            let content = std::fs::read_to_string(&path)
+                .with_context(|| format!("Failed to read NATS server config {}", path.display()))?;
+            let mut server: NatsServerConfig =
+                serde_yaml::from_str(&content).with_context(|| {
+                    format!("Failed to parse NATS server config {}", path.display())
+                })?;
+            server.set_name(stem);
+            Self::expand_nats_server_envs(&mut server);
+            servers.push(server);
+        }
+
+        Ok(servers)
+    }
+
+    pub fn nats_server(&self, cluster_key: &str) -> Result<&NatsServerConfig> {
+        self.nats_servers
+            .iter()
+            .find(|server| server.name == cluster_key)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "unknown NATS cluster '{}' (expected nats_servers/{}.yaml)",
+                    cluster_key,
+                    cluster_key
+                )
+            })
+    }
+
+    pub async fn nats_client(&self, cluster_key: &str) -> Result<async_nats::Client> {
+        let server = self.nats_server(cluster_key)?;
+        Self::connect_nats_server(server).await.with_context(|| {
+            format!(
+                "Failed to connect to NATS cluster '{}' at '{}'",
+                cluster_key, server.url
+            )
+        })
+    }
+
+    pub async fn nats_jetstream(&self, cluster_key: &str) -> Result<jetstream::Context> {
+        let client = self.nats_client(cluster_key).await?;
+        Ok(jetstream::new(client))
+    }
+
+    pub async fn connect_nats_server(server: &NatsServerConfig) -> Result<async_nats::Client> {
+        if !server.has_auth_or_tls_config() {
+            return async_nats::connect(&server.url)
+                .await
+                .with_context(|| format!("Failed to connect to NATS cluster at '{}'", server.url));
+        }
+
+        let options = build_nats_connect_options(server).with_context(|| {
+            format!("Invalid auth/TLS config for NATS cluster '{}'", server.name)
+        })?;
+        options
+            .connect(&server.url)
+            .await
+            .with_context(|| format!("Failed to connect to NATS cluster at '{}'", server.url))
+    }
+
+    pub async fn nats_kv_bucket(
+        &self,
+        cluster_key: &str,
+        bucket: &str,
+    ) -> Result<jetstream::kv::Store> {
+        let js = self.nats_jetstream(cluster_key).await?;
+        js.get_key_value(bucket)
+            .await
+            .with_context(|| format!("Failed to open NATS KV bucket '{}'", bucket))
+    }
+
+    pub(super) fn expand_nats_server_envs(server: &mut NatsServerConfig) {
+        server.url = expand_env_string(&server.url);
+        expand_env_option(&mut server.token);
+        expand_env_option(&mut server.tls_cert);
+        expand_env_option(&mut server.tls_key);
+        expand_env_option(&mut server.tls_ca);
+    }
+}
+
+impl NatsServerConfig {
+    fn has_auth_or_tls_config(&self) -> bool {
+        self.token.is_some()
+            || self.tls.unwrap_or(false)
+            || self.tls_cert.is_some()
+            || self.tls_key.is_some()
+            || self.tls_ca.is_some()
+    }
+}
+
+fn build_nats_connect_options(server: &NatsServerConfig) -> Result<ConnectOptions> {
+    let mut options = ConnectOptions::new();
+    options = apply_nats_auth_options(options, server);
+    options = apply_nats_tls_options(options, server)?;
+
+    if should_require_tls(server) {
+        options = options.require_tls(true);
+    }
+
+    Ok(options)
+}
+
+fn apply_nats_auth_options(
+    mut options: ConnectOptions,
+    server: &NatsServerConfig,
+) -> ConnectOptions {
+    if let Some(token) = &server.token {
+        options = options.token(token.clone());
+    }
+    options
+}
+
+fn apply_nats_tls_options(
+    mut options: ConnectOptions,
+    server: &NatsServerConfig,
+) -> Result<ConnectOptions> {
+    reject_unsupported_tls_combo(server)?;
+    options = apply_client_certificate_options(options, server)?;
+    if let Some(tls_client) = build_custom_tls_client_config(server)? {
+        options = options.tls_client_config(tls_client);
+    }
+    Ok(options)
+}
+
+fn reject_unsupported_tls_combo(server: &NatsServerConfig) -> Result<()> {
+    // A custom `tls_ca` builds a dedicated rustls ClientConfig (below) which
+    // replaces any client certificate registered via `add_client_certificate`.
+    // async-nats 0.42 has no way to attach both a custom root store AND a client
+    // cert through its high-level options, so reject the combination explicitly
+    // rather than silently dropping the client certificate (which would make
+    // mTLS fail at handshake time with a confusing error).
+    if has_client_certificate(server) && server.tls_ca.is_some() {
+        bail!(
+            "NATS cluster '{}' sets both tls_ca and a client certificate (tls_cert/tls_key); \
+             this combination is not supported (the custom CA would override the client cert). \
+             Use a server cert chained to a publicly-trusted CA for mTLS, or drop tls_ca.",
+            server.name
+        );
+    }
+    Ok(())
+}
+
+fn apply_client_certificate_options(
+    mut options: ConnectOptions,
+    server: &NatsServerConfig,
+) -> Result<ConnectOptions> {
+    match (&server.tls_cert, &server.tls_key) {
+        (Some(cert), Some(key)) => {
+            let cert_path = validate_tls_path(server, "tls_cert", cert)?;
+            let key_path = validate_tls_path(server, "tls_key", key)?;
+            options = options.add_client_certificate(cert_path, key_path);
+            Ok(options)
+        }
+        (Some(_), None) => bail!(
+            "NATS cluster '{}' sets tls_cert but missing tls_key",
+            server.name
+        ),
+        (None, Some(_)) => bail!(
+            "NATS cluster '{}' sets tls_key but missing tls_cert",
+            server.name
+        ),
+        (None, None) => Ok(options),
+    }
+}
+
+fn build_custom_tls_client_config(
+    server: &NatsServerConfig,
+) -> Result<Option<async_nats::rustls::ClientConfig>> {
+    let Some(ca_path) = &server.tls_ca else {
+        return Ok(None);
+    };
+
+    let ca_path = validate_tls_path(server, "tls_ca", ca_path)?;
+    let ca_file = std::fs::File::open(&ca_path).with_context(|| {
+        format!(
+            "Failed to read tls_ca '{}' for NATS cluster '{}'",
+            ca_path.display(),
+            server.name
+        )
+    })?;
+    let certs = rustls_pemfile::certs(&mut BufReader::new(ca_file))
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .with_context(|| {
+            format!(
+                "Failed to parse PEM certificates from tls_ca '{}' for NATS cluster '{}'",
+                ca_path.display(),
+                server.name
+            )
+        })?;
+    let mut root_store = async_nats::rustls::RootCertStore::empty();
+    let (added, ignored) = root_store.add_parsable_certificates(certs);
+    if added == 0 {
+        bail!(
+            "Failed to parse tls_ca '{}' for NATS cluster '{}' (ignored {ignored} certs)",
+            ca_path.display(),
+            server.name
+        );
+    }
+    let tls_client = async_nats::rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    Ok(Some(tls_client))
+}
+
+fn has_client_certificate(server: &NatsServerConfig) -> bool {
+    server.tls_cert.is_some() || server.tls_key.is_some()
+}
+
+fn should_require_tls(server: &NatsServerConfig) -> bool {
+    server.tls.unwrap_or(false) || has_client_certificate(server) || server.tls_ca.is_some()
+}
+
+fn validate_tls_path(server: &NatsServerConfig, field: &str, value: &str) -> Result<PathBuf> {
+    let path = PathBuf::from(value);
+    if !path.exists() {
+        bail!(
+            "NATS cluster '{}' {} path '{}' does not exist",
+            server.name,
+            field,
+            path.display()
+        );
+    }
+    if !path.is_file() {
+        bail!(
+            "NATS cluster '{}' {} path '{}' is not a file",
+            server.name,
+            field,
+            path.display()
+        );
+    }
+    Ok(path)
+}
+
+fn expand_env_option(value: &mut Option<String>) {
+    if let Some(inner) = value {
+        *inner = expand_env_string(inner);
+    }
+}
+
+fn expand_env_string(value: &str) -> String {
+    shellexpand::env(value).map_or_else(|_| value.to_string(), |expanded| expanded.into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_nats_server_envs_expands_secret_fields() {
+        unsafe {
+            std::env::set_var("NATS_TOKEN", "secret-token");
+            std::env::set_var("NATS_CERT", "/tmp/client-cert.pem");
+            std::env::set_var("NATS_KEY", "/tmp/client-key.pem");
+            std::env::set_var("NATS_CA", "/tmp/ca.pem");
+        }
+
+        let mut server = NatsServerConfig {
+            name: "local".into(),
+            url: "nats://${NATS_TOKEN}@localhost:4222".into(),
+            token: Some("${NATS_TOKEN}".into()),
+            tls: Some(true),
+            tls_cert: Some("${NATS_CERT}".into()),
+            tls_key: Some("${NATS_KEY}".into()),
+            tls_ca: Some("${NATS_CA}".into()),
+        };
+        Config::expand_nats_server_envs(&mut server);
+
+        assert_eq!(server.url, "nats://secret-token@localhost:4222");
+        assert_eq!(server.token.as_deref(), Some("secret-token"));
+        assert_eq!(server.tls_cert.as_deref(), Some("/tmp/client-cert.pem"));
+        assert_eq!(server.tls_key.as_deref(), Some("/tmp/client-key.pem"));
+        assert_eq!(server.tls_ca.as_deref(), Some("/tmp/ca.pem"));
+    }
+
+    #[test]
+    fn build_nats_connect_options_rejects_partial_client_cert_config() {
+        let server = NatsServerConfig {
+            name: "mtls".into(),
+            url: "tls://localhost:4222".into(),
+            token: None,
+            tls: Some(true),
+            tls_cert: Some("/tmp/client-cert.pem".into()),
+            tls_key: None,
+            tls_ca: None,
+        };
+
+        let error = build_nats_connect_options(&server).unwrap_err().to_string();
+        assert!(error.contains("tls_cert"));
+        assert!(error.contains("tls_key"));
+        assert!(error.contains("mtls"));
+    }
+
+    #[test]
+    fn build_nats_connect_options_rejects_missing_tls_file() {
+        let server = NatsServerConfig {
+            name: "secure".into(),
+            url: "tls://localhost:4222".into(),
+            token: Some("token".into()),
+            tls: Some(true),
+            tls_cert: Some("/definitely/missing-cert.pem".into()),
+            tls_key: Some("/definitely/missing-key.pem".into()),
+            tls_ca: None,
+        };
+
+        let error = build_nats_connect_options(&server).unwrap_err().to_string();
+        assert!(error.contains("does not exist"));
+        assert!(error.contains("tls_cert"));
+        assert!(error.contains("secure"));
+    }
+
+    #[test]
+    fn build_nats_connect_options_rejects_custom_ca_with_client_cert() {
+        // async-nats 0.42 cannot attach both a custom root store and a client
+        // cert; the combination must be rejected, not silently dropped.
+        let server = NatsServerConfig {
+            name: "alb".into(),
+            url: "tls://localhost:4222".into(),
+            token: None,
+            tls: Some(true),
+            tls_cert: Some("/tmp/client-cert.pem".into()),
+            tls_key: Some("/tmp/client-key.pem".into()),
+            tls_ca: Some("/tmp/ca.pem".into()),
+        };
+
+        let error = build_nats_connect_options(&server).unwrap_err().to_string();
+        assert!(error.contains("tls_ca"));
+        assert!(error.contains("not supported"));
+        assert!(error.contains("alb"));
+    }
+}

--- a/crates/harnx-runtime/src/config/paths_split.rs
+++ b/crates/harnx-runtime/src/config/paths_split.rs
@@ -34,6 +34,10 @@ impl Config {
         paths::macro_file(name)
     }
 
+    pub fn nats_server_file(name: &str) -> PathBuf {
+        paths::nats_server_file(name)
+    }
+
     pub fn env_file() -> PathBuf {
         paths::env_file()
     }

--- a/crates/harnx-runtime/src/config/persistence_split.rs
+++ b/crates/harnx-runtime/src/config/persistence_split.rs
@@ -75,6 +75,9 @@ impl Config {
         thought: Option<&str>,
         tool_results: &[crate::tool::ToolResult],
     ) -> Result<()> {
+        // NATS persistence path: use block_in_place for async writes
+
+        // Local file persistence path (existing behavior)
         let request = SessionSaveRequest::new(input, output, thought);
         let Some(session) = self.session_for_save(&request) else {
             return Ok(());

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -1,11 +1,46 @@
 use super::input::*;
+use super::session_externalize::{
+    externalize_content, externalize_persisted_messages, externalize_tool_result_content,
+    record_externalized,
+};
 use super::*;
 
 pub use harnx_core::session::{Session, SessionLogEntry};
 
+use std::any::Any;
+use std::sync::{Arc, Mutex};
+
+pub trait SessionAppendSink: Send + Sync + Any {
+    fn append(&self, entry: &SessionLogEntry) -> Result<u64>;
+}
+
+#[derive(Debug)]
+pub(crate) struct FileSessionLogSink {
+    log: Mutex<FileSessionLog>,
+}
+
+impl FileSessionLogSink {
+    pub(crate) fn new(path: &Path, session_name: &str, header: SessionLogEntry) -> Self {
+        Self {
+            log: Mutex::new(FileSessionLog::new_with_header(path, session_name, header)),
+        }
+    }
+}
+
+impl SessionAppendSink for FileSessionLogSink {
+    fn append(&self, entry: &SessionLogEntry) -> Result<u64> {
+        let mut log = self
+            .log
+            .lock()
+            .map_err(|_| anyhow::anyhow!("file session log sink mutex poisoned"))?;
+        log.append_event(entry)
+    }
+}
+
 use crate::client::{CompletionTokenUsage, Message, MessageContent, MessageRole};
 use harnx_core::{
     event::{AgentEvent, SessionEvent},
+    session_log::SessionLog,
     sink::emit_agent_event,
 };
 
@@ -76,8 +111,18 @@ pub fn load(config: &Config, name: &str, path: &Path) -> Result<Session> {
 }
 
 fn load_from_log(config: &Config, name: &str, path: &Path, content: &str) -> Result<Session> {
-    let raw_entries = collect_raw_log_entries(content, name)?;
-    let mut session = replay_log_entries(&raw_entries, name)?;
+    let log = FileSessionLog::new(path, name);
+    let raw_entries = log.load_events()?;
+    debug_assert_eq!(
+        raw_entries.len(),
+        collect_raw_log_entries(content, name)?.len(),
+        "FileSessionLog::load_events changed entry count"
+    );
+    let replay_entries: Vec<_> = raw_entries
+        .iter()
+        .map(|(seq, entry)| (*seq as usize, entry.clone()))
+        .collect();
+    let mut session = replay_log_entries_for_external(&replay_entries, name)?;
     session.log_entry_count = raw_entries.len();
 
     session.model =
@@ -113,103 +158,14 @@ fn build_effective_log_entries(
     raw_entries: &[(usize, SessionLogEntry)],
     name: &str,
 ) -> Vec<(usize, SessionLogEntry)> {
-    let mut effective_entries = Vec::new();
-
-    for (seq, entry) in raw_entries {
-        match entry {
-            SessionLogEntry::Rewind { after_seq } => {
-                if *after_seq >= *seq {
-                    log::warn!(
-                        "Skipping rewind entry #{seq} in session {name}: after_seq {after_seq} must be less than current seq"
-                    );
-                    continue;
-                }
-                if !effective_entries
-                    .iter()
-                    .any(|(existing_seq, _)| existing_seq == after_seq)
-                {
-                    log::warn!(
-                        "Skipping rewind entry #{seq} in session {name}: after_seq {after_seq} not present in replay state"
-                    );
-                    continue;
-                }
-                effective_entries.retain(|(existing_seq, _)| *existing_seq <= *after_seq);
-            }
-            SessionLogEntry::EditEntries {
-                from,
-                to,
-                replacements,
-            } => {
-                if from > to {
-                    log::warn!(
-                        "Skipping edit_entries entry #{seq} in session {name}: invalid range [{from}, {to}]"
-                    );
-                    continue;
-                }
-                if *to >= *seq {
-                    log::warn!(
-                        "Skipping edit_entries entry #{seq} in session {name}: range [{from}, {to}] must reference earlier entries only"
-                    );
-                    continue;
-                }
-
-                let Some(start_idx) = effective_entries
-                    .iter()
-                    .position(|(existing_seq, _)| existing_seq == from)
-                else {
-                    log::warn!(
-                        "Skipping edit_entries entry #{seq} in session {name}: from seq {from} not present in replay state"
-                    );
-                    continue;
-                };
-                let Some(end_idx) = effective_entries
-                    .iter()
-                    .rposition(|(existing_seq, _)| existing_seq == to)
-                else {
-                    log::warn!(
-                        "Skipping edit_entries entry #{seq} in session {name}: to seq {to} not present in replay state"
-                    );
-                    continue;
-                };
-                if start_idx > end_idx {
-                    log::warn!(
-                        "Skipping edit_entries entry #{seq} in session {name}: range [{from}, {to}] not in replay order"
-                    );
-                    continue;
-                }
-
-                let parsed_replacements: Vec<_> = replacements
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(replacement_idx, replacement)| {
-                        match serde_yaml::from_str::<SessionLogEntry>(replacement) {
-                            Ok(parsed) => {
-                                // Replacements inherit EditEntries seq because originals are
-                                // logically removed from effective stream. Future rewind/edit
-                                // operations must target mutation seq, not replaced seqs.
-                                Some((*seq, parsed))
-                            },
-                            Err(err) => {
-                                log::warn!(
-                                    "Skipping replacement #{replacement_idx} in edit_entries entry #{seq} for session {name}: {err}"
-                                );
-                                None
-                            }
-                        }
-                    })
-                    .collect();
-
-                effective_entries.splice(start_idx..=end_idx, parsed_replacements);
-            }
-            SessionLogEntry::Unknown => {}
-            _ => effective_entries.push((*seq, entry.clone())),
-        }
-    }
-
-    effective_entries
+    // Delegate to the canonical implementation in harnx-core
+    harnx_core::session_reconstruct::apply_log_mutations_with_name(raw_entries, name)
 }
 
-fn replay_log_entries(raw_entries: &[(usize, SessionLogEntry)], name: &str) -> Result<Session> {
+pub(crate) fn replay_log_entries_for_external(
+    raw_entries: &[(usize, SessionLogEntry)],
+    name: &str,
+) -> Result<Session> {
     let effective_entries = build_effective_log_entries(raw_entries, name);
     let mut session = Session::default();
 
@@ -261,6 +217,7 @@ fn replay_log_entries(raw_entries: &[(usize, SessionLogEntry)], name: &str) -> R
                 role,
                 content,
                 timestamp,
+                ..
             } => {
                 if let Some(pending) = pending.take() {
                     session
@@ -283,6 +240,7 @@ fn replay_log_entries(raw_entries: &[(usize, SessionLogEntry)], name: &str) -> R
                 thought,
                 calls,
                 timestamp,
+                ..
             } => {
                 if let Some(pending) = pending.take() {
                     session
@@ -338,6 +296,7 @@ fn replay_log_entries(raw_entries: &[(usize, SessionLogEntry)], name: &str) -> R
                 session.compressed_messages.clear();
                 session.data_urls.clear();
             }
+            SessionLogEntry::Cancel { .. } => {}
             SessionLogEntry::EditEntries { .. }
             | SessionLogEntry::Rewind { .. }
             | SessionLogEntry::Unknown => {}
@@ -360,7 +319,8 @@ fn replay_log_entries(raw_entries: &[(usize, SessionLogEntry)], name: &str) -> R
 #[cfg(test)]
 fn load_from_log_for_test(content: &str) -> Session {
     let raw_entries = collect_raw_log_entries(content, "test").expect("valid log entries");
-    let mut session = replay_log_entries(&raw_entries, "test").expect("replay should succeed");
+    let mut session =
+        replay_log_entries_for_external(&raw_entries, "test").expect("replay should succeed");
     session.log_entry_count = raw_entries.len();
     session
 }
@@ -451,6 +411,105 @@ fn assemble_tool_message(
     )
 }
 
+#[derive(Debug)]
+pub(crate) struct FileSessionLog {
+    path: std::path::PathBuf,
+    session_name: String,
+    next_seq: Option<u64>,
+    initial_header: Option<SessionLogEntry>,
+}
+
+impl FileSessionLog {
+    fn new(path: &Path, session_name: &str) -> Self {
+        Self {
+            path: path.to_path_buf(),
+            session_name: session_name.to_string(),
+            next_seq: None,
+            initial_header: None,
+        }
+    }
+
+    fn new_with_header(path: &Path, session_name: &str, header: SessionLogEntry) -> Self {
+        Self {
+            path: path.to_path_buf(),
+            session_name: session_name.to_string(),
+            next_seq: None,
+            initial_header: Some(header),
+        }
+    }
+}
+
+impl SessionLog for FileSessionLog {
+    fn append_event(&mut self, entry: &SessionLogEntry) -> Result<u64> {
+        let assigned_seq = match self.next_seq {
+            Some(seq) => seq,
+            None => match self.load_events() {
+                Ok(entries) => entries.len() as u64,
+                Err(_)
+                    if !self.path.exists()
+                        || self
+                            .path
+                            .metadata()
+                            .is_ok_and(|metadata| metadata.len() == 0) =>
+                {
+                    let Some(header) = &self.initial_header else {
+                        return self.load_events().map(|entries| entries.len() as u64);
+                    };
+                    ensure_parent_exists(&self.path)?;
+                    let content = serde_yaml::to_string(header).with_context(|| {
+                        format!(
+                            "Failed to serialize session header in '{}'",
+                            self.session_name
+                        )
+                    })?;
+                    write(&self.path, content).with_context(|| {
+                        format!(
+                            "Failed to initialize session {} at {}",
+                            self.session_name,
+                            self.path.display()
+                        )
+                    })?;
+                    1
+                }
+                Err(err) => return Err(err),
+            },
+        };
+        let yaml = serde_yaml::to_string(entry)
+            .with_context(|| format!("Failed to serialize log entry in '{}'", self.session_name))?;
+        let mut data = String::from("---\n");
+        data.push_str(&yaml);
+        let mut file = OpenOptions::new().append(true).open(&self.path)?;
+        file.write_all(data.as_bytes())?;
+        self.next_seq = Some(assigned_seq + 1);
+        Ok(assigned_seq)
+    }
+
+    fn load_events(&self) -> Result<Vec<(u64, SessionLogEntry)>> {
+        let content = read_to_string(&self.path).with_context(|| {
+            format!(
+                "Failed to load session {} at {}",
+                self.session_name,
+                self.path.display()
+            )
+        })?;
+        collect_raw_log_entries(&content, &self.session_name).map(|entries| {
+            entries
+                .into_iter()
+                .map(|(seq, entry)| (seq as u64, entry))
+                .collect()
+        })
+    }
+
+    fn replay_from(&self, seq: u64) -> Result<Vec<SessionLogEntry>> {
+        Ok(self
+            .load_events()?
+            .into_iter()
+            .filter(|(entry_seq, _)| *entry_seq >= seq)
+            .map(|(_, entry)| entry)
+            .collect())
+    }
+}
+
 fn apply_name_and_path(
     session: &mut Session,
     name: &str,
@@ -523,24 +582,29 @@ pub fn ensure_log_file(session: &mut Session) {
 /// Lazily initializes the log file on the first call.
 /// Returns true if the entry was successfully written.
 pub fn append_event(session: &mut Session, entry: &SessionLogEntry) -> bool {
+    if let Some(runtime) = session.runtime.as_ref() {
+        if let Some(append_sink) = runtime.downcast_ref::<Arc<dyn SessionAppendSink>>() {
+            return match append_sink.append(entry) {
+                Ok(seq) => {
+                    session.log_entry_count = seq as usize + 1;
+                    true
+                }
+                Err(_) => false,
+            };
+        }
+    }
+
     ensure_log_file(session);
     let Some(path_str) = &session.path else {
         return false;
     };
-    let path = Path::new(path_str);
-    let Ok(yaml) = serde_yaml::to_string(entry) else {
-        return false;
-    };
-    let mut data = String::from("---\n");
-    data.push_str(&yaml);
-    let Ok(mut file) = OpenOptions::new().append(true).open(path) else {
-        return false;
-    };
-    if file.write_all(data.as_bytes()).is_ok() {
-        session.log_entry_count += 1;
-        true
-    } else {
-        false
+    let mut log = FileSessionLog::new(Path::new(path_str), &session.id);
+    match log.append_event(entry) {
+        Ok(seq) => {
+            session.log_entry_count = seq as usize + 1;
+            true
+        }
+        Err(_) => false,
     }
 }
 
@@ -644,6 +708,7 @@ fn append_message_entries(content: &mut String, msg: &Message, session_id: &str)
                 thought: tc.thought.clone(),
                 calls,
                 timestamp: None,
+                fence_token: None,
             };
             content.push_str("---\n");
             content
@@ -677,9 +742,11 @@ fn append_message_entries(content: &mut String, msg: &Message, session_id: &str)
     }
 
     let entry = SessionLogEntry::Message {
+        id: None,
         role: msg.role,
         content: msg.content.clone(),
         timestamp: None,
+        fence_token: None,
     };
     content.push_str("---\n");
     content.push_str(
@@ -865,6 +932,7 @@ fn relog_message(session: &mut Session, msg: &Message) -> usize {
                     thought: tc.thought.clone(),
                     calls,
                     timestamp: msg.log_timestamp,
+                    fence_token: None,
                 },
             );
             let results: Vec<harnx_core::session::ToolOutput> = tc
@@ -894,9 +962,11 @@ fn relog_message(session: &mut Session, msg: &Message) -> usize {
     if !append_event(
         session,
         &SessionLogEntry::Message {
+            id: None,
             role: msg.role,
             content: msg.content.clone(),
             timestamp: msg.log_timestamp,
+            fence_token: None,
         },
     ) {
         session.dirty = true;
@@ -942,9 +1012,11 @@ pub fn add_assistant_text(
         all_appended &= append_event(
             session,
             &SessionLogEntry::Message {
+                id: None,
                 role: assistant_msg.role,
                 content: assistant_msg.content.clone(),
                 timestamp: Some(timestamp),
+                fence_token: None,
             },
         );
         session.messages.push(assistant_msg);
@@ -984,6 +1056,7 @@ pub fn add_tool_calls(
             thought: thought.map(str::to_string),
             calls: calls.clone(),
             timestamp: Some(Utc::now()),
+            fence_token: None,
         },
     );
     emit_agent_event(AgentEvent::Session(SessionEvent::LogSeqAssigned {
@@ -1116,166 +1189,66 @@ fn is_tool_continuation(input: &Input, messages: &[Message]) -> bool {
     input.tool_calls.is_some() && messages.last().is_some_and(|m| m.role == MessageRole::Tool)
 }
 
-/// Externalize inline image data URIs in a single message's content — both
-/// plain content arrays and tool-result content — into `cid:` references,
-/// writing files to `dir` and recording `cid -> filename` in `map`. On partial
-/// failure, keeps whatever was already externalized (those files are on disk
-/// and their refs are already in `content`).
-fn externalize_message(
-    dir: &std::path::Path,
-    content: &mut MessageContent,
-    map: &mut std::collections::HashMap<String, String>,
-) {
-    let result = match content {
-        MessageContent::Array(parts) => {
-            crate::config::attachments::externalize_parts(dir, parts, map)
-        }
-        MessageContent::ToolCalls(tool_calls) => {
-            let mut res = Ok(());
-            for tool_result in tool_calls.tool_results.iter_mut() {
-                if let Err(err) = crate::config::attachments::externalize_parts(
-                    dir,
-                    &mut tool_result.content,
-                    map,
-                ) {
-                    res = Err(err);
-                }
-            }
-            res
-        }
-        MessageContent::Text(_) => Ok(()),
-    };
-    if let Err(err) = result {
-        log::warn!("attachment externalization failed: {err}");
-    }
-}
-
-/// Rewrite inline image data URIs in `content` to `cid:` references in place,
-/// writing the bytes to the session's attachments dir. Returns the
-/// `cid -> filename` map of newly externalized blobs (empty when there are
-/// none, or when the session has no saved path yet — in which case the blob
-/// stays inline and is externalized on a later save).
-fn externalize_content(
-    session: &Session,
-    content: &mut MessageContent,
-) -> std::collections::HashMap<String, String> {
-    let mut map = std::collections::HashMap::new();
-    let Some(path) = session.path.as_deref() else {
-        return map;
-    };
-    let dir = crate::config::attachments::attachments_dir_for(std::path::Path::new(path));
-    externalize_message(&dir, content, &mut map);
-    map
-}
-
-/// Externalize inline image data URIs across a slice of tool results into
-/// `cid:` references, recording `cid -> filename` in `map`. No-op when the
-/// session has no attachments dir yet.
-fn externalize_tool_result_content(
-    dir: Option<&std::path::Path>,
-    results: &mut [crate::tool::ToolResult],
-    map: &mut std::collections::HashMap<String, String>,
-) {
-    let Some(dir) = dir else {
-        return;
-    };
-    for slot in results.iter_mut() {
-        if let Err(err) = crate::config::attachments::externalize_parts(dir, &mut slot.content, map)
-        {
-            log::warn!("tool-result attachment externalization failed: {err}");
-        }
-    }
-}
-
-/// Externalize still-inline image content across every stored message
-/// (compressed + active) into the session's attachments dir, merging the new
-/// `cid -> filename` mappings into the session map. Idempotent — used by the
-/// full-rewrite `save()` to migrate first-turn/legacy inline blobs.
-fn externalize_persisted_messages(session: &mut Session, session_path: &std::path::Path) {
-    let dir = crate::config::attachments::attachments_dir_for(session_path);
-    let mut map = std::collections::HashMap::new();
-    for msg in session.compressed_messages.iter_mut() {
-        externalize_message(&dir, &mut msg.content, &mut map);
-    }
-    for msg in session.messages.iter_mut() {
-        externalize_message(&dir, &mut msg.content, &mut map);
-    }
-    session.data_urls.extend(map);
-}
-
-/// Record freshly externalized `cid -> filename` mappings: append a `DataUrls`
-/// log entry and merge them into the session map. No-op when empty. Returns
-/// whether the append (if any) succeeded.
-fn record_externalized(
-    session: &mut Session,
-    cid_urls: std::collections::HashMap<String, String>,
-) -> bool {
-    if cid_urls.is_empty() {
-        return true;
-    }
-    let appended = append_event(
-        session,
-        &SessionLogEntry::DataUrls {
-            urls: cid_urls.clone(),
-        },
-    );
-    session.data_urls.extend(cid_urls);
-    appended
-}
-
-/// Shared round-opening setup used by both `add_assistant_text` and
-/// `add_tool_calls`: first-turn agent-message injection, user-message
-/// push (skipped on continuation rounds), data-URL persistence, and
-/// any queued injected-user-text.  Returns `true` iff every log
-/// append succeeded.
 fn begin_turn(session: &mut Session, input: &Input, _output: &str) -> Result<bool> {
     let mut all_appended = true;
     let is_continuation = is_tool_continuation(input, &session.messages);
+
     if session.messages.is_empty() {
-        let agent_messages = input.agent().build_messages(input)?;
-        let mut cid_urls = std::collections::HashMap::new();
-        for mut msg in agent_messages {
-            // `externalize_content` only writes files + rewrites `content` in
-            // memory (takes `&Session`, cannot append), so `seq` stays correct.
-            let seq = session.next_seq();
-            cid_urls.extend(externalize_content(session, &mut msg.content));
-            all_appended &= append_event(
-                session,
-                &SessionLogEntry::Message {
-                    role: msg.role,
-                    content: msg.content.clone(),
-                    timestamp: Some(Utc::now()),
-                },
-            );
-            session.messages.push(msg.with_log_seq(seq));
-        }
-        // Seq-less metadata record for the cids written above; appended after
-        // the messages so message log_seqs are unaffected.
-        all_appended &= record_externalized(session, cid_urls);
-    } else if !is_continuation {
-        // `seq` is the message's log-document index. `externalize_content` only
-        // writes attachment files + rewrites `content` in memory (it takes
-        // `&Session`, so it cannot append), so nothing must be appended between
-        // here and the Message append below or `seq` would be off by one. The
-        // cid DataUrls entry is a seq-less metadata record appended *after* the
-        // message.
-        let seq = session.next_seq();
-        let mut content = input.message_content();
-        let cid_urls = externalize_content(session, &mut content);
-        let user_msg = Message::new(MessageRole::User, content).with_log_seq(seq);
-        all_appended &= append_event(
-            session,
-            &SessionLogEntry::Message {
-                role: user_msg.role,
-                content: user_msg.content.clone(),
-                timestamp: Some(Utc::now()),
-            },
-        );
-        session.messages.push(user_msg);
-        emit_agent_event(AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }));
-        all_appended &= record_externalized(session, cid_urls);
+        all_appended &= append_initial_agent_messages(session, input)?;
+    } else if !is_continuation && !input.skip_user_log_append {
+        // `skip_user_log_append` is set by the NATS HA worker: the user
+        // message is already durably logged by the client and present in the
+        // loaded `session.messages`, so re-appending it would duplicate it and
+        // reorder the assistant barrier past concurrent arrivals.
+        all_appended &= append_user_turn_message(session, input);
     }
+
+    all_appended &= append_input_data_urls(session, input);
+    all_appended &= append_injected_user_text(session, input);
+    Ok(all_appended)
+}
+
+fn append_initial_agent_messages(session: &mut Session, input: &Input) -> Result<bool> {
+    let agent_messages = input.agent().build_messages(input)?;
+    let mut all_appended = true;
+    let mut cid_urls = std::collections::HashMap::new();
+
+    for mut msg in agent_messages {
+        // `externalize_content` only writes files + rewrites `content` in
+        // memory (takes `&Session`, cannot append), so `seq` stays correct.
+        let seq = session.next_seq();
+        cid_urls.extend(externalize_content(session, &mut msg.content));
+        all_appended &= append_session_message(session, msg.role, msg.content.clone());
+        session.messages.push(msg.with_log_seq(seq));
+    }
+
+    // Seq-less metadata record for the cids written above; appended after
+    // the messages so message log_seqs are unaffected.
+    all_appended &= record_externalized(session, cid_urls);
+    Ok(all_appended)
+}
+
+fn append_user_turn_message(session: &mut Session, input: &Input) -> bool {
+    // `seq` is the message's log-document index. `externalize_content` only
+    // writes attachment files + rewrites `content` in memory (it takes
+    // `&Session`, so it cannot append), so nothing must be appended between
+    // here and the Message append below or `seq` would be off by one. The
+    // cid DataUrls entry is a seq-less metadata record appended *after* the
+    // message.
+    let seq = session.next_seq();
+    let mut content = input.message_content();
+    let cid_urls = externalize_content(session, &mut content);
+    let user_msg = Message::new(MessageRole::User, content).with_log_seq(seq);
+    let mut all_appended = append_session_message(session, user_msg.role, user_msg.content.clone());
+    session.messages.push(user_msg);
+    emit_agent_event(AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }));
+    all_appended &= record_externalized(session, cid_urls);
+    all_appended
+}
+
+fn append_input_data_urls(session: &mut Session, input: &Input) -> bool {
     let new_data_urls = input.data_urls();
+    let mut all_appended = true;
     if !new_data_urls.is_empty() {
         all_appended &= append_event(
             session,
@@ -1285,25 +1258,42 @@ fn begin_turn(session: &mut Session, input: &Input, _output: &str) -> Result<boo
         );
     }
     session.data_urls.extend(new_data_urls);
-    if let Some(injected) = input.injected_user_text() {
-        let seq = session.next_seq();
-        let injected_msg = Message::new(
-            MessageRole::User,
-            MessageContent::Text(injected.to_string()),
-        )
-        .with_log_seq(seq);
-        all_appended &= append_event(
-            session,
-            &SessionLogEntry::Message {
-                role: injected_msg.role,
-                content: injected_msg.content.clone(),
-                timestamp: Some(Utc::now()),
-            },
-        );
-        session.messages.push(injected_msg);
-        emit_agent_event(AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }));
-    }
-    Ok(all_appended)
+    all_appended
+}
+
+fn append_injected_user_text(session: &mut Session, input: &Input) -> bool {
+    let Some(injected) = input.injected_user_text() else {
+        return true;
+    };
+
+    let seq = session.next_seq();
+    let injected_msg = Message::new(
+        MessageRole::User,
+        MessageContent::Text(injected.to_string()),
+    )
+    .with_log_seq(seq);
+    let all_appended =
+        append_session_message(session, injected_msg.role, injected_msg.content.clone());
+    session.messages.push(injected_msg);
+    emit_agent_event(AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }));
+    all_appended
+}
+
+fn append_session_message(
+    session: &mut Session,
+    role: MessageRole,
+    content: MessageContent,
+) -> bool {
+    append_event(
+        session,
+        &SessionLogEntry::Message {
+            id: None,
+            role,
+            content,
+            timestamp: Some(Utc::now()),
+            fence_token: None,
+        },
+    )
 }
 
 pub fn clear_messages(session: &mut Session) {
@@ -2856,7 +2846,9 @@ content: second
         let appended = super::append_event(
             &mut session,
             &SessionLogEntry::Message {
+                id: None,
                 timestamp: None,
+                fence_token: None,
                 role: MessageRole::User,
                 content: MessageContent::Text("third".to_string()),
             },
@@ -3164,7 +3156,7 @@ content: second
             },
         ]);
 
-        let map = super::externalize_content(&session, &mut content);
+        let map = super::session_externalize::externalize_content(&session, &mut content);
         assert_eq!(map.len(), 1, "one cid recorded");
         assert!(
             map.keys().next().unwrap().starts_with("cid:"),

--- a/crates/harnx-runtime/src/config/session_edit_tests.rs
+++ b/crates/harnx-runtime/src/config/session_edit_tests.rs
@@ -11,6 +11,7 @@ use harnx_core::{
 fn tool_calls_yaml(call_ids: &[&str]) -> String {
     serde_yaml::to_string(&SessionLogEntry::ToolCalls {
         timestamp: None,
+        fence_token: None,
         text: String::new(),
         thought: None,
         calls: call_ids
@@ -54,7 +55,9 @@ fn tool_results_yaml_with_optional_ids(result_ids: &[Option<String>]) -> String 
 
 fn user_yaml(text: &str) -> String {
     serde_yaml::to_string(&SessionLogEntry::Message {
+        id: None,
         timestamp: None,
+        fence_token: None,
         role: MessageRole::User,
         content: MessageContent::Text(text.to_string()),
     })
@@ -63,11 +66,40 @@ fn user_yaml(text: &str) -> String {
 
 fn assistant_yaml(text: &str) -> String {
     serde_yaml::to_string(&SessionLogEntry::Message {
+        id: None,
         timestamp: None,
+        fence_token: None,
         role: MessageRole::Assistant,
         content: MessageContent::Text(text.to_string()),
     })
     .unwrap()
+}
+
+/// Build a `Config` wired with a dummy `test:model` client and an isolated
+/// sessions dir, for the message-edit tests.
+fn editor_test_config(sessions_dir: std::path::PathBuf) -> Config {
+    let mut config = Config {
+        sessions_dir_override: Some(sessions_dir),
+        working_mode: WorkingMode::Cmd,
+        ..Config::default()
+    };
+    config
+        .clients
+        .push(harnx_client::ClientConfig::OpenAICompatibleConfig(
+            harnx_core::provider_config::openai_compatible::OpenAICompatibleConfig {
+                name: "test".to_string(),
+                api_base: None,
+                api_key: None,
+                models: vec![],
+                patches: None,
+                extra: None,
+                system_prompt_prefix: None,
+                package: None,
+            },
+        ));
+    config.model = harnx_client::Model::new("test", "model");
+    config.model_id = "test:model".to_string();
+    config
 }
 
 #[test]
@@ -190,34 +222,16 @@ fn edit_message_range_supports_reordering_plain_messages() {
     std::env::set_var("EDITOR", "true");
 
     let result = (|| -> Result<()> {
-        let mut config = Config {
-            sessions_dir_override: Some(tmp.path().to_path_buf()),
-            working_mode: WorkingMode::Cmd,
-            ..Config::default()
-        };
-        config
-            .clients
-            .push(harnx_client::ClientConfig::OpenAICompatibleConfig(
-                harnx_core::provider_config::openai_compatible::OpenAICompatibleConfig {
-                    name: "test".to_string(),
-                    api_base: None,
-                    api_key: None,
-                    models: vec![],
-                    patches: None,
-                    extra: None,
-                    system_prompt_prefix: None,
-                    package: None,
-                },
-            ));
-        config.model = harnx_client::Model::new("test", "model");
-        config.model_id = "test:model".to_string();
+        let mut config = editor_test_config(tmp.path().to_path_buf());
         config.use_session(Some("reorder"))?;
 
         let session = config.session.as_mut().context("No session")?;
         assert!(crate::config::session::append_event(
             session,
             &SessionLogEntry::Message {
+                id: None,
                 timestamp: None,
+                fence_token: None,
                 role: MessageRole::User,
                 content: MessageContent::Text("first".to_string()),
             },
@@ -225,7 +239,9 @@ fn edit_message_range_supports_reordering_plain_messages() {
         assert!(crate::config::session::append_event(
             session,
             &SessionLogEntry::Message {
+                id: None,
                 timestamp: None,
+                fence_token: None,
                 role: MessageRole::Assistant,
                 content: MessageContent::Text("second".to_string()),
             },
@@ -284,6 +300,7 @@ fn make_docs(entries: &[SessionLogEntry]) -> Vec<String> {
 fn tool_calls_entry(id: &str) -> SessionLogEntry {
     SessionLogEntry::ToolCalls {
         timestamp: None,
+        fence_token: None,
         text: String::new(),
         thought: None,
         calls: vec![ToolCall {
@@ -310,7 +327,9 @@ fn tool_results_entry(id: &str) -> SessionLogEntry {
 
 fn user_entry(text: &str) -> SessionLogEntry {
     SessionLogEntry::Message {
+        id: None,
         timestamp: None,
+        fence_token: None,
         role: MessageRole::User,
         content: MessageContent::Text(text.to_string()),
     }

--- a/crates/harnx-runtime/src/config/session_externalize.rs
+++ b/crates/harnx-runtime/src/config/session_externalize.rs
@@ -1,0 +1,112 @@
+use super::{Session, SessionLogEntry};
+
+use crate::client::MessageContent;
+use crate::tool::ToolResult;
+
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Externalize inline image data URIs in a single message's content — both
+/// plain content arrays and tool-result content — into `cid:` references,
+/// writing files to `dir` and recording `cid -> filename` in `map`. On partial
+/// failure, keeps whatever was already externalized (those files are on disk
+/// and their refs are already in `content`).
+pub(crate) fn externalize_message(
+    dir: &Path,
+    content: &mut MessageContent,
+    map: &mut HashMap<String, String>,
+) {
+    let result = match content {
+        MessageContent::Array(parts) => {
+            crate::config::attachments::externalize_parts(dir, parts, map)
+        }
+        MessageContent::ToolCalls(tool_calls) => {
+            let mut res = Ok(());
+            for tool_result in tool_calls.tool_results.iter_mut() {
+                if let Err(err) = crate::config::attachments::externalize_parts(
+                    dir,
+                    &mut tool_result.content,
+                    map,
+                ) {
+                    res = Err(err);
+                }
+            }
+            res
+        }
+        MessageContent::Text(_) => Ok(()),
+    };
+    if let Err(err) = result {
+        log::warn!("attachment externalization failed: {err}");
+    }
+}
+
+/// Externalize inline image data URIs in a single message content into `cid:`
+/// references and return any new `cid -> filename` mappings for later
+/// persistence. No-op for non-session-backed runs.
+pub(crate) fn externalize_content(
+    session: &Session,
+    content: &mut MessageContent,
+) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let Some(path) = session.path.as_deref() else {
+        return map;
+    };
+    let dir = crate::config::attachments::attachments_dir_for(Path::new(path));
+    externalize_message(&dir, content, &mut map);
+    map
+}
+
+/// Externalize inline image data URIs across a slice of tool results into
+/// `cid:` references, recording `cid -> filename` in `map`. No-op when the
+/// session has no attachments dir yet.
+pub(crate) fn externalize_tool_result_content(
+    dir: Option<&Path>,
+    results: &mut [ToolResult],
+    map: &mut HashMap<String, String>,
+) {
+    let Some(dir) = dir else {
+        return;
+    };
+    for slot in results.iter_mut() {
+        if let Err(err) = crate::config::attachments::externalize_parts(dir, &mut slot.content, map)
+        {
+            log::warn!("tool-result attachment externalization failed: {err}");
+        }
+    }
+}
+
+/// Externalize still-inline image content across every stored message
+/// (compressed + active) into the session's attachments dir, merging the new
+/// `cid -> filename` mappings into the session map. Idempotent — used by the
+/// full-rewrite `save()` to migrate first-turn/legacy inline blobs.
+pub(crate) fn externalize_persisted_messages(session: &mut Session, session_path: &Path) {
+    let dir = crate::config::attachments::attachments_dir_for(session_path);
+    let mut map = HashMap::new();
+    for msg in session.compressed_messages.iter_mut() {
+        externalize_message(&dir, &mut msg.content, &mut map);
+    }
+    for msg in session.messages.iter_mut() {
+        externalize_message(&dir, &mut msg.content, &mut map);
+    }
+    session.data_urls.extend(map);
+}
+
+/// Record freshly externalized `cid -> filename` mappings: append a `DataUrls`
+/// log entry and merge them into the session map. No-op when empty. Returns
+/// whether the append (if any) succeeded.
+pub(crate) fn record_externalized(
+    session: &mut Session,
+    cid_urls: HashMap<String, String>,
+) -> bool {
+    if cid_urls.is_empty() {
+        return true;
+    }
+    let appended = crate::config::session::append_event(
+        session,
+        &SessionLogEntry::DataUrls {
+            urls: cid_urls.clone(),
+        },
+    );
+    session.data_urls.extend(cid_urls);
+    appended
+}

--- a/crates/harnx-runtime/src/config/session_ops_compaction.rs
+++ b/crates/harnx-runtime/src/config/session_ops_compaction.rs
@@ -1,0 +1,207 @@
+use super::*;
+
+/// Rendered transcript of the messages to compact, plus the split index, the
+/// covered log-seq range `(from, to, count)`, and the session id.
+type CompactionTranscript = (String, usize, (Option<usize>, Option<usize>, usize), String);
+
+impl Config {
+    pub fn maybe_compact_session(config: GlobalConfig) {
+        let mut need_compact = false;
+        let mut msg_count = 0usize;
+        let mut already_compacting = false;
+        {
+            let mut config = config.write();
+            let compress_threshold = config.compress_threshold;
+            if let Some(session) = config.session.as_mut() {
+                if session.need_compress(compress_threshold) {
+                    already_compacting = session.compressing();
+                    msg_count = session.messages.len();
+                    session.set_compressing(true);
+                    need_compact = true;
+                }
+            }
+        };
+        if !need_compact {
+            return;
+        }
+        if already_compacting {
+            log::warn!(
+                "compaction: triggered while a previous compaction is still in \
+                 progress (messages={msg_count}) — overlapping compaction tasks"
+            );
+        }
+        log::info!("compaction: started (messages={msg_count})");
+        let started = std::time::Instant::now();
+        let compacting_session_id = config
+            .read()
+            .session
+            .as_ref()
+            .map(|session| session.id.clone());
+        harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
+            harnx_core::event::SessionEvent::CompactingStarted,
+        ));
+        tokio::spawn(async move {
+            let result = Config::compact_session(&config).await;
+            if let Some(compacting_session_id) = compacting_session_id.as_deref() {
+                if let Some(session) = config.write().session.as_mut() {
+                    if session.id == compacting_session_id {
+                        session.set_compressing(false);
+                    }
+                }
+            }
+            match &result {
+                Ok(()) => {
+                    log::info!(
+                        "compaction: completed in {:?} (messages_before={msg_count})",
+                        started.elapsed()
+                    );
+                    harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
+                        harnx_core::event::SessionEvent::CompactingCompleted,
+                    ));
+                }
+                Err(err) => {
+                    warn!(
+                        "Failed to compact the session after {:?}: {err}",
+                        started.elapsed()
+                    );
+                    harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
+                        harnx_core::event::SessionEvent::CompactingFailed(err.to_string()),
+                    ));
+                }
+            }
+        });
+    }
+
+    pub async fn compact_session(config: &GlobalConfig) -> Result<()> {
+        Self::ensure_compactable(config)?;
+
+        let summarizer_agent = match Self::resolve_compaction_agent(config) {
+            Some(agent) => agent.into_config(),
+            None => harnx_core::agent_config::AgentConfig::from_prompt(
+                crate::config::compaction::DEFAULT_COMPACT_SYSTEM_PROMPT,
+            ),
+        };
+        let params = crate::config::compaction::compaction_params(&summarizer_agent);
+
+        let (transcript, split, covered, session_id) =
+            Self::build_compaction_transcript(config, &params)?;
+
+        let mut input = harnx_core::input::Input::new(
+            transcript.clone(),
+            (transcript, vec![]),
+            summarizer_agent,
+        );
+        input.with_session = false;
+        input.with_agent = true;
+
+        let summary = crate::config::input::fetch_chat_text(&input, config).await?;
+
+        let summary_with_note = append_recovery_note(summary, covered);
+        Self::apply_compaction_summary(config, &session_id, summary_with_note, split);
+        Ok(())
+    }
+
+    /// Validate that the current session exists and has user messages to compact.
+    fn ensure_compactable(config: &GlobalConfig) -> Result<()> {
+        let guard = config.read();
+        let session = guard.session.as_ref().context("No session")?;
+        if !session.has_user_messages() {
+            bail!("No need to compact since there are no messages in the session");
+        }
+        Ok(())
+    }
+
+    /// Write the compaction summary back into the session, but only if the
+    /// active session is still the one we compacted (it may have been swapped).
+    /// Returns whether the summary was applied.
+    pub(crate) fn apply_compaction_summary(
+        config: &GlobalConfig,
+        session_id: &str,
+        summary_with_note: String,
+        split: usize,
+    ) -> bool {
+        let mut guard = config.write();
+        let Some(session) = guard.session.as_mut() else {
+            return false;
+        };
+        if session.id != session_id {
+            return false;
+        }
+        crate::config::session::compress_keeping_recent(session, summary_with_note, split);
+        guard.discontinuous_last_message();
+        true
+    }
+
+    /// Resolve the configured `compaction_agent` (if any) for the active agent,
+    /// applying package-relative name resolution and variable interpolation.
+    /// Returns `None` (use the default compaction prompt) when not configured or
+    /// when the agent fails to load/resolve.
+    fn resolve_compaction_agent(config: &GlobalConfig) -> Option<crate::config::agent::Agent> {
+        let active_agent_name = config.read().extract_agent().name().to_string();
+        let active_pkg = harnx_core::package_namespace::pkg_from_qualified(&active_agent_name);
+        let name = config
+            .read()
+            .extract_agent()
+            .compaction_agent()
+            .map(str::to_owned)?;
+
+        let resolved_name =
+            harnx_core::package_namespace::resolve_package_relative_name(&name, active_pkg);
+        match config.read().retrieve_agent(&resolved_name) {
+            Ok(mut compaction_agent) => {
+                if let Err(e) = self::agent::resolve_variables(&mut compaction_agent) {
+                    warn!("Failed to resolve variables for compaction_agent '{name}': {e}");
+                }
+                Some(compaction_agent)
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to load compaction_agent '{name}': {e}; falling back to default compaction"
+                );
+                None
+            }
+        }
+    }
+
+    /// Compute the prefix split point and render the transcript of messages to
+    /// be compacted, along with the covered log-seq range and session id.
+    fn build_compaction_transcript(
+        config: &GlobalConfig,
+        params: &crate::config::compaction::CompactionParams,
+    ) -> Result<CompactionTranscript> {
+        let guard = config.read();
+        let session = guard.session.as_ref().context("No session")?;
+        let session_id = session.id.clone();
+        let model = session.model().clone();
+        let split = crate::config::compaction::split_index(
+            &session.messages,
+            &model,
+            params.keep_recent_turns,
+            params.keep_recent_tokens,
+        );
+        if split == 0 {
+            bail!("Nothing to compact");
+        }
+        let prefix = &session.messages[..split];
+        let transcript =
+            crate::config::compaction::render_transcript(prefix, params.tool_output_max_chars);
+        let from = prefix.iter().filter_map(|m| m.log_seq).min();
+        let to = prefix.iter().filter_map(|m| m.log_seq).max();
+        Ok((transcript, split, (from, to, prefix.len()), session_id))
+    }
+}
+
+/// Append short recovery note describing compacted range so future
+/// reader knows detail is recoverable from on-disk log.
+fn append_recovery_note(summary: String, covered: (Option<usize>, Option<usize>, usize)) -> String {
+    let (from, to, count) = covered;
+    let range = match (from, to) {
+        (Some(a), Some(b)) => format!(" (log entries {a}–{b})"),
+        _ => String::new(),
+    };
+    format!(
+        "{summary}\n\n[Earlier conversation: {count} message(s){range} were summarized above. \
+The full pre-compaction transcript remains in this session's log; use the \
+`harnx_agent_session_history_read` tool to search it by entry index, type, tool name, or text.]"
+    )
+}

--- a/crates/harnx-runtime/src/config/session_ops_split.rs
+++ b/crates/harnx-runtime/src/config/session_ops_split.rs
@@ -28,6 +28,15 @@ impl Config {
             // on the first event (avoids creating empty files in tests).
             // Must be set before any add_message() call that triggers logging.
             session.set_sessions_dir(sessions_dir);
+            if session.runtime.is_none() {
+                let session_path = self.session_file(&session.id);
+                session.runtime = Some(Arc::new(Arc::new(self::session::FileSessionLogSink::new(
+                    &session_path,
+                    &session.id,
+                    session.build_header_entry(),
+                ))
+                    as Arc<dyn self::session::SessionAppendSink>));
+            }
             if session.is_empty() {
                 new_session = true;
                 if let Some(LastMessage {
@@ -409,188 +418,10 @@ impl Config {
         }
     }
 
-    pub fn maybe_compact_session(config: GlobalConfig) {
-        let mut need_compact = false;
-        // Instrumentation for the intermittent OOM (#842), which the user has
-        // seen correlate with compaction at the end of a turn. Record the
-        // session size at trigger time and flag a re-entrant trigger (a fresh
-        // compaction starting while a previous one is still running), which
-        // would point at overlapping compaction tasks as the memory source.
-        let mut msg_count = 0usize;
-        let mut already_compacting = false;
-        {
-            let mut config = config.write();
-            let compress_threshold = config.compress_threshold;
-            if let Some(session) = config.session.as_mut() {
-                if session.need_compress(compress_threshold) {
-                    already_compacting = session.compressing();
-                    msg_count = session.messages.len();
-                    session.set_compressing(true);
-                    need_compact = true;
-                }
-            }
-        };
-        if !need_compact {
-            return;
-        }
-        if already_compacting {
-            log::warn!(
-                "compaction: triggered while a previous compaction is still in \
-                 progress (messages={msg_count}) — overlapping compaction tasks"
-            );
-        }
-        log::info!("compaction: started (messages={msg_count})");
-        let started = std::time::Instant::now();
-        // Use SessionEvent for consistent TUI/CLI handling.
-        // The TUI will render CompactingStarted/CompactingCompleted as transcript items.
-        harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
-            harnx_core::event::SessionEvent::CompactingStarted,
-        ));
-        tokio::spawn(async move {
-            let result = Config::compact_session(&config).await;
-            if let Some(session) = config.write().session.as_mut() {
-                session.set_compressing(false);
-            }
-            match &result {
-                Ok(()) => {
-                    log::info!(
-                        "compaction: completed in {:?} (messages_before={msg_count})",
-                        started.elapsed()
-                    );
-                    harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
-                        harnx_core::event::SessionEvent::CompactingCompleted,
-                    ));
-                }
-                Err(err) => {
-                    warn!(
-                        "Failed to compact the session after {:?}: {err}",
-                        started.elapsed()
-                    );
-                    harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
-                        harnx_core::event::SessionEvent::CompactingFailed(err.to_string()),
-                    ));
-                }
-            }
-        });
-    }
-
-    pub async fn compact_session(config: &GlobalConfig) -> Result<()> {
-        match config.read().session.as_ref() {
-            Some(session) => {
-                if !session.has_user_messages() {
-                    bail!("No need to compact since there are no messages in the session")
-                }
-            }
-            None => bail!("No session"),
-        }
-
-        // Check if the current agent has a compaction_agent configured
-        let active_agent_name = config.read().extract_agent().name().to_string();
-        let active_pkg = harnx_core::package_namespace::pkg_from_qualified(&active_agent_name);
-        let compaction_agent_name = config
-            .read()
-            .extract_agent()
-            .compaction_agent()
-            .map(str::to_owned);
-
-        let agent_override = if let Some(name) = compaction_agent_name {
-            let resolved_name =
-                harnx_core::package_namespace::resolve_package_relative_name(&name, active_pkg);
-            match config.read().retrieve_agent(&resolved_name) {
-                Ok(mut compaction_agent) => {
-                    if let Err(e) = self::agent::resolve_variables(&mut compaction_agent) {
-                        warn!("Failed to resolve variables for compaction_agent '{name}': {e}");
-                    }
-                    Some(compaction_agent)
-                }
-                Err(e) => {
-                    warn!(
-                        "Failed to load compaction_agent '{name}': {e}; falling back to default compaction"
-                    );
-                    None
-                }
-            }
-        } else {
-            None
-        };
-
-        // Build the summarizer agent up front (configured compaction_agent, or
-        // the synthetic default), and resolve the compaction tuning params from
-        // it so the snapshot below can use them.
-        let summarizer_agent = match agent_override {
-            Some(agent) => agent.into_config(),
-            None => harnx_core::agent_config::AgentConfig::from_prompt(
-                crate::config::compaction::DEFAULT_COMPACT_SYSTEM_PROMPT,
-            ),
-        };
-        let params = crate::config::compaction::compaction_params(&summarizer_agent);
-
-        // 1. Snapshot what we need under a read lock: the transcript of the prefix
-        //    to compact, the split point, and the covered log-seq range.
-        let (transcript, split, covered, session_id) = {
-            let guard = config.read();
-            let session = guard.session.as_ref().context("No session")?;
-            let session_id = session.id.clone();
-            let model = session.model().clone();
-            let split = crate::config::compaction::split_index(
-                &session.messages,
-                &model,
-                params.keep_recent_turns,
-                params.keep_recent_tokens,
-            );
-            if split == 0 {
-                bail!("Nothing to compact");
-            }
-            let prefix = &session.messages[..split];
-            let transcript =
-                crate::config::compaction::render_transcript(prefix, params.tool_output_max_chars);
-            let from = prefix.iter().filter_map(|m| m.log_seq).min();
-            let to = prefix.iter().filter_map(|m| m.log_seq).max();
-            (transcript, split, (from, to, prefix.len()), session_id)
-        };
-
-        // 2. Build a controlled summarization request: summarizer system prompt +
-        //    the transcript as the user message, WITHOUT the live session.
-        let mut input = harnx_core::input::Input::new(
-            transcript.clone(),
-            (transcript, vec![]),
-            summarizer_agent,
-        );
-        input.with_session = false;
-        input.with_agent = true;
-
-        let summary = crate::config::input::fetch_chat_text(&input, config).await?;
-
-        // 3. Append a recovery note and store, keeping the recent suffix verbatim.
-        let summary_with_note = append_recovery_note(summary, covered);
-        if let Some(session) = config.write().session.as_mut() {
-            if session.id == session_id {
-                crate::config::session::compress_keeping_recent(session, summary_with_note, split);
-            }
-        }
-        config.write().discontinuous_last_message();
-        Ok(())
-    }
-
     pub fn is_compacting_session(&self) -> bool {
         self.session
             .as_ref()
             .map(|v| v.compressing())
             .unwrap_or_default()
     }
-}
-
-/// Append a short recovery note describing the compacted range so a future
-/// reader knows the detail is recoverable from the on-disk log.
-fn append_recovery_note(summary: String, covered: (Option<usize>, Option<usize>, usize)) -> String {
-    let (from, to, count) = covered;
-    let range = match (from, to) {
-        (Some(a), Some(b)) => format!(" (log entries {a}–{b})"),
-        _ => String::new(),
-    };
-    format!(
-        "{summary}\n\n[Earlier conversation: {count} message(s){range} were summarized above. \
-The full pre-compaction transcript remains in this session's log; use the \
-`harnx_agent_session_history_read` tool to search it by entry index, type, tool name, or text.]"
-    )
 }

--- a/crates/harnx-runtime/src/config/tests.rs
+++ b/crates/harnx-runtime/src/config/tests.rs
@@ -501,6 +501,8 @@ fn make_tool_decl(name: &str) -> harnx_core::tool::ToolDeclaration {
         mcp_server_name: None,
         call_template: None,
         result_template: None,
+        idempotent_hint: None,
+        read_only_hint: None,
     }
 }
 
@@ -1095,250 +1097,48 @@ async fn use_agent_scopes_managers_to_package_for_delegation_tools() {
     );
 }
 
-static LOG_CAPTURE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+#[tokio::test]
+async fn use_agent_routes_remote_refs_to_nats_cluster_validation() {
+    use crate::client::TestStateGuard;
+    use harnx_core::{abort::create_abort_signal, working_mode::WorkingMode};
 
-fn lock_log_capture() -> std::sync::MutexGuard<'static, ()> {
-    LOG_CAPTURE_LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|err| err.into_inner())
-}
+    let _guard = TestStateGuard::new(None).await;
 
-#[test]
-fn expand_use_tools_wildcard_returns_concrete_names() {
-    let config = Config {
-        tools: crate::tool::Tools::init_from_mcp(Some(vec![
-            make_tool_decl("alpha_tool"),
-            make_tool_decl("beta_tool"),
-        ])),
-        ..Config::default()
-    };
-
-    let expanded = config.expand_use_tools(Some(&["*".to_string()]), None);
-
-    assert_eq!(
-        expanded,
-        vec!["alpha_tool", "beta_tool", crate::session_history::TOOL_NAME,]
-    );
-}
-
-#[test]
-fn expand_use_tools_empty_is_graceful() {
-    let config = Config::default();
-
-    let expanded = config.expand_use_tools(None, None);
-
-    assert!(expanded.is_empty());
-}
-
-#[test]
-fn expand_use_tools_mcp_failure_logs_warning_and_continues() {
-    let _log_guard = lock_log_capture();
     let temp = tempfile::TempDir::new().unwrap();
-    let log_file = temp.path().join("expand-use-tools.log");
-    let _log_path = EnvGuard::new_file("HARNX_LOG_PATH", &log_file);
-    let prev_level = std::env::var_os("HARNX_LOG_LEVEL");
-    // SAFETY: test-only; this test serializes env + logger-adjacent state.
-    unsafe { std::env::set_var("HARNX_LOG_LEVEL", "debug") };
-    let _ = crate::bootstrap::setup_logger(false);
+    let _env = EnvGuard::new("HARNX_CONFIG_DIR", temp.path());
+    let provider_prev = std::env::var_os("HARNX_PROVIDER");
+    // SAFETY: test-only; shared test lock held for duration.
+    unsafe { std::env::set_var("HARNX_PROVIDER", "claude:some-model") };
 
-    let mut config = Config {
-        tools: crate::tool::Tools::init_from_mcp(Some(vec![make_tool_decl("local_tool")])),
-        mcp_servers: vec![harnx_mcp::McpServerConfig {
-            name: "broken".to_string(),
-            command: std::env::current_exe().unwrap().display().to_string(),
-            args: vec!["--definitely-not-a-valid-harnx-flag".to_string()],
-            env: std::collections::HashMap::new(),
-            roots: vec![],
-            enabled: true,
-            description: None,
-            rename_tools: std::collections::HashMap::new(),
-            tool_templates: std::collections::HashMap::new(),
-            hooks: None,
-            package: None,
-        }],
-        ..Config::default()
-    };
-    config.reinit_managers_for_agent(None);
+    let config = Config::init(WorkingMode::Cmd, false, vec![])
+        .await
+        .expect("config init");
+    let config = std::sync::Arc::new(parking_lot::RwLock::new(config));
 
-    let expanded = config.expand_use_tools(Some(&["*".to_string()]), None);
+    let err = Config::use_agent(&config, "atlas@prod", None, create_abort_signal())
+        .await
+        .expect_err("remote ref with an unknown cluster must fail cluster validation");
 
-    match prev_level {
-        Some(value) => unsafe { std::env::set_var("HARNX_LOG_LEVEL", value) },
-        None => unsafe { std::env::remove_var("HARNX_LOG_LEVEL") },
+    // SAFETY: test-only; restore provider env.
+    unsafe {
+        match &provider_prev {
+            Some(v) => std::env::set_var("HARNX_PROVIDER", v),
+            None => std::env::remove_var("HARNX_PROVIDER"),
+        }
     }
 
-    assert_eq!(
-        expanded,
-        vec!["local_tool", crate::session_history::TOOL_NAME]
-    );
-    let log = std::fs::read_to_string(log_file).unwrap_or_default();
+    // Remote refs are no longer stubbed out — they route into NATS thin-client
+    // mode, which first validates the cluster. With no nats_servers/prod.yaml
+    // the activation fails on cluster lookup, proving the remote path is wired.
+    let msg = err.to_string();
     assert!(
-        log.contains("MCP server 'broken' connection failed"),
-        "expected MCP warning in log, got: {log}"
-    );
-}
-
-// ── expand_use_tools regression tests (#886 filtering) ──────────────────────
-
-/// Regression test for #886: explicit selector must return ONLY that tool,
-/// not ALL builtin tools (the bug was that tool_declarations_for_use_tools
-/// starts from ALL builtins and only ADDS MCP/ACP/handoff tools, never filtering).
-#[test]
-fn expand_use_tools_explicit_selector_returns_only_that_tool() {
-    let config = Config {
-        tools: crate::tool::Tools::init_from_mcp(Some(vec![
-            make_tool_decl("fs_read"),
-            make_tool_decl("fs_write"),
-            make_tool_decl("bash_exec"),
-            make_tool_decl("fetch_fetch_markdown"),
-        ])),
-        ..Config::default()
-    };
-
-    // Explicit selector => only fs_read, NOT all builtins
-    let expanded = config.expand_use_tools(Some(&["fs_read".to_string()]), None);
-
-    // Should have ONLY fs_read (bug was: would have ALL builtins)
-    assert_eq!(expanded, vec!["fs_read"]);
-}
-
-/// Wildcard '*' must still return all available tools.
-#[test]
-fn expand_use_tools_wildcard_returns_all_tools() {
-    let config = Config {
-        tools: crate::tool::Tools::init_from_mcp(Some(vec![
-            make_tool_decl("alpha_tool"),
-            make_tool_decl("beta_tool"),
-        ])),
-        ..Config::default()
-    };
-
-    let expanded = config.expand_use_tools(Some(&["*".to_string()]), None);
-
-    // Wildcard returns all tools
-    assert!(expanded.contains(&"alpha_tool".to_string()));
-    assert!(expanded.contains(&"beta_tool".to_string()));
-    assert!(expanded.contains(&crate::session_history::TOOL_NAME.to_string()));
-}
-
-/// Empty selectors list should return empty (no tools).
-#[test]
-fn expand_use_tools_empty_list_returns_empty() {
-    let config = Config {
-        tools: crate::tool::Tools::init_from_mcp(Some(vec![make_tool_decl("fs_read")])),
-        ..Config::default()
-    };
-
-    let expanded = config.expand_use_tools(Some(&[]), None);
-    assert!(expanded.is_empty());
-}
-
-/// Multiple explicit selectors return only those selected (no others).
-#[test]
-fn expand_use_tools_multiple_explicit_selectors_returns_only_those() {
-    let config = Config {
-        tools: crate::tool::Tools::init_from_mcp(Some(vec![
-            make_tool_decl("fs_read"),
-            make_tool_decl("fs_write"),
-            make_tool_decl("bash_exec"),
-        ])),
-        ..Config::default()
-    };
-
-    let expanded = config.expand_use_tools(
-        Some(&["fs_read".to_string(), "bash_exec".to_string()]),
-        None,
-    );
-
-    // Should have exactly fs_read and bash_exec
-    assert_eq!(expanded.len(), 2);
-    assert!(expanded.contains(&"fs_read".to_string()));
-    assert!(expanded.contains(&"bash_exec".to_string()));
-}
-
-// ── SessionHistoryProvider::call_tool end-to-end ─────────────────────────
-
-/// Exercises the full `call_tool` path of `SessionHistoryProvider`: build a
-/// real on-disk log, wire it up as the active session's `path`, then call
-/// through the provider and verify the envelope shape.
-#[tokio::test]
-async fn session_history_provider_call_tool_returns_message_entries() {
-    use crate::session_history::SessionHistoryProvider;
-    use harnx_core::abort::create_abort_signal;
-    use harnx_core::tool::ToolProvider as _;
-
-    let tmp = tempfile::TempDir::new().unwrap();
-
-    // Build a minimal config with a session that has a real on-disk log.
-    let mut config = Config {
-        data: ConfigData {
-            stream: false,
-            save_session: Some(true),
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-    let mut session = self::session::new(&config, "call-tool-test").unwrap();
-    session.set_sessions_dir(tmp.path().to_path_buf());
-
-    // Append a message entry so the log file is initialized and contains data.
-    let wrote = self::session::append_event(
-        &mut session,
-        &harnx_core::session::SessionLogEntry::Message {
-            role: crate::client::MessageRole::User,
-            content: crate::client::MessageContent::Text("what is 2+2?".to_string()),
-            timestamp: None,
-        },
-    );
-    assert!(wrote, "append_event must write the log file");
-
-    config.session = Some(session);
-    let global_config: GlobalConfig = Arc::new(RwLock::new(config));
-
-    let provider = SessionHistoryProvider::new(global_config.clone());
-    let abort = create_abort_signal();
-
-    // has_tool assertions
-    assert!(
-        provider.has_tool(crate::session_history::TOOL_NAME),
-        "provider must report the session-history tool as owned"
+        msg.contains("prod") && msg.contains("nats_servers/prod.yaml"),
+        "expected unknown-cluster validation error, got: {msg}"
     );
     assert!(
-        !provider.has_tool("other_tool"),
-        "provider must not claim unrelated tools"
-    );
-
-    // call_tool with a type filter so only message entries come back.
-    let result = provider
-        .call_tool(
-            crate::session_history::TOOL_NAME,
-            serde_json::json!({"type": "message"}),
-            &abort,
-        )
-        .await
-        .map_err(|e| match e {
-            harnx_core::tool::ToolError::Recoverable(e) => e,
-            harnx_core::tool::ToolError::Fatal(e) => e,
-        })
-        .unwrap();
-
-    // Verify the content envelope: [{type:"text", text:"[...]"}]
-    let text = result["content"][0]["text"]
-        .as_str()
-        .expect("content[0].text must be a string");
-    assert_eq!(
-        result["content"][0]["type"], "text",
-        "content type must be 'text'"
-    );
-
-    // The text must deserialize as a JSON array containing at least one object
-    // with type == "message".
-    let rows: serde_json::Value =
-        serde_json::from_str(text).expect("content text must be valid JSON");
-    let arr = rows.as_array().expect("rows must be a JSON array");
-    assert!(
-        arr.iter().any(|r| r["type"] == "message"),
-        "at least one entry with type 'message' must be present; got: {arr:?}"
+        !msg.contains("not yet implemented"),
+        "remote refs must no longer be stubbed: {msg}"
     );
 }
+
+pub(super) static LOG_CAPTURE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();

--- a/crates/harnx-runtime/src/config/tests_extra.rs
+++ b/crates/harnx-runtime/src/config/tests_extra.rs
@@ -1,0 +1,267 @@
+#![cfg(test)]
+
+use super::test_support::EnvGuard;
+use super::*;
+
+#[test]
+fn expand_use_tools_wildcard_returns_concrete_names() {
+    let config = Config {
+        tools: crate::tool::Tools::init_from_mcp(Some(vec![
+            make_tool_decl("alpha_tool"),
+            make_tool_decl("beta_tool"),
+        ])),
+        ..Config::default()
+    };
+
+    let expanded = config.expand_use_tools(Some(&["*".to_string()]), None);
+
+    assert_eq!(
+        expanded,
+        vec!["alpha_tool", "beta_tool", crate::session_history::TOOL_NAME,]
+    );
+}
+
+#[test]
+fn expand_use_tools_empty_is_graceful() {
+    let config = Config::default();
+
+    let expanded = config.expand_use_tools(None, None);
+
+    assert!(expanded.is_empty());
+}
+
+#[test]
+fn expand_use_tools_mcp_failure_logs_warning_and_continues() {
+    let _log_guard = lock_log_capture();
+    let temp = tempfile::TempDir::new().unwrap();
+    let log_file = temp.path().join("expand-use-tools.log");
+    let _log_path = EnvGuard::new_file("HARNX_LOG_PATH", &log_file);
+    let prev_level = std::env::var_os("HARNX_LOG_LEVEL");
+    // SAFETY: test-only; this test serializes env + logger-adjacent state.
+    unsafe { std::env::set_var("HARNX_LOG_LEVEL", "debug") };
+    let _ = crate::bootstrap::setup_logger(false);
+
+    let mut config = Config {
+        tools: crate::tool::Tools::init_from_mcp(Some(vec![make_tool_decl("local_tool")])),
+        mcp_servers: vec![harnx_mcp::McpServerConfig {
+            name: "broken".to_string(),
+            command: std::env::current_exe().unwrap().display().to_string(),
+            args: vec!["--definitely-not-a-valid-harnx-flag".to_string()],
+            env: std::collections::HashMap::new(),
+            roots: vec![],
+            enabled: true,
+            description: None,
+            rename_tools: std::collections::HashMap::new(),
+            tool_templates: std::collections::HashMap::new(),
+            hooks: None,
+            package: None,
+        }],
+        ..Config::default()
+    };
+    config.reinit_managers_for_agent(None);
+
+    let expanded = config.expand_use_tools(Some(&["*".to_string()]), None);
+
+    match prev_level {
+        Some(value) => unsafe { std::env::set_var("HARNX_LOG_LEVEL", value) },
+        None => unsafe { std::env::remove_var("HARNX_LOG_LEVEL") },
+    }
+
+    assert_eq!(
+        expanded,
+        vec!["local_tool", crate::session_history::TOOL_NAME]
+    );
+    let log = std::fs::read_to_string(log_file).unwrap_or_default();
+    assert!(
+        log.contains("MCP server 'broken' connection failed"),
+        "expected MCP warning in log, got: {log}"
+    );
+}
+
+// ── expand_use_tools regression tests (#886 filtering) ──────────────────────
+
+/// Regression test for #886: explicit selector must return ONLY that tool,
+/// not ALL builtin tools (the bug was that tool_declarations_for_use_tools
+/// starts from ALL builtins and only ADDS MCP/ACP/handoff tools, never filtering).
+#[test]
+fn expand_use_tools_explicit_selector_returns_only_that_tool() {
+    let config = Config {
+        tools: crate::tool::Tools::init_from_mcp(Some(vec![
+            make_tool_decl("fs_read"),
+            make_tool_decl("fs_write"),
+            make_tool_decl("bash_exec"),
+            make_tool_decl("fetch_fetch_markdown"),
+        ])),
+        ..Config::default()
+    };
+
+    // Explicit selector => only fs_read, NOT all builtins
+    let expanded = config.expand_use_tools(Some(&["fs_read".to_string()]), None);
+
+    // Should have ONLY fs_read (bug was: would have ALL builtins)
+    assert_eq!(expanded, vec!["fs_read"]);
+}
+
+/// Wildcard '*' must still return all available tools.
+#[test]
+fn expand_use_tools_wildcard_returns_all_tools() {
+    let config = Config {
+        tools: crate::tool::Tools::init_from_mcp(Some(vec![
+            make_tool_decl("alpha_tool"),
+            make_tool_decl("beta_tool"),
+        ])),
+        ..Config::default()
+    };
+
+    let expanded = config.expand_use_tools(Some(&["*".to_string()]), None);
+
+    // Wildcard returns all tools
+    assert!(expanded.contains(&"alpha_tool".to_string()));
+    assert!(expanded.contains(&"beta_tool".to_string()));
+    assert!(expanded.contains(&crate::session_history::TOOL_NAME.to_string()));
+}
+
+/// Empty selectors list should return empty (no tools).
+#[test]
+fn expand_use_tools_empty_list_returns_empty() {
+    let config = Config {
+        tools: crate::tool::Tools::init_from_mcp(Some(vec![make_tool_decl("fs_read")])),
+        ..Config::default()
+    };
+
+    let expanded = config.expand_use_tools(Some(&[]), None);
+    assert!(expanded.is_empty());
+}
+
+/// Multiple explicit selectors return only those selected (no others).
+#[test]
+fn expand_use_tools_multiple_explicit_selectors_returns_only_those() {
+    let config = Config {
+        tools: crate::tool::Tools::init_from_mcp(Some(vec![
+            make_tool_decl("fs_read"),
+            make_tool_decl("fs_write"),
+            make_tool_decl("bash_exec"),
+        ])),
+        ..Config::default()
+    };
+
+    let expanded = config.expand_use_tools(
+        Some(&["fs_read".to_string(), "bash_exec".to_string()]),
+        None,
+    );
+
+    // Should have exactly fs_read and bash_exec
+    assert_eq!(expanded.len(), 2);
+    assert!(expanded.contains(&"fs_read".to_string()));
+    assert!(expanded.contains(&"bash_exec".to_string()));
+}
+
+// ── SessionHistoryProvider::call_tool end-to-end ─────────────────────────
+
+/// Exercises the full `call_tool` path of `SessionHistoryProvider`: build a
+/// real on-disk log, wire it up as the active session's `path`, then call
+/// through the provider and verify the envelope shape.
+#[tokio::test]
+async fn session_history_provider_call_tool_returns_message_entries() {
+    use crate::session_history::SessionHistoryProvider;
+    use harnx_core::abort::create_abort_signal;
+    use harnx_core::tool::ToolProvider as _;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+
+    // Build a minimal config with a session that has a real on-disk log.
+    let mut config = Config {
+        data: ConfigData {
+            stream: false,
+            save_session: Some(true),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut session = self::session::new(&config, "call-tool-test").unwrap();
+    session.set_sessions_dir(tmp.path().to_path_buf());
+
+    // Append a message entry so the log file is initialized and contains data.
+    let wrote = self::session::append_event(
+        &mut session,
+        &harnx_core::session::SessionLogEntry::Message {
+            id: None,
+            role: crate::client::MessageRole::User,
+            content: crate::client::MessageContent::Text("what is 2+2?".to_string()),
+            timestamp: None,
+            fence_token: None,
+        },
+    );
+    assert!(wrote, "append_event must write the log file");
+
+    config.session = Some(session);
+    let global_config: GlobalConfig = Arc::new(RwLock::new(config));
+
+    let provider = SessionHistoryProvider::new(global_config.clone());
+    let abort = create_abort_signal();
+
+    // has_tool assertions
+    assert!(
+        provider.has_tool(crate::session_history::TOOL_NAME),
+        "provider must report the session-history tool as owned"
+    );
+    assert!(
+        !provider.has_tool("other_tool"),
+        "provider must not claim unrelated tools"
+    );
+
+    // call_tool with a type filter so only message entries come back.
+    let result = provider
+        .call_tool(
+            crate::session_history::TOOL_NAME,
+            serde_json::json!({"type": "message"}),
+            &abort,
+        )
+        .await
+        .map_err(|e| match e {
+            harnx_core::tool::ToolError::Recoverable(e) => e,
+            harnx_core::tool::ToolError::Fatal(e) => e,
+        })
+        .unwrap();
+
+    // Verify the content envelope: [{type:"text", text:"[...]"}]
+    let text = result["content"][0]["text"]
+        .as_str()
+        .expect("content[0].text must be a string");
+    assert_eq!(
+        result["content"][0]["type"], "text",
+        "content type must be 'text'"
+    );
+
+    // The text must deserialize as a JSON array containing at least one object
+    // with type == "message".
+    let rows: serde_json::Value =
+        serde_json::from_str(text).expect("content text must be valid JSON");
+    let arr = rows.as_array().expect("rows must be a JSON array");
+    assert!(
+        arr.iter().any(|r| r["type"] == "message"),
+        "at least one entry with type 'message' must be present; got: {arr:?}"
+    );
+}
+
+fn make_tool_decl(name: &str) -> crate::tool::ToolDeclaration {
+    crate::tool::ToolDeclaration {
+        name: name.to_string(),
+        description: "desc".to_string(),
+        parameters: serde_json::from_value(serde_json::json!({"type": "object"}))
+            .expect("tool schema must parse"),
+        mcp_tool_name: None,
+        mcp_server_name: None,
+        call_template: None,
+        result_template: None,
+        idempotent_hint: None,
+        read_only_hint: None,
+    }
+}
+
+fn lock_log_capture() -> std::sync::MutexGuard<'static, ()> {
+    super::tests::LOG_CAPTURE_LOCK
+        .get_or_init(|| std::sync::Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|err| err.into_inner())
+}

--- a/crates/harnx-runtime/src/lib.rs
+++ b/crates/harnx-runtime/src/lib.rs
@@ -11,15 +11,28 @@
 extern crate log;
 
 pub mod agent_loop;
+pub mod async_session_log;
 pub mod bootstrap;
 pub mod client;
 pub mod commands;
 pub mod config;
+pub mod nats_admin;
+pub mod nats_client_session;
+pub mod nats_event_sink;
+pub mod nats_lease;
+pub mod nats_metrics;
+pub mod nats_session_log;
+pub mod nats_worker;
 pub mod session_cleanup;
 pub mod session_history;
 pub mod test_utils;
 pub mod tool;
 pub mod utils;
+
+// Re-export thin-client types for frontends
+pub use nats_client_session::{
+    send_control_command, ThinClientConfig, ThinClientSession, ThinClientTurnResult,
+};
 
 pub use agent_loop::{
     run_agent_loop, AgentCallFn, AgentLoopContext, OnTextResponseFn, OnToolRoundFn,

--- a/crates/harnx-runtime/src/nats_admin.rs
+++ b/crates/harnx-runtime/src/nats_admin.rs
@@ -1,0 +1,115 @@
+use crate::{
+    config::Config, nats_lease::NatsLeaseConfig, nats_session_log::stream_name_for_session,
+};
+use anyhow::{Context, Result};
+use async_nats::jetstream::{
+    context::{DeleteStreamErrorKind, GetStreamErrorKind, KeyValueErrorKind},
+    kv::Operation,
+    ErrorCode,
+};
+use std::error::Error as _;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionDeleteResult {
+    pub stream_deleted: bool,
+    pub lease_deleted: bool,
+}
+
+impl SessionDeleteResult {
+    pub fn removed_anything(&self) -> bool {
+        self.stream_deleted || self.lease_deleted
+    }
+}
+
+pub async fn delete_remote_session(
+    config: &Config,
+    cluster: &str,
+    session_id: &str,
+) -> Result<SessionDeleteResult> {
+    let jetstream = config.nats_jetstream(cluster).await?;
+    let lease_bucket = load_optional_lease_bucket(config, cluster).await?;
+    let stream_deleted = delete_session_stream(&jetstream, session_id).await?;
+    let lease_deleted = delete_session_lease(lease_bucket, session_id).await?;
+
+    Ok(SessionDeleteResult {
+        stream_deleted,
+        lease_deleted,
+    })
+}
+
+async fn load_optional_lease_bucket(
+    config: &Config,
+    cluster: &str,
+) -> Result<Option<async_nats::jetstream::kv::Store>> {
+    match config.nats_kv_bucket(cluster, "harnx_leases").await {
+        Ok(bucket) => Ok(Some(bucket)),
+        Err(error) if kv_bucket_missing(&error) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+async fn delete_session_stream(
+    jetstream: &async_nats::jetstream::Context,
+    session_id: &str,
+) -> Result<bool> {
+    let stream_name = stream_name_for_session(session_id);
+    match jetstream.delete_stream(&stream_name).await {
+        Ok(_) => Ok(true),
+        Err(error) if delete_stream_missing(&error.kind()) => Ok(false),
+        Err(error) => Err(error).with_context(|| {
+            format!("Failed to delete session stream '{stream_name}' for '{session_id}'")
+        }),
+    }
+}
+
+async fn delete_session_lease(
+    lease_bucket: Option<async_nats::jetstream::kv::Store>,
+    session_id: &str,
+) -> Result<bool> {
+    let Some(lease_bucket) = lease_bucket else {
+        return Ok(false);
+    };
+    let lease_key = NatsLeaseConfig::default().key_for_session(session_id);
+    match lease_bucket.entry(lease_key.clone()).await {
+        Ok(Some(entry)) if matches!(entry.operation, Operation::Put) => {
+            lease_bucket
+                .delete(&lease_key)
+                .await
+                .with_context(|| format!("Failed to delete session lease key '{lease_key}'"))?;
+            Ok(true)
+        }
+        Ok(Some(_)) | Ok(None) => Ok(false),
+        Err(error) => {
+            Err(error).with_context(|| format!("Failed to inspect session lease key '{lease_key}'"))
+        }
+    }
+}
+
+fn get_stream_missing(kind: &GetStreamErrorKind) -> bool {
+    match kind {
+        GetStreamErrorKind::JetStream(error) => error.kind() == ErrorCode::STREAM_NOT_FOUND,
+        _ => false,
+    }
+}
+
+fn delete_stream_missing(kind: &DeleteStreamErrorKind) -> bool {
+    match kind {
+        DeleteStreamErrorKind::JetStream(error) => error.kind() == ErrorCode::STREAM_NOT_FOUND,
+        _ => false,
+    }
+}
+
+fn kv_bucket_missing(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<async_nats::jetstream::context::KeyValueError>())
+        .is_some_and(|kv_error| match kv_error.kind() {
+            KeyValueErrorKind::GetBucket => kv_error
+                .source()
+                .and_then(|source| {
+                    source.downcast_ref::<async_nats::jetstream::context::GetStreamError>()
+                })
+                .is_some_and(|stream_error| get_stream_missing(&stream_error.kind())),
+            _ => false,
+        })
+}

--- a/crates/harnx-runtime/src/nats_client_session.rs
+++ b/crates/harnx-runtime/src/nats_client_session.rs
@@ -1,0 +1,604 @@
+//! Thin-client driver for remote NATS agents (agent@cluster).
+//!
+//! P4.2 implementation: when an agent ref contains `@` (parsed as
+//! `AgentRef::Remote { agent, cluster }`), the client runs in THIN mode:
+//! it posts the user message + control commands to NATS and renders events
+//! from the fan-out — it does NOT run `run_agent_loop` locally. A separate
+//! `harnx worker --cluster <key>` daemon executes the turn.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! [Client]                                   [Worker Daemon]
+//!    |                                            |
+//!    |--1. Append user message (durable)--------->|
+//!    |                                            |
+//!    |--2. SessionEventStream::attach()           |
+//!    |    (subscribe-first, then history)         |
+//!    |                                            |
+//!    |--3. publish_session_activate()------------>|-- wake up
+//!    |                                            |-- claim lease
+//!    |                                            |-- run_agent_loop
+//!    |<----------- advisory events ---------------|
+//!    |                                            |-- append final state
+//!    |--4. Detect turn complete from durable -----|
+//!    |                                            |
+//!    |--5. Return final response                  |
+//! ```
+//!
+//! ## Turn completion detection
+//!
+//! A turn is complete when the durable log contains a final AssistantMessage
+//! with no pending ToolCalls, or when `reconstruct_state` yields `TurnStatus::Idle`
+//! or `TurnStatus::InFlightCancelled`. The client polls the durable log after
+//! each advisory batch to check for completion.
+
+use anyhow::{Context, Result};
+use async_nats::jetstream;
+use harnx_core::abort::wait_abort_signal;
+use harnx_core::event::{AgentEvent, AgentEventSink};
+use harnx_core::message::{MessageContent, MessageRole};
+use harnx_core::session::SessionLogEntry;
+use harnx_core::session_reconstruct::{reconstruct_state_from_nats, TurnStatus};
+use std::sync::Arc;
+
+use crate::nats_event_sink::SessionEventStream;
+use crate::nats_session_log::NatsSessionLog;
+use crate::nats_worker::{
+    new_remote_session_id, publish_control_command, publish_session_activate, ControlCommand,
+    SessionActivate,
+};
+use crate::utils::AbortSignal;
+
+/// Generate a client-side message ID (UUID v4).
+fn new_client_message_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+/// Configuration for a thin-client session.
+#[derive(Clone)]
+pub struct ThinClientConfig {
+    /// Cluster key (from AgentRef::Remote { cluster, ... }).
+    pub cluster: String,
+    /// Agent name (from AgentRef::Remote { agent, ... }).
+    pub agent: String,
+    /// Existing session ID to resume/attach (None = new session).
+    pub session_id: Option<String>,
+}
+
+/// Thin-client session driver.
+///
+/// Orchestrates the remote-agent workflow: append user message, activate,
+/// stream events, detect completion.
+pub struct ThinClientSession {
+    config: ThinClientConfig,
+    session_id: String,
+    jetstream: jetstream::Context,
+    client: async_nats::Client,
+    abort_signal: AbortSignal,
+}
+
+impl ThinClientSession {
+    /// Create a new thin-client session.
+    ///
+    /// Connects to the NATS cluster and generates/reuses a session ID.
+    ///
+    /// This function takes the NATS connection components directly to avoid
+    /// Send issues with GlobalConfig's parking_lot lock guard across await points.
+    pub async fn new(
+        config: ThinClientConfig,
+        client: async_nats::Client,
+        jetstream: jetstream::Context,
+        abort_signal: AbortSignal,
+    ) -> Result<Self> {
+        // Resolve session ID (new or existing)
+        let session_id = config
+            .session_id
+            .clone()
+            .unwrap_or_else(new_remote_session_id);
+
+        Ok(Self {
+            config,
+            session_id,
+            jetstream,
+            client,
+            abort_signal,
+        })
+    }
+
+    /// Convenience constructor that builds NATS connections from GlobalConfig.
+    pub async fn from_global_config(
+        config: ThinClientConfig,
+        global_config: &crate::config::GlobalConfig,
+        abort_signal: AbortSignal,
+    ) -> Result<Self> {
+        let cluster = config.cluster.clone();
+        let server = {
+            let cfg = global_config.read();
+            cfg.nats_server(&cluster)?.clone()
+        };
+
+        let client = crate::config::Config::connect_nats_server(&server)
+            .await
+            .context("failed to connect to NATS cluster for thin client")?;
+        let jetstream = async_nats::jetstream::new(client.clone());
+
+        Self::new(config, client, jetstream, abort_signal).await
+    }
+
+    /// Get the session ID.
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Run a turn: append user message, activate worker, stream events until completion.
+    ///
+    /// This is the main entry point for all frontends (CLI, TUI, ACP).
+    ///
+    /// # Arguments
+    /// * `user_message` - The user's prompt text.
+    /// * `event_sink` - Event sink to render events (AgentEventSink impl).
+    /// * `pending_cancel` - Optional channel to receive cancel requests.
+    ///
+    /// # Returns
+    /// The final assistant response text (if any), plus the sequence number of the
+    /// appended user message (for retract/edit), or an error.
+    pub async fn run_turn(
+        &self,
+        user_message: &str,
+        event_sink: Arc<dyn AgentEventSink>,
+        pending_cancel: Option<tokio::sync::mpsc::Receiver<()>>,
+    ) -> Result<ThinClientTurnResult> {
+        // Step 1: Append user message to durable log BEFORE activating.
+        // The worker derives input from the last user message.
+        // Generate a client-side ID for retract/edit reference.
+        let user_msg_id = new_client_message_id();
+        let log = NatsSessionLog::new(self.jetstream.clone(), self.session_id.clone());
+        let user_entry = SessionLogEntry::Message {
+            id: Some(user_msg_id.clone()),
+            role: MessageRole::User,
+            content: MessageContent::Text(user_message.to_string()),
+            timestamp: None,
+            fence_token: None,
+        };
+        let user_msg_seq = log
+            .append_event_async(&user_entry)
+            .await
+            .context("failed to append user message to session log")?;
+
+        log::info!(
+            "thin client: appended user message session_id={} len={}",
+            self.session_id,
+            user_message.len()
+        );
+
+        // Step 2: Attach to session event stream (subscribe-first, then history).
+        let event_stream = SessionEventStream::attach(
+            self.jetstream.clone(),
+            self.client.clone(),
+            &self.session_id,
+        )
+        .await
+        .context("failed to attach to session event stream")?;
+
+        // Render history to event sink (for resume/attach scenarios)
+        let history = event_stream.history();
+        // Apply mutations so retracted/edited entries are excluded from history render.
+        let raw_with_seq: Vec<_> = history
+            .iter()
+            .map(|(seq, e)| (*seq as usize, e.clone()))
+            .collect();
+        let effective_history = harnx_core::session_reconstruct::apply_log_mutations(&raw_with_seq);
+        for (_seq, entry) in effective_history {
+            render_log_entry_to_sink(&entry, event_sink.clone());
+        }
+
+        // Step 3: Publish activation to wake a worker.
+        let activation = SessionActivate::new(&self.session_id, &self.config.agent);
+        publish_session_activate(&self.jetstream, &self.config.cluster, &activation)
+            .await
+            .context("failed to publish session activation")?;
+
+        log::info!(
+            "thin client: published activation session_id={} agent={} cluster={}",
+            self.session_id,
+            self.config.agent,
+            self.config.cluster
+        );
+
+        // Step 4: Stream events and handle control until turn completion.
+        let mut event_stream = event_stream;
+        let mut final_response: Option<String> = None;
+        let mut turn_complete = false;
+        // Throttle the durable-log completion check: advisory events arrive at
+        // streaming-token frequency, and reloading the full log on each would be
+        // O(N^2) in session size. Check at most once per interval instead — the
+        // turn-complete signal (a final AssistantMessage) is not latency
+        // sensitive, and the post-loop reload guarantees we never miss it.
+        const COMPLETION_CHECK_INTERVAL: std::time::Duration =
+            std::time::Duration::from_millis(500);
+        let mut last_completion_check = std::time::Instant::now() - COMPLETION_CHECK_INTERVAL;
+
+        // Set up control command sender
+        let (control_tx, mut control_rx) = tokio::sync::mpsc::channel::<ControlCommand>(16);
+        let session_id_control = self.session_id.clone();
+        let client_control = self.client.clone();
+
+        let control_task = tokio::spawn(async move {
+            while let Some(cmd) = control_rx.recv().await {
+                if let Err(e) =
+                    publish_control_command(&client_control, &session_id_control, &cmd).await
+                {
+                    log::warn!("thin client: failed to publish control command: {e}");
+                }
+            }
+        });
+
+        // Wrap channel in Option for select! handling
+        let mut pending_cancel_rx = pending_cancel;
+
+        // Main event loop with abort signal handling
+        let abort_signal_clone = self.abort_signal.clone();
+        loop {
+            tokio::select! {
+                // Check for cancellation via wait_abort_signal
+                _ = wait_abort_signal(&abort_signal_clone) => {
+                    log::info!("thin client: abort signal received, sending cancel");
+                    let _ = control_tx.send(ControlCommand::Cancel).await;
+                    break;
+                }
+
+                // Handle pending cancel requests
+                Some(()) = async {
+                    match &mut pending_cancel_rx {
+                        Some(rx) => rx.recv().await,
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    log::info!("thin client: pending cancel received");
+                    let _ = control_tx.send(ControlCommand::Cancel).await;
+                }
+
+                // Receive advisory events
+                maybe_envelope = event_stream.next() => {
+                    match maybe_envelope {
+                        Some(envelope) => {
+                            // Check if this advisory should be rendered (dedup rule)
+                            if event_stream.should_render(&envelope) {
+                                // Emit to sink for rendering
+                                event_sink.emit(envelope.event.clone(), None);
+                            }
+
+                            // Poll the durable log for turn completion, but at
+                            // most once per COMPLETION_CHECK_INTERVAL so a burst
+                            // of streaming advisories doesn't trigger a full
+                            // log reload each (avoids O(N^2) growth).
+                            if last_completion_check.elapsed() >= COMPLETION_CHECK_INTERVAL {
+                                last_completion_check = std::time::Instant::now();
+                                if let Ok(entries) = self.load_durable_entries().await {
+                                    if self.is_turn_complete(&entries) {
+                                        // Extract final response before we finish
+                                        final_response = self.extract_final_response(&entries);
+                                        turn_complete = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        None => {
+                            // Subscription closed, check final state
+                            log::info!("thin client: event stream closed");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Cleanup: stop control task
+        drop(control_tx);
+        control_task.abort();
+
+        // Re-load durable log to get final state if we haven't already
+        if !turn_complete {
+            let entries = self.load_durable_entries().await?;
+            final_response = self.extract_final_response(&entries);
+        }
+
+        Ok(ThinClientTurnResult {
+            response: final_response,
+            session_id: self.session_id.clone(),
+            was_cancelled: self.abort_signal.aborted(),
+            user_msg_seq,
+            user_msg_id,
+        })
+    }
+
+    /// Retract (delete) a queued user message by appending an EditEntries delete.
+    ///
+    /// This is used to retract a user message that was appended but not yet
+    /// consumed by a worker. The retract is only valid before an assistant
+    /// barrier (response) appears in the log. The edit-vs-deliver race is
+    /// accepted as benign per design.
+    ///
+    /// # Arguments
+    /// * `seq` - The JetStream sequence number of the user message to retract.
+    ///
+    /// # Returns
+    /// The sequence number of the appended EditEntries entry.
+    pub async fn retract_user_message(&self, seq: u64) -> Result<u64> {
+        let log = NatsSessionLog::new(self.jetstream.clone(), self.session_id.clone());
+        let edit_entry = SessionLogEntry::EditEntries {
+            from: seq as usize,
+            to: seq as usize,
+            replacements: vec![], // Empty = deletion
+        };
+        log.append_event_async(&edit_entry)
+            .await
+            .context("failed to append EditEntries for retraction")
+    }
+
+    /// Edit (replace) a queued user message by appending an EditEntries replace.
+    ///
+    /// This is used to edit a user message that was appended but not yet
+    /// consumed by a worker. The edit is only valid before an assistant
+    /// barrier (response) appears in the log. The edit-vs-deliver race is
+    /// accepted as benign per design.
+    ///
+    /// # Arguments
+    /// * `seq` - The JetStream sequence number of the user message to edit.
+    /// * `new_text` - The replacement user-message text.
+    ///
+    /// # Returns
+    /// The sequence number of the appended EditEntries entry.
+    pub async fn edit_user_message(&self, seq: u64, new_text: String) -> Result<u64> {
+        let log = NatsSessionLog::new(self.jetstream.clone(), self.session_id.clone());
+        let replacement_entry = SessionLogEntry::Message {
+            id: Some(uuid::Uuid::new_v4().to_string()),
+            role: MessageRole::User,
+            content: MessageContent::Text(new_text),
+            timestamp: None,
+            fence_token: None,
+        };
+        let replacement_yaml = serde_yaml::to_string(&replacement_entry)
+            .context("failed to serialize replacement entry for user-message edit")?;
+        let edit_entry = SessionLogEntry::EditEntries {
+            from: seq as usize,
+            to: seq as usize,
+            replacements: vec![replacement_yaml],
+        };
+        log.append_event_async(&edit_entry)
+            .await
+            .context("failed to append EditEntries for edit")
+    }
+
+    /// Load all durable entries from the session log.
+    async fn load_durable_entries(&self) -> Result<Vec<(u64, SessionLogEntry)>> {
+        let log = NatsSessionLog::new(self.jetstream.clone(), self.session_id.clone());
+        log.load_events_async()
+            .await
+            .context("failed to load durable session log")
+    }
+
+    /// Check if the turn is complete based on durable entries.
+    fn is_turn_complete(&self, entries: &[(u64, SessionLogEntry)]) -> bool {
+        let state = reconstruct_state_from_nats(entries);
+        matches!(
+            state.turn_status,
+            TurnStatus::Idle | TurnStatus::InFlightCancelled
+        )
+    }
+
+    /// Extract the final assistant response text from durable entries.
+    fn extract_final_response(&self, entries: &[(u64, SessionLogEntry)]) -> Option<String> {
+        // Apply mutations so retracted messages are excluded.
+        let raw_with_seq: Vec<_> = entries
+            .iter()
+            .map(|(seq, e)| (*seq as usize, e.clone()))
+            .collect();
+        let effective_entries = harnx_core::session_reconstruct::apply_log_mutations(&raw_with_seq);
+        // Find the last assistant message in effective entries.
+        for (_, entry) in effective_entries.iter().rev() {
+            if let SessionLogEntry::Message { role, content, .. } = entry {
+                if role.is_assistant() {
+                    return Some(content.to_text());
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Result of a thin-client turn.
+#[derive(Debug, Clone)]
+pub struct ThinClientTurnResult {
+    /// Final assistant response text (if any).
+    pub response: Option<String>,
+    /// Session ID (for resume/attach).
+    pub session_id: String,
+    /// Whether the turn was cancelled.
+    pub was_cancelled: bool,
+    /// Sequence number of the appended user message (for retract/edit).
+    pub user_msg_seq: u64,
+    /// Client-generated message ID of the appended user message.
+    pub user_msg_id: String,
+}
+
+/// Render a session log entry to an event sink.
+///
+/// Used for rendering history when attaching to an existing session.
+fn render_log_entry_to_sink(entry: &SessionLogEntry, sink: Arc<dyn AgentEventSink>) {
+    match entry {
+        SessionLogEntry::Message { role, content, .. } => {
+            render_message_entry(role, content, &sink)
+        }
+        SessionLogEntry::ToolCalls { text, calls, .. } => {
+            render_tool_calls_entry(text, calls, &sink)
+        }
+        SessionLogEntry::ToolResults { results, .. } => render_tool_results_entry(results, &sink),
+        SessionLogEntry::Cancel { .. } => render_cancel_entry(&sink),
+        SessionLogEntry::Header { .. }
+        | SessionLogEntry::DataUrls { .. }
+        | SessionLogEntry::Compress { .. }
+        | SessionLogEntry::Clear
+        | SessionLogEntry::EditEntries { .. }
+        | SessionLogEntry::Rewind { .. }
+        | SessionLogEntry::Unknown => {}
+    }
+    // Note: ToolResults fence_token is not currently exposed in the entry type
+    // (it belongs to ToolCalls which should be followed by ToolResults)
+}
+
+fn render_message_entry(
+    role: &harnx_core::message::MessageRole,
+    content: &harnx_core::message::MessageContent,
+    sink: &Arc<dyn AgentEventSink>,
+) {
+    if role.is_assistant() {
+        use harnx_core::event::ModelEvent;
+        sink.emit(
+            AgentEvent::Model(ModelEvent::Final {
+                output: content.to_text(),
+                usage: Default::default(),
+            }),
+            None,
+        );
+    }
+}
+
+fn render_tool_calls_entry(
+    text: &str,
+    calls: &[harnx_core::tool::ToolCall],
+    sink: &Arc<dyn AgentEventSink>,
+) {
+    use harnx_core::event::{ContentBlock, ModelEvent, ToolEvent, ToolKind};
+
+    for call in calls {
+        sink.emit(
+            AgentEvent::Tool(ToolEvent::Started {
+                id: call.id.clone().unwrap_or_default(),
+                name: call.name.clone(),
+                kind: ToolKind::Other,
+                markdown: None,
+                input: call.arguments.clone(),
+                locations: vec![],
+            }),
+            None,
+        );
+    }
+
+    if !text.is_empty() {
+        sink.emit(
+            AgentEvent::Model(ModelEvent::MessageChunk {
+                blocks: vec![ContentBlock::Text(text.to_string())],
+            }),
+            None,
+        );
+    }
+}
+
+fn render_tool_results_entry(
+    results: &[harnx_core::session::ToolOutput],
+    sink: &Arc<dyn AgentEventSink>,
+) {
+    use harnx_core::event::ToolEvent;
+
+    for result in results {
+        sink.emit(
+            AgentEvent::Tool(ToolEvent::Completed {
+                id: result.id.clone().unwrap_or_default(),
+                output: result.output.clone(),
+                markdown: None,
+            }),
+            None,
+        );
+    }
+}
+
+fn render_cancel_entry(sink: &Arc<dyn AgentEventSink>) {
+    use harnx_core::event::NoticeEvent;
+
+    sink.emit(
+        AgentEvent::Notice(NoticeEvent::Warning("Session cancelled".to_string())),
+        None,
+    );
+}
+
+/// Send a control command to a remote session.
+///
+/// Helper for frontends to send cancel/set-pending without full ThinClientSession.
+pub async fn send_control_command(
+    client: &async_nats::Client,
+    session_id: &str,
+    command: ControlCommand,
+) -> Result<()> {
+    publish_control_command(client, session_id, &command).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct TestSink {
+        count: Arc<AtomicUsize>,
+    }
+    impl AgentEventSink for TestSink {
+        fn emit(&self, _event: AgentEvent, _source: Option<harnx_core::event::AgentSource>) {
+            self.count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn test_render_message_entry() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let sink = Arc::new(TestSink {
+            count: Arc::clone(&count),
+        });
+
+        // Test assistant message
+        let entry = SessionLogEntry::Message {
+            id: None,
+            role: MessageRole::Assistant,
+            content: MessageContent::Text("Hello".to_string()),
+            timestamp: None,
+            fence_token: None,
+        };
+        render_log_entry_to_sink(&entry, sink.clone());
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+
+        // Test user message (should not render)
+        let entry = SessionLogEntry::Message {
+            id: None,
+            role: MessageRole::User,
+            content: MessageContent::Text("Hi".to_string()),
+            timestamp: None,
+            fence_token: None,
+        };
+        render_log_entry_to_sink(&entry, sink.clone());
+        assert_eq!(count.load(Ordering::SeqCst), 1); // Still 1
+    }
+
+    #[test]
+    fn test_render_tool_results_entry() {
+        use harnx_core::session::ToolOutput;
+
+        let count = Arc::new(AtomicUsize::new(0));
+        let sink = Arc::new(TestSink {
+            count: Arc::clone(&count),
+        });
+
+        let entry = SessionLogEntry::ToolResults {
+            results: vec![ToolOutput {
+                id: Some("test".to_string()),
+                name: "echo".to_string(),
+                output: serde_json::json!({"result": "ok"}),
+                content: vec![],
+                switch_agent: None,
+            }],
+            timestamp: None,
+        };
+        render_log_entry_to_sink(&entry, sink.clone());
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/harnx-runtime/src/nats_event_sink.rs
+++ b/crates/harnx-runtime/src/nats_event_sink.rs
@@ -1,0 +1,350 @@
+//! P4.1: Live event fan-out from worker to clients.
+//!
+//! The worker forwards its live `AgentEvent` stream (text chunks, tool progress,
+//! status) to a non-durable NATS fan-out subject `sessions.{session_id}.events`.
+//! Multiple clients can attach to one session: each replays the durable log tail
+//! for history, then subscribes to live events — gap-free and dup-free.
+//!
+//! ## Durable vs advisory contract
+//!
+//! - DURABLE (JetStream session log, authoritative): UserMessage, AssistantMessage(final),
+//!   ToolCalls, ToolResults, Cancel. Reconstructable via NatsSessionLog
+//!   + reconstruct_state.
+//! - ADVISORY (fan-out `sessions.{id}.events` only, non-durable, lossy-OK): streaming token
+//!   deltas (ModelEvent::MessageChunk/ThoughtChunk), thinking/status indicators,
+//!   tool-progress chunks. NEVER authoritative; safe to miss.
+//! - Each advisory message carries `after_seq: u64` = the session-log stream's last_seq
+//!   at emit time, enabling gap-free client attach.
+
+use anyhow::Result;
+use async_nats::jetstream;
+use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource};
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// Advisory subject pattern for a session's live events.
+///
+/// Format: `sessions.{session_id}.events`
+pub fn events_subject(session_id: &str) -> String {
+    format!("sessions.{session_id}.events")
+}
+
+/// Envelope for advisory events published to the fan-out subject.
+///
+/// Each advisory message carries `after_seq` = the session-log stream's current
+/// `last_seq` at emit time. Clients use this for dedup/ordering:
+/// - Durable entries are applied by stream seq (monotonic, idempotent)
+/// - An advisory envelope is rendered only if `after_seq >= client's last-applied durable seq`
+///
+/// This ensures:
+/// - No gap: durable replay complete to last_seq, then continue with live events
+/// - No dup: seq idempotent, advisory filtered by after_seq
+/// - On failover, advisory deltas may drop mid-turn; final state reconciles from durable log
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdvisoryEnvelope {
+    /// The session-log stream sequence this advisory follows.
+    /// Clients should only render this event if they have applied all durable
+    /// entries up to and including this sequence.
+    pub after_seq: u64,
+    /// The actual agent event (Model chunk, tool progress, status, etc.)
+    pub event: AgentEvent,
+}
+
+impl AdvisoryEnvelope {
+    /// Create a new advisory envelope.
+    pub fn new(after_seq: u64, event: AgentEvent) -> Self {
+        Self { after_seq, event }
+    }
+
+    /// Serialize to JSON bytes for NATS publish.
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        Ok(serde_json::to_vec(self)?)
+    }
+
+    /// Deserialize from JSON bytes.
+    pub fn from_bytes(data: &[u8]) -> Result<Self> {
+        Ok(serde_json::from_slice(data)?)
+    }
+}
+
+/// NATS event sink that publishes AgentEvents to the advisory fan-out subject.
+///
+/// Implements `AgentEventSink` and wraps the worker's shared NATS client.
+/// Each event is wrapped in an `AdvisoryEnvelope` with the current session-log
+/// stream `last_seq` as `after_seq` for client-side dedup.
+#[derive(Clone)]
+pub struct NatsEventSink {
+    /// NATS client for publishing (core NATS, non-durable).
+    client: async_nats::Client,
+    /// Cached fan-out subject (`sessions.{id}.events`).
+    subject: String,
+    /// Cached durable-log sequence this sink stamps on advisories as
+    /// `after_seq`. Maintained WITHOUT a per-event JetStream round-trip:
+    /// seeded at construction and advanced by the worker via
+    /// [`NatsEventSink::note_durable_seq`] as durable entries are appended.
+    /// Stale-low values are safe (a caught-up client just drops that advisory;
+    /// advisory delivery is lossy by contract).
+    after_seq: Arc<AtomicU64>,
+}
+
+impl NatsEventSink {
+    /// Create a new NATS event sink, seeding `after_seq` from the session
+    /// log stream's current `last_sequence` (a single query, NOT per-event).
+    ///
+    /// # Arguments
+    /// * `client` - Shared NATS client for core publish (non-durable)
+    /// * `jetstream` - JetStream context, used ONCE to seed the seq
+    /// * `session_id` - Session ID for subject routing
+    pub async fn new(
+        client: async_nats::Client,
+        jetstream: jetstream::Context,
+        session_id: impl Into<String>,
+    ) -> Self {
+        let session_id = session_id.into();
+        let stream_name = crate::nats_session_log::stream_name_for_session(&session_id);
+        let seed = match jetstream.get_stream(&stream_name).await {
+            Ok(mut stream) => stream
+                .info()
+                .await
+                .map(|i| i.state.last_sequence)
+                .unwrap_or(0),
+            Err(_) => 0,
+        };
+        Self {
+            client,
+            subject: events_subject(&session_id),
+            after_seq: Arc::new(AtomicU64::new(seed)),
+        }
+    }
+
+    /// Advance the cached `after_seq` to `seq` (monotonic). The worker calls
+    /// this after appending a durable session-log entry so subsequent
+    /// advisories carry the correct ordering hint without a JetStream query.
+    pub fn note_durable_seq(&self, seq: u64) {
+        self.after_seq.fetch_max(seq, Ordering::Relaxed);
+    }
+
+    /// Handle to the shared `after_seq` cell, so the worker's append path can
+    /// advance it as durable entries land.
+    pub fn after_seq_handle(&self) -> Arc<AtomicU64> {
+        Arc::clone(&self.after_seq)
+    }
+
+    /// Publish an event to the advisory fan-out subject. Best-effort core NATS
+    /// (non-durable); failures are logged, never propagated. No JetStream
+    /// round-trip — `after_seq` comes from the cached atomic.
+    pub async fn publish_event(&self, event: AgentEvent) {
+        let after_seq = self.after_seq.load(Ordering::Relaxed);
+        let envelope = AdvisoryEnvelope::new(after_seq, event);
+        match envelope.to_bytes() {
+            Ok(payload) => {
+                if let Err(e) = self
+                    .client
+                    .publish(self.subject.clone(), payload.into())
+                    .await
+                {
+                    log::debug!("advisory event publish failed (lossy-OK): {e}");
+                }
+            }
+            Err(e) => log::debug!("failed to serialize advisory event: {e}"),
+        }
+    }
+}
+
+impl AgentEventSink for NatsEventSink {
+    fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+        // The trait method is sync but publish is async. Fire-and-forget onto
+        // the current runtime so the agent loop is never blocked, and so this
+        // works on any runtime flavor (block_in_place would panic on a
+        // current-thread runtime). Advisory delivery is lossy by contract, so
+        // dropping on a missing runtime handle is acceptable.
+        let sink = self.clone();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move { sink.publish_event(event).await });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Client-side attach helper
+// ---------------------------------------------------------------------------
+
+/// Client-side helper for attaching to a session's event stream.
+///
+/// Provides gap-free, dup-free event delivery:
+/// 1. Opens the durable NatsSessionLog, records current stream last_seq
+/// 2. Replays log [first..=last_seq] to build history
+/// 3. Subscribes to `sessions.{id}.events`
+/// 4. Dedup rule: durable entries applied by seq; advisory only if after_seq >= last-applied
+///
+/// # Example
+///
+/// ```ignore
+/// use harnx_runtime::nats_event_sink::SessionEventStream;
+///
+/// async fn attach_and_consume(jetstream: jetstream::Context, client: async_nats::Client, session_id: &str) {
+///     let stream = SessionEventStream::attach(jetstream, client, session_id).await.unwrap();
+///     
+///     // First, process durable history
+///     for (seq, entry) in stream.history() {
+///         // Apply entry to local state
+///     }
+///     
+///     // Then, consume live events
+///     while let Some(envelope) = stream.next().await {
+///         if envelope.after_seq >= stream.last_applied_seq() {
+///             // Render the advisory event
+///         }
+///     }
+/// }
+/// ```
+pub struct SessionEventStream {
+    /// History replayed from durable log (seq, entry pairs).
+    history: Vec<(u64, harnx_core::session::SessionLogEntry)>,
+    /// Last sequence number from durable history (for dedup).
+    last_durable_seq: u64,
+    /// Subscription to the advisory events subject.
+    subscriber: async_nats::Subscriber,
+}
+
+impl SessionEventStream {
+    /// Attach to a session's event stream.
+    ///
+    /// 1. Opens the durable session log stream, replays history
+    /// 2. Subscribes to the advisory events subject
+    /// 3. Returns history and live event stream
+    ///
+    /// # Arguments
+    /// * `jetstream` - JetStream context for durable log access
+    /// * `client` - NATS client for advisory subscription
+    /// * `session_id` - Session to attach to
+    pub async fn attach(
+        jetstream: jetstream::Context,
+        client: async_nats::Client,
+        session_id: &str,
+    ) -> Result<Self> {
+        // 1. Subscribe to advisory events FIRST, then load durable history.
+        //    Ordering matters: any advisory emitted while we replay the log
+        //    would be lost if we subscribed afterwards. Subscribing first means
+        //    such advisories are buffered by the subscription; the `after_seq`
+        //    dedup rule then drops the ones already covered by the history we
+        //    load next, and renders the genuinely-newer ones — no gap, no dup.
+        let subject = events_subject(session_id);
+        let subscriber = client
+            .subscribe(subject)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to subscribe to events subject: {e}"))?;
+
+        // 2. Load durable history (after subscribing).
+        let log = crate::nats_session_log::NatsSessionLog::new(jetstream.clone(), session_id);
+        let history = log.load_events_async().await?;
+        let last_durable_seq = history.last().map(|(seq, _)| *seq).unwrap_or(0);
+
+        Ok(Self {
+            history,
+            last_durable_seq,
+            subscriber,
+        })
+    }
+
+    /// Get the durable history (replayed entries).
+    pub fn history(&self) -> &[(u64, harnx_core::session::SessionLogEntry)] {
+        &self.history
+    }
+
+    /// Get the last applied durable sequence number.
+    pub fn last_applied_seq(&self) -> u64 {
+        self.last_durable_seq
+    }
+
+    /// Receive the next advisory envelope.
+    ///
+    /// Returns `None` when the subscription is closed.
+    ///
+    /// Client dedup rule: render the advisory only if `should_render` is true
+    /// (i.e. `after_seq >= last_applied_seq()`).
+    pub async fn next(&mut self) -> Option<AdvisoryEnvelope> {
+        use futures_util::StreamExt;
+
+        loop {
+            let msg = self.subscriber.next().await?;
+            match AdvisoryEnvelope::from_bytes(&msg.payload) {
+                Ok(envelope) => return Some(envelope),
+                Err(error) => {
+                    log::warn!(
+                        "skipping malformed NATS advisory payload for session event stream: {error:#}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Check if an advisory envelope should be rendered.
+    ///
+    /// Dedup rule: render only if the advisory's `after_seq` is `>=` the last
+    /// durable seq the client has applied. `>=` (not `>`) is required so a
+    /// freshly-attached client (history replayed to seq N) still renders the
+    /// LIVE advisories of the in-flight turn — those carry `after_seq = N`
+    /// because they *follow* durable entry N (the next durable entry,
+    /// e.g. the final AssistantMessage, is not yet written). A stale advisory
+    /// from before the client's position (`after_seq < last_durable_seq`) is
+    /// dropped. The authoritative final state always comes from the durable
+    /// log; advisories are lossy previews.
+    pub fn should_render(&self, envelope: &AdvisoryEnvelope) -> bool {
+        envelope.after_seq >= self.last_durable_seq
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harnx_core::event::{ModelEvent, NoticeEvent};
+
+    #[test]
+    fn advisory_envelope_serializes() {
+        let event = AgentEvent::Notice(NoticeEvent::Info("hello".into()));
+        let envelope = AdvisoryEnvelope::new(42, event);
+        let bytes = envelope.to_bytes().unwrap();
+        assert!(!bytes.is_empty());
+
+        let back = AdvisoryEnvelope::from_bytes(&bytes).unwrap();
+        assert_eq!(back.after_seq, 42);
+    }
+
+    #[test]
+    fn advisory_envelope_wraps_model_chunk() {
+        let event = AgentEvent::Model(ModelEvent::MessageChunk {
+            blocks: vec![harnx_core::event::ContentBlock::Text("Hello world".into())],
+        });
+        let envelope = AdvisoryEnvelope::new(100, event);
+        let bytes = envelope.to_bytes().unwrap();
+        let back = AdvisoryEnvelope::from_bytes(&bytes).unwrap();
+        assert_eq!(back.after_seq, 100);
+    }
+
+    #[test]
+    fn should_render_dedup_rule() {
+        // Mirrors SessionEventStream::should_render. last_durable_seq = 10:
+        // - after_seq = 15 -> render (newer advisory)
+        // - after_seq = 10 -> RENDER: live advisories of the in-flight turn
+        //   carry the durable seq they FOLLOW (10); a client caught up to 10
+        //   must still see them as live preview.
+        // - after_seq = 5  -> DROP (stale, predates client position)
+        fn render(after_seq: u64, last_durable_seq: u64) -> bool {
+            after_seq >= last_durable_seq
+        }
+        assert!(render(15, 10), "newer advisory must render");
+        assert!(
+            render(10, 10),
+            "live advisory following the client's last durable seq must render"
+        );
+        assert!(!render(5, 10), "stale advisory must not render");
+
+        // Sanity: envelopes carry the after_seq through serde.
+        let event = AgentEvent::Notice(NoticeEvent::Info("test".into()));
+        let env = AdvisoryEnvelope::new(15, event);
+        let back = AdvisoryEnvelope::from_bytes(&env.to_bytes().unwrap()).unwrap();
+        assert_eq!(back.after_seq, 15);
+    }
+}

--- a/crates/harnx-runtime/src/nats_lease.rs
+++ b/crates/harnx-runtime/src/nats_lease.rs
@@ -1,0 +1,395 @@
+use crate::nats_metrics;
+use anyhow::{anyhow, bail, Context, Result};
+use async_nats::header::{NATS_EXPECTED_LAST_SUBJECT_SEQUENCE, NATS_MESSAGE_TTL};
+use async_nats::jetstream::{self, context::PublishErrorKind, kv, stream};
+use serde::{Deserialize, Serialize};
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use tokio::sync::{watch, Mutex};
+use tokio::task::JoinHandle;
+use tokio::time;
+
+const LEASE_BUCKET: &str = "harnx_leases";
+const LEASE_KEY_PREFIX: &str = "sessions";
+pub const DEFAULT_LEASE_TTL: Duration = Duration::from_secs(30);
+pub const DEFAULT_RENEW_INTERVAL: Duration = Duration::from_secs(10);
+pub const DEFAULT_BUCKET_REPLICAS: usize = 1;
+pub const DEFAULT_TOMBSTONE_TTL: Duration = Duration::from_secs(3600);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LeaseRecord {
+    pub worker_id: String,
+    pub generation: u64,
+    pub acquired_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct NatsLeaseConfig {
+    pub bucket: String,
+    pub ttl: Duration,
+    pub renew_interval: Duration,
+    pub replicas: usize,
+    pub tombstone_ttl: Duration,
+}
+
+impl Default for NatsLeaseConfig {
+    fn default() -> Self {
+        Self {
+            bucket: LEASE_BUCKET.to_string(),
+            ttl: DEFAULT_LEASE_TTL,
+            renew_interval: DEFAULT_RENEW_INTERVAL,
+            replicas: DEFAULT_BUCKET_REPLICAS,
+            tombstone_ttl: DEFAULT_TOMBSTONE_TTL,
+        }
+    }
+}
+
+impl NatsLeaseConfig {
+    pub fn key_for_session(&self, session_id: &str) -> String {
+        format!("{LEASE_KEY_PREFIX}/{session_id}/lock")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NatsLeaseAcquireParams<'a> {
+    pub jetstream: jetstream::Context,
+    pub session_id: &'a str,
+    pub worker_id: String,
+    pub generation: u64,
+    pub config: NatsLeaseConfig,
+}
+
+#[derive(Debug)]
+struct RenewTaskParams {
+    jetstream: jetstream::Context,
+    bucket: kv::Store,
+    key: String,
+    state: Arc<LeaseState>,
+    renew_interval: Duration,
+    session_id: String,
+}
+
+#[derive(Debug)]
+pub struct NatsSessionLease {
+    bucket: kv::Store,
+    jetstream: jetstream::Context,
+    key: String,
+    state: Arc<LeaseState>,
+    renew_task: Mutex<Option<JoinHandle<()>>>,
+}
+
+#[derive(Debug)]
+struct LeaseState {
+    worker_id: String,
+    generation: u64,
+    ttl: Duration,
+    held: AtomicBool,
+    fence_token: AtomicU64,
+    status_tx: watch::Sender<bool>,
+}
+
+impl NatsSessionLease {
+    pub async fn acquire(params: NatsLeaseAcquireParams<'_>) -> Result<Option<Self>> {
+        let NatsLeaseAcquireParams {
+            jetstream,
+            session_id,
+            worker_id,
+            generation,
+            config,
+        } = params;
+        config.validate()?;
+        let bucket = ensure_lease_bucket(&jetstream, &config).await?;
+        let key = config.key_for_session(session_id);
+        let record = LeaseRecord::new(worker_id.clone(), generation);
+        let payload = serde_json::to_vec(&record).context("Failed to serialize lease record")?;
+
+        let revision = match bucket
+            .create_with_ttl(&key, payload.into(), config.ttl)
+            .await
+        {
+            Ok(revision) => revision,
+            Err(error) if is_create_conflict(&error) => return Ok(None),
+            Err(error) => {
+                return Err(anyhow!(error)).with_context(|| {
+                    format!("Failed to acquire NATS lease for session '{session_id}'")
+                })
+            }
+        };
+
+        let (status_tx, _status_rx) = watch::channel(true);
+        let state = Arc::new(LeaseState {
+            worker_id,
+            generation,
+            ttl: config.ttl,
+            held: AtomicBool::new(true),
+            fence_token: AtomicU64::new(revision),
+            status_tx,
+        });
+        info!(
+            "nats lease acquired: session_id={session_id} worker_id={} generation={} revision={revision}",
+            state.worker_id,
+            state.generation
+        );
+        nats_metrics::lease_acquired();
+
+        let renew_task = spawn_renew_task(RenewTaskParams {
+            jetstream: jetstream.clone(),
+            bucket: bucket.clone(),
+            key: key.clone(),
+            state: Arc::clone(&state),
+            renew_interval: config.renew_interval,
+            session_id: session_id.to_string(),
+        });
+
+        Ok(Some(Self {
+            bucket,
+            jetstream,
+            key,
+            state,
+            renew_task: Mutex::new(Some(renew_task)),
+        }))
+    }
+
+    pub fn is_held(&self) -> bool {
+        self.state.held.load(Ordering::SeqCst)
+    }
+
+    pub fn fence_token(&self) -> u64 {
+        self.state.fence_token.load(Ordering::SeqCst)
+    }
+
+    pub fn lost_watch(&self) -> watch::Receiver<bool> {
+        self.state.status_tx.subscribe()
+    }
+
+    pub fn worker_id(&self) -> &str {
+        &self.state.worker_id
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.state.generation
+    }
+
+    pub async fn release(&self) -> Result<()> {
+        let handle = self.stop_renew_task().await;
+        let held = self.state.mark_lost();
+
+        if let Some(handle) = handle {
+            handle.abort();
+            let _ = handle.await;
+        }
+
+        if !held {
+            return Ok(());
+        }
+
+        let revision = self.fence_token();
+        self.bucket
+            .delete_expect_revision(&self.key, Some(revision))
+            .await
+            .with_context(|| format!("Failed to release NATS lease key '{}'", self.key))
+    }
+
+    pub async fn stop_renewal_for_test(&self) {
+        if let Some(handle) = self.stop_renew_task().await {
+            handle.abort();
+            let _ = handle.await;
+        }
+    }
+
+    /// Test helper: simulate detected lease loss. Flips `is_held()` to false
+    /// and fires the lost-watch, exactly as a failed renewal would.
+    pub fn mark_lost_for_test(&self) {
+        if self.state.mark_lost() {
+            nats_metrics::lease_lost();
+        }
+    }
+
+    async fn stop_renew_task(&self) -> Option<JoinHandle<()>> {
+        self.renew_task.lock().await.take()
+    }
+}
+
+impl Drop for NatsSessionLease {
+    fn drop(&mut self) {
+        let bucket = self.bucket.clone();
+        let _jetstream = self.jetstream.clone();
+        let key = self.key.clone();
+        let revision = self.fence_token();
+        let held = self.state.mark_lost();
+        let state = Arc::clone(&self.state);
+
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            if let Some(task) = self.renew_task.get_mut().take() {
+                task.abort();
+            }
+            if held {
+                handle.spawn(async move {
+                    let _ = bucket.delete_expect_revision(&key, Some(revision)).await;
+                    drop(state);
+                });
+            }
+        }
+    }
+}
+
+impl LeaseRecord {
+    fn new(worker_id: String, generation: u64) -> Self {
+        Self {
+            worker_id,
+            generation,
+            acquired_at: chrono::Utc::now().to_rfc3339(),
+        }
+    }
+}
+
+impl NatsLeaseConfig {
+    fn validate(&self) -> Result<()> {
+        if self.ttl.is_zero() {
+            bail!("NATS lease TTL must be > 0")
+        }
+        if self.renew_interval.is_zero() {
+            bail!("NATS lease renew interval must be > 0")
+        }
+        if self.renew_interval >= self.ttl {
+            bail!(
+                "NATS lease renew interval ({:?}) must be smaller than TTL ({:?})",
+                self.renew_interval,
+                self.ttl
+            )
+        }
+        if self.replicas == 0 {
+            bail!("NATS lease replica count must be >= 1")
+        }
+        if self.tombstone_ttl.is_zero() {
+            bail!("NATS lease tombstone TTL must be > 0")
+        }
+        Ok(())
+    }
+}
+
+impl LeaseState {
+    fn mark_lost(&self) -> bool {
+        let was_held = self.held.swap(false, Ordering::SeqCst);
+        if was_held {
+            let _ = self.status_tx.send(false);
+        }
+        was_held
+    }
+}
+
+async fn ensure_lease_bucket(
+    jetstream: &jetstream::Context,
+    config: &NatsLeaseConfig,
+) -> Result<kv::Store> {
+    match jetstream
+        .create_key_value(kv::Config {
+            bucket: config.bucket.clone(),
+            history: 1,
+            limit_markers: Some(config.tombstone_ttl),
+            num_replicas: config.replicas,
+            storage: stream::StorageType::File,
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(bucket) => Ok(bucket),
+        Err(_) => jetstream
+            .get_key_value(&config.bucket)
+            .await
+            .map_err(anyhow::Error::from)
+            .with_context(|| {
+                format!(
+                    "Failed to create or open NATS lease bucket '{}'",
+                    config.bucket
+                )
+            }),
+    }
+}
+
+fn spawn_renew_task(params: RenewTaskParams) -> JoinHandle<()> {
+    let RenewTaskParams {
+        jetstream,
+        bucket,
+        key,
+        state,
+        renew_interval,
+        session_id,
+    } = params;
+    tokio::spawn(async move {
+        let mut ticker = time::interval(renew_interval);
+        ticker.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+        loop {
+            ticker.tick().await;
+            if !state.held.load(Ordering::SeqCst) {
+                break;
+            }
+            match renew_once(&jetstream, &bucket, &key, &state).await {
+                Ok(new_revision) => {
+                    info!(
+                        "nats lease renewed: session_id={} worker_id={} generation={} revision={new_revision}",
+                        session_id,
+                        state.worker_id,
+                        state.generation
+                    );
+                }
+                Err(error) => {
+                    warn!(
+                        "nats lease lost: session_id={} worker_id={} generation={} revision={} reason={error:#}",
+                        session_id,
+                        state.worker_id,
+                        state.generation,
+                        state.fence_token.load(Ordering::SeqCst)
+                    );
+                    if state.mark_lost() {
+                        nats_metrics::lease_lost();
+                    }
+                    break;
+                }
+            }
+        }
+    })
+}
+
+async fn renew_once(
+    jetstream: &jetstream::Context,
+    bucket: &kv::Store,
+    key: &str,
+    state: &LeaseState,
+) -> Result<u64> {
+    let expected_revision = state.fence_token.load(Ordering::SeqCst);
+    let record = LeaseRecord::new(state.worker_id.clone(), state.generation);
+    let payload =
+        serde_json::to_vec(&record).context("Failed to serialize renewed lease record")?;
+    let subject = format!("$KV.{}.{}", bucket.name, key);
+    let mut headers = async_nats::HeaderMap::new();
+    headers.insert(
+        NATS_EXPECTED_LAST_SUBJECT_SEQUENCE,
+        expected_revision.to_string(),
+    );
+    headers.insert(NATS_MESSAGE_TTL, state.ttl.as_secs().to_string());
+    let ack = jetstream
+        .publish_with_headers(subject, headers, payload.into())
+        .await
+        .with_context(|| format!("Failed to publish renewal for lease key '{key}'"))?
+        .await;
+    match ack {
+        Ok(ack) => {
+            state.fence_token.store(ack.sequence, Ordering::SeqCst);
+            Ok(ack.sequence)
+        }
+        Err(error) if error.kind() == PublishErrorKind::WrongLastSequence => {
+            bail!("Lost lease CAS for key '{key}'")
+        }
+        Err(error) => {
+            Err(anyhow!(error)).with_context(|| format!("CAS renewal failed for lease key '{key}'"))
+        }
+    }
+}
+
+fn is_create_conflict(error: &kv::CreateError) -> bool {
+    matches!(error.kind(), kv::CreateErrorKind::AlreadyExists)
+}

--- a/crates/harnx-runtime/src/nats_metrics.rs
+++ b/crates/harnx-runtime/src/nats_metrics.rs
@@ -1,0 +1,71 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct NatsMetricsSnapshot {
+    pub active_sessions_per_worker: u64,
+    pub lease_acquisitions: u64,
+    pub lease_losses: u64,
+    pub fenced_writes_rejected: u64,
+    pub resumes: u64,
+    pub interrupt_errors_synthesized: u64,
+}
+
+static ACTIVE_SESSIONS_PER_WORKER: AtomicU64 = AtomicU64::new(0);
+static LEASE_ACQUISITIONS: AtomicU64 = AtomicU64::new(0);
+static LEASE_LOSSES: AtomicU64 = AtomicU64::new(0);
+static FENCED_WRITES_REJECTED: AtomicU64 = AtomicU64::new(0);
+static RESUMES: AtomicU64 = AtomicU64::new(0);
+static INTERRUPT_ERRORS_SYNTHESIZED: AtomicU64 = AtomicU64::new(0);
+
+pub fn active_session_started() {
+    ACTIVE_SESSIONS_PER_WORKER.fetch_add(1, Ordering::SeqCst);
+}
+
+pub fn active_session_finished() {
+    ACTIVE_SESSIONS_PER_WORKER
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {
+            Some(value.saturating_sub(1))
+        })
+        .ok();
+}
+
+pub fn lease_acquired() {
+    LEASE_ACQUISITIONS.fetch_add(1, Ordering::SeqCst);
+}
+
+pub fn lease_lost() {
+    LEASE_LOSSES.fetch_add(1, Ordering::SeqCst);
+}
+
+pub fn fenced_write_rejected() {
+    FENCED_WRITES_REJECTED.fetch_add(1, Ordering::SeqCst);
+}
+
+pub fn resume_detected() {
+    RESUMES.fetch_add(1, Ordering::SeqCst);
+}
+
+pub fn interrupt_error_synthesized() {
+    INTERRUPT_ERRORS_SYNTHESIZED.fetch_add(1, Ordering::SeqCst);
+}
+
+pub fn snapshot() -> NatsMetricsSnapshot {
+    NatsMetricsSnapshot {
+        active_sessions_per_worker: ACTIVE_SESSIONS_PER_WORKER.load(Ordering::SeqCst),
+        lease_acquisitions: LEASE_ACQUISITIONS.load(Ordering::SeqCst),
+        lease_losses: LEASE_LOSSES.load(Ordering::SeqCst),
+        fenced_writes_rejected: FENCED_WRITES_REJECTED.load(Ordering::SeqCst),
+        resumes: RESUMES.load(Ordering::SeqCst),
+        interrupt_errors_synthesized: INTERRUPT_ERRORS_SYNTHESIZED.load(Ordering::SeqCst),
+    }
+}
+
+#[cfg(test)]
+pub fn reset_for_test() {
+    ACTIVE_SESSIONS_PER_WORKER.store(0, Ordering::SeqCst);
+    LEASE_ACQUISITIONS.store(0, Ordering::SeqCst);
+    LEASE_LOSSES.store(0, Ordering::SeqCst);
+    FENCED_WRITES_REJECTED.store(0, Ordering::SeqCst);
+    RESUMES.store(0, Ordering::SeqCst);
+    INTERRUPT_ERRORS_SYNTHESIZED.store(0, Ordering::SeqCst);
+}

--- a/crates/harnx-runtime/src/nats_session_log.rs
+++ b/crates/harnx-runtime/src/nats_session_log.rs
@@ -1,0 +1,283 @@
+use anyhow::{bail, Context, Result};
+use async_nats::jetstream::{
+    self,
+    context::Publish,
+    stream::{Config as StreamConfig, RetentionPolicy},
+};
+use bytes::Bytes;
+use harnx_core::{session::SessionLogEntry, session_log::SessionLog};
+use std::time::Duration;
+use tokio::runtime::{Builder, Handle};
+use tokio::time::timeout;
+
+const STREAM_NAME_PREFIX: &str = "SESSION_";
+const DUPLICATE_WINDOW: Duration = Duration::from_secs(120);
+const READ_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Clone)]
+pub struct NatsSessionLog {
+    jetstream: jetstream::Context,
+    session_id: String,
+    stream_name: String,
+    subject: String,
+}
+
+impl NatsSessionLog {
+    pub fn new(jetstream: jetstream::Context, session_id: impl Into<String>) -> Self {
+        let session_id = session_id.into();
+        Self {
+            jetstream,
+            stream_name: stream_name_for_session(&session_id),
+            subject: subject_for_session(&session_id),
+            session_id,
+        }
+    }
+
+    pub async fn append_event_async(&self, entry: &SessionLogEntry) -> Result<u64> {
+        self.ensure_stream().await?;
+        let payload = serialize_entry(entry)?;
+        let message_id = new_message_id();
+        let ack = self
+            .jetstream
+            .send_publish(
+                self.subject.clone(),
+                Publish::build()
+                    .payload(Bytes::from(payload))
+                    .message_id(message_id),
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to publish session log entry for session '{}'",
+                    self.session_id
+                )
+            })?
+            .await
+            .with_context(|| {
+                format!(
+                    "JetStream did not ack session log entry for session '{}'",
+                    self.session_id
+                )
+            })?;
+        Ok(ack.sequence)
+    }
+
+    pub async fn load_events_async(&self) -> Result<Vec<(u64, SessionLogEntry)>> {
+        self.ensure_stream().await?;
+        self.read_all_from(1).await
+    }
+
+    /// Like [`load_events_async`], but first waits (bounded) until the stream's
+    /// `last_sequence` reaches `min_seq`, providing read-your-writes consistency.
+    ///
+    /// A publish ack returns the durable sequence, but a subsequent `stream.info()`
+    /// round-trip can momentarily report a lower `last_sequence`. A worker that
+    /// re-reads the log immediately after persisting its own turn output (e.g. the
+    /// end-of-turn drain re-read) must observe its own writes, otherwise it
+    /// re-folds already-answered messages. Pass the max sequence the worker has
+    /// appended to ensure the read reflects it. `min_seq == 0` is a plain load.
+    pub async fn load_events_at_least_async(
+        &self,
+        min_seq: u64,
+    ) -> Result<Vec<(u64, SessionLogEntry)>> {
+        let mut stream = self.ensure_stream().await?;
+        if min_seq > 0 {
+            let deadline = tokio::time::Instant::now() + READ_TIMEOUT;
+            loop {
+                let last_sequence = stream
+                    .info()
+                    .await
+                    .map(|info| info.state.last_sequence)
+                    .unwrap_or(0);
+                if last_sequence >= min_seq || tokio::time::Instant::now() >= deadline {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        }
+        self.read_all_from(1).await
+    }
+
+    pub async fn replay_from_async(&self, seq: u64) -> Result<Vec<SessionLogEntry>> {
+        self.ensure_stream().await?;
+        let start_sequence = if seq == 0 {
+            Some(1)
+        } else {
+            seq.checked_add(1)
+        };
+        let Some(start_sequence) = start_sequence else {
+            return Ok(Vec::new());
+        };
+        self.read_all_from(start_sequence)
+            .await
+            .map(|entries| entries.into_iter().map(|(_, entry)| entry).collect())
+    }
+
+    async fn ensure_stream(&self) -> Result<jetstream::stream::Stream> {
+        self.jetstream
+            .get_or_create_stream(StreamConfig {
+                name: self.stream_name.clone(),
+                subjects: vec![self.subject.clone()],
+                retention: RetentionPolicy::Limits,
+                duplicate_window: DUPLICATE_WINDOW,
+                ..Default::default()
+            })
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to create or open JetStream log stream '{}' for session '{}'",
+                    self.stream_name, self.session_id
+                )
+            })
+    }
+
+    /// Read all persisted entries with stream sequence `>= start_sequence`.
+    ///
+    /// Uses JetStream's direct per-sequence `get_raw_message` lookup rather than
+    /// a consumer. For a bounded historical read this is deterministic and
+    /// terminates cleanly: a consumer's message stream is a live subscription
+    /// that blocks waiting for new messages, and the pull-consumer `fetch` path
+    /// proved flaky here (partial/short batches under a current-thread Tokio
+    /// runtime). Direct get works regardless of runtime flavor and never blocks
+    /// on future messages. Each lookup is bounded by `READ_TIMEOUT`.
+    async fn read_all_from(&self, start_sequence: u64) -> Result<Vec<(u64, SessionLogEntry)>> {
+        let mut stream = self.ensure_stream().await?;
+        let stream_info = stream.info().await.with_context(|| {
+            format!(
+                "Failed to inspect JetStream log stream '{}' for session '{}'",
+                self.stream_name, self.session_id
+            )
+        })?;
+        let first_sequence = stream_info.state.first_sequence;
+        let last_sequence = stream_info.state.last_sequence;
+        let message_count = stream_info.state.messages;
+
+        if message_count == 0 || last_sequence < start_sequence {
+            return Ok(Vec::new());
+        }
+
+        let begin = start_sequence.max(first_sequence).max(1);
+        let mut entries = Vec::new();
+        for seq in begin..=last_sequence {
+            let raw = match timeout(READ_TIMEOUT, stream.get_raw_message(seq)).await {
+                Ok(Ok(raw)) => raw,
+                // Sequence may have been removed (retention/limits) leaving a gap;
+                // skip missing sequences rather than failing the whole read.
+                Ok(Err(_)) => continue,
+                Err(_) => {
+                    return Err(anyhow::anyhow!(
+                        "Timed out after {:?} reading JetStream session log for session '{}' at stream sequence {}",
+                        READ_TIMEOUT,
+                        self.session_id,
+                        seq
+                    ));
+                }
+            };
+            let entry = deserialize_entry(&raw.payload).with_context(|| {
+                format!(
+                    "Failed to deserialize session log entry for session '{}' at stream sequence {}",
+                    self.session_id, raw.sequence
+                )
+            })?;
+            entries.push((raw.sequence, entry));
+        }
+        Ok(entries)
+    }
+}
+
+impl SessionLog for NatsSessionLog {
+    fn append_event(&mut self, entry: &SessionLogEntry) -> Result<u64> {
+        block_on_session_log_future(self.append_event_async(entry))?
+    }
+
+    fn load_events(&self) -> Result<Vec<(u64, SessionLogEntry)>> {
+        block_on_session_log_future(self.load_events_async())?
+    }
+
+    fn replay_from(&self, seq: u64) -> Result<Vec<SessionLogEntry>> {
+        block_on_session_log_future(self.replay_from_async(seq))?
+    }
+}
+
+pub fn serialize_entry(entry: &SessionLogEntry) -> Result<String> {
+    serde_yaml::to_string(entry).context("Failed to serialize SessionLogEntry")
+}
+
+pub fn deserialize_entry(payload: &[u8]) -> Result<SessionLogEntry> {
+    serde_yaml::from_slice(payload).context("Failed to deserialize SessionLogEntry")
+}
+
+pub fn load_session_from_entries(
+    entries: &[(u64, SessionLogEntry)],
+    name: &str,
+) -> Result<harnx_core::session::Session> {
+    let raw_entries: Vec<(usize, SessionLogEntry)> = entries
+        .iter()
+        .map(|(seq, entry)| {
+            usize::try_from(*seq)
+                .map(|seq| (seq, entry.clone()))
+                .context("session log sequence does not fit into usize")
+        })
+        .collect::<Result<_>>()?;
+    crate::config::session::replay_log_entries_for_external(&raw_entries, name)
+}
+
+pub fn load_session_from_yaml(content: &str, name: &str) -> Result<harnx_core::session::Session> {
+    let raw_entries = crate::config::session::collect_raw_log_entries(content, name)?;
+    crate::config::session::replay_log_entries_for_external(&raw_entries, name)
+}
+
+pub fn subject_for_session(session_id: &str) -> String {
+    format!("sessions.{session_id}.log")
+}
+
+pub fn stream_name_for_session(session_id: &str) -> String {
+    let mut name = String::with_capacity(STREAM_NAME_PREFIX.len() + session_id.len());
+    name.push_str(STREAM_NAME_PREFIX);
+    for ch in session_id.chars() {
+        name.push(sanitize_stream_name_char(ch));
+    }
+    name
+}
+
+fn sanitize_stream_name_char(ch: char) -> char {
+    if is_valid_stream_name_char(ch) {
+        ch.to_ascii_uppercase()
+    } else {
+        '_'
+    }
+}
+
+fn is_valid_stream_name_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_')
+}
+
+/// Unique idempotency key for a single append.
+///
+/// Each logical append gets a fresh UUID so that two distinct entries with
+/// identical serialized content (e.g. two identical user messages, or two
+/// duplicate log entries with the same text are BOTH stored — a content-derived
+/// id would make JetStream's `duplicate_window` silently drop the second.
+/// The id still protects against an accidental double-publish of the *same*
+/// `send_publish` call within the dedup window.
+fn new_message_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+fn block_on_session_log_future<F>(future: F) -> Result<F::Output>
+where
+    F: std::future::Future + Send,
+    F::Output: Send,
+{
+    if Handle::try_current().is_ok() {
+        bail!(
+            "NatsSessionLog: use append_event_async/load_events_async/replay_from_async from within a Tokio runtime; sync SessionLog methods are only supported from non-async callers"
+        );
+    }
+
+    Ok(Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("Failed to build temporary Tokio runtime for NatsSessionLog")?
+        .block_on(future))
+}

--- a/crates/harnx-runtime/src/nats_worker/agent_loop.rs
+++ b/crates/harnx-runtime/src/nats_worker/agent_loop.rs
@@ -1,0 +1,792 @@
+//! Agent loop entrypoint for NATS-backed sessions.
+
+use super::backend::{FencedSessionLogSink, NatsSessionLogBackend};
+use crate::agent_loop::OnToolRoundFn;
+use crate::config::{GlobalConfig, Input};
+use crate::nats_lease::NatsSessionLease;
+use crate::nats_metrics;
+use crate::utils::AbortSignal;
+use anyhow::Result;
+use harnx_core::message::Message;
+use harnx_hooks::{AsyncHookManager, PersistentHookManager};
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct RunAgentLoopArgs<'a> {
+    pub cluster_key: &'a str,
+    pub session_id: &'a str,
+    pub config: GlobalConfig,
+    pub initial_input: Input,
+    pub abort_signal: AbortSignal,
+    pub call_fn: Option<crate::agent_loop::AgentCallFn>,
+    pub lease: Option<Arc<NatsSessionLease>>,
+    pub after_seq_observer: Option<Arc<AtomicU64>>,
+    pub on_tool_round: Option<OnToolRoundFn>,
+}
+
+impl<'a> RunAgentLoopArgs<'a> {
+    pub fn with_lease(mut self, lease: Arc<NatsSessionLease>) -> Self {
+        self.lease = Some(lease);
+        self
+    }
+
+    pub fn with_after_seq_observer(mut self, observer: Arc<AtomicU64>) -> Self {
+        self.after_seq_observer = Some(observer);
+        self
+    }
+}
+
+fn fold_user_messages(messages: &[Message]) -> String {
+    messages
+        .iter()
+        .map(|message| message.content.to_text())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+#[allow(dead_code)]
+pub(crate) fn last_fed_user_log_seq(_input: &Input) -> Option<u64> {
+    // DEPRECATED: This function cannot meaningfully derive a cursor from Input.
+    // The cursor MUST be derived from the log seq of messages that went into
+    // the turn input. Callers should use the `seed_cursor` returned by
+    // `derive_turn_input` or pass messages directly.
+    //
+    // Kept for compatibility with resumable path which passes a synthesized
+    // Input from resumable_ctx.last_user, but the cursor must come from
+    // `resumable_ctx.last_user.log_seq` directly at the call site.
+    #[allow(dead_code)]
+    None
+}
+
+pub(crate) fn fold_new_user_messages_since(
+    entries: &[(u64, harnx_core::session::SessionLogEntry)],
+    cursor: Option<u64>,
+) -> (Vec<Message>, Option<u64>) {
+    // Apply mutations first: retracted/edited entries must be filtered.
+    let raw_with_seq: Vec<_> = entries
+        .iter()
+        .map(|(seq, e)| (*seq as usize, e.clone()))
+        .collect();
+    let effective_entries = harnx_core::session_reconstruct::apply_log_mutations(&raw_with_seq);
+
+    let mut messages = Vec::new();
+    let mut latest_seq = cursor;
+    for (seq, entry) in effective_entries {
+        // Entry may be mutated; cursor semantics still skip seq <= cursor.
+        if cursor.is_some_and(|seen| seq as u64 <= seen) {
+            continue;
+        }
+        if let harnx_core::session::SessionLogEntry::Message {
+            role,
+            content,
+            timestamp,
+            ..
+        } = entry
+        {
+            if role.is_user() {
+                messages.push(
+                    Message::new(role, content)
+                        .with_log_seq(seq)
+                        .with_log_timestamp(timestamp.unwrap_or_else(chrono::Utc::now)),
+                );
+                latest_seq = Some(seq as u64);
+            }
+        }
+    }
+    (messages, latest_seq)
+}
+
+pub(crate) fn build_mid_turn_injection_callback(
+    backend: NatsSessionLogBackend,
+    cursor: Arc<AtomicU64>,
+) -> OnToolRoundFn {
+    Arc::new(move |merged_input, _results| {
+        let backend = backend.clone();
+        let cursor = Arc::clone(&cursor);
+        Box::pin(async move {
+            let tail = match backend.load_events_blocking() {
+                Ok(entries) => entries,
+                Err(err) => {
+                    log::warn!("failed to reload session log for mid-turn injection: {err}");
+                    return;
+                }
+            };
+            let current = match cursor.load(std::sync::atomic::Ordering::SeqCst) {
+                0 => None,
+                seq => Some(seq),
+            };
+            let (messages, latest_seq) = fold_new_user_messages_since(&tail, current);
+            if messages.is_empty() {
+                return;
+            }
+            merged_input.set_injected_user_text(fold_user_messages(&messages));
+            if let Some(seq) = latest_seq {
+                cursor.store(seq, std::sync::atomic::Ordering::SeqCst);
+            }
+        })
+    })
+}
+
+struct RepairOrphanToolCallsArgs<'a> {
+    config: GlobalConfig,
+    fence_token: Option<u64>,
+    worker_id: Option<String>,
+    session_id: &'a str,
+    abort_signal: &'a AbortSignal,
+}
+
+/// Run the agent loop with a remote NATS session.
+///
+/// Connects to the given cluster, loads/replays the session from JetStream,
+/// then runs `run_agent_loop` with persistence redirected to NATS.
+///
+/// For P1.3: single worker assumed sole owner (no HA/lease).
+pub async fn run_agent_loop_with_nats(args: RunAgentLoopArgs<'_>) -> Result<()> {
+    run_agent_loop_with_nats_inner(args).await
+}
+
+/// Like [`run_agent_loop_with_nats`], but fence-guarded by the holding lease
+/// (P2.2). When `lease` is `Some`, every worker-originated append is gated on
+/// `lease.is_held()` and stamped with the lease fence, and the session resume
+/// is aborted if the persisted log tail already carries a fence GREATER than
+/// the lease revision this worker holds (a newer worker has taken over).
+pub async fn run_agent_loop_with_nats_inner(args: RunAgentLoopArgs<'_>) -> Result<()> {
+    let RunAgentLoopArgs {
+        cluster_key,
+        session_id,
+        config,
+        initial_input,
+        abort_signal,
+        call_fn,
+        lease,
+        after_seq_observer,
+        on_tool_round,
+    } = args;
+    // Get JetStream context from config (extract URL before await)
+    // Connect through the config-driven helper so per-cluster auth/TLS
+    // (token, require_tls, client cert, custom CA) is applied. Connecting with
+    // a bare `async_nats::connect(url)` here would silently drop all auth/TLS
+    // settings, breaking secure clusters. Snapshot the Config first so we don't
+    // hold the lock across the await.
+    let cfg_snapshot = config.read().clone();
+    let jetstream_ctx = cfg_snapshot.nats_jetstream(cluster_key).await?;
+
+    // Load or create session from NATS
+    let mut backend = NatsSessionLogBackend::new(jetstream_ctx, session_id);
+    if let Some(observer) = after_seq_observer {
+        backend = backend.with_after_seq_observer(observer);
+    }
+
+    abort_resume_if_fenced(&backend, lease.as_deref())?;
+
+    let session = load_or_repair_session(LoadOrRepairSessionParams {
+        backend: &backend,
+        config: &config,
+        input: &initial_input,
+        lease: lease.as_deref(),
+        session_id,
+        abort_signal: &abort_signal,
+    })
+    .await?;
+
+    attach_session_to_config(&config, session, &backend, lease.as_ref());
+
+    // Build AgentLoopContext
+    let ctx = crate::agent_loop::AgentLoopContext {
+        config: config.clone(),
+        abort_signal,
+        async_manager: Arc::new(tokio::sync::Mutex::new(AsyncHookManager::new())),
+        persistent_manager: Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new())),
+        call_fn,
+        on_tool_round,
+        on_text_response: None,
+        initial_with_embeddings: false,
+        initial_resume_count: 0,
+        max_resume: None,
+        pending_async_context: None,
+    };
+
+    // Run the unified agent loop
+    // Persistence goes through shared Config.save_message entry construction; append_event routes sink
+    crate::agent_loop::run_agent_loop(&ctx, initial_input).await
+}
+
+/// Fence-on-resume fail-safe: if the persisted tail carries a worker fence
+fn abort_resume_if_fenced(
+    backend: &NatsSessionLogBackend,
+    lease: Option<&NatsSessionLease>,
+) -> Result<()> {
+    let Some(lease) = lease else {
+        return Ok(());
+    };
+    let entries: Vec<harnx_core::session::SessionLogEntry> = backend
+        .load_events_blocking()?
+        .into_iter()
+        .map(|(_, e)| e)
+        .collect();
+    if let Some(max_fence) = harnx_core::session::max_worker_fence_token(&entries) {
+        if max_fence > lease.fence_token() {
+            anyhow::bail!(
+                "aborting resume: log tail fence {max_fence} exceeds held lease revision {} (fenced by a newer worker)",
+                lease.fence_token()
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Parameters for [`load_or_repair_session`].
+struct LoadOrRepairSessionParams<'a> {
+    backend: &'a NatsSessionLogBackend,
+    config: &'a GlobalConfig,
+    input: &'a Input,
+    lease: Option<&'a NatsSessionLease>,
+    session_id: &'a str,
+    abort_signal: &'a AbortSignal,
+}
+
+/// Load the session from the backend, creating a new one when the log is empty
+/// or repairing orphan tool calls (with idempotency hints) when resuming an
+/// existing session.
+async fn load_or_repair_session(
+    params: LoadOrRepairSessionParams<'_>,
+) -> Result<harnx_core::session::Session> {
+    let LoadOrRepairSessionParams {
+        backend,
+        config,
+        input,
+        lease,
+        session_id,
+        abort_signal,
+    } = params;
+    let entries = backend.load_events_blocking()?;
+    if entries.is_empty() {
+        // New session: write header and load
+        return write_header_and_load_session(backend, config, input, session_id).await;
+    }
+
+    // Existing session: check for orphan tool calls and repair with hints
+    let mut entries_vec = entries;
+    let orphan_calls = find_orphan_tool_calls(&entries_vec);
+    if !orphan_calls.is_empty() {
+        nats_metrics::resume_detected();
+        info!(
+            "resume detected: session_id={} worker_id={} revision={} orphan_batches={}",
+            session_id,
+            lease.map(|l| l.worker_id()).unwrap_or("none"),
+            lease.map(|l| l.fence_token()).unwrap_or(0),
+            orphan_calls.len()
+        );
+        repair_orphan_tool_calls_with_hints(
+            backend,
+            &orphan_calls,
+            RepairOrphanToolCallsArgs {
+                config: config.clone(),
+                fence_token: lease.map(|l| l.fence_token()),
+                worker_id: lease.map(|l| l.worker_id().to_string()),
+                session_id,
+                abort_signal,
+            },
+        )
+        .await?;
+        // Repair appended ToolResults to the backend; reload so the
+        // in-memory session reflects the repaired log rather than the
+        // stale snapshot that still contains the orphan ToolCalls.
+        entries_vec = backend.load_events_blocking()?;
+    }
+    crate::nats_session_log::load_session_from_entries(&entries_vec, session_id)
+}
+
+/// Attach the reconstructed session to the shared config with the NATS append
+/// sink for the unified persistence path. With a lease, use the fence-guarded
+/// sink so writes from a fenced-out worker are rejected.
+fn attach_session_to_config(
+    config: &GlobalConfig,
+    mut session: harnx_core::session::Session,
+    backend: &NatsSessionLogBackend,
+    lease: Option<&Arc<NatsSessionLease>>,
+) {
+    let sink: Arc<dyn crate::config::session::SessionAppendSink> = match lease {
+        Some(lease) => Arc::new(FencedSessionLogSink::new(
+            backend.clone(),
+            Arc::clone(lease),
+        )),
+        None => Arc::new(backend.clone()),
+    };
+    session.runtime = Some(Arc::new(sink));
+    let mut cfg = config.write();
+    cfg.session = Some(session);
+}
+
+/// Pending ToolCalls entry that lacks matching ToolResults.
+#[allow(dead_code)]
+struct PendingToolCalls {
+    seq: u64,
+    text: String,
+    thought: Option<String>,
+    calls: Vec<harnx_core::tool::ToolCall>,
+    timestamp: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Decide whether an orphan tool call may be safely re-run during resume
+/// repair. A tool is re-runnable when its declaration marks it idempotent or
+/// read-only (MCP annotation hints). Unknown tools (absent from the map) are
+/// treated as non-idempotent and must NOT be re-run.
+pub(super) fn tool_can_rerun(
+    decl_map: &std::collections::HashMap<String, harnx_core::tool::ToolDeclaration>,
+    name: &str,
+) -> bool {
+    decl_map
+        .get(name)
+        .map(|d| d.idempotent_hint == Some(true) || d.read_only_hint == Some(true))
+        .unwrap_or(false)
+}
+
+/// Find orphan tool calls in session log entries (trailing ToolCalls without matching ToolResults).
+fn find_orphan_tool_calls(
+    entries: &[(u64, harnx_core::session::SessionLogEntry)],
+) -> Vec<PendingToolCalls> {
+    use harnx_core::session::SessionLogEntry;
+
+    // Find the last ToolCalls entry that lacks a matching ToolResults
+    let mut orphans = Vec::new();
+    let mut last_tool_calls: Option<PendingToolCalls> = None;
+
+    for (seq, entry) in entries {
+        match entry {
+            SessionLogEntry::ToolCalls {
+                text,
+                thought,
+                calls,
+                timestamp,
+                ..
+            } => {
+                last_tool_calls = Some(PendingToolCalls {
+                    seq: *seq,
+                    text: text.clone(),
+                    thought: thought.clone(),
+                    calls: calls.clone(),
+                    timestamp: *timestamp,
+                });
+            }
+            SessionLogEntry::ToolResults { .. } => {
+                // ToolResults clears the pending ToolCalls
+                last_tool_calls = None;
+            }
+            SessionLogEntry::Message { role, .. } if role.is_user() => {
+                // A new user message ends the prior turn; any orphan ToolCalls above it is still an orphan
+                if let Some(tc) = last_tool_calls.take() {
+                    orphans.push(tc);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // If we end with a pending ToolCalls, that's the orphan
+    if let Some(tc) = last_tool_calls {
+        orphans.push(tc);
+    }
+
+    orphans
+}
+
+/// Repair orphan tool calls: for each orphan, re-run idempotent/readonly tools,
+/// synthesize interrupt-error for non-idempotent ones.
+/// All ToolResults are appended via the backend (fence-stamped when lease is held).
+async fn repair_orphan_tool_calls_with_hints(
+    backend: &NatsSessionLogBackend,
+    orphan_calls: &[PendingToolCalls],
+    args: RepairOrphanToolCallsArgs<'_>,
+) -> Result<()> {
+    use harnx_core::session::SessionLogEntry;
+
+    let tool_repair = build_tool_repair_context(&args.config);
+    let eval_ctx = build_orphan_tool_eval_context(&args.config, &tool_repair);
+
+    for orphan in orphan_calls {
+        let results = repair_single_orphan(orphan, &args, &tool_repair, &eval_ctx).await;
+        let entry = apply_optional_fence_token(
+            SessionLogEntry::ToolResults {
+                results,
+                timestamp: orphan.timestamp,
+            },
+            args.fence_token,
+        );
+        backend.append_event_blocking(&entry)?;
+    }
+
+    Ok(())
+}
+
+struct ToolRepairContext {
+    decl_map: std::collections::HashMap<String, harnx_core::tool::ToolDeclaration>,
+    agent_use_tools: Option<String>,
+    current_agent_package: Option<String>,
+    persistent_manager: Arc<tokio::sync::Mutex<PersistentHookManager>>,
+}
+
+fn build_tool_repair_context(config: &GlobalConfig) -> ToolRepairContext {
+    let (decl_map, agent_use_tools, current_agent_package) = {
+        let guard = config.read();
+        let (tool_declarations, _) = guard.tool_declarations_for_use_tools(Some("*"), None);
+        let decl_map = tool_declarations
+            .into_iter()
+            .map(|d| (d.name.clone(), d))
+            .collect();
+        let agent_use_tools = guard
+            .agent
+            .as_ref()
+            .and_then(|a| a.use_tools().map(|v| v.join(",")));
+        let current_agent_package = guard
+            .agent
+            .as_ref()
+            .and_then(|a| harnx_core::package_namespace::pkg_from_qualified(a.name()))
+            .map(str::to_string);
+        (decl_map, agent_use_tools, current_agent_package)
+    };
+
+    ToolRepairContext {
+        decl_map,
+        agent_use_tools,
+        current_agent_package,
+        persistent_manager: Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new())),
+    }
+}
+
+fn build_orphan_tool_eval_context(
+    config: &GlobalConfig,
+    repair: &ToolRepairContext,
+) -> crate::tool::ToolEvalContext {
+    crate::tool::build_tool_eval_context(
+        config,
+        repair.agent_use_tools.as_deref(),
+        repair.current_agent_package.clone(),
+        &repair.persistent_manager,
+    )
+}
+
+async fn repair_single_orphan(
+    orphan: &PendingToolCalls,
+    args: &RepairOrphanToolCallsArgs<'_>,
+    repair: &ToolRepairContext,
+    eval_ctx: &crate::tool::ToolEvalContext,
+) -> Vec<harnx_core::session::ToolOutput> {
+    let (mut results, rerun_calls) = partition_orphan_calls(orphan, args, repair);
+    if !rerun_calls.is_empty() {
+        let rerun_results =
+            rerun_or_synthesize_tool_results(rerun_calls, eval_ctx, args.abort_signal).await;
+        results.extend(rerun_results);
+    }
+    results
+}
+
+fn partition_orphan_calls(
+    orphan: &PendingToolCalls,
+    args: &RepairOrphanToolCallsArgs<'_>,
+    repair: &ToolRepairContext,
+) -> (
+    Vec<harnx_core::session::ToolOutput>,
+    Vec<harnx_core::tool::ToolCall>,
+) {
+    let mut results = Vec::new();
+    let mut rerun_calls = Vec::new();
+
+    for call in &orphan.calls {
+        if tool_can_rerun(&repair.decl_map, &call.name) {
+            log_resume_decision("rerun", args, call);
+            rerun_calls.push(call.clone());
+        } else {
+            log_resume_decision("synthesize_interrupt_error", args, call);
+            nats_metrics::interrupt_error_synthesized();
+            results.push(interrupt_error_output(call));
+        }
+    }
+
+    (results, rerun_calls)
+}
+
+async fn rerun_or_synthesize_tool_results(
+    rerun_calls: Vec<harnx_core::tool::ToolCall>,
+    eval_ctx: &crate::tool::ToolEvalContext,
+    abort_signal: &AbortSignal,
+) -> Vec<harnx_core::session::ToolOutput> {
+    match crate::tool::eval_tool_calls(eval_ctx, rerun_calls.clone(), abort_signal).await {
+        Ok(tool_results) => tool_results
+            .into_iter()
+            .map(|result| harnx_core::session::ToolOutput {
+                id: result.call.id.clone(),
+                name: result.call.name.clone(),
+                output: result.output,
+                content: result.content,
+                switch_agent: result.switch_agent,
+            })
+            .collect(),
+        Err(err) => rerun_calls
+            .into_iter()
+            .map(|call| rerun_failure_output(&call, &err))
+            .collect(),
+    }
+}
+
+fn apply_optional_fence_token(
+    mut entry: harnx_core::session::SessionLogEntry,
+    fence_token: Option<u64>,
+) -> harnx_core::session::SessionLogEntry {
+    if let Some(fence_token) = fence_token {
+        entry.set_fence_token(fence_token);
+    }
+    entry
+}
+
+/// Log a per-call resume decision (`rerun` or `synthesize_interrupt_error`).
+fn log_resume_decision(
+    decision: &str,
+    args: &RepairOrphanToolCallsArgs<'_>,
+    call: &harnx_core::tool::ToolCall,
+) {
+    info!(
+        "resume decision {decision}: session_id={} worker_id={} revision={} tool_name={} call_id={}",
+        args.session_id,
+        args.worker_id.as_deref().unwrap_or("none"),
+        args.fence_token.unwrap_or(0),
+        call.name,
+        call.id.as_deref().unwrap_or("none")
+    );
+}
+
+fn interrupt_error_output(call: &harnx_core::tool::ToolCall) -> harnx_core::session::ToolOutput {
+    harnx_core::session::ToolOutput {
+        id: call.id.clone(),
+        name: call.name.clone(),
+        output: serde_json::json!({
+            "error": "tool response lost (session was interrupted before results were persisted)"
+        }),
+        content: Vec::new(),
+        switch_agent: None,
+    }
+}
+
+fn rerun_failure_output(
+    call: &harnx_core::tool::ToolCall,
+    err: &anyhow::Error,
+) -> harnx_core::session::ToolOutput {
+    harnx_core::session::ToolOutput {
+        id: call.id.clone(),
+        name: call.name.clone(),
+        output: serde_json::json!({
+            "error": format!("tool re-run failed: {err:#}")
+        }),
+        content: Vec::new(),
+        switch_agent: None,
+    }
+}
+
+fn build_remote_session_header(
+    config: &GlobalConfig,
+    input: &Input,
+    session_id: &str,
+) -> Result<harnx_core::session::SessionLogEntry> {
+    let mut header_session = crate::config::session::new(&config.read(), session_id)?;
+    header_session.set_agent(&input.agent)?;
+    Ok(header_session.build_header_entry())
+}
+
+/// Write a new session header and load the session.
+pub(crate) async fn write_header_and_load_session(
+    backend: &NatsSessionLogBackend,
+    config: &GlobalConfig,
+    input: &Input,
+    session_id: &str,
+) -> Result<harnx_core::session::Session> {
+    let header = build_remote_session_header(config, input, session_id)?;
+    backend.append_event_blocking(&header)?;
+    let entries = backend.load_events_blocking()?;
+    crate::nats_session_log::load_session_from_entries(&entries, session_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fold_new_user_messages_since;
+    use chrono::{TimeZone, Utc};
+    use harnx_core::message::{MessageContent, MessageRole};
+    use harnx_core::session::SessionLogEntry;
+
+    fn user_entry(id: &str, text: &str, timestamp: chrono::DateTime<Utc>) -> SessionLogEntry {
+        SessionLogEntry::Message {
+            id: Some(id.to_string()),
+            role: MessageRole::User,
+            content: MessageContent::Text(text.to_string()),
+            timestamp: Some(timestamp),
+            fence_token: None,
+        }
+    }
+
+    #[test]
+    fn fold_new_user_messages_since_excludes_retracted_messages() {
+        let entries = vec![
+            (
+                1,
+                user_entry(
+                    "msg-1",
+                    "retracted message",
+                    Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 1).unwrap(),
+                ),
+            ),
+            (
+                2,
+                SessionLogEntry::EditEntries {
+                    from: 1,
+                    to: 1,
+                    replacements: vec![],
+                },
+            ),
+            (
+                3,
+                user_entry(
+                    "msg-3",
+                    "valid message",
+                    Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 3).unwrap(),
+                ),
+            ),
+        ];
+
+        let (messages, latest_seq) = fold_new_user_messages_since(&entries, None);
+
+        assert_eq!(messages.len(), 1, "retracted message must be excluded");
+        assert_eq!(messages[0].content.to_text(), "valid message");
+        assert_eq!(messages[0].log_seq, Some(3));
+        assert_eq!(
+            messages[0].log_timestamp,
+            Some(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 3).unwrap())
+        );
+        assert_eq!(latest_seq, Some(3));
+    }
+
+    #[test]
+    fn fold_new_user_messages_since_skips_non_user_entries_but_tracks_latest_user_seq() {
+        let entries = vec![
+            (
+                1,
+                user_entry(
+                    "msg-1",
+                    "first valid",
+                    Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 1).unwrap(),
+                ),
+            ),
+            (
+                2,
+                SessionLogEntry::Message {
+                    id: Some("assistant-2".to_string()),
+                    role: MessageRole::Assistant,
+                    content: MessageContent::Text("assistant reply".to_string()),
+                    timestamp: Some(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 2).unwrap()),
+                    fence_token: None,
+                },
+            ),
+            (
+                3,
+                user_entry(
+                    "msg-3",
+                    "second valid",
+                    Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 3).unwrap(),
+                ),
+            ),
+        ];
+
+        let (messages, latest_seq) = fold_new_user_messages_since(&entries, None);
+
+        let folded: Vec<_> = messages
+            .iter()
+            .map(|message| {
+                (
+                    message.content.to_text(),
+                    message.log_seq,
+                    message.log_timestamp,
+                )
+            })
+            .collect();
+        assert_eq!(
+            folded,
+            vec![
+                (
+                    "first valid".to_string(),
+                    Some(1),
+                    Some(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 1).unwrap())
+                ),
+                (
+                    "second valid".to_string(),
+                    Some(3),
+                    Some(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 3).unwrap())
+                ),
+            ]
+        );
+        assert_eq!(
+            latest_seq,
+            Some(3),
+            "latest_seq must be max consumed user-message seq"
+        );
+    }
+
+    #[test]
+    fn fold_new_user_messages_since_cursor_semantics_with_retracts() {
+        let entries = vec![
+            (
+                1,
+                user_entry(
+                    "msg-1",
+                    "retracted",
+                    Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 1).unwrap(),
+                ),
+            ),
+            (
+                2,
+                SessionLogEntry::EditEntries {
+                    from: 1,
+                    to: 1,
+                    replacements: vec![],
+                },
+            ),
+            (
+                3,
+                user_entry(
+                    "msg-3",
+                    "first valid",
+                    Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 3).unwrap(),
+                ),
+            ),
+            (
+                4,
+                user_entry(
+                    "msg-4",
+                    "second valid",
+                    Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 4).unwrap(),
+                ),
+            ),
+        ];
+
+        let (messages, latest_seq) = fold_new_user_messages_since(&entries, Some(3));
+
+        assert_eq!(
+            messages.len(),
+            1,
+            "entries with seq <= cursor must be skipped after mutations"
+        );
+        assert_eq!(messages[0].content.to_text(), "second valid");
+        assert_eq!(
+            messages[0].log_seq,
+            Some(4),
+            "returned message must preserve original seq for stamping"
+        );
+        assert_eq!(
+            messages[0].log_timestamp,
+            Some(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 4).unwrap())
+        );
+        assert_eq!(
+            latest_seq,
+            Some(4),
+            "latest_seq must track max consumed user-message seq"
+        );
+    }
+}

--- a/crates/harnx-runtime/src/nats_worker/backend.rs
+++ b/crates/harnx-runtime/src/nats_worker/backend.rs
@@ -1,0 +1,146 @@
+//! NATS session log backend for the async worker.
+
+use crate::nats_lease::NatsSessionLease;
+use crate::nats_metrics;
+use anyhow::Result;
+use async_nats::jetstream;
+use std::sync::Arc;
+
+/// NATS session log backend for the async worker.
+///
+/// Wraps `NatsSessionLog` and provides blocking entrypoints for the sync
+/// persistence path used by `run_agent_loop`.
+#[derive(Clone)]
+pub struct NatsSessionLogBackend {
+    jetstream: jetstream::Context,
+    session_id: String,
+    /// Optional observer of the latest durable append sequence. When set, every
+    /// successful append advances it via `fetch_max`, so the live-event fan-out
+    /// sink (P4.1) can stamp advisories with an up-to-date `after_seq` during
+    /// multi-step turns WITHOUT a per-event JetStream query.
+    after_seq_observer: Option<Arc<std::sync::atomic::AtomicU64>>,
+}
+
+impl crate::config::session::SessionAppendSink for NatsSessionLogBackend {
+    fn append(&self, entry: &harnx_core::session::SessionLogEntry) -> Result<u64> {
+        self.append_event_blocking(entry)
+    }
+}
+
+/// Fence-guarded append sink for HA worker writes (P2.2).
+///
+/// Wraps a [`NatsSessionLogBackend`] with the holding [`NatsSessionLease`].
+/// Before EVERY worker-originated append it verifies `lease.is_held()` (mutual
+/// exclusion: a worker that has lost its lease must not write), and it stamps
+/// `fence_token = lease.fence_token()` on entries that carry one
+/// (`Message`/`ToolCalls`). A stale worker therefore cannot append, and a newer
+/// worker can detect stale entries via the fence on resume.
+#[derive(Clone)]
+pub struct FencedSessionLogSink {
+    backend: NatsSessionLogBackend,
+    lease: Arc<NatsSessionLease>,
+}
+
+impl FencedSessionLogSink {
+    pub fn new(backend: NatsSessionLogBackend, lease: Arc<NatsSessionLease>) -> Self {
+        Self { backend, lease }
+    }
+}
+
+impl crate::config::session::SessionAppendSink for FencedSessionLogSink {
+    fn append(&self, entry: &harnx_core::session::SessionLogEntry) -> Result<u64> {
+        if !self.lease.is_held() {
+            nats_metrics::fenced_write_rejected();
+            warn!(
+                "fenced write rejected: session_id={} worker_id={} revision={} entry_type={}",
+                self.backend.session_id(),
+                self.lease.worker_id(),
+                self.lease.fence_token(),
+                crate::session_history::entry_type(entry)
+            );
+            anyhow::bail!("refusing worker-originated append: session lease not held (fenced out)");
+        }
+        let mut fenced = entry.clone();
+        fenced.set_fence_token(self.lease.fence_token());
+        self.backend.append_event_blocking(&fenced)
+    }
+}
+
+impl NatsSessionLogBackend {
+    pub fn new(jetstream: jetstream::Context, session_id: impl Into<String>) -> Self {
+        Self {
+            jetstream,
+            session_id: session_id.into(),
+            after_seq_observer: None,
+        }
+    }
+
+    /// Attach an observer that tracks the latest durable append sequence
+    /// (advanced via `fetch_max` on every successful append). Used to keep the
+    /// P4.1 live-event sink's `after_seq` current during multi-step turns.
+    pub fn with_after_seq_observer(mut self, observer: Arc<std::sync::atomic::AtomicU64>) -> Self {
+        self.after_seq_observer = Some(observer);
+        self
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Append an entry, blocking on the async NATS call.
+    ///
+    /// Must be called from within a Tokio multi-threaded runtime.
+    /// Uses `tokio::task::block_in_place` to escape the async context.
+    pub fn append_event_blocking(
+        &self,
+        entry: &harnx_core::session::SessionLogEntry,
+    ) -> Result<u64> {
+        let log = crate::nats_session_log::NatsSessionLog::new(
+            self.jetstream.clone(),
+            self.session_id.clone(),
+        );
+        let seq = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(log.append_event_async(entry))
+        })?;
+        // Advance the P4.1 fan-out `after_seq` so subsequent advisories in this
+        // (possibly multi-step) turn carry an up-to-date durable sequence.
+        if let Some(observer) = &self.after_seq_observer {
+            observer.fetch_max(seq, std::sync::atomic::Ordering::Relaxed);
+        }
+        Ok(seq)
+    }
+
+    /// Load all events, blocking on async NATS reads.
+    pub fn load_events_blocking(&self) -> Result<Vec<(u64, harnx_core::session::SessionLogEntry)>> {
+        let log = crate::nats_session_log::NatsSessionLog::new(
+            self.jetstream.clone(),
+            self.session_id.clone(),
+        );
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(log.load_events_async())
+        })
+    }
+
+    /// Load all events with read-your-writes consistency: wait (bounded) until
+    /// the stream reflects at least the worker's latest durable append before
+    /// reading. Uses the shared `after_seq_observer` high-water mark when set;
+    /// falls back to a plain load otherwise. Used by the end-of-turn drain
+    /// re-read so the worker sees its own just-written turn barrier and does not
+    /// re-fold already-answered messages.
+    pub fn load_events_consistent_blocking(
+        &self,
+    ) -> Result<Vec<(u64, harnx_core::session::SessionLogEntry)>> {
+        let min_seq = self
+            .after_seq_observer
+            .as_ref()
+            .map(|o| o.load(std::sync::atomic::Ordering::Relaxed))
+            .unwrap_or(0);
+        let log = crate::nats_session_log::NatsSessionLog::new(
+            self.jetstream.clone(),
+            self.session_id.clone(),
+        );
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(log.load_events_at_least_async(min_seq))
+        })
+    }
+}

--- a/crates/harnx-runtime/src/nats_worker/control.rs
+++ b/crates/harnx-runtime/src/nats_worker/control.rs
@@ -1,0 +1,60 @@
+//! Control plane for cancel over NATS.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// P2.4 Control plane: cancel over NATS
+// ---------------------------------------------------------------------------
+
+/// Control command sent over the control subject (`sessions.{id}.control`).
+///
+/// Clients publish these commands to interact with an active session without
+/// going through the durable activation workflow. Control is fire-and-forget;
+/// durable state lands in the session log.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ControlCommand {
+    /// Cancel the current turn.
+    ///
+    /// Worker-originated: carries the fence token for tombstone.
+    /// The worker appends a Cancel entry BEFORE firing the AbortSignal.
+    Cancel,
+}
+
+impl ControlCommand {
+    /// Serialize the command to JSON bytes for NATS publish.
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        Ok(serde_json::to_vec(self)?)
+    }
+
+    /// Deserialize from JSON bytes.
+    pub fn from_bytes(data: &[u8]) -> Result<Self> {
+        Ok(serde_json::from_slice(data)?)
+    }
+}
+
+/// Control subject pattern for a session.
+///
+/// Format: `sessions.{session_id}.control`
+pub fn control_subject(session_id: &str) -> String {
+    format!("sessions.{session_id}.control")
+}
+
+/// Publish a control command to a session's control subject.
+///
+/// This is the client-side helper for driving control commands. Workers
+/// subscribe to this subject and handle commands when holding the lease.
+pub async fn publish_control_command(
+    client: &async_nats::Client,
+    session_id: &str,
+    command: &ControlCommand,
+) -> Result<()> {
+    let subject = control_subject(session_id);
+    let payload = command.to_bytes()?;
+    client
+        .publish(subject, payload.into())
+        .await
+        .context("publish control command")?;
+    Ok(())
+}

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -1,0 +1,732 @@
+//! Worker daemon and session activation.
+
+use super::agent_loop::{
+    build_mid_turn_injection_callback, fold_new_user_messages_since,
+    run_agent_loop_with_nats_inner, RunAgentLoopArgs,
+};
+use super::backend::NatsSessionLogBackend;
+use super::control::{control_subject, ControlCommand};
+use crate::config::{GlobalConfig, Input};
+use crate::nats_lease::{NatsLeaseAcquireParams, NatsLeaseConfig, NatsSessionLease};
+use crate::nats_metrics;
+use anyhow::{Context, Result};
+use async_nats::header::{HeaderValue, NATS_MESSAGE_ID};
+use async_nats::jetstream::{
+    self,
+    consumer::{pull, DeliverPolicy},
+    stream::{Config as StreamConfig, RetentionPolicy, StorageType},
+};
+use chrono::Utc;
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+// ---------------------------------------------------------------------------
+// P2.1 worker daemon + SessionActivate dispatch
+// ---------------------------------------------------------------------------
+
+const WORK_NOTIFY_STREAM_PREFIX: &str = "WORK_NOTIFY_";
+const WORK_NOTIFY_CONSUMER_PREFIX: &str = "worker-";
+const WORK_NOTIFY_ACK_WAIT: Duration = Duration::from_secs(30);
+const WORK_NOTIFY_INACTIVE_THRESHOLD: Duration = Duration::from_secs(60 * 60);
+
+/// Configuration for a worker daemon instance.
+#[derive(Debug, Clone)]
+pub struct WorkerDaemonConfig {
+    pub cluster: String,
+    pub worker_id: String,
+    pub lease: NatsLeaseConfig,
+}
+
+impl WorkerDaemonConfig {
+    pub fn new(cluster: impl Into<String>, worker_id: impl Into<String>) -> Self {
+        Self {
+            cluster: cluster.into(),
+            worker_id: worker_id.into(),
+            lease: NatsLeaseConfig::default(),
+        }
+    }
+}
+
+/// Activation request published by a client to wake/claim a session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionActivate {
+    pub session_id: String,
+    pub agent: String,
+    pub epoch: String,
+}
+
+impl SessionActivate {
+    pub fn new(session_id: impl Into<String>, agent: impl Into<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            agent: agent.into(),
+            epoch: Utc::now().to_rfc3339(),
+        }
+    }
+
+    /// Dedup id for the notify stream (`Nats-Msg-Id`): session + epoch.
+    pub fn msg_id(&self) -> String {
+        format!("{}:{}", self.session_id, self.epoch)
+    }
+}
+
+/// Generate a fresh remote session id (uuid v7, time-ordered).
+pub fn new_remote_session_id() -> String {
+    uuid::Uuid::now_v7().to_string()
+}
+
+/// Notify subject for a cluster's session activations.
+pub fn notify_subject(cluster: &str) -> String {
+    format!("cluster.{cluster}.sessions.notify")
+}
+
+fn notify_stream_name(cluster: &str) -> String {
+    format!(
+        "{WORK_NOTIFY_STREAM_PREFIX}{}",
+        sanitize_name_component(cluster)
+    )
+}
+
+fn durable_consumer_name(worker_id: &str) -> String {
+    format!(
+        "{WORK_NOTIFY_CONSUMER_PREFIX}{}",
+        sanitize_name_component(worker_id)
+    )
+}
+
+pub(crate) fn should_append_control_log_entry(lease: &NatsSessionLease) -> bool {
+    lease.is_held()
+}
+
+fn sanitize_name_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if is_valid_name_component_char(ch) {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn is_valid_name_component_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_')
+}
+
+async fn ensure_notify_stream(
+    jetstream: &jetstream::Context,
+    cluster: &str,
+    subject: &str,
+) -> Result<jetstream::stream::Stream> {
+    let name = notify_stream_name(cluster);
+    if let Ok(stream) = jetstream.get_stream(&name).await {
+        return Ok(stream);
+    }
+    match jetstream
+        .create_stream(StreamConfig {
+            name: name.clone(),
+            description: Some("session activation work queue".to_string()),
+            subjects: vec![subject.to_string()],
+            retention: RetentionPolicy::WorkQueue,
+            storage: StorageType::File,
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(stream) => Ok(stream),
+        Err(_) => jetstream
+            .get_stream(&name)
+            .await
+            .map_err(anyhow::Error::from)
+            .with_context(|| format!("Failed to create notify stream for cluster '{cluster}'")),
+    }
+}
+
+/// Publish a `SessionActivate` notification (idempotent via `Nats-Msg-Id`).
+pub async fn publish_session_activate(
+    jetstream: &jetstream::Context,
+    cluster: &str,
+    activation: &SessionActivate,
+) -> Result<u64> {
+    let subject = notify_subject(cluster);
+    ensure_notify_stream(jetstream, cluster, &subject).await?;
+    let payload = serde_json::to_vec(activation).context("serialize SessionActivate")?;
+    let mut headers = async_nats::HeaderMap::new();
+    headers.insert(NATS_MESSAGE_ID, HeaderValue::from(activation.msg_id()));
+    let ack = jetstream
+        .publish_with_headers(subject, headers, payload.into())
+        .await
+        .context("publish SessionActivate")?
+        .await
+        .context("ack SessionActivate")?;
+    Ok(ack.sequence)
+}
+
+/// Run a worker daemon: pull `SessionActivate` notifications, claim each via a
+/// KV lease, and execute the session (exactly one worker per session).
+pub async fn run_worker_daemon(
+    config: GlobalConfig,
+    daemon: WorkerDaemonConfig,
+    call_fn: Option<crate::agent_loop::AgentCallFn>,
+) -> Result<()> {
+    let (jetstream, client) = {
+        let cfg = config.read().clone();
+        let jetstream = cfg.nats_jetstream(&daemon.cluster).await?;
+        let client = cfg.nats_client(&daemon.cluster).await?;
+        (jetstream, client)
+    };
+    let subject = notify_subject(&daemon.cluster);
+    let stream = ensure_notify_stream(&jetstream, &daemon.cluster, &subject).await?;
+    let consumer_name = durable_consumer_name(&daemon.worker_id);
+    let consumer = stream
+        .get_or_create_consumer(
+            &consumer_name,
+            pull::Config {
+                durable_name: Some(consumer_name.clone()),
+                deliver_policy: DeliverPolicy::All,
+                ack_wait: WORK_NOTIFY_ACK_WAIT,
+                filter_subject: subject.clone(),
+                inactive_threshold: WORK_NOTIFY_INACTIVE_THRESHOLD,
+                max_deliver: -1,
+                ..Default::default()
+            },
+        )
+        .await
+        .with_context(|| format!("create worker consumer '{consumer_name}'"))?;
+
+    let runtime = Arc::new(WorkerRuntime {
+        config,
+        cluster: daemon.cluster.clone(),
+        worker_id: daemon.worker_id.clone(),
+        lease: daemon.lease,
+        jetstream: jetstream.clone(),
+        client,
+        call_fn,
+        generation: AtomicU64::new(1),
+        active: Mutex::new(HashMap::new()),
+    });
+
+    let mut messages = consumer
+        .messages()
+        .await
+        .context("worker notify message stream")?;
+    while let Some(message) = messages.next().await {
+        let message = message.context("receive activation")?;
+        if let Err(error) = runtime.handle_activation(message).await {
+            warn!("worker activation handling failed: {error:#}");
+        }
+    }
+    Ok(())
+}
+
+/// Borrowed parameters for [`WorkerRuntime::spawn_control_listener`].
+struct ControlListenerCtx<'a> {
+    client: &'a async_nats::Client,
+    session_id: &'a str,
+    lease: &'a Arc<NatsSessionLease>,
+    backend: &'a NatsSessionLogBackend,
+    abort_signal: &'a crate::utils::AbortSignal,
+}
+
+struct WorkerRuntime {
+    config: GlobalConfig,
+    #[allow(dead_code)]
+    cluster: String,
+    worker_id: String,
+    lease: NatsLeaseConfig,
+    jetstream: jetstream::Context,
+    /// Shared NATS client for control-plane subscriptions (cloned per session
+    /// rather than reconnecting on each activation).
+    client: async_nats::Client,
+    call_fn: Option<crate::agent_loop::AgentCallFn>,
+    generation: AtomicU64,
+    active: Mutex<HashMap<String, JoinHandle<()>>>,
+}
+
+impl WorkerRuntime {
+    async fn handle_activation(
+        self: &Arc<Self>,
+        message: async_nats::jetstream::Message,
+    ) -> Result<()> {
+        let activation: SessionActivate =
+            serde_json::from_slice(&message.payload).context("decode SessionActivate")?;
+
+        // Re-activation of an already-running session is a no-op.
+        {
+            let mut active = self.active.lock().await;
+            active.retain(|_, handle| !handle.is_finished());
+            if active.contains_key(&activation.session_id) {
+                let _ = message.ack().await;
+                return Ok(());
+            }
+        }
+
+        // Try to claim the session via the KV lease. Loser drops (does not ack,
+        // so the message stays for the holder to ack; another worker holds it).
+        let generation = self.generation.fetch_add(1, Ordering::SeqCst);
+        let lease = match NatsSessionLease::acquire(NatsLeaseAcquireParams {
+            jetstream: self.jetstream.clone(),
+            session_id: &activation.session_id,
+            worker_id: self.worker_id.clone(),
+            generation,
+            config: self.lease.clone(),
+        })
+        .await?
+        {
+            Some(lease) => lease,
+            None => return Ok(()),
+        };
+        info!(
+            "session activate claimed: session_id={} worker_id={} revision={} epoch={}",
+            activation.session_id,
+            lease.worker_id(),
+            lease.fence_token(),
+            activation.epoch
+        );
+
+        // We hold the lease: ack the activation and spawn execution.
+        let _ = message.ack().await;
+        let worker = Arc::clone(self);
+        let session_id = activation.session_id.clone();
+        let task_session_id = session_id.clone();
+        let lease = Arc::new(lease);
+        nats_metrics::active_session_started();
+        let handle = tokio::spawn(async move {
+            let snapshot = nats_metrics::snapshot();
+            info!(
+                "active session started: session_id={} worker_id={} revision={} active_sessions_per_worker={}",
+                activation.session_id,
+                lease.worker_id(),
+                lease.fence_token(),
+                snapshot.active_sessions_per_worker
+            );
+            let result = worker.execute_session(activation, Arc::clone(&lease)).await;
+            nats_metrics::active_session_finished();
+            let snapshot = nats_metrics::snapshot();
+            info!(
+                "active session finished: session_id={} worker_id={} revision={} active_sessions_per_worker={}",
+                task_session_id,
+                lease.worker_id(),
+                lease.fence_token(),
+                snapshot.active_sessions_per_worker
+            );
+            if let Err(error) = result {
+                warn!("worker session execution failed: {error:#}");
+            }
+        });
+        self.active.lock().await.insert(session_id, handle);
+        Ok(())
+    }
+
+    /// Derive the turn input for an activation from the reconstructed session
+    /// state, honoring cancel tombstones, resumable turns, and pending messages.
+    async fn derive_turn_input(
+        &self,
+        activation: &SessionActivate,
+        lease: &NatsSessionLease,
+        per_session: &GlobalConfig,
+        backend: &NatsSessionLogBackend,
+        high_water: Option<u64>,
+    ) -> (Input, Option<u64>) {
+        // Continuation turns (high_water set) derive input CURSOR-based, not
+        // barrier-based. A user message that arrives DURING a turn is logged at
+        // a seq BELOW that turn's assistant barrier, so the barrier-based
+        // reconstruct would treat it as already-answered and never fold it. The
+        // cursor (high-water mark of messages already fed this activation) is the
+        // authoritative "unanswered" boundary and matches the drain decision.
+        if let Some(hw) = high_water {
+            let tail = backend
+                .load_events_consistent_blocking()
+                .unwrap_or_default();
+            let (new_messages, latest_seq) = fold_new_user_messages_since(&tail, Some(hw));
+            if !new_messages.is_empty() {
+                let (mut input, seed) = self
+                    .derive_idle_turn_input(activation, per_session, new_messages)
+                    .await;
+                input.with_session = true;
+                input.skip_user_log_append = true;
+                return (input, seed.or(latest_seq));
+            }
+            // No new user messages past the cursor: fall through to reconstruct,
+            // which still handles a genuinely-resumable in-flight tool round.
+        }
+
+        let reconstructed = self.reconstruct_session_state(backend).await;
+        log::debug!(
+            "derive_turn_input: session_id={} turn_status={:?} next_turn_count={} resumable_ctx={}",
+            activation.session_id,
+            reconstructed.turn_status,
+            reconstructed.next_turn_messages.len(),
+            reconstructed.resumable_ctx.is_some(),
+        );
+        let (mut input, seed_cursor) = match reconstructed.turn_status {
+            harnx_core::session_reconstruct::TurnStatus::InFlightCancelled => {
+                // Terminal: Cancel tombstone prevents resume. Do NOT consume pending.
+                // The turn is idle; wait for new user input or activation.
+                log::info!(
+                    "session has cancelled turn tombstone; not resuming (session_id={})",
+                    activation.session_id
+                );
+                (crate::config::input::from_str(per_session, "", None), None)
+            }
+            harnx_core::session_reconstruct::TurnStatus::InFlightResumable => {
+                // Resume existing turn (orphan repair handled inside run_agent_loop_with_nats_inner).
+                info!(
+                    "resume state: session_id={} worker_id={} revision={} mode=resumable",
+                    activation.session_id,
+                    lease.worker_id(),
+                    lease.fence_token()
+                );
+                // Extract the last_user Message to get both its text (for Input) and log_seq (for cursor).
+                let last_user_msg = reconstructed
+                    .resumable_ctx
+                    .as_ref()
+                    .and_then(|ctx| ctx.last_user.as_ref());
+                let input = if let Some(last_user) = last_user_msg {
+                    crate::config::input::from_str(per_session, &last_user.content.to_text(), None)
+                } else {
+                    crate::config::input::from_str(per_session, "", None)
+                };
+                // Cursor: the log_seq of the last user message that kicked off this resumable turn.
+                // Any messages appended AFTER this (seq > cursor) will be folded mid-turn.
+                let seed_cursor = last_user_msg.and_then(|msg| msg.log_seq.map(|seq| seq as u64));
+                (input, seed_cursor)
+            }
+            harnx_core::session_reconstruct::TurnStatus::Idle => {
+                let msg_count = reconstructed.next_turn_messages.len();
+                let result = self
+                    .derive_idle_turn_input(
+                        activation,
+                        per_session,
+                        reconstructed.next_turn_messages,
+                    )
+                    .await;
+                // DEBUG: log the seed_cursor for this path
+                log::debug!(
+                    "derive_turn_input idle: session_id={} seed_cursor={:?} messages_count={}",
+                    activation.session_id,
+                    result.1,
+                    msg_count,
+                );
+                result
+            }
+        };
+        // The NATS worker ALWAYS operates on a session. The input is derived
+        // before `run_agent_loop_with_nats_inner` attaches the session to the
+        // per-session config, so `from_str` sees no session and leaves
+        // `with_session=false`. That would make `save_message` a no-op and the
+        // turn's assistant barrier would never be persisted. Force it true.
+        input.with_session = true;
+        // The folded user messages are ALREADY durable in the log (clients
+        // append them directly) and loaded into `session.messages`. The worker
+        // must not re-append them: doing so duplicates the user message and
+        // reorders the assistant barrier past concurrently-arrived messages,
+        // burying them so they are never folded into a continuation turn.
+        input.skip_user_log_append = true;
+        (input, seed_cursor)
+    }
+
+    /// Idle-state input: fold queued next-turn messages in log order.
+    async fn derive_idle_turn_input(
+        &self,
+        _activation: &SessionActivate,
+        per_session: &GlobalConfig,
+        next_turn_messages: Vec<harnx_core::message::Message>,
+    ) -> (Input, Option<u64>) {
+        let seed_cursor = next_turn_messages
+            .last()
+            .and_then(|message| message.log_seq.map(|seq| seq as u64));
+        let folded = next_turn_messages
+            .into_iter()
+            .map(|message| message.content.to_text())
+            .filter(|text| !text.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n");
+        (
+            crate::config::input::from_str(per_session, &folded, None),
+            seed_cursor,
+        )
+    }
+
+    async fn execute_session(
+        &self,
+        activation: SessionActivate,
+        lease: Arc<NatsSessionLease>,
+    ) -> Result<()> {
+        // Per-session config clone with the requested agent (loaded from the
+        // worker's OWN config) and the session selected.
+        let per_session = {
+            let base = self.config.read().clone();
+            Arc::new(parking_lot::RwLock::new(base))
+        };
+        if let Ok(agent) = self.config.read().retrieve_agent(&activation.agent) {
+            let mut cfg = per_session.write();
+            let _ = cfg.use_agent_obj(agent);
+        }
+
+        let abort_signal = crate::utils::create_abort_signal();
+
+        // Create event sink for live fan-out. `new` seeds `after_seq` from stream once.
+        let event_sink = crate::nats_event_sink::NatsEventSink::new(
+            self.client.clone(),
+            self.jetstream.clone(),
+            activation.session_id.clone(),
+        )
+        .await;
+        let after_seq_observer = event_sink.after_seq_handle();
+        let event_sink = Arc::new(event_sink);
+
+        // Build the backend for control-plane operations and state reconstruction.
+        // Share the `after_seq` high-water mark so the drain re-read can enforce
+        // read-your-writes consistency on the worker's own turn-output appends.
+        let backend = NatsSessionLogBackend::new(self.jetstream.clone(), &activation.session_id)
+            .with_after_seq_observer(Arc::clone(&after_seq_observer));
+
+        // Abort turns promptly if lease is lost.
+        let watch_task =
+            Self::spawn_lease_loss_watch(&lease, &abort_signal, &activation.session_id);
+
+        // Subscribe to control commands for this session.
+        let control_task = Self::spawn_control_listener(ControlListenerCtx {
+            client: &self.client,
+            session_id: &activation.session_id,
+            lease: &lease,
+            backend: &backend,
+            abort_signal: &abort_signal,
+        });
+
+        let result = harnx_core::sink::with_agent_event_sink(event_sink, async {
+            // Activation high-water cursor: max log seq of ANY user message we've fed into this
+            // activation. Includes messages folded into turn inputs AND mid-round injections.
+            // A continuation turn only runs if there's a user message with seq > this cursor.
+            let mut activation_high_water: Option<u64> = None;
+
+            loop {
+                if !lease.is_held() {
+                    break Ok(());
+                }
+
+                let (input, seed_cursor) = self
+                    .derive_turn_input(
+                        &activation,
+                        &lease,
+                        &per_session,
+                        &backend,
+                        activation_high_water,
+                    )
+                    .await;
+
+                log::info!(
+                    "execute_session turn: session_id={} seed_cursor={:?}",
+                    activation.session_id,
+                    seed_cursor,
+                );
+
+                // Initialize cursor for this turn. Use seed_cursor (from derive_turn_input)
+                // which is the max seq of messages folded into the input.
+                let turn_cursor = Arc::new(AtomicU64::new(seed_cursor.unwrap_or(0)));
+
+                // Update activation high-water if seed_cursor is higher.
+                if let Some(seed) = seed_cursor {
+                    activation_high_water = Some(activation_high_water.map_or(seed, |h| h.max(seed)));
+                }
+
+                let on_tool_round =
+                    build_mid_turn_injection_callback(backend.clone(), Arc::clone(&turn_cursor));
+
+                run_agent_loop_with_nats_inner(
+                    RunAgentLoopArgs {
+                        cluster_key: &self.cluster,
+                        session_id: &activation.session_id,
+                        config: per_session.clone(),
+                        initial_input: input,
+                        abort_signal: abort_signal.clone(),
+                        call_fn: self.call_fn.clone(),
+                        lease: None,
+                        after_seq_observer: None,
+                        on_tool_round: Some(on_tool_round),
+                    }
+                    .with_lease(Arc::clone(&lease))
+                    .with_after_seq_observer(Arc::clone(&after_seq_observer)),
+                )
+                .await?;
+
+                // After turn completes, update activation high-water from turn_cursor.
+                // turn_cursor was updated by mid-round injection callback for any messages
+                // injected during multi-round tool execution.
+                let turn_cursor_val = turn_cursor.load(Ordering::SeqCst);
+                if turn_cursor_val > 0 {
+                    activation_high_water = Some(activation_high_water.map_or(turn_cursor_val, |h| h.max(turn_cursor_val)));
+                }
+
+                log::info!(
+                    "execute_session turn complete: session_id={} turn_cursor={} activation_high_water={:?}",
+                    activation.session_id,
+                    turn_cursor_val,
+                    activation_high_water,
+                );
+
+                if !lease.is_held() {
+                    break Ok(());
+                }
+
+                // DRAIN DECISION: cursor-based, not barrier-based.
+                // Re-run another turn ONLY if there's a user message with seq > activation_high_water.
+                // This prevents re-running when we've already consumed everything.
+                // Use the read-your-writes consistent load so this re-read reflects
+                // the worker's own just-persisted turn barrier (otherwise it would
+                // re-fold already-answered messages).
+                let tail = backend.load_events_consistent_blocking()?;
+
+                // Check for resumable in-flight tool rounds (multi-turn tool execution).
+                // Use reconstruct_state_from_nats to preserve NATS seqs for EditEntries resolution.
+                let reconstructed = harnx_core::session_reconstruct::reconstruct_state_from_nats(&tail);
+                let has_resumable = reconstructed.resumable_ctx.is_some();
+
+                // Check for new user messages beyond the high-water cursor.
+                let (new_messages, latest_new_seq) = fold_new_user_messages_since(&tail, activation_high_water);
+
+                log::info!(
+                    "execute_session drain check: session_id={} new_messages_count={} has_resumable={} latest_new_seq={:?}",
+                    activation.session_id,
+                    new_messages.len(),
+                    has_resumable,
+                    latest_new_seq,
+                );
+
+                // Continue only if there are genuinely new user messages OR a resumable tool context.
+                // A completed turn with nothing new => exactly one execution.
+                //
+                // Do NOT advance `activation_high_water` here. The drain only
+                // DETECTS that unanswered messages exist; the continuation turn
+                // CONSUMES them and advances the high-water from its own
+                // `seed_cursor` at the top of the loop. Advancing here would mark
+                // the messages consumed before the turn runs, so the continuation
+                // turn would derive an empty input and never answer them.
+                if new_messages.is_empty() && !has_resumable {
+                    break Ok(());
+                }
+            }
+        })
+        .await;
+
+        if !lease.is_held() {
+            warn!(
+                "session execution ended after failover: session_id={} worker_id={} revision={}",
+                activation.session_id,
+                lease.worker_id(),
+                lease.fence_token()
+            );
+        }
+
+        watch_task.abort();
+        control_task.abort();
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(100), watch_task).await;
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(100), control_task).await;
+
+        let _ = lease.release().await;
+        result
+    }
+
+    /// Spawn a task that watches for lease loss and aborts on loss.
+    fn spawn_lease_loss_watch(
+        lease: &Arc<NatsSessionLease>,
+        abort_signal: &crate::utils::AbortSignal,
+        session_id: &str,
+    ) -> tokio::task::JoinHandle<()> {
+        let mut lost = lease.lost_watch();
+        let abort_for_watch = abort_signal.clone();
+        let watch_session_id = session_id.to_string();
+        let watch_lease = Arc::clone(lease);
+        tokio::spawn(async move {
+            while lost.changed().await.is_ok() {
+                if !*lost.borrow() {
+                    warn!(
+                        "failover abort: session_id={} worker_id={} revision={} reason=lease_lost",
+                        watch_session_id,
+                        watch_lease.worker_id(),
+                        watch_lease.fence_token()
+                    );
+                    abort_for_watch.set_ctrlc();
+                    break;
+                }
+            }
+        })
+    }
+
+    /// Spawn a task that listens for control commands and handles them.
+    fn spawn_control_listener(ctx: ControlListenerCtx<'_>) -> tokio::task::JoinHandle<()> {
+        let ctrl_subject = control_subject(ctx.session_id);
+        let ctrl_abort = ctx.abort_signal.clone();
+        let ctrl_lease = Arc::clone(ctx.lease);
+        let ctrl_backend = ctx.backend.clone();
+        let client = ctx.client.clone();
+        tokio::spawn(async move {
+            let subscriber = match client.subscribe(ctrl_subject).await {
+                Ok(s) => s,
+                Err(e) => {
+                    log::warn!("failed to subscribe to control subject: {e}");
+                    return;
+                }
+            };
+            use futures_util::StreamExt;
+            let mut messages = subscriber;
+            while let Some(msg) = messages.next().await {
+                // Parse the control command.
+                let Ok(command) = ControlCommand::from_bytes(&msg.payload) else {
+                    log::debug!("invalid control command payload, ignoring");
+                    continue;
+                };
+                match command {
+                    ControlCommand::Cancel => {
+                        // Worker-originated: append Cancel entry (worker's fence token),
+                        // THEN fire AbortSignal.
+                        if should_append_control_log_entry(&ctrl_lease) {
+                            let cancel_entry = harnx_core::session::SessionLogEntry::Cancel {
+                                fence_token: ctrl_lease.fence_token(),
+                            };
+                            // Append BEFORE firing abort; if append fails, still abort (safe).
+                            if let Err(e) = ctrl_backend.append_event_blocking(&cancel_entry) {
+                                log::warn!("failed to append Cancel entry: {e}");
+                            }
+                        }
+                        ctrl_abort.set_ctrlc();
+                    }
+                }
+            }
+        })
+    }
+
+    /// Reconstruct session state using the canonical algorithm.
+    ///
+    /// Returns the session's turn status, effective pending message, and
+    /// resumable context for driving the agent loop correctly.
+    async fn reconstruct_session_state(
+        &self,
+        backend: &NatsSessionLogBackend,
+    ) -> harnx_core::session_reconstruct::ReconstructedState {
+        match backend.load_events_consistent_blocking() {
+            Ok(entries) => harnx_core::session_reconstruct::reconstruct_state_from_nats(&entries),
+            Err(err) => {
+                log::warn!(
+                    "failed to load session log for reconstruction: session_id={} worker_id={} err={err}",
+                    backend.session_id(),
+                    self.worker_id,
+                );
+                harnx_core::session_reconstruct::ReconstructedState {
+                    turn_status: harnx_core::session_reconstruct::TurnStatus::Idle,
+                    next_turn_messages: Vec::new(),
+                    resumable_ctx: None,
+                }
+            }
+        }
+    }
+}

--- a/crates/harnx-runtime/src/nats_worker/mod.rs
+++ b/crates/harnx-runtime/src/nats_worker/mod.rs
@@ -1,0 +1,39 @@
+//! NATS worker entrypoint.
+//!
+//! P1.3 implementation: drives `run_agent_loop` with NATS-backed session persistence.
+//!
+//! ## Persistence seam design
+//!
+//! The existing `run_agent_loop` persists session entries through:
+//!   `Config::after_chat_completion` → `save_message` → `session::add_assistant_text`
+//!   → `append_event(session, entry)` → active session append sink
+//!
+//! For NATS mode, we need to redirect this sync file write to async JetStream.
+//! Since `run_agent_loop` is async but the persistence path is sync, we use
+//! `tokio::task::block_in_place` to safely block on async NATS calls.
+//!
+//! **Seam:** Add `session_log_backend: SessionLogBackend` field to `AgentLoopContext`.
+//! The loop's persistence calls remain unchanged. When the backend is `Nats`,
+//! `Config::save_message` uses `block_in_place` to await the async NATS append.
+//!
+//! This approach:
+//! - Keeps LOCAL mode byte-identical (`SessionLogBackend::Local` → sync file write)
+//! - Adds minimal changes to the loop (just the backend enum check in Config)
+//! - Supports future HA/lease wraps around the same `session_log_backend` seam
+
+mod agent_loop;
+mod backend;
+mod control;
+mod daemon;
+
+#[cfg(test)]
+mod tests;
+
+// Re-export public items to preserve the `crate::nats_worker::X` path
+pub use agent_loop::{run_agent_loop_with_nats, run_agent_loop_with_nats_inner, RunAgentLoopArgs};
+pub use backend::{FencedSessionLogSink, NatsSessionLogBackend};
+pub use control::{control_subject, publish_control_command, ControlCommand};
+pub use daemon::{
+    new_remote_session_id, notify_subject, publish_session_activate, run_worker_daemon,
+    SessionActivate, WorkerDaemonConfig,
+};

--- a/crates/harnx-runtime/src/nats_worker/tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests.rs
@@ -1,0 +1,295 @@
+//! Unit tests for nats_worker module.
+
+use crate::config::{self};
+use crate::nats_worker::agent_loop::{tool_can_rerun, write_header_and_load_session};
+use harnx_core::agent_config::AgentConfig;
+use harnx_core::config_data::ConfigData;
+use harnx_core::session::ToolOutput;
+use harnx_core::tool::{ToolCall, ToolDeclaration};
+use serde_json::json;
+use std::sync::Arc;
+
+/// Spawn a local JetStream-enabled nats-server on a free port with an isolated
+/// temp store dir, returning the connect URL, the child process, and the temp
+/// dir guard. Using a free port + per-run store dir avoids cross-run state
+/// bleed (JetStream KV/lease buckets) and port collisions that make tests flaky
+/// when run repeatedly or in parallel. Returns `None` if nats-server is absent.
+async fn spawn_test_nats() -> Option<(String, std::process::Child, tempfile::TempDir)> {
+    if which::which("nats-server").is_err() {
+        eprintln!("skipping: nats-server not available");
+        return None;
+    }
+    // Bind an ephemeral port, then release it for nats-server to claim.
+    let port = {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").ok()?;
+        listener.local_addr().ok()?.port()
+    };
+    let store_dir = tempfile::tempdir().ok()?;
+    let child = std::process::Command::new("nats-server")
+        .args(["-js", "-sd"])
+        .arg(store_dir.path())
+        .args(["-p", &port.to_string()])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+    let url = format!("nats://127.0.0.1:{port}");
+    // Poll for readiness rather than a fixed sleep.
+    for _ in 0..50 {
+        if async_nats::connect(&url).await.is_ok() {
+            return Some((url, child, store_dir));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    let mut child = child;
+    let _ = child.kill();
+    let _ = child.wait();
+    None
+}
+
+#[test]
+fn metrics_snapshot_tracks_counters() {
+    crate::nats_metrics::reset_for_test();
+    crate::nats_metrics::active_session_started();
+    crate::nats_metrics::lease_acquired();
+    crate::nats_metrics::lease_lost();
+    crate::nats_metrics::fenced_write_rejected();
+    crate::nats_metrics::resume_detected();
+    crate::nats_metrics::interrupt_error_synthesized();
+
+    let snapshot = crate::nats_metrics::snapshot();
+    assert_eq!(snapshot.active_sessions_per_worker, 1);
+    assert_eq!(snapshot.lease_acquisitions, 1);
+    assert_eq!(snapshot.lease_losses, 1);
+    assert_eq!(snapshot.fenced_writes_rejected, 1);
+    assert_eq!(snapshot.resumes, 1);
+    assert_eq!(snapshot.interrupt_errors_synthesized, 1);
+
+    crate::nats_metrics::active_session_finished();
+    let snapshot = crate::nats_metrics::snapshot();
+    assert_eq!(snapshot.active_sessions_per_worker, 0);
+}
+
+/// Unit test for the partitioning logic: idempotent tools get re-run,
+/// non-idempotent tools get synthesized error.
+#[test]
+fn test_orphan_partition_logic() {
+    use std::collections::HashMap;
+
+    // Build decl_map with idempotent "echo" and non-idempotent "write_file"
+    let mut decl_map: HashMap<String, ToolDeclaration> = HashMap::new();
+    decl_map.insert(
+        "echo".to_string(),
+        ToolDeclaration {
+            name: "echo".to_string(),
+            description: "Echo tool".to_string(),
+            parameters: harnx_core::tool::JsonSchema::default(),
+            mcp_tool_name: None,
+            mcp_server_name: None,
+            call_template: None,
+            result_template: None,
+            idempotent_hint: Some(true),
+            read_only_hint: Some(true),
+        },
+    );
+    decl_map.insert(
+        "write_file".to_string(),
+        ToolDeclaration {
+            name: "write_file".to_string(),
+            description: "Write tool".to_string(),
+            parameters: harnx_core::tool::JsonSchema::default(),
+            mcp_tool_name: None,
+            mcp_server_name: None,
+            call_template: None,
+            result_template: None,
+            idempotent_hint: None,
+            read_only_hint: None,
+        },
+    );
+
+    // Simulate orphan calls
+    let calls = vec![
+        ToolCall {
+            name: "echo".to_string(),
+            arguments: json!({"message": "hello"}),
+            id: Some("call_echo_1".to_string()),
+            thought_signature: None,
+        },
+        ToolCall {
+            name: "write_file".to_string(),
+            arguments: json!({"path": "/tmp/test", "content": "data"}),
+            id: Some("call_write_1".to_string()),
+            thought_signature: None,
+        },
+    ];
+
+    // Partition based on hints
+    let mut rerun_calls: Vec<ToolCall> = Vec::new();
+    let mut synthesize_count = 0;
+
+    for call in &calls {
+        // Exercise the production decision function, not a re-implementation.
+        if tool_can_rerun(&decl_map, &call.name) {
+            rerun_calls.push(call.clone());
+        } else {
+            synthesize_count += 1;
+        }
+    }
+
+    // Assertions
+    assert_eq!(rerun_calls.len(), 1, "echo should be marked for re-run");
+    assert_eq!(rerun_calls[0].name, "echo");
+    assert_eq!(synthesize_count, 1, "write_file should be synthesized");
+
+    // Unknown tools must default to non-rerunnable (synthesize).
+    assert!(
+        !tool_can_rerun(&decl_map, "nonexistent_tool"),
+        "unknown tools must not be re-run"
+    );
+}
+
+/// Verify that the ToolOutput for non-idempotent tools contains the expected error message.
+#[test]
+fn test_non_idempotent_output_is_synthesized() {
+    let lost = ToolOutput {
+        id: Some("call_1".to_string()),
+        name: "write_file".to_string(),
+        output: json!({
+            "error": "tool response lost (session was interrupted before results were persisted)"
+        }),
+        content: Vec::new(),
+        switch_agent: None,
+    };
+
+    let output_str = lost.output.to_string();
+    assert!(
+        output_str.contains("tool response lost"),
+        "expected synthesized error message, got: {output_str}"
+    );
+    assert!(
+        !output_str.contains("marked for re-run"),
+        "should NOT contain 'marked for re-run' placeholder"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn remote_header_matches_local_header_source_of_truth() {
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+    let client = async_nats::connect(&url).await.unwrap();
+    let jetstream = async_nats::jetstream::new(client);
+    let session_id = "remote-header-test";
+    let backend = crate::nats_worker::backend::NatsSessionLogBackend::new(jetstream, session_id);
+
+    let mut config = config::Config {
+        data: ConfigData {
+            save_session: Some(false),
+            compress_threshold: 17,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    config.set_model_fallbacks(vec!["openai:gpt-4o-mini".to_string()]);
+    config.set_compaction_agent(Some("pkg/compactor".to_string()));
+    let agent = config::Agent::new(
+        AgentConfig::from_markdown(
+            "pkg/main",
+            "---\nmodel: openai:gpt-4.1\nsave_session: false\n---\nAgent instructions without variables.",
+        )
+        .unwrap(),
+    );
+    config.agent = Some(agent.clone());
+    let config = Arc::new(parking_lot::RwLock::new(config));
+
+    let input = harnx_core::input::Input::new(
+        "hello".to_string(),
+        ("hello".to_string(), vec![]),
+        agent.into_config(),
+    );
+
+    let session = write_header_and_load_session(&backend, &config, &input, session_id)
+        .await
+        .unwrap();
+    let expected_header = {
+        let mut expected_session = config::session::new(&config.read(), session_id).unwrap();
+        expected_session.set_agent(&input.agent).unwrap();
+        expected_session.build_header_entry()
+    };
+
+    let entries = backend.load_events_blocking().unwrap();
+    let actual_header = entries
+        .iter()
+        .find(|(_, entry)| matches!(entry, harnx_core::session::SessionLogEntry::Header { .. }))
+        .expect("header entry present");
+    let actual_header_yaml = serde_yaml::to_string(&actual_header.1).unwrap();
+    let expected_header_yaml = serde_yaml::to_string(&expected_header).unwrap();
+    assert!(actual_header_yaml.contains("agent_name: pkg/main"));
+    assert!(actual_header_yaml.contains("save_session: false"));
+    assert!(
+        actual_header_yaml.contains("agent_instructions: Agent instructions without variables.")
+    );
+    assert!(actual_header_yaml.contains("git_branch: nats"));
+    assert!(actual_header_yaml.contains("git_remote: https://github.com/dobesv/harnx.git"));
+    assert!(actual_header_yaml
+        .contains("working_dir: /mnt/projects/ai-tools/harnx/crates/harnx-runtime"));
+    let loaded_header_yaml = serde_yaml::to_string(&session.build_header_entry()).unwrap();
+    assert!(loaded_header_yaml.contains("agent_name: pkg/main"));
+    assert!(expected_header_yaml.contains("agent_name: pkg/main"));
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn control_log_append_requires_live_lease() {
+    use crate::nats_lease::{NatsLeaseAcquireParams, NatsLeaseConfig, NatsSessionLease};
+    use crate::nats_worker::daemon::should_append_control_log_entry;
+
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+    let client = async_nats::connect(&url).await.unwrap();
+    let jetstream = async_nats::jetstream::new(client);
+
+    let lease = NatsSessionLease::acquire(NatsLeaseAcquireParams {
+        jetstream,
+        session_id: "control-lease-gate",
+        worker_id: "worker-a".to_string(),
+        generation: 1,
+        config: NatsLeaseConfig {
+            ttl: std::time::Duration::from_secs(5),
+            renew_interval: std::time::Duration::from_millis(500),
+            replicas: 1,
+            tombstone_ttl: std::time::Duration::from_secs(10),
+            ..Default::default()
+        },
+    })
+    .await
+    .unwrap()
+    .expect("lease should be acquired with no contention");
+
+    // While the lease is held, control-command log appends are permitted.
+    assert!(
+        should_append_control_log_entry(&lease),
+        "held lease must allow control log appends"
+    );
+
+    // After the lease is lost (failover / fenced out), appends must be skipped.
+    lease.mark_lost_for_test();
+    assert!(
+        !should_append_control_log_entry(&lease),
+        "lost lease must skip control log appends"
+    );
+
+    // Regardless of lease state, the Cancel path must still be able to abort.
+    let abort_signal = harnx_core::abort::create_abort_signal();
+    abort_signal.set_ctrlc();
+    assert!(
+        abort_signal.aborted(),
+        "cancel path still aborts worker without lease"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}

--- a/crates/harnx-runtime/src/session_history.rs
+++ b/crates/harnx-runtime/src/session_history.rs
@@ -38,6 +38,7 @@ pub fn entry_type(entry: &SessionLogEntry) -> &'static str {
         SessionLogEntry::DataUrls { .. } => "data_urls",
         SessionLogEntry::Compress { .. } => "compress",
         SessionLogEntry::Clear => "clear",
+        SessionLogEntry::Cancel { .. } => "cancel",
         SessionLogEntry::EditEntries { .. } => "edit_entries",
         SessionLogEntry::Rewind { .. } => "rewind",
         SessionLogEntry::Unknown => "unknown",
@@ -189,6 +190,8 @@ Returns a JSON array of matching log entries (seq, type, text, tool names)."
         mcp_server_name: None,
         call_template: None,
         result_template: None,
+        idempotent_hint: None,
+        read_only_hint: None,
     }
 }
 
@@ -274,9 +277,11 @@ mod tests {
     fn entry_type_maps_variants() {
         assert_eq!(
             entry_type(&SessionLogEntry::Message {
+                id: None,
                 role: MessageRole::User,
                 content: MessageContent::Text("hi".into()),
                 timestamp: None,
+                fence_token: None,
             }),
             "message"
         );
@@ -293,9 +298,11 @@ mod tests {
             (
                 0,
                 SessionLogEntry::Message {
+                    id: None,
                     role: MessageRole::User,
                     content: MessageContent::Text("please run the build".into()),
                     timestamp: None,
+                    fence_token: None,
                 },
             ),
             (
@@ -310,6 +317,7 @@ mod tests {
                         thought_signature: None,
                     }],
                     timestamp: None,
+                    fence_token: None,
                 },
             ),
             (
@@ -328,9 +336,11 @@ mod tests {
             (
                 3,
                 SessionLogEntry::Message {
+                    id: None,
                     role: MessageRole::Assistant,
                     content: MessageContent::Text("the build passed".into()),
                     timestamp: None,
+                    fence_token: None,
                 },
             ),
         ]

--- a/crates/harnx-runtime/src/tool.rs
+++ b/crates/harnx-runtime/src/tool.rs
@@ -44,6 +44,7 @@ pub async fn execute_tool_round(
     persistent_manager: &std::sync::Arc<tokio::sync::Mutex<PersistentHookManager>>,
 ) -> Result<Vec<ToolResult>> {
     let dry_run = config.read().dry_run;
+
     if !dry_run {
         config.write().save_session_tool_calls(
             input,
@@ -52,6 +53,7 @@ pub async fn execute_tool_round(
             &tool_calls,
         )?;
     }
+
     let agent_use_tools = input.agent().use_tools().map(|v| v.join(","));
     // Derive the active agent's package (e.g. `pantheon` for `pantheon/daedalus`)
     // so bare `_session_handoff` targets resolve to the same package (#709).
@@ -663,6 +665,8 @@ mod tests {
             mcp_server_name: None,
             call_template: call_template.map(String::from),
             result_template: result_template.map(String::from),
+            idempotent_hint: None,
+            read_only_hint: None,
         }
     }
 

--- a/crates/harnx-runtime/tests/common/mod.rs
+++ b/crates/harnx-runtime/tests/common/mod.rs
@@ -1,0 +1,168 @@
+use anyhow::{Context, Result};
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+pub struct NatsServerHandle {
+    pub url: String,
+    _store_dir: TempDir,
+    child: Child,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SpawnNatsServerOptions {
+    pub auth_token: Option<String>,
+}
+
+impl NatsServerHandle {
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+}
+
+impl Drop for NatsServerHandle {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+pub async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
+    spawn_nats_server_with_options(SpawnNatsServerOptions::default()).await
+}
+
+pub async fn spawn_nats_server_with_options(
+    options: SpawnNatsServerOptions,
+) -> Result<Option<NatsServerHandle>> {
+    let binary = match nats_server_binary() {
+        Some(binary) => binary,
+        None => {
+            eprintln!("skipping NATS integration test: nats-server binary not found");
+            return Ok(None);
+        }
+    };
+
+    // Allocating a free port and then handing it to nats-server has an
+    // inherent TOCTOU race: under parallel test execution another server can
+    // grab the same port between our probe and nats-server's bind. Retry the
+    // whole spawn-and-wait with a fresh port a few times to make the harness
+    // robust instead of intermittently failing (e.g. lease_contention).
+    let mut last_err = None;
+    for _ in 0..5 {
+        match try_spawn_nats_once(&binary, &options).await {
+            Ok(handle) => return Ok(Some(handle)),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("failed to spawn nats-server")))
+}
+
+async fn try_spawn_nats_once(
+    binary: &std::path::Path,
+    options: &SpawnNatsServerOptions,
+) -> Result<NatsServerHandle> {
+    let port = free_tcp_port()?;
+    let store_dir = tempfile::tempdir().context("Failed to create temp NATS store dir")?;
+    let mut command = Command::new(binary);
+    command
+        .arg("-js")
+        .arg("-sd")
+        .arg(store_dir.path())
+        .arg("-p")
+        .arg(port.to_string());
+    if let Some(token) = &options.auth_token {
+        command.arg("--auth").arg(token);
+    }
+    let mut child = command
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("Failed to spawn {}", binary.display()))?;
+
+    let url = format!("nats://127.0.0.1:{port}");
+    if let Err(e) = wait_for_nats_ready(&url, options.auth_token.as_deref()).await {
+        // Readiness failed (likely the port was stolen by a parallel server);
+        // reap this child so the retry starts clean.
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(e);
+    }
+
+    Ok(NatsServerHandle {
+        url,
+        _store_dir: store_dir,
+        child,
+    })
+}
+
+fn nats_server_binary() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("NATS_SERVER_BIN") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    which::which("nats-server").ok()
+}
+
+fn free_tcp_port() -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").context("Failed to allocate free TCP port")?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(port)
+}
+
+async fn wait_for_nats_ready(url: &str, auth_token: Option<&str>) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut attempts = 0u32;
+    loop {
+        attempts += 1;
+        let connect_result = match auth_token {
+            Some(token) => {
+                tokio::time::timeout(
+                    Duration::from_secs(1),
+                    async_nats::ConnectOptions::new()
+                        .token(token.to_string())
+                        .connect(url),
+                )
+                .await
+            }
+            None => tokio::time::timeout(Duration::from_secs(1), async_nats::connect(url)).await,
+        };
+        match connect_result {
+            Ok(Ok(client)) => {
+                client
+                    .flush()
+                    .await
+                    .context("Failed to flush NATS connection")?;
+                return Ok(());
+            }
+            Ok(Err(error)) if Instant::now() < deadline => {
+                eprintln!("waiting for NATS server at {url} (attempt {attempts}): {error}");
+                sleep(Duration::from_millis(100)).await;
+            }
+            Err(_) if Instant::now() < deadline => {
+                eprintln!(
+                    "waiting for NATS server at {url} (attempt {attempts}): connection attempt timed out"
+                );
+                sleep(Duration::from_millis(100)).await;
+            }
+            Ok(Err(error)) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "NATS server at {url} did not become ready within 15s after {attempts} attempts"
+                    )
+                });
+            }
+            Err(_) => {
+                anyhow::bail!(
+                    "NATS server at {url} did not become ready within 15s after {attempts} attempts: connection attempts timed out"
+                );
+            }
+        }
+    }
+}

--- a/crates/harnx-runtime/tests/file_log_forward_compat.rs
+++ b/crates/harnx-runtime/tests/file_log_forward_compat.rs
@@ -1,0 +1,63 @@
+use anyhow::Result;
+use harnx_core::{require_nextest, session::SessionLogEntry};
+
+#[test]
+fn file_log_yaml_round_trips_byte_identical_without_fence_tokens() -> Result<()> {
+    require_nextest();
+
+    let yaml = concat!(
+        "type: header\n",
+        "model: test-model\n",
+        "save_session: true\n",
+        "session_id: sess-1\n",
+        "agent_instructions: You are Oracle\n",
+        "---\n",
+        "type: message\n",
+        "role: user\n",
+        "content: hello\n",
+        "---\n",
+        "type: message\n",
+        "role: assistant\n",
+        "content: hi there\n",
+        "---\n",
+        "type: tool_calls\n",
+        "text: checking\n",
+        "calls:\n",
+        "- name: Bash\n",
+        "  arguments:\n",
+        "    command: pwd\n",
+        "  id: call-1\n",
+        "---\n",
+        "type: tool_results\n",
+        "results:\n",
+        "- id: call-1\n",
+        "  name: Bash\n",
+        "  output:\n",
+        "    stdout: /tmp\n",
+    );
+
+    let docs = yaml
+        .split("---\n")
+        .map(serde_yaml::from_str::<SessionLogEntry>)
+        .collect::<Result<Vec<_>, _>>()?;
+    let reserialized = docs
+        .iter()
+        .map(serde_yaml::to_string)
+        .collect::<Result<Vec<_>, _>>()?
+        .join("---\n");
+
+    assert_eq!(reserialized, yaml);
+    assert!(!reserialized.contains("fence_token"));
+    assert!(!reserialized.contains("null"));
+    Ok(())
+}
+
+#[test]
+fn unknown_session_log_entry_type_is_tolerated() -> Result<()> {
+    require_nextest();
+
+    let yaml = "type: future_variant\nnew_field: true\n";
+    let entry: SessionLogEntry = serde_yaml::from_str(yaml)?;
+    assert!(matches!(entry, SessionLogEntry::Unknown));
+    Ok(())
+}

--- a/crates/harnx-runtime/tests/nats_connect.rs
+++ b/crates/harnx-runtime/tests/nats_connect.rs
@@ -1,0 +1,141 @@
+mod common;
+
+use common::{spawn_nats_server, spawn_nats_server_with_options, SpawnNatsServerOptions};
+use harnx_core::require_nextest;
+use harnx_runtime::client::Model;
+use harnx_runtime::config::Config;
+use std::ffi::OsString;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+struct EnvGuard {
+    key: &'static str,
+    prev: Option<OsString>,
+}
+
+impl EnvGuard {
+    fn set_path(key: &'static str, value: &Path) -> Self {
+        let prev = std::env::var_os(key);
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prev }
+    }
+
+    fn set_value(key: &'static str, value: &str) -> Self {
+        let prev = std::env::var_os(key);
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
+
+fn write_fixture_config(dir: &TempDir, cluster: &str, body: &str) {
+    fs::create_dir_all(dir.path().join("nats_servers")).unwrap();
+    fs::write(dir.path().join("config.yaml"), "save: false\n").unwrap();
+    fs::write(
+        dir.path()
+            .join("nats_servers")
+            .join(format!("{cluster}.yaml")),
+        body,
+    )
+    .unwrap();
+}
+
+fn test_config_from_tmp(tmp: &TempDir) -> Config {
+    Config {
+        nats_servers: Config::load_nats_servers_from_dir(&tmp.path().join("nats_servers")).unwrap(),
+        model: Model::new("test", "test-model"),
+        ..Default::default()
+    }
+}
+
+fn token_auth_config(server_url: &str, token: &str) -> (TempDir, EnvGuard, EnvGuard) {
+    let tmp = tempfile::tempdir().unwrap();
+    write_fixture_config(
+        &tmp,
+        "secure",
+        &format!(
+            "url: {}
+token: ${{NATS_TEST_TOKEN}}
+tls: false
+",
+            server_url
+        ),
+    );
+    let config_guard = EnvGuard::set_path("HARNX_CONFIG_FILE", &tmp.path().join("config.yaml"));
+    let token_guard = EnvGuard::set_value("NATS_TEST_TOKEN", token);
+    (tmp, config_guard, token_guard)
+}
+
+#[tokio::test]
+async fn nats_client_connects_and_jetstream_is_reachable() {
+    require_nextest();
+
+    let Some(server) = spawn_nats_server().await.unwrap() else {
+        return;
+    };
+
+    let tmp = tempfile::tempdir().unwrap();
+    write_fixture_config(&tmp, "local", &format!("url: {}\n", server.url()));
+    let _config_guard = EnvGuard::set_path("HARNX_CONFIG_FILE", &tmp.path().join("config.yaml"));
+
+    let config = test_config_from_tmp(&tmp);
+    let client = config.nats_client("local").await.unwrap();
+    client.flush().await.unwrap();
+
+    let _jetstream = config.nats_jetstream("local").await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_client_connects_with_token_auth_and_env_expansion() {
+    require_nextest();
+
+    let token = "s3cr3t-token";
+    let Some(server) = spawn_nats_server_with_options(SpawnNatsServerOptions {
+        auth_token: Some(token.to_string()),
+    })
+    .await
+    .unwrap() else {
+        return;
+    };
+
+    let (tmp, _config_guard, _token_guard) = token_auth_config(server.url(), token);
+
+    let config = test_config_from_tmp(&tmp);
+    let client = config.nats_client("secure").await.unwrap();
+    client.flush().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_client_fails_with_clear_error_when_token_wrong() {
+    require_nextest();
+
+    let token = "s3cr3t-token";
+    let Some(server) = spawn_nats_server_with_options(SpawnNatsServerOptions {
+        auth_token: Some(token.to_string()),
+    })
+    .await
+    .unwrap() else {
+        return;
+    };
+
+    let tmp = tempfile::tempdir().unwrap();
+    write_fixture_config(
+        &tmp,
+        "secure",
+        &format!("url: {}\ntoken: wrong-token\n", server.url()),
+    );
+    let _config_guard = EnvGuard::set_path("HARNX_CONFIG_FILE", &tmp.path().join("config.yaml"));
+
+    let config = test_config_from_tmp(&tmp);
+    let error = config.nats_client("secure").await.unwrap_err().to_string();
+    assert!(error.contains("Failed to connect to NATS cluster 'secure' at '"));
+}

--- a/crates/harnx-runtime/tests/nats_control.rs
+++ b/crates/harnx-runtime/tests/nats_control.rs
@@ -1,0 +1,154 @@
+// Integration tests for P2.4 control plane cancel semantics.
+//!
+//! Note: These tests verify the control command contract and reconstruct_state
+//! behavior over durable session-log entries.
+
+mod common;
+
+use anyhow::Result;
+use common::spawn_nats_server;
+use harnx_core::{
+    require_nextest,
+    session::SessionLogEntry,
+    session_reconstruct::{reconstruct_state, TurnStatus},
+};
+use harnx_runtime::{
+    nats_session_log::NatsSessionLog,
+    nats_worker::{publish_control_command, ControlCommand},
+};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancel_control_command_serializes_and_is_publishable() -> Result<()> {
+    require_nextest();
+
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let client = async_nats::connect(server.url()).await?;
+    let mut control_sub = client
+        .subscribe(harnx_runtime::nats_worker::control_subject(
+            "control-cancel-only",
+        ))
+        .await?;
+
+    publish_control_command(&client, "control-cancel-only", &ControlCommand::Cancel).await?;
+
+    use futures_util::StreamExt;
+    let msg = tokio::time::timeout(std::time::Duration::from_secs(2), control_sub.next())
+        .await?
+        .expect("should receive control message");
+
+    let cmd: ControlCommand = serde_json::from_slice(&msg.payload)?;
+    assert!(matches!(cmd, ControlCommand::Cancel));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancel_appends_entry_before_abort() -> Result<()> {
+    require_nextest();
+
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let client = async_nats::connect(server.url()).await?;
+    let js = async_nats::jetstream::new(client.clone());
+    let session_id = "control-cancel-session";
+
+    let log = NatsSessionLog::new(js.clone(), session_id);
+    log.append_event_async(&header(session_id)).await?;
+    log.append_event_async(&SessionLogEntry::Message {
+        id: None,
+        role: harnx_core::message::MessageRole::User,
+        content: harnx_core::message::MessageContent::Text("go".to_string()),
+        timestamp: None,
+        fence_token: None,
+    })
+    .await?;
+    log.append_event_async(&SessionLogEntry::ToolCalls {
+        text: "working".to_string(),
+        thought: None,
+        calls: vec![],
+        timestamp: None,
+        fence_token: Some(42),
+    })
+    .await?;
+    log.append_event_async(&SessionLogEntry::Cancel { fence_token: 42 })
+        .await?;
+
+    let entries = log.load_events_async().await?;
+    let entries_only: Vec<_> = entries.into_iter().map(|(_, e)| e).collect();
+    assert!(entries_only
+        .iter()
+        .any(|e| matches!(e, SessionLogEntry::Cancel { fence_token } if *fence_token == 42)));
+
+    let state = reconstruct_state(&entries_only);
+    assert_eq!(state.turn_status, TurnStatus::InFlightCancelled);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancel_prevents_resume_on_reactivation() -> Result<()> {
+    require_nextest();
+
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let js = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+    let session_id = "control-cancel-no-resume";
+
+    let log = NatsSessionLog::new(js.clone(), session_id);
+    log.append_event_async(&header(session_id)).await?;
+    log.append_event_async(&SessionLogEntry::Message {
+        id: None,
+        role: harnx_core::message::MessageRole::User,
+        content: harnx_core::message::MessageContent::Text("go".to_string()),
+        timestamp: None,
+        fence_token: None,
+    })
+    .await?;
+    log.append_event_async(&SessionLogEntry::ToolCalls {
+        text: "working".to_string(),
+        thought: None,
+        calls: vec![],
+        timestamp: None,
+        fence_token: Some(10),
+    })
+    .await?;
+    log.append_event_async(&SessionLogEntry::Cancel { fence_token: 10 })
+        .await?;
+
+    let entries = log.load_events_async().await?;
+    let entries_only: Vec<_> = entries.into_iter().map(|(_, e)| e).collect();
+    let state = reconstruct_state(&entries_only);
+
+    assert_eq!(state.turn_status, TurnStatus::InFlightCancelled);
+    Ok(())
+}
+
+fn header(session_id: &str) -> SessionLogEntry {
+    SessionLogEntry::Header {
+        model_id: "test".to_string(),
+        temperature: None,
+        top_p: None,
+        use_tools: None,
+        save_session: Some(true),
+        compress_threshold: None,
+        agent_name: None,
+        session_id: Some(session_id.to_string()),
+        working_dir: None,
+        git_branch: None,
+        git_remote: None,
+        terminal_session_id: None,
+        agent_variables: Default::default(),
+        agent_instructions: String::new(),
+        model_fallbacks: vec![],
+        compaction_agent: None,
+    }
+}

--- a/crates/harnx-runtime/tests/nats_event_fanout.rs
+++ b/crates/harnx-runtime/tests/nats_event_fanout.rs
@@ -1,0 +1,384 @@
+//! P4.1 integration tests: Live event fan-out from worker to clients.
+//!
+//! Tests that:
+//! (a) Two subscribers to one session both receive emitted advisory events
+//! (b) Early + late subscriber converge to identical final durable-derived state
+//! (c) Mid-turn drop of advisory still converges via durable log
+
+mod common;
+
+use anyhow::Result;
+use common::spawn_nats_server;
+use futures_util::StreamExt;
+use harnx_core::event::{AgentEvent, NoticeEvent};
+use harnx_core::message::{MessageContent, MessageRole};
+use harnx_core::session::SessionLogEntry;
+use harnx_runtime::nats_event_sink::{events_subject, AdvisoryEnvelope, SessionEventStream};
+use harnx_runtime::nats_worker::NatsSessionLogBackend;
+use std::time::Duration;
+use tokio::time::timeout;
+
+/// Test (a): Two subscribers to one session both receive emitted advisory events.
+#[tokio::test]
+async fn two_subscribers_receive_advisory_events() -> Result<()> {
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not found");
+        return Ok(());
+    };
+
+    let client = async_nats::connect(server.url()).await?;
+    let _jetstream = async_nats::jetstream::new(client.clone());
+
+    let session_id = format!("test-{}", uuid::Uuid::new_v4());
+    let subject = events_subject(&session_id);
+
+    // Create two subscribers BEFORE publishing
+    let mut sub1 = client.subscribe(subject.clone()).await?;
+    let mut sub2 = client.subscribe(subject.clone()).await?;
+
+    // Publish an advisory event
+    let event = AgentEvent::Notice(NoticeEvent::Info("hello from worker".into()));
+    let envelope = AdvisoryEnvelope::new(0, event);
+    let payload = envelope.to_bytes()?;
+    client.publish(subject, payload.into()).await?;
+    client.flush().await?;
+
+    // Both subscribers should receive it
+    let msg1 = timeout(Duration::from_secs(2), sub1.next()).await;
+    let msg2 = timeout(Duration::from_secs(2), sub2.next()).await;
+
+    assert!(
+        msg1.is_ok() && msg1.unwrap().is_some(),
+        "sub1 should receive event"
+    );
+    assert!(
+        msg2.is_ok() && msg2.unwrap().is_some(),
+        "sub2 should receive event"
+    );
+
+    Ok(())
+}
+
+/// Test (b): Late subscriber gets history first, then live events.
+/// Uses multi_thread flavor because it calls block_in_place via append_event_blocking.
+#[tokio::test(flavor = "multi_thread")]
+async fn late_subscriber_gets_history_then_live() -> Result<()> {
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not found");
+        return Ok(());
+    };
+
+    let client = async_nats::connect(server.url()).await?;
+    let jetstream = async_nats::jetstream::new(client.clone());
+
+    let session_id = format!("test-{}", uuid::Uuid::new_v4());
+
+    // Create session and append some entries to the DURABLE log
+    let backend = NatsSessionLogBackend::new(jetstream.clone(), &session_id);
+
+    // Append Message (user)
+    let user_msg = SessionLogEntry::Message {
+        id: None,
+        role: MessageRole::User,
+        content: MessageContent::Text("Hello from user".into()),
+        timestamp: None,
+        fence_token: None,
+    };
+    backend.append_event_blocking(&user_msg)?;
+
+    // Give JetStream a moment to sync
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Early subscriber attaches
+    let early_stream =
+        SessionEventStream::attach(jetstream.clone(), client.clone(), &session_id).await?;
+
+    // Early subscriber sees history
+    let early_history = early_stream.history();
+    assert!(
+        !early_history.is_empty(),
+        "early subscriber should have history"
+    );
+    let early_last_seq = early_stream.last_applied_seq();
+    assert!(early_last_seq > 0, "history should have entries");
+
+    // Now append more entries (simulating continued work)
+    let assistant_msg = SessionLogEntry::Message {
+        id: None,
+        role: MessageRole::Assistant,
+        content: MessageContent::Text("Response from assistant".into()),
+        timestamp: None,
+        fence_token: None,
+    };
+    backend.append_event_blocking(&assistant_msg)?;
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Late subscriber attaches AFTER more entries
+    let late_stream =
+        SessionEventStream::attach(jetstream.clone(), client.clone(), &session_id).await?;
+
+    // Late subscriber should see ALL history (including new entries)
+    let late_history = late_stream.history();
+    assert!(
+        late_history.len() > early_history.len(),
+        "late subscriber should have more history than early"
+    );
+
+    // Late subscriber's last_seq should be greater
+    let late_last_seq = late_stream.last_applied_seq();
+    assert!(
+        late_last_seq > early_last_seq,
+        "late subscriber should have later seq"
+    );
+
+    // Both should be able to reconstruct the same state from their history
+    // (they see all durable entries up to different points)
+
+    Ok(())
+}
+
+/// Test: Advisory envelope after_seq enables dedup.
+/// Uses multi_thread flavor because it calls block_in_place via append_event_blocking.
+#[tokio::test(flavor = "multi_thread")]
+async fn advisory_envelope_dedup_by_after_seq() -> Result<()> {
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not found");
+        return Ok(());
+    };
+
+    let client = async_nats::connect(server.url()).await?;
+    let jetstream = async_nats::jetstream::new(client.clone());
+
+    let session_id = format!("test-{}", uuid::Uuid::new_v4());
+
+    // Create session and append entries to durable log
+    let backend = NatsSessionLogBackend::new(jetstream.clone(), &session_id);
+
+    let user_msg = SessionLogEntry::Message {
+        id: None,
+        role: MessageRole::User,
+        content: MessageContent::Text("Hello".into()),
+        timestamp: None,
+        fence_token: None,
+    };
+    let seq1 = backend.append_event_blocking(&user_msg)?;
+
+    // Create event sink and publish advisory with current last_seq
+    let event_sink = harnx_runtime::nats_event_sink::NatsEventSink::new(
+        client.clone(),
+        jetstream.clone(),
+        session_id.clone(),
+    )
+    .await;
+
+    // Subscribe before publishing
+    let subject = events_subject(&session_id);
+    let mut sub = client.subscribe(subject).await?;
+
+    // Publish advisory events
+    event_sink
+        .publish_event(AgentEvent::Notice(NoticeEvent::Info("advisory 1".into())))
+        .await;
+
+    // Receive and parse
+    let msg = timeout(Duration::from_secs(2), sub.next()).await;
+    assert!(msg.is_ok(), "should receive advisory event");
+    let msg = msg.unwrap().expect("message should exist");
+    let envelope = AdvisoryEnvelope::from_bytes(&msg.payload)?;
+
+    // after_seq should be >= seq1 (the durable entry we appended)
+    assert!(
+        envelope.after_seq >= seq1,
+        "advisory after_seq {} should be >= durable seq {}",
+        envelope.after_seq,
+        seq1
+    );
+
+    Ok(())
+}
+
+/// Test (c): Advisory dropout mid-turn, state converges from durable log.
+/// Uses multi_thread flavor because it calls block_in_place via append_event_blocking.
+#[tokio::test(flavor = "multi_thread")]
+async fn advisory_dropout_converges_from_durable_log() -> Result<()> {
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not found");
+        return Ok(());
+    };
+
+    let client = async_nats::connect(server.url()).await?;
+    let jetstream = async_nats::jetstream::new(client.clone());
+
+    let session_id = format!("test-{}", uuid::Uuid::new_v4());
+
+    // Create session and append durable state
+    let backend = NatsSessionLogBackend::new(jetstream.clone(), &session_id);
+
+    // User message and assistant response (authoritative)
+    let user_msg = SessionLogEntry::Message {
+        id: None,
+        role: MessageRole::User,
+        content: MessageContent::Text("What is 2+2?".into()),
+        timestamp: None,
+        fence_token: None,
+    };
+    backend.append_event_blocking(&user_msg)?;
+
+    let assistant_msg = SessionLogEntry::Message {
+        id: None,
+        role: MessageRole::Assistant,
+        content: MessageContent::Text("The answer is 4.".into()),
+        timestamp: None,
+        fence_token: None,
+    };
+    backend.append_event_blocking(&assistant_msg)?;
+
+    // Simulate advisory events being published (but client misses some)
+    let event_sink = harnx_runtime::nats_event_sink::NatsEventSink::new(
+        client.clone(),
+        jetstream.clone(),
+        session_id.clone(),
+    )
+    .await;
+
+    // Publish advisory (would be chunks in real scenario)
+    event_sink
+        .publish_event(AgentEvent::Notice(NoticeEvent::Info(
+            "streaming chunk 1".into(),
+        )))
+        .await;
+
+    // Client subscribes LATE (missed all advisories)
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let stream = SessionEventStream::attach(jetstream.clone(), client.clone(), &session_id).await?;
+
+    // Client replays durable history
+    let history = stream.history();
+    assert!(!history.is_empty(), "should have durable history");
+
+    // Final authoritative state is derived from durable log, not advisory
+    // Reconstruct state from entries
+    let entries: Vec<SessionLogEntry> = history.iter().map(|(_, e)| e.clone()).collect();
+    let state = harnx_core::session_reconstruct::reconstruct_state(&entries);
+
+    // State should be Idle (final assistant message is the barrier)
+    assert!(
+        matches!(
+            state.turn_status,
+            harnx_core::session_reconstruct::TurnStatus::Idle
+        ),
+        "turn should be idle after final assistant message"
+    );
+
+    // Even though client missed advisory chunks, the authoritative state
+    // is correct because it's derived from durable log
+    // (In real scenario, client would render history, not the dropped chunks)
+
+    Ok(())
+}
+
+/// Test: NatsEventSink publishes to correct subject.
+#[tokio::test]
+async fn nats_event_sink_publishes_to_correct_subject() -> Result<()> {
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not found");
+        return Ok(());
+    };
+
+    let client = async_nats::connect(server.url()).await?;
+    let jetstream = async_nats::jetstream::new(client.clone());
+
+    let session_id = format!("test-{}", uuid::Uuid::new_v4());
+    let subject = events_subject(&session_id);
+
+    // Subscribe first
+    let mut sub = client.subscribe(subject.clone()).await?;
+
+    // Create and emit event via sink
+    let sink = std::sync::Arc::new(
+        harnx_runtime::nats_event_sink::NatsEventSink::new(
+            client.clone(),
+            jetstream.clone(),
+            session_id.clone(),
+        )
+        .await,
+    );
+
+    sink.publish_event(AgentEvent::Notice(NoticeEvent::Info("test message".into())))
+        .await;
+
+    // Should receive on subscription
+    let msg = timeout(Duration::from_secs(2), sub.next()).await;
+    assert!(msg.is_ok(), "should receive published event");
+    let msg = msg.unwrap().expect("message should exist");
+
+    // Parse and verify
+    let envelope = AdvisoryEnvelope::from_bytes(&msg.payload)?;
+    assert!(matches!(
+        envelope.event,
+        AgentEvent::Notice(NoticeEvent::Info(_))
+    ));
+
+    Ok(())
+}
+
+/// Test: Multiple events maintain ordering.
+#[tokio::test]
+async fn multiple_events_maintain_ordering() -> Result<()> {
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not found");
+        return Ok(());
+    };
+
+    let client = async_nats::connect(server.url()).await?;
+    let jetstream = async_nats::jetstream::new(client.clone());
+
+    let session_id = format!("test-{}", uuid::Uuid::new_v4());
+    let subject = events_subject(&session_id);
+
+    let mut sub = client.subscribe(subject.clone()).await?;
+
+    let sink = std::sync::Arc::new(
+        harnx_runtime::nats_event_sink::NatsEventSink::new(
+            client.clone(),
+            jetstream.clone(),
+            session_id.clone(),
+        )
+        .await,
+    );
+
+    // Publish multiple events
+    for i in 0..5 {
+        sink.publish_event(AgentEvent::Notice(NoticeEvent::Info(format!(
+            "event {}",
+            i
+        ))))
+        .await;
+    }
+
+    client.flush().await?;
+
+    // Receive and verify ordering
+    let mut received = Vec::new();
+    for _ in 0..5 {
+        if let Some(msg) = timeout(Duration::from_secs(2), sub.next())
+            .await
+            .ok()
+            .flatten()
+        {
+            let envelope = AdvisoryEnvelope::from_bytes(&msg.payload)?;
+            if let AgentEvent::Notice(NoticeEvent::Info(msg)) = envelope.event {
+                received.push(msg);
+            }
+        }
+    }
+
+    // All 5 should arrive (ordering in NATS is preserved per publisher)
+    assert_eq!(received.len(), 5, "should receive all 5 events");
+    let expected: Vec<String> = (0..5).map(|i| format!("event {}", i)).collect();
+    assert_eq!(received, expected, "events should arrive in order");
+
+    Ok(())
+}

--- a/crates/harnx-runtime/tests/nats_lease.rs
+++ b/crates/harnx-runtime/tests/nats_lease.rs
@@ -1,0 +1,227 @@
+//! Integration tests for the per-session NATS KV lease (P2.1).
+//! Spawns a real local nats-server (see tests/common). Multi-thread runtime
+//! is required for async-nats + block-style waits.
+
+mod common;
+
+use anyhow::{Context, Result};
+use common::spawn_nats_server;
+use harnx_core::require_nextest;
+use harnx_runtime::nats_lease::{NatsLeaseConfig, NatsSessionLease};
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+
+fn fast_lease_config() -> NatsLeaseConfig {
+    NatsLeaseConfig {
+        ttl: Duration::from_secs(2),
+        renew_interval: Duration::from_millis(400),
+        replicas: 1,
+        tombstone_ttl: Duration::from_secs(10),
+        ..Default::default()
+    }
+}
+
+async fn jetstream(url: &str) -> Result<async_nats::jetstream::Context> {
+    Ok(async_nats::jetstream::new(async_nats::connect(url).await?))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lease_contention_allows_exactly_one_holder() -> Result<()> {
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+    let js = jetstream(server.url()).await?;
+    let cfg = fast_lease_config();
+
+    let one = NatsSessionLease::acquire(harnx_runtime::nats_lease::NatsLeaseAcquireParams {
+        jetstream: js.clone(),
+        session_id: "contention",
+        worker_id: "worker-a".to_string(),
+        generation: 1,
+        config: cfg.clone(),
+    })
+    .await?;
+    let two = NatsSessionLease::acquire(harnx_runtime::nats_lease::NatsLeaseAcquireParams {
+        jetstream: js.clone(),
+        session_id: "contention",
+        worker_id: "worker-b".to_string(),
+        generation: 1,
+        config: cfg.clone(),
+    })
+    .await?;
+
+    assert!(
+        one.is_some() ^ two.is_some(),
+        "exactly one worker must hold the lease (one={}, two={})",
+        one.is_some(),
+        two.is_some()
+    );
+    if let Some(lease) = one.or(two) {
+        assert!(lease.is_held());
+        assert!(lease.fence_token() > 0);
+        lease.release().await.context("release should succeed")?;
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lease_release_succeeds_after_renewals() -> Result<()> {
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+    let js = jetstream(server.url()).await?;
+    let cfg = fast_lease_config();
+
+    let lease = NatsSessionLease::acquire(harnx_runtime::nats_lease::NatsLeaseAcquireParams {
+        jetstream: js.clone(),
+        session_id: "release",
+        worker_id: "worker-a".to_string(),
+        generation: 1,
+        config: cfg,
+    })
+    .await?
+    .context("acquire")?;
+    let initial_fence = lease.fence_token();
+    // Let at least two renewal ticks bump the fence.
+    sleep(Duration::from_millis(1000)).await;
+    assert!(lease.is_held(), "lease should still be held after renewals");
+    assert!(
+        lease.fence_token() > initial_fence,
+        "fence should advance on renewal (initial={}, now={})",
+        initial_fence,
+        lease.fence_token()
+    );
+    // Release must succeed even though the fence advanced via renewal CAS.
+    lease
+        .release()
+        .await
+        .context("release after renewals must succeed")?;
+
+    // After release the key is gone: a new worker can acquire.
+    let reacquire = NatsSessionLease::acquire(harnx_runtime::nats_lease::NatsLeaseAcquireParams {
+        jetstream: js.clone(),
+        session_id: "release",
+        worker_id: "worker-b".to_string(),
+        generation: 2,
+        config: fast_lease_config(),
+    })
+    .await?;
+    assert!(
+        reacquire.is_some(),
+        "lease should be acquirable after release"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lease_failover_after_holder_stops_renewing() -> Result<()> {
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+    let js = jetstream(server.url()).await?;
+    let cfg = fast_lease_config();
+
+    let lease_one = NatsSessionLease::acquire(harnx_runtime::nats_lease::NatsLeaseAcquireParams {
+        jetstream: js.clone(),
+        session_id: "failover",
+        worker_id: "worker-a".to_string(),
+        generation: 1,
+        config: cfg.clone(),
+    })
+    .await?
+    .context("first acquire")?;
+    // Simulate worker death: stop renewing and forget the lease (no release).
+    lease_one.stop_renewal_for_test().await;
+    std::mem::forget(lease_one);
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(lease_two) =
+            NatsSessionLease::acquire(harnx_runtime::nats_lease::NatsLeaseAcquireParams {
+                jetstream: js.clone(),
+                session_id: "failover",
+                worker_id: "worker-b".to_string(),
+                generation: 1,
+                config: cfg.clone(),
+            })
+            .await?
+        {
+            lease_two.release().await?;
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("second worker failed to acquire after TTL expiry");
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lease_renewal_survives_long_operation() -> Result<()> {
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+    let js = jetstream(server.url()).await?;
+    let cfg = fast_lease_config(); // ttl 2s, renew 400ms
+
+    let lease = NatsSessionLease::acquire(harnx_runtime::nats_lease::NatsLeaseAcquireParams {
+        jetstream: js.clone(),
+        session_id: "long-op",
+        worker_id: "worker-a".to_string(),
+        generation: 1,
+        config: cfg,
+    })
+    .await?
+    .context("acquire")?;
+
+    // Simulate a long (> ttl) operation on the holder's thread; the renewal
+    // task runs on the multi-thread runtime and keeps the lease alive.
+    tokio::task::spawn_blocking(|| std::thread::sleep(Duration::from_secs(4))).await?;
+    assert!(
+        lease.is_held(),
+        "renewal task should keep the lease alive across a >TTL op"
+    );
+    lease.release().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lease_loss_is_signalled_on_watch() -> Result<()> {
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+    let js = jetstream(server.url()).await?;
+    let cfg = fast_lease_config();
+
+    let lease = NatsSessionLease::acquire(harnx_runtime::nats_lease::NatsLeaseAcquireParams {
+        jetstream: js.clone(),
+        session_id: "loss",
+        worker_id: "worker-a".to_string(),
+        generation: 1,
+        config: cfg,
+    })
+    .await?
+    .context("acquire")?;
+    let mut watch = lease.lost_watch();
+    assert!(*watch.borrow(), "watch starts held=true");
+
+    // Mark the lease lost (simulates renewal failure / detected loss).
+    lease.mark_lost_for_test();
+
+    // Watch must transition to false promptly.
+    let changed = tokio::time::timeout(Duration::from_secs(2), watch.changed()).await;
+    assert!(changed.is_ok(), "lost-watch should fire");
+    assert!(!*watch.borrow(), "lost-watch should report false");
+    assert!(!lease.is_held());
+    Ok(())
+}

--- a/crates/harnx-runtime/tests/nats_session_delete.rs
+++ b/crates/harnx-runtime/tests/nats_session_delete.rs
@@ -1,0 +1,117 @@
+mod common;
+
+use anyhow::{Context, Result};
+use common::spawn_nats_server;
+use harnx_core::{
+    message::{MessageContent, MessageRole},
+    require_nextest,
+    session::SessionLogEntry,
+};
+use harnx_runtime::{
+    config::Config,
+    nats_admin::delete_remote_session,
+    nats_lease::NatsLeaseConfig,
+    nats_session_log::{stream_name_for_session, NatsSessionLog},
+};
+use indexmap::IndexMap;
+
+#[tokio::test]
+async fn session_delete_removes_stream_and_lease_and_is_idempotent() -> Result<()> {
+    require_nextest();
+
+    let Some(server) = spawn_nats_server().await? else {
+        return Ok(());
+    };
+
+    let config = Config {
+        nats_servers: vec![harnx_runtime::config::NatsServerConfig {
+            name: "local".to_string(),
+            url: server.url().to_string(),
+            token: None,
+            tls: None,
+            tls_cert: None,
+            tls_key: None,
+            tls_ca: None,
+        }],
+        ..Default::default()
+    };
+    let jetstream = config.nats_jetstream("local").await?;
+    let session_id = "delete-me";
+    let log = NatsSessionLog::new(jetstream.clone(), session_id);
+    log.append_event_async(&header(session_id)).await?;
+    log.append_event_async(&SessionLogEntry::Message {
+        id: None,
+        role: MessageRole::User,
+        content: MessageContent::Text("hello".to_string()),
+        timestamp: None,
+        fence_token: None,
+    })
+    .await?;
+
+    let lease = harnx_runtime::nats_lease::NatsSessionLease::acquire(
+        harnx_runtime::nats_lease::NatsLeaseAcquireParams {
+            jetstream: jetstream.clone(),
+            session_id,
+            worker_id: "w1".to_string(),
+            generation: 1,
+            config: NatsLeaseConfig::default(),
+        },
+    )
+    .await?
+    .expect("lease acquired");
+    let lease_key = NatsLeaseConfig::default().key_for_session(session_id);
+    lease.stop_renewal_for_test().await;
+
+    let deleted = delete_remote_session(&config, "local", session_id).await?;
+    assert!(deleted.stream_deleted);
+    assert!(deleted.lease_deleted);
+
+    let stream_name = stream_name_for_session(session_id);
+    let err = jetstream
+        .get_stream(&stream_name)
+        .await
+        .expect_err("stream should be gone");
+    assert!(
+        err.to_string().contains("stream not found") || err.to_string().contains("no responders")
+    );
+
+    let leases = config.nats_kv_bucket("local", "harnx_leases").await?;
+    let lease_entry = leases
+        .entry(lease_key.clone())
+        .await
+        .context("load deleted lease entry")?;
+    assert!(
+        lease_entry.is_none()
+            || !matches!(
+                lease_entry.unwrap().operation,
+                async_nats::jetstream::kv::Operation::Put
+            )
+    );
+
+    let deleted_again = delete_remote_session(&config, "local", session_id).await?;
+    assert!(!deleted_again.stream_deleted);
+    assert!(!deleted_again.lease_deleted);
+
+    Ok(())
+}
+
+fn header(session_id: &str) -> SessionLogEntry {
+    SessionLogEntry::Header {
+        model_id: "test-model".to_string(),
+        temperature: None,
+        top_p: None,
+        use_tools: None,
+        save_session: Some(true),
+        compress_threshold: None,
+        agent_name: Some("oracle".to_string()),
+        session_id: Some(session_id.to_string()),
+        working_dir: None,
+        git_branch: None,
+        git_remote: None,
+        terminal_session_id: None,
+        agent_variables: IndexMap::new(),
+        agent_instructions: "delete me".to_string(),
+        model_fallbacks: vec![],
+        compaction_agent: None,
+    }
+}

--- a/crates/harnx-runtime/tests/nats_session_log.rs
+++ b/crates/harnx-runtime/tests/nats_session_log.rs
@@ -1,0 +1,236 @@
+mod common;
+
+use anyhow::Result;
+use common::spawn_nats_server;
+use harnx_core::{
+    message::{MessageContent, MessageRole},
+    require_nextest,
+    session::{SessionLogEntry, ToolOutput},
+    session_reconstruct::{reconstruct_state, TurnStatus},
+    tool::ToolCall,
+};
+use harnx_runtime::{config::Config, nats_session_log::NatsSessionLog};
+use indexmap::IndexMap;
+use serde_json::json;
+
+#[tokio::test]
+async fn nats_session_log_round_trips_and_reconstructs() -> Result<()> {
+    require_nextest();
+
+    let Some(server) = spawn_nats_server().await? else {
+        return Ok(());
+    };
+
+    let config = Config {
+        nats_servers: vec![harnx_runtime::config::NatsServerConfig {
+            name: "local".to_string(),
+            url: server.url().to_string(),
+            token: None,
+            tls: None,
+            tls_cert: None,
+            tls_key: None,
+            tls_ca: None,
+        }],
+        ..Default::default()
+    };
+    let jetstream = config.nats_jetstream("local").await?;
+    let log = NatsSessionLog::new(jetstream.clone(), "session-roundtrip");
+
+    let entries = mixed_entries();
+    let expected_yaml: Vec<String> = entries.iter().map(entry_yaml).collect::<Result<_>>()?;
+    let mut seqs = Vec::new();
+    for entry in &entries {
+        seqs.push(log.append_event_async(entry).await?);
+    }
+
+    let loaded = log.load_events_async().await?;
+    let loaded_entries: Vec<SessionLogEntry> =
+        loaded.iter().map(|(_, entry)| entry.clone()).collect();
+    let loaded_yaml: Vec<String> = loaded_entries
+        .iter()
+        .map(entry_yaml)
+        .collect::<Result<_>>()?;
+    assert_eq!(loaded_yaml, expected_yaml);
+    assert_eq!(seqs, loaded.iter().map(|(seq, _)| *seq).collect::<Vec<_>>());
+
+    let replayed = log.replay_from_async(loaded[1].0).await?;
+    let replayed_yaml: Vec<String> = replayed.iter().map(entry_yaml).collect::<Result<_>>()?;
+    assert_eq!(replayed_yaml, expected_yaml[2..].to_vec());
+
+    let state = reconstruct_state(&loaded_entries);
+    assert_eq!(state.turn_status, TurnStatus::Idle);
+    assert!(state.next_turn_messages.is_empty());
+    assert!(state.resumable_ctx.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn nats_session_log_orphan_repair_matches_file_replay() -> Result<()> {
+    require_nextest();
+
+    let Some(server) = spawn_nats_server().await? else {
+        return Ok(());
+    };
+
+    let config = Config {
+        nats_servers: vec![harnx_runtime::config::NatsServerConfig {
+            name: "local".to_string(),
+            url: server.url().to_string(),
+            token: None,
+            tls: None,
+            tls_cert: None,
+            tls_key: None,
+            tls_ca: None,
+        }],
+        ..Default::default()
+    };
+    let jetstream = config.nats_jetstream("local").await?;
+    let log = NatsSessionLog::new(jetstream.clone(), "session-orphan");
+
+    let entries = orphan_entries();
+    let expected_yaml: Vec<String> = entries.iter().map(entry_yaml).collect::<Result<_>>()?;
+    for entry in &entries {
+        log.append_event_async(entry).await?;
+    }
+
+    let loaded = log.load_events_async().await?;
+    let loaded_entries: Vec<SessionLogEntry> =
+        loaded.iter().map(|(_, entry)| entry.clone()).collect();
+    let loaded_yaml: Vec<String> = loaded_entries
+        .iter()
+        .map(entry_yaml)
+        .collect::<Result<_>>()?;
+    assert_eq!(loaded_yaml, expected_yaml);
+
+    let state = reconstruct_state(&loaded_entries);
+    assert_eq!(state.turn_status, TurnStatus::InFlightResumable);
+    let resumable = state.resumable_ctx.expect("resumable ctx");
+    assert_eq!(resumable.pending_tool_results.len(), 0);
+    assert_eq!(resumable.fence_token, Some(77));
+
+    let repaired =
+        harnx_runtime::nats_session_log::load_session_from_entries(&loaded, "nats-session")?;
+    let tail = repaired.messages.last().expect("tail message");
+    assert_eq!(tail.role, MessageRole::Tool);
+    // Orphan repair synthesizes a "lost" ToolResults for the un-answered tool
+    // call. The marker lives in the tool result's `output` JSON (same as the
+    // file-log path), not in the message's rendered text.
+    let MessageContent::ToolCalls(tc) = &tail.content else {
+        panic!("expected ToolCalls content on repaired tail message");
+    };
+    assert_eq!(tc.tool_results.len(), 1);
+    let output_str = tc.tool_results[0].output.to_string();
+    assert!(
+        output_str.contains("tool response lost"),
+        "expected synthesized lost-response error, got: {output_str}"
+    );
+
+    Ok(())
+}
+
+fn entry_yaml(entry: &SessionLogEntry) -> Result<String> {
+    harnx_runtime::nats_session_log::serialize_entry(entry)
+}
+
+fn mixed_entries() -> Vec<SessionLogEntry> {
+    vec![
+        SessionLogEntry::Header {
+            model_id: "test-model".to_string(),
+            temperature: Some(0.2),
+            top_p: Some(0.8),
+            use_tools: Some(vec!["Bash".to_string()]),
+            save_session: Some(true),
+            compress_threshold: Some(9000),
+            agent_name: Some("oracle".to_string()),
+            session_id: Some("session-roundtrip".to_string()),
+            working_dir: Some("/tmp/work".to_string()),
+            git_branch: Some("main".to_string()),
+            git_remote: Some("origin".to_string()),
+            terminal_session_id: Some("term-1".to_string()),
+            agent_variables: IndexMap::new(),
+            agent_instructions: "You are Oracle".to_string(),
+            model_fallbacks: vec!["backup-model".to_string()],
+            compaction_agent: Some("compactor".to_string()),
+        },
+        SessionLogEntry::Message {
+            id: None,
+            role: MessageRole::User,
+            content: MessageContent::Text("hello".to_string()),
+            timestamp: None,
+            fence_token: None,
+        },
+        SessionLogEntry::ToolCalls {
+            text: "running bash".to_string(),
+            thought: Some("need directory list".to_string()),
+            calls: vec![ToolCall::new(
+                "Bash".to_string(),
+                json!({"command": "ls"}),
+                Some("call-1".to_string()),
+                None,
+            )],
+            timestamp: None,
+            fence_token: Some(41),
+        },
+        SessionLogEntry::ToolResults {
+            results: vec![ToolOutput {
+                id: Some("call-1".to_string()),
+                name: "Bash".to_string(),
+                output: json!({"stdout": "Cargo.toml"}),
+                content: vec![],
+                switch_agent: None,
+            }],
+            timestamp: None,
+        },
+        SessionLogEntry::Cancel { fence_token: 41 },
+        SessionLogEntry::Message {
+            id: None,
+            role: MessageRole::Assistant,
+            content: MessageContent::Text("done".to_string()),
+            timestamp: None,
+            fence_token: None,
+        },
+    ]
+}
+
+fn orphan_entries() -> Vec<SessionLogEntry> {
+    vec![
+        SessionLogEntry::Header {
+            model_id: "test-model".to_string(),
+            temperature: None,
+            top_p: None,
+            use_tools: None,
+            save_session: Some(true),
+            compress_threshold: None,
+            agent_name: Some("oracle".to_string()),
+            session_id: Some("session-orphan".to_string()),
+            working_dir: None,
+            git_branch: None,
+            git_remote: None,
+            terminal_session_id: None,
+            agent_variables: IndexMap::new(),
+            agent_instructions: "repair me".to_string(),
+            model_fallbacks: vec![],
+            compaction_agent: None,
+        },
+        SessionLogEntry::Message {
+            id: None,
+            role: MessageRole::User,
+            content: MessageContent::Text("run tool".to_string()),
+            timestamp: None,
+            fence_token: None,
+        },
+        SessionLogEntry::ToolCalls {
+            text: "working".to_string(),
+            thought: Some("thinking".to_string()),
+            calls: vec![ToolCall::new(
+                "Bash".to_string(),
+                json!({"command": "pwd"}),
+                Some("call-orphan".to_string()),
+                None,
+            )],
+            timestamp: None,
+            fence_token: Some(77),
+        },
+    ]
+}

--- a/crates/harnx-runtime/tests/nats_thin_client.rs
+++ b/crates/harnx-runtime/tests/nats_thin_client.rs
@@ -1,0 +1,392 @@
+mod common;
+
+use anyhow::Result;
+use common::spawn_nats_server;
+use harnx_core::{
+    message::{MessageContent, MessageRole},
+    require_nextest,
+    session::SessionLogEntry,
+    session_reconstruct::{reconstruct_state_from_nats, TurnStatus},
+};
+use harnx_runtime::{
+    nats_session_log::NatsSessionLog, nats_worker::ControlCommand, send_control_command,
+    ThinClientConfig, ThinClientSession,
+};
+use std::time::Duration;
+use uuid::Uuid;
+
+fn new_remote_session_id() -> String {
+    format!("test-{}", Uuid::new_v4())
+}
+
+/// Test that control commands are sent correctly
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn thin_client_sends_control_commands() -> Result<()> {
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let client = async_nats::connect(server.url()).await?;
+
+    // Subscribe to control subject
+    let session_id = new_remote_session_id();
+    let mut control_sub = client
+        .subscribe(harnx_runtime::nats_worker::control_subject(&session_id))
+        .await?;
+
+    // Send a control command
+    send_control_command(&client, &session_id, ControlCommand::Cancel).await?;
+
+    // Verify it was received
+    use futures_util::StreamExt;
+    let msg = tokio::time::timeout(Duration::from_secs(2), control_sub.next())
+        .await?
+        .expect("should receive control message");
+
+    let cmd: ControlCommand = serde_json::from_slice(&msg.payload)?;
+    assert!(matches!(cmd, ControlCommand::Cancel));
+
+    Ok(())
+}
+
+/// Test that user messages are stamped with a client-generated ID.
+///
+/// This test directly appends a user message (mimicking ThinClientSession's append path)
+/// and verifies the ID field is set to a valid UUID. Does NOT call run_turn because
+/// there's no worker to pick up the activation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_message_has_client_id() -> Result<()> {
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let client = async_nats::connect(server.url()).await?;
+    let jetstream = async_nats::jetstream::new(client.clone());
+
+    let session_id = new_remote_session_id();
+    let log = NatsSessionLog::new(jetstream.clone(), session_id.clone());
+
+    // Append a header first (required for session reconstruct)
+    let header = SessionLogEntry::Header {
+        model_id: "test-model".to_string(),
+        temperature: None,
+        top_p: None,
+        use_tools: None,
+        save_session: None,
+        compress_threshold: None,
+        agent_name: Some("test-agent".to_string()),
+        session_id: Some(session_id.clone()),
+        working_dir: None,
+        git_branch: None,
+        git_remote: None,
+        terminal_session_id: None,
+        agent_variables: Default::default(),
+        agent_instructions: String::new(),
+        model_fallbacks: vec![],
+        compaction_agent: None,
+    };
+    log.append_event_async(&header).await?;
+
+    // Create a thin client session (mirrors retract test pattern)
+    let config = ThinClientConfig {
+        cluster: "test".to_string(),
+        agent: "test-agent".to_string(),
+        session_id: Some(session_id.clone()),
+    };
+    let abort_signal = harnx_runtime::utils::create_abort_signal();
+
+    let _session = ThinClientSession::new(config, client, jetstream, abort_signal).await?;
+
+    // Append a user message directly (same pattern as in ThinClientSession::run_turn)
+    let user_msg_id = uuid::Uuid::new_v4().to_string();
+    let user_entry = SessionLogEntry::Message {
+        id: Some(user_msg_id.clone()),
+        role: MessageRole::User,
+        content: MessageContent::Text("Hello world".to_string()),
+        timestamp: None,
+        fence_token: None,
+    };
+    log.append_event_async(&user_entry).await?;
+
+    // Load entries and verify the user message has a valid UUID ID
+    let entries = log.load_events_async().await?;
+    let user_msg = entries.iter().find(
+        |(_, e)| matches!(e, SessionLogEntry::Message { role, .. } if *role == MessageRole::User),
+    );
+
+    assert!(user_msg.is_some(), "User message should be in log");
+
+    if let Some((_seq, entry)) = user_msg {
+        if let SessionLogEntry::Message { id, .. } = entry {
+            assert!(
+                id.is_some(),
+                "User message should have a client-generated ID"
+            );
+            let id = id.as_ref().unwrap();
+            // UUID v4 format: 8-4-4-4-12 hex chars
+            assert!(
+                Uuid::parse_str(id).is_ok(),
+                "Client ID should be a valid UUID"
+            );
+        } else {
+            panic!("Expected Message entry");
+        }
+    }
+
+    Ok(())
+}
+
+/// Test retract-before-consume appends correct EditEntries and removes the message
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retract_queued_user_message() -> Result<()> {
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let client = async_nats::connect(server.url()).await?;
+    let jetstream = async_nats::jetstream::new(client.clone());
+
+    let session_id = new_remote_session_id();
+    let log = NatsSessionLog::new(jetstream.clone(), session_id.clone());
+
+    // Append a header first
+    let header = SessionLogEntry::Header {
+        model_id: "test-model".to_string(),
+        temperature: None,
+        top_p: None,
+        use_tools: None,
+        save_session: None,
+        compress_threshold: None,
+        agent_name: Some("test-agent".to_string()),
+        session_id: Some(session_id.clone()),
+        working_dir: None,
+        git_branch: None,
+        git_remote: None,
+        terminal_session_id: None,
+        agent_variables: Default::default(),
+        agent_instructions: String::new(),
+        model_fallbacks: vec![],
+        compaction_agent: None,
+    };
+    let _header_seq = log.append_event_async(&header).await?;
+
+    // Append a user message directly (simulating what ThinClientSession does)
+    let user_msg_id = uuid::Uuid::new_v4().to_string();
+    let user_entry = SessionLogEntry::Message {
+        id: Some(user_msg_id.clone()),
+        role: MessageRole::User,
+        content: MessageContent::Text("Hello world".to_string()),
+        timestamp: None,
+        fence_token: None,
+    };
+    let user_msg_seq = log.append_event_async(&user_entry).await?;
+
+    // Verify the message is there
+    let entries = log.load_events_async().await?;
+    let user_msg_before = entries.iter().find(|(seq, _)| *seq == user_msg_seq);
+    assert!(
+        user_msg_before.is_some(),
+        "User message should exist before retract"
+    );
+
+    // Create ThinClientSession and retract the message
+    let config = ThinClientConfig {
+        cluster: "test".to_string(),
+        agent: "test-agent".to_string(),
+        session_id: Some(session_id.clone()),
+    };
+    let abort_signal = harnx_runtime::utils::create_abort_signal();
+
+    let session = ThinClientSession::new(config, client, jetstream.clone(), abort_signal).await?;
+
+    // Retract the message
+    let edit_seq = session.retract_user_message(user_msg_seq).await?;
+    assert!(
+        edit_seq > user_msg_seq,
+        "EditEntries should come after user message"
+    );
+
+    // Load entries and verify EditEntries was appended
+    let entries = log.load_events_async().await?;
+    let edit_entry = entries.iter().find(|(seq, _)| *seq == edit_seq);
+    assert!(edit_entry.is_some(), "EditEntries should be in log");
+
+    if let Some((
+        _,
+        SessionLogEntry::EditEntries {
+            from,
+            to,
+            replacements,
+        },
+    )) = edit_entry
+    {
+        assert_eq!(
+            *from, user_msg_seq as usize,
+            "EditEntries.from should match user message seq"
+        );
+        assert_eq!(
+            *to, user_msg_seq as usize,
+            "EditEntries.to should match user message seq"
+        );
+        assert!(
+            replacements.is_empty(),
+            "EditEntries.replacements should be empty for deletion"
+        );
+    } else {
+        panic!("Expected EditEntries entry");
+    }
+
+    // Reconstruct state and verify the user message is gone from next_turn_messages
+    // Reconstruct state and verify the user message is gone from next_turn_messages
+    // Use the NATS-aware function that properly handles JetStream sequence numbers
+    let state = reconstruct_state_from_nats(&entries);
+    eprintln!("Turn status: {:?}", state.turn_status);
+    eprintln!("Next turn messages: {:?}", state.next_turn_messages.len());
+
+    assert!(
+        matches!(state.turn_status, TurnStatus::Idle),
+        "Turn should be idle after retraction"
+    );
+
+    // The user message should not appear in next_turn_messages
+    // (It would be the first user message if present)
+    // next_turn_messages filters out entries covered by EditEntries.
+    let has_user_msg = state.next_turn_messages.iter().any(|m| {
+        matches!(m, harnx_core::message::Message {
+            role: harnx_core::message::MessageRole::User,
+            content: harnx_core::message::MessageContent::Text(t),
+            ..
+        } if t == "Hello world")
+    });
+    assert!(
+        !has_user_msg,
+        "User message should be removed by EditEntries deletion"
+    );
+
+    Ok(())
+}
+
+/// Test edit-before-consume appends parseable replacement YAML and keeps edited text in replay
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn edit_queued_user_message_replaces_text_in_reconstructed_state() -> Result<()> {
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let client = async_nats::connect(server.url()).await?;
+    let jetstream = async_nats::jetstream::new(client.clone());
+
+    let session_id = new_remote_session_id();
+    let log = NatsSessionLog::new(jetstream.clone(), session_id.clone());
+
+    let header = SessionLogEntry::Header {
+        model_id: "test-model".to_string(),
+        temperature: None,
+        top_p: None,
+        use_tools: None,
+        save_session: None,
+        compress_threshold: None,
+        agent_name: Some("test-agent".to_string()),
+        session_id: Some(session_id.clone()),
+        working_dir: None,
+        git_branch: None,
+        git_remote: None,
+        terminal_session_id: None,
+        agent_variables: Default::default(),
+        agent_instructions: String::new(),
+        model_fallbacks: vec![],
+        compaction_agent: None,
+    };
+    let _header_seq = log.append_event_async(&header).await?;
+
+    let original_entry = SessionLogEntry::Message {
+        id: Some(Uuid::new_v4().to_string()),
+        role: MessageRole::User,
+        content: MessageContent::Text("Hello world".to_string()),
+        timestamp: None,
+        fence_token: None,
+    };
+    let user_msg_seq = log.append_event_async(&original_entry).await?;
+
+    let config = ThinClientConfig {
+        cluster: "test".to_string(),
+        agent: "test-agent".to_string(),
+        session_id: Some(session_id.clone()),
+    };
+    let abort_signal = harnx_runtime::utils::create_abort_signal();
+    let session = ThinClientSession::new(config, client, jetstream.clone(), abort_signal).await?;
+
+    let edit_seq = session
+        .edit_user_message(user_msg_seq, "edited text".to_string())
+        .await?;
+    assert!(
+        edit_seq > user_msg_seq,
+        "EditEntries should come after user message"
+    );
+
+    let entries = log.load_events_async().await?;
+    let edit_entry = entries.iter().find(|(seq, _)| *seq == edit_seq);
+    assert!(edit_entry.is_some(), "EditEntries should be in log");
+
+    let replacement_yaml = match edit_entry {
+        Some((
+            _,
+            SessionLogEntry::EditEntries {
+                from,
+                to,
+                replacements,
+            },
+        )) => {
+            assert_eq!(*from, user_msg_seq as usize);
+            assert_eq!(*to, user_msg_seq as usize);
+            assert_eq!(
+                replacements.len(),
+                1,
+                "edit should write one replacement entry"
+            );
+            replacements[0].clone()
+        }
+        _ => panic!("Expected EditEntries entry"),
+    };
+
+    let parsed_replacement = serde_yaml::from_str::<SessionLogEntry>(&replacement_yaml)?;
+    match parsed_replacement {
+        SessionLogEntry::Message {
+            role,
+            content: MessageContent::Text(text),
+            timestamp,
+            fence_token,
+            ..
+        } => {
+            assert_eq!(role, MessageRole::User);
+            assert_eq!(text, "edited text");
+            assert!(timestamp.is_none());
+            assert!(fence_token.is_none());
+        }
+        other => panic!("expected replacement message entry, got {other:?}"),
+    }
+
+    let state = reconstruct_state_from_nats(&entries);
+    assert!(matches!(state.turn_status, TurnStatus::Idle));
+
+    let next_turn_texts: Vec<_> = state
+        .next_turn_messages
+        .iter()
+        .filter_map(|message| match (&message.role, &message.content) {
+            (MessageRole::User, MessageContent::Text(text)) => Some(text.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(next_turn_texts, vec!["edited text".to_string()]);
+    assert!(!next_turn_texts.iter().any(|text| text == "Hello world"));
+
+    Ok(())
+}

--- a/crates/harnx-runtime/tests/nats_worker.rs
+++ b/crates/harnx-runtime/tests/nats_worker.rs
@@ -1,0 +1,1111 @@
+//! Integration test: drive run_agent_loop with NATS-backed persistence.
+//!
+//! Validates end-to-end persistence of a full turn via NatsSessionLog.
+
+mod common;
+
+use anyhow::Result;
+use common::spawn_nats_server;
+use harnx_core::{
+    message::MessageRole,
+    require_nextest,
+    session::SessionLogEntry,
+    session_reconstruct::{reconstruct_state, TurnStatus},
+    tool::ToolCall,
+};
+use harnx_runtime::{
+    client::CompletionTokenUsage,
+    config::{Config, NatsServerConfig},
+    nats_session_log::NatsSessionLog,
+    nats_worker::{
+        publish_session_activate, run_agent_loop_with_nats, run_worker_daemon,
+        NatsSessionLogBackend, RunAgentLoopArgs, SessionActivate, WorkerDaemonConfig,
+    },
+    utils::create_abort_signal,
+};
+use std::sync::LazyLock;
+
+static MID_ROUND_APPEND_READY: LazyLock<Notify> = LazyLock::new(Notify::new);
+static MID_ROUND_APPEND_DONE: LazyLock<Notify> = LazyLock::new(Notify::new);
+static MID_ROUND_FINAL_CALLS: AtomicUsize = AtomicUsize::new(0);
+static END_TURN_APPEND_READY: LazyLock<Notify> = LazyLock::new(Notify::new);
+static END_TURN_APPEND_DONE: LazyLock<Notify> = LazyLock::new(Notify::new);
+static END_TURN_CALLS: AtomicUsize = AtomicUsize::new(0);
+use parking_lot::RwLock;
+use serde_json::json;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{Mutex as AsyncMutex, Notify};
+
+/// Stub LLM that returns: assistant with tool call on turn 1, final text on turn 2.
+/// Description of a single NATS server entry for test configs.
+struct NatsServerSpec<'a> {
+    name: &'a str,
+    url: &'a str,
+    token: Option<&'a str>,
+}
+
+fn local_nats_config(spec: NatsServerSpec<'_>) -> Config {
+    let mut config = Config {
+        nats_servers: vec![NatsServerConfig {
+            name: spec.name.to_string(),
+            url: spec.url.to_string(),
+            token: spec.token.map(str::to_string),
+            tls: None,
+            tls_cert: None,
+            tls_key: None,
+            tls_ca: None,
+        }],
+        ..Default::default()
+    };
+    config.dry_run = false;
+    config
+}
+
+fn session_header(session_id: &str) -> SessionLogEntry {
+    SessionLogEntry::Header {
+        model_id: "test-model".to_string(),
+        temperature: None,
+        top_p: None,
+        use_tools: None,
+        save_session: Some(true),
+        compress_threshold: None,
+        agent_name: None,
+        session_id: Some(session_id.to_string()),
+        working_dir: None,
+        git_branch: None,
+        git_remote: None,
+        terminal_session_id: None,
+        agent_variables: Default::default(),
+        agent_instructions: String::new(),
+        model_fallbacks: vec![],
+        compaction_agent: None,
+    }
+}
+
+async fn seed_session_and_attach_runtime(
+    global_config: &Arc<RwLock<Config>>,
+    jetstream: async_nats::jetstream::Context,
+    session_id: &str,
+) -> Result<NatsSessionLog> {
+    let backend = NatsSessionLogBackend::new(jetstream.clone(), session_id);
+    backend.append_event_blocking(&session_header(session_id))?;
+
+    let log = NatsSessionLog::new(jetstream, session_id);
+    let entries = log.load_events_async().await?;
+    let mut session =
+        harnx_runtime::nats_session_log::load_session_from_entries(&entries, session_id)?;
+    let runtime = std::sync::Arc::new(backend.clone())
+        as std::sync::Arc<dyn harnx_runtime::config::session::SessionAppendSink>;
+    session.runtime = Some(std::sync::Arc::new(runtime));
+    global_config.write().session = Some(session);
+    Ok(log)
+}
+
+struct WorkerTurnLabels<'a> {
+    cluster_key: &'a str,
+    session_id: &'a str,
+    prompt: &'a str,
+}
+
+struct WorkerTurnParams<'a> {
+    global_config: Arc<RwLock<Config>>,
+    labels: WorkerTurnLabels<'a>,
+    call_fn: harnx_runtime::agent_loop::AgentCallFn,
+}
+
+async fn run_worker_turn(params: WorkerTurnParams<'_>) -> Result<()> {
+    let WorkerTurnParams {
+        global_config,
+        labels:
+            WorkerTurnLabels {
+                cluster_key,
+                session_id,
+                prompt,
+            },
+        call_fn,
+    } = params;
+    let input = harnx_runtime::config::input::from_str(&global_config, prompt, None);
+    run_agent_loop_with_nats(RunAgentLoopArgs {
+        cluster_key,
+        session_id,
+        config: global_config,
+        initial_input: input,
+        abort_signal: create_abort_signal(),
+        call_fn: Some(call_fn),
+        lease: None,
+        after_seq_observer: None,
+        on_tool_round: None,
+    })
+    .await
+}
+
+fn make_stub_llm_call_fn() -> harnx_runtime::agent_loop::AgentCallFn {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    Arc::new(move |_input, _config, _abort| {
+        let cc = call_count.clone();
+        Box::pin(async move {
+            let n = cc.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                // Turn 1: assistant calls echo tool
+                Ok((
+                    "let me help you".to_string(),
+                    None,
+                    vec![ToolCall::new(
+                        "echo".to_string(),
+                        json!({"message": "hello"}),
+                        Some("call-echo-1".to_string()),
+                        None,
+                    )],
+                    harnx_runtime::client::CompletionTokenUsage::default(),
+                ))
+            } else {
+                // Turn 2: final text response
+                Ok((
+                    "done!".to_string(),
+                    None,
+                    vec![],
+                    harnx_runtime::client::CompletionTokenUsage::default(),
+                ))
+            }
+        })
+    })
+}
+
+fn append_user_message_entry(text: &str) -> SessionLogEntry {
+    SessionLogEntry::Message {
+        id: None,
+        role: MessageRole::User,
+        content: harnx_core::message::MessageContent::Text(text.to_string()),
+        timestamp: None,
+        fence_token: None,
+    }
+}
+
+fn mid_round_call_fn() -> harnx_runtime::agent_loop::AgentCallFn {
+    Arc::new(move |input, _config, _abort| {
+        // The mid-turn injection is delivered via `input.injected_user_text`
+        // (set by the worker's `on_tool_round` callback between tool rounds).
+        // `build_messages` appends it to the wire request, so the LLM sees it,
+        // but it is only persisted to `session.messages` AFTER this call. Detect
+        // it directly on the input.
+        let injected_arrived = input
+            .injected_user_text()
+            .map(|t| t.contains("late message"))
+            .unwrap_or(false);
+        Box::pin(async move {
+            if !injected_arrived {
+                // First round: signal readiness, block until the test appends the
+                // late message, then emit a tool call so the loop runs another round
+                // (the `on_tool_round` seam fires between rounds and injects it).
+                MID_ROUND_APPEND_READY.notify_one();
+                MID_ROUND_APPEND_DONE.notified().await;
+                Ok((
+                    "round-one".to_string(),
+                    None,
+                    vec![ToolCall::new(
+                        "echo".to_string(),
+                        json!({}),
+                        Some("call-mid".to_string()),
+                        None,
+                    )],
+                    CompletionTokenUsage::default(),
+                ))
+            } else {
+                // Subsequent round: the injected message is now visible — emit a
+                // final assistant text echoing it so the test can assert it was
+                // delivered into the SAME turn exactly once.
+                MID_ROUND_FINAL_CALLS.fetch_add(1, Ordering::SeqCst);
+                Ok((
+                    "final: saw late message".to_string(),
+                    None,
+                    vec![],
+                    CompletionTokenUsage::default(),
+                ))
+            }
+        })
+    })
+}
+
+fn end_turn_call_fn() -> harnx_runtime::agent_loop::AgentCallFn {
+    Arc::new(move |input, _config, _abort| {
+        let prompt = input.raw.0.clone();
+        Box::pin(async move {
+            let call_no = END_TURN_CALLS.fetch_add(1, Ordering::SeqCst) + 1;
+            // Signal readiness using notify_one() (stores a permit if no waiter yet).
+            // This avoids the lost-wakeup race where notify_waiters fires before
+            // the test registers its notified() future.
+            if call_no == 1 {
+                END_TURN_APPEND_READY.notify_one();
+                // Block until test signals DONE - this prevents turn 1 from completing
+                // before the test appends "second", ensuring the daemon's drain loop
+                // sees the new message when it re-reads the tail.
+                END_TURN_APPEND_DONE.notified().await;
+            }
+            Ok((
+                format!("turn:{call_no} prompt:{prompt}"),
+                None,
+                vec![],
+                CompletionTokenUsage::default(),
+            ))
+        })
+    })
+}
+
+fn fold_capture_call_fn(
+    calls: Arc<AtomicUsize>,
+    prompts: Arc<AsyncMutex<Vec<String>>>,
+) -> harnx_runtime::agent_loop::AgentCallFn {
+    Arc::new(move |input, _config, _abort| {
+        let calls = calls.clone();
+        let prompts = prompts.clone();
+        let prompt = input.raw.0.clone();
+        Box::pin(async move {
+            calls.fetch_add(1, Ordering::SeqCst);
+            prompts.lock().await.push(prompt.clone());
+            Ok((
+                format!("folded:{prompt}"),
+                None,
+                vec![],
+                CompletionTokenUsage::default(),
+            ))
+        })
+    })
+}
+
+fn final_assistant_texts(entries: &[(u64, SessionLogEntry)]) -> Vec<String> {
+    entries
+        .iter()
+        .filter_map(|(_, entry)| match entry {
+            SessionLogEntry::Message {
+                role,
+                content,
+                fence_token: _, // Include all assistant messages, fenced or not
+                ..
+            } if role.is_assistant() => Some(content.to_text()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn user_message_texts(entries: &[(u64, SessionLogEntry)]) -> Vec<String> {
+    entries
+        .iter()
+        .filter_map(|(_, entry)| match entry {
+            SessionLogEntry::Message { role, content, .. } if role.is_user() => {
+                Some(content.to_text())
+            }
+            _ => None,
+        })
+        .collect()
+}
+// Reset static state between tests
+fn reset_test_state() {
+    // These must be reset in case tests are run in the same process
+    // Note: We can't truly clear Notify state across tests without async runtime
+    // Just reset the counters - tests may flake if run in same process
+    MID_ROUND_FINAL_CALLS.store(0, Ordering::SeqCst);
+    END_TURN_CALLS.store(0, Ordering::SeqCst);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mid_tool_round_user_message_is_injected_once_into_same_turn() -> Result<()> {
+    reset_test_state();
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("Skipping test: nats-server not available");
+        return Ok(());
+    };
+
+    let config = Arc::new(RwLock::new(local_nats_config(NatsServerSpec {
+        name: "local",
+        url: server.url(),
+        token: None,
+    })));
+    let worker_config = WorkerDaemonConfig::new("local", "worker-mid-round");
+    let daemon = tokio::spawn({
+        let cfg = config.clone();
+        async move { run_worker_daemon(cfg, worker_config, Some(mid_round_call_fn())).await }
+    });
+    // Give daemon time to initialize consumer
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    let js = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+    let session_id = "mid-round-injection";
+    let log = NatsSessionLog::new(js.clone(), session_id);
+
+    // CRITICAL: Create the notified future BEFORE publishing the activate
+    // to avoid lost wakeup race between notify_one() and notified().await
+    let ready_fut = MID_ROUND_APPEND_READY.notified();
+
+    log.append_event_async(&append_user_message_entry("seed message"))
+        .await?;
+    publish_session_activate(
+        &js,
+        "local",
+        &SessionActivate::new(session_id, "ignored-agent"),
+    )
+    .await?;
+
+    // Now await the ready signal - the permit was stored by notify_one()
+    ready_fut.await;
+
+    log.append_event_async(&append_user_message_entry("late message"))
+        .await?;
+    // Use notify_one() to signal completion - matches the notify_one() in call_fn
+    MID_ROUND_APPEND_DONE.notify_one();
+
+    wait_until(Duration::from_secs(10), || {
+        MID_ROUND_FINAL_CALLS.load(Ordering::SeqCst) >= 1
+    })
+    .await?;
+
+    let entries = log.load_events_async().await?;
+    let assistants = final_assistant_texts(&entries);
+    assert!(assistants.iter().any(|text| text.contains("late message")));
+    assert_eq!(
+        assistants
+            .iter()
+            .filter(|text| text.contains("late message"))
+            .count(),
+        1
+    );
+
+    daemon.abort();
+    let _ = daemon.await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn end_of_turn_reread_runs_continuation_turn_with_same_activation() -> Result<()> {
+    reset_test_state();
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("Skipping test: nats-server not available");
+        return Ok(());
+    };
+
+    let config = Arc::new(RwLock::new(local_nats_config(NatsServerSpec {
+        name: "local",
+        url: server.url(),
+        token: None,
+    })));
+    let worker_config = WorkerDaemonConfig::new("local", "worker-reread");
+    let daemon = tokio::spawn({
+        let cfg = config.clone();
+        async move { run_worker_daemon(cfg, worker_config, Some(end_turn_call_fn())).await }
+    });
+    // Give daemon time to initialize consumer
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    let js = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+    let session_id = "end-turn-reread";
+    let log = NatsSessionLog::new(js.clone(), session_id);
+
+    // CRITICAL: Create the notified future BEFORE publishing the activate
+    // to avoid lost wakeup race between notify_one() and notified().await
+    let ready_fut = END_TURN_APPEND_READY.notified();
+
+    log.append_event_async(&append_user_message_entry("first"))
+        .await?;
+    publish_session_activate(
+        &js,
+        "local",
+        &SessionActivate::new(session_id, "ignored-agent"),
+    )
+    .await?;
+
+    // Now await the ready signal - the permit was stored by notify_one()
+    ready_fut.await;
+
+    // Give a moment for the NATS message to propagate
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    log.append_event_async(&append_user_message_entry("second"))
+        .await?;
+    // Signal to turn 1 that it can complete now
+    END_TURN_APPEND_DONE.notify_one();
+
+    // Poll the DURABLE log for two persisted `turn:` assistant messages.
+    // `END_TURN_CALLS` is bumped at the START of each LLM call, so waiting on it
+    // races turn 2's persistence; assert on the committed log instead.
+    let mut entries;
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        entries = log.load_events_async().await?;
+        let count = final_assistant_texts(&entries)
+            .iter()
+            .filter(|text| text.contains("turn:"))
+            .count();
+        if count >= 2 {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "continuation turn never persisted a second assistant (got {count} turn: messages)"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    let assistants = final_assistant_texts(&entries);
+    assert_eq!(
+        assistants
+            .iter()
+            .filter(|text| text.contains("turn:"))
+            .count(),
+        2
+    );
+    // Turn 1 consumed "first" (its assistant barrier), so the continuation turn 2
+    // folds only the post-barrier message "second".
+    assert!(assistants
+        .iter()
+        .any(|text| text.contains("turn:1 prompt:first")));
+    assert!(assistants
+        .iter()
+        .any(|text| text.contains("turn:2 prompt:second")));
+
+    // `skip_user_log_append` invariant: the worker must NOT re-append the user
+    // messages it reads from the log. The durable log must contain EXACTLY the
+    // two client-appended user messages — "first" and "second" — with no
+    // duplicates. A regression (re-appending the folded input) would both
+    // duplicate the user message and reorder the assistant barrier past
+    // concurrently-arrived messages.
+    let users = user_message_texts(&entries);
+    assert_eq!(
+        users,
+        vec!["first".to_string(), "second".to_string()],
+        "durable log must contain exactly the two client user messages with no worker re-appends; got {users:?}"
+    );
+
+    daemon.abort();
+    let _ = daemon.await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn idle_concurrent_messages_fold_in_seq_order_into_single_turn() -> Result<()> {
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("Skipping test: nats-server not available");
+        return Ok(());
+    };
+
+    let config = Arc::new(RwLock::new(local_nats_config(NatsServerSpec {
+        name: "local",
+        url: server.url(),
+        token: None,
+    })));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let prompts = Arc::new(AsyncMutex::new(Vec::<String>::new()));
+    let worker_config = WorkerDaemonConfig::new("local", "worker-fold");
+    let daemon = tokio::spawn({
+        let cfg = config.clone();
+        let calls = calls.clone();
+        let prompts = prompts.clone();
+        async move {
+            run_worker_daemon(
+                cfg,
+                worker_config,
+                Some(fold_capture_call_fn(calls, prompts)),
+            )
+            .await
+        }
+    });
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let js = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+    let session_id = "fold-order";
+    let log = NatsSessionLog::new(js.clone(), session_id);
+    log.append_event_async(&append_user_message_entry("alpha"))
+        .await?;
+    log.append_event_async(&append_user_message_entry("beta"))
+        .await?;
+    publish_session_activate(
+        &js,
+        "local",
+        &SessionActivate::new(session_id, "ignored-agent"),
+    )
+    .await?;
+
+    wait_until(Duration::from_secs(10), || {
+        calls.load(Ordering::SeqCst) >= 1
+    })
+    .await?;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    let prompts = prompts.lock().await.clone();
+    assert_eq!(prompts, vec!["alpha\nbeta".to_string()]);
+
+    daemon.abort();
+    let _ = daemon.await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn nats_worker_persists_full_turn_end_to_end() -> Result<()> {
+    require_nextest();
+
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("Skipping test: nats-server not available");
+        return Ok(());
+    };
+
+    let global_config = Arc::new(RwLock::new(local_nats_config(NatsServerSpec {
+        name: "local",
+        url: server.url(),
+        token: None,
+    })));
+    let session_id = "test-session-full-turn";
+
+    let jetstream_ctx = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+    let log = seed_session_and_attach_runtime(&global_config, jetstream_ctx, session_id).await?;
+
+    run_worker_turn(WorkerTurnParams {
+        global_config: global_config.clone(),
+        labels: WorkerTurnLabels {
+            cluster_key: "local",
+            session_id,
+            prompt: "test prompt",
+        },
+        call_fn: make_stub_llm_call_fn(),
+    })
+    .await?;
+
+    // Verify: load entries from NATS
+    let entries = log.load_events_async().await?;
+    let entries_only: Vec<SessionLogEntry> = entries.iter().map(|(_, e)| e.clone()).collect();
+
+    // Should have: Header, User message, ToolCalls, ToolResults, final assistant Message
+    assert!(
+        entries.len() >= 4,
+        "expected at least 4 entries, got {}",
+        entries.len()
+    );
+
+    // Verify reconstruction shows Idle at end
+    let state = reconstruct_state(&entries_only);
+    assert_eq!(
+        state.turn_status,
+        TurnStatus::Idle,
+        "expected Idle, got {:?}",
+        state.turn_status
+    );
+
+    Ok(())
+}
+
+/// Regression test for the Aristarchus blocker: the worker execution path must
+/// connect through the config-driven `nats_jetstream`/`nats_client` (applying
+/// token/TLS auth), NOT a bare `async_nats::connect(url)`. Run the worker
+/// against a TOKEN-AUTH nats-server with the token configured: with the old
+/// bare connect this fails (auth required); with the fix it persists the turn.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn nats_worker_honors_configured_token_auth() -> Result<()> {
+    require_nextest();
+
+    let token = "s3cr3t-worker-token";
+    let Some(server) = common::spawn_nats_server_with_options(common::SpawnNatsServerOptions {
+        auth_token: Some(token.to_string()),
+    })
+    .await?
+    else {
+        eprintln!("Skipping test: nats-server not available");
+        return Ok(());
+    };
+
+    // Config carries the token so the config-driven connect can authenticate.
+    let global_config = Arc::new(RwLock::new(local_nats_config(NatsServerSpec {
+        name: "secure",
+        url: server.url(),
+        token: Some(token),
+    })));
+    let session_id = "test-session-token-auth";
+
+    // Seed a header via an authenticated backend (proves auth works for setup).
+    let auth_js = {
+        let cfg = global_config.read().clone();
+        cfg.nats_jetstream("secure").await?
+    };
+    let log = seed_session_and_attach_runtime(&global_config, auth_js, session_id).await?;
+
+    // The worker connects internally via the config-driven path; this only
+    // succeeds if it applies the configured token.
+    run_worker_turn(WorkerTurnParams {
+        global_config: global_config.clone(),
+        labels: WorkerTurnLabels {
+            cluster_key: "secure",
+            session_id,
+            prompt: "test prompt",
+        },
+        call_fn: make_stub_llm_call_fn(),
+    })
+    .await?;
+
+    let entries = log.load_events_async().await?;
+    assert!(
+        entries.len() >= 4,
+        "expected the authenticated worker to persist a full turn, got {} entries",
+        entries.len()
+    );
+    Ok(())
+}
+
+/// Stub call_fn that increments an external counter on each LLM call, then
+/// returns a final text response (single-turn).
+fn counting_stub_call_fn(counter: Arc<AtomicUsize>) -> harnx_runtime::agent_loop::AgentCallFn {
+    Arc::new(move |_input, _config, _abort| {
+        let counter = counter.clone();
+        Box::pin(async move {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Ok((
+                "done".to_string(),
+                None,
+                vec![],
+                harnx_runtime::client::CompletionTokenUsage::default(),
+            ))
+        })
+    })
+}
+
+fn cluster_config(url: &str) -> Arc<RwLock<Config>> {
+    Arc::new(RwLock::new(local_nats_config(NatsServerSpec {
+        name: "local",
+        url,
+        token: None,
+    })))
+}
+
+async fn wait_until(timeout: std::time::Duration, mut cond: impl FnMut() -> bool) -> Result<()> {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if cond() {
+            return Ok(());
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    anyhow::bail!("condition not met within {:?}", timeout)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dispatch_runs_exactly_one_worker_per_activation_and_reactivation_is_noop() -> Result<()> {
+    use harnx_runtime::nats_lease::NatsLeaseConfig;
+    use harnx_runtime::nats_worker::{
+        publish_session_activate, run_worker_daemon, SessionActivate, WorkerDaemonConfig,
+    };
+    use std::time::Duration;
+
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let fast_lease = NatsLeaseConfig {
+        ttl: Duration::from_secs(3),
+        renew_interval: Duration::from_millis(500),
+        replicas: 1,
+        tombstone_ttl: Duration::from_secs(10),
+        ..Default::default()
+    };
+
+    let counter_one = Arc::new(AtomicUsize::new(0));
+    let counter_two = Arc::new(AtomicUsize::new(0));
+
+    let mut cfg_one = WorkerDaemonConfig::new("local", "worker-one");
+    cfg_one.lease = fast_lease.clone();
+    let mut cfg_two = WorkerDaemonConfig::new("local", "worker-two");
+    cfg_two.lease = fast_lease.clone();
+
+    let config_one = cluster_config(server.url());
+    let config_two = cluster_config(server.url());
+
+    let h1 = tokio::spawn({
+        let c = config_one.clone();
+        let call = counting_stub_call_fn(counter_one.clone());
+        async move { run_worker_daemon(c, cfg_one, Some(call)).await }
+    });
+    let h2 = tokio::spawn({
+        let c = config_two.clone();
+        let call = counting_stub_call_fn(counter_two.clone());
+        async move { run_worker_daemon(c, cfg_two, Some(call)).await }
+    });
+
+    // Give the daemons a moment to subscribe.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let js = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+
+    // Client appends a user message to the session log, then activates it.
+    let session_id = "dispatch-session";
+    let client_log = NatsSessionLog::new(js.clone(), session_id);
+    client_log
+        .append_event_async(&SessionLogEntry::Message {
+            id: None,
+            role: harnx_core::message::MessageRole::User,
+            content: harnx_core::message::MessageContent::Text("hello worker".to_string()),
+            timestamp: None,
+            fence_token: None,
+        })
+        .await?;
+
+    let activation = SessionActivate::new(session_id, "ignored-agent");
+    publish_session_activate(&js, "local", &activation).await?;
+    // Duplicate publish is deduped by Nats-Msg-Id; still only one execution.
+    publish_session_activate(&js, "local", &activation).await?;
+
+    // Exactly one worker executes one turn.
+    wait_until(Duration::from_secs(10), || {
+        counter_one.load(Ordering::SeqCst) + counter_two.load(Ordering::SeqCst) >= 1
+    })
+    .await?;
+    // Let any erroneous second executor surface.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let total = counter_one.load(Ordering::SeqCst) + counter_two.load(Ordering::SeqCst);
+    assert_eq!(
+        total, 1,
+        "exactly one worker should execute the activation (got {total})"
+    );
+
+    h1.abort();
+    h2.abort();
+    let _ = h1.await;
+    let _ = h2.await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fenced_sink_rejects_append_when_lease_lost() -> Result<()> {
+    use harnx_runtime::config::session::SessionAppendSink;
+    use harnx_runtime::nats_lease::{NatsLeaseConfig, NatsSessionLease};
+    use harnx_runtime::nats_worker::{FencedSessionLogSink, NatsSessionLogBackend};
+    use std::time::Duration;
+
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+    let js = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+    let session_id = "fenced-session";
+
+    let lease = Arc::new(
+        NatsSessionLease::acquire(harnx_runtime::nats_lease::NatsLeaseAcquireParams {
+            jetstream: js.clone(),
+            session_id,
+            worker_id: "worker-a".to_string(),
+            generation: 1,
+            config: NatsLeaseConfig {
+                ttl: Duration::from_secs(30),
+                renew_interval: Duration::from_secs(10),
+                ..Default::default()
+            },
+        })
+        .await?
+        .expect("acquire"),
+    );
+
+    let backend = NatsSessionLogBackend::new(js.clone(), session_id);
+    let sink = FencedSessionLogSink::new(backend, Arc::clone(&lease));
+
+    // Held lease: an assistant append succeeds and is fence-stamped.
+    let entry = SessionLogEntry::Message {
+        id: None,
+        role: harnx_core::message::MessageRole::Assistant,
+        content: harnx_core::message::MessageContent::Text("hi".to_string()),
+        timestamp: None,
+        fence_token: None,
+    };
+    let fence_at_append = lease.fence_token();
+    sink.append(&entry)
+        .expect("append while held should succeed");
+
+    // Verify the persisted entry carries the lease fence stamped at append time.
+    let log = NatsSessionLog::new(js.clone(), session_id);
+    let loaded = log.load_events_async().await?;
+    let stamped = loaded
+        .iter()
+        .any(|(_, e)| matches!(e, SessionLogEntry::Message { fence_token: Some(f), .. } if *f == fence_at_append));
+    assert!(
+        stamped,
+        "persisted assistant entry should carry the lease fence ({fence_at_append}); loaded={loaded:?}"
+    );
+
+    // Lose the lease: subsequent worker append must be rejected (fenced out).
+    lease.mark_lost_for_test();
+    let rejected = sink.append(&entry);
+    assert!(
+        rejected.is_err(),
+        "append after lease loss must be rejected"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn resume_aborts_when_tail_fence_exceeds_held_revision() -> Result<()> {
+    use harnx_runtime::nats_lease::{NatsLeaseConfig, NatsSessionLease};
+    use harnx_runtime::nats_session_log::NatsSessionLog;
+    use harnx_runtime::nats_worker::run_agent_loop_with_nats_inner;
+    use std::time::Duration;
+
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+    let js = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+    let session_id = "resume-fence-session";
+
+    // Persist an assistant entry stamped with a very high fence, as if a newer
+    // worker (higher KV revision) had written it.
+    let log = NatsSessionLog::new(js.clone(), session_id);
+    log.append_event_async(&SessionLogEntry::Message {
+        id: None,
+        role: harnx_core::message::MessageRole::User,
+        content: harnx_core::message::MessageContent::Text("go".to_string()),
+        timestamp: None,
+        fence_token: None,
+    })
+    .await?;
+    log.append_event_async(&SessionLogEntry::Message {
+        id: None,
+        role: harnx_core::message::MessageRole::Assistant,
+        content: harnx_core::message::MessageContent::Text("from newer worker".to_string()),
+        timestamp: None,
+        fence_token: Some(u64::MAX),
+    })
+    .await?;
+
+    // This worker holds a fresh lease whose revision is far below u64::MAX.
+    let lease = Arc::new(
+        NatsSessionLease::acquire(harnx_runtime::nats_lease::NatsLeaseAcquireParams {
+            jetstream: js.clone(),
+            session_id,
+            worker_id: "worker-stale".to_string(),
+            generation: 1,
+            config: NatsLeaseConfig {
+                ttl: Duration::from_secs(30),
+                renew_interval: Duration::from_secs(10),
+                ..Default::default()
+            },
+        })
+        .await?
+        .expect("acquire"),
+    );
+
+    let config = cluster_config(server.url());
+    let input = harnx_runtime::config::input::from_str(&config, "go", None);
+    let result = run_agent_loop_with_nats_inner(
+        RunAgentLoopArgs {
+            cluster_key: "local",
+            session_id,
+            config,
+            initial_input: input,
+            abort_signal: create_abort_signal(),
+            call_fn: Some(counting_stub_call_fn(Arc::new(AtomicUsize::new(0)))),
+            lease: None,
+            after_seq_observer: None,
+            on_tool_round: None,
+        }
+        .with_lease(lease),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "resume must abort when tail fence exceeds held lease revision"
+    );
+    let msg = format!("{:#}", result.unwrap_err());
+    assert!(
+        msg.contains("fenced") || msg.contains("exceeds held lease"),
+        "error should indicate fencing, got: {msg}"
+    );
+    Ok(())
+}
+
+/// Read-your-writes seam (Step 2): a backend wired with an `after_seq_observer`
+/// advances the observer to the durable ack sequence on every append, and
+/// `load_events_consistent_blocking` waits until the stream reflects at least
+/// that sequence before returning. This is the mechanism that lets the
+/// end-of-turn drain re-read observe the worker's own just-persisted barrier
+/// instead of a stale tail.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn after_seq_observer_advances_and_consistent_read_honors_it() -> Result<()> {
+    use harnx_runtime::nats_worker::NatsSessionLogBackend;
+    use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+    let js = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+    let session_id = "ryw-observer";
+
+    let observer = Arc::new(AtomicU64::new(0));
+    let backend = NatsSessionLogBackend::new(js.clone(), session_id)
+        .with_after_seq_observer(Arc::clone(&observer));
+
+    // Append two entries; the observer must advance to the durable ack seq of
+    // the latest append (monotonic via fetch_max).
+    let user = SessionLogEntry::Message {
+        id: None,
+        role: harnx_core::message::MessageRole::User,
+        content: harnx_core::message::MessageContent::Text("hi".to_string()),
+        timestamp: None,
+        fence_token: None,
+    };
+    let assistant = SessionLogEntry::Message {
+        id: None,
+        role: harnx_core::message::MessageRole::Assistant,
+        content: harnx_core::message::MessageContent::Text("there".to_string()),
+        timestamp: None,
+        fence_token: Some(7),
+    };
+
+    let seq1 = backend.append_event_blocking(&user)?;
+    assert_eq!(
+        observer.load(AtomicOrdering::SeqCst),
+        seq1,
+        "observer must advance to the first append's ack sequence"
+    );
+    let seq2 = backend.append_event_blocking(&assistant)?;
+    assert!(seq2 > seq1, "second append must get a higher sequence");
+    assert_eq!(
+        observer.load(AtomicOrdering::SeqCst),
+        seq2,
+        "observer must advance to the latest append's ack sequence"
+    );
+
+    // The consistent read uses the observer's high-water mark; it must return a
+    // tail that reflects at least seq2 (both entries visible), never a stale
+    // read missing the worker's own latest barrier.
+    let entries = backend.load_events_consistent_blocking()?;
+    assert!(
+        entries.iter().any(|(s, _)| *s == seq2),
+        "consistent read must include the latest appended entry (seq {seq2}); got {entries:?}"
+    );
+    assert_eq!(
+        final_assistant_texts(&entries),
+        vec!["there".to_string()],
+        "consistent read must surface the just-persisted assistant barrier"
+    );
+    Ok(())
+}
+
+/// Worker-side retract: a user message that is retracted BEFORE the worker drains
+/// must NOT be folded into worker input and NOT executed.
+///
+/// This test proves the worker path honors EditEntries mutations. Without the fix,
+/// `fold_new_user_messages_since` would iterate raw entries and fold the retracted
+/// message, causing unwanted worker execution.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retracted_user_message_is_not_executed_by_worker() -> Result<()> {
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let prompts = Arc::new(AsyncMutex::new(Vec::<String>::new()));
+
+    let config = Arc::new(RwLock::new(local_nats_config(NatsServerSpec {
+        name: "local",
+        url: server.url(),
+        token: None,
+    })));
+    let worker_config = WorkerDaemonConfig::new("local", "worker-retract");
+    let daemon = tokio::spawn({
+        let cfg = config.clone();
+        let calls = counter.clone();
+        let captured_prompts = prompts.clone();
+        async move {
+            run_worker_daemon(
+                cfg,
+                worker_config,
+                Some(fold_capture_call_fn(calls, captured_prompts)),
+            )
+            .await
+        }
+    });
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let js = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+    let session_id = "retract-test";
+    let log = NatsSessionLog::new(js.clone(), session_id);
+
+    // Append a user message and an EditEntries that retracts it.
+    let user_seq = log
+        .append_event_async(&SessionLogEntry::Message {
+            id: Some("msg-to-retract".to_string()),
+            role: MessageRole::User,
+            content: harnx_core::message::MessageContent::Text("please ignore this".to_string()),
+            timestamp: None,
+            fence_token: None,
+        })
+        .await?;
+    log.append_event_async(&SessionLogEntry::EditEntries {
+        from: user_seq as usize,
+        to: user_seq as usize,
+        replacements: vec![], // deletion
+    })
+    .await?;
+
+    // Append a valid user message that SHOULD be processed.
+    log.append_event_async(&SessionLogEntry::Message {
+        id: Some("valid-msg".to_string()),
+        role: MessageRole::User,
+        content: harnx_core::message::MessageContent::Text("hello world".to_string()),
+        timestamp: None,
+        fence_token: None,
+    })
+    .await?;
+
+    // Activate the session.
+    publish_session_activate(
+        &js,
+        "local",
+        &SessionActivate::new(session_id, "ignored-agent"),
+    )
+    .await?;
+
+    // Wait for the worker to process.
+    wait_until(Duration::from_secs(10), || {
+        counter.load(Ordering::SeqCst) >= 1
+    })
+    .await?;
+
+    // Verify: only ONE call was made, and the prompt is "hello world", NOT "please ignore this"
+    // If the bug is present, the prompt would contain the retracted message.
+    let captured_prompts = prompts.lock().await.clone();
+    assert_eq!(
+        captured_prompts.len(),
+        1,
+        "worker should have made exactly one call"
+    );
+    assert_eq!(
+        captured_prompts[0],
+        "hello world".to_string(),
+        "worker input should be the valid message, not the retracted one"
+    );
+
+    // Verify the durable log: no assistant turn for the retracted message.
+    let entries = log.load_events_async().await?;
+    let assistant_texts = final_assistant_texts(&entries);
+    assert_eq!(
+        assistant_texts.len(),
+        1,
+        "exactly one assistant message should be persisted"
+    );
+    assert!(
+        assistant_texts[0].contains("hello world"),
+        "assistant should respond to the valid message, got: {:?}",
+        assistant_texts
+    );
+
+    daemon.abort();
+    let _ = daemon.await;
+    Ok(())
+}

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1380,7 +1380,22 @@ impl Tui {
         };
 
         let handle = tokio::spawn(async move {
-            let result: Result<()> = Self::run_prompt_task(msg, ctx).await;
+            // Check if we're running a remote agent
+            // Clone remote_agent before spawning to avoid holding lock across await
+            let remote_agent = {
+                let guard = ctx.config.read();
+                guard.remote_agent.clone()
+            };
+            // Guard is dropped here before any await
+
+            let result: Result<()> = if let Some((agent, cluster)) = remote_agent {
+                // Run remote agent via NATS thin-client
+                Self::run_remote_prompt_task(msg, ctx, agent, cluster).await
+            } else {
+                // Run local agent
+                Self::run_prompt_task(msg, ctx).await
+            };
+
             if let Err(err) = result {
                 use harnx_core::event::{AgentEvent, ModelEvent};
                 let _ = event_tx.send(TuiEvent::Agent(

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -803,6 +803,8 @@ mod tests {
             mcp_server_name: None,
             call_template: Some("${{ args.command }}".to_string()),
             result_template: None,
+            idempotent_hint: None,
+            read_only_hint: None,
         };
         decl_map.insert(decl.name.clone(), decl);
 
@@ -857,6 +859,8 @@ mod tests {
             mcp_server_name: None,
             call_template: None,
             result_template: None,
+            idempotent_hint: None,
+            read_only_hint: None,
         };
         let mut decl_map = HashMap::new();
         decl_map.insert(decl.name.clone(), decl);

--- a/crates/harnx-tui/src/prompt.rs
+++ b/crates/harnx-tui/src/prompt.rs
@@ -1,12 +1,14 @@
 use crate::types::Tui;
 use crate::types::{PendingMessage, TuiEvent};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use harnx_hooks::{AsyncHookManager, PersistentHookManager};
 use harnx_runtime::client::CompletionTokenUsage;
 use harnx_runtime::config::{GlobalConfig, Input};
 use harnx_runtime::utils::AbortSignal;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
+
+use crate::agent_event_sink::TuiAgentEventSink;
 
 pub(super) struct PromptTaskContext {
     pub(super) config: GlobalConfig,
@@ -149,6 +151,72 @@ impl Tui {
         };
 
         harnx_runtime::run_agent_loop(&loop_ctx, input).await
+    }
+
+    /// Run a prompt task for a remote agent (NATS thin-client mode).
+    ///
+    /// This drives the turn via `ThinClientSession` instead of running
+    /// `run_agent_loop` locally. The worker daemon executes the actual agent loop.
+    pub(super) async fn run_remote_prompt_task(
+        msg: PendingMessage,
+        ctx: PromptTaskContext,
+        agent: String,
+        cluster: String,
+    ) -> Result<()> {
+        use harnx_runtime::{ThinClientConfig, ThinClientSession};
+
+        // Clean up any attachment directory to avoid leaking temp files
+        if let Some(dir) = msg.attachment_dir.clone() {
+            let cleanup_dir = dir.clone();
+            let _ = tokio::task::spawn_blocking(move || {
+                crate::types::cleanup_attachment_dir(&cleanup_dir);
+            })
+            .await;
+        }
+
+        // We do not support attachments in remote mode yet
+        if !msg.attachments.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Attachments are not yet supported in remote (thin-client) mode"
+            ));
+        }
+
+        let text = msg.text.clone();
+
+        // Create a TUI event sink that forwards to the event channel
+        let event_tx = ctx.event_tx.clone();
+        let sink = Arc::new(TuiAgentEventSink::new(event_tx.clone()));
+
+        // Build thin-client config
+        let thin_config = ThinClientConfig {
+            cluster,
+            agent,
+            session_id: None, // New session for this turn
+        };
+
+        // Create the thin-client session
+        // We pass a cloned GlobalConfig, but we must be careful about the
+        // read guard - we need to avoid holding it across the await boundary
+        let session = ThinClientSession::from_global_config(
+            thin_config,
+            &ctx.config,
+            ctx.abort_signal.clone(),
+        )
+        .await
+        .context("failed to create thin-client session")?;
+
+        // We don't have pending cancel channels in TUI yet
+        // (those would come from UI controls in future work)
+        let result = session.run_turn(&text, sink, None).await?;
+
+        // Log result for debugging
+        log::info!(
+            "remote prompt completed: session_id={} cancelled={}",
+            result.session_id,
+            result.was_cancelled
+        );
+
+        Ok(())
     }
 
     async fn call_chat_completions_streaming_tui(

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -916,6 +916,8 @@ async fn info_agent_overlay_renders_in_tui_snapshot() {
                 mcp_server_name: None,
                 call_template: None,
                 result_template: None,
+                idempotent_hint: None,
+                read_only_hint: None,
             },
             harnx_runtime::tool::ToolDeclaration {
                 name: "beta_tool".to_string(),
@@ -925,6 +927,8 @@ async fn info_agent_overlay_renders_in_tui_snapshot() {
                 mcp_server_name: None,
                 call_template: None,
                 result_template: None,
+                idempotent_hint: None,
+                read_only_hint: None,
             },
         ]));
         let mut agent = harnx_runtime::config::Agent::new(

--- a/crates/harnx/src/cli.rs
+++ b/crates/harnx/src/cli.rs
@@ -101,6 +101,41 @@ pub struct Cli {
 pub enum Commands {
     /// Inspect harnx state
     Info(InfoArgs),
+    /// Session management commands
+    Session(SessionArgs),
+    /// Run a remote worker daemon for a NATS cluster (HA mode)
+    Worker(WorkerArgs),
+}
+
+#[derive(Args, Debug, PartialEq, Eq)]
+pub struct WorkerArgs {
+    /// Cluster key from nats_servers/<name>.yaml
+    #[arg(long)]
+    pub cluster: String,
+    /// Stable worker identity for leases and the durable consumer name.
+    /// Defaults to a generated id if omitted.
+    #[arg(long)]
+    pub worker_id: Option<String>,
+}
+
+#[derive(Args, Debug, PartialEq, Eq)]
+pub struct SessionArgs {
+    #[command(subcommand)]
+    pub command: SessionSubcommands,
+}
+
+#[derive(Subcommand, Debug, PartialEq, Eq)]
+pub enum SessionSubcommands {
+    /// Delete remote NATS session log stream + lease key for a cluster
+    Delete(DeleteSessionArgs),
+}
+
+#[derive(Args, Debug, PartialEq, Eq)]
+pub struct DeleteSessionArgs {
+    pub session_id: String,
+    /// Cluster key from nats_servers/<name>.yaml
+    #[arg(long)]
+    pub cluster: String,
 }
 
 #[derive(Args, Debug, PartialEq, Eq)]
@@ -164,7 +199,7 @@ impl Cli {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Commands, InfoSubcommands};
+    use super::{Cli, Commands, InfoSubcommands, SessionSubcommands};
     use clap::Parser;
 
     #[test]
@@ -185,5 +220,49 @@ mod tests {
         let cli = Cli::try_parse_from(["harnx", "--list-agents"]).unwrap();
         assert!(cli.command.is_none());
         assert!(cli.list_agents);
+    }
+
+    #[test]
+    fn parses_session_delete_subcommand() {
+        let cli =
+            Cli::try_parse_from(["harnx", "session", "delete", "sess-1", "--cluster", "local"])
+                .unwrap();
+        match cli.command {
+            Some(Commands::Session(args)) => match args.command {
+                SessionSubcommands::Delete(delete) => {
+                    assert_eq!(delete.session_id, "sess-1");
+                    assert_eq!(delete.cluster, "local");
+                }
+            },
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod agent_ref_tests {
+    use super::Cli;
+    use clap::Parser;
+    use harnx_core::agent_ref::AgentRef;
+
+    #[test]
+    fn cli_agent_flag_preserves_local_agent_refs() {
+        let cli = Cli::try_parse_from(["harnx", "--agent", "pkg/bar"]).unwrap();
+        assert_eq!(
+            AgentRef::parse(cli.agent.as_deref().unwrap()),
+            AgentRef::Local("pkg/bar".into())
+        );
+    }
+
+    #[test]
+    fn cli_agent_flag_preserves_remote_agent_refs() {
+        let cli = Cli::try_parse_from(["harnx", "--agent", "bar@foo"]).unwrap();
+        assert_eq!(
+            AgentRef::parse(cli.agent.as_deref().unwrap()),
+            AgentRef::Remote {
+                agent: "bar".into(),
+                cluster: "foo".into(),
+            }
+        );
     }
 }

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -21,7 +21,9 @@ pub use harnx_mcp::safety as mcp_safety;
 pub use harnx_runtime::{client, commands, config, tool};
 pub use harnx_tui as tui;
 
-use crate::cli::{Cli, Commands, InfoSubcommands};
+use crate::cli::{
+    Cli, Commands, DeleteSessionArgs, InfoSubcommands, SessionSubcommands, WorkerArgs,
+};
 use crate::client::{list_models, retry::call_with_retry_and_fallback, ModelType};
 use crate::config::{
     list_agents, list_assistant_agents, load_env_file, macro_execute, render_agent_dump,
@@ -95,7 +97,57 @@ async fn run_command(command: &Commands) -> Result<()> {
                 Ok(())
             }
         },
+        Commands::Session(session_args) => match &session_args.command {
+            SessionSubcommands::Delete(delete_args) => {
+                run_session_delete_command(delete_args).await
+            }
+        },
+        Commands::Worker(worker_args) => run_worker_command(worker_args).await,
     }
+}
+
+async fn run_session_delete_command(delete_args: &DeleteSessionArgs) -> Result<()> {
+    let config = Config::init(WorkingMode::Cmd, true, vec![]).await?;
+    let result = harnx_runtime::nats_admin::delete_remote_session(
+        &config,
+        &delete_args.cluster,
+        &delete_args.session_id,
+    )
+    .await?;
+
+    if result.removed_anything() {
+        println!(
+            "Deleted remote session '{}' on cluster '{}' (stream_deleted={}, lease_deleted={})",
+            delete_args.session_id,
+            delete_args.cluster,
+            result.stream_deleted,
+            result.lease_deleted
+        );
+    } else {
+        println!(
+            "Remote session '{}' on cluster '{}' not found; nothing to delete.",
+            delete_args.session_id, delete_args.cluster
+        );
+    }
+
+    Ok(())
+}
+
+async fn run_worker_command(worker_args: &WorkerArgs) -> Result<()> {
+    let config = Arc::new(RwLock::new(
+        Config::init(WorkingMode::Cmd, true, vec![]).await?,
+    ));
+    let worker_id = worker_args
+        .worker_id
+        .clone()
+        .unwrap_or_else(harnx_runtime::nats_worker::new_remote_session_id);
+    let daemon =
+        harnx_runtime::nats_worker::WorkerDaemonConfig::new(worker_args.cluster.clone(), worker_id);
+    let call_fn: harnx_runtime::agent_loop::AgentCallFn =
+        std::sync::Arc::new(|input, config, abort| {
+            Box::pin(call_with_retry_and_fallback(input, config, abort))
+        });
+    harnx_runtime::nats_worker::run_worker_daemon(config, daemon, Some(call_fn)).await
 }
 
 fn legacy_info_flag(cli: &Cli) -> bool {

--- a/crates/harnx/tests/tmux_e2e.rs
+++ b/crates/harnx/tests/tmux_e2e.rs
@@ -2564,6 +2564,7 @@ fn session_mutation_edit_delete_rewind_persists_across_sessions() -> Result<()> 
         let entry = serde::Deserialize::deserialize(document)?;
         match entry {
             SessionLogEntry::Message {
+                id: None,
                 role: MessageRole::User,
                 ..
             } => {
@@ -2573,6 +2574,7 @@ fn session_mutation_edit_delete_rewind_persists_across_sessions() -> Result<()> 
                 }
             }
             SessionLogEntry::Message {
+                id: None,
                 role: MessageRole::Assistant,
                 ..
             } => {

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -146,6 +146,23 @@ env:
 idle_timeout_secs: 600
 ```
 
+## NATS Servers (`nats_servers/`)
+
+Harnx supports high-availability distributed mode via NATS. Each cluster is defined in a file like `nats_servers/local.yaml`.
+
+The **filename** (without `.yaml`) is used as the cluster key (e.g., `agent@local`).
+
+```yaml
+url: "nats://localhost:4222" # NATS server URL
+token: "${NATS_TOKEN}"       # Optional auth token
+tls: true                    # Enable TLS
+tls_cert: "/path/to/cert"    # Optional client cert
+tls_key: "/path/to/key"      # Optional client key
+# tls_ca: "/path/to/ca"      # Optional CA (Note: not supported with client cert)
+```
+
+See the [NATS HA Guide](nats-ha.md) for more details.
+
 ## Example Configuration
 
 A comprehensive reference for the new folder structure and common provider/server examples can be found in the repository at:

--- a/docs/nats-ha.md
+++ b/docs/nats-ha.md
@@ -1,0 +1,136 @@
+# High-Availability Deployment (NATS Mode)
+
+Harnx supports a distributed, high-availability (HA) mode backed by [NATS JetStream](https://nats.io/). In this mode, the agent tool loop runs in a dedicated **worker** process, while thin **clients** (TUI, CLI, or ACP server) connect to the worker via a NATS cluster.
+
+## Architecture Overview
+
+Harnx NATS mode decouples the execution of an agent from the user interface:
+
+- **Clients**: Thin processes (TUI, ACP, CLI) that post user messages and render events. They do not execute tools.
+- **NATS Cluster**: The central nervous system. Uses JetStream for a durable session log and Key-Value (KV) for leader election (leases).
+- **Workers**: One or more daemon processes that execute the agent loop. Multiple workers provide redundancy; only one worker holds the active lease for a given session at a time.
+
+## Prerequisites
+
+- **NATS Server 2.11+**: Requires JetStream and Key-Value support.
+- **Configuration**: A NATS cluster configuration file in your `nats_servers/` directory.
+
+## Standing up NATS
+
+For development, a single NATS server with JetStream is sufficient:
+
+```bash
+nats-server -js
+```
+
+For production HA, run a NATS cluster with at least 3 nodes and set `replicas: 3` for JetStream assets.
+
+### JetStream Resources
+Harnx automatically manages the following JetStream resources:
+- **KV Bucket**: `harnx_leases` (Stores session leases with TTL).
+- **Streams**: `SESSION_<id>` (Subject: `sessions.{id}.log`) stores the durable append-only session history.
+
+## Configuration
+
+Harnx looks for NATS cluster definitions in `nats_servers/<cluster_key>.yaml`. The filename (stem) is used as the cluster key.
+
+### Example: Development (Plaintext)
+`nats_servers/local.yaml`:
+```yaml
+url: "nats://localhost:4222"
+```
+
+### Example: Production (Token + TLS)
+`nats_servers/prod.yaml`:
+```yaml
+url: "nats://nats.example.com:4222"
+token: "${NATS_TOKEN}"
+tls: true
+tls_cert: "/etc/harnx/client-cert.pem"
+tls_key: "/etc/harnx/client-key.pem"
+# Note: tls_ca + client cert is NOT supported; use trusted certs or drop tls_ca.
+```
+*Note: Environment variable expansion `${ENV_VAR}` is supported in all fields.*
+
+## Running Workers
+
+A worker joins a cluster and waits for session assignments.
+
+```bash
+harnx worker --cluster local --worker-id worker-1
+```
+
+- `--cluster`: The key from `nats_servers/`.
+- `--worker-id`: (Optional but recommended) A stable identity for the worker.
+
+You can run multiple workers for redundancy. If the active worker for a session dies, another worker will acquire the lease and resume execution.
+
+## Using Remote Agents
+
+To use an agent via NATS, append `@cluster` to the agent name:
+
+```bash
+harnx -a coder@local
+```
+
+This works from the CLI, TUI, and ACP server.
+
+- **New Sessions**: A new session log and lease are created in NATS.
+- **Resuming Sessions**: Clients attach to an existing `session_id`. Multiple clients can attach to the same session simultaneously (Multiplayer Mode).
+
+## Control Plane
+
+Clients communicate with the active worker over specific NATS subjects:
+- **Cancel**: `sessions.{id}.control` — Deliver a cancel command to the worker.
+- **Set Pending**: Update the pending user message without triggering execution.
+
+Semantics are consistent because the authoritative state is derived from the durable JetStream log.
+
+## Multi-Client Support
+
+Multiple clients can attach to a single session:
+1.  Clients replay the **durable history** from the JetStream stream.
+2.  Clients subscribe to **live advisory events** on `sessions.{id}.events` for real-time updates (streaming chunks, tool progress).
+
+Late-joining clients automatically converge to the same state by replaying the durable log.
+
+## Failover & Safety
+
+### Leases & Fencing
+Harnx uses a renewable CAS (Compare-And-Swap) lease in NATS KV:
+- **TTL**: ~30 seconds.
+- **Renewal**: Every ~10 seconds.
+- **Fence Token**: The KV revision of the lease. Every write to the durable log is gated by this token.
+
+If a worker loses its lease (e.g., network partition), it immediately aborts. This prevents "split-brain" scenarios where two workers think they are active.
+
+### Resume & Idempotency
+When a worker resumes an interrupted session:
+- **Idempotent Tools**: Tools marked with `idempotent_hint` or `read_only_hint` in MCP are re-run if their result was lost.
+- **Non-idempotent Tools**: If a result is missing for a non-idempotent tool, Harnx synthesizes an "interrupt-error" result to prevent accidental double-execution of side effects.
+
+## Cleanup
+
+Session logs and leases persist in JetStream until explicitly deleted.
+
+```bash
+harnx session delete <session_id> --cluster local
+```
+
+## Observability
+
+### Logs
+Workers emit structured logs for:
+- Lease acquisition, renewal, and loss.
+- Fenced-write rejections.
+- Session activation and failover.
+
+### Metrics
+Harnx tracks internal counters (exported to logs and future metrics endpoints):
+- `active_sessions_per_worker`: Current active loops.
+- `lease_acquisitions` / `lease_losses`: Lease churn.
+- `fenced_writes_rejected`: Safety triggers.
+- `interrupt_errors_synthesized`: Data points on failover impact.
+
+## TLS Support Note
+Harnx supports TLS and mTLS for NATS connections. While token authentication and config-based TLS have been verified, automated PKI-backed integration tests for live TLS handshakes are ongoing.

--- a/docs/solutions/logic-errors/nats-session-log-mutations-canonical-resolution-2026-06-23.md
+++ b/docs/solutions/logic-errors/nats-session-log-mutations-canonical-resolution-2026-06-23.md
@@ -1,0 +1,215 @@
+---
+title: "NATS session-log mutations: retract/edit via EditEntries + canonical resolution"
+date: 2026-06-23
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-nats-session-log"
+root_cause: "Raw log entry iteration without mutation resolution allowed retracted messages to be executed by workers"
+resolution_type: code_fix
+severity: high
+tags:
+  - session-log
+  - mutation
+  - EditEntries
+  - NATS
+  - distributed
+  - canonical-resolution
+  - testing
+plan_ref: "harnx-nats-ha"
+---
+
+## Problem
+
+NATS distributed mode introduced queued user messages that clients could retract or edit before worker consumption. The initial implementation allowed retracted messages to be executed by workers because multiple code paths read the raw durable log without applying mutations first. Additionally, an EditEntries YAML serialization bug silently turned edits into deletes.
+
+## Symptoms
+
+- Retracted user messages were still processed by workers (executed despite EditEntries delete)
+- Worker integration test `retracted_user_message_is_not_executed_by_worker` failed
+- EditEntries with non-serialized replacement strings silently degraded to deletions
+- Thin-client history render and final-response extraction showed retracted messages
+- Two review cycles (Aristarchus) required to catch all mutation-resolution gaps
+
+## Investigation Steps
+
+1. Initial implementation appended `EditEntries { from, to, replacements: [] }` for retraction
+2. Central `apply_log_mutations` function worked correctly in isolation
+3. Client and core `reconstruct_state` paths were fixed to apply mutations
+4. **Cycle-1 blockers (Aristarchus)**: Worker execution paths still used raw entries:
+   - `fold_new_user_messages_since` (mid-turn continuation) did not apply mutations
+   - `daemon drain` did not use `reconstruct_state_from_nats` (preserved NATS seqs)
+   - Thin-client `extract_final_response` did not apply mutations
+5. **Cycle-2 blockers (Aristarchus)**: `edit_user_message` serialized raw string instead of YAML SessionLogEntry:
+   - Replacement: `"new text"` instead of proper YAML `SessionLogEntry::Message { ... }`
+   - `apply_log_mutations` parsed via `serde_yaml::from_str::<SessionLogEntry>`
+   - Parse failed silently → `filter_map` dropped replacement → empty replacements = delete
+   - Edit operation silently became retract operation
+
+## Root Cause
+
+**Core issue: Raw-entry iteration without mutation resolution.**
+
+The session log is append-only. Mutations (EditEntries, Rewind) are also entries that modify effective state during replay. Any code path that iterates raw entries without first resolving mutations will see retracted/edited content.
+
+**Affected paths (initially missed):**
+- Worker turn-input fold (`fold_new_user_messages_since`)
+- Worker drain/resumable check
+- Thin-client history render
+- Final-response extraction
+- `reconstruct_state` in various forms
+
+**Secondary issue: YAML serialization mismatch.**
+
+`EditEntries.replacements` contains YAML strings parsed as `SessionLogEntry`. Raw text strings fail deserialization and are silently dropped, turning non-empty edit into deletion.
+
+## Solution
+
+### 1. Retract/edit via existing EditEntries primitive
+
+Reuse the two-pass-replay mutation primitive instead of inventing a `RetractPending` log variant:
+
+```rust
+// Retract (delete)
+pub async fn retract_user_message(&self, seq: u64) -> Result<u64> {
+    let edit_entry = SessionLogEntry::EditEntries {
+        from: seq as usize,
+        to: seq as usize,
+        replacements: vec![],  // Empty = deletion
+    };
+    log.append_event_async(&edit_entry).await
+}
+
+// Edit (replace)
+pub async fn edit_user_message(&self, seq: u64, new_text: String) -> Result<u64> {
+    let replacement_entry = SessionLogEntry::Message {
+        id: Some(uuid::Uuid::new_v4().to_string()),
+        role: MessageRole::User,
+        content: MessageContent::Text(new_text),
+        timestamp: None,
+        fence_token: None,
+    };
+    // CRITICAL: Serialize as YAML, not raw string
+    let replacement_yaml = serde_yaml::to_string(&replacement_entry)
+        .context("failed to serialize replacement entry")?;
+    let edit_entry = SessionLogEntry::EditEntries {
+        from: seq as usize,
+        to: seq as usize,
+        replacements: vec![replacement_yaml],
+    };
+    log.append_event_async(&edit_entry).await
+}
+```
+
+### 2. Canonical-resolution rule
+
+**ANY code path reading the durable log to make a decision MUST first resolve mutations.**
+
+Centralized in `harnx-core/src/session_reconstruct.rs`:
+
+```rust
+/// Apply mutation entries (EditEntries, Rewind) to build effective entry stream.
+pub fn apply_log_mutations(
+    raw_entries: &[(usize, SessionLogEntry)],
+) -> Vec<(usize, SessionLogEntry)> {
+    // Two-pass replay: mutations modify effective state
+}
+
+/// Reconstruct from NATS entries (1-based JetStream seqs).
+pub fn reconstruct_state_from_nats(entries: &[(u64, SessionLogEntry)]) -> ReconstructedState {
+    let raw_with_seq: Vec<_> = entries
+        .iter()
+        .map(|(seq, e)| (*seq as usize, e.clone()))
+        .collect();
+    let effective_entries = apply_log_mutations(&raw_with_seq);
+    reconstruct_state_effective(&effective_entries)
+}
+```
+
+Worker fold path:
+
+```rust
+pub(crate) fn fold_new_user_messages_since(
+    entries: &[(u64, SessionLogEntry)],
+    cursor: Option<u64>,
+) -> (Vec<Message>, Option<u64>) {
+    // CRITICAL: Apply mutations FIRST
+    let raw_with_seq: Vec<_> = entries
+        .iter()
+        .map(|(seq, e)| (*seq as usize, e.clone()))
+        .collect();
+    let effective_entries = apply_log_mutations(&raw_with_seq);
+
+    // Now safe to fold
+    for (seq, entry) in effective_entries {
+        // ...
+    }
+}
+```
+
+### 3. Preserve sequence domain
+
+0-based local seqs vs 1-based NATS JetStream seqs require separate functions:
+
+- `reconstruct_state` — 0-based `enumerate()` seqs
+- `reconstruct_state_from_nats` — 1-based JetStream seqs (u64 → usize cast)
+
+Using the wrong function strips/mismatches seqs so EditEntries existence-guards never match.
+
+### 4. Testing pub(crate) functions
+
+In-module `#[cfg(test)] mod tests` required to call `pub(crate)` functions directly:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fold_new_user_messages_since_with_retracts() {
+        // Direct call to pub(crate) fn
+        let (messages, _) = fold_new_user_messages_since(&entries, None);
+        assert_eq!(messages.len(), 0, "retracted messages must not appear");
+    }
+}
+```
+
+**External test crate tests are ineffective**: they must reimplement logic inline, producing tests that pass even when the actual function is broken.
+
+**Sanity-gate regression tests**: Revert the fix and confirm test fails.
+
+## Why This Works
+
+**EditEntries reuse**: The two-pass-replay primitive already handles mutations correctly. Reusing it ensures consistent semantics across local and distributed modes.
+
+**Canonical resolution**: All log readers go through the same mutation resolver. No path can accidentally see pre-mutation state.
+
+**YAML serialization**: Proper `SessionLogEntry` YAML docs parse correctly. Malformed strings are logged and dropped, but valid entries are preserved.
+
+**Sequence domain preservation**: NATS JetStream seqs start at 1, file-based seqs start at 0. Separate reconstruction functions maintain correct seq semantics for EditEntries range checks.
+
+## Prevention Strategies
+
+**Test cases:**
+- Worker integration test: retracted message is NOT executed (verify via mock LLM call count)
+- Unit test: `fold_new_user_messages_since` with EditEntries retract
+- Unit test: `apply_log_mutations` with EditEntries replace (verify replacement content)
+- Sanity-gate: revert fix, confirm test fails
+
+**Best practices:**
+- ANY log reader MUST call `apply_log_mutations` or use `reconstruct_state_*` wrapper
+- EditEntries replacements MUST be serialized `SessionLogEntry` YAML docs
+- Preserve seq domain: use `reconstruct_state_from_nats` for NATS, `reconstruct_state` for file
+- In-module tests for `pub(crate)` functions; external tests are insufficient
+
+**Code review checklist:**
+- [ ] Does this code path read raw log entries?
+- [ ] If yes, does it call `apply_log_mutations` or use reconstruction wrapper?
+- [ ] Are EditEntries replacements serialized as YAML SessionLogEntry docs?
+- [ ] Is the correct seq domain used (0-based vs 1-based)?
+- [ ] Are regression tests sanity-gated (fail when fix reverted)?
+
+## Related Issues
+
+- **PR:** Step 3 commits (a2227b64852, 570e1d81715, 01b43637e79)
+- **Related Solution:** [non-destructive-session-mutation-two-pass-replay-2026-05-01.md](non-destructive-session-mutation-two-pass-replay-2026-05-01.md) — Two-pass replay foundation
+- **Related Solution:** [stacked-mutation-replay-rposition-2026-05-01.md](stacked-mutation-replay-rposition-2026-05-01.md) — rposition for stacked edits

--- a/docs/solutions/nats-ha-lease.md
+++ b/docs/solutions/nats-ha-lease.md
@@ -1,0 +1,272 @@
+---
+title: "Renewable CAS KV Lease with Fencing for NATS HA Workers"
+date: 2026-06-21
+category: "integration-issues"
+problem_type: integration_issue
+component: "nats-worker-lease"
+root_cause: "async-nats 0.42 lacks update_with_ttl; bucket-wide max_age breaks CAS re-acquire"
+resolution_type: code_fix
+severity: critical
+tags:
+  - nats
+  - distributed-systems
+  - lease
+  - fencing
+  - high-availability
+  - jetstream
+  - kv
+plan_ref: "harnx-nats-ha"
+last_updated: 2026-06-21
+---
+
+# Solution: Distributed HA Lease & Fencing
+
+## Problem
+
+In a distributed environment, ensuring exactly one worker executes a session's agent loop is critical. Without proper lease mechanics, multiple workers could process the same session, causing state corruption, duplicate tool execution, and split-brain scenarios.
+
+## Symptoms
+
+- Multiple workers processing the same session after failover
+- `WrongLastSequence` errors during lease renewal being misdiagnosed
+- Lease holders continuing execution after losing the lease
+- Ghost sequence errors when re-acquiring leases after expiration
+- Workers bypassing token/TLS auth when connecting to NATS
+- Test hangs when reading bounded history from JetStream consumers
+- Silent message drops due to content-derived Nats-Msg-Id deduplication
+
+## Investigation Steps
+
+1. **Library Gap Discovery**: Searched async-nats 0.42 source for `update_with_ttl` — doesn't exist. Only `update(key, value, revision)` without TTL override.
+
+2. **Bucket max_age Rejection**: Tried bucket-wide `max_age` as alternative. Discovered CAS "ghost sequence" bug: when a key expires and a new worker attempts `create`, the server returns stale sequence numbers from pre-expiry state, breaking CAS guarantees on re-acquire.
+
+3. **Low-Level Renewal Path**: Found that JetStream publishes to `$KV.<bucket>.<key>` with headers `Nats-Expected-Last-Subject-Sequence` (CAS) and `Nats-TTL` work for TTL-refreshing updates. This requires `server_2_11` feature flag.
+
+4. **Limit_markers Requirement**: Discovered that per-key TTL requires `kv::Config.limit_markers: Some(tombstone_ttl)` on bucket creation. Without this, expired keys don't produce tombstones, and subsequent `create` calls fail to read the prior state correctly.
+
+5. **Worker Auth Bypass**: Caught during review — `run_agent_loop_with_nats_inner` extracted only `server.url` and called bare `async_nats::connect(url)`, silently dropping token/TLS config.
+
+6. **Consumer Read Hang**: Tried pull consumer `.messages()` for bounded history read — blocks forever (live subscription). Tried `.fetch()` — flaky under current-thread runtime, returns partial/zero batches.
+
+7. **Nats-Msg-Id Dedup Trap**: Used content-hash for message IDs. Duplicate content (e.g., two identical user messages) caused silent drops within the duplicate window.
+
+## Root Cause
+
+The root causes are multi-layered:
+
+1. **No TTL-refresh primitive**: async-nats 0.42 provides `create_with_ttl` for initial acquisition but has no high-level way to refresh TTL while preserving CAS guarantees. Plain `update()` drops the per-key TTL entirely.
+
+2. **Bucket max_age Cas bug**: Using bucket-wide `max_age` instead of per-key TTL causes "ghost sequence" errors on re-acquire after expiration.
+
+3. **Auth bypass in worker**: Bare `async_nats::connect(url)` skips all token/TLS configuration silently.
+
+4. **Consumer vs. direct get**: Consumer `.messages()` is a live subscription that never terminates; `.fetch()` is runtime-flavor-sensitive.
+
+5. **Dedup semantics**: Nats-Msg-Id deduplication is per-subject within duplicate_window; content-derived IDs cause silent drops of legitimate duplicate-content entries.
+
+## Solution
+
+### Lease Bucket Configuration
+
+```rust
+// Cargo.toml: add server_2_11 feature
+async-nats = { version = "0.42", features = ["server_2_10", "server_2_11", "ring"] }
+
+// Bucket creation with limit_markers
+jetstream.create_key_value(kv::Config {
+    bucket: "harnx_leases",
+    history: 1,
+    limit_markers: Some(Duration::from_secs(3600)), // tombstone_ttl
+    num_replicas: 1, // configurable; use 3 for production HA
+    storage: StorageType::File,
+    ..Default::default()
+}).await?
+```
+
+### Acquisition
+
+```rust
+// Per-key TTL on acquire; revision = fence token
+let revision = bucket.create_with_ttl(
+    key,
+    record_bytes,
+    Duration::from_secs(30)
+).await?; // Returns KV revision = fence token
+```
+
+### Renewal (Low-Level)
+
+```rust
+// async-nats 0.42 has NO update_with_ttl; use low-level publish
+let subject = format!("$KV.{}.{}", bucket.name, key);
+let mut headers = async_nats::HeaderMap::new();
+headers.insert(NATS_EXPECTED_LAST_SUBJECT_SEQUENCE, expected_revision.to_string());
+headers.insert(NATS_MESSAGE_TTL, ttl.as_secs().to_string());
+
+let ack = jetstream
+    .publish_with_headers(subject, headers, payload.into())
+    .await?
+    .await?;
+
+match ack {
+    Ok(ack) => {
+        // Update local fence token
+        state.fence_token.store(ack.sequence, Ordering::SeqCst);
+    }
+    Err(error) if error.kind() == PublishErrorKind::WrongLastSequence => {
+        // CAS failure => lease lost => ABORT immediately
+        bail!("Lost lease CAS for key '{}'", key);
+    }
+    // ...
+}
+```
+
+### Worker Connection (Auth-Safe)
+
+```rust
+// WRONG: bypasses auth
+let client = async_nats::connect(&server.url).await?;
+
+// CORRECT: goes through config-driven path
+let jetstream = config.nats_jetstream(cluster_key).await?;
+// Uses build_nats_connect_options internally, applies token/TLS
+```
+
+### Historical Read (No Hang)
+
+```rust
+// WRONG: consumer.messages() blocks forever
+let mut messages = consumer.messages().await?;
+while let Some(msg) = messages.next().await { ... } // NEVER terminates
+
+// CORRECT: direct get per sequence, bounded by stream info
+let stream_info = stream.info().await?;
+for seq in first_seq..=last_seq {
+    let raw = timeout(READ_TIMEOUT, stream.get_raw_message(seq)).await?;
+    // Process entry
+}
+```
+
+### Message ID (Unique Per Append)
+
+```rust
+// WRONG: content-derived
+let msg_id = format!("{:x}", md5::compute(&payload));
+
+// CORRECT: unique per append
+let msg_id = uuid::Uuid::new_v4().to_string();
+```
+
+## Why This Works
+
+1. **Per-key TTL + limit_markers**: Each lease key has its own TTL. On expiration, a tombstone is written, which subsequent `create` calls can read correctly for CAS semantics.
+
+2. **Low-level renewal preserves TTL**: Publishing to `$KV.<bucket>.<key>` with `Nats-TTL` header refreshes the TTL while `Nats-Expected-Last-Subject-Sequence` maintains CAS. Failure means another worker took over.
+
+3. **Fence token as revision**: The KV revision number is monotonically increasing and tied to the CAS operation. Embedding it in log entries allows resume-time detection of split-brain.
+
+4. **Config-driven connection**: All worker connections go through `Config::nats_jetstream()`, which applies token/TLS via `build_nats_connect_options`. No silent auth bypass.
+
+5. **Direct get terminates**: `get_raw_message(seq)` returns immediately (or errors). No live subscription, no blocking, works on any runtime flavor.
+
+6. **Unique msg_id prevents drops**: UUID-based IDs ensure every append is unique, even if content duplicates. Dedup only catches true retries.
+
+## Prevention Strategies
+
+### Test Cases
+
+- Lease contention test: 2 workers, 1 activation, exactly 1 acquires
+- Failover test: holder stops, new worker acquires within TTL window
+- Resume abort test: tail fence > held revision => abort
+- Auth bypass test: worker connects to token-auth server with config; bare connect fails
+- Historical read test: bounded read completes without hang
+- Dedup test: identical content entries both live (different UUIDs)
+
+### Code Review Checklist
+
+- [ ] Bucket uses `limit_markers: Some(tombstone_ttl)`?
+- [ ] Renewal uses `publish_with_headers` with both CAS and TTL headers?
+- [ ] Worker connects via `Config::nats_jetstream()`, NOT bare `async_nats::connect(url)`?
+- [ ] Historical reads use `get_raw_message(seq)` in loop, not consumer?
+- [ ] Nats-Msg-Id is UUID, not content-derived?
+- [ ] `server_2_11` feature enabled for async-nats?
+
+### Integration Test Convention
+
+Spawn real `nats-server` binary (gated on presence, skip if absent):
+
+```rust
+pub async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
+    let bin = env::var("NATS_SERVER_BIN")
+        .unwrap_or_else(|_| "nats-server".to_string());
+    
+    // Skip if binary not found
+    if which::which(&bin).is_err() {
+        eprintln!(" Skipping: nats-server binary not found");
+        return Ok(None);
+    }
+    
+    let tempdir = tempfile::tempdir()?;
+    let port = get_free_port()?;
+    let mut child = Command::new(&bin)
+        .args(["-js", "-sd", tempdir.path().to_str().unwrap(), "-p", &port.to_string()])
+        .spawn()?;
+    
+    // Wait for readiness
+    wait_for_nats_ready(port).await?;
+    
+    Ok(Some(NatsServerHandle { child, tempdir }))
+}
+```
+
+## Split-Brain Protection: Fencing
+
+The fence token (KV revision) is embedded in every worker-originated log entry (e.g., `AssistantMessage`, `ToolCalls`, `Cancel`):
+
+1. **Gated Appends**: Every append to the JetStream session log is checked against `lease.is_held()`.
+2. **Resume Validation**: When a worker resumes a session, it reads the tail of the durable log. If it finds a fence token *greater* than its own held revision, another worker has taken over — abort immediately.
+
+```rust
+// Before agent loop
+let tail_fence = max_fence_token_in_tail(&entries);
+if tail_fence > lease.fence_token() {
+    bail!("Split-brain detected: tail fence {} > held {}", tail_fence, lease.fence_token());
+}
+```
+
+## Event Contract
+
+### Durable vs. Advisory
+
+- **Durable Log**: Authoritative history (User messages, final Assistant messages, Tool results, `Cancel`). Queued user messages that arrive while a turn is running are ordinary `Message` entries folded into the next turn. Stored in JetStream log streams (`SESSION_<id>`).
+- **Advisory Events**: Lossy, real-time previews (Streaming chunks, thought segments, status updates). Published to core NATS fan-out subject `sessions.{id}.events`.
+
+### Attach Logic
+
+Clients subscribe to the advisory subject *before* loading durable history. Advisory envelopes carry `after_seq` (the durable seq they follow). Client renders advisory only when `after_seq >= last_applied_durable_seq` — gap-free and duplicate-free transition from history to live streaming.
+
+```rust
+pub struct AdvisoryEnvelope {
+    pub after_seq: u64,  // Durable log seq this advisory follows
+    pub event: AgentEvent,
+}
+
+// Client-side filter
+fn should_render(&self, envelope: &AdvisoryEnvelope) -> bool {
+    envelope.after_seq >= self.last_applied_durable_seq
+}
+```
+
+## Safety: Resume Heuristic
+
+If a worker crashes mid-tool-call:
+
+- **Idempotent tools** (per MCP `idempotent_hint` or `read_only_hint`): Safe to re-run. Worker re-executes the tool.
+- **Non-idempotent tools**: Synthesize an interrupt-error result (`"tool response lost (session was interrupted before results were persisted)"`), allowing the user/operator to see the response was lost and decide how to proceed.
+
+## Related Issues
+
+- **Plan notes**: `cf699445` (lease TTL decision), `4f7c58ba` (blocking ambiguity), `10c63569` (lease+dispatch), `84ec130b` (NATS gotchas), `1ead17b4` (auth-bypass fix), `23777a0a` (test convention)
+- **Code**: `crates/harnx-runtime/src/nats_lease.rs`, `nats_worker.rs`, `nats_session_log.rs`
+- **Operator guide**: `docs/nats-ha.md`


### PR DESCRIPTION
Separates thin clients (TUI, CLI, ACP) from backend workers to enable distributed, high-availability agent execution. Sessions are persisted as append-only logs in NATS JetStream, allowing multiple workers to provide failover with single-active-worker mutual exclusion.

Key features:
- Thin-client driver for remote agents using agent@cluster syntax.
- Durable session storage and event fan-out via NATS JetStream.
- Lease-based mutual exclusion with fence tokens to prevent stale writes.
- Distributed control plane for remote cancellation and pending messages.
- Support for NATS token authentication and mTLS.
- New harnx worker daemon for remote backend execution.
- High-availability deployment documentation and architectural guides.

#889

Plan: harnx-nats-ha

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added high-availability distributed agent execution using NATS JetStream with durable session persistence and multi-worker failover.
  * Added remote agent execution via `agent@cluster` syntax with thin-client routing.
  * Added live event fan-out and control-plane support for session cancellation and pending message management.
  * Added `harnx worker` command to run worker daemons and `harnx session delete` command for session cleanup.
  * Added NATS server configuration support with token auth and mTLS capabilities.

* **Documentation**
  * Added comprehensive NATS HA deployment guide and configuration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->