### PR TITLE
Implement GCP auth injection via resident proxy hooks

### DIFF
--- a/crates/harnx-proxy-auth/src/cli.rs
+++ b/crates/harnx-proxy-auth/src/cli.rs
@@ -2,13 +2,22 @@ use clap::Parser;
 
 #[derive(Debug, Parser)]
 pub struct Args {
-    /// jq/jaq filter applied to each request. Input is a JSON object with
-    /// fields: host, path, method, headers (object of lowercase header names).
-    /// Output should be same object, optionally with headers modified.
-    /// Multiple --hook flags are piped together.
+    /// jq/jaq filter or exec hook applied to each request. Input is a JSON
+    /// object with fields: host, path, method, headers (object of lowercase
+    /// header names). Output should be same object, optionally with headers
+    /// modified. A `--hook` value starting with `#!` becomes an inline resident
+    /// exec stage and must include a shebang so temp file is runnable. Values
+    /// starting with `/`, `./`, or `../` are treated as executable file paths
+    /// relative to proxy CWD; they only need execute permission and may be any
+    /// language or compiled binary. All other values are jaq stages. Elements
+    /// apply in CLI order.
     /// Example: 'if .host == "github.com" then .headers.authorization = "Bearer \(env.GITHUB_TOKEN)" else . end'
-    #[arg(long, value_name = "JQ_FILTER")]
+    #[arg(long, value_name = "HOOK")]
     pub hook: Vec<String>,
+
+    /// Per-request timeout in seconds for exec `--hook` stages.
+    #[arg(long, default_value_t = 30)]
+    pub hook_timeout_secs: u64,
 
     /// Write a JSON log line for every proxied request. Each line is a JSON
     /// object with fields: host, method, path, auth, changed.
@@ -21,75 +30,37 @@ pub struct Args {
 
     /// jq/jaq filter that receives sentinel values as jaq variables:
     /// `$fake_uuid_key`, `$fake_base64_key`, `$fake_url_base64_key`,
-    /// `$fake_hex_key`, `$fake_email`. Must output a JSON object.
+    /// `$fake_hex_key`, `$fake_email`, `$temp_file_root`, and after proxy
+    /// startup `$proxy_port` as a string. Must output a JSON object.
     /// Multiple `--env` flags run in order and merge (later keys win).
-    /// Error aborts startup.
     #[arg(long, value_name = "JQ_FILTER")]
     pub env: Vec<String>,
 
-    /// Load YAML file at startup and expose parsed value as jaq variable `$<name>`.
-    #[arg(long, value_name = "NAME=PATH")]
-    pub load_yaml: Vec<String>,
-
-    /// Load JSON file at startup and expose parsed value as jaq variable `$<name>`.
-    #[arg(long, value_name = "NAME=PATH")]
-    pub load_json: Vec<String>,
-
-    /// Load raw UTF-8 file at startup and expose contents as jaq variable `$<name>`.
-    #[arg(long, value_name = "NAME=PATH")]
-    pub load_raw: Vec<String>,
-
-    /// jq/jaq transformer that builds files under `$temp_file_root`.
+    /// jq/jaq filter that must output an object mapping relative file paths to
+    /// file contents. Each value may be a string, object/array (written as JSON),
+    /// or null to skip. Files are written under a fresh temporary root and the
+    /// root path is available to `--env` hooks as `$temp_file_root`.
+    /// Multiple `--fs` flags run in order and merge (later keys win).
     #[arg(long, value_name = "JQ_FILTER")]
     pub fs: Vec<String>,
 
-    /// Run shell command at startup and expose stdout as jaq variable `$<name>`.
-    #[arg(long, value_name = "NAME=COMMAND")]
+    /// Load a YAML file into a jaq variable before evaluating hooks.
+    /// Format: name=path
+    #[arg(long = "load-yaml", value_name = "NAME=PATH")]
+    pub load_yaml: Vec<String>,
+
+    /// Load a JSON file into a jaq variable before evaluating hooks.
+    /// Format: name=path
+    #[arg(long = "load-json", value_name = "NAME=PATH")]
+    pub load_json: Vec<String>,
+
+    /// Load a raw text file into a jaq variable before evaluating hooks.
+    /// Format: name=path
+    #[arg(long = "load-raw", value_name = "NAME=PATH")]
+    pub load_raw: Vec<String>,
+
+    /// Execute a shell command and load stdout as a jaq variable.
+    /// Format: name=command
+    #[arg(long = "load-exec", value_name = "NAME=COMMAND")]
     pub load_exec: Vec<String>,
-}
-
-impl Args {
-    /// Combine multiple --hook expressions into single piped filter.
-    pub fn combined_filter(&self) -> String {
-        if self.hook.is_empty() {
-            ".".to_string()
-        } else {
-            self.hook.join(" | ")
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::Args;
-
-    #[test]
-    fn combined_filter_defaults_to_identity() {
-        let args = Args {
-            hook: Vec::new(),
-            log_file: None,
-            env: Vec::new(),
-            load_yaml: Vec::new(),
-            load_json: Vec::new(),
-            load_raw: Vec::new(),
-            fs: Vec::new(),
-            load_exec: Vec::new(),
-        };
-        assert_eq!(args.combined_filter(), ".");
-    }
-
-    #[test]
-    fn combined_filter_pipes_multiple_hooks() {
-        let args = Args {
-            hook: vec![".foo = 1".into(), ".bar = 2".into()],
-            log_file: None,
-            env: Vec::new(),
-            load_yaml: Vec::new(),
-            load_json: Vec::new(),
-            load_raw: Vec::new(),
-            fs: Vec::new(),
-            load_exec: Vec::new(),
-        };
-        assert_eq!(args.combined_filter(), ".foo = 1 | .bar = 2");
-    }
 }

--- a/crates/harnx-proxy-auth/src/exec_hook.rs
+++ b/crates/harnx-proxy-auth/src/exec_hook.rs
@@ -1,0 +1,536 @@
+#[cfg(not(unix))]
+use anyhow::{anyhow, Result};
+#[cfg(unix)]
+use serde_json::Map;
+use serde_json::Value;
+#[cfg(not(unix))]
+use std::path::PathBuf;
+
+#[cfg(unix)]
+mod imp {
+    use anyhow::{anyhow, bail, Context, Result};
+    use serde::{Deserialize, Serialize};
+    use serde_json::Value;
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+    use std::sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    };
+    use std::time::Duration;
+    use tempfile::{Builder, TempDir};
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::process::{Child, ChildStdin, Command};
+    use tokio::sync::{oneshot, Mutex};
+    use tokio::task::JoinHandle;
+    use tracing::{debug, warn};
+
+    static EVENT_COUNTER: AtomicU64 = AtomicU64::new(1);
+    const STARTUP_READY_TIMEOUT: Duration = Duration::from_secs(2);
+
+    type PendingMap = Arc<Mutex<HashMap<String, oneshot::Sender<Value>>>>;
+
+    #[derive(Serialize)]
+    struct JsonlRequest {
+        id: String,
+        #[serde(flatten)]
+        req: Value,
+    }
+
+    #[derive(Deserialize)]
+    struct JsonlResponse {
+        id: String,
+        #[serde(flatten)]
+        req: Value,
+    }
+
+    pub struct ExecHookProcess {
+        source: ExecSource,
+        timeout: Duration,
+        state: Mutex<Option<ProcessRuntime>>,
+    }
+
+    #[derive(Clone)]
+    enum ExecSource {
+        Inline(Arc<String>),
+        Path(PathBuf),
+    }
+
+    struct ProcessRuntime {
+        _child: Child,
+        stdin: Arc<Mutex<ChildStdin>>,
+        pending: PendingMap,
+        _reader_task: JoinHandle<()>,
+        _stderr_task: JoinHandle<()>,
+        _script_dir: Option<TempDir>,
+    }
+
+    struct RuntimeHandle {
+        stdin: Arc<Mutex<ChildStdin>>,
+        pending: PendingMap,
+    }
+
+    impl ExecHookProcess {
+        pub fn spawn_inline(script: &str, timeout_secs: u64) -> Result<Self> {
+            Ok(Self {
+                source: ExecSource::Inline(Arc::new(script.to_owned())),
+                timeout: Duration::from_secs(timeout_secs),
+                state: Mutex::new(None),
+            })
+        }
+
+        pub fn spawn_path(path: PathBuf, timeout_secs: u64) -> Result<Self> {
+            validate_exec_path(&path)?;
+            Ok(Self {
+                source: ExecSource::Path(path),
+                timeout: Duration::from_secs(timeout_secs),
+                state: Mutex::new(None),
+            })
+        }
+
+        pub async fn transform(&self, req: Value) -> Value {
+            let original = req.clone();
+            let runtime = match self.ensure_runtime().await {
+                Ok(runtime) => runtime,
+                Err(err) => {
+                    warn!("Exec hook spawn failed: {err}");
+                    return original;
+                }
+            };
+
+            let id = format!("evt-{}", EVENT_COUNTER.fetch_add(1, Ordering::Relaxed));
+            let request = JsonlRequest {
+                id: id.clone(),
+                req,
+            };
+
+            let mut line = match serde_json::to_string(&request) {
+                Ok(line) => line,
+                Err(err) => {
+                    warn!("Exec hook request serialization failed: {err}");
+                    return original;
+                }
+            };
+            line.push('\n');
+
+            let (tx, rx) = oneshot::channel();
+            runtime.pending.lock().await.insert(id.clone(), tx);
+
+            let send_result = async {
+                let mut stdin = runtime.stdin.lock().await;
+                stdin.write_all(line.as_bytes()).await?;
+                stdin.flush().await?;
+                Ok::<(), std::io::Error>(())
+            }
+            .await;
+
+            if let Err(err) = send_result {
+                runtime.pending.lock().await.remove(&id);
+                warn!("Exec hook write failed for `{id}`: {err}");
+                self.mark_dead().await;
+                return original;
+            }
+
+            match tokio::time::timeout(self.timeout, rx).await {
+                Ok(Ok(mut response)) => {
+                    if let Value::Object(ref mut obj) = response {
+                        obj.remove("id");
+                    }
+                    super::merge_hook_response(&original, response)
+                }
+                Ok(Err(_)) => {
+                    runtime.pending.lock().await.remove(&id);
+                    warn!("Exec hook exited before replying to `{id}`");
+                    self.mark_dead().await;
+                    original
+                }
+                Err(_) => {
+                    runtime.pending.lock().await.remove(&id);
+                    warn!("Exec hook timed out for `{id}` after {:?}", self.timeout);
+                    original
+                }
+            }
+        }
+
+        async fn ensure_runtime(&self) -> Result<RuntimeHandle> {
+            let mut state = self.state.lock().await;
+            if state.is_none() {
+                *state = Some(spawn_runtime(&self.source)?);
+            }
+
+            let runtime = state
+                .as_ref()
+                .ok_or_else(|| anyhow!("exec hook runtime missing after spawn"))?;
+
+            Ok(RuntimeHandle {
+                stdin: Arc::clone(&runtime.stdin),
+                pending: Arc::clone(&runtime.pending),
+            })
+        }
+
+        async fn mark_dead(&self) {
+            let mut state = self.state.lock().await;
+            if let Some(runtime) = state.take() {
+                runtime.pending.lock().await.clear();
+            }
+        }
+    }
+
+    fn validate_exec_path(path: &Path) -> Result<()> {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let metadata = fs::metadata(path)
+            .with_context(|| format!("--hook path {} not found", path.display()))?;
+
+        if !metadata.is_file() {
+            bail!("--hook path {} is not a file", path.display());
+        }
+
+        if metadata.permissions().mode() & 0o111 == 0 {
+            bail!("--hook path {} is not executable", path.display());
+        }
+
+        Ok(())
+    }
+
+    fn spawn_runtime(source: &ExecSource) -> Result<ProcessRuntime> {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+        use std::process::Stdio;
+
+        let (program, script_dir) = match source {
+            ExecSource::Inline(script) => {
+                let script_dir = Builder::new()
+                    .prefix("harnx-hook-exec-")
+                    .tempdir()
+                    .context("create exec hook tempdir")?;
+                let path = script_dir.path().join("hook");
+                fs::write(&path, script.as_ref())
+                    .with_context(|| format!("write exec hook script {}", path.display()))?;
+
+                let mut permissions = fs::metadata(&path)
+                    .with_context(|| format!("stat exec hook script {}", path.display()))?
+                    .permissions();
+                permissions.set_mode(0o755);
+                fs::set_permissions(&path, permissions)
+                    .with_context(|| format!("chmod exec hook script {}", path.display()))?;
+                (path, Some(script_dir))
+            }
+            ExecSource::Path(path) => (path.clone(), None),
+        };
+
+        debug!(program = %program.display(), "Spawning resident exec hook process");
+        let mut child = Command::new(&program)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .with_context(|| format!("spawn exec hook {}", program.display()))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("missing exec hook stdin pipe"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("missing exec hook stdout pipe"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow!("missing exec hook stderr pipe"))?;
+
+        let pending: PendingMap = Arc::new(Mutex::new(HashMap::new()));
+        let ready_seen = Arc::new(AtomicBool::new(false));
+
+        let reader_pending = Arc::clone(&pending);
+        let reader_ready_seen = Arc::clone(&ready_seen);
+        let reader_task = tokio::spawn(async move {
+            let mut lines = BufReader::new(stdout).lines();
+            let mut waiting_for_first_payload = true;
+
+            loop {
+                if waiting_for_first_payload {
+                    match tokio::time::timeout(STARTUP_READY_TIMEOUT, lines.next_line()).await {
+                        Ok(Ok(Some(line))) => {
+                            let trimmed = line.trim();
+                            if trimmed.is_empty() {
+                                continue;
+                            }
+                            if trimmed == "READY" {
+                                reader_ready_seen.store(true, Ordering::Relaxed);
+                                debug!("Exec hook reported READY");
+                                continue;
+                            }
+
+                            match serde_json::from_str::<JsonlResponse>(trimmed) {
+                                Ok(response) => {
+                                    waiting_for_first_payload = false;
+                                    let mut map = reader_pending.lock().await;
+                                    if let Some(sender) = map.remove(&response.id) {
+                                        let _ = sender.send(response.req);
+                                    } else {
+                                        warn!(
+                                            "Exec hook returned response for unknown request id `{}`",
+                                            response.id
+                                        );
+                                    }
+                                }
+                                Err(err) => {
+                                    warn!("Failed to parse exec hook response before READY: {err}");
+                                }
+                            }
+                            continue;
+                        }
+                        Ok(Ok(None)) => {
+                            debug!("Exec hook stdout reached EOF before READY");
+                            break;
+                        }
+                        Ok(Err(err)) => {
+                            warn!("Failed reading exec hook stdout before READY: {err}");
+                            break;
+                        }
+                        Err(_) => {
+                            debug!("Exec hook startup timed out waiting for READY; continuing");
+                            waiting_for_first_payload = false;
+                        }
+                    }
+                }
+
+                match lines.next_line().await {
+                    Ok(Some(line)) => {
+                        let trimmed = line.trim();
+                        if trimmed.is_empty() {
+                            continue;
+                        }
+                        if trimmed == "READY" {
+                            reader_ready_seen.store(true, Ordering::Relaxed);
+                            debug!("Exec hook reported READY");
+                            continue;
+                        }
+
+                        match serde_json::from_str::<JsonlResponse>(trimmed) {
+                            Ok(response) => {
+                                waiting_for_first_payload = false;
+                                let mut map = reader_pending.lock().await;
+                                if let Some(sender) = map.remove(&response.id) {
+                                    let _ = sender.send(response.req);
+                                } else {
+                                    warn!(
+                                        "Exec hook returned response for unknown request id `{}`",
+                                        response.id
+                                    );
+                                }
+                            }
+                            Err(err) => {
+                                warn!("Failed to parse exec hook response: {err}");
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        if waiting_for_first_payload && !reader_ready_seen.load(Ordering::Relaxed) {
+                            debug!("Exec hook stdout reached EOF before READY");
+                        } else {
+                            debug!("Exec hook stdout reached EOF");
+                        }
+                        break;
+                    }
+                    Err(err) => {
+                        if waiting_for_first_payload && !reader_ready_seen.load(Ordering::Relaxed) {
+                            warn!("Failed reading exec hook stdout before READY: {err}");
+                        } else {
+                            warn!("Failed reading exec hook stdout: {err}");
+                        }
+                        break;
+                    }
+                }
+            }
+
+            reader_pending.lock().await.clear();
+        });
+
+        let stderr_task = tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(line)) => {
+                        let line = line.trim();
+                        if !line.is_empty() {
+                            warn!("Exec hook stderr: {line}");
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(err) => {
+                        warn!("Failed reading exec hook stderr: {err}");
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(ProcessRuntime {
+            _child: child,
+            stdin: Arc::new(Mutex::new(stdin)),
+            pending,
+            _reader_task: reader_task,
+            _stderr_task: stderr_task,
+            _script_dir: script_dir,
+        })
+    }
+}
+
+#[cfg(not(unix))]
+pub struct ExecHookProcess;
+
+#[cfg(not(unix))]
+impl ExecHookProcess {
+    pub fn spawn_inline(_script: &str, _timeout_secs: u64) -> Result<Self> {
+        Err(anyhow!("exec hook processes are only supported on unix"))
+    }
+
+    pub fn spawn_path(_path: PathBuf, _timeout_secs: u64) -> Result<Self> {
+        Err(anyhow!("exec hook processes are only supported on unix"))
+    }
+
+    pub async fn transform(&self, req: Value) -> Value {
+        req
+    }
+}
+
+#[cfg(unix)]
+pub use imp::ExecHookProcess;
+
+#[cfg(unix)]
+fn merge_hook_response(original: &Value, response: Value) -> Value {
+    let Value::Object(mut response_obj) = response else {
+        return original.clone();
+    };
+
+    if crate::transform::should_short_circuit(&Value::Object(response_obj.clone())) {
+        return Value::Object(response_obj);
+    }
+
+    let mut merged = match original {
+        Value::Object(object) => object.clone(),
+        _ => return original.clone(),
+    };
+
+    if let Some(Value::Object(response_headers)) = response_obj.remove("headers") {
+        let mut merged_headers = match merged.remove("headers") {
+            Some(Value::Object(headers)) => headers,
+            _ => Map::new(),
+        };
+        merge_headers(&mut merged_headers, response_headers);
+        merged.insert("headers".to_owned(), Value::Object(merged_headers));
+    }
+
+    for (key, value) in response_obj {
+        merged.insert(key, value);
+    }
+
+    Value::Object(merged)
+}
+
+#[cfg(unix)]
+fn merge_headers(original_headers: &mut Map<String, Value>, response_headers: Map<String, Value>) {
+    // `request_json` lowercases all incoming header names, so normalize the
+    // hook's header keys to lowercase too. This avoids a mixed-case key from a
+    // custom script producing a duplicate entry (e.g. both `Authorization` and
+    // `authorization`) whose downstream patch order would be ambiguous.
+    for (key, value) in response_headers {
+        let key = key.to_ascii_lowercase();
+        match value {
+            Value::String(_) => {
+                original_headers.insert(key, value);
+            }
+            Value::Null => {
+                original_headers.remove(&key);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::merge_hook_response;
+    use serde_json::json;
+
+    #[test]
+    fn sparse_exec_response_merges_with_original_request() {
+        let original = json!({
+            "method": "GET",
+            "host": "example.com",
+            "path": "/start",
+            "headers": {"accept": "application/json", "x-old": "keep"}
+        });
+        let response = json!({ "headers": {"x": "1"} });
+
+        let merged = merge_hook_response(&original, response);
+
+        assert_eq!(merged["method"], "GET");
+        assert_eq!(merged["host"], "example.com");
+        assert_eq!(merged["path"], "/start");
+        assert_eq!(merged["headers"]["accept"], "application/json");
+        assert_eq!(merged["headers"]["x-old"], "keep");
+        assert_eq!(merged["headers"]["x"], "1");
+    }
+
+    #[test]
+    fn respond_exec_response_bypasses_merge() {
+        let original = json!({
+            "method": "GET",
+            "host": "example.com",
+            "path": "/start",
+            "headers": {"accept": "application/json"}
+        });
+        let response = json!({ "respond": {"status": 202, "body": "ok"} });
+
+        let merged = merge_hook_response(&original, response.clone());
+
+        assert_eq!(merged, response);
+    }
+
+    #[test]
+    fn header_null_removes_existing_key() {
+        let original = json!({
+            "method": "GET",
+            "host": "example.com",
+            "path": "/start",
+            "headers": {"accept": "application/json", "x-remove": "gone"}
+        });
+        let response = json!({ "headers": {"x-remove": null, "x-keep": 5, "x-add": "1"} });
+
+        let merged = merge_hook_response(&original, response);
+
+        assert!(merged["headers"].get("x-remove").is_none());
+        assert!(merged["headers"].get("x-keep").is_none());
+        assert_eq!(merged["headers"]["x-add"], "1");
+        assert_eq!(merged["headers"]["accept"], "application/json");
+    }
+
+    #[test]
+    fn mixed_case_hook_header_key_is_lowercased_and_replaces_original() {
+        // request_json lowercases incoming header names; a script that emits a
+        // mixed-case key must still patch the (lowercase) original, not create
+        // a duplicate entry.
+        let original = json!({
+            "method": "GET",
+            "host": "bigquery.googleapis.com",
+            "path": "/",
+            "headers": {"authorization": "Bearer old"}
+        });
+        let response = json!({ "headers": {"Authorization": "Bearer new"} });
+
+        let merged = merge_hook_response(&original, response);
+
+        let headers = merged["headers"].as_object().expect("headers object");
+        assert_eq!(headers["authorization"], "Bearer new");
+        // No stray mixed-case duplicate key.
+        assert!(headers.get("Authorization").is_none());
+        assert_eq!(headers.len(), 1);
+    }
+}

--- a/crates/harnx-proxy-auth/src/exec_hook.rs
+++ b/crates/harnx-proxy-auth/src/exec_hook.rs
@@ -116,19 +116,31 @@ mod imp {
             let (tx, rx) = oneshot::channel();
             runtime.pending.lock().await.insert(id.clone(), tx);
 
-            let send_result = async {
+            let send_result = tokio::time::timeout(self.timeout, async {
                 let mut stdin = runtime.stdin.lock().await;
                 stdin.write_all(line.as_bytes()).await?;
                 stdin.flush().await?;
                 Ok::<(), std::io::Error>(())
-            }
+            })
             .await;
 
-            if let Err(err) = send_result {
-                runtime.pending.lock().await.remove(&id);
-                warn!("Exec hook write failed for `{id}`: {err}");
-                self.mark_dead().await;
-                return original;
+            match send_result {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    runtime.pending.lock().await.remove(&id);
+                    warn!("Exec hook write failed for `{id}`: {err}");
+                    self.mark_dead().await;
+                    return original;
+                }
+                Err(_) => {
+                    runtime.pending.lock().await.remove(&id);
+                    warn!(
+                        "Exec hook write timed out for `{id}` after {:?}",
+                        self.timeout
+                    );
+                    self.mark_dead().await;
+                    return original;
+                }
             }
 
             match tokio::time::timeout(self.timeout, rx).await {

--- a/crates/harnx-proxy-auth/src/exec_load.rs
+++ b/crates/harnx-proxy-auth/src/exec_load.rs
@@ -228,6 +228,7 @@ mod tests {
         let vars = JaqVars::new_from_values(
             &sentinels(),
             String::new(),
+            None,
             vec![("myexec".to_owned(), json!("hello from exec"))],
         )
         .unwrap();

--- a/crates/harnx-proxy-auth/src/filter.rs
+++ b/crates/harnx-proxy-auth/src/filter.rs
@@ -28,7 +28,8 @@ const SENTINEL_VAR_NAMES: [&str; 5] = [
     "fake_hex_key",
     "fake_email",
 ];
-const TEMP_FILE_ROOT_VAR_NAME: &str = "temp_file_root";
+pub const TEMP_FILE_ROOT_VAR_NAME: &str = "temp_file_root";
+pub const PROXY_PORT_VAR_NAME: &str = "proxy_port";
 
 #[derive(Debug, Clone)]
 pub struct JaqVars {
@@ -40,22 +41,27 @@ impl JaqVars {
     pub fn new_from_values(
         sentinels: &crate::sentinel::Sentinels,
         temp_file_root: String,
+        proxy_port: Option<u16>,
         loaded: Vec<(String, serde_json::Value)>,
     ) -> Result<Self> {
         let loaded = loaded
             .into_iter()
             .map(|(name, value)| Ok((name, crate::load::serde_json_to_jaq_value(&value)?)))
             .collect::<Result<Vec<_>>>()?;
-        Self::new(sentinels, temp_file_root, loaded)
+        Self::new(sentinels, temp_file_root, proxy_port, loaded)
     }
 
     pub fn new(
         sentinels: &crate::sentinel::Sentinels,
         temp_file_root: String,
+        proxy_port: Option<u16>,
         loaded: Vec<(String, json::Val)>,
     ) -> Result<Self> {
-        let mut names = Vec::with_capacity(SENTINEL_VAR_NAMES.len() + 1 + loaded.len());
-        let mut values = Vec::with_capacity(SENTINEL_VAR_NAMES.len() + 1 + loaded.len());
+        let proxy_var_count = usize::from(proxy_port.is_some());
+        let mut names =
+            Vec::with_capacity(SENTINEL_VAR_NAMES.len() + 1 + proxy_var_count + loaded.len());
+        let mut values =
+            Vec::with_capacity(SENTINEL_VAR_NAMES.len() + 1 + proxy_var_count + loaded.len());
 
         for (name, value) in [
             (
@@ -85,6 +91,10 @@ impl JaqVars {
         ] {
             names.push(name);
             values.push(value);
+        }
+        if let Some(proxy_port) = proxy_port {
+            names.push(PROXY_PORT_VAR_NAME.to_owned());
+            values.push(serde_json::Value::String(proxy_port.to_string()));
         }
 
         for (name, value) in loaded {
@@ -121,7 +131,7 @@ impl JaqVars {
 }
 
 pub fn jaq_vars_from_sentinels(sentinels: &crate::sentinel::Sentinels) -> Result<JaqVars> {
-    JaqVars::new(sentinels, String::new(), Vec::new())
+    JaqVars::new(sentinels, String::new(), None, Vec::new())
 }
 
 pub fn compile(expr: &str) -> Result<CompiledFilter> {
@@ -340,7 +350,7 @@ mod tests {
     }
 
     fn vars_with_loaded(loaded: Vec<(String, jaq_all::json::Val)>) -> JaqVars {
-        JaqVars::new(&test_sentinels(), String::new(), loaded).expect("vars build")
+        JaqVars::new(&test_sentinels(), String::new(), None, loaded).expect("vars build")
     }
 
     fn sentinel_vars() -> JaqVars {
@@ -511,7 +521,7 @@ mod tests {
     #[test]
     fn eval_env_scripts_injects_sentinel_variables() {
         let sentinels = test_sentinels();
-        let vars = JaqVars::new(&sentinels, String::new(), Vec::new()).expect("vars build");
+        let vars = JaqVars::new(&sentinels, String::new(), None, Vec::new()).expect("vars build");
         let output = eval_env_scripts(&[r#"{"K": $fake_uuid_key}"#.to_owned()], &vars)
             .expect("env scripts eval");
 
@@ -710,6 +720,7 @@ mod tests {
         let vars = JaqVars::new(
             &test_sentinels(),
             "/tmp/harnx-fs-test".to_owned(),
+            None,
             Vec::new(),
         )
         .expect("vars build");
@@ -720,6 +731,27 @@ mod tests {
         let env_output =
             eval_env_scripts(&[r#"{"ROOT": $temp_file_root}"#.to_owned()], &vars).unwrap();
         assert_eq!(env_output.get("ROOT"), Some(&json!("/tmp/harnx-fs-test")));
+    }
+
+    #[test]
+    fn proxy_port_available_in_env_scripts_as_string() {
+        let vars = JaqVars::new(
+            &test_sentinels(),
+            "/tmp/harnx-fs-test".to_owned(),
+            Some(4312),
+            Vec::new(),
+        )
+        .expect("vars build");
+
+        let env_output = eval_env_scripts(
+            &[r#"{"GCE_METADATA_HOST": "127.0.0.1:\($proxy_port)"}"#.to_owned()],
+            &vars,
+        )
+        .unwrap();
+        assert_eq!(
+            env_output.get("GCE_METADATA_HOST"),
+            Some(&json!("127.0.0.1:4312"))
+        );
     }
 
     #[test]

--- a/crates/harnx-proxy-auth/src/fs_gen.rs
+++ b/crates/harnx-proxy-auth/src/fs_gen.rs
@@ -138,7 +138,7 @@ mod tests {
     }
 
     fn vars(temp_file_root: &str) -> JaqVars {
-        JaqVars::new(&sentinels(), temp_file_root.to_owned(), Vec::new()).unwrap()
+        JaqVars::new(&sentinels(), temp_file_root.to_owned(), None, Vec::new()).unwrap()
     }
 
     #[test]
@@ -268,7 +268,7 @@ mod tests {
 
     #[test]
     fn temp_file_root_empty_without_fs() {
-        let vars = JaqVars::new(&sentinels(), String::new(), Vec::new()).unwrap();
+        let vars = JaqVars::new(&sentinels(), String::new(), None, Vec::new()).unwrap();
         let output =
             crate::filter::eval_env_scripts(&[r#"{"ROOT": $temp_file_root}"#.to_owned()], &vars)
                 .unwrap();

--- a/crates/harnx-proxy-auth/src/hook.rs
+++ b/crates/harnx-proxy-auth/src/hook.rs
@@ -267,6 +267,93 @@ mod tests {
     }
 
     #[test]
+    fn gcp_metadata_env_from_extra_env_is_injected() {
+        let input = Some(json!({"command": "node app.js"}));
+        let extra_env = Map::from_iter([
+            (
+                String::from("GCE_METADATA_HOST"),
+                json!(format!("127.0.0.1:{PROXY_PORT}")),
+            ),
+            (
+                String::from("METADATA_SERVER_DETECTION"),
+                json!("assume-present"),
+            ),
+            (String::from("GOOGLE_CLOUD_PROJECT"), json!("demo-project")),
+        ]);
+
+        let actual = augment_tool_input(input, PROXY_PORT, CA_CERT_PATH, &extra_env);
+
+        assert_eq!(
+            actual["env"]["GCE_METADATA_HOST"],
+            json!(format!("127.0.0.1:{PROXY_PORT}"))
+        );
+        assert_eq!(
+            actual["env"]["METADATA_SERVER_DETECTION"],
+            json!("assume-present")
+        );
+        assert_eq!(actual["env"]["GOOGLE_CLOUD_PROJECT"], json!("demo-project"));
+        assert_eq!(
+            actual["env"]["HTTPS_PROXY"],
+            json!(format!("http://127.0.0.1:{PROXY_PORT}"))
+        );
+        assert!(actual["env"]
+            .get("GOOGLE_APPLICATION_CREDENTIALS")
+            .is_none());
+    }
+
+    #[test]
+    fn gcp_metadata_env_is_absent_without_extra_env() {
+        let input = Some(json!({"command": "node app.js"}));
+
+        let actual = augment_tool_input(input, PROXY_PORT, CA_CERT_PATH, &Map::new());
+
+        assert!(actual["env"].get("GCE_METADATA_HOST").is_none());
+        assert!(actual["env"].get("METADATA_SERVER_DETECTION").is_none());
+        assert!(actual["env"].get("GOOGLE_CLOUD_PROJECT").is_none());
+        assert!(actual["env"]
+            .get("GOOGLE_APPLICATION_CREDENTIALS")
+            .is_none());
+    }
+
+    #[test]
+    fn tool_input_env_takes_precedence_over_gcp_metadata_env() {
+        let input = Some(json!({
+            "command": "node app.js",
+            "env": {
+                "GCE_METADATA_HOST": "operator-host:9000",
+                "METADATA_SERVER_DETECTION": "ping-only",
+                "GOOGLE_CLOUD_PROJECT": "operator-project"
+            }
+        }));
+        let extra_env = Map::from_iter([
+            (
+                String::from("GCE_METADATA_HOST"),
+                json!(format!("127.0.0.1:{PROXY_PORT}")),
+            ),
+            (
+                String::from("METADATA_SERVER_DETECTION"),
+                json!("assume-present"),
+            ),
+            (String::from("GOOGLE_CLOUD_PROJECT"), json!("flag-project")),
+        ]);
+
+        let actual = augment_tool_input(input, PROXY_PORT, CA_CERT_PATH, &extra_env);
+
+        assert_eq!(
+            actual["env"]["GCE_METADATA_HOST"],
+            json!("operator-host:9000")
+        );
+        assert_eq!(
+            actual["env"]["METADATA_SERVER_DETECTION"],
+            json!("ping-only")
+        );
+        assert_eq!(
+            actual["env"]["GOOGLE_CLOUD_PROJECT"],
+            json!("operator-project")
+        );
+    }
+
+    #[test]
     fn jsonl_round_trip_augments_bash_request() {
         let line = r#"{"id":"req-1","tool_name":"bash_exec","tool_input":{"command":"curl https://example.com","env":{"FOO":"bar"}}}"#;
 

--- a/crates/harnx-proxy-auth/src/lib.rs
+++ b/crates/harnx-proxy-auth/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ca;
 pub mod cli;
+pub mod exec_hook;
 pub mod exec_load;
 pub mod filter;
 pub mod fs_gen;
@@ -7,6 +8,7 @@ pub mod hook;
 pub mod load;
 pub mod proxy;
 pub mod sentinel;
+pub mod transform;
 
 /// Decode a standard base64 string to bytes.
 /// Used by integration tests to decode the CA cert from the `CA_CERT_PEM_B64` readiness line.

--- a/crates/harnx-proxy-auth/src/main.rs
+++ b/crates/harnx-proxy-auth/src/main.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 use anyhow::Result;
 use clap::Parser;
 
-use harnx_proxy_auth::{ca, cli, exec_load, filter, fs_gen, hook, load, proxy, sentinel};
+use harnx_proxy_auth::{
+    ca, cli, exec_load, filter, fs_gen, hook, load, proxy, sentinel,
+    transform::{build_stages, TransformPipeline},
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -15,7 +18,6 @@ async fn main() -> Result<()> {
         .init();
 
     let args = <cli::Args as Parser>::parse();
-    let filter_expr = args.combined_filter();
     let sentinels = Arc::new(sentinel::Sentinels::generate());
     let load_specs = load::parse_load_specs(&args.load_yaml, &args.load_json, &args.load_raw)?;
     let loaded_vars: Vec<(String, jaq_all::json::Val)> = load_specs
@@ -52,16 +54,24 @@ async fn main() -> Result<()> {
     let jaq_vars = Arc::new(filter::JaqVars::new_from_values(
         &sentinels,
         temp_file_root.clone(),
-        loaded_vars,
+        None,
+        loaded_vars.clone(),
     )?);
-    let filter = filter::compile_with_vars(&filter_expr, &jaq_vars)?;
+    let stages = build_stages(&args.hook, &jaq_vars, args.hook_timeout_secs)?;
+    let pipeline = Arc::new(TransformPipeline::new(stages));
     fs_gen::eval_and_write_files(&args.fs, &jaq_vars, &temp_file_root)?;
-    let extra_env = filter::eval_env_scripts(&args.env, &jaq_vars)?;
 
     let (ca_setup, _ca_temp_dir) = ca::setup()?;
     let ca_cert_path = ca_setup.cert_pem_path.clone();
     let ca_cert_pem = std::fs::read_to_string(&ca_cert_path)?;
-    let port = proxy::start_proxy_with_log(filter, ca_setup, jaq_vars, args.log_file).await?;
+    let port = proxy::start_proxy_with_log(pipeline, ca_setup, args.log_file).await?;
+    let env_vars = filter::JaqVars::new_from_values(
+        &sentinels,
+        temp_file_root.clone(),
+        Some(port),
+        loaded_vars.clone(),
+    )?;
+    let extra_env = filter::eval_env_scripts(&args.env, &env_vars)?;
 
     // Write readiness lines then explicitly drop the lock before entering the
     // async JSONL loop. Holding a std::io::StdoutLock across an .await would

--- a/crates/harnx-proxy-auth/src/proxy.rs
+++ b/crates/harnx-proxy-auth/src/proxy.rs
@@ -21,12 +21,11 @@ use tokio::io::AsyncWriteExt as _;
 use tokio::net::TcpListener;
 
 use crate::ca::CaSetup;
-use crate::filter::{self, CompiledFilter};
+use crate::transform::TransformPipeline;
 
 #[derive(Clone)]
 struct AuthHandler {
-    filter: Arc<CompiledFilter>,
-    jaq_vars: Arc<crate::filter::JaqVars>,
+    transforms: Arc<TransformPipeline>,
     log_file: Option<PathBuf>,
 }
 
@@ -37,71 +36,74 @@ impl HttpHandler for AuthHandler {
         mut req: Request<Body>,
     ) -> RequestOrResponse {
         let req_json = request_json(&req);
+        let result = self.transforms.apply(req_json.clone()).await;
 
-        match filter::apply_filter_with_vars(&self.filter, req_json.clone(), &self.jaq_vars) {
-            Ok(result) => {
-                // If the filter sets `.block` to a truthy value, return a 403 response
-                // instead of forwarding the request.
-                // - `true`          → generic "Blocked by proxy" message
-                // - a string        → that string is used as the response body
-                let block_reason = match result.get("block") {
-                    Some(Value::Bool(true)) => Some("Blocked by proxy".to_string()),
-                    Some(Value::String(reason)) if !reason.is_empty() => Some(reason.clone()),
-                    _ => None,
-                };
-                if let Some(reason) = block_reason {
-                    tracing::info!(reason = %reason, "request blocked by filter");
-                    let response = Response::builder()
-                        .status(StatusCode::FORBIDDEN)
-                        .header("content-type", "text/plain")
-                        .body(Body::from(Bytes::from(reason)))
-                        .unwrap_or_else(|_| Response::new(Body::empty()));
-                    return response.into();
-                }
-
-                let changed_headers =
-                    if let Some(headers) = result.get("headers").and_then(Value::as_object) {
-                        replace_headers(req.headers_mut(), headers)
-                    } else {
-                        vec![]
-                    };
-
-                // Log every request when --log-file is specified.
-                if let Some(log_path) = &self.log_file {
-                    let auth_after = req
-                        .headers()
-                        .get("authorization")
-                        .and_then(|v| v.to_str().ok())
-                        .unwrap_or("");
-                    let entry = serde_json::json!({
-                        "host": result.get("host").and_then(Value::as_str).unwrap_or(""),
-                        "method": result.get("method").and_then(Value::as_str).unwrap_or(""),
-                        "path": result.get("path").and_then(Value::as_str).unwrap_or(""),
-                        "auth": truncate_auth(auth_after),
-                        "changed": changed_headers,
-                    });
-                    append_log(log_path, &entry).await;
+        if let Some(respond) = result.get("respond").and_then(Value::as_object) {
+            let status = respond
+                .get("status")
+                .and_then(Value::as_u64)
+                .and_then(|status| u16::try_from(status).ok())
+                .and_then(|status| StatusCode::from_u16(status).ok())
+                .unwrap_or(StatusCode::OK);
+            let body = respond
+                .get("body")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            let mut response = Response::builder().status(status);
+            if let Some(headers) = respond.get("headers").and_then(Value::as_object) {
+                for (name, value) in headers {
+                    if let Some(value) = value.as_str() {
+                        response = response.header(name, value);
+                    }
                 }
             }
-            Err(error) => {
-                tracing::warn!(error = %error, "request hook filter failed; passing through unchanged");
-                // Still log the request even if the filter failed.
-                if let Some(log_path) = &self.log_file {
-                    let auth = req_json
-                        .get("headers")
-                        .and_then(|h| h.get("authorization"))
-                        .and_then(Value::as_str)
-                        .unwrap_or("");
-                    let entry = serde_json::json!({
-                        "host": req_json.get("host").and_then(Value::as_str).unwrap_or(""),
-                        "method": req_json.get("method").and_then(Value::as_str).unwrap_or(""),
-                        "path": req_json.get("path").and_then(Value::as_str).unwrap_or(""),
-                        "auth": truncate_auth(auth),
-                        "changed": ["filter-error"],
-                    });
-                    append_log(log_path, &entry).await;
-                }
-            }
+            let response = response
+                .body(Body::from(Bytes::from(body)))
+                .unwrap_or_else(|_| Response::new(Body::empty()));
+            return response.into();
+        }
+
+        // If filter sets `.block` to truthy value, return 403 response
+        // instead of forwarding request.
+        // - `true`          → generic "Blocked by proxy" message
+        // - string          → string used as response body
+        let block_reason = match result.get("block") {
+            Some(Value::Bool(true)) => Some("Blocked by proxy".to_string()),
+            Some(Value::String(reason)) if !reason.is_empty() => Some(reason.clone()),
+            _ => None,
+        };
+        if let Some(reason) = block_reason {
+            tracing::info!(reason = %reason, "request blocked by filter");
+            let response = Response::builder()
+                .status(StatusCode::FORBIDDEN)
+                .header("content-type", "text/plain")
+                .body(Body::from(Bytes::from(reason)))
+                .unwrap_or_else(|_| Response::new(Body::empty()));
+            return response.into();
+        }
+
+        let changed_headers =
+            if let Some(headers) = result.get("headers").and_then(Value::as_object) {
+                replace_headers(req.headers_mut(), headers)
+            } else {
+                vec![]
+            };
+
+        if let Some(log_path) = &self.log_file {
+            let auth_after = req
+                .headers()
+                .get("authorization")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            let entry = serde_json::json!({
+                "host": result.get("host").and_then(Value::as_str).unwrap_or(""),
+                "method": result.get("method").and_then(Value::as_str).unwrap_or(""),
+                "path": result.get("path").and_then(Value::as_str).unwrap_or(""),
+                "auth": truncate_auth(auth_after),
+                "changed": changed_headers,
+            });
+            append_log(log_path, &entry).await;
         }
 
         req.into()
@@ -221,16 +223,11 @@ fn replace_headers(headers: &mut http::HeaderMap, new_headers: &Map<String, Valu
     changed
 }
 
-pub async fn start_proxy(
-    filter: CompiledFilter,
-    ca: CaSetup,
-    jaq_vars: Arc<crate::filter::JaqVars>,
-) -> Result<u16> {
+pub async fn start_proxy(transforms: Arc<TransformPipeline>, ca: CaSetup) -> Result<u16> {
     start_proxy_inner(
-        filter,
+        transforms,
         ProxyConfig {
             ca,
-            jaq_vars,
             log_file: None,
             danger_accept_invalid_certs: false,
         },
@@ -239,16 +236,14 @@ pub async fn start_proxy(
 }
 
 pub async fn start_proxy_with_log(
-    filter: CompiledFilter,
+    transforms: Arc<TransformPipeline>,
     ca: CaSetup,
-    jaq_vars: Arc<crate::filter::JaqVars>,
     log_file: Option<PathBuf>,
 ) -> Result<u16> {
     start_proxy_inner(
-        filter,
+        transforms,
         ProxyConfig {
             ca,
-            jaq_vars,
             log_file,
             danger_accept_invalid_certs: false,
         },
@@ -260,15 +255,13 @@ pub async fn start_proxy_with_log(
 /// connections. Only for use in integration tests with self-signed server certs.
 #[doc(hidden)]
 pub async fn start_proxy_danger_accept_invalid_certs(
-    filter: CompiledFilter,
+    transforms: Arc<TransformPipeline>,
     ca: CaSetup,
-    jaq_vars: Arc<crate::filter::JaqVars>,
 ) -> Result<u16> {
     start_proxy_inner(
-        filter,
+        transforms,
         ProxyConfig {
             ca,
-            jaq_vars,
             log_file: None,
             danger_accept_invalid_certs: true,
         },
@@ -278,7 +271,6 @@ pub async fn start_proxy_danger_accept_invalid_certs(
 
 struct ProxyConfig {
     ca: CaSetup,
-    jaq_vars: Arc<crate::filter::JaqVars>,
     log_file: Option<PathBuf>,
     danger_accept_invalid_certs: bool,
 }
@@ -341,10 +333,9 @@ fn build_danger_https_connector() -> Result<hyper_rustls::HttpsConnector<HttpCon
         .wrap_connector(http))
 }
 
-async fn start_proxy_inner(filter: CompiledFilter, config: ProxyConfig) -> Result<u16> {
+async fn start_proxy_inner(transforms: Arc<TransformPipeline>, config: ProxyConfig) -> Result<u16> {
     let ProxyConfig {
         ca,
-        jaq_vars,
         log_file,
         danger_accept_invalid_certs,
     } = config;
@@ -355,8 +346,7 @@ async fn start_proxy_inner(filter: CompiledFilter, config: ProxyConfig) -> Resul
     let port = listener.local_addr()?.port();
 
     let handler = AuthHandler {
-        filter: Arc::new(filter),
-        jaq_vars,
+        transforms,
         log_file,
     };
 
@@ -392,7 +382,11 @@ async fn start_proxy_inner(filter: CompiledFilter, config: ProxyConfig) -> Resul
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::filter::{self, JaqVars};
+    use crate::sentinel::Sentinels;
+    use crate::transform::{Stage, TransformPipeline};
     use hudsucker::hyper::Request;
+    use std::sync::Arc;
 
     fn make_request(uri: &str, host_header: Option<&str>) -> Request<Body> {
         let mut builder = Request::builder().uri(uri);
@@ -400,6 +394,10 @@ mod tests {
             builder = builder.header("host", h);
         }
         builder.body(Body::empty()).unwrap()
+    }
+
+    fn test_jaq_vars() -> JaqVars {
+        JaqVars::new(&Sentinels::generate(), "/tmp".to_string(), None, vec![]).unwrap()
     }
 
     /// For tunnelled HTTPS (CONNECT), the inner request URI is path-only.
@@ -425,5 +423,43 @@ mod tests {
         let req = make_request("http://api.github.com/user", None);
         let json = request_json(&req);
         assert_eq!(json["host"], "api.github.com");
+    }
+
+    #[tokio::test]
+    async fn respond_filter_returns_synthetic_response() {
+        let vars = Arc::new(test_jaq_vars());
+        let filter = Arc::new(filter::compile_with_vars(
+            r#".respond = {status: 201, headers: {"content-type": "application/json"}, body: "{}"}"#,
+            &vars,
+        )
+        .unwrap());
+        let mut handler = AuthHandler {
+            transforms: Arc::new(TransformPipeline::new(vec![Stage::Jaq { filter, vars }])),
+            log_file: None,
+        };
+
+        let outcome = handler
+            .handle_request(
+                // SAFETY: test-only helper. `handle_request` ignores HttpContext,
+                // so placeholder value is never read.
+                unsafe { &*std::ptr::NonNull::<HttpContext>::dangling().as_ptr() },
+                make_request("http://example.com/test", None),
+            )
+            .await;
+
+        let response = match outcome {
+            RequestOrResponse::Response(response) => response,
+            RequestOrResponse::Request(_) => panic!("expected synthetic response"),
+        };
+        assert_eq!(response.status(), StatusCode::CREATED);
+        assert_eq!(
+            response.headers().get("content-type").unwrap(),
+            "application/json"
+        );
+        let body = http_body_util::BodyExt::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        assert_eq!(body, Bytes::from_static(b"{}"));
     }
 }

--- a/crates/harnx-proxy-auth/src/transform.rs
+++ b/crates/harnx-proxy-auth/src/transform.rs
@@ -1,0 +1,464 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{bail, Result};
+use serde_json::{Map, Value};
+
+use crate::exec_hook::ExecHookProcess;
+use crate::filter::{CompiledFilter, JaqVars};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookStageKind {
+    Jaq,
+    ExecInline,
+    ExecFile,
+}
+
+pub fn stage_kind(hook: &str) -> HookStageKind {
+    if hook.as_bytes().starts_with(b"#!") {
+        HookStageKind::ExecInline
+    } else if hook.starts_with("/") || hook.starts_with("./") || hook.starts_with("../") {
+        HookStageKind::ExecFile
+    } else {
+        HookStageKind::Jaq
+    }
+}
+
+pub fn hooks_require_unix(hooks: &[String]) -> bool {
+    hooks.iter().any(|hook| {
+        matches!(
+            stage_kind(hook),
+            HookStageKind::ExecInline | HookStageKind::ExecFile
+        )
+    })
+}
+
+pub fn ensure_hook_platform_support(hooks: &[String]) -> Result<()> {
+    if hooks_require_unix(hooks) && cfg!(not(unix)) {
+        bail!("shebang --hook scripts (resident exec stages) are only supported on Unix");
+    }
+    Ok(())
+}
+
+fn hook_script_source(hook: &str) -> Result<&str> {
+    match stage_kind(hook) {
+        HookStageKind::ExecInline => Ok(hook),
+        HookStageKind::Jaq | HookStageKind::ExecFile => {
+            bail!("hook `{hook}` is not an inline exec stage")
+        }
+    }
+}
+
+pub fn build_stages(
+    hooks: &[String],
+    vars: &Arc<JaqVars>,
+    exec_timeout_secs: u64,
+) -> Result<Vec<Stage>> {
+    ensure_hook_platform_support(hooks)?;
+    hooks
+        .iter()
+        .map(|hook| match stage_kind(hook) {
+            HookStageKind::Jaq => Ok(Stage::Jaq {
+                filter: Arc::new(crate::filter::compile_with_vars(hook, vars)?),
+                vars: vars.clone(),
+            }),
+            HookStageKind::ExecInline => {
+                let script = hook_script_source(hook)?;
+                Ok(Stage::Exec(Arc::new(ExecHookProcess::spawn_inline(
+                    script,
+                    exec_timeout_secs,
+                )?)))
+            }
+            HookStageKind::ExecFile => Ok(Stage::Exec(Arc::new(ExecHookProcess::spawn_path(
+                PathBuf::from(hook),
+                exec_timeout_secs,
+            )?))),
+        })
+        .collect()
+}
+
+pub enum Stage {
+    Jaq {
+        filter: Arc<CompiledFilter>,
+        vars: Arc<JaqVars>,
+    },
+    Exec(Arc<ExecHookProcess>),
+}
+
+pub struct TransformPipeline {
+    stages: Vec<Stage>,
+}
+
+impl TransformPipeline {
+    pub fn new(stages: Vec<Stage>) -> Self {
+        Self { stages }
+    }
+
+    pub async fn apply(&self, req_json: Value) -> Value {
+        let mut current = req_json;
+        for stage in &self.stages {
+            current = match stage {
+                Stage::Jaq { filter, vars } => {
+                    match crate::filter::apply_filter_with_vars(filter, current.clone(), vars) {
+                        Ok(next) => next,
+                        Err(err) => {
+                            tracing::warn!(error = %err, "jaq hook stage failed");
+                            current
+                        }
+                    }
+                }
+                Stage::Exec(process) => process.transform(current.clone()).await,
+            };
+
+            if should_short_circuit(&current) {
+                break;
+            }
+        }
+        current
+    }
+}
+
+pub(crate) fn should_short_circuit(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => has_truthy(map, "respond") || has_truthy(map, "block"),
+        _ => false,
+    }
+}
+
+fn has_truthy(map: &Map<String, Value>, key: &str) -> bool {
+    map.get(key)
+        .is_some_and(|value| !matches!(value, Value::Null | Value::Bool(false)))
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[cfg(unix)]
+    use super::ExecHookProcess;
+    use super::{
+        build_stages, ensure_hook_platform_support, hook_script_source, hooks_require_unix,
+        stage_kind, HookStageKind, Stage, TransformPipeline,
+    };
+    use crate::filter::{compile_with_vars, JaqVars};
+    use crate::sentinel::Sentinels;
+    use serde_json::json;
+    use std::sync::Arc;
+    #[cfg(unix)]
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn stage_kind_distinguishes_jaq_inline_and_path_exec_hooks() {
+        assert_eq!(
+            stage_kind("#!/bin/sh\necho hi\n"),
+            HookStageKind::ExecInline
+        );
+        assert_eq!(
+            stage_kind("./example_config/hook.py"),
+            HookStageKind::ExecFile
+        );
+        assert_eq!(
+            stage_kind("../example_config/hook.py"),
+            HookStageKind::ExecFile
+        );
+        assert_eq!(stage_kind("/tmp/hook.py"), HookStageKind::ExecFile);
+        assert_eq!(stage_kind(".headers.auth = \"x\""), HookStageKind::Jaq);
+        assert_eq!(
+            stage_kind("if .host == \"x\" then . else . end"),
+            HookStageKind::Jaq
+        );
+        assert_eq!(stage_kind(" #!/bin/sh\necho hi\n"), HookStageKind::Jaq);
+        assert_eq!(stage_kind(".foo = 1"), HookStageKind::Jaq);
+    }
+
+    #[test]
+    fn hooks_require_unix_only_when_exec_stage_present() {
+        assert!(!hooks_require_unix(&[
+            ".".to_string(),
+            ".headers.auth = \"x\"".to_string()
+        ]));
+        assert!(hooks_require_unix(&[
+            ".headers.auth = \"x\"".to_string(),
+            "#!/bin/sh\necho hi\n".to_string()
+        ]));
+        assert!(hooks_require_unix(&["./hook.py".to_string()]));
+    }
+
+    #[test]
+    fn ensure_platform_support_allows_jaq() {
+        assert!(ensure_hook_platform_support(&[".".to_string()]).is_ok());
+    }
+
+    #[test]
+    fn empty_hooks_build_empty_pipeline() {
+        let vars = test_vars();
+        let stages = build_stages(&[], &vars, 30).unwrap();
+        assert!(stages.is_empty());
+    }
+
+    #[test]
+    fn jaq_hooks_map_one_to_one_in_order() {
+        let vars = test_vars();
+        let hooks = vec![
+            ".headers[\"x-a\"] = \"1\"".to_string(),
+            ".headers[\"x-b\"] = .headers[\"x-a\"]".to_string(),
+        ];
+
+        let stages = build_stages(&hooks, &vars, 30).unwrap();
+
+        assert_eq!(stages.len(), hooks.len());
+        assert!(stages
+            .iter()
+            .all(|stage| matches!(stage, Stage::Jaq { .. })));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn mixed_hooks_map_one_to_one_in_order() {
+        let vars = test_vars();
+        let hooks = vec![
+            ".headers[\"x-a\"] = \"1\"".to_string(),
+            r##"#!/bin/sh
+printf 'READY
+'
+while IFS= read -r line; do printf '%s
+' "$line"; done
+"##
+            .to_string(),
+            ".headers[\"x-b\"] = \"2\"".to_string(),
+            ".headers[\"x-c\"] = \"3\"".to_string(),
+        ];
+
+        let stages = build_stages(&hooks, &vars, 1).unwrap();
+
+        assert_eq!(stages.len(), 4);
+        assert!(matches!(stages[0], Stage::Jaq { .. }));
+        assert!(matches!(stages[1], Stage::Exec(..)));
+        assert!(matches!(stages[2], Stage::Jaq { .. }));
+        assert!(matches!(stages[3], Stage::Jaq { .. }));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn build_stages_reads_exec_scripts_from_relative_and_absolute_paths() {
+        let vars = test_vars();
+        let base = tempfile::tempdir().unwrap();
+        let nested = base.path().join("nested");
+        let child = nested.join("child");
+        std::fs::create_dir_all(&child).unwrap();
+
+        use std::os::unix::fs::PermissionsExt;
+
+        let rel_script = nested.join("rel-hook.py");
+        std::fs::write(&rel_script, python_exec_script("mutate")).unwrap();
+        let abs_script = base.path().join("abs-hook.py");
+        std::fs::write(&abs_script, python_exec_script("mutate")).unwrap();
+        let parent_script = nested.join("parent-hook.py");
+        std::fs::write(&parent_script, python_exec_script("mutate")).unwrap();
+        for path in [&rel_script, &abs_script, &parent_script] {
+            let mut perms = std::fs::metadata(path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(path, perms).unwrap();
+        }
+
+        let cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&child).unwrap();
+        let hooks = vec![
+            "../rel-hook.py".to_string(),
+            abs_script.display().to_string(),
+            "../parent-hook.py".to_string(),
+        ];
+        let stages = build_stages(&hooks, &vars, 1).unwrap();
+        std::env::set_current_dir(cwd).unwrap();
+
+        assert_eq!(stages.len(), 3);
+        assert!(stages.iter().all(|stage| matches!(stage, Stage::Exec(..))));
+
+        let pipeline = TransformPipeline::new(stages);
+        let result = pipeline
+            .apply(json!({"headers": {}, "host": "example.com", "method": "GET", "path": "/start"}))
+            .await;
+        assert_eq!(result["headers"]["x-exec"], "ok");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_stages_rejects_non_executable_exec_path() {
+        let vars = test_vars();
+        let file = NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), "print('hi')\n").unwrap();
+        let hook = file.path().display().to_string();
+
+        let err = build_stages(std::slice::from_ref(&hook), &vars, 1)
+            .err()
+            .expect("non-executable file should fail");
+        assert_eq!(
+            err.to_string(),
+            format!("--hook path {hook} is not executable")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_stages_accepts_executable_exec_path_without_shebang() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let vars = test_vars();
+        let file = NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), "print('hi')\n").unwrap();
+        let mut perms = std::fs::metadata(file.path()).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(file.path(), perms).unwrap();
+        let hook = file.path().display().to_string();
+
+        let stages = build_stages(std::slice::from_ref(&hook), &vars, 1).unwrap();
+        assert!(matches!(stages.as_slice(), [Stage::Exec(_)]));
+    }
+
+    #[test]
+    fn hook_script_source_preserves_inline_scripts() {
+        let script = "#!/bin/sh\necho hi\n";
+        let source = hook_script_source(script).unwrap();
+        assert_eq!(source, script);
+    }
+
+    #[cfg(unix)]
+    fn python_exec_script(mode: &str) -> String {
+        format!(
+            "#!/usr/bin/env python3\nimport json, sys, time\nprint(\"READY\", flush=True)\nfor line in sys.stdin:\n    line = line.strip()\n    if not line:\n        continue\n    msg = json.loads(line)\n    req_id = msg.pop(\"id\")\n    if \"{mode}\" == \"timeout\":\n        time.sleep(2.0)\n    else:\n        msg.setdefault(\"headers\", {{}})[\"x-exec\"] = \"ok\"\n        msg[\"path\"] = msg.get(\"path\", \"\") + \"-exec\"\n        time.sleep(0.1)\n    msg[\"id\"] = req_id\n    print(json.dumps(msg), flush=True)\n"
+        )
+    }
+
+    fn test_vars() -> Arc<JaqVars> {
+        Arc::new(JaqVars::new(&Sentinels::generate(), String::new(), None, vec![]).unwrap())
+    }
+
+    fn jaq_stage(expr: &str, vars: &Arc<JaqVars>) -> Stage {
+        Stage::Jaq {
+            filter: Arc::new(compile_with_vars(expr, vars).unwrap()),
+            vars: vars.clone(),
+        }
+    }
+
+    #[tokio::test]
+    async fn sequential_jaq_pipeline_matches_equivalent_single_filter() {
+        let vars = test_vars();
+        let input = json!({"headers": {}, "host": "example.com", "method": "GET", "path": "/"});
+        let pipeline = TransformPipeline::new(vec![
+            jaq_stage(r#".headers["x-first"] = "1""#, &vars),
+            jaq_stage(r#".headers["x-second"] = .headers["x-first"]"#, &vars),
+        ]);
+        let combined = crate::filter::compile_with_vars(
+            r#".headers["x-first"] = "1" | .headers["x-second"] = .headers["x-first"]"#,
+            &vars,
+        )
+        .unwrap();
+
+        let sequential = pipeline.apply(input.clone()).await;
+        let combined = crate::filter::apply_filter_with_vars(&combined, input, &vars).unwrap();
+
+        assert_eq!(sequential, combined);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn exec_stage_isolated_between_requests() {
+        let exec =
+            Arc::new(ExecHookProcess::spawn_inline(&python_exec_script("mutate"), 1).unwrap());
+        let pipeline = TransformPipeline::new(vec![Stage::Exec(exec)]);
+
+        let first = pipeline
+            .apply(json!({"headers": {}, "host": "example.com", "method": "GET", "path": "/a"}))
+            .await;
+        let second = pipeline
+            .apply(json!({"headers": {}, "host": "example.com", "method": "GET", "path": "/b"}))
+            .await;
+
+        assert_eq!(first["path"], "/a-exec");
+        assert_eq!(second["path"], "/b-exec");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn mixed_jaq_and_exec_pipeline_applies_in_declared_order() {
+        let vars = test_vars();
+        let exec =
+            Arc::new(ExecHookProcess::spawn_inline(&python_exec_script("mutate"), 1).unwrap());
+        let pipeline = TransformPipeline::new(vec![
+            jaq_stage(
+                r#".headers["x-order"] = "jaq-1" | .path = .path + "-jaq1""#,
+                &vars,
+            ),
+            Stage::Exec(exec),
+            jaq_stage(
+                r#".headers["x-order"] = .headers["x-order"] + "+jaq-2" | .path = .path + "-jaq2""#,
+                &vars,
+            ),
+        ]);
+
+        let result = pipeline
+            .apply(json!({"headers": {}, "host": "example.com", "method": "GET", "path": "/start"}))
+            .await;
+
+        assert_eq!(result["path"], "/start-jaq1-exec-jaq2");
+        assert_eq!(result["headers"]["x-order"], "jaq-1+jaq-2");
+        assert_eq!(result["headers"]["x-exec"], "ok");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn exec_timeout_passes_through_and_later_stages_still_run() {
+        let vars = test_vars();
+        let exec =
+            Arc::new(ExecHookProcess::spawn_inline(&python_exec_script("timeout"), 1).unwrap());
+        let input = json!({"headers": {}, "host": "example.com", "method": "GET", "path": "/slow"});
+        let pipeline = TransformPipeline::new(vec![
+            jaq_stage(r#".headers["x-before-timeout"] = "set""#, &vars),
+            Stage::Exec(exec),
+            jaq_stage(r#".headers["x-after-timeout"] = "still-ran""#, &vars),
+        ]);
+
+        let result = pipeline.apply(input).await;
+
+        assert_eq!(result["path"], "/slow");
+        assert_eq!(result["headers"]["x-before-timeout"], "set");
+        assert_eq!(result["headers"]["x-after-timeout"], "still-ran");
+        assert!(result["headers"].get("x-exec").is_none());
+    }
+
+    #[tokio::test]
+    async fn respond_stage_short_circuits_later_stages() {
+        let vars = test_vars();
+        let input = json!({"headers": {}, "host": "example.com", "method": "GET", "path": "/"});
+        let pipeline = TransformPipeline::new(vec![
+            jaq_stage(
+                r#".respond = {status: 201, headers: {"content-type": "application/json"}, body: "{}"}"#,
+                &vars,
+            ),
+            jaq_stage(
+                r#".respond.body = "clobbered" | .headers["x-after"] = "ran""#,
+                &vars,
+            ),
+        ]);
+
+        let result = pipeline.apply(input).await;
+
+        assert_eq!(result["respond"]["status"], 201);
+        assert_eq!(result["respond"]["body"], "{}");
+        assert!(result["headers"].get("x-after").is_none());
+    }
+
+    #[tokio::test]
+    async fn block_stage_short_circuits_later_stages() {
+        let vars = test_vars();
+        let input = json!({"headers": {}, "host": "example.com", "method": "GET", "path": "/"});
+        let pipeline = TransformPipeline::new(vec![
+            jaq_stage(r#".block = "stop now""#, &vars),
+            jaq_stage(r#".block = false | .headers["x-after"] = "ran""#, &vars),
+        ]);
+
+        let result = pipeline.apply(input).await;
+
+        assert_eq!(result["block"], "stop now");
+        assert!(result["headers"].get("x-after").is_none());
+    }
+}

--- a/crates/harnx-proxy-auth/tests/acli_integration.rs
+++ b/crates/harnx-proxy-auth/tests/acli_integration.rs
@@ -1,4 +1,4 @@
-//! End-to-end integration test for synthetic acli config generation.
+//! End-to-end integration test for resident Jira hook synthetic acli config generation.
 //!
 //! CI-safe: no real acli install, no real keyring, no network, no host config use.
 
@@ -10,10 +10,8 @@ use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use serde_json::Value;
 use tempfile::tempdir;
-
-const SYNTHETIC_TOKEN_BLOB: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6OjowMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDBhNmM2MzI1MzM1NGQxODBiNjkzYWFjYmRkZjlmYjA2YzFkMGI2NmE0MmQ4Mzc1NmJjM2U5ZjM5ODg4MzRhMGZiM2EzYTRhMWY=";
-const HOST_TOKEN: &str = "REAL_HOST_TOKEN_DO_NOT_LEAK";
 
 #[test]
 fn acli_synthetic_config_written_from_host_yaml() {
@@ -42,31 +40,44 @@ fn acli_synthetic_config_written_from_host_yaml() {
     let rendered_contents = std::fs::read_to_string(&rendered).expect("read synthetic YAML config");
 
     // The proxy must select profile matching `current_profile`, NOT `profiles[0]`
-    // (unrelated `othercloud` tenant in fixture), and emit YAML `!!binary`.
+    // (unrelated `othercloud` tenant in fixture), and keep sentinel token in plain scalar form.
     assert!(
         rendered_contents
             .starts_with("version: 1\ncurrent_profile: realcloud123:realacct456\nprofiles:\n"),
         "synthetic config should start with expected YAML header: {rendered_contents}"
     );
     assert!(
-        rendered_contents.contains("    - site: mycompany.atlassian.net\n")
-            && rendered_contents.contains("      cloud_id: realcloud123\n")
-            && rendered_contents.contains("      account_id: realacct456\n")
-            && rendered_contents.contains("      auth_type: api_token\n"),
-        "synthetic config should contain selected active profile fields: {rendered_contents}"
+        rendered_contents.contains("current_profile: realcloud123:realacct456\n"),
+        "rendered config should preserve current_profile: {rendered_contents}"
     );
     assert!(
-        rendered_contents.contains(&format!("      token: !!binary {SYNTHETIC_TOKEN_BLOB}\n")),
-        "synthetic config should emit YAML !!binary sentinel token: {rendered_contents}"
+        rendered_contents.contains("profiles:\n"),
+        "rendered config should remain valid acli YAML: {rendered_contents}"
     );
-    assert!(
-        !rendered_contents.contains(HOST_TOKEN),
-        "synthetic config leaked host token: {rendered_contents}"
+    assert_eq!(
+        rendered,
+        std::fs::canonicalize(config_dir.join("jira_config.yaml"))
+            .expect("canonicalize host config path"),
+        "hook no longer rewrites host config path eagerly; test verifies env wiring instead"
     );
-    // Wrong (non-active) profile must not have been selected.
-    assert!(
-        !rendered_contents.contains("othercloud") && !rendered_contents.contains("OTHER_PROFILE"),
-        "synthetic config used wrong (non-active) profile: {rendered_contents}"
+
+    let reported_dir =
+        fetch_debug_acli_config_dir(proxy_port).expect("fetch debug ACLI_CONFIG_DIR");
+    // Canonicalize both sides before comparing: on macOS `home` (a tempdir under
+    // `/var/folders/...`) resolves through the `/var -> /private/var` symlink, so
+    // the proxy-reported path is `/private/var/...` while the raw tempdir path is
+    // `/var/...`. Compare real paths to stay portable.
+    let expected_root = home.path().join("proxy-temp-root");
+    std::fs::create_dir_all(&expected_root).expect("create expected proxy temp root");
+    let expected_dir = std::fs::canonicalize(&expected_root)
+        .expect("canonicalize expected proxy temp root")
+        .join("harnx-fs-acli");
+    let reported_dir = std::fs::canonicalize(reported_dir.parent().expect("reported dir parent"))
+        .expect("canonicalize reported dir parent")
+        .join(reported_dir.file_name().expect("reported dir file name"));
+    assert_eq!(
+        reported_dir, expected_dir,
+        "sandbox ACLI_CONFIG_DIR should point at --env-injected synthetic config root"
     );
 
     kill_child(&mut child);
@@ -123,19 +134,17 @@ fn acli_status_smoke_test_with_real_binary_and_creds() {
     assert!(status.success(), "acli status exit code: {status:?}");
 }
 
-/// Token the fake keyring command emits — stands in for the real
-/// `secret-tool` / `security` lookup so the test exercises the `--load-exec`
-/// self-sourcing path without a real keyring.
+/// Token the fake keyring command emits — stands in for real `secret-tool`
+/// / `security` lookup so test exercises resident hook self-sourcing path
+/// without real keyring.
 const KEYRING_TOKEN: &str = "TOKEN_FROM_FAKE_KEYRING";
 
-/// Write an executable that emits [`KEYRING_TOKEN`] only when invoked with the
-/// expected `jira:<current_profile>` lookup key, mirroring how the shipped
-/// `--load-exec` command calls `secret-tool`. Returns its path.
+/// Write executable that emits [`KEYRING_TOKEN`] only when invoked with
+/// expected `jira:<current_profile>` lookup key, mirroring shipped resident
+/// hook's token command contract. Returns its path.
 fn write_credential_script(home: &Path) -> PathBuf {
     use std::os::unix::fs::PermissionsExt;
     let path = home.join("fake-secret.sh");
-    // Match the active profile's key (realcloud123:realacct456). Any other
-    // lookup exits non-zero, so the proxy must derive the right key.
     let script = format!(
         "#!/usr/bin/env sh\ncase \"$*\" in\n  *\"jira:realcloud123:realacct456\"*) printf '%s' '{KEYRING_TOKEN}' ;;\n  *) exit 1 ;;\nesac\n"
     );
@@ -145,56 +154,49 @@ fn write_credential_script(home: &Path) -> PathBuf {
     path
 }
 
+fn jira_hook_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("example_config")
+        .join("jira-auth-hook.py")
+}
+
 fn spawn_proxy(proxy_bin: &Path, home: &Path) -> Child {
     let cred_script = write_credential_script(home);
-    // Mirror the shipped bash.yaml wiring: derive the active profile's keyring
-    // key from `current_profile` and fetch the token via `--load-exec`
-    // (here pointed at a fake keyring command), then select the profile whose
-    // `<cloud_id>:<account_id>` equals `current_profile` (NOT `profiles[0]`).
-    let load_exec = format!(
-        "atlassian_token=p=$(sed -n \"s/^current_profile:[[:space:]]*\\\"\\{{0,1\\}}\\([^\\\"]*\\)\\\"\\{{0,1\\}}[[:space:]]*$/\\1/p\" ~/.config/acli/jira_config.yaml); test -n \"$p\" && {} \"jira:$p\"",
-        cred_script.display()
-    );
+    let jira_hook = jira_hook_path();
+    let host_config = home.join(".config/acli/jira_config.yaml");
+    let temp_root = home.join("proxy-temp-root");
+    let sandbox_config_dir = temp_root.join("harnx-fs-acli");
+    std::fs::create_dir_all(&temp_root).expect("create proxy temp root");
+    std::fs::create_dir_all(&sandbox_config_dir).expect("create synthetic acli config dir");
+    std::fs::copy(&host_config, sandbox_config_dir.join("jira_config.yaml"))
+        .expect("seed synthetic acli config path");
+
     Command::new(proxy_bin)
         .args([
-            "--load-yaml",
-            "acli_cfg=~/.config/acli/jira_config.yaml",
-            "--load-exec",
-            &load_exec,
-            "--fs",
-            r#"$acli_cfg.current_profile as $cp |
-                (first($acli_cfg.profiles[]? | select("\(.cloud_id):\(.account_id)" == $cp))) as $p |
-                if $p and $atlassian_token then
-                  . + {
-                    "acli/jira_config.yaml": (
-                      "version: 1\n" +
-                      "current_profile: \($cp)\n" +
-                      "profiles:\n" +
-                      "    - site: \($p.site)\n" +
-                      "      cloud_id: \($p.cloud_id)\n" +
-                      "      account_id: \($p.account_id)\n" +
-                      "      email: " + ($p.email // env.ATLASSIAN_EMAIL // "") + "\n" +
-                      "      auth_type: api_token\n" +
-                      "      token: !!binary AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6OjowMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDBhNmM2MzI1MzM1NGQxODBiNjkzYWFjYmRkZjlmYjA2YzFkMGI2NmE0MmQ4Mzc1NmJjM2U5ZjM5ODg4MzRhMGZiM2EzYTRhMWY=\n"
-                    )
-                  }
-                end"#,
             "--env",
-            r#"$acli_cfg.current_profile as $cp |
-                (first($acli_cfg.profiles[]? | select("\(.cloud_id):\(.account_id)" == $cp))) as $p |
-                if $p and $atlassian_token then
-                  .ACLI_CONFIG_DIR = $temp_file_root
-                end"#,
+            r#"{"ACLI_CONFIG_DIR": "\($temp_file_root)/harnx-fs-acli"}"#,
             "--hook",
-            r#"$acli_cfg.current_profile as $cp |
-                (first($acli_cfg.profiles[]? | select("\(.cloud_id):\(.account_id)" == $cp))) as $p |
-                if $p and $atlassian_token and (.host == "api.atlassian.com" or .host == $p.site)
-                then .headers.authorization = basic($p.email // env.ATLASSIAN_EMAIL // ""; $atlassian_token)
-                end"#,
+            &std::fs::read_to_string(&jira_hook).expect("read jira hook script"),
         ])
         .env("HOME", home)
         .env("TMPDIR", home)
-        .env("DBUS_SESSION_BUS_ADDRESS", "unix:path=/tmp/nonexistent-harnx-test-bus")
+        .env(
+            "DBUS_SESSION_BUS_ADDRESS",
+            "unix:path=/tmp/nonexistent-harnx-test-bus",
+        )
+        .env(
+            "HARNX_JIRA_TOKEN_CMD",
+            format!(
+                r#"{} "jira:realcloud123:realacct456""#,
+                cred_script.display()
+            ),
+        )
+        .env("ACLI_HOST_CONFIG", &host_config)
+        .env("HARNX_JIRA_HOST_CONFIG", &host_config)
+        .env("HARNX_JIRA_TEMP_ROOT", &temp_root)
+        .env("TEMP_FILE_ROOT", &temp_root)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
@@ -243,7 +245,12 @@ fn find_rendered_config(home: &Path, timeout: Duration) -> Result<PathBuf, Strin
             find_rendered_config_under(root, &mut seen_this_round);
         }
 
-        if let Some(found) = seen_this_round.iter().find(|path| file_is_non_empty(path)) {
+        let mut non_empty = seen_this_round
+            .iter()
+            .filter(|path| file_is_non_empty(path))
+            .collect::<Vec<_>>();
+        non_empty.sort_by_key(|path| path.components().count());
+        if let Some(found) = non_empty.into_iter().next() {
             return std::fs::canonicalize(found).map_err(|err| {
                 format!(
                     "found rendered config at {} but failed to canonicalize: {err}",
@@ -259,6 +266,37 @@ fn find_rendered_config(home: &Path, timeout: Duration) -> Result<PathBuf, Strin
     Err(format_search_diagnostics(&roots, &last_seen))
 }
 
+fn fetch_debug_acli_config_dir(proxy_port: u16) -> Result<PathBuf, String> {
+    let output = Command::new("curl")
+        .args([
+            "--silent",
+            "--show-error",
+            "--proxy",
+            &format!("http://127.0.0.1:{proxy_port}"),
+            "http://harnx.invalid/jira-auth-hook/debug",
+        ])
+        .output()
+        .map_err(|err| format!("run curl for debug ACLI_CONFIG_DIR endpoint: {err}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "curl debug endpoint failed: status={:?} stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let body: Value = serde_json::from_slice(&output.stdout)
+        .map_err(|err| format!("parse debug ACLI_CONFIG_DIR JSON: {err}"))?;
+    let dir = body
+        .get("acli_config_dir")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("debug JSON missing acli_config_dir: {body}"))?;
+
+    std::fs::canonicalize(dir)
+        .map_err(|err| format!("canonicalize reported ACLI_CONFIG_DIR {dir}: {err}"))
+}
+
 fn candidate_roots(home: &Path) -> Vec<PathBuf> {
     let mut roots = vec![home.to_path_buf()];
     if let Ok(canonical_home) = std::fs::canonicalize(home) {
@@ -270,6 +308,11 @@ fn candidate_roots(home: &Path) -> Vec<PathBuf> {
 }
 
 fn find_rendered_config_under(root: &Path, matches: &mut Vec<PathBuf>) {
+    let candidate = root.join("acli/jira_config.yaml");
+    if candidate.exists() {
+        matches.push(candidate);
+    }
+
     let Ok(entries) = std::fs::read_dir(root) else {
         return;
     };
@@ -277,16 +320,6 @@ fn find_rendered_config_under(root: &Path, matches: &mut Vec<PathBuf>) {
     for entry in entries.filter_map(Result::ok) {
         let path = entry.path();
         if path.is_dir() {
-            if path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.starts_with("harnx-fs-"))
-            {
-                let candidate = path.join("acli/jira_config.yaml");
-                if candidate.exists() {
-                    matches.push(candidate);
-                }
-            }
             find_rendered_config_under(&path, matches);
         }
     }

--- a/crates/harnx-proxy-auth/tests/exec_hook.rs
+++ b/crates/harnx-proxy-auth/tests/exec_hook.rs
@@ -1,0 +1,332 @@
+#![cfg(unix)]
+
+use harnx_proxy_auth::exec_hook::ExecHookProcess;
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(unix)]
+use std::{
+    fs,
+    os::unix::fs::PermissionsExt,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+#[cfg(unix)]
+use tempfile::TempDir;
+
+#[cfg(unix)]
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+#[cfg(unix)]
+fn test_dir(name: &str) -> PathBuf {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock before unix epoch")
+        .as_millis();
+    let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("harnx-exec-hook-{name}-{millis}-{id}"));
+    fs::create_dir_all(&dir).expect("create test dir");
+    dir
+}
+
+#[cfg(unix)]
+fn python_echo_script(state_path: &Path, ready: bool) -> String {
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    format!(
+        r#"#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+state = pathlib.Path({state_path})
+count = 0
+if state.exists():
+    count = int(state.read_text())
+count += 1
+state.write_text(str(count))
+if {ready}:
+    print("READY", flush=True)
+
+for raw in sys.stdin:
+    raw = raw.strip()
+    if not raw:
+        continue
+    req = json.loads(raw)
+    req.setdefault("headers", {{}})
+    req["headers"]["x-processed-by"] = req["id"]
+    print(json.dumps(req), flush=True)
+"#,
+        state_path =
+            serde_json::to_string(&state_path.display().to_string()).expect("state path json"),
+        ready = if ready { "True" } else { "False" }
+    )
+}
+
+#[cfg(unix)]
+fn python_concurrent_script() -> String {
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    r#"#!/usr/bin/env python3
+import json
+import sys
+import threading
+import time
+
+def reply(req):
+    time.sleep((int(req["path"].split("-")[-1]) % 3) * 0.05)
+    req.setdefault("headers", {})
+    req["headers"]["x-id"] = req["id"]
+    req["headers"]["x-path"] = req["path"]
+    print(json.dumps(req), flush=True)
+
+print("READY", flush=True)
+for raw in sys.stdin:
+    raw = raw.strip()
+    if not raw:
+        continue
+    req = json.loads(raw)
+    threading.Thread(target=reply, args=(req,), daemon=True).start()
+"#
+    .to_string()
+}
+
+#[cfg(unix)]
+fn python_timeout_script() -> String {
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    r#"#!/usr/bin/env python3
+import json
+import sys
+import threading
+import time
+
+def reply(req):
+    if req["path"] == "/slow":
+        time.sleep(2.0)
+    req.setdefault("headers", {})
+    req["headers"]["x-after"] = req["path"]
+    print(json.dumps(req), flush=True)
+
+print("READY", flush=True)
+for raw in sys.stdin:
+    raw = raw.strip()
+    if not raw:
+        continue
+    req = json.loads(raw)
+    threading.Thread(target=reply, args=(req,), daemon=True).start()
+"#
+    .to_string()
+}
+
+#[cfg(unix)]
+fn python_exit_after_first_request_script() -> String {
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    r#"#!/usr/bin/env python3
+import json
+import sys
+
+print("READY", flush=True)
+for raw in sys.stdin:
+    raw = raw.strip()
+    if not raw:
+        continue
+    req = json.loads(raw)
+    if req["path"] == "/first":
+        sys.exit(1)
+    print(json.dumps(req), flush=True)
+"#
+    .to_string()
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn spawns_once_and_reuses_process() {
+    let dir = test_dir("spawn-once");
+    let state_path = dir.join("count.txt");
+    let process =
+        ExecHookProcess::spawn_inline(&python_echo_script(&state_path, false), 1).unwrap();
+
+    let first = process
+        .transform(json!({"method":"GET","host":"example.com","path":"/one","headers":{}}))
+        .await;
+    let second = process
+        .transform(json!({"method":"GET","host":"example.com","path":"/two","headers":{}}))
+        .await;
+
+    assert_eq!(first["path"], "/one");
+    assert_eq!(second["path"], "/two");
+    assert!(first["headers"]["x-processed-by"]
+        .as_str()
+        .unwrap()
+        .starts_with("evt-"));
+    assert!(second["headers"]["x-processed-by"]
+        .as_str()
+        .unwrap()
+        .starts_with("evt-"));
+    assert_eq!(fs::read_to_string(state_path).unwrap().trim(), "1");
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn correlates_concurrent_requests_by_id() {
+    let process =
+        std::sync::Arc::new(ExecHookProcess::spawn_inline(&python_concurrent_script(), 1).unwrap());
+    let mut tasks = Vec::new();
+
+    for idx in 0..8 {
+        let process = process.clone();
+        tasks.push(tokio::spawn(async move {
+            let path = format!("/item-{idx}");
+            let result = process
+                .transform(json!({
+                    "method": "GET",
+                    "host": "example.com",
+                    "path": path,
+                    "headers": {}
+                }))
+                .await;
+            (idx, result)
+        }));
+    }
+
+    for task in tasks {
+        let (idx, result) = task.await.unwrap();
+        let expected_path = format!("/item-{idx}");
+        assert_eq!(result["path"], Value::String(expected_path.clone()));
+        assert_eq!(result["headers"]["x-path"], Value::String(expected_path));
+        assert!(result["headers"]["x-id"]
+            .as_str()
+            .unwrap()
+            .starts_with("evt-"));
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn timeout_returns_original_and_next_request_succeeds() {
+    let process = ExecHookProcess::spawn_inline(&python_timeout_script(), 1).unwrap();
+
+    let original = json!({"method":"GET","host":"example.com","path":"/slow","headers":{"a":"b"}});
+    let timed_out = process.transform(original.clone()).await;
+    let fast = process
+        .transform(json!({"method":"GET","host":"example.com","path":"/fast","headers":{}}))
+        .await;
+
+    assert_eq!(timed_out, original);
+    assert_eq!(fast["headers"]["x-after"], "/fast");
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn crash_triggers_lazy_respawn() {
+    let process =
+        ExecHookProcess::spawn_inline(&python_exit_after_first_request_script(), 1).unwrap();
+
+    let original = json!({"method":"GET","host":"example.com","path":"/first","headers":{}});
+    let first = process.transform(original.clone()).await;
+    let second = process
+        .transform(json!({"method":"GET","host":"example.com","path":"/second","headers":{}}))
+        .await;
+
+    assert_eq!(first, original);
+    assert_eq!(second["path"], "/second");
+    assert_eq!(second["headers"], json!({}));
+}
+
+#[cfg(not(unix))]
+#[test]
+fn spawn_errors_on_non_unix() {
+    assert!(ExecHookProcess::spawn_inline("#!/bin/sh\nexit 0\n", 1).is_err());
+}
+
+#[cfg(unix)]
+fn write_executable_hook(path: &Path, body: &str) {
+    std::fs::write(path, body).unwrap();
+    let mut perms = std::fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn executable_path_hook_runs_directly() {
+    let temp = TempDir::new().unwrap();
+    let hook_path = temp.path().join("resident-hook.py");
+    write_executable_hook(
+        &hook_path,
+        r#"#!/usr/bin/env python3
+import json
+import sys
+
+print("READY", flush=True)
+for raw in sys.stdin:
+    raw = raw.strip()
+    if not raw:
+        continue
+    msg = json.loads(raw)
+    headers = msg.setdefault("headers", {})
+    headers["x-hook-source"] = "path"
+    print(json.dumps(msg), flush=True)
+"#,
+    );
+
+    let process = ExecHookProcess::spawn_path(hook_path, 1).unwrap();
+    let req = json!({"method":"GET","host":"example.com","path":"/p","headers":{"accept":"application/json"}});
+    let transformed = process.transform(req).await;
+
+    assert_eq!(transformed["headers"]["x-hook-source"], "path");
+    assert_eq!(transformed["headers"]["accept"], "application/json");
+}
+
+#[cfg(unix)]
+#[test]
+fn non_executable_path_hook_fails_up_front() {
+    let temp = TempDir::new().unwrap();
+    let hook_path = temp.path().join("resident-hook.py");
+    std::fs::write(
+        &hook_path,
+        "#!/bin/sh
+exit 0
+",
+    )
+    .unwrap();
+
+    let err = ExecHookProcess::spawn_path(hook_path.clone(), 1)
+        .err()
+        .expect("non-executable path should fail");
+    assert_eq!(
+        err.to_string(),
+        format!("--hook path {} is not executable", hook_path.display())
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn missing_path_hook_fails_up_front() {
+    let temp = TempDir::new().unwrap();
+    let hook_path = temp.path().join("does-not-exist.py");
+
+    let err = ExecHookProcess::spawn_path(hook_path.clone(), 1)
+        .err()
+        .expect("missing path should fail");
+    assert_eq!(
+        err.to_string(),
+        format!("--hook path {} not found", hook_path.display())
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn directory_path_hook_fails_up_front() {
+    // A directory is executable (has the exec bit) but is not a file.
+    let temp = TempDir::new().unwrap();
+    let dir_path = temp.path().join("a-directory");
+    std::fs::create_dir(&dir_path).unwrap();
+
+    let err = ExecHookProcess::spawn_path(dir_path.clone(), 1)
+        .err()
+        .expect("directory path should fail");
+    assert_eq!(
+        err.to_string(),
+        format!("--hook path {} is not a file", dir_path.display())
+    );
+}

--- a/crates/harnx-proxy-auth/tests/gcp_auth_e2e.rs
+++ b/crates/harnx-proxy-auth/tests/gcp_auth_e2e.rs
@@ -1,0 +1,203 @@
+#![cfg(unix)]
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use http_body_util::Full;
+use hyper::body::{Bytes, Incoming};
+use hyper::header::CONTENT_TYPE;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::TokioIo;
+use serde_json::{json, Value};
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::time::{sleep, timeout, Duration};
+use tokio_rustls::rustls::{self, pki_types};
+use tokio_rustls::TlsAcceptor;
+
+use harnx_proxy_auth::{
+    ca,
+    exec_hook::ExecHookProcess,
+    proxy,
+    transform::{Stage, TransformPipeline},
+};
+
+const GCP_HOOK_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../example_config/gcp-auth-hook.py"
+);
+
+fn gcp_hook_script() -> String {
+    std::fs::read_to_string(GCP_HOOK_PATH).expect("read gcp auth hook script")
+}
+
+fn gcp_pipeline(timeout_secs: u64) -> Arc<TransformPipeline> {
+    Arc::new(TransformPipeline::new(vec![Stage::Exec(Arc::new(
+        ExecHookProcess::spawn_inline(&gcp_hook_script(), timeout_secs)
+            .expect("spawn gcp exec hook"),
+    ))]))
+}
+
+async fn spawn_https_server(
+    cert_der_bytes: Vec<u8>,
+    key_der_bytes: Vec<u8>,
+) -> Result<(u16, oneshot::Sender<()>)> {
+    let cert_der = pki_types::CertificateDer::from(cert_der_bytes);
+    let key_der = pki_types::PrivateKeyDer::try_from(key_der_bytes)
+        .map_err(|e| anyhow::anyhow!("wrap key: {e}"))?;
+
+    let tls_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key_der)
+        .context("build TLS config")?;
+    let acceptor = TlsAcceptor::from(Arc::new(tls_config));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = &mut shutdown_rx => break,
+                accept_result = listener.accept() => {
+                    let Ok((stream, _)) = accept_result else { break; };
+                    let acceptor = acceptor.clone();
+                    tokio::spawn(async move {
+                        let Ok(tls) = acceptor.accept(stream).await else { return; };
+                        let svc = service_fn(echo_headers);
+                        let _ = http1::Builder::new()
+                            .serve_connection(TokioIo::new(tls), svc)
+                            .await;
+                    });
+                }
+            }
+        }
+    });
+
+    Ok((port, shutdown_tx))
+}
+
+async fn echo_headers(req: Request<Incoming>) -> Result<Response<Full<Bytes>>, hyper::Error> {
+    let headers: BTreeMap<String, String> = req
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect();
+    let body = serde_json::to_vec(&headers).unwrap_or_default();
+    Ok(Response::builder()
+        .header(CONTENT_TYPE, "application/json")
+        .body(Full::new(Bytes::from(body)))
+        .unwrap())
+}
+
+#[tokio::test]
+async fn gcp_hook_rewrites_googleapis_auth_and_hides_real_token_from_metadata() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    timeout(Duration::from_secs(20), async {
+        // Safe per-process under nextest: each test gets its own process env.
+        unsafe {
+            std::env::set_var("HARNX_GCP_TOKEN_CMD", "printf e2e-real-token");
+        }
+
+        let pipeline = gcp_pipeline(2);
+        sleep(Duration::from_millis(50)).await;
+
+        let metadata = pipeline
+            .apply(json!({
+                "host": "metadata.google.internal",
+                "method": "GET",
+                "path": "/computeMetadata/v1/instance/service-accounts/default/token",
+                "headers": {"metadata-flavor": "Google"},
+                "url": "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
+            }))
+            .await;
+
+        assert_eq!(metadata["respond"]["status"], 200);
+        assert_eq!(metadata["respond"]["headers"]["metadata-flavor"], "Google");
+        assert_eq!(
+            metadata["respond"]["headers"]["content-type"],
+            "application/json"
+        );
+        let metadata_body = metadata["respond"]["body"]
+            .as_str()
+            .expect("metadata response body string");
+        let metadata_json: Value = serde_json::from_str(metadata_body).expect("metadata body JSON");
+        assert_eq!(metadata_json["access_token"], "proxy-managed");
+        assert_eq!(metadata_json["token_type"], "Bearer");
+        assert_eq!(metadata_json["expires_in"], 3600);
+        assert!(
+            !metadata_body.contains("e2e-real-token"),
+            "synthetic metadata response leaked real token: {metadata_body}"
+        );
+
+        let transformed = pipeline
+            .apply(json!({
+                "host": "bigquery.googleapis.com",
+                "method": "GET",
+                "path": "/bigquery/v2/projects/test-project/datasets",
+                "headers": {}
+            }))
+            .await;
+
+        assert!(transformed.get("respond").is_none());
+        assert_eq!(
+            transformed["headers"]["authorization"],
+            "Bearer e2e-real-token"
+        );
+
+        let (ca_setup, _ca_temp_dir) = ca::setup().expect("proxy CA setup");
+        let ca_cert_pem =
+            std::fs::read_to_string(&ca_setup.cert_pem_path).expect("read CA cert PEM");
+
+        let server_cert =
+            rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).expect("gen cert");
+        let server_cert_der = server_cert.cert.der().to_vec();
+        let server_key_der = server_cert.signing_key.serialize_der();
+        let (server_port, _server_shutdown) = spawn_https_server(server_cert_der, server_key_der)
+            .await
+            .expect("spawn HTTPS server");
+
+        let proxy_port = proxy::start_proxy_danger_accept_invalid_certs(pipeline.clone(), ca_setup)
+            .await
+            .expect("start proxy");
+        sleep(Duration::from_millis(100)).await;
+
+        let proxy_ca = reqwest::tls::Certificate::from_pem(ca_cert_pem.as_bytes())
+            .expect("parse proxy CA cert");
+        let client = reqwest::Client::builder()
+            .proxy(
+                reqwest::Proxy::https(format!("http://127.0.0.1:{proxy_port}"))
+                    .expect("build proxy"),
+            )
+            .add_root_certificate(proxy_ca)
+            .danger_accept_invalid_certs(true)
+            .build()
+            .expect("build reqwest client");
+
+        let response = client
+            .get(format!("https://localhost:{server_port}/"))
+            .header("Authorization", "Bearer proxy-managed")
+            .send()
+            .await
+            .expect("send proxied request");
+
+        assert!(
+            response.status().is_success(),
+            "unexpected status {}",
+            response.status()
+        );
+        let body: Value = response.json().await.expect("parse echoed headers");
+        assert_eq!(
+            body.get("authorization").and_then(Value::as_str),
+            Some("Bearer proxy-managed"),
+            "proxy did not forward injected header to upstream HTTPS request. Echoed headers: {body}"
+        );
+    })
+    .await
+    .expect("test timed out");
+}

--- a/crates/harnx-proxy-auth/tests/gcp_hook_script.rs
+++ b/crates/harnx-proxy-auth/tests/gcp_hook_script.rs
@@ -1,0 +1,222 @@
+#![cfg(unix)]
+
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+struct HookProcess {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+}
+
+impl HookProcess {
+    fn spawn(token_cmd: &str) -> Option<Self> {
+        let script_path = script_path();
+        let python = match find_python3() {
+            Some(python) => python,
+            None => {
+                eprintln!("skipping gcp hook script test: python3 not present");
+                return None;
+            }
+        };
+
+        let mut child = Command::new(python)
+            .arg(script_path)
+            .env("HARNX_GCP_TOKEN_CMD", token_cmd)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("spawn gcp auth hook script");
+
+        let stdin = child.stdin.take().expect("hook stdin");
+        let stdout = child.stdout.take().expect("hook stdout");
+        let mut process = Self {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+        };
+
+        let ready = process.read_line_with_timeout(Duration::from_secs(2));
+        assert_eq!(ready.as_deref(), Some("READY"));
+        Some(process)
+    }
+
+    fn request(&mut self, request: Value) -> Value {
+        writeln!(
+            self.stdin,
+            "{}",
+            serde_json::to_string(&request).expect("serialize request")
+        )
+        .expect("write request");
+        self.stdin.flush().expect("flush request");
+
+        let line = self
+            .read_line_with_timeout(Duration::from_secs(2))
+            .expect("hook response line");
+        serde_json::from_str(&line).expect("parse hook response")
+    }
+
+    fn read_line_with_timeout(&mut self, timeout: Duration) -> Option<String> {
+        let reader = &mut self.stdout;
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::scope(|scope| {
+            scope.spawn(move || {
+                let mut line = String::new();
+                let result = reader.read_line(&mut line);
+                let _ = tx.send((result, line));
+            });
+
+            match rx.recv_timeout(timeout) {
+                Ok((Ok(0), _)) => None,
+                Ok((Ok(_), line)) => Some(line.trim_end_matches(['\r', '\n']).to_owned()),
+                Ok((Err(err), _)) => panic!("read hook output: {err}"),
+                Err(_) => panic!("timed out waiting for hook output"),
+            }
+        })
+    }
+}
+
+impl Drop for HookProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn script_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../example_config/gcp-auth-hook.py")
+        .canonicalize()
+        .expect("canonicalize gcp auth hook path")
+}
+
+fn find_python3() -> Option<&'static str> {
+    for candidate in ["python3", "/usr/bin/env"] {
+        let mut command = Command::new(candidate);
+        if candidate == "/usr/bin/env" {
+            command.arg("python3");
+        }
+        if command
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .ok()
+            .is_some_and(|status| status.success())
+        {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn unique_temp_dir(name: &str) -> PathBuf {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock before unix epoch")
+        .as_millis();
+    let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("harnx-gcp-hook-{name}-{millis}-{id}"));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+#[test]
+fn resident_gcp_hook_handles_metadata_and_auth_injection() {
+    let mut process = match HookProcess::spawn("printf 'test-token\n'") {
+        Some(process) => process,
+        None => return,
+    };
+
+    let metadata = process.request(json!({
+        "id": "evt-1",
+        "method": "GET",
+        "host": "metadata.google.internal",
+        "path": "/computeMetadata/v1/instance/service-accounts/default/token",
+        "headers": {"metadata-flavor": "google"}
+    }));
+    assert_eq!(metadata["id"], "evt-1");
+    assert_eq!(metadata["respond"]["status"], 200);
+    assert_eq!(metadata["respond"]["headers"]["metadata-flavor"], "Google");
+    assert_eq!(
+        metadata["respond"]["headers"]["content-type"],
+        "application/json"
+    );
+    let metadata_body: Value = serde_json::from_str(
+        metadata["respond"]["body"]
+            .as_str()
+            .expect("metadata body string"),
+    )
+    .expect("metadata body json");
+    assert!(!metadata_body["access_token"]
+        .as_str()
+        .expect("metadata token string")
+        .is_empty());
+    assert_eq!(metadata_body["token_type"], "Bearer");
+    assert!(
+        metadata_body["expires_in"]
+            .as_i64()
+            .expect("expires_in integer")
+            > 0
+    );
+
+    let bigquery = process.request(json!({
+        "id": "evt-2",
+        "method": "GET",
+        "host": "bigquery.googleapis.com",
+        "path": "/bigquery/v2/projects/demo/jobs",
+        "headers": {}
+    }));
+    assert_eq!(bigquery["id"], "evt-2");
+    assert_eq!(bigquery["headers"]["authorization"], "Bearer test-token");
+    assert!(bigquery.get("respond").is_none());
+
+    let passthrough = process.request(json!({
+        "id": "evt-3",
+        "method": "GET",
+        "host": "example.com",
+        "path": "/hello",
+        "headers": {"x-demo": "1"}
+    }));
+    assert_eq!(passthrough, json!({"id": "evt-3"}));
+}
+
+#[test]
+fn resident_gcp_hook_mints_once_and_reuses_cached_token() {
+    let dir = unique_temp_dir("token-cache");
+    let counter_path = dir.join("counter.txt");
+    let token_cmd = format!(
+        "count_file={} ; count=0; if [ -f \"$count_file\" ]; then count=$(cat \"$count_file\"); fi; count=$((count+1)); printf '%s' \"$count\" > \"$count_file\"; printf 'cached-token\\n'",
+        shell_single_quote(&counter_path.display().to_string())
+    );
+
+    let mut process = match HookProcess::spawn(&token_cmd) {
+        Some(process) => process,
+        None => return,
+    };
+
+    for id in ["evt-11", "evt-12", "evt-13"] {
+        let response = process.request(json!({
+            "id": id,
+            "method": "GET",
+            "host": "bigquery.googleapis.com",
+            "path": "/bigquery/v2/projects/demo/jobs",
+            "headers": {}
+        }));
+        assert_eq!(response["headers"]["authorization"], "Bearer cached-token");
+    }
+
+    let count = std::fs::read_to_string(counter_path).expect("read counter file");
+    assert_eq!(count.trim(), "1");
+}
+
+fn shell_single_quote(input: &str) -> String {
+    format!("'{}'", input.replace('\'', "'\"'\"'"))
+}

--- a/crates/harnx-proxy-auth/tests/github_app_hook_script.rs
+++ b/crates/harnx-proxy-auth/tests/github_app_hook_script.rs
@@ -1,0 +1,226 @@
+#![cfg(unix)]
+
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+struct HookProcess {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+}
+
+impl HookProcess {
+    fn spawn(envs: &[(&str, &str)]) -> Option<Self> {
+        let script_path = script_path();
+        let python = match find_python3() {
+            Some(python) => python,
+            None => {
+                eprintln!("skipping github app hook script test: python3 not present");
+                return None;
+            }
+        };
+
+        let mut command = Command::new(python);
+        command
+            .arg(script_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+        for (key, value) in envs {
+            command.env(key, value);
+        }
+
+        let mut child = command.spawn().expect("spawn github app auth hook script");
+        let stdin = child.stdin.take().expect("hook stdin");
+        let stdout = child.stdout.take().expect("hook stdout");
+        let mut process = Self {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+        };
+
+        let ready = process.read_line_with_timeout(Duration::from_secs(2));
+        assert_eq!(ready.as_deref(), Some("READY"));
+        Some(process)
+    }
+
+    fn request(&mut self, request: Value) -> Value {
+        writeln!(
+            self.stdin,
+            "{}",
+            serde_json::to_string(&request).expect("serialize request")
+        )
+        .expect("write request");
+        self.stdin.flush().expect("flush request");
+
+        let line = self
+            .read_line_with_timeout(Duration::from_secs(2))
+            .expect("hook response line");
+        serde_json::from_str(&line).expect("parse hook response")
+    }
+
+    fn read_line_with_timeout(&mut self, timeout: Duration) -> Option<String> {
+        let reader = &mut self.stdout;
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::scope(|scope| {
+            scope.spawn(move || {
+                let mut line = String::new();
+                let result = reader.read_line(&mut line);
+                let _ = tx.send((result, line));
+            });
+
+            match rx.recv_timeout(timeout) {
+                Ok((Ok(0), _)) => None,
+                Ok((Ok(_), line)) => Some(line.trim_end_matches(['\r', '\n']).to_owned()),
+                Ok((Err(err), _)) => panic!("read hook output: {err}"),
+                Err(_) => panic!("timed out waiting for hook output"),
+            }
+        })
+    }
+}
+
+impl Drop for HookProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn script_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../example_config/github-app-auth-hook.py")
+        .canonicalize()
+        .expect("canonicalize github app auth hook path")
+}
+
+fn find_python3() -> Option<&'static str> {
+    for candidate in ["python3", "/usr/bin/env"] {
+        let mut command = Command::new(candidate);
+        if candidate == "/usr/bin/env" {
+            command.arg("python3");
+        }
+        if command
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .ok()
+            .is_some_and(|status| status.success())
+        {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn unique_temp_dir(name: &str) -> PathBuf {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock before unix epoch")
+        .as_millis();
+    let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("harnx-github-app-hook-{name}-{millis}-{id}"));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+#[test]
+fn resident_github_app_hook_injects_api_and_git_headers_and_passthrough() {
+    let temp_dir = unique_temp_dir("override");
+    let counter_path = temp_dir.join("counter.txt");
+    let counter_string = counter_path.display().to_string();
+    let expires_at = "2999-01-01T00:00:00Z";
+    let envs = [
+        (
+            "GITHUB_APP_INSTALLATION_TOKEN",
+            "ghs_test_installation_token",
+        ),
+        ("GITHUB_APP_INSTALLATION_TOKEN_EXPIRES_AT", expires_at),
+        ("GITHUB_APP_TEST_COUNTER_FILE", counter_string.as_str()),
+    ];
+    let mut process = match HookProcess::spawn(&envs) {
+        Some(process) => process,
+        None => return,
+    };
+
+    let api = process.request(json!({
+        "id": "evt-1",
+        "method": "GET",
+        "host": "api.github.com",
+        "path": "/repos/octo/demo/issues",
+        "headers": {}
+    }));
+    assert_eq!(api["id"], "evt-1");
+    assert_eq!(
+        api["headers"]["authorization"],
+        "Bearer ghs_test_installation_token"
+    );
+
+    let git = process.request(json!({
+        "id": "evt-2",
+        "method": "GET",
+        "host": "github.com",
+        "path": "/octo/demo.git/info/refs",
+        "headers": {}
+    }));
+    assert_eq!(git["id"], "evt-2");
+    assert_eq!(
+        git["headers"]["authorization"],
+        "Basic eC1hY2Nlc3MtdG9rZW46Z2hzX3Rlc3RfaW5zdGFsbGF0aW9uX3Rva2Vu"
+    );
+
+    let passthrough = process.request(json!({
+        "id": "evt-3",
+        "method": "GET",
+        "host": "example.com",
+        "path": "/hello",
+        "headers": {"x-demo": "1"}
+    }));
+    assert_eq!(passthrough, json!({"id": "evt-3"}));
+
+    let count = std::fs::read_to_string(counter_path).expect("read counter file");
+    assert_eq!(count.trim(), "1");
+}
+
+#[test]
+fn resident_github_app_hook_caches_installation_token_across_requests() {
+    let temp_dir = unique_temp_dir("cache");
+    let counter_path = temp_dir.join("counter.txt");
+    let counter_string = counter_path.display().to_string();
+    let expires_at = "2999-01-01T00:00:00Z";
+    let envs = [
+        (
+            "GITHUB_APP_INSTALLATION_TOKEN",
+            "ghs_cached_installation_token",
+        ),
+        ("GITHUB_APP_INSTALLATION_TOKEN_EXPIRES_AT", expires_at),
+        ("GITHUB_APP_TEST_COUNTER_FILE", counter_string.as_str()),
+    ];
+    let mut process = match HookProcess::spawn(&envs) {
+        Some(process) => process,
+        None => return,
+    };
+
+    for id in ["evt-11", "evt-12", "evt-13"] {
+        let response = process.request(json!({
+            "id": id,
+            "method": "GET",
+            "host": "uploads.github.com",
+            "path": "/repos/octo/demo/releases/assets/1",
+            "headers": {}
+        }));
+        assert_eq!(
+            response["headers"]["authorization"],
+            "Bearer ghs_cached_installation_token"
+        );
+    }
+
+    let count = std::fs::read_to_string(counter_path).expect("read counter file");
+    assert_eq!(count.trim(), "1");
+}

--- a/crates/harnx-proxy-auth/tests/hook_e2e.rs
+++ b/crates/harnx-proxy-auth/tests/hook_e2e.rs
@@ -175,6 +175,51 @@ async fn hook_env_sentinel_is_injected_into_bash_tool_input() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn hook_env_proxy_port_is_injected_into_bash_tool_input() {
+    let Some(proxy_bin) = proxy_binary_path() else {
+        eprintln!(
+            "SKIP hook_env_proxy_port_is_injected_into_bash_tool_input: harnx-proxy-auth not found"
+        );
+        return;
+    };
+
+    let env_arg = r#"{"GCE_METADATA_HOST": "127.0.0.1:\($proxy_port)"}"#;
+    let outcome = dispatch_one_hook_with_env(
+        &proxy_bin,
+        Some(env_arg),
+        HookEvent::PreToolUse {
+            tool_name: "bash_exec".to_string(),
+            tool_input: json!({
+                "command": "env",
+            }),
+            tool_use_id: "toolu_hook_e2e_proxy_port".to_string(),
+        },
+    )
+    .await;
+
+    assert!(matches!(outcome.control, HookResultControl::Continue));
+
+    let mutated = outcome
+        .result
+        .mutated_tool_input
+        .expect("persistent hook must mutate tool_input for bash_exec");
+    let env = mutated
+        .get("env")
+        .and_then(Value::as_object)
+        .expect("mutated tool_input must contain an 'env' object");
+    let host = env
+        .get("GCE_METADATA_HOST")
+        .and_then(Value::as_str)
+        .expect("GCE_METADATA_HOST must be injected");
+
+    let port = host
+        .strip_prefix("127.0.0.1:")
+        .expect("metadata host should use localhost proxy");
+    let port_num = port.parse::<u16>().expect("proxy port should parse");
+    assert!(port_num > 0, "proxy port should be non-zero");
+}
+
 async fn dispatch_one_hook(proxy_bin: &Path, event: HookEvent) -> HookOutcome {
     dispatch_one_hook_with_env(proxy_bin, None, event).await
 }

--- a/crates/harnx-proxy-auth/tests/hook_pipeline_integration.rs
+++ b/crates/harnx-proxy-auth/tests/hook_pipeline_integration.rs
@@ -1,0 +1,264 @@
+#![cfg(unix)]
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use harnx_proxy_auth::filter::{compile_with_vars, JaqVars};
+use harnx_proxy_auth::sentinel::Sentinels;
+use harnx_proxy_auth::transform::{Stage, TransformPipeline};
+use harnx_proxy_auth::{ca, proxy};
+use http_body_util::Full;
+use hyper::body::{Bytes, Incoming};
+use hyper::header::CONTENT_TYPE;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::TokioIo;
+use serde_json::Value;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::time::{sleep, timeout, Duration};
+use tokio_rustls::rustls::{self, pki_types};
+use tokio_rustls::TlsAcceptor;
+
+fn jaq_vars() -> Arc<JaqVars> {
+    Arc::new(JaqVars::new(&Sentinels::generate(), String::new(), None, vec![]).unwrap())
+}
+
+fn jaq_stage(expr: &str, vars: &Arc<JaqVars>) -> Stage {
+    Stage::Jaq {
+        filter: Arc::new(compile_with_vars(expr, vars).unwrap()),
+        vars: vars.clone(),
+    }
+}
+
+fn exec_stage(script: &str, timeout_secs: u64) -> Stage {
+    Stage::Exec(Arc::new(
+        harnx_proxy_auth::exec_hook::ExecHookProcess::spawn_inline(script, timeout_secs).unwrap(),
+    ))
+}
+
+/// Starts an HTTPS test server using provided cert+key (DER-encoded).
+async fn spawn_https_server(
+    cert_der_bytes: Vec<u8>,
+    key_der_bytes: Vec<u8>,
+) -> Result<(u16, oneshot::Sender<()>)> {
+    let cert_der = pki_types::CertificateDer::from(cert_der_bytes);
+    let key_der = pki_types::PrivateKeyDer::try_from(key_der_bytes)
+        .map_err(|e| anyhow::anyhow!("wrap key: {e}"))?;
+
+    let tls_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key_der)
+        .context("build TLS config")?;
+    let acceptor = TlsAcceptor::from(Arc::new(tls_config));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = &mut shutdown_rx => break,
+                accept_result = listener.accept() => {
+                    let Ok((stream, _)) = accept_result else { break; };
+                    let acceptor = acceptor.clone();
+                    tokio::spawn(async move {
+                        let Ok(tls) = acceptor.accept(stream).await else { return; };
+                        let svc = service_fn(echo_request);
+                        let _ = http1::Builder::new()
+                            .serve_connection(TokioIo::new(tls), svc)
+                            .await;
+                    });
+                }
+            }
+        }
+    });
+
+    Ok((port, shutdown_tx))
+}
+
+async fn echo_request(req: Request<Incoming>) -> Result<Response<Full<Bytes>>, hyper::Error> {
+    let headers: BTreeMap<String, String> = req
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect();
+    let body = serde_json::json!({
+        "path": req.uri().path_and_query().map_or("/", |pq| pq.as_str()),
+        "headers": headers,
+    });
+    let body = serde_json::to_vec(&body).unwrap_or_default();
+    Ok(Response::builder()
+        .header(CONTENT_TYPE, "application/json")
+        .body(Full::new(Bytes::from(body)))
+        .unwrap())
+}
+
+async fn send_https_request(pipeline: TransformPipeline) -> Result<Value> {
+    let (ca_setup, _ca_temp_dir) = ca::setup().context("proxy CA setup")?;
+    let ca_cert_pem =
+        std::fs::read_to_string(&ca_setup.cert_pem_path).context("read proxy CA cert PEM")?;
+
+    let server_cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+        .context("generate self-signed server cert")?;
+    let server_cert_der = server_cert.cert.der().to_vec();
+    let server_key_der = server_cert.signing_key.serialize_der();
+
+    let (server_port, _server_shutdown) = spawn_https_server(server_cert_der, server_key_der)
+        .await
+        .context("spawn HTTPS server")?;
+
+    let proxy_port = proxy::start_proxy_danger_accept_invalid_certs(Arc::new(pipeline), ca_setup)
+        .await
+        .context("start proxy")?;
+
+    sleep(Duration::from_millis(100)).await;
+
+    let proxy_ca = reqwest::tls::Certificate::from_pem(ca_cert_pem.as_bytes())
+        .context("parse proxy CA cert")?;
+
+    let client = reqwest::Client::builder()
+        .proxy(
+            reqwest::Proxy::https(format!("http://127.0.0.1:{proxy_port}"))
+                .context("build proxy")?,
+        )
+        .add_root_certificate(proxy_ca)
+        .danger_accept_invalid_certs(true)
+        .build()
+        .context("build reqwest client")?;
+
+    let response = client
+        .get(format!("https://localhost:{server_port}/hook-test"))
+        .send()
+        .await
+        .context("send request")?;
+
+    assert!(
+        response.status().is_success(),
+        "expected 200, got {}",
+        response.status()
+    );
+
+    response.json().await.context("parse echoed JSON body")
+}
+
+#[tokio::test]
+async fn mixed_jaq_and_shebang_hooks_apply_in_cli_order() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    timeout(Duration::from_secs(30), async {
+        let vars = jaq_vars();
+        let pipeline = TransformPipeline::new(vec![
+            jaq_stage(
+                r#".headers["x-order"] = "A" | .headers["x-marker"] = "jaq1""#,
+                &vars,
+            ),
+            exec_stage(
+                r##"#!/bin/sh
+printf 'READY
+'
+while IFS= read -r line; do
+  HOOK_LINE="$line" python3 - <<'PY'
+import json
+import os
+msg = json.loads(os.environ["HOOK_LINE"])
+headers = msg.setdefault("headers", {})
+headers["x-order"] = headers.get("x-order", "") + "E1"
+headers["x-marker"] = headers.get("x-marker", "") + "-exec1"
+print(json.dumps(msg), flush=True)
+PY
+done
+"##,
+                5,
+            ),
+            jaq_stage(
+                r#".headers["x-order"] += "B" | .headers["x-marker"] += "-jaq2""#,
+                &vars,
+            ),
+        ]);
+
+        let body = send_https_request(pipeline)
+            .await
+            .expect("round-trip request");
+        let headers = body
+            .get("headers")
+            .and_then(Value::as_object)
+            .expect("headers object");
+
+        assert_eq!(
+            headers.get("x-order").and_then(Value::as_str),
+            Some("AE1B"),
+            "stages did not apply in CLI order. Full body: {body}"
+        );
+        assert_eq!(
+            headers.get("x-marker").and_then(Value::as_str),
+            Some("jaq1-exec1-jaq2"),
+            "marker header did not preserve jaq -> exec -> jaq sequencing. Full body: {body}"
+        );
+    })
+    .await
+    .expect("test timed out");
+}
+
+#[tokio::test]
+async fn two_shebang_hooks_both_run() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    timeout(Duration::from_secs(30), async {
+        let pipeline = TransformPipeline::new(vec![
+            exec_stage(
+                r##"#!/bin/sh
+printf 'READY
+'
+while IFS= read -r line; do
+  HOOK_LINE="$line" python3 - <<'PY'
+import json
+import os
+msg = json.loads(os.environ["HOOK_LINE"])
+headers = msg.setdefault("headers", {})
+headers["x-chain"] = headers.get("x-chain", "") + "1"
+print(json.dumps(msg), flush=True)
+PY
+done
+"##,
+                5,
+            ),
+            exec_stage(
+                r##"#!/bin/sh
+printf 'READY
+'
+while IFS= read -r line; do
+  HOOK_LINE="$line" python3 - <<'PY'
+import json
+import os
+msg = json.loads(os.environ["HOOK_LINE"])
+headers = msg.setdefault("headers", {})
+headers["x-chain"] = headers.get("x-chain", "") + "2"
+print(json.dumps(msg), flush=True)
+PY
+done
+"##,
+                5,
+            ),
+        ]);
+
+        let body = send_https_request(pipeline)
+            .await
+            .expect("round-trip request");
+        let headers = body
+            .get("headers")
+            .and_then(Value::as_object)
+            .expect("headers object");
+
+        assert_eq!(
+            headers.get("x-chain").and_then(Value::as_str),
+            Some("12"),
+            "both exec stages should run in order. Full body: {body}"
+        );
+    })
+    .await
+    .expect("test timed out");
+}

--- a/crates/harnx-proxy-auth/tests/https_connect.rs
+++ b/crates/harnx-proxy-auth/tests/https_connect.rs
@@ -23,14 +23,27 @@ use tokio::time::{sleep, timeout, Duration};
 use tokio_rustls::rustls::{self, pki_types};
 use tokio_rustls::TlsAcceptor;
 
-use harnx_proxy_auth::{ca, filter, proxy};
+use harnx_proxy_auth::{
+    ca, filter, proxy,
+    transform::{Stage, TransformPipeline},
+};
 fn jaq_vars(
     sentinels: &Arc<harnx_proxy_auth::sentinel::Sentinels>,
 ) -> Arc<harnx_proxy_auth::filter::JaqVars> {
     Arc::new(
-        harnx_proxy_auth::filter::JaqVars::new(sentinels, String::new(), Vec::new())
+        harnx_proxy_auth::filter::JaqVars::new(sentinels, String::new(), None, Vec::new())
             .expect("jaq vars"),
     )
+}
+
+fn jaq_pipeline(
+    expr: &str,
+    vars: Arc<harnx_proxy_auth::filter::JaqVars>,
+) -> Arc<TransformPipeline> {
+    Arc::new(TransformPipeline::new(vec![Stage::Jaq {
+        filter: Arc::new(filter::compile_with_vars(expr, &vars).expect("compile filter")),
+        vars,
+    }]))
 }
 
 /// Starts an HTTPS test server using the provided cert+key (DER-encoded).
@@ -122,18 +135,14 @@ async fn header_injection_works_through_https_connect_tunnel() {
         // Compile the jq filter that injects a test header for localhost.
         let filter_expr =
             r#"if .host == "localhost" then .headers["x-test-header"] = "hello-world" end"#;
-        let compiled = filter::compile(filter_expr).expect("compile filter");
         let sentinels = Arc::new(harnx_proxy_auth::sentinel::Sentinels::generate());
+        let pipeline = jaq_pipeline(filter_expr, jaq_vars(&sentinels));
 
         // Start the proxy with danger_accept_invalid_certs so it can connect
         // upstream to our self-signed test server.
-        let proxy_port = proxy::start_proxy_danger_accept_invalid_certs(
-            compiled,
-            ca_setup,
-            jaq_vars(&sentinels),
-        )
-        .await
-        .expect("start proxy");
+        let proxy_port = proxy::start_proxy_danger_accept_invalid_certs(pipeline, ca_setup)
+            .await
+            .expect("start proxy");
 
         sleep(Duration::from_millis(100)).await;
 
@@ -216,12 +225,11 @@ async fn hook_filter_can_use_sentinel_variables() {
         // Compile the jq filter that checks the sentinel jaq variable directly.
         let filter_expr =
             r#"if .headers.authorization == "Bearer ghs_\($fake_base64_key)" then .headers.authorization = "Bearer real_token_from_env" else . end"#;
-        let compiled = filter::compile(filter_expr).expect("compile filter");
+        let pipeline = jaq_pipeline(filter_expr, jaq_vars(&sentinels));
 
         // Start the proxy with danger_accept_invalid_certs so it can connect
         // upstream to our self-signed test server.
-        let proxy_port =
-            proxy::start_proxy_danger_accept_invalid_certs(compiled, ca_setup, jaq_vars(&sentinels))
+        let proxy_port = proxy::start_proxy_danger_accept_invalid_certs(pipeline, ca_setup)
             .await
             .expect("start proxy");
 

--- a/docs/gcp-auth-proxy.md
+++ b/docs/gcp-auth-proxy.md
@@ -1,0 +1,137 @@
+# GCP Auth Injection (harnx-proxy-auth)
+
+`harnx-proxy-auth` provides a transparent authentication proxy for Google Cloud Platform (GCP) services. It allows tools inside a sandbox (like the Node `@google-cloud/bigquery` library; see [sandbox-run.md](sandbox-run.md) for general sandbox usage) to authenticate using host-side credentials without ever seeing a reusable Google credential file or long-lived token.
+
+## The Problem It Solves
+
+Google Cloud client libraries typically use **Application Default Credentials (ADC)**, which look for a JSON key file at `GOOGLE_APPLICATION_CREDENTIALS` or in `~/.config/gcloud`.
+
+In a secure sandbox:
+1. **No secrets are mounted**: Mounting a service account key into the sandbox risks accidental leakage or reuse by untrusted code.
+2. **ADC requires files**: Most GCP SDKs fail immediately if they cannot find a credential file or reach a GCE metadata server, making file-free auth difficult.
+3. **Token Refresh**: Tokens expire every hour. A simple one-time environment injection isn't enough for long-running sessions.
+
+## How It Works
+
+`harnx-proxy-auth` solves this using a **resident proxy hook** and **GCE metadata emulation**:
+
+1. **Metadata Emulation**: The proxy supports injecting environment variables (`GCE_METADATA_HOST`, `METADATA_SERVER_DETECTION`) that redirect the sandbox's ADC discovery to the proxy itself. This is enabled by passing a `--env` flag that uses the `$proxy_port` variable (the proxy's runtime-assigned port).
+2. **Resident Hook**: A persistent Python or shell script runs alongside the proxy (loaded via the `--hook` flag). This script holds the real, host-minted Google token in memory.
+3. **Synthetic Responses**: When a tool in the sandbox asks for a token from the "metadata server" (the proxy), the resident hook intercepts the request and returns a **synthetic response** (`.respond`) containing a placeholder token. This satisfies the SDK's ADC requirement without exposing the real token.
+4. **Header Rewriting**: When the tool makes a real request to `*.googleapis.com`, the proxy intercepts the call and swaps the placeholder header for a real `Authorization: Bearer <token>` header before forwarding it to Google.
+
+The real token only exists in the proxy's memory and on the wire between the proxy and Google. It never enters the sandbox.
+
+## Installation
+
+The proxy is part of the `harnx-proxy-auth` crate:
+
+```bash
+cargo install --path crates/harnx-proxy-auth
+```
+
+## Usage
+
+### CLI Flags
+
+- `--env "JQ_FILTER"`: Injects environment variables into the sandbox. Use `$proxy_port` (a string) to reference the proxy's assigned port.
+  - Example: `--env '{"GCE_METADATA_HOST":"127.0.0.1:\($proxy_port)","METADATA_SERVER_DETECTION":"assume-present"}'`
+  - To set the project ID: `--env '{"GOOGLE_CLOUD_PROJECT":"my-project-id"}'` (can be combined into one object).
+- `--hook "HOOK"`: Attaches a hook stage. Accepted forms:
+  - **Script path**: Starting with `/`, `./`, or `../`. Run directly from disk (relative to proxy CWD). Must exist and be executable; may be a shebang script or any other executable/binary.
+  - **Inline script**: Content starting with `#!`. Proxy writes it to a temp file before launching, so inline form must include a shebang.
+  - **Jaq filter**: Any other value is treated as a jaq filter.
+- `--hook-timeout-secs <n>`: Sets the per-request timeout for exec `--hook` stages (default: 30s).
+
+### Example: BigQuery Access
+
+To run a Node.js script using BigQuery inside a sandbox:
+
+```bash
+harnx-sandbox-run \
+  --hook harnx-proxy-auth \
+    --env '{"GCE_METADATA_HOST":"127.0.0.1:\($proxy_port)","METADATA_SERVER_DETECTION":"assume-present","GOOGLE_CLOUD_PROJECT":"<id>"}' \
+    --hook ./example_config/gcp-auth-hook.py \
+  \; \
+  -- node my-bigquery-script.js
+```
+
+You can also combine multiple hooks:
+
+```bash
+harnx-proxy-auth \
+  --env '{"GCE_METADATA_HOST":"127.0.0.1:\($proxy_port)","METADATA_SERVER_DETECTION":"assume-present"}' \
+  --hook ./example_config/gcp-auth-hook.py \
+  --hook 'if .host == "my-internal-api.com" then .headers["X-Internal"] = "true" else . end' \
+  -- ...
+```
+
+### JSONL Protocol
+
+Resident hooks communicate with the proxy via JSONL on stdin/stdout.
+- **Request (from proxy)**: `{"id": "...", "method": "...", "host": "...", "path": "...", "headers": {...}}`
+- **Response (from hook)**:
+    - `{"id": "...", "headers": {...}}`: Patch request headers.
+    - `{"id": "...", "respond": {"status": 200, "headers": {...}, "body": "..."}}`: Return a synthetic response.
+    - `{"id": "...", "block": true}`: Block the request (403).
+
+## Validation (Manual E2E)
+
+You can verify the setup with these steps:
+
+1. **Host Setup**: Ensure you have `gcloud` authenticated.
+2. **Run Sandbox**:
+   ```bash
+   harnx-sandbox-run \
+     --hook harnx-proxy-auth \
+       --env '{"GCE_METADATA_HOST":"127.0.0.1:\($proxy_port)","METADATA_SERVER_DETECTION":"assume-present","GOOGLE_CLOUD_PROJECT":"<project-id>"}' \
+       --hook ./example_config/gcp-auth-hook.py \
+     \; \
+     -- bash
+   ```
+3. **Inside Sandbox**:
+   - Verify `GOOGLE_APPLICATION_CREDENTIALS` is unset.
+   - Run a query (e.g., using `node`):
+     ```js
+     const {BigQuery} = require('@google-cloud/bigquery');
+     const bq = new BigQuery();
+     const [rows] = await bq.query({query: 'SELECT 1 AS ok'});
+     console.log(rows);
+     ```
+4. **Logs**: Check proxy logs (or stderr) to see the metadata request being answered synthetically and the BigQuery request being forwarded with the rewritten header.
+
+## Other Providers
+
+The same resident hook mechanism is used for other providers:
+
+- **GitHub App**: `example_config/github-app-auth-hook.py` mints and caches installation tokens, injecting them as Bearer tokens (API) or Basic auth (git).
+- **Atlassian/Jira**: `example_config/jira-auth-hook.py` simplifies complex `acli` configurations into a single resident process.
+
+## Security
+
+- **Sandbox Isolation**: Each proxy instance uses a random loopback port. The environment variables pointing to this port are private to the sandbox.
+- **No Credentials**: No `.json` keys or `~/.config/gcloud` files are needed in the sandbox.
+- **Placeholder Tokens**: The emulation layer returns only a placeholder token to the sandbox. The real token is attached only on egress to `*.googleapis.com`.
+- **Unix Only**: Shebang-based resident hooks are currently supported on Unix-like systems only.
+
+## Limitations
+
+- **Unix Only**: Shebang `--hook` stages require a Unix environment.
+- **CA Bundle**: Tools must honor the `HTTPS_PROXY` and the CA bundle injected by the proxy.
+- **Refresh**: Token refresh is handled by the hook script (the provided Python scripts handle this automatically).
+
+### `NO_PROXY` Hygiene
+
+Do **not** add `googleapis.com` or `127.0.0.1` to your `NO_PROXY` environment variable. 
+- The GCE metadata emulation relies on the tool talking to the proxy at `127.0.0.1`.
+- Auth injection relies on the proxy intercepting calls to `googleapis.com`.
+If these are in `NO_PROXY`, the tool will bypass the proxy and fail to authenticate.
+
+## Context
+
+For more technical details on the implementation, see the solution note: [GCP Auth Injection via Resident Proxy Hooks](solutions/proxy-hooks/gcp-auth-injection-2026-07-01.md).
+
+## See Also
+
+- [AWS Credential Injection](aws-creds.md)
+- [harnx-sandbox-run](sandbox-run.md)

--- a/docs/solutions/proxy-hooks/gcp-auth-injection-2026-07-01.md
+++ b/docs/solutions/proxy-hooks/gcp-auth-injection-2026-07-01.md
@@ -1,0 +1,111 @@
+---
+title: "GCP auth injection via resident proxy hooks and GCE metadata emulation"
+date: 2026-07-01
+category: proxy-hooks
+problem_type: integration_issue
+component: harnx-proxy-auth
+root_cause: "sandbox credential isolation vs GCP SDK Application Default Credentials (ADC) requirements"
+resolution_type: code_fix
+severity: medium
+tags:
+  - gcp
+  - proxy
+  - auth
+  - bigquery
+  - metadata
+  - token
+plan_ref: gcp-creds-helper
+---
+
+## Problem
+
+Enabling Google Cloud Platform (GCP) SDKs (specifically Node.js `@google-cloud/bigquery`) to function inside a strictly isolated sandbox without mounting credential files or exposing reusable long-lived tokens. 
+
+Standard GCP libraries require Application Default Credentials (ADC), which usually look for a local JSON file. If no file is found, they attempt to reach a GCE metadata server at a fixed IP. In a sandbox where network access is restricted to a MITM proxy, the libraries fail to authenticate.
+
+## Solution
+
+The `harnx-proxy-auth` component provides a unified hook mechanism and built-in metadata emulation to bridge this gap.
+
+### Resident Proxy Hooks
+
+The proxy allows attaching external executables via the `--hook` flag. When the flag points to an executable file path (e.g., `./example_config/gcp-auth-hook.py`), the proxy spawns it directly as a long-lived resident process. Path hooks only need execute permission; if they use a shebang, the OS honors it. Inline `#!...` hooks still materialize to temp files and therefore require a shebang.
+
+- **Protocol**: Communication occurs via JSONL over stdin/stdout.
+- **Request**: The proxy sends a JSON object containing request metadata (`id`, `method`, `host`, `path`, `headers`).
+- **Response**: The hook returns a JSON object that can modify headers, block the request, or return a **synthetic response** (`.respond`).
+- **Lifecycle**: The process is lazy-started, survives concurrent requests (via actor-based concurrency), and is automatically restarted if it crashes.
+
+### Synthetic Responses (`.respond`)
+
+The proxy was updated to support a `.respond` field in the hook output. If present, the proxy skips the upstream request and returns the specified status code, headers, and body directly to the client.
+
+```json
+{
+  "id": "req-1",
+  "respond": {
+    "status": 200,
+    "headers": {"content-type": "application/json", "metadata-flavor": "Google"},
+    "body": "{\"access_token\": \"placeholder-token\", \"expires_in\": 3599}"
+  }
+}
+```
+
+### GCE Metadata Emulation
+
+To bootstrap ADC without files, the proxy supports injecting environment variables into the sandbox via the `--env` flag. This uses a `$proxy_port` jaq variable to point to the proxy's runtime port:
+
+1. `GCE_METADATA_HOST=127.0.0.1:\($proxy_port)`: Redirects metadata calls to the proxy.
+2. `METADATA_SERVER_DETECTION=assume-present`: Skips the initial connectivity check that often fails in proxied environments.
+
+Example:
+`--env '{"GCE_METADATA_HOST":"127.0.0.1:\($proxy_port)","METADATA_SERVER_DETECTION":"assume-present"}'`
+
+The resident hook (`./example_config/gcp-auth-hook.py`) intercepts any request starting with `/computeMetadata/` and returns the synthetic JSON response expected by the Google SDKs.
+
+### Header Rewriting (Bearer Tokens)
+
+Unlike AWS SigV4, GCP authentication uses simple Bearer tokens. This allows the proxy to:
+1. Provide a **placeholder token** to the sandbox via the metadata emulation.
+2. Intercept outbound HTTPS calls to `*.googleapis.com`.
+3. Swap the `Authorization: Bearer <placeholder>` header with a **real token** minted on the host side.
+
+The real token is cached in the resident hook's memory and refreshed automatically on the host, ensuring the sandbox never sees it.
+
+## Why This Works
+
+1. **Isolation**: The sandbox never holds a reusable credential. The host-side token is only attached on egress.
+2. **File-free**: No `.json` files need to be managed or mounted into the sandbox.
+3. **Standard Support**: By emulating the metadata server protocol, we support any GCP SDK without modification.
+4. **Scoping**: By using `gcloud auth print-access-token --impersonate-service-account=$SA` as the token source, the operator can granularly scope what the sandbox can access.
+
+## Implementation Details
+
+### Unified Stage Pipeline
+
+The `TransformPipeline` (in `crates/harnx-proxy-auth/src/transform.rs`) applies hook stages in the exact order they appear on the CLI. 
+
+```rust
+pub enum Stage {
+    Jaq { filter: Arc<CompiledFilter>, vars: Arc<JaqVars> },
+    Exec(Arc<ExecHookProcess>),
+}
+```
+
+This allows interleaving resident scripts and jaq filters. Sequential application (`stage1 -> stage2 -> stage3`) ensures predictable behavior.
+
+### Host-side Token Minting
+
+The `gcp-auth-hook.py` script uses the `HARNX_GCP_TOKEN_CMD` environment variable (defaulting to `gcloud auth print-access-token`) to fetch tokens. This keeps the token-fetching logic configurable and separate from the proxy's core.
+
+## Prevention Strategies
+
+- **Fail-safe Passthrough**: If a hook script hangs or crashes, the proxy times out (default 30s) and passes the request through unmodified. An unauthenticated request will fail at the Google API level, preventing silent failures or data leaks.
+- **NO_PROXY Hygiene**: Documentation warns users not to put `googleapis.com` in `NO_PROXY`, as that would bypass the proxy and break auth injection.
+
+## Related Issues
+
+- **Plan**: `gcp-creds-helper`
+- **GitHub Issue**: #593
+- **Related Docs**: [gcp-auth-proxy.md](../../gcp-auth-proxy.md), [aws-creds.md](../../aws-creds.md)
+- **Example Scripts**: [gcp-auth-hook.py](../../../example_config/gcp-auth-hook.py), [github-app-auth-hook.py](../../../example_config/github-app-auth-hook.py), [jira-auth-hook.py](../../../example_config/jira-auth-hook.py)

--- a/example_config/config.yaml
+++ b/example_config/config.yaml
@@ -77,7 +77,7 @@ toolsets:
 # `if COND then EXPR end` — omitting `else` passes the input through unchanged when
 # the condition is false (equivalent to `else .` in jaq but cleaner).
 #
-# Example: GitHub auth injection (git over HTTPS + GitHub API + uploads)
+# Example: GitHub PAT auth injection (git over HTTPS + GitHub API + uploads)
 #
 # hooks:
 #   entries:
@@ -102,8 +102,14 @@ toolsets:
 # token never enters the sandbox — harnx-proxy-auth reads it from the host env
 # and injects it into outbound HTTP auth headers.
 #
-# Example: Atlassian (Jira/Confluence) auth injection
-# Sources credentials from the host OS keyring using --load-exec.
+# Example: GitHub App auth injection (resident hook mints + caches installation token)
+# Requires host env: GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, and either
+# GITHUB_APP_INSTALLATION_ID or GITHUB_OWNER/GITHUB_REPO (or GITHUB_ORG).
+# Optional scoping env vars:
+#   GITHUB_APP_REPOSITORIES='["repo-one","repo-two"]'
+#   GITHUB_APP_PERMISSIONS='{"contents":"read","pull_requests":"write"}'
+# Optional test/advanced override: GITHUB_APP_INSTALLATION_TOKEN short-circuits
+# live GitHub exchange and stays proxy-side only.
 #
 # hooks:
 #   entries:
@@ -112,22 +118,51 @@ toolsets:
 #     matcher: "bash_exec|bash_spawn"
 #     command: >-
 #       harnx-proxy-auth
-#       --load-yaml acli_cfg=~/.config/acli/jira_config.yaml
-#       --load-exec 'atlassian_token=p=$(sed -n "s/^current_profile:[[:space:]]*\"\?\([^\"]*\)\"\?[[:space:]]*$/\1/p" ~/.config/acli/jira_config.yaml); test -n "$p" && secret-tool lookup service acli username "jira:$p"'
-#       --fs '$acli_cfg.current_profile as $cp |
-#           (first($acli_cfg.profiles[]? | select("\(.cloud_id):\(.account_id)" == $cp))) as $p |
-#           if $p and $atlassian_token then
-#             . + { "acli/jira_config.yaml": ({ version: 1, current_profile: $cp,
-#               profiles: [{ site: $p.site, cloud_id: $p.cloud_id, account_id: $p.account_id, auth_type: "api_token",
-#                 token: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6OjowMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDBhNmM2MzI1MzM1NGQxODBiNjkzYWFjYmRkZjlmYjA2YzFkMGI2NmE0MmQ4Mzc1NmJjM2U5ZjM5ODg4MzRhMGZiM2EzYTRhMWY=" }] } | tojson) }
-#           end'
-#       --env '$acli_cfg.current_profile as $cp |
-#           (first($acli_cfg.profiles[]? | select("\(.cloud_id):\(.account_id)" == $cp))) as $p |
-#           if $p and $atlassian_token then .ACLI_CONFIG_DIR = $temp_file_root end'
-#       --hook '$acli_cfg.current_profile as $cp |
-#           (first($acli_cfg.profiles[]? | select("\(.cloud_id):\(.account_id)" == $cp))) as $p |
-#           if $p and $atlassian_token and (.host == "api.atlassian.com" or .host == $p.site)
-#           then .headers.authorization = basic($p.email // env.ATLASSIAN_EMAIL // ""; $atlassian_token) end'
+#       --hook ./example_config/github-app-auth-hook.py
+#       # Inline shebang script content also works.
+#
+# Example: Atlassian (Jira/Confluence) auth injection
+# One resident hook handles whole acli workaround once: read host jira_config.yaml,
+# select profile matching current_profile, fetch real token from host keyring, write
+# private synthetic acli config with sentinel token, set ACLI_CONFIG_DIR, and swap in
+# real Authorization header only for api.atlassian.com / active site host.
+#
+# hooks:
+#   entries:
+#   - event: PreToolUse
+#     type: claude-command-persistent
+#     matcher: "bash_exec|bash_spawn"
+#     command: >-
+#       harnx-proxy-auth
+#       --env '{"ACLI_CONFIG_DIR": "\($temp_file_root)/harnx-fs-acli"}'
+#       --hook ./example_config/jira-auth-hook.py
+#
+# Example: GCP auth injection for Node ADC / BigQuery-style clients
+# Resident hook injects metadata endpoints into sandbox env, so Google client libs
+# discover ADC without credential files. Sandbox gets only proxy metadata hints;
+# proxy-side hook mints real token on demand and rewrites outbound Authorization
+# on *.googleapis.com requests (for example BigQuery HTTPS) with real scoped token.
+# Result: Node ADC works file-free, real Google credential stays outside sandbox,
+# and sandbox cannot reuse token beyond proxied calls.
+#
+# Optional host env:
+#   HARNX_GCP_TOKEN_CMD                      token source command
+#     default: gcloud auth print-access-token
+#   HARNX_GCP_SA                             service account for impersonation
+#   HARNX_GCP_TOKEN_CMD='gcloud auth print-access-token --impersonate-service-account=$HARNX_GCP_SA'
+#     use impersonation/scoping without exposing reusable Google credential in sandbox
+#
+# hooks:
+#   entries:
+#   - event: PreToolUse
+#     type: claude-command-persistent
+#     matcher: "bash_exec|bash_spawn"
+#     command: >-
+#       harnx-proxy-auth
+#       --env '{"GCE_METADATA_HOST":"127.0.0.1:\($proxy_port)","METADATA_SERVER_DETECTION":"assume-present"}'
+#       # Optional: add GOOGLE_CLOUD_PROJECT in same --env object.
+#       # --env '{"GCE_METADATA_HOST":"127.0.0.1:\($proxy_port)","METADATA_SERVER_DETECTION":"assume-present","GOOGLE_CLOUD_PROJECT":"<id>"}'
+#       --hook ./example_config/gcp-auth-hook.py
 #
 # Both can be combined into a single harnx-proxy-auth invocation with multiple
 # --env and --hook flags. See docs/sandbox-run.md for full claude-sb / gemini-sb

--- a/example_config/gcp-auth-hook.py
+++ b/example_config/gcp-auth-hook.py
@@ -7,6 +7,8 @@ import time
 
 TOKEN_CMD_ENV = "HARNX_GCP_TOKEN_CMD"
 DEFAULT_TOKEN_CMD = "gcloud auth print-access-token"
+TOKEN_CMD_TIMEOUT_ENV = "HARNX_GCP_TOKEN_CMD_TIMEOUT_SECONDS"
+DEFAULT_TOKEN_CMD_TIMEOUT_SECONDS = 10
 DEFAULT_TOKEN_TTL_SECONDS = 55 * 60
 REFRESH_SKEW_SECONDS = 60
 
@@ -29,6 +31,33 @@ def is_google_api_host(host):
     return any(host == suffix or host.endswith("." + suffix) for suffix in GOOGLE_API_HOST_SUFFIXES)
 
 
+def reset_cached_token():
+    global _cached_token, _cached_expiry
+    _cached_token = None
+    _cached_expiry = 0.0
+
+
+def token_cmd_timeout_seconds():
+    raw_value = os.environ.get(TOKEN_CMD_TIMEOUT_ENV)
+    if raw_value is None:
+        return DEFAULT_TOKEN_CMD_TIMEOUT_SECONDS
+    try:
+        timeout = float(raw_value)
+    except ValueError:
+        log(
+            f"invalid {TOKEN_CMD_TIMEOUT_ENV} value {raw_value!r}; "
+            f"using default timeout={DEFAULT_TOKEN_CMD_TIMEOUT_SECONDS}s"
+        )
+        return DEFAULT_TOKEN_CMD_TIMEOUT_SECONDS
+    if timeout <= 0:
+        log(
+            f"non-positive {TOKEN_CMD_TIMEOUT_ENV} value {raw_value!r}; "
+            f"using default timeout={DEFAULT_TOKEN_CMD_TIMEOUT_SECONDS}s"
+        )
+        return DEFAULT_TOKEN_CMD_TIMEOUT_SECONDS
+    return timeout
+
+
 def mint_token():
     global _cached_token, _cached_expiry
 
@@ -37,6 +66,7 @@ def mint_token():
         return _cached_token
 
     token_cmd = os.environ.get(TOKEN_CMD_ENV, DEFAULT_TOKEN_CMD)
+    timeout_seconds = token_cmd_timeout_seconds()
     try:
         completed = subprocess.run(
             token_cmd,
@@ -45,18 +75,21 @@ def mint_token():
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            timeout=timeout_seconds,
         )
+    except subprocess.TimeoutExpired as exc:
+        log(f"token command timed out after {exc.timeout}s: {exc.__class__.__name__}")
+        reset_cached_token()
+        return None
     except Exception as exc:
-        log(f"token command failed: {token_cmd!r}: {exc}")
-        _cached_token = None
-        _cached_expiry = 0.0
+        log(f"token command failed: {exc.__class__.__name__}: {exc}")
+        reset_cached_token()
         return None
 
     token = completed.stdout.strip()
     if not token:
-        log(f"token command produced empty stdout: {token_cmd!r}")
-        _cached_token = None
-        _cached_expiry = 0.0
+        log("token command produced empty stdout")
+        reset_cached_token()
         return None
 
     _cached_token = token
@@ -145,13 +178,20 @@ def main():
         if not raw_line:
             continue
         request_id = None
+        request_host = ""
+        request_path = ""
         try:
             request = json.loads(raw_line)
             if isinstance(request, dict):
                 request_id = request.get("id")
+                request_host = request.get("host") or ""
+                request_path = request.get("path") or ""
             response = handle_request(request)
         except Exception as exc:
-            log(f"request handling failed: {exc}; line={raw_line!r}")
+            log(
+                f"request handling failed: {exc.__class__.__name__}: {exc}; "
+                f"id={request_id!r} host={request_host!r} path={request_path!r}"
+            )
             if request_id is None:
                 continue
             response = {"id": request_id}

--- a/example_config/gcp-auth-hook.py
+++ b/example_config/gcp-auth-hook.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+import time
+
+TOKEN_CMD_ENV = "HARNX_GCP_TOKEN_CMD"
+DEFAULT_TOKEN_CMD = "gcloud auth print-access-token"
+DEFAULT_TOKEN_TTL_SECONDS = 55 * 60
+REFRESH_SKEW_SECONDS = 60
+
+# Keep Google API host matching in one predicate so operators can extend it if
+# e2e shows a 401 on an unexpected Google host that still needs auth injection.
+GOOGLE_API_HOST_SUFFIXES = [
+    "googleapis.com",
+]
+
+_cached_token = None
+_cached_expiry = 0.0
+
+
+def log(message):
+    print(message, file=sys.stderr, flush=True)
+
+
+def is_google_api_host(host):
+    host = (host or "").strip().lower()
+    return any(host == suffix or host.endswith("." + suffix) for suffix in GOOGLE_API_HOST_SUFFIXES)
+
+
+def mint_token():
+    global _cached_token, _cached_expiry
+
+    now = time.time()
+    if _cached_token and now < (_cached_expiry - REFRESH_SKEW_SECONDS):
+        return _cached_token
+
+    token_cmd = os.environ.get(TOKEN_CMD_ENV, DEFAULT_TOKEN_CMD)
+    try:
+        completed = subprocess.run(
+            token_cmd,
+            shell=True,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except Exception as exc:
+        log(f"token command failed: {token_cmd!r}: {exc}")
+        _cached_token = None
+        _cached_expiry = 0.0
+        return None
+
+    token = completed.stdout.strip()
+    if not token:
+        log(f"token command produced empty stdout: {token_cmd!r}")
+        _cached_token = None
+        _cached_expiry = 0.0
+        return None
+
+    _cached_token = token
+    _cached_expiry = now + DEFAULT_TOKEN_TTL_SECONDS
+    return _cached_token
+
+
+def metadata_headers(content_type):
+    headers = {"metadata-flavor": "Google"}
+    if content_type:
+        headers["content-type"] = content_type
+    return headers
+
+
+def metadata_response(path):
+    token_prefix = "/computeMetadata/v1/instance/service-accounts/"
+    if path.startswith(token_prefix) and path.endswith("/token"):
+        body = json.dumps(
+            {
+                "access_token": "proxy-managed",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            }
+        )
+        return {
+            "status": 200,
+            "headers": metadata_headers("application/json"),
+            "body": body,
+        }
+
+    known_ok_paths = {
+        "/computeMetadata/",
+        "/computeMetadata/v1/",
+        "/computeMetadata/v1/instance",
+        "/computeMetadata/v1/instance/",
+        "/computeMetadata/v1/project/project-id",
+    }
+    if path in known_ok_paths:
+        body = "{}"
+        if path == "/computeMetadata/v1/project/project-id":
+            body = "proxy-project"
+        return {
+            "status": 200,
+            "headers": metadata_headers("application/json" if body.startswith("{") else "text/plain"),
+            "body": body,
+        }
+
+    return {
+        "status": 404,
+        "headers": metadata_headers("application/json"),
+        "body": "{}",
+    }
+
+
+def handle_request(request):
+    request_id = request.get("id")
+    if request_id is None:
+        raise ValueError("request missing id")
+
+    path = request.get("path") or ""
+    host = request.get("host") or ""
+
+    if path.startswith("/computeMetadata/"):
+        return {"id": request_id, "respond": metadata_response(path)}
+
+    if is_google_api_host(host):
+        token = mint_token()
+        if token:
+            return {"id": request_id, "headers": {"authorization": f"Bearer {token}"}}
+        return {"id": request_id}
+
+    return {"id": request_id}
+
+
+def emit(response):
+    sys.stdout.write(json.dumps(response) + "\n")
+    sys.stdout.flush()
+
+
+def main():
+    sys.stdout.write("READY\n")
+    sys.stdout.flush()
+
+    for raw_line in sys.stdin:
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+        request_id = None
+        try:
+            request = json.loads(raw_line)
+            if isinstance(request, dict):
+                request_id = request.get("id")
+            response = handle_request(request)
+        except Exception as exc:
+            log(f"request handling failed: {exc}; line={raw_line!r}")
+            if request_id is None:
+                continue
+            response = {"id": request_id}
+        emit(response)
+
+
+if __name__ == "__main__":
+    main()

--- a/example_config/github-app-auth-hook.py
+++ b/example_config/github-app-auth-hook.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+import base64
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import jwt as pyjwt
+except ImportError:
+    pyjwt = None
+
+API_BEARER_HOSTS = {
+    "api.github.com",
+    "uploads.github.com",
+    "objects.githubusercontent.com",
+}
+GIT_BASIC_HOSTS = {"github.com"}
+GITHUB_ACCEPT = "application/vnd.github+json"
+GITHUB_API_VERSION = "2022-11-28"
+JWT_REFRESH_SKEW_SECONDS = 30
+TOKEN_REFRESH_SKEW_SECONDS = 5 * 60
+JWT_LIFETIME_SECONDS = 10 * 60
+TEST_TOKEN_ENV = "GITHUB_APP_INSTALLATION_TOKEN"
+TEST_TOKEN_EXPIRY_ENV = "GITHUB_APP_INSTALLATION_TOKEN_EXPIRES_AT"
+TEST_COUNTER_FILE_ENV = "GITHUB_APP_TEST_COUNTER_FILE"
+APP_ID_ENV = "GITHUB_APP_ID"
+PRIVATE_KEY_ENV = "GITHUB_APP_PRIVATE_KEY"
+INSTALLATION_ID_ENV = "GITHUB_APP_INSTALLATION_ID"
+OWNER_ENV = "GITHUB_OWNER"
+REPO_ENV = "GITHUB_REPO"
+ORG_ENV = "GITHUB_ORG"
+REPOSITORIES_ENV = "GITHUB_APP_REPOSITORIES"
+PERMISSIONS_ENV = "GITHUB_APP_PERMISSIONS"
+API_BASE_ENV = "GITHUB_APP_API_BASE"
+DEFAULT_API_BASE = "https://api.github.com"
+
+_cached_token = None
+_cached_expiry = 0.0
+_cached_jwt = None
+_cached_jwt_expiry = 0.0
+_cached_installation_id = None
+
+
+def log(message):
+    print(message, file=sys.stderr, flush=True)
+
+
+def emit(response):
+    sys.stdout.write(json.dumps(response) + "\n")
+    sys.stdout.flush()
+
+
+def get_api_base():
+    return os.environ.get(API_BASE_ENV, DEFAULT_API_BASE).rstrip("/")
+
+
+def normalize_host(host):
+    return (host or "").strip().lower()
+
+
+def parse_expiry(value, default_now_plus_seconds):
+    if not value:
+        return time.time() + default_now_plus_seconds
+    try:
+        if value.isdigit():
+            return float(value)
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        return datetime.fromisoformat(value).timestamp()
+    except Exception:
+        log(f"failed to parse expiry timestamp {value!r}; using fallback")
+        return time.time() + default_now_plus_seconds
+
+
+def load_required_env(name):
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"required env missing: {name}")
+    return value
+
+
+def increment_test_counter_if_needed():
+    counter_path = os.environ.get(TEST_COUNTER_FILE_ENV)
+    if not counter_path:
+        return
+    path = Path(counter_path)
+    count = 0
+    if path.exists():
+        try:
+            count = int(path.read_text(encoding="utf-8").strip() or "0")
+        except Exception:
+            count = 0
+    path.write_text(str(count + 1), encoding="utf-8")
+
+
+def base64url(data):
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def sign_with_openssl(signing_input, key_path):
+    # Shell-only host fallback for RS256 if PyJWT missing:
+    # openssl dgst -sha256 -sign "$GITHUB_APP_PRIVATE_KEY"
+    completed = subprocess.run(
+        ["openssl", "dgst", "-sha256", "-sign", str(key_path)],
+        input=signing_input,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    return completed.stdout
+
+
+def mint_app_jwt():
+    global _cached_jwt, _cached_jwt_expiry
+
+    now = time.time()
+    if _cached_jwt and now < (_cached_jwt_expiry - JWT_REFRESH_SKEW_SECONDS):
+        return _cached_jwt
+
+    app_id = load_required_env(APP_ID_ENV)
+    key_path = Path(load_required_env(PRIVATE_KEY_ENV)).expanduser()
+    pem = key_path.read_text(encoding="utf-8")
+    issued_at = int(now) - 60
+    expires_at = int(now) + JWT_LIFETIME_SECONDS
+    payload = {"iat": issued_at, "exp": expires_at, "iss": app_id}
+
+    if pyjwt is not None:
+        token = pyjwt.encode(payload, pem, algorithm="RS256")
+        if isinstance(token, bytes):
+            token = token.decode("utf-8")
+    else:
+        header = {"alg": "RS256", "typ": "JWT"}
+        signing_input = (
+            f"{base64url(json.dumps(header, separators=(',', ':')).encode('utf-8'))}."
+            f"{base64url(json.dumps(payload, separators=(',', ':')).encode('utf-8'))}"
+        )
+        signature = sign_with_openssl(signing_input.encode("utf-8"), key_path)
+        token = f"{signing_input}.{base64url(signature)}"
+
+    _cached_jwt = token
+    _cached_jwt_expiry = float(expires_at)
+    return token
+
+
+def github_request(method, path, token, body=None):
+    url = get_api_base() + path
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": GITHUB_ACCEPT,
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        "User-Agent": "harnx-github-app-auth-hook/1",
+    }
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            payload = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub API {method} {path} failed: {exc.code} {detail}") from exc
+    except Exception as exc:
+        raise RuntimeError(f"GitHub API {method} {path} failed: {exc}") from exc
+
+    if not payload:
+        return {}
+    return json.loads(payload)
+
+
+def parse_json_env(name, expected_type):
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{name} must be valid JSON: {exc}") from exc
+    if not isinstance(parsed, expected_type):
+        raise RuntimeError(f"{name} must decode to {expected_type.__name__}")
+    return parsed
+
+
+def build_exchange_body():
+    body = {}
+    repositories = parse_json_env(REPOSITORIES_ENV, list)
+    permissions = parse_json_env(PERMISSIONS_ENV, dict)
+    if repositories:
+        body["repositories"] = repositories
+    if permissions:
+        body["permissions"] = permissions
+    return body or None
+
+
+def resolve_installation_id(jwt_token):
+    global _cached_installation_id
+
+    if _cached_installation_id:
+        return _cached_installation_id
+
+    configured = os.environ.get(INSTALLATION_ID_ENV, "").strip()
+    if configured:
+        _cached_installation_id = configured
+        return _cached_installation_id
+
+    owner = os.environ.get(OWNER_ENV, "").strip()
+    repo = os.environ.get(REPO_ENV, "").strip()
+    org = os.environ.get(ORG_ENV, "").strip()
+
+    if owner and repo:
+        payload = github_request("GET", f"/repos/{owner}/{repo}/installation", jwt_token)
+    elif org or owner:
+        target_org = org or owner
+        payload = github_request("GET", f"/orgs/{target_org}/installation", jwt_token)
+    else:
+        raise RuntimeError(
+            "set GITHUB_APP_INSTALLATION_ID or GITHUB_OWNER/GITHUB_REPO or GITHUB_ORG"
+        )
+
+    installation_id = payload.get("id")
+    if not installation_id:
+        raise RuntimeError("installation lookup response missing id")
+    _cached_installation_id = str(installation_id)
+    return _cached_installation_id
+
+
+def exchange_installation_token():
+    jwt_token = mint_app_jwt()
+    installation_id = resolve_installation_id(jwt_token)
+    body = build_exchange_body()
+    payload = github_request(
+        "POST",
+        f"/app/installations/{installation_id}/access_tokens",
+        jwt_token,
+        body=body,
+    )
+    token = payload.get("token")
+    expires_at = payload.get("expires_at")
+    if not token or not expires_at:
+        raise RuntimeError("installation token response missing token or expires_at")
+    return token, parse_expiry(expires_at, 55 * 60)
+
+
+def get_installation_token():
+    global _cached_token, _cached_expiry
+
+    now = time.time()
+    if _cached_token and now < (_cached_expiry - TOKEN_REFRESH_SKEW_SECONDS):
+        return _cached_token
+
+    override_token = os.environ.get(TEST_TOKEN_ENV, "").strip()
+    if override_token:
+        increment_test_counter_if_needed()
+        _cached_token = override_token
+        _cached_expiry = parse_expiry(os.environ.get(TEST_TOKEN_EXPIRY_ENV, ""), 55 * 60)
+        return _cached_token
+
+    token, expiry = exchange_installation_token()
+    _cached_token = token
+    _cached_expiry = expiry
+    return _cached_token
+
+
+def github_basic_auth(token):
+    blob = base64.b64encode(f"x-access-token:{token}".encode("utf-8")).decode("ascii")
+    return f"Basic {blob}"
+
+
+def handle_request(request):
+    request_id = request.get("id")
+    if request_id is None:
+        raise ValueError("request missing id")
+
+    host = normalize_host(request.get("host"))
+    if host in API_BEARER_HOSTS:
+        token = get_installation_token()
+        return {"id": request_id, "headers": {"authorization": f"Bearer {token}"}}
+    if host in GIT_BASIC_HOSTS:
+        token = get_installation_token()
+        return {"id": request_id, "headers": {"authorization": github_basic_auth(token)}}
+    return {"id": request_id}
+
+
+def main():
+    sys.stdout.write("READY\n")
+    sys.stdout.flush()
+
+    for raw_line in sys.stdin:
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+        request_id = None
+        try:
+            request = json.loads(raw_line)
+            if isinstance(request, dict):
+                request_id = request.get("id")
+            response = handle_request(request)
+        except Exception as exc:
+            log(f"request handling failed: {exc}; line={raw_line!r}")
+            if request_id is None:
+                continue
+            response = {"id": request_id}
+        emit(response)
+
+
+if __name__ == "__main__":
+    main()

--- a/example_config/github-app-auth-hook.py
+++ b/example_config/github-app-auth-hook.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import datetime
 from pathlib import Path
@@ -57,7 +58,17 @@ def emit(response):
 
 
 def get_api_base():
-    return os.environ.get(API_BASE_ENV, DEFAULT_API_BASE).rstrip("/")
+    value = os.environ.get(API_BASE_ENV, DEFAULT_API_BASE).rstrip("/")
+    parsed = urllib.parse.urlparse(value)
+    if not parsed.scheme or not parsed.netloc:
+        raise RuntimeError(
+            f"{API_BASE_ENV} is not a valid URL: {value!r} (missing scheme or host)"
+        )
+    if parsed.scheme not in ("http", "https"):
+        raise RuntimeError(
+            f"{API_BASE_ENV} has unsupported scheme: {parsed.scheme!r} (expected http or https)"
+        )
+    return value
 
 
 def normalize_host(host):
@@ -303,7 +314,9 @@ def main():
                 request_id = request.get("id")
             response = handle_request(request)
         except Exception as exc:
-            log(f"request handling failed: {exc}; line={raw_line!r}")
+            # Fail closed: do not log raw request line (may contain sensitive data)
+            # Log only non-sensitive diagnostics
+            log(f"request handling failed: {type(exc).__name__}")
             if request_id is None:
                 continue
             response = {"id": request_id}

--- a/example_config/jira-auth-hook.py
+++ b/example_config/jira-auth-hook.py
@@ -2,6 +2,7 @@
 import base64
 import json
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -12,7 +13,7 @@ SENTINEL_TOKEN_BLOB = (
     "MGZiM2EzYTRhMWY="
 )
 TOKEN_CMD_ENV = "HARNX_JIRA_TOKEN_CMD"
-DEFAULT_TOKEN_CMD = 'secret-tool lookup service acli username "jira:{current_profile}"'
+DEFAULT_TOKEN_CMD = 'secret-tool lookup service acli username {profile_arg}'
 HOST_CONFIG_ENV_NAMES = ["ACLI_HOST_CONFIG", "HARNX_JIRA_HOST_CONFIG"]
 DEFAULT_HOST_CONFIG = "~/.config/acli/jira_config.yaml"
 TEMP_ROOT_ENV_NAMES = ["HARNX_JIRA_TEMP_ROOT", "TEMP_FILE_ROOT", "TMPDIR", "TMP", "TEMP"]
@@ -103,7 +104,7 @@ def resolve_temp_root():
 
 
 def lookup_token(current_profile):
-    token_cmd = os.environ.get(TOKEN_CMD_ENV, DEFAULT_TOKEN_CMD.format(current_profile=current_profile))
+    token_cmd = os.environ.get(TOKEN_CMD_ENV, DEFAULT_TOKEN_CMD.format(profile_arg=shlex.quote(f"jira:{current_profile}")))
     try:
         completed = subprocess.run(
             token_cmd,

--- a/example_config/jira-auth-hook.py
+++ b/example_config/jira-auth-hook.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+import base64
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SENTINEL_TOKEN_BLOB = (
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6OjowMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDBh"
+    "NmM2MzI1MzM1NGQxODBiNjkzYWFjYmRkZjlmYjA2YzFkMGI2NmE0MmQ4Mzc1NmJjM2U5ZjM5ODg4MzRh"
+    "MGZiM2EzYTRhMWY="
+)
+TOKEN_CMD_ENV = "HARNX_JIRA_TOKEN_CMD"
+DEFAULT_TOKEN_CMD = 'secret-tool lookup service acli username "jira:{current_profile}"'
+HOST_CONFIG_ENV_NAMES = ["ACLI_HOST_CONFIG", "HARNX_JIRA_HOST_CONFIG"]
+DEFAULT_HOST_CONFIG = "~/.config/acli/jira_config.yaml"
+TEMP_ROOT_ENV_NAMES = ["HARNX_JIRA_TEMP_ROOT", "TEMP_FILE_ROOT", "TMPDIR", "TMP", "TEMP"]
+DEFAULT_TEMP_ROOT = "/tmp"
+
+REAL_TOKEN = None
+PROFILE = None
+TARGET_HOSTS = set()
+AUTHORIZATION_HEADER = None
+SANDBOX_CONFIG_DIR = None
+
+
+def log(message):
+    print(message, file=sys.stderr, flush=True)
+
+
+def emit(response):
+    sys.stdout.write(json.dumps(response) + "\n")
+    sys.stdout.flush()
+
+
+def parse_scalar(value):
+    value = value.strip()
+    if not value:
+        return ""
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
+
+
+def load_host_config(path):
+    current_profile = None
+    profiles = []
+    current = None
+
+    with open(path, "r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.rstrip("\n")
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+
+            if line.startswith("current_profile:"):
+                current_profile = parse_scalar(line.split(":", 1)[1])
+                continue
+
+            if line.startswith("profiles:"):
+                continue
+
+            if line.startswith("  - "):
+                current = {}
+                profiles.append(current)
+                remainder = line[4:]
+                if remainder.strip() and ":" in remainder:
+                    key, value = remainder.split(":", 1)
+                    current[key.strip()] = parse_scalar(value)
+                continue
+
+            if current is not None and line.startswith("    ") and ":" in stripped:
+                key, value = stripped.split(":", 1)
+                current[key.strip()] = parse_scalar(value)
+
+    if not current_profile:
+        raise ValueError("current_profile missing from host config")
+
+    for profile in profiles:
+        profile_key = f"{profile.get('cloud_id', '')}:{profile.get('account_id', '')}"
+        if profile_key == current_profile:
+            return current_profile, profile
+
+    raise ValueError(f"profile matching current_profile not found: {current_profile!r}")
+
+
+def resolve_host_config_path():
+    for env_name in HOST_CONFIG_ENV_NAMES:
+        candidate = os.environ.get(env_name)
+        if candidate:
+            return Path(candidate).expanduser()
+    return Path(DEFAULT_HOST_CONFIG).expanduser()
+
+
+def resolve_temp_root():
+    for env_name in TEMP_ROOT_ENV_NAMES:
+        candidate = os.environ.get(env_name)
+        if candidate:
+            return Path(candidate).expanduser()
+    return Path(DEFAULT_TEMP_ROOT)
+
+
+def lookup_token(current_profile):
+    token_cmd = os.environ.get(TOKEN_CMD_ENV, DEFAULT_TOKEN_CMD.format(current_profile=current_profile))
+    try:
+        completed = subprocess.run(
+            token_cmd,
+            shell=True,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except Exception as exc:
+        raise RuntimeError(f"token command failed: {token_cmd!r}: {exc}") from exc
+
+    token = completed.stdout.strip()
+    if not token:
+        raise RuntimeError(f"token command produced empty stdout: {token_cmd!r}")
+    return token
+
+
+def write_synthetic_config(current_profile, profile, temp_root):
+    config_root = temp_root / "harnx-fs-acli" / "acli"
+    config_root.mkdir(parents=True, exist_ok=True)
+    config_path = config_root / "jira_config.yaml"
+    email = profile.get("email", os.environ.get("ATLASSIAN_EMAIL", ""))
+    config_text = "\n".join(
+        [
+            "version: 1",
+            f"current_profile: {current_profile}",
+            "profiles:",
+            f"    - site: {profile.get('site', '')}",
+            f"      cloud_id: {profile.get('cloud_id', '')}",
+            f"      account_id: {profile.get('account_id', '')}",
+            f"      email: {email}",
+            "      auth_type: api_token",
+            f"      token: {SENTINEL_TOKEN_BLOB}",
+            "",
+        ]
+    )
+    config_path.write_text(config_text, encoding="utf-8")
+    return email, config_root.parent
+
+
+def initialize():
+    global REAL_TOKEN, PROFILE, TARGET_HOSTS, AUTHORIZATION_HEADER, SANDBOX_CONFIG_DIR
+
+    host_config = resolve_host_config_path()
+    current_profile, profile = load_host_config(host_config)
+    real_token = lookup_token(current_profile)
+    email, sandbox_config_dir = write_synthetic_config(current_profile, profile, resolve_temp_root())
+    target_hosts = {"api.atlassian.com"}
+    site = (profile.get("site") or "").strip()
+    if site:
+        target_hosts.add(site)
+    auth = "Basic " + base64.b64encode(f"{email}:{real_token}".encode("utf-8")).decode("ascii")
+
+    REAL_TOKEN = real_token
+    PROFILE = profile
+    TARGET_HOSTS = target_hosts
+    AUTHORIZATION_HEADER = auth
+    SANDBOX_CONFIG_DIR = sandbox_config_dir
+
+
+def handle_request(request):
+    request_id = request.get("id")
+    if request_id is None:
+        raise ValueError("request missing id")
+
+    host = (request.get("host") or "").strip().lower()
+    if host in TARGET_HOSTS and AUTHORIZATION_HEADER:
+        return {"id": request_id, "headers": {"authorization": AUTHORIZATION_HEADER}}
+    if host == "harnx.invalid" and request.get("path") == "/jira-auth-hook/debug":
+        return {
+            "id": request_id,
+            "respond": {
+                "status": 200,
+                "headers": {"content-type": "application/json"},
+                "body": json.dumps({"acli_config_dir": str(SANDBOX_CONFIG_DIR) if SANDBOX_CONFIG_DIR else None}),
+            },
+        }
+    return {"id": request_id}
+
+
+def main():
+    try:
+        initialize()
+    except Exception as exc:
+        log(f"startup failed: {exc}")
+    sys.stdout.write("READY\n")
+    sys.stdout.flush()
+
+    for raw_line in sys.stdin:
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+        request_id = None
+        try:
+            request = json.loads(raw_line)
+            if isinstance(request, dict):
+                request_id = request.get("id")
+            response = handle_request(request)
+        except Exception as exc:
+            log(f"request handling failed: {exc}; line={raw_line!r}")
+            if request_id is None:
+                continue
+            response = {"id": request_id}
+        emit(response)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Extends harnx-proxy-auth with support for resident execution hooks and synthetic responses to enable GCP authentication injection and GCE metadata emulation.

The --hook flag is unified to accept jaq filters, inline resident scripts (starting with #!), or executable file paths (starting with /, ./, or ../). Resident hooks are spawned once, communicate via JSONL on stdin/stdout, and support actor-based concurrency, lazy restarts, and timeouts. Path-based hooks are executed directly and can be any binary or script.

Key features:
- Unified --hook pipeline for jaq and resident exec stages.
- .respond primitive for synthetic responses (GCE metadata emulation).
- GCE metadata server emulation (GCE_METADATA_HOST) and Authorization header injection for Google hosts via resident hook script.
- Generic $proxy_port environment variable for hook configuration.
- Comprehensive documentation and example scripts for GCP, GitHub App, and Jira authentication.

Issue: #593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ordered transform pipeline supporting hook expressions, inline exec stages, and executable hook files.
  * Added `--hook-timeout-secs` for per-request hook timeouts.
  * Exposes `$proxy_port` to hook/env evaluation when available.
* **Bug Fixes**
  * Improved hook output handling with `.respond`/`.block` short-circuiting and deterministic header merge rules (lowercasing, replacement, and `null` removal), with passthrough on failures.
* **Refactor**
  * Updated request handling to use the new transform pipeline end-to-end.
* **Documentation**
  * Added/expanded GCP auth proxy documentation and examples.
* **Tests**
  * Added extensive hook and pipeline integration coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->