### PR TITLE
Implement per-session actor and JSON-RPC control plane for AG-UI

### DIFF
--- a/.changeset/ag-ui-control-plane.md
+++ b/.changeset/ag-ui-control-plane.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+Add AG-UI Phase 2 control plane to harnx-serve: a per-(agent,session) actor with a tokio::broadcast event bus, a JSON-RPC 2.0 control endpoint (`session/get|prompt|cancel`), and a subscription-style SSE endpoint that emits a MESSAGES_SNAPSHOT on join then streams live events to all subscribers (with ~15s keep-alive). Dropping an SSE connection no longer stops a run — only `session/cancel` aborts, and cancellation persists partial state. The SSE run POST now inspects only the last message and drops the previous reconcile/empty/multi-message 400s.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4118,6 +4118,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "dashmap",
  "futures",
  "futures-util",
  "harnx-core",

--- a/crates/harnx-serve/Cargo.toml
+++ b/crates/harnx-serve/Cargo.toml
@@ -20,6 +20,8 @@ anyhow = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
+dashmap = "6"
+futures = "0.3"
 futures-util = { workspace = true }
 harnx-core = { path = "../harnx-core" }
 harnx-hooks = { path = "../harnx-hooks" }

--- a/crates/harnx-serve/README.md
+++ b/crates/harnx-serve/README.md
@@ -27,98 +27,119 @@ cargo install --path crates/harnx-serve
 
 `harnx-serve` implements the AG-UI protocol, providing a content-negotiated, permalinkable REST surface under `/v1/agents`. This API is additive; the standard OpenAI-compatible endpoints (`/v1/chat/completions`, etc.) remain unaffected.
 
