### PR TITLE
chore(release): keep debug line tables so crash backtraces symbolicate

### DIFF
--- a/.changeset/release-debuginfo.md
+++ b/.changeset/release-debuginfo.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Release binaries now ship with line-table debug info and are no longer stripped, so crash backtraces — including the heap-guard abort trace and panic backtraces — resolve to real function names and line numbers instead of `<unknown>`. This makes crash reports from release builds actionable out of the box, at the cost of a somewhat larger binary.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,12 @@ keywords = ["chatgpt", "llm", "cli", "ai", "tui"]
 
 [profile.release]
 lto = true
-strip = true
+# Keep symbols and line tables (don't strip) so crash backtraces in released
+# binaries — notably the heap-guard abort trace and panic backtraces — resolve
+# to real function names and file:line instead of `<unknown>`. Line-tables-only
+# keeps the added size modest, and opt-level = "z" still minimises the code.
+strip = false
+debug = "line-tables-only"
 opt-level = "z"
 
 [workspace.dependencies]


### PR DESCRIPTION
## Why

Release binaries are built with `strip = true` and no debug info, so the heap-guard abort trace and panic backtraces show `<unknown>` for every application frame. That is exactly why the compaction OOM crashes (#842) were undiagnosable from release builds — we had to reproduce on a debug build to symbolicate.

## Change

In `[profile.release]`:
- `strip = false`
- `debug = "line-tables-only"`

`lto = true` and `opt-level = "z"` are unchanged, so the code itself stays size-optimised; this only retains the symbol table and adds DWARF line tables.

## Effect

The heap guard captures its backtrace in-process via `Backtrace::force_capture()`, and `coredumpctl` resolves core dumps against the binary — both now produce real `function (file:line)` frames. Debug builds already symbolicate cleanly (as seen while reproducing the scroll-widget crash); this brings parity to release.

## Tradeoff

Larger binary (embedded line tables). Embedded — not split — debug info is required because the guard resolves its own backtrace in-process, and an installed binary won't have a separate `.dwp` file alongside it.

## Verified

- `cargo build --workspace` (validates the profile syntax and that nothing breaks), `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` — all clean.

Refs #842, #895.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release binaries now include line-number and function information in crash and panic backtraces.

* **Bug Fixes**
  * Backtraces that previously showed `<unknown>` now resolve to readable function names and source locations.
  * Heap-guard abort traces are easier to understand during failures.

* **Chores**
  * Release builds now keep more debug information, which may slightly increase binary size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->