### PR TITLE
Render user turns on NATS attach and resume

### DIFF
--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -20,7 +20,7 @@ use agent_client_protocol::schema::*;
 use harnx_hooks::{AsyncHookManager, PersistentHookManager};
 use std::{collections::HashMap, sync::Arc};
 
-use harnx_core::event::{AgentEvent, AgentSource, ModelEvent, ToolEvent};
+use harnx_core::event::{AgentEvent, AgentSource, ModelEvent, ToolEvent, UserEvent};
 use harnx_runtime::config::GlobalConfig;
 use harnx_runtime::utils::{AbortSignal, AbortSignalInner};
 
@@ -90,6 +90,9 @@ impl harnx_core::event::AgentEventSink for AcpChunkSink {
             }
             AgentEvent::Model(ModelEvent::Final { output, .. }) if !output.is_empty() => {
                 let _ = self.tx.send(AcpForward::Text(output, source));
+            }
+            AgentEvent::User(UserEvent::Message { content }) if !content.is_empty() => {
+                let _ = self.tx.send(AcpForward::Text(content, source));
             }
             AgentEvent::Tool(ToolEvent::Started {
                 id,

--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -33,6 +33,11 @@ use harnx_runtime::utils::{AbortSignal, AbortSignalInner};
 enum AcpForward {
     /// Text chunk for `SessionUpdate::AgentMessageChunk`.
     Text(String, Option<AgentSource>),
+    /// User-turn text for `SessionUpdate::UserMessageChunk`. Kept separate
+    /// from `Text` so replayed/attached user turns are NOT mixed into the
+    /// parent's accumulated `response_text` (which forms the next agent's
+    /// input). The parent client renders these as user transcript entries.
+    UserText(String, Option<AgentSource>),
     /// Sub-agent tool invocation for `SessionUpdate::ToolCall`.
     ToolCall {
         id: String,
@@ -92,7 +97,7 @@ impl harnx_core::event::AgentEventSink for AcpChunkSink {
                 let _ = self.tx.send(AcpForward::Text(output, source));
             }
             AgentEvent::User(UserEvent::Message { content }) if !content.is_empty() => {
-                let _ = self.tx.send(AcpForward::Text(content, source));
+                let _ = self.tx.send(AcpForward::UserText(content, source));
             }
             AgentEvent::Tool(ToolEvent::Started {
                 id,
@@ -381,6 +386,36 @@ impl HarnxAgent {
             }
         }
 
+        fn spawn_notify_user_text(
+            conn: &Option<acp::ConnectionTo<acp::Client>>,
+            session_key: &str,
+            text: String,
+            source: Option<AgentSource>,
+        ) {
+            if text.is_empty() {
+                return;
+            }
+            if let Some(conn) = conn.clone() {
+                let sid = session_key.to_string();
+                tokio::task::spawn_local(async move {
+                    let mut chunk = ContentChunk::new(text.into());
+                    if let Some(source) = source.as_ref() {
+                        if let Some(meta) = meta_from_source(source) {
+                            chunk = chunk.meta(meta);
+                        }
+                    }
+                    // Use `UserMessageChunk` (not `AgentMessageChunk`) so the
+                    // parent renders this as a user turn and does NOT append it
+                    // to `response_text` (the next agent's input).
+                    let notification = SessionNotification::new(
+                        SessionId::new(sid),
+                        SessionUpdate::UserMessageChunk(chunk),
+                    );
+                    let _ = conn.send_notification(notification);
+                });
+            }
+        }
+
         fn spawn_notify_tool_call(
             conn: &Option<acp::ConnectionTo<acp::Client>>,
             session_key: &str,
@@ -492,6 +527,9 @@ impl HarnxAgent {
             match update {
                 AcpForward::Text(text, source) => {
                     spawn_notify_text(conn, session_key, text, source)
+                }
+                AcpForward::UserText(text, source) => {
+                    spawn_notify_user_text(conn, session_key, text, source)
                 }
                 AcpForward::ToolCall {
                     id,

--- a/crates/harnx-acp-server/src/lib_tests.rs
+++ b/crates/harnx-acp-server/src/lib_tests.rs
@@ -4,7 +4,7 @@ mod tests {
     use agent_client_protocol::schema::{
         CancelNotification, ContentBlock, NewSessionRequest, PromptRequest, PromptResponse,
     };
-    use harnx_core::event::{AgentEvent, AgentEventSink, ToolEvent, ToolStatus};
+    use harnx_core::event::{AgentEvent, AgentEventSink, ToolEvent, ToolStatus, UserEvent};
     use harnx_runtime::{
         client::{ClientConfig, ModelType, TestStateGuard},
         config::Config,
@@ -370,6 +370,39 @@ mod tests {
             }
             _ => panic!("expected ToolUpdate"),
         }
+    }
+
+    #[test]
+    fn acp_chunk_sink_forwards_non_empty_user_messages_only() {
+        let (tx, mut rx) = unbounded_channel::<AcpForward>();
+        let sink = AcpChunkSink { tx };
+
+        sink.emit(
+            AgentEvent::User(UserEvent::Message {
+                content: "hello user".to_string(),
+            }),
+            None,
+        );
+
+        match rx.try_recv().expect("should forward user text") {
+            AcpForward::Text(text, source) => {
+                assert_eq!(text, "hello user");
+                assert!(source.is_none());
+            }
+            _ => panic!("expected Text forward"),
+        }
+
+        sink.emit(
+            AgentEvent::User(UserEvent::Message {
+                content: String::new(),
+            }),
+            None,
+        );
+
+        assert!(
+            rx.try_recv().is_err(),
+            "empty user message should not forward anything"
+        );
     }
 
     #[test]

--- a/crates/harnx-acp-server/src/lib_tests.rs
+++ b/crates/harnx-acp-server/src/lib_tests.rs
@@ -385,11 +385,11 @@ mod tests {
         );
 
         match rx.try_recv().expect("should forward user text") {
-            AcpForward::Text(text, source) => {
+            AcpForward::UserText(text, source) => {
                 assert_eq!(text, "hello user");
                 assert!(source.is_none());
             }
-            _ => panic!("expected Text forward"),
+            _ => panic!("expected UserText forward"),
         }
 
         sink.emit(

--- a/crates/harnx-acp/src/client.rs
+++ b/crates/harnx-acp/src/client.rs
@@ -13,6 +13,7 @@ use agent_client_protocol::schema::{
 use anyhow::{anyhow, bail, Context, Result};
 use harnx_core::event::{
     AgentEvent, AgentSource, ContentBlock, ModelEvent, PlanEntry, ToolEvent, ToolKind, ToolStatus,
+    UserEvent,
 };
 use serde_json::json;
 use std::collections::HashMap;
@@ -260,8 +261,19 @@ impl AcpNotificationClient {
                 }
             }
             SessionUpdate::SessionInfoUpdate(_) => unreachable!(),
-            SessionUpdate::UserMessageChunk(_)
-            | SessionUpdate::AvailableCommandsUpdate(_)
+            SessionUpdate::UserMessageChunk(chunk) => {
+                // User turns (e.g. from remote attach/resume history replay)
+                // are rendered as user transcript entries and deliberately
+                // NOT accumulated into `response_text` (`is_agent_message` is
+                // only set for `AgentMessageChunk`).
+                let text = chunk_text(&chunk.content);
+                if text.is_empty() {
+                    None
+                } else {
+                    Some(AgentEvent::User(UserEvent::Message { content: text }))
+                }
+            }
+            SessionUpdate::AvailableCommandsUpdate(_)
             | SessionUpdate::CurrentModeUpdate(_)
             | SessionUpdate::ConfigOptionUpdate(_) => None,
             other => {
@@ -1711,6 +1723,47 @@ mod tests {
             .get("outer-session")
             .expect("session state recorded");
         assert_eq!(state.response_text, expected);
+    }
+
+    /// User-message chunks (e.g. from remote attach/resume history replay) must
+    /// be forwarded as `AgentEvent::User` for rendering, but must NOT be
+    /// accumulated into `response_text` (which forms the next agent's input).
+    #[tokio::test]
+    async fn user_message_chunk_forwards_user_event_without_polluting_response_text() {
+        let sessions = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let chunk_forwarder = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel();
+        chunk_forwarder.write().await.insert(1, chunk_tx);
+        let (activity_tx, _) = tokio::sync::broadcast::channel(8);
+        let client = AcpNotificationClient::new(
+            "working".to_string(),
+            sessions.clone(),
+            chunk_forwarder,
+            activity_tx,
+        );
+
+        let notification = SessionNotification::new(
+            SessionId::new("outer-session"),
+            SessionUpdate::UserMessageChunk(ContentChunk::new("hello from attach".into())),
+        );
+        client.session_notification(notification).await.unwrap();
+
+        let forwarded = chunk_rx.recv().await.expect("forwarded user chunk");
+        match forwarded {
+            NestedAcpEvent::Agent(AgentEvent::User(UserEvent::Message { content }), _) => {
+                assert_eq!(content, "hello from attach");
+            }
+            other => panic!("unexpected nested ACP event: {other:?}"),
+        }
+
+        // Critically: a user turn must NOT be appended to response_text.
+        let sessions = sessions.read().await;
+        if let Some(state) = sessions.get("outer-session") {
+            assert!(
+                state.response_text.is_empty(),
+                "user message chunk must not accumulate into response_text"
+            );
+        }
     }
 
     /// Regression test for issue #862, thought-chunk path: whitespace-only

--- a/crates/harnx-core/src/event.rs
+++ b/crates/harnx-core/src/event.rs
@@ -22,6 +22,7 @@ pub enum AgentEvent {
     Turn(TurnEvent),
     Session(SessionEvent),
     Notice(NoticeEvent),
+    User(UserEvent),
     Status(StatusLine),
     Plan { entries: Vec<PlanEntry> },
 }
@@ -147,6 +148,11 @@ pub enum NoticeEvent {
     Info(String),
     Warning(String),
     Error(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum UserEvent {
+    Message { content: String },
 }
 
 // --- supporting types --------------------------------------------------------
@@ -334,5 +340,20 @@ mod tests {
         };
         sink.emit(AgentEvent::Turn(TurnEvent::Started), Some(source));
         sink.emit(AgentEvent::Turn(TurnEvent::Started), None);
+    }
+
+    #[test]
+    fn user_event_round_trips_through_serde() {
+        let event = AgentEvent::User(UserEvent::Message {
+            content: "hello from user".into(),
+        });
+        let json = serde_json::to_string(&event).unwrap();
+        let decoded: AgentEvent = serde_json::from_str(&json).unwrap();
+        match decoded {
+            AgentEvent::User(UserEvent::Message { content }) => {
+                assert_eq!(content, "hello from user");
+            }
+            other => panic!("wrong variant after round-trip: {other:?}"),
+        }
     }
 }

--- a/crates/harnx-runtime/src/nats_client_session.rs
+++ b/crates/harnx-runtime/src/nats_client_session.rs
@@ -36,7 +36,7 @@
 use anyhow::{Context, Result};
 use async_nats::jetstream;
 use harnx_core::abort::wait_abort_signal;
-use harnx_core::event::{AgentEvent, AgentEventSink};
+use harnx_core::event::{AgentEvent, AgentEventSink, UserEvent};
 use harnx_core::message::{MessageContent, MessageRole};
 use harnx_core::session::SessionLogEntry;
 use harnx_core::session_reconstruct::{reconstruct_state_from_nats, TurnStatus};
@@ -191,12 +191,10 @@ impl ThinClientSession {
                     log::warn!(
                     "failed to apply NATS log mutations while rendering thin-client history: {err}"
                 );
-                    Vec::new()
+                    history.to_vec()
                 }
             };
-        for (_seq, entry) in effective_history {
-            render_log_entry_to_sink(&entry, event_sink.clone());
-        }
+        replay_history_to_sink(&effective_history, user_msg_seq, event_sink.clone());
 
         // Step 3: Publish activation to wake a worker.
         let activation = SessionActivate::new(&self.session_id, &self.config.agent);
@@ -468,6 +466,23 @@ pub struct ThinClientTurnResult {
 /// Render a session log entry to an event sink.
 ///
 /// Used for rendering history when attaching to an existing session.
+fn should_skip_replay_entry(seq: u64, user_msg_seq: u64) -> bool {
+    seq == user_msg_seq
+}
+
+fn replay_history_to_sink(
+    effective_history: &[(u64, SessionLogEntry)],
+    user_msg_seq: u64,
+    sink: Arc<dyn AgentEventSink>,
+) {
+    for (seq, entry) in effective_history {
+        if should_skip_replay_entry(*seq, user_msg_seq) {
+            continue;
+        }
+        render_log_entry_to_sink(entry, sink.clone());
+    }
+}
+
 fn render_log_entry_to_sink(entry: &SessionLogEntry, sink: Arc<dyn AgentEventSink>) {
     match entry {
         SessionLogEntry::Message { role, content, .. } => {
@@ -501,6 +516,13 @@ fn render_message_entry(
             AgentEvent::Model(ModelEvent::Final {
                 output: content.to_text(),
                 usage: Default::default(),
+            }),
+            None,
+        );
+    } else if role.is_user() {
+        sink.emit(
+            AgentEvent::User(UserEvent::Message {
+                content: content.to_text(),
             }),
             None,
         );
@@ -579,14 +601,18 @@ pub async fn send_control_command(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harnx_core::event::AgentSource;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
 
     struct TestSink {
         count: Arc<AtomicUsize>,
+        events: Mutex<Vec<AgentEvent>>,
     }
     impl AgentEventSink for TestSink {
-        fn emit(&self, _event: AgentEvent, _source: Option<harnx_core::event::AgentSource>) {
+        fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
             self.count.fetch_add(1, Ordering::SeqCst);
+            self.events.lock().unwrap().push(event);
         }
     }
 
@@ -613,6 +639,7 @@ mod tests {
         let count = Arc::new(AtomicUsize::new(0));
         let sink = Arc::new(TestSink {
             count: Arc::clone(&count),
+            events: Mutex::new(Vec::new()),
         });
 
         // Test assistant message
@@ -626,7 +653,7 @@ mod tests {
         render_log_entry_to_sink(&entry, sink.clone());
         assert_eq!(count.load(Ordering::SeqCst), 1);
 
-        // Test user message (should not render)
+        // Test user message
         let entry = SessionLogEntry::Message {
             id: None,
             role: MessageRole::User,
@@ -635,7 +662,41 @@ mod tests {
             fence_token: None,
         };
         render_log_entry_to_sink(&entry, sink.clone());
-        assert_eq!(count.load(Ordering::SeqCst), 1); // Still 1
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn test_replay_history_skips_last_user_message_only() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let sink = Arc::new(TestSink {
+            count: Arc::clone(&count),
+            events: Mutex::new(Vec::new()),
+        });
+
+        let effective_history = test_entries(&[
+            (1, MessageRole::User, "first user"),
+            (2, MessageRole::Assistant, "assistant"),
+            (3, MessageRole::User, "current user"),
+        ]);
+
+        replay_history_to_sink(&effective_history, 3, sink.clone());
+
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+        let rendered_messages: Vec<String> = sink
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|event| match event {
+                AgentEvent::User(UserEvent::Message { content }) => Some(content.clone()),
+                AgentEvent::Model(harnx_core::event::ModelEvent::Final { output, .. }) => {
+                    Some(output.clone())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(rendered_messages, vec!["first user", "assistant"]);
+        assert!(!rendered_messages.iter().any(|msg| msg == "current user"));
     }
 
     #[test]
@@ -645,6 +706,7 @@ mod tests {
         let count = Arc::new(AtomicUsize::new(0));
         let sink = Arc::new(TestSink {
             count: Arc::clone(&count),
+            events: Mutex::new(Vec::new()),
         });
 
         let entry = SessionLogEntry::ToolResults {

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -907,7 +907,9 @@ impl Tui {
     }
 
     async fn render_agent_event(&mut self, event: AgentEvent, source: Option<AgentSource>) {
-        use harnx_core::event::{ModelEvent, NoticeEvent, SessionEvent, ToolEvent, TurnEvent};
+        use harnx_core::event::{
+            ModelEvent, NoticeEvent, SessionEvent, ToolEvent, TurnEvent, UserEvent,
+        };
 
         let is_thought = matches!(&event, AgentEvent::Model(ModelEvent::ThoughtChunk { .. }));
         let is_usage = matches!(&event, AgentEvent::Model(ModelEvent::Usage { .. }));
@@ -1012,6 +1014,13 @@ impl Tui {
                 } else {
                     vec![TranscriptItem::SystemText(clean)]
                 }
+            }
+            AgentEvent::User(UserEvent::Message { content }) => {
+                vec![TranscriptItem::UserText {
+                    text: content,
+                    seq: None,
+                    timestamp: Some(chrono::Utc::now()),
+                }]
             }
             AgentEvent::Tool(ToolEvent::Completed {
                 output, markdown, ..

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1016,10 +1016,16 @@ impl Tui {
                 }
             }
             AgentEvent::User(UserEvent::Message { content }) => {
+                // Replayed/attached history item — NOT a live turn. Use
+                // `timestamp: None` (matching the agent banner) so this row is
+                // excluded from the `LogSeqAssigned` backfill heuristic above,
+                // which only patches "live" items (`timestamp: Some`). A fresh
+                // timestamp would let the next live seq bind to this replayed
+                // row, breaking edit/delete/rewind targeting.
                 vec![TranscriptItem::UserText {
                     text: content,
                     seq: None,
-                    timestamp: Some(chrono::Utc::now()),
+                    timestamp: None,
                 }]
             }
             AgentEvent::Tool(ToolEvent::Completed {

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -5,7 +5,7 @@ use crate::types::{ToolCallBody, TranscriptItem, TuiEvent};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use harnx_core::event::{
     AgentEvent, AgentSource, ContentBlock, ModelEvent, NoticeEvent, PlanEntry, SessionEvent,
-    ToolEvent, ToolKind, ToolStatus,
+    ToolEvent, ToolKind, ToolStatus, UserEvent,
 };
 use harnx_hooks::{AsyncHookManager, PersistentHookManager};
 use harnx_runtime::client::{Client, ClientConfig, TestStateGuard};
@@ -8243,6 +8243,29 @@ async fn test_agent_command_leaves_tui_without_session_gap() {
         modal_open,
         "Expected a picker to be open when session is missing!"
     );
+}
+
+#[tokio::test]
+async fn render_agent_event_user_message_produces_user_transcript_entry() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::User(UserEvent::Message {
+            content: "hello from attach".to_string(),
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    assert!(matches!(
+        tui.app.transcript.last(),
+        Some(TranscriptItem::UserText { text, .. }) if text == "hello from attach"
+    ));
 }
 
 #[tokio::test]

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -8262,9 +8262,26 @@ async fn render_agent_event_user_message_produces_user_transcript_entry() {
     .await
     .unwrap();
 
+    // Replayed/attached user turns must have no live timestamp and no seq, so
+    // they are excluded from the LogSeqAssigned backfill heuristic (which only
+    // patches items with `timestamp: Some`). Binding a live seq to a replayed
+    // row would break edit/delete/rewind targeting.
     assert!(matches!(
         tui.app.transcript.last(),
-        Some(TranscriptItem::UserText { text, .. }) if text == "hello from attach"
+        Some(TranscriptItem::UserText { text, seq: None, timestamp: None })
+            if text == "hello from attach"
+    ));
+
+    // A subsequent LogSeqAssigned must NOT backfill into the replayed row.
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 42 }),
+        None,
+    ))
+    .await
+    .unwrap();
+    assert!(matches!(
+        tui.app.transcript.last(),
+        Some(TranscriptItem::UserText { seq: None, .. })
     ));
 }
 

--- a/crates/harnx/src/cli_event_sink.rs
+++ b/crates/harnx/src/cli_event_sink.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 
 use harnx_core::event::{
     AgentEvent, AgentEventSink, AgentSource, ContentBlock, ModelEvent, NoticeEvent, SessionEvent,
-    ToolEvent, TurnEvent,
+    ToolEvent, TurnEvent, UserEvent,
 };
 
 use harnx_render::{MarkdownRender, RenderOptions};
@@ -34,6 +34,7 @@ fn is_model_output_event(event: &AgentEvent) -> bool {
             | AgentEvent::Model(ModelEvent::ThoughtChunk { .. })
             | AgentEvent::Model(ModelEvent::Final { .. })
             | AgentEvent::Model(ModelEvent::Error(_))
+            | AgentEvent::User(UserEvent::Message { .. })
     )
 }
 
@@ -363,6 +364,17 @@ impl AgentEventSink for CliAgentEventSink {
                 }
                 eprintln!("{}", warning_text(&format!("LLM error: {err}")));
             }
+            AgentEvent::User(UserEvent::Message { content }) => {
+                if let Err(err) = state.cleanup() {
+                    eprintln!(
+                        "{}",
+                        warning_text(&format!("cli-sink cleanup failed: {err}"))
+                    );
+                }
+                if !content.is_empty() {
+                    eprintln!("{}", dimmed_text(&content));
+                }
+            }
             AgentEvent::Model(ModelEvent::Usage {
                 input,
                 output,
@@ -500,6 +512,12 @@ mod tests {
         );
         sink.emit(AgentEvent::Model(ModelEvent::Error("boom".into())), None);
         sink.emit(
+            AgentEvent::User(UserEvent::Message {
+                content: "hello user".into(),
+            }),
+            None,
+        );
+        sink.emit(
             AgentEvent::Tool(ToolEvent::Blocked {
                 id: String::new(),
                 name: "test_tool".into(),
@@ -508,6 +526,42 @@ mod tests {
             }),
             None,
         );
+    }
+
+    #[test]
+    fn user_message_is_model_output_event() {
+        assert!(is_model_output_event(&AgentEvent::User(
+            UserEvent::Message {
+                content: "hello user".into(),
+            }
+        )));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_message_cleans_up_spinner_without_panic() {
+        let sink = CliAgentEventSink::new(
+            false,
+            RenderOptions::default(),
+            harnx_core::abort::create_abort_signal(),
+        );
+        sink.emit(AgentEvent::Turn(TurnEvent::Started), None);
+        {
+            let state = sink.state.lock().unwrap();
+            assert!(state.spinner.is_some(), "spinner should be started");
+        }
+        sink.emit(
+            AgentEvent::User(UserEvent::Message {
+                content: "hello user".into(),
+            }),
+            None,
+        );
+        {
+            let state = sink.state.lock().unwrap();
+            assert!(
+                state.spinner.is_none(),
+                "spinner should be cleared before printing user text"
+            );
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/docs/solutions/integration-issues/user-message-agent-event-attach-2026-06-29.md
+++ b/docs/solutions/integration-issues/user-message-agent-event-attach-2026-06-29.md
@@ -1,0 +1,169 @@
+---
+title: "Fix one-sided NATS attach/resume transcript by adding AgentEvent::User"
+date: 2026-06-29
+category: integration-issues
+problem_type: integration_issue
+component: "harnx-runtime, harnx-core, harnx-tui, harnx-acp-server, harnx"
+root_cause: "AgentEvent protocol had no user-message variant, so replay rendered only assistant messages"
+resolution_type: code_fix
+severity: medium
+tags:
+  - agent-event-sink
+  - nats
+  - attach-resume
+  - transcript
+  - event-protocol
+plan_ref: issue-916-attach-transcript
+---
+
+## Problem
+
+Remote attach/resume transcripts showed only assistant messages. User turns were missing because `AgentEvent` had no variant to carry user text from the runtime to sinks.
+
+## Symptoms
+
+- Resumed remote sessions displayed one-sided transcripts (assistant-only).
+- `render_log_entry_to_sink` in `nats_client_session.rs` rendered user messages as no-ops.
+- No event type existed to represent user input in the replay path.
+
+## Investigation Steps
+
+1. Traced replay path: `replay_history_to_sink` → `render_log_entry_to_sink` → matched `SessionLogEntry::Message` but had no way to emit user role.
+2. Checked `AgentEvent` enum — only `Model`, `Tool`, `Turn`, `Session`, `Notice`, `Status`, `Plan` variants. No `User`.
+3. Audited sink implementations (`harnx-tui`, `harnx-acp-server`, `harnx`) — all used catch-all `_ => {}` matches that silently dropped unknown events.
+4. Identified dedup hazard: current turn's user message is both appended to the NATS log AND locally echoed by the TUI on submit. Naive replay duplicates it.
+
+## Root Cause
+
+**Protocol gap**: `AgentEvent` (crates/harnx-core/src/event.rs) lacked a user-message variant. The event protocol is the single source of truth for frontend rendering; without `User` events, replay could not render user turns.
+
+**Catch-all trap**: All `AgentEventSink::emit()` implementations used `_ => {}` fallbacks. The Rust compiler does not warn when new enum variants are added, so missing handlers silently drop events.
+
+## Solution
+
+### 1. Add `UserEvent` to the protocol
+
+In `crates/harnx-core/src/event.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum UserEvent {
+    Message { content: String },
+}
+
+// In AgentEvent:
+pub enum AgentEvent {
+    // ... existing variants
+    User(UserEvent),
+}
+```
+
+### 2. Handle `AgentEvent::User` in every sink
+
+**TUI** — `crates/harnx-tui/src/input.rs`, `render_agent_event()`:
+```rust
+AgentEvent::User(UserEvent::Message { content }) => {
+    vec![TranscriptItem::UserText(content.clone())]
+}
+```
+
+**ACP server** — `crates/harnx-acp-server/src/lib.rs`, `AcpChunkSink::emit()`:
+```rust
+AgentEvent::User(UserEvent::Message { content }) => {
+    if !content.is_empty() {
+        forward(AcpForward::Text(content));
+    }
+}
+```
+
+**CLI** — `crates/harnx/src/cli_event_sink.rs`:
+- Added `UserEvent` to imports.
+- Added match arm: cleanup spinner, print dimmed user text via `eprintln!`.
+- Added to `is_model_output_event()` (marks message-bearing events).
+
+### 3. Render user entries in history replay
+
+In `crates/harnx-runtime/src/nats_client_session.rs`, `render_message_entry()`:
+```rust
+match role {
+    MessageRole::User => {
+        sink.emit(AgentEvent::User(UserEvent::Message { content: text }), None);
+    }
+    MessageRole::Assistant => { /* existing assistant handling */ }
+}
+```
+
+### 4. Dedup current-turn user message by exact seq
+
+The current turn's user message is appended to the durable log BEFORE attach/replay. The TUI also locally echoes it on submit. Naive replay duplicates.
+
+**Correct approach**: Skip the entry whose `seq == user_msg_seq` (exact seq returned from `append_event_async`).
+
+```rust
+fn should_skip_replay_entry(seq: u64, user_msg_seq: u64) -> bool {
+    seq == user_msg_seq
+}
+
+fn replay_history_to_sink(
+    effective_history: &[(u64, SessionLogEntry)],
+    user_msg_seq: u64,
+    sink: Arc<dyn AgentEventSink>,
+) {
+    for (seq, entry) in effective_history {
+        if should_skip_replay_entry(*seq, user_msg_seq) {
+            continue;
+        }
+        render_log_entry_to_sink(entry, sink.clone());
+    }
+}
+```
+
+**Why not reverse-search?** A concurrent writer could append another user message between the append and replay, causing a reverse-search to skip the wrong message. Exact-seq comparison is race-safe.
+
+### 5. Robust mutation handling
+
+On mutation-reconstruction failure, fall back to `history.to_vec()` (raw log) rather than an empty vec. Don't blank the transcript.
+
+## Why This Works
+
+- **Protocol completeness**: `AgentEvent::User(UserEvent::Message)` gives replay a carrier for user text.
+- **Sink coverage**: Every `AgentEventSink` implementation now handles `User` events. No silent drops.
+- **Exact-seq dedup**: The current turn's user message is skipped by precise seq, avoiding both duplication and race conditions.
+- **Fallback preserves history**: Mutation failures no longer result in empty transcripts.
+
+## Prevention Strategies
+
+**When adding an `AgentEvent` variant:**
+
+1. **Audit all sinks**. The compiler will not flag missing handlers due to catch-all `_ => {}`.
+2. For each sink file:
+   - `crates/harnx-tui/src/input.rs` — `render_agent_event()`
+   - `crates/harnx-acp-server/src/lib.rs` — `AcpChunkSink::emit()`
+   - `crates/harnx/src/cli_event_sink.rs` — `CliAgentEventSink::emit()` + `is_model_output_event()` if message-bearing
+3. Add a serde round-trip test if the event crosses the NATS wire.
+4. Add per-sink rendering tests.
+
+**Dedup patterns:**
+
+- Use exact sequence IDs, not reverse-search, when skipping entries during replay.
+- Document the race condition rationale in code comments.
+
+**Testing:**
+
+- Exercise production replay helper directly in tests (don't duplicate loop logic).
+- Verify which entry is skipped by seq, not by position.
+
+**Code Review Checklist:**
+
+- [ ] New `AgentEvent` variant handled in TUI `render_agent_event()`?
+- [ ] New `AgentEvent` variant handled in ACP `AcpChunkSink::emit()`?
+- [ ] New `AgentEvent` variant handled in CLI `CliAgentEventSink::emit()`?
+- [ ] If message-bearing: added to CLI `is_model_output_event()`?
+- [ ] Serde round-trip test for wire-crossing events?
+- [ ] Replay dedup uses exact seq, not reverse-search?
+
+## Related Issues
+
+- **Issue:** [#916](https://github.com/dobesv/harnx/issues/916) — NATS attach/resume renders one-sided transcript
+- **Prior Solution:** [tui-compaction-spinner-corruption-2026-06-08.md](./tui-compaction-spinner-corruption-2026-06-08.md) — AgentEvent sink pattern and catch-all trap
+- **Prior Solution:** [mcp-tool-template-acp-propagation-2026-04-30.md](./mcp-tool-template-acp-propagation-2026-04-30.md) — AcpChunkSink event handling

--- a/docs/solutions/integration-issues/user-message-agent-event-attach-2026-06-29.md
+++ b/docs/solutions/integration-issues/user-message-agent-event-attach-2026-06-29.md
@@ -63,18 +63,35 @@ pub enum AgentEvent {
 **TUI** — `crates/harnx-tui/src/input.rs`, `render_agent_event()`:
 ```rust
 AgentEvent::User(UserEvent::Message { content }) => {
-    vec![TranscriptItem::UserText(content.clone())]
+    // `TranscriptItem::UserText` is a struct variant. Use `timestamp: None`
+    // (and `seq: None`) so replayed history rows are excluded from the
+    // `LogSeqAssigned` backfill heuristic, which only patches "live" items
+    // (`timestamp: Some`). A fabricated live timestamp would let the next
+    // live seq bind to a replayed row and break edit/delete/rewind targeting.
+    vec![TranscriptItem::UserText {
+        text: content,
+        seq: None,
+        timestamp: None,
+    }]
 }
 ```
 
 **ACP server** — `crates/harnx-acp-server/src/lib.rs`, `AcpChunkSink::emit()`:
 ```rust
-AgentEvent::User(UserEvent::Message { content }) => {
-    if !content.is_empty() {
-        forward(AcpForward::Text(content));
-    }
+AgentEvent::User(UserEvent::Message { content }) if !content.is_empty() => {
+    // Use a dedicated `AcpForward::UserText(content, source)` variant — NOT
+    // `AcpForward::Text` (which maps to `AgentMessageChunk` and would pollute
+    // the parent's accumulated `response_text`, i.e. the next agent's input).
+    let _ = self.tx.send(AcpForward::UserText(content, source));
 }
 ```
+
+`AcpForward::UserText` is forwarded via `spawn_notify_user_text`, which emits
+`SessionUpdate::UserMessageChunk` (not `AgentMessageChunk`). The parent client
+(`crates/harnx-acp/src/client.rs`) maps `UserMessageChunk` to
+`AgentEvent::User(UserEvent::Message { .. })` for rendering and deliberately
+does NOT accumulate it into `response_text` (only `AgentMessageChunk` sets
+`is_agent_message`).
 
 **CLI** — `crates/harnx/src/cli_event_sink.rs`:
 - Added `UserEvent` to imports.


### PR DESCRIPTION
Enable rendering of user turns during NATS session attachment and replay by introducing a new AgentEvent::User variant. This ensures the thin-client transcript correctly reflects the full conversation history.

Key changes:
- Added AgentEvent::User(UserEvent) variant to harnx-core with serde round-trip validation.
- Implemented exact-sequence deduplication in nats_client_session.rs to prevent double-rendering of the current turn's user message during replay.
- Added handling for AgentEvent::User in TUI, ACP, and CLI sinks. The ACP sink now forwards non-empty user messages as text, and the CLI sink properly cleans up spinners before printing user turns to stderr.
- Improved robustness of history replay by falling back to the raw event log if mutation application fails.
- Captured architectural patterns for AgentEvent sink coverage and race-safe deduplication in a new solution document.

Fixes #916

Plan: issue-916-attach-transcript

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User messages are now emitted through the event stream and shown in transcripts alongside assistant responses.
  * CLI, TUI, and ACP forwarding/rendering now surface user text as dedicated transcript entries (not mixed into assistant response text).

* **Bug Fixes**
  * Replay and resume flows avoid duplicating the current user message.
  * Empty user messages are ignored to prevent blank output.
  * Consistent handling ensures user turns don’t backfill sequence/timestamps incorrectly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->