### PR TITLE
refactor(nats): low-priority cleanups (dedupe mutation, id helper, ca…

### DIFF
--- a/crates/harnx-core/src/session_reconstruct.rs
+++ b/crates/harnx-core/src/session_reconstruct.rs
@@ -319,22 +319,25 @@ pub fn reconstruct_state(entries: &[SessionLogEntry]) -> ReconstructedState {
 ///
 /// NATS sequences start at 1, not 0.
 pub fn reconstruct_state_from_nats(entries: &[(u64, SessionLogEntry)]) -> ReconstructedState {
-    let effective_entries_nats = match apply_log_mutations_nats(entries) {
-        Ok(entries) => entries,
+    // Convert u64 sequences to usize once upfront, avoiding the double round-trip
+    // through apply_log_mutations_nats (which would convert u64→usize→u64, then we'd
+    // convert back to usize for reconstruct_state_effective).
+    let raw_with_usize: Vec<_> = match entries
+        .iter()
+        .map(|(seq, entry)| {
+            usize::try_from(*seq)
+                .map(|s| (s, entry.clone()))
+                .map_err(|_| format!("JetStream seq {seq} does not fit into usize"))
+        })
+        .collect::<Result<_, _>>()
+    {
+        Ok(v) => v,
         Err(err) => {
-            log::warn!("failed to apply NATS log mutations during reconstruction: {err}");
+            log::warn!("failed to convert NATS sequences during reconstruction: {err}");
             return reconstruct_state_effective(&[]);
         }
     };
-    let effective_entries: Vec<_> = effective_entries_nats
-        .into_iter()
-        .map(|(seq, entry)| {
-            (
-                usize::try_from(seq).expect("JetStream seq fits usize"),
-                entry,
-            )
-        })
-        .collect();
+    let effective_entries = apply_log_mutations(&raw_with_usize);
     reconstruct_state_effective(&effective_entries)
 }
 

--- a/crates/harnx-runtime/src/config/remote_session_ops.rs
+++ b/crates/harnx-runtime/src/config/remote_session_ops.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::nats_client_session::{ThinClientConfig, ThinClientSession};
+use crate::nats_client_session::{new_client_message_id, ThinClientConfig, ThinClientSession};
 use crate::nats_session_log::NatsSessionLog;
 use crate::utils::{edit_file, temp_file, AbortSignal};
 use anyhow::{anyhow, bail, Context, Result};
@@ -124,7 +124,7 @@ fn build_edit_replacements(
 
 fn serialize_edited_user_entry(new_text: &str) -> Result<String> {
     let edited_entry = SessionLogEntry::Message {
-        id: Some(uuid::Uuid::new_v4().to_string()),
+        id: Some(new_client_message_id()),
         role: harnx_core::message::MessageRole::User,
         content: harnx_core::message::MessageContent::Text(new_text.to_string()),
         timestamp: None,

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -444,7 +444,8 @@ impl WorkerRuntime {
                 };
                 // Cursor: the log_seq of the last user message that kicked off this resumable turn.
                 // Any messages appended AFTER this (seq > cursor) will be folded mid-turn.
-                let seed_cursor = last_user_msg.and_then(|msg| msg.log_seq.map(|seq| seq as u64));
+                let seed_cursor = last_user_msg
+                    .and_then(|msg| msg.log_seq.and_then(|seq| u64::try_from(seq).ok()));
                 (input, seed_cursor)
             }
             harnx_core::session_reconstruct::TurnStatus::Idle => {
@@ -490,7 +491,7 @@ impl WorkerRuntime {
     ) -> (Input, Option<u64>) {
         let seed_cursor = next_turn_messages
             .last()
-            .and_then(|message| message.log_seq.map(|seq| seq as u64));
+            .and_then(|message| message.log_seq.and_then(|seq| u64::try_from(seq).ok()));
         let folded = next_turn_messages
             .into_iter()
             .map(|message| message.content.to_text())


### PR DESCRIPTION
…sts)

Removes a redundant u64↔usize round-trip in reconstruct_state_from_nats. Centralizes user-message ID generation via the new_client_message_id() helper in remote_session_ops.rs. Replaces unsafe sequence casts with u64::try_from(...).ok() in the NATS worker daemon.

The proposed caching of effective history per turn was intentionally deferred as it would require changing function signatures, exceeding the scope of this behavior-neutral cleanup.

#920
Plan: nats-cleanups-920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session recovery and message handling reliability by making sequence-number conversion safer.
  * Prevented invalid sequence values from causing incorrect session state or turn resumption behavior.
  * Updated edited message identifiers to use a more consistent client-generated format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->