### PR TITLE
Fix NATS HA orphan-repair resurrection and improve consistency

### DIFF
--- a/crates/harnx-core/src/session_reconstruct.rs
+++ b/crates/harnx-core/src/session_reconstruct.rs
@@ -1,6 +1,7 @@
 use crate::message::{Message, MessageRole};
 use crate::session::{SessionLogEntry, ToolOutput};
 use crate::tool::ToolCall;
+use anyhow::{bail, Result};
 
 /// Apply mutation entries (EditEntries, Rewind) to build the effective entry stream.
 ///
@@ -27,20 +28,25 @@ pub fn apply_log_mutations(
 /// sequence numbers and returning same typed sequence numbers.
 pub fn apply_log_mutations_nats(
     raw_entries: &[(u64, SessionLogEntry)],
-) -> Vec<(u64, SessionLogEntry)> {
+) -> Result<Vec<(u64, SessionLogEntry)>> {
     let raw_with_seq: Vec<_> = raw_entries
         .iter()
         .map(|(seq, entry)| {
-            (
-                usize::try_from(*seq).expect("JetStream seq fits usize"),
-                entry.clone(),
-            )
+            let Ok(seq) = usize::try_from(*seq) else {
+                bail!("JetStream seq {seq} does not fit into usize");
+            };
+            Ok((seq, entry.clone()))
         })
-        .collect();
-    apply_log_mutations(&raw_with_seq)
+        .collect::<Result<_>>()?;
+    Ok(apply_log_mutations(&raw_with_seq)
         .into_iter()
-        .map(|(seq, entry)| (u64::try_from(seq).expect("effective seq fits u64"), entry))
-        .collect()
+        .map(|(seq, entry)| {
+            // SAFETY: effective seqs are a subset of input seqs. Resolver only
+            // deletes/replaces existing entries, and replacements inherit the
+            // EditEntries seq, so no new seq can exceed input JetStream seq range.
+            (u64::try_from(seq).expect("effective seq fits u64"), entry)
+        })
+        .collect())
 }
 
 /// Variant that accepts a session name for logging context.
@@ -196,7 +202,13 @@ pub fn reconstruct_state(entries: &[SessionLogEntry]) -> ReconstructedState {
 ///
 /// NATS sequences start at 1, not 0.
 pub fn reconstruct_state_from_nats(entries: &[(u64, SessionLogEntry)]) -> ReconstructedState {
-    let effective_entries_nats = apply_log_mutations_nats(entries);
+    let effective_entries_nats = match apply_log_mutations_nats(entries) {
+        Ok(entries) => entries,
+        Err(err) => {
+            log::warn!("failed to apply NATS log mutations during reconstruction: {err}");
+            return reconstruct_state_effective(&[]);
+        }
+    };
     let effective_entries: Vec<_> = effective_entries_nats
         .into_iter()
         .map(|(seq, entry)| {
@@ -677,47 +689,61 @@ mod tests {
         );
     }
 
-    #[test]
-    fn edit_entries_replacement_yaml_is_applied() {
-        let replacement = serde_yaml::to_string(&SessionLogEntry::Message {
+    fn edited_user_replacement_yaml() -> String {
+        serde_yaml::to_string(&SessionLogEntry::Message {
             id: Some("edited-id".to_string()),
             role: MessageRole::User,
             content: MessageContent::Text("edited".to_string()),
             timestamp: None,
             fence_token: None,
         })
-        .expect("serialize replacement");
+        .expect("serialize replacement")
+    }
 
-        let effective = apply_log_mutations(&[
-            (1, user_message("original")),
-            (
-                2,
-                SessionLogEntry::EditEntries {
-                    from: 1,
-                    to: 1,
-                    replacements: vec![replacement],
-                },
-            ),
-        ]);
+    fn apply_edit_replacement_case(
+        from: usize,
+        to: usize,
+        replacements: Vec<String>,
+        prefix_entries: Vec<(usize, SessionLogEntry)>,
+        edit_seq: usize,
+        suffix_entries: Vec<(usize, SessionLogEntry)>,
+    ) -> Vec<(usize, SessionLogEntry)> {
+        let mut entries = prefix_entries;
+        entries.push((
+            edit_seq,
+            SessionLogEntry::EditEntries {
+                from,
+                to,
+                replacements,
+            },
+        ));
+        entries.extend(suffix_entries);
+        apply_log_mutations(&entries)
+    }
+
+    #[test]
+    fn edit_entries_replacement_yaml_is_applied() {
+        let effective = apply_edit_replacement_case(
+            1,
+            1,
+            vec![edited_user_replacement_yaml()],
+            vec![(1, user_message("original"))],
+            2,
+            vec![],
+        );
 
         assert_eq!(effective.len(), 1);
         assert_eq!(effective[0].0, 2);
         assert_eq!(message_text(&entry_as_message(&effective[0].1)), "edited");
     }
 
-    #[test]
-    fn edit_entries_invalid_range_is_skipped() {
+    /// Apply `[first, second, edit]` and assert the malformed `edit` was skipped,
+    /// leaving the original two user messages untouched.
+    fn assert_edit_is_skipped(edit: SessionLogEntry) {
         let effective = apply_log_mutations(&[
             (1, user_message("first")),
             (2, user_message("second")),
-            (
-                3,
-                SessionLogEntry::EditEntries {
-                    from: 2,
-                    to: 1,
-                    replacements: vec![],
-                },
-            ),
+            (3, edit),
         ]);
 
         assert_eq!(effective.len(), 2);
@@ -728,26 +754,23 @@ mod tests {
     }
 
     #[test]
-    fn edit_entries_missing_target_seq_is_skipped() {
-        let effective = apply_log_mutations(&[
-            (1, user_message("first")),
-            (2, user_message("second")),
-            (
-                3,
-                SessionLogEntry::EditEntries {
-                    from: 1,
-                    to: 99,
-                    replacements: vec![serde_yaml::to_string(&user_message("edited"))
-                        .expect("serialize replacement")],
-                },
-            ),
-        ]);
+    fn edit_entries_invalid_range_is_skipped() {
+        assert_edit_is_skipped(SessionLogEntry::EditEntries {
+            from: 2,
+            to: 1,
+            replacements: vec![],
+        });
+    }
 
-        assert_eq!(effective.len(), 2);
-        assert_eq!(effective[0].0, 1);
-        assert_eq!(effective[1].0, 2);
-        assert_eq!(message_text(&entry_as_message(&effective[0].1)), "first");
-        assert_eq!(message_text(&entry_as_message(&effective[1].1)), "second");
+    #[test]
+    fn edit_entries_missing_target_seq_is_skipped() {
+        assert_edit_is_skipped(SessionLogEntry::EditEntries {
+            from: 1,
+            to: 99,
+            replacements: vec![
+                serde_yaml::to_string(&user_message("edited")).expect("serialize replacement")
+            ],
+        });
     }
 
     #[test]
@@ -773,30 +796,17 @@ mod tests {
 
     #[test]
     fn edit_entries_malformed_replacement_is_dropped_while_valid_one_is_applied() {
-        let valid_replacement = serde_yaml::to_string(&SessionLogEntry::Message {
-            id: Some("edited-id".to_string()),
-            role: MessageRole::User,
-            content: MessageContent::Text("edited".to_string()),
-            timestamp: None,
-            fence_token: None,
-        })
-        .expect("serialize replacement");
-
-        let effective = apply_log_mutations(&[
-            (1, user_message("original")),
-            (2, final_assistant("done")),
-            (
-                3,
-                SessionLogEntry::EditEntries {
-                    from: 1,
-                    to: 2,
-                    replacements: vec![
-                        valid_replacement,
-                        ": not valid yaml for session entry".to_string(),
-                    ],
-                },
-            ),
-        ]);
+        let effective = apply_edit_replacement_case(
+            1,
+            2,
+            vec![
+                edited_user_replacement_yaml(),
+                ": not valid yaml for session entry".to_string(),
+            ],
+            vec![(1, user_message("original")), (2, final_assistant("done"))],
+            3,
+            vec![],
+        );
 
         assert_eq!(effective.len(), 1);
         assert_eq!(effective[0].0, 3);
@@ -805,28 +815,17 @@ mod tests {
 
     #[test]
     fn rewind_truncates_effective_entries_after_prior_edit() {
-        let replacement = serde_yaml::to_string(&SessionLogEntry::Message {
-            id: Some("edited-id".to_string()),
-            role: MessageRole::User,
-            content: MessageContent::Text("edited".to_string()),
-            timestamp: None,
-            fence_token: None,
-        })
-        .expect("serialize replacement");
-
-        let effective = apply_log_mutations(&[
-            (1, user_message("original")),
-            (
-                2,
-                SessionLogEntry::EditEntries {
-                    from: 1,
-                    to: 1,
-                    replacements: vec![replacement],
-                },
-            ),
-            (3, final_assistant("done")),
-            (4, SessionLogEntry::Rewind { after_seq: 2 }),
-        ]);
+        let effective = apply_edit_replacement_case(
+            1,
+            1,
+            vec![edited_user_replacement_yaml()],
+            vec![(1, user_message("original"))],
+            2,
+            vec![
+                (3, final_assistant("done")),
+                (4, SessionLogEntry::Rewind { after_seq: 2 }),
+            ],
+        );
 
         assert_eq!(effective.len(), 1);
         assert_eq!(effective[0].0, 2);

--- a/crates/harnx-core/src/session_reconstruct.rs
+++ b/crates/harnx-core/src/session_reconstruct.rs
@@ -11,10 +11,36 @@ use crate::tool::ToolCall;
 ///
 /// Invalid/malformed mutations are skipped with warnings (logged via the `log` crate).
 /// Replacements inherit the mutation's seq number for future addressing.
+///
+/// Complexity: O(N*M) in worst case because each mutation may scan current
+/// effective entries with linear `position`/`rposition` lookups. Acceptable for
+/// typical session sizes.
 pub fn apply_log_mutations(
     raw_entries: &[(usize, SessionLogEntry)],
 ) -> Vec<(usize, SessionLogEntry)> {
     apply_log_mutations_with_name(raw_entries, "session")
+}
+
+/// NATS-seq wrapper for [`apply_log_mutations`].
+///
+/// Preserves exact mutation semantics while accepting JetStream `u64`
+/// sequence numbers and returning same typed sequence numbers.
+pub fn apply_log_mutations_nats(
+    raw_entries: &[(u64, SessionLogEntry)],
+) -> Vec<(u64, SessionLogEntry)> {
+    let raw_with_seq: Vec<_> = raw_entries
+        .iter()
+        .map(|(seq, entry)| {
+            (
+                usize::try_from(*seq).expect("JetStream seq fits usize"),
+                entry.clone(),
+            )
+        })
+        .collect();
+    apply_log_mutations(&raw_with_seq)
+        .into_iter()
+        .map(|(seq, entry)| (u64::try_from(seq).expect("effective seq fits u64"), entry))
+        .collect()
 }
 
 /// Variant that accepts a session name for logging context.
@@ -170,12 +196,16 @@ pub fn reconstruct_state(entries: &[SessionLogEntry]) -> ReconstructedState {
 ///
 /// NATS sequences start at 1, not 0.
 pub fn reconstruct_state_from_nats(entries: &[(u64, SessionLogEntry)]) -> ReconstructedState {
-    // Convert u64 seq to usize and apply mutations
-    let raw_with_seq: Vec<_> = entries
-        .iter()
-        .map(|(seq, e)| (*seq as usize, e.clone()))
+    let effective_entries_nats = apply_log_mutations_nats(entries);
+    let effective_entries: Vec<_> = effective_entries_nats
+        .into_iter()
+        .map(|(seq, entry)| {
+            (
+                usize::try_from(seq).expect("JetStream seq fits usize"),
+                entry,
+            )
+        })
         .collect();
-    let effective_entries = apply_log_mutations(&raw_with_seq);
     reconstruct_state_effective(&effective_entries)
 }
 
@@ -672,6 +702,104 @@ mod tests {
 
         assert_eq!(effective.len(), 1);
         assert_eq!(effective[0].0, 2);
+        assert_eq!(message_text(&entry_as_message(&effective[0].1)), "edited");
+    }
+
+    #[test]
+    fn edit_entries_invalid_range_is_skipped() {
+        let effective = apply_log_mutations(&[
+            (1, user_message("first")),
+            (2, user_message("second")),
+            (
+                3,
+                SessionLogEntry::EditEntries {
+                    from: 2,
+                    to: 1,
+                    replacements: vec![],
+                },
+            ),
+        ]);
+
+        assert_eq!(effective.len(), 2);
+        assert_eq!(effective[0].0, 1);
+        assert_eq!(effective[1].0, 2);
+        assert_eq!(message_text(&entry_as_message(&effective[0].1)), "first");
+        assert_eq!(message_text(&entry_as_message(&effective[1].1)), "second");
+    }
+
+    #[test]
+    fn edit_entries_missing_target_seq_is_skipped() {
+        let effective = apply_log_mutations(&[
+            (1, user_message("first")),
+            (2, user_message("second")),
+            (
+                3,
+                SessionLogEntry::EditEntries {
+                    from: 1,
+                    to: 99,
+                    replacements: vec![serde_yaml::to_string(&user_message("edited"))
+                        .expect("serialize replacement")],
+                },
+            ),
+        ]);
+
+        assert_eq!(effective.len(), 2);
+        assert_eq!(effective[0].0, 1);
+        assert_eq!(effective[1].0, 2);
+        assert_eq!(message_text(&entry_as_message(&effective[0].1)), "first");
+        assert_eq!(message_text(&entry_as_message(&effective[1].1)), "second");
+    }
+
+    #[test]
+    fn edit_entries_all_malformed_replacements_delete_target_range() {
+        let effective = apply_log_mutations(&[
+            (1, user_message("first")),
+            (2, user_message("second")),
+            (
+                3,
+                SessionLogEntry::EditEntries {
+                    from: 1,
+                    to: 2,
+                    replacements: vec![": not valid yaml for session entry".to_string()],
+                },
+            ),
+            (4, user_message("tail")),
+        ]);
+
+        assert_eq!(effective.len(), 1);
+        assert_eq!(effective[0].0, 4);
+        assert_eq!(message_text(&entry_as_message(&effective[0].1)), "tail");
+    }
+
+    #[test]
+    fn edit_entries_malformed_replacement_is_dropped_while_valid_one_is_applied() {
+        let valid_replacement = serde_yaml::to_string(&SessionLogEntry::Message {
+            id: Some("edited-id".to_string()),
+            role: MessageRole::User,
+            content: MessageContent::Text("edited".to_string()),
+            timestamp: None,
+            fence_token: None,
+        })
+        .expect("serialize replacement");
+
+        let effective = apply_log_mutations(&[
+            (1, user_message("original")),
+            (2, final_assistant("done")),
+            (
+                3,
+                SessionLogEntry::EditEntries {
+                    from: 1,
+                    to: 2,
+                    replacements: vec![
+                        valid_replacement,
+                        ": not valid yaml for session entry".to_string(),
+                    ],
+                },
+            ),
+        ]);
+
+        assert_eq!(effective.len(), 1);
+        assert_eq!(effective[0].0, 3);
         assert_eq!(message_text(&entry_as_message(&effective[0].1)), "edited");
     }
 

--- a/crates/harnx-runtime/src/nats_client_session.rs
+++ b/crates/harnx-runtime/src/nats_client_session.rs
@@ -184,11 +184,7 @@ impl ThinClientSession {
         // Render history to event sink (for resume/attach scenarios)
         let history = event_stream.history();
         // Apply mutations so retracted/edited entries are excluded from history render.
-        let raw_with_seq: Vec<_> = history
-            .iter()
-            .map(|(seq, e)| (*seq as usize, e.clone()))
-            .collect();
-        let effective_history = harnx_core::session_reconstruct::apply_log_mutations(&raw_with_seq);
+        let effective_history = harnx_core::session_reconstruct::apply_log_mutations_nats(history);
         for (_seq, entry) in effective_history {
             render_log_entry_to_sink(&entry, event_sink.clone());
         }
@@ -328,9 +324,10 @@ impl ThinClientSession {
     /// The sequence number of the appended EditEntries entry.
     pub async fn retract_user_message(&self, seq: u64) -> Result<u64> {
         let log = NatsSessionLog::new(self.jetstream.clone(), self.session_id.clone());
+        let seq = usize::try_from(seq).expect("JetStream seq fits usize");
         let edit_entry = SessionLogEntry::EditEntries {
-            from: seq as usize,
-            to: seq as usize,
+            from: seq,
+            to: seq,
             replacements: vec![], // Empty = deletion
         };
         log.append_event_async(&edit_entry)
@@ -354,7 +351,7 @@ impl ThinClientSession {
     pub async fn edit_user_message(&self, seq: u64, new_text: String) -> Result<u64> {
         let log = NatsSessionLog::new(self.jetstream.clone(), self.session_id.clone());
         let replacement_entry = SessionLogEntry::Message {
-            id: Some(uuid::Uuid::new_v4().to_string()),
+            id: Some(new_client_message_id()),
             role: MessageRole::User,
             content: MessageContent::Text(new_text),
             timestamp: None,
@@ -362,9 +359,10 @@ impl ThinClientSession {
         };
         let replacement_yaml = serde_yaml::to_string(&replacement_entry)
             .context("failed to serialize replacement entry for user-message edit")?;
+        let seq = usize::try_from(seq).expect("JetStream seq fits usize");
         let edit_entry = SessionLogEntry::EditEntries {
-            from: seq as usize,
-            to: seq as usize,
+            from: seq,
+            to: seq,
             replacements: vec![replacement_yaml],
         };
         log.append_event_async(&edit_entry)
@@ -392,11 +390,7 @@ impl ThinClientSession {
     /// Extract the final assistant response text from durable entries.
     fn extract_final_response(&self, entries: &[(u64, SessionLogEntry)]) -> Option<String> {
         // Apply mutations so retracted messages are excluded.
-        let raw_with_seq: Vec<_> = entries
-            .iter()
-            .map(|(seq, e)| (*seq as usize, e.clone()))
-            .collect();
-        let effective_entries = harnx_core::session_reconstruct::apply_log_mutations(&raw_with_seq);
+        let effective_entries = harnx_core::session_reconstruct::apply_log_mutations_nats(entries);
         // Find the last assistant message in effective entries.
         for (_, entry) in effective_entries.iter().rev() {
             if let SessionLogEntry::Message { role, content, .. } = entry {

--- a/crates/harnx-runtime/src/nats_client_session.rs
+++ b/crates/harnx-runtime/src/nats_client_session.rs
@@ -184,7 +184,16 @@ impl ThinClientSession {
         // Render history to event sink (for resume/attach scenarios)
         let history = event_stream.history();
         // Apply mutations so retracted/edited entries are excluded from history render.
-        let effective_history = harnx_core::session_reconstruct::apply_log_mutations_nats(history);
+        let effective_history =
+            match harnx_core::session_reconstruct::apply_log_mutations_nats(history) {
+                Ok(history) => history,
+                Err(err) => {
+                    log::warn!(
+                    "failed to apply NATS log mutations while rendering thin-client history: {err}"
+                );
+                    Vec::new()
+                }
+            };
         for (_seq, entry) in effective_history {
             render_log_entry_to_sink(&entry, event_sink.clone());
         }
@@ -324,7 +333,7 @@ impl ThinClientSession {
     /// The sequence number of the appended EditEntries entry.
     pub async fn retract_user_message(&self, seq: u64) -> Result<u64> {
         let log = NatsSessionLog::new(self.jetstream.clone(), self.session_id.clone());
-        let seq = usize::try_from(seq).expect("JetStream seq fits usize");
+        let seq = usize::try_from(seq).context("JetStream seq does not fit into usize")?;
         let edit_entry = SessionLogEntry::EditEntries {
             from: seq,
             to: seq,
@@ -359,7 +368,7 @@ impl ThinClientSession {
         };
         let replacement_yaml = serde_yaml::to_string(&replacement_entry)
             .context("failed to serialize replacement entry for user-message edit")?;
-        let seq = usize::try_from(seq).expect("JetStream seq fits usize");
+        let seq = usize::try_from(seq).context("JetStream seq does not fit into usize")?;
         let edit_entry = SessionLogEntry::EditEntries {
             from: seq,
             to: seq,
@@ -390,7 +399,16 @@ impl ThinClientSession {
     /// Extract the final assistant response text from durable entries.
     fn extract_final_response(&self, entries: &[(u64, SessionLogEntry)]) -> Option<String> {
         // Apply mutations so retracted messages are excluded.
-        let effective_entries = harnx_core::session_reconstruct::apply_log_mutations_nats(entries);
+        let effective_entries =
+            match harnx_core::session_reconstruct::apply_log_mutations_nats(entries) {
+                Ok(entries) => entries,
+                Err(err) => {
+                    log::warn!(
+                        "failed to apply NATS log mutations while extracting final response: {err}"
+                    );
+                    return None;
+                }
+            };
         // Find the last assistant message in effective entries.
         for (_, entry) in effective_entries.iter().rev() {
             if let SessionLogEntry::Message { role, content, .. } = entry {

--- a/crates/harnx-runtime/src/nats_worker/agent_loop.rs
+++ b/crates/harnx-runtime/src/nats_worker/agent_loop.rs
@@ -64,7 +64,14 @@ pub(crate) fn fold_new_user_messages_since(
     cursor: Option<u64>,
 ) -> (Vec<Message>, Option<u64>) {
     // Apply mutations first: retracted/edited entries must be filtered.
-    let effective_entries = harnx_core::session_reconstruct::apply_log_mutations_nats(entries);
+    let effective_entries = match harnx_core::session_reconstruct::apply_log_mutations_nats(entries)
+    {
+        Ok(entries) => entries,
+        Err(err) => {
+            log::warn!("failed to apply NATS log mutations while folding user messages: {err}");
+            return (Vec::new(), cursor);
+        }
+    };
 
     let mut messages = Vec::new();
     let mut latest_seq = cursor;
@@ -101,7 +108,7 @@ pub(crate) fn build_mid_turn_injection_callback(
         let backend = backend.clone();
         let cursor = Arc::clone(&cursor);
         Box::pin(async move {
-            let tail = match backend.load_events_consistent_blocking() {
+            let tail = match backend.load_events_consistent_async().await {
                 Ok(entries) => entries,
                 Err(err) => {
                     log::warn!("failed to reload session log for mid-turn injection: {err}");
@@ -264,7 +271,8 @@ async fn load_or_repair_session(
 
     // Existing session: check effective session log for orphan tool calls and repair with hints
     let mut entries_vec = entries;
-    let effective_entries = harnx_core::session_reconstruct::apply_log_mutations_nats(&entries_vec);
+    let effective_entries =
+        harnx_core::session_reconstruct::apply_log_mutations_nats(&entries_vec)?;
     let orphan_calls = find_orphan_tool_calls(&effective_entries);
     if !orphan_calls.is_empty() {
         nats_metrics::resume_detected();

--- a/crates/harnx-runtime/src/nats_worker/agent_loop.rs
+++ b/crates/harnx-runtime/src/nats_worker/agent_loop.rs
@@ -64,17 +64,13 @@ pub(crate) fn fold_new_user_messages_since(
     cursor: Option<u64>,
 ) -> (Vec<Message>, Option<u64>) {
     // Apply mutations first: retracted/edited entries must be filtered.
-    let raw_with_seq: Vec<_> = entries
-        .iter()
-        .map(|(seq, e)| (*seq as usize, e.clone()))
-        .collect();
-    let effective_entries = harnx_core::session_reconstruct::apply_log_mutations(&raw_with_seq);
+    let effective_entries = harnx_core::session_reconstruct::apply_log_mutations_nats(entries);
 
     let mut messages = Vec::new();
     let mut latest_seq = cursor;
     for (seq, entry) in effective_entries {
         // Entry may be mutated; cursor semantics still skip seq <= cursor.
-        if cursor.is_some_and(|seen| seq as u64 <= seen) {
+        if cursor.is_some_and(|seen| seq <= seen) {
             continue;
         }
         if let harnx_core::session::SessionLogEntry::Message {
@@ -87,10 +83,10 @@ pub(crate) fn fold_new_user_messages_since(
             if role.is_user() {
                 messages.push(
                     Message::new(role, content)
-                        .with_log_seq(seq)
+                        .with_log_seq(usize::try_from(seq).expect("JetStream seq fits usize"))
                         .with_log_timestamp(timestamp.unwrap_or_else(chrono::Utc::now)),
                 );
-                latest_seq = Some(seq as u64);
+                latest_seq = Some(seq);
             }
         }
     }
@@ -105,7 +101,7 @@ pub(crate) fn build_mid_turn_injection_callback(
         let backend = backend.clone();
         let cursor = Arc::clone(&cursor);
         Box::pin(async move {
-            let tail = match backend.load_events_blocking() {
+            let tail = match backend.load_events_consistent_blocking() {
                 Ok(entries) => entries,
                 Err(err) => {
                     log::warn!("failed to reload session log for mid-turn injection: {err}");
@@ -266,9 +262,10 @@ async fn load_or_repair_session(
         return write_header_and_load_session(backend, config, input, session_id).await;
     }
 
-    // Existing session: check for orphan tool calls and repair with hints
+    // Existing session: check effective session log for orphan tool calls and repair with hints
     let mut entries_vec = entries;
-    let orphan_calls = find_orphan_tool_calls(&entries_vec);
+    let effective_entries = harnx_core::session_reconstruct::apply_log_mutations_nats(&entries_vec);
+    let orphan_calls = find_orphan_tool_calls(&effective_entries);
     if !orphan_calls.is_empty() {
         nats_metrics::resume_detected();
         info!(

--- a/crates/harnx-runtime/src/nats_worker/backend.rs
+++ b/crates/harnx-runtime/src/nats_worker/backend.rs
@@ -127,7 +127,7 @@ impl NatsSessionLogBackend {
     /// falls back to a plain load otherwise. Used by the end-of-turn drain
     /// re-read so the worker sees its own just-written turn barrier and does not
     /// re-fold already-answered messages.
-    pub fn load_events_consistent_blocking(
+    pub async fn load_events_consistent_async(
         &self,
     ) -> Result<Vec<(u64, harnx_core::session::SessionLogEntry)>> {
         let min_seq = self
@@ -139,8 +139,14 @@ impl NatsSessionLogBackend {
             self.jetstream.clone(),
             self.session_id.clone(),
         );
+        log.load_events_at_least_async(min_seq).await
+    }
+
+    pub fn load_events_consistent_blocking(
+        &self,
+    ) -> Result<Vec<(u64, harnx_core::session::SessionLogEntry)>> {
         tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(log.load_events_at_least_async(min_seq))
+            tokio::runtime::Handle::current().block_on(self.load_events_consistent_async())
         })
     }
 }

--- a/crates/harnx-runtime/src/nats_worker/backend.rs
+++ b/crates/harnx-runtime/src/nats_worker/backend.rs
@@ -141,12 +141,4 @@ impl NatsSessionLogBackend {
         );
         log.load_events_at_least_async(min_seq).await
     }
-
-    pub fn load_events_consistent_blocking(
-        &self,
-    ) -> Result<Vec<(u64, harnx_core::session::SessionLogEntry)>> {
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(self.load_events_consistent_async())
-        })
-    }
 }

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -348,7 +348,7 @@ impl WorkerRuntime {
         // cursor (high-water mark of messages already fed this activation) is the
         // authoritative "unanswered" boundary and matches the drain decision.
         let hw = high_water?;
-        let tail = match ctx.backend.load_events_consistent_blocking() {
+        let tail = match ctx.backend.load_events_consistent_async().await {
             Ok(entries) => entries,
             Err(err) => {
                 log::warn!(
@@ -615,7 +615,7 @@ impl WorkerRuntime {
                 // Use the read-your-writes consistent load so this re-read reflects
                 // the worker's own just-persisted turn barrier (otherwise it would
                 // re-fold already-answered messages).
-                let tail = backend.load_events_consistent_blocking()?;
+                let tail = backend.load_events_consistent_async().await?;
 
                 // Check for resumable in-flight tool rounds (multi-turn tool execution).
                 // Use reconstruct_state_from_nats to preserve NATS seqs for EditEntries resolution.
@@ -744,7 +744,7 @@ impl WorkerRuntime {
         &self,
         backend: &NatsSessionLogBackend,
     ) -> harnx_core::session_reconstruct::ReconstructedState {
-        match backend.load_events_consistent_blocking() {
+        match backend.load_events_consistent_async().await {
             Ok(entries) => harnx_core::session_reconstruct::reconstruct_state_from_nats(&entries),
             Err(err) => {
                 log::warn!(

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -221,7 +221,7 @@ pub async fn run_worker_daemon(
     while let Some(message) = messages.next().await {
         let message = message.context("receive activation")?;
         if let Err(error) = runtime.handle_activation(message).await {
-            warn!("worker activation handling failed: {error:#}");
+            log::warn!("worker activation handling failed: {error:#}");
         }
     }
     Ok(())
@@ -284,7 +284,7 @@ impl WorkerRuntime {
             Some(lease) => lease,
             None => return Ok(()),
         };
-        info!(
+        log::info!(
             "session activate claimed: session_id={} worker_id={} revision={} epoch={}",
             activation.session_id,
             lease.worker_id(),
@@ -301,7 +301,7 @@ impl WorkerRuntime {
         nats_metrics::active_session_started();
         let handle = tokio::spawn(async move {
             let snapshot = nats_metrics::snapshot();
-            info!(
+            log::info!(
                 "active session started: session_id={} worker_id={} revision={} active_sessions_per_worker={}",
                 activation.session_id,
                 lease.worker_id(),
@@ -311,7 +311,7 @@ impl WorkerRuntime {
             let result = worker.execute_session(activation, Arc::clone(&lease)).await;
             nats_metrics::active_session_finished();
             let snapshot = nats_metrics::snapshot();
-            info!(
+            log::info!(
                 "active session finished: session_id={} worker_id={} revision={} active_sessions_per_worker={}",
                 task_session_id,
                 lease.worker_id(),
@@ -319,7 +319,7 @@ impl WorkerRuntime {
                 snapshot.active_sessions_per_worker
             );
             if let Err(error) = result {
-                warn!("worker session execution failed: {error:#}");
+                log::warn!("worker session execution failed: {error:#}");
             }
         });
         self.active.lock().await.insert(session_id, handle);
@@ -343,9 +343,17 @@ impl WorkerRuntime {
         // cursor (high-water mark of messages already fed this activation) is the
         // authoritative "unanswered" boundary and matches the drain decision.
         if let Some(hw) = high_water {
-            let tail = backend
-                .load_events_consistent_blocking()
-                .unwrap_or_default();
+            let tail = match backend.load_events_consistent_blocking() {
+                Ok(entries) => entries,
+                Err(err) => {
+                    log::warn!(
+                        "failed to load session log for continuation drain: session_id={} worker_id={} err={err}",
+                        backend.session_id(),
+                        self.worker_id,
+                    );
+                    Vec::new()
+                }
+            };
             let (new_messages, latest_seq) = fold_new_user_messages_since(&tail, Some(hw));
             if !new_messages.is_empty() {
                 let (mut input, seed) = self
@@ -379,7 +387,7 @@ impl WorkerRuntime {
             }
             harnx_core::session_reconstruct::TurnStatus::InFlightResumable => {
                 // Resume existing turn (orphan repair handled inside run_agent_loop_with_nats_inner).
-                info!(
+                log::info!(
                     "resume state: session_id={} worker_id={} revision={} mode=resumable",
                     activation.session_id,
                     lease.worker_id(),
@@ -619,7 +627,7 @@ impl WorkerRuntime {
         .await;
 
         if !lease.is_held() {
-            warn!(
+            log::warn!(
                 "session execution ended after failover: session_id={} worker_id={} revision={}",
                 activation.session_id,
                 lease.worker_id(),
@@ -649,7 +657,7 @@ impl WorkerRuntime {
         tokio::spawn(async move {
             while lost.changed().await.is_ok() {
                 if !*lost.borrow() {
-                    warn!(
+                    log::warn!(
                         "failover abort: session_id={} worker_id={} revision={} reason=lease_lost",
                         watch_session_id,
                         watch_lease.worker_id(),

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -170,6 +170,16 @@ pub async fn publish_session_activate(
     Ok(ack.sequence)
 }
 
+/// Shared, borrowed context for the `derive_*_turn_input` helpers. Groups the
+/// three references they all thread through so each helper stays within the
+/// function-argument budget.
+#[derive(Clone, Copy)]
+struct TurnInputCtx<'a> {
+    activation: &'a SessionActivate,
+    per_session: &'a GlobalConfig,
+    backend: &'a NatsSessionLogBackend,
+}
+
 /// Run a worker daemon: pull `SessionActivate` notifications, claim each via a
 /// KV lease, and execute the session (exactly one worker per session).
 pub async fn run_worker_daemon(
@@ -326,6 +336,41 @@ impl WorkerRuntime {
         Ok(())
     }
 
+    async fn derive_continuation_turn_input(
+        &self,
+        ctx: TurnInputCtx<'_>,
+        high_water: Option<u64>,
+    ) -> Option<(Input, Option<u64>)> {
+        // Continuation turns (high_water set) derive input CURSOR-based, not
+        // barrier-based. A user message that arrives DURING a turn is logged at
+        // a seq BELOW that turn's assistant barrier, so the barrier-based
+        // reconstruct would treat it as already-answered and never fold it. The
+        // cursor (high-water mark of messages already fed this activation) is the
+        // authoritative "unanswered" boundary and matches the drain decision.
+        let hw = high_water?;
+        let tail = match ctx.backend.load_events_consistent_blocking() {
+            Ok(entries) => entries,
+            Err(err) => {
+                log::warn!(
+                    "failed to load session log for continuation drain: session_id={} worker_id={} err={err}",
+                    ctx.backend.session_id(),
+                    self.worker_id,
+                );
+                Vec::new()
+            }
+        };
+        let (new_messages, latest_seq) = fold_new_user_messages_since(&tail, Some(hw));
+        if new_messages.is_empty() {
+            return None;
+        }
+        let (mut input, seed) = self
+            .derive_idle_turn_input(ctx.activation, ctx.per_session, new_messages)
+            .await;
+        input.with_session = true;
+        input.skip_user_log_append = true;
+        Some((input, seed.or(latest_seq)))
+    }
+
     /// Derive the turn input for an activation from the reconstructed session
     /// state, honoring cancel tombstones, resumable turns, and pending messages.
     async fn derive_turn_input(
@@ -336,35 +381,13 @@ impl WorkerRuntime {
         backend: &NatsSessionLogBackend,
         high_water: Option<u64>,
     ) -> (Input, Option<u64>) {
-        // Continuation turns (high_water set) derive input CURSOR-based, not
-        // barrier-based. A user message that arrives DURING a turn is logged at
-        // a seq BELOW that turn's assistant barrier, so the barrier-based
-        // reconstruct would treat it as already-answered and never fold it. The
-        // cursor (high-water mark of messages already fed this activation) is the
-        // authoritative "unanswered" boundary and matches the drain decision.
-        if let Some(hw) = high_water {
-            let tail = match backend.load_events_consistent_blocking() {
-                Ok(entries) => entries,
-                Err(err) => {
-                    log::warn!(
-                        "failed to load session log for continuation drain: session_id={} worker_id={} err={err}",
-                        backend.session_id(),
-                        self.worker_id,
-                    );
-                    Vec::new()
-                }
-            };
-            let (new_messages, latest_seq) = fold_new_user_messages_since(&tail, Some(hw));
-            if !new_messages.is_empty() {
-                let (mut input, seed) = self
-                    .derive_idle_turn_input(activation, per_session, new_messages)
-                    .await;
-                input.with_session = true;
-                input.skip_user_log_append = true;
-                return (input, seed.or(latest_seq));
-            }
-            // No new user messages past the cursor: fall through to reconstruct,
-            // which still handles a genuinely-resumable in-flight tool round.
+        let ctx = TurnInputCtx {
+            activation,
+            per_session,
+            backend,
+        };
+        if let Some(continuation) = self.derive_continuation_turn_input(ctx, high_water).await {
+            return continuation;
         }
 
         let reconstructed = self.reconstruct_session_state(backend).await;

--- a/crates/harnx-runtime/tests/nats_worker.rs
+++ b/crates/harnx-runtime/tests/nats_worker.rs
@@ -10,7 +10,7 @@ use harnx_core::{
     message::MessageRole,
     require_nextest,
     session::SessionLogEntry,
-    session_reconstruct::{reconstruct_state, TurnStatus},
+    session_reconstruct::{reconstruct_state, reconstruct_state_from_nats, TurnStatus},
     tool::ToolCall,
 };
 use harnx_runtime::{
@@ -360,6 +360,8 @@ async fn mid_tool_round_user_message_is_injected_once_into_same_turn() -> Result
         MID_ROUND_FINAL_CALLS.load(Ordering::SeqCst) >= 1
     })
     .await?;
+
+    tokio::time::sleep(Duration::from_millis(1500)).await;
 
     let entries = log.load_events_async().await?;
     let assistants = final_assistant_texts(&entries);
@@ -1000,6 +1002,348 @@ async fn after_seq_observer_advances_and_consistent_read_honors_it() -> Result<(
 /// This test proves the worker path honors EditEntries mutations. Without the fix,
 /// `fold_new_user_messages_since` would iterate raw entries and fold the retracted
 /// message, causing unwanted worker execution.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retracted_mid_tool_round_message_is_not_injected() -> Result<()> {
+    reset_test_state();
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("Skipping test: nats-server not available");
+        return Ok(());
+    };
+
+    let config = Arc::new(RwLock::new(local_nats_config(NatsServerSpec {
+        name: "local",
+        url: server.url(),
+        token: None,
+    })));
+    let worker_config = WorkerDaemonConfig::new("local", "worker-mid-round-retract");
+    let daemon = tokio::spawn({
+        let cfg = config.clone();
+        async move { run_worker_daemon(cfg, worker_config, Some(mid_round_call_fn())).await }
+    });
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    let js = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+    let session_id = "mid-round-retracted-injection";
+    let log = NatsSessionLog::new(js.clone(), session_id);
+
+    let ready_fut = MID_ROUND_APPEND_READY.notified();
+
+    log.append_event_async(&append_user_message_entry("seed message"))
+        .await?;
+    publish_session_activate(
+        &js,
+        "local",
+        &SessionActivate::new(session_id, "ignored-agent"),
+    )
+    .await?;
+
+    ready_fut.await;
+
+    let retracted_seq = log
+        .append_event_async(&SessionLogEntry::Message {
+            id: Some("msg-retracted-before-injection".to_string()),
+            role: MessageRole::User,
+            content: harnx_core::message::MessageContent::Text("late message".to_string()),
+            timestamp: None,
+            fence_token: None,
+        })
+        .await?;
+    log.append_event_async(&SessionLogEntry::EditEntries {
+        from: retracted_seq as usize,
+        to: retracted_seq as usize,
+        replacements: vec![],
+    })
+    .await?;
+
+    MID_ROUND_APPEND_DONE.notify_one();
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let entries = log.load_events_async().await?;
+    let assistants = final_assistant_texts(&entries);
+
+    assert_eq!(
+        MID_ROUND_FINAL_CALLS.load(Ordering::SeqCst),
+        0,
+        "retracted message should not trigger injected follow-up round"
+    );
+    assert!(
+        assistants.is_empty(),
+        "no final assistant turn should be persisted without injected message"
+    );
+    // The raw durable log still physically contains the retracted "late message"
+    // entry plus its EditEntries tombstone (retract is a tombstone, never a
+    // physical delete). The EFFECTIVE stream (mutations applied via
+    // reconstruct_state_from_nats) is what the worker folds, and it must exclude
+    // the retracted message from next_turn_messages.
+    let effective_user_texts: Vec<String> = reconstruct_state_from_nats(&entries)
+        .next_turn_messages
+        .iter()
+        .map(|m| m.content.to_text())
+        .collect();
+    assert!(
+        !effective_user_texts.iter().any(|t| t == "late message"),
+        "effective next-turn stream should exclude retracted mid-round message, got: {effective_user_texts:?}"
+    );
+
+    daemon.abort();
+    let _ = daemon.await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rewind_truncates_worker_visible_tail_before_activation() -> Result<()> {
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let prompts = Arc::new(AsyncMutex::new(Vec::<String>::new()));
+
+    let config = Arc::new(RwLock::new(local_nats_config(NatsServerSpec {
+        name: "local",
+        url: server.url(),
+        token: None,
+    })));
+    let worker_config = WorkerDaemonConfig::new("local", "worker-rewind");
+    let daemon = tokio::spawn({
+        let cfg = config.clone();
+        let calls = counter.clone();
+        let captured_prompts = prompts.clone();
+        async move {
+            run_worker_daemon(
+                cfg,
+                worker_config,
+                Some(fold_capture_call_fn(calls, captured_prompts)),
+            )
+            .await
+        }
+    });
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let js = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+    let session_id = "rewind-worker-test";
+    let log = NatsSessionLog::new(js.clone(), session_id);
+
+    let first_seq = log
+        .append_event_async(&SessionLogEntry::Message {
+            id: Some("msg-first".to_string()),
+            role: MessageRole::User,
+            content: harnx_core::message::MessageContent::Text("first prompt".to_string()),
+            timestamp: None,
+            fence_token: None,
+        })
+        .await?;
+    log.append_event_async(&SessionLogEntry::Message {
+        id: Some("msg-second".to_string()),
+        role: MessageRole::User,
+        content: harnx_core::message::MessageContent::Text("second prompt".to_string()),
+        timestamp: None,
+        fence_token: None,
+    })
+    .await?;
+    log.append_event_async(&SessionLogEntry::Rewind {
+        after_seq: first_seq as usize,
+    })
+    .await?;
+
+    publish_session_activate(
+        &js,
+        "local",
+        &SessionActivate::new(session_id, "ignored-agent"),
+    )
+    .await?;
+
+    wait_until(Duration::from_secs(10), || {
+        counter.load(Ordering::SeqCst) >= 1
+    })
+    .await?;
+
+    let captured_prompts = prompts.lock().await.clone();
+    assert_eq!(captured_prompts, vec!["first prompt".to_string()]);
+
+    let entries = log.load_events_async().await?;
+    let assistant_texts = final_assistant_texts(&entries);
+    assert_eq!(
+        assistant_texts.len(),
+        1,
+        "worker should persist one response"
+    );
+    assert!(
+        assistant_texts[0].contains("first prompt"),
+        "worker should answer only unre-wound prompt, got: {:?}",
+        assistant_texts
+    );
+    assert!(
+        assistant_texts
+            .iter()
+            .all(|text| !text.contains("second prompt")),
+        "rewound tail must not leak into worker execution: {:?}",
+        assistant_texts
+    );
+
+    let reconstructed = reconstruct_state(
+        &entries
+            .iter()
+            .map(|(_, entry)| entry.clone())
+            .collect::<Vec<_>>(),
+    );
+    assert_eq!(reconstructed.turn_status, TurnStatus::Idle);
+
+    daemon.abort();
+    let _ = daemon.await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retracted_orphan_tool_call_is_not_repaired_by_worker() -> Result<()> {
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let config = Arc::new(RwLock::new(local_nats_config(NatsServerSpec {
+        name: "local",
+        url: server.url(),
+        token: None,
+    })));
+    let worker_config = WorkerDaemonConfig::new("local", "worker-retracted-orphan");
+    let tool_calls_seen = Arc::new(AtomicUsize::new(0));
+    let daemon = tokio::spawn({
+        let cfg = config.clone();
+        let seen = tool_calls_seen.clone();
+        let call_fn: harnx_runtime::agent_loop::AgentCallFn =
+            Arc::new(move |_input, _config, _abort| {
+                let seen = seen.clone();
+                Box::pin(async move {
+                    seen.fetch_add(1, Ordering::SeqCst);
+                    Ok((
+                        "should not run".to_string(),
+                        None,
+                        vec![],
+                        CompletionTokenUsage::default(),
+                    ))
+                })
+            });
+        async move { run_worker_daemon(cfg, worker_config, Some(call_fn)).await }
+    });
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let js = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+    let session_id = "retracted-orphan-test";
+    let log = NatsSessionLog::new(js.clone(), session_id);
+
+    log.append_event_async(&session_header(session_id)).await?;
+    // NOTE: deliberately NO unanswered user message in the seed. We want the log to
+    // contain ONLY a retracted tool round, so that after mutations are applied the
+    // effective log is idle and the worker has nothing to do. A pending user message
+    // would (correctly) make the worker run a normal turn and invoke call_fn,
+    // confounding the "orphan repair must not run" assertions below.
+    let tool_calls_seq = log
+        .append_event_async(&SessionLogEntry::ToolCalls {
+            text: "working".to_string(),
+            thought: Some("thinking".to_string()),
+            calls: vec![ToolCall::new(
+                "echo".to_string(),
+                json!({"message": "ghost"}),
+                Some("call-retracted-orphan".to_string()),
+                None,
+            )],
+            timestamp: None,
+            // fence_token MUST be None (or <= the worker's lease revision) so the
+            // resume is NOT aborted by abort_resume_if_fenced before it reaches
+            // load_or_repair_session. A stale fence here would make the test pass
+            // vacuously (resume aborted before the orphan scan ever runs).
+            fence_token: None,
+        })
+        .await?;
+    log.append_event_async(&SessionLogEntry::EditEntries {
+        from: tool_calls_seq as usize,
+        to: tool_calls_seq as usize,
+        replacements: vec![],
+    })
+    .await?;
+
+    // Snapshot HA metrics before activation. With the bug (raw orphan scan) the
+    // worker would detect the retracted ToolCalls as an orphan (resumes += 1) and
+    // synthesize an interrupt-error ToolResults (interrupt_errors_synthesized += 1).
+    // With the fix (effective scan) the retract is honored: neither increments.
+    let metrics_before = harnx_runtime::nats_metrics::snapshot();
+
+    publish_session_activate(
+        &js,
+        "local",
+        &SessionActivate::new(session_id, "ignored-agent"),
+    )
+    .await?;
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let entries = log.load_events_async().await?;
+    let retracted_results = entries
+        .iter()
+        .filter_map(|(_, entry)| match entry {
+            SessionLogEntry::ToolResults { results, .. }
+                if results
+                    .iter()
+                    .any(|result| result.id.as_deref() == Some("call-retracted-orphan")) =>
+            {
+                Some(results)
+            }
+            _ => None,
+        })
+        .count();
+    assert_eq!(
+        retracted_results, 0,
+        "worker must not synthesize or replay ToolResults for retracted orphan tool call"
+    );
+    assert_eq!(
+        tool_calls_seen.load(Ordering::SeqCst),
+        0,
+        "orphan repair must not invoke call_fn for retracted tool call"
+    );
+
+    // The retracted tool round must not be detected as a resume orphan, and no
+    // interrupt-error result may be synthesized for it. These HA-metric deltas are
+    // the direct observable of the bug: with the raw-scan bug they would each be 1.
+    let metrics_after = harnx_runtime::nats_metrics::snapshot();
+    assert_eq!(
+        metrics_after.resumes, metrics_before.resumes,
+        "retracted tool round must not trigger a resume/orphan repair"
+    );
+    assert_eq!(
+        metrics_after.interrupt_errors_synthesized, metrics_before.interrupt_errors_synthesized,
+        "retracted tool round must not synthesize an interrupt-error result"
+    );
+
+    let effective = harnx_core::session_reconstruct::apply_log_mutations_nats(&entries);
+    assert!(
+        !effective.iter().any(|(_, entry)| matches!(
+            entry,
+            SessionLogEntry::ToolCalls { calls, .. }
+                if calls.iter().any(|call| call.id.as_deref() == Some("call-retracted-orphan"))
+        )),
+        "effective log must not contain retracted tool call"
+    );
+    assert!(
+        !effective.iter().any(|(_, entry)| matches!(
+            entry,
+            SessionLogEntry::ToolResults { results, .. }
+                if results
+                    .iter()
+                    .any(|result| result.id.as_deref() == Some("call-retracted-orphan"))
+        )),
+        "effective log must not contain resurrected ToolResults for retracted tool call"
+    );
+
+    daemon.abort();
+    let _ = daemon.await;
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn retracted_user_message_is_not_executed_by_worker() -> Result<()> {
     require_nextest();

--- a/crates/harnx-runtime/tests/nats_worker.rs
+++ b/crates/harnx-runtime/tests/nats_worker.rs
@@ -964,7 +964,7 @@ async fn resume_aborts_when_tail_fence_exceeds_held_revision() -> Result<()> {
 
 /// Read-your-writes seam (Step 2): a backend wired with an `after_seq_observer`
 /// advances the observer to the durable ack sequence on every append, and
-/// `load_events_consistent_blocking` waits until the stream reflects at least
+/// `load_events_consistent_async` waits until the stream reflects at least
 /// that sequence before returning. This is the mechanism that lets the
 /// end-of-turn drain re-read observe the worker's own just-persisted barrier
 /// instead of a stale tail.
@@ -1019,7 +1019,7 @@ async fn after_seq_observer_advances_and_consistent_read_honors_it() -> Result<(
     // The consistent read uses the observer's high-water mark; it must return a
     // tail that reflects at least seq2 (both entries visible), never a stale
     // read missing the worker's own latest barrier.
-    let entries = backend.load_events_consistent_blocking()?;
+    let entries = backend.load_events_consistent_async().await?;
     assert!(
         entries.iter().any(|(s, _)| *s == seq2),
         "consistent read must include the latest appended entry (seq {seq2}); got {entries:?}"

--- a/crates/harnx-runtime/tests/nats_worker.rs
+++ b/crates/harnx-runtime/tests/nats_worker.rs
@@ -28,9 +28,11 @@ use std::sync::LazyLock;
 static MID_ROUND_APPEND_READY: LazyLock<Notify> = LazyLock::new(Notify::new);
 static MID_ROUND_APPEND_DONE: LazyLock<Notify> = LazyLock::new(Notify::new);
 static MID_ROUND_FINAL_CALLS: AtomicUsize = AtomicUsize::new(0);
+static MID_ROUND_RELOAD_SEEN: AtomicUsize = AtomicUsize::new(0);
 static END_TURN_APPEND_READY: LazyLock<Notify> = LazyLock::new(Notify::new);
 static END_TURN_APPEND_DONE: LazyLock<Notify> = LazyLock::new(Notify::new);
 static END_TURN_CALLS: AtomicUsize = AtomicUsize::new(0);
+static RETRACTED_ORPHAN_ACTIVATION_CALLS: AtomicUsize = AtomicUsize::new(0);
 use parking_lot::RwLock;
 use serde_json::json;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -183,6 +185,39 @@ fn append_user_message_entry(text: &str) -> SessionLogEntry {
     }
 }
 
+async fn spawn_worker_daemon_with_call_fn(
+    config: Arc<RwLock<Config>>,
+    worker_id: &str,
+    call_fn: harnx_runtime::agent_loop::AgentCallFn,
+) -> tokio::task::JoinHandle<Result<()>> {
+    let worker_config = WorkerDaemonConfig::new("local", worker_id);
+    let daemon = tokio::spawn({
+        let cfg = config.clone();
+        async move { run_worker_daemon(cfg, worker_config, Some(call_fn)).await }
+    });
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    daemon
+}
+
+async fn local_test_nats(server_url: &str) -> Result<async_nats::jetstream::Context> {
+    Ok(async_nats::jetstream::new(
+        async_nats::connect(server_url).await?,
+    ))
+}
+
+async fn activate_session(
+    jetstream: &async_nats::jetstream::Context,
+    session_id: &str,
+) -> Result<()> {
+    publish_session_activate(
+        jetstream,
+        "local",
+        &SessionActivate::new(session_id, "ignored-agent"),
+    )
+    .await?;
+    Ok(())
+}
+
 fn mid_round_call_fn() -> harnx_runtime::agent_loop::AgentCallFn {
     Arc::new(move |input, _config, _abort| {
         // The mid-turn injection is delivered via `input.injected_user_text`
@@ -201,6 +236,7 @@ fn mid_round_call_fn() -> harnx_runtime::agent_loop::AgentCallFn {
                 // (the `on_tool_round` seam fires between rounds and injects it).
                 MID_ROUND_APPEND_READY.notify_one();
                 MID_ROUND_APPEND_DONE.notified().await;
+                MID_ROUND_RELOAD_SEEN.fetch_add(1, Ordering::SeqCst);
                 Ok((
                     "round-one".to_string(),
                     None,
@@ -1005,6 +1041,7 @@ async fn after_seq_observer_advances_and_consistent_read_honors_it() -> Result<(
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn retracted_mid_tool_round_message_is_not_injected() -> Result<()> {
     reset_test_state();
+    MID_ROUND_RELOAD_SEEN.store(0, Ordering::SeqCst);
     require_nextest();
     let Some(server) = spawn_nats_server().await? else {
         eprintln!("Skipping test: nats-server not available");
@@ -1016,28 +1053,18 @@ async fn retracted_mid_tool_round_message_is_not_injected() -> Result<()> {
         url: server.url(),
         token: None,
     })));
-    let worker_config = WorkerDaemonConfig::new("local", "worker-mid-round-retract");
-    let daemon = tokio::spawn({
-        let cfg = config.clone();
-        async move { run_worker_daemon(cfg, worker_config, Some(mid_round_call_fn())).await }
-    });
-    tokio::time::sleep(Duration::from_millis(1000)).await;
+    let daemon =
+        spawn_worker_daemon_with_call_fn(config, "worker-mid-round-retract", mid_round_call_fn())
+            .await;
 
-    let js = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+    let js = local_test_nats(server.url()).await?;
     let session_id = "mid-round-retracted-injection";
     let log = NatsSessionLog::new(js.clone(), session_id);
-
     let ready_fut = MID_ROUND_APPEND_READY.notified();
 
     log.append_event_async(&append_user_message_entry("seed message"))
         .await?;
-    publish_session_activate(
-        &js,
-        "local",
-        &SessionActivate::new(session_id, "ignored-agent"),
-    )
-    .await?;
-
+    activate_session(&js, session_id).await?;
     ready_fut.await;
 
     let retracted_seq = log
@@ -1049,15 +1076,19 @@ async fn retracted_mid_tool_round_message_is_not_injected() -> Result<()> {
             fence_token: None,
         })
         .await?;
+    let retracted_seq = usize::try_from(retracted_seq).expect("JetStream seq fits usize");
     log.append_event_async(&SessionLogEntry::EditEntries {
-        from: retracted_seq as usize,
-        to: retracted_seq as usize,
+        from: retracted_seq,
+        to: retracted_seq,
         replacements: vec![],
     })
     .await?;
 
     MID_ROUND_APPEND_DONE.notify_one();
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    wait_until(Duration::from_secs(10), || {
+        MID_ROUND_RELOAD_SEEN.load(Ordering::SeqCst) >= 1
+    })
+    .await?;
 
     let entries = log.load_events_async().await?;
     let assistants = final_assistant_texts(&entries);
@@ -1107,23 +1138,14 @@ async fn rewind_truncates_worker_visible_tail_before_activation() -> Result<()> 
         url: server.url(),
         token: None,
     })));
-    let worker_config = WorkerDaemonConfig::new("local", "worker-rewind");
-    let daemon = tokio::spawn({
-        let cfg = config.clone();
-        let calls = counter.clone();
-        let captured_prompts = prompts.clone();
-        async move {
-            run_worker_daemon(
-                cfg,
-                worker_config,
-                Some(fold_capture_call_fn(calls, captured_prompts)),
-            )
-            .await
-        }
-    });
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    let daemon = spawn_worker_daemon_with_call_fn(
+        config,
+        "worker-rewind",
+        fold_capture_call_fn(counter.clone(), prompts.clone()),
+    )
+    .await;
 
-    let js = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+    let js = local_test_nats(server.url()).await?;
     let session_id = "rewind-worker-test";
     let log = NatsSessionLog::new(js.clone(), session_id);
 
@@ -1145,16 +1167,11 @@ async fn rewind_truncates_worker_visible_tail_before_activation() -> Result<()> 
     })
     .await?;
     log.append_event_async(&SessionLogEntry::Rewind {
-        after_seq: first_seq as usize,
+        after_seq: usize::try_from(first_seq).expect("JetStream seq fits usize"),
     })
     .await?;
 
-    publish_session_activate(
-        &js,
-        "local",
-        &SessionActivate::new(session_id, "ignored-agent"),
-    )
-    .await?;
+    activate_session(&js, session_id).await?;
 
     wait_until(Duration::from_secs(10), || {
         counter.load(Ordering::SeqCst) >= 1
@@ -1184,12 +1201,7 @@ async fn rewind_truncates_worker_visible_tail_before_activation() -> Result<()> 
         assistant_texts
     );
 
-    let reconstructed = reconstruct_state(
-        &entries
-            .iter()
-            .map(|(_, entry)| entry.clone())
-            .collect::<Vec<_>>(),
-    );
+    let reconstructed = reconstruct_state_from_nats(&entries);
     assert_eq!(reconstructed.turn_status, TurnStatus::Idle);
 
     daemon.abort();
@@ -1199,6 +1211,7 @@ async fn rewind_truncates_worker_visible_tail_before_activation() -> Result<()> 
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn retracted_orphan_tool_call_is_not_repaired_by_worker() -> Result<()> {
+    RETRACTED_ORPHAN_ACTIVATION_CALLS.store(0, Ordering::SeqCst);
     require_nextest();
     let Some(server) = spawn_nats_server().await? else {
         eprintln!("skipping: nats-server not available");
@@ -1210,29 +1223,25 @@ async fn retracted_orphan_tool_call_is_not_repaired_by_worker() -> Result<()> {
         url: server.url(),
         token: None,
     })));
-    let worker_config = WorkerDaemonConfig::new("local", "worker-retracted-orphan");
     let tool_calls_seen = Arc::new(AtomicUsize::new(0));
-    let daemon = tokio::spawn({
-        let cfg = config.clone();
-        let seen = tool_calls_seen.clone();
-        let call_fn: harnx_runtime::agent_loop::AgentCallFn =
-            Arc::new(move |_input, _config, _abort| {
-                let seen = seen.clone();
-                Box::pin(async move {
-                    seen.fetch_add(1, Ordering::SeqCst);
-                    Ok((
-                        "should not run".to_string(),
-                        None,
-                        vec![],
-                        CompletionTokenUsage::default(),
-                    ))
-                })
-            });
-        async move { run_worker_daemon(cfg, worker_config, Some(call_fn)).await }
-    });
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    let seen_for_call_fn = Arc::clone(&tool_calls_seen);
+    let call_fn: harnx_runtime::agent_loop::AgentCallFn =
+        Arc::new(move |_input, _config, _abort| {
+            let seen = seen_for_call_fn.clone();
+            Box::pin(async move {
+                RETRACTED_ORPHAN_ACTIVATION_CALLS.fetch_add(1, Ordering::SeqCst);
+                seen.fetch_add(1, Ordering::SeqCst);
+                Ok((
+                    "should not run".to_string(),
+                    None,
+                    vec![],
+                    CompletionTokenUsage::default(),
+                ))
+            })
+        });
+    let daemon = spawn_worker_daemon_with_call_fn(config, "worker-retracted-orphan", call_fn).await;
 
-    let js = async_nats::jetstream::new(async_nats::connect(server.url()).await?);
+    let js = local_test_nats(server.url()).await?;
     let session_id = "retracted-orphan-test";
     let log = NatsSessionLog::new(js.clone(), session_id);
 
@@ -1260,9 +1269,10 @@ async fn retracted_orphan_tool_call_is_not_repaired_by_worker() -> Result<()> {
             fence_token: None,
         })
         .await?;
+    let tool_calls_seq = usize::try_from(tool_calls_seq).expect("JetStream seq fits usize");
     log.append_event_async(&SessionLogEntry::EditEntries {
-        from: tool_calls_seq as usize,
-        to: tool_calls_seq as usize,
+        from: tool_calls_seq,
+        to: tool_calls_seq,
         replacements: vec![],
     })
     .await?;
@@ -1273,14 +1283,22 @@ async fn retracted_orphan_tool_call_is_not_repaired_by_worker() -> Result<()> {
     // With the fix (effective scan) the retract is honored: neither increments.
     let metrics_before = harnx_runtime::nats_metrics::snapshot();
 
-    publish_session_activate(
-        &js,
-        "local",
-        &SessionActivate::new(session_id, "ignored-agent"),
-    )
-    .await?;
+    activate_session(&js, session_id).await?;
 
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    // Deterministic barrier: wait until the worker has actually CLAIMED the session
+    // (lease_acquisitions increments) — which proves it reached load_or_repair_session
+    // and ran the orphan scan — and then FINISHED (active_sessions back to 0). Without
+    // this, the assertions could run before the worker did anything (a 0==0 check is
+    // satisfied immediately), letting the test pass vacuously even with the bug present.
+    wait_until(Duration::from_secs(10), || {
+        harnx_runtime::nats_metrics::snapshot().lease_acquisitions
+            > metrics_before.lease_acquisitions
+    })
+    .await?;
+    wait_until(Duration::from_secs(10), || {
+        harnx_runtime::nats_metrics::snapshot().active_sessions_per_worker == 0
+    })
+    .await?;
 
     let entries = log.load_events_async().await?;
     let retracted_results = entries
@@ -1319,7 +1337,7 @@ async fn retracted_orphan_tool_call_is_not_repaired_by_worker() -> Result<()> {
         "retracted tool round must not synthesize an interrupt-error result"
     );
 
-    let effective = harnx_core::session_reconstruct::apply_log_mutations_nats(&entries);
+    let effective = harnx_core::session_reconstruct::apply_log_mutations_nats(&entries)?;
     assert!(
         !effective.iter().any(|(_, entry)| matches!(
             entry,


### PR DESCRIPTION
Fixes a defect where the NATS worker's orphan-repair scan read raw log entries instead of the effective history, causing it to resurrect logically-retracted tool rounds (via EditEntries or Rewind).

Updates mid-turn tool injection to use a consistent (read-your-writes) NATS load, ensuring it captures client edits/retracts immediately preceding the injection. Improves observability by logging NATS read errors during continuation-turn drains instead of silently swallowing them.

Introduces apply_log_mutations_nats helper to DRY up u64 sequence conversion logic across nats_client_session, agent_loop, and daemon. Performs cosmetic cleanup of redundant u64->usize casts and log! style.

Expands test coverage for log mutations (skip paths, mid-round retracts) and adds a worker integration test verifying that retracted orphans are not repaired.

Follow-up to #891 / plan harnx-nats-ha.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NATS-aware mutation application for durable log “effective” state and switched read-your-writes session loading to an async consistent path.
* **Bug Fixes**
  * Improved edit/retract/rewind handling by applying mutations before history rendering, final-response extraction, and session reconstruction.
  * Added safer bounds-checked sequence conversions and fallback behavior to avoid incorrect or resurrected state.
  * Prevented retracted/orphan messages and tool calls from being injected, repaired, or resurfaced.
* **Tests**
  * Expanded NATS integration/regression coverage for retract visibility, rewind truncation, and orphan tool-call repair avoidance, plus additional edge cases around invalid edit ranges and malformed replacements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->