### PR TITLE
fix(tui): keep transcript visible after compaction (#904)

### DIFF
--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -82,8 +82,11 @@ fn transcript_footprint(items: &[TranscriptItem]) -> (usize, usize) {
             | TranscriptItem::AssistantText { text, .. }
             | TranscriptItem::ToolResultMarkdown { text, .. } => text.len(),
             TranscriptItem::CompactionMarker {
-                text, detail_text, ..
-            } => text.len() + detail_text.len(),
+                text,
+                summary_text,
+                detail_text,
+                ..
+            } => text.len() + summary_text.len() + detail_text.len(),
             TranscriptItem::ToolCall { tool_name, .. } => tool_name.len(),
             TranscriptItem::Plan(_) | TranscriptItem::SourceHeading(_) => 0,
         })
@@ -748,25 +751,64 @@ fn append_message_compaction_detail_sections(
 
 fn build_compaction_marker(
     messages: &[Message],
+    summary_text: String,
     decl_map: &HashMap<String, ToolDeclaration>,
 ) -> TranscriptItem {
     let from_seq = messages.iter().filter_map(|msg| msg.log_seq).min();
     let to_seq = messages.iter().filter_map(|msg| msg.log_seq).max();
+    let archived_count = messages.len();
     let mut detail_sections = Vec::new();
+    if !summary_text.is_empty() {
+        detail_sections.push(format!("── summary ──\n{summary_text}"));
+    }
+    detail_sections.push(format!("archived messages: {archived_count}"));
     for message in messages {
         append_message_compaction_detail_sections(&mut detail_sections, message, decl_map);
     }
-    let detail_text = detail_sections.join(
-        "
-
-",
-    );
+    let detail_text = detail_sections.join("\n\n");
     TranscriptItem::CompactionMarker {
         text: "─── session compacted ───".to_string(),
+        summary_text,
         from_seq,
         to_seq,
         detail_text,
     }
+}
+
+/// Build the transcript for a (possibly compacted) session view.
+///
+/// When `compressed_messages` is non-empty the archived history is rendered
+/// inline first so it stays visible, followed by a single compaction marker
+/// carrying the summary (the leading `System` message of the active window),
+/// then the active/preserved messages. Shared by the local and remote resume
+/// paths to keep their layout in lockstep (#904).
+pub(crate) fn build_transcript_with_compaction(
+    compressed_messages: &[Message],
+    active_messages: &[Message],
+    decl_map: &HashMap<String, ToolDeclaration>,
+) -> Vec<TranscriptItem> {
+    use harnx_core::message::MessageRole;
+
+    let mut items = Vec::new();
+    if !compressed_messages.is_empty() {
+        items.extend(messages_to_transcript_items(compressed_messages, decl_map));
+        // Invariant: `compress_keeping_recent` prepends the compaction summary as
+        // the leading `System` message of the active window, so the summary (when
+        // present) is `active_messages[0]`. If that contract changes, the summary
+        // would silently render empty rather than showing wrong content.
+        let summary_text = active_messages
+            .first()
+            .filter(|msg| msg.role == MessageRole::System)
+            .map(|msg| msg.content.to_text())
+            .unwrap_or_default();
+        items.push(build_compaction_marker(
+            compressed_messages,
+            summary_text,
+            decl_map,
+        ));
+    }
+    items.extend(messages_to_transcript_items(active_messages, decl_map));
+    items
 }
 
 pub(crate) fn session_history_transcript_items(config: &GlobalConfig) -> Vec<TranscriptItem> {
@@ -833,27 +875,15 @@ pub(crate) fn session_history_transcript_items(config: &GlobalConfig) -> Vec<Tra
             }
         };
 
-        let mut items = Vec::new();
-        if !state.compressed_messages.is_empty() {
-            items.push(build_compaction_marker(
-                &state.compressed_messages,
-                &decl_map,
-            ));
-        }
-        items.extend(messages_to_transcript_items(&state.messages, &decl_map));
-        return items;
+        return build_transcript_with_compaction(
+            &state.compressed_messages,
+            &state.messages,
+            &decl_map,
+        );
     }
 
     let session = cfg.session.as_ref().expect("checked above");
