### PR TITLE
test(harnx-core): add edge-case tests for apply_log_mutations skip pa…

### DIFF
--- a/crates/harnx-core/src/session_reconstruct.rs
+++ b/crates/harnx-core/src/session_reconstruct.rs
@@ -806,6 +806,10 @@ mod tests {
         );
     }
 
+    fn to_yaml(entry: &SessionLogEntry) -> String {
+        serde_yaml::to_string(entry).expect("serialize replacement")
+    }
+
     fn edited_user_replacement_yaml() -> String {
         serde_yaml::to_string(&SessionLogEntry::Message {
             id: Some("edited-id".to_string()),
@@ -875,19 +879,74 @@ mod tests {
         assert_edit_is_skipped(SessionLogEntry::EditEntries {
             from: 2,
             to: 1,
-            replacements: vec![],
+            replacements: vec![edited_user_replacement_yaml()],
         });
     }
 
     #[test]
-    fn edit_entries_missing_target_seq_is_skipped() {
+    fn edit_entries_missing_from_seq_is_skipped() {
+        assert_edit_is_skipped(SessionLogEntry::EditEntries {
+            from: 99,
+            to: 2,
+            replacements: vec![edited_user_replacement_yaml()],
+        });
+    }
+
+    #[test]
+    fn edit_entries_missing_to_seq_is_skipped() {
         assert_edit_is_skipped(SessionLogEntry::EditEntries {
             from: 1,
             to: 99,
-            replacements: vec![
-                serde_yaml::to_string(&user_message("edited")).expect("serialize replacement")
-            ],
+            replacements: vec![edited_user_replacement_yaml()],
         });
+    }
+
+    #[test]
+    fn edit_entries_not_in_replay_order_is_skipped() {
+        let effective = apply_log_mutations(&[
+            (1, user_message("first")),
+            (2, user_message("second")),
+            (
+                3,
+                SessionLogEntry::EditEntries {
+                    from: 1,
+                    to: 1,
+                    replacements: vec![to_yaml(&user_message("first replacement one"))],
+                },
+            ),
+            (
+                4,
+                SessionLogEntry::EditEntries {
+                    from: 2,
+                    to: 3,
+                    replacements: vec![edited_user_replacement_yaml()],
+                },
+            ),
+        ]);
+
+        assert_eq!(effective.len(), 2);
+        assert_eq!(effective[0].0, 3);
+        assert_eq!(effective[1].0, 2);
+        assert_eq!(
+            message_text(&entry_as_message(&effective[0].1)),
+            "first replacement one"
+        );
+        assert_eq!(message_text(&entry_as_message(&effective[1].1)), "second");
+    }
+
+    #[test]
+    fn rewind_missing_after_seq_is_skipped() {
+        let effective = apply_log_mutations(&[
+            (1, user_message("first")),
+            (2, final_assistant("done")),
+            (3, SessionLogEntry::Rewind { after_seq: 99 }),
+        ]);
+
+        assert_eq!(effective.len(), 2);
+        assert_eq!(effective[0].0, 1);
+        assert_eq!(effective[1].0, 2);
+        assert_eq!(message_text(&entry_as_message(&effective[0].1)), "first");
+        assert_eq!(message_text(&entry_as_message(&effective[1].1)), "done");
     }
 
     #[test]
@@ -1231,12 +1290,9 @@ mod tests {
                     from: 50,
                     to: 50,
                     replacements: vec![
-                        serde_yaml::to_string(&user_message("u1 clone"))
-                            .expect("serialize replacement"),
-                        serde_yaml::to_string(&user_message("u2 clone"))
-                            .expect("serialize replacement"),
-                        serde_yaml::to_string(&final_assistant("a1 clone"))
-                            .expect("serialize replacement"),
+                        to_yaml(&user_message("u1 clone")),
+                        to_yaml(&user_message("u2 clone")),
+                        to_yaml(&final_assistant("a1 clone")),
                     ],
                 },
             ),

--- a/docs/solutions/logic-errors/apply-log-mutations-skip-branch-testing-2026-07-02.md
+++ b/docs/solutions/logic-errors/apply-log-mutations-skip-branch-testing-2026-07-02.md
@@ -1,0 +1,112 @@
+---
+title: "apply_log_mutations skip-branch testing: non-vacuous replay-order case and shared helper pattern"
+date: 2026-07-02
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-core/session_reconstruct"
+root_cause: "Test vacuum: from>to EditEntries trips invalid-range guard before reaching not-in-replay-order branch; effective seqs are NOT monotonic after splicing"
+resolution_type: test_fix
+severity: medium
+tags:
+  - session-log
+  - mutation
+  - EditEntries
+  - testing
+  - non-vacuous-test
+  - skip-branch
+plan_ref: "nats-edge-case-tests"
+---
+
+## Problem
+
+`apply_log_mutations_with_name` has 5 skip branches (log::warn! + continue, never errors/panics) for invalid mutations. A test using `EditEntries { from: 3, to: 2 }` to exercise the "not in replay order" branch was VACUOUS — tripped the `from > to` invalid-range guard (line 79) and never reached the `start_idx > end_idx` branch (line 107).
+
+## Symptoms
+
+- Test passed but exercised wrong guard
+- Review caught that `from: 3, to: 2` fails at line 79, not line 107
+- Line 107 branch appeared unreachable without deeper analysis
+
+## Investigation Steps
+
+1. Traced guard order: `from > to` checked before position lookups
+2. Analyzed effective seq stream structure after EditEntries splices
+3. Found: after `EditEntries { from: 1, to: 1, replacements: [...] }`, effective stream has entries with non-monotonic seqs
+4. Constructed concrete case:
+   - seq1: user("first")
+   - seq2: user("second")
+   - seq3: EditEntries { from: 1, to: 1, replacements: [user("first replacement one")] }
+   - seq4: EditEntries { from: 2, to: 3, replacements: [edited_user] }
+5. At seq4: effective before edit is `[(3, "first replacement one"), (2, "second")]`
+   - from=2, to=3 → passes `from <= to` guard
+   - position(2) = 1, rposition(3) = 0
+   - start_idx=1 > end_idx=0 → line 107 fires
+
+## Root Cause
+
+**Effective seqs are NOT strictly monotonic** after EditEntries splices replacements that inherit the mutation's seq. Replacements splice into the middle of the stream, creating out-of-order seq positions.
+
+Test using `from > to` is vacuous because it hits the invalid-range guard first. Real reachable case requires VALID `from <= to` where seq positions become inverted in effective stream.
+
+## Solution
+
+Replaced vacuous test with genuine line-107 coverage:
+
+**Test:** `edit_entries_not_in_replay_order_is_skipped`
+```rust
+let effective = apply_log_mutations(&[
+    (1, user_message("first")),
+    (2, user_message("second")),
+    (3, SessionLogEntry::EditEntries {
+        from: 1,
+        to: 1,
+        replacements: vec![to_yaml(&user_message("first replacement one"))],
+    }),
+    (4, SessionLogEntry::EditEntries {
+        from: 2,
+        to: 3,  // from <= to, but position(2)=1 > rposition(3)=0
+        replacements: vec![edited_user_replacement_yaml()],
+    }),
+]);
+```
+
+**Added helper:** `to_yaml(entry: &SessionLogEntry) -> String` in test module (line 809) to cut serde_yaml boilerplate for replacement YAML construction.
+
+**Shared assertion helper:** `assert_edit_is_skipped(edit: SessionLogEntry)` (line 863) asserts effective stream unchanged — non-vacuous, would fail if guard removed.
+
+## Why This Works
+
+**Correct branch exercised:** `from: 2, to: 3` passes line-79 guard, allowing execution to reach line-107 where inverted positions trigger the skip.
+
+**Non-vacuous assertion:** If line-107 guard were removed, `splice(1..=0, ...)` would run on invalid inclusive range and panic — test would catch regression.
+
+**Helper reduces boilerplate:** `to_yaml()` used in touched tests; single source for replacement YAML construction.
+
+## Prevention Strategies
+
+**Test cases:**
+- Verify guard-order dependencies before writing skip-branch tests
+- For position-inversion branches, construct realistic effective streams with non-monotonic seqs
+- Use shared `assert_edit_is_skipped` helper for all skip-branch tests (non-vacuous baseline)
+- Sanity-gate: confirm test would fail if targeted guard removed
+
+**Best practices:**
+- Analyze what the effective stream looks like BEFORE writing mutation tests
+- EditEntries splices inject entries with mutation seq into stream middle
+- Shared test helpers (assert_edit_is_skipped, to_yaml) cut boilerplate and enforce consistency
+
+**Code review checklist:**
+- [ ] Does skip-branch test actually reach the targeted line?
+- [ ] Is the test case non-vacuous (would fail if guard removed)?
+- [ ] For position-based guards, is the effective stream structure realistic?
+
+## Related Issues
+
+- **Plan:** nats-edge-case-tests — Part 1 unit tests for apply_log_mutations skip branches
+- **File:** `crates/harnx-core/src/session_reconstruct.rs` lines 79-135 (guard logic), 863-949 (tests)
+- **Process note:** Part 2/3 (mid-turn injection, Rewind worker) already covered by NATS integration tests:
+  - `mid_tool_round_user_message_is_injected_once_into_same_turn` (nats_worker.rs:477)
+  - `retracted_mid_tool_round_message_is_not_injected` (nats_worker.rs:1162)
+  - `remote_rewind_appends_mutation_without_truncating_stream` (tests.rs:1947)
+- **Related Solution:** [nats-session-log-mutations-canonical-resolution-2026-06-23.md](nats-session-log-mutations-canonical-resolution-2026-06-23.md)
+- **Related Solution:** [stacked-mutation-replay-rposition-2026-05-01.md](stacked-mutation-replay-rposition-2026-05-01.md) — rposition for stacked edits


### PR DESCRIPTION
…ths (#919)

Adds 5 non-vacuous unit tests for the mutation resolver's invalid-mutation skip branches (invalid-range, missing from/to seq, out-of-replay-order, missing rewind after_seq). Includes a new docs/solutions entry capturing the testing pattern.

Confirmed mid-turn injection and Rewind worker integration (#919 Parts 2/3) are already covered by existing NATS integration tests in `crates/harnx-runtime/tests/nats_worker.rs`.

Issue: #919

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage for log mutation handling, including cases where edits or rewinds are safely skipped when required sequence points are missing or out of order.
  * Fixed a test scenario that previously didn’t exercise the intended skip path.

* **Tests**
  * Expanded and refined session reconstruction tests to better validate mutation behavior.

* **Documentation**
  * Added a guide explaining the corrected test scenario and the reasoning behind the updated skip-branch coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->