### PR TITLE
fix(sandbox): allow file-ioctl on macOS so TUIs can enter raw mode

### DIFF
--- a/.changeset/macos-sandbox-allow-file-ioctl.md
+++ b/.changeset/macos-sandbox-allow-file-ioctl.md
@@ -1,0 +1,8 @@
+---
+harnx: patch
+---
+Fix interactive TUIs (claude, gemini, bash readline) failing inside `harnx-sandbox-run` on macOS.
+
+birdcage 0.8.1's default Seatbelt profile omits `(allow file-ioctl)`, which causes `tcsetattr` to return EPERM inside the sandbox. As a result, every TUI launched via `harnx-sandbox-run` (or any consumer of `harnx-sandbox-common`) silently loses raw mode: arrow keys leak as literal `^[[A`/`^[OB`, terminal DA1 responses appear in input fields, and trust/confirmation prompts become unnavigable.
+
+birdcage's public `Exception` API only grants path/env/network exceptions — there's no surface for adding operation-level rules like `file-ioctl`, so the macOS sandbox path is now implemented in-tree as `harnx_sandbox_common::macos_sandbox::MacSandbox`. The new profile mirrors birdcage's macOS rule generation (identical deny-then-allow ordering, identical subpath escaping) with one extra line in the default header: `(allow file-ioctl)`. Linux continues to use birdcage unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4035,7 +4035,9 @@ version = "0.33.0"
 dependencies = [
  "anyhow",
  "birdcage",
+ "bitflags 2.13.0",
  "gix",
+ "libc",
  "log",
  "tempfile",
 ]

--- a/crates/harnx-sandbox-common/Cargo.toml
+++ b/crates/harnx-sandbox-common/Cargo.toml
@@ -16,6 +16,22 @@ birdcage = { workspace = true }
 gix = { workspace = true }
 tempfile = "3"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+bitflags = { workspace = true }
+libc = { workspace = true }
+
 [[bin]]
 name = "harnx-sandbox-exec"
 path = "src/bin/sandbox_exec.rs"
+
+# Test helper invoked by `tests/macos_tty.rs`. Reads stdin termios and writes
+# them back, exiting 0 on success. Not intended for general consumption — the
+# README documents `cargo install --path ... --bin harnx-sandbox-exec` which
+# skips this helper.
+#
+# Name uses underscores rather than the project-standard hyphen because cargo
+# exposes the bin path to integration tests via `CARGO_BIN_EXE_<name>`, and
+# rustc's `env!()` cannot expand environment variable names that contain `-`.
+[[bin]]
+name = "harnx_tty_probe"
+path = "src/bin/tty_probe.rs"

--- a/crates/harnx-sandbox-common/README.md
+++ b/crates/harnx-sandbox-common/README.md
@@ -22,7 +22,7 @@ For a higher-level wrapper with sensible defaults and hook support, see
 To install `harnx-sandbox-exec` from the `harnx` workspace:
 
 ```sh
-cargo install --path crates/harnx-sandbox-common
+cargo install --path crates/harnx-sandbox-common --bin harnx-sandbox-exec
 ```
 
 ## Usage

--- a/crates/harnx-sandbox-common/src/bin/sandbox_exec.rs
+++ b/crates/harnx-sandbox-common/src/bin/sandbox_exec.rs
@@ -1,18 +1,28 @@
 //! Sandbox execution CLI wrapper.
 //!
-//! Configures birdcage sandbox and spawns supplied command.
+//! Configures a birdcage sandbox (Linux) or our own Seatbelt profile (macOS)
+//! and spawns the supplied command. macOS uses an in-tree profile builder so
+//! we can include `(allow file-ioctl)`, which birdcage 0.8.1 omits; see
+//! [`crate::macos_sandbox`].
 
 #[cfg(unix)]
 use std::env;
 #[cfg(unix)]
 use std::ffi::{OsStr, OsString};
