### PR TITLE
fix(acp): per-session MCP manager lifecycle, log-filter capture, restart notices

### DIFF
--- a/.changeset/acp-session-context-988.md
+++ b/.changeset/acp-session-context-988.md
@@ -1,0 +1,17 @@
+---
+harnx: minor
+---
+
+Fix #988: ACP server now creates per-session context once instead of forking config per-prompt, preventing MCP subprocess respawn on every turn.
+
+**Problem:** The ACP server re-derived config per prompt via `fork_prompt_config` → `use_agent_by_name` → `reinit_managers_for_agent`, which unconditionally rebuilt McpManager. This killed and respawned all MCP subprocesses (bash, fs, time, plans) on every prompt, breaking `read_exec_log` and degrading performance.
+
+**Solution:** Introduced `SessionContext` that holds a forked `GlobalConfig` (with its own `McpManager`/`AcpManager`) set up once at session creation. The `HarnxAgent.sessions` map now stores `Arc<SessionContext>` instead of bare concurrency primitives.
+
+- `new_session`: Fork config once, call `use_agent_by_name` + `use_session`, store `Arc<SessionContext>`.
+- `prompt`: Look up `Arc<SessionContext>`, reuse its stored config (no per-prompt fork).
+- `cancel`: Works identically via `SessionContext.abort_signal`/`cancel_notify`.
+- Lazy resume: Sessions on disk but absent from memory are rebuilt on-demand via `get_or_build_session`.
+- Idle reaper: Sessions idle > 15 minutes are evicted (reusing `session_actor.rs` pattern), reaping only when not holding the `prompt_lock`.
+
+This mirrors the NATS worker's correct per-session config pattern from `daemon.rs::execute_session`.

--- a/.changeset/feat-mcp-restart-notices.md
+++ b/.changeset/feat-mcp-restart-notices.md
@@ -1,0 +1,5 @@
+---
+harnx: minor
+---
+
+Surface MCP server transport failures and subprocess churn as user-visible notices, including reconnect warnings and child stderr/closure signals, so ACP/TUI users can see MCP restarts and deaths without digging through logs. Fixes #990.

--- a/.changeset/fix-log-filter-server-mode-989.md
+++ b/.changeset/fix-log-filter-server-mode-989.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Fix server-mode log filter default (`harnx::serve` → `harnx`) so logs from `harnx_*` crates are captured. Correct `.env` precedence to standard dotenv semantics: the ambient/inherited environment always wins and the `.env` file only fills in variables that are not already set (previously `.env` unconditionally overrode inherited variables, silently clobbering operator-set values like `HARNX_LOG_LEVEL`). Fixes #989.

--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -17,11 +17,16 @@ mod test_regression_issue_68;
 
 use agent_client_protocol as acp;
 use agent_client_protocol::schema::*;
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
-use harnx_core::event::{AgentEvent, AgentSource, ModelEvent, ToolEvent, UserEvent};
+use harnx_core::event::{AgentEvent, AgentSource, ModelEvent, NoticeEvent, ToolEvent, UserEvent};
 use harnx_runtime::config::GlobalConfig;
 use harnx_runtime::utils::{AbortSignal, AbortSignalInner};
+
+/// Idle session reaper TTL: evict SessionContexts idle > 15 minutes.
+const SESSION_IDLE_TTL: Duration = Duration::from_secs(15 * 60);
 
 /// Update payloads forwarded from the per-prompt `AcpChunkSink` to the
 /// local `fwd_task`. Each variant carries the original `AgentSource` so
@@ -29,6 +34,7 @@ use harnx_runtime::utils::{AbortSignal, AbortSignalInner};
 /// which agent (parent vs. some sub-agent) actually produced the event;
 /// the parent's `AcpNotificationClient::resolve_notification_source`
 /// reads that meta to render the right `> agent ▸ session` heading.
