### PR TITLE
fix(scrolling): resize height cache instead of underflowing when items shrink

### DIFF
--- a/.changeset/fix-scroll-height-cache-underflow.md
+++ b/.changeset/fix-scroll-height-cache-underflow.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Fix a crash when scrolling the transcript after compaction. The scrolling widget's per-width height cache assumed the number of items only ever grows; when compaction shrank or blanked the transcript, an internal length calculation underflowed — panicking in debug builds and, in release builds, wrapping into an unbounded allocation that could exhaust memory. The cache now resizes to the current item count.

--- a/crates/ratatui-widget-scrolling/src/lib.rs
+++ b/crates/ratatui-widget-scrolling/src/lib.rs
@@ -90,13 +90,16 @@ impl ScrollState {
         width: u16,
         num_elements: usize,
     ) -> &Vec<usize> {
-        let list = self.render_height_cache.entry(width).or_insert_with(|| {
-            let tmp_height_list = vec![1; num_elements];
-            tmp_height_list
-        });
-        for _ in 0..num_elements - list.len() {
-            list.push(1);
-        }
+        let list = self.render_height_cache.entry(width).or_default();
+        // Resize the cached height log to the current element count: pad new
+        // entries with a default height of 1, and drop stale trailing entries
+        // when the element count shrinks (e.g. when compaction replaces many
+        // transcript items with a single summary, or blanks the transcript).
+        // Computing the growth count as `num_elements - list.len()` underflowed
+        // once the list became shorter than the cache — a panic in debug, and in
+        // release a wraparound that pushed ~usize::MAX entries (runaway
+        // allocation / out-of-memory).
+        list.resize(num_elements, 1);
         list
     }
 
@@ -1171,6 +1174,27 @@ mod tests {
         assert_eq!(
             pos, 3,
             "empty cache with many elements should center the item"
+        );
+    }
+
+    /// Regression: the width-keyed height cache must tolerate the element count
+    /// shrinking between renders. Compaction can replace many transcript items
+    /// with a single summary (or blank the transcript entirely), so a render at
+    /// the pre-compaction count is followed by one with far fewer elements. The
+    /// cache still holds the larger length, so the helper must shrink it rather
+    /// than computing `num_elements - list.len()`, which underflowed — panicking
+    /// in debug and, in release, wrapping into an unbounded push loop that
+    /// exhausted memory.
+    #[test]
+    fn height_cache_tolerates_element_count_shrinking() {
+        let mut state = ScrollState::new();
+        // Prime the width-80 cache with 10 elements (pre-compaction).
+        let _ = state.scroll_position_to_show_item(0, 80, 10, 10);
+        // Compaction drops us to 2 elements; must not panic or underflow.
+        let pos = state.scroll_position_to_show_item(0, 80, 10, 2);
+        assert_eq!(
+            pos, 0,
+            "content fits after shrinking, so position clamps to 0"
         );
     }
 }


### PR DESCRIPTION
## Problem

`ScrollState::get_height_log_from_cache_for_width` extended its per-width height cache with:

```rust
for _ in 0..num_elements - list.len() { list.push(1); }
```

which assumes the element count only ever grows. When the transcript **shrinks** — most often when compaction replaces many messages with a single summary (see #904) — `num_elements` drops below the cached length and the subtraction underflows:

- **debug builds:** `attempt to subtract with overflow` panic at `ratatui-widget-scrolling/src/lib.rs:97` — this is #895.
- **release builds:** no overflow checks, so it wraps to ~`usize::MAX`; the loop then pushes into a `Vec<usize>` unbounded and the process balloons until the heap guard aborts it at 4 GB — this is #842 (always "right after compaction", on the main render thread, with an `<unknown>` stripped backtrace).

Same defect, two manifestations. Reproduced by reverting the compaction on a session and re-compacting; also reproduced as a unit test by priming the width cache at N elements then rendering with fewer.

## Fix

Replace the grow-only loop with `Vec::resize(num_elements, 1)`, which pads new entries with the default height and truncates stale ones when the element count shrinks — no underflow in either direction.

## Why #907 didn't cover it

#907 hardened this widget (bounded the retry loop to 10 iterations, `.get()`/`.get_mut()` guards for stale indices) but never touched `get_height_log_from_cache_for_width`. That line predates it (`5dba07c2a5`) and remained on `main`.

## Testing

- New regression test `height_cache_tolerates_element_count_shrinking` — fails with the exact `lib.rs:97` overflow before the fix, passes after.
- `cargo nextest run -p ratatui_widget_scrolling --stress-count=5` → 5/5 iterations, 22/22.
- `cargo fmt --all`, `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` — all clean.
- Not run locally: `cs delta` (needs `CS_ACCESS_TOKEN`, unavailable in this environment) and the full `cargo nextest run --workspace --stress-count=5` — left to CI.

## Follow-ups (separate)

- #904 — compaction blanks the whole transcript (UX issue, and it is the trigger for this crash).
- `harnx_tui::terminal::PanicTerminalHookGuard::drop` calls `std::panic::set_hook` while unwinding → double-panic ("panic in a destructor during cleanup") → abort/coredump instead of a clean exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that could occur when scrolling after content was compacted or reduced in size.
  * Improved scroll height caching so it now adjusts correctly when the number of visible items shrinks.
  * Prevented incorrect scroll calculations that could lead to excessive allocation or a panic.
  * Added coverage for shrinking-content scroll behavior to ensure the view clamps safely when everything fits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->