### PR TITLE
feat(acp): stop MCP subprocess churn, forward subagent logs, surface restart notices

### DIFF
--- a/.changeset/feat-mcp-restart-notices.md
+++ b/.changeset/feat-mcp-restart-notices.md
@@ -1,0 +1,5 @@
+---
+harnx: minor
+---
+
+Surface MCP server transport failures and subprocess churn as user-visible notices, including reconnect warnings and child stderr/closure signals, so ACP/TUI users can see MCP restarts and deaths without digging through logs. Fixes #990.

--- a/.changeset/fix-acp-subagent-log-forwarding.md
+++ b/.changeset/fix-acp-subagent-log-forwarding.md
@@ -1,0 +1,5 @@
+---
+harnx: patch
+---
+
+Fix ACP/MCP subprocess log forwarding so explicit `HARNX_LOG_LEVEL` and `HARNX_LOG_PATH` propagate into child servers, preserve inherited log settings over `.env`, and support `{pid}` log-path templates for per-process files. Fixes #989.

--- a/.changeset/fix-mcp-acp-manager-restarts.md
+++ b/.changeset/fix-mcp-acp-manager-restarts.md
@@ -1,0 +1,5 @@
+---
+harnx: patch
+---
+
+Fix ACP prompt-time MCP/ACP manager churn so re-selecting same agent scope preserves running subprocesses instead of restarting MCP servers every turn. Also stop ACP single-threaded tool discovery from invalidating freshly connected MCP services. Fixes #988.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3583,6 +3583,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "tokio",
 ]
 

