### PR TITLE
feat(nats): implement remote session enumeration via KV-backed index

### DIFF
--- a/.changeset/nats-remote-session-enumeration.md
+++ b/.changeset/nats-remote-session-enumeration.md
@@ -1,0 +1,7 @@
+---
+harnx: minor
+---
+
+Enables remote session enumeration for NATS-backed agents in the TUI session picker, CLI `--list-sessions`, and shell completion. 
+
+Previously, remote (`agent@cluster`) sessions were invisible to enumeration tools unless they existed in the local session directory. This change introduces a NATS KV-backed session index (`harnx_sessions`) that workers populate upon session activation and refresh during lease renewal. Clients now automatically route enumeration requests to this remote index when a remote agent is in context, with graceful degradation and timeouts to ensure local operations remain responsive even during NATS connectivity issues.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -189,7 +189,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1898,7 +1898,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2066,7 +2066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4812,7 +4812,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5479,9 +5479,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.15.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a6ceddfe3ce334925e96bf420fdb2dcee5bed6c632a168ece622676dadeaf8a"
+checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -5493,9 +5493,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.15.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cfe16fbe8a314aeec0b861ac24e60b1e123e97634bab045475b9d6a18416fd8"
+checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -5603,7 +5603,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5991,7 +5991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7104,7 +7104,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7172,7 +7172,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7785,7 +7785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8034,7 +8034,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8077,7 +8077,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook 0.3.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9118,7 +9118,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ log = "0.4.20"
 gix = { version = "0.85.0", features = ["blob-diff", "worktree-mutation", "tree-editor", "blocking-network-client"] }
 oci-client = "0.17"
 semver = { version = "1.0", features = ["serde"] }
-mockall = "0.15"
+mockall = "0.14"
 registry-testkit = "0.1"
 shell-words = "1.1.0"
 sha2 = "0.11.0"

--- a/crates/harnx-runtime/src/config/completion_split.rs
+++ b/crates/harnx-runtime/src/config/completion_split.rs
@@ -169,6 +169,53 @@ impl Config {
         };
         fuzzy_filter(values, |v| v.0.as_str(), filter)
     }
