### PR TITLE
fix(tui): overhaul transcript history navigation seq mapping

### DIFF
--- a/crates/harnx-runtime/src/config/session_edit_tests.rs
+++ b/crates/harnx-runtime/src/config/session_edit_tests.rs
@@ -76,32 +76,7 @@ fn assistant_yaml(text: &str) -> String {
     .unwrap()
 }
 
-/// Build a `Config` wired with a dummy `test:model` client and an isolated
-/// sessions dir, for the message-edit tests.
-fn editor_test_config(sessions_dir: std::path::PathBuf) -> Config {
-    let mut config = Config {
-        sessions_dir_override: Some(sessions_dir),
-        working_mode: WorkingMode::Cmd,
-        ..Config::default()
-    };
-    config
-        .clients
-        .push(harnx_client::ClientConfig::OpenAICompatibleConfig(
-            harnx_core::provider_config::openai_compatible::OpenAICompatibleConfig {
-                name: "test".to_string(),
-                api_base: None,
-                api_key: None,
-                models: vec![],
-                patches: None,
-                extra: None,
-                system_prompt_prefix: None,
-                package: None,
-            },
-        ));
-    config.model = harnx_client::Model::new("test", "model");
-    config.model_id = "test:model".to_string();
-    config
-}
+use super::test_support::editor_test_config;
 
 #[test]
 fn validate_edited_session_documents_accepts_valid_yaml_documents() {

--- a/crates/harnx-runtime/src/config/session_ops_core.rs
+++ b/crates/harnx-runtime/src/config/session_ops_core.rs
@@ -186,6 +186,28 @@ mod tests {
     }
 
     #[test]
+    fn adjust_range_expands_tool_calls_to_include_results() {
+        // documents[1] = ToolCalls, documents[2] = ToolResults.
+        let docs = vec![
+            serde_yaml::to_string(&header()).unwrap(),
+            serde_yaml::to_string(&SessionLogEntry::ToolCalls {
+                text: String::new(),
+                thought: None,
+                calls: vec![],
+                timestamp: None,
+                fence_token: None,
+            })
+            .unwrap(),
+            serde_yaml::to_string(&SessionLogEntry::ToolResults {
+                results: vec![],
+                timestamp: None,
+            })
+            .unwrap(),
+        ];
+        assert_eq!(adjust_range_for_tool_pairs(1, 1, &docs).unwrap(), (1, 2));
+    }
+
+    #[test]
     fn compute_rewind_point_rejects_boundary_or_earlier() {
         let entries = vec![user("old"), compress(), user("new")];
         let err = compute_rewind_point(1, entries.len(), &entries).expect_err("boundary protected");

--- a/crates/harnx-runtime/src/config/session_ops_split.rs
+++ b/crates/harnx-runtime/src/config/session_ops_split.rs
@@ -202,16 +202,23 @@ impl Config {
         Ok(())
     }
 
+    /// Read and split the active session's on-disk log into YAML documents,
+    /// one per log entry (seq `n` is `documents[n]`). Returns `None` when
+    /// there is no active session or the session file cannot be read.
+    fn read_session_log_documents(&self) -> Option<Vec<String>> {
+        let session = self.session.as_ref()?;
+        let session_path = self.session_file(session.id());
+        let raw_log = std::fs::read_to_string(&session_path).ok()?;
+        Some(split_session_log_documents(&raw_log))
+    }
+
     /// Return the raw YAML documents for sequence numbers `from_seq..=to_seq`
     /// exactly as `.edit message` would open them in the editor, including
     /// auto-expansion for tool-call/result pairs.  Returns `None` when there is
     /// no active session, the session file cannot be read, or the range is
     /// invalid.  Documents are joined with `\n---\n`.
     pub fn get_message_range_yaml(&self, from_seq: usize, to_seq: usize) -> Option<String> {
-        let session = self.session.as_ref()?;
-        let session_path = self.session_file(session.id());
-        let raw_log = std::fs::read_to_string(&session_path).ok()?;
-        let documents = split_session_log_documents(&raw_log);
+        let documents = self.read_session_log_documents()?;
         if from_seq == 0 || to_seq >= documents.len() {
             return None;
         }
@@ -220,6 +227,26 @@ impl Config {
             return None;
         }
         Some(documents[from..=to].join("\n---\n"))
+    }
+
+    /// Resolve a user-selected seq to a safe rewind target. A `ToolCalls` entry
+    /// cannot be a rewind point (it would orphan its paired `ToolResults`), so
+    /// map it back to the entry just before the round — the message that
+    /// prompted it. Any other seq is returned unchanged; callers still validate
+    /// via `compute_rewind_point`.
+    pub fn resolve_rewind_seq(&self, seq: usize) -> usize {
+        let Some(documents) = self.read_session_log_documents() else {
+            return seq;
+        };
+        let is_tool_calls = documents
+            .get(seq)
+            .and_then(|raw| serde_yaml::from_str::<SessionLogEntry>(raw).ok())
+            .is_some_and(|entry| matches!(entry, SessionLogEntry::ToolCalls { .. }));
+        if is_tool_calls {
+            seq.saturating_sub(1)
+        } else {
+            seq
+        }
     }
 
     pub fn delete_message_range(&mut self, from: usize, to: usize) -> Result<()> {
@@ -572,5 +599,52 @@ mod tests_remote_sessions {
         let meta = session_index_record_to_meta(&record);
 
         assert!(meta.modified.is_none());
+    }
+}
+
+#[cfg(test)]
+mod resolve_rewind_seq_tests {
+    use super::super::test_support::editor_test_config;
+    use super::*;
+    use harnx_core::message::{MessageContent, MessageRole};
+
+    #[test]
+    fn resolve_rewind_seq_maps_tool_calls_to_prior_entry() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut config = editor_test_config(tmp.path().to_path_buf());
+        config.use_session(Some("rewind")).unwrap();
+        let session = config.session.as_mut().unwrap();
+        // seq 1: a user message
+        crate::config::session::append_event(
+            session,
+            &SessionLogEntry::Message {
+                id: None,
+                timestamp: None,
+                fence_token: None,
+                role: MessageRole::User,
+                content: MessageContent::Text("hi".into()),
+            },
+        );
+        // seq 2: a ToolCalls entry, seq 3: its ToolResults entry
+        crate::config::session::append_event(
+            session,
+            &SessionLogEntry::ToolCalls {
+                text: String::new(),
+                thought: None,
+                calls: vec![],
+                timestamp: None,
+                fence_token: None,
+            },
+        );
+        crate::config::session::append_event(
+            session,
+            &SessionLogEntry::ToolResults {
+                results: vec![],
+                timestamp: None,
+            },
+        );
+
+        assert_eq!(config.resolve_rewind_seq(2), 1);
+        assert_eq!(config.resolve_rewind_seq(1), 1);
     }
 }

--- a/crates/harnx-runtime/src/config/test_support.rs
+++ b/crates/harnx-runtime/src/config/test_support.rs
@@ -48,6 +48,33 @@ pub(super) fn env_lock() -> std::sync::MutexGuard<'static, ()> {
     }
 }
 
