### PR TITLE
Update node sandbox example to passthrough NODE_OPTIONS

### DIFF
--- a/docs/sandbox-run.md
+++ b/docs/sandbox-run.md
@@ -100,6 +100,7 @@ exec harnx-sandbox-run \
   --extra-rwx '$NODE_PROJECT_ROOT' \
   --extra-rwx '$GIT_COMMON_DIR' \
   --env 'AWS_PROFILE=' \
+  --env NODE_OPTIONS \
   --hook claude-command-persistent harnx-aws-creds --profile my-profile \; \
   -- "$tool" "$@"
 ```


### PR DESCRIPTION
This is a very useful environment variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the sandbox run instructions to forward the host’s `NODE_OPTIONS` into sandboxed Node command executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->