+
+    /// Generate tab-completion candidates for session IDs.
+    ///
+    /// This is the async variant that should be used from async contexts (TUI).
+    /// When a remote agent is in context, fetches session IDs from the remote
+    /// NATS KV index with a short timeout for snappy completion. Otherwise,
+    /// returns local session IDs.
+    ///
+    /// # Arguments
+    /// * `cluster` - The cluster name if a remote agent is active, or `None` for local
+    ///
+    /// # Returns
+    /// Session ID strings suitable for completion. Returns empty vec on timeout/error
+    /// (graceful degradation).
+    pub async fn list_sessions_for_completion(&self, cluster: Option<&str>) -> Vec<String> {
+        match cluster {
+            Some(cluster) => {
+                // Short timeout to keep completion snappy; on timeout/error,
+                // fall back to empty vec (graceful degradation).
+                match tokio::time::timeout(
+                    std::time::Duration::from_millis(500),
+                    self.list_remote_sessions_with_meta(cluster),
+                )
+                .await
+                {
+                    Ok(Ok(sessions)) => sessions.into_iter().map(|s| s.id).collect(),
+                    Ok(Err(e)) => {
+                        log::debug!("Remote session completion failed: {:#}", e);
+                        vec![]
+                    }
+                    Err(_) => {
+                        log::debug!("Remote session completion timed out");
+                        vec![]
+                    }
+                }
+            }
+            None => {
+                let config = self.clone();
+                tokio::task::spawn_blocking(move || config.list_sessions())
+                    .await
+                    .unwrap_or_else(|error| {
+                        log::debug!("Local session completion task failed: {error}");
+                        vec![]
+                    })
+            }
+        }
+    }
 }
 
 fn complete_bool(value: bool) -> Vec<String> {
@@ -180,5 +227,85 @@ fn complete_option_bool(value: Option<bool>) -> Vec<String> {
         Some(true) => vec!["false".to_string(), "null".to_string()],
         Some(false) => vec!["true".to_string(), "null".to_string()],
         None => vec!["true".to_string(), "false".to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Test that list_sessions_for_completion returns local sessions when cluster is None.
+    ///
+    /// Creates a temp sessions dir with known session files, verifies that
+    /// `list_sessions_for_completion(None)` returns those session IDs.
+    #[tokio::test]
+    async fn test_list_sessions_for_completion_local_branch() {
+        // Create a temp directory to act as sessions_dir
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let sessions_dir = temp.path();
+
+        // Create session files: session-alpha.yaml, session-beta.yaml
+        let session_alpha = sessions_dir.join("session-alpha.yaml");
+        let session_beta = sessions_dir.join("session-beta.yaml");
+        std::fs::File::create(&session_alpha)
+            .expect("create session-alpha")
+            .write_all(b"id: session-alpha\n")
+            .expect("write session-alpha");
+        std::fs::File::create(&session_beta)
+            .expect("create session-beta")
+            .write_all(b"id: session-beta\n")
+            .expect("write session-beta");
+
+        // Build a minimal Config with sessions_dir_override pointing to temp
+        let config = Config {
+            sessions_dir_override: Some(sessions_dir.to_path_buf()),
+            ..Config::default()
+        };
+
+        // WHEN cluster = None, local branch fires
+        let result = config.list_sessions_for_completion(None).await;
+
+        // THEN result contains our session IDs (sorted alphabetically)
+        assert_eq!(
+            result,
+            vec!["session-alpha", "session-beta"],
+            "cluster=None should return local session IDs from list_sessions()"
+        );
+    }
+
+    /// Test that remote session completion gracefully degrades on unreachable cluster.
+    ///
+    /// Passes a bogus cluster name that has no NATS server; the method should:
+    /// 1. Return an empty Vec (no panic/error)
+    /// 2. Complete within the timeout (~500ms), not hang indefinitely.
+    #[tokio::test]
+    async fn test_remote_completion_graceful_degradation() {
+        let config = Config::default();
+
+        // Start timing before the call
+        let start = std::time::Instant::now();
+
+        // Call with a bogus-unreachable cluster name (no live NATS at this address)
+        let result = config
+            .list_sessions_for_completion(Some("bogus-unreachable-cluster-xyz-9f8e7d"))
+            .await;
+
+        let elapsed = start.elapsed();
+
+        // THEN: graceful degradation — empty vec, no panic
+        assert!(
+            result.is_empty(),
+            "remote completion on unreachable cluster should return empty vec, got: {:?}",
+            result
+        );
+
+        // AND: completes within the timeout budget (500ms + margin)
+        // The implementation uses 500ms timeout; we allow some overhead.
+        assert!(
+            elapsed < std::time::Duration::from_millis(1500),
+            "remote completion should not hang; took {:?}",
+            elapsed
+        );
     }
 }

--- a/crates/harnx-runtime/src/config/session_ops_split.rs
+++ b/crates/harnx-runtime/src/config/session_ops_split.rs
@@ -1,5 +1,25 @@
 //! Session lifecycle and editing methods extracted from config/mod.rs for code health.
 use super::*;
+use crate::nats_admin::kv_bucket_missing;
+use crate::nats_session_index::{self, SessionIndexRecord};
+use std::time::{Duration, UNIX_EPOCH};
+
+/// Convert a `SessionIndexRecord` to `SessionMeta`.
+///
+/// This mapping is used by `list_remote_sessions_with_meta` to translate
+/// NATS KV index records into the picker/CLI-friendly `SessionMeta` format.
+fn session_index_record_to_meta(record: &SessionIndexRecord) -> SessionMeta {
+    SessionMeta {
+        id: record.session_id.clone(),
+        session_id: Some(record.session_id.clone()),
+        working_dir: record.working_dir.clone(),
+        git_branch: record.git_branch.clone(),
+        git_remote: record.git_remote.clone(),
+        terminal_session_id: None,
+        agent_name: Some(record.agent_name.clone()),
+        modified: UNIX_EPOCH.checked_add(Duration::from_secs(record.last_activity)),
+    }
+}
 
 impl Config {
     pub fn use_session(&mut self, session_name: Option<&str>) -> Result<()> {
@@ -388,6 +408,72 @@ impl Config {
         sessions
     }
 
+    /// List remote sessions for a specific NATS cluster.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(vec![])` when the session index bucket does not exist or exists but is empty.
+    ///   These are legitimate "no sessions indexed yet" cases and do not indicate failure.
+    ///
+    /// - `Err(...)` for actual fetch failures: connection refused, auth/permission denied,
+    ///   network timeouts, or errors listing records from an existing bucket. The error
+    ///   message includes the cluster name and root cause for user-facing diagnostics.
+    ///
+    /// This distinction allows callers to differentiate "no remote sessions" from
+    /// "could not reach the cluster" — important for CLI error reporting and TUI visibility.
+    pub async fn list_remote_sessions_with_meta(&self, cluster: &str) -> Result<Vec<SessionMeta>> {
+        let jetstream = match self.nats_jetstream(cluster).await {
+            Ok(js) => js,
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!("Failed to connect to NATS cluster '{cluster}' for session enumeration")
+                });
+            }
+        };
+
+        let store = match jetstream
+            .get_key_value(nats_session_index::SESSION_INDEX_BUCKET)
+            .await
+        {
+            Ok(store) => store,
+            Err(e) => {
+                // Bucket not found -> empty result (no sessions indexed yet).
+                // All other errors (auth, network, permissions) -> propagate as Err.
+                if kv_bucket_missing(&e) {
+                    log::debug!(
+                        "Session index bucket '{}' not found for cluster '{}' (no sessions indexed yet)",
+                        nats_session_index::SESSION_INDEX_BUCKET,
+                        cluster
+                    );
+                    return Ok(vec![]);
+                }
+                return Err(e).with_context(|| {
+                    format!(
+                        "Failed to access session index bucket '{}' for cluster '{cluster}'",
+                        nats_session_index::SESSION_INDEX_BUCKET
+                    )
+                });
+            }
+        };
+
+        let records = match nats_session_index::list_records(&store).await {
+            Ok(records) => records,
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!("Failed to list session index records for cluster '{cluster}'")
+                });
+            }
+        };
+
+        let mut metas: Vec<SessionMeta> = records
+            .into_iter()
+            .map(|record| session_index_record_to_meta(&record))
+            .collect();
+        metas.sort_unstable_by(|left, right| left.id.cmp(&right.id));
+
+        Ok(metas)
+    }
+
     fn collect_session_metas(sessions_dir: &Path, dir: &Path, out: &mut Vec<SessionMeta>) {
         let Ok(entries) = std::fs::read_dir(dir) else {
             return;
@@ -423,5 +509,88 @@ impl Config {
             .as_ref()
             .map(|v| v.compressing())
             .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests_remote_sessions {
+    use super::*;
+
+    #[test]
+    fn test_session_index_record_to_meta_mapping() {
+        let record = SessionIndexRecord {
+            session_id: "test-session-123".to_string(),
+            agent_name: "hephaestus".to_string(),
+            working_dir: Some("/home/user/project".to_string()),
+            git_branch: Some("feature-branch".to_string()),
+            git_remote: Some("git@github.com:org/repo.git".to_string()),
+            last_activity: 1_719_531_234,
+        };
+
+        let meta = session_index_record_to_meta(&record);
+
+        assert_eq!(meta.id, "test-session-123");
+        assert_eq!(meta.session_id.as_deref(), Some("test-session-123"));
+        assert_eq!(meta.working_dir.as_deref(), Some("/home/user/project"));
+        assert_eq!(meta.git_branch.as_deref(), Some("feature-branch"));
+        assert_eq!(
+            meta.git_remote.as_deref(),
+            Some("git@github.com:org/repo.git")
+        );
+        assert!(meta.agent_name.is_some());
+        assert_eq!(meta.agent_name.as_deref(), Some("hephaestus"));
+        assert!(meta.terminal_session_id.is_none());
+        assert!(meta.modified.is_some());
+        let modified = meta.modified.unwrap();
+        assert_eq!(
+            modified.duration_since(UNIX_EPOCH).unwrap().as_secs(),
+            1_719_531_234_u64
+        );
+    }
+
+    #[test]
+    fn test_session_index_record_to_meta_minimal_fields() {
+        let record = SessionIndexRecord {
+            session_id: "minimal-session".to_string(),
+            agent_name: "default".to_string(),
+            working_dir: None,
+            git_branch: None,
+            git_remote: None,
+            last_activity: 0,
+        };
+
+        let meta = session_index_record_to_meta(&record);
+
+        assert_eq!(meta.id, "minimal-session");
+        assert_eq!(meta.session_id.as_deref(), Some("minimal-session"));
+        assert!(meta.working_dir.is_none());
+        assert!(meta.git_branch.is_none());
+        assert!(meta.git_remote.is_none());
+        assert_eq!(meta.agent_name.as_deref(), Some("default"));
+        assert!(meta.terminal_session_id.is_none());
+        assert_eq!(
+            meta.modified
+                .unwrap()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            0_u64
+        );
+    }
+
+    #[test]
+    fn test_session_index_record_to_meta_overflow_yields_none_modified() {
+        let record = SessionIndexRecord {
+            session_id: "overflow-session".to_string(),
+            agent_name: "hephaestus".to_string(),
+            working_dir: None,
+            git_branch: None,
+            git_remote: None,
+            last_activity: u64::MAX,
+        };
+
+        let meta = session_index_record_to_meta(&record);
+
+        assert!(meta.modified.is_none());
     }
 }

--- a/crates/harnx-runtime/src/lib.rs
+++ b/crates/harnx-runtime/src/lib.rs
@@ -21,6 +21,7 @@ pub mod nats_client_session;
 pub mod nats_event_sink;
 pub mod nats_lease;
 pub mod nats_metrics;
+pub mod nats_session_index;
 pub mod nats_session_log;
 pub mod nats_worker;
 pub mod session_cleanup;

--- a/crates/harnx-runtime/src/nats_admin.rs
+++ b/crates/harnx-runtime/src/nats_admin.rs
@@ -1,5 +1,6 @@
 use crate::{
-    config::Config, nats_lease::NatsLeaseConfig, nats_session_log::stream_name_for_session,
+    config::Config, nats_lease::NatsLeaseConfig, nats_session_index,
+    nats_session_log::stream_name_for_session,
 };
 use anyhow::{Context, Result};
 use async_nats::jetstream::{
@@ -30,11 +31,39 @@ pub async fn delete_remote_session(
     let lease_bucket = load_optional_lease_bucket(config, cluster).await?;
     let stream_deleted = delete_session_stream(&jetstream, session_id).await?;
     let lease_deleted = delete_session_lease(lease_bucket, session_id).await?;
+    best_effort_delete_session_index_record(&jetstream, session_id).await;
 
     Ok(SessionDeleteResult {
         stream_deleted,
         lease_deleted,
     })
+}
+
+async fn best_effort_delete_session_index_record(
+    jetstream: &async_nats::jetstream::Context,
+    session_id: &str,
+) {
+    let store = match jetstream
+        .get_key_value(nats_session_index::SESSION_INDEX_BUCKET)
+        .await
+    {
+        Ok(store) => store,
+        Err(error) if kv_bucket_missing(&error) => return,
+        Err(error) => {
+            log::warn!(
+                "failed to open remote session index for cleanup: session_id={} err={error:#}",
+                session_id
+            );
+            return;
+        }
+    };
+
+    if let Err(error) = nats_session_index::delete_record(&store, session_id).await {
+        log::warn!(
+            "failed to delete remote session index record: session_id={} err={error:#}",
+            session_id
+        );
+    }
 }
 
 async fn load_optional_lease_bucket(
@@ -43,8 +72,20 @@ async fn load_optional_lease_bucket(
 ) -> Result<Option<async_nats::jetstream::kv::Store>> {
     match config.nats_kv_bucket(cluster, "harnx_leases").await {
         Ok(bucket) => Ok(Some(bucket)),
-        Err(error) if kv_bucket_missing(&error) => Ok(None),
-        Err(error) => Err(error),
+        Err(error) => {
+            // Check if error chain contains a KeyValueError with bucket-not-found
+            if error
+                .chain()
+                .find_map(|cause| {
+                    cause.downcast_ref::<async_nats::jetstream::context::KeyValueError>()
+                })
+                .is_some_and(kv_bucket_missing)
+            {
+                Ok(None)
+            } else {
+                Err(error)
+            }
+        }
     }
 }
 
@@ -99,17 +140,15 @@ fn delete_stream_missing(kind: &DeleteStreamErrorKind) -> bool {
     }
 }
 
-fn kv_bucket_missing(error: &anyhow::Error) -> bool {
-    error
-        .chain()
-        .find_map(|cause| cause.downcast_ref::<async_nats::jetstream::context::KeyValueError>())
-        .is_some_and(|kv_error| match kv_error.kind() {
-            KeyValueErrorKind::GetBucket => kv_error
-                .source()
-                .and_then(|source| {
-                    source.downcast_ref::<async_nats::jetstream::context::GetStreamError>()
-                })
-                .is_some_and(|stream_error| get_stream_missing(&stream_error.kind())),
-            _ => false,
-        })
+/// Check if an async_nats KeyValueError indicates a missing bucket (stream not found).
+pub(crate) fn kv_bucket_missing(error: &async_nats::jetstream::context::KeyValueError) -> bool {
+    match error.kind() {
+        KeyValueErrorKind::GetBucket => error
+            .source()
+            .and_then(|source| {
+                source.downcast_ref::<async_nats::jetstream::context::GetStreamError>()
+            })
+            .is_some_and(|stream_error| get_stream_missing(&stream_error.kind())),
+        _ => false,
+    }
 }

--- a/crates/harnx-runtime/src/nats_lease.rs
+++ b/crates/harnx-runtime/src/nats_lease.rs
@@ -1,8 +1,10 @@
 use crate::nats_metrics;
+use crate::nats_session_index::{self, update_record_with_revision, SessionIndexRecord};
 use anyhow::{anyhow, bail, Context, Result};
 use async_nats::header::{NATS_EXPECTED_LAST_SUBJECT_SEQUENCE, NATS_MESSAGE_TTL};
 use async_nats::jetstream::{self, context::PublishErrorKind, kv, stream};
 use serde::{Deserialize, Serialize};
+use std::cmp;
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
     Arc,
@@ -18,6 +20,8 @@ pub const DEFAULT_LEASE_TTL: Duration = Duration::from_secs(30);
 pub const DEFAULT_RENEW_INTERVAL: Duration = Duration::from_secs(10);
 pub const DEFAULT_BUCKET_REPLICAS: usize = 1;
 pub const DEFAULT_TOMBSTONE_TTL: Duration = Duration::from_secs(3600);
+const INDEX_REFRESH_RETRY_LIMIT: usize = 3;
+const INDEX_REFRESH_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LeaseRecord {
@@ -60,6 +64,7 @@ pub struct NatsLeaseAcquireParams<'a> {
     pub worker_id: String,
     pub generation: u64,
     pub config: NatsLeaseConfig,
+    pub session_index: Option<kv::Store>,
 }
 
 #[derive(Debug)]
@@ -70,6 +75,7 @@ struct RenewTaskParams {
     state: Arc<LeaseState>,
     renew_interval: Duration,
     session_id: String,
+    session_index: Option<kv::Store>,
 }
 
 #[derive(Debug)]
@@ -99,6 +105,7 @@ impl NatsSessionLease {
             worker_id,
             generation,
             config,
+            session_index,
         } = params;
         config.validate()?;
         let bucket = ensure_lease_bucket(&jetstream, &config).await?;
@@ -142,6 +149,7 @@ impl NatsSessionLease {
             state: Arc::clone(&state),
             renew_interval: config.renew_interval,
             session_id: session_id.to_string(),
+            session_index,
         });
 
         Ok(Some(Self {
@@ -187,10 +195,16 @@ impl NatsSessionLease {
         }
 
         let revision = self.fence_token();
-        self.bucket
+        match self
+            .bucket
             .delete_expect_revision(&self.key, Some(revision))
             .await
-            .with_context(|| format!("Failed to release NATS lease key '{}'", self.key))
+        {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == kv::UpdateErrorKind::WrongLastRevision => Ok(()),
+            Err(error) => Err(anyhow::Error::from(error))
+                .with_context(|| format!("Failed to release NATS lease key '{}'", self.key)),
+        }
     }
 
     pub async fn stop_renewal_for_test(&self) {
@@ -318,6 +332,7 @@ fn spawn_renew_task(params: RenewTaskParams) -> JoinHandle<()> {
         state,
         renew_interval,
         session_id,
+        session_index,
     } = params;
     tokio::spawn(async move {
         let mut ticker = time::interval(renew_interval);
@@ -329,6 +344,33 @@ fn spawn_renew_task(params: RenewTaskParams) -> JoinHandle<()> {
             }
             match renew_once(&jetstream, &bucket, &key, &state).await {
                 Ok(new_revision) => {
+                    if let Some(store) = session_index.as_ref() {
+                        match time::timeout(
+                            INDEX_REFRESH_TIMEOUT,
+                            refresh_session_index_last_activity(store, &session_id),
+                        )
+                        .await
+                        {
+                            Ok(Ok(())) => {}
+                            Ok(Err(error)) => {
+                                warn!(
+                                    "failed to refresh remote session index on lease renew: session_id={} worker_id={} generation={} err={error:#}",
+                                    session_id,
+                                    state.worker_id,
+                                    state.generation
+                                );
+                            }
+                            Err(_) => {
+                                warn!(
+                                    "timed out refreshing remote session index on lease renew: session_id={} worker_id={} generation={} timeout_ms={}",
+                                    session_id,
+                                    state.worker_id,
+                                    state.generation,
+                                    INDEX_REFRESH_TIMEOUT.as_millis()
+                                );
+                            }
+                        }
+                    }
                     info!(
                         "nats lease renewed: session_id={} worker_id={} generation={} revision={new_revision}",
                         session_id,
@@ -390,6 +432,102 @@ async fn renew_once(
     }
 }
 
+async fn refresh_session_index_last_activity(store: &kv::Store, session_id: &str) -> Result<()> {
+    for attempt in 0..INDEX_REFRESH_RETRY_LIMIT {
+        let Some((record, revision)) =
+            nats_session_index::get_record_with_revision(store, session_id).await?
+        else {
+            return Ok(());
+        };
+
+        let updated_record = with_refreshed_last_activity(record)?;
+        match update_record_with_revision(store, &updated_record, revision).await {
+            Ok(_) => return Ok(()),
+            Err(error)
+                if is_wrong_last_revision(&error) && attempt + 1 < INDEX_REFRESH_RETRY_LIMIT =>
+            {
+                continue;
+            }
+            Err(error) if is_wrong_last_revision(&error) => return Ok(()),
+            Err(error) => return Err(error),
+        }
+    }
+
+    Ok(())
+}
+
+fn with_refreshed_last_activity(mut record: SessionIndexRecord) -> Result<SessionIndexRecord> {
+    record.last_activity = cmp::max(
+        record.last_activity.saturating_add(1),
+        unix_timestamp_now()?,
+    );
+    Ok(record)
+}
+
+fn unix_timestamp_now() -> Result<u64> {
+    Ok(std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .context("system clock before unix epoch")?
+        .as_secs())
+}
+
+fn is_wrong_last_revision(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<kv::UpdateError>())
+        .is_some_and(|error| error.kind() == kv::UpdateErrorKind::WrongLastRevision)
+}
+
 fn is_create_conflict(error: &kv::CreateError) -> bool {
     matches!(error.kind(), kv::CreateErrorKind::AlreadyExists)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_refreshed_last_activity_saturates_on_overflow() {
+        let record = SessionIndexRecord {
+            session_id: "overflow-session".to_string(),
+            agent_name: "hephaestus".to_string(),
+            working_dir: None,
+            git_branch: None,
+            git_remote: None,
+            last_activity: u64::MAX,
+        };
+
+        let refreshed = with_refreshed_last_activity(record).expect("refresh should not panic");
+
+        assert_eq!(refreshed.last_activity, u64::MAX);
+    }
+
+    #[test]
+    fn is_wrong_last_revision_detects_wrapped_update_error() {
+        let wrapped_error = Err::<(), _>(anyhow::Error::from(kv::UpdateError::new(
+            kv::UpdateErrorKind::WrongLastRevision,
+        )))
+        .with_context(|| {
+            "Failed to CAS-update session index record for key 'sessions/test/meta' at revision 7"
+        })
+        .expect_err("wrong-last-revision should remain an error");
+
+        assert!(is_wrong_last_revision(&wrapped_error));
+        assert!(!is_wrong_last_revision(&anyhow::anyhow!("unrelated error")));
+    }
+
+    #[tokio::test]
+    async fn best_effort_index_refresh_times_out_without_blocking_long() {
+        let never_returns = async {
+            let store = futures_util::future::pending::<kv::Store>().await;
+            refresh_session_index_last_activity(&store, "session-timeout").await
+        };
+
+        let result = time::timeout(INDEX_REFRESH_TIMEOUT, never_returns).await;
+
+        assert!(
+            result.is_err(),
+            "refresh_session_index_last_activity path should time out when store acquisition never completes"
+        );
+    }
 }

--- a/crates/harnx-runtime/src/nats_session_index.rs
+++ b/crates/harnx-runtime/src/nats_session_index.rs
@@ -1,0 +1,411 @@
+//! Session index metadata for remote NATS session enumeration.
+//!
+//! Session Header is canonical source of this metadata. This index stores a
+//! denormalized copy for enumeration only.
+
+use anyhow::{Context, Result};
+use async_nats::jetstream::{self, kv, stream};
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_BUCKET_REPLICAS: usize = 1;
+
+pub const SESSION_INDEX_BUCKET: &str = "harnx_sessions";
+
+/// Denormalized session metadata copied from Session Header for enumeration.
+/// Session Header remains canonical source of truth.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct SessionIndexRecord {
+    pub session_id: String,
+    pub agent_name: String,
+    pub working_dir: Option<String>,
+    pub git_branch: Option<String>,
+    pub git_remote: Option<String>,
+    pub last_activity: u64,
+}
+
+pub fn session_index_key(session_id: &str) -> String {
+    format!("sessions/{session_id}/meta")
+}
+
+pub async fn ensure_index_bucket(jetstream: &jetstream::Context) -> Result<kv::Store> {
+    match jetstream
+        .create_key_value(kv::Config {
+            bucket: SESSION_INDEX_BUCKET.to_string(),
+            history: 1,
+            num_replicas: DEFAULT_BUCKET_REPLICAS,
+            storage: stream::StorageType::File,
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(bucket) => Ok(bucket),
+        Err(_) => jetstream
+            .get_key_value(SESSION_INDEX_BUCKET)
+            .await
+            .map_err(anyhow::Error::from)
+            .with_context(|| {
+                format!("Failed to open session index bucket '{SESSION_INDEX_BUCKET}'")
+            }),
+    }
+}
+
+pub async fn put_record(store: &kv::Store, record: &SessionIndexRecord) -> Result<u64> {
+    let key = session_index_key(&record.session_id);
+    let payload = serde_json::to_vec(record).with_context(|| {
+        format!(
+            "Failed to serialize session index record '{}'",
+            record.session_id
+        )
+    })?;
+    store
+        .put(&key, payload.into())
+        .await
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("Failed to put session index record for key '{key}'"))
+}
+
+pub async fn get_record(store: &kv::Store, session_id: &str) -> Result<Option<SessionIndexRecord>> {
+    Ok(get_record_with_revision(store, session_id)
+        .await?
+        .map(|(record, _revision)| record))
+}
+
+pub async fn get_record_with_revision(
+    store: &kv::Store,
+    session_id: &str,
+) -> Result<Option<(SessionIndexRecord, u64)>> {
+    let key = session_index_key(session_id);
+    match store.entry(key.clone()).await {
+        Ok(Some(entry)) if matches!(entry.operation, kv::Operation::Put) => {
+            let record: SessionIndexRecord =
+                serde_json::from_slice(&entry.value).with_context(|| {
+                    format!("Failed to deserialize session index record for key '{key}'")
+                })?;
+            Ok(Some((record, entry.revision)))
+        }
+        Ok(Some(_)) | Ok(None) => Ok(None),
+        Err(error) => Err(anyhow::Error::from(error))
+            .with_context(|| format!("Failed to read session index record for key '{key}'")),
+    }
+}
+
+pub async fn list_records(store: &kv::Store) -> Result<Vec<SessionIndexRecord>> {
+    let mut keys = store
+        .keys()
+        .await
+        .map_err(anyhow::Error::from)
+        .with_context(|| {
+            format!("Failed to list keys in session index bucket '{SESSION_INDEX_BUCKET}'")
+        })?;
+    let mut records = Vec::new();
+
+    while let Some(key_result) = keys.next().await {
+        let key = key_result.map_err(anyhow::Error::from).with_context(|| {
+            format!("Failed to enumerate key in session index bucket '{SESSION_INDEX_BUCKET}'")
+        })?;
+
+        match store.entry(key.clone()).await {
+            Ok(Some(entry)) if matches!(entry.operation, kv::Operation::Put) => {
+                match serde_json::from_slice::<SessionIndexRecord>(&entry.value) {
+                    Ok(record) => records.push(record),
+                    Err(error) => warn!(
+                        "skipping invalid session index record: bucket={} key={} error={error:#}",
+                        SESSION_INDEX_BUCKET, key
+                    ),
+                }
+            }
+            Ok(Some(_)) | Ok(None) => {}
+            Err(error) => {
+                return Err(anyhow::Error::from(error)).with_context(|| {
+                    format!("Failed to read session index record for key '{key}'")
+                });
+            }
+        }
+    }
+
+    Ok(records)
+}
+
+pub async fn delete_record(store: &kv::Store, session_id: &str) -> Result<()> {
+    let key = session_index_key(session_id);
+    store
+        .delete(&key)
+        .await
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("Failed to delete session index record for key '{key}'"))
+}
+
+pub async fn update_record_with_revision(
+    store: &kv::Store,
+    record: &SessionIndexRecord,
+    revision: u64,
+) -> Result<u64> {
+    let key = session_index_key(&record.session_id);
+    let payload = serde_json::to_vec(record).with_context(|| {
+        format!(
+            "Failed to serialize session index record '{}'",
+            record.session_id
+        )
+    })?;
+    store
+        .update(&key, payload.into(), revision)
+        .await
+        .map_err(anyhow::Error::from)
+        .with_context(|| {
+            format!(
+                "Failed to CAS-update session index record for key '{key}' at revision {revision}"
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        get_record, get_record_with_revision, list_records, put_record, session_index_key,
+        update_record_with_revision, SessionIndexRecord, SESSION_INDEX_BUCKET,
+    };
+    use async_nats::jetstream::kv::Store;
+
+    // =============================================================================
+    // Test helpers for NATS integration tests
+    // =============================================================================
+
+    /// Get NATS test URL from environment, returning None if not set.
+    /// Tests should skip gracefully when this returns None.
+    fn test_nats_url() -> Option<String> {
+        std::env::var("HARNX_NATS_TEST_URL").ok()
+    }
+
+    /// Connect to JetStream using the test NATS URL.
+    /// Panics if connection fails.
+    async fn connect_jetstream(server_url: &str) -> async_nats::jetstream::Context {
+        let client = async_nats::connect(server_url)
+            .await
+            .expect("connect to test nats");
+        async_nats::jetstream::new(client)
+    }
+
+    /// Ensure the session index bucket exists for testing.
+    async fn ensure_test_bucket(jetstream: &async_nats::jetstream::Context) -> Store {
+        super::ensure_index_bucket(jetstream)
+            .await
+            .expect("ensure bucket")
+    }
+
+    fn sample_record(session_id: &str) -> SessionIndexRecord {
+        SessionIndexRecord {
+            session_id: session_id.to_string(),
+            agent_name: "hephaestus".to_string(),
+            working_dir: Some("/tmp/project".to_string()),
+            git_branch: Some("main".to_string()),
+            git_remote: Some("git@github.com:dobesv/harnx.git".to_string()),
+            last_activity: 1_719_531_234,
+        }
+    }
+
+    #[test]
+    fn session_index_record_json_round_trip() {
+        let record = sample_record("session-123");
+
+        let json = serde_json::to_string(&record).expect("serialize record");
+        let decoded: SessionIndexRecord = serde_json::from_str(&json).expect("deserialize record");
+
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn session_index_key_format_matches_bucket_layout() {
+        assert_eq!(SESSION_INDEX_BUCKET, "harnx_sessions");
+        assert_eq!(session_index_key("abc123"), "sessions/abc123/meta");
+    }
+
+    #[tokio::test]
+    async fn nats_session_index_kv_crud_round_trip() {
+        let Some(server_url) = test_nats_url() else {
+            eprintln!("skipping nats_session_index_kv_crud_round_trip: HARNX_NATS_TEST_URL unset");
+            return;
+        };
+
+        let jetstream = connect_jetstream(&server_url).await;
+        let store = ensure_test_bucket(&jetstream).await;
+
+        let unique = format!("session-index-test-{}", std::process::id());
+        let record = sample_record(&unique);
+        let revision = put_record(&store, &record).await.expect("put record");
+        assert!(revision > 0);
+
+        let loaded = get_record(&store, &unique)
+            .await
+            .expect("get record")
+            .expect("record exists");
+        assert_eq!(loaded, record);
+
+        let (mut cas_record, cas_revision) = get_record_with_revision(&store, &unique)
+            .await
+            .expect("get record with revision")
+            .expect("record with revision exists");
+        assert_eq!(cas_revision, revision);
+        cas_record.last_activity += 1;
+        let updated_revision = update_record_with_revision(&store, &cas_record, cas_revision)
+            .await
+            .expect("cas update record");
+        assert!(updated_revision > cas_revision);
+
+        let listed = list_records(&store).await.expect("list records");
+        assert!(listed.iter().any(|entry| entry.session_id == unique));
+
+        super::delete_record(&store, &unique)
+            .await
+            .expect("delete record");
+        assert!(get_record(&store, &unique)
+            .await
+            .expect("get deleted record")
+            .is_none());
+    }
+
+    /// Integration test for `list_remote_sessions_with_meta` via config.
+    /// Gated on HARNX_NATS_TEST_URL like other NATS integration tests.
+    #[tokio::test]
+    async fn list_remote_sessions_with_meta_returns_records_from_bucket() {
+        use crate::config::{Config, NatsServerConfig};
+
+        let Some(server_url) = test_nats_url() else {
+            eprintln!("skipping list_remote_sessions_with_meta test: HARNX_NATS_TEST_URL unset");
+            return;
+        };
+
+        let jetstream = connect_jetstream(&server_url).await;
+        let store = ensure_test_bucket(&jetstream).await;
+
+        // Write a unique test record
+        let unique = format!("list-remote-test-{}", std::process::id());
+        let record = sample_record(&unique);
+        let _revision = put_record(&store, &record).await.expect("put record");
+
+        // Build a minimal Config with the test cluster
+        let nats_server = NatsServerConfig {
+            name: "test-cluster".into(),
+            url: server_url.clone(),
+            token: None,
+            tls: None,
+            tls_cert: None,
+            tls_key: None,
+            tls_ca: None,
+            agents: vec![],
+        };
+
+        let config = Config {
+            nats_servers: vec![nats_server],
+            ..Config::default()
+        };
+
+        // Call list_remote_sessions_with_meta
+        let metas = config
+            .list_remote_sessions_with_meta("test-cluster")
+            .await
+            .expect("list remote sessions");
+
+        // Verify our record appears
+        let found: Vec<_> = metas.iter().filter(|m| m.id == unique).collect();
+        assert_eq!(found.len(), 1, "expected exactly one matching session");
+        let meta = &found[0];
+        assert_eq!(meta.session_id.as_deref(), Some(unique.as_str()));
+        assert!(meta.agent_name.is_some());
+        assert!(meta.modified.is_some());
+
+        // Cleanup
+        super::delete_record(&store, &unique)
+            .await
+            .expect("delete test record");
+    }
+
+    /// Unit test: verify unreachable cluster returns Err (not Ok(empty)).
+    /// This guards against regressions where network failures were silently
+    /// converted to empty lists.
+    ///
+    /// Uses a 3-second timeout to ensure fast test completion even on CI.
+    #[tokio::test]
+    async fn list_remote_sessions_unreachable_cluster_returns_error() {
+        use crate::config::{Config, NatsServerConfig};
+
+        // Use a bogus URL that will definitely fail to connect
+        // Using a non-routable IP address (198.51.100.1 is in TEST-NET-2, reserved for documentation)
+        let nats_server = NatsServerConfig {
+            name: "unreachable-cluster".into(),
+            url: "nats://198.51.100.1:4222".into(), // non-routable, guaranteed to fail
+            token: None,
+            tls: None,
+            tls_cert: None,
+            tls_key: None,
+            tls_ca: None,
+            agents: vec![],
+        };
+
+        let config = Config {
+            nats_servers: vec![nats_server],
+            ..Config::default()
+        };
+
+        // Bound by timeout to ensure fast test completion
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            config.list_remote_sessions_with_meta("unreachable-cluster"),
+        )
+        .await;
+
+        // Either the connection fails within the timeout (expected), or it times out.
+        // Both are acceptable error outcomes for this test.
+        match result {
+            Ok(Err(_)) => {
+                // Connection failed within timeout - expected behavior
+            }
+            Ok(Ok(sessions)) => {
+                panic!(
+                    "expected Err for unreachable cluster, got Ok({:?})",
+                    sessions
+                );
+            }
+            Err(_timeout) => {
+                // Timed out - also acceptable as "couldn't fetch" outcome
+            }
+        }
+    }
+
+    /// Integration test: missing session index bucket returns Ok(empty) via production API.
+    #[tokio::test]
+    async fn list_remote_sessions_with_meta_on_missing_bucket_returns_empty() {
+        let Some(server_url) = test_nats_url() else {
+            eprintln!("skipping missing bucket test: HARNX_NATS_TEST_URL unset");
+            return;
+        };
+
+        let jetstream = connect_jetstream(&server_url).await;
+        let _ = jetstream.delete_key_value(SESSION_INDEX_BUCKET).await;
+
+        let nats_server = crate::config::NatsServerConfig {
+            name: "test-cluster".to_string(),
+            url: server_url,
+            token: None,
+            tls: None,
+            tls_cert: None,
+            tls_key: None,
+            tls_ca: None,
+            agents: vec![],
+        };
+        let config = crate::config::Config {
+            nats_servers: vec![nats_server],
+            ..crate::config::Config::default()
+        };
+
+        let sessions = config
+            .list_remote_sessions_with_meta("test-cluster")
+            .await
+            .expect("missing bucket should map to empty result");
+
+        assert!(
+            sessions.is_empty(),
+            "expected no sessions when bucket is missing"
+        );
+    }
+}

--- a/crates/harnx-runtime/src/nats_worker/agent_loop.rs
+++ b/crates/harnx-runtime/src/nats_worker/agent_loop.rs
@@ -5,12 +5,14 @@ use crate::agent_loop::OnToolRoundFn;
 use crate::config::{GlobalConfig, Input};
 use crate::nats_lease::NatsSessionLease;
 use crate::nats_metrics;
+use crate::nats_session_index::{put_record, SessionIndexRecord};
 use crate::utils::AbortSignal;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use harnx_core::message::Message;
 use harnx_hooks::{AsyncHookManager, PersistentHookManager};
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Clone)]
 pub struct RunAgentLoopArgs<'a> {
@@ -188,6 +190,7 @@ pub async fn run_agent_loop_with_nats_inner(args: RunAgentLoopArgs<'_>) -> Resul
         config: &config,
         input: &initial_input,
         lease: lease.as_deref(),
+        session_index: None,
         session_id,
         abort_signal: &abort_signal,
     })
@@ -245,6 +248,7 @@ struct LoadOrRepairSessionParams<'a> {
     config: &'a GlobalConfig,
     input: &'a Input,
     lease: Option<&'a NatsSessionLease>,
+    session_index: Option<&'a async_nats::jetstream::kv::Store>,
     session_id: &'a str,
     abort_signal: &'a AbortSignal,
 }
@@ -260,13 +264,15 @@ async fn load_or_repair_session(
         config,
         input,
         lease,
+        session_index,
         session_id,
         abort_signal,
     } = params;
     let entries = backend.load_events_blocking()?;
     if entries.is_empty() {
         // New session: write header and load
-        return write_header_and_load_session(backend, config, input, session_id).await;
+        return write_header_and_load_session(backend, config, input, session_index, session_id)
+            .await;
     }
 
     // Existing session: check effective session log for orphan tool calls and repair with hints
@@ -598,15 +604,66 @@ fn build_remote_session_header(
     Ok(header_session.build_header_entry())
 }
 
+fn build_session_index_record_from_header(
+    header: &harnx_core::session::SessionLogEntry,
+) -> Result<SessionIndexRecord> {
+    let harnx_core::session::SessionLogEntry::Header {
+        session_id,
+        agent_name,
+        working_dir,
+        git_branch,
+        git_remote,
+        ..
+    } = header
+    else {
+        anyhow::bail!("remote session index requires header entry")
+    };
+
+    Ok(SessionIndexRecord {
+        session_id: session_id
+            .clone()
+            .context("remote session header missing session_id")?,
+        agent_name: agent_name
+            .clone()
+            .context("remote session header missing agent_name")?,
+        working_dir: working_dir.clone(),
+        git_branch: git_branch.clone(),
+        git_remote: git_remote.clone(),
+        last_activity: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .context("system clock before unix epoch")?
+            .as_secs(),
+    })
+}
+
+async fn upsert_session_index_record(
+    store: &async_nats::jetstream::kv::Store,
+    header: &harnx_core::session::SessionLogEntry,
+) -> Result<u64> {
+    let record = build_session_index_record_from_header(header)?;
+    put_record(store, &record)
+        .await
+        .with_context(|| format!("put session index record for {}", record.session_id))
+}
+
 /// Write a new session header and load the session.
 pub(crate) async fn write_header_and_load_session(
     backend: &NatsSessionLogBackend,
     config: &GlobalConfig,
     input: &Input,
+    session_index: Option<&async_nats::jetstream::kv::Store>,
     session_id: &str,
 ) -> Result<harnx_core::session::Session> {
     let header = build_remote_session_header(config, input, session_id)?;
     backend.append_event_blocking(&header)?;
+    if let Some(store) = session_index {
+        if let Err(err) = upsert_session_index_record(store, &header).await {
+            log::warn!(
+                "failed to upsert remote session index after header write: session_id={} err={err:#}",
+                session_id
+            );
+        }
+    }
     let entries = backend.load_events_blocking()?;
     crate::nats_session_log::load_session_from_entries(&entries, session_id)
 }

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -9,6 +9,7 @@ use super::control::{control_subject, ControlCommand};
 use crate::config::{GlobalConfig, Input};
 use crate::nats_lease::{NatsLeaseAcquireParams, NatsLeaseConfig, NatsSessionLease};
 use crate::nats_metrics;
+use crate::nats_session_index;
 use anyhow::{Context, Result};
 use async_nats::header::{HeaderValue, NATS_MESSAGE_ID};
 use async_nats::jetstream::{
@@ -212,12 +213,24 @@ pub async fn run_worker_daemon(
         .await
         .with_context(|| format!("create worker consumer '{consumer_name}'"))?;
 
+    let session_index = match nats_session_index::ensure_index_bucket(&jetstream).await {
+        Ok(store) => Some(store),
+        Err(error) => {
+            log::warn!(
+                "session index disabled: failed to ensure harnx_sessions index bucket: {:#}",
+                error
+            );
+            None
+        }
+    };
+
     let runtime = Arc::new(WorkerRuntime {
         config,
         cluster: daemon.cluster.clone(),
         worker_id: daemon.worker_id.clone(),
         lease: daemon.lease,
         jetstream: jetstream.clone(),
+        session_index,
         client,
         call_fn,
         generation: AtomicU64::new(1),
@@ -253,6 +266,7 @@ struct WorkerRuntime {
     worker_id: String,
     lease: NatsLeaseConfig,
     jetstream: jetstream::Context,
+    session_index: Option<async_nats::jetstream::kv::Store>,
     /// Shared NATS client for control-plane subscriptions (cloned per session
     /// rather than reconnecting on each activation).
     client: async_nats::Client,
@@ -288,6 +302,7 @@ impl WorkerRuntime {
             worker_id: self.worker_id.clone(),
             generation,
             config: self.lease.clone(),
+            session_index: self.session_index.clone(),
         })
         .await?
         {
@@ -379,6 +394,7 @@ impl WorkerRuntime {
         lease: &NatsSessionLease,
         per_session: &GlobalConfig,
         backend: &NatsSessionLogBackend,
+        _session_index: Option<&async_nats::jetstream::kv::Store>,
         high_water: Option<u64>,
     ) -> (Input, Option<u64>) {
         let ctx = TurnInputCtx {
@@ -551,6 +567,7 @@ impl WorkerRuntime {
                         &lease,
                         &per_session,
                         &backend,
+                        self.session_index.as_ref(),
                         activation_high_water,
                     )
                     .await;

--- a/crates/harnx-runtime/src/nats_worker/tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests.rs
@@ -1,9 +1,13 @@
 //! Unit tests for nats_worker module.
 
 use crate::config::{self, Config};
+use crate::nats_session_index::{
+    ensure_index_bucket, get_record, session_index_key, SessionIndexRecord,
+};
 use crate::nats_worker::agent_loop::{tool_can_rerun, write_header_and_load_session};
 use crate::nats_worker::run_worker_daemon;
 use anyhow::Context;
+use futures_util::StreamExt;
 use harnx_core::agent_config::AgentConfig;
 use harnx_core::config_data::ConfigData;
 use harnx_core::event::{AgentEvent, AgentEventSink};
@@ -12,8 +16,9 @@ use harnx_core::tool::{ToolCall, ToolDeclaration};
 use serde_json::json;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
+use tokio::sync::Mutex as AsyncMutex;
 
 /// Spawn a local JetStream-enabled nats-server on a free port with an isolated
 /// temp store dir, returning the connect URL, the child process, and the temp
@@ -53,8 +58,8 @@ async fn spawn_test_nats() -> Option<(String, std::process::Child, tempfile::Tem
     None
 }
 
-static CWD_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-static ENV_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+static CWD_MUTEX: LazyLock<std::sync::Mutex<()>> = LazyLock::new(|| std::sync::Mutex::new(()));
+static ENV_MUTEX: LazyLock<AsyncMutex<()>> = LazyLock::new(|| AsyncMutex::new(()));
 
 struct CurrentDirGuard {
     original_dir: PathBuf,
@@ -80,11 +85,8 @@ impl Drop for CurrentDirGuard {
     }
 }
 
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    match ENV_MUTEX.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    }
+async fn env_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    ENV_MUTEX.lock().await
 }
 
 struct TestEnvGuard {
@@ -257,6 +259,17 @@ fn spawn_metis_worker(url: &str) -> tokio::task::JoinHandle<anyhow::Result<()>> 
 }
 
 async fn run_remote_round_trip(parent_config: Config) -> anyhow::Result<()> {
+    run_remote_round_trip_with_session_id(
+        parent_config,
+        crate::nats_worker::new_remote_session_id(),
+    )
+    .await
+}
+
+async fn run_remote_round_trip_with_session_id(
+    parent_config: Config,
+    session_id: String,
+) -> anyhow::Result<()> {
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
     let mut parent_config = parent_config;
@@ -267,7 +280,7 @@ async fn run_remote_round_trip(parent_config: Config) -> anyhow::Result<()> {
     let thin_cfg = crate::ThinClientConfig {
         cluster: "local".to_string(),
         agent: "metis".to_string(),
-        session_id: Some(crate::nats_worker::new_remote_session_id()),
+        session_id: Some(session_id),
     };
     let thin =
         crate::ThinClientSession::from_global_config(thin_cfg, &parent_global_config, abort_signal)
@@ -468,6 +481,7 @@ fn test_non_idempotent_output_is_synthesized() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn remote_header_matches_local_header_source_of_truth() {
+    let _env_guard = env_lock().await;
     let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
         return;
     };
@@ -508,7 +522,7 @@ async fn remote_header_matches_local_header_source_of_truth() {
     let (session, expected_header) = {
         let _cwd_guard = CurrentDirGuard::change_to(&temp_repo_path)
             .expect("must switch into hermetic git repo for header generation");
-        let session = write_header_and_load_session(&backend, &config, &input, session_id)
+        let session = write_header_and_load_session(&backend, &config, &input, None, session_id)
             .await
             .unwrap();
         let expected_header = {
@@ -586,6 +600,7 @@ async fn control_log_append_requires_live_lease() {
             tombstone_ttl: std::time::Duration::from_secs(10),
             ..Default::default()
         },
+        session_index: None,
     })
     .await
     .unwrap()
@@ -635,14 +650,13 @@ fn fixed_prompt_call_fn(reply: &'static str) -> crate::agent_loop::AgentCallFn {
     })
 }
 
-#[allow(clippy::await_holding_lock)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn remote_agent_tool_family_and_nats_call_and_return_round_trip() {
     let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
         return;
     };
 
-    let _env_guard = env_lock();
+    let _env_guard = env_lock().await;
     let mut seeded = seed_remote_config(&url);
     let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
     assert_remote_tool_family(&mut seeded.parent_config);
@@ -656,4 +670,135 @@ async fn remote_agent_tool_family_and_nats_call_and_return_round_trip() {
     let _ = child.kill();
     let _ = child.wait();
     test_result.unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_session_activation_writes_session_index_record() {
+    let server_url = match std::env::var("HARNX_NATS_TEST_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            eprintln!(
+                "skipping remote_session_activation_writes_session_index_record: HARNX_NATS_TEST_URL unset"
+            );
+            return;
+        }
+    };
+
+    let _env_guard = env_lock().await;
+    let mut seeded = seed_remote_config(&server_url);
+    let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
+    assert_remote_tool_family(&mut seeded.parent_config);
+    assert_remote_tool_descriptions(&mut seeded.parent_config);
+
+    // Capture the session_id that will be created so we can assert on it specifically
+    let expected_session_id = crate::nats_worker::new_remote_session_id();
+
+    let client = async_nats::connect(&server_url)
+        .await
+        .expect("connect to test nats");
+    let jetstream = async_nats::jetstream::new(client);
+    let store = ensure_index_bucket(&jetstream)
+        .await
+        .expect("ensure session index bucket");
+
+    let daemon = spawn_metis_worker(&server_url);
+    // Use the expected_session_id in the thin client config
+    let round_trip =
+        run_remote_round_trip_with_session_id(seeded.parent_config, expected_session_id.clone())
+            .await;
+
+    // Assert on the specific session_id we created, not just "first key in bucket"
+    let record = get_record(&store, &expected_session_id)
+        .await
+        .expect("load session index record")
+        .expect("remote session index record exists");
+    assert_eq!(record.session_id, expected_session_id);
+    assert_eq!(record.agent_name, "metis");
+    assert!(record.last_activity > 0);
+
+    daemon.abort();
+    let _ = daemon.await;
+    round_trip.expect("remote round trip must succeed");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_session_renew_updates_last_activity_without_clobbering_header_fields() {
+    let server_url = match std::env::var("HARNX_NATS_TEST_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            eprintln!(
+                "skipping remote_session_renew_updates_last_activity_without_clobbering_header_fields: HARNX_NATS_TEST_URL unset"
+            );
+            return;
+        }
+    };
+
+    let _env_guard = env_lock().await;
+    let mut seeded = seed_remote_config(&server_url);
+    let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
+    assert_remote_tool_family(&mut seeded.parent_config);
+    assert_remote_tool_descriptions(&mut seeded.parent_config);
+
+    // Capture the session_id that will be created so we can assert on it specifically
+    let expected_session_id = crate::nats_worker::new_remote_session_id();
+
+    let client = async_nats::connect(&server_url)
+        .await
+        .expect("connect to test nats");
+    let jetstream = async_nats::jetstream::new(client);
+    let store = ensure_index_bucket(&jetstream)
+        .await
+        .expect("ensure session index bucket");
+
+    let daemon = spawn_metis_worker(&server_url);
+    // Use the expected_session_id in the thin client config
+    let round_trip =
+        run_remote_round_trip_with_session_id(seeded.parent_config, expected_session_id.clone())
+            .await;
+
+    // Assert on the specific session_id we created, not just "first key in bucket"
+    let first_record = get_record(&store, &expected_session_id)
+        .await
+        .expect("load initial session index record")
+        .expect("initial session index record exists");
+    let first_last_activity = first_record.last_activity;
+
+    let record_key = session_index_key(&expected_session_id);
+    let mut watcher = store
+        .watch(record_key.clone())
+        .await
+        .expect("watch session index record");
+
+    let mut refreshed_record: Option<SessionIndexRecord> = None;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    while tokio::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let Some(entry) = tokio::time::timeout(remaining, watcher.next())
+            .await
+            .expect("timed out waiting for renewed session index record")
+        else {
+            break;
+        };
+        let entry = entry.expect("watch entry result");
+        if !matches!(entry.operation, async_nats::jetstream::kv::Operation::Put) {
+            continue;
+        }
+        let record: SessionIndexRecord =
+            serde_json::from_slice(&entry.value).expect("deserialize watched session index record");
+        if record.session_id == expected_session_id && record.last_activity > first_last_activity {
+            refreshed_record = Some(record);
+            break;
+        }
+    }
+
+    let refreshed_record = refreshed_record.expect("renew should refresh last_activity");
+    assert!(refreshed_record.last_activity > first_last_activity);
+    assert_eq!(refreshed_record.agent_name, first_record.agent_name);
+    assert_eq!(refreshed_record.working_dir, first_record.working_dir);
+    assert_eq!(refreshed_record.git_branch, first_record.git_branch);
+    assert_eq!(refreshed_record.git_remote, first_record.git_remote);
+
+    daemon.abort();
+    let _ = daemon.await;
+    round_trip.expect("remote round trip must succeed");
 }

--- a/crates/harnx-runtime/tests/nats_lease.rs
+++ b/crates/harnx-runtime/tests/nats_lease.rs
@@ -41,6 +41,7 @@ async fn lease_contention_allows_exactly_one_holder() -> Result<()> {
         worker_id: "worker-a".to_string(),
         generation: 1,
         config: cfg.clone(),
+        session_index: None,
     })
     .await?;
     let two = NatsSessionLease::acquire(harnx_runtime::nats_lease::NatsLeaseAcquireParams {
@@ -49,6 +50,7 @@ async fn lease_contention_allows_exactly_one_holder() -> Result<()> {
         worker_id: "worker-b".to_string(),
         generation: 1,
         config: cfg.clone(),
+        session_index: None,
     })
     .await?;
 
@@ -82,6 +84,7 @@ async fn lease_release_succeeds_after_renewals() -> Result<()> {
         worker_id: "worker-a".to_string(),
         generation: 1,
         config: cfg,
+        session_index: None,
     })
     .await?
     .context("acquire")?;
@@ -108,6 +111,7 @@ async fn lease_release_succeeds_after_renewals() -> Result<()> {
         worker_id: "worker-b".to_string(),
         generation: 2,
         config: fast_lease_config(),
+        session_index: None,
     })
     .await?;
     assert!(
@@ -133,6 +137,7 @@ async fn lease_failover_after_holder_stops_renewing() -> Result<()> {
         worker_id: "worker-a".to_string(),
         generation: 1,
         config: cfg.clone(),
+        session_index: None,
     })
     .await?
     .context("first acquire")?;
@@ -149,6 +154,7 @@ async fn lease_failover_after_holder_stops_renewing() -> Result<()> {
                 worker_id: "worker-b".to_string(),
                 generation: 1,
                 config: cfg.clone(),
+                session_index: None,
             })
             .await?
         {
@@ -178,6 +184,7 @@ async fn lease_renewal_survives_long_operation() -> Result<()> {
         worker_id: "worker-a".to_string(),
         generation: 1,
         config: cfg,
+        session_index: None,
     })
     .await?
     .context("acquire")?;
@@ -209,6 +216,7 @@ async fn lease_loss_is_signalled_on_watch() -> Result<()> {
         worker_id: "worker-a".to_string(),
         generation: 1,
         config: cfg,
+        session_index: None,
     })
     .await?
     .context("acquire")?;

--- a/crates/harnx-runtime/tests/nats_session_delete.rs
+++ b/crates/harnx-runtime/tests/nats_session_delete.rs
@@ -11,6 +11,9 @@ use harnx_runtime::{
     config::Config,
     nats_admin::delete_remote_session,
     nats_lease::NatsLeaseConfig,
+    nats_session_index::{
+        delete_record, ensure_index_bucket, get_record, put_record, SessionIndexRecord,
+    },
     nats_session_log::{stream_name_for_session, NatsSessionLog},
 };
 use indexmap::IndexMap;
@@ -56,12 +59,24 @@ async fn session_delete_removes_stream_and_lease_and_is_idempotent() -> Result<(
             worker_id: "w1".to_string(),
             generation: 1,
             config: NatsLeaseConfig::default(),
+            session_index: None,
         },
     )
     .await?
     .expect("lease acquired");
     let lease_key = NatsLeaseConfig::default().key_for_session(session_id);
     lease.stop_renewal_for_test().await;
+
+    let index_store = ensure_index_bucket(&jetstream).await?;
+    let index_record = SessionIndexRecord {
+        session_id: session_id.to_string(),
+        agent_name: "oracle".to_string(),
+        working_dir: Some("/tmp".to_string()),
+        git_branch: Some("main".to_string()),
+        git_remote: Some("origin".to_string()),
+        last_activity: 1_700_000_000,
+    };
+    put_record(&index_store, &index_record).await?;
 
     let deleted = delete_remote_session(&config, "local", session_id).await?;
     assert!(deleted.stream_deleted);
@@ -89,9 +104,16 @@ async fn session_delete_removes_stream_and_lease_and_is_idempotent() -> Result<(
             )
     );
 
+    assert!(
+        get_record(&index_store, session_id).await?.is_none(),
+        "session index record should be removed"
+    );
+
     let deleted_again = delete_remote_session(&config, "local", session_id).await?;
     assert!(!deleted_again.stream_deleted);
     assert!(!deleted_again.lease_deleted);
+
+    delete_record(&index_store, session_id).await.ok();
 
     Ok(())
 }

--- a/crates/harnx-runtime/tests/nats_worker.rs
+++ b/crates/harnx-runtime/tests/nats_worker.rs
@@ -957,6 +957,7 @@ async fn fenced_sink_rejects_append_when_lease_lost() -> Result<()> {
                 renew_interval: Duration::from_secs(10),
                 ..Default::default()
             },
+            session_index: None,
         })
         .await?
         .expect("acquire"),
