### PR TITLE
fix(tui): don't restore the panic hook while unwinding

### DIFF
--- a/.changeset/fix-panic-hook-double-panic.md
+++ b/.changeset/fix-panic-hook-double-panic.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Fix a crash where a panic in the TUI aborted the process (and dumped core) instead of exiting cleanly. Restoring the terminal's panic hook while a panic was already unwinding triggered a fatal double-panic ("panic in a destructor during cleanup"); the guard now skips hook restoration when it is dropped during unwinding, so the original panic is reported and the terminal is restored normally.

--- a/crates/harnx-tui/src/terminal.rs
+++ b/crates/harnx-tui/src/terminal.rs
@@ -51,6 +51,16 @@ impl PanicTerminalHookGuard {
 
 impl Drop for PanicTerminalHookGuard {
     fn drop(&mut self) {
+        // `panic::set_hook` itself panics ("cannot modify the panic hook from a
+        // panicking thread") when called while a panic is unwinding. If this
+        // guard is dropped as part of that unwinding, restoring the previous
+        // hook would turn a normal panic into a fatal double-panic ("panic in a
+        // destructor during cleanup") that aborts the process. Skip restoration
+        // in that case — the installed hook has already restored the terminal,
+        // and the panic can continue to unwind normally.
+        if std::thread::panicking() {
+            return;
+        }
         if let Some(previous_hook) = self.previous_hook.take() {
             panic::set_hook(Box::new(move |panic_info: &panic::PanicHookInfo<'_>| {
                 previous_hook(panic_info);
@@ -97,5 +107,24 @@ impl Tui {
         cleanup_terminal_state();
         terminal.show_cursor()?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Dropping the guard while a panic is unwinding must not call
+    /// `panic::set_hook` (which aborts with "cannot modify the panic hook from a
+    /// panicking thread"). The original panic should propagate to `catch_unwind`
+    /// and the process must survive — reaching the assertion at all proves we did
+    /// not abort during cleanup.
+    #[test]
+    fn guard_drop_during_panic_does_not_double_panic() {
+        let result = std::panic::catch_unwind(|| {
+            let _guard = PanicTerminalHookGuard::install();
+            panic!("boom");
+        });
+        assert!(result.is_err(), "the original panic should propagate");
     }
 }


### PR DESCRIPTION
## Problem

`PanicTerminalHookGuard::drop` restores the previous panic hook by calling `panic::set_hook`. But `set_hook` panics ("cannot modify the panic hook from a panicking thread") if called while a panic is unwinding. So when a panic occurred in the TUI, the guard's `drop` — running during unwind — triggered a **second** panic → "panic in a destructor during cleanup" → the process aborted and dumped core instead of printing the panic and exiting cleanly.

This is what turned the scroll-widget panic (surfaced while diagnosing the compaction OOM #842 / #895) into a coredump rather than a readable crash.

## Fix

Skip hook restoration when `std::thread::panicking()` is true. The installed hook has already restored the terminal (`cleanup_terminal_state`), so the panic can unwind and be reported normally. On the normal (non-panicking) drop path, the previous hook is restored as before.

## Testing

- New regression test `terminal::tests::guard_drop_during_panic_does_not_double_panic` — drops the guard inside a panicking `catch_unwind`; passes with the fix, and aborts the test process without it.
- `cargo fmt --all`, `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run -p harnx-tui -E 'test(guard_drop_during_panic)'` — all clean/green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a terminal crash that could happen after a panic by avoiding panic-hook restoration during panic unwinding.
  * This helps ensure the original panic is reported cleanly and the terminal is restored without aborting.
* **Tests**
  * Added coverage for the panic-handling flow to verify the process recovers correctly under unwind conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->