### PR TITLE
fix(exa): forward EXA_API_KEY through the sandbox for the exa MCP server

### DIFF
--- a/.changeset/exa-sandbox-env-passthrough.md
+++ b/.changeset/exa-sandbox-env-passthrough.md
@@ -1,0 +1,6 @@
+---
+harnx: patch
+pantheon: patch
+coding: patch
+---
+Fix the Exa MCP server so web search works when `npx`/`node` is wrapped by a harnx sandbox. The configs previously set `EXA_API_KEY: "$EXA_API_KEY"`, but harnx does not expand `$VAR` in MCP `env:` values and the sandbox scrubs the child environment — so the server received no usable key and returned `API key must be provided`. They now use `HARNX_BASH_ENV_PASSTHROUGH: EXA_API_KEY`, which `harnx-sandbox-run` honors to forward the real host value. Also documents both footguns (literal `env:` values; sandbox env stripping) in the configuration guide, environment-variables, sandbox-run, and FAQ docs.

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -126,6 +126,19 @@ roots:                    # Directories the server can access
 description: "Filesystem access tools"
 ```
 
+> **Passing secrets to MCP servers.** Two things commonly trip people up:
+>
+> - **`env:` values are literal — they are *not* shell-expanded.** Unlike `roots:` above (and the NATS `token:` below), `$VAR`/`${VAR}` in an `env:` value is passed through verbatim rather than substituted. Writing `API_KEY: "$API_KEY"` sends the literal string `$API_KEY` to the server.
+> - **A sandbox wrapper strips the child environment.** If you've wrapped `npx`/`node` with a [harnx sandbox](sandbox-run.md), the server starts with a scrubbed environment, so neither an `env:` value nor an inherited host variable reaches it by default. Forward the specific variable with `HARNX_BASH_ENV_PASSTHROUGH` instead — the sandbox reads it and passes the host value through:
+>
+>   ```yaml
+>   # Server needs EXA_API_KEY, and npx is sandbox-wrapped:
+>   env:
+>     HARNX_BASH_ENV_PASSTHROUGH: EXA_API_KEY   # forwards the host's EXA_API_KEY
+>   ```
+>
+>   Set the actual secret (`EXA_API_KEY=…`) in `~/.local/share/harnx/.env`.
+
 ## ACP Servers (`acp_servers/`)
 
 Agent Client Protocol (ACP) servers allow Harnx to delegate tasks to other agents.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -77,9 +77,13 @@ Harnx can load environment variables from a `.env` file located in the data dire
 
 ## Bash MCP Server Envs
 
-- **HARNX_BASH_ENV_PASSTHROUGH**: Comma-separated list of extra host env var names to pass through to child bash processes spawned by `harnx-mcp-bash`. Example: `HARNX_BASH_ENV_PASSTHROUGH=GITHUB_TOKEN,SSH_AUTH_SOCK`.
+These are honored by **both** `harnx-mcp-bash` (for `bash_exec` child processes) and `harnx-sandbox-run` — so they apply not only to the bash tool but to any MCP server launched through a sandbox-wrapped `npx`/`node` shim (e.g. the Exa server, whose environment would otherwise be scrubbed). The same shell-profile settings work for both.
+
+- **HARNX_BASH_ENV_PASSTHROUGH**: Comma-separated list of extra host env var names to forward into the sandbox (e.g. so the Exa MCP server receives `EXA_API_KEY`). Example: `HARNX_BASH_ENV_PASSTHROUGH=GITHUB_TOKEN,SSH_AUTH_SOCK`.
 - **HARNX_BASH_EXTRA_READABLE**: Colon-separated extra sandbox read-only paths.
+- **HARNX_BASH_EXTRA_WRITABLE**: Colon-separated extra sandbox writable paths.
 - **HARNX_BASH_EXTRA_EXEC**: Colon-separated extra sandbox executable paths.
+- **HARNX_BASH_EXTRA_RWX**: Colon-separated extra sandbox read/write/execute paths.
 
 ## Generic Envs
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,6 +22,23 @@ Some models have built-in web search capabilities (e.g., Perplexity, OpenRouter 
 
 Use the `web_search` tool to give your LLM web search capabilities through tool use.
 
+## Why does my MCP server say its API key is missing (even though it's in `.env`)?
+
+If an MCP server — e.g. the Exa web-search server run via `npx` — reports a missing or empty API key even though you set it in `~/.local/share/harnx/.env`, the cause is almost always the **sandbox**. When `npx`/`node` is wrapped by a [harnx sandbox](sandbox-run.md), the server launches with a scrubbed environment, so the key never reaches it.
+
+Forward the specific variable through the sandbox from the server's config:
+
+```yaml
+# mcp_servers/exa.yaml
+env:
+  HARNX_BASH_ENV_PASSTHROUGH: EXA_API_KEY
+```
+
+Two related gotchas:
+
+- **`env:` values are not `$VAR`-expanded.** `EXA_API_KEY: "$EXA_API_KEY"` sends the literal string `$EXA_API_KEY`, not its value — use `HARNX_BASH_ENV_PASSTHROUGH` (above) to forward the real value instead.
+- **The error text tells you which problem you have.** "API key must be provided" means an *empty* value reached the server (stripped, or never set); "Invalid API key" means a *wrong* value reached it (e.g. the un-expanded literal `$EXA_API_KEY`).
+
 ## Why compress sessions?
 
 The Chat API is stateless, so the full conversation history is sent with every request. This means history grows rapidly, causing two problems:

--- a/docs/sandbox-run.md
+++ b/docs/sandbox-run.md
@@ -292,6 +292,8 @@ These match the `harnx-mcp-bash` environment variables, so the same shell profil
 
 Paths support `~` expansion and project-root pseudo-variables. CLI flags and env vars both accumulate — they are not mutually exclusive.
 
+> **MCP servers that need a static API key.** When an MCP server is launched through a sandbox-wrapped shim (e.g. `npx exa-mcp-server`), its environment is scrubbed like any other sandboxed process — so a key set in `~/.local/share/harnx/.env`, or in the server's `env:` block, will not reach it. Unlike the GitHub/Atlassian token flows below (where the real secret is kept out of the sandbox and injected into outbound requests by a proxy hook), a server that authenticates by sending the key itself just needs the value forwarded: add `HARNX_BASH_ENV_PASSTHROUGH=EXA_API_KEY` (or `--env EXA_API_KEY`). See the [MCP server config guide](configuration-guide.md#mcp-servers-mcp_servers).
+
 > **Note:** The `<COMMAND>` must come after `--` or at the very end of the arguments.
 
 ## Default Whitelist

--- a/example_config/mcp_servers/exa.yaml
+++ b/example_config/mcp_servers/exa.yaml
@@ -5,3 +5,7 @@ args:
   - "exa-mcp-server"
 enabled: true
 description: "Web search via Exa API"
+# If you've wrapped npx/node with a harnx sandbox, this allows the EXA_API_KEY to pass through
+env:
+  HARNX_BASH_ENV_PASSTHROUGH: EXA_API_KEY
+

--- a/packages/coding/mcp_servers/exa.yaml
+++ b/packages/coding/mcp_servers/exa.yaml
@@ -1,13 +1,11 @@
+# Note: set EXA_API_KEY in ~/.local/share/harnx/.env
 command: npx
 args:
   - "-y"
   - "exa-mcp-server"
-description: >-
-  Web search via Exa API. Used by Librarian, Sisyphus, and Zosimus for
-  research and fact-finding.
-
-# Requires: Node.js / npx and an Exa API key.
-# Set EXA_API_KEY in ~/.local/share/harnx/.env
-# Sign up at https://exa.ai to get a key.
+enabled: true
+description: "Web search via Exa API"
+# If you've wrapped npx/node with a harnx sandbox, this allows the EXA_API_KEY to pass through
 env:
-  EXA_API_KEY: "$EXA_API_KEY"
+  HARNX_BASH_ENV_PASSTHROUGH: EXA_API_KEY
+

--- a/packages/pantheon/mcp_servers/exa.yaml
+++ b/packages/pantheon/mcp_servers/exa.yaml
@@ -1,3 +1,6 @@
+# Requires: Node.js / npx and an Exa API key.
+# Set EXA_API_KEY in ~/.local/share/harnx/.env
+# Sign up at https://exa.ai to get a key.
 command: npx
 args:
   - "-y"
@@ -5,9 +8,6 @@ args:
 description: >-
   Web search via Exa API. Used by Librarian, Sisyphus, and Zosimus for
   research and fact-finding.
-
-# Requires: Node.js / npx and an Exa API key.
-# Set EXA_API_KEY in ~/.local/share/harnx/.env
-# Sign up at https://exa.ai to get a key.
+# If you've wrapped npx/node with a harnx sandbox, this allows the EXA_API_KEY to pass through
 env:
-  EXA_API_KEY: "$EXA_API_KEY"
+  HARNX_BASH_ENV_PASSTHROUGH: EXA_API_KEY


### PR DESCRIPTION
## Problem

Running the Exa web-search MCP server (shipped in the `pantheon` and `coding` packages) failed with:

```
web_search_exa error (401): API key must be provided as an environment variable (EXA_API_KEY)
```

…even with a valid `EXA_API_KEY` set in `~/.local/share/harnx/.env`. Two layers each dropped the key:

1. **`$VAR` isn't expanded in MCP `env:` values.** The configs used `EXA_API_KEY: "$EXA_API_KEY"`, but harnx passes MCP `env:` values verbatim (only `roots:` and NATS fields are shell-expanded), so the literal string `$EXA_API_KEY` was sent.
2. **The sandbox scrubs the child environment.** When `npx`/`node` is wrapped by a harnx sandbox shim, `harnx-sandbox-run` does `env_clear()` and forwards only a whitelist — `EXA_API_KEY` was not on it.

The error text tells you which layer bites: an **empty** value yields *"API key must be provided"*, a **wrong** value yields *"Invalid API key"*. Users saw the former (stripped).

## Fix

Switch all three Exa configs to forward the key through the sandbox via the passthrough var `harnx-sandbox-run` already honors:

```yaml
env:
  HARNX_BASH_ENV_PASSTHROUGH: EXA_API_KEY