@@ -1043,6 +1044,7 @@ async fn resume_aborts_when_tail_fence_exceeds_held_revision() -> Result<()> {
                 renew_interval: Duration::from_secs(10),
                 ..Default::default()
             },
+            session_index: None,
         })
         .await?
         .expect("acquire"),

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1720,7 +1720,7 @@ impl Tui {
                     return;
                 }
                 Some(PickerCommand::Session) => {
-                    self.open_session_picker();
+                    self.open_session_picker().await;
                     return;
                 }
                 None => return,
@@ -1869,6 +1869,22 @@ impl Tui {
             } else {
                 Vec::new()
             };
+
+            // When completing .session in remote-agent context, use the async
+            // helper that queries the NATS KV index with a short timeout.
+            // Otherwise, fall back to local sessions.
+            if cmd == ".session" && args.len() == 1 {
+                let cluster = self
+                    .config
+                    .read()
+                    .remote_agent
+                    .as_ref()
+                    .map(|(_, c)| c.clone());
+                let cfg = self.config.read().clone();
+                let sessions = cfg.list_sessions_for_completion(cluster.as_deref()).await;
+                return sessions.into_iter().map(|s| (s, None)).collect();
+            }
+
             return self
                 .config
                 .read()
@@ -1886,8 +1902,33 @@ impl Tui {
         });
     }
 
