### PR TITLE
test: require nextest for two global-state-mutating flaky tests

### DIFF
--- a/crates/harnx-runtime/src/nats_worker/tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests.rs
@@ -613,6 +613,11 @@ fn test_non_idempotent_output_is_synthesized() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn remote_header_matches_local_header_source_of_truth() {
+    // Changes the process-global current directory (via CurrentDirGuard) to
+    // generate the header from a hermetic git repo. Under `cargo test` that cwd
+    // mutation races every other test that resolves paths against the cwd;
+    // nextest's per-test process isolation is required to keep it hermetic.
+    harnx_core::require_nextest();
     let _env_guard = env_lock().await;
     let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
         return;

--- a/crates/harnx-tui/src/terminal.rs
+++ b/crates/harnx-tui/src/terminal.rs
@@ -121,6 +121,12 @@ mod tests {
     /// not abort during cleanup.
     #[test]
     fn guard_drop_during_panic_does_not_double_panic() {
+        // Installs and mutates the process-global panic hook, and its guard
+        // deliberately leaves that hook in place when dropped mid-unwind
+        // (restoring it there would abort). Under `cargo test` that leaked hook
+        // bleeds into every later panic in the shared process and destabilizes
+        // sibling tests; nextest's per-test process isolation contains it.
+        harnx_core::require_nextest();
         let result = std::panic::catch_unwind(|| {
             let _guard = PanicTerminalHookGuard::install();
             panic!("boom");


### PR DESCRIPTION
## Summary

Two tests were reported as flaky: `guard_drop_during_panic_does_not_double_panic` (harnx-tui) and `remote_header_matches_local_header_source_of_truth` (harnx-runtime). Investigation showed **neither is flaky under CI's runner** (`cargo nextest`, one process per test) — both are deterministic in isolation and under concurrent-process stress (guard 200/200; header 80/80 across 8 concurrent processes; both 5/5 under `--stress-count=5`).

The flakiness only appears under an **in-process** runner (`cargo test` / `cargo insta test` / IDE runners), because both tests mutate **process-global state** and leak into / race against the sibling tests that share the process:

- **Guard test** — installs and mutates the global panic hook; its guard deliberately leaves the hook installed when dropped mid-unwind (restoring there would abort). Under `cargo test` that leaked hook fires `cleanup_terminal_state()` on every later panic. Empirically it drove the full harnx-tui binary from clean to **~2 failures / 25** in-process runs (control with the test skipped: 60/60 clean).
- **Header test** — changes the process-global current directory to build a header from a hermetic git repo, racing every other test that resolves paths against the cwd.

The whole `harnx-runtime` lib suite already fails when forced into a single process (config/`HOME`/insta/cwd races across dozens of tests); the suite depends on nextest isolation by design.

## Fix

Guard both tests with `harnx_core::require_nextest()` — the repo's existing, self-documenting mechanism for process-global-state tests (already used by the tmux/interrupt e2e and nats integration tests, and called out in AGENTS.md → *Verifying Changes*). They now **fail with actionable guidance** under `cargo test` instead of flaking, and pass normally under `cargo nextest`.

## Verification

- `cargo clippy -p harnx-tui -p harnx-runtime --all-targets -- -D warnings` — clean
- `cargo nextest run -p harnx-tui -p harnx-runtime` — 709/709 pass
- `--stress-count=5` on both tests — 5/5 pass
- Under `cargo test` both now fail loudly with the nextest redirect message (intended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)