```

harnx loads the real key into its own environment from `.env`; this forwards that value into the sandbox **for the Exa server only** (narrower than adding `--env EXA_API_KEY` to the shim, which would leak it to every sandboxed node tool). Verified end-to-end by driving the real stdio MCP server.

## Docs

- **configuration-guide** — MCP `env:` values are literal (no `$VAR` expansion); a sandbox strips env → use `HARNX_BASH_ENV_PASSTHROUGH`.
- **environment-variables** — clarified that `HARNX_BASH_ENV_PASSTHROUGH` (and the `EXTRA_*` path vars) are honored by **both** `harnx-mcp-bash` and `harnx-sandbox-run`; added the previously-missing `HARNX_BASH_EXTRA_WRITABLE` and `HARNX_BASH_EXTRA_RWX`.
- **sandbox-run** — note distinguishing static-API-key MCP servers (just forward the value) from the proxy-injected token flows (GitHub/Atlassian).
- **faq** — troubleshooting entry, including the empty-vs-invalid error distinction.

## Notes

- Docs + YAML + changeset only — no Rust changed, so the `build`/`clippy`/`nextest`/`cs delta` pipeline isn't applicable. Validated the three configs parse and confirmed no test is coupled to the old config content.
- Changeset bumps `harnx` / `pantheon` / `coding` (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed web search MCP servers failing in sandboxed runs when API keys were not reaching the process.
  * Improved environment handling so required secrets can be passed through reliably in sandboxed setups.

* **Documentation**
  * Added clearer guidance on passing secrets to MCP servers.
  * Expanded docs and FAQ with environment-variable behavior, sandbox pass-through options, and common setup pitfalls.

* **New Features**
  * Added a documented pass-through mechanism for forwarding specific environment variables into sandboxed MCP server runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->