-    fn open_session_picker(&mut self) {
-        let sessions = self.config.read().list_sessions_with_meta();
+    pub(crate) async fn open_session_picker(&mut self) {
+        let (is_remote, cluster) = {
+            let cfg = self.config.read();
+            if let Some((_, ref cluster)) = cfg.remote_agent {
+                (true, cluster.clone())
+            } else {
+                (false, String::new())
+            }
+        };
+
+        let (sessions, fetch_error) = if is_remote {
+            let cfg = self.config.read().clone();
+            match cfg.list_remote_sessions_with_meta(&cluster).await {
+                Ok(s) => (s, None),
+                Err(e) => {
+                    log::warn!(
+                        "Failed to list remote sessions for cluster '{}': {:#}",
+                        cluster,
+                        e
+                    );
+                    (vec![], Some(format!("remote sessions unavailable: {e:#}")))
+                }
+            }
+        } else {
+            (self.config.read().list_sessions_with_meta(), None)
+        };
+
         let ctx = build_picker_context();
         let sessions = sort_sessions_for_picker(sessions, &ctx);
         let origin_agent = self
@@ -1907,6 +1948,7 @@ impl Tui {
             selected: 0,
             origin_agent,
             origin_session,
+            error: fetch_error,
         });
     }
 
@@ -1917,12 +1959,15 @@ impl Tui {
     ) {
         match outcome {
             harnx_runtime::commands::CommandOutcome::Continue => {
-                let cfg = self.config.read();
-                let curr_agent = cfg.agent.as_ref().map(|a| a.name().to_string());
-                let session_missing = cfg.session.is_none();
-                drop(cfg);
+                let (curr_agent, session_missing) = {
+                    let cfg = self.config.read();
+                    (
+                        cfg.agent.as_ref().map(|a| a.name().to_string()),
+                        cfg.session.is_none(),
+                    )
+                };
                 if prev_agent != curr_agent && session_missing {
-                    self.open_session_picker();
+                    self.open_session_picker().await;
                 }
             }
             harnx_runtime::commands::CommandOutcome::Exit => {
@@ -1932,7 +1977,7 @@ impl Tui {
                 self.open_agent_picker().await;
             }
             harnx_runtime::commands::CommandOutcome::OpenSessionPicker => {
-                self.open_session_picker();
+                self.open_session_picker().await;
             }
         }
     }
@@ -2343,6 +2388,7 @@ impl Tui {
                                 selected: 0,
                                 origin_agent: prev_agent,
                                 origin_session: prev_session,
+                                error: None,
                             });
                         }
                     }
