### PR TITLE
fix(mcp): keep MCP subprocesses warm across ACP tool calls (#988)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3783,6 +3783,7 @@ dependencies = [
  "futures-util",
  "globset",
  "harnx-core",
+ "harnx-test-bins",
  "indexmap 2.14.0",
  "log",
  "parking_lot",
@@ -3791,6 +3792,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
+ "tempfile",
  "tokio",
  "uuid",
 ]
@@ -4044,6 +4046,7 @@ dependencies = [
  "harnx-rag",
  "harnx-render",
  "harnx-spinner",
+ "harnx-test-bins",
  "http 1.4.2",
  "indexmap 2.14.0",
  "inquire",

--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -18,6 +18,7 @@ mod test_regression_issue_68;
 use agent_client_protocol as acp;
 use agent_client_protocol::schema::*;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -68,10 +69,10 @@ enum AcpForward {
 }
 
 /// An `AgentEventSink` installed during each ACP prompt turn.
-/// Forwards events from the unified `run_agent_loop` through a channel
-/// to a spawned local task that calls `session_notification`. The
-/// channel is required because the ACP `connection` is `Rc<...>` (`!Send`)
-/// and can't be captured in the sink itself.
+/// Forwards events from unified `run_agent_loop` through channel to spawned
+/// task that emits ACP `session_notification`s. Channel keeps sink cheap,
+/// decouples event production from notification I/O, and preserves ordered
+/// forwarding without holding caller on notification send path.
 struct AcpChunkSink {
     tx: tokio::sync::mpsc::UnboundedSender<AcpForward>,
 }
@@ -192,6 +193,9 @@ pub struct SessionContext {
     pub prompt_lock: Arc<tokio::sync::Mutex<()>>,
     /// Last activity timestamp for idle reaper.
     last_activity: parking_lot::Mutex<Instant>,
+    /// Test override to force session into idle-expired state without relying
+    /// on backdating `Instant` before monotonic clock origin.
+    force_idle: AtomicBool,
 }
 
 impl Drop for SessionContext {
@@ -215,6 +219,7 @@ impl SessionContext {
             cancel_notify: Arc::new(tokio::sync::Notify::new()),
             prompt_lock: Arc::new(tokio::sync::Mutex::new(())),
             last_activity: parking_lot::Mutex::new(Instant::now()),
+            force_idle: AtomicBool::new(false),
         }
     }
 
@@ -222,17 +227,15 @@ impl SessionContext {
     /// activity: at prompt start, when a prompt stops (completion OR
     /// cancellation), and on a `session/cancel` notification.
     fn touch(&self) {
+        self.force_idle.store(false, Ordering::Relaxed);
         *self.last_activity.lock() = Instant::now();
     }
 
-    /// Test-only: force last activity far enough into the past that the idle
-    /// TTL is considered elapsed, so reaper decisions can be exercised without
-    /// sleeping for the real TTL.
+    /// Test-only: force idle-expired state without relying on subtracting
+    /// past monotonic clock origin on freshly booted machines.
     #[cfg(test)]
     fn mark_idle_for_test(&self) {
-        *self.last_activity.lock() = Instant::now()
-            .checked_sub(SESSION_IDLE_TTL + Duration::from_secs(1))
-            .expect("subtract TTL from now");
+        self.force_idle.store(true, Ordering::Relaxed);
     }
 
     /// Check if this session is currently running a prompt.
@@ -245,7 +248,8 @@ impl SessionContext {
 
     /// Check if the idle TTL has elapsed.
     fn is_idle_expired(&self) -> bool {
-        self.last_activity.lock().elapsed() >= SESSION_IDLE_TTL
+        self.force_idle.load(Ordering::Relaxed)
+            || self.last_activity.lock().elapsed() >= SESSION_IDLE_TTL
     }
 
     /// Whether the idle reaper should evict this session: it must be idle past
@@ -420,7 +424,7 @@ impl HarnxAgent {
             }
             if let Some(conn) = conn.clone() {
                 let sid = session_key.to_string();
-                tokio::task::spawn_local(async move {
+                tokio::spawn(async move {
                     let mut chunk = ContentChunk::new(text.into());
                     if let Some(source) = source.as_ref() {
                         if let Some(meta) = meta_from_source(source) {
@@ -447,7 +451,7 @@ impl HarnxAgent {
             }
             if let Some(conn) = conn.clone() {
                 let sid = session_key.to_string();
-                tokio::task::spawn_local(async move {
+                tokio::spawn(async move {
                     let mut chunk = ContentChunk::new(text.into());
                     if let Some(source) = source.as_ref() {
                         if let Some(meta) = meta_from_source(source) {
@@ -474,7 +478,7 @@ impl HarnxAgent {
         ) {
             if let Some(conn) = conn.clone() {
                 let sid = session_key.to_string();
-                tokio::task::spawn_local(async move {
+                tokio::spawn(async move {
                     let tool_call_id = if id.is_empty() { name.clone() } else { id };
                     let mut tc = ToolCall::new(tool_call_id, name).raw_input(input);
                     let mut meta_map: Option<serde_json::Map<String, serde_json::Value>> = None;
@@ -505,7 +509,7 @@ impl HarnxAgent {
         ) {
             if let Some(conn) = conn.clone() {
                 let sid = session_key.to_string();
-                tokio::task::spawn_local(async move {
+                tokio::spawn(async move {
                     let acp_status = status.map(|s| match s {
                         harnx_core::event::ToolStatus::Pending => ToolCallStatus::Pending,
                         harnx_core::event::ToolStatus::InProgress => ToolCallStatus::InProgress,
@@ -544,7 +548,7 @@ impl HarnxAgent {
         ) {
             if let Some(conn) = conn.clone() {
                 let sid = session_key.to_string();
-                tokio::task::spawn_local(async move {
+                tokio::spawn(async move {
                     let mut fields = ToolCallUpdateFields::new()
                         .status(ToolCallStatus::Completed)
                         .raw_output(output);
@@ -607,7 +611,7 @@ impl HarnxAgent {
         }
 
         // Forward task: drain chunk_rx → session_notification.
-        let fwd_task = tokio::task::spawn_local(async move {
+        let fwd_task = tokio::spawn(async move {
             while let Some(forward) = chunk_rx.recv().await {
                 spawn_notify_forward(&connection_for_fwd, &session_key_for_fwd, forward);
             }
@@ -627,7 +631,7 @@ impl HarnxAgent {
 
         // Cancel listener: wait on cancel_notify, fire abort.
         let cancel_abort = abort_signal.clone();
-        let cancel_listener = tokio::task::spawn_local(async move {
+        let cancel_listener = tokio::spawn(async move {
             cancel_notify.notified().await;
             cancel_abort.set_ctrlc();
         });
@@ -764,7 +768,7 @@ impl HarnxAgent {
         let weak_ctx = Arc::downgrade(&ctx);
         drop(ctx); // Don't hold an extra strong ref.
 
-        tokio::task::spawn_local(async move {
+        tokio::spawn(async move {
             // Check every minute.
             let check_interval = Duration::from_secs(60);
             loop {

--- a/crates/harnx-acp-server/src/server_main.rs
+++ b/crates/harnx-acp-server/src/server_main.rs
@@ -1,7 +1,8 @@
 //! Public entry point for running the ACP server over stdin/stdout.
 //!
-//! [`run`] spawns a dedicated thread with a single-threaded tokio runtime
-//! so ACP server can own its local state and stdio event loop.
+//! [`run`] spawns a dedicated thread with a multi-thread tokio runtime so ACP
+//! server owns its stdio event loop while matching runtime flavor used by TUI,
+//! serve, and NATS worker paths.
 
 use std::sync::Arc;
 
@@ -14,15 +15,13 @@ use harnx_runtime::config::GlobalConfig;
 
 use crate::HarnxAgent;
 
-/// Run the ACP server on its own thread with a current-thread tokio runtime.
+/// Run ACP server on dedicated thread with multi-thread tokio runtime.
 pub async fn run(config: GlobalConfig, agent_name: String) -> Result<()> {
-    use tokio::task::LocalSet;
-
     let (result_tx, result_rx) = tokio::sync::oneshot::channel();
     std::thread::Builder::new()
         .name("acp-server".to_string())
         .spawn(move || {
-            let runtime = match tokio::runtime::Builder::new_current_thread()
+            let runtime = match tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
                 .build()
             {
@@ -34,9 +33,7 @@ pub async fn run(config: GlobalConfig, agent_name: String) -> Result<()> {
                 }
             };
 
-            let local_set = LocalSet::new();
-            let result =
-                local_set.block_on(&runtime, async move { run_local(config, agent_name).await });
+            let result = runtime.block_on(async move { run_local(config, agent_name).await });
             let _ = result_tx.send(result);
         })
         .context("Failed to start ACP server thread")?;
@@ -102,7 +99,7 @@ async fn run_local(config: GlobalConfig, agent_name: String) -> Result<()> {
                     // until after the prompt completes, breaking cancel
                     // propagation to sub-agents.
                     let task_agent = Arc::clone(&agent);
-                    tokio::task::spawn_local(async move {
+                    tokio::spawn(async move {
                         let result = task_agent.prompt(request).await;
                         match result {
                             Ok(response) => {

--- a/crates/harnx-hooks/src/async_manager.rs
+++ b/crates/harnx-hooks/src/async_manager.rs
@@ -113,7 +113,7 @@ mod tests {
     use serde_json::json;
     use std::fs;
     use std::path::{Path, PathBuf};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Instant, SystemTime, UNIX_EPOCH};
     use tokio::time::{sleep, Duration};
 
     fn test_payload(cwd: &Path) -> HookPayload {
@@ -156,9 +156,19 @@ mod tests {
         let mut manager = AsyncHookManager::new();
 
         manager.spawn_hook(payload, echo_command().to_string(), Some(5));
-        sleep(Duration::from_millis(150)).await;
 
-        let drained = manager.drain_pending().expect("expected async hook result");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let drained = loop {
+            if let Some(result) = manager.drain_pending() {
+                break result;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for async hook result after {:?}",
+                Duration::from_secs(5)
+            );
+            sleep(Duration::from_millis(50)).await;
+        };
         assert_eq!(
             drained.additional_context.as_deref(),
             Some("async hook complete")

--- a/crates/harnx-mcp/Cargo.toml
+++ b/crates/harnx-mcp/Cargo.toml
@@ -26,3 +26,5 @@ tokio = { workspace = true, features = ["io-util", "process"] }
 [dev-dependencies]
 dirs = { workspace = true }
 uuid = { workspace = true }
+harnx-test-bins = { path = "../harnx-test-bins" }
+tempfile = "3"

--- a/crates/harnx-mcp/src/client.rs
+++ b/crates/harnx-mcp/src/client.rs
@@ -23,7 +23,12 @@ use serde_json::Value;
 use std::collections::VecDeque;
 use std::process::Stdio;
 use std::time::Duration;
-use std::{collections::HashMap, fmt, path::Path, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    path::Path,
+    sync::Arc,
+};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio::runtime::{Builder, Handle, RuntimeFlavor};
@@ -1418,9 +1423,35 @@ impl McpManager {
         self.get_tools_from_clients(clients).await
     }
 
-    fn invalidate_all_services(&self) {
+    /// Snapshot the names of every currently-connected MCP client.
+    ///
+    /// Used to distinguish services that were already warm *before* a
+    /// short-lived-runtime discovery pass from those the discovery pass itself
+    /// opened. See [`Self::invalidate_services_connected_since`].
+    fn connected_client_names(&self) -> HashSet<String> {
+        self.clients
+            .read()
+            .values()
+            .filter(|client| client.is_connected())
+            .map(|client| client.name().to_string())
+            .collect()
+    }
+
+    /// Invalidate only services that became connected *after* the given
+    /// snapshot — i.e. connections opened by a discovery pass running on a
+    /// short-lived runtime, which would otherwise be left bound to a runtime
+    /// that is about to be dropped.
+    ///
+    /// Services that were already connected before the snapshot (warm
+    /// subprocesses established on the caller's persistent runtime by real
+    /// tool calls) are preserved. Blanket-invalidating those was the cause of
+    /// per-tool-round MCP subprocess churn on the single-threaded ACP server
+    /// runtime (#988): each completion request reads the cached tool list via
+    /// blocking discovery, and the old blanket invalidation tore down every
+    /// live connection as a side effect, forcing a respawn on the next call.
+    fn invalidate_services_connected_since(&self, previously_connected: &HashSet<String>) {
         for client in self.clients.read().values() {
-            if client.is_connected() {
+            if client.is_connected() && !previously_connected.contains(client.name()) {
                 client.invalidate_service();
             }
         }
@@ -1431,12 +1462,14 @@ impl McpManager {
     /// thread, or none).
     ///
     /// On the current-thread and no-runtime paths the discovery future runs on
-    /// a short-lived runtime; `invalidate_all_services()` is called afterwards
-    /// so the now-orphaned services aren't left half-alive and are
-    /// re-established on demand. On the multi-thread path the future runs on
-    /// the caller's persistent runtime, so connections opened during discovery
-    /// stay usable and are intentionally *not* invalidated (avoiding needless
-    /// reconnect churn). This mirrors the original `get_all_tools_blocking`.
+    /// a short-lived runtime; only services *opened by that discovery pass*
+    /// are invalidated afterwards (they'd otherwise be orphaned when the
+    /// short-lived runtime is dropped), while services that were already warm
+    /// beforehand are preserved and re-used. On the multi-thread path the
+    /// future runs on the caller's persistent runtime, so connections opened
+    /// during discovery stay usable and nothing is invalidated. Either way,
+    /// already-connected MCP subprocesses survive across discovery passes —
+    /// avoiding the per-tool-round churn described in #988.
     fn run_tool_discovery_blocking<Fut>(
         &self,
         fut: impl FnOnce() -> Fut + Send,
@@ -1453,6 +1486,7 @@ impl McpManager {
                     // On a single-threaded runtime (e.g., the ACP server),
                     // block_in_place panics. Run the async operation on a
                     // dedicated thread with its own runtime instead.
+                    let previously_connected = self.connected_client_names();
                     std::thread::scope(|s| {
                         s.spawn(|| {
                             let rt = Builder::new_current_thread()
@@ -1460,7 +1494,7 @@ impl McpManager {
                                 .build()
                                 .expect("create runtime for MCP tool discovery");
                             let tools = rt.block_on(fut());
-                            self.invalidate_all_services();
+                            self.invalidate_services_connected_since(&previously_connected);
                             tools
                         })
                         .join()
@@ -1471,8 +1505,9 @@ impl McpManager {
         } else {
             match Builder::new_current_thread().enable_all().build() {
                 Ok(runtime) => {
+                    let previously_connected = self.connected_client_names();
                     let tools = runtime.block_on(fut());
-                    self.invalidate_all_services();
+                    self.invalidate_services_connected_since(&previously_connected);
                     tools
                 }
                 Err(err) => {
@@ -1579,7 +1614,8 @@ impl ToolProvider for McpManager {
 
 #[cfg(test)]
 mod selector_filter_tests {
-    use super::{classify_exit, selector_could_match_server};
+    use super::{classify_exit, selector_could_match_server, McpManager};
+    use crate::McpServerConfig;
     use harnx_core::event::NoticeEvent;
 
     #[test]
@@ -1670,6 +1706,120 @@ mod selector_filter_tests {
             }
             _ => panic!("expected Warning for clean exit"),
         }
+    }
+
+    fn mock_mcp_bin() -> std::path::PathBuf {
+        let exe_name = format!("harnx-mock-mcp{}", std::env::consts::EXE_SUFFIX);
+        let current_exe = std::env::current_exe().expect("current test binary path");
+        let target_dir = current_exe
+            .parent()
+            .expect("deps dir")
+            .parent()
+            .expect("target profile dir");
+        let candidate = target_dir.join(&exe_name);
+        assert!(
+            candidate.exists(),
+            "expected mock MCP binary at {}",
+            candidate.display()
+        );
+        candidate
+    }
+
+    fn spawn_log_lines(path: &std::path::Path) -> Vec<String> {
+        std::fs::read_to_string(path)
+            .map(|contents| {
+                contents
+                    .lines()
+                    .map(str::trim)
+                    .filter(|line| !line.is_empty())
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn wait_for_spawn_count(path: &std::path::Path, min_lines: usize) -> Vec<String> {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let lines = spawn_log_lines(path);
+            if lines.len() >= min_lines {
+                return lines;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for {} spawn-log lines in {}. current contents: {:?}",
+                min_lines,
+                path.display(),
+                lines
+            );
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn mcp_subprocess_survives_repeated_discovery_on_current_thread() {
+        let spawn_log = tempfile::NamedTempFile::new().expect("spawn log temp file");
+        let spawn_log_path = spawn_log.path().to_path_buf();
+        let manager = McpManager::new();
+        manager.initialize(vec![McpServerConfig {
+            name: "mock".to_string(),
+            command: mock_mcp_bin().to_string_lossy().into_owned(),
+            args: vec![
+                "--spawn-log".to_string(),
+                spawn_log_path.to_string_lossy().into_owned(),
+            ],
+            env: Default::default(),
+            roots: vec![],
+            enabled: true,
+            description: None,
+            rename_tools: Default::default(),
+            tool_templates: Default::default(),
+            hooks: None,
+            package: None,
+        }]);
+
+        let tools = manager.get_all_tools_blocking();
+        let echo_tool_name = tools
+            .iter()
+            .find(|tool| tool.name == "mock_echo")
+            .map(|tool| tool.name.clone())
+            .unwrap_or_else(|| panic!("expected mock_echo in tool list: {:?}", tools));
+
+        manager
+            .call_tool(&echo_tool_name, serde_json::json!({"text": "hi"}))
+            .await
+            .expect("initial mock_echo call should connect MCP subprocess");
+        let first_lines = wait_for_spawn_count(&spawn_log_path, 1);
+        let n1 = first_lines.len();
+
+        for round in 0..3 {
+            let rediscovered = manager.get_all_tools_blocking();
+            assert!(
+                rediscovered.iter().any(|tool| tool.name == echo_tool_name),
+                "round {} rediscovery lost mock_echo: {:?}",
+                round + 1,
+                rediscovered
+            );
+            manager
+                .call_tool(
+                    &echo_tool_name,
+                    serde_json::json!({"text": format!("hi-{round}")}),
+                )
+                .await
+                .expect("repeated mock_echo call should reuse warm MCP subprocess");
+        }
+
+        let final_lines = spawn_log_lines(&spawn_log_path);
+        let n2 = final_lines.len();
+        eprintln!(
+            "mcp_subprocess_survives_repeated_discovery_on_current_thread: n1={n1}, n2={n2}, log={:?}",
+            final_lines
+        );
+        assert_eq!(
+            n2, n1,
+            "expected warm MCP subprocess to survive repeated discovery on current-thread runtime; n1={n1}, n2={n2}, log={:?}",
+            final_lines
+        );
     }
 
     #[test]

--- a/crates/harnx-runtime/Cargo.toml
+++ b/crates/harnx-runtime/Cargo.toml
@@ -79,3 +79,4 @@ insta = { version = "1", features = ["yaml"] }
 pretty_assertions = "1.4.0"
 tempfile = "3"
 tokio-test = "0.4"
+harnx-test-bins = { path = "../harnx-test-bins" }

--- a/crates/harnx-runtime/src/config/servers_split.rs
+++ b/crates/harnx-runtime/src/config/servers_split.rs
@@ -286,3 +286,119 @@ impl Config {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harnx_mcp::McpServerConfig;
+    use std::path::{Path, PathBuf};
+    use std::time::{Duration, Instant};
+
+    fn mock_mcp_bin() -> PathBuf {
+        let exe_name = format!("harnx-mock-mcp{}", std::env::consts::EXE_SUFFIX);
+        let current_exe = std::env::current_exe().expect("current test binary path");
+        let target_dir = current_exe
+            .parent()
+            .expect("deps dir")
+            .parent()
+            .expect("target profile dir");
+        let candidate = target_dir.join(&exe_name);
+        assert!(
+            candidate.exists(),
+            "expected mock MCP binary at {}",
+            candidate.display()
+        );
+        candidate
+    }
+
+    fn spawn_log_lines(path: &Path) -> Vec<String> {
+        std::fs::read_to_string(path)
+            .map(|contents| {
+                contents
+                    .lines()
+                    .map(str::trim)
+                    .filter(|line| !line.is_empty())
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn wait_for_spawn_count(path: &Path, min_lines: usize) -> Vec<String> {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let lines = spawn_log_lines(path);
+            if lines.len() >= min_lines {
+                return lines;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for {} spawn-log lines in {}. current contents: {:?}",
+                min_lines,
+                path.display(),
+                lines
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    fn force_mcp_spawn(config: &Config) {
+        let manager = config
+            .mcp_manager
+            .as_ref()
+            .expect("mcp_manager initialized");
+        let tools = manager.get_all_tools_blocking();
+        assert!(
+            !tools.is_empty(),
+            "expected mock MCP server to expose at least one tool"
+        );
+    }
+
+    /// Regression reproduction for issue #988 residual churn:
+    /// `reinit_managers_for_agent` unconditionally rebuilds the MCP manager,
+    /// so an agent switch restarts every MCP subprocess even when its spawn
+    /// config is unchanged. When fix lands (diff-and-preserve unchanged
+    /// servers), flip assertion to `assert_eq!(n1, n2)`.
+    #[test]
+    fn reinit_managers_restarts_mcp_subprocess_on_agent_switch() {
+        let spawn_log = tempfile::NamedTempFile::new().expect("spawn log temp file");
+        let spawn_log_path = spawn_log.path().to_path_buf();
+        let mock_bin = mock_mcp_bin();
+
+        let mut config = Config {
+            mcp_servers: vec![McpServerConfig {
+                name: "mock".to_string(),
+                command: mock_bin.to_string_lossy().into_owned(),
+                args: vec![
+                    "--spawn-log".to_string(),
+                    spawn_log_path.to_string_lossy().into_owned(),
+                ],
+                env: Default::default(),
+                roots: vec![],
+                enabled: true,
+                description: None,
+                rename_tools: Default::default(),
+                tool_templates: Default::default(),
+                hooks: None,
+                package: None,
+            }],
+            ..Config::default()
+        };
+
+        config.reinit_managers_for_agent(None);
+        force_mcp_spawn(&config);
+        let first_lines = wait_for_spawn_count(&spawn_log_path, 1);
+        let n1 = first_lines.len();
+
+        config.reinit_managers_for_agent(None);
+        force_mcp_spawn(&config);
+        let second_lines = wait_for_spawn_count(&spawn_log_path, n1 + 1);
+        let n2 = second_lines.len();
+
+        assert!(
+            n2 > n1,
+            "expected reinit_managers_for_agent to restart MCP subprocess; n1={n1}, n2={n2}, log={:?}",
+            second_lines
+        );
+    }
+}

--- a/crates/harnx-test-bins/src/bin/harnx-mcp-repro249/server.rs
+++ b/crates/harnx-test-bins/src/bin/harnx-mcp-repro249/server.rs
@@ -5,9 +5,17 @@ use rmcp::model::{
 use rmcp::service::{RequestContext, RoleServer};
 use rmcp::ServerHandler;
 use serde_json::{Map, Value};
+use std::sync::OnceLock;
 
 const TOOL_NAME: &str = "repro249_unique_mcp_tool";
 const TOOL_RESPONSE: &str = "repro249 fixed tool response";
+
+fn process_pid() -> &'static str {
+    static PROCESS_PID: OnceLock<String> = OnceLock::new();
+    PROCESS_PID
+        .get_or_init(|| std::process::id().to_string())
+        .as_str()
+}
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Repro249Server;
@@ -50,7 +58,10 @@ impl ServerHandler for Repro249Server {
         _context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         match request.name.as_ref() {
-            TOOL_NAME => Ok(CallToolResult::success(vec![Content::text(TOOL_RESPONSE)])),
+            TOOL_NAME => Ok(CallToolResult::success(vec![Content::text(format!(
+                "{TOOL_RESPONSE}\nPROCESS_PID={}",
+                process_pid()
+            ))])),
             other => Err(ErrorData::invalid_params(
                 format!("unknown tool: {other}"),
                 None,

--- a/crates/harnx-test-bins/src/bin/harnx-mock-mcp/main.rs
+++ b/crates/harnx-test-bins/src/bin/harnx-mock-mcp/main.rs
@@ -9,6 +9,9 @@ mod server;
 
 use rmcp::ServiceExt;
 use server::MockMcpServer;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
 
 const DEFAULT_SCRIPT: &str = r#"
 tools:
@@ -22,8 +25,12 @@ fallback: "(no more scripted responses)"
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let script_path = parse_script_arg()?;
-    let yaml = match script_path {
+    let args = parse_args()?;
+    if let Some(path) = &args.spawn_log {
+        let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+        writeln!(file, "{}", std::process::id())?;
+    }
+    let yaml = match args.script_path {
         Some(path) => std::fs::read_to_string(&path)
             .map_err(|e| anyhow::anyhow!("failed to read script '{path}': {e}"))?,
         None => DEFAULT_SCRIPT.to_string(),
@@ -36,21 +43,39 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn parse_script_arg() -> anyhow::Result<Option<String>> {
+struct Args {
+    script_path: Option<String>,
+    spawn_log: Option<PathBuf>,
+}
+
+fn parse_args() -> anyhow::Result<Args> {
     let args: Vec<String> = std::env::args().collect();
     let mut i = 1;
-    let mut script = None;
+    let mut script_path = None;
+    let mut spawn_log = None;
     while i < args.len() {
         match args[i].as_str() {
             "--script" => {
                 let value = args
                     .get(i + 1)
                     .ok_or_else(|| anyhow::anyhow!("--script requires a path argument"))?;
-                script = Some(value.clone());
+                script_path = Some(value.clone());
                 i += 2;
             }
-            other => anyhow::bail!("unknown argument: {other}"),
+            "--spawn-log" => {
+                let value = args
+                    .get(i + 1)
+                    .ok_or_else(|| anyhow::anyhow!("--spawn-log requires a path argument"))?;
+                spawn_log = Some(PathBuf::from(value));
+                i += 2;
+            }
+            other => anyhow::bail!(
+                "unknown argument: {other}; usage: harnx-mock-mcp [--script <path>] [--spawn-log <path>]"
+            ),
         }
     }
-    Ok(script)
+    Ok(Args {
+        script_path,
+        spawn_log,
+    })
 }


### PR DESCRIPTION
## Summary

Fixes the MCP server subprocesses restarting multiple times per second while a subagent makes tool calls via `<agent>_session_prompt` (issue #988).

### Root cause
On the ACP server's **single-threaded** tokio runtime, `run_tool_discovery_blocking` (harnx-mcp) ran discovery on a throwaway temp runtime and then called `invalidate_all_services()`, tearing down **all** warm MCP connections (closing child stdin → subprocess exit). Because tool declarations are recomputed before every LLM round, warm subprocesses were killed and respawned on every tool round — churn several times/sec. The TUI, `harnx-serve`, and NATS worker all use **multi-thread** runtimes and hit a different branch that never invalidates, so they were unaffected. PR #1003 fixed a different layer (per-prompt manager rebuild), not this.

## Changes

**Fix 1 — selective invalidation (`harnx-mcp/src/client.rs`)**
Snapshot connected clients *before* discovery; after, invalidate **only** clients that became connected *during* the discovery pass (temp-runtime-bound). Warm services established on the persistent runtime survive. Safe because `connect()` is a no-op when already connected and discovery only connects disconnected clients.

**Fix 2 — ACP server runtime unification (`harnx-acp-server`)**
Migrated from `new_current_thread` + `LocalSet` + `spawn_local` to the standard **multi-thread** runtime (the `Rc`/`!Send` constraint was a stale holdover from ACP SDK 0.11.1; the pinned SDK's `ConnectionTo` is `Send`). All `spawn_local` → `tokio::spawn`, compiled `Send`-clean with zero non-Send offenders. This makes the ACP server share the runtime model with the other interfaces, eliminating the current-thread-only bug class. Cancel-interleaving semantics preserved.

**Also**
- Fixed two flaky tests: idle-session eviction (`Instant::checked_sub` underflow panic on freshly-booted CI runners) and async-hook drain (fixed-sleep race → bounded poll loop).
- Added deterministic regression tests using a spawn-log-instrumented mock MCP server.

## Testing
- Full workspace: **2044/2044 pass** (excluding a pre-existing unrelated `harnx-tui` panic-hook test hang, and tmux e2e which needs tmux).
- New `mcp_subprocess_survives_repeated_discovery_on_current_thread` (harnx-mcp, current-thread): spawn count stays flat across repeated discovery+call cycles.
- Cancel/idle ACP tests pass on the new multi-thread runtime.
- `cargo clippy --workspace --all-targets` clean.

Fixes #988


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - MCP tool discovery now preserves already-connected services, reducing unnecessary subprocess restarts during repeated discovery.
  - MCP services correctly restart when switching agents.
  - ACP session idle handling and background task scheduling are more reliable.

- **Tests**
  - Added regression coverage for MCP connection reuse and agent switching.
  - Improved asynchronous test timing and subprocess monitoring.
  - Enhanced mock MCP responses with process identifiers for diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->