### PR TITLE
feat(nats): add static remote agent catalog to cluster configuration

### DIFF
--- a/.changeset/nats-static-agent-catalog.md
+++ b/.changeset/nats-static-agent-catalog.md
@@ -1,0 +1,5 @@
+---
+harnx: minor
+---
+
+Add an optional `agents:` list to NATS cluster config (`nats_servers/<cluster>.yaml`). Declared remote agents appear as `name@cluster` in `--list-agents`/shell completion, and assistant-role entries also appear in the interactive picker. Static config only — no network calls.

--- a/crates/harnx-runtime/src/config/agent.rs
+++ b/crates/harnx-runtime/src/config/agent.rs
@@ -473,6 +473,7 @@ fn ensure_no_unset_variables(unset_variables: &[&AgentVariable]) -> Result<()> {
 pub fn list_agents() -> Vec<String> {
     let mut output = list_local_agent_names();
     output.extend(list_package_agent_names());
+    output.extend(list_remote_agent_names(None));
     output.sort();
     output.dedup();
     output
@@ -510,6 +511,25 @@ fn list_package_agent_names() -> Vec<String> {
             if let Some(stem) = markdown_stem(&agent_entry.path()) {
                 names.push(format!("{pkg_name}/{stem}"));
             }
+        }
+    }
+    names
+}
+
+fn list_remote_agent_names(role_filter: Option<AgentRole>) -> Vec<String> {
+    let nats_servers_dir = Config::config_dir().join(paths::NATS_SERVERS_DIR_NAME);
+    let Ok(servers) = Config::load_nats_servers_from_dir(&nats_servers_dir) else {
+        return vec![];
+    };
+
+    let mut names = vec![];
+    for server in servers {
+        let cluster_name = server.name;
+        for agent in server.agents {
+            if role_filter.as_ref().is_some_and(|role| agent.role != *role) {
+                continue;
+            }
+            names.push(format!("{}@{}", agent.name, cluster_name));
         }
     }
     names
@@ -584,6 +604,7 @@ pub async fn list_assistant_agents() -> Vec<String> {
     let mut output =
         collect_assistant_agents_in_dir(&Config::agents_config_dir(), |stem| stem.to_string())
             .await;
+    output.extend(list_remote_agent_names(Some(AgentRole::Assistant)));
 
     let packages_dir = harnx_core::config_paths::packages_dir();
     if let Ok(mut pkg_dir) = tokio::fs::read_dir(&packages_dir).await {

--- a/crates/harnx-runtime/src/config/agent_tests.rs
+++ b/crates/harnx-runtime/src/config/agent_tests.rs
@@ -148,6 +148,13 @@ fn assert_path_variable_rejected(name: &str, path: &str) {
     assert!(message.contains("not allowed"));
 }
 
+fn write_remote_cluster_fixture(config_dir: &Path, cluster: &str, body: &str) -> Result<()> {
+    let nats_servers_dir = config_dir.join("nats_servers");
+    fs::create_dir_all(&nats_servers_dir)?;
+    fs::write(nats_servers_dir.join(format!("{cluster}.yaml")), body)?;
+    Ok(())
+}
+
 #[test]
 fn test_agent_from_markdown_full() {
     let content = "---\nmodel: openai:gpt-4o\ntemperature: 0.7\ntop_p: 0.9\nuse_tools: fs,web_search\ndescription: A test agent\nversion: '1.0'\n---\nYou are a helpful test agent.";
@@ -577,6 +584,86 @@ fn test_list_assistant_agents_sorted() {
         let runtime = tokio::runtime::Runtime::new()?;
         let result = runtime.block_on(list_assistant_agents());
         assert_eq!(result, vec!["apple", "mango", "zebra"]);
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_list_agents_merges_remote_and_local_agents() {
+    with_test_config_dir(|config_dir| {
+        let agents_dir = config_dir.join("agents");
+        fs::write(agents_dir.join("zz-local-forge.md"), "You are local forge.")?;
+        write_remote_cluster_fixture(
+            config_dir,
+            "cluster-nats-static-enum",
+            r#"url: nats://localhost:4222
+agents:
+  - name: atlas-forge-remote
+    role: assistant
+  - name: helper-forge-remote
+    role: subagent
+"#,
+        )?;
+
+        let result = list_agents();
+        assert!(result.contains(&"atlas-forge-remote@cluster-nats-static-enum".to_string()));
+        assert!(result.contains(&"helper-forge-remote@cluster-nats-static-enum".to_string()));
+        assert!(result.contains(&"zz-local-forge".to_string()));
+
+        let mut expected = result.clone();
+        expected.sort();
+        expected.dedup();
+        assert_eq!(result, expected);
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_list_assistant_agents_includes_remote_assistants_only() {
+    with_test_config_dir(|config_dir| {
+        write_remote_cluster_fixture(
+            config_dir,
+            "cluster-nats-static-filter",
+            r#"url: nats://localhost:4222
+agents:
+  - name: atlas-filter-remote
+    role: assistant
+  - name: helper-filter-remote
+    role: subagent
+  - name: default-role-remote
+"#,
+        )?;
+
+        let runtime = tokio::runtime::Runtime::new()?;
+        let result = runtime.block_on(list_assistant_agents());
+        assert!(result.contains(&"atlas-filter-remote@cluster-nats-static-filter".to_string()));
+        assert!(result.contains(&"default-role-remote@cluster-nats-static-filter".to_string()));
+        assert!(!result.contains(&"helper-filter-remote@cluster-nats-static-filter".to_string()));
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_agent_lists_ignore_remote_clusters_when_none_seeded() {
+    with_test_config_dir(|config_dir| {
+        let agents_dir = config_dir.join("agents");
+        fs::write(
+            agents_dir.join("solo-local-forge.md"),
+            "You are solo local forge.",
+        )?;
+
+        let all_agents = list_agents();
+        assert_eq!(all_agents, vec!["solo-local-forge"]);
+        assert!(all_agents.iter().all(|name| !name.contains('@')));
+
+        let runtime = tokio::runtime::Runtime::new()?;
+        let assistant_agents = runtime.block_on(list_assistant_agents());
+        assert_eq!(assistant_agents, vec!["solo-local-forge"]);
+        assert!(assistant_agents.iter().all(|name| !name.contains('@')));
+        assert!(!config_dir.join("nats_servers").exists());
         Ok(())
     })
     .unwrap();

--- a/crates/harnx-runtime/src/config/nats_split.rs
+++ b/crates/harnx-runtime/src/config/nats_split.rs
@@ -2,11 +2,21 @@
 use super::*;
 use anyhow::{bail, Context, Result};
 use async_nats::{jetstream, ConnectOptions};
+use harnx_core::agent_config::AgentRole;
 use serde::{Deserialize, Serialize};
 use std::{
     io::BufReader,
     path::{Path, PathBuf},
 };
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoteAgentEntry {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub role: AgentRole,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NatsServerConfig {
@@ -23,6 +33,8 @@ pub struct NatsServerConfig {
     pub tls_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls_ca: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agents: Vec<RemoteAgentEntry>,
 }
 
 impl NatsServerConfig {
@@ -306,6 +318,7 @@ mod tests {
             tls_cert: Some("${NATS_CERT}".into()),
             tls_key: Some("${NATS_KEY}".into()),
             tls_ca: Some("${NATS_CA}".into()),
+            agents: vec![],
         };
         Config::expand_nats_server_envs(&mut server);
 
@@ -314,6 +327,69 @@ mod tests {
         assert_eq!(server.tls_cert.as_deref(), Some("/tmp/client-cert.pem"));
         assert_eq!(server.tls_key.as_deref(), Some("/tmp/client-key.pem"));
         assert_eq!(server.tls_ca.as_deref(), Some("/tmp/ca.pem"));
+    }
+
+    #[test]
+    fn nats_server_config_parses_agents_list_with_description_and_role() {
+        let config: NatsServerConfig = serde_yaml::from_str(
+            r#"
+url: nats://localhost:4222
+agents:
+  - name: forge-atlas
+    description: Handles heavy planning
+    role: subagent
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.url, "nats://localhost:4222");
+        assert_eq!(config.agents.len(), 1);
+        assert_eq!(config.agents[0].name, "forge-atlas");
+        assert_eq!(
+            config.agents[0].description.as_deref(),
+            Some("Handles heavy planning")
+        );
+        assert_eq!(config.agents[0].role, AgentRole::Subagent);
+    }
+
+    #[test]
+    fn nats_server_config_parses_agents_defaults_for_missing_fields() {
+        let config: NatsServerConfig = serde_yaml::from_str(
+            r#"
+url: nats://localhost:4222
+agents:
+  - name: no-description
+    role: subagent
+  - name: no-role
+    description: Defaults role to assistant
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.agents.len(), 2);
+        assert_eq!(config.agents[0].name, "no-description");
+        assert_eq!(config.agents[0].description, None);
+        assert_eq!(config.agents[0].role, AgentRole::Subagent);
+        assert_eq!(config.agents[1].name, "no-role");
+        assert_eq!(
+            config.agents[1].description.as_deref(),
+            Some("Defaults role to assistant")
+        );
+        assert_eq!(config.agents[1].role, AgentRole::Assistant);
+    }
+
+    #[test]
+    fn nats_server_config_parses_without_agents_key_for_back_compat() {
+        let config: NatsServerConfig = serde_yaml::from_str(
+            r#"
+url: nats://localhost:4222
+tls: false
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.url, "nats://localhost:4222");
+        assert!(config.agents.is_empty());
     }
 
     #[test]
@@ -326,6 +402,7 @@ mod tests {
             tls_cert: Some("/tmp/client-cert.pem".into()),
             tls_key: None,
             tls_ca: None,
+            agents: vec![],
         };
 
         let error = build_nats_connect_options(&server).unwrap_err().to_string();
@@ -344,6 +421,7 @@ mod tests {
             tls_cert: Some("/definitely/missing-cert.pem".into()),
             tls_key: Some("/definitely/missing-key.pem".into()),
             tls_ca: None,
+            agents: vec![],
         };
 
         let error = build_nats_connect_options(&server).unwrap_err().to_string();
@@ -364,6 +442,7 @@ mod tests {
             tls_cert: Some("/tmp/client-cert.pem".into()),
             tls_key: Some("/tmp/client-key.pem".into()),
             tls_ca: Some("/tmp/ca.pem".into()),
+            agents: vec![],
         };
 
         let error = build_nats_connect_options(&server).unwrap_err().to_string();

--- a/crates/harnx-runtime/tests/nats_session_delete.rs
+++ b/crates/harnx-runtime/tests/nats_session_delete.rs
@@ -32,6 +32,7 @@ async fn session_delete_removes_stream_and_lease_and_is_idempotent() -> Result<(
             tls_cert: None,
             tls_key: None,
             tls_ca: None,
+            agents: vec![],
         }],
         ..Default::default()
     };

--- a/crates/harnx-runtime/tests/nats_session_log.rs
+++ b/crates/harnx-runtime/tests/nats_session_log.rs
@@ -30,6 +30,7 @@ async fn nats_session_log_round_trips_and_reconstructs() -> Result<()> {
             tls_cert: None,
             tls_key: None,
             tls_ca: None,
+            agents: vec![],
         }],
         ..Default::default()
     };
@@ -82,6 +83,7 @@ async fn nats_session_log_orphan_repair_matches_file_replay() -> Result<()> {
             tls_cert: None,
             tls_key: None,
             tls_ca: None,
+            agents: vec![],
         }],
         ..Default::default()
     };

--- a/crates/harnx-runtime/tests/nats_worker.rs
+++ b/crates/harnx-runtime/tests/nats_worker.rs
@@ -59,6 +59,7 @@ fn local_nats_config(spec: NatsServerSpec<'_>) -> Config {
             tls_cert: None,
             tls_key: None,
             tls_ca: None,
+            agents: vec![],
         }],
         ..Default::default()
     };

--- a/docs/nats-ha.md
+++ b/docs/nats-ha.md
@@ -78,6 +78,30 @@ This works from the CLI, TUI, and ACP server.
 - **New Sessions**: A new session log and lease are created in NATS.
 - **Resuming Sessions**: Clients attach to an existing `session_id`. Multiple clients can attach to the same session simultaneously (Multiplayer Mode).
 
+## Agent Catalog (Static Discovery)
+
+To make remote agents discoverable in shell completion and interactive pickers, you can declare them in your cluster configuration.
+
+Add an `agents:` list to `nats_servers/<cluster>.yaml`:
+
+```yaml
+url: "nats://nats.example.com:4222"
+agents:
+  - name: atlas
+    description: "Main orchestrator"  # Reserved for future use / stored only
+    role: assistant                # Optional: 'assistant' (default) or 'subagent'
+  - name: critic
+    role: subagent
+```
+
+### Discovery Behavior
+
+- **Naming**: Agents appear as `name@cluster`. For example, `name: atlas` in `prod.yaml` surfaces as `atlas@prod`.
+- **Filtering**:
+    - **Shell Completion**: All agents appear in `--list-agents` and tab-completion regardless of role.
+    - **Assistant Picker**: Only agents with `role: assistant` (the default) appear in interactive assistant selection menus. `subagent` entries are excluded from the picker.
+- **Static Config**: This is purely local configuration. Harnx does not perform network calls to discover or list these agents.
+
 ## Control Plane
 
 Clients communicate with the active worker over specific NATS subjects:

--- a/docs/solutions/integration-issues/static-remote-agent-catalog-2026-06-26.md
+++ b/docs/solutions/integration-issues/static-remote-agent-catalog-2026-06-26.md
@@ -1,0 +1,137 @@
+---
+title: "Static remote agent catalog from NATS cluster config"
+date: 2026-06-26
+category: "integration-issues"
+problem_type: integration_issue
+component: "agent-discovery"
+root_cause: "enumeration functions have no Config parameter; needed static path to nats_servers config"
+resolution_type: code_fix
+severity: medium
+tags:
+  - agent-discovery
+  - nats
+  - static-config
+  - remote-agents
+  - serde
+plan_ref: "nats-static-agent-catalog"
+---
+
+## Problem
+
+Agent enumeration functions `list_agents()` and `list_assistant_agents()` are free functions with no `Config` argument. To surface remote agents declared in NATS cluster configs (`nats_servers/<cluster>.yaml`), needed a way to read nats_servers without threading a Config instance through existing call sites.
+
+## Symptoms
+
+- Remote agents defined in NATS cluster YAML were invisible to `--list-agents` and shell completion
+- No mechanism to declare cluster-resident agents for discovery without network calls
+- Existing enumeration functions had no access point to NATS server configs
+
+## Investigation Steps
+
+Analyzed `list_agents()` signature — sync free fn, no Config parameter. Same for `list_assistant_agents()`. Config is loaded lazily in most paths, but these are utility functions called from completion/picker contexts.
+
+Traced the established pattern: `Config::config_dir()` honors `HARNX_CONFIG_DIR`, which `with_test_config_dir` sets. The nats_servers directory lives at `Config::config_dir().join(paths::NATS_SERVERS_DIR_NAME)`.
+
+Key insight: `Config::load_nats_servers_from_dir()` is a static method accepting any directory path. No Config instance needed.
+
+## Root Cause
+
+Enumeration functions were designed for local/package agent discovery only. Remote agents live in a different config namespace (`nats_servers/`), and the free-function signatures prevented passing Config-derived data.
+
+## Solution
+
+Added `RemoteAgentEntry` struct and helper function:
+
+**Struct (nats_split.rs):**
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoteAgentEntry {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub role: AgentRole,
+}
+```
+
+**NatsServerConfig field:**
+
+```rust
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub agents: Vec<RemoteAgentEntry>,
+```
+
+**Helper function (agent.rs):**
+
+```rust
+fn list_remote_agent_names(role_filter: Option<AgentRole>) -> Vec<String> {
+    let nats_servers_dir = Config::config_dir().join(paths::NATS_SERVERS_DIR_NAME);
+    let Ok(servers) = Config::load_nats_servers_from_dir(&nats_servers_dir) else {
+        return vec![];
+    };
+
+    let mut names = vec![];
+    for server in servers {
+        let cluster_name = server.name;
+        for agent in server.agents {
+            if role_filter.as_ref().is_some_and(|role| agent.role != *role) {
+                continue;
+            }
+            names.push(format!("{}@{}", agent.name, cluster_name));
+        }
+    }
+    names
+}
+```
+
+**Wiring:**
+
+```rust
+// list_agents() - all roles
+output.extend(list_remote_agent_names(None));
+
+// list_assistant_agents() - assistant only
+output.extend(list_remote_agent_names(Some(AgentRole::Assistant)));
+```
+
+## Why This Works
+
+**Static on-disk read pattern:** `Config::config_dir()` returns the test-configurable path. `load_nats_servers_from_dir()` parses YAML from that directory. No Config instance, no network I/O, pure filesystem read.
+
+**Role filtering:** `list_agents()` passes `None` (all remote agents). `list_assistant_agents()` passes `Some(Assistant)` (assistant-only).
+
+**Naming:** Format `name@cluster` ensures remote agents never collide with local/package agents.
+
+**Merge pattern:** Extend existing Vec, then `sort()` + `dedup()` — matches prior art in package-agent-discovery.
+
+## Prevention Strategies
+
+**Testing seed pattern:**
+
+```rust
+// In test, seed under with_test_config_dir temp root:
+// <config_dir>/nats_servers/<cluster>.yaml
+// No config.yaml needed — code reads nats_servers/ directly
+```
+
+**Struct literal hygiene:** Adding a field to a serde struct with many manual struct-literal constructions in tests requires updating each literal:
+
+```rust
+// Always add:
+agents: vec![],
+```
+
+Consider `#[serde(default)]` on new fields to minimize breakage, but Rust struct construction still requires all fields when using literals.
+
+**Known caveat:** Single malformed cluster YAML makes `load_nats_servers_from_dir` return `Err`, which maps to `vec![]` — all remote entries silently disappear. Local agents unaffected. Deferred follow-up: log warning instead of swallowing.
+
+**Sync I/O in async:** `list_assistant_agents()` is async but calls `list_remote_agent_names()` which performs sync file reads. Accepted for small config files, consistent with existing pattern. Document as known minor smell.
+
+## Related Issues
+
+- **agent-role-filtering-completions-2026-05-04.md** — Original `AgentRole` enum and `list_assistant_agents()` pattern
+- **package-agent-discovery-paths-2026-05-16.md** — Extend→sort→dedup merge pattern, package scanning
+- **nats-ha-lease.md** — NATS cluster config structure
+- **Plan note `142c5b08`** — Helper design decision
+- **Plan note `ac1f5fa0`** — Static config read path analysis


### PR DESCRIPTION
Add an optional agents: list to NATS cluster configuration files in nats_servers/<cluster>.yaml. This allows remote agents to be declared statically so they appear in agent discovery (e.g., --list-agents, shell completion, and the interactive assistant picker) without requiring network calls or an active NATS connection.

Remote agents are formatted as name@cluster. The discovery logic filters by agent role, ensuring only assistant-role remote agents appear in the assistant picker while all remote agents appear in general listings.

Includes comprehensive unit tests for discovery and role filtering, updated documentation in docs/nats-ha.md, and a new solution document detailing implementation patterns and caveats.

#912

Plan: nats-static-agent-catalog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering agents from static cluster configuration.
  * Agent lists and shell completion now show remote entries using `agent@cluster` format.
  * Interactive assistant selection now includes eligible remote assistant agents.

* **Bug Fixes**
  * Agent listings now merge local and remote entries consistently, with duplicates removed and results sorted.
  * Existing behavior remains unchanged when no remote cluster configuration is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->