### PR TITLE
fix: surface mid-stream streaming LLM errors instead of stopping silently

### DIFF
--- a/.changeset/fix-streaming-midstream-error-905.md
+++ b/.changeset/fix-streaming-midstream-error-905.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Fix silent stop with no output when a streaming LLM response returns a mid-stream error (issue #905).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,6 +3697,7 @@ dependencies = [
  "harnx-client",
  "harnx-core",
  "harnx-render",
+ "harnx-runtime",
  "parking_lot",
  "serde_json",
  "tokio",

--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -80,68 +80,72 @@ impl harnx_core::event::AgentEventSink for AcpChunkSink {
         // notification`). The parent's UI reconstructs source from the
         // chunk's `meta` (set by `spawn_notify_text` /
         // `spawn_notify_tool_call`) and renders the heading itself.
-        match event {
-            AgentEvent::Model(ModelEvent::MessageChunk { blocks }) => {
-                let text: String = blocks
-                    .iter()
-                    .filter_map(|b| match b {
-                        harnx_core::event::ContentBlock::Text(t) => Some(t.as_str()),
-                        _ => None,
-                    })
-                    .collect();
-                if !text.is_empty() {
-                    let _ = self.tx.send(AcpForward::Text(text, source));
-                }
-            }
-            AgentEvent::Model(ModelEvent::Final { output, .. }) if !output.is_empty() => {
-                let _ = self.tx.send(AcpForward::Text(output, source));
-            }
-            AgentEvent::User(UserEvent::Message { content }) if !content.is_empty() => {
-                let _ = self.tx.send(AcpForward::UserText(content, source));
-            }
-            AgentEvent::Tool(ToolEvent::Started {
-                id,
-                name,
-                input,
-                markdown,
-                ..
-            }) => {
-                let _ = self.tx.send(AcpForward::ToolCall {
-                    id,
-                    name,
-                    input,
-                    markdown,
-                    source,
-                });
-            }
-            AgentEvent::Tool(ToolEvent::Update {
-                id,
-                markdown,
-                status,
-                ..
-            }) => {
-                let _ = self.tx.send(AcpForward::ToolUpdate {
-                    id,
-                    markdown,
-                    status,
-                    source,
-                });
-            }
-            AgentEvent::Tool(ToolEvent::Completed {
-                id,
-                output,
-                markdown,
-                ..
-            }) => {
-                let _ = self.tx.send(AcpForward::ToolCompleted {
-                    id,
-                    output,
-                    markdown,
-                    source,
-                });
-            }
-            _ => {}
+        if let Some(forward) = event_to_forward(event, source) {
+            let _ = self.tx.send(forward);
         }
+    }
+}
+
+/// Map an `AgentEvent` to the `AcpForward` it should produce, or `None`
+/// when the event carries no forwardable payload (e.g. empty text). Kept
+/// as a free function so `AcpChunkSink::emit` stays a trivial dispatch.
+fn event_to_forward(event: AgentEvent, source: Option<AgentSource>) -> Option<AcpForward> {
+    match event {
+        AgentEvent::Model(ModelEvent::MessageChunk { blocks }) => {
+            let text: String = blocks
+                .iter()
+                .filter_map(|b| match b {
+                    harnx_core::event::ContentBlock::Text(t) => Some(t.as_str()),
+                    _ => None,
+                })
+                .collect();
+            (!text.is_empty()).then(|| AcpForward::Text(text, source))
+        }
+        AgentEvent::Model(ModelEvent::Final { output, .. }) if !output.is_empty() => {
+            Some(AcpForward::Text(output, source))
+        }
+        AgentEvent::Model(ModelEvent::Error(err)) if !err.is_empty() => {
+            Some(AcpForward::Text(format!("error: {err}"), source))
+        }
+        AgentEvent::User(UserEvent::Message { content }) if !content.is_empty() => {
+            Some(AcpForward::UserText(content, source))
+        }
+        AgentEvent::Tool(ToolEvent::Started {
+            id,
+            name,
+            input,
+            markdown,
+            ..
+        }) => Some(AcpForward::ToolCall {
+            id,
+            name,
+            input,
+            markdown,
+            source,
+        }),
+        AgentEvent::Tool(ToolEvent::Update {
+            id,
+            markdown,
+            status,
+            ..
+        }) => Some(AcpForward::ToolUpdate {
+            id,
+            markdown,
+            status,
+            source,
+        }),
+        AgentEvent::Tool(ToolEvent::Completed {
+            id,
+            output,
+            markdown,
+            ..
+        }) => Some(AcpForward::ToolCompleted {
+            id,
+            output,
+            markdown,
+            source,
+        }),
+        _ => None,
     }
 }
 

--- a/crates/harnx-acp-server/src/lib_tests.rs
+++ b/crates/harnx-acp-server/src/lib_tests.rs
@@ -406,6 +406,27 @@ mod tests {
     }
 
     #[test]
+    fn acp_chunk_sink_forwards_model_errors_as_visible_text() {
+        let (tx, mut rx) = unbounded_channel::<AcpForward>();
+        let sink = AcpChunkSink { tx };
+
+        sink.emit(
+            AgentEvent::Model(harnx_core::event::ModelEvent::Error(
+                "Internal server error".to_string(),
+            )),
+            None,
+        );
+
+        match rx.try_recv().expect("should forward error text") {
+            AcpForward::Text(text, source) => {
+                assert_eq!(text, "error: Internal server error");
+                assert!(source.is_none());
+            }
+            _ => panic!("expected Text forward"),
+        }
+    }
+
+    #[test]
     fn meta_from_source_includes_model_when_present() {
         use harnx_core::event::AgentSource;
 

--- a/crates/harnx-engine/Cargo.toml
+++ b/crates/harnx-engine/Cargo.toml
@@ -19,4 +19,5 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 
 [dev-dependencies]
+harnx-runtime = { path = "../harnx-runtime" }
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/harnx-engine/src/chat_completions.rs
+++ b/crates/harnx-engine/src/chat_completions.rs
@@ -5,43 +5,22 @@
 //! `Input + Config` to compute the echo text.
 
 use anyhow::{Context, Result};
-use harnx_client::{Client, ClientCallContext, SseHandler};
+use harnx_client::{
+    ChatCompletionsData, ChatCompletionsOutput, Client, ClientCallContext, CompletionTokenUsage,
+    SseHandler,
+};
 use harnx_core::abort::wait_abort_signal;
-use harnx_core::api_types::{ChatCompletionsData, ChatCompletionsOutput, CompletionTokenUsage};
 use harnx_core::event::{AgentEvent, ModelEvent};
 use harnx_core::sink::emit_agent_event;
 use harnx_core::text::{extract_code_block, strip_think_tag};
 use harnx_core::tool::ToolCall;
 use harnx_render::pretty_error_string;
 
-/// Non-streaming LLM call. Builds the `reqwest::Client`, invokes
-/// `Client::chat_completions_inner`, and wraps the error with a useful
-/// context string. Mirrors the original harnx `chat_completions_with_input`
-/// body minus the dry-run branch and the `ChatCompletionsData`
-/// construction — both of which stay on the harnx caller.
-pub async fn chat_completions_with_data(
-    client: &dyn Client,
-    data: ChatCompletionsData,
-    ctx: &ClientCallContext<'_>,
-) -> Result<ChatCompletionsOutput> {
-    let reqwest_client = client.build_client(ctx)?;
-    client
-        .chat_completions_inner(&reqwest_client, data)
-        .await
-        .with_context(|| {
-            format!(
-                "Failed to call chat-completions api (client: {}, model: {})",
-                client.name(),
-                client.model().id()
-            )
-        })
-}
-
-/// Streaming LLM call. Races the underlying streaming inner method
-/// against `wait_abort_signal`. On abort, notifies the handler via
-/// `handler.done()` and returns Ok — the abort-signal mechanism is
-/// how the caller communicates cancellation, so the streaming-side
-/// doesn't need to surface an error.
+/// Orchestrate one streaming chat-completions call, honouring the caller's abort signal.
+///
+/// This is the lowest-level transport wrapper used by both the engine and the TUI.
+/// It *only* runs the client's streaming API and turns transport-level aborts into
+/// `Ok(())`; higher layers decide how to interpret partial text/tool calls.
 pub async fn chat_completions_streaming_with_data(
     client: &dyn Client,
     data: ChatCompletionsData,
@@ -193,11 +172,192 @@ pub async fn run_chat_completion_streaming(
             emit_agent_event(AgentEvent::Model(ModelEvent::Error(pretty_error_string(
                 &err,
             ))));
-            if text.is_empty() {
+            if text.trim().is_empty() {
                 Err(err)
             } else {
                 Ok((text, thought, vec![], usage, false))
             }
         }
+    }
+}
+
+/// Non-streaming LLM call. Builds the `reqwest::Client`, invokes
+/// `Client::chat_completions_inner`, and wraps the error with a useful
+/// context string. Mirrors the original harnx `chat_completions_with_input`
+/// body minus the dry-run branch and the `ChatCompletionsData`
+/// construction — both of which stay on the harnx caller.
+pub async fn chat_completions_with_data(
+    client: &dyn Client,
+    data: ChatCompletionsData,
+    ctx: &ClientCallContext<'_>,
+) -> Result<ChatCompletionsOutput> {
+    let reqwest_client = client.build_client(ctx)?;
+    client
+        .chat_completions_inner(&reqwest_client, data)
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to call chat-completions api (client: {}, model: {})",
+                client.name(),
+                client.model().id()
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_chat_completion_streaming;
+    use harnx_client::{ChatCompletionsData, ClientCallContext, CompletionTokenUsage, SseHandler};
+    use harnx_core::abort::create_abort_signal;
+    use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource, ModelEvent};
+    use harnx_core::sink::{clear_agent_event_sink, install_agent_event_sink};
+    use harnx_runtime::test_utils::{MockClient, MockTurnBuilder};
+    use parking_lot::Mutex;
+    use std::sync::Arc;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    /// The agent event sink is process-global state. These tests
+    /// `clear_agent_event_sink` / `install_agent_event_sink`, so running two
+    /// of them in the same process in parallel would let them swap collectors
+    /// mid-flight. Acquire this guard for the full setup/call/cleanup window.
+    /// Mirrors `harnx-core`'s `sink` test module.
+    static SINK_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Ignore `PoisonError` so a panic in one test doesn't cascade-fail the
+    /// rest of the sink tests in this module.
+    fn lock_sink_tests() -> std::sync::MutexGuard<'static, ()> {
+        SINK_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    struct CollectingSink {
+        events: Mutex<Vec<AgentEvent>>,
+    }
+
+    impl CollectingSink {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                events: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn event_messages(&self) -> Vec<String> {
+            self.events
+                .lock()
+                .iter()
+                .filter_map(|event| match event {
+                    AgentEvent::Model(ModelEvent::Error(message)) => Some(message.clone()),
+                    _ => None,
+                })
+                .collect()
+        }
+    }
+
+    impl AgentEventSink for CollectingSink {
+        fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+            self.events.lock().push(event);
+        }
+    }
+
+    fn install_collecting_sink() -> Arc<CollectingSink> {
+        clear_agent_event_sink();
+        let sink = CollectingSink::new();
+        install_agent_event_sink(sink.clone());
+        sink
+    }
+
+    fn streaming_data() -> ChatCompletionsData {
+        ChatCompletionsData {
+            messages: Vec::new(),
+            temperature: None,
+            top_p: None,
+            functions: None,
+            stream: true,
+            attachments_dir: None,
+        }
+    }
+
+    fn sse_handler() -> SseHandler {
+        let (tx, _rx) = unbounded_channel();
+        SseHandler::new(tx, create_abort_signal())
+    }
+
+    fn stream_error() -> anyhow::Error {
+        anyhow::anyhow!("Internal server error (type: api_error)")
+    }
+
+    type StreamingResult = anyhow::Result<(
+        String,
+        Option<String>,
+        Vec<harnx_core::tool::ToolCall>,
+        CompletionTokenUsage,
+        bool,
+    )>;
+
+    /// Run `run_chat_completion_streaming` against a mock turn that streams
+    /// `text_chunk` (when `Some`) followed by a mid-stream error. Returns the
+    /// call result plus the error messages emitted to the agent-event sink so
+    /// each test can assert its own expectations.
+    async fn run_streaming_error_case(text_chunk: Option<&str>) -> (StreamingResult, Vec<String>) {
+        let sink = install_collecting_sink();
+        let mut turn = MockTurnBuilder::new();
+        if let Some(chunk) = text_chunk {
+            turn = turn.add_text_chunk(chunk);
+        }
+        let client = MockClient::builder()
+            .add_turn(turn.add_error(stream_error()).build())
+            .build();
+
+        let result = run_chat_completion_streaming(
+            &client,
+            streaming_data(),
+            &ClientCallContext {
+                user_agent: None,
+                dry_run: false,
+            },
+            sse_handler(),
+            create_abort_signal(),
+        )
+        .await;
+
+        let messages = sink.event_messages();
+        clear_agent_event_sink();
+        (result, messages)
+    }
+
+    /// Serialized, synchronous wrapper around `run_streaming_error_case`.
+    /// Holds the sink guard in sync context (never across an `.await`, which
+    /// would trip `clippy::await_holding_lock`) and drives the async body on a
+    /// fresh current-thread runtime.
+    fn run_streaming_error_case_serial(text_chunk: Option<&str>) -> (StreamingResult, Vec<String>) {
+        let _sink_guard = lock_sink_tests();
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build current-thread runtime")
+            .block_on(run_streaming_error_case(text_chunk))
+    }
+
+    #[test]
+    fn streaming_error_with_empty_text_returns_err() {
+        let (result, messages) = run_streaming_error_case_serial(None);
+        assert!(result.is_err());
+        assert_eq!(messages.len(), 1);
+    }
+
+    #[test]
+    fn streaming_error_with_whitespace_only_text_returns_err() {
+        let (result, messages) = run_streaming_error_case_serial(Some("\n"));
+        assert!(result.is_err());
+        assert_eq!(messages.len(), 1);
+    }
+
+    #[test]
+    fn streaming_error_with_partial_text_returns_ok_and_emits_error() {
+        let (result, messages) = run_streaming_error_case_serial(Some("partial"));
+        let output = result.expect("partial text should be returned");
+        assert_eq!(output.0, "partial");
+        assert!(output.2.is_empty());
+        assert_eq!(messages.len(), 1);
+        assert!(!messages[0].is_empty());
     }
 }