+#[cfg(all(unix, not(target_os = "macos")))]
+use std::path::Path;
 #[cfg(unix)]
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 #[cfg(unix)]
 use std::process;
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 use birdcage::{process::Command, Birdcage, Exception, Sandbox};
+
+#[cfg(target_os = "macos")]
+use harnx_sandbox_common::macos_sandbox::MacSandbox;
+#[cfg(target_os = "macos")]
+use std::process::Command;
 
 #[cfg(unix)]
 struct SandboxConfig {
@@ -130,7 +140,7 @@ fn parse_args() -> Result<Option<SandboxConfig>, String> {
     Err("sandbox-exec: missing -- before command".to_string())
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 fn add_path_exception(
     sandbox: &mut Birdcage,
     path: &Path,
@@ -151,12 +161,66 @@ fn add_path_exception(
         })
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 fn add_write_exception(sandbox: &mut Birdcage, path: &Path) -> Result<(), String> {
     add_path_exception(sandbox, path, Exception::WriteAndRead)
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "macos")]
+fn run() -> Result<i32, String> {
+    let Some(config) = parse_args()? else {
+        print_usage();
+        return Ok(0);
+    };
+
+    let mut sandbox = MacSandbox::new();
+
+    for path in &config.exec_paths {
+        sandbox.allow_execute_and_read(path)?;
+    }
+    for path in &config.write_paths {
+        sandbox.allow_write_and_read(path)?;
+    }
+    for path in &config.read_paths {
+        sandbox.allow_read(path)?;
+    }
+    if !config.no_network {
+        sandbox.allow_networking();
+    }
+
+    for (key, value) in &config.env_vars {
+        // Put the value in the current process env so MacSandbox's
+        // env-restriction step preserves it for the child.
+        //
+        // SAFETY: `env::set_var` mutates process-global state. This binary
+        // runs single-threaded up to here (`parse_args` and the sandbox
+        // setup never spawn threads, and `MacSandbox::apply_and_spawn` has
+        // not been called yet), so no other thread can be observing the
+        // environment concurrently.
+        unsafe { env::set_var(key, value) };
+        sandbox.allow_env(key.clone());
+    }
+
+    let mut command = {
+        let mut command = Command::new(&config.command[0]);
+        if let Some(working_dir) = &config.working_dir {
+            command.current_dir(working_dir);
+        }
+        command
+    };
+    command.args(&config.command[1..]);
+
+    let mut child = sandbox
+        .apply_and_spawn(command)
+        .map_err(|error| format!("sandbox-exec: failed to spawn process: {error}"))?;
+    let status = child
+        .wait()
+        .map_err(|error| format!("sandbox-exec: failed to wait for child: {error}"))?;
+
+    Ok(status.code().unwrap_or(1))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
 fn run() -> Result<i32, String> {
     let Some(config) = parse_args()? else {
         print_usage();
@@ -204,16 +268,6 @@ fn run() -> Result<i32, String> {
             })?;
     }
 
-    #[cfg(target_os = "macos")]
-    let mut command = {
-        let mut command = Command::new(&config.command[0]);
-        if let Some(working_dir) = &config.working_dir {
-            command.current_dir(working_dir);
-        }
-        command
-    };
-
-    #[cfg(not(target_os = "macos"))]
     let mut command = if let Some(working_dir) = &config.working_dir {
         // birdcage::process::Command on Linux lacks current_dir; rely on GNU env's
         // --chdir extension for now. Known limitation on Alpine/Busybox systems.
@@ -254,7 +308,10 @@ fn main() {
     std::process::exit(1);
 }
 
-#[cfg(all(test, unix))]
+// These tests exercise birdcage's `add_path_exception` / `add_write_exception`
+// helpers, which are linux-only after the macOS path moved to `MacSandbox`.
+// `MacSandbox`'s equivalents are covered by unit tests in `macos_sandbox.rs`.
+#[cfg(all(test, unix, not(target_os = "macos")))]
 mod tests {
     use super::*;
     use std::env;

--- a/crates/harnx-sandbox-common/src/bin/tty_probe.rs
+++ b/crates/harnx-sandbox-common/src/bin/tty_probe.rs
@@ -1,0 +1,42 @@
+//! Test helper for `tests/macos_tty.rs`.
+//!
+//! Reads termios state from stdin and writes it back unchanged. This is the
+//! minimal exercise of `tcsetattr` — the operation that fails silently inside
+//! a birdcage-only sandbox because `file-ioctl` isn't granted. Used to verify
+//! that `MacSandbox`'s default profile (which adds `(allow file-ioctl)`)
+//! actually permits raw-mode entry at runtime, not just in the generated
+//! profile string.
+//!
+//! Exit codes:
+//!   0 — tcgetattr and tcsetattr both succeeded
+//!   1 — tcgetattr failed (likely stdin not a tty)
+//!   2 — tcsetattr failed (likely sandbox denying file-ioctl)
+
+#[cfg(target_os = "macos")]
+fn main() {
+    use std::os::unix::io::AsRawFd;
+
+    let fd = std::io::stdin().as_raw_fd();
+    let mut t: libc::termios = unsafe { std::mem::zeroed() };
+
+    let rc = unsafe { libc::tcgetattr(fd, &mut t) };
+    if rc != 0 {
+        eprintln!("tcgetattr failed: {}", std::io::Error::last_os_error());
+        std::process::exit(1);
+    }
+
+    let rc = unsafe { libc::tcsetattr(fd, libc::TCSANOW, &t) };
+    if rc != 0 {
+        eprintln!("tcsetattr failed: {}", std::io::Error::last_os_error());
+        std::process::exit(2);
+    }
+
+    println!("tcsetattr OK");
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    // Helper is only meaningful on macOS — other platforms exit cleanly so
+    // cargo build doesn't fail when this crate is compiled cross-platform.
+    std::process::exit(0);
+}

--- a/crates/harnx-sandbox-common/src/lib.rs
+++ b/crates/harnx-sandbox-common/src/lib.rs
@@ -4,6 +4,8 @@ pub mod config;
 pub mod defaults;
 #[cfg(unix)]
 pub mod home_guard;
+#[cfg(target_os = "macos")]
+pub mod macos_sandbox;
 pub mod path_expand;
 #[cfg(unix)]
 pub mod root_detection;

--- a/crates/harnx-sandbox-common/src/macos_sandbox.rs
+++ b/crates/harnx-sandbox-common/src/macos_sandbox.rs
@@ -1,0 +1,426 @@
+//! macOS sandbox implementation that bypasses birdcage on this platform.
+//!
+//! The Seatbelt profile mirrors birdcage 0.8.1 with one addition: `(allow
+//! file-ioctl)` in the default header so child processes can call `tcsetattr`
+//! on their TTY. Without that operation, every TUI inside the sandbox
+//! (claude/Ink, bash readline) silently loses raw mode and arrow keys leak as
+//! literal `^[[A` etc.
+//!
+//! Behaviour matches birdcage **as observed through the `harnx-sandbox-exec`
+//! CLI**, not method-for-method: `add_path` silently skips non-existent paths
+//! (birdcage 0.8.1's `update_path_exceptions` errors via `canonicalize`),
+//! preserving the existence-check the linux helper already had. Net effect for
+//! the binary is identical.
+//!
+//! Birdcage's `Exception` API can only grant path/env/network access — there's
+//! no public surface for adding profile-level operation exceptions like
+//! `file-ioctl`, so this module reimplements the macOS-side profile builder
+//! and `sandbox_init` call directly. Linux continues to use birdcage.
+//!
+//! This module is exposed `pub` so the `harnx-sandbox-exec` binary and the
+//! integration test in `tests/macos_tty.rs` can reach it; it is not part of
+//! the stable `harnx-sandbox-common` public API and may change without notice.
+
+// Hidden from rustdoc because this is an internal helper, not part of the
+// crate's public API surface. Downstream crates should call `harnx-sandbox-exec`
+// rather than use `MacSandbox` directly.
+#![doc(hidden)]
+
+use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+use std::fs;
+use std::os::raw::c_char;
+use std::path::Path;
+use std::process::{Child, Command};
+use std::ptr;
+
+use bitflags::bitflags;
+
+const DEFAULT_PROFILE: &str = "\
+(version 1)
+(import \"system.sb\")
+
+(deny default)
+(allow mach*)
+(allow ipc*)
+(allow signal (target others))
+(allow process-fork)
+(allow sysctl*)
+(allow system*)
+(allow file-read-metadata)
+(allow file-ioctl)
+";
+
+extern "C" {
+    fn sandbox_init(profile: *const c_char, flags: u64, errorbuf: *mut *mut c_char) -> i32;
+    fn sandbox_free_error(errorbuf: *mut c_char);
+}
+
+bitflags! {
+    struct PathAccess: u8 {
+        const EXEC  = 0b001;
+        const WRITE = 0b010;
+        const READ  = 0b100;
+    }
+}
+
+#[derive(Default)]
+pub struct MacSandbox {
+    paths: HashMap<String, PathAccess>,
+    env_exceptions: Vec<String>,
+    full_env: bool,
+    networking: bool,
+}
+
+impl MacSandbox {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn allow_read(&mut self, path: &Path) -> Result<(), String> {
+        self.add_path(path, PathAccess::READ)
+    }
+
+    pub fn allow_write_and_read(&mut self, path: &Path) -> Result<(), String> {
+        self.add_path(path, PathAccess::READ | PathAccess::WRITE)
+    }
+
+    pub fn allow_execute_and_read(&mut self, path: &Path) -> Result<(), String> {
+        self.add_path(path, PathAccess::READ | PathAccess::EXEC)
+    }
+
+    pub fn allow_networking(&mut self) {
+        self.networking = true;
+    }
+
+    pub fn allow_env(&mut self, var: String) {
+        self.env_exceptions.push(var);
+    }
+
+    pub fn allow_full_env(&mut self) {
+        self.full_env = true;
+    }
+
+    /// Record `access` for `path` in the sandbox profile.
+    ///
+    /// **Silently returns `Ok(())` when `path` does not exist** — the rule is
+    /// dropped from the profile rather than erroring. This matches the
+    /// `add_path_exception` wrapper the linux helper had before this rewrite
+    /// (which dates to issue #619), so the `harnx-sandbox-exec` CLI surface
+    /// is unchanged. Diverges from birdcage 0.8.1's `update_path_exceptions`,
+    /// which surfaces a `canonicalize` error for missing paths.
+    fn add_path(&mut self, path: &Path, access: PathAccess) -> Result<(), String> {
+        if !path.exists() {
+            return Ok(());
+        }
+        let escaped = escape_path(path)?;
+        self.paths
+            .entry(escaped)
+            .or_insert(PathAccess::empty())
+            .insert(access);
+        Ok(())
+    }
+
+    /// Apply the Seatbelt profile to the current process, then spawn `command`.
+    /// The child inherits the sandbox via fork.
+    ///
+    /// **Caller threading constraint:** must be called from a single-threaded
+    /// process or from a position where no other thread can be reading the
+    /// environment. The implementation calls `std::env::remove_var`, which is
+    /// unsound when other threads are concurrently reading env. The
+    /// `harnx-sandbox-exec` binary satisfies this trivially (no async runtime,
+    /// no extra threads spawned before this call); external callers must
+    /// either uphold the same invariant or use `allow_full_env()` to skip env
+    /// restriction entirely.
+    pub fn apply_and_spawn(self, mut command: Command) -> Result<Child, String> {
+        // Build + install the Seatbelt profile FIRST so a sandbox_init failure
+        // returns Err without having mutated the parent process's env.
+        let profile = self.build_profile();
+        let c_profile =
+            CString::new(profile).map_err(|_| "sandbox profile contained NUL byte".to_string())?;
+        let mut err: *mut c_char = ptr::null_mut();
+        // SAFETY: `sandbox_init` is the documented Seatbelt entry point. We
+        // pass a NUL-terminated profile and a writable pointer to receive the
+        // error string (which we free with `sandbox_free_error`).
+        let rc = unsafe { sandbox_init(c_profile.as_ptr(), 0, &mut err) };
+        if rc != 0 {
+            let msg = unsafe { CStr::from_ptr(err) }
+                .to_string_lossy()
+                .into_owned();
+            unsafe { sandbox_free_error(err) };
+            return Err(format!("sandbox_init failed: {msg}"));
+        }
+
+        // With the sandbox now installed, strip non-allowlisted env vars from
+        // the current process so the forked child doesn't inherit them.
+        // Mirrors birdcage's `restrict_env_variables`. SAFETY for
+        // `env::remove_var`: see the method docstring above — caller is
+        // responsible for the single-threaded invariant.
+        if !self.full_env {
+            let keep: Vec<String> = self.env_exceptions.clone();
+            for (key, _) in std::env::vars() {
+                if !keep.iter().any(|k| k == &key) {
+                    unsafe { std::env::remove_var(&key) };
+                }
+            }
+        }
+
+        command.spawn().map_err(|e| format!("spawn failed: {e}"))
+    }
+
+    fn build_profile(&self) -> String {
+        let mut p = DEFAULT_PROFILE.to_string();
+
+        // Sort parents before children so a more-restrictive child can
+        // override a granted parent. Matches birdcage 0.8.1 ordering.
+        let mut paths: Vec<_> = self.paths.iter().collect();
+        paths.sort_by_key(|(s, _)| s.len());
+
+        for (path, access) in paths {
+            // Clear any inherited grants for this exact subpath first.
+            for op in ["file-read*", "file-write*", "process-exec"] {
+                p.push_str(&format!("(deny {op} (subpath {path}))\n"));
+            }
+            if access.contains(PathAccess::READ) {
+                p.push_str(&format!("(allow file-read* (subpath {path}))\n"));
+            }
+            if access.contains(PathAccess::WRITE) {
+                p.push_str(&format!("(allow file-write* (subpath {path}))\n"));
+            }
+            if access.contains(PathAccess::EXEC) {
+                p.push_str(&format!("(allow process-exec (subpath {path}))\n"));
+            }
+        }
+
+        if self.networking {
+            p.push_str("(allow network*)\n");
+        }
+        p.push_str("(system-network)\n");
+        p
+    }
+}
+
+/// Canonicalize and quote a path for use in a Seatbelt `subpath` expression.
+///
+/// Escapes backslashes BEFORE quotes — the reverse order (which birdcage 0.8.1
+/// has) double-escapes the backslash inserted by the quote-escape pass,
+/// producing malformed SBPL for paths containing `"`. macOS paths can legally
+/// contain both characters, so the order matters for correctness.
+fn escape_path(path: &Path) -> Result<String, String> {
+    let canonical =
+        fs::canonicalize(path).map_err(|_| format!("invalid path: {}", path.display()))?;
+    let mut s = canonical
+        .into_os_string()
+        .into_string()
+        .map_err(|_| format!("path not valid UTF-8: {}", path.display()))?;
+    while s.ends_with('/') && s != "/" {
+        s.pop();
+    }
+    let s = s.replace('\\', "\\\\").replace('"', "\\\"");
+    Ok(format!("\"{s}\""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_profile_allows_file_ioctl() {
+        let s = MacSandbox::new();
+        let p = s.build_profile();
+        assert!(
+            p.contains("(allow file-ioctl)"),
+            "default profile must allow file-ioctl so tcsetattr works inside the sandbox"
+        );
+    }
+
+    #[test]
+    fn read_path_emits_subpath_rule() {
+        let dir = std::env::temp_dir(); // always exists, gets canonicalized
+        let canonical = std::fs::canonicalize(&dir).unwrap();
+        let canonical_str = canonical.to_str().unwrap();
+
+        let mut s = MacSandbox::new();
+        s.allow_read(&dir).unwrap();
+        let p = s.build_profile();
+        let expected = format!("(allow file-read* (subpath \"{canonical_str}\"))");
+        assert!(
+            p.contains(&expected),
+            "profile missing expected rule {expected}, got:\n{p}"
+        );
+    }
+
+    #[test]
+    fn networking_flag_appends_rule() {
+        let mut s = MacSandbox::new();
+        s.allow_networking();
+        let p = s.build_profile();
+        assert!(p.contains("(allow network*)"));
+    }
+
+    /// Helper: canonical path string for a directory that always exists.
+    fn canonical_temp() -> String {
+        let dir = std::env::temp_dir();
+        std::fs::canonicalize(&dir)
+            .unwrap()
+            .into_os_string()
+            .into_string()
+            .unwrap()
+    }
+
+    #[test]
+    fn write_path_emits_subpath_rule() {
+        let canonical_str = canonical_temp();
+        let mut s = MacSandbox::new();
+        s.allow_write_and_read(Path::new(&canonical_str)).unwrap();
+        let p = s.build_profile();
+        assert!(
+            p.contains(&format!(
+                "(allow file-write* (subpath \"{canonical_str}\"))"
+            )),
+            "missing file-write* allow for {canonical_str} in:\n{p}"
+        );
+        assert!(
+            p.contains(&format!("(allow file-read* (subpath \"{canonical_str}\"))")),
+            "write_and_read should also emit file-read* allow for {canonical_str}"
+        );
+    }
+
+    #[test]
+    fn execute_path_emits_subpath_rule() {
+        let canonical_str = canonical_temp();
+        let mut s = MacSandbox::new();
+        s.allow_execute_and_read(Path::new(&canonical_str)).unwrap();
+        let p = s.build_profile();
+        assert!(
+            p.contains(&format!(
+                "(allow process-exec (subpath \"{canonical_str}\"))"
+            )),
+            "missing process-exec allow for {canonical_str} in:\n{p}"
+        );
+        assert!(
+            p.contains(&format!("(allow file-read* (subpath \"{canonical_str}\"))")),
+            "execute_and_read should also emit file-read* allow for {canonical_str}"
+        );
+    }
+
+    #[test]
+    fn rwx_emits_all_three_allow_rules() {
+        let canonical_str = canonical_temp();
+        let p_ref = Path::new(&canonical_str);
+        let mut s = MacSandbox::new();
+        s.allow_read(p_ref).unwrap();
+        s.allow_write_and_read(p_ref).unwrap();
+        s.allow_execute_and_read(p_ref).unwrap();
+        let p = s.build_profile();
+        for op in ["file-read*", "file-write*", "process-exec"] {
+            let expected = format!("(allow {op} (subpath \"{canonical_str}\"))");
+            assert!(
+                p.contains(&expected),
+                "RWX path missing {op} allow rule, got profile:\n{p}"
+            );
+        }
+    }
+
+    #[test]
+    fn path_rules_use_deny_then_allow_pattern() {
+        // The macro pattern revokes inherited grants before adding our allow,
+        // so a parent-granted access can be tightened on a child path. Each
+        // path must emit `deny` lines *before* its `allow` lines.
+        let canonical_str = canonical_temp();
+        let mut s = MacSandbox::new();
+        s.allow_read(Path::new(&canonical_str)).unwrap();
+        let p = s.build_profile();
+        let deny = format!("(deny file-read* (subpath \"{canonical_str}\"))");
+        let allow = format!("(allow file-read* (subpath \"{canonical_str}\"))");
+        let deny_pos = p
+            .find(&deny)
+            .unwrap_or_else(|| panic!("deny line missing in:\n{p}"));
+        let allow_pos = p
+            .find(&allow)
+            .unwrap_or_else(|| panic!("allow line missing in:\n{p}"));
+        assert!(
+            deny_pos < allow_pos,
+            "deny must precede allow so per-path overrides survive parent grants"
+        );
+    }
+
+    #[test]
+    fn parents_sort_before_children() {
+        // Per-test temp dir keeps parallel `cargo nextest` runs from racing on
+        // a shared path; the TempDir guard removes the whole tree on drop so
+        // we don't depend on `remove_dir` succeeding against a non-empty dir.
+        let parent_guard = tempfile::tempdir().expect("tempdir");
+        let parent = std::fs::canonicalize(parent_guard.path()).unwrap();
+        let child = parent.join("child");
+        std::fs::create_dir(&child).unwrap();
+
+        let mut s = MacSandbox::new();
+        // Add in reversed order — sort should put parent first.
+        s.allow_read(&child).unwrap();
+        s.allow_read(&parent).unwrap();
+        let p = s.build_profile();
+
+        let parent_str = parent.to_str().unwrap();
+        let child_str = child.to_str().unwrap();
+        let parent_allow = format!("(allow file-read* (subpath \"{parent_str}\"))");
+        let child_allow = format!("(allow file-read* (subpath \"{child_str}\"))");
+        let parent_pos = p.find(&parent_allow).expect("parent allow line missing");
+        let child_pos = p.find(&child_allow).expect("child allow line missing");
+        assert!(
+            parent_pos < child_pos,
+            "parent path must emit before child path so child rules can override"
+        );
+    }
+
+    #[test]
+    fn nonexistent_path_silently_skipped() {
+        // Regression guard for the `if !path.exists()` early-return in
+        // `add_path`. Mirrors the linux-side test in `sandbox_exec.rs`
+        // (`test_write_exception_nonexistent_path`) so the same invariant is
+        // pinned on macOS.
+        let dir_guard = tempfile::tempdir().expect("tempdir");
+        let missing = dir_guard.path().join("does-not-exist");
+        assert!(!missing.exists(), "test setup: path must not exist");
+
+        let mut s = MacSandbox::new();
+        s.allow_read(&missing)
+            .expect("non-existent path should be Ok");
+        s.allow_write_and_read(&missing)
+            .expect("non-existent path should be Ok");
+        s.allow_execute_and_read(&missing)
+            .expect("non-existent path should be Ok");
+
+        let p = s.build_profile();
+        assert!(
+            !p.contains("does-not-exist"),
+            "non-existent path must not emit any rule, got profile:\n{p}"
+        );
+    }
+
+    #[test]
+    fn escape_path_handles_embedded_quote() {
+        // A path containing `"` must produce SBPL that parses correctly.
+        // Bug-history: if backslash were escaped AFTER quote, the `\` inserted
+        // by the quote-escape pass would itself be doubled, yielding `\\"` —
+        // an escaped backslash followed by an unescaped quote that
+        // prematurely terminates the subpath string.
+        let dir_guard = tempfile::tempdir().expect("tempdir");
+        let weird = dir_guard.path().join("foo\"bar");
+        std::fs::create_dir(&weird).unwrap();
+        let canonical = std::fs::canonicalize(&weird).unwrap();
+        let canonical_str = canonical.to_str().unwrap();
+        // What we expect after correct escaping: each `"` becomes `\"`,
+        // no extra backslashes injected.
+        let expected_escaped = canonical_str.replace('"', "\\\"");
+
+        let mut s = MacSandbox::new();
+        s.allow_read(&weird).unwrap();
+        let p = s.build_profile();
+        let expected = format!("(allow file-read* (subpath \"{expected_escaped}\"))");
+        assert!(
+            p.contains(&expected),
+            "embedded `\"` not escaped correctly. expected:\n  {expected}\ngot profile:\n{p}"
+        );
+    }
+}

--- a/crates/harnx-sandbox-common/tests/macos_tty.rs
+++ b/crates/harnx-sandbox-common/tests/macos_tty.rs
@@ -1,0 +1,79 @@
+//! Integration test: confirm that `tcsetattr` succeeds inside a `MacSandbox`.
+//!
+//! This is the runtime counterpart to the `default_profile_allows_file_ioctl`
+//! unit test. The unit test verifies the SBPL string contains the magic line;
+//! this test fork+execs a child with a real pty as its stdin and verifies the
+//! child's `tcsetattr` call actually goes through. Catches the kind of break
+//! a string match wouldn't — e.g. someone moves the `file-ioctl` allow into a
+//! path-scoped rule where it no longer matches the pty device.
+//!
+//! Single-test file by design: `MacSandbox::apply_and_spawn` applies
+//! `sandbox_init` to the current process, which is irreversible. Running a
+//! second sandbox-using test in the same binary would inherit the first
+//! sandbox's restrictions.
+
+#![cfg(target_os = "macos")]
+
+use std::fs::File;
+use std::os::unix::io::FromRawFd;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::ptr;
+
+use harnx_sandbox_common::macos_sandbox::MacSandbox;
+
+#[test]
+fn tcsetattr_succeeds_inside_sandbox() {
+    // Cargo sets this at test-build time to the absolute path of the
+    // `harnx_tty_probe` binary it just compiled.
+    let probe = env!("CARGO_BIN_EXE_harnx_tty_probe");
+    let probe_path = Path::new(probe);
+    let probe_dir = probe_path
+        .parent()
+        .expect("probe should not live at filesystem root");
+
+    // Allocate a pty pair so the probe child has a real terminal as stdin.
+    // Without this, `tcgetattr` would fail with ENOTTY before we get to test
+    // the actually-interesting `tcsetattr`.
+    let mut master_fd: libc::c_int = 0;
+    let mut slave_fd: libc::c_int = 0;
+    let rc = unsafe {
+        libc::openpty(
+            &mut master_fd,
+            &mut slave_fd,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());
+
+    // Wrap the slave fd as a File so std::process::Command can take it as stdin.
+    // SAFETY: openpty just returned a fresh, owned fd. No one else holds it.
+    let slave_file = unsafe { File::from_raw_fd(slave_fd) };
+
+    let mut command = Command::new(probe);
+    command.stdin(Stdio::from(slave_file));
+
+    let mut sandbox = MacSandbox::new();
+    // Grant exec on the dir containing the probe so the kernel can load it.
+    sandbox
+        .allow_execute_and_read(probe_dir)
+        .expect("granting probe dir failed");
+    // Keep the full env so the probe inherits anything Rust's runtime needs.
+    sandbox.allow_full_env();
+
+    let mut child = sandbox
+        .apply_and_spawn(command)
+        .expect("apply_and_spawn failed");
+    let status = child.wait().expect("waiting for probe failed");
+
+    // Hand back the master fd; the child closed its slave when it exited.
+    unsafe { libc::close(master_fd) };
+
+    assert!(
+        status.success(),
+        "tty_probe exited with {:?} — file-ioctl is likely being denied by the sandbox",
+        status.code()
+    );
+}


### PR DESCRIPTION
## Problem

Interactive TUIs launched through `harnx-sandbox-run` on macOS lose raw mode
silently. Reproduced with a 30-line C probe (`tcgetattr` + `tcsetattr`):
runs cleanly outside the sandbox, returns `EPERM` from `tcsetattr` inside.

## Root cause

birdcage 0.8.1's default Seatbelt profile omits `(allow file-ioctl)`.
`tcsetattr` is implemented as a TTY ioctl, and Seatbelt's `file-write*` glob
does **not** include `file-ioctl` in modern macOS — so any granted path's
write rule still denies the ioctl. The sandboxed Node TTY layer (Ink) calls
`setRawMode(true)`, `tcsetattr` silently fails, and every keystroke goes
through cooked-mode echo.

Verified empirically:

| Variant                                    | `tcsetattr` |
|--------------------------------------------|-------------|
| stock birdcage, no extra perms             | EPERM       |
| stock birdcage, `--extra-rwx /dev/tty`     | EPERM       |
| stock birdcage, `--extra-rwx $(tty)`       | EPERM       |
| patched birdcage with `(allow file-ioctl)` | OK          |

## Why not just patch birdcage upstream

birdcage's public `Exception` API only grants path/env/network exceptions —
there's no surface for adding operation-level rules like `file-ioctl` from
outside the crate. Patching birdcage directly would also be slow to ship:
the repo has had no non-Dependabot commits since August 2025 and no formal
releases for some time (last `cargo` build pins 0.8.1). Reimplementing the
~120 lines of macOS profile generation in-tree is the smaller delta to
maintain than carrying a long-running fork.

## Fix

New module `harnx_sandbox_common::macos_sandbox::MacSandbox`:

- Hand-built Seatbelt profile mirroring birdcage 0.8.1's macOS rule
  generation (identical deny-then-allow ordering, identical sort order)
- One added rule: `(allow file-ioctl)` in the default header
- Marked `#[doc(hidden)]`; not part of the stable public API surface

`harnx-sandbox-exec` switches to `MacSandbox` on macOS via cfg-gating;
Linux continues to use birdcage unchanged.

Two latent bugs cleaned up while we were in there:

- `escape_path` now escapes `\` before `"`, fixing a malformed-SBPL bug
  for paths containing `"` (birdcage 0.8.1 has the same bug; ours is fixed
  and pinned by a regression test)
- `apply_and_spawn` runs `sandbox_init` *before* stripping env, so a
  sandbox-init failure no longer leaves the caller with a destroyed
  environment

## Testing

- 9 unit tests in `macos_sandbox.rs` covering: default profile contains
  file-ioctl, read/write/exec path rule emission, RWX accumulation,
  deny-then-allow ordering, parent-before-child sort, non-existent path
  silently skipped, embedded-quote escaping
- 1 integration test `tests/macos_tty.rs` (with helper bin
  `harnx_tty_probe`): opens a real pty via `libc::openpty`, spawns the
  probe inside `MacSandbox` with the pty slave as stdin, asserts
  `tcsetattr` succeeds — the runtime counterpart to the file-ioctl unit
  test
- `cargo nextest run --workspace --stress-count=5` → 1652 tests × 5
  iterations, all pass
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --all` clean
- End-to-end smoke test in a real terminal: `claude` arrow-key navigation
  and trust prompt work as expected, no `^[[A` leakage

## Reproduction (without this PR)

```bash
cat > /tmp/tty_test.c <<'EOF'
#include <termios.h>
#include <unistd.h>
#include <stdio.h>
#include <string.h>
#include <errno.h>
int main(void) {
    struct termios t;
    if (tcgetattr(0, &t) != 0) return 1;
    if (tcsetattr(0, TCSANOW, &t) != 0) {
        fprintf(stderr, "tcsetattr FAILED: %s\n", strerror(errno));
        return 2;
    }
    puts("tcsetattr OK");
    return 0;
}
EOF
cc -o /tmp/tty_test /tmp/tty_test.c
script -q /dev/null harnx-sandbox-run --extra-rwx /tmp -- /tmp/tty_test
# Without this PR: "tcsetattr FAILED: Operation not permitted"
# With this PR:    "tcsetattr OK"
```

## Out of scope

`crates/harnx-mcp-bash/src/bin/sandbox_run.rs` is a second sandbox-setup
binary that still calls birdcage directly. It looks like dead code —
`harnx-mcp-bash/src/main.rs` routes everything through `harnx-sandbox-exec`
— but verifying that and either deleting or porting the duplicate belongs
in a follow-up PR rather than expanding this one's scope.

## Changeset

`.changeset/macos-sandbox-allow-file-ioctl.md` (`harnx: patch`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Fixed terminal mode handling in macOS sandbox, allowing interactive TUI applications (claude, gemini, bash readline) to function correctly.

**Improvements**
* Enhanced sandbox implementation with platform-specific execution paths for macOS and Unix systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->