@@ -2351,6 +2397,7 @@ impl Tui {
                         selected,
                         origin_agent,
                         origin_session,
+                        error: _error,
                     }) => {
                         // Index 0 = "New session"; index N (1‥) = sessions[N-1].
                         if selected == 0 {
@@ -2361,6 +2408,7 @@ impl Tui {
                                     selected,
                                     origin_agent,
                                     origin_session,
+                                    error: None,
                                 });
                                 return Err(e);
                             }
@@ -2384,6 +2432,7 @@ impl Tui {
                                 selected,
                                 origin_agent,
                                 origin_session,
+                                error: None,
                             });
                         } else {
                             // Existing session at sessions[selected - 1].
@@ -2395,6 +2444,7 @@ impl Tui {
                                     selected,
                                     origin_agent,
                                     origin_session,
+                                    error: None,
                                 });
                                 return Err(e);
                             }
@@ -2439,6 +2489,7 @@ impl Tui {
                 if let Some(crate::types::ModalState::SessionPicker {
                     origin_session,
                     origin_agent,
+                    error: _,
                     ..
                 }) = self.app.modal.as_ref()
                 {
@@ -2480,6 +2531,7 @@ impl Tui {
                     if let Some(crate::types::ModalState::SessionPicker {
                         origin_agent,
                         origin_session,
+                        error: _,
                         ..
                     }) = self.app.modal.take()
                     {

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -239,7 +239,32 @@ impl Tui {
         if config.read().session.is_none() {
             // sessions_dir() is already scoped to the active agent, so no
             // extra agent_name filter is needed here.
-            let sessions = config.read().list_sessions_with_meta();
+            let (is_remote, cluster) = {
+                let cfg = config.read();
+                if let Some((_, ref cluster)) = cfg.remote_agent {
+                    (true, cluster.clone())
+                } else {
+                    (false, String::new())
+                }
+            };
+
+            let (sessions, fetch_error) = if is_remote {
+                let cfg = config.read().clone();
+                match cfg.list_remote_sessions_with_meta(&cluster).await {
+                    Ok(s) => (s, None),
+                    Err(e) => {
+                        log::warn!(
+                            "Failed to list remote sessions for cluster '{}': {:#}",
+                            cluster,
+                            e
+                        );
+                        (vec![], Some(format!("remote sessions unavailable: {e:#}")))
+                    }
+                }
+            } else {
+                (config.read().list_sessions_with_meta(), None)
+            };
+
             let ctx = build_picker_context();
             let sorted = sort_sessions_for_picker(sessions, &ctx);
             // Always show picker when agent active but no session — even empty list
@@ -251,6 +276,7 @@ impl Tui {
                 selected: 0,
                 origin_agent,
                 origin_session,
+                error: fetch_error,
             });
         }
         None

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -832,7 +832,10 @@ impl Tui {
                 );
             }
             ModalState::SessionPicker {
-                sessions, selected, ..
+                sessions,
+                selected,
+                error,
+                ..
             } => {
                 let title = "Select Session";
                 let footer = "↑↓ navigate  Enter select  Esc cancel";
@@ -851,11 +854,16 @@ impl Tui {
                     };
                     format!("{}  {}  {}", s.id, branch, cwd_tail)
                 }));
+                // Prepend error message if present (visible in picker)
+                if let Some(err) = error {
+                    items.insert(0, format!("⚠ {}", err));
+                }
                 self.render_list_modal(
                     frame,
                     screen_size,
                     &items,
-                    *selected,
+                    // Adjust selected index if error message is prepended
+                    session_picker_highlight_index(*selected, error.is_some()),
                     ListModalOpts {
                         title,
                         footer,
@@ -1523,5 +1531,28 @@ impl Tui {
         let shortcuts_para =
             Paragraph::new(shortcuts_text).style(Style::default().fg(Color::DarkGray));
         frame.render_widget(shortcuts_para, footer_chunks[1]);
+    }
+}
+
+pub(crate) fn session_picker_highlight_index(selected: usize, has_error: bool) -> usize {
+    if has_error {
+        selected + 1
+    } else {
+        selected
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_picker_highlight_index() {
+        // - error: Some, selected: 0 → highlighted display row is "✦ New session" (display index 1), NOT the ⚠ error row (index 0).
+        assert_eq!(session_picker_highlight_index(0, true), 1);
+        // - error: Some, selected: 1 → highlighted display row is the first session (display index 2).
+        assert_eq!(session_picker_highlight_index(1, true), 2);
+        // - error: None, selected: 0 → highlighted row is "New session" (display index 0).
+        assert_eq!(session_picker_highlight_index(0, false), 0);
     }
 }

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -7300,6 +7300,7 @@ async fn session_picker_esc_without_prior_session_goes_back_to_agent_picker() {
         selected: 0,
         origin_agent: None, // came from AgentPicker during startup
         origin_session: None,
+        error: None,
     });
 
     tui.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
@@ -7353,6 +7354,7 @@ async fn session_picker_esc_with_agent_origin_but_no_session_exits() {
         selected: 0,
         origin_agent: Some("hermes".to_string()), // direct startup with -a hermes
         origin_session: None,
+        error: None,
     });
 
     tui.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
@@ -7477,6 +7479,7 @@ async fn picker_ctrl_d_exits_from_session_picker() {
         selected: 0,
         origin_agent: Some("hermes".to_string()),
         origin_session: None,
+        error: None,
     });
 
     tui.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL))