-    let mut items = Vec::new();
-    if !session.compressed_messages.is_empty() {
-        items.push(build_compaction_marker(
-            &session.compressed_messages,
-            &decl_map,
-        ));
-    }
-    items.extend(messages_to_transcript_items(&session.messages, &decl_map));
-    items
+    build_transcript_with_compaction(&session.compressed_messages, &session.messages, &decl_map)
 }
 
 /// Compact one-line preview of a tool call's arguments for the confirmation

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -143,8 +143,10 @@ impl Tui {
                 );
                 RenderedEntry::from_lines(lines, width)
             }
-            TranscriptItem::CompactionMarker { text, .. } => {
-                let lines = Self::render_text_entry(
+            TranscriptItem::CompactionMarker {
+                text, summary_text, ..
+            } => {
+                let mut lines = Self::render_text_entry(
                     "",
                     text,
                     Style::default()
@@ -152,6 +154,16 @@ impl Tui {
                         .add_modifier(Modifier::DIM),
                     false,
                 );
+                if !summary_text.is_empty() {
+                    lines.extend(Self::render_text_entry(
+                        "",
+                        summary_text,
+                        Style::default()
+                            .fg(Color::DarkGray)
+                            .add_modifier(Modifier::DIM),
+                        false,
+                    ));
+                }
                 RenderedEntry::from_lines(lines, width)
             }
             TranscriptItem::SystemText(text) => {
@@ -1141,6 +1153,7 @@ impl Tui {
             }
             TranscriptItem::CompactionMarker {
                 text,
+                summary_text,
                 from_seq,
                 to_seq,
                 detail_text,
@@ -1150,6 +1163,9 @@ impl Tui {
                     label_style,
                 )));
                 push_field!("text", text);
+                if !summary_text.is_empty() {
+                    push_field!("summary", summary_text);
+                }
                 let seq_range = match (from_seq, to_seq) {
                     (Some(from), Some(to)) => format!("{from}–{to}"),
                     _ => "n/a".to_string(),

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -108,6 +108,41 @@ fn seed_compressed_session(config: &GlobalConfig) {
     guard.session = Some(session);
 }
 
+/// Like `seed_compressed_session`, but the active window begins with a
+/// `System` compaction summary message (as produced by `compress_keeping_recent`),
+/// so the compaction marker carries a non-empty `summary_text`.
+fn seed_compressed_session_with_summary(config: &GlobalConfig) {
+    let mut guard = config.write();
+    let mut session = harnx_runtime::config::session::new(&guard, "compacted-summary").unwrap();
+    session.compressed_messages = vec![
+        make_compacted_message(
+            harnx_core::message::MessageRole::User,
+            harnx_core::message::MessageContent::Text("Old question".to_string()),
+            0,
+        ),
+        make_compacted_message(
+            harnx_core::message::MessageRole::Assistant,
+            harnx_core::message::MessageContent::Text("Old answer".to_string()),
+            1,
+        ),
+    ];
+    session.messages = vec![
+        make_compacted_message(
+            harnx_core::message::MessageRole::System,
+            harnx_core::message::MessageContent::Text(
+                "Prior conversation summary line".to_string(),
+            ),
+            2,
+        ),
+        make_compacted_message(
+            harnx_core::message::MessageRole::User,
+            harnx_core::message::MessageContent::Text("Current question".to_string()),
+            3,
+        ),
+    ];
+    guard.session = Some(session);
+}
+
 fn normalize_screen(contents: &str) -> String {
     let trimmed = contents
         .lines()
@@ -8388,7 +8423,7 @@ async fn render_agent_event_compacting_completed_reconciles_live_transcript() {
             .iter()
             .filter(|item| matches!(item, TranscriptItem::UserText { text, .. } if text == "Old question"))
             .count(),
-        0
+        1
     );
     assert_eq!(
         tui.app
@@ -8396,7 +8431,7 @@ async fn render_agent_event_compacting_completed_reconciles_live_transcript() {
             .iter()
             .filter(|item| matches!(item, TranscriptItem::AssistantText { text, .. } if text == "Old answer"))
             .count(),
-        0
+        1
     );
     assert_eq!(
         tui.app
@@ -8408,21 +8443,219 @@ async fn render_agent_event_compacting_completed_reconciles_live_transcript() {
     );
     // seed_compressed_session assigns log_seq 0,1,2 to the compressed
     // messages, so the marker must span that full range.
+    let marker_idx = tui
+        .app
+        .transcript
+        .iter()
+        .position(|item| matches!(item, TranscriptItem::CompactionMarker { .. }))
+        .expect("compaction marker present");
+    assert_eq!(marker_idx, 2);
     assert!(matches!(
         tui.app.transcript.first(),
-        Some(TranscriptItem::CompactionMarker { text, detail_text, from_seq, to_seq })
+        Some(TranscriptItem::UserText { text, .. }) if text == "Old question"
+    ));
+    assert!(matches!(
+        tui.app.transcript.get(1),
+        Some(TranscriptItem::AssistantText { text, .. }) if text == "Old answer"
+    ));
+    assert!(matches!(
+        tui.app.transcript.get(marker_idx),
+        Some(TranscriptItem::CompactionMarker {
+            text,
+            summary_text,
+            detail_text,
+            from_seq,
+            to_seq,
+        })
             if text == "─── session compacted ───"
+                && summary_text.is_empty()
+                && detail_text.contains("archived messages: 3")
                 && detail_text.contains("Old question")
                 && detail_text.contains("Old answer")
                 && *from_seq == Some(0)
                 && *to_seq == Some(2)
     ));
-    assert!(tui.app.transcript[0].is_navigable());
+    assert!(tui.app.transcript[marker_idx].is_navigable());
     assert!(!tui.app.streaming_open);
     assert_eq!(tui.app.last_usage_transcript_idx, None);
     assert_eq!(tui.app.last_usage_source, None);
     assert_eq!(tui.app.transcript_focus, None);
     assert_eq!(tui.app.transcript_selection_anchor, None);
+}
+
+#[tokio::test]
+async fn session_history_compaction_keeps_archived_history_visible_inline() {
+    let config = test_config_with_mock_client_and_agent("test-agent", None);
+    seed_compressed_session(&config);
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    let old_question_idx = tui
+        .app
+        .transcript
+        .iter()
+        .position(
+            |item| matches!(item, TranscriptItem::UserText { text, .. } if text == "Old question"),
+        )
+        .expect("old question present");
+    let old_answer_idx = tui
+        .app
+        .transcript
+        .iter()
+        .position(|item| matches!(item, TranscriptItem::AssistantText { text, .. } if text == "Old answer"))
+        .expect("old answer present");
+    let marker_idx = tui
+        .app
+        .transcript
+        .iter()
+        .position(|item| matches!(item, TranscriptItem::CompactionMarker { .. }))
+        .expect("compaction marker present");
+    let current_question_idx = tui
+        .app
+        .transcript
+        .iter()
+        .position(|item| matches!(item, TranscriptItem::UserText { text, .. } if text == "Current question"))
+        .expect("current question present");
+
+    assert!(old_question_idx < old_answer_idx);
+    assert!(old_answer_idx < marker_idx);
+    assert!(marker_idx < current_question_idx);
+}
+
+#[tokio::test]
+async fn session_history_compaction_marker_carries_summary_text() {
+    let config = test_config_with_mock_client_and_agent("test-agent", None);
+    seed_compressed_session_with_summary(&config);
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    // The System summary from the head of the active window is surfaced on the
+    // marker as `summary_text` rather than being silently dropped.
+    let summary_text = tui
+        .app
+        .transcript
+        .iter()
+        .find_map(|item| match item {
+            TranscriptItem::CompactionMarker { summary_text, .. } => Some(summary_text.clone()),
+            _ => None,
+        })
+        .expect("compaction marker present");
+    assert!(
+        summary_text.contains("Prior conversation summary line"),
+        "summary should be carried on the marker, got: {summary_text:?}"
+    );
+
+    // The summary must not leak back in as a duplicate top-level System row.
+    assert!(!tui.app.transcript.iter().any(|item| matches!(
+        item,
+        TranscriptItem::SystemText(text) if text.contains("Prior conversation summary line")
+    )));
+
+    // Archived history stays visible, and the preserved suffix follows.
+    assert!(tui.app.transcript.iter().any(
+        |item| matches!(item, TranscriptItem::UserText { text, .. } if text == "Old question")
+    ));
+    assert!(tui.app.transcript.iter().any(
+        |item| matches!(item, TranscriptItem::UserText { text, .. } if text == "Current question")
+    ));
+}
+
+#[tokio::test]
+async fn compaction_marker_summary_rendered_inline() {
+    let config = test_config_with_mock_client_and_agent("test-agent", None);
+    seed_compressed_session_with_summary(&config);
+    let mut harness = TuiTestHarness::with_config(config).await;
+    harness.render();
+    let contents = harness.screen_contents();
+    assert!(
+        contents.contains("Prior conversation summary line"),
+        "summary should render inline in the transcript, screen was:\n{contents}"
+    );
+}
+
+#[test]
+fn build_transcript_with_compaction_orders_history_marker_and_suffix() {
+    use harnx_core::message::{MessageContent, MessageRole};
+    use std::collections::HashMap;
+
+    let decl_map: HashMap<String, harnx_runtime::tool::ToolDeclaration> = HashMap::new();
+    let compressed = vec![
+        make_compacted_message(
+            MessageRole::User,
+            MessageContent::Text("Archived question".to_string()),
+            0,
+        ),
+        make_compacted_message(
+            MessageRole::Assistant,
+            MessageContent::Text("Archived answer".to_string()),
+            1,
+        ),
+    ];
+    let active = vec![
+        make_compacted_message(
+            MessageRole::System,
+            MessageContent::Text("Summary of the past".to_string()),
+            2,
+        ),
+        make_compacted_message(
+            MessageRole::User,
+            MessageContent::Text("Fresh question".to_string()),
+            3,
+        ),
+    ];
+
+    let items = crate::lifecycle::build_transcript_with_compaction(&compressed, &active, &decl_map);
+
+    let archived_q = items
+        .iter()
+        .position(
+            |item| matches!(item, TranscriptItem::UserText { text, .. } if text == "Archived question"),
+        )
+        .expect("archived question rendered inline");
+    let marker = items
+        .iter()
+        .position(|item| matches!(item, TranscriptItem::CompactionMarker { .. }))
+        .expect("compaction marker present");
+    let fresh_q = items
+        .iter()
+        .position(
+            |item| matches!(item, TranscriptItem::UserText { text, .. } if text == "Fresh question"),
+        )
+        .expect("preserved suffix rendered");
+
+    // Layout: [...archived history, marker, ...preserved suffix].
+    assert!(archived_q < marker, "archived history must precede marker");
+    assert!(marker < fresh_q, "marker must precede preserved suffix");
+
+    // Marker carries exactly one compaction event with the summary and range.
+    let markers: Vec<_> = items
+        .iter()
+        .filter(|item| matches!(item, TranscriptItem::CompactionMarker { .. }))
+        .collect();
+    assert_eq!(markers.len(), 1);
+    match markers[0] {
+        TranscriptItem::CompactionMarker {
+            summary_text,
+            from_seq,
+            to_seq,
+            ..
+        } => {
+            assert!(summary_text.contains("Summary of the past"));
+            assert_eq!(*from_seq, Some(0));
+            assert_eq!(*to_seq, Some(1));
+        }
+        _ => unreachable!(),
+    }
+
+    // No archived messages => no marker, only the active messages render.
+    let no_compaction = crate::lifecycle::build_transcript_with_compaction(&[], &active, &decl_map);
+    assert!(!no_compaction
+        .iter()
+        .any(|item| matches!(item, TranscriptItem::CompactionMarker { .. })));
 }
 
 #[tokio::test]
@@ -8444,6 +8677,7 @@ async fn session_history_compaction_detail_includes_system_messages() {
         })
         .expect("expected compaction marker");
 
+    assert!(marker.contains("archived messages: 3"));
     assert!(marker.contains("── system ──"));
     assert!(marker.contains("Old system note"));
 }
@@ -8513,10 +8747,12 @@ async fn session_history_compaction_is_single_navigable_item() {
         .collect();
     assert_eq!(compaction_items.len(), 1);
     assert!(compaction_items[0].is_navigable());
-    assert!(!tui.app.transcript.iter().any(|item| {
-        matches!(item, TranscriptItem::UserText { text, .. } if text == "Old question")
-            || matches!(item, TranscriptItem::AssistantText { text, .. } if text == "Old answer")
-    }));
+    assert!(tui.app.transcript.iter().any(
+        |item| matches!(item, TranscriptItem::UserText { text, .. } if text == "Old question")
+    ));
+    assert!(tui.app.transcript.iter().any(
+        |item| matches!(item, TranscriptItem::AssistantText { text, .. } if text == "Old answer")
+    ));
 }
 
 #[tokio::test]
@@ -8570,7 +8806,16 @@ async fn enter_on_compaction_marker_opens_full_detail_view() {
     let config = test_config();
     seed_compressed_session(&config);
     let mut harness = TuiTestHarness::with_config(config).await;
-    harness.tui().app.transcript_focus = Some(1);
+    // Archived messages now render inline before the marker, so locate the
+    // compaction marker dynamically rather than assuming a fixed index.
+    let marker_idx = harness
+        .tui()
+        .app
+        .transcript
+        .iter()
+        .position(|item| matches!(item, TranscriptItem::CompactionMarker { .. }))
+        .expect("compaction marker present");
+    harness.tui().app.transcript_focus = Some(marker_idx);
 
     harness
         .tui()

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -267,6 +267,7 @@ pub enum TranscriptItem {
     StatusLine(String),
     CompactionMarker {
         text: String,
+        summary_text: String,
         from_seq: Option<usize>,
         to_seq: Option<usize>,
         detail_text: String,

--- a/docs/solutions/logic-errors/tui-compaction-transcript-blanked-2026-07-04.md
+++ b/docs/solutions/logic-errors/tui-compaction-transcript-blanked-2026-07-04.md
@@ -1,0 +1,176 @@
+---
+title: "TUI transcript blanked out by compaction summary collapse"
+date: 2026-07-04
+category: logic-errors
+problem_type: logic_error
+component: "harnx-tui"
+root_cause: "compaction rebuilt transcript with compressed history hidden inside CompactionMarker.detail_text and System summary silently dropped by messages_to_transcript_items filter"
+resolution_type: code_fix
+severity: high
+tags:
+  - tui
+  - ratatui
+  - transcript
+  - compaction
+  - visibility
+  - event-boundary
+plan_ref: issue-904-compaction-transcript
+---
+
+## Problem
+
+After session compaction completed, the TUI transcript appeared completely empty even though the session history was intact. Prior conversation vanished into a single collapsed line.
+
+## Symptoms
+
+```
+- User runs `.compact session` (or auto-compaction triggers)
+- Compaction completes successfully
+- Transcript shows only: `─── session compacted ───`
+- All prior user/assistant messages disappear
+- Opening the compaction marker detail view showed archived messages, but inline transcript was blank
+- Compaction summary text (leading System message) was not visible anywhere
+```
+
+## Investigation Steps
+
+1. Traced `SessionEvent::CompactingCompleted` handler in `lifecycle.rs` — it calls `session_history_transcript_items()` to rebuild transcript.
+
+2. Found `session_history_transcript_items()` built transcript as:
+   - `[CompactionMarker{ detail_text = <all compressed messages collapsed> }]` + preserved suffix
+   - Inline transcript showed only the marker text, not the archived messages
+
+3. Discovered `messages_to_transcript_items()` ignores `MessageRole::System` messages — the compaction summary (prepended by `compress_keeping_recent` as `active_messages[0]`) was silently dropped.
+
+4. Identified two independent bugs:
+   - Compressed history was hidden, not rendered inline
+   - System summary was swallowed by filter
+
+5. Review flagged coverage gaps: non-empty summary path and remote path untested.
+
+## Root Cause
+
+The compaction rebuild treated archived messages as hidden detail content rather than visible transcript history. The `CompactionMarker.detail_text` field aggregated all compressed messages into invisible storage. Additionally, the generic `messages_to_transcript_items()` filter that drops System messages swallowed the compaction summary, which by invariant sits at `active_messages[0]` after `compress_keeping_recent`.
+
+**Key invariant violated:** Compaction is an event boundary, not a replacement. Prior history should remain visible with a marker separating archived from active.
+
+## Solution
+
+### 1. Model compaction as inline event boundary
+
+Rebuild transcript structure: `[...compressed_messages as visible items, CompactionMarker, ...preserved suffix]`
+
+```rust
+pub(crate) fn build_transcript_with_compaction(
+    compressed_messages: &[Message],
+    active_messages: &[Message],
+    decl_map: &HashMap<String, ToolDeclaration>,
+) -> Vec<TranscriptItem> {
+    let mut items = Vec::new();
+    if !compressed_messages.is_empty() {
+        // Render archived history inline, not hidden in detail_text
+        items.extend(messages_to_transcript_items(compressed_messages, decl_map));
+        
+        // Extract summary from leading System message (invariant: compress_keeping_recent prepends it)
+        let summary_text = active_messages
+            .first()
+            .filter(|msg| msg.role == MessageRole::System)
+            .map(|msg| msg.content.to_text())
+            .unwrap_or_default();
+        
+        items.push(build_compaction_marker(compressed_messages, summary_text, decl_map));
+    }
+    items.extend(messages_to_transcript_items(active_messages, decl_map));
+    items
+}
+```
+
+### 2. Surface System summary on the marker
+
+Add `summary_text` field to `CompactionMarker`:
+
+```rust
+// types.rs
+CompactionMarker {
+    text: String,           // "─── session compacted ───"
+    summary_text: String,    // Compaction summary (extracted from System message)
+    from_seq: Option<usize>,
+    to_seq: Option<usize>,
+    detail_text: String,     // Full archived content for detail view
+}
+```
+
+Render inline with summary:
+
+```rust
+// render.rs
+TranscriptItem::CompactionMarker { text, summary_text, .. } => {
+    let mut lines = Self::render_text_entry("", text, dim_style, false);
+    if !summary_text.is_empty() {
+        lines.extend(Self::render_text_entry("", summary_text, dim_style, false));
+    }
+    RenderedEntry::from_lines(lines, width)
+}
+```
+
+### 3. Shared helper for local/remote parity
+
+Extract `build_transcript_with_compaction()` as `pub(crate)` helper called by BOTH:
+- Local path: `session.compressed_messages`, `session.messages`
+- Remote path: `load_remote_transcript_for_render()` result
+
+This prevents layout drift and makes remote logic unit-testable directly.
+
+```rust
+// Both paths now identical:
+build_transcript_with_compaction(&compressed, &active, &decl_map)
+```
+
+### 4. Update footprint accounting
+
+Include `summary_text.len()` in size tracking:
+
+```rust
+// lifecycle.rs transcript_footprint
+TranscriptItem::CompactionMarker { text, summary_text, detail_text, .. } => {
+    text.len() + summary_text.len() + detail_text.len()
+}
+```
+
+## Why This Works
+
+1. **Event boundary model**: Archival is transparent — prior history stays visible with marker as separator
+2. **Summary surfacing**: System message is extracted and rendered on marker, not swallowed by generic filter
+3. **Shared helper**: Local and remote paths converge — no code duplication, testable directly
+4. **Invariant documented**: Code comment explains that `active_messages[0]` being System is contract from `compress_keeping_recent`
+
+## Prevention Strategies
+
+**Test Cases:**
+- `session_history_compaction_marker_carries_summary_text`: Seed session with System summary at active[0]; assert marker carries it and no duplicate System row appears
+- `compaction_marker_summary_rendered_inline`: Screen render assertion shows summary text below marker line
+- `build_transcript_with_compaction_orders_history_marker_and_suffix`: Direct unit test of shared helper — ordering, single marker, summary + from/to_seq populated, empty-compressed => no marker
+
+**Seed helper pattern:**
+```rust
+/// Active window begins with System summary (as produced by compress_keeping_recent)
+fn seed_compressed_session_with_summary(config: &GlobalConfig) {
+    session.compressed_messages = vec![/* archived turns */];
+    session.messages = vec![
+        make_compacted_message(MessageRole::System, "Summary...", 2),
+        make_compacted_message(MessageRole::User, "Fresh question", 3),
+    ];
+}
+```
+
+**Code Review Checklist:**
+- [ ] Does `messages_to_transcript_items()` silently drop messages? Document which roles are filtered and why
+- [ ] When adding TranscriptItem variants with summary/boundary semantics, ensure they render inline
+- [ ] Do local and remote transcript paths call the same builder? Extract shared helper if duplicated
+- [ ] Is the `active_messages[0] is System` invariant documented where it's consumed?
+
+## Related Issues
+
+- **Issue:** [#904](https://github.com/dobesv/harnx/issues/904) — TUI transcript blanked out by compaction
+- **Prior Solution:** [tui-compaction-marker-detail-view-2026-06-12.md](../integration-issues/tui-compaction-marker-detail-view-2026-06-12.md) — Marker as navigable event with detail view
+- **Prior Solution:** [tui-compaction-spinner-corruption-2026-06-08.md](../integration-issues/tui-compaction-spinner-corruption-2026-06-08.md) — AgentEvent-based compaction progress


### PR DESCRIPTION
Fixes the issue where the TUI transcript was blanked out by history compaction. Renders archived compressed_messages inline, adds a compaction event marker carrying the summary text, and ensures the preserved suffix remains visible. Extracts a shared build_transcript_with_compaction helper for parity between local and remote history paths and adds test coverage.

Issue: #904

Plan: issue-904-compaction-transcript