### PR TITLE
chore(renovate): add 3-day minimumReleaseAge stability window

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,8 @@
   "automerge": false,
   "automergeType": "pr",
   "platformAutomerge": true,
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "description": "Automerge minor and patch updates",


### PR DESCRIPTION
Renovate auto-merges patch/minor/digest/pin updates immediately, which commits pnpm-lock.yaml entries referencing just-published packages. The local pnpm supply-chain policy enforces a 24h minimumReleaseAge, so those fresh lockfiles fail `pnpm install` with ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION (e.g. @types/node@24.13.3 published <24h before install).

Set Renovate's minimumReleaseAge to "3 days" (comfortably above the local 24h window) and internalChecksFilter to "strict" so PRs are held until the stability age is met. This keeps landed lockfiles installable locally and reduces dependency churn.