+/// Build a `Config` wired with a dummy `test:model` client and an isolated
+/// sessions dir. Shared by the message-edit and session-ops test modules.
+pub(super) fn editor_test_config(sessions_dir: std::path::PathBuf) -> Config {
+    let mut config = Config {
+        sessions_dir_override: Some(sessions_dir),
+        working_mode: WorkingMode::Cmd,
+        ..Config::default()
+    };
+    config
+        .clients
+        .push(harnx_client::ClientConfig::OpenAICompatibleConfig(
+            harnx_core::provider_config::openai_compatible::OpenAICompatibleConfig {
+                name: "test".to_string(),
+                api_base: None,
+                api_key: None,
+                models: vec![],
+                patches: None,
+                extra: None,
+                system_prompt_prefix: None,
+                package: None,
+            },
+        ));
+    config.model = harnx_client::Model::new("test", "model");
+    config.model_id = "test:model".to_string();
+    config
+}
+
 /// A package-loaded server identity: the bare yaml stem plus the package it
 /// belongs to. Mirrors what `load_package_servers` records on disk.
 pub(super) struct PackageServer<'a> {

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -141,6 +141,7 @@ fn tool_call_body(
 /// string outputs before extraction so pre-dimmed test inputs render
 /// cleanly.
 fn tool_completed_to_transcript_items(
+    id: &str,
     output: &serde_json::Value,
     markdown: Option<&str>,
 ) -> Vec<TranscriptItem> {
@@ -155,6 +156,7 @@ fn tool_completed_to_transcript_items(
     }
     vec![TranscriptItem::ToolResultMarkdown {
         text: clean,
+        id: id.to_string(),
         rendered_cache: None,
     }]
 }
@@ -186,6 +188,11 @@ impl Tui {
             }
         }
         self.app.detail_view_open = true;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn open_detail_view_for_focused_item_for_test(&mut self) {
+        self.open_detail_view_for_focused_item();
     }
 
     async fn handle_detail_view_key(&mut self, key: KeyEvent) -> Result<()> {
@@ -1055,8 +1062,11 @@ impl Tui {
                 }]
             }
             AgentEvent::Tool(ToolEvent::Completed {
-                output, markdown, ..
-            }) => tool_completed_to_transcript_items(&output, markdown.as_deref()),
+                id,
+                output,
+                markdown,
+                ..
+            }) => tool_completed_to_transcript_items(&id, &output, markdown.as_deref()),
             AgentEvent::Model(ModelEvent::MessageChunk { blocks }) => {
                 let text = concat_text_blocks(&blocks);
                 if text.is_empty() {
@@ -1247,6 +1257,7 @@ impl Tui {
                 }
             }
             AgentEvent::Tool(ToolEvent::Started {
+                id,
                 name,
                 markdown,
                 input,
@@ -1254,6 +1265,7 @@ impl Tui {
             }) => {
                 vec![TranscriptItem::ToolCall {
                     tool_name: name,
+                    id,
                     body: tool_call_body(markdown.as_deref(), &input),
                     seq: self.app.current_group_seq,
                     timestamp: Some(chrono::Utc::now()),
@@ -1261,6 +1273,7 @@ impl Tui {
                 }]
             }
             AgentEvent::Tool(ToolEvent::Blocked {
+                id,
                 name,
                 input,
                 reason,
@@ -1280,6 +1293,7 @@ impl Tui {
                 };
                 vec![TranscriptItem::ToolCall {
                     tool_name: name,
+                    id,
                     body,
                     seq: self.app.current_group_seq,
                     timestamp: Some(chrono::Utc::now()),
@@ -2848,7 +2862,7 @@ mod tests {
             "isError": false
         });
 
-        let items = tool_completed_to_transcript_items(&output, None);
+        let items = tool_completed_to_transcript_items("call_1", &output, None);
 
         assert_eq!(items.len(), 1);
         match &items[0] {

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -953,47 +953,43 @@ impl Tui {
         // is a pure seq-assignment event and should not create stray headings
         // or flush pending thoughts.
         if let AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }) = event {
-            // Try to backfill the seq into the most recent unsequenced transcript
-            // item (UserText, AssistantText, or ToolCall). If an item is found and
-            // patched, the seq has been consumed — clear pending_tool_seq.  If no
-            // item is found yet (e.g. ToolEvent::Started arrives after this event),
-            // store seq in pending_tool_seq so the upcoming ToolCall can pick it up.
-            let mut backfilled = false;
+            // This seq identifies the log entry currently being assembled.
+            // Assign it to every not-yet-sequenced *live* row belonging to that
+            // entry's group: walk back from the tail and stop at the first row
+            // that already carries a seq (the previous group's boundary). Rows
+            // without a timestamp (the agent banner, replayed history) are not
+            // live and are skipped so they neither consume nor block a seq.
+            // Then remember it as the current group seq: tool-call rows are
+            // created *after* this event (ToolEvent::Started fires once
+            // execution begins) and inherit it, so all parallel calls of a
+            // round share the round's ToolCalls seq — matching
+            // messages_to_transcript_items.
             for item in self.app.transcript.iter_mut().rev() {
                 match item {
-                    // Only backfill "live" entries — items with a timestamp are
-                    // created during an active session.  The agent banner is
-                    // AssistantText { seq: None, timestamp: None } and must not
-                    // consume a seq that belongs to the first real message.
                     TranscriptItem::UserText {
-                        seq: item_seq @ None,
+                        seq: item_seq,
                         timestamp: Some(_),
                         ..
                     }
                     | TranscriptItem::AssistantText {
-                        seq: item_seq @ None,
+                        seq: item_seq,
                         timestamp: Some(_),
                         ..
                     }
                     | TranscriptItem::ToolCall {
-                        seq: item_seq @ None,
+                        seq: item_seq,
                         timestamp: Some(_),
                         ..
                     } => {
+                        if item_seq.is_some() {
+                            break;
+                        }
                         *item_seq = Some(seq);
-                        backfilled = true;
-                        break;
                     }
                     _ => {}
                 }
             }
-            if backfilled {
-                // Seq consumed by an existing item; clear any pending slot.
-                self.app.pending_tool_seq = None;
-            } else {
-                // No existing item to patch; save for the next ToolCall creation.
-                self.app.pending_tool_seq = Some(seq);
-            }
+            self.app.current_group_seq = Some(seq);
             return;
         }
 
@@ -1259,7 +1255,7 @@ impl Tui {
                 vec![TranscriptItem::ToolCall {
                     tool_name: name,
                     body: tool_call_body(markdown.as_deref(), &input),
-                    seq: self.app.pending_tool_seq,
+                    seq: self.app.current_group_seq,
                     timestamp: Some(chrono::Utc::now()),
                     rendered_cache: None,
                 }]
@@ -1285,7 +1281,7 @@ impl Tui {
                 vec![TranscriptItem::ToolCall {
                     tool_name: name,
                     body,
-                    seq: self.app.pending_tool_seq,
+                    seq: self.app.current_group_seq,
                     timestamp: Some(chrono::Utc::now()),
                     rendered_cache: None,
                 }]

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -2839,11 +2839,17 @@ impl Tui {
         let Some(seq) = item.seq() else {
             return;
         };
+        let seq = self.config.read().resolve_rewind_seq(seq);
         let user_text = match item {
             TranscriptItem::UserText { text, .. } => Some(text.clone()),
             _ => None,
         };
         self.app.modal = Some(crate::types::ModalState::ConfirmRewind { seq, user_text });
+    }
+
+    #[cfg(test)]
+    pub(crate) fn handle_transcript_rewind_for_test(&mut self) {
+        self.handle_transcript_rewind();
     }
 }
 

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -179,12 +179,19 @@ impl Tui {
                 // would be computed but never displayed. Skip it.
                 self.app.detail_view_text = Some(detail_text.clone());
                 self.app.detail_view_raw_yaml = None;
+                self.app.detail_view_raw_unavailable = false;
             }
             _ => {
                 self.app.detail_view_text = None;
-                self.app.detail_view_raw_yaml = self
-                    .selected_seq_range()
+                let range = self.selected_seq_range();
+                self.app.detail_view_raw_yaml = range
                     .and_then(|(from, to)| self.config.read().get_message_range_yaml(from, to));
+                // A seq-bearing selection in an active session that fails to
+                // resolve is a real failure, not a "no raw available" case:
+                // surface it instead of silently showing the rendered summary.
+                let has_session = self.config.read().session.is_some();
+                self.app.detail_view_raw_unavailable =
+                    range.is_some() && has_session && self.app.detail_view_raw_yaml.is_none();
             }
         }
         self.app.detail_view_open = true;

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -202,6 +202,11 @@ impl Tui {
         self.open_detail_view_for_focused_item();
     }
 
+    #[cfg(test)]
+    pub(crate) async fn handle_detail_view_key_for_test(&mut self, key: KeyEvent) -> Result<()> {
+        self.handle_detail_view_key(key).await
+    }
+
     async fn handle_detail_view_key(&mut self, key: KeyEvent) -> Result<()> {
         match (key.code, key.modifiers) {
             (KeyCode::Esc, KeyModifiers::NONE) => {
@@ -2762,15 +2767,27 @@ impl Tui {
         }
     }
 
-    /// Handle 'e' key: open edit command for selected item(s).
-    async fn handle_transcript_edit(&mut self) -> Result<()> {
-        let Some((from, to)) = self.selected_seq_range() else {
-            return Ok(());
-        };
-        let cmd = if from == to {
+    /// Build the `.edit message ...` command for the current selection, from
+    /// its resolved seq range. Shared by `handle_transcript_edit` and the
+    /// test seam below so tests exercise the real construction.
+    fn transcript_edit_command(&self) -> Option<String> {
+        let (from, to) = self.selected_seq_range()?;
+        Some(if from == to {
             format!(".edit message {}", from)
         } else {
             format!(".edit message {}-{}", from, to)
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn transcript_edit_command_for_test(&self) -> Option<String> {
+        self.transcript_edit_command()
+    }
+
+    /// Handle 'e' key: open edit command for selected item(s).
+    async fn handle_transcript_edit(&mut self) -> Result<()> {
+        let Some(cmd) = self.transcript_edit_command() else {
+            return Ok(());
         };
         self.run_command(&cmd).await?;
         self.app.transcript_focus = None;

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -169,7 +169,7 @@ impl Tui {
             last_usage_transcript_idx: None,
             pending_thought_source: None,
             pending_thought_text: String::new(),
-            pending_tool_seq: None,
+            current_group_seq: None,
             pending_message: None,
             completions: vec![],
             completion_index: 0,

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -196,6 +196,7 @@ impl Tui {
             },
             detail_view_open: false,
             detail_view_raw_yaml: None,
+            detail_view_raw_unavailable: false,
             detail_view_text: None,
             transcript_browsing: false,
             browsing_view_scroll: {

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -640,6 +640,7 @@ pub(crate) fn messages_to_transcript_items(
                         };
                         items.push(TranscriptItem::ToolCall {
                             tool_name: r.call.name.clone(),
+                            id: r.call.id.clone().unwrap_or_default(),
                             body,
                             seq: msg.log_seq,
                             timestamp: msg.log_timestamp,
@@ -663,6 +664,7 @@ pub(crate) fn messages_to_transcript_items(
                         if !trimmed.is_empty() {
                             items.push(TranscriptItem::ToolResultMarkdown {
                                 text: trimmed.to_string(),
+                                id: r.call.id.clone().unwrap_or_default(),
                                 rendered_cache: None,
                             });
                         }

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -1286,6 +1286,12 @@ impl Tui {
                 format!("Detail ({doc_count} entries)")
             };
             (entries, title)
+        } else if self.app.detail_view_raw_unavailable {
+            let entries = vec![vec![Line::from(Span::styled(
+                "⚠ Raw log entry unavailable for this item.",
+                Style::default().fg(Color::Yellow),
+            ))]];
+            (entries, "Detail".to_string())
         } else {
             // Fallback: no session / no seq — render TUI fields verbatim
             let (from, to) = self.app.selected_transcript_range();

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -293,6 +293,7 @@ impl Tui {
             TranscriptItem::ToolResultMarkdown {
                 text,
                 rendered_cache,
+                ..
             } => {
                 if let Some((w, ss, sts, utc, cached)) = rendered_cache.as_ref() {
                     if *w == width && *ss == show_seq && *sts == show_ts && *utc == use_utc {
@@ -355,6 +356,7 @@ impl Tui {
                 seq,
                 timestamp,
                 rendered_cache,
+                ..
             } => {
                 if let Some((w, ss, sts, utc, cached)) = rendered_cache.as_ref() {
                     if *w == width && *ss == show_seq && *sts == show_ts && *utc == use_utc {
@@ -1096,6 +1098,7 @@ impl Tui {
                 seq,
                 timestamp,
                 rendered_cache: _,
+                id: _,
             } => {
                 lines.push(Line::from(Span::styled("── tool call ──", label_style)));
                 if let Some(s) = seq {
@@ -1250,69 +1253,74 @@ impl Tui {
         //
         // Fallback: render_entry_detail() for items that have no seq number or
         // when no session is active.
-        let (entries_as_vec, title): (Vec<Vec<Line<'static>>>, String) =
-            if let Some(text) = &self.app.detail_view_text {
-                let entries = vec![text
+        let (entries_as_vec, title): (Vec<Vec<Line<'static>>>, String) = if let Some(text) =
+            &self.app.detail_view_text
+        {
+            let entries = vec![text
+                .lines()
+                .map(|line| Line::from(Span::raw(line.to_string())))
+                .collect()];
+            (entries, "Compacted session".to_string())
+        } else if let Some(yaml) = &self.app.detail_view_raw_yaml {
+            // Split on the same separator edit_message_range joins with.
+            let docs: Vec<&str> = yaml.split("\n---\n").collect();
+            let doc_count = docs.len();
+            let mut entries: Vec<Vec<Line<'static>>> = Vec::new();
+            for (i, doc) in docs.into_iter().enumerate() {
+                let doc_lines: Vec<Line<'static>> = doc
                     .lines()
-                    .map(|line| Line::from(Span::raw(line.to_string())))
-                    .collect()];
-                (entries, "Compacted session".to_string())
-            } else if let Some(yaml) = &self.app.detail_view_raw_yaml {
-                // Split on the same separator edit_message_range joins with.
-                let docs: Vec<&str> = yaml.split("\n---\n").collect();
-                let doc_count = docs.len();
-                let mut entries: Vec<Vec<Line<'static>>> = Vec::new();
-                for (i, doc) in docs.into_iter().enumerate() {
-                    let doc_lines: Vec<Line<'static>> = doc
-                        .lines()
-                        .map(|l| Line::from(Span::raw(l.to_string())))
-                        .collect();
-                    entries.push(doc_lines);
-                    if i + 1 < doc_count {
-                        // Visual separator between documents
-                        entries.push(vec![Line::from(Span::styled(
-                            "---",
-                            Style::default().fg(Color::DarkGray),
-                        ))]);
-                    }
+                    .map(|l| Line::from(Span::raw(l.to_string())))
+                    .collect();
+                entries.push(doc_lines);
+                if i + 1 < doc_count {
+                    // Visual separator between documents
+                    entries.push(vec![Line::from(Span::styled(
+                        "---",
+                        Style::default().fg(Color::DarkGray),
+                    ))]);
                 }
-                let title = if doc_count == 1 {
-                    "Detail".to_string()
-                } else {
-                    format!("Detail ({doc_count} entries)")
-                };
-                (entries, title)
+            }
+            let title = if doc_count == 1 {
+                "Detail".to_string()
             } else {
-                // Fallback: no session / no seq — render TUI fields verbatim
-                let (from, to) = self.app.selected_transcript_range();
-                let mut entries = Vec::new();
-                for i in from..=to {
-                    if i < self.app.transcript.len() {
-                        let entry = &self.app.transcript[i];
-                        entries.push(Self::render_entry_detail(entry));
-                        // When the selected range is a single ToolCall with no
-                        // adjacent result in the range, peek at the next item so
-                        // the fallback view includes the paired result.
-                        if matches!(entry, TranscriptItem::ToolCall { .. }) && i + 1 > to {
-                            if let Some(next) = self.app.transcript.get(i + 1) {
-                                if matches!(next, TranscriptItem::ToolResultMarkdown { .. }) {
+                format!("Detail ({doc_count} entries)")
+            };
+            (entries, title)
+        } else {
+            // Fallback: no session / no seq — render TUI fields verbatim
+            let (from, to) = self.app.selected_transcript_range();
+            let mut entries = Vec::new();
+            for i in from..=to {
+                if i < self.app.transcript.len() {
+                    let entry = &self.app.transcript[i];
+                    entries.push(Self::render_entry_detail(entry));
+                    // A selected ToolCall shows its paired result by id,
+                    // regardless of where the result row sits in the
+                    // transcript (they can be separated by interleaving
+                    // rows). Only look outside the range for a single
+                    // ToolCall selection.
+                    if from == to {
+                        if let TranscriptItem::ToolCall { id, .. } = entry {
+                            if let Some(result) = self.app.transcript.iter().find(|it| {
+                                    matches!(it, TranscriptItem::ToolResultMarkdown { id: rid, .. } if !rid.is_empty() && rid == id)
+                                }) {
                                     entries.push(vec![Line::from("")]);
-                                    entries.push(Self::render_entry_detail(next));
+                                    entries.push(Self::render_entry_detail(result));
                                 }
-                            }
-                        }
-                        if i < to {
-                            entries.push(vec![Line::from("")]);
                         }
                     }
+                    if i < to {
+                        entries.push(vec![Line::from("")]);
+                    }
                 }
-                let title = if from == to {
-                    "Detail".to_string()
-                } else {
-                    format!("Detail ({from}–{to})")
-                };
-                (entries, title)
+            }
+            let title = if from == to {
+                "Detail".to_string()
+            } else {
+                format!("Detail ({from}–{to})")
             };
+            (entries, title)
+        };
 
         // Create block with horizontal (top + bottom) borders and a title.
         //

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -6794,26 +6794,79 @@ async fn transcript_edit_targets_selected_seq_range() {
 
 #[tokio::test]
 async fn detail_view_edit_restores_focus_when_index_valid() {
-    let mut harness = TuiTestHarness::new().await;
+    // Drive a *real* `.edit message 1` (via a stubbed `true` editor and an
+    // after-hook that writes the replacement YAML) so `handle_transcript_edit`
+    // actually clears transcript_focus/transcript_browsing/detail_view_open,
+    // forcing the 'e' arm's restoration + reopen block to do real work.
+    // With a `seq: None` row (the old version of this test), that clearing
+    // never happens and the block is never exercised.
+    let sessions_tmp = tempfile::TempDir::new().unwrap();
+    let editor_tmp = tempfile::TempDir::new().unwrap();
+
+    let config = test_config();
+    {
+        let mut guard = config.write();
+        guard.sessions_dir_override = Some(sessions_tmp.path().to_path_buf());
+        guard.editor = Some("true".to_string());
+        guard.use_session(Some("detail-edit")).unwrap();
+
+        let session = guard.session.as_mut().unwrap();
+        harnx_runtime::config::session::append_event(
+            session,
+            &harnx_core::session::SessionLogEntry::Message {
+                id: None,
+                timestamp: None,
+                fence_token: None,
+                role: harnx_core::message::MessageRole::User,
+                content: harnx_core::message::MessageContent::Text("original".into()),
+            },
+        );
+
+        let editor_tmp_path = editor_tmp.path().to_path_buf();
+        guard.temp_dir_override = Some(editor_tmp_path.clone());
+        guard.set_tui_editor_hooks(
+            None,
+            Some(Box::new(move || {
+                let temp_path = std::fs::read_dir(&editor_tmp_path)
+                    .unwrap()
+                    .filter_map(|e| e.ok().map(|e| e.path()))
+                    .find(|p| p.extension().and_then(|e| e.to_str()) == Some("yaml"))
+                    .expect("message edit temp file");
+                let replacement =
+                    serde_yaml::to_string(&harnx_core::session::SessionLogEntry::Message {
+                        id: None,
+                        timestamp: None,
+                        fence_token: None,
+                        role: harnx_core::message::MessageRole::User,
+                        content: harnx_core::message::MessageContent::Text("edited".into()),
+                    })
+                    .unwrap();
+                std::fs::write(&temp_path, replacement).unwrap();
+            })),
+        );
+    }
+
+    let mut harness = TuiTestHarness::with_config(config).await;
     harness.tui().app.transcript.clear();
     harness.tui().app.transcript.push(TranscriptItem::UserText {
-        text: "row".to_string(),
-        seq: None,
+        text: "original".to_string(),
+        seq: Some(1),
         timestamp: None,
     });
     harness.tui().app.transcript_focus = Some(0);
     harness.tui().app.transcript_browsing = true;
     harness.tui().app.detail_view_open = true;
 
-    // Selection has no seq -> handle_transcript_edit is a no-op (returns
-    // early), so this exercises the reopen/focus-restoration bookkeeping
-    // without invoking an editor.
     harness
         .tui()
         .handle_detail_view_key_for_test(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE))
         .await
         .unwrap();
 
+    assert!(
+        harness.tui().app.detail_view_open,
+        "detail view reopened after edit"
+    );
     assert_eq!(
         harness.tui().app.transcript_focus,
         Some(0),

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -6117,6 +6117,7 @@ async fn tui_assistant_text_preserves_line_breaks() {
 async fn tool_call_display_format() {
     let mut harness = TuiTestHarness::new().await;
     harness.tui().app.transcript.push(TranscriptItem::ToolCall {
+        id: String::new(),
         tool_name: "exec".to_string(),
         body: Some(ToolCallBody::Yaml(
             "command: ls -la\nworking_dir: /tmp\n".to_string(),
@@ -6126,6 +6127,7 @@ async fn tool_call_display_format() {
         rendered_cache: None,
     });
     harness.tui().app.transcript.push(TranscriptItem::ToolCall {
+        id: String::new(),
         tool_name: "write_file".to_string(),
         body: Some(ToolCallBody::Markdown(
             "write **hello.txt** with 3 lines".to_string(),
@@ -6135,6 +6137,7 @@ async fn tool_call_display_format() {
         rendered_cache: None,
     });
     harness.tui().app.transcript.push(TranscriptItem::ToolCall {
+        id: String::new(),
         tool_name: "think".to_string(),
         body: None,
         seq: None,
@@ -6142,6 +6145,7 @@ async fn tool_call_display_format() {
         rendered_cache: None,
     });
     harness.tui().app.transcript.push(TranscriptItem::ToolCall {
+        id: String::new(),
         tool_name: "search".to_string(),
         body: Some(ToolCallBody::Yaml(
             "query: rust async patterns\nmax_results: 10\ninclude_code: true\n".to_string(),
@@ -6159,6 +6163,7 @@ async fn tool_call_display_format() {
 fn render_tool_call_markdown_body_suppresses_header() {
     let lines = render_entry_lines(
         &TranscriptItem::ToolCall {
+            id: String::new(),
             tool_name: "write_file".to_string(),
             body: Some(ToolCallBody::Markdown(
                 "write **hello.txt** with 3 lines".to_string(),
@@ -6181,6 +6186,7 @@ fn render_tool_call_markdown_body_suppresses_header() {
 fn render_tool_call_yaml_body_keeps_header() {
     let lines = render_entry_lines(
         &TranscriptItem::ToolCall {
+            id: String::new(),
             tool_name: "read".to_string(),
             body: Some(ToolCallBody::Yaml("path: /tmp/foo.txt\n".to_string())),
             seq: None,
@@ -6203,6 +6209,7 @@ fn render_tool_call_meta_line_precedes_markdown_body() {
         .with_timezone(&chrono::Utc);
     let lines = render_entry_lines(
         &TranscriptItem::ToolCall {
+            id: String::new(),
             tool_name: "write_file".to_string(),
             body: Some(ToolCallBody::Markdown("write hello.txt".to_string())),
             seq: Some(3),
@@ -6226,6 +6233,7 @@ async fn tool_call_with_seq_number() {
     let mut harness = TuiTestHarness::new().await;
     harness.tui().app.show_sequence_numbers = true;
     harness.tui().app.transcript.push(TranscriptItem::ToolCall {
+        id: String::new(),
         tool_name: "read".to_string(),
         body: Some(ToolCallBody::Yaml("path: /tmp/foo.txt\n".to_string())),
         seq: Some(7),
@@ -6609,6 +6617,7 @@ async fn test_d4_key_i_copies_tool_call() {
     let mut harness = TuiTestHarness::new().await;
     harness.tui().app.transcript.clear();
     harness.tui().app.transcript.push(TranscriptItem::ToolCall {
+        id: String::new(),
         tool_name: "search".to_string(),
         body: Some(crate::types::ToolCallBody::Yaml("query: rust".to_string())),
         seq: Some(9),
@@ -8285,6 +8294,7 @@ async fn test_browsing_mode_non_navigable_items_visible_not_focusable() {
         .transcript
         .push(TranscriptItem::ToolResultMarkdown {
             text: "thinking...".to_string(),
+            id: String::new(),
             rendered_cache: None,
         });
     harness
@@ -8313,6 +8323,45 @@ async fn test_browsing_mode_non_navigable_items_visible_not_focusable() {
         harness.tui().app.transcript_focus,
         Some(2),
         "Down should skip non-navigable ToolResultMarkdown at index 1 and focus AssistantText at index 2"
+    );
+}
+
+#[tokio::test]
+async fn detail_fallback_pairs_tool_result_by_id_when_not_adjacent() {
+    let mut harness = crate::test_utils::TuiTestHarness::new().await;
+    let tui = harness.tui();
+
+    // Clear the initial welcome banner so transcript_focus 0 lands on the
+    // ToolCall pushed below rather than that seeded row.
+    tui.app.transcript.clear();
+
+    // A tool call and its result separated by an interleaving row. No session,
+    // so the detail view uses the fallback render path.
+    tui.app.transcript.push(TranscriptItem::ToolCall {
+        tool_name: "read".to_string(),
+        body: None,
+        seq: None,
+        timestamp: Some(chrono::Utc::now()),
+        rendered_cache: None,
+        id: "call_x".to_string(),
+    });
+    tui.app
+        .transcript
+        .push(TranscriptItem::SystemText("noise".to_string()));
+    tui.app.transcript.push(TranscriptItem::ToolResultMarkdown {
+        text: "RESULT-X-CONTENT".to_string(),
+        rendered_cache: None,
+        id: "call_x".to_string(),
+    });
+
+    tui.app.transcript_focus = Some(0);
+    tui.app.transcript_selection_anchor = None;
+    tui.open_detail_view_for_focused_item_for_test();
+    harness.render();
+
+    assert!(
+        harness.screen_contents().contains("RESULT-X-CONTENT"),
+        "detail view must show the id-matched result even when not adjacent"
     );
 }
 

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -2177,22 +2177,22 @@ async fn live_log_seq_assignment_applies_to_tool_calls_started_after_seq_event()
         other => panic!("expected ToolCall transcript item, got {other:?}"),
     }
 
-    // Verify pending_tool_seq is still set: multiple tool calls in the same round
+    // Verify current_group_seq is still set: multiple tool calls in the same round
     // share the same log_seq, so we intentionally do NOT clear it after first use.
-    // It will be cleared when the next LogSeqAssigned arrives (for a different round)
-    // and successfully backfills a UserText or AssistantText item, or overwritten by
-    // the next tool round's LogSeqAssigned.
+    // It is only replaced when the next LogSeqAssigned arrives, for the next group.
     assert_eq!(
-        tui.app.pending_tool_seq,
+        tui.app.current_group_seq,
         Some(5),
-        "pending_tool_seq should remain set so subsequent ToolCalls in same round share seq"
+        "current_group_seq should remain set so subsequent ToolCalls in same round share seq"
     );
 }
 
 #[tokio::test]
-async fn log_seq_backfill_clears_pending_tool_seq() {
-    // When LogSeqAssigned arrives and backfills an EXISTING transcript item,
-    // pending_tool_seq must be cleared (not left set for the next ToolCall).
+async fn log_seq_assignment_sets_current_group_seq_even_after_backfill() {
+    // LogSeqAssigned always records the incoming seq as current_group_seq,
+    // regardless of whether it also backfilled an existing transcript row.
+    // Tool-call rows created afterward (for the same group) must still be
+    // able to read it.
     let config = test_config();
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
     let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
@@ -2209,7 +2209,7 @@ async fn log_seq_backfill_clears_pending_tool_seq() {
     .await
     .unwrap();
 
-    // Now LogSeqAssigned should backfill the AssistantText and NOT set pending_tool_seq.
+    // LogSeqAssigned backfills the AssistantText AND records current_group_seq.
     tui.handle_tui_event(TuiEvent::Agent(
         AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 3 }),
         None,
@@ -2217,16 +2217,16 @@ async fn log_seq_backfill_clears_pending_tool_seq() {
     .await
     .unwrap();
 
-    // Backfill succeeded — pending should be None.
     assert_eq!(
-        tui.app.pending_tool_seq, None,
-        "pending_tool_seq must be None after backfill consumed the seq"
+        tui.app.current_group_seq,
+        Some(3),
+        "current_group_seq must be set to the assigned seq even after backfilling an existing row"
     );
 }
 
 #[tokio::test]
 async fn live_log_seq_assignment_applies_to_blocked_tool_calls() {
-    // ToolEvent::Blocked also uses pending_tool_seq, same as ToolEvent::Started.
+    // ToolEvent::Blocked also uses current_group_seq, same as ToolEvent::Started.
     let config = test_config();
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
     let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
@@ -2264,11 +2264,185 @@ async fn live_log_seq_assignment_applies_to_blocked_tool_calls() {
             assert_eq!(
                 *seq,
                 Some(7),
-                "blocked ToolCall should inherit pending_tool_seq"
+                "blocked ToolCall should inherit current_group_seq"
             );
         }
         other => panic!("expected ToolCall, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn live_seq_assistant_text_and_tools_share_round_seq() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    // User turn logged at seq 1.
+    tui.app.transcript.push(TranscriptItem::UserText {
+        text: "do it".to_string(),
+        seq: None,
+        timestamp: Some(chrono::Utc::now()),
+    });
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 1 }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    // Assistant streams accompanying text, THEN the round's tool-calls entry is
+    // logged at seq 2 (LogSeqAssigned arrives before ToolEvent::Started), then
+    // two parallel tool calls execute.
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Model(ModelEvent::MessageChunk {
+            blocks: vec![ContentBlock::Text("calling tools".to_string())],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 2 }),
+        None,
+    ))
+    .await
+    .unwrap();
+    for id in ["call_a", "call_b"] {
+        tui.handle_tui_event(TuiEvent::Agent(
+            AgentEvent::Tool(harnx_core::event::ToolEvent::Started {
+                id: id.to_string(),
+                name: "read".to_string(),
+                kind: Default::default(),
+                markdown: None,
+                input: serde_json::Value::Null,
+                locations: vec![],
+            }),
+            None,
+        ))
+        .await
+        .unwrap();
+    }
+
+    let user_seq = tui.app.transcript.iter().find_map(|i| match i {
+        TranscriptItem::UserText { seq, .. } => Some(*seq),
+        _ => None,
+    });
+    let assistant_seq = tui.app.transcript.iter().find_map(|i| match i {
+        TranscriptItem::AssistantText { seq, .. } => Some(*seq),
+        _ => None,
+    });
+    let tool_seqs: Vec<Option<usize>> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|i| match i {
+            TranscriptItem::ToolCall { seq, .. } => Some(*seq),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(user_seq, Some(Some(1)), "user text keeps its own seq");
+    assert_eq!(
+        assistant_seq,
+        Some(Some(2)),
+        "accompanying text joins the tool round"
+    );
+    assert_eq!(
+        tool_seqs,
+        vec![Some(2), Some(2)],
+        "both parallel tool calls share the round seq"
+    );
+}
+
+#[tokio::test]
+async fn live_seq_plain_assistant_turn_gets_own_seq() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    tui.app.transcript.push(TranscriptItem::UserText {
+        text: "hi".to_string(),
+        seq: None,
+        timestamp: Some(chrono::Utc::now()),
+    });
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 1 }),
+        None,
+    ))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Model(ModelEvent::MessageChunk {
+            blocks: vec![ContentBlock::Text("hello".to_string())],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 2 }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let seqs: Vec<Option<usize>> =
+        tui.app
+            .transcript
+            .iter()
+            .filter_map(|i| match i {
+                TranscriptItem::UserText { seq, .. }
+                | TranscriptItem::AssistantText { seq, .. } => Some(*seq),
+                _ => None,
+            })
+            .collect();
+    assert_eq!(seqs, vec![Some(1), Some(2)]);
+}
+
+#[tokio::test]
+async fn live_seq_banner_excluded_from_grouping() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+    // Clear the startup welcome/banner items so the pushed rows below land at
+    // known indices 0 and 1.
+    tui.clear_transcript();
+
+    // Agent banner: AssistantText with no timestamp. Must never consume a seq.
+    tui.app.transcript.push(TranscriptItem::AssistantText {
+        text: "agent ready".to_string(),
+        seq: None,
+        timestamp: None,
+        rendered_cache: None,
+    });
+    tui.app.transcript.push(TranscriptItem::UserText {
+        text: "hi".to_string(),
+        seq: None,
+        timestamp: Some(chrono::Utc::now()),
+    });
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 1 }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let banner_seq = match &tui.app.transcript[0] {
+        TranscriptItem::AssistantText { seq, .. } => *seq,
+        other => panic!("expected banner, got {other:?}"),
+    };
+    let user_seq = match &tui.app.transcript[1] {
+        TranscriptItem::UserText { seq, .. } => *seq,
+        other => panic!("expected user text, got {other:?}"),
+    };
+    assert_eq!(banner_seq, None, "banner never gets a seq");
+    assert_eq!(user_seq, Some(1), "seq lands on the live user row");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -8365,6 +8365,36 @@ async fn detail_fallback_pairs_tool_result_by_id_when_not_adjacent() {
     );
 }
 
+#[tokio::test]
+async fn detail_view_shows_explicit_message_when_raw_entry_unresolvable() {
+    // Session present (so resolution is expected) but the row's seq points past
+    // the log, so get_message_range_yaml returns None.
+    let config = test_config_with_mock_client_and_agent("test-agent", Some("detail-unavailable"));
+    let mut harness = crate::test_utils::TuiTestHarness::with_config(config).await;
+    let tui = harness.tui();
+
+    // Clear the initial welcome banner so transcript_focus lands on the row
+    // pushed below rather than that seeded row.
+    tui.app.transcript.clear();
+
+    tui.app.transcript.push(TranscriptItem::AssistantText {
+        text: "SUMMARY-ONLY".to_string(),
+        seq: Some(9999),
+        timestamp: Some(chrono::Utc::now()),
+        rendered_cache: None,
+    });
+    tui.app.transcript_focus = Some(tui.app.transcript.len() - 1);
+    tui.app.transcript_selection_anchor = None;
+    tui.open_detail_view_for_focused_item_for_test();
+    harness.render();
+
+    let screen = harness.screen_contents();
+    assert!(
+        screen.contains("Raw log entry unavailable"),
+        "expected explicit unavailable message, got: {screen}"
+    );
+}
+
 /// Regression test for GitHub issue #507.
 ///
 /// When entering browsing mode with enough items to overflow the viewport,

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -6756,6 +6756,76 @@ async fn rewind_on_tool_call_row_resolves_to_prior_seq() {
 }
 
 #[tokio::test]
+async fn transcript_edit_targets_selected_seq_range() {
+    let mut harness = TuiTestHarness::new().await;
+    harness.tui().app.transcript.clear();
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "first".to_string(),
+        seq: Some(3),
+        timestamp: None,
+    });
+    harness
+        .tui()
+        .app
+        .transcript
+        .push(TranscriptItem::AssistantText {
+            text: "second".to_string(),
+            seq: Some(4),
+            timestamp: None,
+            rendered_cache: None,
+        });
+
+    // Single selection.
+    harness.tui().app.transcript_focus = Some(0);
+    harness.tui().app.transcript_selection_anchor = None;
+    assert_eq!(
+        harness.tui().transcript_edit_command_for_test().as_deref(),
+        Some(".edit message 3")
+    );
+
+    // Range selection across both rows.
+    harness.tui().app.transcript_focus = Some(1);
+    harness.tui().app.transcript_selection_anchor = Some(0);
+    assert_eq!(
+        harness.tui().transcript_edit_command_for_test().as_deref(),
+        Some(".edit message 3-4")
+    );
+}
+
+#[tokio::test]
+async fn detail_view_edit_restores_focus_when_index_valid() {
+    let mut harness = TuiTestHarness::new().await;
+    harness.tui().app.transcript.clear();
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        text: "row".to_string(),
+        seq: None,
+        timestamp: None,
+    });
+    harness.tui().app.transcript_focus = Some(0);
+    harness.tui().app.transcript_browsing = true;
+    harness.tui().app.detail_view_open = true;
+
+    // Selection has no seq -> handle_transcript_edit is a no-op (returns
+    // early), so this exercises the reopen/focus-restoration bookkeeping
+    // without invoking an editor.
+    harness
+        .tui()
+        .handle_detail_view_key_for_test(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        harness.tui().app.transcript_focus,
+        Some(0),
+        "focus restored"
+    );
+    assert!(
+        harness.tui().app.transcript_browsing,
+        "browsing state restored"
+    );
+}
+
+#[tokio::test]
 async fn test_d4_enter_opens_detail_view() {
     let mut harness = TuiTestHarness::new().await;
     harness.tui().app.transcript.clear();

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -6693,6 +6693,69 @@ async fn test_d4_key_r_opens_rewind_modal_assistant_text() {
 }
 
 #[tokio::test]
+async fn rewind_on_tool_call_row_resolves_to_prior_seq() {
+    // Session log on disk: seq 1 user message, seq 2 ToolCalls, seq 3 ToolResults.
+    // Rewinding a row whose seq is the ToolCalls entry must resolve to seq 1
+    // (the message that preceded the round) rather than orphaning the pair.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config: GlobalConfig = Arc::new(RwLock::new(Config {
+        sessions_dir_override: Some(tmp.path().to_path_buf()),
+        ..Config::default()
+    }));
+    {
+        let mut guard = config.write();
+        guard.use_session(Some("rewind")).unwrap();
+        let session = guard.session.as_mut().unwrap();
+        harnx_runtime::config::session::append_event(
+            session,
+            &harnx_core::session::SessionLogEntry::Message {
+                id: None,
+                timestamp: None,
+                fence_token: None,
+                role: harnx_core::message::MessageRole::User,
+                content: harnx_core::message::MessageContent::Text("hi".into()),
+            },
+        );
+        harnx_runtime::config::session::append_event(
+            session,
+            &harnx_core::session::SessionLogEntry::ToolCalls {
+                text: String::new(),
+                thought: None,
+                calls: vec![],
+                timestamp: None,
+                fence_token: None,
+            },
+        );
+        harnx_runtime::config::session::append_event(
+            session,
+            &harnx_core::session::SessionLogEntry::ToolResults {
+                results: vec![],
+                timestamp: None,
+            },
+        );
+    }
+
+    let mut harness = TuiTestHarness::with_config(config).await;
+    harness.tui().app.transcript.push(TranscriptItem::ToolCall {
+        tool_name: "read".to_string(),
+        id: "c1".to_string(),
+        body: None,
+        seq: Some(2),
+        timestamp: Some(chrono::Utc::now()),
+        rendered_cache: None,
+    });
+    harness.tui().app.transcript_focus = Some(harness.tui().app.transcript.len() - 1);
+    harness.tui().app.transcript_selection_anchor = None;
+
+    harness.tui().handle_transcript_rewind_for_test();
+
+    match &harness.tui().app.modal {
+        Some(crate::types::ModalState::ConfirmRewind { seq, .. }) => assert_eq!(*seq, 1),
+        other => panic!("expected ConfirmRewind {{ seq: 1 }}, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn test_d4_enter_opens_detail_view() {
     let mut harness = TuiTestHarness::new().await;
     harness.tui().app.transcript.clear();

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -2445,6 +2445,373 @@ async fn live_seq_banner_excluded_from_grouping() {
     assert_eq!(user_seq, Some(1), "seq lands on the live user row");
 }
 
+/// Extracts the (kind, seq) pairs for every seq-bearing row (`UserText`,
+/// `AssistantText`, `ToolCall`), in transcript order. Other row kinds
+/// (thoughts, notices, tool results, …) are intentionally omitted: they
+/// never carry a seq, and their exact interleaving position can legally
+/// differ between the live and reconstruction paths.
+fn seq_bearing_rows(items: &[TranscriptItem]) -> Vec<(&'static str, Option<usize>)> {
+    items
+        .iter()
+        .filter_map(|item| match item {
+            TranscriptItem::UserText { seq, .. } => Some(("user", *seq)),
+            TranscriptItem::AssistantText { seq, .. } => Some(("assistant", *seq)),
+            TranscriptItem::ToolCall { seq, .. } => Some(("tool_call", *seq)),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Keystone regression guard: the live seq-assignment path in
+/// `handle_agent_event` (`LogSeqAssigned` + `current_group_seq`) must
+/// produce the exact same per-row seq mapping as the reconstruction path
+/// `messages_to_transcript_items`. This drives an equivalent multi-round
+/// session through both paths and compares the seq-bearing rows directly,
+/// rather than relying on hand-substituted scenario tests to imply
+/// equivalence.
+#[tokio::test]
+async fn live_seq_map_matches_reconstruction() {
+    use harnx_core::message::{Message, MessageContent, MessageContentToolCalls, MessageRole};
+    use harnx_core::tool::{ToolCall, ToolResult};
+
+    let call_a = ToolCall::new(
+        "read".to_string(),
+        serde_json::Value::Null,
+        Some("a".to_string()),
+        None,
+    );
+    let call_b = ToolCall::new(
+        "write".to_string(),
+        serde_json::Value::Null,
+        Some("b".to_string()),
+        None,
+    );
+
+    let messages = vec![
+        make_compacted_message(MessageRole::User, MessageContent::Text("q1".to_string()), 1),
+        Message {
+            role: MessageRole::Tool,
+            content: MessageContent::ToolCalls(MessageContentToolCalls::new(
+                vec![
+                    ToolResult::new(call_a, serde_json::json!({"ok": 1})),
+                    ToolResult::new(call_b, serde_json::json!({"ok": 2})),
+                ],
+                "working".to_string(),
+                None,
+            )),
+            id: None,
+            log_seq: Some(2),
+            log_timestamp: None,
+        },
+        make_compacted_message(
+            MessageRole::Assistant,
+            MessageContent::Text("answer".to_string()),
+            3,
+        ),
+    ];
+
+    let expected = crate::lifecycle::messages_to_transcript_items(
+        &messages,
+        &std::collections::HashMap::new(),
+    );
+
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+    tui.clear_transcript();
+
+    // Round 1: user turn logged at seq 1.
+    tui.app.transcript.push(TranscriptItem::UserText {
+        text: "q1".to_string(),
+        seq: None,
+        timestamp: Some(chrono::Utc::now()),
+    });
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 1 }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    // Round 2: accompanying text + two parallel tool calls, all logged at
+    // seq 2 (mirrors the Tool-role message with two ToolResults above).
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Model(ModelEvent::MessageChunk {
+            blocks: vec![ContentBlock::Text("working".to_string())],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 2 }),
+        None,
+    ))
+    .await
+    .unwrap();
+    for (id, name) in [("a", "read"), ("b", "write")] {
+        tui.handle_tui_event(TuiEvent::Agent(
+            AgentEvent::Tool(ToolEvent::Started {
+                id: id.to_string(),
+                name: name.to_string(),
+                kind: Default::default(),
+                markdown: None,
+                input: serde_json::Value::Null,
+                locations: vec![],
+            }),
+            None,
+        ))
+        .await
+        .unwrap();
+    }
+    for (id, ok) in [("a", 1), ("b", 2)] {
+        tui.handle_tui_event(TuiEvent::Agent(
+            AgentEvent::Tool(ToolEvent::Completed {
+                id: id.to_string(),
+                output: serde_json::json!({"ok": ok}),
+                markdown: None,
+            }),
+            None,
+        ))
+        .await
+        .unwrap();
+    }
+
+    // Round 3: plain assistant turn logged at seq 3.
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Model(ModelEvent::MessageChunk {
+            blocks: vec![ContentBlock::Text("answer".to_string())],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 3 }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let expected_rows = seq_bearing_rows(&expected);
+    let actual_rows = seq_bearing_rows(&tui.app.transcript);
+
+    assert_eq!(
+        expected_rows,
+        vec![
+            ("user", Some(1)),
+            ("assistant", Some(2)),
+            ("tool_call", Some(2)),
+            ("tool_call", Some(2)),
+            ("assistant", Some(3)),
+        ],
+        "sanity-check the reconstruction side matches the documented mapping"
+    );
+    assert_eq!(
+        actual_rows, expected_rows,
+        "live seq-bearing row map must match reconstruction exactly"
+    );
+
+    // Tool results carry no seq at all (in either path) — just confirm the
+    // count of rendered result rows lines up.
+    let expected_result_count = expected
+        .iter()
+        .filter(|item| matches!(item, TranscriptItem::ToolResultMarkdown { .. }))
+        .count();
+    let actual_result_count = tui
+        .app
+        .transcript
+        .iter()
+        .filter(|item| matches!(item, TranscriptItem::ToolResultMarkdown { .. }))
+        .count();
+    assert_eq!(expected_result_count, 2);
+    assert_eq!(actual_result_count, expected_result_count);
+}
+
+/// A `ThoughtChunk` and a `NoticeEvent::Info` land between the round's
+/// accompanying `MessageChunk` and its tool calls. Neither should steal the
+/// round's `LogSeqAssigned` seq (they don't match the walk-back patterns in
+/// `handle_agent_event`) nor block it from reaching the still-unsequenced
+/// `AssistantText` row further back in the transcript.
+#[tokio::test]
+async fn live_seq_interleaved_thoughts_and_notices_within_round() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    tui.app.transcript.push(TranscriptItem::UserText {
+        text: "q".to_string(),
+        seq: None,
+        timestamp: Some(chrono::Utc::now()),
+    });
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 1 }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Model(ModelEvent::MessageChunk {
+            blocks: vec![ContentBlock::Text("thinking about tools".to_string())],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Model(ModelEvent::ThoughtChunk {
+            blocks: vec![ContentBlock::Text("considering options".to_string())],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Notice(NoticeEvent::Info("checking cache".to_string())),
+        None,
+    ))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 2 }),
+        None,
+    ))
+    .await
+    .unwrap();
+    for id in ["call_a", "call_b"] {
+        tui.handle_tui_event(TuiEvent::Agent(
+            AgentEvent::Tool(ToolEvent::Started {
+                id: id.to_string(),
+                name: "read".to_string(),
+                kind: Default::default(),
+                markdown: None,
+                input: serde_json::Value::Null,
+                locations: vec![],
+            }),
+            None,
+        ))
+        .await
+        .unwrap();
+    }
+
+    let has_thought = tui
+        .app
+        .transcript
+        .iter()
+        .any(|i| matches!(i, TranscriptItem::ThoughtText(_)));
+    let has_notice =
+        tui.app.transcript.iter().any(
+            |i| matches!(i, TranscriptItem::SystemText(text) if text.contains("checking cache")),
+        );
+    let assistant_seq = tui.app.transcript.iter().find_map(|i| match i {
+        TranscriptItem::AssistantText { seq, .. } => Some(*seq),
+        _ => None,
+    });
+    let tool_seqs: Vec<Option<usize>> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|i| match i {
+            TranscriptItem::ToolCall { seq, .. } => Some(*seq),
+            _ => None,
+        })
+        .collect();
+
+    assert!(has_thought, "the thought row should still be rendered");
+    assert!(has_notice, "the notice row should still be rendered");
+    assert_eq!(
+        assistant_seq,
+        Some(Some(2)),
+        "accompanying text still joins the round despite the interleaving thought/notice"
+    );
+    assert_eq!(
+        tool_seqs,
+        vec![Some(2), Some(2)],
+        "interleaving thought/notice rows must not steal or block the round seq"
+    );
+}
+
+/// Two consecutive plain user/assistant turns: each row gets its own seq
+/// and no seq leaks across the turn boundary (the second `LogSeqAssigned`
+/// walk-back must stop at the first already-sequenced row).
+#[tokio::test]
+async fn live_seq_back_to_back_turns() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    tui.app.transcript.push(TranscriptItem::UserText {
+        text: "user1".to_string(),
+        seq: None,
+        timestamp: Some(chrono::Utc::now()),
+    });
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 1 }),
+        None,
+    ))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Model(ModelEvent::MessageChunk {
+            blocks: vec![ContentBlock::Text("assistant1".to_string())],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 2 }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    tui.app.transcript.push(TranscriptItem::UserText {
+        text: "user2".to_string(),
+        seq: None,
+        timestamp: Some(chrono::Utc::now()),
+    });
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 3 }),
+        None,
+    ))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Model(ModelEvent::MessageChunk {
+            blocks: vec![ContentBlock::Text("assistant2".to_string())],
+        }),
+        None,
+    ))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 4 }),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    let rows: Vec<(&'static str, Option<usize>)> = seq_bearing_rows(&tui.app.transcript);
+    assert_eq!(
+        rows,
+        vec![
+            ("user", Some(1)),
+            ("assistant", Some(2)),
+            ("user", Some(3)),
+            ("assistant", Some(4)),
+        ],
+        "each turn's rows get their own seq with no leakage across the turn boundary"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_streaming_with_tool_calls() {
     let config =

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -88,7 +88,11 @@ pub(super) struct App {
     pub(super) last_usage_transcript_idx: Option<usize>,
     pub(super) pending_thought_source: Option<AgentSource>,
     pub(super) pending_thought_text: String,
-    pub(super) pending_tool_seq: Option<usize>,
+    /// Log seq of the entry currently being assembled from the live event
+    /// stream. Assigned when `LogSeqAssigned` arrives and read by tool-call
+    /// rows created afterward, so every row belonging to one logged entry
+    /// (accompanying assistant text + all tool calls of a round) shares its seq.
+    pub(super) current_group_seq: Option<usize>,
     pub(super) pending_message: Option<PendingMessage>,
     pub(super) completions: Vec<(String, Option<String>)>,
     pub(super) completion_index: usize,

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -266,6 +266,9 @@ pub enum TranscriptItem {
     /// inline emphasis from a `result_template` both display correctly.
     ToolResultMarkdown {
         text: String,
+        /// Tool-call id this result answers; used to pair a result with its
+        /// ToolCall row independent of transcript position. Empty when unknown.
+        id: String,
         rendered_cache: RenderedCache,
     },
     StatusLine(String),
@@ -280,6 +283,9 @@ pub enum TranscriptItem {
     UsageLine(String),
     ToolCall {
         tool_name: String,
+        /// Stable tool-call id from the event stream / session log. Empty when
+        /// unknown. Pairs this call with its ToolResultMarkdown row.
+        id: String,
         body: Option<ToolCallBody>,
         seq: Option<usize>,
         timestamp: Option<DateTime<Utc>>,

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -130,6 +130,11 @@ pub(super) struct App {
     /// detail_view_open is set.  None when no session is active or the item
     /// has no sequence number.
     pub(super) detail_view_raw_yaml: Option<String>,
+    /// True when the focused row should resolve to a raw log entry (active
+    /// session + the selection carries a seq) but resolution failed. Drives an
+    /// explicit "unavailable" line instead of silently falling back to the
+    /// already-rendered (summarized) row.
+    pub(super) detail_view_raw_unavailable: bool,
     pub(super) detail_view_text: Option<String>,
     /// True when the user is browsing history in fullscreen mode.
     /// Distinct from detail_view_open which shows raw YAML.


### PR DESCRIPTION
## Why

Transcript history navigation (arrow-up to browse, ENTER for the detail view, `e`/`d`/`r` to edit/delete/rewind) was unreliable in live sessions: selecting a tool call showed its result only when the result row happened to be adjacent; selecting a streaming assistant message could open an unrelated user message; the detail view sometimes showed a truncated summary instead of the raw log entry; and rewind surfaced raw errors like `Sequence 27 is a tool-calls entry paired with tool-results at 28`.

These were not independent bugs. Every history feature resolves the selected row to its session-log sequence number (`seq`), then asks the log for that entry — so a wrong or missing `seq` breaks all of them at once. The live TUI assigned `seq`s by a fragile backward-scan heuristic plus a sticky `pending_tool_seq`, which mis-assigned rows whenever the display rows and log entries weren't 1:1 (e.g. an assistant message with accompanying tool calls, or multiple parallel calls in one round).

## What changed

- **Group-based seq assignment** (`input.rs`): replaces the heuristic. Every row produced while one log entry is being written shares that entry's `seq`, mirroring the authoritative reconstruction path (`messages_to_transcript_items`). A round's accompanying assistant text and all its parallel tool-call rows now correctly share the round's `ToolCalls` seq.
- **Id-based tool pairing**: `ToolCall`/`ToolResultMarkdown` rows carry the stable tool-call `id`; the detail-view fallback pairs a call with its result by id instead of by transcript adjacency.
- **No silent degradation**: when a seq-bearing row in an active session fails to resolve, the detail view shows an explicit "raw log entry unavailable" line instead of quietly rendering the summarized row.
- **Rewind UX**: new `Config::resolve_rewind_seq` maps a selection whose seq is a `ToolCalls` entry back to the preceding message, so rewinding a tool-call/assistant row lands on a sane point instead of surfacing the raw pairing error.
- **Editing** verified end-to-end (edit-command targeting + detail-view reopen focus).

## Testing

- New seq-assignment scenario tests + a keystone **live↔reconstruction seq-map equivalence** property test (the two paths must produce the same per-row seq mapping); detail-view resolution tests; a falsifiable editing reopen-focus test (verified by removing the restoration block and watching it fail).
- `cargo nextest run -p harnx-runtime -p harnx-tui` → 709/709 passing; `cargo fmt --check` and `clippy --all-targets -D warnings` clean. (Rebased onto latest `main`, including the `rmcp` v2 / `mockall` 0.15 upgrades, and re-verified.)

## Not included

Issue #1024 (system prompt shown after compaction) was investigated during this work and deferred to its own workstream — analysis posted on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript grouping so assistant messages and related tool activity share the correct sequence.
  * Rewind actions now safely target the preceding message when initiated from a tool-call entry.
  * Tool results are paired with their corresponding tool calls even when they are not adjacent.
  * Detail views now clearly indicate when raw session data is unavailable.
  * Improved transcript editing, rewinding, and focus restoration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->