### PR TITLE
fix(mcp): only prefetch selector-matching MCP servers at agent init (#1029)

### DIFF
--- a/crates/harnx-runtime/src/config/agent.rs
+++ b/crates/harnx-runtime/src/config/agent.rs
@@ -5,7 +5,7 @@ use inquire::{validator::Validation, Text};
 use std::path::Path;
 
 pub use harnx_core::agent_config::{
-    AgentConfig, AgentRole, AgentVariable, AgentVariables, TEMP_AGENT_NAME,
+    split_tool_selectors, AgentConfig, AgentRole, AgentVariable, AgentVariables, TEMP_AGENT_NAME,
 };
 
 const DEFAULT_AGENT_NAME: &str = "rag";
@@ -239,6 +239,24 @@ pub fn resolve_variables(agent: &mut Agent) -> Result<()> {
     Ok(())
 }
 
+fn expand_agent_use_tool_selectors(config: &Config, use_tools: Option<Vec<String>>) -> Vec<String> {
+    let Some(use_tools) = use_tools.filter(|selectors| !selectors.is_empty()) else {
+        return Vec::new();
+    };
+
+    split_tool_selectors(&use_tools.join(","))
+        .into_iter()
+        .flat_map(|selector| {
+            let selector = selector.trim();
+            config
+                .toolsets
+                .get(selector)
+                .cloned()
+                .unwrap_or_else(|| vec![selector.to_string()])
+        })
+        .collect()
+}
+
 pub async fn init(config: &GlobalConfig, name: &str, abort_signal: AbortSignal) -> Result<Agent> {
     let agent_file_path = Config::agent_file(name);
     let mut agent = if agent_file_path.exists() {
@@ -247,11 +265,19 @@ pub async fn init(config: &GlobalConfig, name: &str, abort_signal: AbortSignal) 
         builtin(name)?
     };
 
+    let prefetched_tool_selectors = {
+        let guard = config.read();
+        expand_agent_use_tool_selectors(&guard, agent.config.use_tools())
+    };
     let mcp_manager = config.read().mcp_manager.clone();
     agent.mcp_manager = mcp_manager.clone();
 
     let mcp_tools = match &mcp_manager {
-        Some(manager) => Some(manager.get_all_tools().await),
+        Some(manager) => Some(
+            manager
+                .get_tools_for_selectors(&prefetched_tool_selectors)
+                .await,
+        ),
         None => None,
     };
     agent.config.set_tools(Tools::init_from_mcp(mcp_tools));

--- a/crates/harnx-runtime/src/config/agent_ops_split.rs
+++ b/crates/harnx-runtime/src/config/agent_ops_split.rs
@@ -299,10 +299,11 @@ impl Config {
             config.write().exit_agent()?;
         }
         // Scope the MCP/ACP managers to the incoming agent's package BEFORE
-        // `agent::init` snapshots the MCP tool declarations (it reads
-        // `mcp_manager.get_all_tools()` during init). Without this the agent
-        // would inherit the global (`None`) scope left by `Config::init` and
-        // its same-package tools would be wrongly prefixed (#826).
+        // `agent::init` snapshots selector-filtered MCP tool declarations (it
+        // reads `mcp_manager.get_tools_for_selectors(...)` during init).
+        // Without this the agent would inherit the global (`None`) scope left
+        // by `Config::init` and its same-package tools would be wrongly
+        // prefixed (#826).
         //
         // Scoping + install go through the same `scope_managers_for_agent` /
         // `set_active_agent` helpers as the synchronous `use_agent_obj` path, so

--- a/crates/harnx-runtime/src/config/agent_tests.rs
+++ b/crates/harnx-runtime/src/config/agent_tests.rs
@@ -5,6 +5,7 @@ use super::*;
 use crate::client::MessageRole;
 use crate::config::GlobalConfig;
 use crate::utils::create_abort_signal;
+use harnx_mcp::McpServerConfig;
 use std::{
     fs,
     path::Path,
@@ -12,6 +13,65 @@ use std::{
     sync::{LazyLock, Mutex},
     time::{SystemTime, UNIX_EPOCH},
 };
+
+fn mock_mcp_bin() -> PathBuf {
+    let exe_name = format!("harnx-mock-mcp{}", std::env::consts::EXE_SUFFIX);
+    let current_exe = std::env::current_exe().expect("current test binary path");
+    let target_dir = current_exe
+        .parent()
+        .expect("deps dir")
+        .parent()
+        .expect("target profile dir");
+    let candidate = target_dir.join(&exe_name);
+    if candidate.exists() {
+        return candidate;
+    }
+    let fallback = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..");
+    let fallback = fallback.join("target").join("debug").join(&exe_name);
+    assert!(
+        fallback.exists(),
+        "expected mock MCP binary at {} or {}",
+        candidate.display(),
+        fallback.display()
+    );
+    fallback
+}
+
+fn spawn_log_lines(path: &Path) -> Vec<String> {
+    fs::read_to_string(path)
+        .ok()
+        .map(|contents| {
+            contents
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn wait_for_spawn_count(path: &Path, min_lines: usize) -> Vec<String> {
+    use std::time::{Duration, Instant};
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let lines = spawn_log_lines(path);
+        if lines.len() >= min_lines {
+            return lines;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {} spawn-log lines in {}. current contents: {:?}",
+            min_lines,
+            path.display(),
+            lines
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
 
 static TEST_CONFIG_DIR_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
@@ -740,4 +800,227 @@ fn apply_agent_patch_with_invalid_jq_expression_returns_err() {
 
     assert!(result.is_err());
     assert_eq!(config.model_id(), original_model.as_deref());
+}
+
+// Holds `TEST_CONFIG_DIR_LOCK` across `init(...).await` to serialize access to
+// the shared `HARNX_CONFIG_DIR` env var during agent init. The guard must span
+// the await; concurrent tests mutating the same env var would race otherwise.
+// Safe here: it is a test-only serialization lock, and this is the established
+// pattern for config-dir-isolated async tests in the workspace.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn init_prefetches_only_selector_matching_mcp_servers() {
+    let spawn_log = tempfile::NamedTempFile::new().expect("spawn log temp file");
+    let spawn_log_path = spawn_log.path().to_path_buf();
+    let mock_bin = mock_mcp_bin();
+
+    let manager = Arc::new(McpManager::new());
+    manager.initialize(vec![
+        McpServerConfig {
+            name: "fs".to_string(),
+            command: mock_bin.to_string_lossy().into_owned(),
+            args: vec![
+                "--spawn-log".to_string(),
+                spawn_log_path.to_string_lossy().into_owned(),
+            ],
+            env: Default::default(),
+            roots: vec![],
+            enabled: true,
+            description: None,
+            rename_tools: Default::default(),
+            tool_templates: Default::default(),
+            hooks: None,
+            package: None,
+        },
+        McpServerConfig {
+            name: "context7".to_string(),
+            command: mock_bin.to_string_lossy().into_owned(),
+            args: vec![
+                "--spawn-log".to_string(),
+                spawn_log_path.to_string_lossy().into_owned(),
+            ],
+            env: Default::default(),
+            roots: vec![],
+            enabled: true,
+            description: None,
+            rename_tools: Default::default(),
+            tool_templates: Default::default(),
+            hooks: None,
+            package: None,
+        },
+    ]);
+
+    let mut config = Config {
+        mcp_manager: Some(manager.clone()),
+        ..Config::default()
+    };
+    config
+        .toolsets
+        .insert("docs".to_string(), vec!["context7_*".to_string()]);
+    let global_config: GlobalConfig = Arc::new(RwLock::new(config));
+
+    // Isolate HARNX_CONFIG_DIR so the agent file this test writes does not
+    // leak into the shared config dir and pollute other tests (e.g. the
+    // handoff-target scan in `expand_use_tools`). Mirrors `with_test_config_dir`.
+    let _dir_guard = TEST_CONFIG_DIR_LOCK.lock().unwrap();
+    let config_dir = unique_test_config_dir();
+    let agents_dir = config_dir.join("agents");
+    fs::create_dir_all(&agents_dir).expect("create agents dir");
+    // SAFETY: test-only; serialized by TEST_CONFIG_DIR_LOCK.
+    unsafe { std::env::set_var("HARNX_CONFIG_DIR", &config_dir) };
+
+    let agent_path = Config::agent_file("selector-agent");
+    fs::write(
+        &agent_path,
+        "---\nuse_tools: docs\n---\nselector-aware init",
+    )
+    .expect("write agent file");
+
+    let initialized = init(&global_config, "selector-agent", create_abort_signal())
+        .await
+        .expect("agent init succeeds");
+
+    // Restore global state before assertions so a panic still cleans up.
+    unsafe { std::env::remove_var("HARNX_CONFIG_DIR") };
+    let _ = fs::remove_dir_all(&config_dir);
+
+    let tool_names: Vec<String> = initialized
+        .tools()
+        .declarations()
+        .into_iter()
+        .map(|d| d.name)
+        .collect();
+    assert_eq!(tool_names, vec!["context7_echo"]);
+
+    let spawn_lines = wait_for_spawn_count(&spawn_log_path, 1);
+    assert_eq!(spawn_lines.len(), 1, "only matching server should spawn");
+    // spawn-log records only child PIDs; count proves one matching server
+    // connected and unmatched server stayed cold.
+
+    let context7_client = manager.get_client("context7").expect("context7 client");
+    let fs_client = manager.get_client("fs").expect("fs client");
+    assert!(context7_client.is_connected());
+    assert!(!fs_client.is_connected());
+}
+
+// Build a two-server MCP manager (`fs`, `context7`), both pointing at the
+// spawn-log mock binary. Returns (manager, spawn_log tempfile). Shared by the
+// selector-aware init tests below.
+fn two_server_spawn_log_manager() -> (Arc<McpManager>, tempfile::NamedTempFile) {
+    let spawn_log = tempfile::NamedTempFile::new().expect("spawn log temp file");
+    let mock_bin = mock_mcp_bin();
+    let mk = |name: &str| McpServerConfig {
+        name: name.to_string(),
+        command: mock_bin.to_string_lossy().into_owned(),
+        args: vec![
+            "--spawn-log".to_string(),
+            spawn_log.path().to_string_lossy().into_owned(),
+        ],
+        env: Default::default(),
+        roots: vec![],
+        enabled: true,
+        description: None,
+        rename_tools: Default::default(),
+        tool_templates: Default::default(),
+        hooks: None,
+        package: None,
+    };
+    let manager = Arc::new(McpManager::new());
+    manager.initialize(vec![mk("fs"), mk("context7")]);
+    (manager, spawn_log)
+}
+
+// Run `init` for an agent whose markdown frontmatter is `frontmatter`, with the
+// given MCP manager installed, under an isolated HARNX_CONFIG_DIR. Returns the
+// initialized Agent's MCP tool names.
+//
+// Holds `TEST_CONFIG_DIR_LOCK` across `init(...).await` to serialize access to
+// the shared `HARNX_CONFIG_DIR` env var during agent init; the guard must span
+// the await. Safe (test-only serialization lock); matches the established
+// pattern for config-dir-isolated async tests in the workspace.
+#[allow(clippy::await_holding_lock)]
+async fn init_agent_tool_names(manager: Arc<McpManager>, frontmatter: &str) -> Vec<String> {
+    let config = Config {
+        mcp_manager: Some(manager),
+        ..Config::default()
+    };
+    let global_config: GlobalConfig = Arc::new(RwLock::new(config));
+
+    let _dir_guard = TEST_CONFIG_DIR_LOCK.lock().unwrap();
+    let config_dir = unique_test_config_dir();
+    fs::create_dir_all(config_dir.join("agents")).expect("create agents dir");
+    // SAFETY: test-only; serialized by TEST_CONFIG_DIR_LOCK.
+    unsafe { std::env::set_var("HARNX_CONFIG_DIR", &config_dir) };
+
+    let agent_path = Config::agent_file("selector-agent");
+    fs::write(&agent_path, format!("{frontmatter}selector-aware init")).expect("write agent file");
+
+    let initialized = init(&global_config, "selector-agent", create_abort_signal())
+        .await
+        .expect("agent init succeeds");
+
+    unsafe { std::env::remove_var("HARNX_CONFIG_DIR") };
+    let _ = fs::remove_dir_all(&config_dir);
+
+    let mut names: Vec<String> = initialized
+        .tools()
+        .declarations()
+        .into_iter()
+        .map(|d| d.name)
+        .collect();
+    names.sort();
+    names
+}
+
+// `use_tools: *` prefetches every enabled MCP server's tools (all connect).
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn init_with_wildcard_use_tools_prefetches_all_servers() {
+    let (manager, spawn_log) = two_server_spawn_log_manager();
+    let names = init_agent_tool_names(manager.clone(), "---\nuse_tools: \"*\"\n---\n").await;
+    assert_eq!(
+        names,
+        vec!["context7_echo".to_string(), "fs_echo".to_string()]
+    );
+    let lines = wait_for_spawn_count(spawn_log.path(), 2);
+    assert_eq!(lines.len(), 2, "both servers should spawn for wildcard");
+    assert!(manager.get_client("fs").unwrap().is_connected());
+    assert!(manager.get_client("context7").unwrap().is_connected());
+}
+
+// An agent with NO `use_tools` prefetches nothing (no servers connect). This
+// matches the per-round `select_tools`, which returns `None` for such agents —
+// so the init snapshot and the completion path agree.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn init_without_use_tools_prefetches_no_servers() {
+    let (manager, spawn_log) = two_server_spawn_log_manager();
+    let names = init_agent_tool_names(manager.clone(), "---\n---\n").await;
+    assert!(
+        names.is_empty(),
+        "no use_tools should prefetch nothing: {names:?}"
+    );
+    assert!(spawn_log_lines(spawn_log.path()).is_empty());
+    assert!(!manager.get_client("fs").unwrap().is_connected());
+    assert!(!manager.get_client("context7").unwrap().is_connected());
+}
+
+#[test]
+fn expand_agent_use_tool_selectors_flattens_toolsets() {
+    let mut config = Config::default();
+    config.toolsets.insert(
+        "docs".to_string(),
+        vec!["context7_*".to_string(), "docs_search".to_string()],
+    );
+
+    assert_eq!(
+        expand_agent_use_tool_selectors(&config, Some(vec!["docs,fs_read".to_string()])),
+        vec![
+            "context7_*".to_string(),
+            "docs_search".to_string(),
+            "fs_read".to_string(),
+        ]
+    );
+    assert!(expand_agent_use_tool_selectors(&config, None).is_empty());
+    assert!(expand_agent_use_tool_selectors(&config, Some(vec![])).is_empty());
 }


### PR DESCRIPTION
## Summary

Fixes #1029. `agent::init` previously called `mcp_manager.get_all_tools()`, connecting **every** enabled MCP server at agent activation regardless of `use_tools` — defeating the #793 lazy-init optimization on every `Config::use_agent` / `_session_handoff`. It also made the tool-execution allow-list over-broad, since `build_tool_eval_context` seeds `allowed_tool_names` from the (previously unfiltered) prefetch stored in `agent.config.tools`.

## Changes

**`crates/harnx-runtime/src/config/agent.rs`**
- New helper `expand_agent_use_tool_selectors(config, use_tools)` — expands the agent's `use_tools` + toolset names into a flat selector list (mirrors `Config::tool_declarations_for_use_tools`); returns empty for `None`/empty.
- `init` now prefetches `manager.get_tools_for_selectors(&selectors).await` instead of `get_all_tools()`. `get_tools_for_selectors` already: returns all tools for `*`, always includes already-connected servers, and applies the `selector_could_match_server` prefix pre-filter. So only servers whose tool-name prefix could match the agent's selectors get connected.

This single change fixes **both** issues:
- **Startup cost**: servers whose prefix can't match `use_tools` are no longer connected at init.
- **Allow-list accuracy**: `agent.config.tools` is now selector-accurate, so the execution allow-list matches the tools actually offered to the LLM (the LLM list itself was already filtered by `select_tools`).

**`crates/harnx-runtime/src/config/agent_ops_split.rs`** — updated the stale comment (init reads `get_tools_for_selectors`, not `get_all_tools`); kept the #826 package-scoping rationale (managers are still scoped before init, so selectors match correctly-scoped names).

**`crates/harnx-runtime/src/config/agent_tests.rs`** — added deterministic tests using a spawn-log-instrumented mock MCP server under isolated `HARNX_CONFIG_DIR`:
- `init_prefetches_only_selector_matching_mcp_servers` — `use_tools: docs` (toolset → `context7_*`) connects only `context7`; `fs` stays cold.
- `init_with_wildcard_use_tools_prefetches_all_servers` — `use_tools: *` connects both.
- `init_without_use_tools_prefetches_no_servers` — no `use_tools` connects nothing (consistent with per-round `select_tools`, which returns `None`).
- `expand_agent_use_tool_selectors_flattens_toolsets` — unit test for toolset flattening.

## Behavior notes
- `*` still connects all servers (by design).
- Agents with no `use_tools` prefetch nothing — identical to what the per-round `select_tools` path resolves (both read `agent.use_tools()`), so init and completion agree. No global-`*` fallback applies on the async `agent::init` path.

## Testing
- `cargo nextest run -p harnx-runtime` → 445/445 pass (repeated; deterministic).
- core/mcp/acp/acp-server/tui → all pass (excl. a pre-existing unrelated `harnx-tui` panic-hook test hang).
- `cargo clippy -p harnx-runtime --all-targets` clean; `cargo fmt --all --check` clean.

Related: #790, #793, #988.

Fixes #1029


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents now connect only to MCP tool servers selected by their configured tool selectors.
  * Toolset selectors are expanded and normalized before tools are loaded.
  * Wildcard selection continues to load all enabled MCP tools.

* **Bug Fixes**
  * Prevented unnecessary MCP server connections when agents do not request tools.
  * Improved tool scoping when agents inherit configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->