--- a/crates/harnx-acp-server/src/server_main.rs
+++ b/crates/harnx-acp-server/src/server_main.rs
@@ -49,6 +49,14 @@ pub async fn run(config: GlobalConfig, agent_name: String) -> Result<()> {
 
 async fn run_local(config: GlobalConfig, agent_name: String) -> Result<()> {
     let config_for_cleanup = config.clone();
+    // `HARNX_MCP_KEEP_SERVICES_AFTER_DISCOVERY` is an INTERNAL, undocumented
+    // flag (not a user-facing config knob). The ACP server runs on a
+    // current-thread runtime and re-runs MCP tool discovery on every prompt;
+    // without this, discovery would invalidate freshly-connected MCP services
+    // and churn subprocesses each turn (see #988). Set here at process startup
+    // before the async runtime spawns any worker threads, so the `set_var` is
+    // effectively single-threaded (the `unsafe` contract is upheld).
+    unsafe { std::env::set_var("HARNX_MCP_KEEP_SERVICES_AFTER_DISCOVERY", "1") };
     let agent = Arc::new(HarnxAgent::new(agent_name, config));
 
     let result = acp::Agent

--- a/crates/harnx-acp/Cargo.toml
+++ b/crates/harnx-acp/Cargo.toml
@@ -24,4 +24,5 @@ tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 serde_yaml = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/harnx-acp/src/client.rs
+++ b/crates/harnx-acp/src/client.rs
@@ -17,6 +17,7 @@ use harnx_core::event::{
 };
 use serde_json::json;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::thread;
@@ -56,6 +57,41 @@ fn idle_activity_resets_timer(
         Err(broadcast::error::RecvError::Lagged(_)) => true,
         Err(broadcast::error::RecvError::Closed) => false,
     }
+}
+
+fn absolutize_log_path_template(path: &str) -> PathBuf {
+    let path = PathBuf::from(path);
+    if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    }
+}
+
+fn forwarded_log_env() -> HashMap<String, String> {
+    let mut env_map = HashMap::new();
+    if let Ok(level) = std::env::var("HARNX_LOG_LEVEL") {
+        if !level.is_empty() {
+            env_map.insert("HARNX_LOG_LEVEL".to_string(), level);
+        }
+    }
+    if let Ok(path) = std::env::var("HARNX_LOG_PATH") {
+        if !path.is_empty() {
+            env_map.insert(
+                "HARNX_LOG_PATH".to_string(),
+                absolutize_log_path_template(&path)
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+        }
+    }
+    env_map
+}
+
+fn apply_forwarded_log_env(env_map: &mut HashMap<String, String>) {
+    env_map.extend(forwarded_log_env());
 }
 
 pub struct AcpClient {
@@ -382,6 +418,10 @@ impl AcpClient {
 
     pub fn description(&self) -> Option<&str> {
         self.config.description.as_deref()
+    }
+
+    pub fn config(&self) -> &AcpServerConfig {
+        &self.config
     }
 
     pub async fn connect(&self) -> Result<()> {
@@ -713,12 +753,15 @@ async fn worker_main(
     mut abort_rx: oneshot::Receiver<()>,
     activity_tx: broadcast::Sender<String>,
 ) -> Result<()> {
+    let mut child_env = config.env.clone();
+    apply_forwarded_log_env(&mut child_env);
+
     let mut cmd = Command::new(&config.command);
     cmd.args(&config.args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .envs(&config.env)
+        .envs(&child_env)
         .kill_on_drop(true);
 
     #[cfg(unix)]
@@ -1971,6 +2014,81 @@ mod tests {
         assert!(
             !idle_activity_resets_timer(&result, "sess-1"),
             "a closed activity channel must NOT reset the idle timer"
+        );
+    }
+
+    #[test]
+    fn forwarded_log_env_absolutizes_relative_path_and_keeps_pid_template() {
+        let prev_level = std::env::var_os("HARNX_LOG_LEVEL");
+        let prev_path = std::env::var_os("HARNX_LOG_PATH");
+        let prev_cwd = std::env::current_dir().unwrap();
+        let temp = tempfile::TempDir::new().unwrap();
+
+        unsafe {
+            std::env::set_var("HARNX_LOG_LEVEL", "debug");
+            std::env::set_var("HARNX_LOG_PATH", "logs/harnx-{pid}.log");
+        }
+        std::env::set_current_dir(temp.path()).unwrap();
+
+        let env_map = forwarded_log_env();
+
+        std::env::set_current_dir(prev_cwd).unwrap();
+        match prev_level {
+            Some(value) => unsafe { std::env::set_var("HARNX_LOG_LEVEL", value) },
+            None => unsafe { std::env::remove_var("HARNX_LOG_LEVEL") },
+        }
+        match prev_path {
+            Some(value) => unsafe { std::env::set_var("HARNX_LOG_PATH", value) },
+            None => unsafe { std::env::remove_var("HARNX_LOG_PATH") },
+        }
+
+        assert_eq!(
+            env_map.get("HARNX_LOG_LEVEL").map(String::as_str),
+            Some("debug")
+        );
+        assert_eq!(
+            env_map.get("HARNX_LOG_PATH").map(String::as_str),
+            Some(
+                temp.path()
+                    .join("logs/harnx-{pid}.log")
+                    .to_string_lossy()
+                    .as_ref()
+            )
+        );
+    }
+
+    #[test]
+    fn apply_forwarded_log_env_injects_explicit_harnx_log_vars() {
+        let prev_level = std::env::var_os("HARNX_LOG_LEVEL");
+        let prev_path = std::env::var_os("HARNX_LOG_PATH");
+        let temp = tempfile::TempDir::new().unwrap();
+        let absolute = temp.path().join("harnx.log");
+
+        unsafe {
+            std::env::set_var("HARNX_LOG_LEVEL", "debug");
+            std::env::set_var("HARNX_LOG_PATH", &absolute);
+        }
+
+        let mut env_map = HashMap::from([("EXISTING".to_string(), "value".to_string())]);
+        apply_forwarded_log_env(&mut env_map);
+
+        match prev_level {
+            Some(value) => unsafe { std::env::set_var("HARNX_LOG_LEVEL", value) },
+            None => unsafe { std::env::remove_var("HARNX_LOG_LEVEL") },
+        }
+        match prev_path {
+            Some(value) => unsafe { std::env::set_var("HARNX_LOG_PATH", value) },
+            None => unsafe { std::env::remove_var("HARNX_LOG_PATH") },
+        }
+
+        assert_eq!(env_map.get("EXISTING").map(String::as_str), Some("value"));
+        assert_eq!(
+            env_map.get("HARNX_LOG_LEVEL").map(String::as_str),
+            Some("debug")
+        );
+        assert_eq!(
+            env_map.get("HARNX_LOG_PATH").map(String::as_str),
+            Some(absolute.to_string_lossy().as_ref())
         );
     }
 

--- a/crates/harnx-acp/src/config.rs
+++ b/crates/harnx-acp/src/config.rs
@@ -13,7 +13,7 @@ fn default_operation_timeout() -> u64 {
     3600
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct AcpServerConfig {
     #[serde(default)]
     pub name: String,

--- a/crates/harnx-acp/src/manager.rs
+++ b/crates/harnx-acp/src/manager.rs
@@ -92,6 +92,17 @@ impl AcpManager {
         self.clients.read().get(server_name).cloned()
     }
 
+    pub fn configs(&self) -> Vec<AcpServerConfig> {
+        let mut configs: Vec<AcpServerConfig> = self
+            .clients
+            .read()
+            .values()
+            .map(|client| client.config().clone())
+            .collect();
+        configs.sort_by(|left, right| left.name.cmp(&right.name));
+        configs
+    }
+
     pub async fn get_all_tools(&self) -> Vec<ToolDeclaration> {
         let clients = self.clients.read();
         let mut tools: Vec<_> = clients

--- a/crates/harnx-core/src/hooks.rs
+++ b/crates/harnx-core/src/hooks.rs
@@ -127,7 +127,7 @@ fn default_timeout() -> Option<u64> {
 }
 
 /// Configuration for a single hook entry
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct HookConfig {
     /// Hook event name (e.g., "PreToolUse", "Stop")
     pub event: String,
@@ -168,7 +168,7 @@ impl HookConfig {
 }
 
 /// Configuration for all hooks (global or per-agent)
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct HooksConfig {
     /// Maximum number of resume iterations
     #[serde(default)]

--- a/crates/harnx-mcp/Cargo.toml
+++ b/crates/harnx-mcp/Cargo.toml
@@ -17,7 +17,7 @@ indexmap = { workspace = true }
 log = { workspace = true }
 parking_lot = { workspace = true }
 process-wrap = { workspace = true }
-rmcp = { workspace = true }
+rmcp = { workspace = true, features = ["transport-async-rw"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 shellexpand = { workspace = true }

--- a/crates/harnx-mcp/src/client.rs
+++ b/crates/harnx-mcp/src/client.rs
@@ -2,6 +2,8 @@ use crate::config::{McpServerConfig, ToolDisplayTemplates};
 use crate::convert::{mcp_tool_to_declaration, ToolTemplates};
 use crate::safety::path_to_file_uri;
 use harnx_core::abort::{wait_abort_signal, AbortSignal};
+use harnx_core::event::NoticeEvent;
+use harnx_core::sink::emit_agent_event;
 use harnx_core::tool::{ToolDeclaration, ToolError, ToolProvider};
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -17,7 +19,6 @@ use rmcp::model::{
     ListRootsResult, Root,
 };
 use rmcp::service::{RequestContext, RoleClient, RunningService, ServiceError};
-use rmcp::transport::TokioChildProcess;
 use serde_json::Value;
 use std::collections::VecDeque;
 use std::process::Stdio;
@@ -30,6 +31,126 @@ use tokio::runtime::{Builder, Handle, RuntimeFlavor};
 /// Maximum number of stderr lines to keep from an MCP child process for
 /// inclusion in connection error messages. Old lines are dropped first.
 const MCP_STDERR_TAIL_LINES: usize = 64;
+
+/// Minimum time between duplicate notices for the same server+key.
+const NOTICE_DEDUP_WINDOW: Duration = Duration::from_secs(5);
+
+/// Shared per-client dedup state: the (key, timestamp) of the last emitted
+/// notice. Wrapped in `Arc` so the background child-wait task can share the
+/// same state as the synchronous reconnect path — this keeps notice
+/// deduplication consistent across reconnects rather than resetting per
+/// connection.
+type NoticeDedupState = Arc<RwLock<Option<(String, std::time::Instant)>>>;
+
+/// Emit a `NoticeEvent` through the global agent-event sink, suppressing a
+/// duplicate `(key)` within `NOTICE_DEDUP_WINDOW`. Returns true if emitted,
+/// false if suppressed. Shared by `McpClient::emit_notice` and the detached
+/// child-wait task so both honour the same dedup window.
+fn emit_notice_dedup(state: &NoticeDedupState, key: &str, event: NoticeEvent) -> bool {
+    let now = std::time::Instant::now();
+    let mut last_notice = state.write();
+    if let Some((ref last_key, ref last_time)) = *last_notice {
+        if last_key == key && now.duration_since(*last_time) < NOTICE_DEDUP_WINDOW {
+            return false;
+        }
+    }
+    *last_notice = Some((key.to_string(), now));
+    drop(last_notice);
+    emit_agent_event(harnx_core::event::AgentEvent::Notice(event));
+    true
+}
+
+// --- Part A: log env forwarding helpers -------------------------------------
+
+/// Resolve a `HARNX_LOG_PATH` value to an absolute path.
+/// - If already absolute, return as-is.
+/// - If relative, resolve relative to `cwd`.
+/// - If the path contains `{pid}` template token, preserve the token but
+///   absolutize the directory portion (e.g., `logs/{pid}.log` → `<cwd>/logs/{pid}.log`).
+pub fn resolve_forwarded_log_path(raw: &str, cwd: &Path) -> String {
+    // If already absolute, return as-is
+    if Path::new(raw).is_absolute() {
+        return raw.to_string();
+    }
+
+    // If contains {pid} template, absolutize the directory portion
+    if raw.contains("{pid}") {
+        // The {pid} might be in the filename or directory
+        // We want to make the whole path absolute but preserve {pid}
+        let abs = cwd.join(raw);
+        abs.to_string_lossy().into_owned()
+    } else {
+        // Simple relative path - absolutize fully
+        let abs = cwd.join(raw);
+        abs.to_string_lossy().into_owned()
+    }
+}
+
+/// Forward `HARNX_LOG_LEVEL` and `HARNX_LOG_PATH` from the current process
+/// environment to `child_env`, if set. Does NOT overwrite existing values.
+pub fn apply_forwarded_log_env(child_env: &mut HashMap<String, String>) {
+    if let Ok(level) = std::env::var("HARNX_LOG_LEVEL") {
+        // Don't overwrite if already set from config
+        if !child_env.contains_key("HARNX_LOG_LEVEL") {
+            child_env.insert("HARNX_LOG_LEVEL".to_string(), level);
+        }
+    }
+
+    if let Ok(path) = std::env::var("HARNX_LOG_PATH") {
+        // Don't overwrite if already set from config
+        if !child_env.contains_key("HARNX_LOG_PATH") {
+            // Resolve to absolute path (relative to current_dir)
+            if let Ok(cwd) = std::env::current_dir() {
+                let resolved = resolve_forwarded_log_path(&path, &cwd);
+                child_env.insert("HARNX_LOG_PATH".to_string(), resolved);
+            }
+        }
+    }
+}
+
+// --- Part B: exit status classification -------------------------------------
+
+/// Classify exit status into a NoticeEvent.
+/// - Clean exit (code 0, or SIGTERM/SIGINT on Unix) → Warning
+/// - Nonzero code or SIGKILL/other signals → Error
+/// - No status available → Error
+#[cfg(unix)]
+pub fn classify_exit(name: &str, code: Option<i32>, signal: Option<i32>) -> NoticeEvent {
+    // Check signal first (if killed by signal)
+    if let Some(sig) = signal {
+        // Common signal mappings
+        match sig {
+            15 | 2 => NoticeEvent::Warning(format!(
+                "MCP server '{}' terminated by SIG{}",
+                name,
+                if sig == 15 { "TERM" } else { "INT" }
+            )),
+            9 => NoticeEvent::Error(format!("MCP server '{}' killed by SIGKILL", name)),
+            _ => NoticeEvent::Error(format!("MCP server '{}' died: signal {}", name, sig)),
+        }
+    } else if let Some(c) = code {
+        if c == 0 {
+            NoticeEvent::Warning(format!("MCP server '{}' exited cleanly", name))
+        } else {
+            NoticeEvent::Error(format!("MCP server '{}' exited with code {}", name, c))
+        }
+    } else {
+        NoticeEvent::Error(format!("MCP server '{}' exited (status unavailable)", name))
+    }
+}
+
+#[cfg(not(unix))]
+pub fn classify_exit(name: &str, code: Option<i32>, _signal: Option<i32>) -> NoticeEvent {
+    if let Some(c) = code {
+        if c == 0 {
+            NoticeEvent::Warning(format!("MCP server '{}' exited cleanly", name))
+        } else {
+            NoticeEvent::Error(format!("MCP server '{}' exited with code {}", name, c))
+        }
+    } else {
+        NoticeEvent::Error(format!("MCP server '{}' exited (status unavailable)", name))
+    }
+}
 
 /// How long to wait for the stderr reader to drain after a connection
 /// error before snapshotting the buffer for the error message. Short
@@ -67,6 +188,15 @@ pub struct McpClient {
     connected: Arc<RwLock<bool>>,
     connection_failed: Arc<RwLock<bool>>,
     service: Arc<RwLock<Option<RunningService<RoleClient, McpClientHandler>>>>,
+    /// Persistent stderr buffer for notice messages (survives reconnects)
+    stderr_buffer: StderrBuffer,
+    /// Last emitted notice (key, timestamp) for deduplication. Shared with the
+    /// background child-wait task so exit and reconnect notices dedup together.
+    last_notice: NoticeDedupState,
+    /// Handle to the background task that waits for the current child process
+    /// and emits an exit notice. Aborted and replaced on each (re)connect so a
+    /// stale task from a prior connection cannot linger past teardown.
+    child_wait_task: RwLock<Option<tokio::task::JoinHandle<()>>>,
 }
 
 #[derive(Clone)]
@@ -126,6 +256,7 @@ impl fmt::Debug for McpClient {
             .field("roots", &*self.roots.read())
             .field("connected", &*self.connected.read())
             .field("service", &service)
+            .field("stderr_buffer_len", &self.stderr_buffer.lock().len())
             .finish()
     }
 }
@@ -135,6 +266,12 @@ impl McpClient {
         shellexpand::full(path)
             .map(|p| p.to_string())
             .unwrap_or_else(|_| path.to_string())
+    }
+
+    /// Emit a notice event with deduplication against this client's shared
+    /// dedup state. Returns true if emitted, false if suppressed as duplicate.
+    fn emit_notice(&self, key: &str, event: NoticeEvent) -> bool {
+        emit_notice_dedup(&self.last_notice, key, event)
     }
 
     pub fn new(config: McpServerConfig) -> Self {
@@ -152,6 +289,9 @@ impl McpClient {
             connected: Arc::new(RwLock::new(false)),
             connection_failed: Arc::new(RwLock::new(false)),
             service: Arc::new(RwLock::new(None)),
+            stderr_buffer: new_stderr_buffer(),
+            last_notice: Arc::new(RwLock::new(None)),
+            child_wait_task: RwLock::new(None),
         }
     }
 
@@ -191,7 +331,16 @@ impl McpClient {
     async fn connect_inner(&self) -> Result<()> {
         let mut command = Command::new(&self.config.command);
         command.args(&self.config.args);
-        command.envs(&self.config.env);
+
+        // Apply forwarded log env (HARNX_LOG_LEVEL, HARNX_LOG_PATH)
+        let mut child_env = self.config.env.clone();
+        apply_forwarded_log_env(&mut child_env);
+        command.envs(&child_env);
+
+        // Pipe stdin/stdout/stderr for MCP transport
+        command.stdin(Stdio::piped());
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
 
         // Spawn in a new process group so SIGINT (Ctrl+C) in the parent
         // terminal doesn't propagate to MCP server child processes.
@@ -200,16 +349,71 @@ impl McpClient {
         #[cfg(unix)]
         wrap.wrap(ProcessGroup::leader());
 
-        let stderr_buffer = new_stderr_buffer();
-
-        let (transport, stderr) = TokioChildProcess::builder(wrap)
-            .stderr(Stdio::piped())
+        // Spawn the child process ourselves (instead of using TokioChildProcess)
+        // so we can own the child handle and wait for exit.
+        let mut child = wrap
             .spawn()
             .with_context(|| format!("Failed to spawn MCP server '{}'", self.name))?;
 
+        let stdin = child
+            .stdin()
+            .take()
+            .ok_or_else(|| anyhow!("MCP server '{}' stdin not piped", self.name))?;
+        let stdout = child
+            .stdout()
+            .take()
+            .ok_or_else(|| anyhow!("MCP server '{}' stdout not piped", self.name))?;
+        let stderr = child.stderr().take();
+
+        // Spawn a background task that waits for the child and emits an exit
+        // notice. It shares the client's `last_notice` dedup state so exit and
+        // reconnect notices are deduplicated together. Any wait task from a
+        // prior connection is aborted first so stale tasks don't linger.
+        let name_for_wait = self.name.clone();
+        let stderr_buffer_for_wait = self.stderr_buffer.clone();
+        let dedup_state = self.last_notice.clone();
+        let wait_handle = tokio::spawn(async move {
+            if let Ok(status) = child.wait().await {
+                #[cfg(unix)]
+                let (code, signal) = {
+                    use std::os::unix::process::ExitStatusExt;
+                    (status.code(), status.signal())
+                };
+                #[cfg(not(unix))]
+                let (code, signal) = (status.code(), None);
+
+                // Snapshot stderr tail for the notice message
+                let stderr_tail = {
+                    let buf = stderr_buffer_for_wait.lock();
+                    if buf.is_empty() {
+                        String::new()
+                    } else {
+                        let joined = buf.iter().cloned().collect::<Vec<_>>().join("\n");
+                        format!("\nMCP server stderr:\n{joined}")
+                    }
+                };
+
+                let event = match classify_exit(&name_for_wait, code, signal) {
+                    NoticeEvent::Warning(msg) if !stderr_tail.is_empty() => {
+                        NoticeEvent::Warning(format!("{}\n{}", msg, stderr_tail))
+                    }
+                    NoticeEvent::Error(msg) if !stderr_tail.is_empty() => {
+                        NoticeEvent::Error(format!("{}\n{}", msg, stderr_tail))
+                    }
+                    other => other,
+                };
+                let key = format!("exit:{}", name_for_wait);
+                emit_notice_dedup(&dedup_state, &key, event);
+            }
+        });
+        if let Some(prev) = self.child_wait_task.write().replace(wait_handle) {
+            prev.abort();
+        }
+
+        // Spawn stderr reader task using the persistent buffer
         if let Some(stderr) = stderr {
             let server_name = self.name.clone();
-            let buffer = stderr_buffer.clone();
+            let buffer = self.stderr_buffer.clone();
             tokio::spawn(async move {
                 let reader = BufReader::new(stderr);
                 let mut lines = reader.lines();
@@ -224,6 +428,10 @@ impl McpClient {
             });
         }
 
+        // Create transport from (stdout, stdin) pair
+        let transport =
+            rmcp::transport::async_rw::AsyncRwTransport::<RoleClient, _, _>::new(stdout, stdin);
+
         let handler = McpClientHandler::new(self.roots.clone());
         let serve_result = tokio::time::timeout(
             Duration::from_secs(30),
@@ -232,7 +440,7 @@ impl McpClient {
         .await;
         let service = match serve_result {
             Err(_) => {
-                let tail = snapshot_stderr_tail(&stderr_buffer).await;
+                let tail = snapshot_stderr_tail(&self.stderr_buffer).await;
                 bail!(
                     "MCP server '{}' timed out during initialization (30s){}",
                     self.name,
@@ -240,7 +448,7 @@ impl McpClient {
                 );
             }
             Ok(Err(err)) => {
-                let tail = snapshot_stderr_tail(&stderr_buffer).await;
+                let tail = snapshot_stderr_tail(&self.stderr_buffer).await;
                 return Err(anyhow::Error::from(err)).with_context(|| {
                     format!(
                         "Failed to initialize MCP client for server '{}'{}",
@@ -258,7 +466,7 @@ impl McpClient {
         .await;
         let tools_result = match list_result {
             Err(_) => {
-                let tail = snapshot_stderr_tail(&stderr_buffer).await;
+                let tail = snapshot_stderr_tail(&self.stderr_buffer).await;
                 bail!(
                     "MCP server '{}' timed out listing tools (10s){}",
                     self.name,
@@ -266,7 +474,7 @@ impl McpClient {
                 );
             }
             Ok(Err(err)) => {
-                let tail = snapshot_stderr_tail(&stderr_buffer).await;
+                let tail = snapshot_stderr_tail(&self.stderr_buffer).await;
                 return Err(anyhow::Error::from(err)).with_context(|| {
                     format!(
                         "Failed to list tools for MCP server '{}'{}",
@@ -447,8 +655,25 @@ impl McpClient {
                         err,
                     );
 
+                    // Snapshot stderr tail BEFORE reconnect for the notice
+                    let stderr_tail = render_stderr_tail(&self.stderr_buffer);
+
                     *self.connected.write() = false;
                     self.service.write().take();
+
+                    // Emit Warning notice about the transport failure and reconnect attempt
+                    self.emit_notice(
+                        &format!("reconnect:{}", self.name),
+                        NoticeEvent::Warning(format!(
+                            "MCP server '{}' disconnected, reconnecting{}",
+                            self.name,
+                            if stderr_tail.is_empty() {
+                                String::new()
+                            } else {
+                                format!(" ({})", stderr_tail.trim())
+                            }
+                        )),
+                    );
 
                     // Heal the connection for future calls (best-effort)
                     if let Err(reconnect_err) = self.connect().await {
@@ -456,6 +681,14 @@ impl McpClient {
                             "Failed to reconnect to MCP server '{}' after transport error: {}",
                             self.name,
                             reconnect_err,
+                        );
+                        // Emit Error notice about failed reconnect
+                        self.emit_notice(
+                            &format!("reconnect-failed:{}", self.name),
+                            NoticeEvent::Error(format!(
+                                "MCP server '{}' reconnection failed: {}",
+                                self.name, reconnect_err
+                            )),
                         );
                     }
 
@@ -1121,6 +1354,18 @@ pub struct McpManager {
     clients: Arc<RwLock<HashMap<String, Arc<McpClient>>>>,
 }
 
+/// Whether tool discovery on a short-lived runtime should invalidate the
+/// just-connected MCP services afterwards.
+///
+/// The ACP server runs on a current-thread runtime and re-runs discovery on
+/// every prompt; invalidating there would tear down freshly-connected MCP
+/// subprocesses each turn (see #988). It sets
+/// `HARNX_MCP_KEEP_SERVICES_AFTER_DISCOVERY=1` to opt out of invalidation.
+/// The multi-thread (TUI) path never reaches this code and is unaffected.
+fn should_invalidate_after_discovery() -> bool {
+    std::env::var_os("HARNX_MCP_KEEP_SERVICES_AFTER_DISCOVERY").is_none_or(|value| value != "1")
+}
+
 impl McpManager {
     pub fn new() -> Self {
         Self {
@@ -1130,6 +1375,21 @@ impl McpManager {
 
     pub fn get_client(&self, server_name: &str) -> Option<Arc<McpClient>> {
         self.clients.read().get(server_name).cloned()
+    }
+
+    /// Snapshot of the effective configs of the currently-registered clients,
+    /// sorted by server name. Used by the runtime to detect whether an agent
+    /// re-activation changed the effective MCP server set; if it hasn't, the
+    /// existing manager (and its live subprocesses) is preserved (see #988).
+    pub fn configs(&self) -> Vec<McpServerConfig> {
+        let mut configs: Vec<McpServerConfig> = self
+            .clients
+            .read()
+            .values()
+            .map(|client| client.config.clone())
+            .collect();
+        configs.sort_by(|left, right| left.name.cmp(&right.name));
+        configs
     }
 
     pub fn initialize(&self, configs: Vec<McpServerConfig>) {
@@ -1277,7 +1537,9 @@ impl McpManager {
                                 .build()
                                 .expect("create runtime for MCP tool discovery");
                             let tools = rt.block_on(fut());
-                            self.invalidate_all_services();
+                            if should_invalidate_after_discovery() {
+                                self.invalidate_all_services();
+                            }
                             tools
                         })
                         .join()
@@ -1289,7 +1551,9 @@ impl McpManager {
             match Builder::new_current_thread().enable_all().build() {
                 Ok(runtime) => {
                     let tools = runtime.block_on(fut());
-                    self.invalidate_all_services();
+                    if should_invalidate_after_discovery() {
+                        self.invalidate_all_services();
+                    }
                     tools
                 }
                 Err(err) => {
@@ -1396,7 +1660,8 @@ impl ToolProvider for McpManager {
 
 #[cfg(test)]
 mod selector_filter_tests {
-    use super::selector_could_match_server;
+    use super::{classify_exit, resolve_forwarded_log_path, selector_could_match_server};
+    use harnx_core::event::NoticeEvent;
 
     #[test]
     fn star_matches_every_server() {
@@ -1473,5 +1738,132 @@ mod selector_filter_tests {
             "context7",
             &targets
         ));
+    }
+
+    // --- Part A tests: log env forwarding ---
+
+    #[test]
+    fn test_resolve_forwarded_log_path_absolute() {
+        let cwd = std::env::current_dir().unwrap();
+        let abs_path = if cfg!(windows) {
+            "C:\\logs\\app.log"
+        } else {
+            "/var/log/app.log"
+        };
+        let resolved = resolve_forwarded_log_path(abs_path, &cwd);
+        assert_eq!(resolved, abs_path);
+    }
+
+    #[test]
+    fn test_resolve_forwarded_log_path_relative() {
+        let cwd = std::env::current_dir().unwrap();
+        let resolved = resolve_forwarded_log_path("logs/app.log", &cwd);
+        let expected = cwd.join("logs/app.log");
+        assert_eq!(resolved, expected.to_string_lossy());
+    }
+
+    #[test]
+    fn test_resolve_forwarded_log_path_with_pid_template() {
+        let cwd = std::env::current_dir().unwrap();
+        let resolved = resolve_forwarded_log_path("logs/{pid}.log", &cwd);
+        let expected = cwd.join("logs/{pid}.log");
+        assert_eq!(resolved, expected.to_string_lossy());
+    }
+
+    #[test]
+    fn test_resolve_forwarded_log_path_with_pid_template_preserved() {
+        let cwd = std::env::current_dir().unwrap();
+        // The {pid} should be preserved, not expanded
+        let resolved = resolve_forwarded_log_path("app-{pid}.log", &cwd);
+        assert!(
+            resolved.contains("{pid}"),
+            "resolved path should preserve {{pid}} template: {}",
+            resolved
+        );
+        let expected = cwd.join("app-{pid}.log");
+        assert_eq!(resolved, expected.to_string_lossy());
+    }
+
+    // --- Part B tests: exit classification ---
+
+    #[test]
+    fn test_classify_exit_clean_exit_code_zero() {
+        let event = classify_exit("test-server", Some(0), None);
+        match event {
+            NoticeEvent::Warning(msg) => {
+                assert!(msg.contains("exited cleanly"));
+            }
+            _ => panic!("expected Warning for clean exit"),
+        }
+    }
+
+    #[test]
+    fn test_classify_exit_nonzero_code() {
+        let event = classify_exit("test-server", Some(3), None);
+        match event {
+            NoticeEvent::Error(msg) => {
+                assert!(msg.contains("exited with code 3"));
+            }
+            _ => panic!("expected Error for nonzero exit code"),
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_classify_exit_sigterm_warning() {
+        let event = classify_exit("test-server", None, Some(15));
+        match event {
+            NoticeEvent::Warning(msg) => {
+                assert!(msg.contains("terminated by SIGTERM"));
+            }
+            _ => panic!("expected Warning for SIGTERM"),
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_classify_exit_sigint_warning() {
+        let event = classify_exit("test-server", None, Some(2));
+        match event {
+            NoticeEvent::Warning(msg) => {
+                assert!(msg.contains("terminated by SIGINT"));
+            }
+            _ => panic!("expected Warning for SIGINT"),
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_classify_exit_sigkill_error() {
+        let event = classify_exit("test-server", None, Some(9));
+        match event {
+            NoticeEvent::Error(msg) => {
+                assert!(msg.contains("killed by SIGKILL"));
+            }
+            _ => panic!("expected Error for SIGKILL"),
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_classify_exit_unknown_signal_error() {
+        let event = classify_exit("test-server", None, Some(11)); // SIGSEGV
+        match event {
+            NoticeEvent::Error(msg) => {
+                assert!(msg.contains("died: signal 11"));
+            }
+            _ => panic!("expected Error for unknown signal"),
+        }
+    }
+
+    #[test]
+    fn test_classify_exit_no_status_error() {
+        let event = classify_exit("test-server", None, None);
+        match event {
+            NoticeEvent::Error(msg) => {
+                assert!(msg.contains("status unavailable"));
+            }
+            _ => panic!("expected Error for no status"),
+        }
     }
 }

--- a/crates/harnx-mcp/src/config.rs
+++ b/crates/harnx-mcp/src/config.rs
@@ -8,7 +8,7 @@ fn default_true() -> bool {
 
 /// Per-tool display template overrides. Keys are the server-side tool name
 /// (e.g. `"exec"`, `"read_file"`), not the prefixed display name.
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ToolDisplayTemplates {
     #[serde(default)]
     pub call_template: Option<String>,
@@ -16,7 +16,7 @@ pub struct ToolDisplayTemplates {
     pub result_template: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct McpServerConfig {
     #[serde(default)]
     pub name: String,

--- a/crates/harnx-runtime/src/config/env_split.rs
+++ b/crates/harnx-runtime/src/config/env_split.rs
@@ -153,6 +153,10 @@ pub fn load_env_file() -> Result<()> {
         if let Some((key, value)) = line.split_once('=') {
             let key = key.trim();
             if !key.is_empty() {
+                if matches!(key, "HARNX_LOG_LEVEL" | "HARNX_LOG_PATH") && env::var_os(key).is_some()
+                {
+                    continue;
+                }
                 unsafe {
                     env::set_var(key, value.trim());
                 }
@@ -202,5 +206,54 @@ mod tests {
         if let Some(v) = prev {
             unsafe { std::env::set_var("HARNX_CLEANUP_REMOTE_SESSIONS_DAYS", v) }
         }
+    }
+
+    #[test]
+    fn load_env_file_does_not_override_inherited_harnx_log_vars() {
+        let _lock = crate::config::test_support::env_lock();
+        let temp = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join(".env"),
+            "HARNX_LOG_LEVEL=info\nHARNX_LOG_PATH=from-dot-env.log\nOTHER_VAR=ok\n",
+        )
+        .unwrap();
+
+        let prev_cwd = std::env::current_dir().unwrap();
+        let prev_level = std::env::var_os("HARNX_LOG_LEVEL");
+        let prev_path = std::env::var_os("HARNX_LOG_PATH");
+        let prev_other = std::env::var_os("OTHER_VAR");
+
+        let result = {
+            unsafe {
+                std::env::set_var("HARNX_LOG_LEVEL", "debug");
+                std::env::set_var("HARNX_LOG_PATH", "/tmp/inherited.log");
+                std::env::remove_var("OTHER_VAR");
+            }
+            std::env::set_current_dir(temp.path()).unwrap();
+
+            load_env_file().unwrap();
+
+            let level = std::env::var("HARNX_LOG_LEVEL").unwrap();
+            let path = std::env::var("HARNX_LOG_PATH").unwrap();
+            let other = std::env::var("OTHER_VAR").ok();
+            (level, path, other)
+        };
+
+        std::env::set_current_dir(prev_cwd).unwrap();
+        match prev_level {
+            Some(value) => unsafe { std::env::set_var("HARNX_LOG_LEVEL", value) },
+            None => unsafe { std::env::remove_var("HARNX_LOG_LEVEL") },
+        }
+        match prev_path {
+            Some(value) => unsafe { std::env::set_var("HARNX_LOG_PATH", value) },
+            None => unsafe { std::env::remove_var("HARNX_LOG_PATH") },
+        }
+        match prev_other {
+            Some(value) => unsafe { std::env::set_var("OTHER_VAR", value) },
+            None => unsafe { std::env::remove_var("OTHER_VAR") },
+        }
+
+        assert_eq!(result.0, "debug");
+        assert_eq!(result.1, "/tmp/inherited.log");
     }
 }

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -552,6 +552,25 @@ impl Config {
         Ok((log_level, Self::resolve_log_path(is_serve)))
     }
 
+    pub fn forwarded_log_env() -> HashMap<String, String> {
+        let mut env_map = HashMap::new();
+        if let Ok(level) = env::var(get_env_name("log_level")) {
+            if !level.is_empty() {
+                env_map.insert(get_env_name("log_level"), level);
+            }
+        }
+        if let Ok(path) = env::var(get_env_name("log_path")) {
+            if !path.is_empty() {
+                let absolute = Self::absolutize_log_path_template(&path);
+                env_map.insert(
+                    get_env_name("log_path"),
+                    absolute.to_string_lossy().into_owned(),
+                );
+            }
+        }
+        env_map
+    }
+
     /// Default log level when `log_level` is unset: `Debug` in debug builds,
     /// otherwise `Info` for serve mode and `Off` for interactive use.
     fn default_log_level(is_serve: bool) -> LevelFilter {
@@ -566,19 +585,39 @@ impl Config {
 
     /// Resolve the log file path: an explicit `log_path` env value wins;
     /// otherwise default to the state-dir log file (or none in serve mode).
+    /// Supports a `{pid}` token, expanded when the current process opens the log.
     fn resolve_log_path(is_serve: bool) -> Option<PathBuf> {
         if let Ok(v) = env::var(get_env_name("log_path")) {
             if !v.is_empty() {
-                return Some(PathBuf::from(v));
+                return Some(Self::expand_log_path_pid(
+                    Self::absolutize_log_path_template(&v),
+                ));
             }
         }
         if is_serve {
             return None;
         }
-        Some(paths::state_path(&format!(
+        Some(Self::expand_log_path_pid(paths::state_path(&format!(
             "{}.log",
             env!("CARGO_CRATE_NAME")
-        )))
+        ))))
+    }
+
+    pub fn absolutize_log_path_template(path: &str) -> PathBuf {
+        let path = PathBuf::from(path);
+        if path.is_absolute() {
+            path
+        } else {
+            env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(path)
+        }
+    }
+
+    pub fn expand_log_path_pid(path: PathBuf) -> PathBuf {
+        let pid = std::process::id().to_string();
+        let rendered = path.to_string_lossy().replace("{pid}", &pid);
+        PathBuf::from(rendered)
     }
 
     pub fn edit_config(&mut self) -> Result<()> {

--- a/crates/harnx-runtime/src/config/servers_split.rs
+++ b/crates/harnx-runtime/src/config/servers_split.rs
@@ -1,6 +1,8 @@
 //! MCP/ACP server management extracted from config/mod.rs for code health.
 use super::*;
+use harnx_acp::AcpServerConfig;
 use harnx_core::package_namespace::qualify_agent_name;
+use harnx_mcp::McpServerConfig;
 use std::env;
 
 fn normalize_package_acp_server_args(server: &mut AcpServerConfig, pkg_name: &str) {
@@ -11,6 +13,90 @@ fn normalize_package_acp_server_args(server: &mut AcpServerConfig, pkg_name: &st
             *arg = qualified.clone();
         }
     }
+}
+
+fn effective_mcp_servers(
+    mcp_servers: &[McpServerConfig],
+    mcp_root: &[String],
+    agent_package: Option<&str>,
+) -> Vec<McpServerConfig> {
+    let mut effective_servers: Vec<McpServerConfig> = mcp_servers
+        .iter()
+        .filter_map(|server| {
+            if !server.enabled {
+                return None;
+            }
+            let mut server = server.clone();
+            server.name = mcp_server_display_name(&server, agent_package);
+            Some(server)
+        })
+        .collect();
+
+    let mut extra_roots = mcp_root.to_vec();
+    if let Ok(cwd) = env::current_dir() {
+        #[cfg(unix)]
+        if path_is_home_or_ancestor(&cwd) {
+            warn!(
+                "sandbox: skipping CWD {:?} as MCP root — equals or is ancestor of $HOME",
+                cwd.display()
+            );
+        } else if let Ok(cwd_str) = cwd.into_os_string().into_string() {
+            if !extra_roots.contains(&cwd_str) {
+                extra_roots.insert(0, cwd_str);
+            }
+        }
+        #[cfg(not(unix))]
+        if let Ok(cwd_str) = cwd.into_os_string().into_string() {
+            if !extra_roots.contains(&cwd_str) {
+                extra_roots.insert(0, cwd_str);
+            }
+        }
+    }
+    if !extra_roots.is_empty() {
+        for server in &mut effective_servers {
+            for root in extra_roots.iter().rev() {
+                #[cfg(unix)]
+                if path_is_home_or_ancestor(Path::new(root)) {
+                    warn!(
+                        "sandbox: skipping root {:?} from mcp_roots — equals or is ancestor of $HOME",
+                        root
+                    );
+                    continue;
+                }
+                if !server.roots.contains(root) {
+                    server.roots.insert(0, root.clone());
+                }
+            }
+        }
+    }
+
+    // Sort by name so this matches the ordering of `McpManager::configs()`,
+    // which the manager-reuse check in `reinit_managers_for_agent` compares
+    // against. Without this, servers defined out of alphabetical order in YAML
+    // would compare unequal and defeat the #988 no-churn preservation.
+    effective_servers.sort_by(|left, right| left.name.cmp(&right.name));
+
+    effective_servers
+}
+
+fn effective_acp_servers(
+    acp_servers: &[AcpServerConfig],
+    agent_package: Option<&str>,
+) -> Vec<AcpServerConfig> {
+    let mut effective_servers: Vec<AcpServerConfig> = acp_servers
+        .iter()
+        .map(|server| {
+            let mut server = server.clone();
+            server.name = acp_server_display_name(&server, agent_package);
+            server
+        })
+        .collect();
+
+    // Sort by name to match `AcpManager::configs()` ordering (see the MCP note
+    // above) so the manager-reuse comparison is order-insensitive.
+    effective_servers.sort_by(|left, right| left.name.cmp(&right.name));
+
+    effective_servers
 }
 
 impl Config {
@@ -120,83 +206,39 @@ impl Config {
     /// keep their prefixed name (e.g. `otherpkg__db`), and top-level servers
     /// are always registered under their original name.
     ///
-    /// When switching agents this replaces the old managers entirely, killing
-    /// any running MCP server subprocesses, giving a clean slate.
+    /// Re-activating same agent/scope should preserve existing managers so MCP
+    /// and ACP subprocesses stay alive across prompts. Only rebuild when the
+    /// effective scoped server config changes.
     pub(crate) fn reinit_managers_for_agent(&mut self, agent_package: Option<&str>) {
-        // ── MCP ──────────────────────────────────────────────────────────────
-        self.mcp_manager = if self.mcp_servers.is_empty() {
+        let mcp_servers = effective_mcp_servers(&self.mcp_servers, &self.mcp_root, agent_package);
+        self.mcp_manager = if mcp_servers.is_empty() {
             None
+        } else if let Some(existing) = self.mcp_manager.as_ref() {
+            if existing.configs() == mcp_servers {
+                Some(existing.clone())
+            } else {
+                let manager = McpManager::new();
+                manager.initialize(mcp_servers);
+                Some(Arc::new(manager))
+            }
         } else {
-            let mut mcp_servers: Vec<McpServerConfig> = self
-                .mcp_servers
-                .iter()
-                .filter_map(|s| {
-                    if !s.enabled {
-                        return None;
-                    }
-                    let mut s = s.clone();
-                    s.name = mcp_server_display_name(&s, agent_package);
-                    Some(s)
-                })
-                .collect();
-
-            // Prepend cwd to roots for every server
-            let mut extra_roots = self.mcp_root.clone();
-            if let Ok(cwd) = env::current_dir() {
-                #[cfg(unix)]
-                if path_is_home_or_ancestor(&cwd) {
-                    warn!(
-                        "sandbox: skipping CWD {:?} as MCP root — equals or is ancestor of $HOME",
-                        cwd.display()
-                    );
-                } else if let Ok(cwd_str) = cwd.into_os_string().into_string() {
-                    if !extra_roots.contains(&cwd_str) {
-                        extra_roots.insert(0, cwd_str);
-                    }
-                }
-                #[cfg(not(unix))]
-                if let Ok(cwd_str) = cwd.into_os_string().into_string() {
-                    if !extra_roots.contains(&cwd_str) {
-                        extra_roots.insert(0, cwd_str);
-                    }
-                }
-            }
-            if !extra_roots.is_empty() {
-                for server in mcp_servers.iter_mut() {
-                    for root in extra_roots.iter().rev() {
-                        #[cfg(unix)]
-                        if path_is_home_or_ancestor(Path::new(root)) {
-                            warn!(
-                                "sandbox: skipping root {:?} from mcp_roots — equals or is ancestor of $HOME",
-                                root
-                            );
-                            continue;
-                        }
-                        if !server.roots.contains(root) {
-                            server.roots.insert(0, root.clone());
-                        }
-                    }
-                }
-            }
-
             let manager = McpManager::new();
             manager.initialize(mcp_servers);
             Some(Arc::new(manager))
         };
 
-        // ── ACP ──────────────────────────────────────────────────────────────
-        self.acp_manager = if self.acp_servers.is_empty() {
+        let acp_servers = effective_acp_servers(&self.acp_servers, agent_package);
+        self.acp_manager = if acp_servers.is_empty() {
             None
+        } else if let Some(existing) = self.acp_manager.as_ref() {
+            if existing.configs() == acp_servers {
+                Some(existing.clone())
+            } else {
+                let manager = AcpManager::new();
+                manager.initialize(acp_servers);
+                Some(Arc::new(manager))
+            }
         } else {
-            let acp_servers: Vec<AcpServerConfig> = self
-                .acp_servers
-                .iter()
-                .map(|s| {
-                    let mut s = s.clone();
-                    s.name = acp_server_display_name(&s, agent_package);
-                    s
-                })
-                .collect();
             let manager = AcpManager::new();
             manager.initialize(acp_servers);
             Some(Arc::new(manager))

--- a/crates/harnx-runtime/src/config/tests.rs
+++ b/crates/harnx-runtime/src/config/tests.rs
@@ -150,6 +150,197 @@ fn test_init_mcp_manager_with_roots() {
     assert_eq!(roots[2], "/existing");
 }
 
+#[test]
+fn reinit_managers_preserves_manager_arcs_when_effective_scope_is_unchanged() {
+    #[cfg(unix)]
+    let _env_guard = env_lock();
+
+    let mut config = Config {
+        mcp_servers: vec![McpServerConfig {
+            name: "fs".to_string(),
+            command: "fs-server".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            roots: vec!["/workspace".to_string()],
+            enabled: true,
+            description: None,
+            rename_tools: HashMap::new(),
+            tool_templates: HashMap::new(),
+            hooks: None,
+            package: None,
+        }],
+        acp_servers: vec![AcpServerConfig {
+            name: "atlas".to_string(),
+            command: "atlas-server".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            enabled: true,
+            description: Some("Atlas".to_string()),
+            idle_timeout_secs: 600,
+            operation_timeout_secs: 3600,
+            package: None,
+        }],
+        ..Default::default()
+    };
+
+    config.reinit_managers_for_agent(None);
+    let first_mcp = config.mcp_manager.as_ref().expect("mcp_manager").clone();
+    let first_mcp_client = first_mcp.get_client("fs").expect("fs client");
+    let first_acp = config.acp_manager.as_ref().expect("acp_manager").clone();
+    let first_acp_client = first_acp.get_client("atlas").expect("atlas client");
+
+    config.reinit_managers_for_agent(None);
+
+    let second_mcp = config.mcp_manager.as_ref().expect("mcp_manager");
+    let second_mcp_client = second_mcp.get_client("fs").expect("fs client");
+    let second_acp = config.acp_manager.as_ref().expect("acp_manager");
+    let second_acp_client = second_acp.get_client("atlas").expect("atlas client");
+
+    assert!(Arc::ptr_eq(&first_mcp, second_mcp));
+    assert!(Arc::ptr_eq(&first_mcp_client, &second_mcp_client));
+    assert!(Arc::ptr_eq(&first_acp, second_acp));
+    assert!(Arc::ptr_eq(&first_acp_client, &second_acp_client));
+}
+
+#[test]
+fn reinit_managers_rebuilds_when_effective_scope_changes() {
+    #[cfg(unix)]
+    let _env_guard = env_lock();
+
+    let mut config = Config {
+        mcp_servers: vec![McpServerConfig {
+            name: "fs".to_string(),
+            command: "fs-server".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            roots: vec!["/workspace".to_string()],
+            enabled: true,
+            description: None,
+            rename_tools: HashMap::new(),
+            tool_templates: HashMap::new(),
+            hooks: None,
+            package: Some("pantheon".to_string()),
+        }],
+        acp_servers: vec![AcpServerConfig {
+            name: "atlas".to_string(),
+            command: "atlas-server".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            enabled: true,
+            description: Some("Atlas".to_string()),
+            idle_timeout_secs: 600,
+            operation_timeout_secs: 3600,
+            package: Some("pantheon".to_string()),
+        }],
+        ..Default::default()
+    };
+
+    config.reinit_managers_for_agent(None);
+    let first_mcp = config.mcp_manager.as_ref().expect("mcp_manager").clone();
+    let first_acp = config.acp_manager.as_ref().expect("acp_manager").clone();
+    assert!(first_mcp.get_client("pantheon__fs").is_some());
+    assert!(first_acp.get_client("pantheon__atlas").is_some());
+
+    config.reinit_managers_for_agent(Some("pantheon"));
+
+    let second_mcp = config.mcp_manager.as_ref().expect("mcp_manager");
+    let second_acp = config.acp_manager.as_ref().expect("acp_manager");
+    assert!(!Arc::ptr_eq(&first_mcp, second_mcp));
+    assert!(!Arc::ptr_eq(&first_acp, second_acp));
+    assert!(second_mcp.get_client("fs").is_some());
+    assert!(second_acp.get_client("atlas").is_some());
+}
+
+/// Regression for #988 review (blocker F1): a change to a server's `hooks`
+/// alone must rebuild the MCP manager. `McpServerConfig`'s `PartialEq` used to
+/// omit `hooks`, so a hooks-only edit was silently ignored and the old hook
+/// policy kept running. `hooks` is now part of equality, so the effective
+/// config differs and the manager is rebuilt.
+#[test]
+fn reinit_managers_rebuilds_when_only_hooks_change() {
+    #[cfg(unix)]
+    let _env_guard = env_lock();
+
+    let mut config = Config {
+        mcp_servers: vec![McpServerConfig {
+            name: "fs".to_string(),
+            command: "fs-server".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            roots: vec!["/workspace".to_string()],
+            enabled: true,
+            description: None,
+            rename_tools: HashMap::new(),
+            tool_templates: HashMap::new(),
+            hooks: None,
+            package: None,
+        }],
+        ..Default::default()
+    };
+
+    config.reinit_managers_for_agent(None);
+    let first_mcp = config.mcp_manager.as_ref().expect("mcp_manager").clone();
+
+    // Change ONLY the hooks config, nothing else.
+    config.mcp_servers[0].hooks = Some(HooksConfig {
+        max_resume: Some(3),
+        entries: vec![],
+    });
+
+    config.reinit_managers_for_agent(None);
+    let second_mcp = config.mcp_manager.as_ref().expect("mcp_manager");
+
+    assert!(
+        !Arc::ptr_eq(&first_mcp, second_mcp),
+        "hooks-only change must rebuild the MCP manager"
+    );
+}
+
+/// Regression for #988 review (blocker F2): re-selecting the same agent with
+/// the server list defined in a *different order* must still preserve the
+/// existing manager. `effective_mcp_servers`/`effective_acp_servers` now sort
+/// by name to match `configs()`, so definition order does not cause spurious
+/// rebuilds (which would defeat the no-churn goal).
+#[test]
+fn reinit_managers_preserves_when_server_definition_order_differs() {
+    #[cfg(unix)]
+    let _env_guard = env_lock();
+
+    let mk = |name: &str| McpServerConfig {
+        name: name.to_string(),
+        command: format!("{name}-server"),
+        args: vec![],
+        env: HashMap::new(),
+        roots: vec!["/workspace".to_string()],
+        enabled: true,
+        description: None,
+        rename_tools: HashMap::new(),
+        tool_templates: HashMap::new(),
+        hooks: None,
+        package: None,
+    };
+
+    // Defined out of alphabetical order: "zeta" before "alpha".
+    let mut config = Config {
+        mcp_servers: vec![mk("zeta"), mk("alpha")],
+        ..Default::default()
+    };
+
+    config.reinit_managers_for_agent(None);
+    let first_mcp = config.mcp_manager.as_ref().expect("mcp_manager").clone();
+
+    // Same servers, reversed definition order.
+    config.mcp_servers = vec![mk("alpha"), mk("zeta")];
+
+    config.reinit_managers_for_agent(None);
+    let second_mcp = config.mcp_manager.as_ref().expect("mcp_manager");
+
+    assert!(
+        Arc::ptr_eq(&first_mcp, second_mcp),
+        "reordering server definitions must not rebuild the manager"
+    );
+}
+
 // ── handoff session emptying tests ─────────────────────────────────────
 
 /// Verify that empty_session clears messages from a session that was loaded

--- a/crates/harnx-runtime/src/config/tests_extra.rs
+++ b/crates/harnx-runtime/src/config/tests_extra.rs
@@ -121,6 +121,29 @@ fn expand_use_tools_wildcard_returns_all_tools() {
     assert!(expanded.contains(&crate::session_history::TOOL_NAME.to_string()));
 }
 
+#[test]
+fn log_path_template_is_absolutized_and_pid_expanded() {
+    let _lock = crate::config::test_support::env_lock();
+    let prev_cwd = std::env::current_dir().unwrap();
+    let prev_path = std::env::var_os("HARNX_LOG_PATH");
+    let temp = tempfile::TempDir::new().unwrap();
+    std::env::set_current_dir(temp.path()).unwrap();
+    unsafe { std::env::set_var("HARNX_LOG_PATH", "logs/harnx-{pid}.log") };
+
+    let (_, log_path) = Config::log_config(false).unwrap();
+
+    std::env::set_current_dir(prev_cwd).unwrap();
+    match prev_path {
+        Some(value) => unsafe { std::env::set_var("HARNX_LOG_PATH", value) },
+        None => unsafe { std::env::remove_var("HARNX_LOG_PATH") },
+    }
+
+    let log_path = log_path.expect("log path");
+    let rendered = log_path.to_string_lossy().into_owned();
+    assert!(rendered.starts_with(temp.path().join("logs").to_string_lossy().as_ref()));
+    assert!(rendered.ends_with(&format!("harnx-{}.log", std::process::id())));
+}
+
 /// Empty selectors list should return empty (no tools).
 #[test]
 fn expand_use_tools_empty_list_returns_empty() {

--- a/docs/solutions/integration-issues/mcp-subprocess-lifecycle-churn-2026-07-08.md
+++ b/docs/solutions/integration-issues/mcp-subprocess-lifecycle-churn-2026-07-08.md
@@ -1,0 +1,260 @@
+---
+title: "MCP subprocess lifecycle churn under ACP prompt loop"
+date: 2026-07-08
+category: integration-issues
+problem_type: logic_error
+component: harnx-runtime
+root_cause: "Unconditional manager rebuild on every agent activation + rmcp child ownership prevents exit status capture"
+resolution_type: code_fix
+severity: high
+tags:
+  - mcp
+  - subprocess
+  - rmcp
+  - lifecycle
+  - acp
+  - process-wrap
+  - manager-reinit
+plan_ref: mcp-restarts-fixups
+---
+
+## Problem
+
+MCP servers (bash/fs/time/plans) constantly restarted on every ACP prompt, dropping all `Arc<McpClient>` references, closing child stdin, and killing subprocesses. Additionally, MCP subprocess exit status (clean/error/signal) was invisible to the runtime, and ACP subagents failed to capture logs.
+
+GitHub issues: #988, #989, #990.
+
+## Symptoms
+
+- MCP servers restart on each prompt under ACP
+- `read_exec_log` fails with "cannot resolve execution_id" — new harnx-mcp-bash spawns with fresh temp log dir each turn
+- MCP subprocess exit code/signal unavailable — cannot distinguish clean exit from SIGKILL/OOM
+- ACP subagent logs not captured to expected path
+
+## Investigation Steps
+
+1. Traced `Config::reinit_managers_for_agent` — found it calls `McpManager::initialize` which does `clients.clear()`, dropping all `Arc<McpClient>` refs
+2. ACP server (harnx-acp-server) activates its agent on *every* prompt → each turn rebuilt managers
+3. `run_tool_discovery_blocking` called `invalidate_all_services()` after discovery — fine for multithread TUI, but ACP runs on `new_current_thread()` runtime
+4. rmcp 1.7.0: `TokioChildProcess::spawn()` consumes child into transport; `serve_client()` consumes transport — child handle irretrievable for `wait()`
+5. Large file `client.rs` churned under agent edits — two agents reverted partially, silently wiping unrelated changes
+
+## Root Cause
+
+**Primary churn source (#988):** `reinit_managers_for_agent` unconditionally rebuilt `McpManager`/`AcpManager` from scratch. Each activation dropped all `Arc<McpClient>` refs, closing stdin and killing subprocesses.
+
+Two order/comparison gotchas:
+- `configs()` returns name-sorted — effective-server list must ALSO sort by name, else non-alphabetical YAML order causes spurious rebuilds
+- Manual `PartialEq` impl on `McpServerConfig` omitted `hooks` — hooks-only edit silently kept stale hook policy running
+
+**Secondary churn source (#988):** `run_tool_discovery_blocking`'s `invalidate_all_services()` dropped just-connected services on single-threaded ACP runtime.
+
+**Exit status capture (#990):** rmcp's `serve_client(handler, transport)` consumes the transport which owns the child — no way to `wait()` afterward.
+
+**Log capture (#989):** `HARNX_LOG_LEVEL`/`HARNX_LOG_PATH` not explicitly forwarded into child spawn env.
+
+## Solution
+
+### 1. Preserve manager when unchanged
+
+Compute *effective* scoped server set and PRESERVE existing manager `Arc` when unchanged:
+
+```rust
+// crates/harnx-runtime/src/config/servers_split.rs
+
+pub fn reinit_managers_for_agent(&self, package_filter: Option<&str>) {
+    let effective_mcp = self.effective_mcp_servers(package_filter);
+    let effective_acp = self.effective_acp_servers(package_filter);
+    
+    // ORDER-INSENSITIVE comparison: both lists sorted by name
+    let mcp_unchanged = self.mcp_manager.read().unwrap().configs() == effective_mcp;
+    let acp_unchanged = self.acp_manager.read().unwrap().configs() == effective_acp;
+    
+    if mcp_unchanged && acp_unchanged {
+        return; // No rebuild needed
+    }
+    
+    // Rebuild only if truly changed
+    if !mcp_unchanged {
+        self.mcp_manager.write().unwrap().initialize(effective_mcp);
+    }
+    if !acp_unchanged {
+        self.acp_manager.write().unwrap().initialize(effective_acp);
+    }
+}
+
+impl McpManager {
+    fn configs(&self) -> Vec<McpServerConfig> {
+        self.clients.keys().cloned().collect() // sorted by name
+    }
+}
+```
+
+**Key fix:** `effective_mcp_servers`/`effective_acp_servers` must `sort_by(|a, b| a.name.cmp(&b.name))` to match `configs()` order.
+
+**Key fix:** Derive `PartialEq` instead of hand-written:
+
+```rust
+// Before (broken): manual impl omitted hooks
+impl PartialEq for McpServerConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.command == other.command
+        // hooks omitted!
+    }
+}
+
+// After: include all fields automatically
+#[derive(PartialEq)]
+pub struct McpServerConfig {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub hooks: HooksConfig, // now included
+    // ... future fields auto-included
+}
+```
+
+### 2. Gate service invalidation for single-threaded runtime
+
+```rust
+// crates/harnx-mcp/src/client.rs
+
+fn should_invalidate_after_discovery() -> bool {
+    std::env::var("HARNX_MCP_KEEP_SERVICES_AFTER_DISCOVERY")
+        .ok()
+        .map(|v| v != "1")
+        .unwrap_or(true)
+}
+
+pub fn run_tool_discovery_blocking(/* ... */) {
+    // ... discovery ...
+    if should_invalidate_after_discovery() {
+        self.invalidate_all_services();
+    }
+}
+```
+
+harnx-acp-server sets `HARNX_MCP_KEEP_SERVICES_AFTER_DISCOVERY=1` at startup (internal, not user-facing).
+
+### 3. Capture rmcp child exit status (key pattern)
+
+Spawn child yourself, take stdio, build transport directly:
+
+```rust
+// crates/harnx-mcp/src/client.rs
+
+use process_wrap::ProcessGroup;
+use rmcp::transport::async_rw::AsyncRwTransport;
+
+impl McpClient {
+    async fn connect(&mut self, config: &McpServerConfig) -> Result<()> {
+        // Abort prior wait task on reconnect
+        if let Some(task) = self.child_wait_task.take() {
+            task.abort();
+        }
+        
+        // Spawn child ourselves with process group leader
+        let mut child = ProcessGroup::leader()
+            .command(&config.command)
+            .args(&config.args)
+            .spawn()?;
+        
+        // Take stdio (process-wrap 9.1.0 uses METHODS)
+        let stdin = child.stdin().take().ok_or("no stdin")?;
+        let stdout = child.stdout().take().ok_or("no stdout")?;
+        let stderr = child.stderr().take().ok_or("no stderr")?;
+        
+        // Build transport directly (requires rmcp feature: transport-async-rw)
+        let transport = AsyncRwTransport::<RoleClient, _, _>::new(stdout, stdin);
+        
+        // Keep child wrapper for exit capture
+        let child_wrapper: Box<dyn ChildWrapper> = child;
+        let last_notice = self.last_notice.clone();
+        self.child_wait_task = Some(tokio::spawn(async move {
+            let status = child_wrapper.wait().await;
+            // Map to notice: 0/SIGTERM => Warning, else => Error
+            let notice = match status {
+                Ok(s) if s.success() => Notice::warning("MCP server exited cleanly"),
+                Ok(s) if s.code() == Some(0) => Notice::warning("MCP server exited"),
+                Ok(s) => Notice::error(format!("MCP server exit: {:?}", s)),
+                Err(e) => Notice::error(format!("MCP server wait error: {}", e)),
+            };
+            emit_notice_dedup(&last_notice, notice);
+        }));
+        
+        // serve_client consumes transport
+        let handler = McpClientHandler::new(self.clone());
+        serve_client(handler, transport).await?;
+        
+        Ok(())
+    }
+}
+```
+
+**Key insight:** No double-close — stdio ownership moved to transport, child owns only the process.
+
+### 4. Forward log env explicitly
+
+```rust
+// crates/harnx-runtime/src/config/servers_split.rs
+
+fn build_child_env(&self) -> Vec<(String, String)> {
+    let mut env = Vec::new();
+    
+    // Forward log config explicitly
+    if let Ok(level) = std::env::var("HARNX_LOG_LEVEL") {
+        env.push(("HARNX_LOG_LEVEL".into(), level));
+    }
+    if let Ok(path) = std::env::var("HARNX_LOG_PATH") {
+        // Absolutize and preserve {pid} template for children
+        let abs_path = dunce::canonicalize(&path).unwrap_or_else(|_| path.into());
+        env.push(("HARNX_LOG_PATH".into(), abs_path.to_string_lossy().into()));
+    }
+    
+    env
+}
+```
+
+Emit notices via `harnx_core::sink::emit_agent_event(AgentEvent::Notice(...))` — propagates through ACP nesting.
+
+## Why This Works
+
+1. **Preserve-manager pattern:** Only rebuild on *actual* config change, not every activation. Sorted comparison prevents spurious rebuilds from YAML reordering.
+
+2. **Derived PartialEq:** Automatically includes all fields — future additions won't silently break equality.
+
+3. **Self-spawned child:** Owns the waitable handle before transport consumes stdio. `JoinHandle` stored/aborted on reconnect prevents lingering tasks.
+
+4. **Explicit env forwarding:** Don't rely on inheritance — absolutize paths, preserve `{pid}` template for per-process expansion.
+
+5. **Notice propagation:** Global/task-local `harnx_core::sink` reachable from any crate; ACP subagent notices bubble up automatically.
+
+## Prevention Strategies
+
+**Code Review Checklist:**
+- [ ] Manager rebuild: compute effective set, compare order-insensitively (sorted), preserve when unchanged
+- [ ] `#[derive(PartialEq)]` over hand-written impls to avoid field omission
+- [ ] Process spawn: own child before transport takes stdio; abort prior wait-task on reconnect
+- [ ] Env forwarding: explicit, absolutized paths, template tokens preserved
+
+**Best Practices:**
+- Verify `cargo build` after agent hands back large-file edit
+- Establish pre-existing failure baseline: stash changes, run tests on base branch
+- Gate runtime-specific behavior via internal env flags (document safety rationale)
+- Store `JoinHandle` for background tasks; abort on reconnect to prevent leaks
+
+**Test Cases:**
+- Manager preserves when server definition order differs (alphabetical vs YAML)
+- Manager rebuilds when only hooks change (regression test for omitted-field bug)
+- MCP subprocess exit captured as Warning/Error based on exit code
+- MCP notices propagate through ACP nesting
+
+**Process meta-lesson:**
+Large files (`client.rs`) churn badly under agent edits. Verify `cargo build` after each agent handoff. Establish pre-existing-failure baseline before trusting "these failures are pre-existing."
+
+## Related Issues
+
+- **GitHub:** [#988](https://github.com/dobesv/harnx/issues/988) — MCP servers constantly restarting under ACP
+- **GitHub:** [#989](https://github.com/dobesv/harnx/issues/989) — ACP subagent log capture
+- **GitHub:** [#990](https://github.com/dobesv/harnx/issues/990) — MCP subprocess exit status
+- **Related Solution:** [async-patterns/mcp-server-background-task-supervision-2026-05-25.md](../async-patterns/mcp-server-background-task-supervision-2026-05-25.md) — rmcp RunningService supervision patterns


### PR DESCRIPTION
Prevents MCP server managers from being torn down and respawned on every ACP agent activation by preserving manager Arcs when the configuration scope remains unchanged. Fixes log capture in subagent subprocesses by explicitly forwarding HARNX_LOG_LEVEL and HARNX_LOG_PATH. Surfaces MCP server restarts and deaths to the user as AgentEvent::Notice events with exit status and stderr details.

Fixes #988 (MCP servers constantly restarting under ACP — preserve managers across agent re-activation instead of tearing down every prompt) Fixes #989 (ACP subagent logs not captured — explicitly forward HARNX_LOG_LEVEL/HARNX_LOG_PATH into child subprocesses) Fixes #990 (surface MCP server restarts/deaths as user-visible AgentEvent::Notice with real exit status)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP/ACP servers now keep running more reliably between prompts, reducing unnecessary restarts.
  * Log settings can be inherited by child processes, with support for `{pid}` in log paths.
  * MCP transport failures and subprocess exit/restart events now appear as visible notices in the UI.

* **Bug Fixes**
  * Fixed log forwarding so child servers receive the expected logging configuration.
  * Improved reconnect behavior and notice handling to reduce duplicate or missing status messages.

* **Documentation**
  * Added a guide describing MCP subprocess lifecycle churn and the resulting improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->