### PR TITLE
feat(serve): implement AG-UI protocol server support

### DIFF
--- a/.changeset/ag-ui-server.md
+++ b/.changeset/ag-ui-server.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+Add AG-UI protocol server support to harnx-serve (content-negotiated /v1/agents tree with SSE run, session enumeration, history, and durable message ids).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ag-ui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfd1ace43da05cf4dc0ffeb6d55dc16003df69b9c6959f1ac1262611137c2e2"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
 name = "agent-client-protocol"
 version = "0.14.0"
 source = "git+https://github.com/agentclientprotocol/rust-sdk?rev=5ce2e5d40fac5bf2596dfba1b8e4d562defff177#5ce2e5d40fac5bf2596dfba1b8e4d562defff177"
@@ -178,7 +190,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -189,7 +201,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1898,7 +1910,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2066,7 +2078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4101,12 +4113,15 @@ dependencies = [
 name = "harnx-serve"
 version = "0.33.1"
 dependencies = [
+ "ag-ui-core",
  "anyhow",
  "bytes",
  "chrono",
  "clap",
+ "futures",
  "futures-util",
  "harnx-core",
+ "harnx-hooks",
  "harnx-rag",
  "harnx-render",
  "harnx-runtime",
@@ -4119,6 +4134,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-graceful",
  "tokio-stream",
@@ -4813,7 +4829,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5604,7 +5620,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5992,7 +6008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7105,7 +7121,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7173,7 +7189,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7578,6 +7594,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7786,7 +7808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8032,10 +8054,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8078,7 +8100,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook 0.3.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8749,6 +8771,8 @@ dependencies = [
  "atomic",
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -9119,7 +9143,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/harnx-core/src/input.rs
+++ b/crates/harnx-core/src/input.rs
@@ -48,6 +48,7 @@ pub struct Input {
     /// already present in the loaded `session.messages`, so the LLM still sees
     /// them; only the redundant durable append is suppressed.
     pub skip_user_log_append: bool,
+    pub preferred_assistant_message_id: Option<String>,
 }
 
 impl Input {
@@ -73,6 +74,7 @@ impl Input {
             inject_system_prompt: false,
             injected_user_text: None,
             skip_user_log_append: false,
+            preferred_assistant_message_id: None,
         }
     }
 
@@ -169,6 +171,14 @@ impl Input {
 
     pub fn with_session(&self) -> bool {
         self.with_session
+    }
+
+    pub fn set_preferred_assistant_message_id(&mut self, message_id: String) {
+        self.preferred_assistant_message_id = Some(message_id);
+    }
+
+    pub fn preferred_assistant_message_id(&self) -> Option<&str> {
+        self.preferred_assistant_message_id.as_deref()
     }
 
     pub fn with_agent(&self) -> bool {

--- a/crates/harnx-core/src/message.rs
+++ b/crates/harnx-core/src/message.rs
@@ -12,6 +12,11 @@ use crate::tool::ToolResult;
 pub struct Message {
     pub role: MessageRole,
     pub content: MessageContent,
+    /// Stable persisted message id from session log replay. `None` for
+    /// pre-P1.5 session entries or messages not yet persisted.
+    /// Never serialised — source of truth stays on `SessionLogEntry`.
+    #[serde(skip)]
+    pub id: Option<String>,
     /// 0-based index of the YAML document in the session log that produced
     /// this message. Set during log replay; `None` for messages created
     /// during a live session (before they are persisted and reloaded).
@@ -29,6 +34,7 @@ impl Default for Message {
         Self {
             role: MessageRole::User,
             content: MessageContent::Text(String::new()),
+            id: None,
             log_seq: None,
             log_timestamp: None,
         }
@@ -40,9 +46,15 @@ impl Message {
         Self {
             role,
             content,
+            id: None,
             log_seq: None,
             log_timestamp: None,
         }
+    }
+
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
     }
 
     pub fn with_log_seq(mut self, seq: usize) -> Self {

--- a/crates/harnx-core/src/session_reconstruct.rs
+++ b/crates/harnx-core/src/session_reconstruct.rs
@@ -538,6 +538,7 @@ impl ReplayAccumulator {
 
 fn cloned_message(entry: &SessionLogEntry) -> Option<Message> {
     let SessionLogEntry::Message {
+        id,
         role,
         content,
         timestamp,
@@ -550,6 +551,7 @@ fn cloned_message(entry: &SessionLogEntry) -> Option<Message> {
     Some(Message {
         role: *role,
         content: content.clone(),
+        id: id.clone(),
         log_seq: None,
         log_timestamp: *timestamp,
     })
@@ -1112,6 +1114,7 @@ mod tests {
     fn entry_as_message(entry: &SessionLogEntry) -> Message {
         match entry {
             SessionLogEntry::Message {
+                id,
                 role,
                 content,
                 timestamp,
@@ -1119,6 +1122,7 @@ mod tests {
             } => Message {
                 role: *role,
                 content: content.clone(),
+                id: id.clone(),
                 log_seq: None,
                 log_timestamp: *timestamp,
             },

--- a/crates/harnx-runtime/src/client/message.rs
+++ b/crates/harnx-runtime/src/client/message.rs
@@ -104,6 +104,7 @@ pub fn patch_messages(messages: &mut Vec<Message>, model: &Model) {
                 Message {
                     role: MessageRole::System,
                     content: prefix_content,
+                    id: None,
                     log_seq: None,
                     log_timestamp: None,
                 },

--- a/crates/harnx-runtime/src/config/compaction_tests.rs
+++ b/crates/harnx-runtime/src/config/compaction_tests.rs
@@ -246,6 +246,130 @@ async fn test_compact_session_package_bare_compaction_agent_resolves_within_pack
     );
 }
 
+#[tokio::test]
+async fn test_compaction_preserves_ids_for_preserved_suffix_messages() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let session_name = "suffix-id-preservation";
+    let session_path = temp.path().join(format!("{session_name}.yaml"));
+
+    let mut config = Config {
+        model: crate::client::Model::new("gemini", "gemini-3.1-flash-lite"),
+        data: ConfigData {
+            stream: false,
+            compress_threshold: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut session = self::session::new(&config, session_name).unwrap();
+    session.set_sessions_dir(temp.path().to_path_buf());
+    self::session::ensure_log_file(&mut session);
+
+    let mut file = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&session_path)
+        .unwrap();
+    for (role, text) in [
+        (MessageRole::User, "user turn 1"),
+        (MessageRole::Assistant, "assistant reply 1"),
+        (MessageRole::User, "user turn 2"),
+        (MessageRole::Assistant, "assistant reply 2"),
+        (MessageRole::User, "user turn 3"),
+        (MessageRole::Assistant, "assistant reply 3"),
+        (MessageRole::User, "user turn 4"),
+        (MessageRole::Assistant, "assistant reply 4"),
+    ] {
+        let id = uuid::Uuid::now_v7().to_string();
+        let entry = harnx_core::session::SessionLogEntry::Message {
+            id: Some(id.clone()),
+            role,
+            content: MessageContent::Text(text.to_string()),
+            timestamp: Some(chrono::Utc::now()),
+            fence_token: None,
+        };
+        writeln!(file, "---").unwrap();
+        write!(file, "{}", serde_yaml::to_string(&entry).unwrap()).unwrap();
+        let seq = session.next_seq();
+        session.messages.push(
+            Message::new(role, MessageContent::Text(text.to_string()))
+                .with_id(id.clone())
+                .with_log_seq(seq),
+        );
+    }
+
+    let preserved_suffix_before: Vec<(MessageRole, String, String)> = session
+        .messages
+        .iter()
+        .skip(6)
+        .map(|message| {
+            (
+                message.role,
+                message.content.to_text(),
+                message.id.clone().expect("persisted message id"),
+            )
+        })
+        .collect();
+    assert_eq!(
+        preserved_suffix_before.len(),
+        2,
+        "test setup must preserve exactly final turn as suffix"
+    );
+
+    config.session = Some(session);
+    let global_config = Arc::new(RwLock::new(config));
+    let (mock, _guard) = install_summarizer_mock().await;
+
+    Config::compact_session(&global_config).await.unwrap();
+
+    let history = mock.conversation_history();
+    assert_eq!(
+        history.conversation_history.len(),
+        1,
+        "expected one LLM call"
+    );
+
+    let reloaded =
+        super::session::load_from_log_for_test(&std::fs::read_to_string(&session_path).unwrap());
+
+    let preserved_suffix_after: Vec<(MessageRole, String, Option<String>)> = reloaded
+        .messages
+        .iter()
+        .rev()
+        .take(preserved_suffix_before.len())
+        .cloned()
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .map(|message| (message.role, message.content.to_text(), message.id.clone()))
+        .collect();
+
+    assert_eq!(
+        preserved_suffix_after.len(),
+        preserved_suffix_before.len(),
+        "reloaded session must keep preserved suffix length"
+    );
+
+    for ((before_role, before_text, before_id), (after_role, after_text, after_id)) in
+        preserved_suffix_before
+            .iter()
+            .zip(preserved_suffix_after.iter())
+    {
+        assert_eq!(
+            after_role, before_role,
+            "preserved suffix role changed across compaction"
+        );
+        assert_eq!(
+            after_text, before_text,
+            "preserved suffix text changed across compaction"
+        );
+        assert_eq!(
+            after_id.as_deref(),
+            Some(before_id.as_str()),
+            "preserved suffix message id changed across compaction"
+        );
+    }
+}
+
 /// compact_session must honor a non-default `compaction_keep_recent_turns`
 /// from the compaction agent's frontmatter: a smaller value keeps fewer recent
 /// turns verbatim and therefore compacts MORE of the conversation. With

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -4,6 +4,7 @@ use super::session_externalize::{
     record_externalized,
 };
 use super::*;
+use crate::nats_client_session::new_client_message_id;
 
 pub use harnx_core::session::{Session, SessionLogEntry};
 
@@ -214,6 +215,7 @@ pub(crate) fn replay_log_entries_for_external(
                 session.compaction_agent = compaction_agent;
             }
             SessionLogEntry::Message {
+                id,
                 role,
                 content,
                 timestamp,
@@ -230,6 +232,9 @@ pub(crate) fn replay_log_entries_for_external(
                     );
                 }
                 let mut message = Message::new(role, content).with_log_seq(seq);
+                if let Some(id) = id {
+                    message = message.with_id(id);
+                }
                 if let Some(timestamp) = timestamp {
                     message = message.with_log_timestamp(timestamp);
                 }
@@ -317,7 +322,7 @@ pub(crate) fn replay_log_entries_for_external(
 /// `super::load` performs, so it works against minimal `Config::default`
 /// used in unit tests.
 #[cfg(test)]
-fn load_from_log_for_test(content: &str) -> Session {
+pub(crate) fn load_from_log_for_test(content: &str) -> Session {
     let raw_entries = collect_raw_log_entries(content, "test").expect("valid log entries");
     let mut session =
         replay_log_entries_for_external(&raw_entries, "test").expect("replay should succeed");
@@ -351,7 +356,9 @@ fn repair_orphan_tool_calls(pending: PendingToolCalls, _name: &str) -> Result<Me
             ..lost.clone()
         })
         .collect();
-    let mut message = assemble_tool_message(text, thought, calls, results).with_log_seq(seq);
+    let mut message = assemble_tool_message(text, thought, calls, results)
+        .with_id(persisted_message_id())
+        .with_log_seq(seq);
     if let Some(timestamp) = timestamp {
         message = message.with_log_timestamp(timestamp);
     }
@@ -698,6 +705,10 @@ pub fn exit(session: &mut Session, session_dir: &Path, is_tui: bool) -> Result<(
 /// `tool_results` entry (the tool outputs), matching the format that
 /// `replay_log_entries` expects. All other messages are written as a
 /// single `message` entry.
+fn persisted_message_id() -> String {
+    new_client_message_id()
+}
+
 fn append_message_entries(content: &mut String, msg: &Message, session_id: &str) -> Result<()> {
     if msg.role == MessageRole::Tool {
         if let MessageContent::ToolCalls(tc) = &msg.content {
@@ -742,7 +753,7 @@ fn append_message_entries(content: &mut String, msg: &Message, session_id: &str)
     }
 
     let entry = SessionLogEntry::Message {
-        id: None,
+        id: msg.id.clone().or_else(|| Some(persisted_message_id())),
         role: msg.role,
         content: msg.content.clone(),
         timestamp: None,
@@ -921,6 +932,7 @@ pub fn compress_keeping_recent(session: &mut Session, mut prompt: String, keep_f
 /// event so the on-disk layout is self-describing (no stored index).
 fn relog_message(session: &mut Session, msg: &Message) -> usize {
     let seq = session.next_seq();
+    let message_id = msg.id.clone();
     if msg.role == MessageRole::Tool {
         if let MessageContent::ToolCalls(tc) = &msg.content {
             let calls: Vec<crate::tool::ToolCall> =
@@ -962,7 +974,7 @@ fn relog_message(session: &mut Session, msg: &Message) -> usize {
     if !append_event(
         session,
         &SessionLogEntry::Message {
-            id: None,
+            id: message_id,
             role: msg.role,
             content: msg.content.clone(),
             timestamp: msg.log_timestamp,
@@ -1006,13 +1018,18 @@ pub fn add_assistant_text(
         };
         let seq = session.next_seq();
         let timestamp = Utc::now();
+        let message_id = input
+            .preferred_assistant_message_id()
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(persisted_message_id);
         let assistant_msg = Message::new(MessageRole::Assistant, content)
+            .with_id(message_id.clone())
             .with_log_seq(seq)
             .with_log_timestamp(timestamp);
         all_appended &= append_event(
             session,
             &SessionLogEntry::Message {
-                id: None,
+                id: Some(message_id),
                 role: assistant_msg.role,
                 content: assistant_msg.content.clone(),
                 timestamp: Some(timestamp),
@@ -1049,6 +1066,7 @@ pub fn add_tool_calls(
     let calls = crate::tool::ToolCall::dedup(calls.to_vec());
     let mut all_appended = begin_turn(session, input, output)?;
     let tool_calls_seq = session.next_seq();
+    let tool_message_id = persisted_message_id();
     all_appended &= append_event(
         session,
         &SessionLogEntry::ToolCalls {
@@ -1083,9 +1101,11 @@ pub fn add_tool_calls(
         output.to_string(),
         thought.map(str::to_string),
     ));
-    session
-        .messages
-        .push(Message::new(MessageRole::Tool, content).with_log_seq(tool_calls_seq));
+    session.messages.push(
+        Message::new(MessageRole::Tool, content)
+            .with_id(tool_message_id)
+            .with_log_seq(tool_calls_seq),
+    );
     session.dirty = !all_appended;
     session.update_tokens();
     Ok(())
@@ -1287,13 +1307,17 @@ fn append_session_message(
     append_event(
         session,
         &SessionLogEntry::Message {
-            id: None,
+            id: Some(persisted_message_id()),
             role,
             content,
             timestamp: Some(Utc::now()),
             fence_token: None,
         },
     )
+}
+
+pub fn append_message(session: &mut Session, role: MessageRole, content: MessageContent) -> bool {
+    append_session_message(session, role, content)
 }
 
 pub fn clear_messages(session: &mut Session) {
@@ -2168,6 +2192,52 @@ prompt: summary
             .last()
             .expect("assistant message reloaded");
         assert!(last.log_timestamp.is_some());
+    }
+
+    #[test]
+    fn load_from_log_accepts_old_message_entries_without_ids() {
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("old-session.yaml");
+        let content = r#"---
+type: header
+model: openai:gpt-4o
+---
+type: message
+role: user
+content: legacy prompt
+---
+type: message
+role: assistant
+content: legacy reply
+"#;
+        std::fs::write(&path, content).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let loaded = load_from_log_for_test(&content);
+
+        assert_eq!(
+            loaded.messages.len(),
+            2,
+            "both legacy messages must reconstruct"
+        );
+        assert!(
+            loaded.messages.iter().all(|message| message.id.is_none()),
+            "pre-P1.5 messages without id fields must reconstruct with id == None"
+        );
+        assert_eq!(
+            loaded.messages[0].log_seq,
+            Some(1),
+            "legacy user message should still get seq fallback coordinate"
+        );
+        assert_eq!(
+            loaded.messages[1].log_seq,
+            Some(2),
+            "legacy assistant message should still get seq fallback coordinate"
+        );
+        assert_eq!(loaded.messages[0].content.to_text(), "legacy prompt");
+        assert_eq!(loaded.messages[1].content.to_text(), "legacy reply");
     }
 
     #[test]

--- a/crates/harnx-serve/Cargo.toml
+++ b/crates/harnx-serve/Cargo.toml
@@ -15,12 +15,14 @@ name = "harnx-serve"
 path = "src/bin/harnx-serve.rs"
 
 [dependencies]
+ag-ui-core = "=0.1.0"
 anyhow = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 futures-util = { workspace = true }
 harnx-core = { path = "../harnx-core" }
+harnx-hooks = { path = "../harnx-hooks" }
 harnx-rag = { path = "../harnx-rag" }
 harnx-render = { path = "../harnx-render" }
 harnx-runtime = { path = "../harnx-runtime" }
@@ -36,4 +38,8 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-graceful = { workspace = true }
 tokio-stream = { workspace = true }
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["v5"] }
+
+[dev-dependencies]
+futures = "0.3"
+tempfile = { workspace = true }

--- a/crates/harnx-serve/README.md
+++ b/crates/harnx-serve/README.md
@@ -22,3 +22,102 @@ cargo install --path crates/harnx-serve
 | `--model <MODEL>` | `-m` | Select a specific LLM model to use. |
 | `--dry-run` | | Echo prompts instead of sending them to the LLM. |
 | `--mcp-root <PATH>` | | Add one or more MCP roots (comma-separated). |
+
+## AG-UI (Agent User Interaction Protocol)
+
+`harnx-serve` implements the AG-UI protocol, providing a content-negotiated, permalinkable REST surface under `/v1/agents`. This API is additive; the standard OpenAI-compatible endpoints (`/v1/chat/completions`, etc.) remain unaffected.
+
+The AG-UI surface allows modern web interfaces (e.g., [assistant-ui](https://assistant-ui.com)) to interact with `harnx` agents using a stock `HttpAgent`.
+
+### Endpoints
+
+| Method | Path | Accept | Purpose |
+| :--- | :--- | :--- | :--- |
+| `GET` | `/v1/agents` | `application/json` | List all configured agents. |
+| `GET` | `/v1/agents/:agent` | `text/html` | HTML placeholder page for the agent. |
+| `GET` | `/v1/agents/:agent` | `application/json` | Agent details (name, description, active sessions). |
+| `GET` | `/v1/agents/:agent/sessions` | `application/json` | List sessions for the agent (filtered by `agent_name`). |
+| `GET` | `/v1/agents/:agent/sessions/:session` | `text/html` | HTML placeholder page for the session. |
+| `GET` | `/v1/agents/:agent/sessions/:session` | `application/json` | Session history in AG-UI format (array of `{ id, role, content }`). |
+| `POST` | `/v1/agents/:agent/sessions/:session` | `text/event-stream` | Execute an agent run via SSE. |
+
+### Key Behaviors
+
+- **Content Negotiation:** The same URL serves HTML (for browsers), JSON (for data), or SSE (for execution) based on the `Accept` header and HTTP method.
+- **Permalink Model:** The `:session` ID in the URL corresponds to the AG-UI `threadId`. Sessions are lazily created upon the first run to a new session ID.
+- **SSE Framing:** Each event is delivered as `data: {json}\n\n`. The event type is specified in the JSON `type` field.
+- **Server-Authoritative History:** While clients send the full message array on each run, the server reconciles history and persists only new user turns. Resuming a session continues context without duplicating messages.
+- **Single-Message Run Contract:** Phase 1 accepts exactly **one** new user message per run. 
+  - If the sent array contains NO new messages (exact resend) → returns **400 Bad Request**.
+  - If it contains MORE THAN ONE new message → returns **400 Bad Request**.
+  - This matches standard `assistant-ui` `HttpAgent` behavior (full history + one new turn).
+
+#### P1 Event Set
+The following events are supported in the initial implementation:
+1. `RUN_STARTED`
+2. `TEXT_MESSAGE_START`
+3. `TEXT_MESSAGE_CONTENT` (streamed)
+4. `TEXT_MESSAGE_END`
+5. `RUN_FINISHED` (Successful completion)
+6. `RUN_ERROR` (Terminal failure; replaces `RUN_FINISHED`). On error, the stream terminates immediately without emitting `TEXT_MESSAGE_END` or `RUN_FINISHED`. Clients should treat `RUN_ERROR` as the end of the run and the current message.
+
+### Operational Notes
+
+- **Persistence and `--dry-run`:** Session persistence is skipped in `--dry-run` mode. To enable session enumeration, history, and resumption, run the server without the `--dry-run` flag.
+- **Consistency Barrier:** History and enumeration reflect a run only AFTER the SSE stream reaches `RUN_FINISHED`. The turn is persisted as it completes.
+
+### Quickstart
+
+1. **Start the server:**
+   ```sh
+   harnx-serve --addr 127.0.0.1:8000
+   ```
+   *Note: Do not use `--dry-run` if you want sessions to persist.*
+
+2. **Execute a run via `curl`:**
+   ```bash
+   curl -N -X POST http://127.0.0.1:8000/v1/agents/my-agent/sessions/my-session \
+     -H "Accept: text/event-stream" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "threadId": "my-session",
+       "messages": [
+         { "role": "user", "content": "hello" }
+       ]
+     }'
+   ```
+
+3. **Expected SSE Output:**
+   ```text
+   data: {"type":"RUN_STARTED","threadId":"my-session","runId":"..."}
+
+   data: {"type":"TEXT_MESSAGE_START","messageId":"<uuid>","role":"assistant"}
+
+   data: {"type":"TEXT_MESSAGE_CONTENT","messageId":"<uuid>","delta":"Hello"}
+
+   data: {"type":"TEXT_MESSAGE_END","messageId":"<uuid>"}
+
+   data: {"type":"RUN_FINISHED","threadId":"my-session","runId":"..."}
+   ```
+
+   The assistant `messageId` in the SSE stream is a durable UUID. This `messageId` 
+   matches the `id` returned by the history endpoint for that message and is 
+   stable across session reloads and history compaction (enabling permalinks).
+
+4. **Configure an AG-UI `HttpAgent` (JS):**
+   ```javascript
+   const agent = new HttpAgent({
+     url: "http://localhost:8000/v1/agents/my-agent/sessions/my-session"
+   });
+   ```
+
+### Roadmap
+
+The following features are included in this release (Phase 1 + 1.5):
+- **P1:** Text streaming, content negotiation, session enumeration, and history.
+- **P1.5:** Durable per-message UUIDs (stable message IDs across compaction/reloads).
+
+The following features are planned for future phases:
+- **P2:** Tool and reasoning events.
+- **P3:** NATS-backed sessions and shared state.
+- **P4:** Full `assistant-ui` frontend integration (replacing HTML placeholders).

--- a/crates/harnx-serve/README.md
+++ b/crates/harnx-serve/README.md
@@ -44,7 +44,7 @@ The AG-UI surface allows modern web interfaces (e.g., [assistant-ui](https://ass
 ### Key Behaviors
 
 - **Content Negotiation:** The same URL serves HTML (for browsers), JSON (for data), or SSE (for execution) based on the `Accept` header and HTTP method.
-- **Permalink Model:** The `:session` ID in the URL corresponds to the AG-UI `threadId`. Sessions are lazily created upon the first run to a new session ID.
+- **Permalink Model:** The `:session` ID in the URL is the stable session key from which the AG-UI `threadId` is derived. If the session ID is already a UUID, the `threadId` is identical; otherwise, it is a stable UUIDv5 hash of the slug. Sessions are lazily created upon the first run to a new session ID.
 - **SSE Framing:** Each event is delivered as `data: {json}\n\n`. The event type is specified in the JSON `type` field.
 - **Server-Authoritative History:** While clients send the full message array on each run, the server reconciles history and persists only new user turns. Resuming a session continues context without duplicating messages.
 - **Single-Message Run Contract:** Phase 1 accepts exactly **one** new user message per run. 
@@ -80,16 +80,17 @@ The following events are supported in the initial implementation:
      -H "Accept: text/event-stream" \
      -H "Content-Type: application/json" \
      -d '{
-       "threadId": "my-session",
+       "threadId": "<derived-thread-id>",
        "messages": [
          { "role": "user", "content": "hello" }
        ]
      }'
    ```
+   *Note: When the session ID (e.g., `my-session`) is not a UUID, the wire `threadId` is a derived UUID, not the literal slug.*
 
 3. **Expected SSE Output:**
    ```text
-   data: {"type":"RUN_STARTED","threadId":"my-session","runId":"..."}
+   data: {"type":"RUN_STARTED","threadId":"<derived-thread-id>","runId":"..."}
 
    data: {"type":"TEXT_MESSAGE_START","messageId":"<uuid>","role":"assistant"}
 
@@ -97,7 +98,7 @@ The following events are supported in the initial implementation:
 
    data: {"type":"TEXT_MESSAGE_END","messageId":"<uuid>"}
 
-   data: {"type":"RUN_FINISHED","threadId":"my-session","runId":"..."}
+   data: {"type":"RUN_FINISHED","threadId":"<derived-thread-id>","runId":"..."}
    ```
 
    The assistant `messageId` in the SSE stream is a durable UUID. This `messageId` 

--- a/crates/harnx-serve/src/ag_ui.rs
+++ b/crates/harnx-serve/src/ag_ui.rs
@@ -1,0 +1,1686 @@
+#![allow(dead_code)]
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use ag_ui_core::{
+    event::{
+        BaseEvent, Event, RunErrorEvent, RunFinishedEvent, RunStartedEvent,
+        TextMessageContentEvent, TextMessageEndEvent, TextMessageStartEvent,
+    },
+    types::{
+        ids::{MessageId, RunId, ThreadId},
+        input::RunAgentInput,
+        message::{Message as AgUiMessage, Role},
+    },
+    JsonValue,
+};
+use bytes::Bytes;
+use harnx_core::{
+    abort::create_abort_signal,
+    agent_config::AgentConfig,
+    event::{AgentEvent, AgentSource, ContentBlock, ModelEvent, NoticeEvent},
+    message::{Message as HistoryMsg, MessageContent, MessageRole},
+    sink::with_agent_event_sink,
+};
+use harnx_hooks::{AsyncHookManager, PersistentHookManager};
+use harnx_runtime::{
+    config::{input, Agent, Config, GlobalConfig},
+    run_agent_loop, AgentCallFn, AgentLoopContext,
+};
+use http::{Response, StatusCode};
+use http_body_util::{combinators::BoxBody, BodyExt, StreamBody};
+use hyper::body::Frame;
+use parking_lot::RwLock;
+use tokio::sync::mpsc::{self, UnboundedSender};
+use tokio_stream::{wrappers::UnboundedReceiverStream, StreamExt};
+use uuid::Uuid;
+
+const THREAD_ID_NAMESPACE: Uuid = Uuid::from_u128(0x9f1f_5b4f_8080_4c1a_9544_1ce1_4b63_1a2f);
+
+pub type AppResponse = Response<BoxBody<Bytes, Infallible>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgUiError {
+    BadRequest(String),
+    NotFound(String),
+    Internal(String),
+}
+
+impl AgUiError {
+    pub fn status_code(&self) -> StatusCode {
+        match self {
+            Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+            Self::NotFound(_) => StatusCode::NOT_FOUND,
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+impl std::fmt::Display for AgUiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadRequest(msg) | Self::NotFound(msg) | Self::Internal(msg) => f.write_str(msg),
+        }
+    }
+}
+
+impl std::error::Error for AgUiError {}
+
+/// Sink that maps harnx `AgentEvent`s to ag-ui-core `Event`s.
+///
+/// Phase-1 mapping: text message content and errors only.
+/// Lifecycle events (RUN_STARTED, TEXT_MESSAGE_START, etc.) are handled by caller.
+pub struct AgUiSink {
+    tx: UnboundedSender<Event>,
+    message_id: MessageId,
+}
+
+impl AgUiSink {
+    pub fn new(tx: UnboundedSender<Event>, message_id: MessageId) -> Self {
+        Self { tx, message_id }
+    }
+}
+
+impl harnx_core::event::AgentEventSink for AgUiSink {
+    fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+        match event {
+            AgentEvent::Model(ModelEvent::MessageChunk { blocks }) => {
+                let delta: String = blocks
+                    .iter()
+                    .filter_map(|b| match b {
+                        ContentBlock::Text(t) => Some(t.as_str()),
+                        _ => None,
+                    })
+                    .collect();
+                if !delta.is_empty() {
+                    let _ = self
+                        .tx
+                        .send(Event::TextMessageContent(TextMessageContentEvent {
+                            base: BaseEvent {
+                                timestamp: None,
+                                raw_event: None,
+                            },
+                            message_id: self.message_id.clone(),
+                            delta,
+                        }));
+                }
+            }
+            AgentEvent::Model(ModelEvent::Final { output, .. }) if !output.is_empty() => {
+                let _ = self
+                    .tx
+                    .send(Event::TextMessageContent(TextMessageContentEvent {
+                        base: BaseEvent {
+                            timestamp: None,
+                            raw_event: None,
+                        },
+                        message_id: self.message_id.clone(),
+                        delta: output,
+                    }));
+            }
+            AgentEvent::Model(ModelEvent::Error(message))
+            | AgentEvent::Notice(NoticeEvent::Error(message)) => {
+                let _ = self.tx.send(Event::RunError(RunErrorEvent {
+                    base: BaseEvent {
+                        timestamp: None,
+                        raw_event: None,
+                    },
+                    message,
+                    code: None,
+                }));
+            }
+            AgentEvent::Model(ModelEvent::ThoughtChunk { .. }) => {}
+            _ => {}
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NewMsg {
+    pub role: Role,
+    pub content: String,
+}
+
+pub fn frame_event(event: &Event) -> Result<String, AgUiError> {
+    let json = serde_json::to_string(event)
+        .map_err(|err| AgUiError::Internal(format!("failed to serialize AG-UI event: {err}")))?;
+    Ok(format!("data: {json}\n\n"))
+}
+
+pub fn parse_run_input(body: &[u8]) -> Result<RunAgentInput<JsonValue, JsonValue>, AgUiError> {
+    // Parse into a generic JSON value first to inject defaults for optional envelope fields.
+    // ag-ui-core's RunAgentInput requires state/tools/context/forwardedProps, but per plan
+    // guardrails only `messages` is truly required — others should default if omitted.
+    let mut value: serde_json::Value = serde_json::from_slice(body)
+        .map_err(|err| AgUiError::BadRequest(format!("invalid AG-UI request body: {err}")))?;
+
+    // Inject defaults for optional envelope fields if missing.
+    if let Some(obj) = value.as_object_mut() {
+        if !obj.contains_key("state") {
+            obj.insert("state".to_string(), serde_json::json!({}));
+        }
+        if !obj.contains_key("tools") {
+            obj.insert("tools".to_string(), serde_json::json!([]));
+        }
+        if !obj.contains_key("context") {
+            obj.insert("context".to_string(), serde_json::json!([]));
+        }
+        if !obj.contains_key("forwardedProps") {
+            obj.insert("forwardedProps".to_string(), serde_json::json!({}));
+        }
+    }
+
+    let input: RunAgentInput<JsonValue, JsonValue> = serde_json::from_value(value)
+        .map_err(|err| AgUiError::BadRequest(format!("invalid AG-UI request body: {err}")))?;
+    if input.messages.is_empty() {
+        return Err(AgUiError::BadRequest(
+            "AG-UI request must include at least one message".to_string(),
+        ));
+    }
+    Ok(input)
+}
+
+pub fn resolve_agent(config: &Config, name: &str) -> Result<AgentConfig, AgUiError> {
+    config
+        .retrieve_agent(name)
+        .map(Agent::into_config)
+        .map_err(|_| AgUiError::NotFound(format!("agent '{name}' not found")))
+}
+
+pub fn reconcile_new_messages(
+    persisted: &[HistoryMsg],
+    client_msgs: &[AgUiMessage],
+) -> Vec<NewMsg> {
+    let matched = client_msgs
+        .iter()
+        .zip(persisted.iter())
+        .take_while(|(client, history)| client_matches_history(client, history))
+        .count();
+
+    client_msgs[matched..]
+        .iter()
+        .filter_map(as_new_msg)
+        .collect()
+}
+pub fn derive_thread_id(session_id: &str) -> ThreadId {
+    let uuid = Uuid::parse_str(session_id)
+        .unwrap_or_else(|_| Uuid::new_v5(&THREAD_ID_NAMESPACE, session_id.as_bytes()));
+    ThreadId::from(uuid)
+}
+
+pub fn run_id_from_input(input: &RunAgentInput<JsonValue, JsonValue>) -> RunId {
+    input.run_id.clone()
+}
+
+pub fn fork_prompt_config(base: &Config) -> GlobalConfig {
+    Arc::new(RwLock::new(base.fork_session_scope()))
+}
+
+pub fn build_local_input(
+    prompt_config: &GlobalConfig,
+    agent_name: &str,
+    _session_key: &str,
+    prompt_text: &str,
+) -> Result<harnx_runtime::config::Input, AgUiError> {
+    let mut agent = prompt_config
+        .read()
+        .retrieve_agent(agent_name)
+        .map_err(|e| AgUiError::Internal(format!("failed to retrieve agent: {e}")))?;
+    if let Err(e) = harnx_runtime::config::agent::resolve_variables(&mut agent) {
+        log::warn!("Failed to resolve variables for agent '{agent_name}': {e}");
+    }
+
+    let mut input = input::from_str(prompt_config, prompt_text, None);
+    input::set_agent(&mut input, prompt_config, agent.into_config());
+    Ok(input)
+}
+
+pub fn build_loop_ctx(
+    prompt_config: GlobalConfig,
+    call_fn: Option<AgentCallFn>,
+) -> AgentLoopContext {
+    AgentLoopContext {
+        config: prompt_config,
+        abort_signal: create_abort_signal(),
+        async_manager: Arc::new(tokio::sync::Mutex::new(AsyncHookManager::default())),
+        persistent_manager: Arc::new(tokio::sync::Mutex::new(PersistentHookManager::default())),
+        call_fn,
+        on_tool_round: None,
+        on_text_response: None,
+        initial_with_embeddings: true,
+        initial_resume_count: 0,
+        max_resume: None,
+        pending_async_context: None,
+    }
+}
+
+pub async fn ag_ui_run_with_call_fn(
+    base_config: &Config,
+    agent: &str,
+    session: &str,
+    req_body: &[u8],
+    call_fn: Option<AgentCallFn>,
+) -> Result<AppResponse, AgUiError> {
+    let run_input = parse_run_input(req_body)?;
+    resolve_agent(base_config, agent)?;
+
+    let prompt_config = fork_prompt_config(base_config);
+    {
+        let mut config = prompt_config.write();
+        config
+            .use_agent_by_name(agent)
+            .map_err(|e| AgUiError::Internal(format!("failed to set agent: {e}")))?;
+        config
+            .use_session(Some(session))
+            .map_err(|e| AgUiError::Internal(format!("failed to use session: {e}")))?;
+    }
+    let persisted_history = prompt_config
+        .read()
+        .session
+        .as_ref()
+        .map(|session| {
+            session
+                .messages
+                .iter()
+                .filter(|msg| msg.role.is_user() || msg.role.is_assistant())
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let new_messages = reconcile_new_messages(&persisted_history, &run_input.messages);
+    if new_messages.is_empty() {
+        return Err(AgUiError::BadRequest(
+            "no new user message; session already up to date".to_string(),
+        ));
+    }
+    let assistant_replays = new_messages
+        .iter()
+        .take_while(|message| message.role == Role::Assistant)
+        .count();
+    let new_user_messages = new_messages[assistant_replays..]
+        .iter()
+        .filter(|message| message.role == Role::User)
+        .count();
+    if new_user_messages > 1 {
+        return Err(AgUiError::BadRequest(
+            "multiple new messages are not supported in Phase 1; send exactly one new user message per run"
+                .to_string(),
+        ));
+    }
+    let new_message = new_messages[assistant_replays..]
+        .iter()
+        .find(|message| message.role == Role::User)
+        .ok_or_else(|| {
+            AgUiError::BadRequest("the new message must be a user message".to_string())
+        })?;
+    let prompt_text = new_message.content.clone();
+
+    let message_id = MessageId::random();
+    let mut input = build_local_input(&prompt_config, agent, session, &prompt_text)?;
+    input.set_preferred_assistant_message_id(message_id.to_string());
+    let thread_id = derive_thread_id(session);
+    let run_id = run_id_from_input(&run_input);
+
+    let (evt_tx, evt_rx) = mpsc::unbounded_channel::<Event>();
+    let sink = Arc::new(AgUiSink::new(evt_tx.clone(), message_id.clone()));
+
+    evt_tx
+        .send(Event::RunStarted(RunStartedEvent {
+            base: BaseEvent {
+                timestamp: None,
+                raw_event: None,
+            },
+            thread_id: thread_id.clone(),
+            run_id: run_id.clone(),
+        }))
+        .map_err(|err| AgUiError::Internal(format!("failed to queue RUN_STARTED event: {err}")))?;
+    evt_tx
+        .send(Event::TextMessageStart(TextMessageStartEvent {
+            base: BaseEvent {
+                timestamp: None,
+                raw_event: None,
+            },
+            message_id: message_id.clone(),
+            role: Role::Assistant,
+        }))
+        .map_err(|err| {
+            AgUiError::Internal(format!("failed to queue TEXT_MESSAGE_START event: {err}"))
+        })?;
+
+    let loop_ctx = build_loop_ctx(prompt_config, call_fn);
+    let done_tx = evt_tx.clone();
+    tokio::spawn(async move {
+        let loop_result = with_agent_event_sink(sink, async {
+            Box::pin(run_agent_loop(&loop_ctx, input)).await
+        })
+        .await;
+
+        match loop_result {
+            Ok(()) => {
+                let _ = done_tx.send(Event::TextMessageEnd(TextMessageEndEvent {
+                    base: BaseEvent {
+                        timestamp: None,
+                        raw_event: None,
+                    },
+                    message_id,
+                }));
+                let _ = done_tx.send(Event::RunFinished(RunFinishedEvent {
+                    base: BaseEvent {
+                        timestamp: None,
+                        raw_event: None,
+                    },
+                    thread_id,
+                    run_id,
+                    result: None,
+                }));
+            }
+            Err(err) => {
+                let _ = done_tx.send(Event::RunError(RunErrorEvent {
+                    base: BaseEvent {
+                        timestamp: None,
+                        raw_event: None,
+                    },
+                    message: err.to_string(),
+                    code: None,
+                }));
+            }
+        }
+    });
+    drop(evt_tx);
+
+    let stream = UnboundedReceiverStream::new(evt_rx).map(|event| {
+        let frame = frame_event(&event).expect("AG-UI event framing should serialize");
+        Ok::<_, Infallible>(Frame::data(Bytes::from(frame)))
+    });
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "text/event-stream")
+        .body(BodyExt::boxed(StreamBody::new(stream)))
+        .map_err(|err| AgUiError::Internal(format!("failed to build AG-UI response: {err}")))
+}
+
+fn client_matches_history(client: &AgUiMessage, history: &HistoryMsg) -> bool {
+    client_role(client) == ag_ui_role_for_history(history.role)
+        && normalize_visible_text(&client_content(client).unwrap_or_default())
+            == normalize_visible_text(&history_content_text(&history.content))
+}
+
+fn normalize_visible_text(text: &str) -> String {
+    let trimmed = text.trim();
+    if let Some(stripped) = trimmed
+        .strip_prefix("<think>")
+        .and_then(|rest| rest.strip_suffix("</think>"))
+    {
+        stripped.trim().to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn ag_ui_role_for_history(role: MessageRole) -> Role {
+    match role {
+        MessageRole::System => Role::System,
+        MessageRole::Assistant => Role::Assistant,
+        MessageRole::User => Role::User,
+        MessageRole::Tool => Role::Tool,
+    }
+}
+
+fn as_new_msg(message: &AgUiMessage) -> Option<NewMsg> {
+    let role = client_role(message);
+    let content = client_content(message)?;
+    Some(NewMsg { role, content })
+}
+
+fn client_role(message: &AgUiMessage) -> Role {
+    match message {
+        AgUiMessage::Developer { .. } => Role::Developer,
+        AgUiMessage::System { .. } => Role::System,
+        AgUiMessage::Assistant { .. } => Role::Assistant,
+        AgUiMessage::User { .. } => Role::User,
+        AgUiMessage::Tool { .. } => Role::Tool,
+    }
+}
+
+fn client_content(message: &AgUiMessage) -> Option<String> {
+    match message {
+        AgUiMessage::Developer { content, .. }
+        | AgUiMessage::System { content, .. }
+        | AgUiMessage::User { content, .. }
+        | AgUiMessage::Tool { content, .. } => Some(content.clone()),
+        AgUiMessage::Assistant { content, .. } => content.clone(),
+    }
+}
+
+fn history_content_text(content: &MessageContent) -> String {
+    content.to_text()
+}
+
+fn history_role_for_client(role: &Role) -> MessageRole {
+    match role {
+        Role::Developer | Role::System => MessageRole::System,
+        Role::Assistant => MessageRole::Assistant,
+        Role::User => MessageRole::User,
+        Role::Tool => MessageRole::Tool,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::anyhow;
+    use harnx_core::{
+        api_types::CompletionTokenUsage,
+        event::{AgentEventSink, ModelEvent},
+    };
+    use harnx_runtime::{
+        client::ToolCall,
+        config::{Config, WorkingMode},
+    };
+    use http_body_util::BodyExt;
+    use serde_json::{json, Value};
+    use std::{
+        fs,
+        path::PathBuf,
+        sync::{LazyLock, Mutex},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    #[test]
+    fn ag_ui_sink_emits_text_message_content_for_chunk() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let message_id =
+            MessageId::from(uuid::Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap());
+        let sink = super::AgUiSink::new(tx, message_id.clone());
+
+        sink.emit(
+            AgentEvent::Model(ModelEvent::MessageChunk {
+                blocks: vec![ContentBlock::Text("hello".to_string())],
+            }),
+            None,
+        );
+
+        let event = rx.try_recv().expect("should receive event");
+        match event {
+            Event::TextMessageContent(TextMessageContentEvent {
+                base,
+                message_id: mid,
+                delta,
+            }) => {
+                assert_eq!(base.timestamp, None);
+                assert_eq!(base.raw_event, None);
+                assert_eq!(mid, message_id);
+                assert_eq!(delta, "hello");
+            }
+            _ => panic!("expected TextMessageContent event, got: {:?}", event),
+        }
+
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn ag_ui_sink_skips_empty_chunk() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let message_id = MessageId::from(uuid::Uuid::new_v4());
+        let sink = super::AgUiSink::new(tx, message_id);
+
+        sink.emit(
+            AgentEvent::Model(ModelEvent::MessageChunk { blocks: vec![] }),
+            None,
+        );
+        assert!(rx.try_recv().is_err());
+
+        sink.emit(
+            AgentEvent::Model(ModelEvent::MessageChunk {
+                blocks: vec![ContentBlock::Image {
+                    data: vec![],
+                    mime: "image/png".to_string(),
+                }],
+            }),
+            None,
+        );
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn ag_ui_sink_emits_run_error_for_model_error() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let message_id = MessageId::from(uuid::Uuid::new_v4());
+        let sink = super::AgUiSink::new(tx, message_id);
+
+        sink.emit(
+            AgentEvent::Model(ModelEvent::Error("boom".to_string())),
+            None,
+        );
+
+        let event = rx.try_recv().expect("should receive event");
+        match event {
+            Event::RunError(RunErrorEvent {
+                base,
+                message,
+                code,
+            }) => {
+                assert_eq!(base.timestamp, None);
+                assert_eq!(base.raw_event, None);
+                assert_eq!(message, "boom");
+                assert!(code.is_none());
+            }
+            _ => panic!("expected RunError event, got: {:?}", event),
+        }
+    }
+
+    #[test]
+    fn ag_ui_sink_emits_run_error_for_notice_error() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let message_id = MessageId::from(uuid::Uuid::new_v4());
+        let sink = super::AgUiSink::new(tx, message_id);
+
+        sink.emit(
+            AgentEvent::Notice(NoticeEvent::Error("fatal error".to_string())),
+            None,
+        );
+
+        let event = rx.try_recv().expect("should receive event");
+        match event {
+            Event::RunError(RunErrorEvent { message, .. }) => {
+                assert_eq!(message, "fatal error");
+            }
+            _ => panic!("expected RunError event, got: {:?}", event),
+        }
+    }
+
+    #[test]
+    fn ag_ui_sink_emits_final_as_content_when_non_empty() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let message_id = MessageId::from(uuid::Uuid::new_v4());
+        let sink = super::AgUiSink::new(tx, message_id.clone());
+
+        let usage = CompletionTokenUsage::new(Some(10), Some(5), Some(0));
+        sink.emit(
+            AgentEvent::Model(ModelEvent::Final {
+                output: "final text".to_string(),
+                usage,
+            }),
+            None,
+        );
+
+        let event = rx.try_recv().expect("should receive event");
+        match event {
+            Event::TextMessageContent(TextMessageContentEvent {
+                base,
+                message_id: mid,
+                delta,
+            }) => {
+                assert_eq!(mid, message_id);
+                assert_eq!(delta, "final text");
+                assert_eq!(base.timestamp, None);
+            }
+            _ => panic!("expected TextMessageContent event, got: {:?}", event),
+        }
+    }
+
+    #[test]
+    fn ag_ui_sink_skips_final_when_empty() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let message_id = MessageId::from(uuid::Uuid::new_v4());
+        let sink = super::AgUiSink::new(tx, message_id);
+
+        let usage = CompletionTokenUsage::new(Some(10), Some(5), Some(0));
+        sink.emit(
+            AgentEvent::Model(ModelEvent::Final {
+                output: String::new(),
+                usage,
+            }),
+            None,
+        );
+
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn ag_ui_sink_drops_thought_chunk() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let message_id = MessageId::from(uuid::Uuid::new_v4());
+        let sink = super::AgUiSink::new(tx, message_id);
+
+        sink.emit(
+            AgentEvent::Model(ModelEvent::ThoughtChunk {
+                blocks: vec![ContentBlock::Text("thinking...".to_string())],
+            }),
+            None,
+        );
+
+        assert!(
+            rx.try_recv().is_err(),
+            "ThoughtChunk should be dropped in Phase-1"
+        );
+    }
+
+    #[test]
+    fn frame_event_uses_data_only_sse_format() {
+        let event: Event = Event::RunStarted(RunStartedEvent {
+            base: BaseEvent {
+                timestamp: None,
+                raw_event: None,
+            },
+            thread_id: ThreadId::from(
+                Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap(),
+            ),
+            run_id: RunId::from(Uuid::parse_str("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb").unwrap()),
+        });
+
+        let framed = frame_event(&event).expect("frame should serialize");
+        assert!(framed.starts_with("data: {\"type\":\"RUN_STARTED\""));
+        assert!(framed.ends_with("\n\n"));
+        assert!(!framed.contains("event:"));
+    }
+
+    #[test]
+    fn parse_run_input_accepts_valid_body() {
+        let body = json!({
+            "threadId": Uuid::new_v4(),
+            "runId": Uuid::new_v4(),
+            "state": {},
+            "messages": [{
+                "id": Uuid::new_v4(),
+                "role": "user",
+                "content": "hello"
+            }],
+            "tools": [],
+            "context": [],
+            "forwardedProps": {}
+        });
+
+        let parsed = parse_run_input(&serde_json::to_vec(&body).unwrap()).expect("valid body");
+        assert_eq!(parsed.messages.len(), 1);
+    }
+
+    #[test]
+    fn parse_run_input_accepts_minimal_body_without_optional_fields() {
+        // Per plan guardrail: only `messages` is required; state/tools/context/forwardedProps
+        // are semantically optional and should default if omitted.
+        let thread_id = Uuid::new_v4();
+        let run_id = Uuid::new_v4();
+        let body = json!({
+            "threadId": thread_id,
+            "runId": run_id,
+            "messages": [{
+                "id": Uuid::new_v4(),
+                "role": "user",
+                "content": "hello"
+            }]
+        });
+
+        let parsed = parse_run_input(&serde_json::to_vec(&body).unwrap()).expect("minimal body");
+        assert_eq!(parsed.messages.len(), 1);
+        assert_eq!(parsed.thread_id, ThreadId::from(thread_id));
+        assert_eq!(parsed.run_id, RunId::from(run_id));
+    }
+
+    #[test]
+    fn parse_run_input_rejects_missing_messages_field() {
+        let body = json!({
+            "threadId": Uuid::new_v4(),
+            "runId": Uuid::new_v4(),
+            "state": {},
+            "tools": [],
+            "context": [],
+            "forwardedProps": {}
+        });
+
+        let err = parse_run_input(&serde_json::to_vec(&body).unwrap())
+            .expect_err("missing messages should fail");
+        assert!(matches!(err, AgUiError::BadRequest(msg) if msg.contains("messages")));
+    }
+
+    #[test]
+    fn parse_run_input_rejects_empty_messages() {
+        let body = json!({
+            "threadId": Uuid::new_v4(),
+            "runId": Uuid::new_v4(),
+            "state": {},
+            "messages": [],
+            "tools": [],
+            "context": [],
+            "forwardedProps": {}
+        });
+
+        let err = parse_run_input(&serde_json::to_vec(&body).unwrap())
+            .expect_err("empty messages should fail");
+        assert_eq!(
+            err,
+            AgUiError::BadRequest("AG-UI request must include at least one message".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_agent_finds_existing_agent() {
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("hephaestus", "You are Hephaestus.");
+        let config = sandbox.config();
+
+        let agent = resolve_agent(&config, "hephaestus").expect("agent should resolve");
+        assert_eq!(agent.name(), "hephaestus");
+    }
+
+    #[test]
+    fn resolve_agent_returns_not_found_for_unknown_agent() {
+        let sandbox = TestConfigSandbox::new();
+        let config = sandbox.config();
+
+        let err = resolve_agent(&config, "missing-agent").expect_err("missing agent should fail");
+        assert_eq!(
+            err,
+            AgUiError::NotFound("agent 'missing-agent' not found".to_string())
+        );
+    }
+
+    #[test]
+    fn reconcile_new_messages_returns_only_trailing_new_suffix() {
+        let persisted = vec![
+            HistoryMsg::new(MessageRole::User, MessageContent::Text("hello".to_string())),
+            HistoryMsg::new(
+                MessageRole::Assistant,
+                MessageContent::Text("hi".to_string()),
+            ),
+        ];
+        let client_msgs = vec![
+            user_msg("hello"),
+            assistant_msg("hi"),
+            user_msg("what next?"),
+        ];
+
+        let new_messages = reconcile_new_messages(&persisted, &client_msgs);
+        assert_eq!(
+            new_messages,
+            vec![NewMsg {
+                role: Role::User,
+                content: "what next?".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn reconcile_new_messages_returns_verified_suffix_after_divergence() {
+        let persisted = vec![
+            HistoryMsg::new(MessageRole::User, MessageContent::Text("old".to_string())),
+            HistoryMsg::new(
+                MessageRole::Assistant,
+                MessageContent::Text("assistant-old".to_string()),
+            ),
+        ];
+        let client_msgs = vec![assistant_msg("fresh assistant"), user_msg("last user wins")];
+
+        let new_messages = reconcile_new_messages(&persisted, &client_msgs);
+        assert_eq!(
+            new_messages,
+            vec![
+                NewMsg {
+                    role: Role::Assistant,
+                    content: "fresh assistant".to_string(),
+                },
+                NewMsg {
+                    role: Role::User,
+                    content: "last user wins".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn derive_thread_id_is_deterministic_and_passes_through_uuid() {
+        let non_uuid = "not-a-uuid-session";
+        let derived_a = derive_thread_id(non_uuid);
+        let derived_b = derive_thread_id(non_uuid);
+        assert_eq!(derived_a, derived_b);
+
+        let session_uuid = Uuid::new_v4();
+        let thread_id = derive_thread_id(&session_uuid.to_string());
+        assert_eq!(thread_id, ThreadId::from(session_uuid));
+    }
+
+    #[test]
+    fn build_local_input_sets_agent_and_session_meta() {
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("hephaestus", "You are Hephaestus.");
+        let base_config = sandbox.config();
+        let prompt_config = fork_prompt_config(&base_config);
+        {
+            let mut config = prompt_config.write();
+            config
+                .use_agent_by_name("hephaestus")
+                .expect("agent should load");
+            config
+                .use_session(Some("session-a"))
+                .expect("session should load");
+        }
+
+        let input = build_local_input(&prompt_config, "hephaestus", "session-a", "hello world")
+            .expect("input should build");
+        assert!(input.with_session());
+        assert!(input.with_agent());
+
+        let session = prompt_config
+            .read()
+            .session
+            .clone()
+            .expect("session should exist");
+        assert_eq!(session.agent_name.as_deref(), Some("hephaestus"));
+    }
+
+    #[tokio::test]
+    async fn ag_ui_run_streams_ordered_events_with_stubbed_call_fn() {
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("hephaestus", "You are Hephaestus.");
+        let config = sandbox.config();
+
+        let run_id_uuid = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+        let session_id = "run-session-1";
+        let req_body = serde_json::to_vec(&json!({
+            "threadId": Uuid::new_v4(),
+            "runId": run_id_uuid,
+            "state": {},
+            "messages": [{
+                "id": Uuid::new_v4(),
+                "role": "user",
+                "content": "forge response"
+            }],
+            "tools": [],
+            "context": [],
+            "forwardedProps": {}
+        }))
+        .unwrap();
+
+        let call_fn: AgentCallFn = Arc::new(|_input, _config, _abort| {
+            Box::pin(async move {
+                harnx_core::sink::emit_agent_event(AgentEvent::Model(ModelEvent::MessageChunk {
+                    blocks: vec![ContentBlock::Text("chunk-text".to_string())],
+                }));
+                Ok((
+                    "assistant final".to_string(),
+                    None,
+                    Vec::<ToolCall>::new(),
+                    CompletionTokenUsage::default(),
+                ))
+            })
+        });
+
+        let response =
+            ag_ui_run_with_call_fn(&config, "hephaestus", session_id, &req_body, Some(call_fn))
+                .await
+                .expect("AG-UI run should succeed");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("Content-Type")
+                .and_then(|v| v.to_str().ok()),
+            Some("text/event-stream")
+        );
+
+        let collected =
+            futures_util::StreamExt::collect::<Vec<_>>(response.into_body().into_data_stream())
+                .await
+                .into_iter()
+                .map(|chunk| {
+                    String::from_utf8(chunk.expect("stream chunk").to_vec()).expect("utf8")
+                })
+                .collect::<Vec<_>>();
+
+        let parsed_events = collected
+            .iter()
+            .map(|frame| {
+                assert!(frame.starts_with("data: "));
+                assert!(!frame.contains("event:"));
+                let json = frame
+                    .strip_prefix("data: ")
+                    .and_then(|v| v.strip_suffix("\n\n"))
+                    .expect("SSE data frame");
+                serde_json::from_str::<serde_json::Value>(json).expect("valid event json")
+            })
+            .collect::<Vec<_>>();
+
+        let event_types = parsed_events
+            .iter()
+            .map(|event| event["type"].as_str().unwrap().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            event_types,
+            vec![
+                "RUN_STARTED",
+                "TEXT_MESSAGE_START",
+                "TEXT_MESSAGE_CONTENT",
+                "TEXT_MESSAGE_END",
+                "RUN_FINISHED",
+            ]
+        );
+
+        let thread_id = derive_thread_id(session_id).to_string();
+        let run_id = run_id_uuid.to_string();
+        assert_eq!(
+            parsed_events[0]["threadId"].as_str(),
+            Some(thread_id.as_str())
+        );
+        assert_eq!(parsed_events[0]["runId"].as_str(), Some(run_id.as_str()));
+        assert_eq!(parsed_events[2]["delta"].as_str(), Some("chunk-text"));
+        assert_eq!(
+            parsed_events[4]["threadId"].as_str(),
+            Some(thread_id.as_str())
+        );
+        assert_eq!(parsed_events[4]["runId"].as_str(), Some(run_id.as_str()));
+
+        let start_message_id = parsed_events[1]["messageId"].as_str().unwrap().to_string();
+        assert_eq!(
+            parsed_events[2]["messageId"].as_str(),
+            Some(start_message_id.as_str())
+        );
+        assert_eq!(
+            parsed_events[3]["messageId"].as_str(),
+            Some(start_message_id.as_str())
+        );
+
+        let session_messages = load_session_texts(&config, "hephaestus", session_id);
+        assert!(
+            session_messages.iter().any(|text| text == "forge response"),
+            "user prompt should persist via loop"
+        );
+        assert!(
+            session_messages
+                .iter()
+                .any(|text| text == "assistant final"),
+            "assistant output should persist via loop"
+        );
+    }
+
+    #[tokio::test]
+    async fn ag_ui_run_emits_run_error_without_run_finished_when_call_fn_fails() {
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+        let config = sandbox.config();
+        let session_id = "error-path-session";
+        let body = json!({
+            "threadId": Uuid::new_v4(),
+            "runId": Uuid::new_v4(),
+            "messages": [{
+                "id": Uuid::new_v4(),
+                "role": "user",
+                "content": "fail deterministically"
+            }]
+        });
+
+        let call_fn: AgentCallFn = Arc::new(|_input, _config, _abort| {
+            Box::pin(async { Err(anyhow!("stubbed call failure")) })
+        });
+
+        let response = ag_ui_run_with_call_fn(
+            &config,
+            "plain",
+            session_id,
+            &serde_json::to_vec(&body).unwrap(),
+            Some(call_fn),
+        )
+        .await
+        .expect("ag ui response");
+        let parsed_events = parse_sse_events(response).await;
+        let event_types = parsed_events
+            .iter()
+            .map(|event| event["type"].as_str().unwrap().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            event_types,
+            vec!["RUN_STARTED", "TEXT_MESSAGE_START", "RUN_ERROR"]
+        );
+        assert_eq!(
+            parsed_events[2]["message"].as_str(),
+            Some("stubbed call failure")
+        );
+        assert!(parsed_events
+            .iter()
+            .all(|event| event["type"].as_str() != Some("RUN_FINISHED")));
+    }
+
+    #[tokio::test]
+    async fn ag_ui_run_lists_persisted_session_and_history_for_agent() {
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+        let config = sandbox.config();
+        let session_id = "enumeration-session";
+        let body = json!({
+            "threadId": Uuid::new_v4(),
+            "runId": Uuid::new_v4(),
+            "messages": [{
+                "id": Uuid::new_v4(),
+                "role": "user",
+                "content": "enumerate persisted history"
+            }]
+        });
+
+        let call_fn: AgentCallFn = Arc::new(|_input, _config, _abort| {
+            Box::pin(async {
+                let usage = CompletionTokenUsage::new(Some(1), Some(1), Some(0));
+                Ok(("persisted assistant".into(), None, vec![], usage))
+            })
+        });
+
+        let response = ag_ui_run_with_call_fn(
+            &config,
+            "plain",
+            session_id,
+            &serde_json::to_vec(&body).unwrap(),
+            Some(call_fn),
+        )
+        .await
+        .expect("persisted run response");
+        assert_run_finished(parse_sse_events(response).await);
+
+        let scoped = super::super::agent_scoped_config(&config, "plain").expect("scoped config");
+        let sessions = super::super::agent_sessions_json(&config, "plain").expect("session list");
+        assert_eq!(sessions.len(), 1);
+        assert!(sessions[0].get("session_id").is_some());
+
+        let loaded = harnx_runtime::config::session::load(
+            &scoped,
+            session_id,
+            &scoped.session_file(session_id),
+        )
+        .expect("load persisted session");
+        assert_eq!(loaded.agent_name.as_deref(), Some("plain"));
+
+        let mut history_iter = loaded.messages.iter();
+        let persisted_user = history_iter
+            .find(|message| message.role.is_user())
+            .expect("persisted user message");
+        let persisted_assistant = history_iter
+            .find(|message| message.role.is_assistant())
+            .expect("persisted assistant message");
+        assert_eq!(
+            persisted_user.content.to_text(),
+            "enumerate persisted history"
+        );
+        assert_eq!(persisted_assistant.content.to_text(), "persisted assistant");
+
+        let shaped = loaded
+            .messages
+            .iter()
+            .filter(|message| message.role.is_user() || message.role.is_assistant())
+            .map(|message| {
+                json!({
+                    "id": format!(
+                        "seq:{}:0",
+                        message.log_seq.expect("persisted history should have log seq")
+                    ),
+                    "role": super::super::history_role_name(message.role),
+                    "content": super::super::history_message_content(message),
+                })
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            shaped,
+            vec![
+                json!({
+                    "id": persisted_user
+                        .log_seq
+                        .map(|seq| format!("seq:{seq}:0"))
+                        .expect("persisted user should have log seq"),
+                    "role": "user",
+                    "content": "enumerate persisted history"
+                }),
+                json!({
+                    "id": persisted_assistant
+                        .log_seq
+                        .map(|seq| format!("seq:{seq}:0"))
+                        .expect("persisted assistant should have log seq"),
+                    "role": "assistant",
+                    "content": "persisted assistant"
+                }),
+            ]
+        );
+
+        let all_agents = Config::all_agents();
+        assert!(all_agents.iter().any(|agent| agent.name() == "plain"));
+    }
+
+    #[tokio::test]
+    async fn ag_ui_run_uses_same_message_id_for_wire_and_persistence() {
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+        let config = sandbox.config();
+        let session_id = "wire-id-session";
+        let body = json!({
+            "threadId": Uuid::new_v4(),
+            "runId": Uuid::new_v4(),
+            "messages": [{
+                "id": Uuid::new_v4(),
+                "role": "user",
+                "content": "user1"
+            }]
+        });
+
+        let call_fn: AgentCallFn = Arc::new(|_input, _config, _abort| {
+            Box::pin(async {
+                let usage = CompletionTokenUsage::new(Some(1), Some(1), Some(0));
+                Ok(("assistant1".into(), None, vec![], usage))
+            })
+        });
+
+        let response = ag_ui_run_with_call_fn(
+            &config,
+            "plain",
+            session_id,
+            &serde_json::to_vec(&body).unwrap(),
+            Some(call_fn),
+        )
+        .await
+        .expect("run response");
+        let events = parse_sse_events(response).await;
+        assert_run_finished(events.clone());
+
+        let wire_message_ids = events
+            .iter()
+            .filter_map(|event| match event["type"].as_str() {
+                Some("TEXT_MESSAGE_START")
+                | Some("TEXT_MESSAGE_CONTENT")
+                | Some("TEXT_MESSAGE_END") => event["messageId"].as_str().map(str::to_string),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            !wire_message_ids.is_empty(),
+            "expected wire message ids in SSE: {events:?}"
+        );
+        assert!(
+            wire_message_ids.windows(2).all(|ids| ids[0] == ids[1]),
+            "wire message ids should stay stable across SSE events: {wire_message_ids:?}"
+        );
+        let wire_message_id = wire_message_ids[0].clone();
+
+        let persisted_messages = load_session_messages(&config, "plain", session_id);
+        let persisted_assistant = persisted_messages
+            .iter()
+            .find(|msg| msg.role.is_assistant())
+            .expect("persisted assistant message");
+        assert_eq!(
+            persisted_assistant.id.as_deref(),
+            Some(wire_message_id.as_str())
+        );
+    }
+
+    fn assert_bad_request_contains(err: &AgUiError, expected: &str) {
+        assert_eq!(err.status_code(), StatusCode::BAD_REQUEST);
+        match err {
+            AgUiError::BadRequest(message) => {
+                assert!(
+                    message.contains(expected),
+                    "expected bad request to contain {expected:?}, got {message:?}"
+                );
+            }
+            other => panic!("expected bad request error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn ag_ui_run_exact_resend_returns_bad_request_without_duplication() {
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+        let config = sandbox.config();
+        let session_id = "exact-resend-session";
+
+        let first_body = json!({
+            "threadId": Uuid::new_v4(),
+            "runId": Uuid::new_v4(),
+            "messages": [{
+                "id": Uuid::new_v4(),
+                "role": "user",
+                "content": "user1"
+            }]
+        });
+        let first_call_fn: AgentCallFn = Arc::new(|_input, _config, _abort| {
+            Box::pin(async {
+                let usage = CompletionTokenUsage::new(Some(1), Some(1), Some(0));
+                Ok(("assistant1".into(), None, vec![], usage))
+            })
+        });
+        let first_response = ag_ui_run_with_call_fn(
+            &config,
+            "plain",
+            session_id,
+            &serde_json::to_vec(&first_body).unwrap(),
+            Some(first_call_fn),
+        )
+        .await
+        .expect("first run");
+        assert_run_finished(parse_sse_events(first_response).await);
+        let first_messages = load_session_texts(&config, "plain", session_id);
+        assert_eq!(
+            first_messages,
+            vec!["user1".to_string(), "assistant1".to_string()]
+        );
+
+        let persisted_messages = load_session_messages(&config, "plain", session_id);
+        let persisted_assistant_id = persisted_messages
+            .iter()
+            .find(|msg| msg.role.is_assistant())
+            .and_then(|msg| msg.id.clone())
+            .expect("persisted assistant id");
+
+        let resend_body = json!({
+            "threadId": Uuid::new_v4(),
+            "runId": Uuid::new_v4(),
+            "messages": [
+                {
+                    "id": Uuid::new_v4(),
+                    "role": "user",
+                    "content": "user1"
+                },
+                {
+                    "id": persisted_assistant_id,
+                    "role": "assistant",
+                    "content": "assistant1"
+                }
+            ]
+        });
+
+        let err = ag_ui_run_with_call_fn(
+            &config,
+            "plain",
+            session_id,
+            &serde_json::to_vec(&resend_body).unwrap(),
+            None,
+        )
+        .await
+        .expect_err("exact resend should fail");
+        assert_eq!(err.status_code(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            load_session_texts(&config, "plain", session_id),
+            first_messages
+        );
+    }
+
+    #[tokio::test]
+    async fn ag_ui_run_rejects_multiple_new_messages() {
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+        let config = sandbox.config();
+        let session_id = "multi-tail-session";
+
+        let first_body = json!({
+            "threadId": Uuid::new_v4(),
+            "runId": Uuid::new_v4(),
+            "messages": [{
+                "id": Uuid::new_v4(),
+                "role": "user",
+                "content": "user1"
+            }]
+        });
+        let first_call_fn: AgentCallFn = Arc::new(|_input, _config, _abort| {
+            Box::pin(async {
+                let usage = CompletionTokenUsage::new(Some(1), Some(1), Some(0));
+                Ok(("assistant1".into(), None, vec![], usage))
+            })
+        });
+        let first_response = ag_ui_run_with_call_fn(
+            &config,
+            "plain",
+            session_id,
+            &serde_json::to_vec(&first_body).unwrap(),
+            Some(first_call_fn),
+        )
+        .await
+        .expect("first run");
+        assert_run_finished(parse_sse_events(first_response).await);
+        assert_eq!(
+            load_session_texts(&config, "plain", session_id),
+            vec!["user1".to_string(), "assistant1".to_string()]
+        );
+
+        let persisted_messages = load_session_messages(&config, "plain", session_id);
+        let persisted_assistant_id = persisted_messages
+            .iter()
+            .find(|msg| msg.role.is_assistant())
+            .and_then(|msg| msg.id.clone())
+            .expect("persisted assistant id");
+
+        let second_body = json!({
+            "threadId": Uuid::new_v4(),
+            "runId": Uuid::new_v4(),
+            "messages": [
+                {
+                    "id": MessageId::random(),
+                    "role": "user",
+                    "content": "user1"
+                },
+                {
+                    "id": persisted_assistant_id,
+                    "role": "assistant",
+                    "content": "assistant1"
+                },
+                {
+                    "id": Uuid::new_v4(),
+                    "role": "user",
+                    "content": "user2"
+                },
+                {
+                    "id": Uuid::new_v4(),
+                    "role": "user",
+                    "content": "user3"
+                }
+            ]
+        });
+        let second_call_fn: AgentCallFn = Arc::new(|_input, _config, _abort| {
+            Box::pin(async {
+                let usage = CompletionTokenUsage::new(Some(1), Some(1), Some(0));
+                Ok(("assistant2".into(), None, vec![], usage))
+            })
+        });
+        let err = ag_ui_run_with_call_fn(
+            &config,
+            "plain",
+            session_id,
+            &serde_json::to_vec(&second_body).unwrap(),
+            Some(second_call_fn),
+        )
+        .await
+        .expect_err("multiple new messages should be rejected");
+        assert_bad_request_contains(
+            &err,
+            "multiple new messages are not supported in Phase 1; send exactly one new user message per run",
+        );
+        assert_eq!(
+            load_session_texts(&config, "plain", session_id),
+            vec!["user1".to_string(), "assistant1".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn ag_ui_run_resume_same_session_persists_only_new_turn() {
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+        let config = sandbox.config();
+        let session_id = "resume-session";
+
+        let first_body = json!({
+            "threadId": Uuid::new_v4(),
+            "runId": Uuid::new_v4(),
+            "messages": [{
+                "id": Uuid::new_v4(),
+                "role": "user",
+                "content": "user1"
+            }]
+        });
+        let first_call_fn: AgentCallFn = Arc::new(|_input, _config, _abort| {
+            Box::pin(async {
+                let usage = CompletionTokenUsage::new(Some(1), Some(1), Some(0));
+                Ok(("assistant1".into(), None, vec![], usage))
+            })
+        });
+        let first_response = ag_ui_run_with_call_fn(
+            &config,
+            "plain",
+            session_id,
+            &serde_json::to_vec(&first_body).unwrap(),
+            Some(first_call_fn),
+        )
+        .await
+        .expect("first run");
+        assert_run_finished(parse_sse_events(first_response).await);
+        let first_messages = load_session_texts(&config, "plain", session_id);
+        assert_eq!(
+            first_messages,
+            vec!["user1".to_string(), "assistant1".to_string()]
+        );
+
+        let persisted_messages = load_session_messages(&config, "plain", session_id);
+        let persisted_assistant_id = persisted_messages
+            .iter()
+            .find(|msg| msg.role.is_assistant())
+            .and_then(|msg| msg.id.clone())
+            .expect("persisted assistant id");
+
+        let second_body = json!({
+            "threadId": Uuid::new_v4(),
+            "runId": Uuid::new_v4(),
+            "messages": [
+                {
+                    "id": MessageId::random(),
+                    "role": "user",
+                    "content": "user1"
+                },
+                {
+                    "id": persisted_assistant_id,
+                    "role": "assistant",
+                    "content": "assistant1"
+                },
+                {
+                    "id": MessageId::random(),
+                    "role": "user",
+                    "content": "user2"
+                }
+            ]
+        });
+        let second_call_fn: AgentCallFn = Arc::new(|_input, _config, _abort| {
+            Box::pin(async {
+                let usage = CompletionTokenUsage::new(Some(1), Some(1), Some(0));
+                Ok(("assistant2".into(), None, vec![], usage))
+            })
+        });
+        let second_response = ag_ui_run_with_call_fn(
+            &config,
+            "plain",
+            session_id,
+            &serde_json::to_vec(&second_body).unwrap(),
+            Some(second_call_fn),
+        )
+        .await
+        .expect("second run");
+        assert_run_finished(parse_sse_events(second_response).await);
+        let second_messages = load_session_texts(&config, "plain", session_id);
+        assert_eq!(second_messages.len(), first_messages.len() + 2);
+        assert_eq!(
+            second_messages,
+            vec![
+                "user1".to_string(),
+                "assistant1".to_string(),
+                "user2".to_string(),
+                "assistant2".to_string(),
+            ]
+        );
+    }
+
+    fn parse_sse_frames(body: &str) -> Vec<String> {
+        body.split("\n\n")
+            .filter_map(|frame| {
+                let trimmed = frame.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            })
+            .collect()
+    }
+
+    async fn parse_sse_events(response: AppResponse) -> Vec<Value> {
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("collect sse body")
+            .to_bytes();
+        let body_text = std::str::from_utf8(&body).expect("sse utf8");
+        parse_sse_frames(body_text)
+            .into_iter()
+            .map(|frame| {
+                let payload = frame
+                    .strip_prefix("data: ")
+                    .expect("sse frame should start with data prefix");
+                serde_json::from_str(payload).expect("frame should be valid json")
+            })
+            .collect()
+    }
+
+    fn assert_run_finished(events: Vec<Value>) {
+        assert!(
+            events
+                .iter()
+                .any(|event| event["type"].as_str() == Some("RUN_FINISHED")),
+            "expected RUN_FINISHED barrier, got events: {events:?}"
+        );
+    }
+
+    fn load_session_texts(config: &Config, agent: &str, session_id: &str) -> Vec<String> {
+        let prompt_config = fork_prompt_config(config);
+        {
+            let mut cfg = prompt_config.write();
+            cfg.use_agent_by_name(agent).expect("set agent");
+            cfg.use_session(Some(session_id)).expect("load session");
+        }
+        let session_messages = prompt_config
+            .read()
+            .session
+            .as_ref()
+            .expect("session should exist")
+            .messages
+            .iter()
+            .filter(|msg| msg.role.is_user() || msg.role.is_assistant())
+            .map(|msg| msg.content.to_text())
+            .collect();
+        session_messages
+    }
+    fn load_session_messages(config: &Config, agent: &str, session_id: &str) -> Vec<HistoryMsg> {
+        let prompt_config = fork_prompt_config(config);
+        {
+            let mut cfg = prompt_config.write();
+            cfg.use_agent_by_name(agent).expect("set agent");
+            cfg.use_session(Some(session_id)).expect("load session");
+        }
+        let messages = prompt_config
+            .read()
+            .session
+            .as_ref()
+            .expect("session should exist")
+            .messages
+            .iter()
+            .filter(|msg| msg.role.is_user() || msg.role.is_assistant())
+            .cloned()
+            .collect();
+        messages
+    }
+
+    fn user_msg(content: &str) -> AgUiMessage {
+        AgUiMessage::User {
+            id: MessageId::random(),
+            content: content.to_string(),
+            name: None,
+        }
+    }
+
+    fn assistant_msg(content: &str) -> AgUiMessage {
+        AgUiMessage::Assistant {
+            id: MessageId::random(),
+            content: Some(content.to_string()),
+            name: None,
+            tool_calls: None,
+        }
+    }
+
+    static TEST_CONFIG_DIR_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    struct TestConfigSandbox {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        root: PathBuf,
+        data_dir: PathBuf,
+        state_dir: PathBuf,
+        vars: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl TestConfigSandbox {
+        fn new() -> Self {
+            let lock = TEST_CONFIG_DIR_LOCK.lock().expect("test config dir lock");
+            let root = unique_test_config_dir();
+            let data_dir = root.join("data");
+            let state_dir = root.join("state");
+
+            fs::create_dir_all(root.join("clients")).expect("create clients dir");
+            fs::create_dir_all(root.join("agents")).expect("create agents dir");
+            fs::create_dir_all(&data_dir).expect("create data dir");
+            fs::create_dir_all(&state_dir).expect("create state dir");
+            fs::write(
+                root.join("config.yaml"),
+                "model: openai:gpt-4o\nsave_session: true\n",
+            )
+            .expect("write config");
+            fs::write(
+                root.join("clients/openai.yaml"),
+                concat!(
+                    "type: openai\n",
+                    "api_key: sk-test\n",
+                    "models:\n",
+                    "  - name: gpt-4o\n",
+                    "    type: chat\n",
+                    "    max_input_tokens: 4096\n"
+                ),
+            )
+            .expect("write openai client");
+
+            let vars = vec![
+                ("HARNX_CONFIG_DIR", std::env::var_os("HARNX_CONFIG_DIR")),
+                ("HARNX_DATA_DIR", std::env::var_os("HARNX_DATA_DIR")),
+                ("HARNX_STATE_DIR", std::env::var_os("HARNX_STATE_DIR")),
+            ];
+            unsafe {
+                std::env::set_var("HARNX_CONFIG_DIR", &root);
+                std::env::set_var("HARNX_DATA_DIR", &data_dir);
+                std::env::set_var("HARNX_STATE_DIR", &state_dir);
+                std::env::remove_var("HARNX_CONFIG_FILE");
+            }
+
+            Self {
+                _lock: lock,
+                root,
+                data_dir,
+                state_dir,
+                vars,
+            }
+        }
+
+        fn config(&self) -> Config {
+            let prev = std::env::current_dir().expect("cwd");
+            std::env::set_current_dir(&self.root).expect("switch cwd");
+            let result = futures::executor::block_on(Config::init(WorkingMode::Cmd, false, vec![]));
+            std::env::set_current_dir(prev).expect("restore cwd");
+            result.expect("load config")
+        }
+
+        fn write_agent(&self, name: &str, prompt: &str) {
+            let body = format!("---\nmodel: openai:gpt-4o\n---\n{prompt}\n");
+            fs::write(self.root.join("agents").join(format!("{name}.md")), body)
+                .expect("write agent");
+        }
+    }
+
+    impl Drop for TestConfigSandbox {
+        fn drop(&mut self) {
+            for (key, previous) in &self.vars {
+                match previous {
+                    Some(value) => unsafe { std::env::set_var(key, value) },
+                    None => unsafe { std::env::remove_var(key) },
+                }
+            }
+            let _ = fs::remove_dir_all(&self.data_dir);
+            let _ = fs::remove_dir_all(&self.state_dir);
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn unique_test_config_dir() -> PathBuf {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "harnx-serve-ag-ui-test-{}-{timestamp}",
+            std::process::id()
+        ))
+    }
+}

--- a/crates/harnx-serve/src/lib.rs
+++ b/crates/harnx-serve/src/lib.rs
@@ -2,13 +2,18 @@
 //! (plan P47, β+ progressive peel). Extracted from `harnx::serve`.
 //! Depends on `harnx-runtime` for Config + Client orchestration.
 
+mod ag_ui;
+
+use crate::ag_ui::{fork_prompt_config, resolve_agent, AgUiError, AppResponse as AgUiAppResponse};
+
+use harnx_core::message::{Message, MessageRole};
 use harnx_rag::*;
 use harnx_runtime::{client::*, config::*, tool::*, utils::*};
 use log::{debug, error, info};
 
 use anyhow::{anyhow, bail, Result};
 use bytes::Bytes;
-use chrono::{Timelike, Utc};
+use chrono::{DateTime, Timelike, Utc};
 use futures_util::StreamExt;
 use http::{Method, Response, StatusCode};
 use http_body_util::{combinators::BoxBody, BodyExt, Full, StreamBody};
@@ -21,12 +26,14 @@ use parking_lot::RwLock;
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::{
+    collections::BTreeMap,
     convert::Infallible,
     net::IpAddr,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
+    time::SystemTime,
 };
 use tokio::{
     net::TcpListener,
@@ -75,6 +82,22 @@ struct Server {
     models: Vec<Value>,
     agents: Vec<AgentConfig>,
     rags: Vec<String>,
+}
+
+type RouteMatch<'a> = (&'a str, Option<&'a str>, AgentsRoute);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AgentsRoute {
+    Agent,
+    Sessions,
+    Session,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AgentsRepresentation {
+    Html,
+    Json,
+    AgUiSse,
 }
 
 impl Server {
@@ -171,6 +194,8 @@ impl Server {
             self.list_models()
         } else if path == "/v1/agents" {
             self.list_agents()
+        } else if path.starts_with("/v1/agents/") {
+            self.handle_agent_tree(req).await
         } else if path == "/v1/rags" {
             self.list_rags()
         } else if path == "/v1/rags/search" {
@@ -190,7 +215,7 @@ impl Server {
             }
             Err(err) => {
                 if status == StatusCode::OK {
-                    status = StatusCode::BAD_REQUEST;
+                    status = status_from_error(&err).unwrap_or(StatusCode::BAD_REQUEST);
                 }
                 error!("{method} {uri} {} {err}", status.as_u16());
                 ret_err(err)
@@ -229,6 +254,125 @@ impl Server {
             .header("Content-Type", "application/json; charset=utf-8")
             .body(Full::new(Bytes::from(data.to_string())).boxed())?;
         Ok(res)
+    }
+
+    async fn handle_agent_tree(&self, req: hyper::Request<Incoming>) -> Result<AppResponse> {
+        let method = req.method().clone();
+        let path = req.uri().path().to_string();
+        let route = match parse_agents_route(&path) {
+            Some(route) => route,
+            None => return Err(anyhow!("Not Found")),
+        };
+        let (agent_name, session_name, agent_route) = route;
+
+        resolve_agent(&self.config, agent_name).map_err(ag_ui_error_to_anyhow)?;
+
+        match agent_route {
+            AgentsRoute::Agent => {
+                match negotiate_agents_route(&method, req.headers(), agent_route)? {
+                    AgentsRepresentation::Html => self.agent_html_page(agent_name),
+                    AgentsRepresentation::Json => self.agent_json(agent_name),
+                    AgentsRepresentation::AgUiSse => Err(anyhow!("Not Acceptable")),
+                }
+            }
+            AgentsRoute::Sessions => {
+                match negotiate_agents_route(&method, req.headers(), agent_route)? {
+                    AgentsRepresentation::Json => self.sessions_json(agent_name),
+                    AgentsRepresentation::Html | AgentsRepresentation::AgUiSse => {
+                        Err(anyhow!("Not Acceptable"))
+                    }
+                }
+            }
+            AgentsRoute::Session => {
+                let session_name = session_name.expect("session route always has session name");
+                match negotiate_agents_route(&method, req.headers(), agent_route)? {
+                    AgentsRepresentation::Html => self.session_html_page(agent_name, session_name),
+                    AgentsRepresentation::Json => {
+                        self.session_history_json(agent_name, session_name)
+                    }
+                    AgentsRepresentation::AgUiSse => {
+                        self.ag_ui_run_route(req, agent_name, session_name).await
+                    }
+                }
+            }
+        }
+    }
+
+    fn agent_html_page(&self, agent: &str) -> Result<AppResponse> {
+        let html = format!("<h1>agent: {agent}</h1>");
+        let res = Response::builder()
+            .header("Content-Type", "text/html; charset=utf-8")
+            .body(Full::new(Bytes::from(html)).boxed())?;
+        Ok(res)
+    }
+
+    fn session_html_page(&self, _agent: &str, session: &str) -> Result<AppResponse> {
+        let html = format!("<h1>session: {session}</h1>");
+        let res = Response::builder()
+            .header("Content-Type", "text/html; charset=utf-8")
+            .body(Full::new(Bytes::from(html)).boxed())?;
+        Ok(res)
+    }
+
+    fn agent_json(&self, agent: &str) -> Result<AppResponse> {
+        let sessions = agent_sessions_json(&self.config, agent)?;
+        let description = self
+            .agents
+            .iter()
+            .find(|candidate| candidate.name() == agent)
+            .map(AgentConfig::description)
+            .filter(|description| !description.is_empty());
+        let data = json!({
+            "name": agent,
+            "description": description,
+            "sessions": sessions,
+        });
+        json_response(data)
+    }
+
+    fn sessions_json(&self, agent: &str) -> Result<AppResponse> {
+        json_response(Value::Array(agent_sessions_json(&self.config, agent)?))
+    }
+
+    fn session_history_json(&self, agent: &str, session: &str) -> Result<AppResponse> {
+        let config = agent_scoped_config(&self.config, agent)?;
+        let session_path = config.session_file(session);
+        if !session_path.exists() {
+            bail!("Not Found");
+        }
+
+        let loaded_session = harnx_runtime::config::session::load(&config, session, &session_path)
+            .map_err(|err| anyhow!("Failed to load session history for '{session}': {err}"))?;
+        if loaded_session.agent_name.as_deref() != Some(agent) {
+            bail!("Not Found");
+        }
+
+        let mut seq_counts = BTreeMap::new();
+        let messages = loaded_session
+            .messages
+            .iter()
+            .map(|message| {
+                let id = history_message_id(message, &mut seq_counts);
+                json!({
+                    "id": id,
+                    "role": history_role_name(message.role),
+                    "content": history_message_content(message),
+                })
+            })
+            .collect();
+        json_response(Value::Array(messages))
+    }
+
+    async fn ag_ui_run_route(
+        &self,
+        req: hyper::Request<Incoming>,
+        agent: &str,
+        session: &str,
+    ) -> Result<AppResponse> {
+        let req_body = req.collect().await?.to_bytes();
+        self.ag_ui_run(agent, session, &req_body)
+            .await
+            .map_err(ag_ui_error_to_anyhow)
     }
 
     fn list_rags(&self) -> Result<AppResponse> {
@@ -484,6 +628,15 @@ impl Server {
                 )?;
             Ok(res)
         }
+    }
+
+    pub(crate) async fn ag_ui_run(
+        &self,
+        agent: &str,
+        session: &str,
+        req_body: &[u8],
+    ) -> Result<AgUiAppResponse, AgUiError> {
+        ag_ui::ag_ui_run_with_call_fn(&self.config, agent, session, req_body, None).await
     }
 
     async fn embeddings(&self, req: hyper::Request<Incoming>) -> Result<AppResponse> {
@@ -860,6 +1013,182 @@ fn ret_err<T: std::fmt::Display>(err: T) -> AppResponse {
         .unwrap()
 }
 
+fn parse_agents_route(path: &str) -> Option<RouteMatch<'_>> {
+    let suffix = path.strip_prefix("/v1/agents/")?;
+    let segments: Vec<_> = suffix
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    match segments.as_slice() {
+        [agent] => Some((*agent, None, AgentsRoute::Agent)),
+        [agent, "sessions"] => Some((*agent, None, AgentsRoute::Sessions)),
+        [agent, "sessions", session] => Some((*agent, Some(*session), AgentsRoute::Session)),
+        _ => None,
+    }
+}
+
+fn negotiate_agents_route(
+    method: &Method,
+    headers: &http::HeaderMap,
+    route: AgentsRoute,
+) -> Result<AgentsRepresentation> {
+    match (method, route) {
+        (&Method::GET, AgentsRoute::Agent | AgentsRoute::Session) => {
+            if accepts_html(headers) {
+                Ok(AgentsRepresentation::Html)
+            } else {
+                Ok(AgentsRepresentation::Json)
+            }
+        }
+        (&Method::GET, AgentsRoute::Sessions) => Ok(AgentsRepresentation::Json),
+        (&Method::POST, AgentsRoute::Session) => {
+            if accepts_event_stream(headers) || content_type_is_json(headers) {
+                Ok(AgentsRepresentation::AgUiSse)
+            } else {
+                Err(anyhow!("Not Acceptable"))
+            }
+        }
+        _ => Err(anyhow!("Method Not Allowed")),
+    }
+}
+
+fn accepts_html(headers: &http::HeaderMap) -> bool {
+    headers
+        .get(http::header::ACCEPT)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.contains("text/html"))
+}
+
+fn accepts_event_stream(headers: &http::HeaderMap) -> bool {
+    headers
+        .get(http::header::ACCEPT)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.contains("text/event-stream"))
+}
+
+fn agent_scoped_config(config: &Config, agent: &str) -> Result<Config> {
+    let scoped = fork_prompt_config(config);
+    scoped
+        .write()
+        .use_agent_by_name(agent)
+        .map_err(|err| anyhow!("Failed to scope config to agent '{agent}': {err}"))?;
+    let config = scoped.read().clone();
+    Ok(config)
+}
+
+fn agent_sessions_json(config: &Config, agent: &str) -> Result<Vec<Value>> {
+    Ok(agent_scoped_config(config, agent)?
+        .list_sessions_with_meta()
+        .into_iter()
+        // Per-agent endpoints must not leak sessions without agent attribution or for other agents.
+        // Missing/empty agent_name stays excluded from per-agent lists until a later backfill pass.
+        .filter(|session| session.agent_name.as_deref() == Some(agent))
+        .map(|session| {
+            let session_id = session.session_id.unwrap_or(session.id);
+            let mut value = serde_json::Map::from_iter([(
+                String::from("session_id"),
+                Value::String(session_id),
+            )]);
+            if let Some(modified) = session.modified {
+                value.insert(
+                    String::from("updated_at"),
+                    Value::String(format_system_time(modified)),
+                );
+            }
+            Value::Object(value)
+        })
+        .collect())
+}
+
+fn format_system_time(value: SystemTime) -> String {
+    DateTime::<Utc>::from(value).to_rfc3339()
+}
+
+fn history_role_name(role: MessageRole) -> &'static str {
+    match role {
+        MessageRole::System => "system",
+        MessageRole::Assistant => "assistant",
+        MessageRole::User => "user",
+        MessageRole::Tool => "tool",
+    }
+}
+
+fn history_message_content(message: &Message) -> String {
+    match &message.content {
+        harnx_core::message::MessageContent::ToolCalls(tool_calls) => {
+            if let Some(thought) = tool_calls
+                .thought
+                .as_deref()
+                .filter(|thought| !thought.is_empty())
+            {
+                if tool_calls.text.is_empty() {
+                    thought.to_string()
+                } else {
+                    format!("<think>\n{thought}\n</think>\n{}", tool_calls.text)
+                }
+            } else {
+                tool_calls.text.clone()
+            }
+        }
+        _ => message.content.to_text(),
+    }
+}
+
+fn history_message_id(message: &Message, seq_counts: &mut BTreeMap<usize, usize>) -> String {
+    if let Some(id) = &message.id {
+        return id.clone();
+    }
+
+    match message.log_seq {
+        Some(seq) => {
+            let subindex = seq_counts.entry(seq).or_insert(0);
+            let id = format!("seq:{seq}:{subindex}");
+            *subindex += 1;
+            id
+        }
+        None => {
+            let subindex = seq_counts.entry(usize::MAX).or_insert(0);
+            let id = format!("seq:none:{subindex}");
+            *subindex += 1;
+            id
+        }
+    }
+}
+
+fn content_type_is_json(headers: &http::HeaderMap) -> bool {
+    headers
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.starts_with("application/json"))
+}
+
+fn json_response(data: Value) -> Result<AppResponse> {
+    let res = Response::builder()
+        .header("Content-Type", "application/json; charset=utf-8")
+        .body(Full::new(Bytes::from(data.to_string())).boxed())?;
+    Ok(res)
+}
+
+fn ag_ui_error_to_anyhow(err: AgUiError) -> anyhow::Error {
+    anyhow!(format!("{}::__status={}", err, err.status_code().as_u16()))
+}
+
+fn status_from_error(err: &anyhow::Error) -> Option<StatusCode> {
+    let message = err.to_string();
+    if message == "Not Found" {
+        return Some(StatusCode::NOT_FOUND);
+    }
+    if message == "Method Not Allowed" {
+        return Some(StatusCode::METHOD_NOT_ALLOWED);
+    }
+    if message == "Not Acceptable" {
+        return Some(StatusCode::NOT_ACCEPTABLE);
+    }
+    let marker = "__status=";
+    let status = message.split(marker).nth(1)?;
+    let code = status.parse::<u16>().ok()?;
+    StatusCode::from_u16(code).ok()
+}
 fn parse_messages(message: Vec<Value>) -> Result<Vec<Message>> {
     let mut output = vec![];
     let mut tool_results = None;
@@ -987,4 +1316,466 @@ fn parse_tools(tools: Option<Vec<Value>>) -> Result<Option<Vec<ToolDeclaration>>
         }
     }
     Ok(Some(functions))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::HeaderValue;
+    use std::{
+        fs,
+        path::PathBuf,
+        sync::{LazyLock, Mutex},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    static TEST_CONFIG_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    struct TestConfigSandbox {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        root: PathBuf,
+        data_dir: PathBuf,
+        state_dir: PathBuf,
+        vars: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl TestConfigSandbox {
+        fn new() -> Self {
+            let lock = TEST_CONFIG_ENV_LOCK.lock().expect("config env lock");
+            let root = unique_test_config_dir();
+            let data_dir = root.join("data");
+            let state_dir = root.join("state");
+            fs::create_dir_all(root.join("clients")).expect("create clients dir");
+            fs::create_dir_all(root.join("agents")).expect("create agents dir");
+            fs::create_dir_all(&data_dir).expect("create data dir");
+            fs::create_dir_all(&state_dir).expect("create state dir");
+            fs::write(
+                root.join("config.yaml"),
+                "model: openai:gpt-4o\nclients: []\n",
+            )
+            .expect("write config");
+            fs::write(
+                root.join("clients/openai.yaml"),
+                concat!(
+                    "type: openai\n",
+                    "api_key: sk-test\n",
+                    "models:\n",
+                    "  - name: gpt-4o\n",
+                    "    type: chat\n",
+                    "    max_input_tokens: 4096\n"
+                ),
+            )
+            .expect("write openai client");
+
+            let vars = vec![
+                ("HARNX_CONFIG_DIR", std::env::var_os("HARNX_CONFIG_DIR")),
+                ("HARNX_DATA_DIR", std::env::var_os("HARNX_DATA_DIR")),
+                ("HARNX_STATE_DIR", std::env::var_os("HARNX_STATE_DIR")),
+            ];
+            unsafe {
+                std::env::set_var("HARNX_CONFIG_DIR", &root);
+                std::env::set_var("HARNX_DATA_DIR", &data_dir);
+                std::env::set_var("HARNX_STATE_DIR", &state_dir);
+                std::env::remove_var("HARNX_CONFIG_FILE");
+            }
+
+            Self {
+                _lock: lock,
+                root,
+                data_dir,
+                state_dir,
+                vars,
+            }
+        }
+
+        fn config(&self) -> Config {
+            let prev = std::env::current_dir().expect("cwd");
+            std::env::set_current_dir(&self.root).expect("switch cwd");
+            let result = futures::executor::block_on(Config::init(WorkingMode::Cmd, false, vec![]));
+            std::env::set_current_dir(prev).expect("restore cwd");
+            result.expect("load config")
+        }
+
+        fn write_agent(&self, name: &str, prompt: &str) {
+            let body = format!("---\nmodel: openai:gpt-4o\n---\n{prompt}\n");
+            fs::write(self.root.join("agents").join(format!("{name}.md")), body)
+                .expect("write agent");
+        }
+    }
+
+    impl Drop for TestConfigSandbox {
+        fn drop(&mut self) {
+            for (key, previous) in &self.vars {
+                match previous {
+                    Some(value) => unsafe { std::env::set_var(key, value) },
+                    None => unsafe { std::env::remove_var(key) },
+                }
+            }
+            let _ = fs::remove_dir_all(&self.data_dir);
+            let _ = fs::remove_dir_all(&self.state_dir);
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn unique_test_config_dir() -> PathBuf {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "harnx-serve-lib-test-{}-{timestamp}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn parse_agents_route_extracts_agent_and_session_segments() {
+        assert_eq!(
+            parse_agents_route("/v1/agents/hephaestus"),
+            Some(("hephaestus", None, AgentsRoute::Agent))
+        );
+        assert_eq!(
+            parse_agents_route("/v1/agents/hephaestus/sessions"),
+            Some(("hephaestus", None, AgentsRoute::Sessions))
+        );
+        assert_eq!(
+            parse_agents_route("/v1/agents/hephaestus/sessions/thread-1"),
+            Some(("hephaestus", Some("thread-1"), AgentsRoute::Session))
+        );
+        assert_eq!(parse_agents_route("/v1/agents"), None);
+        assert_eq!(parse_agents_route("/v1/agents/hephaestus/extra"), None);
+    }
+
+    #[test]
+    fn negotiate_agents_route_prefers_html_for_browser_gets() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::ACCEPT,
+            HeaderValue::from_static("text/html,application/xhtml+xml"),
+        );
+        assert_eq!(
+            negotiate_agents_route(&Method::GET, &headers, AgentsRoute::Agent).unwrap(),
+            AgentsRepresentation::Html
+        );
+        assert_eq!(
+            negotiate_agents_route(&Method::GET, &headers, AgentsRoute::Session).unwrap(),
+            AgentsRepresentation::Html
+        );
+    }
+
+    #[test]
+    fn negotiate_agents_route_defaults_gets_to_json() {
+        let headers = http::HeaderMap::new();
+        assert_eq!(
+            negotiate_agents_route(&Method::GET, &headers, AgentsRoute::Agent).unwrap(),
+            AgentsRepresentation::Json
+        );
+        assert_eq!(
+            negotiate_agents_route(&Method::GET, &headers, AgentsRoute::Sessions).unwrap(),
+            AgentsRepresentation::Json
+        );
+        assert_eq!(
+            negotiate_agents_route(&Method::GET, &headers, AgentsRoute::Session).unwrap(),
+            AgentsRepresentation::Json
+        );
+    }
+
+    #[test]
+    fn negotiate_agents_route_accepts_ag_ui_post_shape() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::ACCEPT,
+            HeaderValue::from_static("text/event-stream"),
+        );
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
+        assert_eq!(
+            negotiate_agents_route(&Method::POST, &headers, AgentsRoute::Session).unwrap(),
+            AgentsRepresentation::AgUiSse
+        );
+    }
+
+    #[test]
+    fn negotiate_agents_route_rejects_wrong_method_and_headers() {
+        let headers = http::HeaderMap::new();
+        assert_eq!(
+            negotiate_agents_route(&Method::POST, &headers, AgentsRoute::Session)
+                .unwrap_err()
+                .to_string(),
+            "Not Acceptable"
+        );
+        assert_eq!(
+            negotiate_agents_route(&Method::DELETE, &headers, AgentsRoute::Agent)
+                .unwrap_err()
+                .to_string(),
+            "Method Not Allowed"
+        );
+    }
+
+    #[test]
+    fn agent_route_error_mapping_covers_404_405_and_406_shapes() {
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+        let config = sandbox.config();
+
+        let missing_agent = resolve_agent(&config, "missing").map_err(ag_ui_error_to_anyhow);
+        let missing_err = missing_agent.expect_err("unknown agent should 404");
+        assert!(missing_err.to_string().contains("__status=404"));
+        assert_eq!(status_from_error(&missing_err), Some(StatusCode::NOT_FOUND));
+
+        let wrong_method_err =
+            negotiate_agents_route(&Method::DELETE, &http::HeaderMap::new(), AgentsRoute::Agent)
+                .expect_err("wrong method should 405");
+        assert_eq!(wrong_method_err.to_string(), "Method Not Allowed");
+        assert_eq!(
+            status_from_error(&wrong_method_err),
+            Some(StatusCode::METHOD_NOT_ALLOWED)
+        );
+
+        let mut bad_post_headers = http::HeaderMap::new();
+        bad_post_headers.insert(
+            http::header::ACCEPT,
+            HeaderValue::from_static("application/json"),
+        );
+        bad_post_headers.insert(
+            http::header::CONTENT_TYPE,
+            HeaderValue::from_static("text/plain"),
+        );
+        let not_acceptable_err =
+            negotiate_agents_route(&Method::POST, &bad_post_headers, AgentsRoute::Session)
+                .expect_err("bad post accept should 406");
+        assert_eq!(not_acceptable_err.to_string(), "Not Acceptable");
+        assert_eq!(
+            status_from_error(&not_acceptable_err),
+            Some(StatusCode::NOT_ACCEPTABLE)
+        );
+    }
+
+    #[test]
+    fn negotiate_agents_route_accept_header_drives_html_json_and_sse_cases() {
+        let mut html_headers = http::HeaderMap::new();
+        html_headers.insert(http::header::ACCEPT, HeaderValue::from_static("text/html"));
+        assert_eq!(
+            negotiate_agents_route(&Method::GET, &html_headers, AgentsRoute::Agent).unwrap(),
+            AgentsRepresentation::Html
+        );
+        assert_eq!(
+            negotiate_agents_route(&Method::GET, &html_headers, AgentsRoute::Session).unwrap(),
+            AgentsRepresentation::Html
+        );
+
+        let mut json_headers = http::HeaderMap::new();
+        json_headers.insert(
+            http::header::ACCEPT,
+            HeaderValue::from_static("application/json"),
+        );
+        assert_eq!(
+            negotiate_agents_route(&Method::GET, &json_headers, AgentsRoute::Agent).unwrap(),
+            AgentsRepresentation::Json
+        );
+        assert_eq!(
+            negotiate_agents_route(&Method::GET, &json_headers, AgentsRoute::Session).unwrap(),
+            AgentsRepresentation::Json
+        );
+
+        let mut sse_headers = http::HeaderMap::new();
+        sse_headers.insert(
+            http::header::ACCEPT,
+            HeaderValue::from_static("text/event-stream"),
+        );
+        assert_eq!(
+            negotiate_agents_route(&Method::POST, &sse_headers, AgentsRoute::Session).unwrap(),
+            AgentsRepresentation::AgUiSse
+        );
+    }
+
+    #[test]
+    fn status_from_error_maps_agent_route_errors() {
+        assert_eq!(
+            status_from_error(&anyhow!("Not Found")),
+            Some(StatusCode::NOT_FOUND)
+        );
+        assert_eq!(
+            status_from_error(&anyhow!("Method Not Allowed")),
+            Some(StatusCode::METHOD_NOT_ALLOWED)
+        );
+        assert_eq!(
+            status_from_error(&anyhow!("Not Acceptable")),
+            Some(StatusCode::NOT_ACCEPTABLE)
+        );
+        let err = ag_ui_error_to_anyhow(AgUiError::BadRequest("bad body".to_string()));
+        assert_eq!(status_from_error(&err), Some(StatusCode::BAD_REQUEST));
+    }
+
+    #[test]
+    fn agent_sessions_json_excludes_other_agents_and_missing_agent_names() {
+        let sessions = vec![
+            SessionMeta {
+                id: "local-1".into(),
+                session_id: Some("alpha".into()),
+                working_dir: None,
+                git_branch: None,
+                git_remote: None,
+                terminal_session_id: None,
+                agent_name: Some("plain".into()),
+                modified: None,
+            },
+            SessionMeta {
+                id: "local-2".into(),
+                session_id: Some("beta".into()),
+                working_dir: None,
+                git_branch: None,
+                git_remote: None,
+                terminal_session_id: None,
+                agent_name: Some("other".into()),
+                modified: None,
+            },
+            SessionMeta {
+                id: "local-3".into(),
+                session_id: None,
+                working_dir: None,
+                git_branch: None,
+                git_remote: None,
+                terminal_session_id: None,
+                agent_name: None,
+                modified: None,
+            },
+        ];
+
+        let filtered: Vec<Value> = sessions
+            .into_iter()
+            .filter(|session| session.agent_name.as_deref() == Some("plain"))
+            .map(|session| {
+                json!({
+                    "session_id": session.session_id.unwrap_or(session.id),
+                })
+            })
+            .collect();
+
+        assert_eq!(filtered, vec![json!({"session_id": "alpha"})]);
+    }
+
+    #[test]
+    fn agent_scoped_resolution_lists_and_loads_agent_sessions() {
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+        sandbox.write_agent("other", "You are other.");
+        let config = sandbox.config();
+
+        let scoped = agent_scoped_config(&config, "plain").expect("scope config");
+        let agent_session_path = scoped.session_file("akjG7w");
+        std::fs::create_dir_all(
+            agent_session_path
+                .parent()
+                .expect("agent session parent directory"),
+        )
+        .expect("create agent sessions dir");
+        let flat_session_path = config.session_file("flat-only");
+        std::fs::create_dir_all(
+            flat_session_path
+                .parent()
+                .expect("flat session parent directory"),
+        )
+        .expect("create flat sessions dir");
+
+        let prompt_config = fork_prompt_config(&config);
+        {
+            let mut prompt = prompt_config.write();
+            prompt.use_agent_by_name("plain").expect("set agent");
+            prompt.use_session(Some("akjG7w")).expect("open session");
+            let session = prompt.session.as_mut().expect("session loaded");
+            session.messages.push(Message::new(
+                MessageRole::User,
+                harnx_core::message::MessageContent::Text("hi from scoped dir".into()),
+            ));
+            harnx_runtime::config::session::save(session, "agent-real", &agent_session_path, false)
+                .expect("save scoped session");
+        }
+
+        std::fs::write(
+            &flat_session_path,
+            concat!(
+                "type: header
+",
+                "session_id: flat-only
+",
+                "working_dir: /tmp/project
+",
+                "agent_name: plain
+",
+                "---
+",
+                "type: message
+",
+                "role: user
+",
+                "content: hi from flat dir
+",
+            ),
+        )
+        .expect("write flat session");
+
+        let listed = agent_sessions_json(&config, "plain").expect("list scoped sessions");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].get("session_id"), Some(&json!("akjG7w")));
+        assert!(listed[0].get("updated_at").is_some());
+
+        let loaded =
+            harnx_runtime::config::session::load(&scoped, "agent-real", &agent_session_path)
+                .expect("load scoped session");
+        assert_eq!(loaded.agent_name.as_deref(), Some("plain"));
+        assert!(!loaded.messages.is_empty());
+        assert_eq!(
+            history_message_content(loaded.messages.last().expect("latest message")),
+            "hi from scoped dir"
+        );
+        assert!(!scoped.session_file("flat-only").exists());
+    }
+
+    #[test]
+    fn history_message_helpers_map_roles_and_ids() {
+        let messages = [
+            Message::new(
+                MessageRole::User,
+                harnx_core::message::MessageContent::Text("hi".into()),
+            )
+            .with_log_seq(7),
+            Message::new(
+                MessageRole::Assistant,
+                harnx_core::message::MessageContent::Text("hello".into()),
+            )
+            .with_log_seq(7),
+            Message::new(
+                MessageRole::Tool,
+                harnx_core::message::MessageContent::Array(vec![
+                    harnx_core::message::MessageContentPart::Text {
+                        text: "tool text".into(),
+                    },
+                ]),
+            )
+            .with_log_seq(8),
+        ];
+        let mut seq_counts = BTreeMap::new();
+        let shaped: Vec<Value> = messages
+            .iter()
+            .map(|message| {
+                json!({
+                    "id": history_message_id(message, &mut seq_counts),
+                    "role": history_role_name(message.role),
+                    "content": history_message_content(message),
+                })
+            })
+            .collect();
+
+        assert_eq!(
+            shaped,
+            vec![
+                json!({"id": "seq:7:0", "role": "user", "content": "hi"}),
+                json!({"id": "seq:7:1", "role": "assistant", "content": "hello"}),
+                json!({"id": "seq:8:0", "role": "tool", "content": "tool text"}),
+            ]
+        );
+    }
 }

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -909,6 +909,7 @@ mod tests {
         let messages = vec![Message {
             role: MessageRole::Tool,
             content: MessageContent::ToolCalls(tc),
+            id: None,
             log_seq: None,
             log_timestamp: None,
         }];
@@ -966,6 +967,7 @@ mod tests {
         let messages = vec![Message {
             role: MessageRole::Tool,
             content: MessageContent::ToolCalls(tc),
+            id: None,
             log_seq: None,
             log_timestamp: None,
         }];

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -75,6 +75,7 @@ fn make_compacted_message(
     harnx_core::message::Message {
         role,
         content,
+        id: None,
         log_seq: Some(log_seq),
         log_timestamp: None,
     }
@@ -8766,6 +8767,7 @@ fn messages_to_transcript_items_renders_tool_message_with_seq() {
             "calling tool".to_string(),
             Some("tool thought".to_string()),
         )),
+        id: None,
         log_seq: Some(5),
         log_timestamp: None,
     };

--- a/crates/harnx/tests/tmux_e2e.rs
+++ b/crates/harnx/tests/tmux_e2e.rs
@@ -2564,7 +2564,6 @@ fn session_mutation_edit_delete_rewind_persists_across_sessions() -> Result<()> 
         let entry = serde::Deserialize::deserialize(document)?;
         match entry {
             SessionLogEntry::Message {
-                id: None,
                 role: MessageRole::User,
                 ..
             } => {
@@ -2574,7 +2573,6 @@ fn session_mutation_edit_delete_rewind_persists_across_sessions() -> Result<()> 
                 }
             }
             SessionLogEntry::Message {
-                id: None,
                 role: MessageRole::Assistant,
                 ..
             } => {

--- a/docs/solutions/integration-issues/ag-ui-server-protocol-integration-2026-07-04.md
+++ b/docs/solutions/integration-issues/ag-ui-server-protocol-integration-2026-07-04.md
@@ -132,8 +132,9 @@ pub fn derive_thread_id(session_id: &str) -> ThreadId {
     if let Ok(uuid) = Uuid::parse_str(session_id) {
         ThreadId::from(uuid)
     } else {
-        // Stable UUIDv5 for non-UUID sessions
-        Uuid::new_v5(&Uuid::NAMESPACE_URL, session_id.as_bytes()).into()
+        // Stable UUIDv5 for non-UUID sessions.
+        // THREAD_ID_NAMESPACE is a fixed constant in ag_ui.rs for stable derivation.
+        Uuid::new_v5(&THREAD_ID_NAMESPACE, session_id.as_bytes()).into()
     }
 }
 

--- a/docs/solutions/integration-issues/ag-ui-server-protocol-integration-2026-07-04.md
+++ b/docs/solutions/integration-issues/ag-ui-server-protocol-integration-2026-07-04.md
@@ -1,0 +1,401 @@
+---
+title: "AG-UI protocol server integration in harnx-serve"
+date: 2026-07-04
+category: "integration-issues"
+problem_type: integration_issue
+component: "harnx-serve, harnx-runtime, harnx-core"
+root_cause: "ag-ui-core v0.1.0 UUID-newtype IDs incompatible with harnx session IDs; session storage agent-scoped not flat; resume reconciliation requires single-fork pattern"
+resolution_type: code_fix
+severity: high
+tags:
+  - ag-ui
+  - sse
+  - session-management
+  - uuid
+  - content-negotiation
+  - run_agent_loop
+plan_ref: "ag-ui-server-harnx-serve"
+---
+
+## Problem
+
+AG-UI (Agent User Interaction Protocol) server support was added to `harnx-serve` as a content-negotiated REST tree under `/v1/agents`, backed by `harnx_runtime::run_agent_loop`. Multiple non-obvious integration issues arose from:
+
+1. **ag-ui-core v0.1.0 ID types are UUID newtypes** — `ThreadId`, `RunId`, `MessageId` wrap `Uuid` with `FromStr` requiring valid UUID. harnx session IDs are 6-char base64/UUIDv7, NOT always UUID-parseable.
+2. **Session storage is agent-scoped** — `config_paths::sessions_dir(Some(agent))` = `agent_data_dir(agent)/sessions`, NOT flat `$HARNX_STATE_DIR/sessions`.
+3. **Resume reconciliation required single-fork architecture** — two-fork model caused duplicated prefix messages.
+4. **Durable message IDs required threading through replay paths** — two code paths dropped IDs during reconstruction.
+
+## Symptoms
+
+```
+# Session resolution failures:
+ThreadId::from_str(session_id) => parse error for non-UUID session names
+
+# Agent-scoped directory mismatch:
+GET /v1/agents/:agent/sessions => [] (looked in flat dir)
+GET /v1/agents/:agent/sessions/:session => 404 (wrong path)
+
+# Resume duplication:
+Session log after resume: [user1, user1, assistant1] (duplicated prefix)
+
+# Dropped message IDs:
+Compaction test: assistant turn IDs change after compaction
+Old logs: load correctly but IDs lost on replay
+
+# Dry-run confusion:
+Integration tests: no sessions persisted, empty history
+```
+
+## Root Cause Analysis
+
+### 1. ag-ui-core UUID ID Constraint
+
+ag-ui-core types:
+```rust
+pub struct ThreadId(Uuid);  // FromStr = Uuid::parse_str, errors on non-UUID
+pub struct MessageId(Uuid); // same
+pub struct ToolCallId(String); // plain String — different!
+```
+
+harnx session IDs from `utils/session_name.rs`:
+- UUIDv7 format, OR
+- 6-char base64url encoded timestamp
+
+**Trap**: Blindly parsing `:session` path as `ThreadId::from_str()` fails for non-UUID sessions.
+
+### 2. Agent-Scoped Session Directories
+
+Run handler:
+```rust
+// ag_ui.rs run path
+let mut cfg = base_config.fork_session_scope();
+cfg.use_agent_by_name(agent)?;
+cfg.use_session(Some(session))?;  // writes to agent-scoped dir
+```
+
+List/history handlers (initially):
+```rust
+// lib.rs — WRONG
+self.config.list_sessions_with_meta()  // scans flat dir
+self.config.session_file(session)       // flat dir path
+```
+
+`config_paths::sessions_dir(agent_opt)`:
+```rust
+match agent_opt {
+    Some(agent) => agent_data_dir(agent)/sessions,
+    None => state_path("sessions"),  // flat
+}
+```
+
+Result: run writes to `$DATA/agents/<agent>/sessions/<session>.yaml`, list reads `$STATE/sessions/`, finds nothing.
+
+### 3. Two-Fork Resume Pattern (The Duplication Trap)
+
+**Wrong** (two forks):
+```rust
+// Fork #1: reconcile
+let fork1 = base_config.fork_session_scope();
+fork1.use_agent_by_name(agent)?;
+fork1.use_session(Some(session))?;  // loads history
+let new_msgs = reconcile(&fork1.read().session.messages, &client_msgs);
+// Maybe persist user here...
+
+// Fork #2: run
+let fork2 = base_config.fork_session_scope();  // PROBLEM!
+fork2.use_agent_by_name(agent)?;
+fork2.use_session(Some(session))?;  // reloads history again
+run_agent_loop(&fork2, input).await;  // begin_turn appends user+assistant AGAIN
+```
+
+Result: `[user1, user1, assistant1]` — user persisted in fork1, then fork2 reloads and `begin_turn` appends again.
+
+### 4. Dropped Message IDs in Replay Paths
+
+`SessionLogEntry::Message.id: Option<String>` added for P1.5 durable IDs.
+
+Two replay paths missed the ID:
+
+1. `session_reconstruct.rs::cloned_message()` — copied fields, didn't thread `id` through.
+2. `runtime/session.rs::replay_log_entries_for_external()` — the `Message` construction dropped `id`.
+
+Compaction test caught #2: old `id: Some(uuid)` entries returned `id: None` after replay.
+
+## Solution
+
+### 1. Session Resolution: Raw String + ThreadId Derivation
+
+```rust
+// ag_ui.rs
+pub fn derive_thread_id(session_id: &str) -> ThreadId {
+    if let Ok(uuid) = Uuid::parse_str(session_id) {
+        ThreadId::from(uuid)
+    } else {
+        // Stable UUIDv5 for non-UUID sessions
+        Uuid::new_v5(&Uuid::NAMESPACE_URL, session_id.as_bytes()).into()
+    }
+}
+
+// Resolve session by RAW string, never parse as UUID
+let session = Session::load(&config, session_id, &path)?;
+let thread_id = derive_thread_id(session_id);  // for wire events
+```
+
+### 2. Agent-Scoped Config Helper
+
+```rust
+// lib.rs
+fn agent_scoped_config(config: &Config, agent: &str) -> Result<Config> {
+    let mut cfg = config.fork_prompt_config();  // clones
+    cfg.use_agent_by_name(agent)?;
+    Ok(cfg)
+}
+
+// Both list and history now use:
+let scoped = agent_scoped_config(&self.config, agent)?;
+scoped.list_sessions_with_meta()  // scans agent dir
+scoped.session_file(session)       // agent-scoped path
+```
+
+### 3. Single-Fork Resume Architecture
+
+```rust
+// ag_ui.rs — correct pattern
+let prompt_config: GlobalConfig = Arc::new(RwLock::new(
+    base_config.fork_session_scope()
+));
+
+// ONE use_session call
+prompt_config.write().use_agent_by_name(agent)?;
+prompt_config.write().use_session(Some(session))?;
+let persisted = prompt_config.read().session.as_ref()
+    .map(|s| s.messages.clone()).unwrap_or_default();
+
+// Reconcile
+let new_msgs = reconcile_new_messages(&persisted, &input.messages);
+if new_msgs.is_empty() {
+    return Err(AgUiError::BadRequest("no new messages".into()));  // 400
+}
+if new_msgs.len() > 1 {
+    return Err(AgUiError::BadRequest(
+        "single new message per run in P1".into()
+    ));  // 400, no silent drop
+}
+
+// Wire message ID BEFORE building input
+let message_id = MessageId::random();
+input.set_preferred_assistant_message_id(message_id.to_string());
+
+// Run on SAME fork — begin_turn appends user+assistant exactly once
+run_agent_loop(&loop_ctx, input).await;
+```
+
+**Invariants tested**:
+- First run `[user1]` → `[user1, assistant1]` (no duplicate)
+- Exact resend `[user1, assistant1]` (0 new) → 400, session unchanged
+- Normal resume `[user1, assistant1, user2]` → grows by `[user2, assistant2]` only
+- Multi-new `[.., user2, user3]` → 400 (explicit scope limit, no silent loss)
+
+### 4. Thread Message IDs Through All Paths
+
+```rust
+// session.rs — append paths now write Some(uuid)
+pub fn append_message_entries(...) {
+    let id = msg.id.clone().unwrap_or_else(|| persisted_message_id());
+    // ... write SessionLogEntry::Message { id: Some(id), ... }
+}
+
+// session_reconstruct.rs — preserve id
+fn cloned_message(entry: &SessionLogEntry) -> Option<Message> {
+    match entry {
+        SessionLogEntry::Message { id, role, content, .. } => {
+            Some(Message::new(...).with_id(id.clone()))  // thread through
+        }
+        // ...
+    }
+}
+
+// runtime/session.rs — replay path
+fn replay_log_entries_for_external(...) {
+    // Was: Message::new(role, content)
+    // Now: message.with_id(entry.id.clone())
+}
+
+// relog preserves across compaction
+fn relog_message(session: &mut Session, msg: &Message) -> usize {
+    // msg.id cloned to new entry
+}
+```
+
+**Mandatory tests**:
+```rust
+#[test]
+fn test_compaction_preserves_ids() {
+    // Create session with IDs
+    // Compact
+    // Assert IDs unchanged
+}
+
+#[test]
+fn load_from_log_accepts_old_message_entries_without_ids() {
+    // Backward compat: id: None still loads
+}
+```
+
+### 5. Input.preferred_assistant_message_id Threading
+
+```rust
+// runtime/input.rs
+pub struct Input {
+    // ... existing fields
+    preferred_assistant_message_id: Option<String>,  // new, defaults None
+}
+
+impl Input {
+    pub fn set_preferred_assistant_message_id(&mut self, id: String) {
+        self.preferred_assistant_message_id = Some(id);
+    }
+}
+
+// session.rs add_assistant_text
+pub fn add_assistant_text(...) {
+    let message_id = input.preferred_assistant_message_id
+        .clone()
+        .unwrap_or_else(persisted_message_id);
+    // Use message_id for persistence
+}
+```
+
+TUI/ACP/CLI unchanged (pass `None` → existing UUID generation).
+
+### 6. RunAgentInput Parsing: Lenient for Envelope
+
+ag-ui-core `RunAgentInput` fields `state`, `tools`, `context`, `forwarded_props` are non-optional with no serde default. Stock assistant-ui sends all, but minimal test bodies fail.
+
+```rust
+pub fn parse_run_input(body: &[u8]) -> Result<RunAgentInput, AgUiError> {
+    // Parse into shadow struct with #[serde(default)]
+    #[derive(Deserialize)]
+    struct LenientInput {
+        #[serde(default)]
+        state: JsonValue,
+        #[serde(default)]
+        tools: Vec<Tool>,
+        #[serde(default)]
+        context: Vec<Context>,
+        #[serde(default = "empty_json_object")]
+        forwarded_props: JsonValue,
+        messages: Vec<Message>,  // REQUIRED
+        #[serde(default)]
+        thread_id: Option<ThreadId>,
+        #[serde(default)]
+        run_id: Option<RunId>,
+    }
+    
+    let lenient: LenientInput = serde_json::from_slice(body)?;
+    if lenient.messages.is_empty() {
+        return Err(AgUiError::BadRequest("messages required".into()));
+    }
+    
+    // Convert to strict RunAgentInput
+    Ok(RunAgentInput {
+        state: lenient.state,
+        tools: lenient.tools,
+        // ...
+    })
+}
+```
+
+## Why This Works
+
+1. **Session resolution by raw string** never fails due to UUID format mismatch. ThreadId for wire derived stably (UUIDv5) for permalink consistency.
+
+2. **Agent-scoped config** ensures all handlers (run, list, history) resolve through same directory structure. Path mismatch eliminated.
+
+3. **Single-fork pattern** ensures `begin_turn` appends user+assistant exactly once. No manual pre-persist, no second `use_session` reload.
+
+4. **ID threading through replay** ensures compaction and session restoration preserve permalinks. `preferred_assistant_message_id` lets SSE wire ID match persisted history ID.
+
+5. **Lenient parsing** accepts minimal bodies while requiring semantic mandatory field (`messages`).
+
+## Prevention Strategies
+
+### Test Cases
+
+```rust
+#[test]
+fn ag_ui_run_streams_ordered_events_with_stubbed_call_fn() {
+    // Assert RUN_STARTED → TEXT_MESSAGE_START → CONTENT* → END → RUN_FINISHED
+    // Assert messageId consistent across START/CONTENT/END
+    // Assert threadId == derive_thread_id(session)
+    // Assert runId echoed
+    // Drain to RUN_FINISHED
+    // Assert persisted session has same IDs
+}
+
+#[test]
+fn ag_ui_run_resume_same_session_persists_only_new_turn() {
+    // First run: [u1, a1]
+    // Second run: [u1, a1, u2]
+    // Reload session, assert exactly [u1, a1, a2] (no duplicates)
+}
+
+#[test]
+fn ag_ui_rejects_exact_resend() {
+    // Run creates session
+    // Resend same messages → 400
+    // Assert session unchanged
+}
+
+#[test]
+fn agent_scoped_resolution_lists_and_loads_agent_sessions() {
+    // Persist session in agent-scoped dir
+    // Write decoy session to flat dir
+    // Assert list returns only scoped session
+    // Assert history loads scoped content
+}
+
+#[test]
+fn test_compaction_preserves_ids_for_preserved_suffix_messages() {
+    // Create session with known IDs
+    // Compact
+    // Reload
+    // Assert all IDs unchanged
+}
+```
+
+### Best Practices
+
+1. **Resolve sessions by raw string** — never parse `:session` path as ThreadId/RunId.
+2. **Derive ThreadId deterministically** — UUIDv5 for non-UUID sessions ensures stable permalinks.
+3. **Use single-fork for resume** — one `use_session` load, reconcile, run on same fork.
+4. **Reject exact resend and multi-new** — explicit 400 scope limit, no silent data loss.
+5. **Thread message IDs through all paths** — replay, compaction, relog must preserve.
+6. **Test persistence barrier** — drain SSE to `RUN_FINISHED` before asserting session state.
+7. **Use non-dry stubs for integration tests** — dry-run skips persistence.
+
+### Code Review Checklist
+
+- [ ] Session resolution uses raw `:session` string?
+- [ ] ThreadId derived via UUIDv5 for non-UUID sessions?
+- [ ] List/history use agent-scoped config?
+- [ ] Resume uses single fork + single use_session?
+- [ ] Exact resend → 400?
+- [ ] Multi-new → 400 (no silent drop)?
+- [ ] preferred_assistant_message_id threaded to persistence?
+- [ ] Replay paths preserve message.id?
+- [ ] Compaction test covers ID preservation?
+- [ ] Backward compat test for old logs without IDs?
+- [ ] Integration tests drain to RUN_FINISHED?
+
+## Related Issues
+
+- **Plan**: `ag-ui-server-harnx-serve` — comprehensive review notes
+- **ADR**: `ce1aaeb4` — architecture decision for AG-UI over OpenAI-plus
+- **ag-ui-core**: v0.1.0 dependency, UUID newtype constraints documented in `54d709e4`
+- **Session ID mapping**: Decision `8df10db1` — UUID/threadId binding rules
+- **Agent-scoped bug**: Problem `463b6f6c` — directory mismatch investigation
+- **Single-fork pattern**: Decision `1ea8647e` — Oracle-guided architecture
+- **Review blockers**: Problem `47bc5064` — Aristarchus review cycle findings
+- **P1.5 durable IDs**: Feature `d15bdb3b6c` — message ID threading implementation


### PR DESCRIPTION
Integrates the Agent Client Protocol (ACP) / Agent UI (AG-UI) server into harnx-serve, enabling external UIs to connect to and control harnx agents.

Key changes:
- Implement ag_ui module in harnx-serve with request/session management and AgUiSink for message streaming.
- Add durable message IDs to harnx-core and harnx-runtime for session reconciliation (Phase 1.5).
- Support AG-UI negotiation, JSON endpoints, and session persistence.
- Add comprehensive integration tests and documentation for the AG-UI server protocol.
- Include a changeset and a detailed solution doc for the integration.

Refs #959

Plan: ag-ui-server-harnx-serve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AG-UI protocol server support with `/v1/agents` routes, including SSE run streaming, session listing, and session history access.
  * Message IDs are now tracked more consistently across runs and saved sessions.

* **Bug Fixes**
  * Improved session replay and compaction so preserved messages keep their IDs.
  * Fixed compatibility with older session logs that do not include message IDs.

* **Documentation**
  * Added updated AG-UI usage details, examples, and integration notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->