### PR TITLE
feat(tui,runtime): wire remote control surface for agent@cluster (#915)

### DIFF
--- a/.changeset/nats-remote-tui-control.md
+++ b/.changeset/nats-remote-tui-control.md
@@ -1,0 +1,7 @@
+---
+harnx: minor
+---
+
+Wire the remote control surface for NATS-backed `agent@cluster` sessions into the TUI, mirroring existing local-session operations.
+
+Remote sessions can now be resumed from the session picker (the picked session id is threaded into the thin-client turn instead of always starting a new session), cancelled with Ctrl+C (publishes `ControlCommand::Cancel` to the session's NATS control subject, fire-and-forget), and retracted/edited with the existing `d`/`e` keybindings (routed to the thin-client `retract_user_message`/`edit_user_message`, converting the displayed index to the JetStream user-message sequence). Local-agent execution paths are unchanged. CI now installs `nats-server` on Linux so the NATS integration tests run.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,20 @@ jobs:
     - name: Build workspace
       run: cargo build --workspace --all-targets
 
+    - name: Install nats-server (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        set -euo pipefail
+        VERSION="v2.11.6"
+        ASSET="nats-server-${VERSION}-linux-amd64.tar.gz"
+        DOWNLOAD_URL="https://github.com/nats-io/nats-server/releases/download/${VERSION}/${ASSET}"
+        BINDIR="${HOME}/.local/bin"
+        mkdir -p "${BINDIR}"
+        curl -sL "${DOWNLOAD_URL}" | tar -xzf - -C "${BINDIR}" --strip-components=1 "nats-server-${VERSION}-linux-amd64/nats-server"
+        chmod +x "${BINDIR}/nats-server"
+        echo "${BINDIR}" >> "${GITHUB_PATH}"
+      shell: bash
+
     - name: Test
       run: cargo nextest run --all
 

--- a/crates/harnx-core/src/session_reconstruct.rs
+++ b/crates/harnx-core/src/session_reconstruct.rs
@@ -142,6 +142,123 @@ pub fn apply_log_mutations_with_name(
     effective_entries
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LogicalEntryRef<P> {
+    pub logical_index: usize,
+    pub physical_seq: P,
+}
+
+pub trait PhysicalSessionEntry {
+    type PhysicalSeq: Copy;
+
+    fn physical_seq(&self) -> Self::PhysicalSeq;
+    fn entry(&self) -> &SessionLogEntry;
+}
+
+impl PhysicalSessionEntry for (usize, SessionLogEntry) {
+    type PhysicalSeq = usize;
+
+    fn physical_seq(&self) -> Self::PhysicalSeq {
+        self.0
+    }
+
+    fn entry(&self) -> &SessionLogEntry {
+        &self.1
+    }
+}
+
+impl PhysicalSessionEntry for (u64, SessionLogEntry) {
+    type PhysicalSeq = u64;
+
+    fn physical_seq(&self) -> Self::PhysicalSeq {
+        self.0
+    }
+
+    fn entry(&self) -> &SessionLogEntry {
+        &self.1
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActiveContextWindow<'a, T: PhysicalSessionEntry> {
+    entries: &'a [T],
+    boundary_index: Option<usize>,
+}
+
+impl<'a, T: PhysicalSessionEntry> ActiveContextWindow<'a, T> {
+    pub fn entries(&self) -> &'a [T] {
+        self.entries
+    }
+
+    pub fn boundary_index(&self) -> Option<usize> {
+        self.boundary_index
+    }
+
+    pub fn logical_entries(&self) -> impl Iterator<Item = LogicalEntryRef<T::PhysicalSeq>> + '_ {
+        self.entries
+            .iter()
+            .enumerate()
+            .map(|(logical_index, entry)| LogicalEntryRef {
+                logical_index,
+                physical_seq: entry.physical_seq(),
+            })
+    }
+
+    pub fn physical_seq_for_logical(&self, logical_index: usize) -> Option<T::PhysicalSeq> {
+        self.entries
+            .get(logical_index)
+            .map(PhysicalSessionEntry::physical_seq)
+    }
+
+    pub fn logical_indices_for_physical(
+        &self,
+        physical_seq: T::PhysicalSeq,
+    ) -> impl Iterator<Item = usize> + '_
+    where
+        T::PhysicalSeq: PartialEq,
+    {
+        self.logical_entries()
+            .filter(move |entry| entry.physical_seq == physical_seq)
+            .map(|entry| entry.logical_index)
+    }
+
+    pub fn is_protected_logical_index(&self, logical_index: usize) -> bool {
+        self.entries
+            .get(logical_index)
+            .map(PhysicalSessionEntry::entry)
+            .is_some_and(is_context_boundary)
+    }
+}
+
+pub fn active_context_window<T: PhysicalSessionEntry>(entries: &[T]) -> ActiveContextWindow<'_, T> {
+    let boundary_index = entries
+        .iter()
+        .rposition(|entry| is_context_boundary(entry.entry()));
+    match boundary_index {
+        Some(index) if matches!(entries[index].entry(), SessionLogEntry::Header { .. }) => {
+            ActiveContextWindow {
+                entries: &entries[index..],
+                boundary_index: Some(index),
+            }
+        }
+        Some(index) => ActiveContextWindow {
+            entries: &entries[index + 1..],
+            boundary_index: Some(index),
+        },
+        None => ActiveContextWindow {
+            entries,
+            boundary_index: None,
+        },
+    }
+}
+
+fn is_context_boundary(entry: &SessionLogEntry) -> bool {
+    matches!(
+        entry,
+        SessionLogEntry::Header { .. } | SessionLogEntry::Compress { .. }
+    )
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TurnStatus {
     Idle,
@@ -992,6 +1109,191 @@ mod tests {
                 switch_agent: None,
             }],
             timestamp: None,
+        }
+    }
+
+    #[test]
+    fn active_context_window_includes_header_boundary_as_logical_zero() {
+        let entries = vec![
+            (10_u64, header_entry()),
+            (11, user_message("u1")),
+            (12, final_assistant("a1")),
+        ];
+
+        let window = active_context_window(&entries);
+        let logical_entries: Vec<_> = window.logical_entries().collect();
+
+        assert_eq!(window.boundary_index(), Some(0));
+        assert_eq!(window.entries().len(), 3);
+        assert_eq!(
+            logical_entries,
+            vec![
+                LogicalEntryRef {
+                    logical_index: 0,
+                    physical_seq: 10
+                },
+                LogicalEntryRef {
+                    logical_index: 1,
+                    physical_seq: 11
+                },
+                LogicalEntryRef {
+                    logical_index: 2,
+                    physical_seq: 12
+                },
+            ]
+        );
+        assert_eq!(window.physical_seq_for_logical(0), Some(10));
+        assert_eq!(window.physical_seq_for_logical(1), Some(11));
+        assert!(window.is_protected_logical_index(0));
+        assert!(!window.is_protected_logical_index(1));
+        assert_eq!(
+            window.logical_indices_for_physical(10).collect::<Vec<_>>(),
+            vec![0]
+        );
+    }
+
+    #[test]
+    fn active_context_window_uses_whole_log_when_headerless() {
+        let entries = vec![(0_usize, user_message("u1")), (1, final_assistant("a1"))];
+
+        let window = active_context_window(&entries);
+        let logical_entries: Vec<_> = window.logical_entries().collect();
+
+        assert_eq!(window.boundary_index(), None);
+        assert_eq!(window.entries().len(), 2);
+        assert_eq!(
+            logical_entries,
+            vec![
+                LogicalEntryRef {
+                    logical_index: 0,
+                    physical_seq: 0
+                },
+                LogicalEntryRef {
+                    logical_index: 1,
+                    physical_seq: 1
+                },
+            ]
+        );
+        assert_eq!(window.physical_seq_for_logical(0), Some(0));
+        assert_eq!(window.physical_seq_for_logical(1), Some(1));
+        assert!(!window.is_protected_logical_index(0));
+    }
+
+    #[test]
+    fn active_context_window_starts_after_most_recent_compress() {
+        let entries = vec![
+            (20_u64, header_entry()),
+            (21, user_message("u1")),
+            (22, final_assistant("a1")),
+            (
+                30,
+                SessionLogEntry::Compress {
+                    prompt: "summary".to_string(),
+                },
+            ),
+            (31, user_message("u2")),
+            (32, final_assistant("a2")),
+        ];
+
+        let window = active_context_window(&entries);
+        let logical_entries: Vec<_> = window.logical_entries().collect();
+
+        assert_eq!(window.boundary_index(), Some(3));
+        assert_eq!(window.entries().len(), 2);
+        assert_eq!(
+            logical_entries,
+            vec![
+                LogicalEntryRef {
+                    logical_index: 0,
+                    physical_seq: 31
+                },
+                LogicalEntryRef {
+                    logical_index: 1,
+                    physical_seq: 32
+                },
+            ]
+        );
+        assert_eq!(window.physical_seq_for_logical(0), Some(31));
+        assert_eq!(
+            window.logical_indices_for_physical(30).collect::<Vec<_>>(),
+            Vec::<usize>::new()
+        );
+    }
+
+    #[test]
+    fn active_context_window_preserves_many_logical_entries_for_one_physical_seq() {
+        let entries = vec![
+            (40_u64, header_entry()),
+            (50, user_message("u1")),
+            (
+                51,
+                SessionLogEntry::EditEntries {
+                    from: 50,
+                    to: 50,
+                    replacements: vec![
+                        serde_yaml::to_string(&user_message("u1 clone"))
+                            .expect("serialize replacement"),
+                        serde_yaml::to_string(&user_message("u2 clone"))
+                            .expect("serialize replacement"),
+                        serde_yaml::to_string(&final_assistant("a1 clone"))
+                            .expect("serialize replacement"),
+                    ],
+                },
+            ),
+        ];
+        let effective = apply_log_mutations_nats(&entries).expect("mutations apply");
+        let window = active_context_window(&effective);
+        let logical_entries: Vec<_> = window.logical_entries().collect();
+
+        assert_eq!(window.boundary_index(), Some(0));
+        assert_eq!(
+            logical_entries,
+            vec![
+                LogicalEntryRef {
+                    logical_index: 0,
+                    physical_seq: 40
+                },
+                LogicalEntryRef {
+                    logical_index: 1,
+                    physical_seq: 51
+                },
+                LogicalEntryRef {
+                    logical_index: 2,
+                    physical_seq: 51
+                },
+                LogicalEntryRef {
+                    logical_index: 3,
+                    physical_seq: 51
+                },
+            ]
+        );
+        assert_eq!(window.physical_seq_for_logical(1), Some(51));
+        assert_eq!(window.physical_seq_for_logical(2), Some(51));
+        assert_eq!(window.physical_seq_for_logical(3), Some(51));
+        assert_eq!(
+            window.logical_indices_for_physical(51).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
+    fn header_entry() -> SessionLogEntry {
+        SessionLogEntry::Header {
+            model_id: "model".to_string(),
+            temperature: None,
+            top_p: None,
+            use_tools: None,
+            save_session: None,
+            compress_threshold: None,
+            agent_name: None,
+            session_id: None,
+            working_dir: None,
+            git_branch: None,
+            git_remote: None,
+            terminal_session_id: None,
+            agent_variables: Default::default(),
+            agent_instructions: String::new(),
+            model_fallbacks: vec![],
+            compaction_agent: None,
         }
     }
 

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -2,7 +2,9 @@ use std::io::Write;
 
 use syntect::highlighting::{Color, Theme};
 
-use crate::config::{macro_execute, AgentVariables, Config, GlobalConfig, Input, LastMessage};
+use crate::config::{
+    macro_execute, remote_session_ops, AgentVariables, Config, GlobalConfig, Input, LastMessage,
+};
 use crate::utils::{dimmed_text, set_text, AbortSignal};
 use harnx_hooks::{
     dispatch_hooks_with_managers, AsyncHookManager, HookEvent, HookResultControl,
@@ -387,7 +389,17 @@ pub async fn run_command_with_output(
                     }
                     Some(args) if args.starts_with("message ") => {
                         let (from, to) = parse_message_range(&args[8..])?;
-                        config.write().edit_message_range(from, to)?;
+                        if config.read().is_remote_agent() {
+                            remote_session_ops::edit_remote_message_range(
+                                config,
+                                from,
+                                to,
+                                &abort_signal,
+                            )
+                            .await?;
+                        } else {
+                            config.write().edit_message_range(from, to)?;
+                        }
                     }
                     _ => writeln!(output, r#"Usage: .edit <config|agent|session|rag-docs|message <n>|message <n>-<m>>"#)?,
                 }
@@ -756,7 +768,17 @@ Commands:
             ".delete" => match args {
                 Some(args) if args.starts_with("message ") => {
                     let (from, to) = parse_message_range(&args[8..])?;
-                    config.write().delete_message_range(from, to)?;
+                    if config.read().is_remote_agent() {
+                        remote_session_ops::delete_remote_message_range(
+                            config,
+                            from,
+                            to,
+                            &abort_signal,
+                        )
+                        .await?;
+                    } else {
+                        config.write().delete_message_range(from, to)?;
+                    }
                     writeln!(output, "Deleted entries {from}-{to}.")?;
                 }
                 Some(args) => {
@@ -773,7 +795,11 @@ Commands:
                     .trim()
                     .parse::<usize>()
                     .context("Invalid sequence number")?;
-                config.write().rewind_session(n)?;
+                if config.read().is_remote_agent() {
+                    remote_session_ops::rewind_remote_session(config, n, &abort_signal).await?;
+                } else {
+                    config.write().rewind_session(n)?;
+                }
                 writeln!(output, "↩ Rewound session to entry {n}.")?;
             }
             ".copy" => {

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -12,6 +12,7 @@ mod patches_split;
 mod paths_split;
 mod persistence_split;
 mod rag_split;
+pub mod remote_session_ops;
 mod servers_split;
 pub mod session;
 mod session_dump;
@@ -19,6 +20,7 @@ mod session_externalize;
 mod session_log_split;
 pub mod session_meta;
 mod session_ops_compaction;
+mod session_ops_core;
 mod session_ops_split;
 mod settings_split;
 

--- a/crates/harnx-runtime/src/config/remote_session_ops.rs
+++ b/crates/harnx-runtime/src/config/remote_session_ops.rs
@@ -1,0 +1,611 @@
+use super::*;
+use crate::nats_client_session::{ThinClientConfig, ThinClientSession};
+use crate::nats_session_log::NatsSessionLog;
+use crate::utils::{edit_file, temp_file, AbortSignal};
+use anyhow::{anyhow, bail, Context, Result};
+use harnx_core::session_reconstruct::active_context_window;
+
+impl Config {
+    pub(crate) fn edit_message_text_with_tui_hooks(
+        &mut self,
+        initial_text: &str,
+    ) -> Result<String> {
+        let temp_file = if let Some(ref dir) = self.temp_dir_override {
+            dir.join(format!("message-edit-{}.txt", uuid::Uuid::new_v4()))
+        } else {
+            temp_file("message-edit", ".txt")
+        };
+
+        std::fs::write(&temp_file, initial_text)
+            .with_context(|| format!("Failed to write to '{}'", temp_file.display()))?;
+
+        let edit_result = self.edit_with_tui_hooks(|this| {
+            let editor = this.editor()?;
+            edit_file(&editor, &temp_file).with_context(|| {
+                format!("Failed to edit '{}' with '{}'", temp_file.display(), editor)
+            })
+        });
+        let edited_content = std::fs::read_to_string(&temp_file)
+            .with_context(|| format!("Failed to read '{}'", temp_file.display()));
+        let _ = std::fs::remove_file(&temp_file);
+        edit_result?;
+        edited_content
+    }
+}
+
+pub(crate) async fn edit_remote_message_range(
+    config: &GlobalConfig,
+    from: usize,
+    to: usize,
+    abort_signal: &AbortSignal,
+) -> Result<()> {
+    let thin = remote_thin_session(config, abort_signal).await?;
+
+    let selected_messages = remote_user_messages_for_range(from, to, &thin).await?;
+    if selected_messages.len() > 1 {
+        bail!("Remote edit supports a single user message at a time");
+    }
+    let target = selected_messages
+        .into_iter()
+        .next()
+        .context("Selected range does not contain any user messages")?;
+
+    let new_text = {
+        let mut cfg = config.write();
+        cfg.edit_message_text_with_tui_hooks(&target.text)?
+    };
+
+    append_session_mutation_batch_cas(&thin, |state| {
+        let target_logical_index = find_target_logical_index(state, target.js_seq)?;
+        let group = load_seq_group(state, target.js_seq)?;
+        let replacements = build_edit_replacements(group, target_logical_index, &new_text)?;
+        build_seq_edit_mutation(target.js_seq, replacements)
+    })
+    .await?;
+
+    Ok(())
+}
+
+fn find_target_logical_index(state: &RemoteRenderState, target_seq: u64) -> Result<usize> {
+    state
+        .logical_targets
+        .iter()
+        .enumerate()
+        .find(|(_, target)| {
+            target.js_seq == target_seq
+                && matches!(
+                    &target.entry,
+                    SessionLogEntry::Message { role, .. } if role.is_user()
+                )
+        })
+        .map(|(index, _)| index)
+        .context("target user message not found in logical targets")
+}
+
+fn load_seq_group(state: &RemoteRenderState, target_seq: u64) -> Result<Vec<(usize, String)>> {
+    let seq = usize::try_from(target_seq).context("JetStream seq does not fit into usize")?;
+    let mut group = state
+        .logical_targets
+        .iter()
+        .enumerate()
+        .filter(|(_, target)| target.js_seq == target_seq)
+        .map(|(index, target)| {
+            let yaml = serde_yaml::to_string(&target.entry)
+                .context("failed to serialize remote group member")?;
+            Ok((index, yaml))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    group.sort_by_key(|(index, _)| *index);
+    verify_contiguous_group(seq, &group)?;
+    Ok(group)
+}
+
+fn build_edit_replacements(
+    group: Vec<(usize, String)>,
+    target_logical_index: usize,
+    new_text: &str,
+) -> Result<Vec<String>> {
+    if group.len() == 1 {
+        return Ok(vec![serialize_edited_user_entry(new_text)?]);
+    }
+
+    let edited_yaml = serialize_edited_user_entry(new_text)?;
+    Ok(group
+        .into_iter()
+        .map(|(logical_index, yaml)| {
+            if logical_index == target_logical_index {
+                edited_yaml.clone()
+            } else {
+                yaml
+            }
+        })
+        .collect())
+}
+
+fn serialize_edited_user_entry(new_text: &str) -> Result<String> {
+    let edited_entry = SessionLogEntry::Message {
+        id: Some(uuid::Uuid::new_v4().to_string()),
+        role: harnx_core::message::MessageRole::User,
+        content: harnx_core::message::MessageContent::Text(new_text.to_string()),
+        timestamp: None,
+        fence_token: None,
+    };
+    serde_yaml::to_string(&edited_entry).context("failed to serialize edited entry")
+}
+
+fn build_seq_edit_mutation(
+    target_seq: u64,
+    replacements: Vec<String>,
+) -> Result<Vec<SessionLogEntry>> {
+    let seq = usize::try_from(target_seq).context("JetStream seq does not fit into usize")?;
+    Ok(vec![SessionLogEntry::EditEntries {
+        from: seq,
+        to: seq,
+        replacements,
+    }])
+}
+
+pub(crate) async fn delete_remote_message_range(
+    config: &GlobalConfig,
+    from: usize,
+    to: usize,
+    abort_signal: &AbortSignal,
+) -> Result<()> {
+    let thin = remote_thin_session(config, abort_signal).await?;
+    append_session_mutation_batch_cas(&thin, |state| {
+        let (from, to) = self::session_ops_core::compute_delete_range(
+            from,
+            to,
+            &state.logical_entries,
+            &state.logical_documents,
+        )?;
+        // Build the set of targeted logical indices
+        let targeted_logical_indices: std::collections::HashSet<usize> = (from..=to).collect();
+        // Use group-aware deletions to preserve siblings in shared-seq groups
+        group_aware_delete_mutations(state, targeted_logical_indices)
+    })
+    .await?;
+    Ok(())
+}
+
+/// Build group-aware deletion mutations: for each distinct physical seq touched,
+/// emit `EditEntries{seq,seq}` with `replacements` = surviving group members (in order).
+/// This preserves siblings in shared-seq groups (e.g. Header+U1 after header-insert migration)
+/// while deleting exactly the targeted logical rows.
+fn group_aware_delete_mutations(
+    state: &RemoteRenderState,
+    targeted_logical_indices: std::collections::HashSet<usize>,
+) -> Result<Vec<SessionLogEntry>> {
+    if targeted_logical_indices.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let groups = build_logical_target_groups(state)?;
+    let targeted_seqs = targeted_group_seqs(state, &targeted_logical_indices)?;
+
+    targeted_seqs
+        .into_iter()
+        .map(|seq| build_group_delete_mutation(seq, &groups, &targeted_logical_indices))
+        .collect()
+}
+
+fn build_logical_target_groups(
+    state: &RemoteRenderState,
+) -> Result<std::collections::BTreeMap<usize, Vec<(usize, String)>>> {
+    let mut groups = std::collections::BTreeMap::new();
+    for (logical_index, target) in state.logical_targets.iter().enumerate() {
+        let seq =
+            usize::try_from(target.js_seq).context("JetStream seq does not fit into usize")?;
+        let yaml = serde_yaml::to_string(&target.entry)
+            .context("failed to serialize remote logical target")?;
+        groups
+            .entry(seq)
+            .or_insert_with(Vec::new)
+            .push((logical_index, yaml));
+    }
+    for (seq, members) in &groups {
+        verify_contiguous_group(*seq, members)?;
+    }
+    Ok(groups)
+}
+
+fn targeted_group_seqs(
+    state: &RemoteRenderState,
+    targeted_logical_indices: &std::collections::HashSet<usize>,
+) -> Result<Vec<usize>> {
+    let mut targeted_seqs: Vec<usize> = state
+        .logical_targets
+        .iter()
+        .enumerate()
+        .filter(|(logical_index, _)| targeted_logical_indices.contains(logical_index))
+        .map(|(_, target)| {
+            usize::try_from(target.js_seq).context("JetStream seq does not fit into usize")
+        })
+        .collect::<Result<Vec<_>>>()?;
+    targeted_seqs.sort_unstable();
+    targeted_seqs.dedup();
+    Ok(targeted_seqs)
+}
+
+fn build_group_delete_mutation(
+    seq: usize,
+    groups: &std::collections::BTreeMap<usize, Vec<(usize, String)>>,
+    targeted_logical_indices: &std::collections::HashSet<usize>,
+) -> Result<SessionLogEntry> {
+    let group_members = groups
+        .get(&seq)
+        .context("physical seq not found in groups")?;
+    let survivors = survivor_group_members(group_members, targeted_logical_indices);
+    Ok(SessionLogEntry::EditEntries {
+        from: seq,
+        to: seq,
+        replacements: survivors,
+    })
+}
+
+fn survivor_group_members(
+    group_members: &[(usize, String)],
+    targeted_logical_indices: &std::collections::HashSet<usize>,
+) -> Vec<String> {
+    group_members
+        .iter()
+        .filter(|(logical_index, _)| !targeted_logical_indices.contains(logical_index))
+        .map(|(_, entry_yaml)| entry_yaml.clone())
+        .collect()
+}
+
+fn verify_contiguous_group(seq: usize, members: &[(usize, String)]) -> Result<()> {
+    let first_idx = members.first().map(|(index, _)| *index);
+    let last_idx = members.last().map(|(index, _)| *index);
+    if let (Some(first), Some(last)) = (first_idx, last_idx) {
+        let expected_len = last.saturating_sub(first) + 1;
+        if members.len() != expected_len {
+            bail!(
+                "shared-seq group members are non-contiguous: seq {} spans logical indices {:?} (gap in middle unsupported)",
+                seq,
+                members.iter().map(|(index, _)| *index).collect::<Vec<_>>()
+            );
+        }
+    }
+    Ok(())
+}
+
+pub(crate) async fn rewind_remote_session(
+    config: &GlobalConfig,
+    after_seq: usize,
+    abort_signal: &AbortSignal,
+) -> Result<()> {
+    let thin = remote_thin_session(config, abort_signal).await?;
+    append_session_mutation_batch_cas(&thin, |state| {
+        let len = state.logical_entries.len();
+        let after_seq =
+            self::session_ops_core::compute_rewind_point(after_seq, len, &state.logical_entries)?;
+        // A logical rewind drops the exact logical SUFFIX (every logical entry
+        // after the cutoff). Use group-aware deletions to preserve any siblings
+        // in shared-seq groups that are in the kept prefix.
+        let suffix_logical_indices: std::collections::HashSet<usize> =
+            (after_seq + 1..len).collect();
+        group_aware_delete_mutations(state, suffix_logical_indices)
+    })
+    .await?;
+    Ok(())
+}
+
+async fn remote_thin_session(
+    config: &GlobalConfig,
+    abort_signal: &AbortSignal,
+) -> Result<ThinClientSession> {
+    let (agent, cluster, session_id) = {
+        let cfg = config.read();
+        let (agent, cluster) = cfg.remote_agent.clone().context("No remote agent")?;
+        let session_id = cfg
+            .session
+            .as_ref()
+            .map(|session| session.id().to_string())
+            .context("No session")?;
+        (agent, cluster, session_id)
+    };
+
+    ThinClientSession::from_global_config(
+        ThinClientConfig {
+            cluster,
+            agent,
+            session_id: Some(session_id),
+        },
+        config,
+        abort_signal.clone(),
+    )
+    .await
+}
+
+pub struct RemoteTranscriptState {
+    pub compressed_messages: Vec<harnx_core::message::Message>,
+    pub messages: Vec<harnx_core::message::Message>,
+}
+
+fn renumber_remote_messages_for_window(
+    messages: &mut [harnx_core::message::Message],
+    _effective_entries: &[(u64, SessionLogEntry)],
+    window: &harnx_core::session_reconstruct::ActiveContextWindow<'_, (u64, SessionLogEntry)>,
+) {
+    let mut available_members = build_window_member_queues(window);
+    for message in messages.iter_mut() {
+        let Some(seq) = message.log_seq.and_then(|seq| u64::try_from(seq).ok()) else {
+            message.log_seq = None;
+            continue;
+        };
+        let Some(member) = consume_window_member(&mut available_members, seq, message.role) else {
+            message.log_seq = None;
+            continue;
+        };
+        message.log_seq = Some(member.logical_index);
+    }
+}
+
+#[derive(Clone, Copy)]
+struct WindowMemberAssignment {
+    logical_index: usize,
+    role: harnx_core::message::MessageRole,
+}
+
+fn build_window_member_queues(
+    window: &harnx_core::session_reconstruct::ActiveContextWindow<'_, (u64, SessionLogEntry)>,
+) -> std::collections::HashMap<u64, std::collections::VecDeque<WindowMemberAssignment>> {
+    // Pair each active-window entry with its OWN logical index (window.entries()
+    // and window.logical_entries() are in the same order). For a header-insert
+    // shared-physical-seq group [Header, U1, U2, ...] every member has a distinct
+    // logical index (Header=0, U1=1, ...). Queue the renderable (non-Header)
+    // members per physical seq, in order, each with its own logical index — so a
+    // transcript row sharing that seq is assigned the NEXT member's index rather
+    // than collapsing to the group's first/last. The Header renders no transcript
+    // row, so it is never queued/consumed.
+    let mut available_members: std::collections::HashMap<
+        u64,
+        std::collections::VecDeque<WindowMemberAssignment>,
+    > = std::collections::HashMap::new();
+    for ((physical_seq, entry), logical) in window.entries().iter().zip(window.logical_entries()) {
+        if matches!(entry, SessionLogEntry::Header { .. }) {
+            continue;
+        }
+        let Some(role) = message_role_for_assignment(entry) else {
+            continue;
+        };
+        available_members
+            .entry(*physical_seq)
+            .or_default()
+            .push_back(WindowMemberAssignment {
+                logical_index: logical.logical_index,
+                role,
+            });
+    }
+    available_members
+}
+
+fn message_role_for_assignment(
+    entry: &SessionLogEntry,
+) -> Option<harnx_core::message::MessageRole> {
+    match entry {
+        SessionLogEntry::Message { role, .. } => Some(*role),
+        _ => None,
+    }
+}
+
+fn consume_window_member(
+    available_members: &mut std::collections::HashMap<
+        u64,
+        std::collections::VecDeque<WindowMemberAssignment>,
+    >,
+    seq: u64,
+    role: harnx_core::message::MessageRole,
+) -> Option<WindowMemberAssignment> {
+    let queue = available_members.get_mut(&seq)?;
+    while let Some(member) = queue.pop_front() {
+        if member.role == role {
+            return Some(member);
+        }
+    }
+    None
+}
+
+pub async fn load_remote_transcript_for_render(
+    thin: &ThinClientSession,
+) -> Result<RemoteTranscriptState> {
+    let log = NatsSessionLog::new(thin.jetstream().clone(), thin.session_id().to_string());
+    let entries = log.load_events_async().await?;
+    let effective_entries = harnx_core::session_reconstruct::apply_log_mutations_nats(&entries)
+        .context("failed to reconstruct remote session log for transcript render")?;
+    let window = active_context_window(&effective_entries);
+
+    if window.boundary_index().is_none() {
+        return Ok(RemoteTranscriptState {
+            compressed_messages: vec![],
+            messages: vec![],
+        });
+    }
+
+    let raw_entries = effective_entries
+        .iter()
+        .map(|(seq, entry)| {
+            Ok((
+                usize::try_from(*seq).context("JetStream seq does not fit into usize")?,
+                entry.clone(),
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let mut session =
+        super::session::replay_log_entries_for_external(&raw_entries, thin.session_id())?;
+
+    renumber_remote_messages_for_window(
+        &mut session.compressed_messages,
+        &effective_entries,
+        &window,
+    );
+    renumber_remote_messages_for_window(&mut session.messages, &effective_entries, &window);
+
+    Ok(RemoteTranscriptState {
+        compressed_messages: session.compressed_messages,
+        messages: session.messages,
+    })
+}
+
+struct RemoteUserMessageSelection {
+    js_seq: u64,
+    text: String,
+}
+
+async fn remote_user_messages_for_range(
+    from: usize,
+    to: usize,
+    thin: &ThinClientSession,
+) -> Result<Vec<RemoteUserMessageSelection>> {
+    let state = load_remote_session_for_render(thin).await?;
+    let mut user_messages = Vec::new();
+    for logical_index in from..=to {
+        let target = state.logical_target(logical_index)?;
+        if let SessionLogEntry::Message { role, content, .. } = &target.entry {
+            if role.is_user() {
+                let text = match content {
+                    harnx_core::message::MessageContent::Text(text) => text.clone(),
+                    _ => bail!("Remote edit supports only text user messages"),
+                };
+                user_messages.push(RemoteUserMessageSelection {
+                    js_seq: target.js_seq,
+                    text,
+                });
+            }
+        }
+    }
+
+    if user_messages.is_empty() {
+        bail!("Selected range does not contain any user messages")
+    }
+
+    Ok(user_messages)
+}
+
+async fn append_session_mutation_batch_cas<F>(
+    thin: &ThinClientSession,
+    build_entries: F,
+) -> Result<()>
+where
+    F: Fn(&RemoteRenderState) -> Result<Vec<SessionLogEntry>>,
+{
+    const MAX_CAS_ATTEMPTS: usize = 10;
+    let log = NatsSessionLog::new(thin.jetstream().clone(), thin.session_id().to_string());
+    for attempt in 1..=MAX_CAS_ATTEMPTS {
+        let state = load_remote_session_for_render(thin).await?;
+        let entries = build_entries(&state)?;
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let mut expected_last = state.last_seen_stream_seq;
+        let mut should_retry = false;
+        for entry in &entries {
+            match log
+                .append_event_with_expected_last_sequence_async(entry, expected_last)
+                .await
+            {
+                Ok(seq) => expected_last = seq,
+                Err(err) if is_stream_advanced_error(&err) => {
+                    should_retry = true;
+                    break;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        if !should_retry {
+            return Ok(());
+        }
+        if attempt == MAX_CAS_ATTEMPTS {
+            break;
+        }
+        tokio::time::sleep(cas_retry_delay(attempt)).await;
+    }
+    Err(anyhow!(
+        "remote session mutation failed after {MAX_CAS_ATTEMPTS} attempts due to concurrent writes"
+    ))
+}
+
+fn cas_retry_delay(attempt: usize) -> std::time::Duration {
+    let millis = 5_u64.saturating_mul(attempt as u64);
+    std::time::Duration::from_millis(millis)
+}
+
+fn is_stream_advanced_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause.to_string().contains("wrong last sequence")
+            || cause.to_string().contains("expected last sequence")
+            || cause.to_string().contains("stream sequence does not match")
+    })
+}
+
+pub(crate) struct RemoteRenderState {
+    pub(crate) logical_entries: Vec<SessionLogEntry>,
+    pub(crate) logical_documents: Vec<String>,
+    logical_targets: Vec<RemoteLogicalTarget>,
+    pub(crate) last_seen_stream_seq: u64,
+}
+
+impl RemoteRenderState {
+    fn logical_target(&self, logical_index: usize) -> Result<&RemoteLogicalTarget> {
+        self.logical_targets
+            .get(logical_index)
+            .context("Sequence numbers out of range")
+    }
+
+    #[allow(dead_code)]
+    fn logical_index_to_js_seq(&self, logical_index: usize) -> Result<usize> {
+        let js_seq = self.logical_target(logical_index)?.js_seq;
+        usize::try_from(js_seq).context("JetStream seq does not fit into usize")
+    }
+
+    #[allow(dead_code)]
+    fn logical_range_to_targeted_js_seqs(&self, from: usize, to: usize) -> Result<Vec<usize>> {
+        let mut js_seqs = Vec::with_capacity(to.saturating_sub(from) + 1);
+        for logical_index in from..=to {
+            js_seqs.push(self.logical_index_to_js_seq(logical_index)?);
+        }
+        Ok(js_seqs)
+    }
+}
+
+struct RemoteLogicalTarget {
+    js_seq: u64,
+    entry: SessionLogEntry,
+}
+
+pub(crate) async fn load_remote_session_for_render(
+    thin: &ThinClientSession,
+) -> Result<RemoteRenderState> {
+    let log = NatsSessionLog::new(thin.jetstream().clone(), thin.session_id().to_string());
+    let entries = log.load_events_async().await?;
+    let rendered = harnx_core::session_reconstruct::apply_log_mutations_nats(&entries)
+        .context("failed to reconstruct remote session log before edit/delete")?;
+
+    let last_seen_stream_seq = entries.last().map(|(seq, _)| *seq).unwrap_or(0);
+    let logical_window = active_context_window(&rendered);
+    let logical_targets = logical_window
+        .entries()
+        .iter()
+        .zip(logical_window.logical_entries())
+        .map(|((_, entry), logical_entry)| RemoteLogicalTarget {
+            js_seq: logical_entry.physical_seq,
+            entry: entry.clone(),
+        })
+        .collect::<Vec<_>>();
+    let logical_entries = logical_targets
+        .iter()
+        .map(|target| target.entry.clone())
+        .collect::<Vec<_>>();
+    let logical_documents = logical_entries
+        .iter()
+        .map(serde_yaml::to_string)
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    Ok(RemoteRenderState {
+        logical_entries,
+        logical_documents,
+        logical_targets,
+        last_seen_stream_seq,
+    })
+}

--- a/crates/harnx-runtime/src/config/session_log_split.rs
+++ b/crates/harnx-runtime/src/config/session_log_split.rs
@@ -1,4 +1,5 @@
 //! Session-log parsing/validation helpers extracted from config/mod.rs for code health.
+pub(crate) use super::session_ops_core::adjust_range_for_tool_pairs;
 use super::*;
 
 pub(crate) fn split_session_log_documents(raw_log: &str) -> Vec<String> {
@@ -47,43 +48,6 @@ pub(crate) fn validate_edited_session_documents(content: &str) -> Result<Vec<Str
 ///   `ToolResults`, auto-expand `to` by one.
 ///
 /// Returns `(adjusted_from, adjusted_to)`.
-pub(crate) fn adjust_range_for_tool_pairs(
-    from: usize,
-    to: usize,
-    documents: &[String],
-) -> Result<(usize, usize)> {
-    // Parse only the entries we need: the one just before `from` (to check if
-    // `from` is a dangling ToolResults) and up through `to + 1` (to check if
-    // `to` is a ToolCalls that needs its partner).
-    let parse = |idx: usize| -> Option<SessionLogEntry> {
-        documents
-            .get(idx)
-            .and_then(|raw| serde_yaml::from_str::<SessionLogEntry>(raw).ok())
-    };
-
-    // Reject: range starts on a ToolResults whose ToolCalls is outside the range.
-    if matches!(parse(from), Some(SessionLogEntry::ToolResults { .. })) {
-        // Check if the immediately preceding entry is a ToolCalls — if so,
-        // this is definitely a dangling-results situation.
-        bail!(
-            "Sequence {from} is a tool-results entry; its paired tool-calls entry ({}) \
-             would be outside the range. Expand your range to include it.",
-            from.saturating_sub(1)
-        );
-    }
-
-    // Auto-expand: range ends on a ToolCalls whose ToolResults is just outside.
-    let mut adjusted_to = to;
-    if matches!(parse(to), Some(SessionLogEntry::ToolCalls { .. }))
-        && to + 1 < documents.len()
-        && matches!(parse(to + 1), Some(SessionLogEntry::ToolResults { .. }))
-    {
-        adjusted_to = to + 1;
-    }
-
-    Ok((from, adjusted_to))
-}
-
 pub(crate) fn validate_tool_pair_integrity(start_seq: usize, documents: &[String]) -> Result<()> {
     let entries = documents
         .iter()

--- a/crates/harnx-runtime/src/config/session_ops_core.rs
+++ b/crates/harnx-runtime/src/config/session_ops_core.rs
@@ -1,0 +1,197 @@
+//! Pure session-operation decision helpers shared by local and remote adapters.
+use super::*;
+use harnx_core::session_reconstruct::active_context_window;
+
+pub(crate) fn adjust_range_for_tool_pairs(
+    from: usize,
+    to: usize,
+    documents: &[String],
+) -> Result<(usize, usize)> {
+    let parse = |idx: usize| -> Option<SessionLogEntry> {
+        documents
+            .get(idx)
+            .and_then(|raw| serde_yaml::from_str::<SessionLogEntry>(raw).ok())
+    };
+
+    if matches!(parse(from), Some(SessionLogEntry::ToolResults { .. })) {
+        bail!(
+            "Sequence {from} is a tool-results entry; its paired tool-calls entry ({}) \
+             would be outside the range. Expand your range to include it.",
+            from.saturating_sub(1)
+        );
+    }
+
+    let mut adjusted_to = to;
+    if matches!(parse(to), Some(SessionLogEntry::ToolCalls { .. }))
+        && to + 1 < documents.len()
+        && matches!(parse(to + 1), Some(SessionLogEntry::ToolResults { .. }))
+    {
+        adjusted_to = to + 1;
+    }
+
+    Ok((from, adjusted_to))
+}
+
+pub(crate) fn validate_not_deleting_protected(
+    entries: &[SessionLogEntry],
+    from: usize,
+) -> Result<()> {
+    if matches!(entries.get(from), Some(SessionLogEntry::Header { .. })) {
+        bail!("Cannot edit or delete the session header (sequence 0)");
+    }
+    if matches!(entries.get(from), Some(SessionLogEntry::Compress { .. })) {
+        bail!("Cannot delete protected session history at or before most-recent boundary");
+    }
+
+    let indexed: Vec<_> = entries.iter().cloned().enumerate().collect();
+    let window = active_context_window(&indexed);
+    if window
+        .boundary_index()
+        .is_some_and(|boundary| from <= boundary)
+    {
+        bail!("Cannot delete protected session history at or before most-recent boundary");
+    }
+
+    Ok(())
+}
+
+pub(crate) fn compute_delete_range(
+    from: usize,
+    to: usize,
+    entries: &[SessionLogEntry],
+    documents: &[String],
+) -> Result<(usize, usize)> {
+    validate_not_deleting_protected(entries, from)?;
+    if to >= documents.len() {
+        bail!("Sequence numbers out of range");
+    }
+    let (from, to) = adjust_range_for_tool_pairs(from, to, documents)?;
+    if from > to || to >= documents.len() {
+        bail!("Sequence numbers out of range");
+    }
+    Ok((from, to))
+}
+
+pub(crate) fn compute_rewind_point(
+    after_seq: usize,
+    log_entry_count: usize,
+    entries: &[SessionLogEntry],
+) -> Result<usize> {
+    if after_seq >= log_entry_count {
+        bail!(
+            "Sequence number {} is out of range (log has {} entries)",
+            after_seq,
+            log_entry_count
+        );
+    }
+
+    let indexed: Vec<_> = entries.iter().cloned().enumerate().collect();
+    let window = active_context_window(&indexed);
+    if window
+        .boundary_index()
+        .is_some_and(|boundary| after_seq <= boundary)
+    {
+        bail!("Cannot rewind to or before most-recent boundary");
+    }
+
+    let parse = |idx: usize| entries.get(idx);
+    if matches!(parse(after_seq), Some(SessionLogEntry::ToolCalls { .. }))
+        && matches!(
+            parse(after_seq + 1),
+            Some(SessionLogEntry::ToolResults { .. })
+        )
+    {
+        bail!(
+            "Sequence {after_seq} is a tool-calls entry paired with tool-results at {}; \
+             rewinding here would orphan the tool calls. \
+             Use {} to keep the pair or {} to exclude it.",
+            after_seq + 1,
+            after_seq + 1,
+            after_seq.saturating_sub(1),
+        );
+    }
+
+    Ok(after_seq)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harnx_core::message::{MessageContent, MessageRole};
+
+    fn user(text: &str) -> SessionLogEntry {
+        SessionLogEntry::Message {
+            id: None,
+            timestamp: None,
+            fence_token: None,
+            role: MessageRole::User,
+            content: MessageContent::Text(text.into()),
+        }
+    }
+
+    fn assistant(text: &str) -> SessionLogEntry {
+        SessionLogEntry::Message {
+            id: None,
+            timestamp: None,
+            fence_token: None,
+            role: MessageRole::Assistant,
+            content: MessageContent::Text(text.into()),
+        }
+    }
+
+    fn header() -> SessionLogEntry {
+        Session::default().build_header_entry()
+    }
+
+    fn compress() -> SessionLogEntry {
+        SessionLogEntry::Compress {
+            prompt: "summary".into(),
+        }
+    }
+
+    #[test]
+    fn validate_not_deleting_protected_rejects_header() {
+        let entries = vec![header(), user("u")];
+        let err = validate_not_deleting_protected(&entries, 0).expect_err("header protected");
+        assert_eq!(
+            err.to_string(),
+            "Cannot edit or delete the session header (sequence 0)"
+        );
+    }
+
+    #[test]
+    fn validate_not_deleting_protected_rejects_compress_boundary() {
+        let entries = vec![user("old"), compress(), user("new")];
+        let err = validate_not_deleting_protected(&entries, 1).expect_err("compress protected");
+        assert_eq!(
+            err.to_string(),
+            "Cannot delete protected session history at or before most-recent boundary"
+        );
+    }
+
+    #[test]
+    fn validate_not_deleting_protected_rejects_pre_boundary_history() {
+        let entries = vec![user("old"), assistant("older"), compress(), user("new")];
+        let err = validate_not_deleting_protected(&entries, 0).expect_err("pre-boundary protected");
+        assert_eq!(
+            err.to_string(),
+            "Cannot delete protected session history at or before most-recent boundary"
+        );
+    }
+
+    #[test]
+    fn validate_not_deleting_protected_allows_post_boundary_turn() {
+        let entries = vec![user("old"), compress(), user("new"), assistant("reply")];
+        validate_not_deleting_protected(&entries, 2).unwrap();
+    }
+
+    #[test]
+    fn compute_rewind_point_rejects_boundary_or_earlier() {
+        let entries = vec![user("old"), compress(), user("new")];
+        let err = compute_rewind_point(1, entries.len(), &entries).expect_err("boundary protected");
+        assert_eq!(
+            err.to_string(),
+            "Cannot rewind to or before most-recent boundary"
+        );
+    }
+}

--- a/crates/harnx-runtime/src/config/session_ops_split.rs
+++ b/crates/harnx-runtime/src/config/session_ops_split.rs
@@ -152,16 +152,12 @@ impl Config {
         let raw_log = std::fs::read_to_string(&session_path)
             .with_context(|| format!("Failed to read '{}'", session_path.display()))?;
         let documents = split_session_log_documents(&raw_log);
-        if from == 0 {
-            bail!("Cannot edit or delete the session header (sequence 0)");
-        }
-        if to >= documents.len() {
-            bail!("Sequence numbers out of range");
-        }
-        let (from, to) = adjust_range_for_tool_pairs(from, to, &documents)?;
-        if from > to || to >= documents.len() {
-            bail!("Sequence numbers out of range");
-        }
+        let entries = documents
+            .iter()
+            .map(|document| serde_yaml::from_str::<SessionLogEntry>(document))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let (from, to) =
+            self::session_ops_core::compute_delete_range(from, to, &entries, &documents)?;
 
         // Replacement list order becomes new order for edited range. Reordering
         // plain message entries in editor is supported as long as edited YAML still
@@ -236,16 +232,12 @@ impl Config {
         let raw_log = std::fs::read_to_string(&session_path)
             .with_context(|| format!("Failed to read '{}'", session_path.display()))?;
         let documents = split_session_log_documents(&raw_log);
-        if from == 0 {
-            bail!("Cannot edit or delete the session header (sequence 0)");
-        }
-        if to >= documents.len() {
-            bail!("Sequence numbers out of range");
-        }
-        let (from, to) = adjust_range_for_tool_pairs(from, to, &documents)?;
-        if from > to || to >= documents.len() {
-            bail!("Sequence numbers out of range");
-        }
+        let entries = documents
+            .iter()
+            .map(|document| serde_yaml::from_str::<SessionLogEntry>(document))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let (from, to) =
+            self::session_ops_core::compute_delete_range(from, to, &entries, &documents)?;
 
         let edit_entry = SessionLogEntry::EditEntries {
             from,
@@ -277,30 +269,18 @@ impl Config {
             );
         }
 
-        // Reject a cut point that splits a ToolCalls/ToolResults pair.
         let raw_log = std::fs::read_to_string(&session_path)
             .with_context(|| format!("Failed to read '{}'", session_path.display()))?;
         let documents = split_session_log_documents(&raw_log);
-        let parse = |idx: usize| -> Option<SessionLogEntry> {
-            documents
-                .get(idx)
-                .and_then(|raw| serde_yaml::from_str::<SessionLogEntry>(raw).ok())
-        };
-        if matches!(parse(after_seq), Some(SessionLogEntry::ToolCalls { .. }))
-            && matches!(
-                parse(after_seq + 1),
-                Some(SessionLogEntry::ToolResults { .. })
-            )
-        {
-            bail!(
-                "Sequence {after_seq} is a tool-calls entry paired with tool-results at {}; \
-                 rewinding here would orphan the tool calls. \
-                 Use {} to keep the pair or {} to exclude it.",
-                after_seq + 1,
-                after_seq + 1,
-                after_seq.saturating_sub(1),
-            );
-        }
+        let entries = documents
+            .iter()
+            .map(|document| serde_yaml::from_str::<SessionLogEntry>(document))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let after_seq = self::session_ops_core::compute_rewind_point(
+            after_seq,
+            session.log_entry_count,
+            &entries,
+        )?;
 
         let rewind_entry = SessionLogEntry::Rewind { after_seq };
         let session = self.session.as_mut().context("No session")?;

--- a/crates/harnx-runtime/src/lib.rs
+++ b/crates/harnx-runtime/src/lib.rs
@@ -34,6 +34,7 @@ pub mod utils;
 pub use nats_client_session::{
     send_control_command, ThinClientConfig, ThinClientSession, ThinClientTurnResult,
 };
+pub use nats_worker::ControlCommand;
 
 pub use agent_loop::{
     run_agent_loop, AgentCallFn, AgentLoopContext, OnTextResponseFn, OnToolRoundFn,

--- a/crates/harnx-runtime/src/nats_client_session.rs
+++ b/crates/harnx-runtime/src/nats_client_session.rs
@@ -36,10 +36,13 @@
 use anyhow::{Context, Result};
 use async_nats::jetstream;
 use harnx_core::abort::wait_abort_signal;
-use harnx_core::event::{AgentEvent, AgentEventSink, UserEvent};
+use harnx_core::event::{AgentEvent, AgentEventSink, SessionEvent, UserEvent};
 use harnx_core::message::{MessageContent, MessageRole};
 use harnx_core::session::SessionLogEntry;
-use harnx_core::session_reconstruct::{reconstruct_state_from_nats, TurnStatus};
+use harnx_core::session_reconstruct::{
+    active_context_window, reconstruct_state_from_nats, ActiveContextWindow, TurnStatus,
+};
+use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 
 use crate::nats_event_sink::SessionEventStream;
@@ -51,7 +54,7 @@ use crate::nats_worker::{
 use crate::utils::AbortSignal;
 
 /// Generate a client-side message ID (UUID v4).
-fn new_client_message_id() -> String {
+pub(crate) fn new_client_message_id() -> String {
     uuid::Uuid::new_v4().to_string()
 }
 
@@ -131,6 +134,10 @@ impl ThinClientSession {
         &self.session_id
     }
 
+    pub(crate) fn jetstream(&self) -> &jetstream::Context {
+        &self.jetstream
+    }
+
     /// Run a turn: append user message, activate worker, stream events until completion.
     ///
     /// This is the main entry point for all frontends (CLI, TUI, ACP).
@@ -194,7 +201,13 @@ impl ThinClientSession {
                     history.to_vec()
                 }
             };
-        replay_history_to_sink(&effective_history, user_msg_seq, event_sink.clone());
+        let history_window = active_context_window(&effective_history);
+        replay_history_to_sink(
+            &effective_history,
+            &history_window,
+            user_msg_seq,
+            event_sink.clone(),
+        );
 
         // Step 3: Publish activation to wake a worker.
         let activation = SessionActivate::new(&self.session_id, &self.config.agent);
@@ -213,6 +226,12 @@ impl ThinClientSession {
         let mut event_stream = event_stream;
         let mut final_response: Option<String> = None;
         let mut turn_complete = false;
+        // Cached effective log for emitting LogSeqAssigned on live advisory
+        // events. Refreshed on throttled durable reloads so we avoid O(N^2)
+        // full-log load per streaming token.
+        let mut cached_effective: Option<Vec<(u64, SessionLogEntry)>> = None;
+        let mut pending_advisories = VecDeque::new();
+        let mut emitted_logical_seqs = HashSet::new();
         // Throttle the durable-log completion check: advisory events arrive at
         // streaming-token frequency, and reloading the full log on each would be
         // O(N^2) in session size. Check at most once per interval instead — the
@@ -223,7 +242,6 @@ impl ThinClientSession {
         let mut last_completion_check = std::time::Instant::now() - COMPLETION_CHECK_INTERVAL;
         let mut completion_interval = tokio::time::interval(COMPLETION_CHECK_INTERVAL);
         completion_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-
         // Set up control command sender
         let (control_tx, mut control_rx) = tokio::sync::mpsc::channel::<ControlCommand>(16);
         let session_id_control = self.session_id.clone();
@@ -269,6 +287,21 @@ impl ThinClientSession {
                 // complete the turn promptly.
                 _ = completion_interval.tick() => {
                     if let Ok(entries) = self.load_durable_entries().await {
+                        // Refresh cached effective log for live LogSeqAssigned.
+                        if let Ok(effective) = harnx_core::session_reconstruct::apply_log_mutations_nats(&entries) {
+                            cached_effective = Some(effective);
+                            emit_all_logical_seqs_for_window(
+                                cached_effective.as_deref(),
+                                &event_sink,
+                                &mut emitted_logical_seqs,
+                            );
+                            flush_pending_advisories(
+                                &mut pending_advisories,
+                                cached_effective.as_deref(),
+                                &event_sink,
+                                &mut emitted_logical_seqs,
+                            );
+                        }
                         if self.is_turn_complete(&entries, user_msg_seq) {
                             final_response = Self::extract_final_response(&entries, user_msg_seq);
                             turn_complete = true;
@@ -283,17 +316,36 @@ impl ThinClientSession {
                         Some(envelope) => {
                             // Check if this advisory should be rendered (dedup rule)
                             if event_stream.should_render(&envelope) {
-                                // Emit to sink for rendering
-                                event_sink.emit(envelope.event.clone(), None);
+                                pending_advisories.push_back(envelope.clone());
+                                flush_pending_advisories(
+                                    &mut pending_advisories,
+                                    cached_effective.as_deref(),
+                                    &event_sink,
+                                    &mut emitted_logical_seqs,
+                                );
                             }
 
-                            // Poll the durable log for turn completion, but at
-                            // most once per COMPLETION_CHECK_INTERVAL so a burst
-                            // of streaming advisories doesn't trigger a full
-                            // log reload each (avoids O(N^2) growth).
+                            // Poll durable log for turn completion, but at most
+                            // once per COMPLETION_CHECK_INTERVAL so bursty
+                            // streaming advisories do not trigger full log reload
+                            // each time (avoids O(N^2) growth).
                             if last_completion_check.elapsed() >= COMPLETION_CHECK_INTERVAL {
                                 last_completion_check = std::time::Instant::now();
                                 if let Ok(entries) = self.load_durable_entries().await {
+                                    if let Ok(effective) = harnx_core::session_reconstruct::apply_log_mutations_nats(&entries) {
+                                        cached_effective = Some(effective);
+                                        emit_all_logical_seqs_for_window(
+                                cached_effective.as_deref(),
+                                &event_sink,
+                                &mut emitted_logical_seqs,
+                            );
+                                        flush_pending_advisories(
+                                            &mut pending_advisories,
+                                            cached_effective.as_deref(),
+                                            &event_sink,
+                                            &mut emitted_logical_seqs,
+                                        );
+                                    }
                                     if self.is_turn_complete(&entries, user_msg_seq) {
                                         // Extract final response before we finish
                                         final_response = Self::extract_final_response(&entries, user_msg_seq);
@@ -472,6 +524,7 @@ fn should_skip_replay_entry(seq: u64, user_msg_seq: u64) -> bool {
 
 fn replay_history_to_sink(
     effective_history: &[(u64, SessionLogEntry)],
+    history_window: &ActiveContextWindow<'_, (u64, SessionLogEntry)>,
     user_msg_seq: u64,
     sink: Arc<dyn AgentEventSink>,
 ) {
@@ -479,30 +532,177 @@ fn replay_history_to_sink(
         if should_skip_replay_entry(*seq, user_msg_seq) {
             continue;
         }
-        render_log_entry_to_sink(entry, sink.clone());
+        render_log_entry_to_sink(entry, *seq, history_window, sink.clone());
     }
 }
 
-fn render_log_entry_to_sink(entry: &SessionLogEntry, sink: Arc<dyn AgentEventSink>) {
-    match entry {
+fn render_log_entry_to_sink(
+    entry: &SessionLogEntry,
+    physical_seq: u64,
+    history_window: &ActiveContextWindow<'_, (u64, SessionLogEntry)>,
+    sink: Arc<dyn AgentEventSink>,
+) {
+    let rendered = match entry {
         SessionLogEntry::Message { role, content, .. } => {
-            render_message_entry(role, content, &sink)
+            render_message_entry(role, content, &sink);
+            true
         }
         SessionLogEntry::ToolCalls { text, calls, .. } => {
-            render_tool_calls_entry(text, calls, &sink)
+            render_tool_calls_entry(text, calls, &sink);
+            true
         }
-        SessionLogEntry::ToolResults { results, .. } => render_tool_results_entry(results, &sink),
-        SessionLogEntry::Cancel { .. } => render_cancel_entry(&sink),
+        SessionLogEntry::ToolResults { results, .. } => {
+            render_tool_results_entry(results, &sink);
+            false
+        }
+        SessionLogEntry::Cancel { .. } => {
+            render_cancel_entry(&sink);
+            false
+        }
         SessionLogEntry::Header { .. }
         | SessionLogEntry::DataUrls { .. }
         | SessionLogEntry::Compress { .. }
         | SessionLogEntry::Clear
         | SessionLogEntry::EditEntries { .. }
         | SessionLogEntry::Rewind { .. }
-        | SessionLogEntry::Unknown => {}
+        | SessionLogEntry::Unknown => false,
+    };
+    // Only emit logical seqs during replay when the window has a Header/Compress
+    // boundary. A headerless-origin remote session has no boundary at replay
+    // time (the worker inserts the Header via migration only AFTER activation),
+    // so any replay-time number would be wrong and — because the TUI never
+    // overrides a `Some(seq)` — would permanently mis-label the row. In that
+    // case seq assignment is deferred to the post-migration reload pass
+    // (`emit_all_logical_seqs_for_window`). An already-headered session (resume)
+    // has a boundary and numbers replayed rows immediately here.
+    if rendered && history_window.boundary_index().is_some() {
+        for logical_index in logical_indices_for_entry(physical_seq, entry, history_window) {
+            sink.emit(
+                AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: logical_index }),
+                None,
+            );
+        }
     }
     // Note: ToolResults fence_token is not currently exposed in the entry type
     // (it belongs to ToolCalls which should be followed by ToolResults)
+}
+
+fn emit_live_logical_seq_for_physical(
+    physical_seq: u64,
+    history_window: &ActiveContextWindow<'_, (u64, SessionLogEntry)>,
+    sink: &Arc<dyn AgentEventSink>,
+    emitted_logical_seqs: &mut HashSet<usize>,
+) -> Option<usize> {
+    let logical_index = history_window
+        .logical_indices_for_physical(physical_seq)
+        .last()?;
+    emit_deduped_logical_seq(logical_index, sink, emitted_logical_seqs);
+    Some(logical_index)
+}
+
+fn flush_pending_advisories(
+    pending_advisories: &mut VecDeque<crate::nats_event_sink::AdvisoryEnvelope>,
+    effective_entries: Option<&[(u64, SessionLogEntry)]>,
+    sink: &Arc<dyn AgentEventSink>,
+    emitted_logical_seqs: &mut HashSet<usize>,
+) {
+    let Some(effective_entries) = effective_entries else {
+        return;
+    };
+    let window = active_context_window(effective_entries);
+    while let Some(envelope) = pending_advisories.front() {
+        let Some(_) = emit_live_logical_seq_for_physical(
+            envelope.after_seq,
+            &window,
+            sink,
+            emitted_logical_seqs,
+        ) else {
+            break;
+        };
+        let envelope = pending_advisories
+            .pop_front()
+            .expect("front checked before pop");
+        if !matches!(
+            envelope.event,
+            AgentEvent::Session(SessionEvent::LogSeqAssigned { .. })
+        ) {
+            sink.emit(envelope.event, None);
+        }
+    }
+}
+
+/// Assign logical `LogSeqAssigned` seqs for every renderable row in the
+/// post-migration active window, deduped.
+///
+/// Remote sessions start headerless; the worker inserts the Header via an
+/// `EditEntries` migration only AFTER activation (S2). Replay renders the
+/// historical rows BEFORE that migration, when the window has no boundary and
+/// logical numbers are not yet authoritative — so replay defers seq emission
+/// (see `render_log_entry_to_sink`). This pass runs on each post-activation
+/// durable reload: once the effective log carries a Header/Compress boundary,
+/// it emits the FINAL logical index for each renderable row (replayed history
+/// rows AND the just-submitted live user), exactly once via the shared dedup
+/// set. The TUI backfills each `seq: None` row with its number and never
+/// overrides it, so emitting the correct number once is essential.
+///
+/// Live worker rows (streamed assistant/tool events) are numbered via advisory
+/// translation; the shared dedup set keeps this pass and that path consistent.
+fn emit_all_logical_seqs_for_window(
+    effective_entries: Option<&[(u64, SessionLogEntry)]>,
+    sink: &Arc<dyn AgentEventSink>,
+    emitted_logical_seqs: &mut HashSet<usize>,
+) {
+    let Some(effective_entries) = effective_entries else {
+        return;
+    };
+    let window = active_context_window(effective_entries);
+    // Wait for the header-insert migration to land: no boundary means the
+    // numbering isn't authoritative yet.
+    if window.boundary_index().is_none() {
+        return;
+    }
+    // The logical index of a row is its position WITHIN the active window
+    // (Header/Compress boundary = 0). Iterate the window slice directly so the
+    // logical index stays aligned even when a boundary trims a pre-window prefix.
+    for (logical_index, (_js_seq, entry)) in window.entries().iter().enumerate() {
+        let renders = matches!(
+            entry,
+            SessionLogEntry::Message { .. } | SessionLogEntry::ToolCalls { .. }
+        );
+        if renders {
+            emit_deduped_logical_seq(logical_index, sink, emitted_logical_seqs);
+        }
+    }
+}
+
+fn emit_deduped_logical_seq(
+    logical_index: usize,
+    sink: &Arc<dyn AgentEventSink>,
+    emitted_logical_seqs: &mut HashSet<usize>,
+) {
+    if emitted_logical_seqs.insert(logical_index) {
+        sink.emit(
+            AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: logical_index }),
+            None,
+        );
+    }
+}
+
+pub(crate) fn logical_indices_for_entry(
+    physical_seq: u64,
+    entry: &SessionLogEntry,
+    history_window: &ActiveContextWindow<'_, (u64, SessionLogEntry)>,
+) -> Vec<usize> {
+    let logical_indices: Vec<usize> = history_window
+        .logical_indices_for_physical(physical_seq)
+        .collect();
+    if logical_indices.len() <= 1 {
+        return logical_indices;
+    }
+    match entry {
+        SessionLogEntry::Message { role, .. } if role.is_user() => logical_indices,
+        _ => logical_indices.into_iter().rev().take(1).collect(),
+    }
 }
 
 fn render_message_entry(
@@ -650,7 +850,9 @@ mod tests {
             timestamp: None,
             fence_token: None,
         };
-        render_log_entry_to_sink(&entry, sink.clone());
+        let empty: Vec<(u64, SessionLogEntry)> = vec![];
+        let window = active_context_window(&empty);
+        render_log_entry_to_sink(&entry, 0, &window, sink.clone());
         assert_eq!(count.load(Ordering::SeqCst), 1);
 
         // Test user message
@@ -661,7 +863,9 @@ mod tests {
             timestamp: None,
             fence_token: None,
         };
-        render_log_entry_to_sink(&entry, sink.clone());
+        let empty: Vec<(u64, SessionLogEntry)> = vec![];
+        let window = active_context_window(&empty);
+        render_log_entry_to_sink(&entry, 0, &window, sink.clone());
         assert_eq!(count.load(Ordering::SeqCst), 2);
     }
 
@@ -679,8 +883,13 @@ mod tests {
             (3, MessageRole::User, "current user"),
         ]);
 
-        replay_history_to_sink(&effective_history, 3, sink.clone());
+        let window = active_context_window(&effective_history);
+        replay_history_to_sink(&effective_history, &window, 3, sink.clone());
 
+        // This fixture is HEADERLESS (no boundary): replay RENDERS the two
+        // non-current rows but DEFERS seq emission (the worker will migrate a
+        // Header in; numbering is only authoritative post-migration). So we see
+        // 2 render events and ZERO LogSeqAssigned events.
         assert_eq!(count.load(Ordering::SeqCst), 2);
         let rendered_messages: Vec<String> = sink
             .events
@@ -697,8 +906,226 @@ mod tests {
             .collect();
         assert_eq!(rendered_messages, vec!["first user", "assistant"]);
         assert!(!rendered_messages.iter().any(|msg| msg == "current user"));
+        let replayed_seqs: Vec<usize> = sink
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|event| match event {
+                AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }) => Some(*seq),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            replayed_seqs.is_empty(),
+            "headerless replay defers seq emission until the migration boundary exists, got {replayed_seqs:?}"
+        );
     }
 
+    #[test]
+    fn test_replay_with_header_boundary_emits_row_seqs() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let sink = Arc::new(TestSink {
+            count: Arc::clone(&count),
+            events: Mutex::new(Vec::new()),
+        });
+
+        // Resume case: the log already carries a Header (boundary present), so
+        // replay numbers rows immediately. Header is logical 0 (renders no row);
+        // the first user is logical 1, the assistant logical 2. The current
+        // user (seq 4) is skipped from replay.
+        let mut effective_history = vec![(
+            1u64,
+            SessionLogEntry::Header {
+                model_id: "m".to_string(),
+                temperature: None,
+                top_p: None,
+                use_tools: None,
+                save_session: None,
+                compress_threshold: None,
+                agent_name: Some("a".to_string()),
+                session_id: Some("s".to_string()),
+                working_dir: None,
+                git_branch: None,
+                git_remote: None,
+                terminal_session_id: None,
+                agent_variables: Default::default(),
+                agent_instructions: String::new(),
+                model_fallbacks: vec![],
+                compaction_agent: None,
+            },
+        )];
+        effective_history.extend(test_entries(&[
+            (2, MessageRole::User, "first user"),
+            (3, MessageRole::Assistant, "assistant"),
+            (4, MessageRole::User, "current user"),
+        ]));
+
+        let window = active_context_window(&effective_history);
+        replay_history_to_sink(&effective_history, &window, 4, sink.clone());
+
+        let replayed_seqs: Vec<usize> = sink
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|event| match event {
+                AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }) => Some(*seq),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(replayed_seqs, vec![1, 2]);
+    }
+
+    #[test]
+    fn test_emit_all_logical_seqs_numbers_every_renderable_window_row() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let sink = Arc::new(TestSink {
+            count: Arc::clone(&count),
+            events: Mutex::new(Vec::new()),
+        });
+        let sink_trait: Arc<dyn AgentEventSink> = sink.clone();
+        let user_msg_id = "live-user".to_string();
+        let effective_history = vec![
+            (
+                3,
+                SessionLogEntry::Header {
+                    model_id: "test-model".to_string(),
+                    temperature: None,
+                    top_p: None,
+                    use_tools: None,
+                    save_session: None,
+                    compress_threshold: None,
+                    agent_name: Some("test-agent".to_string()),
+                    session_id: Some("session".to_string()),
+                    working_dir: None,
+                    git_branch: None,
+                    git_remote: None,
+                    terminal_session_id: None,
+                    agent_variables: Default::default(),
+                    agent_instructions: String::new(),
+                    model_fallbacks: vec![],
+                    compaction_agent: None,
+                },
+            ),
+            (
+                3,
+                SessionLogEntry::Message {
+                    id: Some("legacy-user".to_string()),
+                    role: MessageRole::User,
+                    content: MessageContent::Text("legacy".to_string()),
+                    timestamp: None,
+                    fence_token: None,
+                },
+            ),
+            (
+                3,
+                SessionLogEntry::Message {
+                    id: Some(user_msg_id.clone()),
+                    role: MessageRole::User,
+                    content: MessageContent::Text("live user".to_string()),
+                    timestamp: None,
+                    fence_token: None,
+                },
+            ),
+            (
+                4,
+                SessionLogEntry::Message {
+                    id: Some("assistant".to_string()),
+                    role: MessageRole::Assistant,
+                    content: MessageContent::Text("reply".to_string()),
+                    timestamp: None,
+                    fence_token: None,
+                },
+            ),
+        ];
+        let mut emitted_logical_seqs = HashSet::new();
+
+        emit_all_logical_seqs_for_window(
+            Some(&effective_history),
+            &sink_trait,
+            &mut emitted_logical_seqs,
+        );
+
+        // Window = [Header(0), legacy-user(1), live-user(2), assistant(3)].
+        // The Header renders no row; every message row is numbered by its
+        // logical position, deduped and in order.
+        let assigned_seqs: Vec<usize> = sink
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|event| match event {
+                AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }) => Some(*seq),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(assigned_seqs, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_logical_indices_for_entry_user_fans_out_shared_seq() {
+        let effective_history = vec![
+            (
+                50,
+                SessionLogEntry::Header {
+                    model_id: "test-model".to_string(),
+                    temperature: None,
+                    top_p: None,
+                    use_tools: None,
+                    save_session: None,
+                    compress_threshold: None,
+                    agent_name: Some("test-agent".to_string()),
+                    session_id: Some("session".to_string()),
+                    working_dir: None,
+                    git_branch: None,
+                    git_remote: None,
+                    terminal_session_id: None,
+                    agent_variables: Default::default(),
+                    agent_instructions: String::new(),
+                    model_fallbacks: vec![],
+                    compaction_agent: None,
+                },
+            ),
+            (
+                51,
+                SessionLogEntry::Message {
+                    id: Some("u1".to_string()),
+                    role: MessageRole::User,
+                    content: MessageContent::Text("u1".to_string()),
+                    timestamp: None,
+                    fence_token: None,
+                },
+            ),
+            (
+                51,
+                SessionLogEntry::Message {
+                    id: Some("u2".to_string()),
+                    role: MessageRole::User,
+                    content: MessageContent::Text("u2".to_string()),
+                    timestamp: None,
+                    fence_token: None,
+                },
+            ),
+            (
+                51,
+                SessionLogEntry::Message {
+                    id: Some("a1".to_string()),
+                    role: MessageRole::Assistant,
+                    content: MessageContent::Text("a1".to_string()),
+                    timestamp: None,
+                    fence_token: None,
+                },
+            ),
+        ];
+        let window = active_context_window(&effective_history);
+
+        let user_indices = logical_indices_for_entry(51, &effective_history[1].1, &window);
+        let assistant_indices = logical_indices_for_entry(51, &effective_history[3].1, &window);
+
+        assert_eq!(user_indices, vec![1, 2, 3]);
+        assert_eq!(assistant_indices, vec![3]);
+    }
     #[test]
     fn test_render_tool_results_entry() {
         use harnx_core::session::ToolOutput;
@@ -719,7 +1146,9 @@ mod tests {
             }],
             timestamp: None,
         };
-        render_log_entry_to_sink(&entry, sink.clone());
+        let empty: Vec<(u64, SessionLogEntry)> = vec![];
+        let window = active_context_window(&empty);
+        render_log_entry_to_sink(&entry, 0, &window, sink.clone());
         assert_eq!(count.load(Ordering::SeqCst), 1);
     }
 

--- a/crates/harnx-runtime/src/nats_session_log.rs
+++ b/crates/harnx-runtime/src/nats_session_log.rs
@@ -34,16 +34,48 @@ impl NatsSessionLog {
     }
 
     pub async fn append_event_async(&self, entry: &SessionLogEntry) -> Result<u64> {
+        self.append_event_with_message_id_async(entry, new_message_id())
+            .await
+    }
+
+    pub async fn append_event_with_message_id_async(
+        &self,
+        entry: &SessionLogEntry,
+        message_id: impl Into<String>,
+    ) -> Result<u64> {
+        self.append_event_with_publish_message_async(
+            entry,
+            PublishMessage::build().message_id(message_id.into()),
+        )
+        .await
+    }
+
+    pub async fn append_event_with_expected_last_sequence_async(
+        &self,
+        entry: &SessionLogEntry,
+        expected_last_sequence: u64,
+    ) -> Result<u64> {
+        self.append_event_with_publish_message_async(
+            entry,
+            PublishMessage::build()
+                .message_id(new_message_id())
+                .expected_last_sequence(expected_last_sequence),
+        )
+        .await
+    }
+
+    async fn append_event_with_publish_message_async(
+        &self,
+        entry: &SessionLogEntry,
+        publish_message: PublishMessage,
+    ) -> Result<u64> {
         self.ensure_stream().await?;
         let payload = serialize_entry(entry)?;
-        let message_id = new_message_id();
         let ack = self
             .jetstream
             .send_publish(
                 self.subject.clone(),
-                PublishMessage::build()
-                    .payload(Bytes::from(payload))
-                    .message_id(message_id),
+                publish_message.payload(Bytes::from(payload)),
             )
             .await
             .with_context(|| {

--- a/crates/harnx-runtime/src/nats_worker/agent_loop.rs
+++ b/crates/harnx-runtime/src/nats_worker/agent_loop.rs
@@ -9,6 +9,7 @@ use crate::nats_session_index::{put_record, SessionIndexRecord};
 use crate::utils::AbortSignal;
 use anyhow::{Context, Result};
 use harnx_core::message::Message;
+use harnx_core::session::SessionLogEntry;
 use harnx_hooks::{AsyncHookManager, PersistentHookManager};
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -24,6 +25,19 @@ pub struct RunAgentLoopArgs<'a> {
     pub call_fn: Option<crate::agent_loop::AgentCallFn>,
     pub lease: Option<Arc<NatsSessionLease>>,
     pub after_seq_observer: Option<Arc<AtomicU64>>,
+    /// Optional observer of the JetStream seq of the header-insert migration
+    /// EditEntries (S2), when the worker migrates a headerless remote session on
+    /// this activation. The migration re-maps the leading-user block onto this
+    /// seq, so the daemon must advance its activation high-water cursor to cover
+    /// it — otherwise the end-of-turn drain re-folds the now-remapped (and
+    /// already-answered) leading user messages and re-runs the turn (S3).
+    pub header_insert_observer: Option<Arc<AtomicU64>>,
+    /// Optional NATS KV store for the session index. When set, the worker
+    /// upserts a `SessionIndexRecord` after the effective log has a `Header`
+    /// on this activation, so remote sessions taking the existing-session path
+    /// (headerless-migrated per S2, or normal resumes) are indexed and their
+    /// `last_activity` is refreshed — not just brand-new empty-log sessions.
+    pub session_index: Option<&'a async_nats::jetstream::kv::Store>,
     pub on_tool_round: Option<OnToolRoundFn>,
 }
 
@@ -35,6 +49,11 @@ impl<'a> RunAgentLoopArgs<'a> {
 
     pub fn with_after_seq_observer(mut self, observer: Arc<AtomicU64>) -> Self {
         self.after_seq_observer = Some(observer);
+        self
+    }
+
+    pub fn with_header_insert_observer(mut self, observer: Arc<AtomicU64>) -> Self {
+        self.header_insert_observer = Some(observer);
         self
     }
 }
@@ -166,6 +185,8 @@ pub async fn run_agent_loop_with_nats_inner(args: RunAgentLoopArgs<'_>) -> Resul
         call_fn,
         lease,
         after_seq_observer,
+        header_insert_observer,
+        session_index,
         on_tool_round,
     } = args;
     // Get JetStream context from config (extract URL before await)
@@ -190,9 +211,10 @@ pub async fn run_agent_loop_with_nats_inner(args: RunAgentLoopArgs<'_>) -> Resul
         config: &config,
         input: &initial_input,
         lease: lease.as_deref(),
-        session_index: None,
+        session_index,
         session_id,
         abort_signal: &abort_signal,
+        header_insert_observer: header_insert_observer.as_ref(),
     })
     .await?;
 
@@ -251,6 +273,10 @@ struct LoadOrRepairSessionParams<'a> {
     session_index: Option<&'a async_nats::jetstream::kv::Store>,
     session_id: &'a str,
     abort_signal: &'a AbortSignal,
+    /// When a header-insert migration is performed on this activation, its
+    /// JetStream seq is published here so the daemon can advance its high-water
+    /// cursor past the re-mapped leading-user block (S3).
+    header_insert_observer: Option<&'a Arc<AtomicU64>>,
 }
 
 /// Load the session from the backend, creating a new one when the log is empty
@@ -267,6 +293,7 @@ async fn load_or_repair_session(
         session_index,
         session_id,
         abort_signal,
+        header_insert_observer,
     } = params;
     let entries = backend.load_events_blocking()?;
     if entries.is_empty() {
@@ -277,8 +304,65 @@ async fn load_or_repair_session(
 
     // Existing session: check effective session log for orphan tool calls and repair with hints
     let mut entries_vec = entries;
-    let effective_entries =
+    let mut effective_entries =
         harnx_core::session_reconstruct::apply_log_mutations_nats(&entries_vec)?;
+    if should_insert_remote_header(&effective_entries) {
+        if let Some((first_user_seq, last_user_seq, replacements)) =
+            build_remote_header_insert_replacements(
+                &entries_vec,
+                &effective_entries,
+                config,
+                input,
+                session_id,
+            )?
+        {
+            let edit_entry = SessionLogEntry::EditEntries {
+                from: first_user_seq,
+                to: last_user_seq,
+                replacements,
+            };
+            let message_id = remote_header_insert_message_id(session_id, first_user_seq);
+            let insert_seq = crate::nats_session_log::NatsSessionLog::new(
+                backend.jetstream(),
+                session_id.to_string(),
+            )
+            .append_event_with_message_id_async(&edit_entry, message_id)
+            .await?;
+            debug!("inserted header via EditEntries js{insert_seq}");
+            // Publish the migration seq so the daemon advances its activation
+            // high-water cursor past the re-mapped leading-user block. The
+            // migration re-maps those users onto `insert_seq`; the turn that
+            // runs this activation answers them, so without this the drain would
+            // re-fold them (seq > pre-migration cursor) and re-run the turn (S3).
+            if let Some(observer) = header_insert_observer {
+                observer.fetch_max(insert_seq, std::sync::atomic::Ordering::Relaxed);
+            }
+            entries_vec = backend.load_events_blocking()?;
+            effective_entries =
+                harnx_core::session_reconstruct::apply_log_mutations_nats(&entries_vec)?;
+        }
+    }
+    // Keep the session index current on every activation that takes the
+    // existing-session path. Brand-new (empty-log) sessions register their
+    // index in `write_header_and_load_session`; but headerless sessions
+    // migrated here (S2) and normal resumes take THIS path, so upsert from the
+    // effective `Header` — otherwise the session never appears in
+    // `list_remote_sessions_with_meta` (breaks resume/picker) and its
+    // `last_activity` is never refreshed. Best-effort: warn on failure, never
+    // fail activation. Idempotent (`put_record` upserts).
+    if let Some(store) = session_index {
+        if let Some((_, header)) = effective_entries
+            .iter()
+            .find(|(_, entry)| matches!(entry, SessionLogEntry::Header { .. }))
+        {
+            if let Err(err) = upsert_session_index_record(store, header).await {
+                log::warn!(
+                    "failed to upsert remote session index during activation: \
+                     session_id={session_id} err={err:#}"
+                );
+            }
+        }
+    }
     let orphan_calls = find_orphan_tool_calls(&effective_entries);
     if !orphan_calls.is_empty() {
         nats_metrics::resume_detected();
@@ -307,6 +391,59 @@ async fn load_or_repair_session(
         entries_vec = backend.load_events_blocking()?;
     }
     crate::nats_session_log::load_session_from_entries(&entries_vec, session_id)
+}
+
+fn should_insert_remote_header(effective_entries: &[(u64, SessionLogEntry)]) -> bool {
+    !effective_entries.iter().any(|(_, entry)| {
+        matches!(
+            entry,
+            SessionLogEntry::Header { .. } | SessionLogEntry::Compress { .. }
+        )
+    })
+}
+
+fn build_remote_header_insert_replacements(
+    raw_entries: &[(u64, SessionLogEntry)],
+    effective_entries: &[(u64, SessionLogEntry)],
+    config: &GlobalConfig,
+    input: &Input,
+    session_id: &str,
+) -> Result<Option<(usize, usize, Vec<String>)>> {
+    if effective_entries.is_empty() || !should_insert_remote_header(effective_entries) {
+        return Ok(None);
+    }
+
+    let mut first_user_seq = None;
+    let mut last_user_seq = None;
+    let mut replacements = Vec::new();
+    replacements.push(serde_yaml::to_string(&build_remote_session_header(
+        config, input, session_id,
+    )?)?);
+
+    for (seq, entry) in raw_entries {
+        match entry {
+            SessionLogEntry::Message { role, .. } if role.is_user() => {
+                let seq = usize::try_from(*seq)
+                    .context("session log sequence does not fit into usize")?;
+                if first_user_seq.is_none() {
+                    first_user_seq = Some(seq);
+                }
+                last_user_seq = Some(seq);
+                replacements.push(serde_yaml::to_string(entry)?);
+            }
+            _ if first_user_seq.is_some() => break,
+            _ => return Ok(None),
+        }
+    }
+
+    Ok(match (first_user_seq, last_user_seq) {
+        (Some(from), Some(to)) => Some((from, to, replacements)),
+        _ => None,
+    })
+}
+
+fn remote_header_insert_message_id(session_id: &str, first_user_seq: usize) -> String {
+    format!("{session_id}:header-insert:{first_user_seq}")
 }
 
 /// Attach the reconstructed session to the shared config with the NATS append

--- a/crates/harnx-runtime/src/nats_worker/backend.rs
+++ b/crates/harnx-runtime/src/nats_worker/backend.rs
@@ -75,6 +75,10 @@ impl NatsSessionLogBackend {
         }
     }
 
+    pub fn jetstream(&self) -> jetstream::Context {
+        self.jetstream.clone()
+    }
+
     /// Attach an observer that tracks the latest durable append sequence
     /// (advanced via `fetch_max` on every successful append). Used to keep the
     /// P4.1 live-event sink's `after_seq` current during multi-step turns.

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -590,6 +590,14 @@ impl WorkerRuntime {
                 let on_tool_round =
                     build_mid_turn_injection_callback(backend.clone(), Arc::clone(&turn_cursor));
 
+                // Per-turn observer for the S2 header-insert migration seq. Only
+                // the first activation of a headerless session migrates; the
+                // migration re-maps the leading-user block onto this seq, which
+                // the turn answers. We must advance the activation high-water
+                // past it so the end-of-turn drain does not re-fold the remapped
+                // (already-answered) users and spuriously re-run the turn (S3).
+                let header_insert_seq = Arc::new(AtomicU64::new(0));
+
                 run_agent_loop_with_nats_inner(
                     RunAgentLoopArgs {
                         cluster_key: &self.cluster,
@@ -600,10 +608,13 @@ impl WorkerRuntime {
                         call_fn: self.call_fn.clone(),
                         lease: None,
                         after_seq_observer: None,
+                        header_insert_observer: None,
+                        session_index: self.session_index.as_ref(),
                         on_tool_round: Some(on_tool_round),
                     }
                     .with_lease(Arc::clone(&lease))
-                    .with_after_seq_observer(Arc::clone(&after_seq_observer)),
+                    .with_after_seq_observer(Arc::clone(&after_seq_observer))
+                    .with_header_insert_observer(Arc::clone(&header_insert_seq)),
                 )
                 .await?;
 
@@ -613,6 +624,16 @@ impl WorkerRuntime {
                 let turn_cursor_val = turn_cursor.load(Ordering::SeqCst);
                 if turn_cursor_val > 0 {
                     activation_high_water = Some(activation_high_water.map_or(turn_cursor_val, |h| h.max(turn_cursor_val)));
+                }
+
+                // Advance past the header-insert migration seq (if any). The
+                // migration remaps this turn's leading-user block onto this seq,
+                // so treat it as consumed by this turn's answer.
+                let header_insert_val = header_insert_seq.load(Ordering::SeqCst);
+                if header_insert_val > 0 {
+                    activation_high_water = Some(
+                        activation_high_water.map_or(header_insert_val, |h| h.max(header_insert_val)),
+                    );
                 }
 
                 log::info!(

--- a/crates/harnx-runtime/src/nats_worker/tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests.rs
@@ -1,24 +1,34 @@
 //! Unit tests for nats_worker module.
 
+use crate::config::remote_session_ops::{
+    delete_remote_message_range, edit_remote_message_range, load_remote_session_for_render,
+    load_remote_transcript_for_render, rewind_remote_session,
+};
 use crate::config::{self, Config};
 use crate::nats_session_index::{
     ensure_index_bucket, get_record, session_index_key, SessionIndexRecord,
 };
+use crate::nats_session_log::NatsSessionLog;
 use crate::nats_worker::agent_loop::{tool_can_rerun, write_header_and_load_session};
 use crate::nats_worker::run_worker_daemon;
-use anyhow::Context;
+use crate::ThinClientSession;
+use anyhow::{bail, Context};
 use futures_util::StreamExt;
 use harnx_core::agent_config::AgentConfig;
 use harnx_core::config_data::ConfigData;
-use harnx_core::event::{AgentEvent, AgentEventSink};
-use harnx_core::session::ToolOutput;
+use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource, SessionEvent};
+use harnx_core::session::{SessionLogEntry, ToolOutput};
+use harnx_core::session_reconstruct::{
+    active_context_window, reconstruct_state_from_nats, TurnStatus,
+};
 use harnx_core::tool::{ToolCall, ToolDeclaration};
 use serde_json::json;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::{Mutex as AsyncMutex, Notify};
 
 /// Spawn a local JetStream-enabled nats-server on a free port with an isolated
 /// temp store dir, returning the connect URL, the child process, and the temp
@@ -224,7 +234,121 @@ fn assert_remote_tool_descriptions(parent_config: &mut Config) {
     );
 }
 
+async fn seed_remote_dispatch_session_log(
+    log: &NatsSessionLog,
+    session_id: &str,
+) -> anyhow::Result<()> {
+    use harnx_core::message::{MessageContent, MessageRole};
+    use harnx_core::session::Session;
+
+    let header_session = Session {
+        id: session_id.to_string(),
+        model_id: "test:test-model".to_string(),
+        agent_name: Some("metis".to_string()),
+        session_id: Some(session_id.to_string()),
+        ..Default::default()
+    };
+    log.append_event_async(&header_session.build_header_entry())
+        .await?;
+    log.append_event_async(&SessionLogEntry::Message {
+        id: None,
+        role: MessageRole::User,
+        content: MessageContent::Text("first prompt".to_string()),
+        timestamp: None,
+        fence_token: None,
+    })
+    .await?;
+    log.append_event_async(&SessionLogEntry::Message {
+        id: None,
+        role: MessageRole::Assistant,
+        content: MessageContent::Text("first reply".to_string()),
+        timestamp: None,
+        fence_token: None,
+    })
+    .await?;
+    log.append_event_async(&SessionLogEntry::Message {
+        id: None,
+        role: MessageRole::User,
+        content: MessageContent::Text("second prompt".to_string()),
+        timestamp: None,
+        fence_token: None,
+    })
+    .await?;
+    Ok(())
+}
+
+fn remote_dispatch_user_texts(entries: &[(u64, SessionLogEntry)]) -> Vec<String> {
+    harnx_core::session_reconstruct::apply_log_mutations_nats(entries)
+        .expect("reconstruct remote dispatch effective log")
+        .into_iter()
+        .filter_map(|(_, entry)| match entry {
+            SessionLogEntry::Message { role, content, .. } if role.is_user() => {
+                Some(content.to_text())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
 fn spawn_metis_worker(url: &str) -> tokio::task::JoinHandle<anyhow::Result<()>> {
+    spawn_metis_worker_with_call_fn(url, fixed_prompt_call_fn("stub remote reply over nats"))
+}
+
+/// Like [`spawn_metis_worker`] but with a lease `renew_interval` short enough
+/// that at least one renewal fires during a session's brief active window.
+///
+/// The daemon releases the session lease as soon as the turn goes idle
+/// (`execute_session` breaks and calls `lease.release()` within a second or
+/// two of a fast stub turn). The default 10s renew interval never ticks in
+/// that window, so a test asserting that lease renewal refreshes the session
+/// index would time out. A sub-second interval makes the renewal — and its
+/// index `last_activity` refresh — fire deterministically while the session is
+/// held active.
+///
+/// A worker call_fn that holds the turn open for `delay` before replying, so
+/// the session stays active (lease held, renew task running) long enough for a
+/// lease renewal — and its session-index `last_activity` refresh — to fire.
+fn slow_prompt_call_fn(reply: &'static str, delay: Duration) -> crate::agent_loop::AgentCallFn {
+    Arc::new(move |_input, _config, _abort| {
+        Box::pin(async move {
+            tokio::time::sleep(delay).await;
+            Ok((
+                reply.to_string(),
+                None,
+                vec![],
+                crate::client::CompletionTokenUsage::default(),
+            ))
+        })
+    })
+}
+
+fn spawn_metis_worker_with_fast_renew(
+    url: &str,
+    call_fn: crate::agent_loop::AgentCallFn,
+) -> tokio::task::JoinHandle<anyhow::Result<()>> {
+    let mut daemon = crate::nats_worker::WorkerDaemonConfig::new("local", "worker-metis");
+    // ttl must stay > renew_interval; keep a comfortable margin.
+    daemon.lease.renew_interval = Duration::from_millis(300);
+    daemon.lease.ttl = Duration::from_secs(5);
+    spawn_metis_worker_with_call_fn_and_daemon(url, call_fn, daemon)
+}
+
+fn spawn_metis_worker_with_call_fn(
+    url: &str,
+    call_fn: crate::agent_loop::AgentCallFn,
+) -> tokio::task::JoinHandle<anyhow::Result<()>> {
+    spawn_metis_worker_with_call_fn_and_daemon(
+        url,
+        call_fn,
+        crate::nats_worker::WorkerDaemonConfig::new("local", "worker-metis"),
+    )
+}
+
+fn spawn_metis_worker_with_call_fn_and_daemon(
+    url: &str,
+    call_fn: crate::agent_loop::AgentCallFn,
+    daemon: crate::nats_worker::WorkerDaemonConfig,
+) -> tokio::task::JoinHandle<anyhow::Result<()>> {
     let worker_agent = AgentConfig::from_markdown("metis", "stub worker prompt").unwrap();
     let worker_config = Config {
         data: harnx_core::config_data::ConfigData {
@@ -247,14 +371,7 @@ fn spawn_metis_worker(url: &str) -> tokio::task::JoinHandle<anyhow::Result<()>> 
     let worker_config = Arc::new(parking_lot::RwLock::new(worker_config));
     tokio::spawn({
         let worker_config = Arc::clone(&worker_config);
-        async move {
-            run_worker_daemon(
-                worker_config,
-                crate::nats_worker::WorkerDaemonConfig::new("local", "worker-metis"),
-                Some(fixed_prompt_call_fn("stub remote reply over nats")),
-            )
-            .await
-        }
+        async move { run_worker_daemon(worker_config, daemon, Some(call_fn)).await }
     })
 }
 
@@ -269,6 +386,19 @@ async fn run_remote_round_trip(parent_config: Config) -> anyhow::Result<()> {
 async fn run_remote_round_trip_with_session_id(
     parent_config: Config,
     session_id: String,
+) -> anyhow::Result<()> {
+    run_remote_round_trip_with_session_id_and_sink(
+        parent_config,
+        session_id,
+        Arc::new(NoopEventSink),
+    )
+    .await
+}
+
+async fn run_remote_round_trip_with_session_id_and_sink(
+    parent_config: Config,
+    session_id: String,
+    sink: Arc<dyn AgentEventSink>,
 ) -> anyhow::Result<()> {
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
@@ -288,7 +418,7 @@ async fn run_remote_round_trip_with_session_id(
 
     let turn_result = tokio::time::timeout(
         Duration::from_secs(10),
-        thin.run_turn("delegate over nats", Arc::new(NoopEventSink), None),
+        thin.run_turn("delegate over nats", sink, None),
     )
     .await
     .context("thin client run_turn timed out after 10s in remote NATS round-trip test")??;
@@ -634,7 +764,24 @@ async fn control_log_append_requires_live_lease() {
 struct NoopEventSink;
 
 impl AgentEventSink for NoopEventSink {
-    fn emit(&self, _event: AgentEvent, _source: Option<harnx_core::event::AgentSource>) {}
+    fn emit(&self, _event: AgentEvent, _source: Option<AgentSource>) {}
+}
+
+#[derive(Default)]
+struct RecordingEventSink {
+    events: std::sync::Mutex<Vec<AgentEvent>>,
+}
+
+impl RecordingEventSink {
+    fn events(&self) -> Vec<AgentEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl AgentEventSink for RecordingEventSink {
+    fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+        self.events.lock().unwrap().push(event);
+    }
 }
 
 fn fixed_prompt_call_fn(reply: &'static str) -> crate::agent_loop::AgentCallFn {
@@ -648,6 +795,659 @@ fn fixed_prompt_call_fn(reply: &'static str) -> crate::agent_loop::AgentCallFn {
             ))
         })
     })
+}
+
+fn echoing_call_fn(captured: Arc<AsyncMutex<Vec<String>>>) -> crate::agent_loop::AgentCallFn {
+    Arc::new(move |input, _config, _abort| {
+        let captured = Arc::clone(&captured);
+        let derived = input.text();
+        Box::pin(async move {
+            captured.lock().await.push(derived.clone());
+            Ok((
+                format!("stub remote reply over nats: {derived}"),
+                None,
+                vec![],
+                crate::client::CompletionTokenUsage::default(),
+            ))
+        })
+    })
+}
+
+async fn run_remote_turn_returning_reply(
+    parent_config: Config,
+    session_id: String,
+    prompt: &str,
+) -> anyhow::Result<String> {
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let mut parent_config = parent_config;
+    let parent_session = crate::config::session::new(&parent_config, "parent-nats-roundtrip")?;
+    parent_config.session = Some(parent_session);
+    let parent_global_config = Arc::new(parking_lot::RwLock::new(parent_config));
+    let abort_signal = harnx_core::abort::create_abort_signal();
+    let thin_cfg = crate::ThinClientConfig {
+        cluster: "local".to_string(),
+        agent: "metis".to_string(),
+        session_id: Some(session_id),
+    };
+    let thin =
+        crate::ThinClientSession::from_global_config(thin_cfg, &parent_global_config, abort_signal)
+            .await?;
+
+    let turn_result = tokio::time::timeout(
+        Duration::from_secs(10),
+        thin.run_turn(prompt, Arc::new(NoopEventSink), None),
+    )
+    .await
+    .context("thin client run_turn timed out after 10s in remote NATS round-trip test")??;
+    turn_result
+        .response
+        .context("thin client turn must return final assistant response")
+}
+
+fn leading_user_texts(entries: &[(u64, SessionLogEntry)]) -> Vec<String> {
+    entries
+        .iter()
+        .filter_map(|(_, entry)| match entry {
+            SessionLogEntry::Message { role, content, .. } if role.is_user() => {
+                Some(content.to_text())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+async fn load_effective_entries(log: &NatsSessionLog) -> Vec<(u64, SessionLogEntry)> {
+    let entries = log
+        .load_events_async()
+        .await
+        .expect("load session log entries");
+    harnx_core::session_reconstruct::apply_log_mutations_nats(&entries)
+        .expect("reconstruct effective session log")
+}
+
+async fn assert_remote_header_inserted_once(log: &NatsSessionLog, expected_first_prompt: &str) {
+    let raw_entries = log
+        .load_events_async()
+        .await
+        .expect("load raw session log entries");
+    let effective_entries = harnx_core::session_reconstruct::apply_log_mutations_nats(&raw_entries)
+        .expect("reconstruct effective session log");
+
+    assert!(
+        matches!(
+            effective_entries.first().map(|(_, entry)| entry),
+            Some(SessionLogEntry::Header { .. })
+        ),
+        "effective log must start with header after worker activation"
+    );
+    assert_eq!(
+        leading_user_texts(&effective_entries)
+            .first()
+            .map(std::string::String::as_str),
+        Some(expected_first_prompt),
+        "first user prompt must remain in active window after migration"
+    );
+
+    let edits: Vec<_> = raw_entries
+        .iter()
+        .filter(|(_, entry)| matches!(entry, SessionLogEntry::EditEntries { .. }))
+        .collect();
+    assert_eq!(
+        edits.len(),
+        1,
+        "worker must append exactly one migration EditEntries"
+    );
+
+    match &edits[0].1 {
+        SessionLogEntry::EditEntries {
+            from,
+            to,
+            replacements,
+        } => {
+            assert!(
+                replacements.len() >= 2,
+                "migration must prepend header and clone users"
+            );
+            let header_replacement = serde_yaml::from_str::<SessionLogEntry>(&replacements[0])
+                .expect("header replacement parses");
+            assert!(matches!(header_replacement, SessionLogEntry::Header { .. }));
+            assert_eq!(
+                *from, 1,
+                "headerless realistic origin starts at first user seq"
+            );
+            assert_eq!(
+                *to, 1,
+                "single-prompt fixture edits leading user block only"
+            );
+        }
+        other => panic!("expected EditEntries migration, got {other:?}"),
+    }
+}
+
+async fn wait_for_condition<F>(timeout: Duration, mut predicate: F) -> bool
+where
+    F: FnMut() -> bool,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if predicate() {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_headerless_session_inserts_header_on_first_activation() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
+    assert_remote_tool_family(&mut seeded.parent_config);
+    assert_remote_tool_descriptions(&mut seeded.parent_config);
+
+    let worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+    let session_id = crate::nats_worker::new_remote_session_id();
+    run_remote_round_trip_with_session_id(seeded.parent_config, session_id.clone())
+        .await
+        .expect("run realistic headerless thin-client session");
+
+    let log_client = async_nats::connect(&url)
+        .await
+        .expect("connect nats client for session log verification");
+    let log = NatsSessionLog::new(async_nats::jetstream::new(log_client), session_id);
+    assert_remote_header_inserted_once(&log, "delegate over nats").await;
+
+    worker.abort();
+    let _ = tokio::time::timeout(Duration::from_secs(5), worker).await;
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_multi_turn_after_header_insert_preserves_input_derivation() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
+    assert_remote_tool_family(&mut seeded.parent_config);
+    assert_remote_tool_descriptions(&mut seeded.parent_config);
+
+    let prompts = ["turn one prompt", "turn two prompt", "turn three prompt"];
+    let captured = Arc::new(AsyncMutex::new(Vec::<String>::new()));
+    let worker = spawn_metis_worker_with_call_fn(&url, echoing_call_fn(Arc::clone(&captured)));
+    let session_id = crate::nats_worker::new_remote_session_id();
+
+    for prompt in prompts {
+        let reply = run_remote_turn_returning_reply(
+            seeded.parent_config.clone(),
+            session_id.clone(),
+            prompt,
+        )
+        .await
+        .expect("run remote thin-client turn");
+        assert_eq!(
+            reply,
+            format!("stub remote reply over nats: {prompt}"),
+            "assistant reply must echo exact derived turn input"
+        );
+    }
+
+    worker.abort();
+    let _ = tokio::time::timeout(Duration::from_secs(5), worker).await;
+
+    let derived_inputs = captured.lock().await.clone();
+    assert_eq!(
+        derived_inputs,
+        prompts
+            .iter()
+            .map(|prompt| (*prompt).to_string())
+            .collect::<Vec<_>>(),
+        "worker must derive exactly one turn-input per turn, in order, with no dup/drop"
+    );
+
+    let log_client = async_nats::connect(&url)
+        .await
+        .expect("connect nats client for session log verification");
+    let log = NatsSessionLog::new(async_nats::jetstream::new(log_client), session_id);
+    let raw_entries = log
+        .load_events_async()
+        .await
+        .expect("load raw session log entries");
+    let effective_entries = harnx_core::session_reconstruct::apply_log_mutations_nats(&raw_entries)
+        .expect("reconstruct effective session log");
+
+    let edit_count = raw_entries
+        .iter()
+        .filter(|(_, entry)| matches!(entry, SessionLogEntry::EditEntries { .. }))
+        .count();
+    assert_eq!(
+        edit_count, 1,
+        "exactly one header-migration EditEntries across whole multi-turn session"
+    );
+
+    let header_count = effective_entries
+        .iter()
+        .filter(|(_, entry)| matches!(entry, SessionLogEntry::Header { .. }))
+        .count();
+    assert_eq!(
+        header_count, 1,
+        "effective log must carry exactly one header"
+    );
+    let Some((_, SessionLogEntry::Header { agent_name, .. })) = effective_entries.first() else {
+        panic!("effective log must start with migrated header at logical 0");
+    };
+    assert_eq!(
+        agent_name.as_deref(),
+        Some("metis"),
+        "migrated header must carry worker agent config"
+    );
+
+    let user_texts = leading_user_texts(&effective_entries);
+    assert_eq!(
+        user_texts,
+        prompts
+            .iter()
+            .map(|prompt| (*prompt).to_string())
+            .collect::<Vec<_>>(),
+        "effective log user messages must be exact prompt sequence, once each"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_headerless_session_reactivation_is_idempotent() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
+    assert_remote_tool_family(&mut seeded.parent_config);
+
+    let first_worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+    let session_id = crate::nats_worker::new_remote_session_id();
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("first activation round trip succeeds");
+    first_worker.abort();
+    let _ = tokio::time::timeout(Duration::from_secs(5), first_worker).await;
+
+    let second_worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+    run_remote_round_trip_with_session_id(seeded.parent_config, session_id.clone())
+        .await
+        .expect("reactivation round trip succeeds");
+
+    let log_client = async_nats::connect(&url)
+        .await
+        .expect("connect nats client for session log verification");
+    let log = NatsSessionLog::new(async_nats::jetstream::new(log_client), session_id);
+    let raw_entries = log
+        .load_events_async()
+        .await
+        .expect("load raw session log entries");
+    let edit_count = raw_entries
+        .iter()
+        .filter(|(_, entry)| matches!(entry, SessionLogEntry::EditEntries { .. }))
+        .count();
+    assert_eq!(
+        edit_count, 1,
+        "reactivation must not append a second header migration edit"
+    );
+    let effective_entries = load_effective_entries(&log).await;
+    assert!(matches!(
+        effective_entries.first().map(|(_, entry)| entry),
+        Some(SessionLogEntry::Header { .. })
+    ));
+
+    second_worker.abort();
+    let _ = tokio::time::timeout(Duration::from_secs(5), second_worker).await;
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn legacy_headerless_session_migrates_on_first_activation() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let seeded = seed_remote_config(&url);
+    let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
+    let session_id = crate::nats_worker::new_remote_session_id();
+    let client = async_nats::connect(&url)
+        .await
+        .expect("connect nats client");
+    let jetstream = async_nats::jetstream::new(client);
+    let log = NatsSessionLog::new(jetstream.clone(), session_id.clone());
+    let user_seq = log
+        .append_event_async(&SessionLogEntry::Message {
+            id: Some(uuid::Uuid::new_v4().to_string()),
+            role: harnx_core::message::MessageRole::User,
+            content: harnx_core::message::MessageContent::Text("legacy prompt".to_string()),
+            timestamp: None,
+            fence_token: None,
+        })
+        .await
+        .expect("append legacy user message");
+    assert_eq!(
+        user_seq, 1,
+        "legacy fixture should be truly headerless at origin"
+    );
+
+    let worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+    run_remote_round_trip_with_session_id(seeded.parent_config, session_id.clone())
+        .await
+        .expect("worker should migrate legacy session then answer turn");
+
+    let raw_entries = log
+        .load_events_async()
+        .await
+        .expect("load raw entries after migration");
+    let effective_after = load_effective_entries(&log).await;
+    assert!(matches!(
+        effective_after.first().map(|(_, entry)| entry),
+        Some(SessionLogEntry::Header { .. })
+    ));
+    assert!(
+        raw_entries
+            .iter()
+            .all(|(_, entry)| !matches!(entry, SessionLogEntry::Header { .. })),
+        "migration must not physically reorder or prepend raw header entries"
+    );
+    assert_eq!(
+        leading_user_texts(&effective_after),
+        vec![
+            "legacy prompt".to_string(),
+            "delegate over nats".to_string()
+        ]
+    );
+
+    worker.abort();
+    let _ = tokio::time::timeout(Duration::from_secs(5), worker).await;
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_replay_and_live_rows_emit_logical_seq_assignments() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let seeded = seed_remote_config(&url);
+    let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
+    let session_id = crate::nats_worker::new_remote_session_id();
+    let client = async_nats::connect(&url)
+        .await
+        .expect("connect nats client");
+    let jetstream = async_nats::jetstream::new(client);
+    let log = NatsSessionLog::new(jetstream, session_id.clone());
+    let legacy_user_seq = log
+        .append_event_async(&SessionLogEntry::Message {
+            id: Some(uuid::Uuid::new_v4().to_string()),
+            role: harnx_core::message::MessageRole::User,
+            content: harnx_core::message::MessageContent::Text("legacy prompt".to_string()),
+            timestamp: None,
+            fence_token: None,
+        })
+        .await
+        .expect("append legacy user message");
+    assert_eq!(
+        legacy_user_seq, 1,
+        "fixture must start headerless so worker performs realistic migration"
+    );
+
+    let worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+    let sink = Arc::new(RecordingEventSink::default());
+    run_remote_round_trip_with_session_id_and_sink(
+        seeded.parent_config,
+        session_id.clone(),
+        sink.clone(),
+    )
+    .await
+    .expect("worker should migrate legacy session, replay history, then answer turn");
+
+    let replayed_seqs: Vec<usize> = sink
+        .events()
+        .into_iter()
+        .filter_map(|event| match event {
+            AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }) => Some(seq),
+            _ => None,
+        })
+        .collect();
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let raw_entries = log
+        .load_events_async()
+        .await
+        .expect("load raw entries after replay/live turn");
+    let effective_entries = load_effective_entries(&log).await;
+    let logical_indices: Vec<usize> = active_context_window(&effective_entries)
+        .logical_entries()
+        .map(|entry| entry.logical_index)
+        .collect();
+    assert_eq!(
+        logical_indices,
+        vec![0, 1, 2, 3],
+        "effective migrated session must expose contiguous logical numbering"
+    );
+    let physical_seqs: Vec<u64> = active_context_window(&effective_entries)
+        .logical_entries()
+        .map(|entry| entry.physical_seq)
+        .collect();
+    let user_message_count = raw_entries
+        .iter()
+        .filter(|(_, entry)| {
+            matches!(
+                entry,
+                SessionLogEntry::Message { role, .. } if role.is_user()
+            )
+        })
+        .count();
+    let assistant_message_count = raw_entries
+        .iter()
+        .filter(|(_, entry)| {
+            matches!(
+                entry,
+                SessionLogEntry::Message { role, .. } if role.is_assistant()
+            )
+        })
+        .count();
+    assert_eq!(
+        user_message_count, 2,
+        "realistic round trip must durably append legacy + live user messages"
+    );
+    assert_eq!(
+        assistant_message_count, 1,
+        "realistic round trip must durably append one assistant reply"
+    );
+    assert_eq!(
+        physical_seqs,
+        vec![3, 3, 3, 4],
+        "migrated active window should coalesce migrated header/user/live user onto worker turn seq, then assistant reply"
+    );
+    // The migrated active window is logically [Header(0), legacy user(1), live
+    // user(2), assistant(3)] — but the Header renders NO transcript row, so it
+    // emits no LogSeqAssigned (exactly like a LOCAL session, whose header is
+    // document 0 and whose first USER message is log_seq 1). The numberable
+    // rows therefore carry logical seqs [1, 2, 3]: replayed migrated legacy
+    // user, live thin-client user, then live worker assistant. This is the
+    // local==remote numbering parity that makes resumed/live remote rows
+    // targetable for edit/delete/rewind.
+    assert_eq!(
+        replayed_seqs,
+        vec![1, 2, 3],
+        "sink should number the migrated legacy user, live thin-client user, and live worker assistant rows (Header at logical 0 renders no row, matching local numbering)"
+    );
+    assert_eq!(
+        replayed_seqs
+            .iter()
+            .copied()
+            .collect::<std::collections::HashSet<_>>()
+            .len(),
+        replayed_seqs.len(),
+        "each logical seq should emit once; duplicates would wedge TUI numbering"
+    );
+
+    worker.abort();
+    let _ = tokio::time::timeout(Duration::from_secs(5), worker).await;
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_cancel_published_after_in_flight_marks_session_cancelled() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
+    assert_remote_tool_family(&mut seeded.parent_config);
+    assert_remote_tool_descriptions(&mut seeded.parent_config);
+
+    let session_id = crate::nats_worker::new_remote_session_id();
+    let entered = Arc::new(Notify::new());
+    let worker_saw_abort = Arc::new(AtomicBool::new(false));
+    let call_fn: crate::agent_loop::AgentCallFn = {
+        let entered = Arc::clone(&entered);
+        let worker_saw_abort = Arc::clone(&worker_saw_abort);
+        Arc::new(move |_input, _config, abort| {
+            let entered = Arc::clone(&entered);
+            let worker_saw_abort = Arc::clone(&worker_saw_abort);
+            Box::pin(async move {
+                entered.notify_one();
+                tokio::select! {
+                    _ = harnx_core::abort::wait_abort_signal(&abort) => {
+                        worker_saw_abort.store(true, Ordering::SeqCst);
+                        loop {
+                            tokio::time::sleep(Duration::from_secs(60)).await;
+                        }
+                    }
+                    _ = tokio::time::sleep(Duration::from_secs(20)) => {
+                        bail!("worker call_fn timed out waiting for remote cancel abort")
+                    }
+                }
+            })
+        })
+    };
+
+    let daemon = spawn_metis_worker_with_call_fn(&url, call_fn);
+
+    let mut parent_config = seeded.parent_config;
+    let parent_session = crate::config::session::new(&parent_config, "parent-nats-remote-cancel")
+        .expect("create parent session");
+    parent_config.session = Some(parent_session);
+    let parent_global_config = Arc::new(parking_lot::RwLock::new(parent_config));
+    let abort_signal = harnx_core::abort::create_abort_signal();
+    let thin_cfg = crate::ThinClientConfig {
+        cluster: "local".to_string(),
+        agent: "metis".to_string(),
+        session_id: Some(session_id.clone()),
+    };
+    let thin =
+        crate::ThinClientSession::from_global_config(thin_cfg, &parent_global_config, abort_signal)
+            .await
+            .expect("build thin client session");
+
+    let run_turn = tokio::spawn(async move {
+        thin.run_turn("delegate over nats", Arc::new(NoopEventSink), None)
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(5), entered.notified())
+        .await
+        .expect("worker never entered in-flight call_fn before cancel publish");
+
+    let raw_client = async_nats::connect(&url)
+        .await
+        .expect("connect raw nats client for cancel publish");
+    crate::send_control_command(&raw_client, &session_id, crate::ControlCommand::Cancel)
+        .await
+        .expect("publish cancel control command");
+
+    assert!(
+        wait_for_condition(Duration::from_secs(5), || worker_saw_abort
+            .load(Ordering::SeqCst))
+        .await,
+        "worker call_fn never observed abort after remote cancel publish"
+    );
+
+    let log_client = async_nats::connect(&url)
+        .await
+        .expect("connect nats client for session log polling");
+    let log = NatsSessionLog::new(async_nats::jetstream::new(log_client), session_id.clone());
+    let _cancel_entries = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let entries = log
+                .load_events_async()
+                .await
+                .expect("load session log entries");
+            if entries
+                .iter()
+                .any(|(_, entry)| matches!(entry, SessionLogEntry::Cancel { .. }))
+            {
+                break entries;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("durable session log never recorded Cancel entry");
+
+    let _turn_result = tokio::time::timeout(Duration::from_secs(5), run_turn)
+        .await
+        .expect("run_turn task did not complete after remote cancel")
+        .expect("run_turn join must succeed")
+        .expect("run_turn must return result after remote cancel");
+
+    let final_entries = log
+        .load_events_async()
+        .await
+        .expect("reload final session log entries after run_turn completion");
+    let cancel_fence_token = final_entries.iter().find_map(|(_, entry)| match entry {
+        SessionLogEntry::Cancel { fence_token } => Some(*fence_token),
+        _ => None,
+    });
+    let first_assistant_fence_token = final_entries.iter().find_map(|(_, entry)| match entry {
+        SessionLogEntry::Message {
+            role, fence_token, ..
+        } if role.is_assistant() => *fence_token,
+        _ => None,
+    });
+    let reconstructed = reconstruct_state_from_nats(&final_entries);
+    assert_eq!(
+        reconstructed.turn_status,
+        TurnStatus::InFlightCancelled,
+        "durable log should reconstruct to InFlightCancelled after remote cancel when no assistant message follows cancel; cancel fence={cancel_fence_token:?}, assistant fence={first_assistant_fence_token:?}, entries={final_entries:#?}"
+    );
+
+    daemon.abort();
+    let _ = daemon.await;
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -674,17 +1474,15 @@ async fn remote_agent_tool_family_and_nats_call_and_return_round_trip() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn remote_session_activation_writes_session_index_record() {
-    let server_url = match std::env::var("HARNX_NATS_TEST_URL") {
-        Ok(url) => url,
-        Err(_) => {
-            eprintln!(
-                "skipping remote_session_activation_writes_session_index_record: HARNX_NATS_TEST_URL unset"
-            );
-            return;
-        }
+    let _env_guard = env_lock().await;
+    // Use an ISOLATED, self-provisioned NATS server (not the shared
+    // HARNX_NATS_TEST_URL) so the thin-client `run_turn` isn't slowed by
+    // accumulated JetStream state on a shared server — that staleness made this
+    // test hit its 10s turn timeout intermittently.
+    let Some((server_url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
     };
 
-    let _env_guard = env_lock().await;
     let mut seeded = seed_remote_config(&server_url);
     let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
     assert_remote_tool_family(&mut seeded.parent_config);
@@ -719,21 +1517,19 @@ async fn remote_session_activation_writes_session_index_record() {
     daemon.abort();
     let _ = daemon.await;
     round_trip.expect("remote round trip must succeed");
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn remote_session_renew_updates_last_activity_without_clobbering_header_fields() {
-    let server_url = match std::env::var("HARNX_NATS_TEST_URL") {
-        Ok(url) => url,
-        Err(_) => {
-            eprintln!(
-                "skipping remote_session_renew_updates_last_activity_without_clobbering_header_fields: HARNX_NATS_TEST_URL unset"
-            );
-            return;
-        }
+    let _env_guard = env_lock().await;
+    // Isolated NATS (see activation test) so `run_turn` isn't delayed by shared
+    // JetStream state into a 10s timeout.
+    let Some((server_url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
     };
 
-    let _env_guard = env_lock().await;
     let mut seeded = seed_remote_config(&server_url);
     let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
     assert_remote_tool_family(&mut seeded.parent_config);
@@ -750,33 +1546,39 @@ async fn remote_session_renew_updates_last_activity_without_clobbering_header_fi
         .await
         .expect("ensure session index bucket");
 
-    let daemon = spawn_metis_worker(&server_url);
-    // Use the expected_session_id in the thin client config
-    let round_trip =
-        run_remote_round_trip_with_session_id(seeded.parent_config, expected_session_id.clone())
-            .await;
-
-    // Assert on the specific session_id we created, not just "first key in bucket"
-    let first_record = get_record(&store, &expected_session_id)
-        .await
-        .expect("load initial session index record")
-        .expect("initial session index record exists");
-    let first_last_activity = first_record.last_activity;
-
+    // Arm the KV watcher BEFORE the session runs. `Store::watch` uses
+    // DeliverPolicy::New (future updates only), so it must be established before
+    // the initial index write and the lease-renewal refresh — otherwise both
+    // Puts happen before the watcher exists and it waits forever.
     let record_key = session_index_key(&expected_session_id);
     let mut watcher = store
         .watch(record_key.clone())
         .await
         .expect("watch session index record");
 
+    // Fast lease renewal + a turn slow enough to stay active past a renew
+    // interval, so a renewal (and its index `last_activity` refresh) fires while
+    // the lease is still held — the worker releases the lease (aborting the
+    // renew task) as soon as the turn goes idle.
+    let daemon = spawn_metis_worker_with_fast_renew(
+        &server_url,
+        slow_prompt_call_fn("stub remote reply over nats", Duration::from_millis(1200)),
+    );
+    // Drive the turn concurrently; we observe the index writes via the watcher
+    // while the session is active.
+    let round_trip = tokio::spawn(run_remote_round_trip_with_session_id(
+        seeded.parent_config,
+        expected_session_id.clone(),
+    ));
+
+    // Collect Puts for our session in order: the first is the activation write,
+    // a later one (strictly greater last_activity) is the renewal refresh.
+    let mut first_record: Option<SessionIndexRecord> = None;
     let mut refreshed_record: Option<SessionIndexRecord> = None;
     let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
-    while tokio::time::Instant::now() < deadline {
+    while tokio::time::Instant::now() < deadline && refreshed_record.is_none() {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-        let Some(entry) = tokio::time::timeout(remaining, watcher.next())
-            .await
-            .expect("timed out waiting for renewed session index record")
-        else {
+        let Ok(Some(entry)) = tokio::time::timeout(remaining, watcher.next()).await else {
             break;
         };
         let entry = entry.expect("watch entry result");
@@ -785,14 +1587,22 @@ async fn remote_session_renew_updates_last_activity_without_clobbering_header_fi
         }
         let record: SessionIndexRecord =
             serde_json::from_slice(&entry.value).expect("deserialize watched session index record");
-        if record.session_id == expected_session_id && record.last_activity > first_last_activity {
-            refreshed_record = Some(record);
-            break;
+        if record.session_id != expected_session_id {
+            continue;
+        }
+        match &first_record {
+            None => first_record = Some(record),
+            Some(first) if record.last_activity > first.last_activity => {
+                refreshed_record = Some(record);
+            }
+            _ => {}
         }
     }
 
+    let first_record = first_record.expect("activation should write initial session index record");
     let refreshed_record = refreshed_record.expect("renew should refresh last_activity");
-    assert!(refreshed_record.last_activity > first_last_activity);
+    assert!(refreshed_record.last_activity > first_record.last_activity);
+    // Renewal must refresh only last_activity, never clobber the header fields.
     assert_eq!(refreshed_record.agent_name, first_record.agent_name);
     assert_eq!(refreshed_record.working_dir, first_record.working_dir);
     assert_eq!(refreshed_record.git_branch, first_record.git_branch);
@@ -800,5 +1610,1374 @@ async fn remote_session_renew_updates_last_activity_without_clobbering_header_fi
 
     daemon.abort();
     let _ = daemon.await;
-    round_trip.expect("remote round trip must succeed");
+    round_trip
+        .await
+        .expect("round trip task join")
+        .expect("remote round trip must succeed");
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_dispatch_retract_round_trip() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
+    let session_id = format!("dispatch-retract-{}", uuid::Uuid::new_v4());
+    seeded
+        .parent_config
+        .set_remote_agent("metis".to_string(), "local".to_string());
+    seeded
+        .parent_config
+        .use_session(Some(&session_id))
+        .expect("activate remote session id");
+    let jetstream = seeded
+        .parent_config
+        .nats_jetstream("local")
+        .await
+        .expect("load local jetstream");
+    let log = NatsSessionLog::new(jetstream, session_id.clone());
+    seed_remote_dispatch_session_log(&log, &session_id)
+        .await
+        .expect("seed remote session log");
+    tokio::fs::create_dir_all(seeded.config_dir().join("sessions"))
+        .await
+        .expect("create session dir");
+    let session_log_path = seeded
+        .config_dir()
+        .join("sessions")
+        .join(format!("{session_id}.md"));
+    tokio::fs::write(&session_log_path, "type: header\n")
+        .await
+        .expect("write stub session file");
+    let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
+    let abort = harnx_core::abort::create_abort_signal();
+
+    delete_remote_message_range(&global_config, 3, 3, &abort)
+        .await
+        .expect("delete display index 3");
+
+    let entries = log
+        .load_events_async()
+        .await
+        .expect("reload session log after retract");
+    let edit = entries.last().expect("edit entry appended");
+    match &edit.1 {
+        SessionLogEntry::EditEntries {
+            from,
+            to,
+            replacements,
+        } => {
+            assert_eq!(
+                (*from, *to),
+                (4, 4),
+                "display index 3 must target JetStream seq 4"
+            );
+            assert!(
+                replacements.is_empty(),
+                "retract should append deletion edit"
+            );
+        }
+        other => panic!("expected EditEntries, got {other:?}"),
+    }
+    assert_eq!(
+        remote_dispatch_user_texts(&entries),
+        vec!["first prompt".to_string()],
+        "reconstructed state should only keep first user prompt after retract"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_dispatch_edit_round_trip() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
+    let session_id = format!("dispatch-edit-{}", uuid::Uuid::new_v4());
+    seeded
+        .parent_config
+        .set_remote_agent("metis".to_string(), "local".to_string());
+    seeded
+        .parent_config
+        .use_session(Some(&session_id))
+        .expect("activate remote session id");
+    let jetstream = seeded
+        .parent_config
+        .nats_jetstream("local")
+        .await
+        .expect("load local jetstream");
+    let log = NatsSessionLog::new(jetstream, session_id.clone());
+    seed_remote_dispatch_session_log(&log, &session_id)
+        .await
+        .expect("seed remote session log");
+    tokio::fs::create_dir_all(seeded.config_dir().join("sessions"))
+        .await
+        .expect("create session dir");
+    let session_log_path = seeded
+        .config_dir()
+        .join("sessions")
+        .join(format!("{session_id}.md"));
+    tokio::fs::write(&session_log_path, "type: header\n")
+        .await
+        .expect("write stub session file");
+
+    let editor_tmp = tempfile::TempDir::new().expect("create editor temp dir");
+    let editor_tmp_path = editor_tmp.path().to_path_buf();
+    seeded.parent_config.temp_dir_override = Some(editor_tmp_path.clone());
+    seeded.parent_config.set_tui_editor_hooks(
+        None,
+        Some(Box::new(move || {
+            let temp_path = std::fs::read_dir(&editor_tmp_path)
+                .expect("read editor temp dir")
+                .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+                .find(|path| path.extension().and_then(|ext| ext.to_str()) == Some("txt"))
+                .expect("message edit temp file");
+            std::fs::write(&temp_path, "edited over dispatch").expect("write edited text");
+        })),
+    );
+
+    let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
+    let abort = harnx_core::abort::create_abort_signal();
+
+    edit_remote_message_range(&global_config, 3, 3, &abort)
+        .await
+        .expect("edit display index 3");
+
+    let entries = log
+        .load_events_async()
+        .await
+        .expect("reload session log after edit");
+    let edit = entries.last().expect("edit entry appended");
+    match &edit.1 {
+        SessionLogEntry::EditEntries {
+            from,
+            to,
+            replacements,
+        } => {
+            assert_eq!(
+                (*from, *to),
+                (4, 4),
+                "display index 3 must target JetStream seq 4"
+            );
+            assert_eq!(replacements.len(), 1, "edit should append one replacement");
+            let replacement = serde_yaml::from_str::<SessionLogEntry>(&replacements[0])
+                .expect("replacement parses as session log entry");
+            match replacement {
+                SessionLogEntry::Message { role, content, .. } => {
+                    assert!(role.is_user(), "replacement must stay user role");
+                    assert_eq!(content.to_text(), "edited over dispatch");
+                }
+                other => panic!("expected replacement Message, got {other:?}"),
+            }
+        }
+        other => panic!("expected EditEntries, got {other:?}"),
+    }
+    assert_eq!(
+        remote_dispatch_user_texts(&entries),
+        vec![
+            "first prompt".to_string(),
+            "edited over dispatch".to_string(),
+        ],
+        "reconstructed state should show edited user prompt after dispatch edit"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_delete_turn_matches_local_any_role_parity() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
+    let session_id = crate::nats_worker::new_remote_session_id();
+    let worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("worker should build realistic migrated session");
+
+    let jetstream = seeded
+        .parent_config
+        .nats_jetstream("local")
+        .await
+        .expect("load local jetstream");
+    let log = NatsSessionLog::new(jetstream, session_id.clone());
+
+    seeded
+        .parent_config
+        .set_remote_agent("metis".to_string(), "local".to_string());
+    seeded
+        .parent_config
+        .use_session(Some(&session_id))
+        .expect("activate remote session id");
+    let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
+    let abort = harnx_core::abort::create_abort_signal();
+
+    delete_remote_message_range(&global_config, 2, 2, &abort)
+        .await
+        .expect("delete assistant row by logical row");
+
+    let after_raw = log
+        .load_events_async()
+        .await
+        .expect("reload session log after remote delete");
+    let delete_entry = after_raw.last().expect("delete entry appended");
+    match &delete_entry.1 {
+        SessionLogEntry::EditEntries {
+            from,
+            to,
+            replacements,
+        } => {
+            assert_eq!(
+                (*from, *to),
+                (3, 3),
+                "assistant message must map to physical seq 3"
+            );
+            assert!(
+                replacements.is_empty(),
+                "delete must append empty replacements"
+            );
+        }
+        other => panic!("expected EditEntries, got {other:?}"),
+    }
+
+    let after_effective =
+        harnx_core::session_reconstruct::reconstruct_state_from_nats(&after_raw).next_turn_messages;
+    assert!(
+        !after_effective
+            .iter()
+            .any(|message| message.role.is_assistant()),
+        "assistant turn should be gone after delete"
+    );
+    assert_eq!(
+        after_effective
+            .iter()
+            .filter(|message| message.role.is_user())
+            .count(),
+        1,
+        "initial user prompt should remain"
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_delete_rejects_protected_rows() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let seeded = seed_remote_config(&url);
+    let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
+    let session_id = crate::nats_worker::new_remote_session_id();
+    let client = async_nats::connect(&url)
+        .await
+        .expect("connect nats client");
+    let jetstream = async_nats::jetstream::new(client);
+    let log = NatsSessionLog::new(jetstream, session_id.clone());
+    let legacy_user_seq = log
+        .append_event_async(&SessionLogEntry::Message {
+            id: Some(uuid::Uuid::new_v4().to_string()),
+            role: harnx_core::message::MessageRole::User,
+            content: harnx_core::message::MessageContent::Text("legacy prompt".to_string()),
+            timestamp: None,
+            fence_token: None,
+        })
+        .await
+        .expect("append legacy user message");
+    assert_eq!(legacy_user_seq, 1, "fixture should start headerless");
+
+    let worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("worker should migrate headerless session");
+
+    let mut parent_config = seeded.parent_config;
+    parent_config.set_remote_agent("metis".to_string(), "local".to_string());
+    parent_config
+        .use_session(Some(&session_id))
+        .expect("activate remote session id");
+    let global_config = Arc::new(parking_lot::RwLock::new(parent_config));
+    let abort = harnx_core::abort::create_abort_signal();
+
+    let err = delete_remote_message_range(&global_config, 0, 0, &abort)
+        .await
+        .expect_err("header row must stay protected");
+    assert_eq!(
+        err.to_string(),
+        "Cannot edit or delete the session header (sequence 0)"
+    );
+
+    let err = delete_remote_message_range(&global_config, 0, 0, &abort)
+        .await
+        .expect_err("header row must stay protected");
+    assert_eq!(
+        err.to_string(),
+        "Cannot edit or delete the session header (sequence 0)"
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_rewind_appends_mutation_without_truncating_stream() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
+    let session_id = crate::nats_worker::new_remote_session_id();
+    let worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("worker should build realistic migrated session");
+
+    let jetstream = seeded
+        .parent_config
+        .nats_jetstream("local")
+        .await
+        .expect("load local jetstream");
+    let log = NatsSessionLog::new(jetstream, session_id.clone());
+    let before_raw = log
+        .load_events_async()
+        .await
+        .expect("load raw session entries before rewind");
+    let raw_len_before = before_raw.len();
+
+    seeded
+        .parent_config
+        .set_remote_agent("metis".to_string(), "local".to_string());
+    seeded
+        .parent_config
+        .use_session(Some(&session_id))
+        .expect("activate remote session id");
+    let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
+    let abort = harnx_core::abort::create_abort_signal();
+
+    rewind_remote_session(&global_config, 1, &abort)
+        .await
+        .expect("rewind to first post-header row");
+
+    let after_raw = log
+        .load_events_async()
+        .await
+        .expect("load raw session entries after rewind");
+    assert!(
+        after_raw.len() > raw_len_before,
+        "rewind must append mutation(s) instead of truncating stream"
+    );
+    // The new implementation uses group-aware EditEntries instead of Rewind
+    // for logical suffix deletion (correct for shared-seq groups)
+    let last = after_raw.last().expect("mutation entry appended");
+    match &last.1 {
+        SessionLogEntry::Rewind { after_seq } => {
+            assert_eq!(
+                *after_seq, 2,
+                "logical row 1 must map to physical seq 2 (legacy Rewind path)"
+            );
+        }
+        SessionLogEntry::EditEntries {
+            from,
+            to,
+            replacements,
+        } => {
+            assert!(*from > 0, "edit entries must target post-header sequences");
+            assert_eq!(*from, *to, "exact-set deletion uses from==to");
+            assert!(
+                replacements.is_empty(),
+                "suffix deletion has empty replacements"
+            );
+        }
+        other => panic!("expected Rewind or EditEntries, got {other:?}"),
+    }
+
+    let effective_after = load_effective_entries(&log).await;
+    let effective_texts: Vec<String> = effective_after
+        .iter()
+        .filter_map(|(_, entry)| match entry {
+            SessionLogEntry::Message { content, .. } => Some(content.to_text()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        effective_texts,
+        vec!["delegate over nats".to_string()],
+        "rewind should leave only header + chosen user prompt in effective history"
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_delete_refreshes_after_concurrent_mutation() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
+    let session_id = crate::nats_worker::new_remote_session_id();
+    let worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("worker should build realistic migrated session");
+
+    let jetstream = seeded
+        .parent_config
+        .nats_jetstream("local")
+        .await
+        .expect("load local jetstream");
+    let log = NatsSessionLog::new(jetstream, session_id.clone());
+
+    seeded
+        .parent_config
+        .set_remote_agent("metis".to_string(), "local".to_string());
+    seeded
+        .parent_config
+        .use_session(Some(&session_id))
+        .expect("activate remote session id");
+    let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
+    let abort = harnx_core::abort::create_abort_signal();
+
+    let stale_state = load_remote_session_for_render(
+        &ThinClientSession::from_global_config(
+            crate::ThinClientConfig {
+                cluster: "local".to_string(),
+                agent: "metis".to_string(),
+                session_id: Some(session_id.clone()),
+            },
+            &global_config,
+            abort.clone(),
+        )
+        .await
+        .expect("load thin session"),
+    )
+    .await
+    .expect("capture stale state");
+
+    log.append_event_async(&SessionLogEntry::Message {
+        id: Some(uuid::Uuid::new_v4().to_string()),
+        role: harnx_core::message::MessageRole::User,
+        content: harnx_core::message::MessageContent::Text("late user".to_string()),
+        timestamp: None,
+        fence_token: None,
+    })
+    .await
+    .expect("append concurrent late user message");
+
+    let stale_attempt = log
+        .append_event_with_expected_last_sequence_async(
+            &SessionLogEntry::EditEntries {
+                from: 2,
+                to: 2,
+                replacements: vec![],
+            },
+            stale_state.last_seen_stream_seq,
+        )
+        .await;
+    assert!(stale_attempt.is_err(), "stale cas append must fail");
+
+    delete_remote_message_range(&global_config, 1, 1, &abort)
+        .await
+        .expect("refreshing delete should retry and succeed");
+
+    let after_raw = log
+        .load_events_async()
+        .await
+        .expect("load raw session entries after concurrent delete");
+    let late_user_still_present =
+        harnx_core::session_reconstruct::reconstruct_state_from_nats(&after_raw)
+            .next_turn_messages
+            .iter()
+            .any(|message| message.content.to_text() == "late user");
+    assert!(
+        late_user_still_present,
+        "retry delete must not target concurrent late row"
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn load_remote_transcript_for_render_prerenders_logical_rows() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let session_id = crate::nats_worker::new_remote_session_id();
+    let worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("worker should build realistic migrated session");
+
+    seeded
+        .parent_config
+        .set_remote_agent("metis".to_string(), "local".to_string());
+    seeded
+        .parent_config
+        .use_session(Some(&session_id))
+        .expect("activate remote session id");
+    let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
+    let abort = harnx_core::abort::create_abort_signal();
+    let thin = ThinClientSession::from_global_config(
+        crate::ThinClientConfig {
+            cluster: "local".to_string(),
+            agent: "metis".to_string(),
+            session_id: Some(session_id.clone()),
+        },
+        &global_config,
+        abort,
+    )
+    .await
+    .expect("load thin session");
+
+    let transcript = load_remote_transcript_for_render(&thin)
+        .await
+        .expect("load transcript state");
+    assert!(
+        transcript.compressed_messages.is_empty(),
+        "worker-migrated headerless fixture should have empty compacted prefix"
+    );
+    let row_seqs: Vec<usize> = transcript
+        .messages
+        .iter()
+        .filter_map(|message| message.log_seq)
+        .collect();
+    assert_eq!(row_seqs, vec![1, 2]);
+    let row_texts: Vec<(harnx_core::message::MessageRole, String)> = transcript
+        .messages
+        .iter()
+        .map(|message| (message.role, message.content.to_text()))
+        .collect();
+    assert_eq!(
+        row_texts,
+        vec![
+            (
+                harnx_core::message::MessageRole::User,
+                "delegate over nats".to_string(),
+            ),
+            (
+                harnx_core::message::MessageRole::Assistant,
+                "stub remote reply over nats".to_string(),
+            ),
+        ]
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn load_remote_transcript_for_render_keeps_tool_rows_and_compressed_prefix() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let session_id = crate::nats_worker::new_remote_session_id();
+    let worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("worker should build realistic migrated session");
+
+    let jetstream = seeded
+        .parent_config
+        .nats_jetstream("local")
+        .await
+        .expect("load local jetstream");
+    let log = NatsSessionLog::new(jetstream, session_id.clone());
+
+    let tool_call = ToolCall::new(
+        "fs_read".to_string(),
+        json!({"path": "README.md"}),
+        Some("tool-1".to_string()),
+        None,
+    );
+    log.append_event_async(&SessionLogEntry::ToolCalls {
+        text: "calling tool".to_string(),
+        thought: Some("tool thought".to_string()),
+        calls: vec![tool_call.clone()],
+        timestamp: None,
+        fence_token: None,
+    })
+    .await
+    .expect("append tool calls");
+    log.append_event_async(&SessionLogEntry::ToolResults {
+        results: vec![ToolOutput {
+            id: tool_call.id.clone(),
+            name: tool_call.name.clone(),
+            output: json!({"ok": true}),
+            content: vec![],
+            switch_agent: None,
+        }],
+        timestamp: None,
+    })
+    .await
+    .expect("append tool results");
+    log.append_event_async(&SessionLogEntry::Compress {
+        prompt: "summary prompt".to_string(),
+    })
+    .await
+    .expect("append compress");
+    log.append_event_async(&SessionLogEntry::Message {
+        id: Some(uuid::Uuid::new_v4().to_string()),
+        role: harnx_core::message::MessageRole::User,
+        content: harnx_core::message::MessageContent::Text("after compress user".to_string()),
+        timestamp: None,
+        fence_token: None,
+    })
+    .await
+    .expect("append post-compress user");
+
+    seeded
+        .parent_config
+        .set_remote_agent("metis".to_string(), "local".to_string());
+    seeded
+        .parent_config
+        .use_session(Some(&session_id))
+        .expect("activate remote session id");
+    let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
+    let thin = ThinClientSession::from_global_config(
+        crate::ThinClientConfig {
+            cluster: "local".to_string(),
+            agent: "metis".to_string(),
+            session_id: Some(session_id.clone()),
+        },
+        &global_config,
+        harnx_core::abort::create_abort_signal(),
+    )
+    .await
+    .expect("load thin session");
+
+    let transcript = load_remote_transcript_for_render(&thin)
+        .await
+        .expect("load transcript state");
+
+    assert!(
+        !transcript.compressed_messages.is_empty(),
+        "compressed_messages must be populated after remote Compress"
+    );
+    assert!(
+        transcript
+            .compressed_messages
+            .iter()
+            .any(|message| message.role == harnx_core::message::MessageRole::Tool),
+        "compressed prefix must retain assembled tool message rows"
+    );
+    assert!(
+        transcript.messages.iter().any(|message| message.role
+            == harnx_core::message::MessageRole::System
+            && message.content.to_text() == "summary prompt"),
+        "active transcript must include summary prompt after Compress"
+    );
+
+    let active_rows: Vec<(harnx_core::message::MessageRole, String, Option<usize>)> = transcript
+        .messages
+        .iter()
+        .map(|message| (message.role, message.content.to_text(), message.log_seq))
+        .collect();
+    assert_eq!(
+        active_rows,
+        vec![
+            (
+                harnx_core::message::MessageRole::System,
+                "summary prompt".to_string(),
+                None,
+            ),
+            (
+                harnx_core::message::MessageRole::User,
+                "after compress user".to_string(),
+                Some(0),
+            ),
+        ]
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_edit_preserves_header_in_migrated_session() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let session_id = crate::nats_worker::new_remote_session_id();
+    let worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("first turn");
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("second turn");
+
+    seeded
+        .parent_config
+        .set_remote_agent("metis".to_string(), "local".to_string());
+    seeded
+        .parent_config
+        .use_session(Some(&session_id))
+        .expect("activate remote session id");
+    let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
+    let abort = harnx_core::abort::create_abort_signal();
+
+    // Edit the first user message (logical index 1) which shares physical seq with header
+    edit_remote_message_range(&global_config, 1, 1, &abort)
+        .await
+        .expect("edit older user message");
+
+    let thin = ThinClientSession::from_global_config(
+        crate::ThinClientConfig {
+            cluster: "local".to_string(),
+            agent: "metis".to_string(),
+            session_id: Some(session_id.clone()),
+        },
+        &global_config,
+        abort,
+    )
+    .await
+    .expect("load thin session");
+    let state = load_remote_session_for_render(&thin)
+        .await
+        .expect("load remote render state");
+
+    // CRITICAL: header must survive the edit
+    let header_count = state
+        .logical_entries
+        .iter()
+        .filter(|entry| matches!(entry, SessionLogEntry::Header { .. }))
+        .count();
+    assert_eq!(
+        header_count, 1,
+        "header must survive edit of first user message in migrated session (shared-seq bug fix)"
+    );
+
+    // Verify all expected messages are present
+    let texts: Vec<String> = state
+        .logical_entries
+        .iter()
+        .filter_map(|entry| match entry {
+            SessionLogEntry::Message { content, .. } => Some(content.to_text()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        texts.len(),
+        4,
+        "after edit should have 4 messages (U1, A1, U2, A2)"
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_delete_after_older_edit_deletes_exact_late_range() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let session_id = crate::nats_worker::new_remote_session_id();
+    let worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("first turn");
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("second turn");
+
+    seeded
+        .parent_config
+        .set_remote_agent("metis".to_string(), "local".to_string());
+    seeded
+        .parent_config
+        .use_session(Some(&session_id))
+        .expect("activate remote session id");
+    let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
+    let abort = harnx_core::abort::create_abort_signal();
+
+    edit_remote_message_range(&global_config, 1, 1, &abort)
+        .await
+        .expect("edit older user message");
+    delete_remote_message_range(&global_config, 3, 4, &abort)
+        .await
+        .expect("delete later logical range");
+
+    let thin = ThinClientSession::from_global_config(
+        crate::ThinClientConfig {
+            cluster: "local".to_string(),
+            agent: "metis".to_string(),
+            session_id: Some(session_id.clone()),
+        },
+        &global_config,
+        abort,
+    )
+    .await
+    .expect("load thin session");
+    let state = load_remote_session_for_render(&thin)
+        .await
+        .expect("load remote render state");
+    // Assert header survives the edit (key coverage for shared-seq bug fix)
+    let header_count = state
+        .logical_entries
+        .iter()
+        .filter(|entry| matches!(entry, SessionLogEntry::Header { .. }))
+        .count();
+    assert_eq!(
+        header_count, 1,
+        "header must survive edit of first user message in migrated session"
+    );
+    let texts: Vec<String> = state
+        .logical_entries
+        .iter()
+        .filter_map(|entry| match entry {
+            SessionLogEntry::Message { content, .. } => Some(content.to_text()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        texts,
+        vec![
+            "delegate over nats".to_string(),
+            "stub remote reply over nats".to_string(),
+        ]
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_rewind_after_older_edit_preserves_correct_logical_prefix() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let session_id = crate::nats_worker::new_remote_session_id();
+    let worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("first turn");
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("second turn");
+
+    seeded
+        .parent_config
+        .set_remote_agent("metis".to_string(), "local".to_string());
+    seeded
+        .parent_config
+        .use_session(Some(&session_id))
+        .expect("activate remote session id");
+    let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
+    let abort = harnx_core::abort::create_abort_signal();
+
+    edit_remote_message_range(&global_config, 1, 1, &abort)
+        .await
+        .expect("edit older user message");
+    rewind_remote_session(&global_config, 2, &abort)
+        .await
+        .expect("rewind logical suffix");
+
+    let thin = ThinClientSession::from_global_config(
+        crate::ThinClientConfig {
+            cluster: "local".to_string(),
+            agent: "metis".to_string(),
+            session_id: Some(session_id.clone()),
+        },
+        &global_config,
+        abort,
+    )
+    .await
+    .expect("load thin session");
+    let state = load_remote_session_for_render(&thin)
+        .await
+        .expect("load remote render state");
+    // Assert header survives the edit (key coverage for shared-seq bug fix)
+    let header_count = state
+        .logical_entries
+        .iter()
+        .filter(|entry| matches!(entry, SessionLogEntry::Header { .. }))
+        .count();
+    assert_eq!(
+        header_count, 1,
+        "header must survive edit of first user message in migrated session"
+    );
+    let texts: Vec<String> = state
+        .logical_entries
+        .iter()
+        .filter_map(|entry| match entry {
+            SessionLogEntry::Message { content, .. } => Some(content.to_text()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        texts,
+        vec![
+            "delegate over nats".to_string(),
+            "stub remote reply over nats".to_string(),
+        ]
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_delete_command_routes_to_exact_set_mutations() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let session_id = crate::nats_worker::new_remote_session_id();
+    let worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("first turn");
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("second turn");
+
+    seeded
+        .parent_config
+        .set_remote_agent("metis".to_string(), "local".to_string());
+    seeded
+        .parent_config
+        .use_session(Some(&session_id))
+        .expect("activate remote session id");
+    let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
+    let abort = harnx_core::abort::create_abort_signal();
+
+    edit_remote_message_range(&global_config, 1, 1, &abort)
+        .await
+        .expect("edit older user message");
+
+    let mut async_manager = harnx_hooks::AsyncHookManager::new();
+    let persistent = Arc::new(tokio::sync::Mutex::new(
+        harnx_hooks::PersistentHookManager::new(),
+    ));
+    let mut pending_async_context = None;
+    crate::commands::run_command(
+        &global_config,
+        abort.clone(),
+        ".delete message 3-4",
+        &mut async_manager,
+        &persistent,
+        &mut pending_async_context,
+    )
+    .await
+    .expect("remote delete command succeeds");
+
+    let thin = ThinClientSession::from_global_config(
+        crate::ThinClientConfig {
+            cluster: "local".to_string(),
+            agent: "metis".to_string(),
+            session_id: Some(session_id.clone()),
+        },
+        &global_config,
+        abort.clone(),
+    )
+    .await
+    .expect("load thin session");
+    let state = load_remote_session_for_render(&thin)
+        .await
+        .expect("load remote render state");
+    // Assert header survives the edit (key coverage for shared-seq bug fix)
+    let header_count = state
+        .logical_entries
+        .iter()
+        .filter(|entry| matches!(entry, SessionLogEntry::Header { .. }))
+        .count();
+    assert_eq!(
+        header_count, 1,
+        "header must survive edit of first user message in migrated session"
+    );
+    let texts: Vec<String> = state
+        .logical_documents
+        .iter()
+        .map(|doc| serde_yaml::from_str::<SessionLogEntry>(doc).expect("deserialize logical doc"))
+        .filter_map(|entry| match entry {
+            SessionLogEntry::Message { content, .. } => Some(content.to_text()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        texts,
+        vec![
+            "delegate over nats".to_string(),
+            "stub remote reply over nats".to_string(),
+        ]
+    );
+
+    // Fetch jetstream without holding lock across await
+    let js = {
+        let cfg = global_config.read();
+        cfg.nats_server("local").expect("nats server").clone()
+    };
+    let js = Config::connect_nats_server(&js)
+        .await
+        .expect("connect to jetstream");
+    let js = async_nats::jetstream::new(js);
+    let raw = NatsSessionLog::new(js, session_id)
+        .load_events_async()
+        .await
+        .expect("raw log");
+    // Check reconstructed state instead of counting mutation shapes
+    let effective = harnx_core::session_reconstruct::apply_log_mutations_nats(&raw)
+        .expect("reconstruct effective log");
+    let header_present = effective
+        .iter()
+        .any(|(_, entry)| matches!(entry, SessionLogEntry::Header { .. }));
+    assert!(
+        header_present,
+        "header must be present in reconstructed log after edit+delete"
+    );
+    let effective_texts: Vec<String> = effective
+        .iter()
+        .filter_map(|(_, entry)| match entry {
+            SessionLogEntry::Message { content, .. } => Some(content.to_text()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        effective_texts,
+        vec![
+            "delegate over nats".to_string(),
+            "stub remote reply over nats".to_string(),
+        ],
+        "reconstructed log must have correct message content"
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_rewind_command_routes_to_exact_suffix_deletions() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let session_id = crate::nats_worker::new_remote_session_id();
+    let worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("first turn");
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("second turn");
+
+    seeded
+        .parent_config
+        .set_remote_agent("metis".to_string(), "local".to_string());
+    seeded
+        .parent_config
+        .use_session(Some(&session_id))
+        .expect("activate remote session id");
+    let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
+    let abort = harnx_core::abort::create_abort_signal();
+
+    edit_remote_message_range(&global_config, 1, 1, &abort)
+        .await
+        .expect("edit older user message");
+
+    let mut async_manager = harnx_hooks::AsyncHookManager::new();
+    let persistent = Arc::new(tokio::sync::Mutex::new(
+        harnx_hooks::PersistentHookManager::new(),
+    ));
+    let mut pending_async_context = None;
+    crate::commands::run_command(
+        &global_config,
+        abort.clone(),
+        ".rewind 2",
+        &mut async_manager,
+        &persistent,
+        &mut pending_async_context,
+    )
+    .await
+    .expect("remote rewind command succeeds");
+
+    let thin = ThinClientSession::from_global_config(
+        crate::ThinClientConfig {
+            cluster: "local".to_string(),
+            agent: "metis".to_string(),
+            session_id: Some(session_id.clone()),
+        },
+        &global_config,
+        abort.clone(),
+    )
+    .await
+    .expect("load thin session");
+    let state = load_remote_session_for_render(&thin)
+        .await
+        .expect("load remote render state");
+    // Assert header survives the edit (key coverage for shared-seq bug fix)
+    let header_count = state
+        .logical_entries
+        .iter()
+        .filter(|entry| matches!(entry, SessionLogEntry::Header { .. }))
+        .count();
+    assert_eq!(
+        header_count, 1,
+        "header must survive edit of first user message in migrated session"
+    );
+    let texts: Vec<String> = state
+        .logical_documents
+        .iter()
+        .map(|doc| serde_yaml::from_str::<SessionLogEntry>(doc).expect("deserialize logical doc"))
+        .filter_map(|entry| match entry {
+            SessionLogEntry::Message { content, .. } => Some(content.to_text()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        texts,
+        vec![
+            "delegate over nats".to_string(),
+            "stub remote reply over nats".to_string(),
+        ]
+    );
+
+    // Fetch jetstream without holding lock across await
+    let js = {
+        let cfg = global_config.read();
+        cfg.nats_server("local").expect("nats server").clone()
+    };
+    let js = Config::connect_nats_server(&js)
+        .await
+        .expect("connect to jetstream");
+    let js = async_nats::jetstream::new(js);
+    let raw = NatsSessionLog::new(js, session_id)
+        .load_events_async()
+        .await
+        .expect("raw log");
+    let rewind_entries = raw
+        .iter()
+        .filter(|(_, entry)| matches!(entry, SessionLogEntry::Rewind { .. }))
+        .count();
+    assert_eq!(
+        rewind_entries, 0,
+        "remote rewind should not emit physical-cutoff Rewind entries"
+    );
+    // Check reconstructed state instead of counting mutation shapes
+    let effective = harnx_core::session_reconstruct::apply_log_mutations_nats(&raw)
+        .expect("reconstruct effective log");
+    let header_present = effective
+        .iter()
+        .any(|(_, entry)| matches!(entry, SessionLogEntry::Header { .. }));
+    assert!(
+        header_present,
+        "header must be present in reconstructed log after edit+rewind"
+    );
+    let effective_texts: Vec<String> = effective
+        .iter()
+        .filter_map(|(_, entry)| match entry {
+            SessionLogEntry::Message { content, .. } => Some(content.to_text()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        effective_texts,
+        vec![
+            "delegate over nats".to_string(),
+            "stub remote reply over nats".to_string(),
+        ],
+        "reconstructed log must have correct message content"
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// Regression (PR #956 F-B): a headerless remote session with MULTIPLE leading
+/// user messages before worker activation. The worker migration clones all
+/// leading users into ONE header-insert EditEntries, so Header + every leading
+/// user share the SAME physical JetStream seq. The resume renumbering must give
+/// each shared-seq user row its OWN distinct logical index ([1,2,3,...]) rather
+/// than collapsing them to a single index.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn load_remote_transcript_multi_leading_user_rows_are_distinct() {
+    use harnx_core::message::{MessageContent, MessageRole};
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let session_id = crate::nats_worker::new_remote_session_id();
+
+    // Seed two leading user messages directly to the durable log BEFORE the
+    // worker activates, mirroring a thin client that appended several prompts
+    // before the first worker turn.
+    let jetstream = seeded
+        .parent_config
+        .nats_jetstream("local")
+        .await
+        .expect("load local jetstream");
+    let seed_log = NatsSessionLog::new(jetstream, session_id.clone());
+    for text in ["leading one", "leading two"] {
+        seed_log
+            .append_event_async(&SessionLogEntry::Message {
+                id: None,
+                role: MessageRole::User,
+                content: MessageContent::Text(text.to_string()),
+                timestamp: None,
+                fence_token: None,
+            })
+            .await
+            .expect("seed leading user message");
+    }
+
+    let worker =
+        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
+    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
+        .await
+        .expect("worker migrates multi-leading-user session");
+
+    seeded
+        .parent_config
+        .set_remote_agent("metis".to_string(), "local".to_string());
+    seeded
+        .parent_config
+        .use_session(Some(&session_id))
+        .expect("activate remote session id");
+    let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
+    let abort = harnx_core::abort::create_abort_signal();
+    let thin = ThinClientSession::from_global_config(
+        crate::ThinClientConfig {
+            cluster: "local".to_string(),
+            agent: "metis".to_string(),
+            session_id: Some(session_id.clone()),
+        },
+        &global_config,
+        abort,
+    )
+    .await
+    .expect("load thin session");
+
+    let transcript = load_remote_transcript_for_render(&thin)
+        .await
+        .expect("load transcript state");
+
+    let row_seqs: Vec<usize> = transcript
+        .messages
+        .iter()
+        .filter_map(|message| message.log_seq)
+        .collect();
+    // Header = logical 0 (no row). Rows: leading one=1, leading two=2,
+    // "delegate over nats"=3, assistant=4. On the pre-fix code these collapsed
+    // to [3,3,3,4]. Assert distinct + contiguous starting at 1.
+    assert_eq!(
+        row_seqs,
+        vec![1, 2, 3, 4],
+        "shared-seq leading-user rows must get distinct contiguous logical seqs, not collapse"
+    );
+    let mut sorted = row_seqs.clone();
+    sorted.dedup();
+    assert_eq!(
+        sorted.len(),
+        row_seqs.len(),
+        "resumed row seqs must be unique"
+    );
+
+    let row_texts: Vec<(MessageRole, String)> = transcript
+        .messages
+        .iter()
+        .map(|message| (message.role, message.content.to_text()))
+        .collect();
+    assert_eq!(
+        row_texts,
+        vec![
+            (MessageRole::User, "leading one".to_string()),
+            (MessageRole::User, "leading two".to_string()),
+            (MessageRole::User, "delegate over nats".to_string()),
+            (
+                MessageRole::Assistant,
+                "stub remote reply over nats".to_string()
+            ),
+        ]
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    let _ = child.kill();
+    let _ = child.wait();
 }

--- a/crates/harnx-runtime/tests/nats_worker.rs
+++ b/crates/harnx-runtime/tests/nats_worker.rs
@@ -264,6 +264,8 @@ async fn run_worker_turn(params: WorkerTurnParams<'_>) -> Result<()> {
         call_fn: Some(call_fn),
         lease: None,
         after_seq_observer: None,
+        header_insert_observer: None,
+        session_index: None,
         on_tool_round: None,
     })
     .await
@@ -1062,6 +1064,8 @@ async fn resume_aborts_when_tail_fence_exceeds_held_revision() -> Result<()> {
             call_fn: Some(counting_stub_call_fn(Arc::new(AtomicUsize::new(0)))),
             lease: None,
             after_seq_observer: None,
+            header_insert_observer: None,
+            session_index: None,
             on_tool_round: None,
         }
         .with_lease(lease),

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -320,6 +320,35 @@ impl Tui {
                 if let Some(prompt_abort) = &self.current_prompt_abort {
                     prompt_abort.set_ctrlc();
                 }
+
+                if let Some((ref session_id, ref cluster)) = self.active_remote_session {
+                    let config = self.config.clone();
+                    let session_id = session_id.clone();
+                    let cluster = cluster.clone();
+                    tokio::spawn(async move {
+                        let server = { config.read().nats_server(&cluster).cloned() };
+                        if let Ok(server) = server {
+                            match harnx_runtime::config::Config::connect_nats_server(&server).await
+                            {
+                                Ok(client) => {
+                                    if let Err(e) = harnx_runtime::send_control_command(
+                                        &client,
+                                        &session_id,
+                                        harnx_runtime::ControlCommand::Cancel,
+                                    )
+                                    .await
+                                    {
+                                        log::warn!("Failed to send remote cancel command: {e}");
+                                    }
+                                }
+                                Err(e) => {
+                                    log::warn!("Failed to connect to NATS for remote cancel: {e}");
+                                }
+                            }
+                        }
+                    });
+                }
+
                 self.app.transcript.push(TranscriptItem::SystemText(
                     "(Ctrl+C — operation aborted. Ctrl+D to exit.)".to_string(),
                 ));
@@ -337,6 +366,7 @@ impl Tui {
                 // the flag for parity with the prior UX.
                 if self.current_prompt_handle.is_none() {
                     self.app.llm_busy = false;
+                    self.active_remote_session = None;
                 }
             }
             (KeyCode::Up, KeyModifiers::NONE) => {
@@ -1045,6 +1075,7 @@ impl Tui {
             AgentEvent::Model(ModelEvent::Final { output, usage }) => {
                 self.flush_pending_thought();
                 self.app.llm_busy = false;
+                self.active_remote_session = None;
                 // The task that emitted Final has signalled it is exiting.
                 // Drop our reference to its abort signal — the next Ctrl+C
                 // should not target a task that's already gone. We keep
@@ -1131,6 +1162,7 @@ impl Tui {
             AgentEvent::Model(ModelEvent::Error(err)) => {
                 self.flush_pending_thought();
                 self.app.llm_busy = false;
+                self.active_remote_session = None;
                 // Mirrors the Final cleanup: drop the per-task abort
                 // signal (task has exited) and clear the shared pending
                 // channel so its content can't leak into the next task.
@@ -1381,9 +1413,23 @@ impl Tui {
 
         self.app.llm_busy = true;
         self.app.streaming_open = false;
+
         self.app.streamed_text_this_turn = false;
 
+        let remote_info = {
+            let guard = self.config.read();
+            let agent_and_cluster = guard.remote_agent.clone();
+            let session_id = guard
+                .session
+                .as_ref()
+                .map(|s| s.id().to_string())
+                .unwrap_or_default();
+            agent_and_cluster.map(|(_, cluster)| (session_id, cluster))
+        };
+        self.active_remote_session = remote_info;
+
         let event_tx = self.event_tx.clone();
+
         let ctx = crate::prompt::PromptTaskContext {
             config: self.config.clone(),
             abort_signal: new_abort,

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -16,12 +16,14 @@ use crossterm::terminal::{enable_raw_mode, supports_keyboard_enhancement, EnterA
 use crossterm::ExecutableCommand;
 use harnx_core::message::Message;
 use harnx_hooks::{drain_async_results, AsyncHookManager, PersistentHookManager};
+use harnx_runtime::config::remote_session_ops::load_remote_transcript_for_render;
 use harnx_runtime::config::GlobalConfig;
 use harnx_runtime::config::{
     build_picker_context, list_assistant_agents, sort_sessions_for_picker,
 };
 use harnx_runtime::tool::ToolDeclaration;
 use harnx_runtime::utils::create_abort_signal;
+use harnx_runtime::{ThinClientConfig, ThinClientSession};
 use log::warn;
 use ratatui::Terminal;
 #[cfg(test)]
@@ -217,6 +219,7 @@ impl Tui {
             shared_pending_message: Arc::new(Mutex::new(None)),
             current_prompt_abort: None,
             current_prompt_handle: None,
+            active_remote_session: None,
             needs_full_redraw: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             app,
             event_tx,
@@ -768,10 +771,11 @@ fn build_compaction_marker(
 
 pub(crate) fn session_history_transcript_items(config: &GlobalConfig) -> Vec<TranscriptItem> {
     let cfg = config.read();
-    let session = match cfg.session.as_ref() {
-        Some(s) if !s.is_empty() => s,
+    let session_id = match cfg.session.as_ref() {
+        Some(s) if !s.is_empty() => s.id().to_string(),
         _ => return vec![],
     };
+    let remote_agent = cfg.remote_agent.clone();
     // Spell handoff tool declaration names relative to the active agent's
     // package so the transcript matches what the agent actually saw (#709).
     let active_pkg = cfg.active_package();
@@ -781,6 +785,66 @@ pub(crate) fn session_history_transcript_items(config: &GlobalConfig) -> Vec<Tra
         .into_iter()
         .map(|d| (d.name.clone(), d))
         .collect();
+
+    if let Some((agent, cluster)) = remote_agent {
+        drop(cfg);
+        let abort_signal = harnx_runtime::utils::create_abort_signal();
+        let remote_load = || async {
+            let thin = ThinClientSession::from_global_config(
+                ThinClientConfig {
+                    cluster,
+                    agent,
+                    session_id: Some(session_id),
+                },
+                config,
+                abort_signal,
+            )
+            .await?;
+            load_remote_transcript_for_render(&thin).await
+        };
+        let state = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => match tokio::task::block_in_place(|| handle.block_on(remote_load())) {
+                Ok(state) => state,
+                Err(err) => {
+                    warn!("failed to load remote session transcript for resume: {err:#}");
+                    return vec![];
+                }
+            },
+            Err(_) => {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(err) => {
+                        warn!(
+                            "failed to build Tokio runtime for remote transcript resume: {err:#}"
+                        );
+                        return vec![];
+                    }
+                };
+                match runtime.block_on(remote_load()) {
+                    Ok(state) => state,
+                    Err(err) => {
+                        warn!("failed to load remote session transcript for resume: {err:#}");
+                        return vec![];
+                    }
+                }
+            }
+        };
+
+        let mut items = Vec::new();
+        if !state.compressed_messages.is_empty() {
+            items.push(build_compaction_marker(
+                &state.compressed_messages,
+                &decl_map,
+            ));
+        }
+        items.extend(messages_to_transcript_items(&state.messages, &decl_map));
+        return items;
+    }
+
+    let session = cfg.session.as_ref().expect("checked above");
     let mut items = Vec::new();
     if !session.compressed_messages.is_empty() {
         items.push(build_compaction_marker(

--- a/crates/harnx-tui/src/prompt.rs
+++ b/crates/harnx-tui/src/prompt.rs
@@ -188,10 +188,17 @@ impl Tui {
         let sink = Arc::new(TuiAgentEventSink::new(event_tx.clone()));
 
         // Build thin-client config
+        // Extract session id before any await to avoid holding the read lock.
+        let session_id = ctx
+            .config
+            .read()
+            .session
+            .as_ref()
+            .map(|s| s.id().to_string());
         let thin_config = ThinClientConfig {
             cluster,
             agent,
-            session_id: None, // New session for this turn
+            session_id,
         };
 
         // Create the thin-client session

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -8694,3 +8694,90 @@ async fn test_info_session_single_arg_no_active_agent() {
         text
     );
 }
+
+#[tokio::test]
+async fn test_start_prompt_sets_active_remote_session() {
+    let config = test_config();
+    {
+        let mut guard = config.write();
+        guard.remote_agent = Some(("remote_agent_name".to_string(), "cluster_name".to_string()));
+        // Note: session is None by default in test_config, but we expect it to fallback gracefully or get stringified.
+    }
+
+    let mut harness = TuiTestHarness::with_config(config).await;
+    let tui = harness.tui();
+
+    // Verify it starts as None
+    assert_eq!(tui.active_remote_session, None);
+
+    let msg = crate::types::PendingMessage {
+        text: "hello".to_string(),
+        attachments: vec![],
+        attachment_dir: None,
+        paste_count: 0,
+    };
+
+    // start_prompt handles the spawn
+    tui.start_prompt(msg).await.unwrap();
+
+    // The remote info should be set!
+    let session_opt = tui.active_remote_session.as_ref();
+    assert!(
+        session_opt.is_some(),
+        "active_remote_session should be Some when config.remote_agent is set"
+    );
+    let (session_id, cluster) = session_opt.unwrap();
+    assert_eq!(cluster, "cluster_name");
+    assert_eq!(session_id, ""); // Because we didn't set a session in config, it defaults to ""
+
+    // We can simulate an Error or Final event to clear it
+    use harnx_core::event::{AgentEvent, ModelEvent};
+    let _ = tui
+        .handle_tui_event(crate::types::TuiEvent::Agent(
+            AgentEvent::Model(ModelEvent::Final {
+                output: "done".to_string(),
+                usage: Default::default(),
+            }),
+            None,
+        ))
+        .await;
+
+    assert_eq!(
+        tui.active_remote_session, None,
+        "Final event should clear the active_remote_session"
+    );
+}
+
+#[test]
+fn messages_to_transcript_items_renders_tool_message_with_seq() {
+    use harnx_core::message::{Message, MessageContent, MessageContentToolCalls, MessageRole};
+    use harnx_core::tool::{ToolCall, ToolResult};
+
+    let call = ToolCall::new(
+        "fs_read".to_string(),
+        serde_json::json!({"path": "README.md"}),
+        Some("tool-1".to_string()),
+        None,
+    );
+    let tool_message = Message {
+        role: MessageRole::Tool,
+        content: MessageContent::ToolCalls(MessageContentToolCalls::new(
+            vec![ToolResult::new(call, serde_json::json!({"ok": true}))],
+            "calling tool".to_string(),
+            Some("tool thought".to_string()),
+        )),
+        log_seq: Some(5),
+        log_timestamp: None,
+    };
+
+    let items = crate::lifecycle::messages_to_transcript_items(
+        &[tool_message],
+        &std::collections::HashMap::new(),
+    );
+    assert!(
+        items
+            .iter()
+            .any(|item| matches!(item, TranscriptItem::ToolCall { seq: Some(5), .. })),
+        "tool message should render into targetable tool transcript rows"
+    );
+}

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -44,6 +44,9 @@ pub struct Tui {
     /// prompt task. `start_prompt` awaits/aborts this before spawning a
     /// new task — guaranteeing one prompt task at a time.
     pub(super) current_prompt_handle: Option<JoinHandle<()>>,
+    /// The (session_id, cluster) of the remote agent currently running, if any.
+    /// Set in `start_prompt` and cleared when the turn completes.
+    pub(super) active_remote_session: Option<(String, String)>,
     #[allow(private_interfaces)]
     pub(crate) app: App,
     pub(crate) event_tx: mpsc::UnboundedSender<TuiEvent>,

--- a/docs/solutions/logic-errors/remote-session-shared-seq-group-aware-mutations-2026-07-01.md
+++ b/docs/solutions/logic-errors/remote-session-shared-seq-group-aware-mutations-2026-07-01.md
@@ -1,0 +1,201 @@
+---
+title: "Remote session shared-seq trap: group-aware EditEntries for worker-migrated headerless sessions"
+date: 2026-07-01
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-runtime/remote_session_ops"
+root_cause: "Worker header migration creates shared physical seq between Header and first user; naive per-seq EditEntries drops Header or mis-targets deletes/rewinds"
+resolution_type: code_fix
+severity: high
+tags:
+  - remote-session
+  - NATS
+  - JetStream
+  - EditEntries
+  - session-log
+  - header-migration
+  - shared-seq
+  - logical-index
+  - physical-seq
+plan_ref: "p915-remote-tui-wiring"
+---
+
+## Problem
+
+Remote NATS sessions require edit/delete/rewind/resume operations to work identically to local sessions, but remote sessions use an append-only JetStream log with physical seqs while local sessions use document indices. A subtle trap emerges: worker header migration creates entries that **share a single physical JetStream seq**, and naive per-seq mutations silently corrupt sessions by dropping Headers or mis-targeting operations.
+
+## Symptoms
+
+- Editing the first user turn of a worker-migrated session **drops the Header**, making the session invalid
+- Deleting a logical range mis-targets entries when physical seq order diverges from logical order after edits
+- Rewind `{after_seq}` truncates incorrectly, deleting wrong entries
+- `from > to` no-ops or delete operations hit unintended entries
+- Tests pass with hand-seeded Headers but fail with realistic worker-migrated fixtures
+
+## Investigation Steps
+
+1. Observed s6 exact-set delete/rewind regressions after production fix for seq-only targeting
+2. Traced realistic 2-turn remote session raw/effective shape after worker migration:
+   - raw js1 = U1 `delegate over nats`
+   - raw js2 = header-migration `EditEntries{from:1,to:1,replacements:[Header,U1 clone]}`
+   - raw js3 = A1, js4 = U2, js5 = A2
+3. Effective active window before edit showed **Header and U1 both at physical seq 2**
+4. `edit_remote_message_range(1,1)` stored only `js_seq=2`; `thin.edit_user_message(2, ...)` appended `EditEntries{from:2,to:2,replacements:[edited U1]}`
+5. Resolver semantics: `from=to=2` spans both Header and U1, replaces both with single user replacement → **Header gone**
+6. Delete/rewind similarly mis-targeted when logical order diverged from physical seq order
+
+## Root Cause
+
+**Two intertwined issues:**
+
+1. **Shared-physical-seq trap:** Remote sessions are born headerless. Thin client appends first user before worker activation. Worker migrates by appending ONE `EditEntries{replacements:[Header, cloned users]}`. All replacements **inherit the mutation's single physical js_seq**. Header and first user share seq 2.
+
+2. **Seq-only exact-set model:** `exact_set_delete_mutations` emitted one `EditEntries{seq,seq,[]}` per physical seq, assuming one logical entry per seq. This assumption is **false** for worker-migrated sessions where Header+U1 share seq. The resolver (`apply_log_mutations` in harnx-core) resolves `EditEntries{from:s,to:s}` as `position(seq==s)..=rposition(seq==s)`, splicing the entire span containing **both** entries.
+
+**Consequences:**
+- Edit of first user: `EditEntries{2,2,[edited U1]}` replaces Header+U1 → Header dropped
+- Delete when physical order != logical order: targets wrong entries, `from>to` no-ops, or deletes unintended rows
+- Physical Rewind truncation: wrong boundary
+
+**Additional constraint:** `active_context_window` (entries after most-recent Header|Compress boundary) is for display/dispatch/protection ONLY. Logical indices **must not** enter reconstruct/fold/turn-derivation code paths.
+
+## Solution
+
+### Two Seq Domains
+
+- **Logical index:** Position within `active_context_window` (Header = logical 0, Compress excluded)
+- **Physical seq:** JetStream `js_seq` (1-based u64)
+
+Display, dispatch, and protection code use LOGICAL indices. JetStream mutations (`EditEntries`, `Rewind`) use PHYSICAL seqs. **Never mix.**
+
+### Group-Aware Mutation Construction
+
+For any physical seq shared by multiple effective rows, `EditEntries` replacements must preserve non-targeted siblings in effective order.
+
+**Edit operation:**
+1. Identify target by logical row (not first match on seq)
+2. Target the `role.is_user()` member of the shared-seq group
+3. Re-emit all group members with only the target edited:
+   ```rust
+   append_session_mutation_batch_cas(&thin, |state| {
+       let group = state.logical_targets.iter()
+           .filter(|t| t.js_seq == target_seq)
+           .collect::<Vec<_>>();
+       let replacements: Vec<String> = group.iter().map(|t| {
+           if t.entry.role().is_user() && t.entry.text() == target_text {
+               serde_yaml::to_string(&edited_entry)?
+           } else {
+               serde_yaml::to_string(&t.entry)?
+           }
+       }).collect();
+       Ok(vec![SessionLogEntry::EditEntries {
+           from: target_seq,
+           to: target_seq,
+           replacements,
+       }])
+   }).await?;
+   ```
+
+**Delete operation:**
+1. Build `physical_seq -> [(logical_index, entry_yaml)]` map in effective order
+2. For each targeted physical seq, emit:
+   ```rust
+   SessionLogEntry::EditEntries {
+       from: seq,
+       to: seq,
+       replacements: group_members.iter()
+           .filter(|(idx, _)| !targeted_logical_indices.contains(idx))
+           .map(|(_, yaml)| yaml.clone())
+           .collect(),
+   }
+   ```
+3. Empty replacements when whole group targeted
+4. Bail with error if group members are non-contiguous (gap in middle unsupported)
+
+**Rewind operation:**
+1. Compute logical SUFFIX to delete
+2. Reuse same group-aware deletion (append-only, no physical `Rewind`)
+3. Append per-seq mutations under ONE CAS chain
+
+**CAS batch pattern:**
+```rust
+async fn append_session_mutation_batch_cas<F>(
+    thin: &ThinClientSession,
+    build_entries: F,
+) -> Result<()>
+where
+    F: Fn(&RemoteRenderState) -> Result<Vec<SessionLogEntry>>,
+{
+    let log = NatsSessionLog::new(thin.jetstream().clone(), thin.session_id().to_string());
+    loop {
+        let state = load_remote_session_for_render(thin).await?;
+        let entries = build_entries(&state)?;
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let mut expected_last = state.last_seen_stream_seq;
+        let mut should_retry = false;
+        for entry in &entries {
+            match log.append_event_with_expected_last_sequence_async(entry, expected_last).await {
+                Ok(seq) => expected_last = seq,
+                Err(err) if is_stream_advanced_error(&err) => {
+                    should_retry = true;
+                    break;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        if should_retry {
+            continue;
+        }
+        return Ok(());
+    }
+}
+```
+
+### Resume Parity
+
+Remote pre-render reuses local `replay_log_entries_for_external` (tool-turn folding + compaction markers). Overlay same active-window logical numbering so resumed rows are targetable by the same logical seqs.
+
+## Why This Works
+
+**Group-awareness:** Preserves siblings in shared-seq groups (Header+U1) when targeting only one member. Header survives editing first user turn.
+
+**Logical targeting:** Users operate on logical indices (visible transcript positions). Code maps to physical seqs with full group context before emitting mutations.
+
+**Batch CAS:** All mutations for one operation emit under single optimistic concurrency chain. On stale, reload + rebuild + retry ensures consistent snapshot.
+
+**Contiguity check:** Rejects non-contiguous groups early (should never happen in practice with worker migration pattern).
+
+## Prevention Strategies
+
+**Test fixtures:**
+- Use REALISTIC worker-migrated headerless fixtures: `ThinClientSession::run_turn` then worker-activated
+- NOT hand-seeded headers (they mask off-by-one AND header-drop bugs)
+- Always assert HEADER SURVIVAL after editing/deleting first turn of migrated session
+
+**Test cases:**
+- Edit first user turn of worker-migrated session → Header survives
+- Delete range across logical indices where physical seq order diverges → targets correct entries
+- Rewind after edit → truncates at correct boundary
+- Resume remote session → logical indices match pre-render, editable
+
+**Best practices:**
+- Build `physical_seq -> [(logical_index, entry)]` map before any `EditEntries` construction
+- Always preserve non-targeted siblings in shared-seq groups
+- Emit all mutations for one user operation in single CAS batch
+- Never pass logical indices to reconstruct/fold/turn-derivation code
+
+**Code review checklist:**
+- [ ] Does this mutation handle shared-seq groups?
+- [ ] Are Header+U1 preserved when editing first user turn?
+- [ ] Is group contiguity verified before emitting mutations?
+- [ ] Are mutations batched under single CAS chain?
+- [ ] Do test fixtures use realistic worker-migration, not hand-seeded headers?
+
+## Related Issues
+
+- **PR:** [#915](https://github.com/example/harnx/pull/915) — Group-aware remote edit/delete/rewind
+- **Commit:** d8b0f3597 — fix(runtime): group-aware remote edit/delete/rewind preserves shared-seq siblings
+- **Related Solution:** [nats-session-log-mutations-canonical-resolution-2026-06-23.md](nats-session-log-mutations-canonical-resolution-2026-06-23.md) — EditEntries mutation fold and canonical resolution
+- **Related Solution:** [non-destructive-session-mutation-two-pass-replay-2026-05-01.md](non-destructive-session-mutation-two-pass-replay-2026-05-01.md) — Two-pass replay foundation


### PR DESCRIPTION
Enables remote session resume, Ctrl+C cancellation, and message retract/ edit parity with local sessions. Adds a unified 0-based logical index domain (relative to most-recent Header or Compress boundary) for consistent display, dispatch, and protection across local and remote backends.

Key changes:
- Implemented worker-authored Header migration via EditEntries for headerless-origin remote sessions.
- Extracted session_ops_core for shared turn-based range calculation, protection validation, and rewind-point computation.
- Added group-aware remote mutation construction that preserves shared- sequence siblings (e.g., Header + first user message) to prevent accidental data loss during edits.
- Implemented authoritative logical LogSeqAssigned emission for remote replay and live rows.
- Wired remote transcript pre-render on session pick, reusing the local replay assembly logic for tool-turn folding and compaction markers.
- Added CAS (Check-And-Set) batch mutation support to safely handle concurrent remote writes.
- Installed nats-server in CI to enable automated NATS integration tests.

Fixes #915

Plan: p915-remote-tui-wiring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote sessions can now be resumed from the session picker, preserving the same session instead of starting over.
  * Transcript rendering now supports resuming from remote sessions.
  * Remote prompt Ctrl+C cancels in-flight remote work.

* **Bug Fixes**
  * Edit, delete, and rewind commands now work for remote sessions with consistent message numbering and transcript items.
  * Remote message retraction/editing is supported via the existing TUI shortcuts.
  * Improved protection of session history boundaries during remote updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->