+#[derive(Debug)]
 enum AcpForward {
     /// Text chunk for `SessionUpdate::AgentMessageChunk`.
     Text(String, Option<AgentSource>),
@@ -88,7 +94,10 @@ impl harnx_core::event::AgentEventSink for AcpChunkSink {
 /// Map an `AgentEvent` to the `AcpForward` it should produce, or `None`
 /// when the event carries no forwardable payload (e.g. empty text). Kept
 /// as a free function so `AcpChunkSink::emit` stays a trivial dispatch.
-fn event_to_forward(event: AgentEvent, source: Option<AgentSource>) -> Option<AcpForward> {
+pub(crate) fn event_to_forward(
+    event: AgentEvent,
+    source: Option<AgentSource>,
+) -> Option<AcpForward> {
     match event {
         AgentEvent::Model(ModelEvent::MessageChunk { blocks }) => {
             let text: String = blocks
@@ -144,50 +153,124 @@ fn event_to_forward(event: AgentEvent, source: Option<AgentSource>) -> Option<Ac
             markdown,
             source,
         }),
+        // Only surface Warning/Error notices to ACP clients — these carry the
+        // #990 MCP server restart/death signals. Info notices are a
+        // presentation-layer artifact (nested sub-agent activity headings
+        // routed through NestedAcpEvent::Text → NoticeEvent::Info) and must
+        // NOT leak into the ACP message stream, or they corrupt the transcript
+        // (regression guarded by tmux_e2e::nested_sub_agent_activity_no_duplicates).
+        AgentEvent::Notice(notice) => {
+            let forwarded = match notice {
+                NoticeEvent::Info(_) => None,
+                NoticeEvent::Warning(m) => (!m.is_empty()).then_some(("⚠", m)),
+                NoticeEvent::Error(m) => (!m.is_empty()).then_some(("🔴", m)),
+            };
+            forwarded.map(|(prefix, msg)| AcpForward::Text(format!("{prefix} {msg}"), source))
+        }
         _ => None,
+    }
+}
+
+/// Per-session context owned by HarnxAgent.
+///
+/// Holds a forked GlobalConfig with its OWN McpManager/AcpManager, set up once
+/// at session creation (or lazy resume). The managers persist for the lifetime
+/// of this SessionContext, so MCP subprocesses stay alive across prompts.
+///
+/// Mirrors the NATS worker's per-session config pattern: fork once, reuse
+/// for every turn in the session.
+pub struct SessionContext {
+    /// Session ID (matches the on-disk session log filename).
+    pub session_id: String,
+    /// Forked config with agent+session bound, owning its own managers.
+    pub config: GlobalConfig,
+    /// Abort signal for cancellation.
+    pub abort_signal: AbortSignal,
+    /// Fires when the session receives an ACP `session/cancel` notification.
+    pub cancel_notify: Arc<tokio::sync::Notify>,
+    /// Serializes prompts targeting this session.
+    pub prompt_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Last activity timestamp for idle reaper.
+    last_activity: parking_lot::Mutex<Instant>,
+}
+
+impl Drop for SessionContext {
+    fn drop(&mut self) {
+        debug!(
+            "SessionContext drop: session_id={} — managers will be torn down",
+            self.session_id
+        );
+        // The Arc<SessionContext> drop triggers Config drop, which drops
+        // McpManager → clients.clear() → drops Arc<McpClient> → stdin closes
+        // → MCP subprocess exits.
+    }
+}
+
+impl SessionContext {
+    fn new(session_id: String, config: GlobalConfig) -> Self {
+        Self {
+            session_id,
+            config,
+            abort_signal: AbortSignalInner::new(),
+            cancel_notify: Arc::new(tokio::sync::Notify::new()),
+            prompt_lock: Arc::new(tokio::sync::Mutex::new(())),
+            last_activity: parking_lot::Mutex::new(Instant::now()),
+        }
+    }
+
+    /// Update the last activity timestamp. Called whenever the session sees
+    /// activity: at prompt start, when a prompt stops (completion OR
+    /// cancellation), and on a `session/cancel` notification.
+    fn touch(&self) {
+        *self.last_activity.lock() = Instant::now();
+    }
+
+    /// Test-only: force last activity far enough into the past that the idle
+    /// TTL is considered elapsed, so reaper decisions can be exercised without
+    /// sleeping for the real TTL.
+    #[cfg(test)]
+    fn mark_idle_for_test(&self) {
+        *self.last_activity.lock() = Instant::now()
+            .checked_sub(SESSION_IDLE_TTL + Duration::from_secs(1))
+            .expect("subtract TTL from now");
+    }
+
+    /// Check if this session is currently running a prompt.
+    fn is_running(&self) -> bool {
+        // If we can NOT acquire the lock, a prompt is running.
+        // try_lock returns Ok(MutexGuard) if successful (no lock held),
+        // Err(TryLockError) if locked (prompt running).
+        self.prompt_lock.try_lock().is_err()
+    }
+
+    /// Check if the idle TTL has elapsed.
+    fn is_idle_expired(&self) -> bool {
+        self.last_activity.lock().elapsed() >= SESSION_IDLE_TTL
+    }
+
+    /// Whether the idle reaper should evict this session: it must be idle past
+    /// the TTL AND have no in-flight prompt. A running prompt (prompt_lock held)
+    /// is never reaped, so its live MCP subprocesses aren't pulled out from
+    /// under it.
+    fn should_reap(&self) -> bool {
+        self.is_idle_expired() && !self.is_running()
     }
 }
 
 pub struct HarnxAgent {
     agent_name: String,
-    config: GlobalConfig,
-    sessions: Arc<tokio::sync::Mutex<HashMap<String, HarnxSession>>>,
+    /// Base config to fork from for each new session.
+    base_config: GlobalConfig,
+    /// Active sessions keyed by session_id.
+    sessions: Arc<tokio::sync::Mutex<HashMap<String, Arc<SessionContext>>>>,
     connection: Arc<tokio::sync::Mutex<Option<acp::ConnectionTo<acp::Client>>>>,
-}
-
-#[derive(Clone)]
-struct HarnxSession {
-    abort_signal: AbortSignal,
-    /// Fires when the session receives an ACP `session/cancel` notification.
-    /// We use `notify_one` (rather than `notify_waiters`) so a cancel that
-    /// arrives in the tiny window between the prompt handler entering and
-    /// its `.notified()` future being polled still fires — the permit is
-    /// held until the next listener observes it.
-    ///
-    /// Known limitation: a cancel that arrives AFTER a prompt returns and
-    /// BEFORE the next prompt starts will be consumed by the next prompt's
-    /// first `.notified()` poll. Drain-at-entry was attempted but racing
-    /// the drain against a concurrent cancel is itself unsound (polling a
-    /// Notified registers a waiter that can absorb a concurrent
-    /// notify_one even after we drop it). In practice cancel notifications
-    /// are only sent while a prompt is active, so this case isn't
-    /// exercised by any test.
-    cancel_notify: Arc<tokio::sync::Notify>,
-    /// Serializes prompts that target THIS session. Prompts to *different*
-    /// sessions still run fully concurrently (each holds its own lock).
-    /// Without this, two concurrent prompts with the same `session_id` would
-    /// each fork their own in-memory `Session`, independently load the same
-    /// on-disk log, and clobber each other's appends (last-writer-wins). The
-    /// lock makes the load → run → persist cycle for one session atomic with
-    /// respect to other prompts on the same session.
-    prompt_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl HarnxAgent {
     pub fn new(agent_name: String, config: GlobalConfig) -> Self {
         Self {
             agent_name,
-            config,
+            base_config: config,
             sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             connection: Arc::new(tokio::sync::Mutex::new(None)),
         }
@@ -197,30 +280,30 @@ impl HarnxAgent {
         *self.connection.lock().await = Some(conn);
     }
 
-    /// Build the local-agent turn input: select the agent + session on the
-    /// forked prompt config, resolve agent variables, and construct the `Input`
-    /// from the user's prompt text. Only used for local agent refs (remote
-    /// thin-client mode drives the turn over NATS instead).
-    fn build_local_input(
-        &self,
-        prompt_config: &GlobalConfig,
-        session_key: &str,
-        prompt_text: &str,
-    ) -> acp::Result<harnx_runtime::config::Input> {
+    /// Build a per-session config: fork base, set agent+session.
+    /// Called once at session creation (new_session) and at lazy resume.
+    fn build_session_config(&self, session_id: &str) -> acp::Result<GlobalConfig> {
+        let config = harnx_session::fork_prompt_config(&self.base_config.read().clone());
         {
-            let mut config = prompt_config.write();
-            config
-                .use_agent_by_name(&self.agent_name)
+            let mut cfg = config.write();
+            cfg.use_agent_by_name(&self.agent_name)
                 .map_err(|e| acp::Error::new(-32603, format!("Failed to set agent: {e}")))?;
-            config
-                .use_session(Some(session_key))
+            cfg.use_session(Some(session_id))
                 .map_err(|e| acp::Error::new(-32603, format!("Failed to use session: {e}")))?;
         }
+        Ok(config)
+    }
 
-        // Build a fresh agent for the input. The forked prompt config keeps
-        // per-request session state isolated while still sharing Arc-backed
-        // runtime resources cloned from the base config.
-        let mut agent = prompt_config
+    /// Build the local-agent turn input from an already-configured session.
+    fn build_local_input_from_config(
+        &self,
+        session_config: &GlobalConfig,
+        _session_key: &str,
+        prompt_text: &str,
+    ) -> acp::Result<harnx_runtime::config::Input> {
+        // Agent and session are already set on session_config.
+        // Build a fresh agent for the input.
+        let mut agent = session_config
             .read()
             .retrieve_agent(&self.agent_name)
             .map_err(|e| acp::Error::new(-32603, format!("Failed to retrieve agent: {e}")))?;
@@ -231,8 +314,8 @@ impl HarnxAgent {
             );
         }
 
-        let mut input = harnx_runtime::config::input::from_str(prompt_config, prompt_text, None);
-        harnx_runtime::config::input::set_agent(&mut input, prompt_config, agent.into_config());
+        let mut input = harnx_runtime::config::input::from_str(session_config, prompt_text, None);
+        harnx_runtime::config::input::set_agent(&mut input, session_config, agent.into_config());
         Ok(input)
     }
 }
@@ -252,39 +335,40 @@ impl HarnxAgent {
     }
 
     async fn new_session(&self, _args: NewSessionRequest) -> acp::Result<NewSessionResponse> {
-        let session_id;
-        {
-            let mut config = self.config.write();
-            if config.session.is_some() {
-                config
-                    .exit_session()
+        // Create a new session id and config (managers set up once here).
+        let session_id = {
+            let mut base = self.base_config.write();
+            if base.session.is_some() {
+                base.exit_session()
                     .map_err(|e| acp::Error::new(-32603, format!("Failed to exit session: {e}")))?;
             }
-            config
-                .use_agent_by_name(&self.agent_name)
+            base.use_agent_by_name(&self.agent_name)
                 .map_err(|e| acp::Error::new(-32603, format!("Failed to set agent: {e}")))?;
-            config
-                .use_session(None)
+            base.use_session(None)
                 .map_err(|e| acp::Error::new(-32603, format!("Failed to create session: {e}")))?;
-            session_id = config
+            let id = base
                 .session
                 .as_ref()
                 .expect("session must exist after use_session(None)")
                 .id
                 .clone();
-            config
-                .exit_session()
+            base.exit_session()
                 .map_err(|e| acp::Error::new(-32603, format!("Failed to persist session: {e}")))?;
-        }
-        let session = HarnxSession {
-            abort_signal: AbortSignalInner::new(),
-            cancel_notify: Arc::new(tokio::sync::Notify::new()),
-            prompt_lock: Arc::new(tokio::sync::Mutex::new(())),
+            id
         };
+
+        // Build the per-session config with its own managers.
+        let session_config = self.build_session_config(&session_id)?;
+        let ctx = Arc::new(SessionContext::new(session_id.clone(), session_config));
+
         self.sessions
             .lock()
             .await
-            .insert(session_id.clone(), session);
+            .insert(session_id.clone(), ctx.clone());
+
+        // Start the idle reaper task (spawns once per session, exits when ctx drops).
+        self.spawn_idle_reaper(ctx);
+
         Ok(NewSessionResponse::new(SessionId::new(session_id)))
     }
 
@@ -292,52 +376,31 @@ impl HarnxAgent {
         let session_key = args.session_id.0.to_string();
         let prompt_text = prompt_blocks_to_text(&args.prompt);
 
-        let (abort_signal, cancel_notify, prompt_lock) = {
-            let sessions = self.sessions.lock().await;
-            let session = sessions
-                .get(session_key.as_str())
-                .ok_or_else(acp::Error::invalid_params)?;
-            (
-                session.abort_signal.clone(),
-                session.cancel_notify.clone(),
-                session.prompt_lock.clone(),
-            )
-        };
+        // Look up or lazily build the SessionContext.
+        let session_ctx = self.get_or_build_session(&session_key).await?;
 
-        // Hold the per-session lock for the whole prompt so two prompts to the
-        // SAME session_id can't fork independent in-memory sessions and clobber
-        // each other's on-disk transcript. The `sessions` map lock above is
-        // already released, so prompts to different sessions never contend
-        // here. Guard is kept alive until the function returns.
-        let _prompt_guard = prompt_lock.lock_owned().await;
+        // Update activity timestamp.
+        session_ctx.touch();
 
-        // Reset the abort signal only AFTER winning the per-session lock. If we
-        // reset before acquiring it, a queued same-session prompt could clear a
-        // cancellation that the still-running prompt holding the lock has not
-        // yet observed, effectively un-cancelling it against user intent.
-        abort_signal.reset();
+        // Hold the per-session lock for the whole prompt.
+        let _prompt_guard = session_ctx.prompt_lock.clone().lock_owned().await;
 
-        // P4.2: remote agents (`agent@cluster`) run in thin-client mode — the
-        // turn is driven over NATS by a worker daemon, not by a local agent
-        // loop. Detect from the configured agent name; local refs are unchanged.
+        // Reset abort signal after acquiring lock.
+        session_ctx.abort_signal.reset();
+
+        // P4.2: remote agents (`agent@cluster`) run in thin-client mode.
         let remote_agent = parse_remote_agent(&self.agent_name);
 
-        let prompt_config: GlobalConfig =
-            harnx_session::fork_prompt_config(&self.config.read().clone());
-        // Local-agent setup (agent resolution + input building) only applies to
-        // local refs. For remote thin-client mode the worker resolves the agent
-        // and the input is the user's prompt text posted to the NATS log.
+        // Use the session's own config (managers already initialized).
+        let prompt_config = session_ctx.config.clone();
+
         let input = if remote_agent.is_none() {
-            Some(self.build_local_input(&prompt_config, &session_key, &prompt_text)?)
+            Some(self.build_local_input_from_config(&prompt_config, &session_key, &prompt_text)?)
         } else {
             None
         };
 
-        // Install a per-prompt AgentEventSink for streaming chunks
-        // (MessageChunk events) and tool calls (ToolEvent::Started).
-        // Nested ACP activity from sub-agent delegations also flows through
-        // this sink because `AcpManager::call_tool` captures and reinstalls
-        // the current task-local sink inside its spawned forwarder task.
+        // Install a per-prompt AgentEventSink for streaming chunks.
         let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel::<AcpForward>();
         let sink: Arc<dyn harnx_core::event::AgentEventSink> =
             Arc::new(AcpChunkSink { tx: chunk_tx });
@@ -345,20 +408,6 @@ impl HarnxAgent {
         // Spawn local task to drain chunk_rx → session_notification.
         let connection_for_fwd = self.connection.lock().await.clone();
         let session_key_for_fwd = session_key.clone();
-        // Helpers: fire a session_notification without blocking the LocalSet
-        // thread. Each notification is spawned as its own local task so
-        // run_agent_loop / execute_tool_round are never starved waiting for
-        // the parent to acknowledge a notification write.
-        // Build the `meta` payload that `AcpNotificationClient::resolve_
-        // notification_source` reads to determine `AgentSource`. Without
-        // these fields the parent infers source from the connection's
-        // agent_name, which (a) loses sub-agent identity when this
-        // server is forwarding a nested chunk and (b) prevents
-        // `render_ui_output_heading` from emitting `> agent ▸ session`.
-        // `agent_from_meta_value` / `session_from_meta_value` in
-        // `harnx-acp::client` read `agent` and `session` keys (no
-        // namespace prefix). Match those exactly so the parent recovers
-        // sub-agent identity.
 
         fn spawn_notify_text(
             conn: &Option<acp::ConnectionTo<acp::Client>>,
@@ -405,9 +454,6 @@ impl HarnxAgent {
                             chunk = chunk.meta(meta);
                         }
                     }
-                    // Use `UserMessageChunk` (not `AgentMessageChunk`) so the
-                    // parent renders this as a user turn and does NOT append it
-                    // to `response_text` (the next agent's input).
                     let notification = SessionNotification::new(
                         SessionId::new(sid),
                         SessionUpdate::UserMessageChunk(chunk),
@@ -523,14 +569,14 @@ impl HarnxAgent {
         fn spawn_notify_forward(
             conn: &Option<acp::ConnectionTo<acp::Client>>,
             session_key: &str,
-            update: AcpForward,
+            forward: AcpForward,
         ) {
-            match update {
+            match forward {
                 AcpForward::Text(text, source) => {
-                    spawn_notify_text(conn, session_key, text, source)
+                    spawn_notify_text(conn, session_key, text, source);
                 }
                 AcpForward::UserText(text, source) => {
-                    spawn_notify_user_text(conn, session_key, text, source)
+                    spawn_notify_user_text(conn, session_key, text, source);
                 }
                 AcpForward::ToolCall {
                     id,
@@ -538,34 +584,38 @@ impl HarnxAgent {
                     input,
                     markdown,
                     source,
-                } => spawn_notify_tool_call(conn, session_key, id, name, input, markdown, source),
+                } => {
+                    spawn_notify_tool_call(conn, session_key, id, name, input, markdown, source);
+                }
                 AcpForward::ToolUpdate {
                     id,
                     markdown,
                     status,
                     source,
-                } => spawn_notify_tool_update(conn, session_key, id, markdown, status, source),
+                } => {
+                    spawn_notify_tool_update(conn, session_key, id, markdown, status, source);
+                }
                 AcpForward::ToolCompleted {
                     id,
                     output,
                     markdown,
                     source,
-                } => spawn_notify_tool_completed(conn, session_key, id, output, markdown, source),
+                } => {
+                    spawn_notify_tool_completed(conn, session_key, id, output, markdown, source);
+                }
             }
         }
 
+        // Forward task: drain chunk_rx → session_notification.
         let fwd_task = tokio::task::spawn_local(async move {
-            while let Some(update) = chunk_rx.recv().await {
-                spawn_notify_forward(&connection_for_fwd, &session_key_for_fwd, update);
+            while let Some(forward) = chunk_rx.recv().await {
+                spawn_notify_forward(&connection_for_fwd, &session_key_for_fwd, forward);
             }
         });
 
-        // We deliberately do NOT register an `on_text_response` here:
-        // streaming `MessageChunk` events already flow through the
-        // `AcpChunkSink` / `chunk_rx` / `fwd_task` chain, which
-        // session_notification each chunk to the parent. Adding an
-        // `on_text_response` would re-emit the same final text and the
-        // parent's transcript would render the assistant's reply twice.
+        // Build the agent loop context from the session's config.
+        let abort_signal = session_ctx.abort_signal.clone();
+        let cancel_notify = session_ctx.cancel_notify.clone();
 
         let loop_ctx = harnx_session::build_context(
             prompt_config.clone(),
@@ -575,53 +625,24 @@ impl HarnxAgent {
             None,
         );
 
-        // Bridge cancel_notify → abort_signal for any caller that signals
-        // via the notify without setting the signal directly (HarnxAgent::
-        // cancel does both, but this keeps the contract resilient).
-        let abort_for_listener = abort_signal.clone();
+        // Cancel listener: wait on cancel_notify, fire abort.
+        let cancel_abort = abort_signal.clone();
         let cancel_listener = tokio::task::spawn_local(async move {
             cancel_notify.notified().await;
-            abort_for_listener.set_ctrlc();
+            cancel_abort.set_ctrlc();
         });
 
-        // Two-stage cancellation:
-        //   1. When `abort_signal` fires, give cooperative-cancel layers
-        //      (e.g. AcpManager.session_prompt_with_abort) a grace
-        //      window to dispatch `session/cancel` down to any
-        //      sub-agents. They poll abort every ~25 ms and then send
-        //      a JSON-RPC cancel notification — fast, but not free.
-        //   2. After the grace window, hard-cancel `run_agent_loop` by
-        //      losing the select! race. This drops any stuck SSE/TCP
-        //      reads or stuck tool dispatchers that don't observe
-        //      abort — so a hung upstream can't pin the prompt.
-        // Pure hard-cancel-on-notify (the previous approach) skipped
-        // step 1 — sub-agents were leaked because the AcpManager call
-        // was dropped before it could dispatch `session/cancel`.
-        // 250 ms is well above the ~30 ms a single AcpManager
-        // observes-abort + dispatches-cancel takes; nested layers each
-        // run their own grace in parallel, so the bound doesn't
-        // compound across depth.
+        // Grace period after abort before hard cancellation.
         let abort_for_grace = abort_signal.clone();
         let grace_cancel = async move {
             harnx_core::abort::wait_abort_signal(&abort_for_grace).await;
             tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         };
 
-        // Scope the per-prompt event sink to this prompt's task tree so
-        // concurrent prompts to the same agent never clobber each other's
-        // streaming output. The scope wraps the whole select! (including the
-        // grace-cancel arm) so any chunks emitted up to the cancellation
-        // point still route to this prompt's sink. `loop_result` is
-        // `Option<Result<()>>`: `None` means the grace-cancel arm won, a
-        // `Some` carries the agent loop's own result.
-        // Clone the sink for the remote driver before `sink` is moved into the
-        // scoped-sink wrapper used by the local path.
+        // Run the agent loop.
         let remote_sink = sink.clone();
         let loop_result = harnx_core::sink::with_agent_event_sink(sink, async {
             match &remote_agent {
-                // Remote thin-client mode (P4.2): drive the turn over NATS via a
-                // worker daemon. Events render through the same `remote_sink`
-                // (an AcpChunkSink), so chunks reach the parent identically.
                 Some((agent, cluster)) => {
                     let thin_cfg = harnx_runtime::ThinClientConfig {
                         cluster: cluster.clone(),
@@ -645,13 +666,7 @@ impl HarnxAgent {
                         _ = grace_cancel => None,
                     }
                 }
-                // Local mode: run the agent loop in-process.
                 None => {
-                    // Box the agent-loop future before racing it. `run_agent_loop`
-                    // produces a very large future; embedding it inline in `select!`
-                    // (which itself lives inside the prompt future + LocalSet frames)
-                    // can overflow the thread stack before the first poll. Pinning it
-                    // on the heap keeps the synchronous stack frame small.
                     let input = input.expect("local mode always builds input");
                     let mut run_loop = Box::pin(harnx_runtime::run_agent_loop(&loop_ctx, input));
                     tokio::select! {
@@ -663,6 +678,16 @@ impl HarnxAgent {
         })
         .await;
 
+        // Refresh activity when the turn STOPS being active — on EVERY exit
+        // path (normal completion AND cancellation), not just at prompt start.
+        // A turn can run longer than SESSION_IDLE_TTL; touching only at start
+        // would leave last_activity stale, so the very next reaper tick after a
+        // long turn would evict the just-active session and tear down its warm
+        // MCP subprocesses. Placing this before the cancellation early-return
+        // keeps the session alive for the full TTL measured from when it last
+        // finished doing work, whether it completed or was cancelled.
+        session_ctx.touch();
+
         let Some(loop_result) = loop_result else {
             cancel_listener.abort();
             fwd_task.abort();
@@ -670,8 +695,6 @@ impl HarnxAgent {
         };
 
         cancel_listener.abort();
-        // Drop loop_ctx so all senders into chunk_rx are dropped and
-        // fwd_task can exit cleanly.
         drop(loop_ctx);
         let _ = fwd_task.await;
 
@@ -684,9 +707,98 @@ impl HarnxAgent {
         let session = sessions
             .get(session_id.as_ref())
             .ok_or_else(acp::Error::invalid_params)?;
+        // A cancel is direct user interaction — count it as activity so the
+        // idle reaper doesn't evict a session the user is actively steering.
+        session.touch();
         session.abort_signal.set_ctrlc();
         session.cancel_notify.notify_one();
         Ok(())
+    }
+}
+
+impl HarnxAgent {
+    /// Get an existing session or lazily build one from disk.
+    async fn get_or_build_session(&self, session_id: &str) -> acp::Result<Arc<SessionContext>> {
+        // First check if it's already in memory.
+        {
+            let sessions = self.sessions.lock().await;
+            if let Some(ctx) = sessions.get(session_id) {
+                return Ok(ctx.clone());
+            }
+        }
+
+        // Session not in memory. Check if it exists on disk.
+        let session_path = self.base_config.read().session_file(session_id);
+        if !tokio::fs::try_exists(&session_path).await.unwrap_or(false) {
+            return Err(acp::Error::invalid_params());
+        }
+
+        // Lazy rebuild: fork config, load session from disk.
+        info!("Lazy rebuilding session {} from disk", session_id);
+        let session_config = self.build_session_config(session_id)?;
+        let ctx = Arc::new(SessionContext::new(session_id.to_string(), session_config));
+
+        // Insert and start reaper.
+        let mut sessions = self.sessions.lock().await;
+        // Check again under lock (race with concurrent prompt).
+        if let Some(existing) = sessions.get(session_id) {
+            return Ok(existing.clone());
+        }
+        sessions.insert(session_id.to_string(), ctx.clone());
+        drop(sessions);
+
+        self.spawn_idle_reaper(ctx.clone());
+
+        Ok(ctx)
+    }
+
+    /// Spawn an idle reaper task for a session.
+    /// The task periodically checks if the session is idle past TTL
+    /// and evicts it from the map. Exits when the SessionContext is dropped.
+    fn spawn_idle_reaper(&self, ctx: Arc<SessionContext>) {
+        let sessions = self.sessions.clone();
+        let session_id = ctx.session_id.clone();
+
+        // Hold a weak reference: if the session is evicted by another path,
+        // the reaper task should exit.
+        let weak_ctx = Arc::downgrade(&ctx);
+        drop(ctx); // Don't hold an extra strong ref.
+
+        tokio::task::spawn_local(async move {
+            // Check every minute.
+            let check_interval = Duration::from_secs(60);
+            loop {
+                tokio::time::sleep(check_interval).await;
+
+                // If the SessionContext was already dropped, exit.
+                let Some(ctx) = weak_ctx.upgrade() else {
+                    debug!("Idle reaper: session {} already dropped", session_id);
+                    break;
+                };
+
+                // Evict only if idle past the TTL and no prompt is in flight.
+                if ctx.should_reap() {
+                    info!(
+                        "Idle reaper: evicting session {} (idle > {:?})",
+                        session_id, SESSION_IDLE_TTL
+                    );
+                    let mut sessions = sessions.lock().await;
+                    // Remove only if it's still this exact session and still idle.
+                    if let Some(existing) = sessions.get(&session_id) {
+                        if Arc::ptr_eq(existing, &ctx) {
+                            if ctx.should_reap() {
+                                sessions.remove(&session_id);
+                                drop(sessions);
+                                // ctx drops here, triggering manager teardown.
+                                break;
+                            }
+                            continue;
+                        }
+                    }
+                    drop(sessions);
+                }
+            }
+        });
     }
 }
 

--- a/crates/harnx-acp-server/src/lib_tests.rs
+++ b/crates/harnx-acp-server/src/lib_tests.rs
@@ -70,22 +70,28 @@ mod tests {
         (temp, path_str)
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_new_session_returns_unique_ids() {
         let (_temp, _path) = setup_agent_env("test");
         let _guard = TestStateGuard::new(None).await;
         let config = test_config();
-        let agent = HarnxAgent::new("test".to_string(), config);
+        let agent = Arc::new(HarnxAgent::new("test".to_string(), config));
         let cwd = std::env::current_dir().expect("current dir");
 
-        let resp1 = agent
-            .new_session(NewSessionRequest::new(cwd.clone()))
-            .await
-            .expect("create first session");
-        let resp2 = agent
-            .new_session(NewSessionRequest::new(cwd))
-            .await
-            .expect("create second session");
+        let local = tokio::task::LocalSet::new();
+        let (resp1, resp2) = local
+            .run_until(async {
+                let r1 = agent
+                    .new_session(NewSessionRequest::new(cwd.clone()))
+                    .await
+                    .expect("create first session");
+                let r2 = agent
+                    .new_session(NewSessionRequest::new(cwd))
+                    .await
+                    .expect("create second session");
+                (r1, r2)
+            })
+            .await;
         let session_id1 = resp1.session_id.0.to_string();
         let session_id2 = resp2.session_id.0.to_string();
 
@@ -95,37 +101,52 @@ mod tests {
         assert!(sessions.contains_key(session_id2.as_str()));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_cancel_marks_session() {
         let (_temp, _path) = setup_agent_env("test");
         let _guard = TestStateGuard::new(None).await;
         let config = test_config();
-        let agent = HarnxAgent::new("test".to_string(), config);
+        let agent = Arc::new(HarnxAgent::new("test".to_string(), config));
         let cwd = std::env::current_dir().expect("current dir");
 
-        let response = agent
-            .new_session(NewSessionRequest::new(cwd))
-            .await
-            .expect("create session");
+        let local = tokio::task::LocalSet::new();
+        let response = local
+            .run_until(async {
+                agent
+                    .new_session(NewSessionRequest::new(cwd))
+                    .await
+                    .expect("create session")
+            })
+            .await;
         let session_id = response.session_id.0.to_string();
 
-        agent
-            .cancel(CancelNotification::new(session_id.clone()))
-            .await
-            .expect("cancel session");
+        let local2 = tokio::task::LocalSet::new();
+        local2
+            .run_until(async {
+                agent
+                    .cancel(CancelNotification::new(session_id.clone()))
+                    .await
+                    .expect("cancel session")
+            })
+            .await;
 
         let sessions = agent.sessions.lock().await;
         let session = sessions.get(session_id.as_str()).expect("stored session");
         assert!(session.abort_signal.aborted());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_cancel_unknown_session_errors() {
         let config = test_config();
-        let agent = HarnxAgent::new("test".to_string(), config);
+        let agent = Arc::new(HarnxAgent::new("test".to_string(), config));
 
-        let result = agent
-            .cancel(CancelNotification::new("nonexistent".to_string()))
+        let local = tokio::task::LocalSet::new();
+        let result = local
+            .run_until(async {
+                agent
+                    .cancel(CancelNotification::new("nonexistent".to_string()))
+                    .await
+            })
             .await;
 
         assert!(result.is_err());
@@ -144,13 +165,18 @@ mod tests {
         /// Create a fresh session on `agent`.
         async fn create(agent: &Arc<HarnxAgent>, sessions_dir: &std::path::Path) -> Self {
             let cwd = std::env::current_dir().expect("current dir");
-            let id = agent
-                .new_session(NewSessionRequest::new(cwd))
-                .await
-                .expect("create session")
-                .session_id
-                .0
-                .to_string();
+            let local = tokio::task::LocalSet::new();
+            let id = local
+                .run_until(async {
+                    agent
+                        .new_session(NewSessionRequest::new(cwd))
+                        .await
+                        .expect("create session")
+                        .session_id
+                        .0
+                        .to_string()
+                })
+                .await;
             let log_path = sessions_dir.join(format!("{id}.yaml"));
             Self {
                 agent: Arc::clone(agent),
@@ -165,6 +191,7 @@ mod tests {
                 agent_client_protocol::schema::SessionId::new(self.id.clone()),
                 vec![ContentBlock::from(text.to_string())],
             );
+            // Note: caller should wrap in LocalSet
             self.agent.prompt(request).await
         }
 
@@ -469,5 +496,425 @@ mod tests {
             !meta.contains_key("harnx:model"),
             "harnx:model should not be present when model is None"
         );
+    }
+
+    // ── Session persistence and manager identity tests (issue #988) ──
+    //
+    // These tests verify that:
+    // 1. A single session with multiple prompts preserves the McpManager
+    //    across prompts (no respawn).
+    // 2. Two distinct sessions have distinct managers.
+    // 3. A resumed session (id on disk, absent from map) is lazily rebuilt.
+
+    /// Test that a single session reuses the same GlobalConfig (and thus the
+    /// same McpManager) across multiple prompts. The fix for #988 moved from
+    /// forking config per-prompt to forking once per-session.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_single_session_reuses_config_across_prompts() {
+        let (_temp, _path) = setup_agent_env("test");
+        let config = test_config();
+        let mock = Arc::new(
+            MockClient::builder()
+                .add_turn(MockTurnBuilder::new().add_text_chunk("reply one").build())
+                .add_turn(MockTurnBuilder::new().add_text_chunk("reply two").build())
+                .build(),
+        );
+        let _guard = TestStateGuard::new(Some(mock)).await;
+        let agent = Arc::new(HarnxAgent::new("test".to_string(), config.clone()));
+
+        let cwd = std::env::current_dir().expect("current dir");
+        let local0 = tokio::task::LocalSet::new();
+        let session_resp = local0
+            .run_until(async {
+                agent
+                    .new_session(NewSessionRequest::new(cwd))
+                    .await
+                    .expect("create session")
+            })
+            .await;
+        let session_id = session_resp.session_id.0.to_string();
+
+        // Get the SessionContext after creation.
+        let ctx1 = {
+            let sessions = agent.sessions.lock().await;
+            sessions.get(&session_id).expect("session exists").clone()
+        };
+
+        // First prompt.
+        let local = tokio::task::LocalSet::new();
+        let resp1 = local
+            .run_until(async {
+                agent
+                    .prompt(PromptRequest::new(
+                        agent_client_protocol::schema::SessionId::new(session_id.clone()),
+                        vec![ContentBlock::from("prompt one".to_string())],
+                    ))
+                    .await
+            })
+            .await;
+        assert_eq!(
+            resp1.expect("prompt 1 succeeds").stop_reason,
+            agent_client_protocol::schema::StopReason::EndTurn
+        );
+
+        // Get the SessionContext after first prompt - should be the same Arc.
+        let ctx2 = {
+            let sessions = agent.sessions.lock().await;
+            sessions.get(&session_id).expect("session exists").clone()
+        };
+
+        // Second prompt.
+        let local2 = tokio::task::LocalSet::new();
+        let resp2 = local2
+            .run_until(async {
+                agent
+                    .prompt(PromptRequest::new(
+                        agent_client_protocol::schema::SessionId::new(session_id.clone()),
+                        vec![ContentBlock::from("prompt two".to_string())],
+                    ))
+                    .await
+            })
+            .await;
+        assert_eq!(
+            resp2.expect("prompt 2 succeeds").stop_reason,
+            agent_client_protocol::schema::StopReason::EndTurn
+        );
+
+        // Get the SessionContext after second prompt.
+        let ctx3 = {
+            let sessions = agent.sessions.lock().await;
+            sessions.get(&session_id).expect("session exists").clone()
+        };
+
+        // All three Arcs should point to the same SessionContext.
+        assert!(
+            Arc::ptr_eq(&ctx1, &ctx2),
+            "SessionContext should be the same across prompts"
+        );
+        assert!(
+            Arc::ptr_eq(&ctx2, &ctx3),
+            "SessionContext should be the same across prompts"
+        );
+
+        // The config inside should also be the same Arc.
+        assert!(
+            Arc::ptr_eq(&ctx1.config, &ctx2.config),
+            "GlobalConfig should be the same across prompts"
+        );
+    }
+
+    /// Test that two distinct sessions have distinct SessionContexts and configs.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_distinct_sessions_have_distinct_contexts() {
+        let (_temp, _path) = setup_agent_env("test");
+        let config = test_config();
+        let mock = Arc::new(
+            MockClient::builder()
+                .add_turn(MockTurnBuilder::new().add_text_chunk("reply one").build())
+                .add_turn(MockTurnBuilder::new().add_text_chunk("reply two").build())
+                .build(),
+        );
+        let _guard = TestStateGuard::new(Some(mock)).await;
+        let agent = Arc::new(HarnxAgent::new("test".to_string(), config.clone()));
+
+        let cwd = std::env::current_dir().expect("current dir");
+        let local = tokio::task::LocalSet::new();
+        let (s1, s2) = local
+            .run_until(async {
+                let r1 = agent
+                    .new_session(NewSessionRequest::new(cwd.clone()))
+                    .await
+                    .expect("create session 1");
+                let r2 = agent
+                    .new_session(NewSessionRequest::new(cwd))
+                    .await
+                    .expect("create session 2");
+                (r1, r2)
+            })
+            .await;
+
+        let ctx1 = {
+            let sessions = agent.sessions.lock().await;
+            sessions
+                .get(&s1.session_id.0.to_string())
+                .expect("session 1 exists")
+                .clone()
+        };
+        let ctx2 = {
+            let sessions = agent.sessions.lock().await;
+            sessions
+                .get(&s2.session_id.0.to_string())
+                .expect("session 2 exists")
+                .clone()
+        };
+
+        // Different sessions should have different contexts.
+        assert!(
+            !Arc::ptr_eq(&ctx1, &ctx2),
+            "Different sessions should have different SessionContexts"
+        );
+        assert!(
+            !Arc::ptr_eq(&ctx1.config, &ctx2.config),
+            "Different sessions should have different GlobalConfigs"
+        );
+    }
+
+    /// Test lazy resume: a session that exists on disk but not in memory
+    /// is rebuilt on-demand when a prompt arrives.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_lazy_resume_rebuilds_session_from_disk() {
+        let (_temp, _path) = setup_agent_env("test");
+        let config = test_config();
+        let sessions_dir = config
+            .read()
+            .sessions_dir_override
+            .clone()
+            .expect("sessions dir override");
+        let mock = Arc::new(
+            MockClient::builder()
+                .add_turn(MockTurnBuilder::new().add_text_chunk("first reply").build())
+                .add_turn(
+                    MockTurnBuilder::new()
+                        .add_text_chunk("resumed reply")
+                        .build(),
+                )
+                .build(),
+        );
+        let _guard = TestStateGuard::new(Some(mock)).await;
+        let agent = Arc::new(HarnxAgent::new("test".to_string(), config.clone()));
+
+        // Create a session and run one prompt.
+        let cwd = std::env::current_dir().expect("current dir");
+        let local0 = tokio::task::LocalSet::new();
+        let session_resp = local0
+            .run_until(async {
+                agent
+                    .new_session(NewSessionRequest::new(cwd))
+                    .await
+                    .expect("create session")
+            })
+            .await;
+        let session_id = session_resp.session_id.0.to_string();
+        let log_path = sessions_dir.join(format!("{session_id}.yaml"));
+
+        let local = tokio::task::LocalSet::new();
+        let resp1 = local
+            .run_until(async {
+                agent
+                    .prompt(PromptRequest::new(
+                        agent_client_protocol::schema::SessionId::new(session_id.clone()),
+                        vec![ContentBlock::from("initial prompt".to_string())],
+                    ))
+                    .await
+            })
+            .await;
+        assert!(resp1.is_ok());
+
+        // Verify log exists.
+        assert!(log_path.exists(), "session log should exist");
+
+        // Evict the session from memory (simulate idle timeout).
+        {
+            let mut sessions = agent.sessions.lock().await;
+            sessions.remove(&session_id);
+        }
+
+        // Verify it's gone.
+        {
+            let sessions = agent.sessions.lock().await;
+            assert!(
+                !sessions.contains_key(&session_id),
+                "session should be evicted"
+            );
+        }
+
+        // Prompt again - should trigger lazy rebuild.
+        let local2 = tokio::task::LocalSet::new();
+        let resp2 = local2
+            .run_until(async {
+                agent
+                    .prompt(PromptRequest::new(
+                        agent_client_protocol::schema::SessionId::new(session_id.clone()),
+                        vec![ContentBlock::from("resumed prompt".to_string())],
+                    ))
+                    .await
+            })
+            .await;
+
+        // Should succeed.
+        assert_eq!(
+            resp2.expect("lazy resume succeeds").stop_reason,
+            agent_client_protocol::schema::StopReason::EndTurn
+        );
+
+        // Session is back in memory with a new SessionContext.
+        let _ctx = {
+            let sessions = agent.sessions.lock().await;
+            sessions.get(&session_id).expect("session rebuilt").clone()
+        };
+
+        // Verify the log contains both prompts.
+        let log_contents = tokio::fs::read_to_string(&log_path)
+            .await
+            .expect("read log");
+        assert!(
+            log_contents.contains("initial prompt"),
+            "first prompt in log"
+        );
+        assert!(
+            log_contents.contains("resumed prompt"),
+            "second prompt in log"
+        );
+    }
+
+    /// Test idle reaper logic: a session idle past TTL is evicted.
+    /// Uses a shortened TTL for testing.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_idle_session_is_evicted_after_ttl() {
+        // This test would require injecting a shorter TTL, which needs
+        // a test-only builder or env var. For now, verify the logic works
+        // by checking the is_running and is_idle_expired methods.
+        let (_temp, _path) = setup_agent_env("test");
+        let config = test_config();
+
+        let session_id = "test-session-id".to_string();
+        let session_config = harnx_session::fork_prompt_config(&config.read().clone());
+
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let ctx = Arc::new(crate::SessionContext::new(
+                    session_id.clone(),
+                    session_config,
+                ));
+
+                // Fresh session: not idle expired, not running → NOT reaped.
+                assert!(!ctx.is_idle_expired(), "fresh session not idle");
+                assert!(!ctx.is_running(), "no prompt running");
+                assert!(!ctx.should_reap(), "fresh idle session must not be reaped");
+
+                // Idle past TTL, no prompt running → MUST be reaped.
+                ctx.mark_idle_for_test();
+                assert!(ctx.is_idle_expired(), "backdated session is idle-expired");
+                assert!(!ctx.is_running(), "no prompt running");
+                assert!(
+                    ctx.should_reap(),
+                    "idle session with no in-flight prompt must be reaped"
+                );
+
+                // Idle past TTL BUT a prompt is in flight (lock held) → must NOT
+                // be reaped. This is the case the reaper must never get wrong:
+                // reaping here would kill MCP subprocesses under a live prompt.
+                let guard = ctx.prompt_lock.clone().lock_owned().await;
+                assert!(ctx.is_running(), "prompt is running (lock held)");
+                assert!(ctx.is_idle_expired(), "still idle-expired");
+                assert!(
+                    !ctx.should_reap(),
+                    "must NOT reap a session with an in-flight prompt"
+                );
+
+                // Prompt finishes → reapable again.
+                drop(guard);
+                assert!(!ctx.is_running(), "prompt finished");
+                assert!(ctx.should_reap(), "reapable again after prompt finishes");
+            })
+            .await;
+    }
+
+    /// Regression: a session whose only `touch()` happened at prompt START can
+    /// age past the idle TTL DURING a long turn. Once the prompt finishes and
+    /// releases `prompt_lock`, `should_reap()` becomes true — so without a
+    /// touch-on-completion the very next reaper tick would evict a session that
+    /// just finished active work, tearing down its warm MCP subprocesses.
+    /// `HarnxAgent::prompt` touches again after the turn completes; this test
+    /// asserts that a post-run `touch()` clears the idle state.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_touch_after_long_prompt_prevents_immediate_reap() {
+        let (_temp, _path) = setup_agent_env("test");
+        let config = test_config();
+        let session_config = harnx_session::fork_prompt_config(&config.read().clone());
+
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let ctx = Arc::new(crate::SessionContext::new(
+                    "long-turn-session".to_string(),
+                    session_config,
+                ));
+
+                // Simulate a turn that ran longer than the TTL: activity was
+                // last recorded at prompt start, which is now idle-expired, and
+                // the prompt has just released its lock (not running).
+                ctx.mark_idle_for_test();
+                assert!(ctx.is_idle_expired(), "backdated to idle-expired");
+                assert!(!ctx.is_running(), "prompt finished (lock released)");
+                assert!(
+                    ctx.should_reap(),
+                    "without touch-on-completion the session would be reaped"
+                );
+
+                // The touch that HarnxAgent::prompt performs AFTER the turn
+                // completes must refresh activity and clear the idle state.
+                ctx.touch();
+                assert!(
+                    !ctx.is_idle_expired(),
+                    "touch-on-completion refreshed last_activity"
+                );
+                assert!(
+                    !ctx.should_reap(),
+                    "a just-finished session must not be immediately reapable"
+                );
+            })
+            .await;
+    }
+
+    /// Test that Notice events are forwarded to ACP clients.
+    /// Regression test for #990 — notices were silently dropped.
+    #[test]
+    fn test_notice_event_forwarding() {
+        use crate::event_to_forward;
+        use harnx_core::event::NoticeEvent;
+
+        // Warning notice with message should be forwarded with ⚠ prefix.
+        let forward = event_to_forward(
+            AgentEvent::Notice(NoticeEvent::Warning("boom".into())),
+            None,
+        );
+        match forward {
+            Some(AcpForward::Text(text, source)) => {
+                assert!(text.contains("boom"), "warning message preserved");
+                assert!(text.starts_with("⚠"), "warning has ⚠ prefix");
+                assert!(source.is_none(), "source is None");
+            }
+            other => panic!("expected AcpForward::Text, got {:?}", other),
+        }
+
+        // Error notice with message should be forwarded with 🔴 prefix.
+        let forward = event_to_forward(
+            AgentEvent::Notice(NoticeEvent::Error("fatal error".into())),
+            None,
+        );
+        match forward {
+            Some(AcpForward::Text(text, _)) => {
+                assert!(text.contains("fatal error"), "error message preserved");
+                assert!(text.starts_with("🔴"), "error has 🔴 prefix");
+            }
+            other => panic!("expected AcpForward::Text, got {:?}", other),
+        }
+
+        // Info notices must NOT be forwarded to ACP clients. They are a
+        // presentation-layer artifact (nested sub-agent activity headings
+        // routed via NestedAcpEvent::Text → NoticeEvent::Info) and would
+        // corrupt the ACP transcript if injected (regression guarded by
+        // tmux_e2e::nested_sub_agent_activity_no_duplicates).
+        let forward = event_to_forward(AgentEvent::Notice(NoticeEvent::Info("hello".into())), None);
+        assert!(
+            forward.is_none(),
+            "info notice must not be forwarded to ACP"
+        );
+
+        // Empty message should be dropped (None).
+        let forward = event_to_forward(AgentEvent::Notice(NoticeEvent::Warning("".into())), None);
+        assert!(forward.is_none(), "empty notice should be dropped");
     }
 }

--- a/crates/harnx-core/src/hooks.rs
+++ b/crates/harnx-core/src/hooks.rs
@@ -127,7 +127,7 @@ fn default_timeout() -> Option<u64> {
 }
 
 /// Configuration for a single hook entry
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct HookConfig {
     /// Hook event name (e.g., "PreToolUse", "Stop")
     pub event: String,
@@ -168,7 +168,7 @@ impl HookConfig {
 }
 
 /// Configuration for all hooks (global or per-agent)
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct HooksConfig {
     /// Maximum number of resume iterations
     #[serde(default)]

--- a/crates/harnx-mcp/Cargo.toml
+++ b/crates/harnx-mcp/Cargo.toml
@@ -17,7 +17,7 @@ indexmap = { workspace = true }
 log = { workspace = true }
 parking_lot = { workspace = true }
 process-wrap = { workspace = true }
-rmcp = { workspace = true }
+rmcp = { workspace = true, features = ["transport-async-rw"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 shellexpand = { workspace = true }

--- a/crates/harnx-mcp/src/client.rs
+++ b/crates/harnx-mcp/src/client.rs
@@ -2,6 +2,8 @@ use crate::config::{McpServerConfig, ToolDisplayTemplates};
 use crate::convert::{mcp_tool_to_declaration, ToolTemplates};
 use crate::safety::path_to_file_uri;
 use harnx_core::abort::{wait_abort_signal, AbortSignal};
+use harnx_core::event::NoticeEvent;
+use harnx_core::sink::emit_agent_event;
 use harnx_core::tool::{ToolDeclaration, ToolError, ToolProvider};
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -17,7 +19,6 @@ use rmcp::model::{
     ListRootsResult, Root,
 };
 use rmcp::service::{RequestContext, RoleClient, RunningService, ServiceError};
-use rmcp::transport::TokioChildProcess;
 use serde_json::Value;
 use std::collections::VecDeque;
 use std::process::Stdio;
@@ -30,6 +31,78 @@ use tokio::runtime::{Builder, Handle, RuntimeFlavor};
 /// Maximum number of stderr lines to keep from an MCP child process for
 /// inclusion in connection error messages. Old lines are dropped first.
 const MCP_STDERR_TAIL_LINES: usize = 64;
+
+/// Minimum time between duplicate notices for the same server+key.
+const NOTICE_DEDUP_WINDOW: Duration = Duration::from_secs(5);
+
+/// Shared per-client dedup state: the (key, timestamp) of the last emitted
+/// notice. Wrapped in `Arc` so the background child-wait task can share the
+/// same state as the synchronous reconnect path — this keeps notice
+/// deduplication consistent across reconnects rather than resetting per
+/// connection.
+type NoticeDedupState = Arc<RwLock<Option<(String, std::time::Instant)>>>;
+
+/// Emit a `NoticeEvent` through the global agent-event sink, suppressing a
+/// duplicate `(key)` within `NOTICE_DEDUP_WINDOW`. Returns true if emitted,
+/// false if suppressed. Shared by `McpClient::emit_notice` and the detached
+/// child-wait task so both honour the same dedup window.
+fn emit_notice_dedup(state: &NoticeDedupState, key: &str, event: NoticeEvent) -> bool {
+    let now = std::time::Instant::now();
+    let mut last_notice = state.write();
+    if let Some((ref last_key, ref last_time)) = *last_notice {
+        if last_key == key && now.duration_since(*last_time) < NOTICE_DEDUP_WINDOW {
+            return false;
+        }
+    }
+    *last_notice = Some((key.to_string(), now));
+    drop(last_notice);
+    emit_agent_event(harnx_core::event::AgentEvent::Notice(event));
+    true
+}
+
+// --- Part B: exit status classification -------------------------------------
+
+/// Classify exit status into a NoticeEvent.
+/// - Clean exit (code 0, or SIGTERM/SIGINT on Unix) → Warning
+/// - Nonzero code or SIGKILL/other signals → Error
+/// - No status available → Error
+#[cfg(unix)]
+pub fn classify_exit(name: &str, code: Option<i32>, signal: Option<i32>) -> NoticeEvent {
+    // Check signal first (if killed by signal)
+    if let Some(sig) = signal {
+        // Common signal mappings
+        match sig {
+            15 | 2 => NoticeEvent::Warning(format!(
+                "MCP server '{}' terminated by SIG{}",
+                name,
+                if sig == 15 { "TERM" } else { "INT" }
+            )),
+            9 => NoticeEvent::Error(format!("MCP server '{}' killed by SIGKILL", name)),
+            _ => NoticeEvent::Error(format!("MCP server '{}' died: signal {}", name, sig)),
+        }
+    } else if let Some(c) = code {
+        if c == 0 {
+            NoticeEvent::Warning(format!("MCP server '{}' exited cleanly", name))
+        } else {
+            NoticeEvent::Error(format!("MCP server '{}' exited with code {}", name, c))
+        }
+    } else {
+        NoticeEvent::Error(format!("MCP server '{}' exited (status unavailable)", name))
+    }
+}
+
+#[cfg(not(unix))]
+pub fn classify_exit(name: &str, code: Option<i32>, _signal: Option<i32>) -> NoticeEvent {
+    if let Some(c) = code {
+        if c == 0 {
+            NoticeEvent::Warning(format!("MCP server '{}' exited cleanly", name))
+        } else {
+            NoticeEvent::Error(format!("MCP server '{}' exited with code {}", name, c))
+        }
+    } else {
+        NoticeEvent::Error(format!("MCP server '{}' exited (status unavailable)", name))
+    }
+}
 
 /// How long to wait for the stderr reader to drain after a connection
 /// error before snapshotting the buffer for the error message. Short
@@ -67,6 +140,15 @@ pub struct McpClient {
     connected: Arc<RwLock<bool>>,
     connection_failed: Arc<RwLock<bool>>,
     service: Arc<RwLock<Option<RunningService<RoleClient, McpClientHandler>>>>,
+    /// Persistent stderr buffer for notice messages (survives reconnects)
+    stderr_buffer: StderrBuffer,
+    /// Last emitted notice (key, timestamp) for deduplication. Shared with the
+    /// background child-wait task so exit and reconnect notices dedup together.
+    last_notice: NoticeDedupState,
+    /// Handle to the background task that waits for the current child process
+    /// and emits an exit notice. Aborted and replaced on each (re)connect so a
+    /// stale task from a prior connection cannot linger past teardown.
+    child_wait_task: RwLock<Option<tokio::task::JoinHandle<()>>>,
 }
 
 #[derive(Clone)]
@@ -126,6 +208,7 @@ impl fmt::Debug for McpClient {
             .field("roots", &*self.roots.read())
             .field("connected", &*self.connected.read())
             .field("service", &service)
+            .field("stderr_buffer_len", &self.stderr_buffer.lock().len())
             .finish()
     }
 }
@@ -135,6 +218,12 @@ impl McpClient {
         shellexpand::full(path)
             .map(|p| p.to_string())
             .unwrap_or_else(|_| path.to_string())
+    }
+
+    /// Emit a notice event with deduplication against this client's shared
+    /// dedup state. Returns true if emitted, false if suppressed as duplicate.
+    fn emit_notice(&self, key: &str, event: NoticeEvent) -> bool {
+        emit_notice_dedup(&self.last_notice, key, event)
     }
 
     pub fn new(config: McpServerConfig) -> Self {
@@ -152,6 +241,9 @@ impl McpClient {
             connected: Arc::new(RwLock::new(false)),
             connection_failed: Arc::new(RwLock::new(false)),
             service: Arc::new(RwLock::new(None)),
+            stderr_buffer: new_stderr_buffer(),
+            last_notice: Arc::new(RwLock::new(None)),
+            child_wait_task: RwLock::new(None),
         }
     }
 
@@ -191,7 +283,13 @@ impl McpClient {
     async fn connect_inner(&self) -> Result<()> {
         let mut command = Command::new(&self.config.command);
         command.args(&self.config.args);
+
         command.envs(&self.config.env);
+
+        // Pipe stdin/stdout/stderr for MCP transport
+        command.stdin(Stdio::piped());
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
 
         // Spawn in a new process group so SIGINT (Ctrl+C) in the parent
         // terminal doesn't propagate to MCP server child processes.
@@ -200,16 +298,72 @@ impl McpClient {
         #[cfg(unix)]
         wrap.wrap(ProcessGroup::leader());
 
-        let stderr_buffer = new_stderr_buffer();
-
-        let (transport, stderr) = TokioChildProcess::builder(wrap)
-            .stderr(Stdio::piped())
+        // Spawn the child process ourselves (instead of using TokioChildProcess)
+        // so we can own the child handle and wait for exit.
+        let mut child = wrap
             .spawn()
             .with_context(|| format!("Failed to spawn MCP server '{}'", self.name))?;
 
+        let stdin = child
+            .stdin()
+            .take()
+            .ok_or_else(|| anyhow!("MCP server '{}' stdin not piped", self.name))?;
+        let stdout = child
+            .stdout()
+            .take()
+            .ok_or_else(|| anyhow!("MCP server '{}' stdout not piped", self.name))?;
+        let stderr = child.stderr().take();
+
+        // Spawn a background task that waits for the child and emits an exit
+        // notice. It shares the client's `last_notice` dedup state so exit and
+        // reconnect notices are deduplicated together. Any wait task from a
+        // prior connection is aborted first so stale tasks don't linger.
+        let name_for_wait = self.name.clone();
+        let stderr_buffer_for_wait = self.stderr_buffer.clone();
+        let dedup_state = self.last_notice.clone();
+        let wait_handle = tokio::spawn(async move {
+            if let Ok(status) = child.wait().await {
+                #[cfg(unix)]
+                let (code, signal) = {
+                    use std::os::unix::process::ExitStatusExt;
+                    (status.code(), status.signal())
+                };
+                #[cfg(not(unix))]
+                let (code, signal) = (status.code(), None);
+
+                // Snapshot stderr tail for the notice message
+                let stderr_tail = {
+                    let buf = stderr_buffer_for_wait.lock();
+                    if buf.is_empty() {
+                        String::new()
+                    } else {
+                        let joined = buf.iter().cloned().collect::<Vec<_>>().join("\n");
+                        format!("\nMCP server stderr:\n{joined}")
+                    }
+                };
+
+                let event = match classify_exit(&name_for_wait, code, signal) {
+                    NoticeEvent::Warning(msg) if !stderr_tail.is_empty() => {
+                        NoticeEvent::Warning(format!("{}\n{}", msg, stderr_tail))
+                    }
+                    NoticeEvent::Error(msg) if !stderr_tail.is_empty() => {
+                        NoticeEvent::Error(format!("{}\n{}", msg, stderr_tail))
+                    }
+                    other => other,
+                };
+                let key = format!("exit:{}", name_for_wait);
+                emit_notice_dedup(&dedup_state, &key, event);
+            }
+        });
+        if let Some(prev) = self.child_wait_task.write().replace(wait_handle) {
+            // Detach old wait task so it can finish child.wait().await and reap old process.
+            drop(prev);
+        }
+
+        // Spawn stderr reader task using the persistent buffer
         if let Some(stderr) = stderr {
             let server_name = self.name.clone();
-            let buffer = stderr_buffer.clone();
+            let buffer = self.stderr_buffer.clone();
             tokio::spawn(async move {
                 let reader = BufReader::new(stderr);
                 let mut lines = reader.lines();
@@ -224,6 +378,10 @@ impl McpClient {
             });
         }
 
+        // Create transport from (stdout, stdin) pair
+        let transport =
+            rmcp::transport::async_rw::AsyncRwTransport::<RoleClient, _, _>::new(stdout, stdin);
+
         let handler = McpClientHandler::new(self.roots.clone());
         let serve_result = tokio::time::timeout(
             Duration::from_secs(30),
@@ -232,7 +390,7 @@ impl McpClient {
         .await;
         let service = match serve_result {
             Err(_) => {
-                let tail = snapshot_stderr_tail(&stderr_buffer).await;
+                let tail = snapshot_stderr_tail(&self.stderr_buffer).await;
                 bail!(
                     "MCP server '{}' timed out during initialization (30s){}",
                     self.name,
@@ -240,7 +398,7 @@ impl McpClient {
                 );
             }
             Ok(Err(err)) => {
-                let tail = snapshot_stderr_tail(&stderr_buffer).await;
+                let tail = snapshot_stderr_tail(&self.stderr_buffer).await;
                 return Err(anyhow::Error::from(err)).with_context(|| {
                     format!(
                         "Failed to initialize MCP client for server '{}'{}",
@@ -258,7 +416,7 @@ impl McpClient {
         .await;
         let tools_result = match list_result {
             Err(_) => {
-                let tail = snapshot_stderr_tail(&stderr_buffer).await;
+                let tail = snapshot_stderr_tail(&self.stderr_buffer).await;
                 bail!(
                     "MCP server '{}' timed out listing tools (10s){}",
                     self.name,
@@ -266,7 +424,7 @@ impl McpClient {
                 );
             }
             Ok(Err(err)) => {
-                let tail = snapshot_stderr_tail(&stderr_buffer).await;
+                let tail = snapshot_stderr_tail(&self.stderr_buffer).await;
                 return Err(anyhow::Error::from(err)).with_context(|| {
                     format!(
                         "Failed to list tools for MCP server '{}'{}",
@@ -447,8 +605,25 @@ impl McpClient {
                         err,
                     );
 
+                    // Snapshot stderr tail BEFORE reconnect for the notice
+                    let stderr_tail = render_stderr_tail(&self.stderr_buffer);
+
                     *self.connected.write() = false;
                     self.service.write().take();
+
+                    // Emit Warning notice about the transport failure and reconnect attempt
+                    self.emit_notice(
+                        &format!("reconnect:{}", self.name),
+                        NoticeEvent::Warning(format!(
+                            "MCP server '{}' disconnected, reconnecting{}",
+                            self.name,
+                            if stderr_tail.is_empty() {
+                                String::new()
+                            } else {
+                                format!(" ({})", stderr_tail.trim())
+                            }
+                        )),
+                    );
 
                     // Heal the connection for future calls (best-effort)
                     if let Err(reconnect_err) = self.connect().await {
@@ -456,6 +631,14 @@ impl McpClient {
                             "Failed to reconnect to MCP server '{}' after transport error: {}",
                             self.name,
                             reconnect_err,
+                        );
+                        // Emit Error notice about failed reconnect
+                        self.emit_notice(
+                            &format!("reconnect-failed:{}", self.name),
+                            NoticeEvent::Error(format!(
+                                "MCP server '{}' reconnection failed: {}",
+                                self.name, reconnect_err
+                            )),
                         );
                     }
 
@@ -1396,7 +1579,8 @@ impl ToolProvider for McpManager {
 
 #[cfg(test)]
 mod selector_filter_tests {
-    use super::selector_could_match_server;
+    use super::{classify_exit, selector_could_match_server};
+    use harnx_core::event::NoticeEvent;
 
     #[test]
     fn star_matches_every_server() {
@@ -1473,5 +1657,88 @@ mod selector_filter_tests {
             "context7",
             &targets
         ));
+    }
+
+    // --- Part B tests: exit classification ---
+
+    #[test]
+    fn test_classify_exit_clean_exit_code_zero() {
+        let event = classify_exit("test-server", Some(0), None);
+        match event {
+            NoticeEvent::Warning(msg) => {
+                assert!(msg.contains("exited cleanly"));
+            }
+            _ => panic!("expected Warning for clean exit"),
+        }
+    }
+
+    #[test]
+    fn test_classify_exit_nonzero_code() {
+        let event = classify_exit("test-server", Some(3), None);
+        match event {
+            NoticeEvent::Error(msg) => {
+                assert!(msg.contains("exited with code 3"));
+            }
+            _ => panic!("expected Error for nonzero exit code"),
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_classify_exit_sigterm_warning() {
+        let event = classify_exit("test-server", None, Some(15));
+        match event {
+            NoticeEvent::Warning(msg) => {
+                assert!(msg.contains("terminated by SIGTERM"));
+            }
+            _ => panic!("expected Warning for SIGTERM"),
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_classify_exit_sigint_warning() {
+        let event = classify_exit("test-server", None, Some(2));
+        match event {
+            NoticeEvent::Warning(msg) => {
+                assert!(msg.contains("terminated by SIGINT"));
+            }
+            _ => panic!("expected Warning for SIGINT"),
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_classify_exit_sigkill_error() {
+        let event = classify_exit("test-server", None, Some(9));
+        match event {
+            NoticeEvent::Error(msg) => {
+                assert!(msg.contains("killed by SIGKILL"));
+            }
+            _ => panic!("expected Error for SIGKILL"),
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_classify_exit_unknown_signal_error() {
+        let event = classify_exit("test-server", None, Some(11)); // SIGSEGV
+        match event {
+            NoticeEvent::Error(msg) => {
+                assert!(msg.contains("died: signal 11"));
+            }
+            _ => panic!("expected Error for unknown signal"),
+        }
+    }
+
+    #[test]
+    fn test_classify_exit_no_status_error() {
+        let event = classify_exit("test-server", None, None);
+        match event {
+            NoticeEvent::Error(msg) => {
+                assert!(msg.contains("status unavailable"));
+            }
+            _ => panic!("expected Error for no status"),
+        }
     }
 }

--- a/crates/harnx-runtime/src/bootstrap.rs
+++ b/crates/harnx-runtime/src/bootstrap.rs
@@ -12,9 +12,16 @@ use harnx_core::path::ensure_parent_exists;
 
 /// Initialise the process-wide `log` facade. Reads log level + path from
 /// `Config::log_config` and applies an optional `HARNX_LOG_FILTER` env
-/// override. `is_server` is a hint for the default filter: server modes
-/// (HTTP serve, ACP) default to `harnx::serve` whereas CLI/TUI default to
-/// the top-level `harnx` filter so dot-command logs aren't suppressed.
+/// override. Both server modes (HTTP serve, ACP) and CLI/TUI use `harnx`
+/// as the default filter, matching all `harnx_*` crate targets via prefix
+/// matching (simplelog 0.12 uses `path.starts_with(filter)`). Use
+/// `HARNX_LOG_FILTER` to narrow to a specific crate/module.
+///
+/// # Historical note
+///
+/// Previously, server modes defaulted to `harnx::serve`, but this matched
+/// no `harnx_*` crate targets (underscores vs colons), silently dropping
+/// all logs including startup banners and subagent output. Fixed in #989.
 pub fn setup_logger(is_server: bool) -> Result<()> {
     // LLM trace is independent of the simplelog filter — it must work even
     // when log_level is Off, since it's the user's primary tool for debugging
@@ -32,10 +39,7 @@ pub fn setup_logger(is_server: bool) -> Result<()> {
     const LOG_CRATE_NAME: &str = "harnx";
     let log_filter = match std::env::var(get_env_name("log_filter")) {
         Ok(v) => v,
-        Err(_) => match is_server {
-            true => format!("{LOG_CRATE_NAME}::serve"),
-            false => LOG_CRATE_NAME.into(),
-        },
+        Err(_) => default_log_filter(LOG_CRATE_NAME),
     };
     let config = ConfigBuilder::new()
         .add_filter_allow(log_filter)
@@ -83,4 +87,79 @@ pub fn setup_logger(is_server: bool) -> Result<()> {
         log_target,
     );
     Ok(())
+}
+
+/// Returns the default log filter for simplelog.
+///
+/// Both server and CLI modes use the same default `"harnx"` filter, which
+/// matches all `harnx_*` crate targets via simplelog's prefix matching.
+fn default_log_filter(crate_name: &str) -> String {
+    crate_name.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_log_filter_returns_harnx() {
+        assert_eq!(default_log_filter("harnx"), "harnx");
+    }
+
+    #[test]
+    fn harnx_filter_matches_harnx_underscore_targets() {
+        // simplelog 0.12 uses path.starts_with(filter) for prefix matching.
+        // The fix ensures "harnx" (correct) is used, not "harnx::serve" (bug).
+        let filter = default_log_filter("harnx");
+
+        // All harnx_* crate targets should match the "harnx" prefix.
+        assert!(
+            "harnx_acp::client".starts_with(&filter),
+            "harnx_acp::client should match filter {:?}",
+            filter
+        );
+        assert!(
+            "harnx_mcp::client".starts_with(&filter),
+            "harnx_mcp::client should match filter {:?}",
+            filter
+        );
+        assert!(
+            "harnx_runtime::bootstrap".starts_with(&filter),
+            "harnx_runtime::bootstrap should match filter {:?}",
+            filter
+        );
+        assert!(
+            "harnx_acp_server::server".starts_with(&filter),
+            "harnx_acp_server::server should match filter {:?}",
+            filter
+        );
+    }
+
+    #[test]
+    fn harnx_serve_filter_matches_no_harnx_underscore_targets() {
+        // Bug regression test: "harnx::serve" matches NONE of the harnx_* targets.
+        // simplelog 0.12 uses prefix matching, and underscores != colons.
+        let buggy_filter = "harnx::serve";
+
+        assert!(
+            !"harnx_acp::client".starts_with(buggy_filter),
+            "harnx_acp::client should NOT match buggy filter {:?}",
+            buggy_filter
+        );
+        assert!(
+            !"harnx_mcp::client".starts_with(buggy_filter),
+            "harnx_mcp::client should NOT match buggy filter {:?}",
+            buggy_filter
+        );
+        assert!(
+            !"harnx_runtime::bootstrap".starts_with(buggy_filter),
+            "harnx_runtime::bootstrap should NOT match buggy filter {:?}",
+            buggy_filter
+        );
+        assert!(
+            !"harnx_acp_server::server".starts_with(buggy_filter),
+            "harnx_acp_server::server should NOT match buggy filter {:?}",
+            buggy_filter
+        );
+    }
 }

--- a/crates/harnx-runtime/src/config/env_split.rs
+++ b/crates/harnx-runtime/src/config/env_split.rs
@@ -153,6 +153,18 @@ pub fn load_env_file() -> Result<()> {
         if let Some((key, value)) = line.split_once('=') {
             let key = key.trim();
             if !key.is_empty() {
+                // Standard dotenv precedence: the ambient/inherited environment
+                // always wins. The .env file only FILLS IN variables that are
+                // not already set in the process environment — it never clobbers
+                // an inherited value. This matches python-dotenv / node dotenv /
+                // dotenvy defaults (override is opt-in, not default) and is the
+                // more secure choice: operator-injected env (systemd, Docker,
+                // K8s secrets) takes precedence over a user-writable file.
+                // Fixes #989 (previously .env unconditionally overrode inherited
+                // HARNX_LOG_* vars, which required a per-key special-case guard).
+                if env::var_os(key).is_some() {
+                    continue;
+                }
                 unsafe {
                     env::set_var(key, value.trim());
                 }
@@ -201,6 +213,77 @@ mod tests {
         // Restore prior state
         if let Some(v) = prev {
             unsafe { std::env::set_var("HARNX_CLEANUP_REMOTE_SESSIONS_DAYS", v) }
+        }
+    }
+
+    #[test]
+    fn load_env_file_ambient_env_always_wins() {
+        use std::io::Write;
+
+        let _lock = crate::config::test_support::env_lock();
+        let prev_log_level = std::env::var_os("HARNX_LOG_LEVEL");
+        let prev_inherited = std::env::var_os("SOME_INHERITED_VAR");
+        let prev_unset_var = std::env::var_os("ENV_ONLY_VAR");
+        let prev_harnx_env_file = std::env::var_os("HARNX_ENV_FILE");
+
+        // Set inherited vars: one logging var, one arbitrary non-log var. Both
+        // are already present in the ambient environment.
+        // SAFETY: test-only; global test lock held.
+        unsafe { std::env::set_var("HARNX_LOG_LEVEL", "debug") };
+        unsafe { std::env::set_var("SOME_INHERITED_VAR", "from-ambient") };
+        // Ensure the .env-only var is NOT set ambiently.
+        unsafe { std::env::remove_var("ENV_ONLY_VAR") };
+
+        // .env tries to override both inherited vars AND sets a fresh var.
+        let tmpdir = tempfile::tempdir().expect("tempdir");
+        let env_file = tmpdir.path().join(".env");
+        let mut f = std::fs::File::create(&env_file).expect("create .env");
+        f.write_all(
+            b"HARNX_LOG_LEVEL=info\nSOME_INHERITED_VAR=from-dotenv\nENV_ONLY_VAR=from-dotenv\n",
+        )
+        .expect("write .env");
+        f.sync_all().expect("sync .env");
+
+        unsafe { std::env::set_var("HARNX_ENV_FILE", env_file.display().to_string()) };
+
+        load_env_file().expect("load_env_file");
+
+        // Ambient env ALWAYS wins — .env must not clobber ANY already-set var,
+        // not just the special-cased logging vars.
+        assert_eq!(
+            std::env::var("HARNX_LOG_LEVEL").ok(),
+            Some("debug".to_string()),
+            "inherited HARNX_LOG_LEVEL should win over .env"
+        );
+        assert_eq!(
+            std::env::var("SOME_INHERITED_VAR").ok(),
+            Some("from-ambient".to_string()),
+            "any inherited (non-log) var should win over .env"
+        );
+
+        // A var absent from the ambient env IS filled in from .env.
+        assert_eq!(
+            std::env::var("ENV_ONLY_VAR").ok(),
+            Some("from-dotenv".to_string()),
+            "unset var should be filled in from .env"
+        );
+
+        // Restore prior state
+        unsafe { std::env::remove_var("HARNX_ENV_FILE") };
+        unsafe { std::env::remove_var("ENV_ONLY_VAR") };
+        match prev_log_level {
+            Some(v) => unsafe { std::env::set_var("HARNX_LOG_LEVEL", v) },
+            None => unsafe { std::env::remove_var("HARNX_LOG_LEVEL") },
+        }
+        match prev_inherited {
+            Some(v) => unsafe { std::env::set_var("SOME_INHERITED_VAR", v) },
+            None => unsafe { std::env::remove_var("SOME_INHERITED_VAR") },
+        }
+        if let Some(v) = prev_unset_var {
+            unsafe { std::env::set_var("ENV_ONLY_VAR", v) }
+        }
+        if let Some(v) = prev_harnx_env_file {
+            unsafe { std::env::set_var("HARNX_ENV_FILE", v) }
         }
     }
 }

--- a/docs/solutions/integration-issues/mcp-subprocess-lifecycle-churn-2026-07-08.md
+++ b/docs/solutions/integration-issues/mcp-subprocess-lifecycle-churn-2026-07-08.md
@@ -1,0 +1,220 @@
+---
+title: "MCP subprocess lifecycle churn under ACP — per-session context + log filter fix"
+date: 2026-07-08
+category: integration-issues
+problem_type: logic_error
+component: harnx-acp-server
+root_cause: "Per-prompt config fork/re-scope triggered unconditional manager rebuild + simplelog prefix filter dropped logs"
+resolution_type: code_fix
+severity: high
+tags:
+  - mcp
+  - subprocess
+  - lifecycle
+  - acp
+  - session-context
+  - log-filter
+  - rmcp
+plan_ref: acp-session-context
+last_updated: 2026-07-08
+---
+
+## Problem
+
+Three related issues (one root cause, one log filter gotcha, one observability gap):
+
+1. **#988 — MCP servers constantly restarting under ACP:** Every ACP prompt forked the global config, re-scoped the agent, and called `reinit_managers_for_agent` → unconditional `McpManager::new() + initialize()` → `clients.clear()` → dropped all `Arc<McpClient>` → closed child stdin → killed every MCP subprocess each turn. Also broke `read_exec_log` (respawned bash picked fresh temp log dir each turn).
+
+2. **#989 — ACP subagent logs not captured:** `setup_logger(is_server=true)` set simplelog allow-filter to `"harnx::serve"`. simplelog 0.12 matches `target.starts_with(filter)`. Workspace crate targets are `harnx_acp` / `harnx_mcp` / `harnx_runtime` (underscores) — none start with `"harnx::serve"` → ALL serve/ACP logs silently dropped.
+
+3. **#990 — MCP subprocess exit status invisible:** rmcp's `TokioChildProcess` consumes the child; can't `wait()` for exit status.
+
+GitHub issues: #988, #989, #990.
+
+## Symptoms
+
+- MCP tools (bash/fs/time/plans) reconnected on every ACP prompt (visible as startup latency)
+- `read_exec_log` failed or returned wrong log path after first prompt
+- ACP serve logs never appeared (no startup banner, no `[acp:]`/`[mcp:]` lines)
+- MCP subprocess crashes silently invisible to users
+
+## Root Cause
+
+### #988 — Per-prompt config derivation
+
+`harnx-acp-server` serves ONE fixed agent but re-forked config and re-scoped on EVERY prompt:
+
+```
+prompt() → fork_prompt_config() → use_agent_by_name() → reinit_managers_for_agent() → McpManager::new() + initialize() → clients.clear()
+```
+
+Each `reinit_managers_for_agent` dropped existing `Arc<McpClient>` refs, closing stdin, killing subprocesses.
+
+**KEY INSIGHT:** The NATS worker (`crates/harnx-runtime/src/nats_worker/daemon.rs`) was already correct: clone config ONCE, `use_agent_obj` ONCE per session, then loop turns against the SAME `per_session` Arc. The ACP server was the outlier.
+
+### #989 — simplelog prefix matching + underscore targets
+
+The filter `"harnx::serve"` was intended to match serve-mode logs. But workspace crate targets use underscores (`harnx_acp`, `harnx_mcp`), not `harnx::`. simplelog's `starts_with` match means `"harnx_acp".starts_with("harnx::serve")` → false. Everything dropped.
+
+The env vars (`HARNX_LOG_LEVEL`, `HARNX_LOG_PATH`) WERE inherited correctly — it was the filter, not env.
+
+### #990 — rmcp owns the child
+
+`TokioChildProcess::spawn()` consumes the `Command` and owns the child. stdio moved to transport, but `wait()` unavailable.
+
+## Solution
+
+### 1. Per-session context (SessionContext)
+
+**File:** `crates/harnx-acp-server/src/lib.rs`
+
+Create `SessionContext` owning per-session `GlobalConfig` with its OWN `McpManager`/`AcpManager`:
+
+```rust
+pub struct SessionContext {
+    pub session_id: String,
+    pub config: GlobalConfig,
+    pub abort_signal: AbortSignal,
+    pub cancel_notify: Arc<tokio::sync::Notify>,
+    pub prompt_lock: Arc<tokio::sync::Mutex<()>>,
+    last_activity: parking_lot::Mutex<Instant>,
+}
+
+impl HarnxAgent {
+    pub sessions: HashMap<String, Arc<SessionContext>>,
+}
+```
+
+**Lifecycle:**
+- `new_session()`: build `SessionContext` ONCE, store in HashMap
+- `prompt()`: reuse session's config directly — NO per-prompt fork/reinit
+- Lazy-rebuild when session resumed from disk but absent in memory (no `load_session` handler)
+- Idle reaper (15-min TTL, no hard cap) via `spawn_local` on `LocalSet`
+- `should_reap()`: idle-expired AND not-running (never reaps session with in-flight prompt)
+- Reaper re-checks `should_reap()` AGAIN while holding the sessions map lock before evicting, closing the TOCTOU gap where a prompt could start between the check and the lock
+- `touch()` runs on every activity edge — prompt START, prompt STOP (completion OR cancellation, placed before the cancel early-return), and on a `session/cancel` notification — so a turn that runs longer than the TTL isn't reaped immediately after it finishes or is cancelled
+- Reap = drop `Arc<SessionContext>` → drop Config → drop McpManager → child stdin closes → subprocess exits
+
+**`reinit_managers_for_agent` unchanged:** keeps original unconditional-rebuild behavior for TUI/other callers. ACP path simply never calls it per-prompt.
+
+### 2. Log filter default
+
+**File:** `crates/harnx-runtime/src/bootstrap.rs`
+
+Change default filter from `"harnx::serve"` to `"harnx"` (matches all `harnx_*` targets via prefix). `HARNX_LOG_FILTER` still overrides.
+
+Fix `.env` precedence to standard dotenv semantics: the ambient/inherited environment always wins; `.env` only fills variables NOT already set (never clobbers an inherited value). This generalizes the original per-key guard — no logging-var special-case is needed, and it also protects any other operator-set variable. Matches python-dotenv / node dotenv / dotenvy defaults.
+
+### 3. Self-spawned child for exit status
+
+**File:** `crates/harnx-mcp/src/client.rs`
+
+Spawn child ourselves instead of via rmcp:
+
+```rust
+// Feature: transport-async-rw in harnx-mcp/Cargo.toml
+
+use process_wrap::CommandWrap;
+use process_wrap::ProcessGroup::leader;
+
+let wrap = CommandWrap::new(command).wrap(ProcessGroup::leader());
+let mut child = wrap.spawn()?;
+
+// Take stdin/stdout/stderr BEFORE building transport
+let stdin = child.stdin.take()?;
+let stdout = child.stdout.take()?;
+let stderr = child.stderr.take()?;
+
+// Build rmcp AsyncRwTransport (self-owned)
+let transport = AsyncRwTransport::<RoleClient, _, _>::new(
+    stdout,
+    stdin,
+    MaxMessageSize::default(),
+);
+
+// Retain child handle in background wait-task
+let child_wait_task = tokio::spawn(async move {
+    let status = child.wait().await?;
+    let exit_class = classify_exit(status);
+    // Emit AgentEvent::Notice with stderr tail
+});
+```
+
+**Exit classification (`classify_exit`):**
+- code 0 / SIGTERM / SIGINT → Warning (clean shutdown)
+- nonzero / SIGKILL / other signal → Error
+- none → Error
+
+**Notice deduplication:** 5s window to avoid spam.
+
+**call_tool transport errors:** emit Warning (reconnect in progress) / Error (failed reconnect).
+
+### 4. Notice delivery under ACP
+
+`AgentEvent::Notice` maps to ACP text session/update with prefix (ℹ/⚠/🔴).
+
+**Subtlety:** Synchronous reconnect notices run inside agent-loop task → reach per-turn scoped ACP sink. The DETACHED child-death wait-task emits to GLOBAL sink (tokio task-locals don't cross `spawn`). Under ACP, child death surfaces on NEXT `call_tool` via reconnect path.
+
+**Design choice:** "Lazy" option D (Oracle-recommended) — simpler than per-session long-lived sink plumbing, correct behavior.
+
+## Why This Works
+
+1. **Session-lived managers:** Set up once, reuse per prompt. Matches NATS worker pattern. MCP subprocesses live for session lifetime, not per-prompt.
+
+2. **Prefix filter matches targets:** `"harnx"` prefix matches `harnx_acp`, `harnx_mcp`, `harnx_runtime`. Log inheritance works; filter no longer drops everything.
+
+3. **Self-owned child:** Wait-task captures exit status before transport consumes process. Deduped notices surface to user.
+
+4. **Lazy notice propagation:** Child death surfaces on next tool call when reconnect path triggers. Simpler than long-lived sink plumbing, correct UX.
+
+## Prevention Strategies
+
+**Reference Pattern:**
+- "Exactly one config/manager per session, set up once, reused per prompt" — copy NATS worker architecture
+
+**Simplelog Gotcha:**
+- Workspace crate targets use underscores (`harnx_foo`), not `harnx::`
+-简单日志前缀匹配使用 `starts_with` — 确保 filter 前缀正确
+
+**Code Review Checklist:**
+- [ ] Per-prompt path: does it fork/re-scope config? Should it own session-lived state instead?
+- [ ] Log filter: does it match actual crate targets (check underscore vs `::`)?
+- [ ] Process spawn: do we need exit status? Use self-spawn + AsyncRwTransport, retain child handle.
+
+**Test Cases:**
+- MCP client reused across multiple prompts in same session (no reconnect logs)
+- ACP serve logs visible (startup banner, tool calls)
+- MCP subprocess exit surfaces as Notice with correct severity
+
+## Wrong Turns / Rejected Approaches
+
+### 1. "Preserve-Arc band-aid" in `reinit_managers_for_agent`
+
+**Rejected approach:** Add comparison logic to `reinit_managers_for_agent` comparing effective configs (`existing.configs()` vs `effective`), skip rebuild if unchanged. Added `McpServerConfig`/`AcpServerConfig` `PartialEq` derive.
+
+**Why rejected:** Treats symptom, not root cause. Manager rebuild still happened for OTHER callers. The real fix is ACP not calling `reinit` per-prompt at all.
+
+**Outcome:** Band-aid code dropped. `reinit_managers_for_agent` keeps original unconditional-rebuild behavior. ACP path simply never calls it.
+
+### 2. Per-var env forwarding (`HARNX_LOG_*`)
+
+**Rejected approach:** Add `apply_forwarded_log_env`, `resolve_forwarded_log_path`, forward `HARNX_LOG_LEVEL`/`HARNX_LOG_PATH` explicitly to each child. `Config::forwarded_log_env` absolutized paths, preserved `{pid}` template.
+
+**Why rejected:** Problem was the log FILTER dropping logs, not env inheritance. Children already inherit env+cwd correctly. The per-var forwarding was redundant and did not fix #989.
+
+**Outcome:** Env forwarding code dropped. Log filter fixed instead. Guard added to prevent project `.env` from clobbering inherited log env.
+
+### 3. `HARNX_MCP_KEEP_SERVICES_AFTER_DISCOVERY` flag
+
+**Rejected approach:** Add internal env flag to skip invalidation after discovery.
+
+**Why rejected:** Workaround for symptom, not root cause. Gated runtime behavior with undocumented env var.
+
+**Outcome:** Flag dropped. Session-lived context fixes the root issue.
+
+## Related Issues
+
+- **GitHub:** [#988](https://github.com/dobesv/harnx/issues/988) — MCP servers constantly restarting under ACP
+- **GitHub:** [#989](https://github.com/dobesv/harnx/issues/989) — ACP subagent log capture
+- **GitHub:** [#990](https://github.com/dobesv/harnx/issues/990) — MCP subprocess exit status
+- **Reference Implementation:** `crates/harnx-runtime/src/nats_worker/daemon.rs` — "exactly one worker per session" pattern (correct architecture)


### PR DESCRIPTION
Fixes #988 — MCP servers constantly restarting under ACP. Root fix: the ACP server now builds a per-session SessionContext that owns its MCP/ACP managers once and reuses them across prompts (mirroring the NATS worker), instead of re-forking config and rebuilding managers every prompt. Includes lazy session rebuild from disk and a 15-minute idle-session reaper.

Fixes #989 — ACP subagent logs not captured. Root fix: the serve/ACP default log filter was "harnx::serve", which (simplelog prefix matching) matched none of the harnx_* crate targets and dropped all logs; changed the default to "harnx". Also guards a project .env from clobbering an inherited HARNX_LOG_LEVEL/HARNX_LOG_PATH.

Fixes #990 — surface MCP server restarts/deaths as user-visible notices: self-owned child spawn (rmcp AsyncRwTransport) to capture real exit status, classify_exit → AgentEvent::Notice with stderr tail, deduped; forwarded to ACP clients via event_to_forward.

Plan: acp-session-context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session handling now stays consistent across prompts, improving stability and reducing unnecessary reconnects.
  * Users may now see clearer notices when MCP connections fail or subprocesses restart/die.

* **Bug Fixes**
  * Fixed repeated MCP subprocess restarts between prompts.
  * Improved log behavior so runtime logs are captured more reliably.
  * Preserved existing logging settings from the environment instead of overwriting them with project defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->