@@ -7507,6 +7510,7 @@ async fn picker_ctrl_c_exits_from_session_picker() {
         selected: 0,
         origin_agent: None,
         origin_session: None,
+        error: None,
     });
 
     tui.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL))
@@ -7604,6 +7608,7 @@ async fn session_picker_enter_loads_selected_session() {
         selected: 1,
         origin_agent: None,
         origin_session: None,
+        error: None,
     });
 
     tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
@@ -7695,6 +7700,7 @@ async fn session_picker_enter_reconciles_from_origin_not_current_agent() {
         selected: 0,
         origin_agent: Some("apollo".to_string()),
         origin_session: None,
+        error: None,
     });
 
     tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
@@ -7747,6 +7753,7 @@ async fn session_picker_esc_restores_origin() {
         selected: 0,
         origin_agent: Some("apollo".to_string()),
         origin_session: Some("old-session".to_string()),
+        error: None,
     });
 
     tui.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
@@ -7767,6 +7774,130 @@ async fn session_picker_esc_restores_origin() {
         Some("old-session"),
         "should restore origin session"
     );
+}
+
+// =============================================================================
+// SessionPicker Error Display Tests
+// =============================================================================
+
+/// Verify that SessionPicker can carry an error message from remote fetch failures.
+#[tokio::test]
+async fn session_picker_carries_error_on_remote_fetch_failure() {
+    use crate::types::ModalState;
+
+    // Create a SessionPicker with an error message (simulating remote fetch failure)
+    let error_msg = "remote sessions unavailable: connection refused".to_string();
+    let picker = ModalState::SessionPicker {
+        sessions: vec![],
+        selected: 0,
+        origin_agent: Some("apollo".to_string()),
+        origin_session: None,
+        error: Some(error_msg.clone()),
+    };
+
+    // Verify the error field is correctly set
+    match picker {
+        ModalState::SessionPicker { error, .. } => {
+            assert!(error.is_some(), "expected Some(error)");
+            assert_eq!(error.unwrap(), error_msg);
+        }
+        _ => panic!("expected SessionPicker"),
+    }
+}
+
+/// Verify that SessionPicker with no remote error has error: None.
+#[tokio::test]
+async fn session_picker_no_error_on_successful_fetch() {
+    use crate::types::ModalState;
+
+    let picker = ModalState::SessionPicker {
+        sessions: vec![],
+        selected: 0,
+        origin_agent: Some("apollo".to_string()),
+        origin_session: None,
+        error: None,
+    };
+
+    match picker {
+        ModalState::SessionPicker { error, .. } => {
+            assert!(error.is_none(), "expected None for successful fetch");
+        }
+        _ => panic!("expected SessionPicker"),
+    }
+}
+
+#[tokio::test]
+async fn session_picker_delivery_path_carries_error() {
+    use crate::test_utils::TuiTestHarness;
+    use harnx_runtime::config::{Config, NatsServerConfig};
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    let nats_server = NatsServerConfig {
+        name: "unreachable-cluster".into(),
+        url: "nats://198.51.100.1:4222".into(), // non-routable, guaranteed to fail
+        token: None,
+        tls: None,
+        tls_cert: None,
+        tls_key: None,
+        tls_ca: None,
+        agents: vec![],
+    };
+
+    let config = Config {
+        nats_servers: vec![nats_server],
+        remote_agent: Some(("some-agent".to_string(), "unreachable-cluster".to_string())),
+        ..Config::default()
+    };
+
+    let global_config = Arc::new(RwLock::new(config));
+    let mut harness = TuiTestHarness::with_config(global_config).await;
+
+    // Invoke the real delivery path with a timeout to ensure fast test completion.
+    // The connection to a non-routable IP should fail well within 3 seconds.
+    let picker_result = tokio::time::timeout(
+        std::time::Duration::from_secs(3),
+        harness.tui().open_session_picker(),
+    )
+    .await;
+
+    // Extract the modal state - either we got an error within the timeout, or we timed out.
+    // Both are acceptable error outcomes for the "unreachable cluster" scenario.
+    match picker_result {
+        Ok(()) => {
+            // open_session_picker completed within timeout
+            let modal = harness
+                .tui()
+                .app
+                .modal
+                .as_ref()
+                .expect("expected modal to be open");
+            match modal {
+                crate::types::ModalState::SessionPicker {
+                    error, sessions, ..
+                } => {
+                    assert!(
+                        error.is_some(),
+                        "expected error field to be set due to failed fetch"
+                    );
+                    assert!(
+                        error
+                            .as_ref()
+                            .unwrap()
+                            .contains("remote sessions unavailable"),
+                        "error message should indicate failure: {}",
+                        error.as_ref().unwrap()
+                    );
+                    assert!(sessions.is_empty(), "sessions should be empty on error");
+                }
+                _ => panic!("expected ModalState::SessionPicker"),
+            }
+        }
+        Err(_timeout) => {
+            // Timed out waiting for picker - also acceptable as "couldn't fetch" outcome
+            // This tests that the timeout bound works correctly
+        }
+    }
 }
 
 // =============================================================================

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -214,6 +214,10 @@ pub(super) enum ModalState {
         origin_agent: Option<String>,
         /// Session id *before* the picker flow started (pre-activation).
         origin_session: Option<String>,
+        /// Error message when remote session fetch failed. Displayed visibly
+        /// in the picker so users know the cluster was unreachable, rather
+        /// than seeing an empty list and assuming no sessions exist.
+        error: Option<String>,
     },
 }
 

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -37,6 +37,7 @@ use harnx_hooks::{
     PersistentHookManager,
 };
 use harnx_render::{render_error, MarkdownRender};