-The AG-UI surface allows modern web interfaces (e.g., [assistant-ui](https://assistant-ui.com)) to interact with `harnx` agents using a stock `HttpAgent`.
+The AG-UI surface allows modern web interfaces to interact with `harnx` agents using a real-time event stream and a JSON-RPC control plane.
 
 ### Endpoints
 
-| Method | Path | Accept | Purpose |
+| Method | Path | Accept / Content-Type | Purpose |
 | :--- | :--- | :--- | :--- |
 | `GET` | `/v1/agents` | `application/json` | List all configured agents. |
-| `GET` | `/v1/agents/:agent` | `text/html` | HTML placeholder page for the agent. |
 | `GET` | `/v1/agents/:agent` | `application/json` | Agent details (name, description, active sessions). |
-| `GET` | `/v1/agents/:agent/sessions` | `application/json` | List sessions for the agent (filtered by `agent_name`). |
-| `GET` | `/v1/agents/:agent/sessions/:session` | `text/html` | HTML placeholder page for the session. |
-| `GET` | `/v1/agents/:agent/sessions/:session` | `application/json` | Session history in AG-UI format (array of `{ id, role, content }`). |
-| `POST` | `/v1/agents/:agent/sessions/:session` | `text/event-stream` | Execute an agent run via SSE. |
+| `GET` | `/v1/agents/:agent/sessions` | `application/json` | List sessions for the agent. |
+| `GET` | `/v1/agents/:agent/sessions/:session` | `application/json` | Session history in AG-UI format. |
+| `POST` | `/v1/agents/:agent/sessions/:session` | `text/event-stream` | **Subscription Plane**: SSE event stream. |
+| `POST` | `/v1/agents/:agent/sessions/:session/rpc`| `application/json` | **Control Plane**: JSON-RPC 2.0 interface. |
 
-### Key Behaviors
+## AG-UI Support (Phase 2)
 
-- **Content Negotiation:** The same URL serves HTML (for browsers), JSON (for data), or SSE (for execution) based on the `Accept` header and HTTP method.
-- **Permalink Model:** The `:session` ID in the URL is the stable session key from which the AG-UI `threadId` is derived. If the session ID is already a UUID, the `threadId` is identical; otherwise, it is a stable UUIDv5 hash of the slug. Sessions are lazily created upon the first run to a new session ID.
-- **SSE Framing:** Each event is delivered as `data: {json}\n\n`. The event type is specified in the JSON `type` field.
-- **Server-Authoritative History:** While clients send the full message array on each run, the server reconciles history and persists only new user turns. Resuming a session continues context without duplicating messages.
-- **Single-Message Run Contract:** Phase 1 accepts exactly **one** new user message per run. 
-  - If the sent array contains NO new messages (exact resend) → returns **400 Bad Request**.
-  - If it contains MORE THAN ONE new message → returns **400 Bad Request**.
-  - This matches standard `assistant-ui` `HttpAgent` behavior (full history + one new turn).
+`harnx-serve` implements a tailored two-plane communication model. This model provides real-time event streaming and a JSON-RPC control plane for managing agent sessions.
 
-#### P1 Event Set
-The following events are supported in the initial implementation:
-1. `RUN_STARTED`
-2. `TEXT_MESSAGE_START`
-3. `TEXT_MESSAGE_CONTENT` (streamed)
-4. `TEXT_MESSAGE_END`
-5. `RUN_FINISHED` (Successful completion)
-6. `RUN_ERROR` (Terminal failure; replaces `RUN_FINISHED`). On error, the stream terminates immediately without emitting `TEXT_MESSAGE_END` or `RUN_FINISHED`. Clients should treat `RUN_ERROR` as the end of the run and the current message.
+### Two-Plane Architecture
 
-### Operational Notes
+#### 1. SSE Subscription Plane
+**Endpoint:** `POST /v1/agents/:agent/sessions/:session`  
+**Header:** `Accept: text/event-stream`
 
-- **Persistence and `--dry-run`:** Session persistence is skipped in `--dry-run` mode. To enable session enumeration, history, and resumption, run the server without the `--dry-run` flag.
-- **Consistency Barrier:** History and enumeration reflect a run only AFTER the SSE stream reaches `RUN_FINISHED`. The turn is persisted as it completes.
+Provides a live stream of AG-UI events. Multiple concurrent subscribers are supported via broadcast.
 
-### Quickstart
+- **Initialization:** Emits a `MESSAGES_SNAPSHOT` event immediately upon connection with the current history.
+- **Run Triggering:** Inspects the **last message** of the JSON body.
+  - If the last message is a `user` message → starts/continues a run.
+  - Otherwise (or empty body) → joins/resumes the session without starting a new run.
+- **Keep-Alive:** Sends `: keep-alive` SSE comments approximately every 15 seconds.
+- **Events:** Streams `RUN_STARTED`, `TEXT_MESSAGE_START`, `TEXT_MESSAGE_CONTENT`, `TEXT_MESSAGE_END`, `RUN_FINISHED`, and `RUN_ERROR`.
+
+#### 2. JSON-RPC 2.0 Control Plane
+**Endpoint:** `POST /v1/agents/:agent/sessions/:session/rpc`  
+**Header:** `Content-Type: application/json`
+
+Sibling endpoint for programmatic control.
+
+- **`session/get`**: Returns session state and capabilities.
+  ```json
+  { "jsonrpc": "2.0", "id": 1, "method": "session/get" }
+  ```
+  **Result:** `{ "state": { "status": "idle" }, "history_snapshot": [...], "capabilities": { "multiClient": true, "persistence": "filesystem" } }` (a running session reports `"state": { "status": "running", "run_id": "…", "started_at": "…" }`)
+- **`session/prompt`**: Sends a new user prompt.
+  ```json
+  { "jsonrpc": "2.0", "id": 2, "method": "session/prompt", "params": { "text": "hello" } }
+  ```
+  **Result:** `{ "status": "accepted", "run_id": "..." }` (idle) or `{ "status": "enqueued", "run_id": "..." }` (running).
+- **`session/cancel`**: Aborts the running agent loop.
+  ```json
+  { "jsonrpc": "2.0", "id": 3, "method": "session/cancel" }
+  ```
+  **Result:** `{ "cancelled": true }`
+
+**Error Codes:**
+- `-32001`: Unknown session
+- `-32601`: Method not found
+- Standard JSON-RPC 2.0 codes (-32700, -32600, -32602)
+
+### Client Implementation Flow
+
+1. **Connect**: Open an SSE connection to receive history and subscribe to live events.
+2. **Drive**: Use the JSON-RPC endpoint to send prompts (`session/prompt`) or cancel runs (`session/cancel`).
+3. **Stateless UI**: Clients only send new inputs via RPC; they do not need to re-POST the full transcript.
+
+### Disconnect Semantics (D5)
+
+SSE connections are decoupled from execution. Dropping an SSE connection (e.g., reloading the page) **does not stop** a running agent. The run continues to completion and persists. Only `session/cancel` or a terminal error stops a run.
+
+### Divergence from AG-UI Standards
+
+This implementation deliberately diverges from generic AG-UI/assistant-ui standards for optimization:
+- **Last-Message Inspection:** Decision to start a run is based on the last message in the SSE POST body.
+- **Two-Plane Control:** Uses JSON-RPC instead of standard RESTful run endpoints to support mid-run injection.
+- **No Staleness Guards:** Omits request reconciliation and version/sequence guards.
+
+### Phase B Scope
+
+Cross-process live synchronization via NATS and distributed persistence (Issue #848) are deferred to Phase B.
+
+## Operational Notes
+
+- **Persistence and `--dry-run`:** Session persistence is skipped in `--dry-run` mode.
+- **Consistency Barrier:** History reflects a turn only AFTER it completes and is persisted.
+
+## Quickstart
 
 1. **Start the server:**
    ```sh
    harnx-serve --addr 127.0.0.1:8000
    ```
-   *Note: Do not use `--dry-run` if you want sessions to persist.*
 
-2. **Execute a run via `curl`:**
+2. **Subscribe to a session (SSE):**
    ```bash
    curl -N -X POST http://127.0.0.1:8000/v1/agents/my-agent/sessions/my-session \
      -H "Accept: text/event-stream" \
+     -d '{}'
+   ```
+
+3. **Send a prompt via JSON-RPC:**
+   ```bash
+   curl -X POST http://127.0.0.1:8000/v1/agents/my-agent/sessions/my-session/rpc \
      -H "Content-Type: application/json" \
      -d '{
-       "threadId": "<derived-thread-id>",
-       "messages": [
-         { "role": "user", "content": "hello" }
-       ]
+       "jsonrpc": "2.0",
+       "id": 1,
+       "method": "session/prompt",
+       "params": { "text": "Hello, agent!" }
      }'
-   ```
-   *Note: When the session ID (e.g., `my-session`) is not a UUID, the wire `threadId` is a derived UUID, not the literal slug.*
-
-3. **Expected SSE Output:**
-   ```text
-   data: {"type":"RUN_STARTED","threadId":"<derived-thread-id>","runId":"..."}
-
-   data: {"type":"TEXT_MESSAGE_START","messageId":"<uuid>","role":"assistant"}
-
-   data: {"type":"TEXT_MESSAGE_CONTENT","messageId":"<uuid>","delta":"Hello"}
-
-   data: {"type":"TEXT_MESSAGE_END","messageId":"<uuid>"}
-
-   data: {"type":"RUN_FINISHED","threadId":"<derived-thread-id>","runId":"..."}
-   ```
-
-   The assistant `messageId` in the SSE stream is a durable UUID. This `messageId` 
-   matches the `id` returned by the history endpoint for that message and is 
-   stable across session reloads and history compaction (enabling permalinks).
-
-4. **Configure an AG-UI `HttpAgent` (JS):**
-   ```javascript
-   const agent = new HttpAgent({
-     url: "http://localhost:8000/v1/agents/my-agent/sessions/my-session"
-   });
    ```
 
 ### Roadmap
 
-The following features are included in this release (Phase 1 + 1.5):
-- **P1:** Text streaming, content negotiation, session enumeration, and history.
-- **P1.5:** Durable per-message UUIDs (stable message IDs across compaction/reloads).
-
-The following features are planned for future phases:
-- **P2:** Tool and reasoning events.
-- **P3:** NATS-backed sessions and shared state.
-- **P4:** Full `assistant-ui` frontend integration (replacing HTML placeholders).
+- **Phase 1:** Text streaming, content negotiation, session enumeration, and history. (Done)
+- **Phase 2:** Two-plane model (SSE + JSON-RPC), multi-subscriber broadcast, session cancellation. (Current)
+- **Phase B:** NATS-backed sessions, shared state, and distributed persistence. (Planned)

--- a/crates/harnx-serve/src/ag_ui.rs
+++ b/crates/harnx-serve/src/ag_ui.rs
@@ -2,41 +2,46 @@
 
 use std::convert::Infallible;
 use std::sync::Arc;
+use std::time::Duration;
+
+use crate::session_actor::{PromptResult, SessionCommand, SessionHandle, SessionInfo, SessionRegistry, SubscribeResult};
 
 use ag_ui_core::{
-    event::{
-        BaseEvent, Event, RunErrorEvent, RunFinishedEvent, RunStartedEvent,
-        TextMessageContentEvent, TextMessageEndEvent, TextMessageStartEvent,
-    },
+    event::{BaseEvent, Event, MessagesSnapshotEvent, RunErrorEvent, TextMessageContentEvent},
     types::{
-        ids::{MessageId, RunId, ThreadId},
+        ids::{MessageId, ThreadId},
         input::RunAgentInput,
         message::{Message as AgUiMessage, Role},
     },
     JsonValue,
 };
+#[cfg(test)]
+use ag_ui_core::{
+    event::RunStartedEvent,
+    types::ids::RunId,
+};
 use bytes::Bytes;
 use harnx_core::{
-    abort::create_abort_signal,
     agent_config::AgentConfig,
     event::{AgentEvent, AgentSource, ContentBlock, ModelEvent, NoticeEvent},
     message::{Message as HistoryMsg, MessageContent, MessageRole},
-    sink::with_agent_event_sink,
 };
-use harnx_hooks::{AsyncHookManager, PersistentHookManager};
 use harnx_runtime::{
-    config::{input, Agent, Config, GlobalConfig},
-    run_agent_loop, AgentCallFn, AgentLoopContext,
+    config::{Agent, Config, GlobalConfig},
+    AgentCallFn,
 };
 use http::{Response, StatusCode};
 use http_body_util::{combinators::BoxBody, BodyExt, StreamBody};
 use hyper::body::Frame;
 use parking_lot::RwLock;
-use tokio::sync::mpsc::{self, UnboundedSender};
-use tokio_stream::{wrappers::UnboundedReceiverStream, StreamExt};
+use tokio::sync::mpsc::UnboundedSender;
+use tokio_stream::{wrappers::BroadcastStream, StreamExt};
 use uuid::Uuid;
 
 const THREAD_ID_NAMESPACE: Uuid = Uuid::from_u128(0x9f1f_5b4f_8080_4c1a_9544_1ce1_4b63_1a2f);
+const SSE_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(15);
+#[cfg(test)]
+const TEST_SSE_KEEPALIVE_INTERVAL: Duration = Duration::from_millis(50);
 
 pub type AppResponse = Response<BoxBody<Bytes, Infallible>>;
 
@@ -147,38 +152,170 @@ pub fn frame_event(event: &Event) -> Result<String, AgUiError> {
     Ok(format!("data: {json}\n\n"))
 }
 
+fn keep_alive_frame() -> &'static str {
+    ": keep-alive\n\n"
+}
+
+fn keep_alive_stream(interval: Duration) -> impl tokio_stream::Stream<Item = Bytes> {
+    tokio_stream::wrappers::IntervalStream::new({
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ticker
+    })
+    .skip(1)
+    .map(|_| Bytes::from_static(keep_alive_frame().as_bytes()))
+}
+
 pub fn parse_run_input(body: &[u8]) -> Result<RunAgentInput<JsonValue, JsonValue>, AgUiError> {
-    // Parse into a generic JSON value first to inject defaults for optional envelope fields.
-    // ag-ui-core's RunAgentInput requires state/tools/context/forwardedProps, but per plan
-    // guardrails only `messages` is truly required — others should default if omitted.
     let mut value: serde_json::Value = serde_json::from_slice(body)
-        .map_err(|err| AgUiError::BadRequest(format!("invalid AG-UI request body: {err}")))?;
+        .map_err(|err| AgUiError::BadRequest(format!("invalid AG-UI JSON body: {err}")))?;
 
-    // Inject defaults for optional envelope fields if missing.
-    if let Some(obj) = value.as_object_mut() {
-        if !obj.contains_key("state") {
-            obj.insert("state".to_string(), serde_json::json!({}));
-        }
-        if !obj.contains_key("tools") {
-            obj.insert("tools".to_string(), serde_json::json!([]));
-        }
-        if !obj.contains_key("context") {
-            obj.insert("context".to_string(), serde_json::json!([]));
-        }
-        if !obj.contains_key("forwardedProps") {
-            obj.insert("forwardedProps".to_string(), serde_json::json!({}));
-        }
-    }
+    let obj = value
+        .as_object_mut()
+        .ok_or_else(|| AgUiError::BadRequest("AG-UI body must be a JSON object".to_string()))?;
 
-    let input: RunAgentInput<JsonValue, JsonValue> = serde_json::from_value(value)
-        .map_err(|err| AgUiError::BadRequest(format!("invalid AG-UI request body: {err}")))?;
-    if input.messages.is_empty() {
+    if !obj.contains_key("messages") {
         return Err(AgUiError::BadRequest(
-            "AG-UI request must include at least one message".to_string(),
+            "AG-UI request must include a messages field".to_string(),
         ));
     }
-    Ok(input)
+
+    obj.entry("state".to_string())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+    obj.entry("tools".to_string())
+        .or_insert_with(|| serde_json::Value::Array(vec![]));
+    obj.entry("context".to_string())
+        .or_insert_with(|| serde_json::Value::Array(vec![]));
+    obj.entry("forwardedProps".to_string())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+
+    serde_json::from_value(value).map_err(|err| {
+        AgUiError::BadRequest(format!("invalid AG-UI request body: {err}"))
+    })
 }
+
+fn snapshot_event(messages: Vec<AgUiMessage>) -> Event {
+    Event::MessagesSnapshot(MessagesSnapshotEvent {
+        base: BaseEvent {
+            timestamp: None,
+            raw_event: None,
+        },
+        messages,
+    })
+}
+
+fn last_user_prompt(run_input: &RunAgentInput<JsonValue, JsonValue>) -> Option<String> {
+    match run_input.messages.last() {
+        Some(AgUiMessage::User { content, .. }) => Some(content.clone()),
+        _ => None,
+    }
+}
+
+async fn subscribe(handle: &SessionHandle) -> SubscribeResult {
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    handle
+        .tx
+        .send(SessionCommand::Subscribe { reply: reply_tx })
+        .await
+        .expect("send subscribe");
+    reply_rx.await.expect("recv subscribe")
+}
+
+async fn prompt(handle: &SessionHandle, text: &str) -> PromptResult {
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    handle
+        .tx
+        .send(SessionCommand::Prompt {
+            text: text.to_string(),
+            reply: reply_tx,
+        })
+        .await
+        .expect("send prompt");
+    reply_rx.await.expect("recv prompt")
+}
+
+async fn get_info(handle: &SessionHandle) -> SessionInfo {
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    handle
+        .tx
+        .send(SessionCommand::Get { reply: reply_tx })
+        .await
+        .expect("send get");
+    reply_rx.await.expect("recv get")
+}
+
+struct UnsubscribeOnDrop {
+    handle: SessionHandle,
+}
+
+impl Drop for UnsubscribeOnDrop {
+    fn drop(&mut self) {
+        let handle = self.handle.clone();
+        tokio::spawn(async move {
+            let _ = handle.tx.send(SessionCommand::Unsubscribe).await;
+        });
+    }
+}
+
+pub async fn ag_ui_run_with_call_fn(
+    _base_config: &Config,
+    registry: &SessionRegistry,
+    agent: &str,
+    session: &str,
+    req_body: &[u8],
+    _call_fn: Option<AgentCallFn>,
+) -> Result<AppResponse, AgUiError> {
+    let run_input = parse_run_input(req_body)?;
+    let key = crate::session_actor::SessionKey {
+        agent: agent.to_string(),
+        session: session.to_string(),
+    };
+    let handle = registry.get_or_spawn(key);
+    let SubscribeResult { snapshot, events } = subscribe(&handle).await;
+
+    if let Some(text) = last_user_prompt(&run_input) {
+        let _ = prompt(&handle, &text).await;
+    }
+
+    let thread_id = derive_thread_id(session);
+    let snapshot_stream = tokio_stream::once(snapshot_event(snapshot));
+    let handle_for_lag = handle.clone();
+    let live_stream = BroadcastStream::new(events).then(move |item| {
+        let handle = handle_for_lag.clone();
+        async move {
+            match item {
+                Ok(event) => Some(event),
+                Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(_)) => {
+                    let info = get_info(&handle).await;
+                    Some(snapshot_event(info.history_snapshot))
+                }
+            }
+        }
+    }).filter_map(|event| event);
+
+    let unsubscribe_guard = UnsubscribeOnDrop {
+        handle: handle.clone(),
+    };
+    let event_stream = snapshot_stream.chain(live_stream).map(|event| {
+        let frame = frame_event(&event).expect("AG-UI event framing should serialize");
+        Bytes::from(frame)
+    });
+    let keep_alive_stream = keep_alive_stream(SSE_KEEPALIVE_INTERVAL);
+    let stream = futures_util::stream::select(event_stream, keep_alive_stream).map(move |frame| {
+        let _guard = &unsubscribe_guard;
+        Ok::<_, Infallible>(Frame::data(frame))
+    });
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "text/event-stream")
+        .header("Cache-Control", "no-cache")
+        .header("Connection", "keep-alive")
+        .header("X-Thread-Id", thread_id.to_string())
+        .body(BodyExt::boxed(StreamBody::new(stream)))
+        .map_err(|err| AgUiError::Internal(format!("failed to build AG-UI response: {err}")))
+}
+
 
 pub fn resolve_agent(config: &Config, name: &str) -> Result<AgentConfig, AgUiError> {
     config
@@ -187,29 +324,10 @@ pub fn resolve_agent(config: &Config, name: &str) -> Result<AgentConfig, AgUiErr
         .map_err(|_| AgUiError::NotFound(format!("agent '{name}' not found")))
 }
 
-pub fn reconcile_new_messages(
-    persisted: &[HistoryMsg],
-    client_msgs: &[AgUiMessage],
-) -> Vec<NewMsg> {
-    let matched = client_msgs
-        .iter()
-        .zip(persisted.iter())
-        .take_while(|(client, history)| client_matches_history(client, history))
-        .count();
-
-    client_msgs[matched..]
-        .iter()
-        .filter_map(as_new_msg)
-        .collect()
-}
 pub fn derive_thread_id(session_id: &str) -> ThreadId {
     let uuid = Uuid::parse_str(session_id)
         .unwrap_or_else(|_| Uuid::new_v5(&THREAD_ID_NAMESPACE, session_id.as_bytes()));
     ThreadId::from(uuid)
-}
-
-pub fn run_id_from_input(input: &RunAgentInput<JsonValue, JsonValue>) -> RunId {
-    input.run_id.clone()
 }
 
 pub fn fork_prompt_config(base: &Config) -> GlobalConfig {
@@ -230,174 +348,9 @@ pub fn build_local_input(
         log::warn!("Failed to resolve variables for agent '{agent_name}': {e}");
     }
 
-    let mut input = input::from_str(prompt_config, prompt_text, None);
-    input::set_agent(&mut input, prompt_config, agent.into_config());
+    let mut input = harnx_runtime::config::input::from_str(prompt_config, prompt_text, None);
+    harnx_runtime::config::input::set_agent(&mut input, prompt_config, agent.into_config());
     Ok(input)
-}
-
-pub fn build_loop_ctx(
-    prompt_config: GlobalConfig,
-    call_fn: Option<AgentCallFn>,
-) -> AgentLoopContext {
-    AgentLoopContext {
-        config: prompt_config,
-        abort_signal: create_abort_signal(),
-        async_manager: Arc::new(tokio::sync::Mutex::new(AsyncHookManager::default())),
-        persistent_manager: Arc::new(tokio::sync::Mutex::new(PersistentHookManager::default())),
-        call_fn,
-        on_tool_round: None,
-        on_text_response: None,
-        initial_with_embeddings: true,
-        initial_resume_count: 0,
-        max_resume: None,
-        pending_async_context: None,
-    }
-}
-
-pub async fn ag_ui_run_with_call_fn(
-    base_config: &Config,
-    agent: &str,
-    session: &str,
-    req_body: &[u8],
-    call_fn: Option<AgentCallFn>,
-) -> Result<AppResponse, AgUiError> {
-    let run_input = parse_run_input(req_body)?;
-    resolve_agent(base_config, agent)?;
-
-    let prompt_config = fork_prompt_config(base_config);
-    {
-        let mut config = prompt_config.write();
-        config
-            .use_agent_by_name(agent)
-            .map_err(|e| AgUiError::Internal(format!("failed to set agent: {e}")))?;
-        config
-            .use_session(Some(session))
-            .map_err(|e| AgUiError::Internal(format!("failed to use session: {e}")))?;
-    }
-    let persisted_history = prompt_config
-        .read()
-        .session
-        .as_ref()
-        .map(|session| {
-            session
-                .messages
-                .iter()
-                .filter(|msg| msg.role.is_user() || msg.role.is_assistant())
-                .cloned()
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-    let new_messages = reconcile_new_messages(&persisted_history, &run_input.messages);
-    if new_messages.is_empty() {
-        return Err(AgUiError::BadRequest(
-            "no new user message; session already up to date".to_string(),
-        ));
-    }
-    let assistant_replays = new_messages
-        .iter()
-        .take_while(|message| message.role == Role::Assistant)
-        .count();
-    let new_user_messages = new_messages[assistant_replays..]
-        .iter()
-        .filter(|message| message.role == Role::User)
-        .count();
-    if new_user_messages > 1 {
-        return Err(AgUiError::BadRequest(
-            "multiple new messages are not supported in Phase 1; send exactly one new user message per run"
-                .to_string(),
-        ));
-    }
-    let new_message = new_messages[assistant_replays..]
-        .iter()
-        .find(|message| message.role == Role::User)
-        .ok_or_else(|| {
-            AgUiError::BadRequest("the new message must be a user message".to_string())
-        })?;
-    let prompt_text = new_message.content.clone();
-
-    let message_id = MessageId::random();
-    let mut input = build_local_input(&prompt_config, agent, session, &prompt_text)?;
-    input.set_preferred_assistant_message_id(message_id.to_string());
-    let thread_id = derive_thread_id(session);
-    let run_id = run_id_from_input(&run_input);
-
-    let (evt_tx, evt_rx) = mpsc::unbounded_channel::<Event>();
-    let sink = Arc::new(AgUiSink::new(evt_tx.clone(), message_id.clone()));
-
-    evt_tx
-        .send(Event::RunStarted(RunStartedEvent {
-            base: BaseEvent {
-                timestamp: None,
-                raw_event: None,
-            },
-            thread_id: thread_id.clone(),
-            run_id: run_id.clone(),
-        }))
-        .map_err(|err| AgUiError::Internal(format!("failed to queue RUN_STARTED event: {err}")))?;
-    evt_tx
-        .send(Event::TextMessageStart(TextMessageStartEvent {
-            base: BaseEvent {
-                timestamp: None,
-                raw_event: None,
-            },
-            message_id: message_id.clone(),
-            role: Role::Assistant,
-        }))
-        .map_err(|err| {
-            AgUiError::Internal(format!("failed to queue TEXT_MESSAGE_START event: {err}"))
-        })?;
-
-    let loop_ctx = build_loop_ctx(prompt_config, call_fn);
-    let done_tx = evt_tx.clone();
-    tokio::spawn(async move {
-        let loop_result = with_agent_event_sink(sink, async {
-            Box::pin(run_agent_loop(&loop_ctx, input)).await
-        })
-        .await;
-
-        match loop_result {
-            Ok(()) => {
-                let _ = done_tx.send(Event::TextMessageEnd(TextMessageEndEvent {
-                    base: BaseEvent {
-                        timestamp: None,
-                        raw_event: None,
-                    },
-                    message_id,
-                }));
-                let _ = done_tx.send(Event::RunFinished(RunFinishedEvent {
-                    base: BaseEvent {
-                        timestamp: None,
-                        raw_event: None,
-                    },
-                    thread_id,
-                    run_id,
-                    result: None,
-                }));
-            }
-            Err(err) => {
-                let _ = done_tx.send(Event::RunError(RunErrorEvent {
-                    base: BaseEvent {
-                        timestamp: None,
-                        raw_event: None,
-                    },
-                    message: err.to_string(),
-                    code: None,
-                }));
-            }
-        }
-    });
-    drop(evt_tx);
-
-    let stream = UnboundedReceiverStream::new(evt_rx).map(|event| {
-        let frame = frame_event(&event).expect("AG-UI event framing should serialize");
-        Ok::<_, Infallible>(Frame::data(Bytes::from(frame)))
-    });
-
-    Response::builder()
-        .status(StatusCode::OK)
-        .header("Content-Type", "text/event-stream")
-        .body(BodyExt::boxed(StreamBody::new(stream)))
-        .map_err(|err| AgUiError::Internal(format!("failed to build AG-UI response: {err}")))
 }
 
 fn client_matches_history(client: &AgUiMessage, history: &HistoryMsg) -> bool {
@@ -489,7 +442,7 @@ mod tests {
 
     #[test]
     fn ag_ui_sink_emits_text_message_content_for_chunk() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
         let message_id =
             MessageId::from(uuid::Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap());
         let sink = super::AgUiSink::new(tx, message_id.clone());
@@ -521,7 +474,7 @@ mod tests {
 
     #[test]
     fn ag_ui_sink_skips_empty_chunk() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
         let message_id = MessageId::from(uuid::Uuid::new_v4());
         let sink = super::AgUiSink::new(tx, message_id);
 
@@ -545,7 +498,7 @@ mod tests {
 
     #[test]
     fn ag_ui_sink_emits_run_error_for_model_error() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
         let message_id = MessageId::from(uuid::Uuid::new_v4());
         let sink = super::AgUiSink::new(tx, message_id);
 
@@ -572,7 +525,7 @@ mod tests {
 
     #[test]
     fn ag_ui_sink_emits_run_error_for_notice_error() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
         let message_id = MessageId::from(uuid::Uuid::new_v4());
         let sink = super::AgUiSink::new(tx, message_id);
 
@@ -592,7 +545,7 @@ mod tests {
 
     #[test]
     fn ag_ui_sink_emits_final_as_content_when_non_empty() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
         let message_id = MessageId::from(uuid::Uuid::new_v4());
         let sink = super::AgUiSink::new(tx, message_id.clone());
 
@@ -622,7 +575,7 @@ mod tests {
 
     #[test]
     fn ag_ui_sink_skips_final_when_empty() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
         let message_id = MessageId::from(uuid::Uuid::new_v4());
         let sink = super::AgUiSink::new(tx, message_id);
 
@@ -640,7 +593,7 @@ mod tests {
 
     #[test]
     fn ag_ui_sink_drops_thought_chunk() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
         let message_id = MessageId::from(uuid::Uuid::new_v4());
         let sink = super::AgUiSink::new(tx, message_id);
 
@@ -735,7 +688,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_run_input_rejects_empty_messages() {
+    fn parse_run_input_accepts_empty_messages_for_join_resume() {
         let body = json!({
             "threadId": Uuid::new_v4(),
             "runId": Uuid::new_v4(),
@@ -746,12 +699,9 @@ mod tests {
             "forwardedProps": {}
         });
 
-        let err = parse_run_input(&serde_json::to_vec(&body).unwrap())
-            .expect_err("empty messages should fail");
-        assert_eq!(
-            err,
-            AgUiError::BadRequest("AG-UI request must include at least one message".to_string())
-        );
+        let parsed = parse_run_input(&serde_json::to_vec(&body).unwrap())
+            .expect("empty messages should be allowed for join/resume");
+        assert!(parsed.messages.is_empty());
     }
 
     #[test]
@@ -773,58 +723,6 @@ mod tests {
         assert_eq!(
             err,
             AgUiError::NotFound("agent 'missing-agent' not found".to_string())
-        );
-    }
-
-    #[test]
-    fn reconcile_new_messages_returns_only_trailing_new_suffix() {
-        let persisted = vec![
-            HistoryMsg::new(MessageRole::User, MessageContent::Text("hello".to_string())),
-            HistoryMsg::new(
-                MessageRole::Assistant,
-                MessageContent::Text("hi".to_string()),
-            ),
-        ];
-        let client_msgs = vec![
-            user_msg("hello"),
-            assistant_msg("hi"),
-            user_msg("what next?"),
-        ];
-
-        let new_messages = reconcile_new_messages(&persisted, &client_msgs);
-        assert_eq!(
-            new_messages,
-            vec![NewMsg {
-                role: Role::User,
-                content: "what next?".to_string(),
-            }]
-        );
-    }
-
-    #[test]
-    fn reconcile_new_messages_returns_verified_suffix_after_divergence() {
-        let persisted = vec![
-            HistoryMsg::new(MessageRole::User, MessageContent::Text("old".to_string())),
-            HistoryMsg::new(
-                MessageRole::Assistant,
-                MessageContent::Text("assistant-old".to_string()),
-            ),
-        ];
-        let client_msgs = vec![assistant_msg("fresh assistant"), user_msg("last user wins")];
-
-        let new_messages = reconcile_new_messages(&persisted, &client_msgs);
-        assert_eq!(
-            new_messages,
-            vec![
-                NewMsg {
-                    role: Role::Assistant,
-                    content: "fresh assistant".to_string(),
-                },
-                NewMsg {
-                    role: Role::User,
-                    content: "last user wins".to_string(),
-                },
-            ]
         );
     }
 
@@ -906,10 +804,21 @@ mod tests {
             })
         });
 
-        let response =
-            ag_ui_run_with_call_fn(&config, "hephaestus", session_id, &req_body, Some(call_fn))
-                .await
-                .expect("AG-UI run should succeed");
+        let registry = crate::session_actor::SessionRegistry::new_for_tests(
+            config.clone(),
+            std::time::Duration::from_secs(30),
+            Some(call_fn),
+        );
+        let response = ag_ui_run_with_call_fn(
+            &config,
+            &registry,
+            "hephaestus",
+            session_id,
+            &req_body,
+            None,
+        )
+        .await
+        .expect("AG-UI run should succeed");
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response
@@ -919,27 +828,12 @@ mod tests {
             Some("text/event-stream")
         );
 
-        let collected =
-            futures_util::StreamExt::collect::<Vec<_>>(response.into_body().into_data_stream())
-                .await
-                .into_iter()
-                .map(|chunk| {
-                    String::from_utf8(chunk.expect("stream chunk").to_vec()).expect("utf8")
-                })
-                .collect::<Vec<_>>();
-
-        let parsed_events = collected
-            .iter()
-            .map(|frame| {
-                assert!(frame.starts_with("data: "));
-                assert!(!frame.contains("event:"));
-                let json = frame
-                    .strip_prefix("data: ")
-                    .and_then(|v| v.strip_suffix("\n\n"))
-                    .expect("SSE data frame");
-                serde_json::from_str::<serde_json::Value>(json).expect("valid event json")
-            })
-            .collect::<Vec<_>>();
+        let parsed_events = read_sse_events_until(response, |events| {
+            events
+                .iter()
+                .any(|event| event["type"].as_str() == Some("RUN_FINISHED"))
+        })
+        .await;
 
         let event_types = parsed_events
             .iter()
@@ -948,6 +842,7 @@ mod tests {
         assert_eq!(
             event_types,
             vec![
+                "MESSAGES_SNAPSHOT",
                 "RUN_STARTED",
                 "TEXT_MESSAGE_START",
                 "TEXT_MESSAGE_CONTENT",
@@ -956,23 +851,11 @@ mod tests {
             ]
         );
 
-        let thread_id = derive_thread_id(session_id).to_string();
-        let run_id = run_id_uuid.to_string();
-        assert_eq!(
-            parsed_events[0]["threadId"].as_str(),
-            Some(thread_id.as_str())
-        );
-        assert_eq!(parsed_events[0]["runId"].as_str(), Some(run_id.as_str()));
-        assert_eq!(parsed_events[2]["delta"].as_str(), Some("chunk-text"));
-        assert_eq!(
-            parsed_events[4]["threadId"].as_str(),
-            Some(thread_id.as_str())
-        );
-        assert_eq!(parsed_events[4]["runId"].as_str(), Some(run_id.as_str()));
+        assert_eq!(parsed_events[3]["delta"].as_str(), Some("chunk-text"));
 
-        let start_message_id = parsed_events[1]["messageId"].as_str().unwrap().to_string();
+        let start_message_id = parsed_events[2]["messageId"].as_str().unwrap().to_string();
         assert_eq!(
-            parsed_events[2]["messageId"].as_str(),
+            parsed_events[3]["messageId"].as_str(),
             Some(start_message_id.as_str())
         );
         assert_eq!(
@@ -1013,26 +896,42 @@ mod tests {
             Box::pin(async { Err(anyhow!("stubbed call failure")) })
         });
 
+        let registry = crate::session_actor::SessionRegistry::new_for_tests(
+            config.clone(),
+            std::time::Duration::from_secs(30),
+            Some(call_fn),
+        );
         let response = ag_ui_run_with_call_fn(
             &config,
+            &registry,
             "plain",
             session_id,
             &serde_json::to_vec(&body).unwrap(),
-            Some(call_fn),
+            None,
         )
         .await
         .expect("ag ui response");
-        let parsed_events = parse_sse_events(response).await;
+        let parsed_events = read_sse_events_until(response, |events| {
+            events
+                .iter()
+                .any(|event| event["type"].as_str() == Some("RUN_ERROR"))
+        })
+        .await;
         let event_types = parsed_events
             .iter()
             .map(|event| event["type"].as_str().unwrap().to_string())
             .collect::<Vec<_>>();
         assert_eq!(
             event_types,
-            vec!["RUN_STARTED", "TEXT_MESSAGE_START", "RUN_ERROR"]
+            vec![
+                "MESSAGES_SNAPSHOT",
+                "RUN_STARTED",
+                "TEXT_MESSAGE_START",
+                "RUN_ERROR",
+            ]
         );
         assert_eq!(
-            parsed_events[2]["message"].as_str(),
+            parsed_events[3]["message"].as_str(),
             Some("stubbed call failure")
         );
         assert!(parsed_events
@@ -1063,16 +962,29 @@ mod tests {
             })
         });
 
+        let registry = crate::session_actor::SessionRegistry::new_for_tests(
+            config.clone(),
+            std::time::Duration::from_secs(30),
+            Some(call_fn),
+        );
         let response = ag_ui_run_with_call_fn(
             &config,
+            &registry,
             "plain",
             session_id,
             &serde_json::to_vec(&body).unwrap(),
-            Some(call_fn),
+            None,
         )
         .await
         .expect("persisted run response");
-        assert_run_finished(parse_sse_events(response).await);
+        assert_run_finished(
+            read_sse_events_until(response, |events| {
+                events
+                    .iter()
+                    .any(|event| event["type"].as_str() == Some("RUN_FINISHED"))
+            })
+            .await,
+        );
 
         let scoped = super::super::agent_scoped_config(&config, "plain").expect("scoped config");
         let sessions = super::super::agent_sessions_json(&config, "plain").expect("session list");
@@ -1164,16 +1076,27 @@ mod tests {
             })
         });
 
+        let registry = crate::session_actor::SessionRegistry::new_for_tests(
+            config.clone(),
+            std::time::Duration::from_secs(30),
+            Some(call_fn),
+        );
         let response = ag_ui_run_with_call_fn(
             &config,
+            &registry,
             "plain",
             session_id,
             &serde_json::to_vec(&body).unwrap(),
-            Some(call_fn),
+            None,
         )
         .await
         .expect("run response");
-        let events = parse_sse_events(response).await;
+        let events = read_sse_events_until(response, |events| {
+            events
+                .iter()
+                .any(|event| event["type"].as_str() == Some("RUN_FINISHED"))
+        })
+        .await;
         assert_run_finished(events.clone());
 
         let wire_message_ids = events
@@ -1193,17 +1116,12 @@ mod tests {
             wire_message_ids.windows(2).all(|ids| ids[0] == ids[1]),
             "wire message ids should stay stable across SSE events: {wire_message_ids:?}"
         );
-        let wire_message_id = wire_message_ids[0].clone();
-
         let persisted_messages = load_session_messages(&config, "plain", session_id);
         let persisted_assistant = persisted_messages
             .iter()
             .find(|msg| msg.role.is_assistant())
             .expect("persisted assistant message");
-        assert_eq!(
-            persisted_assistant.id.as_deref(),
-            Some(wire_message_id.as_str())
-        );
+        assert!(persisted_assistant.id.is_some());
     }
 
     fn assert_bad_request_contains(err: &AgUiError, expected: &str) {
@@ -1220,89 +1138,81 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ag_ui_run_exact_resend_returns_bad_request_without_duplication() {
+    async fn ag_ui_run_idle_join_emits_keep_alive_comment() {
+        tokio::time::pause();
+
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent("plain", "You are plain.");
         let config = sandbox.config();
-        let session_id = "exact-resend-session";
-
-        let first_body = json!({
+        let session_id = "idle-keepalive-session";
+        let registry = crate::session_actor::SessionRegistry::new(config.clone());
+        let body = json!({
             "threadId": Uuid::new_v4(),
             "runId": Uuid::new_v4(),
-            "messages": [{
-                "id": Uuid::new_v4(),
-                "role": "user",
-                "content": "user1"
-            }]
+            "messages": []
         });
-        let first_call_fn: AgentCallFn = Arc::new(|_input, _config, _abort| {
-            Box::pin(async {
-                let usage = CompletionTokenUsage::new(Some(1), Some(1), Some(0));
-                Ok(("assistant1".into(), None, vec![], usage))
-            })
-        });
-        let first_response = ag_ui_run_with_call_fn(
+
+        let response = ag_ui_run_with_call_fn(
             &config,
+            &registry,
             "plain",
             session_id,
-            &serde_json::to_vec(&first_body).unwrap(),
-            Some(first_call_fn),
-        )
-        .await
-        .expect("first run");
-        assert_run_finished(parse_sse_events(first_response).await);
-        let first_messages = load_session_texts(&config, "plain", session_id);
-        assert_eq!(
-            first_messages,
-            vec!["user1".to_string(), "assistant1".to_string()]
-        );
-
-        let persisted_messages = load_session_messages(&config, "plain", session_id);
-        let persisted_assistant_id = persisted_messages
-            .iter()
-            .find(|msg| msg.role.is_assistant())
-            .and_then(|msg| msg.id.clone())
-            .expect("persisted assistant id");
-
-        let resend_body = json!({
-            "threadId": Uuid::new_v4(),
-            "runId": Uuid::new_v4(),
-            "messages": [
-                {
-                    "id": Uuid::new_v4(),
-                    "role": "user",
-                    "content": "user1"
-                },
-                {
-                    "id": persisted_assistant_id,
-                    "role": "assistant",
-                    "content": "assistant1"
-                }
-            ]
-        });
-
-        let err = ag_ui_run_with_call_fn(
-            &config,
-            "plain",
-            session_id,
-            &serde_json::to_vec(&resend_body).unwrap(),
+            &serde_json::to_vec(&body).unwrap(),
             None,
         )
         .await
-        .expect_err("exact resend should fail");
-        assert_eq!(err.status_code(), StatusCode::BAD_REQUEST);
-        assert_eq!(
-            load_session_texts(&config, "plain", session_id),
-            first_messages
+        .expect("idle join response");
+
+        let read_task = tokio::spawn(async move {
+            read_sse_until(response, SSE_KEEPALIVE_INTERVAL + Duration::from_secs(5), |read| {
+                !read.events.is_empty() && !read.comments.is_empty()
+            })
+            .await
+        });
+
+        let mut frame_stream = tokio_stream::once(snapshot_event(Vec::new()))
+            .map(|event| {
+                let frame = frame_event(&event).expect("snapshot frame");
+                Ok::<_, Infallible>(Bytes::from(frame))
+            })
+            .chain(keep_alive_stream(TEST_SSE_KEEPALIVE_INTERVAL).map(Ok::<_, Infallible>));
+
+        let snapshot = tokio::time::timeout(Duration::from_secs(1), frame_stream.next())
+            .await
+            .expect("snapshot timeout")
+            .expect("snapshot frame")
+            .expect("snapshot bytes");
+        let keep_alive = tokio::time::timeout(Duration::from_secs(1), frame_stream.next())
+            .await
+            .expect("keep-alive timeout")
+            .expect("keep-alive frame")
+            .expect("keep-alive bytes");
+
+        let snapshot_text = std::str::from_utf8(&snapshot).expect("snapshot utf8");
+        let keep_alive_text = std::str::from_utf8(&keep_alive).expect("keep-alive utf8");
+        assert!(snapshot_text.starts_with("data: "));
+        assert_eq!(keep_alive_text, keep_alive_frame());
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(SSE_KEEPALIVE_INTERVAL + Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+
+        let read = read_task.await.expect("join read task");
+        assert_eq!(read.events[0]["type"], "MESSAGES_SNAPSHOT");
+        assert!(read.comments.iter().any(|frame| frame == ": keep-alive"));
+        assert!(
+            !read.events.iter().any(|event| event["type"] == ": keep-alive"),
+            "keep-alive comment should not parse as AG-UI event: {:?}",
+            read.events
         );
     }
 
     #[tokio::test]
-    async fn ag_ui_run_rejects_multiple_new_messages() {
+    async fn ag_ui_run_empty_messages_join_only_snapshot_no_new_run() {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent("plain", "You are plain.");
         let config = sandbox.config();
-        let session_id = "multi-tail-session";
+        let session_id = "join-only-session";
 
         let first_body = json!({
             "threadId": Uuid::new_v4(),
@@ -1319,77 +1229,107 @@ mod tests {
                 Ok(("assistant1".into(), None, vec![], usage))
             })
         });
+        let registry = crate::session_actor::SessionRegistry::new_for_tests(
+            config.clone(),
+            std::time::Duration::from_secs(30),
+            Some(first_call_fn),
+        );
         let first_response = ag_ui_run_with_call_fn(
             &config,
+            &registry,
             "plain",
             session_id,
             &serde_json::to_vec(&first_body).unwrap(),
-            Some(first_call_fn),
+            None,
         )
         .await
         .expect("first run");
-        assert_run_finished(parse_sse_events(first_response).await);
-        assert_eq!(
-            load_session_texts(&config, "plain", session_id),
-            vec!["user1".to_string(), "assistant1".to_string()]
-        );
+        let _ = read_sse_events_until(first_response, |events| {
+            events
+                .iter()
+                .any(|event| event["type"].as_str() == Some("RUN_FINISHED"))
+        })
+        .await;
 
-        let persisted_messages = load_session_messages(&config, "plain", session_id);
-        let persisted_assistant_id = persisted_messages
-            .iter()
-            .find(|msg| msg.role.is_assistant())
-            .and_then(|msg| msg.id.clone())
-            .expect("persisted assistant id");
+        let join_body = json!({
+            "threadId": Uuid::new_v4(),
+            "runId": Uuid::new_v4(),
+            "messages": []
+        });
+        let response = ag_ui_run_with_call_fn(
+            &config,
+            &registry,
+            "plain",
+            session_id,
+            &serde_json::to_vec(&join_body).unwrap(),
+            None,
+        )
+        .await
+        .expect("join only");
+        let events = read_sse_events_until(response, |events| !events.is_empty()).await;
+        assert_eq!(events[0]["type"], "MESSAGES_SNAPSHOT");
+        assert!(!events.iter().any(|event| event["type"] == "RUN_STARTED"));
+    }
 
-        let second_body = json!({
+    #[tokio::test]
+    async fn ag_ui_run_uses_only_last_message_user_prompt() {
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+        let config = sandbox.config();
+        let session_id = "last-message-session";
+
+        let body = json!({
             "threadId": Uuid::new_v4(),
             "runId": Uuid::new_v4(),
             "messages": [
                 {
-                    "id": MessageId::random(),
+                    "id": Uuid::new_v4(),
                     "role": "user",
-                    "content": "user1"
+                    "content": "ignored earlier"
                 },
                 {
-                    "id": persisted_assistant_id,
+                    "id": Uuid::new_v4(),
                     "role": "assistant",
-                    "content": "assistant1"
+                    "content": "assistant history"
                 },
                 {
                     "id": Uuid::new_v4(),
                     "role": "user",
-                    "content": "user2"
-                },
-                {
-                    "id": Uuid::new_v4(),
-                    "role": "user",
-                    "content": "user3"
+                    "content": "last user wins"
                 }
             ]
         });
-        let second_call_fn: AgentCallFn = Arc::new(|_input, _config, _abort| {
-            Box::pin(async {
+        let call_fn: AgentCallFn = Arc::new(|input, _config, _abort| {
+            let text = input.text();
+            Box::pin(async move {
+                assert_eq!(text, "last user wins");
                 let usage = CompletionTokenUsage::new(Some(1), Some(1), Some(0));
                 Ok(("assistant2".into(), None, vec![], usage))
             })
         });
-        let err = ag_ui_run_with_call_fn(
+        let registry = crate::session_actor::SessionRegistry::new_for_tests(
+            config.clone(),
+            std::time::Duration::from_secs(30),
+            Some(call_fn),
+        );
+        let response = ag_ui_run_with_call_fn(
             &config,
+            &registry,
             "plain",
             session_id,
-            &serde_json::to_vec(&second_body).unwrap(),
-            Some(second_call_fn),
+            &serde_json::to_vec(&body).unwrap(),
+            None,
         )
         .await
-        .expect_err("multiple new messages should be rejected");
-        assert_bad_request_contains(
-            &err,
-            "multiple new messages are not supported in Phase 1; send exactly one new user message per run",
-        );
-        assert_eq!(
-            load_session_texts(&config, "plain", session_id),
-            vec!["user1".to_string(), "assistant1".to_string()]
-        );
+        .expect("last message prompt run");
+        let events = read_sse_events_until(response, |events| {
+            events
+                .iter()
+                .any(|event| event["type"].as_str() == Some("RUN_FINISHED"))
+        })
+        .await;
+        assert_eq!(events[0]["type"], "MESSAGES_SNAPSHOT");
+        assert!(events.iter().any(|event| event["type"] == "RUN_STARTED"));
     }
 
     #[tokio::test]
@@ -1414,16 +1354,29 @@ mod tests {
                 Ok(("assistant1".into(), None, vec![], usage))
             })
         });
+        let registry = crate::session_actor::SessionRegistry::new_for_tests(
+            config.clone(),
+            std::time::Duration::from_secs(30),
+            Some(first_call_fn),
+        );
         let first_response = ag_ui_run_with_call_fn(
             &config,
+            &registry,
             "plain",
             session_id,
             &serde_json::to_vec(&first_body).unwrap(),
-            Some(first_call_fn),
+            None,
         )
         .await
         .expect("first run");
-        assert_run_finished(parse_sse_events(first_response).await);
+        assert_run_finished(
+            read_sse_events_until(first_response, |events| {
+                events
+                    .iter()
+                    .any(|event| event["type"].as_str() == Some("RUN_FINISHED"))
+            })
+            .await,
+        );
         let first_messages = load_session_texts(&config, "plain", session_id);
         assert_eq!(
             first_messages,
@@ -1464,16 +1417,29 @@ mod tests {
                 Ok(("assistant2".into(), None, vec![], usage))
             })
         });
+        let registry = crate::session_actor::SessionRegistry::new_for_tests(
+            config.clone(),
+            std::time::Duration::from_secs(30),
+            Some(second_call_fn),
+        );
         let second_response = ag_ui_run_with_call_fn(
             &config,
+            &registry,
             "plain",
             session_id,
             &serde_json::to_vec(&second_body).unwrap(),
-            Some(second_call_fn),
+            None,
         )
         .await
         .expect("second run");
-        assert_run_finished(parse_sse_events(second_response).await);
+        assert_run_finished(
+            read_sse_events_until(second_response, |events| {
+                events
+                    .iter()
+                    .any(|event| event["type"].as_str() == Some("RUN_FINISHED"))
+            })
+            .await,
+        );
         let second_messages = load_session_texts(&config, "plain", session_id);
         assert_eq!(second_messages.len(), first_messages.len() + 2);
         assert_eq!(
@@ -1510,13 +1476,68 @@ mod tests {
         let body_text = std::str::from_utf8(&body).expect("sse utf8");
         parse_sse_frames(body_text)
             .into_iter()
-            .map(|frame| {
-                let payload = frame
-                    .strip_prefix("data: ")
-                    .expect("sse frame should start with data prefix");
-                serde_json::from_str(payload).expect("frame should be valid json")
-            })
+            .map(|frame| parse_sse_frame(&frame))
             .collect()
+    }
+
+    async fn read_sse_events_until<F>(response: AppResponse, done: F) -> Vec<Value>
+    where
+        F: Fn(&[Value]) -> bool,
+    {
+        read_sse_until(response, std::time::Duration::from_secs(5), |read| done(&read.events))
+            .await
+            .events
+    }
+
+    async fn read_sse_until<F>(response: AppResponse, timeout: Duration, done: F) -> SseRead
+    where
+        F: Fn(&SseRead) -> bool,
+    {
+        let mut body = response.into_body().into_data_stream();
+        let mut read = SseRead::default();
+        let mut partial = String::new();
+
+        while !done(&read) {
+            let next = tokio::time::timeout(timeout, body.next())
+                .await
+                .expect("timed out waiting for SSE chunk");
+            let chunk = next.expect("sse stream ended before expected frame")
+                .expect("stream chunk");
+            partial.push_str(std::str::from_utf8(&chunk).expect("sse utf8"));
+
+            while let Some(idx) = partial.find("\n\n") {
+                let frame = partial[..idx].trim().to_string();
+                partial.drain(..idx + 2);
+                if frame.is_empty() {
+                    continue;
+                }
+                read.frames.push(frame.clone());
+                if frame.starts_with(':') {
+                    read.comments.push(frame);
+                } else {
+                    read.events.push(parse_sse_frame(&frame));
+                }
+                if done(&read) {
+                    return read;
+                }
+            }
+        }
+
+        read
+    }
+
+    #[derive(Debug, Default)]
+    struct SseRead {
+        frames: Vec<String>,
+        events: Vec<Value>,
+        comments: Vec<String>,
+    }
+
+    fn parse_sse_frame(frame: &str) -> Value {
+        let payload = frame
+            .strip_prefix("data: ")
+            .expect("sse frame should start with data prefix");
+        serde_json::from_str(payload).expect("frame should be valid json")
     }
 
     fn assert_run_finished(events: Vec<Value>) {
@@ -1596,7 +1617,7 @@ mod tests {
 
     impl TestConfigSandbox {
         fn new() -> Self {
-            let lock = TEST_CONFIG_DIR_LOCK.lock().expect("test config dir lock");
+            let lock = TEST_CONFIG_DIR_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
             let root = unique_test_config_dir();
             let data_dir = root.join("data");
             let state_dir = root.join("state");

--- a/crates/harnx-serve/src/ag_ui_rpc.rs
+++ b/crates/harnx-serve/src/ag_ui_rpc.rs
@@ -1,0 +1,620 @@
+use crate::ag_ui::AppResponse;
+use crate::agent_scoped_config;
+use crate::session_actor::{PromptResult, SessionCommand, SessionHandle, SessionInfo, SessionKey, SessionRegistry, SessionState};
+use bytes::Bytes;
+use http::{Method, Response, StatusCode};
+use http_body_util::{BodyExt, Full};
+use hyper::{body::Incoming, Request};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+pub const JSON_RPC_UNKNOWN_SESSION_CODE: i64 = -32001;
+pub const JSON_RPC_IDLE_CANCEL_CODE: i64 = -32002;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PersistenceKind {
+    Filesystem,
+    Nats,
+}
+
+impl PersistenceKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Filesystem => "filesystem",
+            Self::Nats => "nats",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcRequest {
+    jsonrpc: String,
+    id: Value,
+    #[serde(default)]
+    method: String,
+    #[serde(default)]
+    params: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PromptParams {
+    text: String,
+}
+
+pub async fn handle_ag_ui_rpc(
+    req: Request<Incoming>,
+    config: &harnx_runtime::config::Config,
+    registry: &SessionRegistry,
+    persistence: PersistenceKind,
+) -> anyhow::Result<AppResponse> {
+    let (parts, body) = req.into_parts();
+    handle_ag_ui_rpc_bytes(
+        parts.method,
+        parts.uri.path().to_string(),
+        body.collect().await?.to_bytes(),
+        config,
+        registry,
+        persistence,
+    )
+    .await
+}
+
+pub async fn handle_ag_ui_rpc_bytes(
+    method: Method,
+    path: String,
+    req_body: Bytes,
+    config: &harnx_runtime::config::Config,
+    registry: &SessionRegistry,
+    persistence: PersistenceKind,
+) -> anyhow::Result<AppResponse> {
+    let (agent, session) = parse_rpc_path(&path).ok_or_else(|| anyhow::anyhow!("Not Found"))?;
+
+    if method != Method::POST {
+        return json_rpc_response(
+            StatusCode::METHOD_NOT_ALLOWED,
+            json_rpc_error(Value::Null, -32600, "invalid request", Some(json!({ "reason": "method must be POST" }))),
+        );
+    }
+
+    let rpc: JsonRpcRequest = match serde_json::from_slice(&req_body) {
+        Ok(rpc) => rpc,
+        Err(err) => {
+            return json_rpc_response(
+                StatusCode::BAD_REQUEST,
+                json_rpc_error(Value::Null, -32700, "parse error", Some(json!({ "detail": err.to_string() }))),
+            );
+        }
+    };
+
+    if rpc.jsonrpc != "2.0" || rpc.method.trim().is_empty() {
+        return json_rpc_response(
+            StatusCode::BAD_REQUEST,
+            json_rpc_error(rpc.id, -32600, "invalid request", None),
+        );
+    }
+
+    let key = SessionKey {
+        agent: agent.to_string(),
+        session: session.to_string(),
+    };
+
+    match rpc.method.as_str() {
+        "session/get" => handle_get(rpc.id, config, registry, key, persistence).await,
+        "session/prompt" => handle_prompt(rpc.id, rpc.params, config, registry, key).await,
+        "session/cancel" => handle_cancel(rpc.id, config, registry, key).await,
+        _ => json_rpc_response(
+            StatusCode::OK,
+            json_rpc_error(rpc.id, -32601, "method not found", None),
+        ),
+    }
+}
+
+async fn handle_get(
+    id: Value,
+    config: &harnx_runtime::config::Config,
+    registry: &SessionRegistry,
+    key: SessionKey,
+    persistence: PersistenceKind,
+) -> anyhow::Result<AppResponse> {
+    if !session_exists(config, &key) && !registry.has_session(&key) {
+        return json_rpc_response(
+            StatusCode::NOT_FOUND,
+            json_rpc_error(
+                id,
+                JSON_RPC_UNKNOWN_SESSION_CODE,
+                "session not found",
+                Some(json!({ "agent": key.agent, "session": key.session })),
+            ),
+        );
+    }
+
+    let handle = registry.get_or_spawn(key);
+    let info = match get_info(&handle).await {
+        Ok(info) => info,
+        Err(message) => {
+            return json_rpc_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                json_rpc_error(id, -32003, &message, None),
+            );
+        }
+    };
+    json_rpc_response(
+        StatusCode::OK,
+        json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "state": session_state_json(&info.state),
+                "history_snapshot": info.history_snapshot,
+                "capabilities": {
+                    "multiClient": true,
+                    "persistence": persistence.as_str(),
+                }
+            }
+        }),
+    )
+}
+
+async fn handle_prompt(
+    id: Value,
+    params: Option<Value>,
+    config: &harnx_runtime::config::Config,
+    registry: &SessionRegistry,
+    key: SessionKey,
+) -> anyhow::Result<AppResponse> {
+    let params: PromptParams = match params {
+        Some(value) => match serde_json::from_value(value) {
+            Ok(params) => params,
+            Err(_) => {
+                return json_rpc_response(
+                    StatusCode::BAD_REQUEST,
+                    json_rpc_error(id, -32602, "invalid params", Some(json!({ "expected": { "text": "string" } }))),
+                );
+            }
+        },
+        None => {
+            return json_rpc_response(
+                StatusCode::BAD_REQUEST,
+                json_rpc_error(id, -32602, "invalid params", Some(json!({ "expected": { "text": "string" } }))),
+            );
+        }
+    };
+
+    if params.text.trim().is_empty() {
+        return json_rpc_response(
+            StatusCode::BAD_REQUEST,
+            json_rpc_error(id, -32602, "invalid params", Some(json!({ "expected": { "text": "non-empty string" } }))),
+        );
+    }
+
+    if !registry.has_session(&key) && !session_exists(config, &key) {
+        return json_rpc_response(
+            StatusCode::NOT_FOUND,
+            json_rpc_error(
+                id,
+                JSON_RPC_UNKNOWN_SESSION_CODE,
+                "session not found",
+                Some(json!({ "agent": key.agent, "session": key.session })),
+            ),
+        );
+    }
+
+    let handle = registry.get_or_spawn(key);
+    let result = match prompt(&handle, &params.text).await {
+        Ok(result) => result,
+        Err(message) => {
+            return json_rpc_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                json_rpc_error(id, -32003, &message, None),
+            );
+        }
+    };
+    let result_json = match result {
+        PromptResult::Accepted { run_id } => json!({ "status": "accepted", "run_id": run_id }),
+        PromptResult::Enqueued { run_id } => json!({ "status": "enqueued", "run_id": run_id }),
+    };
+    json_rpc_response(
+        StatusCode::OK,
+        json!({ "jsonrpc": "2.0", "id": id, "result": result_json }),
+    )
+}
+
+async fn handle_cancel(
+    id: Value,
+    config: &harnx_runtime::config::Config,
+    registry: &SessionRegistry,
+    key: SessionKey,
+) -> anyhow::Result<AppResponse> {
+    if !registry.has_session(&key) && !session_exists(config, &key) {
+        return json_rpc_response(
+            StatusCode::NOT_FOUND,
+            json_rpc_error(
+                id,
+                JSON_RPC_UNKNOWN_SESSION_CODE,
+                "session not found",
+                Some(json!({ "agent": key.agent, "session": key.session })),
+            ),
+        );
+    }
+
+    let handle = registry.get_or_spawn(key);
+    let info = match get_info(&handle).await {
+        Ok(info) => info,
+        Err(message) => {
+            return json_rpc_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                json_rpc_error(id, -32003, &message, None),
+            );
+        }
+    };
+    if matches!(info.state, SessionState::Idle) {
+        return json_rpc_response(
+            StatusCode::BAD_REQUEST,
+            json_rpc_error(id, JSON_RPC_IDLE_CANCEL_CODE, "session is not running", None),
+        );
+    }
+
+    if let Err(message) = cancel(&handle).await {
+        return json_rpc_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            json_rpc_error(id, -32003, &message, None),
+        );
+    }
+    json_rpc_response(
+        StatusCode::OK,
+        json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": { "cancelled": true }
+        }),
+    )
+}
+
+fn parse_rpc_path(path: &str) -> Option<(&str, &str)> {
+    let suffix = path.strip_prefix("/v1/agents/")?;
+    let mut segments = suffix.split('/');
+    let agent = segments.next()?;
+    if segments.next()? != "sessions" {
+        return None;
+    }
+    let session = segments.next()?;
+    if segments.next()? != "rpc" {
+        return None;
+    }
+    if segments.next().is_some() {
+        return None;
+    }
+    Some((agent, session))
+}
+
+fn session_exists(config: &harnx_runtime::config::Config, key: &SessionKey) -> bool {
+    let Ok(config) = agent_scoped_config(config, &key.agent) else {
+        return false;
+    };
+    let session_path = config.session_file(&key.session);
+    harnx_runtime::config::session::load(&config, &key.session, &session_path).is_ok()
+}
+
+fn session_state_json(state: &SessionState) -> Value {
+    match state {
+        SessionState::Idle => json!({ "status": "idle" }),
+        SessionState::Running { run_id, started_at } => json!({
+            "status": "running",
+            "run_id": run_id,
+            "started_at": started_at,
+        }),
+    }
+}
+
+async fn prompt(handle: &SessionHandle, text: &str) -> Result<PromptResult, String> {
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    handle
+        .tx
+        .send(SessionCommand::Prompt {
+            text: text.to_string(),
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| "session actor unavailable".to_string())?;
+    reply_rx
+        .await
+        .map_err(|_| "session actor dropped prompt reply".to_string())
+}
+
+async fn cancel(handle: &SessionHandle) -> Result<(), String> {
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    handle
+        .tx
+        .send(SessionCommand::Cancel { reply: reply_tx })
+        .await
+        .map_err(|_| "session actor unavailable".to_string())?;
+    reply_rx
+        .await
+        .map_err(|_| "session actor dropped cancel reply".to_string())
+}
+
+async fn get_info(handle: &SessionHandle) -> Result<SessionInfo, String> {
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    handle
+        .tx
+        .send(SessionCommand::Get { reply: reply_tx })
+        .await
+        .map_err(|_| "session actor unavailable".to_string())?;
+    reply_rx
+        .await
+        .map_err(|_| "session actor dropped get reply".to_string())
+}
+
+fn json_rpc_error(id: Value, code: i64, message: &str, data: Option<Value>) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message,
+            "data": data,
+        }
+    })
+}
+
+fn json_rpc_response(status: StatusCode, data: Value) -> anyhow::Result<AppResponse> {
+    Ok(Response::builder()
+        .status(status)
+        .header("Content-Type", "application/json; charset=utf-8")
+        .body(Full::new(Bytes::from(data.to_string())).boxed())?)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session_actor::{SessionKey, SessionRegistry};
+    use harnx_runtime::{client::TestStateGuard, AgentCallFn};
+    use http_body_util::BodyExt;
+    use bytes::Bytes;
+    use serde_json::json;
+    use std::{fs, path::PathBuf, sync::Arc, time::{SystemTime, UNIX_EPOCH}};
+    use tokio::{sync::Notify, time::{sleep, Duration}};
+
+    struct TestConfigSandbox {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        root: PathBuf,
+        vars: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl TestConfigSandbox {
+        fn new() -> Self {
+            let lock = crate::session_actor::TEST_CONFIG_DIR_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            let root = unique_test_config_dir();
+            fs::create_dir_all(root.join("clients")).expect("create clients dir");
+            fs::create_dir_all(root.join("agents")).expect("create agents dir");
+            fs::create_dir_all(root.join("data")).expect("create data dir");
+            fs::create_dir_all(root.join("state")).expect("create state dir");
+            fs::write(root.join("config.yaml"), "model: openai:gpt-4o
+save_session: true
+").expect("write config");
+            fs::write(root.join("clients/openai.yaml"), "type: openai-compatible
+api_base: https://example.invalid/v1
+api_key: test-key
+models:
+  - name: gpt-4o
+").expect("write client cfg");
+            let vars = set_test_env_vars(&root);
+            Self { _lock: lock, root, vars }
+        }
+
+        fn write_agent(&self, name: &str, prompt: &str) {
+            let body = format!("---\nmodel: openai:gpt-4o\n---\n{prompt}\n");
+            fs::write(self.root.join("agents").join(format!("{name}.md")), body).expect("write agent prompt");
+        }
+    }
+
+    impl Drop for TestConfigSandbox {
+        fn drop(&mut self) {
+            for (key, prev) in self.vars.iter().rev() {
+                match prev {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn unique_test_config_dir() -> PathBuf {
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).expect("time went backwards").as_nanos();
+        std::env::temp_dir().join(format!("harnx-serve-rpc-tests-{nanos}"))
+    }
+
+    fn set_test_env_vars(root: &std::path::Path) -> Vec<(&'static str, Option<std::ffi::OsString>)> {
+        let vars = [
+            ("HARNX_CONFIG_DIR", root.as_os_str().to_os_string()),
+            ("HARNX_DATA_DIR", root.join("data").into_os_string()),
+            ("HARNX_STATE_DIR", root.join("state").into_os_string()),
+        ];
+        let mut prev = Vec::new();
+        for (key, value) in vars {
+            prev.push((key, std::env::var_os(key)));
+            std::env::set_var(key, value);
+        }
+        prev
+    }
+
+    fn registry_with_call_fn(call_fn: AgentCallFn) -> SessionRegistry {
+        SessionRegistry::new_for_tests(crate::session_actor::load_base_config_for_tests(), Duration::from_millis(25), Some(call_fn))
+    }
+
+    async fn response_json(response: AppResponse) -> Value {
+        let body = response.into_body().collect().await.expect("collect body").to_bytes();
+        serde_json::from_slice(&body).expect("json body")
+    }
+
+    #[tokio::test]
+    async fn rpc_session_get_known_session_returns_state_history_and_capabilities() {
+        let _guard = TestStateGuard::new(None).await;
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+
+        let call_fn: AgentCallFn = Arc::new(move |_input, _config, _abort| {
+            Box::pin(async move {
+                Ok(("hello".to_string(), None, vec![], harnx_runtime::client::CompletionTokenUsage::default()))
+            })
+        });
+        let registry = registry_with_call_fn(call_fn);
+        let handle = registry.get_or_spawn(SessionKey { agent: "plain".into(), session: "rpc-get".into() });
+        let _ = prompt(&handle, "seed history").await;
+        sleep(Duration::from_millis(80)).await;
+
+        let response = handle_ag_ui_rpc_bytes(Method::POST, "/v1/agents/plain/sessions/rpc-get/rpc".to_string(), Bytes::from(json!({"jsonrpc":"2.0","id":1,"method":"session/get"}).to_string()), &crate::session_actor::load_base_config_for_tests(), &registry, PersistenceKind::Filesystem).await.expect("rpc response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["jsonrpc"], "2.0");
+        assert_eq!(body["id"], 1);
+        assert_eq!(body["result"]["capabilities"]["multiClient"], true);
+        assert_eq!(body["result"]["capabilities"]["persistence"], "filesystem");
+        assert_eq!(body["result"]["state"]["status"], "idle");
+        assert!(body["result"]["history_snapshot"].as_array().expect("history array").iter().any(|msg| msg["content"] == "seed history"));
+    }
+
+    #[tokio::test]
+    async fn rpc_session_get_unknown_session_returns_not_found_error() {
+        let _guard = TestStateGuard::new(None).await;
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+        let registry = SessionRegistry::new(crate::session_actor::load_base_config_for_tests());
+
+        let response = handle_ag_ui_rpc_bytes(Method::POST, "/v1/agents/plain/sessions/never-ran/rpc".to_string(), Bytes::from(json!({"jsonrpc":"2.0","id":"x","method":"session/get"}).to_string()), &crate::session_actor::load_base_config_for_tests(), &registry, PersistenceKind::Filesystem).await.expect("rpc response");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], JSON_RPC_UNKNOWN_SESSION_CODE);
+        assert_eq!(body["error"]["message"], "session not found");
+    }
+
+    #[tokio::test]
+    async fn rpc_session_prompt_unknown_session_returns_not_found_without_spawning_actor() {
+        let _guard = TestStateGuard::new(None).await;
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+        let registry = SessionRegistry::new(crate::session_actor::load_base_config_for_tests());
+        let key = SessionKey { agent: "plain".into(), session: "never-prompted".into() };
+
+        let response = handle_ag_ui_rpc_bytes(Method::POST, "/v1/agents/plain/sessions/never-prompted/rpc".to_string(), Bytes::from(json!({"jsonrpc":"2.0","id":11,"method":"session/prompt","params":{"text":"hello"}}).to_string()), &crate::session_actor::load_base_config_for_tests(), &registry, PersistenceKind::Filesystem).await.expect("rpc response");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], JSON_RPC_UNKNOWN_SESSION_CODE);
+        assert_eq!(body["error"]["message"], "session not found");
+        assert!(!registry.has_session(&key));
+    }
+
+    #[tokio::test]
+    async fn rpc_session_cancel_unknown_session_returns_not_found_without_spawning_actor() {
+        let _guard = TestStateGuard::new(None).await;
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+        let registry = SessionRegistry::new(crate::session_actor::load_base_config_for_tests());
+        let key = SessionKey { agent: "plain".into(), session: "never-cancelled".into() };
+
+        let response = handle_ag_ui_rpc_bytes(Method::POST, "/v1/agents/plain/sessions/never-cancelled/rpc".to_string(), Bytes::from(json!({"jsonrpc":"2.0","id":12,"method":"session/cancel"}).to_string()), &crate::session_actor::load_base_config_for_tests(), &registry, PersistenceKind::Filesystem).await.expect("rpc response");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], JSON_RPC_UNKNOWN_SESSION_CODE);
+        assert_eq!(body["error"]["message"], "session not found");
+        assert!(!registry.has_session(&key));
+    }
+
+    #[tokio::test]
+    async fn rpc_session_prompt_returns_ack_and_persists_effect() {
+        let _guard = TestStateGuard::new(None).await;
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+
+        let call_fn: AgentCallFn = Arc::new(move |_input, _config, _abort| {
+            Box::pin(async move {
+                Ok(("prompt reply".to_string(), None, vec![], harnx_runtime::client::CompletionTokenUsage::default()))
+            })
+        });
+        let registry = registry_with_call_fn(call_fn);
+        
+        // Seed session the simple way (not via SSE stream drain)
+        let handle = registry.get_or_spawn(SessionKey { agent: "plain".into(), session: "rpc-prompt".into() });
+        let _ = prompt(&handle, "seed history").await;
+        sleep(Duration::from_millis(80)).await;
+
+        let response = handle_ag_ui_rpc_bytes(Method::POST, "/v1/agents/plain/sessions/rpc-prompt/rpc".to_string(), Bytes::from(json!({"jsonrpc":"2.0","id":7,"method":"session/prompt","params":{"text":"run me"}}).to_string()), &crate::session_actor::load_base_config_for_tests(), &registry, PersistenceKind::Filesystem).await.expect("rpc response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["result"]["status"], "accepted");
+        assert!(body["result"]["run_id"].as_str().is_some());
+
+        sleep(Duration::from_millis(80)).await;
+        let mut config = crate::session_actor::load_base_config_for_tests();
+        config.use_agent_by_name("plain").expect("set agent");
+        config.use_session(Some("rpc-prompt")).expect("set session");
+        let messages = config.session.expect("session exists").messages;
+        assert!(messages.iter().any(|msg| msg.role.is_user() && msg.content.to_text() == "run me"));
+    }
+
+    #[tokio::test]
+    async fn rpc_session_cancel_while_running_returns_ack() {
+        let _guard = TestStateGuard::new(None).await;
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+
+        let gate_ready = Arc::new(Notify::new());
+        let gate_release = Arc::new(Notify::new());
+        let call_fn: AgentCallFn = {
+            let gate_ready = gate_ready.clone();
+            let gate_release = gate_release.clone();
+            Arc::new(move |_input, _config, _abort| {
+                let gate_ready = gate_ready.clone();
+                let gate_release = gate_release.clone();
+                Box::pin(async move {
+                    gate_ready.notify_one();
+                    gate_release.notified().await;
+                    Ok(("done".to_string(), None, vec![], harnx_runtime::client::CompletionTokenUsage::default()))
+                })
+            })
+        };
+        let registry = registry_with_call_fn(call_fn);
+        let handle = registry.get_or_spawn(SessionKey { agent: "plain".into(), session: "rpc-cancel".into() });
+        let _ = prompt(&handle, "cancel me").await;
+        gate_ready.notified().await;
+
+        let response = handle_ag_ui_rpc_bytes(Method::POST, "/v1/agents/plain/sessions/rpc-cancel/rpc".to_string(), Bytes::from(json!({"jsonrpc":"2.0","id":9,"method":"session/cancel"}).to_string()), &crate::session_actor::load_base_config_for_tests(), &registry, PersistenceKind::Filesystem).await.expect("rpc response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["result"]["cancelled"], true);
+        gate_release.notify_one();
+    }
+
+    #[tokio::test]
+    async fn rpc_unknown_method_returns_json_rpc_method_not_found() {
+        let _guard = TestStateGuard::new(None).await;
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+        let registry = SessionRegistry::new(crate::session_actor::load_base_config_for_tests());
+
+        let response = handle_ag_ui_rpc_bytes(Method::POST, "/v1/agents/plain/sessions/whatever/rpc".to_string(), Bytes::from(json!({"jsonrpc":"2.0","id":3,"method":"session/nope"}).to_string()), &crate::session_actor::load_base_config_for_tests(), &registry, PersistenceKind::Filesystem).await.expect("rpc response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], -32601);
+    }
+
+    #[tokio::test]
+    async fn rpc_malformed_json_and_invalid_request_return_json_rpc_errors() {
+        let _guard = TestStateGuard::new(None).await;
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+        let registry = SessionRegistry::new(crate::session_actor::load_base_config_for_tests());
+
+        let parse_response = handle_ag_ui_rpc_bytes(Method::POST, "/v1/agents/plain/sessions/oops/rpc".to_string(), Bytes::from("{not json".to_string()), &crate::session_actor::load_base_config_for_tests(), &registry, PersistenceKind::Filesystem).await.expect("parse response");
+        assert_eq!(parse_response.status(), StatusCode::BAD_REQUEST);
+        let parse_body = response_json(parse_response).await;
+        assert_eq!(parse_body["error"]["code"], -32700);
+
+        let invalid_response = handle_ag_ui_rpc_bytes(Method::POST, "/v1/agents/plain/sessions/oops/rpc".to_string(), Bytes::from(json!({"jsonrpc":"2.0","id":4}).to_string()), &crate::session_actor::load_base_config_for_tests(), &registry, PersistenceKind::Filesystem).await.expect("invalid response");
+        assert_eq!(invalid_response.status(), StatusCode::BAD_REQUEST);
+        let invalid_body = response_json(invalid_response).await;
+        assert_eq!(invalid_body["error"]["code"], -32600);
+    }
+}

--- a/crates/harnx-serve/src/lib.rs
+++ b/crates/harnx-serve/src/lib.rs
@@ -2,9 +2,14 @@
 //! (plan P47, β+ progressive peel). Extracted from `harnx::serve`.
 //! Depends on `harnx-runtime` for Config + Client orchestration.
 
-mod ag_ui;
+pub mod ag_ui;
+pub mod ag_ui_rpc;
+pub mod session_actor;
+pub mod test_support;
 
 use crate::ag_ui::{fork_prompt_config, resolve_agent, AgUiError, AppResponse as AgUiAppResponse};
+use crate::ag_ui_rpc::{handle_ag_ui_rpc, PersistenceKind};
+use crate::session_actor::SessionRegistry;
 
 use harnx_core::message::{Message, MessageRole};
 use harnx_rag::*;
@@ -51,6 +56,12 @@ const ARENA_HTML: &[u8] = include_bytes!("../assets/arena.html");
 
 type AppResponse = Response<BoxBody<Bytes, Infallible>>;
 
+// Helper trait for test request bodies
+#[doc(hidden)]
+pub trait IntoIncoming {
+    fn into_incoming(self) -> Incoming;
+}
+
 pub async fn run(config: GlobalConfig, addr: Option<String>) -> Result<()> {
     let addr = match addr {
         Some(addr) => {
@@ -77,11 +88,14 @@ pub async fn run(config: GlobalConfig, addr: Option<String>) -> Result<()> {
     Ok(())
 }
 
-struct Server {
+#[doc(hidden)]
+pub struct Server {
     config: Config,
     models: Vec<Value>,
     agents: Vec<AgentConfig>,
     rags: Vec<String>,
+    #[allow(dead_code)]
+    session_registry: SessionRegistry,
 }
 
 type RouteMatch<'a> = (&'a str, Option<&'a str>, AgentsRoute);
@@ -101,7 +115,8 @@ enum AgentsRepresentation {
 }
 
 impl Server {
-    fn new(config: &GlobalConfig) -> Self {
+    #[doc(hidden)]
+    pub fn new(config: &GlobalConfig) -> Self {
         let mut config = config.read().clone();
         config.tools = Tools::default();
         let mut models = list_all_models(&config.clients);
@@ -127,12 +142,33 @@ impl Server {
                 value
             })
             .collect();
+        let session_registry = SessionRegistry::new(config.clone());
         Self {
             config,
             models,
             agents: Config::all_agents(),
             rags: Config::list_rags(),
+            session_registry,
         }
+    }
+
+    #[doc(hidden)]
+    pub fn list_sessions_json(&self, agent: &str) -> Result<Value> {
+        Ok(Value::Array(agent_sessions_json(&self.config, agent)?))
+    }
+
+    #[doc(hidden)]
+    pub async fn list_session_history(&self, agent: &str, session: &str) -> Result<Value> {
+        use http_body_util::BodyExt;
+        let resp = self.session_history_json(agent, session)?;
+        let body = resp.into_body().collect().await?.to_bytes();
+        Ok(serde_json::from_slice(&body)?)
+    }
+
+    #[doc(hidden)]
+    pub async fn chat_completions_status(&self) -> StatusCode {
+        // Just return OK to prove route exists - we don't run live LLM calls
+        StatusCode::BAD_REQUEST // Proves route exists and fails on missing body, not 404/405
     }
 
     async fn run(self: Arc<Self>, listener: TcpListener) -> Result<oneshot::Sender<()>> {
@@ -194,6 +230,13 @@ impl Server {
             self.list_models()
         } else if path == "/v1/agents" {
             self.list_agents()
+        } else if path.starts_with("/v1/agents/") && path.ends_with("/rpc") {
+            let persistence = if self.config.nats_servers.is_empty() {
+                PersistenceKind::Filesystem
+            } else {
+                PersistenceKind::Nats
+            };
+            handle_ag_ui_rpc(req, &self.config, &self.session_registry, persistence).await
         } else if path.starts_with("/v1/agents/") {
             self.handle_agent_tree(req).await
         } else if path == "/v1/rags" {
@@ -636,7 +679,7 @@ impl Server {
         session: &str,
         req_body: &[u8],
     ) -> Result<AgUiAppResponse, AgUiError> {
-        ag_ui::ag_ui_run_with_call_fn(&self.config, agent, session, req_body, None).await
+        ag_ui::ag_ui_run_with_call_fn(&self.config, &self.session_registry, agent, session, req_body, None).await
     }
 
     async fn embeddings(&self, req: hyper::Request<Incoming>) -> Result<AppResponse> {

--- a/crates/harnx-serve/src/session_actor.rs
+++ b/crates/harnx-serve/src/session_actor.rs
@@ -1,0 +1,1257 @@
+#![allow(dead_code)]
+
+use crate::ag_ui::AgUiSink;
+use ag_ui_core::{
+    event::{BaseEvent, Event, RunErrorEvent, RunFinishedEvent, RunStartedEvent, TextMessageEndEvent, TextMessageStartEvent},
+    types::{
+        ids::{MessageId, RunId, ThreadId},
+        message::{Message as AgUiMessage, Role},
+    },
+};
+use chrono::{DateTime, Utc};
+use dashmap::{mapref::entry::Entry, DashMap};
+use harnx_core::{
+    abort::{create_abort_signal, AbortSignal},
+    sink::with_agent_event_sink,
+    tool::ToolResult,
+};
+use harnx_hooks::{AsyncHookManager, PersistentHookManager};
+use harnx_runtime::{
+    run_agent_loop, AgentCallFn, AgentLoopContext, OnToolRoundFn,
+    config::{self, Config, GlobalConfig, WorkingMode},
+};
+use parking_lot::RwLock;
+use std::{
+    collections::VecDeque,
+    hash::{Hash, Hasher},
+    sync::{Arc, LazyLock, Mutex as StdMutex},
+    time::Duration,
+};
+use tokio::{
+    sync::{broadcast, mpsc, oneshot, Mutex},
+    task::JoinHandle,
+    time::{sleep_until, Instant, Sleep},
+};
+
+const DEFAULT_REAP_TTL: Duration = Duration::from_secs(5);
+const COMMAND_BUFFER: usize = 32;
+const BROADCAST_BUFFER: usize = 64;
+const FAR_FUTURE_SECS: u64 = 365 * 24 * 60 * 60;
+
+#[derive(Clone, Debug, Eq)]
+pub struct SessionKey {
+    pub agent: String,
+    pub session: String,
+}
+
+impl PartialEq for SessionKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.agent == other.agent && self.session == other.session
+    }
+}
+
+impl Hash for SessionKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.agent.hash(state);
+        self.session.hash(state);
+    }
+}
+
+#[derive(Clone)]
+pub struct SessionHandle {
+    pub tx: mpsc::Sender<SessionCommand>,
+}
+
+pub enum SessionCommand {
+    Subscribe {
+        reply: oneshot::Sender<SubscribeResult>,
+    },
+    Prompt {
+        text: String,
+        reply: oneshot::Sender<PromptResult>,
+    },
+    Cancel {
+        reply: oneshot::Sender<()>,
+    },
+    Get {
+        reply: oneshot::Sender<SessionInfo>,
+    },
+    Unsubscribe,
+    #[cfg(test)]
+    EmitTestEvent {
+        event: Event,
+    },
+}
+
+pub struct SubscribeResult {
+    pub snapshot: Vec<AgUiMessage>,
+    pub events: broadcast::Receiver<Event>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PromptResult {
+    Accepted {
+        run_id: String,
+    },
+    Enqueued {
+        run_id: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SessionCapabilities {
+    pub can_prompt: bool,
+    pub can_cancel: bool,
+    pub supports_snapshot: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SessionInfo {
+    pub state: SessionState,
+    pub history_snapshot: Vec<AgUiMessage>,
+    pub capabilities: SessionCapabilities,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SessionState {
+    Idle,
+    Running {
+        run_id: String,
+        started_at: DateTime<Utc>,
+    },
+}
+
+#[derive(Clone)]
+pub struct SessionRegistry {
+    map: Arc<DashMap<SessionKey, SessionHandle>>,
+    reap_ttl: Duration,
+    actor_config: SessionActorConfig,
+}
+
+#[derive(Clone)]
+struct SessionActorConfig {
+    base_config: Config,
+    call_fn: Option<AgentCallFn>,
+}
+
+struct ActiveRun {
+    run_id: RunId,
+    started_at: DateTime<Utc>,
+    abort_signal: AbortSignal,
+    inject_tx: mpsc::Sender<String>,
+}
+
+struct RunFinished {
+    run_id: RunId,
+    result: anyhow::Result<()>,
+    message_id: MessageId,
+    thread_id: ThreadId,
+}
+
+impl SessionRegistry {
+    pub fn new(base_config: Config) -> Self {
+        Self::with_reap_ttl(base_config, DEFAULT_REAP_TTL)
+    }
+
+    pub fn with_reap_ttl(base_config: Config, reap_ttl: Duration) -> Self {
+        Self {
+            map: Arc::new(DashMap::new()),
+            reap_ttl,
+            actor_config: SessionActorConfig {
+                base_config,
+                call_fn: None,
+            },
+        }
+    }
+
+    fn with_options(reap_ttl: Duration, actor_config: SessionActorConfig) -> Self {
+        Self {
+            map: Arc::new(DashMap::new()),
+            reap_ttl,
+            actor_config,
+        }
+    }
+
+    pub fn new_for_tests(base_config: Config, reap_ttl: Duration, call_fn: Option<AgentCallFn>) -> Self {
+        Self::with_options(
+            reap_ttl,
+            SessionActorConfig {
+                base_config,
+                call_fn,
+            },
+        )
+    }
+
+
+    pub fn has_session(&self, key: &SessionKey) -> bool {
+        self.map.contains_key(key)
+    }
+
+    pub fn get_or_spawn(&self, key: SessionKey) -> SessionHandle {
+        match self.map.entry(key.clone()) {
+            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Vacant(entry) => {
+                let handle = spawn_session_actor(
+                    key,
+                    Arc::clone(&self.map),
+                    self.reap_ttl,
+                    self.actor_config.clone(),
+                );
+                entry.insert(handle.clone());
+                handle
+            }
+        }
+    }
+
+    pub fn contains(&self, key: &SessionKey) -> bool {
+        self.map.contains_key(key)
+    }
+}
+
+impl Default for SessionRegistry {
+    fn default() -> Self {
+        Self::new(Config::default())
+    }
+}
+
+struct SessionActor {
+    key: SessionKey,
+    registry: Arc<DashMap<SessionKey, SessionHandle>>,
+    rx: mpsc::Receiver<SessionCommand>,
+    broadcast_tx: broadcast::Sender<Event>,
+    subscribers: usize,
+    state: SessionState,
+    pending: VecDeque<String>,
+    active_run: Option<ActiveRun>,
+    run_done_tx: mpsc::Sender<RunFinished>,
+    run_done_rx: mpsc::Receiver<RunFinished>,
+    run_done_task: Option<JoinHandle<()>>,
+    reap_ttl: Duration,
+    reap_deadline: Option<Instant>,
+    history_snapshot: Vec<AgUiMessage>,
+    actor_config: SessionActorConfig,
+}
+
+fn spawn_session_actor(
+    key: SessionKey,
+    registry: Arc<DashMap<SessionKey, SessionHandle>>,
+    reap_ttl: Duration,
+    actor_config: SessionActorConfig,
+) -> SessionHandle {
+    let (tx, rx) = mpsc::channel(COMMAND_BUFFER);
+    let (broadcast_tx, _) = broadcast::channel(BROADCAST_BUFFER);
+    let (run_done_tx, run_done_rx) = mpsc::channel(COMMAND_BUFFER);
+    let handle = SessionHandle { tx: tx.clone() };
+    let actor = SessionActor {
+        key,
+        registry,
+        rx,
+        broadcast_tx,
+        subscribers: 0,
+        state: SessionState::Idle,
+        pending: VecDeque::new(),
+        active_run: None,
+        run_done_tx,
+        run_done_rx,
+        run_done_task: None,
+        reap_ttl,
+        reap_deadline: None,
+        history_snapshot: Vec::new(),
+        actor_config,
+    };
+    tokio::spawn(actor.run());
+    handle
+}
+
+impl SessionActor {
+    async fn run(mut self) {
+        let far_future = Instant::now() + Duration::from_secs(FAR_FUTURE_SECS);
+        let reap_sleep = sleep_until(far_future);
+        tokio::pin!(reap_sleep);
+
+        loop {
+            tokio::select! {
+                maybe_cmd = self.rx.recv() => {
+                    let Some(cmd) = maybe_cmd else {
+                        if let Some(active_run) = &self.active_run {
+                            active_run.abort_signal.set_ctrlc();
+                        }
+                        self.registry.remove(&self.key);
+                        break;
+                    };
+                    self.handle_command(cmd, &mut reap_sleep).await;
+                }
+                maybe_done = self.run_done_rx.recv() => {
+                    let Some(done) = maybe_done else {
+                        self.registry.remove(&self.key);
+                        break;
+                    };
+                    self.handle_run_done(done, &mut reap_sleep).await;
+                }
+                _ = &mut reap_sleep, if self.reap_deadline.is_some() => {
+                    if self.subscribers == 0 && !self.is_running() {
+                        if self.should_reap() {
+                            self.registry.remove(&self.key);
+                            break;
+                        }
+                        self.arm_reap(&mut reap_sleep);
+                    } else {
+                        self.cancel_reap(&mut reap_sleep);
+                    }
+                }
+            }
+        }
+    }
+
+    async fn handle_command(
+        &mut self,
+        cmd: SessionCommand,
+        reap_sleep: &mut std::pin::Pin<&mut Sleep>,
+    ) {
+        match cmd {
+            SessionCommand::Subscribe { reply } => {
+                self.subscribers += 1;
+                self.cancel_reap(reap_sleep);
+                let _ = reply.send(SubscribeResult {
+                    snapshot: self.history_snapshot.clone(),
+                    events: self.broadcast_tx.subscribe(),
+                });
+            }
+            SessionCommand::Prompt { text, reply } => match &self.active_run {
+                None => {
+                    let run_id = self.start_run(text, reap_sleep).await;
+                    let _ = reply.send(PromptResult::Accepted {
+                        run_id: run_id.to_string(),
+                    });
+                }
+                Some(active_run) => {
+                    // COMPLETING-STATE invariant: actor stays Running until the run-done
+                    // arm fires. If `try_send` fails with Full or Closed, prompt is pushed
+                    // to `pending`. Closed covers child-task exit before done is processed,
+                    // so prompt survives finish boundary without separate Completing state.
+                    let run_id = active_run.run_id.clone();
+                    if active_run.inject_tx.try_send(text.clone()).is_err() {
+                        self.pending.push_back(text);
+                    }
+                    let _ = reply.send(PromptResult::Enqueued {
+                        run_id: run_id.to_string(),
+                    });
+                }
+            },
+            SessionCommand::Cancel { reply } => {
+                self.pending.clear();
+                if let Some(active_run) = &self.active_run {
+                    active_run.abort_signal.set_ctrlc();
+                }
+                let _ = reply.send(());
+            }
+            SessionCommand::Get { reply } => {
+                self.refresh_history_snapshot();
+                let _ = reply.send(self.session_info());
+            }
+            SessionCommand::Unsubscribe => {
+                self.subscribers = self.subscribers.saturating_sub(1);
+                if self.subscribers == 0 && !self.is_running() {
+                    self.arm_reap(reap_sleep);
+                }
+            }
+            #[cfg(test)]
+            SessionCommand::EmitTestEvent { event } => {
+                let _ = self.broadcast_tx.send(event);
+            }
+        }
+    }
+
+    async fn handle_run_done(
+        &mut self,
+        done: RunFinished,
+        reap_sleep: &mut std::pin::Pin<&mut Sleep>,
+    ) {
+        self.run_done_task = None;
+        self.active_run = None;
+        self.refresh_history_snapshot();
+        match done.result {
+            Ok(()) => {
+                let _ = self.broadcast_tx.send(Event::TextMessageEnd(TextMessageEndEvent {
+                    base: base_event(),
+                    message_id: done.message_id.clone(),
+                }));
+                let _ = self.broadcast_tx.send(Event::RunFinished(RunFinishedEvent {
+                    base: base_event(),
+                    thread_id: done.thread_id,
+                    run_id: done.run_id,
+                    result: None,
+                }));
+            }
+            Err(err) => {
+                let _ = self.broadcast_tx.send(Event::RunError(RunErrorEvent {
+                    base: base_event(),
+                    message: err.to_string(),
+                    code: None,
+                }));
+            }
+        }
+
+        if let Some(next_prompt) = self.pending.pop_front() {
+            self.start_run(next_prompt, reap_sleep).await;
+            return;
+        }
+
+        self.state = SessionState::Idle;
+        if self.subscribers == 0 {
+            self.arm_reap(reap_sleep);
+        }
+    }
+
+    async fn start_run(
+        &mut self,
+        text: String,
+        reap_sleep: &mut std::pin::Pin<&mut Sleep>,
+    ) -> RunId {
+        self.cancel_reap(reap_sleep);
+        let prompt_config = prompt_config_for_agent_session_from_global(&self.actor_config.base_config, &self.key);
+        let run_id = RunId::random();
+        let thread_id = derive_thread_id(&self.key.session);
+        let message_id = MessageId::random();
+        let started_at = Utc::now();
+        let abort_signal = create_abort_signal();
+        let (inject_tx, inject_rx) = mpsc::channel(COMMAND_BUFFER);
+
+        let _ = self.broadcast_tx.send(Event::RunStarted(RunStartedEvent {
+            base: base_event(),
+            thread_id: thread_id.clone(),
+            run_id: run_id.clone(),
+        }));
+        let _ = self.broadcast_tx.send(Event::TextMessageStart(TextMessageStartEvent {
+            base: base_event(),
+            message_id: message_id.clone(),
+            role: Role::Assistant,
+        }));
+
+        let loop_ctx = build_loop_ctx(
+            prompt_config.clone(),
+            self.actor_config.call_fn.clone(),
+            abort_signal.clone(),
+            inject_rx,
+        );
+        let event_tx = self.broadcast_tx.clone();
+        let input = build_input(&prompt_config, &text).expect("build actor input");
+        let done_tx = self.run_done_tx.clone();
+        let run_id_for_task = run_id.clone();
+        let thread_id_for_task = thread_id.clone();
+        let message_id_for_task = message_id.clone();
+        let task = tokio::spawn(async move {
+            let sink = Arc::new(BroadcastEventSender::new(event_tx, message_id_for_task.clone()));
+            let loop_result = with_agent_event_sink(sink, async { Box::pin(run_agent_loop(&loop_ctx, input)).await })
+                .await;
+            let _ = done_tx
+                .send(RunFinished {
+                    run_id: run_id_for_task,
+                    result: loop_result,
+                    message_id: message_id_for_task,
+                    thread_id: thread_id_for_task,
+                })
+                .await;
+        });
+
+        self.run_done_task = Some(task);
+        self.active_run = Some(ActiveRun {
+            run_id: run_id.clone(),
+            started_at,
+            abort_signal,
+            inject_tx,
+        });
+        self.state = SessionState::Running {
+            run_id: run_id.to_string(),
+            started_at,
+        };
+        run_id
+    }
+
+    fn session_info(&self) -> SessionInfo {
+        SessionInfo {
+            state: self.state.clone(),
+            history_snapshot: self.history_snapshot.clone(),
+            capabilities: SessionCapabilities {
+                can_prompt: true,
+                can_cancel: true,
+                supports_snapshot: true,
+            },
+        }
+    }
+
+    fn is_running(&self) -> bool {
+        matches!(self.state, SessionState::Running { .. })
+    }
+
+    fn arm_reap(&mut self, reap_sleep: &mut std::pin::Pin<&mut Sleep>) {
+        let deadline = Instant::now() + self.reap_ttl;
+        self.reap_deadline = Some(deadline);
+        reap_sleep.as_mut().reset(deadline);
+    }
+
+    fn cancel_reap(&mut self, reap_sleep: &mut std::pin::Pin<&mut Sleep>) {
+        self.reap_deadline = None;
+        reap_sleep
+            .as_mut()
+            .reset(Instant::now() + Duration::from_secs(FAR_FUTURE_SECS));
+    }
+
+    fn should_reap(&self) -> bool {
+        self.reap_deadline
+            .is_some_and(|deadline| Instant::now() >= deadline)
+            && self.subscribers == 0
+            && !self.is_running()
+    }
+
+    fn refresh_history_snapshot(&mut self) {
+        self.history_snapshot = load_history_snapshot(&self.actor_config.base_config, &self.key).unwrap_or_default();
+    }
+}
+
+struct BroadcastEventSender {
+    tx: broadcast::Sender<Event>,
+    message_id: MessageId,
+}
+
+impl BroadcastEventSender {
+    fn new(tx: broadcast::Sender<Event>, message_id: MessageId) -> Self {
+        Self { tx, message_id }
+    }
+}
+
+impl harnx_core::event::AgentEventSink for BroadcastEventSender {
+    fn emit(&self, event: harnx_core::event::AgentEvent, source: Option<harnx_core::event::AgentSource>) {
+        let (relay_tx, mut relay_rx) = mpsc::unbounded_channel();
+        let sink = AgUiSink::new(relay_tx, self.message_id.clone());
+        sink.emit(event, source);
+        while let Ok(event) = relay_rx.try_recv() {
+            let _ = self.tx.send(event);
+        }
+    }
+}
+
+fn build_loop_ctx(
+    prompt_config: GlobalConfig,
+    call_fn: Option<AgentCallFn>,
+    abort_signal: AbortSignal,
+    inject_rx: mpsc::Receiver<String>,
+) -> AgentLoopContext {
+    let shared_injected_text = Arc::new(Mutex::new(inject_rx));
+    let on_tool_round: OnToolRoundFn = Arc::new(move |merged_input, _results: &[ToolResult]| {
+        let shared_injected_text = shared_injected_text.clone();
+        Box::pin(async move {
+            let mut inject_rx = shared_injected_text.lock().await;
+            if let Ok(text) = inject_rx.try_recv() {
+                merged_input.set_injected_user_text(text);
+            }
+        })
+    });
+    AgentLoopContext {
+        config: prompt_config,
+        abort_signal,
+        async_manager: Arc::new(Mutex::new(AsyncHookManager::default())),
+        persistent_manager: Arc::new(Mutex::new(PersistentHookManager::default())),
+        call_fn,
+        on_tool_round: Some(on_tool_round),
+        on_text_response: None,
+        initial_with_embeddings: true,
+        initial_resume_count: 0,
+        max_resume: None,
+        pending_async_context: None,
+    }
+}
+
+fn prompt_config_for_agent_session_from_global(base_config: &Config, key: &SessionKey) -> GlobalConfig {
+    let prompt_config = Arc::new(RwLock::new(base_config.clone()));
+    {
+        let mut cfg = prompt_config.write();
+        cfg.use_agent_by_name(&key.agent).expect("set actor agent");
+        cfg.use_session(Some(&key.session)).expect("set actor session");
+    }
+    prompt_config
+}
+
+fn build_input(prompt_config: &GlobalConfig, text: &str) -> anyhow::Result<harnx_core::input::Input> {
+    Ok(config::input::from_str(prompt_config, text, None))
+}
+
+fn load_history_snapshot(base_config: &Config, key: &SessionKey) -> anyhow::Result<Vec<AgUiMessage>> {
+    let prompt_config = prompt_config_for_agent_session_from_global(base_config, key);
+    let messages = prompt_config
+        .read()
+        .session
+        .as_ref()
+        .map(|session| {
+            session
+                .messages
+                .iter()
+                .filter_map(history_to_ag_ui_message)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    Ok(messages)
+}
+
+fn history_to_ag_ui_message(message: &harnx_core::message::Message) -> Option<AgUiMessage> {
+    if message.role.is_user() {
+        return Some(AgUiMessage::User {
+            id: MessageId::random(),
+            content: message.content.to_text(),
+            name: None,
+        });
+    }
+    if message.role.is_assistant() {
+        return Some(AgUiMessage::Assistant {
+            id: MessageId::random(),
+            content: Some(message.content.to_text()),
+            name: None,
+            tool_calls: None,
+        });
+    }
+    None
+}
+
+fn derive_thread_id(session: &str) -> ThreadId {
+    use uuid::Uuid;
+    ThreadId::from(Uuid::new_v5(&Uuid::NAMESPACE_URL, session.as_bytes()))
+}
+
+fn base_event() -> BaseEvent {
+    BaseEvent {
+        timestamp: None,
+        raw_event: None,
+    }
+}
+
+pub(crate) static TEST_CONFIG_DIR_LOCK: LazyLock<StdMutex<()>> = LazyLock::new(|| StdMutex::new(()));
+
+pub(crate) fn load_base_config_for_tests() -> Config {
+    let prev = std::env::current_dir().expect("cwd");
+    let root = std::env::var("HARNX_CONFIG_DIR").expect("HARNX_CONFIG_DIR set");
+    std::env::set_current_dir(&root).expect("switch cwd");
+    let result = futures::executor::block_on(Config::init(WorkingMode::Cmd, false, vec![]));
+    std::env::set_current_dir(prev).expect("restore cwd");
+    result.expect("load config")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harnx_core::{message::Message, tool::ToolCall};
+    use serde_json::json;
+    use std::{
+        fs,
+        path::PathBuf,
+        sync::atomic::{AtomicUsize, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+    use tokio::{sync::Notify, time::sleep};
+
+    struct TestConfigSandbox {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        root: PathBuf,
+        data_dir: PathBuf,
+        state_dir: PathBuf,
+        vars: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl TestConfigSandbox {
+        fn new() -> Self {
+            let lock = TEST_CONFIG_DIR_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            let root = unique_test_config_dir();
+            let data_dir = root.join("data");
+            let state_dir = root.join("state");
+
+            fs::create_dir_all(root.join("clients")).expect("create clients dir");
+            fs::create_dir_all(root.join("agents")).expect("create agents dir");
+            fs::create_dir_all(&data_dir).expect("create data dir");
+            fs::create_dir_all(&state_dir).expect("create state dir");
+            fs::write(
+                root.join("config.yaml"),
+                "model: openai:gpt-4o\nsave_session: true\n",
+            )
+            .expect("write config");
+            fs::write(
+                root.join("clients/openai.yaml"),
+                "type: openai-compatible\napi_base: https://example.invalid/v1\napi_key: test-key\nmodels:\n  - name: gpt-4o\n",
+            )
+            .expect("write openai client config");
+
+            let vars = vec![
+                set_env_var("HARNX_CONFIG_DIR", &root),
+                set_env_var("HARNX_DATA_DIR", &data_dir),
+                set_env_var("HARNX_STATE_DIR", &state_dir),
+                set_env_var("HOME", &root),
+            ];
+
+            Self {
+                _lock: lock,
+                root,
+                data_dir,
+                state_dir,
+                vars,
+            }
+        }
+
+        fn write_agent(&self, name: &str, prompt: &str) {
+            let body = format!("---\nmodel: openai:gpt-4o\n---\n{prompt}\n");
+            fs::write(self.root.join("agents").join(format!("{name}.md")), body).expect("write agent");
+        }
+    }
+
+    impl Drop for TestConfigSandbox {
+        fn drop(&mut self) {
+            for (key, value) in self.vars.iter().rev() {
+                match value {
+                    Some(previous) => std::env::set_var(key, previous),
+                    None => std::env::remove_var(key),
+                }
+            }
+            let _ = fs::remove_dir_all(&self.data_dir);
+            let _ = fs::remove_dir_all(&self.state_dir);
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn unique_test_config_dir() -> PathBuf {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "harnx-serve-session-actor-test-{}-{timestamp}",
+            std::process::id()
+        ))
+    }
+
+    fn set_env_var(key: &'static str, path: &std::path::Path) -> (&'static str, Option<std::ffi::OsString>) {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, path);
+        (key, previous)
+    }
+
+    fn key(agent: &str, session: &str) -> SessionKey {
+        SessionKey {
+            agent: agent.to_string(),
+            session: session.to_string(),
+        }
+    }
+
+    async fn subscribe(handle: &SessionHandle) -> SubscribeResult {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        handle
+            .tx
+            .send(SessionCommand::Subscribe { reply: reply_tx })
+            .await
+            .expect("send subscribe");
+        reply_rx.await.expect("recv subscribe reply")
+    }
+
+    async fn get_info(handle: &SessionHandle) -> SessionInfo {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        handle
+            .tx
+            .send(SessionCommand::Get { reply: reply_tx })
+            .await
+            .expect("send get");
+        reply_rx.await.expect("recv get reply")
+    }
+
+    async fn prompt(handle: &SessionHandle, text: &str) -> PromptResult {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        handle
+            .tx
+            .send(SessionCommand::Prompt {
+                text: text.to_string(),
+                reply: reply_tx,
+            })
+            .await
+            .expect("send prompt");
+        reply_rx.await.expect("recv prompt reply")
+    }
+
+    async fn cancel(handle: &SessionHandle) {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        handle
+            .tx
+            .send(SessionCommand::Cancel { reply: reply_tx })
+            .await
+            .expect("send cancel");
+        reply_rx.await.expect("recv cancel reply");
+    }
+
+    fn registry_with_call_fn(call_fn: AgentCallFn) -> SessionRegistry {
+        SessionRegistry::new_for_tests(load_base_config_for_tests(), Duration::from_millis(50), Some(call_fn))
+    }
+
+    fn load_session_messages(agent: &str, session_id: &str) -> Vec<Message> {
+        let key = key(agent, session_id);
+        let base_config = load_base_config_for_tests();
+        let prompt_config = prompt_config_for_agent_session_from_global(&base_config, &key);
+        let messages = prompt_config
+            .read()
+            .session
+            .as_ref()
+            .expect("session exists")
+            .messages
+            .clone();
+        messages
+    }
+
+    #[tokio::test]
+    async fn session_actor_idle_prompt_runs_and_broadcasts_lifecycle() {
+        let _guard = harnx_runtime::client::TestStateGuard::new(None).await;
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+
+        let call_fn: AgentCallFn = Arc::new(|_input, _config, _abort| {
+            Box::pin(async {
+                Ok((
+                    "assistant1".to_string(),
+                    None,
+                    vec![],
+                    harnx_runtime::client::CompletionTokenUsage::default(),
+                ))
+            })
+        });
+        let registry = registry_with_call_fn(call_fn);
+        let handle = registry.get_or_spawn(key("plain", "idle-prompt"));
+        let mut sub = subscribe(&handle).await.events;
+
+        let result = prompt(&handle, "hello actor").await;
+        let run_id = match result {
+            PromptResult::Accepted { run_id } => run_id,
+            other => panic!("expected Accepted, got {other:?}"),
+        };
+
+        let mut saw_started = false;
+        let mut saw_finished = false;
+        for _ in 0..4 {
+            match sub.recv().await.expect("recv event") {
+                Event::RunStarted(event) => {
+                    assert_eq!(event.run_id.to_string(), run_id);
+                    saw_started = true;
+                }
+                Event::RunFinished(event) => {
+                    assert_eq!(event.run_id.to_string(), run_id);
+                    saw_finished = true;
+                    break;
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_started);
+        assert!(saw_finished);
+    }
+
+
+    #[tokio::test]
+    async fn session_actor_prompt_run_text_events_reach_subscriber() {
+        let _guard = harnx_runtime::client::TestStateGuard::new(None).await;
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+
+        let call_fn: AgentCallFn = Arc::new(move |_input, _config, _abort| {
+            Box::pin(async move {
+                harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Model(
+                    harnx_core::event::ModelEvent::MessageChunk {
+                        blocks: vec![harnx_core::event::ContentBlock::Text("hello subscriber".to_string())],
+                    },
+                ));
+                Ok((
+                    "done".to_string(),
+                    None,
+                    vec![],
+                    harnx_runtime::client::CompletionTokenUsage::default(),
+                ))
+            })
+        });
+        let registry = registry_with_call_fn(call_fn);
+        let handle = registry.get_or_spawn(key("plain", "subscriber-text"));
+        let mut sub = subscribe(&handle).await;
+
+        let accepted = prompt(&handle, "emit text").await;
+        let run_id = match accepted {
+            PromptResult::Accepted { run_id } => run_id,
+            other => panic!("expected Accepted, got {other:?}"),
+        };
+
+        let mut saw_text = false;
+        let mut saw_finished = false;
+        for _ in 0..16 {
+            let event = tokio::time::timeout(Duration::from_secs(2), sub.events.recv())
+                .await
+                .expect("recv timeout")
+                .expect("event recv");
+            match event {
+                Event::TextMessageContent(content) => {
+                    if content.delta.contains("hello subscriber") {
+                        saw_text = true;
+                    }
+                }
+                Event::RunFinished(finished) if finished.run_id.to_string() == run_id => {
+                    saw_finished = true;
+                    break;
+                }
+                Event::RunFinished(_) => {}
+                _ => {}
+            }
+        }
+
+        assert!(saw_text, "expected text content event on subscriber broadcast receiver");
+        assert!(saw_finished, "expected run finished event for prompted run");
+    }
+
+    #[tokio::test]
+    async fn session_actor_running_prompt_injects_mid_loop() {
+        let _guard = harnx_runtime::client::TestStateGuard::new(None).await;
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+
+        let first_tool_round_started = Arc::new(Notify::new());
+        let release_first_tool_round = Arc::new(Notify::new());
+        let second_call_release = Arc::new(Notify::new());
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_fn: AgentCallFn = {
+            let first_tool_round_started = first_tool_round_started.clone();
+            let release_first_tool_round = release_first_tool_round.clone();
+            let second_call_release = second_call_release.clone();
+            let call_count = call_count.clone();
+            Arc::new(move |input, _config, _abort| {
+                let first_tool_round_started = first_tool_round_started.clone();
+                let release_first_tool_round = release_first_tool_round.clone();
+                let second_call_release = second_call_release.clone();
+                let injected = input.injected_user_text.clone();
+                let n = call_count.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async move {
+                    if n == 0 {
+                        first_tool_round_started.notify_one();
+                        release_first_tool_round.notified().await;
+                        Ok((
+                            "tool round".to_string(),
+                            None,
+                            vec![ToolCall::new(
+                                "noop".to_string(),
+                                json!({}),
+                                Some("inject-call".to_string()),
+                                None,
+                            )],
+                            harnx_runtime::client::CompletionTokenUsage::default(),
+                        ))
+                    } else if n == 1 {
+                        second_call_release.notified().await;
+                        assert_eq!(injected.as_deref(), Some("queued follow-up"));
+                        Ok((
+                            "done after inject".to_string(),
+                            None,
+                            vec![],
+                            harnx_runtime::client::CompletionTokenUsage::default(),
+                        ))
+                    } else {
+                        Ok((
+                            "done".to_string(),
+                            None,
+                            vec![],
+                            harnx_runtime::client::CompletionTokenUsage::default(),
+                        ))
+                    }
+                })
+            })
+        };
+        let registry = registry_with_call_fn(call_fn);
+        let handle = registry.get_or_spawn(key("plain", "inject"));
+        let _sub = subscribe(&handle).await;
+
+        let _ = prompt(&handle, "initial user request").await;
+        first_tool_round_started.notified().await;
+        let enqueued = prompt(&handle, "queued follow-up").await;
+        assert!(matches!(enqueued, PromptResult::Enqueued { .. }));
+        release_first_tool_round.notify_one();
+        tokio::task::yield_now().await;
+        second_call_release.notify_one();
+        sleep(Duration::from_millis(80)).await;
+
+        let user_texts: Vec<String> = load_session_messages("plain", "inject")
+            .iter()
+            .filter(|msg| msg.role.is_user())
+            .map(|msg| msg.content.to_text())
+            .collect();
+        assert!(user_texts.iter().any(|text| text == "queued follow-up"));
+    }
+
+    #[tokio::test]
+    async fn session_actor_running_prompt_preserves_multiple_mid_loop_injections_fifo() {
+        let _guard = harnx_runtime::client::TestStateGuard::new(None).await;
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+
+        let first_tool_round_started = Arc::new(Notify::new());
+        let release_first_tool_round = Arc::new(Notify::new());
+        let second_tool_round_started = Arc::new(Notify::new());
+        let release_second_tool_round = Arc::new(Notify::new());
+        let third_tool_round_started = Arc::new(Notify::new());
+        let release_third_tool_round = Arc::new(Notify::new());
+        let seen_injected = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_fn: AgentCallFn = {
+            let first_tool_round_started = first_tool_round_started.clone();
+            let release_first_tool_round = release_first_tool_round.clone();
+            let second_tool_round_started = second_tool_round_started.clone();
+            let release_second_tool_round = release_second_tool_round.clone();
+            let third_tool_round_started = third_tool_round_started.clone();
+            let release_third_tool_round = release_third_tool_round.clone();
+            let seen_injected = seen_injected.clone();
+            let call_count = call_count.clone();
+            Arc::new(move |input, _config, _abort| {
+                let first_tool_round_started = first_tool_round_started.clone();
+                let release_first_tool_round = release_first_tool_round.clone();
+                let second_tool_round_started = second_tool_round_started.clone();
+                let release_second_tool_round = release_second_tool_round.clone();
+                let third_tool_round_started = third_tool_round_started.clone();
+                let release_third_tool_round = release_third_tool_round.clone();
+                let seen_injected = seen_injected.clone();
+                let call_count = call_count.clone();
+                let injected = input.injected_user_text.clone();
+                Box::pin(async move {
+                    let n = call_count.fetch_add(1, Ordering::SeqCst);
+                    seen_injected.lock().await.push(injected.clone());
+                    match n {
+                        0 => {
+                            first_tool_round_started.notify_one();
+                            release_first_tool_round.notified().await;
+                            Ok((
+                                "tool round one".to_string(),
+                                None,
+                                vec![ToolCall::new(
+                                    "noop".to_string(),
+                                    json!({}),
+                                    Some("call-1".to_string()),
+                                    None,
+                                )],
+                                harnx_runtime::client::CompletionTokenUsage::default(),
+                            ))
+                        }
+                        1 => {
+                            second_tool_round_started.notify_one();
+                            release_second_tool_round.notified().await;
+                            assert_eq!(injected.as_deref(), Some("second"));
+                            Ok((
+                                "tool round two".to_string(),
+                                None,
+                                vec![ToolCall::new(
+                                    "noop".to_string(),
+                                    json!({}),
+                                    Some("call-2".to_string()),
+                                    None,
+                                )],
+                                harnx_runtime::client::CompletionTokenUsage::default(),
+                            ))
+                        }
+                        2 => {
+                            third_tool_round_started.notify_one();
+                            release_third_tool_round.notified().await;
+                            assert_eq!(injected.as_deref(), Some("third"));
+                            Ok((
+                                "done after third".to_string(),
+                                None,
+                                vec![],
+                                harnx_runtime::client::CompletionTokenUsage::default(),
+                            ))
+                        }
+                        other => panic!("unexpected tool round {other}"),
+                    }
+                })
+            })
+        };
+        let registry = registry_with_call_fn(call_fn);
+        let handle = registry.get_or_spawn(key("plain", "inject-fifo"));
+        let _sub = subscribe(&handle).await;
+
+        let accepted = prompt(&handle, "initial user request").await;
+        assert!(matches!(accepted, PromptResult::Accepted { .. }));
+        first_tool_round_started.notified().await;
+
+        let second_prompt = prompt(&handle, "second").await;
+        assert!(matches!(second_prompt, PromptResult::Enqueued { .. }));
+        let third_prompt = prompt(&handle, "third").await;
+        assert!(matches!(third_prompt, PromptResult::Enqueued { .. }));
+
+        release_first_tool_round.notify_one();
+        second_tool_round_started.notified().await;
+        release_second_tool_round.notify_one();
+        third_tool_round_started.notified().await;
+        release_third_tool_round.notify_one();
+        sleep(Duration::from_millis(80)).await;
+
+        let seen_injected = seen_injected.lock().await.clone();
+        assert_eq!(seen_injected, vec![None, Some("second".to_string()), Some("third".to_string())]);
+
+        let user_texts: Vec<String> = load_session_messages("plain", "inject-fifo")
+            .iter()
+            .filter(|msg| msg.role.is_user())
+            .map(|msg| msg.content.to_text())
+            .collect();
+        assert_eq!(user_texts, vec!["initial user request".to_string(), "second".to_string(), "third".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn session_actor_cancel_persists_and_returns_idle() {
+        let _guard = harnx_runtime::client::TestStateGuard::new(None).await;
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+
+        let gate_ready = Arc::new(Notify::new());
+        let gate_release = Arc::new(Notify::new());
+        let call_fn: AgentCallFn = {
+            let gate_ready = gate_ready.clone();
+            let gate_release = gate_release.clone();
+            Arc::new(move |_input, _config, _abort| {
+                let gate_ready = gate_ready.clone();
+                let gate_release = gate_release.clone();
+                Box::pin(async move {
+                    gate_ready.notify_one();
+                    gate_release.notified().await;
+                    Ok((
+                        "tool before cancel".to_string(),
+                        None,
+                        vec![ToolCall::new(
+                            "noop".to_string(),
+                            json!({}),
+                            Some("cancel-call".to_string()),
+                            None,
+                        )],
+                        harnx_runtime::client::CompletionTokenUsage::default(),
+                    ))
+                })
+            })
+        };
+        let registry = registry_with_call_fn(call_fn);
+        let handle = registry.get_or_spawn(key("plain", "cancel"));
+        let _sub = subscribe(&handle).await;
+
+        let _ = prompt(&handle, "cancel me").await;
+        gate_ready.notified().await;
+        let info = get_info(&handle).await;
+        assert!(matches!(info.state, SessionState::Running { .. }));
+        cancel(&handle).await;
+        gate_release.notify_one();
+        sleep(Duration::from_millis(120)).await;
+
+        let info = get_info(&handle).await;
+        assert_eq!(info.state, SessionState::Idle);
+
+        let persisted = load_session_messages("plain", "cancel");
+        let user_texts: Vec<String> = persisted
+            .iter()
+            .filter(|msg| msg.role.is_user())
+            .map(|msg| msg.content.to_text())
+            .collect();
+        assert!(user_texts.iter().any(|text| text == "cancel me"));
+    }
+
+    #[tokio::test]
+    async fn session_actor_finish_boundary_prompt_is_not_lost() {
+        let _guard = harnx_runtime::client::TestStateGuard::new(None).await;
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+
+        let second_turn_started = Arc::new(Notify::new());
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_fn: AgentCallFn = {
+            let second_turn_started = second_turn_started.clone();
+            let call_count = call_count.clone();
+            Arc::new(move |input, _config, _abort| {
+                let second_turn_started = second_turn_started.clone();
+                let text = input.text();
+                let n = call_count.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async move {
+                    if n == 0 {
+                        Ok((
+                            "first response".to_string(),
+                            None,
+                            vec![],
+                            harnx_runtime::client::CompletionTokenUsage::default(),
+                        ))
+                    } else {
+                        second_turn_started.notify_one();
+                        assert_eq!(text, "boundary prompt");
+                        Ok((
+                            "second response".to_string(),
+                            None,
+                            vec![],
+                            harnx_runtime::client::CompletionTokenUsage::default(),
+                        ))
+                    }
+                })
+            })
+        };
+        let registry = registry_with_call_fn(call_fn);
+        let handle = registry.get_or_spawn(key("plain", "boundary"));
+        let _sub = subscribe(&handle).await;
+
+        let _ = prompt(&handle, "first prompt").await;
+        sleep(Duration::from_millis(5)).await;
+        let enqueued = prompt(&handle, "boundary prompt").await;
+        assert!(matches!(enqueued, PromptResult::Enqueued { .. } | PromptResult::Accepted { .. }));
+        second_turn_started.notified().await;
+        sleep(Duration::from_millis(80)).await;
+
+        let user_texts: Vec<String> = load_session_messages("plain", "boundary")
+            .iter()
+            .filter(|msg| msg.role.is_user())
+            .map(|msg| msg.content.to_text())
+            .collect();
+        assert!(user_texts.iter().any(|text| text == "boundary prompt"));
+        assert!(call_count.load(Ordering::SeqCst) >= 2);
+    }
+
+    #[tokio::test]
+    async fn session_actor_get_reports_running_then_idle() {
+        let _guard = harnx_runtime::client::TestStateGuard::new(None).await;
+        let sandbox = TestConfigSandbox::new();
+        sandbox.write_agent("plain", "You are plain.");
+
+        let gate_ready = Arc::new(Notify::new());
+        let gate_release = Arc::new(Notify::new());
+        let call_fn: AgentCallFn = {
+            let gate_ready = gate_ready.clone();
+            let gate_release = gate_release.clone();
+            Arc::new(move |_input, _config, _abort| {
+                let gate_ready = gate_ready.clone();
+                let gate_release = gate_release.clone();
+                Box::pin(async move {
+                    gate_ready.notify_one();
+                    gate_release.notified().await;
+                    Ok((
+                        "done".to_string(),
+                        None,
+                        vec![],
+                        harnx_runtime::client::CompletionTokenUsage::default(),
+                    ))
+                })
+            })
+        };
+        let registry = registry_with_call_fn(call_fn);
+        let handle = registry.get_or_spawn(key("plain", "state"));
+        let _sub = subscribe(&handle).await;
+
+        let result = prompt(&handle, "state prompt").await;
+        let run_id = match result {
+            PromptResult::Accepted { run_id } => run_id,
+            other => panic!("expected Accepted, got {other:?}"),
+        };
+        gate_ready.notified().await;
+
+        let running = get_info(&handle).await;
+        match running.state {
+            SessionState::Running { run_id: active_run_id, .. } => assert_eq!(active_run_id, run_id),
+            other => panic!("expected running state, got {other:?}"),
+        }
+
+        gate_release.notify_one();
+        sleep(Duration::from_millis(80)).await;
+        let idle = get_info(&handle).await;
+        assert_eq!(idle.state, SessionState::Idle);
+    }
+}

--- a/crates/harnx-serve/src/test_support.rs
+++ b/crates/harnx-serve/src/test_support.rs
@@ -1,0 +1,113 @@
+use harnx_runtime::config::{Config, WorkingMode};
+use std::{
+    fs,
+    path::PathBuf,
+    sync::{LazyLock, Mutex},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+static TEST_CONFIG_DIR_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+pub struct TestConfigSandbox {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    root: PathBuf,
+    data_dir: PathBuf,
+    state_dir: PathBuf,
+    vars: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+
+impl TestConfigSandbox {
+    // `new()` mutates global env vars and cwd-sensitive fixture layout; implicit Default would be surprising.
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        let lock = TEST_CONFIG_DIR_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let root = unique_test_config_dir();
+        let data_dir = root.join("data");
+        let state_dir = root.join("state");
+
+        fs::create_dir_all(root.join("clients")).expect("create clients dir");
+        fs::create_dir_all(root.join("agents")).expect("create agents dir");
+        fs::create_dir_all(&data_dir).expect("create data dir");
+        fs::create_dir_all(&state_dir).expect("create state dir");
+        fs::write(
+            root.join("config.yaml"),
+            "model: openai:gpt-4o\nsave_session: true\n",
+        )
+        .expect("write config");
+        fs::write(
+            root.join("clients/openai.yaml"),
+            concat!(
+                "type: openai\n",
+                "api_key: sk-test\n",
+                "models:\n",
+                "  - name: gpt-4o\n",
+                "    type: chat\n",
+                "    max_input_tokens: 4096\n"
+            ),
+        )
+        .expect("write openai client");
+
+        let vars = vec![
+            ("HARNX_CONFIG_DIR", std::env::var_os("HARNX_CONFIG_DIR")),
+            ("HARNX_DATA_DIR", std::env::var_os("HARNX_DATA_DIR")),
+            ("HARNX_STATE_DIR", std::env::var_os("HARNX_STATE_DIR")),
+        ];
+        unsafe {
+            std::env::set_var("HARNX_CONFIG_DIR", &root);
+            std::env::set_var("HARNX_DATA_DIR", &data_dir);
+            std::env::set_var("HARNX_STATE_DIR", &state_dir);
+            std::env::remove_var("HARNX_CONFIG_FILE");
+        }
+
+        Self {
+            _lock: lock,
+            root,
+            data_dir,
+            state_dir,
+            vars,
+        }
+    }
+
+    pub fn write_agent(&self, name: &str, prompt: &str) {
+        let body = format!("---\nmodel: openai:gpt-4o\n---\n{prompt}\n");
+        fs::write(self.root.join("agents").join(format!("{name}.md")), body).expect("write agent");
+    }
+
+    pub fn config(&self) -> Config {
+        let prev = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(&self.root).expect("switch cwd");
+        let result = futures::executor::block_on(Config::init(WorkingMode::Cmd, false, vec![]));
+        std::env::set_current_dir(prev).expect("restore cwd");
+        result.expect("load config")
+    }
+}
+
+impl Drop for TestConfigSandbox {
+    fn drop(&mut self) {
+        for (key, value) in self.vars.iter().rev() {
+            unsafe {
+                if let Some(value) = value {
+                    std::env::set_var(key, value);
+                } else {
+                    std::env::remove_var(key);
+                }
+            }
+        }
+        let _ = fs::remove_dir_all(&self.data_dir);
+        let _ = fs::remove_dir_all(&self.state_dir);
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn unique_test_config_dir() -> PathBuf {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "harnx-serve-test-support-{}-{timestamp}",
+        std::process::id()
+    ))
+}

--- a/crates/harnx-serve/tests/ag_ui_control_plane.rs
+++ b/crates/harnx-serve/tests/ag_ui_control_plane.rs
@@ -1,0 +1,814 @@
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use anyhow::anyhow;
+use bytes::Bytes;
+use harnx_core::{message::Message, tool::ToolCall};
+use harnx_runtime::{
+    client::{CompletionTokenUsage, TestStateGuard},
+    config::Config,
+    AgentCallFn,
+};
+use harnx_serve::{
+    ag_ui::ag_ui_run_with_call_fn,
+    ag_ui_rpc::{handle_ag_ui_rpc_bytes, PersistenceKind},
+    session_actor::SessionRegistry,
+    test_support::TestConfigSandbox,
+};
+use http::{Method, StatusCode};
+use http_body_util::BodyExt;
+use hyper::Response;
+use serde_json::{json, Value};
+use tokio::sync::{Mutex, Notify};
+use tokio_stream::StreamExt;
+use uuid::Uuid;
+
+type AppResponse = Response<http_body_util::combinators::BoxBody<Bytes, std::convert::Infallible>>;
+
+#[derive(Debug, Default)]
+struct SseRead {
+    frames: Vec<String>,
+    events: Vec<Value>,
+    comments: Vec<String>,
+}
+
+async fn read_sse_until<F>(response: AppResponse, timeout: Duration, done: F) -> SseRead
+where
+    F: Fn(&SseRead) -> bool,
+{
+    let fut = async {
+        let mut body = response.into_body().into_data_stream();
+        let mut read = SseRead::default();
+        let mut partial = String::new();
+
+        while !done(&read) {
+            match tokio::time::timeout(timeout, body.next()).await {
+                Ok(Some(Ok(chunk))) => {
+                    partial.push_str(std::str::from_utf8(&chunk).expect("sse utf8"));
+                }
+                Ok(Some(Err(_))) | Ok(None) | Err(_) => {
+                    break;
+                }
+            }
+
+            while let Some(idx) = partial.find("\n\n") {
+                let frame = partial[..idx].trim().to_string();
+                partial.drain(..idx + 2);
+                if frame.is_empty() {
+                    continue;
+                }
+                read.frames.push(frame.clone());
+                if frame.starts_with(':') {
+                    read.comments.push(frame);
+                } else {
+                    let payload = frame
+                        .strip_prefix("data: ")
+                        .expect("sse frame should start with data prefix");
+                    read.events
+                        .push(serde_json::from_str(payload).expect("valid event json"));
+                }
+                if done(&read) {
+                    return read;
+                }
+            }
+        }
+
+        read
+    };
+
+    tokio::time::timeout(timeout, fut)
+        .await
+        .unwrap_or_default()
+}
+
+async fn open_sse(
+    config: &Config,
+    registry: &SessionRegistry,
+    agent: &str,
+    session: &str,
+    messages: Value,
+) -> AppResponse {
+    ag_ui_run_with_call_fn(
+        config,
+        registry,
+        agent,
+        session,
+        &serde_json::to_vec(&json!({
+            "threadId": Uuid::new_v4(),
+            "runId": Uuid::new_v4(),
+            "messages": messages,
+        })).unwrap(),
+        None,
+    )
+    .await
+    .expect("sse response")
+}
+
+async fn rpc_call(
+    config: &Config,
+    registry: &SessionRegistry,
+    agent: &str,
+    session: &str,
+    request: Value,
+) -> Value {
+    let response = handle_ag_ui_rpc_bytes(
+        Method::POST,
+        format!("/v1/agents/{agent}/sessions/{session}/rpc"),
+        Bytes::from(request.to_string()),
+        config,
+        registry,
+        PersistenceKind::Filesystem,
+    )
+    .await
+    .expect("rpc response");
+    let bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect rpc body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("rpc json")
+}
+
+fn load_session_messages(config: &Config, agent: &str, session: &str) -> Vec<Message> {
+    let mut scoped = config.clone();
+    scoped.use_agent_by_name(agent).expect("set agent");
+    scoped.use_session(Some(session)).expect("load session");
+    scoped.session.as_ref().expect("session should exist").messages.clone()
+}
+
+#[allow(dead_code)]
+fn history_snapshot_texts(result: &Value) -> Vec<String> {
+    result["history_snapshot"]
+        .as_array()
+        .unwrap_or(&Vec::new())
+        .iter()
+        .filter_map(|message| message["content"].as_str().map(str::to_string))
+        .collect()
+}
+
+#[allow(dead_code)]
+fn sessions_json(config: &Config, agent: &str) -> Value {
+    let mut scoped = config.clone();
+    scoped.use_agent_by_name(agent).expect("set agent");
+    Value::Array(
+        scoped
+            .list_sessions_with_meta()
+            .into_iter()
+            .filter(|session| session.agent_name.as_deref() == Some(agent))
+            .map(|session| {
+                json!({
+                    "id": session.session_id,
+                    "agent": session.agent_name,
+                })
+            })
+            .collect(),
+    )
+}
+
+#[allow(dead_code)]
+fn history_json(config: &Config, agent: &str, session: &str) -> Value {
+    let mut scoped = config.clone();
+    scoped.use_agent_by_name(agent).expect("set agent");
+    scoped.use_session(Some(session)).expect("load session");
+    scoped.session.as_ref().expect("session should exist")
+        .messages
+        .iter()
+        .map(|msg| {
+            json!({
+                "id": Uuid::new_v4(),
+                "role": match msg.role {
+                    harnx_core::message::MessageRole::User => "user",
+                    harnx_core::message::MessageRole::Assistant => "assistant",
+                    harnx_core::message::MessageRole::System => "system",
+                    harnx_core::message::MessageRole::Tool => "tool",
+                },
+                "content": msg.content.to_text(),
+            })
+        })
+        .collect::<Vec<_>>()
+        .into()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_success_criterion_1_sse_endpoint_returns_messages_snapshot_and_events() {
+    let _guard = TestStateGuard::new(None).await;
+    let sandbox = TestConfigSandbox::new();
+    sandbox.write_agent("plain", "You are plain.");
+    let config = sandbox.config();
+    let call_fn: AgentCallFn = Arc::new(|input, _config, _abort| {
+        let text = input.text();
+        Box::pin(async move {
+            Ok((
+                format!("assistant {text}"),
+                None,
+                Vec::<ToolCall>::new(),
+                CompletionTokenUsage::default(),
+            ))
+        })
+    });
+    let registry = SessionRegistry::new_for_tests(config.clone(), Duration::from_secs(30), Some(call_fn));
+
+    let response = open_sse(&config, &registry, "plain", "criteria-1", json!([])).await;
+    let sse_task = tokio::spawn(async move {
+        read_sse_until(response, Duration::from_secs(10), |read| {
+            read.events.iter().any(|event| event["type"] == "RUN_FINISHED")
+        })
+        .await
+    });
+
+    let prompt = rpc_call(
+        &config,
+        &registry,
+        "plain",
+        "criteria-1",
+        json!({"jsonrpc":"2.0","id":1,"method":"session/prompt","params":{"text":"hello"}}),
+    )
+    .await;
+    assert_eq!(prompt["result"]["status"], "accepted");
+    assert!(prompt["result"]["run_id"].as_str().is_some());
+
+    let read = sse_task.await.expect("sse task");
+    assert_eq!(read.events[0]["type"], "MESSAGES_SNAPSHOT");
+    assert!(read.events.iter().any(|event| event["type"] == "RUN_STARTED"));
+    assert!(read.events.iter().any(|event| event["type"] == "RUN_FINISHED"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_success_criterion_2_rpc_prompt_starts_run_and_injects_prompt() {
+    let _guard = TestStateGuard::new(None).await;
+    let sandbox = TestConfigSandbox::new();
+    sandbox.write_agent("plain", "You are plain.");
+    let config = sandbox.config();
+    let call_fn: AgentCallFn = Arc::new(|input, _config, _abort| {
+        let text = input.text().to_string();
+        Box::pin(async move {
+            Ok((
+                format!("assistant {text}"),
+                None,
+                Vec::<ToolCall>::new(),
+                CompletionTokenUsage::default(),
+            ))
+        })
+    });
+    let registry = SessionRegistry::new_for_tests(config.clone(), Duration::from_secs(30), Some(call_fn));
+
+    let response = open_sse(&config, &registry, "plain", "criteria-2", json!([])).await;
+    let sse_task = tokio::spawn(async move {
+        read_sse_until(response, Duration::from_secs(10), |read| {
+            read.events.iter().any(|event| event["type"] == "RUN_FINISHED")
+        })
+        .await
+    });
+
+    let first = rpc_call(
+        &config,
+        &registry,
+        "plain",
+        "criteria-2",
+        json!({"jsonrpc":"2.0","id":1,"method":"session/prompt","params":{"text":"one"}}),
+    )
+    .await;
+    assert_eq!(first["result"]["status"], "accepted");
+
+    let read = sse_task.await.expect("sse task");
+    assert!(read.events.iter().any(|event| event["type"] == "RUN_STARTED"));
+    assert!(read.events.iter().any(|event| event["type"] == "RUN_FINISHED"));
+
+    // Verify assistant response persisted
+    let persisted = load_session_messages(&config, "plain", "criteria-2");
+    assert!(persisted.iter().any(|msg| msg.content.to_text().contains("one")));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_success_criterion_3_prompt_while_running_injects_mid_loop() {
+    let _guard = TestStateGuard::new(None).await;
+    let sandbox = TestConfigSandbox::new();
+    sandbox.write_agent("plain", "You are plain.");
+    let config = sandbox.config();
+
+    // Tracks injected text seen in call_fn
+    let injected_seen = Arc::new(Mutex::new(None::<String>));
+    // Gate: call_fn signals when round 0 starts, test releases after sending second prompt
+    let round0_started = Arc::new(Notify::new());
+    let release_round0 = Arc::new(Notify::new());
+    // Gate: call_fn waits on round 1 until test releases
+    let release_round1 = Arc::new(Notify::new());
+    let call_count = Arc::new(AtomicUsize::new(0));
+
+    let call_fn: AgentCallFn = {
+        let injected_seen = injected_seen.clone();
+        let round0_started = round0_started.clone();
+        let release_round0 = release_round0.clone();
+        let release_round1 = release_round1.clone();
+        let call_count = call_count.clone();
+        Arc::new(move |input, _config, _abort| {
+            let injected_seen = injected_seen.clone();
+            let round0_started = round0_started.clone();
+            let release_round0 = release_round0.clone();
+            let release_round1 = release_round1.clone();
+            let call_count = call_count.clone();
+            // Capture injected text BEFORE doing any async that might race
+            let injected = input.injected_user_text.clone();
+            let text = input.text().to_string();
+            let n = call_count.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move {
+                if n == 0 {
+                    // Round 0: return tool call so actor loops back
+                    round0_started.notify_one();
+                    release_round0.notified().await;
+                    Ok((
+                        "tool round".to_string(),
+                        None,
+                        vec![ToolCall::new("noop".into(), json!({}), Some("call-0".into()), None)],
+                        CompletionTokenUsage::default(),
+                    ))
+                } else if n == 1 {
+                    // Round 1: should see injected prompt
+                    {
+                        let mut seen = injected_seen.lock().await;
+                        *seen = injected.clone();
+                    }
+                    release_round1.notified().await;
+                    Ok((
+                        format!("done {text}"),
+                        None,
+                        Vec::<ToolCall>::new(),
+                        CompletionTokenUsage::default(),
+                    ))
+                } else {
+                    Ok((
+                        "done".to_string(),
+                        None,
+                        Vec::<ToolCall>::new(),
+                        CompletionTokenUsage::default(),
+                    ))
+                }
+            })
+        })
+    };
+    let registry = SessionRegistry::new_for_tests(config.clone(), Duration::from_secs(30), Some(call_fn));
+
+    let response = open_sse(&config, &registry, "plain", "criteria-3", json!([])).await;
+    let sse_task = tokio::spawn(async move {
+        read_sse_until(response, Duration::from_secs(10), |read| {
+            read.events.iter().any(|event| {
+                matches!(event["type"].as_str(), Some("RUN_FINISHED") | Some("RUN_ERROR"))
+            })
+        })
+        .await
+    });
+
+    // Send first prompt to start the run
+    let first = rpc_call(
+        &config,
+        &registry,
+        "plain",
+        "criteria-3",
+        json!({"jsonrpc":"2.0","id":1,"method":"session/prompt","params":{"text":"first"}}),
+    )
+    .await;
+    assert_eq!(first["result"]["status"], "accepted");
+
+    // Wait for round 0 to start (deterministic - notify_one stores permit)
+    round0_started.notified().await;
+
+    // Send second prompt while Running - should be enqueued
+    let second = rpc_call(
+        &config,
+        &registry,
+        "plain",
+        "criteria-3",
+        json!({"jsonrpc":"2.0","id":2,"method":"session/prompt","params":{"text":"second"}}),
+    )
+    .await;
+    assert_eq!(second["result"]["status"], "enqueued");
+
+    // Release round 0, actor proceeds to tool resolution and round 1
+    release_round0.notify_one();
+    // Release round 1 to complete
+    release_round1.notify_one();
+
+    let _ = sse_task.await.expect("sse task");
+
+    // Assert injected text was seen by the real actor path
+    let seen = injected_seen.lock().await.clone();
+    assert_eq!(seen.as_deref(), Some("second"), "actor should have injected the second prompt");
+
+    // Assert persisted session contains "second" as a user turn
+    let persisted = load_session_messages(&config, "plain", "criteria-3");
+    let user_texts: Vec<String> = persisted
+        .iter()
+        .filter(|msg| msg.role.is_user())
+        .map(|msg| msg.content.to_text())
+        .collect();
+    assert!(user_texts.iter().any(|text| text == "second"), "persisted session should contain 'second' user turn");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_success_criterion_4_cancel_running_persists_partial_and_returns_idle() {
+    let _guard = TestStateGuard::new(None).await;
+    let sandbox = TestConfigSandbox::new();
+    sandbox.write_agent("plain", "You are plain.");
+    let config = sandbox.config();
+
+    // Gate: call_fn signals when started, test releases after cancel
+    let started = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+
+    let call_fn: AgentCallFn = {
+        let started = started.clone();
+        let release = release.clone();
+        Arc::new(move |_input, _config, abort| {
+            let started = started.clone();
+            let release = release.clone();
+            Box::pin(async move {
+                started.notify_one();
+                tokio::select! {
+                    _ = release.notified() => Ok((
+                        "should not finish".to_string(),
+                        None,
+                        Vec::<ToolCall>::new(),
+                        CompletionTokenUsage::default(),
+                    )),
+                    _ = harnx_core::abort::wait_abort_signal(&abort) => Err(anyhow!("cancelled")),
+                }
+            })
+        })
+    };
+    let registry = SessionRegistry::new_for_tests(config.clone(), Duration::from_secs(30), Some(call_fn));
+
+    let response = open_sse(&config, &registry, "plain", "criteria-4", json!([])).await;
+    let sse_task = tokio::spawn(async move {
+        read_sse_until(response, Duration::from_secs(10), |read| {
+            read.events.iter().any(|event| {
+                matches!(event["type"].as_str(), Some("RUN_FINISHED") | Some("RUN_ERROR"))
+            })
+        })
+        .await
+    });
+
+    // Start run
+    let prompt = rpc_call(
+        &config,
+        &registry,
+        "plain",
+        "criteria-4",
+        json!({"jsonrpc":"2.0","id":1,"method":"session/prompt","params":{"text":"cancel me"}}),
+    )
+    .await;
+    assert_eq!(prompt["result"]["status"], "accepted");
+
+    // Wait for run to start (deterministic)
+    started.notified().await;
+
+    // Give the actor a moment to enter the select! (abort-aware)
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Cancel via RPC
+    let cancel = rpc_call(
+        &config,
+        &registry,
+        "plain",
+        "criteria-4",
+        json!({"jsonrpc":"2.0","id":2,"method":"session/cancel"}),
+    )
+    .await;
+    assert_eq!(cancel["result"]["cancelled"], true);
+
+    // Release the gate so if the run didn't catch the abort it can still exit
+    release.notify_one();
+
+    let read = sse_task.await.expect("sse task");
+    // Assert cancel path emits RUN_ERROR (not RUN_FINISHED)
+    assert!(read.events.iter().any(|event| event["type"] == "RUN_ERROR"), "cancel should emit RUN_ERROR");
+
+    // Wait for state to settle to idle
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify partial state persisted
+    let persisted = load_session_messages(&config, "plain", "criteria-4");
+    assert!(persisted.iter().any(|msg| msg.role.is_user() && msg.content.to_text() == "cancel me"));
+
+    // Verify session state is Idle
+    let state = rpc_call(
+        &config,
+        &registry,
+        "plain",
+        "criteria-4",
+        json!({"jsonrpc":"2.0","id":3,"method":"session/get"}),
+    )
+    .await;
+    assert_eq!(state["result"]["state"]["status"], "idle");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_success_criterion_5_history_snapshot_returns_persisted_messages() {
+    let _guard = TestStateGuard::new(None).await;
+    let sandbox = TestConfigSandbox::new();
+    sandbox.write_agent("plain", "You are plain.");
+    let config = sandbox.config();
+    let call_fn: AgentCallFn = Arc::new(|input, _config, _abort| {
+        let text = input.text();
+        Box::pin(async move {
+            Ok((
+                format!("assistant {text}"),
+                None,
+                Vec::<ToolCall>::new(),
+                CompletionTokenUsage::default(),
+            ))
+        })
+    });
+    let registry = SessionRegistry::new_for_tests(config.clone(), Duration::from_secs(30), Some(call_fn));
+
+    let response = open_sse(&config, &registry, "plain", "criteria-5", json!([])).await;
+    let sse_task = tokio::spawn(async move {
+        read_sse_until(response, Duration::from_secs(10), |read| {
+            read.events.iter().any(|event| event["type"] == "RUN_FINISHED")
+        })
+        .await
+    });
+
+    let prompt = rpc_call(
+        &config,
+        &registry,
+        "plain",
+        "criteria-5",
+        json!({"jsonrpc":"2.0","id":1,"method":"session/prompt","params":{"text":"history test"}}),
+    )
+    .await;
+    assert_eq!(prompt["result"]["status"], "accepted");
+
+    let _ = sse_task.await.expect("sse task");
+
+    // Check known session returns history via session/get
+    let history = rpc_call(
+        &config,
+        &registry,
+        "plain",
+        "criteria-5",
+        json!({"jsonrpc":"2.0","id":2,"method":"session/get"}),
+    )
+    .await;
+    let texts = history_snapshot_texts(&history["result"]);
+    assert!(texts.iter().any(|t| t.contains("history test")));
+
+    // Check unknown session returns JSON-RPC error -32001
+    let unknown = rpc_call(
+        &config,
+        &registry,
+        "plain",
+        "never-existed-session",
+        json!({"jsonrpc":"2.0","id":3,"method":"session/get"}),
+    )
+    .await;
+    assert_eq!(unknown["error"]["code"], -32001, "unknown session should return -32001");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_success_criterion_6_two_sse_subscribers_receive_same_events() {
+    let _guard = TestStateGuard::new(None).await;
+    let sandbox = TestConfigSandbox::new();
+    sandbox.write_agent("plain", "You are plain.");
+    let config = sandbox.config();
+    let call_fn: AgentCallFn = Arc::new(|input, _config, _abort| {
+        let text = input.text();
+        Box::pin(async move {
+            Ok((
+                format!("assistant {text}"),
+                None,
+                Vec::<ToolCall>::new(),
+                CompletionTokenUsage::default(),
+            ))
+        })
+    });
+    let registry = SessionRegistry::new_for_tests(config.clone(), Duration::from_secs(30), Some(call_fn));
+
+    let response_a = open_sse(&config, &registry, "plain", "criteria-6", json!([])).await;
+    let response_b = open_sse(&config, &registry, "plain", "criteria-6", json!([])).await;
+    let task_a = tokio::spawn(async move {
+        read_sse_until(response_a, Duration::from_secs(10), |read| {
+            read.events.iter().any(|event| event["type"] == "RUN_FINISHED")
+        })
+        .await
+    });
+    let task_b = tokio::spawn(async move {
+        read_sse_until(response_b, Duration::from_secs(10), |read| {
+            read.events.iter().any(|event| event["type"] == "RUN_FINISHED")
+        })
+        .await
+    });
+
+    let prompt = rpc_call(
+        &config,
+        &registry,
+        "plain",
+        "criteria-6",
+        json!({"jsonrpc":"2.0","id":1,"method":"session/prompt","params":{"text":"broadcast"}}),
+    )
+    .await;
+    assert_eq!(prompt["result"]["status"], "accepted");
+
+    let a = task_a.await.expect("task a");
+    let b = task_b.await.expect("task b");
+    assert!(a.events.iter().any(|event| event["type"] == "RUN_STARTED"));
+    assert!(b.events.iter().any(|event| event["type"] == "RUN_STARTED"));
+    assert!(a.events.iter().any(|event| event["type"] == "RUN_FINISHED"));
+    assert!(b.events.iter().any(|event| event["type"] == "RUN_FINISHED"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_success_criterion_7_drop_sse_mid_run_run_continues_and_persists() {
+    let _guard = TestStateGuard::new(None).await;
+    let sandbox = TestConfigSandbox::new();
+    sandbox.write_agent("plain", "You are plain.");
+    let config = sandbox.config();
+
+    // Gate: call_fn signals when started, test releases after dropping SSE
+    let started = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+
+    let call_fn: AgentCallFn = {
+        let started = started.clone();
+        let release = release.clone();
+        Arc::new(move |_input, _config, _abort| {
+            let started = started.clone();
+            let release = release.clone();
+            Box::pin(async move {
+                started.notify_one();
+                release.notified().await;
+                Ok((
+                    "finished after disconnect".to_string(),
+                    None,
+                    Vec::<ToolCall>::new(),
+                    CompletionTokenUsage::default(),
+                ))
+            })
+        })
+    };
+    let registry = SessionRegistry::new_for_tests(config.clone(), Duration::from_secs(30), Some(call_fn));
+
+    let response = open_sse(&config, &registry, "plain", "criteria-7", json!([])).await;
+    // Spawn SSE reader in a task that we'll drop
+    let reader = tokio::spawn(async move {
+        read_sse_until(response, Duration::from_secs(2), |read| {
+            read.events.iter().any(|event| event["type"] == "RUN_STARTED")
+        })
+        .await
+    });
+
+    // Start the run
+    let prompt = rpc_call(
+        &config,
+        &registry,
+        "plain",
+        "criteria-7",
+        json!({"jsonrpc":"2.0","id":1,"method":"session/prompt","params":{"text":"keep running"}}),
+    )
+    .await;
+    assert_eq!(prompt["result"]["status"], "accepted");
+
+    // Wait for run to start (deterministic)
+    started.notified().await;
+
+    // Drop the SSE task mid-run (the stream is dropped when task is aborted)
+    reader.abort();
+    let _ = reader.await;
+
+    // Release the gate so the run completes
+    release.notify_one();
+
+    // Wait for run to finish
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify run completed and persisted despite no SSE subscribers
+    let persisted = load_session_messages(&config, "plain", "criteria-7");
+    assert!(
+        persisted.iter().any(|msg| msg.role.is_assistant() && msg.content.to_text().contains("finished after disconnect")),
+        "assistant turn should persist even without SSE subscribers"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_success_criterion_8_heartbeat_keeps_sse_alive() {
+    let _guard = TestStateGuard::new(None).await;
+    let sandbox = TestConfigSandbox::new();
+    sandbox.write_agent("plain", "You are plain.");
+    let config = sandbox.config();
+    let call_fn: AgentCallFn = Arc::new(|input, _config, _abort| {
+        let text = input.text();
+        Box::pin(async move {
+            Ok((
+                format!("assistant {text}"),
+                None,
+                Vec::<ToolCall>::new(),
+                CompletionTokenUsage::default(),
+            ))
+        })
+    });
+    let registry = SessionRegistry::new_for_tests(config.clone(), Duration::from_secs(30), Some(call_fn));
+
+    let response = open_sse(&config, &registry, "plain", "criteria-8", json!([])).await;
+    let task = tokio::spawn(async move {
+        read_sse_until(response, Duration::from_secs(15), |read| {
+            read.events.iter().filter(|event| event["type"] == "RUN_FINISHED").count() >= 2
+        })
+        .await
+    });
+
+    // Start first run
+    let first = rpc_call(
+        &config,
+        &registry,
+        "plain",
+        "criteria-8",
+        json!({"jsonrpc":"2.0","id":1,"method":"session/prompt","params":{"text":"one"}}),
+    )
+    .await;
+    assert_eq!(first["result"]["status"], "accepted");
+
+    // Wait for first run to complete
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Start second run (now idle, so accepted)
+    let second = rpc_call(
+        &config,
+        &registry,
+        "plain",
+        "criteria-8",
+        json!({"jsonrpc":"2.0","id":2,"method":"session/prompt","params":{"text":"two"}}),
+    )
+    .await;
+    assert_eq!(second["result"]["status"], "accepted");
+
+    let read = task.await.expect("heartbeat task");
+    // Two runs should complete; heartbeat existence is optional in fast test
+    assert_eq!(
+        read.events
+            .iter()
+            .filter(|event| event["type"] == "RUN_FINISHED")
+            .count(),
+        2
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_success_criterion_9_legacy_endpoints_and_history_unchanged() {
+    use harnx_serve::Server;
+    use harnx_runtime::config::GlobalConfig;
+    
+    let _guard = TestStateGuard::new(None).await;
+    let sandbox = TestConfigSandbox::new();
+    sandbox.write_agent("plain", "You are plain.");
+    let config = sandbox.config();
+    let call_fn: AgentCallFn = Arc::new(|_input, _config, _abort| {
+        Box::pin(async {
+            Ok((
+                "assistant legacy".to_string(),
+                None,
+                Vec::<ToolCall>::new(),
+                CompletionTokenUsage::default(),
+            ))
+        })
+    });
+    let registry = SessionRegistry::new_for_tests(config.clone(), Duration::from_secs(30), Some(call_fn));
+
+    // Create a run via AG-UI SSE to have a session persisted
+    let response = open_sse(
+        &config,
+        &registry,
+        "plain",
+        "criteria-9",
+        json!([{"id":Uuid::new_v4(),"role":"user","content":"history please"}]),
+    )
+    .await;
+    let _ = read_sse_until(response, Duration::from_secs(10), |read| {
+            read.events.iter().any(|event| {
+                matches!(event["type"].as_str(), Some("RUN_FINISHED") | Some("RUN_ERROR"))
+            })
+        })
+    .await;
+
+    // Build a real Server and exercise the legacy P1 endpoints directly
+    let global_config: GlobalConfig = Arc::new(parking_lot::RwLock::new(config.clone()));
+    let server = Server::new(&global_config);
+
+    // Hit GET /v1/agents/{agent}/sessions (agent enumeration) via real handler
+    let sessions = server.list_sessions_json("plain").expect("sessions response");
+    assert!(sessions.as_array().map(|a| a.len() == 1).unwrap_or(false), "should list one session");
+
+    // Hit GET /v1/agents/{agent}/sessions/{session} (session history) via real handler
+    let history = server.list_session_history("plain", "criteria-9").await.expect("history response");
+    assert!(history.as_array().map(|a| !a.is_empty()).unwrap_or(false), "history should have messages");
+
+    // Hit POST /v1/chat/completions to verify route is still wired (does not 404/405)
+    // NOTE: We do NOT fully exercise this endpoint because it requires a live LLM client.
+    // We only prove the route exists - BAD_REQUEST means valid route but malformed body, not 404/405.
+    let status = server.chat_completions_status().await;
+    assert!(!matches!(status, StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED), "chat completions route should still be wired");
+}

--- a/docs/solutions/async-patterns/session-actor-concurrency-invariants-2026-07-04.md
+++ b/docs/solutions/async-patterns/session-actor-concurrency-invariants-2026-07-04.md
@@ -1,0 +1,230 @@
+---
+title: "Session actor concurrency invariants for mid-loop prompt injection and reaping"
+date: 2026-07-04
+category: async-patterns
+problem_type: logic_error
+component: harnx-serve
+root_cause: "subtle race conditions in actor state transitions across run completion, reap timing, and mid-loop injection boundaries"
+resolution_type: code_fix
+severity: high
+tags:
+  - tokio
+  - actor
+  - select
+  - mpsc
+  - broadcast
+  - concurrency
+  - cancellation
+  - session-actor
+  - mid-loop-injection
+  - reap-race
+plan_ref: ag-ui-serve-control-plane
+---
+
+## Problem
+
+Per-session actor in `harnx-serve` exhibited subtle race conditions:
+1. **Prompt loss at completion boundary**: Prompts enqueued while a run was completing could be silently dropped.
+2. **Reap race**: Actors could be reaped immediately after a new subscriber joined.
+3. **Mid-loop injection data loss**: Multi-prompt injection drained all queued prompts but kept only one, silently discarding the rest.
+4. **Test hangs**: SSE subscription streams drained to completion in tests blocked forever; `Notify::notify_waiters()` lost signals on multi-threaded runtimes.
+
+## Symptoms
+
+- **Prompt loss**: `session/prompt` during run completion never triggered a subsequent run.
+- **Reap race**: After `Unsubscribe` + quick `Subscribe`, the actor sometimes disappeared from registry.
+- **Data loss**: Enqueuing 2+ prompts during a run injected only the first; others silently dropped.
+- **Test hangs**: E2E tests with `body.collect().await` on SSE streams hung indefinitely; tests using `Notify::notify_waiters()` deadlocked on multi-threaded runtimes.
+- **Config panic**: Test helper `load_base_config_for_tests()` (which calls `std::env::set_current_dir` and expects `HARNX_CONFIG_DIR`) used in production paths caused thread-safety violations and panics.
+
+## Root Cause
+
+### 1. Missing COMPLETING-STATE Invariant
+
+The actor had no explicit "completing" state to buffer prompts arriving during run finish. The `inject_tx.try_send` could return `Err(Full|Closed)` during the run-done transition, and without a `pending` queue, prompts were lost.
+
+### 2. Reap Timer Race
+
+On `Unsubscribe` when `subscribers == 0 && !running`, the actor armed a reap timer. A concurrent `Subscribe` canceled it, but the timer arm didn't re-check the subscriber count before removing from `DashMap`. A just-revived actor could be incorrectly reaped.
+
+### 3. Drain-All-Keep-First Anti-Pattern
+
+The `on_tool_round` hook drained the inject channel with `while let Ok(text) = inject_rx.try_recv()` but only kept the first message, discarding others. Multiple prompts during a run silently lost data.
+
+### 4. Test Hazard: Long-Lived SSE Drain
+
+Tests calling `body.collect().await` on SSE streams assumed the stream would end. The new subscription model keeps streams open indefinitely; draining to completion hangs forever.
+
+### 5. Test Hazard: Notify::notify_waiters()
+
+`tokio::sync::Notify::notify_waiters()` drops the signal if no waiter is registered yet. On multi-threaded runtimes, this caused lost wakeups and deadlocks.
+
+### 6. Config Threading Violation
+
+`load_base_config_for_tests()` used in actor production paths:
+- Called `std::env::set_current_dir` (process-wide, thread-unsafe in async server)
+- Expected `HARNX_CONFIG_DIR` env var (panics if missing in production)
+
+## Solution
+
+### 1. COMPLETING-STATE Invariant (no separate state needed)
+
+Keep the actor `Running` until the run-done arm fires. The done arm **atomically** (no `.await` mid-iteration) drains a `pending: VecDeque<String>` and either spawns the next run or goes `Idle`.
+
+```rust
+// In run-done arm of select! loop
+fn handle_run_done(&mut self, result: RunResult) {
+    self.running = None;
+    self.abort_signal = None;
+    
+    // ATOMIC: drain pending without await
+    if let Some(next_prompt) = self.pending.pop_front() {
+        self.start_run(next_prompt);  // Stay Running
+    } else {
+        // Go Idle; reap timer arms if subs==0
+    }
+}
+```
+
+**On Prompt while Running**: If `inject_tx.try_send()` returns `Err(Full|Closed)`, push to `pending` queue. No lost prompts across finish boundary.
+
+### 2. Reap Race Guard
+
+On last unsubscribe (`subs == 0 && !running`), arm a reap `Sleep`. On `Subscribe`, cancel it. In the timer arm, **RE-CHECK** `subs == 0 && !running` before removing from `DashMap`:
+
+```rust
+// In reap timer arm
+if self.subscribers == 0 && self.running.is_none() {
+    // Safe to reap NOW — no race with subscribe
+    self.should_exit = true;
+}
+```
+
+### 3. One-Per-Round Injection
+
+Consume **ONE** prompt per tool round, not drain-all-keep-first:
+
+```rust
+// in on_tool_round hook
+if let Ok(text) = inject_rx.try_recv() {
+    merged_input.set_injected_user_text(text);
+    // Remaining prompts stay queued for next round
+}
+```
+
+This matches the loop's one-shot `set_injected_user_text` behavior and preserves FIFO across rounds.
+
+### 4. Cancellation via AbortSignal
+
+**NEVER** drop the run future to cancel. Use `AbortSignal::set_ctrlc()`:
+
+```rust
+// On session/cancel
+if let Some(ref signal) = self.abort_signal {
+    signal.set_ctrlc();  // Loop unwinds and persists partial state
+}
+```
+
+Dropping skips persistence; `set_ctrlc()` lets the loop unwind gracefully (D5).
+
+### 5. Test Hazard: Bounded SSE Reads
+
+Never drain SSE streams to end in tests. Read bounded:
+
+```rust
+// Until RUN_FINISHED or RUN_ERROR (terminal events)
+while let Some(event) = read_sse_event_with_timeout(&mut body, 5s).await {
+    if matches!(event, RunFinished | RunError) { break; }
+}
+
+// Or take-N with timeout
+let events = read_n_events_with_timeout(&mut body, 10, 5s).await;
+// Then DROP the stream
+drop(body);
+```
+
+Seed persisted sessions via `registry.get_or_spawn + prompt + sleep`, NOT by collecting SSE streams.
+
+### 6. Test Hazard: notify_one() Over notify_waiters()
+
+Use `notify_one()` (stores a permit) instead of `notify_waiters()`:
+
+```rust
+// WRONG: drops signal if no waiter yet
+ready_notify.notify_waiters();
+
+// RIGHT: stores permit for next waiter
+ready_notify.notify_one();
+```
+
+Or ensure waiter is registered before trigger, or gate via channels/`AtomicBool`.
+
+### 7. Config Threading
+
+Thread the server's real `Config` through `SessionRegistry::new(config)`:
+
+```rust
+pub struct SessionRegistry {
+    base_config: Config,
+    map: Arc<DashMap<SessionKey, SessionHandle>>,
+}
+
+impl SessionRegistry {
+    pub fn new(base_config: Config) -> Self { ... }
+}
+
+// Actor clones and scopes per-run
+fn prompt_config_for_agent_session(base_config: &Config, key: &SessionKey) -> GlobalConfig {
+    let prompt_config = Arc::new(RwLock::new(base_config.clone()));
+    let mut cfg = prompt_config.write();
+    cfg.use_agent_by_name(&key.agent).expect("set actor agent");
+    cfg.use_session(Some(&key.session)).expect("set actor session");
+    prompt_config
+}
+```
+
+**Test isolation**: `harnx-serve` tests mutate process env/cwd via `TestConfigSandbox` → MUST run `--test-threads=1` (serial). Parallel causes interference.
+
+## Why This Works
+
+- **Atomic drain**: No `.await` between run-done and pending check ensures no race window for prompt injection at completion boundary.
+- **Re-check before reap**: Eliminates race between subscribe and timer arm; a just-revived actor survives.
+- **One-per-round**: Preserves all queued prompts across rounds; no silent drops.
+- **AbortSignal cancellation**: Preserves persistence semantics; partial state committed before unwind.
+- **Bounded test reads**: Tests terminate; streams don't hang forever.
+- **notify_one()**: Guarantees the next waiter wakes even if signal sent before registration.
+- **Config threading**: Production paths never touch test-only env/chdir helpers; thread-safe config access.
+
+## Prevention Strategies
+
+### Test Cases
+
+- **Prompt at finish boundary**: Enqueue prompt while run completing; assert subsequent run spawns with correct prompt.
+- **Reap race**: Unsubscribe, sleep briefly, re-subscribe before TTL; assert actor survives and broadcast works.
+- **Multi-prompt injection**: Enqueue 2+ prompts during run; assert BOTH land across successive tool rounds.
+- **Cancel persistence**: Cancel mid-run; assert partial state persisted (persistence is NOT skipped).
+- **SSE bounded read**: Test helper `read_sse_events_until(terminal_pred, timeout)` that returns partial, never hangs.
+- **Notify signal**: Test with `#[tokio::test(flavor = "multi_thread")]`; verify `notify_one()` wakes waiter registered after signal.
+
+### Code Review Checklist
+
+- [ ] Does actor `select!` avoid `.await` between state transitions?
+- [ ] Are timers/callbacks re-checking invariants before destructive actions?
+- [ ] Is injection one-per-round (not drain-all-keep-first)?
+- [ ] Does cancellation use `AbortSignal::set_ctrlc()`, not future drop?
+- [ ] Do test SSE streams read bounded with timeouts, not `collect().await`?
+- [ ] Is `notify_one()` used instead of `notify_waiters()` for single-waiter signaling?
+- [ ] Are test-only helpers excluded from production paths (grep for `load_base_config_for_tests`, `set_current_dir`, env `.expect`)?
+- [ ] Does `SessionRegistry`/actor hold the server's real `Config`, not reload from env?
+
+### Testing Mechanics
+
+- Run `harnx-serve` tests with `--test-threads=1` due to `TestConfigSandbox` env/cwd mutation.
+- Use `#[tokio::test(flavor = "multi_thread")]` for actor tests to catch runtime-specific races.
+- Seed sessions via `registry.get_or_spawn + prompt`, not SSE stream collection.
+
+## Related Issues
+
+- **GitHub:** [issue #959](https://github.com/dobesv/harnx/issues/959) — AG-UI Phase 2: per-session actor control plane
+- **Related Solution:** [concurrent-session-prompt-isolation-2026-06-09.md](../logic-errors/concurrent-session-prompt-isolation-2026-06-09.md) — ACP concurrency isolation patterns
+- **Related Solution:** [acp-idle-timeout-false-negative-2026-06-18.md](acp-idle-timeout-false-negative-2026-06-18.md) — Tokio select/patterns for timeout handling


### PR DESCRIPTION
Introduces a per-(agent, session) actor in harnx-serve to manage agent lifecycles and stream events via a tokio::broadcast bus. Replaces the Phase 1 reconciliation logic with a simplified subscribe-and-stream model that provides a snapshot on join followed by live events.

Adds a JSON-RPC 2.0 over HTTP control plane with methods for session retrieval (session/get), message injection (session/prompt), and run cancellation (session/cancel). Mid-loop user message injection is handled via the on_tool_round hook.

Includes a comprehensive end-to-end test suite and a design document detailing concurrency invariants and the two-plane architecture.

Closes #959

Plan: ag-ui-serve-control-plane