### PR TITLE
feat(client): add unified error handling for streaming events across LLMs

### DIFF
--- a/crates/harnx-client/src/claude.rs
+++ b/crates/harnx-client/src/claude.rs
@@ -321,6 +321,10 @@ fn claude_handle_stream_event(
         "content_block_start" => claude_handle_content_block_start(state, handler, data)?,
         "content_block_delta" => claude_handle_content_block_delta(state, handler, data)?,
         "content_block_stop" => claude_handle_content_block_stop(state, handler)?,
+        "error" => {
+            let _ = data;
+            return crate::catch_error(data, 500, None);
+        }
         _ => {}
     }
     Ok(())
@@ -1277,6 +1281,33 @@ system_prompt_prefix:
             tool_calls.is_empty(),
             "no tool_use blocks were sent; tool_calls must stay empty"
         );
+    }
+
+    #[test]
+    fn claude_streaming_error_event_fails() {
+        use harnx_core::abort::create_abort_signal;
+        use tokio::sync::mpsc::unbounded_channel;
+        use harnx_core::error::LlmError;
+
+        let (tx, _rx) = unbounded_channel();
+        let mut handler = SseHandler::new(tx, create_abort_signal());
+        let mut state = ClaudeStreamState::default();
+
+        let event = json!({
+            "type": "error",
+            "error": {
+                "type": "api_error",
+                "message": "Internal server error"
+            }
+        });
+
+        let result = claude_handle_stream_event(&mut state, &mut handler, &event);
+        assert!(result.is_err(), "Stream error event should return an error");
+        let err = result.unwrap_err();
+        let llm_err = err.downcast_ref::<LlmError>().expect("Should be an LlmError");
+        assert_eq!(llm_err.status, 500);
+        assert!(llm_err.is_retryable());
+        assert!(llm_err.message.contains("Internal server error"));
     }
 
     #[test]

--- a/crates/harnx-client/src/cohere.rs
+++ b/crates/harnx-client/src/cohere.rs
@@ -1,4 +1,5 @@
 use crate::openai::*;
+use std::time::Duration;
 use crate::openai_compatible::*;
 use crate::*;
 
@@ -103,7 +104,7 @@ async fn chat_completions(
     let retry_after = parse_retry_after(res.headers());
     let data: Value = res.json().await?;
     if !status.is_success() {
-        catch_error(&data, status.as_u16(), retry_after)?;
+        cohere_catch_error(&data, status.as_u16(), retry_after)?;
     }
 
     debug!("non-stream-data: {data}");
@@ -157,6 +158,16 @@ fn cohere_handle_tool_call_end(
     Ok(())
 }
 
+fn cohere_catch_error(data: &Value, status: u16, retry_after: Option<Duration>) -> Result<()> {
+    let mut mapped_status = status;
+    if let Some(typ) = data["error"]["type"].as_str() {
+        if typ == "invalid_request_error" {
+            mapped_status = 400;
+        }
+    }
+    crate::catch_error(data, mapped_status, retry_after)
+}
+
 fn cohere_handle_stream_event(
     state: &mut CohereStreamState,
     handler: &mut SseHandler,
@@ -166,6 +177,9 @@ fn cohere_handle_stream_event(
         return Ok(());
     };
     match typ {
+        "message-error" | "stream-error" => {
+            return cohere_catch_error(data, 500, None);
+        }
         "content-delta" => {
             if let Some(text) = data["delta"]["message"]["content"]["text"].as_str() {
                 handler.text(text)?;
@@ -218,7 +232,7 @@ async fn embeddings(builder: RequestBuilder, _model: &Model) -> Result<Embedding
     let status = res.status();
     let data: Value = res.json().await?;
     if !status.is_success() {
-        catch_error(&data, status.as_u16(), None)?;
+        cohere_catch_error(&data, status.as_u16(), None)?;
     }
     let res_body: EmbeddingsResBody =
         serde_json::from_value(data).context("Invalid embeddings data")?;
@@ -342,5 +356,32 @@ mod tests {
             vec![Some("call_A"), Some("call_B")],
             "each tool-call block must be emitted exactly once"
         );
+    }
+
+    #[test]
+    fn cohere_streaming_error_event_fails() {
+        use harnx_core::abort::create_abort_signal;
+        use tokio::sync::mpsc::unbounded_channel;
+        use harnx_core::error::LlmError;
+
+        let (tx, _rx) = unbounded_channel();
+        let mut handler = SseHandler::new(tx, create_abort_signal());
+        let mut state = CohereStreamState::default();
+
+        let event = json!({
+            "type": "message-error",
+            "error": {
+                "message": "The request is invalid.",
+                "type": "invalid_request_error"
+            }
+        });
+
+        let result = cohere_handle_stream_event(&mut state, &mut handler, &event);
+        assert!(result.is_err(), "Stream error event should return an error");
+        let err = result.unwrap_err();
+        let llm_err = err.downcast_ref::<LlmError>().expect("Should be an LlmError");
+        assert_eq!(llm_err.status, 400);
+        assert!(!llm_err.is_retryable());
+        assert!(llm_err.message.contains("The request is invalid"));
     }
 }

--- a/crates/harnx-client/src/openai.rs
+++ b/crates/harnx-client/src/openai.rs
@@ -262,6 +262,9 @@ pub(crate) fn openai_handle_stream_event(
     handler: &mut SseHandler,
     data: &Value,
 ) -> Result<()> {
+    if let Some(_err) = data["error"].as_object() {
+        return crate::catch_error(data, 500, None);
+    }
     openai_handle_text_delta(state, handler, data)?;
     openai_handle_tool_call_delta(state, handler, data)?;
     openai_handle_final_usage(handler, data);
@@ -882,5 +885,33 @@ mod tests {
                 }
             ])
         );
+    }
+
+    #[test]
+    fn openai_streaming_error_event_fails() {
+        use harnx_core::abort::create_abort_signal;
+        use tokio::sync::mpsc::unbounded_channel;
+        use harnx_core::error::LlmError;
+
+        let (tx, _rx) = unbounded_channel();
+        let mut handler = SseHandler::new(tx, create_abort_signal());
+        let mut state = OpenAiStreamState::default();
+
+        let event = json!({
+            "error": {
+                "message": "Rate limit reached",
+                "type": "requests",
+                "param": null,
+                "code": "rate_limit_exceeded"
+            }
+        });
+
+        let result = openai_handle_stream_event(&mut state, &mut handler, &event);
+        assert!(result.is_err(), "Stream error event should return an error");
+        let err = result.unwrap_err();
+        let llm_err = err.downcast_ref::<LlmError>().expect("Should be an LlmError");
+        assert_eq!(llm_err.status, 500); // We map internal stream errors to 500
+        assert!(llm_err.is_retryable());
+        assert!(llm_err.message.contains("Rate limit reached"));
     }
 }