+use harnx_runtime::config::SessionMeta;
 use harnx_runtime::utils::*;
 
 use anyhow::{bail, Result};
@@ -46,6 +47,61 @@ use std::{env, path::PathBuf, sync::Arc, time::Duration};
 
 use harnx_core::sink::emit_agent_event;
 use harnx_runtime::session_cleanup::{humanize_bytes, run_cleanup, CleanupStats};
+
+/// Routing decision for `--list-sessions` handler.
+/// Extracted as a pure function for testability.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ListSessionsTarget {
+    /// List sessions from the local session directory.
+    Local,
+    /// List sessions from a remote NATS cluster.
+    Remote { cluster: String },
+}
+
+/// Pure routing decision for `--list-sessions`.
+/// Given the remote agent context, returns whether to list local or remote sessions.
+///
+/// This function encapsulates the branch selection logic so it can be unit-tested
+/// without requiring a live NATS cluster or mocking async I/O.
+pub fn resolve_list_sessions_target(remote_agent: Option<&(String, String)>) -> ListSessionsTarget {
+    match remote_agent {
+        Some((_, cluster)) => ListSessionsTarget::Remote {
+            cluster: cluster.clone(),
+        },
+        None => ListSessionsTarget::Local,
+    }
+}
+
+/// Format session metadata as one ID per line.
+/// This helper is extracted for testability without touching stdout.
+pub fn format_sessions_for_output(sessions: &[SessionMeta]) -> String {
+    let ids: Vec<&str> = sessions.iter().map(|s| s.id.as_str()).collect();
+    ids.join("\n")
+}
+
+/// Outcome of a remote list-sessions operation.
+/// This pure helper enables unit-testing the error-propagation path without
+/// mocking the async NATS client or relying on assertion side-effects.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ListSessionsOutcome {
+    /// Sessions fetched successfully; output to be printed to stdout.
+    Print(String),
+    /// Remote fetch failed; error message for stderr and non-zero exit.
+    Error(String),
+}
+
+/// Map a remote list-sessions result to an outcome for the CLI.
+/// Ok(sessions) → Print(formatted output)
+/// Err(e) → Error(error message)
+///
+/// This helper exists to make error-propagation genuinely testable.
+/// The handler calls this and then performs the actual println/eprintln/return-Err.
+pub fn remote_list_outcome(result: Result<Vec<SessionMeta>, anyhow::Error>) -> ListSessionsOutcome {
+    match result {
+        Ok(sessions) => ListSessionsOutcome::Print(format_sessions_for_output(&sessions)),
+        Err(e) => ListSessionsOutcome::Error(format!("{e:#}")),
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -257,8 +313,29 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
         }
     }
     if cli.list_sessions {
-        let sessions = config.read().list_sessions().join("\n");
-        println!("{sessions}");
+        // Use the pure routing decision function for branch selection.
+        // This logic is now unit-testable via resolve_list_sessions_target.
+        let target = resolve_list_sessions_target(config.read().remote_agent.as_ref());
+        match target {
+            ListSessionsTarget::Remote { cluster } => {
+                // Clone config to avoid holding lock across await
+                let cfg = config.read().clone();
+                let result = cfg.list_remote_sessions_with_meta(&cluster).await;
+                match remote_list_outcome(result) {
+                    ListSessionsOutcome::Print(output) => {
+                        println!("{output}");
+                    }
+                    ListSessionsOutcome::Error(msg) => {
+                        eprintln!("error: could not list sessions for cluster '{cluster}': {msg}");
+                        return Err(anyhow::anyhow!("{msg}"));
+                    }
+                }
+            }
+            ListSessionsTarget::Local => {
+                let sessions = config.read().list_sessions().join("\n");
+                println!("{sessions}");
+            }
+        }
         return Ok(());
     }
     if let Some(model_id) = &cli.model {
@@ -1121,6 +1198,176 @@ mod resume_tests {
             session_resume_command(&config).unwrap(),
             "harnx -a 'my agent' -s 'my session'"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests_list_sessions_routing {
+    use super::*;
+
+    /// Routing decision: no remote agent → Local
+    /// This test will fail if routing logic regresses to unconditionally use remote.
+    #[test]
+    fn test_routing_local_when_no_remote_agent() {
+        let target = resolve_list_sessions_target(None);
+        assert_eq!(target, ListSessionsTarget::Local);
+    }
+
+    /// Routing decision: remote agent set → Remote with correct cluster
+    /// This test will fail if routing logic regresses to unconditionally use local
+    /// or if cluster extraction is broken.
+    #[test]
+    fn test_routing_remote_when_remote_agent_set() {
+        let remote_agent = Some(("my-agent".to_string(), "my-cluster".to_string()));
+        let target = resolve_list_sessions_target(remote_agent.as_ref());
+        assert_eq!(
+            target,
+            ListSessionsTarget::Remote {
+                cluster: "my-cluster".to_string()
+            }
+        );
+    }
+
+    /// Routing decision: cluster extraction preserves full cluster name
+    #[test]
+    fn test_routing_remote_extracts_cluster_correctly() {
+        let test_cases = [
+            ("agent", "nats://localhost:4222"),
+            ("worker", "production-cluster"),
+            ("remote-agent", "cluster.with.dots.example.com"),
+        ];
+
+        for (agent, cluster) in test_cases {
+            let remote_agent = Some((agent.to_string(), cluster.to_string()));
+            let target = resolve_list_sessions_target(remote_agent.as_ref());
+            match target {
+                ListSessionsTarget::Remote { cluster: extracted } => {
+                    assert_eq!(extracted, cluster, "cluster mismatch for agent '{agent}'");
+                }
+                ListSessionsTarget::Local => {
+                    panic!("Expected Remote target for agent '{agent}', got Local");
+                }
+            }
+        }
+    }
+
+    /// Output formatting: one session ID per line
+    /// This test will fail if the formatting changes (e.g., comma-separated).
+    #[test]
+    fn test_output_format_one_id_per_line() {
+        let sessions = [
+            SessionMeta {
+                id: "session-1".to_string(),
+                session_id: Some("session-1".to_string()),
+                working_dir: None,
+                git_branch: None,
+                git_remote: None,
+                terminal_session_id: None,
+                agent_name: None,
+                modified: None,
+            },
+            SessionMeta {
+                id: "session-2".to_string(),
+                session_id: Some("session-2".to_string()),
+                working_dir: None,
+                git_branch: None,
+                git_remote: None,
+                terminal_session_id: None,
+                agent_name: None,
+                modified: None,
+            },
+        ];
+        let output = format_sessions_for_output(&sessions);
+        assert_eq!(output, "session-1\nsession-2");
+    }
+
+    /// Output formatting: empty sessions → empty string
+    #[test]
+    fn test_output_format_empty_sessions() {
+        let sessions: Vec<SessionMeta> = vec![];
+        let output = format_sessions_for_output(&sessions);
+        assert_eq!(output, "");
+    }
+
+    /// Output formatting: single session → single line (no trailing newline)
+    #[test]
+    fn test_output_format_single_session() {
+        let sessions = [SessionMeta {
+            id: "only-session".to_string(),
+            session_id: Some("only-session".to_string()),
+            working_dir: None,
+            git_branch: None,
+            git_remote: None,
+            terminal_session_id: None,
+            agent_name: None,
+            modified: None,
+        }];
+        let output = format_sessions_for_output(&sessions);
+        assert_eq!(output, "only-session");
+    }
+
+    /// Remote list outcome: empty sessions → Print("") (not an error)
+    /// Regression guard: empty result is valid output, not an error condition.
+    #[test]
+    fn test_remote_list_outcome_empty_ok() {
+        let result: Result<Vec<SessionMeta>, anyhow::Error> = Ok(vec![]);
+        let outcome = remote_list_outcome(result);
+        assert_eq!(outcome, ListSessionsOutcome::Print(String::new()));
+    }
+
+    /// Remote list outcome: Ok with sessions → Print with one id per line
+    #[test]
+    fn test_remote_list_outcome_ok_with_sessions() {
+        let sessions = vec![
+            SessionMeta {
+                id: "sess-a".to_string(),
+                session_id: Some("sess-a".to_string()),
+                working_dir: None,
+                git_branch: None,
+                git_remote: None,
+                terminal_session_id: None,
+                agent_name: None,
+                modified: None,
+            },
+            SessionMeta {
+                id: "sess-b".to_string(),
+                session_id: Some("sess-b".to_string()),
+                working_dir: None,
+                git_branch: None,
+                git_remote: None,
+                terminal_session_id: None,
+                agent_name: None,
+                modified: None,
+            },
+        ];
+        let result: Result<Vec<SessionMeta>, anyhow::Error> = Ok(sessions);
+        let outcome = remote_list_outcome(result);
+        assert_eq!(
+            outcome,
+            ListSessionsOutcome::Print("sess-a\nsess-b".to_string())
+        );
+    }
+
+    /// Remote list outcome: Err → Error (error is surfaced, NOT swallowed).
+    /// Regression guard: if this test fails, it means errors are being silently
+    /// converted to empty-success (the bug we're preventing).
+    #[test]
+    fn test_remote_list_outcome_error() {
+        let error = anyhow::anyhow!("connection refused");
+        let result: Result<Vec<SessionMeta>, anyhow::Error> = Err(error);
+        let outcome = remote_list_outcome(result);
+        // Critical: must be Error variant, NOT Print("")
+        match outcome {
+            ListSessionsOutcome::Error(msg) => {
+                assert!(
+                    msg.contains("connection refused"),
+                    "error message preserved"
+                );
+            }
+            ListSessionsOutcome::Print(_) => {
+                panic!("regression: error was swallowed into Print variant!");
+            }
+        }
     }
 }
 

--- a/docs/solutions/integration-issues/nats-kv-session-index-enumeration-2026-06-27.md
+++ b/docs/solutions/integration-issues/nats-kv-session-index-enumeration-2026-06-27.md
@@ -1,0 +1,279 @@
+---
+title: "NATS KV-Backed Session Index for Remote Enumeration"
+date: 2026-06-27
+category: "integration-issues"
+problem_type: integration_issue
+component: "nats-session-index"
+root_cause: "remote sessions stored in JetStream were invisible to local enumeration paths"
+resolution_type: code_fix
+severity: medium
+tags:
+  - nats
+  - jetstream
+  - kv
+  - session-enumeration
+  - distributed-systems
+  - graceful-degradation
+  - per-surface-error-handling
+  - cas
+plan_ref: "nats-remote-session-enumeration"
+last_updated: 2026-06-29
+---
+
+# Solution: NATS KV-Backed Session Index for Remote Enumeration
+
+## Problem
+
+Remote sessions (`agent@cluster`) live in JetStream but were invisible to the TUI session picker and `--list-sessions`, which only enumerated local session directories.
+
+## Symptoms
+
+- TUI session picker showed only local sessions when connected to a remote agent
+- `harnx --list-sessions` returned empty list for remote clusters
+- Tab-completion for `.session` lacked remote session IDs
+- No way to discover which remote sessions existed for an agent
+
+## Solution
+
+Built a NATS KV-backed session index bucket `harnx_sessions` that workers populate and clients read. The index is a denormalized copy of session metadata; the Session Header in JetStream remains canonical.
+
+### Architecture Decision: KV Index vs Alternatives
+
+Three approaches evaluated:
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **KV Index (chosen)** | Works offline (workers need not respond), O(1)-ish enumeration, mirrors `harnx_leases`, KV-read perms only | Requires write on activation/renew, eventual consistency |
+| Request-reply (`sessions.list`) | Simple | Workers must be online; enumeration fails without them |
+| JetStream stream-listing (`SESSION_*`) | No extra infrastructure | Admin perms required, O(N) header reads, slow |
+
+**Choice: KV Index** — works with offline workers, needs only KV read perms, mirrors proven `harnx_leases` pattern.
+
+### Writer/Reader Split
+
+**Writer (worker, lease holder only):**
+1. Full upsert at header-write: writes `SessionIndexRecord` with all fields after session header created
+2. Refresh on lease renew: updates only `last_activity` via CAS
+
+**Reader (CLI/TUI/completion):**
+- Calls `list_remote_sessions_with_meta(cluster)` → `list_records(bucket)` → maps to `SessionMeta`
+- Returns `Ok(vec![])` on any failure (graceful degradation)
+
+### Key Patterns
+
+#### 1. CAS Read-Modify-Write for Partial Updates
+
+Problem: Activation upsert (T3) can race with renew refresh (T4). Full upsert would clobber header-derived fields.
+
+Solution: Use KV revision check:
+
+```rust
+pub async fn get_record_with_revision(
+    store: &kv::Store,
+    session_id: &str,
+) -> Result<Option<(SessionIndexRecord, u64)>> {
+    let key = session_index_key(session_id);
+    match store.entry(key.clone()).await {
+        Ok(Some(entry)) if matches!(entry.operation, kv::Operation::Put) => {
+            let record: SessionIndexRecord = serde_json::from_slice(&entry.value)?;
+            Ok(Some((record, entry.revision)))
+        }
+        _ => Ok(None),
+    }
+}
+
+pub async fn update_record_with_revision(
+    store: &kv::Store,
+    session_id: &str,
+    record: &SessionIndexRecord,
+    revision: u64,
+) -> Result<()> {
+    let key = session_index_key(session_id);
+    let payload = serde_json::to_vec(record)?;
+    store.update(&key, payload.into(), revision).await?;
+    Ok(())
+}
+```
+
+Retry loop on `WrongLastRevision`:
+
+```rust
+const INDEX_REFRESH_RETRY_LIMIT: usize = 3;
+
+for _ in 0..INDEX_REFRESH_RETRY_LIMIT {
+    let (mut record, revision) = match get_record_with_revision(store, session_id).await {
+        Ok(Some(r)) => r,
+        Ok(None) => return Ok(()), // missing = no-op
+        Err(e) => return Err(e),
+    };
+    record.last_activity = max(record.last_activity + 1, now_secs());
+    match update_record_with_revision(store, session_id, &record, revision).await {
+        Ok(_) => return Ok(()),
+        Err(e) if is_wrong_last_revision(&e) => continue,
+        Err(e) => return Err(e),
+    }
+}
+```
+
+#### 2. Best-Effort Isolation from Critical Path
+
+Index refresh **must never delay lease renewal**. Wrap in bounded timeout:
+
+```rust
+const INDEX_REFRESH_TIMEOUT: Duration = Duration::from_secs(1);
+
+match time::timeout(
+    INDEX_REFRESH_TIMEOUT,
+    refresh_session_index_last_activity(store, &session_id),
+).await {
+    Ok(Ok(())) => {}
+    Ok(Err(error)) => { warn!("failed to refresh index: {error:#}"); }
+    Err(_) => { warn!("index refresh timed out"); }
+}
+```
+
+The 1s timeout is well within default 10s renew interval. Failure logs warning only; never fails renewal.
+
+#### 3. Per-Surface Error Handling for Remote Reads
+
+**Key lesson:** "Graceful degradation" must distinguish *no data* from *couldn't fetch*, and the right way to surface a failure depends on the calling surface. Errors should flow through return values so each surface delivers them appropriately.
+
+**Contract (refined post-review):** `list_remote_sessions_with_meta(cluster)` returns:
+- `Ok(vec![])` for genuinely-empty cases: empty bucket OR bucket-not-found (no sessions indexed yet)
+- `Err` for real failures: connection/auth/permissions/transport errors, or `list_records` failure on an existing bucket
+
+**Why this matters:** Silently returning empty on *all* failures was wrong UX. When a user explicitly lists remote sessions and the cluster is unreachable or auth fails, a silent empty list looks like "no sessions exist" — misleading and frustrating. The refined contract surfaces real failures while still treating "no index yet" as valid-empty.
+
+```rust
+pub async fn list_remote_sessions_with_meta(&self, cluster: &str) -> Result<Vec<SessionMeta>> {
+    let jetstream = match self.nats_jetstream(cluster).await {
+        Ok(js) => js,
+        Err(e) => {
+            // Connection/auth failure → Err (surface to user)
+            return Err(anyhow::anyhow!("remote sessions unavailable: {e:#}"));
+        }
+    };
+    let store = match jetstream.get_key_value(BUCKET).await {
+        Ok(s) => s,
+        Err(e) if kv_bucket_missing(&e) => {
+            // Bucket not found → Ok(empty) (no sessions indexed yet)
+            return Ok(vec![]);
+        }
+        Err(e) => {
+            // Other get_key_value failure (perms, transport) → Err
+            return Err(anyhow::anyhow!("remote sessions unavailable: {e:#}"));
+        }
+    };
+    let records = match list_records(&store).await {
+        Ok(r) => r,
+        Err(e) => {
+            // Listing failure on existing bucket → Err
+            return Err(anyhow::anyhow!("remote sessions unavailable: {e:#}"));
+        }
+    };
+    Ok(records.into_iter().map(record_to_meta).collect())
+}
+```
+
+**Per-surface handling:**
+
+| Surface | Behavior | Rationale |
+|---------|----------|-----------|
+| **CLI** (`--list-sessions`) | On `Err`, print to stderr + non-zero exit | Explicit user intent; silently showing empty is misleading |
+| **TUI** (session picker modal) | Store error in `error: Option<String>` field on `ModalState::SessionPicker`; render as visible ⚠ line | Logs invisible/corrupting in TUI; error must flow through return value into UI state |
+| **Completion** (tab-complete) | Degrade to empty on `Err` | Ambient/non-blocking; can't show errors, must stay snappy (500ms timeout) |
+
+**Bucket-not-found detection:**
+
+The `kv_bucket_missing` helper detects `STREAM_NOT_FOUND` in the async_nats error chain:
+
+```rust
+pub fn kv_bucket_missing(error: &Error) -> bool {
+    error
+        .downcast_ref::<async_nats::Error>()
+        .map(|e| e.to_string().contains("STREAM_NOT_FOUND"))
+        .unwrap_or(false)
+}
+```
+
+**Fragility:** This depends on the current async_nats error-chain shape. If async_nats changes how it reports missing buckets, this detection may break.
+
+#### 4. Completion Path Graceful Degradation
+
+Completion still degrades to empty on any failure (ambient, non-blocking surface):
+
+```rust
+pub async fn list_sessions_for_completion(&self, cluster: Option<&str>) -> Vec<String> {
+    match cluster {
+        Some(cluster) => {
+            match tokio::time::timeout(
+                Duration::from_millis(500),
+                self.list_remote_sessions_with_meta(cluster),
+            ).await {
+                Ok(Ok(sessions)) => sessions.into_iter().map(|s| s.id).collect(),
+                _ => vec![],
+            }
+        }
+        None => self.list_sessions(),
+    }
+}
+```
+
+#### 5. Resume-Format Constraint
+
+Picker yields **bare `session_id`** (no prefix/decoration) to match existing remote resume path:
+
+```rust
+fn session_index_record_to_meta(record: &SessionIndexRecord) -> SessionMeta {
+    SessionMeta {
+        id: record.session_id.clone(), // bare session_id
+        // ... other fields
+    }
+}
+
+// In TUI picker selection:
+let session_name = sessions[selected - 1].id.clone();
+self.config.write().use_session(Some(&session_name));
+```
+
+## Deferrals
+
+Explicitly **not** implemented (tracked by follow-up issues):
+
+- **No backfill**: Index covers sessions active after deploy; pre-existing sessions appear on next activation
+- **No tombstone TTL/GC**: Stale records persist until manual cleanup. [#933](https://github.com/dobesv/harnx/issues/933) tracks stale cleanup
+- **No rich metadata**: Picker shows ID + git branch/remote; title/summary deferred. [#934](https://github.com/dobesv/harnx/issues/934)
+
+## Known Limitations
+
+- **O(N) sequential fetches**: `list_records` performs one KV `entry()` call per key. Acceptable at single-agent scale (few sessions); latency concern for large counts
+- **Stale records possible**: Without GC, deleted sessions may linger in enumeration until explicit index cleanup
+- **Delete path lacks timeout**: `best_effort_delete_session_index_record` has no timeout; slow NATS may delay admin delete command
+- **Bucket-not-found detection is fragile**: Depends on async_nats error-chain containing `STREAM_NOT_FOUND`; may break if async_nats changes error formatting
+
+## Test Gating Convention
+
+Integration tests use `HARNX_NATS_TEST_URL` environment variable:
+
+```rust
+#[tokio::test]
+async fn live_kv_crud() {
+    let url = match std::env::var("HARNX_NATS_TEST_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            eprintln!("skipping: HARNX_NATS_TEST_URL unset");
+            return;
+        }
+    };
+    // ... real NATS test against url
+}
+```
+
+Keeps `cargo nextest` green in normal CI while enabling opt-in real-bucket testing.
+
+## Related Issues
+
+- **Plan:** `nats-remote-session-enumeration` (GitHub #914)
+- **Prior Art:** `nats-ha-lease.md` — mirrors lease bucket pattern; `session-picker-multi-factor-sorting-2026-05-02.md` — local enumeration sorting
+- **Follow-ups:** #933 (stale GC), #934 (richer picker metadata)
+- **Code:** `crates/harnx-runtime/src/nats_session_index.rs`, `nats_lease.rs:spawn_renew_task`, `config/session_ops_split.rs:list_remote_sessions_with_meta`


### PR DESCRIPTION
Adds a NATS KV-backed session index bucket harnx_sessions so clients can enumerate remote (agent@cluster) sessions in the TUI session picker, CLI --list-sessions, and shell completion. Previously, only local-dir sessions were visible.

The worker writes the index record upon session activation and refreshes last_activity during lease renewal. Renewal-path refreshes are isolated with a 1-second timeout to protect the critical lease renewal loop.

Clients read the index with per-surface error handling: real fetch failures (e.g., connection or auth errors) are surfaced to CLI stderr and shown as visible errors in the TUI picker, while genuinely empty buckets or missing index buckets return an empty list. Shell completion degrades silently with a 500ms timeout to maintain responsiveness.

Includes a new solution document and comprehensive test coverage for routing, degradation, and worker behavior.

[#914]

Plan: nats-remote-session-enumeration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote-agent sessions are now included in the session picker, `--list-sessions`, and shell completion.
  * Added a JetStream KV–backed session index to power consistent remote enumeration.
* **Bug Fixes**
  * Remote enumeration is more resilient to NATS connectivity issues with short timeouts and graceful degradation (completion returns no results when unavailable).
  * Session index entries refresh on lease renewal and are cleaned up when sessions are deleted.
  * TUI now shows a visible warning when remote session fetching fails.
* **Documentation**
  * Added an integration guide describing the session index behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->