### PR TITLE
fix(nats): use leader-authoritative read for mid-turn injection decis…

### DIFF
--- a/crates/harnx-runtime/src/nats_session_log.rs
+++ b/crates/harnx-runtime/src/nats_session_log.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Context, Result};
 use async_nats::jetstream::{
     self,
     message::PublishMessage,
-    stream::{Config as StreamConfig, RetentionPolicy},
+    stream::{Config as StreamConfig, LastRawMessageErrorKind, RetentionPolicy},
 };
 use bytes::Bytes;
 use harnx_core::{session::SessionLogEntry, session_log::SessionLog};
@@ -113,6 +113,38 @@ impl NatsSessionLog {
             .map(|entries| entries.into_iter().map(|(_, entry)| entry).collect())
     }
 
+    pub async fn load_events_latest_async(&self) -> Result<Vec<(u64, SessionLogEntry)>> {
+        let mut stream = self.ensure_stream().await?;
+        let latest = match stream.get_last_raw_message_by_subject(&self.subject).await {
+            Ok(raw) => raw,
+            Err(err) if matches!(err.kind(), LastRawMessageErrorKind::NoMessageFound) => {
+                return Ok(Vec::new());
+            }
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!(
+                        "Failed to get latest JetStream session log entry for session '{}' subject '{}'",
+                        self.session_id, self.subject
+                    )
+                });
+            }
+        };
+        let first_sequence = stream
+            .info()
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to inspect JetStream log stream '{}' for session '{}'",
+                    self.stream_name, self.session_id
+                )
+            })?
+            .state
+            .first_sequence;
+        let start = first_sequence.max(1);
+
+        self.read_range(&stream, start, latest.sequence).await
+    }
+
     async fn ensure_stream(&self) -> Result<jetstream::stream::Stream> {
         self.jetstream
             .get_or_create_stream(StreamConfig {
@@ -156,9 +188,26 @@ impl NatsSessionLog {
             return Ok(Vec::new());
         }
 
-        let begin = start_sequence.max(first_sequence).max(1);
+        self.read_range(
+            &stream,
+            start_sequence.max(first_sequence).max(1),
+            last_sequence,
+        )
+        .await
+    }
+
+    async fn read_range(
+        &self,
+        stream: &jetstream::stream::Stream,
+        start_sequence: u64,
+        last_sequence: u64,
+    ) -> Result<Vec<(u64, SessionLogEntry)>> {
+        if last_sequence < start_sequence {
+            return Ok(Vec::new());
+        }
+
         let mut entries = Vec::new();
-        for seq in begin..=last_sequence {
+        for seq in start_sequence..=last_sequence {
             let raw = match timeout(READ_TIMEOUT, stream.get_raw_message(seq)).await {
                 Ok(Ok(raw)) => raw,
                 // Sequence may have been removed (retention/limits) leaving a gap;

--- a/crates/harnx-runtime/src/nats_worker/agent_loop.rs
+++ b/crates/harnx-runtime/src/nats_worker/agent_loop.rs
@@ -108,7 +108,7 @@ pub(crate) fn build_mid_turn_injection_callback(
         let backend = backend.clone();
         let cursor = Arc::clone(&cursor);
         Box::pin(async move {
-            let tail = match backend.load_events_consistent_async().await {
+            let tail = match backend.load_events_latest_async().await {
                 Ok(entries) => entries,
                 Err(err) => {
                     log::warn!("failed to reload session log for mid-turn injection: {err}");

--- a/crates/harnx-runtime/src/nats_worker/backend.rs
+++ b/crates/harnx-runtime/src/nats_worker/backend.rs
@@ -141,4 +141,14 @@ impl NatsSessionLogBackend {
         );
         log.load_events_at_least_async(min_seq).await
     }
+
+    pub async fn load_events_latest_async(
+        &self,
+    ) -> Result<Vec<(u64, harnx_core::session::SessionLogEntry)>> {
+        let log = crate::nats_session_log::NatsSessionLog::new(
+            self.jetstream.clone(),
+            self.session_id.clone(),
+        );
+        log.load_events_latest_async().await
+    }
 }

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -348,7 +348,7 @@ impl WorkerRuntime {
         // cursor (high-water mark of messages already fed this activation) is the
         // authoritative "unanswered" boundary and matches the drain decision.
         let hw = high_water?;
-        let tail = match ctx.backend.load_events_consistent_async().await {
+        let tail = match ctx.backend.load_events_latest_async().await {
             Ok(entries) => entries,
             Err(err) => {
                 log::warn!(
@@ -516,8 +516,8 @@ impl WorkerRuntime {
         let event_sink = Arc::new(event_sink);
 
         // Build the backend for control-plane operations and state reconstruction.
-        // Share the `after_seq` high-water mark so the drain re-read can enforce
-        // read-your-writes consistency on the worker's own turn-output appends.
+        // Share the `after_seq` high-water mark for event-sink fan-out advisories;
+        // worker tail reads themselves use leader-authoritative `load_events_latest_async`.
         let backend = NatsSessionLogBackend::new(self.jetstream.clone(), &activation.session_id)
             .with_after_seq_observer(Arc::clone(&after_seq_observer));
 
@@ -612,10 +612,11 @@ impl WorkerRuntime {
                 // DRAIN DECISION: cursor-based, not barrier-based.
                 // Re-run another turn ONLY if there's a user message with seq > activation_high_water.
                 // This prevents re-running when we've already consumed everything.
-                // Use the read-your-writes consistent load so this re-read reflects
-                // the worker's own just-persisted turn barrier (otherwise it would
-                // re-fold already-answered messages).
-                let tail = backend.load_events_consistent_async().await?;
+                // Use the fresh leader-authoritative load so this re-read reflects
+                // both the worker's own just-persisted turn barrier and any client
+                // edit/retract committed just before the read (otherwise it would
+                // re-fold already-answered or retracted messages).
+                let tail = backend.load_events_latest_async().await?;
 
                 // Check for resumable in-flight tool rounds (multi-turn tool execution).
                 // Use reconstruct_state_from_nats to preserve NATS seqs for EditEntries resolution.
@@ -744,7 +745,7 @@ impl WorkerRuntime {
         &self,
         backend: &NatsSessionLogBackend,
     ) -> harnx_core::session_reconstruct::ReconstructedState {
-        match backend.load_events_consistent_async().await {
+        match backend.load_events_latest_async().await {
             Ok(entries) => harnx_core::session_reconstruct::reconstruct_state_from_nats(&entries),
             Err(err) => {
                 log::warn!(

--- a/crates/harnx-runtime/tests/nats_worker.rs
+++ b/crates/harnx-runtime/tests/nats_worker.rs
@@ -35,6 +35,7 @@ static END_TURN_CALLS: AtomicUsize = AtomicUsize::new(0);
 static RETRACTED_ORPHAN_ACTIVATION_CALLS: AtomicUsize = AtomicUsize::new(0);
 use parking_lot::RwLock;
 use serde_json::json;
+use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -1403,6 +1404,101 @@ async fn retracted_orphan_tool_call_is_not_repaired_by_worker() -> Result<()> {
     Ok(())
 }
 
+/// Verifies `load_events_latest_async` reads leader-authoritative tail end-to-end.
+///
+/// On single-node NATS this cannot differ from old `stream.info()` path because
+/// there is no replication lag, so this is a forward behavioral guarantee rather
+/// than a fail-on-revert differential. Real #917 bug requires multi-node
+/// STREAM.INFO-vs-leader divergence.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn load_events_latest_async_reads_leader_authoritative_tail() -> Result<()> {
+    let Some(server) = require_nats_server().await? else {
+        return Ok(());
+    };
+
+    let js = local_test_nats(server.url()).await?;
+    let session_id = "latest-tail-test";
+    let log = NatsSessionLog::new(js, session_id);
+
+    let user_seq = log
+        .append_event_async(&append_user_message_entry(
+            "msg-to-retract",
+            "please ignore this",
+        ))
+        .await?;
+    let retract_seq = log
+        .append_event_async(&SessionLogEntry::EditEntries {
+            from: user_seq as usize,
+            to: user_seq as usize,
+            replacements: vec![],
+        })
+        .await?;
+
+    let entries = log.load_events_latest_async().await?;
+    let max_seq = entries.iter().map(|(seq, _)| *seq).max().unwrap_or(0);
+    assert!(
+        max_seq >= retract_seq,
+        "latest read must include retract seq {retract_seq}, got max seq {max_seq}"
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|(_, entry)| matches!(entry, SessionLogEntry::EditEntries { .. })),
+        "latest read must include EditEntries retract entry"
+    );
+
+    let effective_messages = reconstruct_state_from_nats(&entries).next_turn_messages;
+    assert!(
+        !effective_messages
+            .iter()
+            .any(|message| message.content.to_text().contains("please ignore this")),
+        "retracted user text must not survive reconstruct_state_from_nats fold"
+    );
+
+    Ok(())
+}
+
+/// Structural regression guard for #917.
+///
+/// Runtime difference only appears under multi-node replication lag, which CI's
+/// single-node NATS cannot reproduce. If production structure changes
+/// legitimately, update this guard.
+#[test]
+fn injection_decision_points_use_leader_authoritative_read() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let agent_loop = std::fs::read_to_string(manifest_dir.join("src/nats_worker/agent_loop.rs"))
+        .expect("agent_loop.rs must be readable");
+    let daemon = std::fs::read_to_string(manifest_dir.join("src/nats_worker/daemon.rs"))
+        .expect("daemon.rs must be readable");
+
+    assert!(
+        agent_loop.contains("build_mid_turn_injection_callback"),
+        "agent_loop.rs must still define build_mid_turn_injection_callback"
+    );
+    assert!(
+        agent_loop.contains("load_events_latest_async"),
+        "mid-turn injection callback must use load_events_latest_async"
+    );
+    assert!(
+        !agent_loop.contains("load_events_consistent_async"),
+        "agent_loop.rs must not route mid-turn injection through load_events_consistent_async"
+    );
+
+    assert_eq!(
+        daemon
+            .lines()
+            .filter(|line| line.contains("load_events_latest_async()"))
+            .count(),
+        3,
+        "daemon.rs must use load_events_latest_async at exact 3 decision points"
+    );
+    assert_eq!(
+        daemon.matches("load_events_consistent_async").count(),
+        0,
+        "daemon.rs must not use load_events_consistent_async at #917 decision points"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn retracted_user_message_is_not_executed_by_worker() -> Result<()> {
     let Some(server) = require_nats_server().await? else {
@@ -1464,5 +1560,22 @@ async fn retracted_user_message_is_not_executed_by_worker() -> Result<()> {
 
     daemon.abort();
     let _ = daemon.await;
+    Ok(())
+}
+
+/// Exercises the NoMessageFound / empty-stream branch of load_events_latest_async (#917).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn load_events_latest_async_empty_stream_returns_empty() -> Result<()> {
+    let Some(server) = require_nats_server().await? else {
+        return Ok(());
+    };
+
+    let js = local_test_nats(server.url()).await?;
+    let session_id = "latest-tail-empty-stream-test";
+    let log = NatsSessionLog::new(js, session_id);
+
+    let entries = log.load_events_latest_async().await?;
+    assert!(entries.is_empty(), "empty stream should return empty Vec");
+
     Ok(())
 }

--- a/docs/solutions/logic-errors/nats-session-log-leader-authoritative-tail-read-2026-06-25.md
+++ b/docs/solutions/logic-errors/nats-session-log-leader-authoritative-tail-read-2026-06-25.md
@@ -1,0 +1,179 @@
+---
+title: "NATS session-log leader-authoritative tail read for decision points"
+date: 2026-06-25
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-nats-session-log"
+root_cause: "Stale read upper bound via stream.info().last_sequence at decision points could miss client edits/retracts due to NATS replication lag"
+resolution_type: code_fix
+severity: high
+tags:
+  - session-log
+  - NATS
+  - distributed-systems
+  - replication-lag
+  - leader-authoritative
+  - jetstream
+  - testing
+plan_ref: "nats-mid-turn-fresh-read-917"
+---
+
+## Problem
+
+The NATS worker's mid-turn injection decision points read the session log tail using `load_events_consistent_async` → `NatsSessionLog::load_events_at_least_async`, which bounds the upper read sequence by `stream.info().state.last_sequence`. This value reflects only the worker's own `after_seq_observer` high-water and can lag behind client writes committed at higher sequences. A client edit/retract committed above the observer's sequence can be missed, causing retracted or stale messages to be injected.
+
+The fold logic (`apply_log_mutations`) was already correct — the bug was purely in the stale read upper bound.
+
+## Symptoms
+
+- Retracted user messages occasionally injected during mid-turn tool rounds
+- Client edits arriving just before injection decision not observed
+- Bug only reproducible under genuine multi-node NATS replication lag
+- Single-node test environments could not reproduce the failure
+
+## Investigation Steps
+
+1. **Identified decision points**: Found 4 sites where worker must observe latest CLIENT writes:
+   - `agent_loop.rs:111` — mid-turn injection callback (`build_mid_turn_injection_callback`)
+   - `daemon.rs:351` — continuation turn input derivation
+   - `daemon.rs:618` — end-of-turn drain reread
+   - `daemon.rs:747` — `reconstruct_session_state` activation
+
+2. **Traced stale read path**: All 4 sites used `load_events_consistent_async` → `load_events_at_least_async` → `read_all_from`. The upper bound came from `stream.info().state.last_sequence`.
+
+3. **Analyzed observer semantics**: `load_events_at_least_async` waits for the worker's own `after_seq_observer` high-water. Client writes committed after the observer's tracked sequence are NOT guaranteed visible.
+
+4. **Confirmed fold logic correct**: `apply_log_mutations` and `fold_new_user_messages_since` handle EditEntries correctly. Bug confined to read path upper bound.
+
+5. **Researched async-nats API**: Found `Stream::get_last_raw_message_by_subject(&subject)` routes via `STREAM.MSG.GET last_by_subject` to the STREAM LEADER — always authoritative for latest sequence, no `allow_direct` flag needed.
+
+## Root Cause
+
+`stream.info().state.last_sequence` on a NATS JetStream follower returns the follower's locally replicated high-water mark, which can lag behind the leader's actual latest sequence during replication delay. The worker's `after_seq_observer` only tracks the worker's own published sequences, not client-published sequences.
+
+When a client retract/edit commits at sequence X+1 on the leader, and the follower's `stream.info()` reports last_sequence = X, the old read path stops at X and misses the retract. The real bug requires:
+
+- Multi-node NATS cluster
+- `STREAM.INFO` hitting a follower with stale metadata
+- Client write committed to leader but not yet replicated
+
+This divergence is impossible on single-node test environments where `STREAM.INFO` always returns the node's authoritative state.
+
+## Solution
+
+Added `NatsSessionLog::load_events_latest_async` that uses leader-authoritative tail discovery:
+
+```rust
+pub async fn load_events_latest_async(&self) -> Result<Vec<(u64, SessionLogEntry)>> {
+    let stream = self.ensure_stream().await?;
+    match stream.get_last_raw_message_by_subject(&self.subject).await {
+        Ok(latest) => {
+            // Read from start through leader-authoritative latest sequence
+            self.read_range(1, latest.sequence).await
+        }
+        Err(e) => match e.kind() {
+            LastRawMessageErrorKind::NoMessageFound => Ok(vec![]),
+            _ => Err(e).context("get_last_raw_message_by_subject failed"),
+        },
+    }
+}
+```
+
+Key implementation details:
+
+1. **Leader-authoritative discovery**: `get_last_raw_message_by_subject` always reaches the stream leader via `STREAM.MSG.GET last_by_subject` — no replication lag possible.
+
+2. **Empty stream handling**: `NoMessageFound` returns `Ok(vec![])` — clean empty-session semantics.
+
+3. **No stream.info() upper bound**: Reads `1..=latest.sequence` directly, avoiding the stale metadata path entirely.
+
+4. **DRY refactor**: Extracted `read_range(start, last)` helper shared with `read_all_from`.
+
+5. **Thin backend wrapper**: `NatsSessionLogBackend::load_events_latest_async` mirrors existing pattern, no observer argument.
+
+Wired into exactly 4 decision points, replacing the stale reads. Preserved `load_events_consistent_async` / `load_events_at_least_async` unchanged for worker read-your-writes semantics.
+
+## Why This Works
+
+`get_last_raw_message_by_subject` uses JetStream's direct message API (`STREAM.MSG.GET last_by_subject`) which:
+
+- Routes to the STREAM LEADER by definition (leader holds authoritative state)
+- Returns the actual latest message for the subject
+- Provides sequence number that IS the true latest, not a possibly-stale replica view
+
+By discovering the latest sequence from the leader first, then reading the full range, we guarantee observation of any client write committed before the read — regardless of follower replication state.
+
+## Prevention Strategies
+
+### Pattern/Rule
+
+For decision points that MUST observe the latest CLIENT writes (not just the worker's own), use a leader-authoritative read (`get_last_raw_message_by_subject`), NOT `stream.info().last_sequence` which only reflects the local replica state.
+
+**When to use `load_events_latest_async`:**
+- Mid-turn injection decisions
+- Activation/reconstruction requiring latest client state
+- Continuation input derivation
+- Drain decisions before turn completion
+
+**When `load_events_consistent_async` is appropriate:**
+- Read-your-writes semantics (worker observing own writes)
+- High-water observer tracking already correct
+
+### Testing Strategy: Behavioral + Structural Guard
+
+**Critical testing insight**: A deterministic "fail-on-revert" regression test is IMPOSSIBLE on single-node NATS.
+
+Evidence from async-nats 0.42.0 source:
+- `Stream::info()` performs a FRESH `STREAM.INFO` round-trip every call (not cached; `cached_info()` is a separate method)
+- harnx builds a fresh `Stream` handle on every read (`ensure_stream` → `get_or_create_stream` round-trips fresh info)
+- Once a client retract at X+1 is acked, the OLD path's next fresh `STREAM.INFO` also returns last_sequence ≥ X+1
+- Both old and new paths pass any such test — VACUOUS
+
+The real bug requires genuine multi-node `STREAM.INFO`-vs-leader REPLICATION DIVERGENCE, which single-node test servers never exhibit.
+
+**Solution: Option C — documented behavioral + structural guard:**
+
+```rust
+/// #917: Behavioral test proving load_events_latest_async reads leader-authoritative tail
+/// and honors EditEntries retractions via fold.
+///
+/// NOTE: Cannot deterministically fail on revert because single-node NATS
+/// STREAM.INFO is fresh (not cached) and returns same last_sequence as leader.
+/// Real bug multi-node replication lag — see plan note "db530bc1".
+#[tokio::test]
+async fn load_events_latest_async_reads_leader_authoritative_tail() {
+    // 1. Append user message at seq X
+    // 2. Append EditEntries retract at seq X+1
+    // 3. Call load_events_latest_async()
+    // 4. Assert returned entries include X+1
+    // 5. Fold with reconstruct_state_from_nats
+    // 6. Assert retracted text absent from effective messages
+}
+
+/// #917: Structural regression guard for decision-point wiring.
+#[test]
+fn injection_decision_points_use_leader_authoritative_read() {
+    let agent_loop = fs::read_to_string(agent_loop_path).unwrap();
+    let daemon = fs::read_to_string(daemon_path).unwrap();
+    
+    assert!(agent_loop.contains("load_events_latest_async"));
+    assert!(!agent_loop.contains("load_events_consistent_async"));
+    assert_eq!(daemon.matches("load_events_latest_async").count(), 3);
+    assert_eq!(daemon.matches("load_events_consistent_async").count(), 0);
+}
+```
+
+**Reusable testing guidance**: When a bug depends on distributed-systems timing/replication divergence that the test environment can't reproduce, prefer documented behavioral + structural-guard approach over injecting test-only seams into production. Record WHY the stronger test is infeasible.
+
+### Code Review Checklist
+
+- [ ] For decision points requiring latest CLIENT writes: does code use `load_events_latest_async`?
+- [ ] Is `stream.info().last_sequence` avoided for decision-point upper bounds?
+- [ ] If adding a new read path: does it need leader-authoritative or read-your-writes semantics?
+- [ ] Structural guards: anchored with issue reference comments?
+
+## Related Issues
+
+- **GitHub:** [#917](https://github.com/dobesv/harnx/issues/917) — NATS: mid-turn injection uses non-consistent read
+- **Related Solution:** [nats-session-log-mutations-canonical-resolution-2026-06-23.md](nats-session-log-mutations-canonical-resolution-2026-06-23.md) — EditEntries mutation fold (correct, this fix addresses the read path)
+- **Related Solution:** [nats-ha-lease.md](../nats-ha-lease.md) — NATS HA worker lease mechanics


### PR DESCRIPTION
…ion points (#917)

Implement leader-authoritative reads for NATS mid-turn decision points to prevent missing client edits or retractions due to replication lag.

Adds `load_events_latest_async` using `get_last_raw_message_by_subject`, ensuring the read upper bound reflects the leader's state rather than potentially stale local replica info from `stream.info().last_sequence`. Wires this fresh read into four critical sites: mid-turn callback, continuation input derivation, end-of-turn drain, and session activation.

Includes behavioral tests for leader-authoritative tails and empty streams, plus a structural regression guard to ensure decision points don't revert to non-consistent reads. Documents the design decision (Option C) and the limitations of single-node NATS testing for replication-divergence bugs.

Issue: #917
Plan: nats-mid-turn-fresh-read-917

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session history/continuation handling to use the latest persisted session-log tail, reducing missed edits or retractions.
  * Added graceful handling for fresh/empty sessions so event loading returns no events instead of failing.
  * Updated session reconstruction and post-turn logic to reflect the latest persisted changes more reliably.

* **Documentation**
  * Added a new guide explaining the leader-authoritative tail read behavior and where it’s applied to prevent missed updates under replication lag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->