--- a/crates/harnx-client/src/vertexai.rs
+++ b/crates/harnx-client/src/vertexai.rs
@@ -220,6 +220,9 @@ fn gemini_handle_part(handler: &mut SseHandler, part: &Value, index: usize) -> R
 /// /OpenAI, Gemini has no accumulator state — each chunk carries complete
 /// parts — so no state struct is needed.
 fn gemini_handle_stream_chunk(handler: &mut SseHandler, data: &Value) -> Result<()> {
+    if let Some(_err) = data["error"].as_object() {
+        return crate::catch_error(data, 500, None);
+    }
     if let Some(parts) = data["candidates"][0]["content"]["parts"].as_array() {
         for (i, part) in parts.iter().enumerate() {
             gemini_handle_part(handler, part, i)?;
@@ -1250,5 +1253,31 @@ mod attachment_emission_tests {
         
         assert_eq!(inline_data["data"], "QUJDREVGR0g=");
         assert_eq!(inline_data["mimeType"], "image/jpeg");
+    }
+
+    #[test]
+    fn gemini_streaming_error_event_fails() {
+        use harnx_core::abort::create_abort_signal;
+        use tokio::sync::mpsc::unbounded_channel;
+        use harnx_core::error::LlmError;
+
+        let (tx, _rx) = unbounded_channel();
+        let mut handler = SseHandler::new(tx, create_abort_signal());
+
+        let event = json!({
+            "error": {
+                "code": 400,
+                "message": "User location is not supported for the API use.",
+                "status": "FAILED_PRECONDITION"
+            }
+        });
+
+        let result = gemini_handle_stream_chunk(&mut handler, &event);
+        assert!(result.is_err(), "Stream error event should return an error");
+        let err = result.unwrap_err();
+        let llm_err = err.downcast_ref::<LlmError>().expect("Should be an LlmError");
+        assert_eq!(llm_err.status, 500);
+        assert!(llm_err.is_retryable());
+        assert!(llm_err.message.contains("User location is not supported"));
     }
 }


### PR DESCRIPTION
Introduces consistent error handling for streaming events in Claude, Cohere, OpenAI, and Vertex AI clients. Maps error events to a 500 status and ensures they are retryable. Adds corresponding tests to validate error propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming responses now correctly surface provider-reported error events across Claude, Cohere, OpenAI, and Gemini instead of continuing normal parsing.
  * Cohere “invalid request” streaming errors are now remapped to a 400 response to better reflect the failure type.
  * Error results are returned consistently as retryable failures with provider error text for clearer recovery.
* **Tests**
  * Added regression tests covering each provider’s streaming error format to prevent silent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->