--- a/crates/harnx-runtime/src/test_utils/mock_client.rs
+++ b/crates/harnx-runtime/src/test_utils/mock_client.rs
@@ -265,6 +265,14 @@ impl MockTurnBuilder {
         self
     }
 
+    /// Add an error event to the response stream.
+    pub fn add_error(mut self, error: anyhow::Error) -> Self {
+        self.turn
+            .events
+            .push(MockResponseEvent::Error(Arc::new(error)));
+        self
+    }
+
     /// Add blocking gate to pause streaming until test releases it.
     pub fn add_gate(mut self, reached: Arc<Notify>, release: Arc<Notify>) -> Self {
         self.turn

--- a/crates/harnx-tui/src/prompt.rs
+++ b/crates/harnx-tui/src/prompt.rs
@@ -1,7 +1,10 @@
 use crate::types::Tui;
 use crate::types::{PendingMessage, TuiEvent};
 use anyhow::{Context, Result};
+use harnx_core::event::{AgentEvent, ModelEvent};
+use harnx_core::sink::emit_agent_event;
 use harnx_hooks::{AsyncHookManager, PersistentHookManager};
+use harnx_render::pretty_error_string;
 use harnx_runtime::client::CompletionTokenUsage;
 use harnx_runtime::config::{GlobalConfig, Input};
 use harnx_runtime::utils::AbortSignal;
@@ -279,9 +282,12 @@ impl Tui {
         match send_ret {
             Ok(_) => Ok((text, thought, tool_calls, usage)),
             Err(err) => {
-                if text.is_empty() {
+                if text.trim().is_empty() {
                     Err(err)
                 } else {
+                    emit_agent_event(AgentEvent::Model(ModelEvent::Error(pretty_error_string(
+                        &err,
+                    ))));
                     Ok((text, thought, vec![], usage))
                 }
             }

--- a/docs/solutions/logic-errors/streaming-midstream-error-visibility-2026-07-04.md
+++ b/docs/solutions/logic-errors/streaming-midstream-error-visibility-2026-07-04.md
@@ -1,0 +1,137 @@
+---
+title: "Fix silent stop on mid-stream streaming LLM error (issue #905)"
+date: 2026-07-04
+category: "logic-errors"
+problem_type: logic_error
+component: "streaming-event-handlers"
+root_cause: "multi-layer error swallowing"
+resolution_type: code_fix
+severity: high
+tags:
+  - streaming
+  - error-handling
+  - sse
+  - tui
+  - acp-server
+  - multi-layer
+plan_ref: "issue-905-stream-error-silent"
+---
+
+## Problem
+
+Mid-stream SSE `error` events from Anthropic Claude caused the harness spinner to stop silently—no error message rendered. Users couldn't tell what went wrong.
+
+## Symptoms
+
+- Behavior: Spinner stopped, no output, no error message
+- Trigger: Claude API returns `{"type":"error","error":{"type":"api_error","message":"Internal server error"}}` mid-stream
+- Frequency: Reproducible when provider returns error after partial text deltas
+
+## Investigation Steps
+
+1. Traced SSE error path: `claude.rs` "error" arm → `catch_error` → `Err(LlmError{status:500,...})`
+2. Error correctly propagates up as `Err`, but UI never showed it
+3. Audited each layer between source and sink:
+   - **TUI**: `crates/harnx-tui/src/prompt.rs:284-293` — on Err with non-empty `text` (including whitespace-only like `"\n"`), returned `Ok` and emitted NO `ModelEvent::Error`
+   - **Engine**: `crates/harnx-engine/src/chat_completions.rs:171-180` — used `text.is_empty()` for propagate-vs-swallow decision, inconsistent with non-streaming
+   - **ACP server**: `crates/harnx-acp-server/src/lib.rs` — `_ => {}` catch-all dropped `ModelEvent::Error` entirely
+4. Identified pattern: error returned correctly from transport, but **each layer independently swallowed or dropped it**
+
+## Root Cause
+
+Multi-layer error swallowing. The mid-stream error correctly became `Err(LlmError{...})` at the client layer, but three separate layers each independently lost it:
+
+1. **TUI streaming wrapper** (`prompt.rs`): `SseHandler::text` only skips truly-empty `""`, so a single whitespace delta before the error counted as "partial content" and triggered swallow-to-Ok without emitting error event.
+
+2. **Engine orchestrator** (`chat_completions.rs`): `text.is_empty()` treated whitespace-only as "has content", returning `Ok` instead of propagating `Err`.
+
+3. **ACP server sink** (`lib.rs`): wildcard match arm `_ => {}` dropped `ModelEvent::Error`, so ACP/headless sessions never surfaced streaming errors.
+
+## Solution
+
+### TUI (`crates/harnx-tui/src/prompt.rs`)
+
+```rust
+// Before: silent swallow
+Err(err) => {
+    if text.is_empty() {
+        Err(err)
+    } else {
+        Ok((text, ...))
+    }
+}
+
+// After: emit error event, use trim() for empty check
+Err(err) => {
+    if text.trim().is_empty() {
+        Err(err)
+    } else {
+        emit_agent_event(AgentEvent::Model(ModelEvent::Error(pretty_error_string(&err))));
+        Ok((text, ...))
+    }
+}
+```
+
+### Engine (`crates/harnx-engine/src/chat_completions.rs`)
+
+```rust
+// Before: whitespace-only counted as "has content"
+if text.is_empty() {
+
+// After: whitespace-only is "no meaningful output"
+if text.trim().is_empty() {
+```
+
+### ACP Server (`crates/harnx-acp-server/src/lib.rs`)
+
+Extracted match into pure function:
+
+```rust
+fn event_to_forward(event: AgentEvent, source: Option<AgentSource>) -> Option<AcpForward> {
+    match event {
+        AgentEvent::Model(ModelEvent::Error(err)) if !err.is_empty() => {
+            Some(AcpForward::Text(format!("error: {err}"), source))
+        }
+        // ... other arms
+    }
+}
+```
+
+Added explicit error arm (previously dropped by `_ => {}`).
+
+## Why This Works
+
+- **TUI**: Whitespace-only partial text no longer triggers silent success. Error event emitted before returning Ok, ensuring visibility.
+- **Engine**: `trim().is_empty()` consistent with non-streaming path semantics (propagate error when no meaningful output).
+- **ACP**: Structured error event now maps to visible text chunk instead of being dropped. Extracting match avoids cohesion/complexity threshold issues.
+
+Key insight: when an error must reach the user, audit **every layer** between source and sink—a correctly-returned `Err` can still be swallowed independently at multiple hops.
+
+## Prevention Strategies
+
+**Test Cases:**
+- `streaming_error_with_empty_text_returns_err` — empty partial → propagate Err
+- `streaming_error_with_whitespace_only_text_returns_err` — whitespace-only → propagate Err
+- `streaming_error_with_partial_text_returns_ok_and_emits_error` — partial text → Ok + error event
+- `acp_chunk_sink_forwards_model_errors_as_visible_text` — ACP forwards error
+
+**Best Practices:**
+- Partial-content heuristics for error surfacing should use `text.trim().is_empty()`, not `text.is_empty()`
+- Streaming and non-streaming paths should have consistent error-surfacing semantics
+- Audit all match arms that drop events (`_ => {}`) — ensure intentional, not oversight
+- When adding a new match arm, check CodeScene cohesion/complexity; extracting to a free function restores health
+
+**Code Review Checklist:**
+- [ ] Does error handling emit `ModelEvent::Error` before returning partial success?
+- [ ] Is the "empty text" check using `trim().is_empty()` for consistency?
+- [ ] Are there catch-all match arms dropping relevant events?
+- [ ] Do streaming and non-streaming paths handle errors consistently?
+
+**Known Follow-up (non-blocking):**
+Forwarding errors as ACP text chunks makes them visible but pollutes `response_text` for nested agents. A dedicated ACP error notification type would be cleaner but requires protocol change.
+
+## Related Issues
+
+- **GitHub Issue:** #905 — "Processing stops with no output on internal server error in streaming LLM response"
+- **Related Solution:** [logic-errors/streaming-whitespace-chunk-handling-2026-06-16.md](streaming-whitespace-chunk-handling-2026-06-16.md) — opposite pattern: when preserving whitespace-only chunks is correct
+- **Related Solution:** [logic-errors/streaming-final-deduplication-2026-06-09.md](streaming-final-deduplication-2026-06-09.md) — ACP chunk handling patterns


### PR DESCRIPTION
Streaming LLM api_error mid-stream events were swallowed/dropped at three layers (TUI wrapper, engine orchestrator run_chat_completion_streaming, and ACP server event sink), causing the spinner to stop with no message. This fix ensures mid-stream errors are emitted as ModelEvent::Error and forwarded correctly.

Key changes:
- In the engine orchestrator and TUI, use text.trim().is_empty() to treat whitespace-only partial text as empty, ensuring errors are surfaced even if some whitespace was emitted.
- If partial text was received before the error, the engine now returns the partial text and still emits the ModelEvent::Error event.
- The ACP server event sink now forwards ModelEvent::Error as visible text to clients via an extracted event_to_forward helper, rather than dropping them.
- Includes regression tests for engine and ACP server.
- Adds a changeset and solution documentation.

Closes #905
Issue: #905

Plan: issue-905-stream-error-silent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a case where mid-stream streaming errors could stop responses silently with no output.
  * Whitespace-only streamed text is now treated as empty, ensuring errors are correctly surfaced.
  * Streaming error details are now forwarded and displayed consistently across the UI and response pipeline (including partial-output scenarios).
* **New Features**
  * Improved user-visible handling of mid-stream error visibility for streamed replies.
* **Documentation**
  * Added a new guide documenting the mid-stream error visibility issue and the implemented fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->