### PR TITLE
feat(prompt): render system prompt at request time with tool and mode…

### DIFF
--- a/.changeset/system-prompt-runtime-rendering.md
+++ b/.changeset/system-prompt-runtime-rendering.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+Render agent system prompts at request time with current tool and model context instead of storing them in session transcripts.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -223,7 +223,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.12.0
+          version: 11.11.0
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.12.0
+          version: 11.11.0
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.12.0
+          version: 11.11.0
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -203,7 +203,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1946,7 +1946,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2114,7 +2114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2956,7 +2956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -4928,7 +4928,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5738,7 +5738,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6126,7 +6126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6196,18 +6196,21 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "path-absolutize"
-version = "4.0.1"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f808742975794703469f67a28dd14b1d1009a1743c18b0353b4b951dbb0068ad"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
 dependencies = [
  "path-dedot",
 ]
 
 [[package]]
 name = "path-dedot"
-version = "4.0.1"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03351d0f1c066c114015408dc6a3e101f080fc03ef9d8d799aa58ec760cac5a6"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "pem"
@@ -7236,7 +7239,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7304,7 +7307,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7935,7 +7938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8187,10 +8190,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8233,7 +8236,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook 0.3.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9285,7 +9288,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ secrecy = { version = "0.10" }
 urlencoding = "2.1.3"
 unicode-segmentation = "1.11.0"
 bitflags = "2.5.0"
-path-absolutize = "4.0.0"
+path-absolutize = "3.1.1"
 hnsw_rs = "0.3.0"
 rayon = "1.10.0"
 uuid = { version = "1.9.1", features = ["v4", "v7"] }

--- a/crates/harnx-core/src/agent_config.rs
+++ b/crates/harnx-core/src/agent_config.rs
@@ -7,7 +7,7 @@ use crate::hooks::HooksConfig;
 use crate::model::Model;
 use crate::retry_config::RetryConfig;
 use crate::system_vars::render_template;
-use crate::tool::Tools;
+use crate::tool::{ToolDeclaration, Tools};
 
 use anyhow::Result;
 use fancy_regex::Regex;
@@ -34,6 +34,26 @@ video-game-development-insights"#;
 pub const CREATE_TITLE_AGENT_NAME: &str = "%create-title%";
 
 pub type AgentVariables = IndexMap<String, String>;
+
+/// Collect flat `[KEY, VALUE, KEY, VALUE, ...]` CLI pairs (as produced by the
+/// `--agent-variable` / `-x` flag) into `AgentVariables`. Returns `None` for an
+/// empty input so callers can leave `config.agent_variables` unset. Errors when
+/// the values don't form complete key/value pairs.
+pub fn collect_agent_variables(values: &[String]) -> Result<Option<AgentVariables>> {
+    if values.is_empty() {
+        return Ok(None);
+    }
+    anyhow::ensure!(
+        values.len().is_multiple_of(2),
+        "agent_variable values must be key/value pairs"
+    );
+    Ok(Some(
+        values
+            .chunks(2)
+            .map(|v| (v[0].to_string(), v[1].to_string()))
+            .collect(),
+    ))
+}
 
 static RE_METADATA: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?s)\A-{3,}\s*(.*?)\s*-{3,}\s*(.*)").unwrap());
@@ -403,8 +423,7 @@ impl AgentConfig {
     }
 
     pub fn interpolated_instructions(&self) -> anyhow::Result<String> {
-        let template = self.instructions.as_deref().unwrap_or(&self.prompt);
-        render_template(template, self)
+        self.system_text()
     }
 
     pub fn variables(&self) -> &AgentVariables {
@@ -443,8 +462,16 @@ impl AgentConfig {
     /// `Config::tool_declarations_for_use_tools`). Appending an unfiltered
     /// text list duplicated those definitions and leaked tools from other
     /// packages into the prompt.
+    pub fn instructions_template(&self) -> &str {
+        self.instructions.as_deref().unwrap_or(&self.prompt)
+    }
+
     pub fn system_text(&self) -> anyhow::Result<String> {
-        self.interpolated_instructions()
+        render_template(self.instructions_template(), self, None)
+    }
+
+    pub fn system_text_with_tools(&self, tools: &[ToolDeclaration]) -> anyhow::Result<String> {
+        render_template(self.instructions_template(), self, Some(tools))
     }
 
     /// Build the messages for a one-shot LLM call using this agent's prompt and
@@ -456,7 +483,8 @@ impl AgentConfig {
         input: &crate::input::Input,
     ) -> anyhow::Result<Vec<crate::message::Message>> {
         use crate::message::{Message, MessageContent, MessageRole};
-        let prompt = self.interpolated_instructions()?;
+        let prompt =
+            self.system_text_with_tools(input.resolved_tools.as_deref().unwrap_or_default())?;
         let content = input.message_content();
         let mut messages = vec![];
         if !prompt.is_empty() {
@@ -478,7 +506,8 @@ impl AgentConfig {
     /// Render the prompt + input markdown for the echo-mode (`.echo`) command.
     /// Companion of `build_messages`.
     pub fn echo_messages(&self, input: &crate::input::Input) -> anyhow::Result<String> {
-        let prompt = self.interpolated_instructions()?;
+        let prompt =
+            self.system_text_with_tools(input.resolved_tools.as_deref().unwrap_or_default())?;
         let input_markdown = input.render();
 
         if prompt.is_empty() {
@@ -621,6 +650,31 @@ fn serialize_frontmatter(frontmatter: &AgentFrontMatter) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn collect_agent_variables_empty_is_none() {
+        assert!(collect_agent_variables(&[]).unwrap().is_none());
+    }
+
+    #[test]
+    fn collect_agent_variables_builds_map() {
+        let values = vec![
+            "cloud_env".to_string(),
+            "true".to_string(),
+            "debug".to_string(),
+            "false".to_string(),
+        ];
+        let vars = collect_agent_variables(&values).unwrap().unwrap();
+        assert_eq!(vars.get("cloud_env").map(String::as_str), Some("true"));
+        assert_eq!(vars.get("debug").map(String::as_str), Some("false"));
+        assert_eq!(vars.len(), 2);
+    }
+
+    #[test]
+    fn collect_agent_variables_rejects_odd_pairs() {
+        let values = vec!["lonely_key".to_string()];
+        assert!(collect_agent_variables(&values).is_err());
+    }
 
     #[test]
     fn compaction_knobs_parse_from_frontmatter() {
@@ -775,6 +829,60 @@ You are a compaction agent.\n";
             msg.contains("Template error"),
             "expected error message to contain 'Template error', got: {msg:?}"
         );
+    }
+
+    #[test]
+    fn system_text_with_tools_renders_tool_names_in_jinja() {
+        use crate::tool::ToolDeclaration;
+
+        let agent = AgentConfig::from_prompt(
+            "Tools: {% for t in tools %}{{ t.name }}{% if not loop.last %}, {% endif %}{% endfor %}",
+        );
+        let tools = vec![
+            ToolDeclaration {
+                name: "fs_read".to_string(),
+                description: "Read files".to_string(),
+                parameters: Default::default(),
+                mcp_tool_name: None,
+                mcp_server_name: None,
+                call_template: None,
+                result_template: None,
+                idempotent_hint: None,
+                read_only_hint: None,
+            },
+            ToolDeclaration {
+                name: "bash_exec".to_string(),
+                description: "Run shell commands".to_string(),
+                parameters: Default::default(),
+                mcp_tool_name: None,
+                mcp_server_name: None,
+                call_template: None,
+                result_template: None,
+                idempotent_hint: None,
+                read_only_hint: None,
+            },
+        ];
+
+        let rendered = agent.system_text_with_tools(&tools).unwrap();
+
+        assert!(rendered.contains("fs_read"), "rendered prompt: {rendered}");
+        assert!(
+            rendered.contains("bash_exec"),
+            "rendered prompt: {rendered}"
+        );
+    }
+
+    #[test]
+    fn interpolated_instructions_renders_current_model_id_after_model_change() {
+        let mut agent = AgentConfig::from_prompt("Model={{ agent.model }}");
+        agent.set_model_id(Some("openai:gpt-4o-mini".to_string()));
+
+        let first = agent.interpolated_instructions().unwrap();
+        assert_eq!(first, "Model=openai:gpt-4o-mini");
+
+        agent.set_model_id(Some("anthropic:claude-3-7-sonnet".to_string()));
+        let second = agent.interpolated_instructions().unwrap();
+        assert_eq!(second, "Model=anthropic:claude-3-7-sonnet");
     }
 
     #[test]

--- a/crates/harnx-core/src/input.rs
+++ b/crates/harnx-core/src/input.rs
@@ -7,7 +7,7 @@
 use crate::agent_config::AgentConfig;
 use crate::crypto::sha256;
 use crate::message::{ImageUrl, MessageContent, MessageContentPart, MessageContentToolCalls};
-use crate::tool::ToolResult;
+use crate::tool::{ToolDeclaration, ToolResult};
 
 use std::collections::HashMap;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
@@ -26,6 +26,7 @@ pub struct Input {
     pub attachment_refs: Vec<String>,
     pub data_urls: HashMap<String, String>,
     pub tool_calls: Option<MessageContentToolCalls>,
+    pub resolved_tools: Option<Vec<ToolDeclaration>>,
     pub agent: AgentConfig,
     pub rag_name: Option<String>,
     pub with_session: bool,
@@ -69,11 +70,12 @@ impl Input {
             attachment_refs: Vec::new(),
             data_urls: HashMap::new(),
             tool_calls: None,
+            resolved_tools: None,
             agent,
             rag_name: None,
             with_session: false,
             with_agent: false,
-            inject_system_prompt: false,
+            inject_system_prompt: true,
             injected_user_text: None,
             skip_user_log_append: false,
             preferred_assistant_message_id: None,

--- a/crates/harnx-core/src/session.rs
+++ b/crates/harnx-core/src/session.rs
@@ -221,6 +221,8 @@ pub struct Session {
     pub model_fallbacks: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compaction_agent: Option<String>,
+    #[serde(skip)]
+    pub compaction_summary: Option<String>,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub compressed_messages: Vec<Message>,
@@ -412,7 +414,7 @@ impl Session {
         };
         self.agent_prompt = new_prompt;
         self.agent_variables = new_variables;
-        self.agent_instructions = self.agent_prompt.clone();
+        self.agent_instructions = agent.instructions_template().to_string();
         self.dirty = true;
         self.update_tokens();
         Ok(())
@@ -429,7 +431,7 @@ impl Session {
         };
         self.agent_prompt = new_prompt;
         self.agent_variables = new_variables;
-        self.agent_instructions = self.agent_prompt.clone();
+        self.agent_instructions = agent.instructions_template().to_string();
         Ok(())
     }
 
@@ -493,12 +495,13 @@ impl Session {
 impl Session {
     pub fn to_agent_config(&self) -> Result<AgentConfig> {
         let agent_name = self.agent_name.as_deref().unwrap_or(TEMP_AGENT_NAME);
-        let prompt = if self.agent_prompt.is_empty() {
-            self.agent_instructions.as_str()
-        } else {
+        let prompt = if self.agent_instructions.is_empty() {
             self.agent_prompt.as_str()
+        } else {
+            self.agent_instructions.as_str()
         };
-        let mut config = AgentConfig::from_markdown(agent_name, prompt)?;
+        let mut config = AgentConfig::from_prompt(prompt);
+        config.set_name(agent_name);
         config.set_model(self.model.clone());
         config.set_temperature(self.temperature);
         config.set_top_p(self.top_p);
@@ -676,6 +679,20 @@ mod tests {
             }
             other => panic!("expected tool_results, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn to_agent_config_preserves_prompt_starting_with_frontmatter_delimiter() {
+        let mut session = Session::default();
+        session.agent_name = Some("resume-agent".to_string());
+        session.agent_instructions = "---\nModel={{ agent.model }}".to_string();
+        session.model = Model::new("openai", "gpt-4o");
+        session.model_id = session.model.id();
+
+        let config = session.to_agent_config().unwrap();
+        assert_eq!(config.name(), "resume-agent");
+        let rendered = config.system_text().unwrap();
+        assert_eq!(rendered, "---\nModel=openai:gpt-4o");
     }
 
     #[test]

--- a/crates/harnx-core/src/system_vars.rs
+++ b/crates/harnx-core/src/system_vars.rs
@@ -7,6 +7,7 @@
 //! command dispatch.
 
 use crate::agent_config::AgentConfig;
+use crate::tool::ToolDeclaration;
 use anyhow::Result;
 use minijinja::{Environment, UndefinedBehavior, Value};
 use std::collections::BTreeMap;
@@ -102,7 +103,11 @@ pub fn now() -> String {
     chrono::Local::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, false)
 }
 
-pub fn render_template(template: &str, agent: &AgentConfig) -> Result<String> {
+pub fn render_template(
+    template: &str,
+    agent: &AgentConfig,
+    tools: Option<&[ToolDeclaration]>,
+) -> Result<String> {
     let mut env = Environment::new();
     env.set_undefined_behavior(UndefinedBehavior::Strict);
     env.set_debug(true);
@@ -146,6 +151,10 @@ pub fn render_template(template: &str, agent: &AgentConfig) -> Result<String> {
     ctx.insert("__cwd__".to_string(), Value::from(current_dir));
     ctx.insert("__os_distro__".to_string(), Value::from(os_distro));
     ctx.insert("agent".to_string(), Value::from_serialize(&agent_ctx));
+    ctx.insert(
+        "tools".to_string(),
+        Value::from_serialize(tools.unwrap_or_default()),
+    );
 
     for (k, v) in agent.variables() {
         ctx.insert(k.clone(), Value::from(v.clone()));

--- a/crates/harnx-engine/src/retry.rs
+++ b/crates/harnx-engine/src/retry.rs
@@ -13,6 +13,7 @@ use harnx_core::api_types::CompletionTokenUsage;
 use harnx_core::error::LlmError;
 use harnx_core::event::{AgentEvent, TurnEvent};
 use harnx_core::input::Input;
+use harnx_core::model::Model;
 use harnx_core::model::ModelType;
 use harnx_core::retry_config::{ModelCooldownMap, RetryConfig};
 use harnx_core::tool::ToolCall;
@@ -38,9 +39,10 @@ pub type CallFuture<'a> = Pin<
 /// Type alias for a client-construction callback. Callers (harnx) inject
 /// this so the engine can build clients without knowing about harnx's
 /// test-client override (installed via `TestStateGuard`).
-pub type InitClientFn = Arc<
-    dyn Fn(&[ClientConfig], &harnx_core::model::Model) -> Result<Box<dyn Client>> + Send + Sync,
->;
+pub type InitClientFn =
+    Arc<dyn Fn(&[ClientConfig], &Model) -> Result<Box<dyn Client>> + Send + Sync>;
+
+pub type SelectModelFn = Arc<dyn Fn(&mut Input, &Model) + Send + Sync>;
 
 /// Narrowed config view required by the retry/fallback loop. Callers
 /// (in harnx) construct this from their own `GlobalConfig` and pass it
@@ -64,6 +66,7 @@ pub struct TurnContext {
     pub warn_fn: Arc<dyn Fn(&str) + Send + Sync>,
     pub event_fn: Arc<dyn Fn(AgentEvent) + Send + Sync>,
     pub init_client_fn: InitClientFn,
+    pub select_model_fn: SelectModelFn,
 }
 
 impl TurnContext {
@@ -150,24 +153,25 @@ pub fn is_non_retryable_non_auth(err: &anyhow::Error) -> bool {
 /// allows callers (e.g. the TUI) to supply their own streaming implementation
 /// while still benefiting from the retry/fallback loop.
 pub async fn call_with_retry_and_fallback_custom<F>(
-    input: &Input,
+    input: &mut Input,
     ctx: &TurnContext,
     abort_signal: AbortSignal,
     call_fn: F,
 ) -> Result<(String, Option<String>, Vec<ToolCall>, CompletionTokenUsage)>
 where
-    F: for<'a> Fn(&'a Input, &'a dyn Client, AbortSignal) -> CallFuture<'a>,
+    F: for<'a> Fn(&'a mut Input, &'a dyn Client, AbortSignal) -> CallFuture<'a>,
 {
-    let agent = input.agent();
-    let retry_config = agent.retry_config();
+    let retry_config = input.agent().retry_config();
 
     // Build model list: primary model + fallbacks
-    let primary_model_id = agent
+    let primary_model = input.agent().model().clone();
+    let primary_model_id = input
+        .agent()
         .model_id()
         .unwrap_or(&ctx.default_model_id)
         .to_string();
     let mut model_ids: Vec<String> = vec![primary_model_id];
-    model_ids.extend(agent.model_fallbacks().iter().cloned());
+    model_ids.extend(input.agent().model_fallbacks().iter().cloned());
 
     // Eagerly validate all fallback model IDs so the user gets immediate
     // feedback about typos / missing models instead of a silent skip.
@@ -206,7 +210,7 @@ where
         // For the primary model (idx 0), use the already-resolved model from
         // the input's agent. For fallbacks, resolve from the model catalog.
         let client = if idx == 0 {
-            match ctx.init_client(agent.model()) {
+            match ctx.init_client(&primary_model) {
                 Ok(client) => client,
                 Err(err) => {
                     ctx.warn(&format!(
@@ -232,6 +236,10 @@ where
                 }
             }
         };
+
+        let selected_model = client.model().clone();
+        // ordering: model updated before prompt render so {{ agent.model }} reflects fallback
+        (ctx.select_model_fn)(input, &selected_model);
 
         match try_model_with_retries_custom(
             input,
@@ -374,7 +382,7 @@ fn retry_delay_for_llm_error(
 /// harnx — harnx retains a thin test wrapper that builds a `TurnContext`
 /// from its `GlobalConfig` and calls this function.
 pub async fn try_model_with_retries_custom<F>(
-    input: &Input,
+    input: &mut Input,
     client: &dyn Client,
     ctx: &TurnContext,
     retry_config: &RetryConfig,
@@ -382,7 +390,7 @@ pub async fn try_model_with_retries_custom<F>(
     call_fn: &F,
 ) -> Result<(String, Option<String>, Vec<ToolCall>, CompletionTokenUsage)>
 where
-    F: for<'a> Fn(&'a Input, &'a dyn Client, AbortSignal) -> CallFuture<'a>,
+    F: for<'a> Fn(&'a mut Input, &'a dyn Client, AbortSignal) -> CallFuture<'a>,
 {
     let mut last_error: Option<anyhow::Error> = None;
     // Ensure at least one attempt even if configured as 0

--- a/crates/harnx-runtime/src/agent_loop.rs
+++ b/crates/harnx-runtime/src/agent_loop.rs
@@ -38,7 +38,7 @@ use crate::utils::AbortSignal;
 /// `call_with_retry_and_fallback`.
 pub type AgentCallFn = Arc<
     dyn for<'a> Fn(
-            &'a Input,
+            &'a mut Input,
             &'a GlobalConfig,
             AbortSignal,
         ) -> Pin<
@@ -337,7 +337,7 @@ pub async fn run_agent_loop(ctx: &AgentLoopContext, initial_input: Input) -> Res
 
         // LLM call (with retry + fallback).
         let llm_result = if let Some(ref call_fn) = ctx.call_fn {
-            call_fn(&input, config, abort_signal.clone()).await
+            call_fn(&mut input, config, abort_signal.clone()).await
         } else {
             // Use the default call function, which respects config.stream:
             // streaming (call_chat_completions_streaming) when enabled, or
@@ -346,7 +346,7 @@ pub async fn run_agent_loop(ctx: &AgentLoopContext, initial_input: Input) -> Res
             // matters for ACP server mode where stdout is the JSON-RPC
             // transport. The old hardcoded call_chat_completions(inp, true, ...)
             // always printed to stdout, corrupting the ACP connection.
-            call_with_retry_and_fallback(&input, config, abort_signal.clone()).await
+            call_with_retry_and_fallback(&mut input, config, abort_signal.clone()).await
         };
 
         let (output, thought, tool_calls, usage) = match llm_result {

--- a/crates/harnx-runtime/src/client/common.rs
+++ b/crates/harnx-runtime/src/client/common.rs
@@ -32,16 +32,16 @@ use tokio::sync::mpsc::unbounded_channel;
 /// only the `ChatCompletionsData`-based inner method.
 pub async fn chat_completions_with_input(
     client: &dyn Client,
-    input: Input,
+    mut input: Input,
     config: &GlobalConfig,
     ctx: &ClientCallContext<'_>,
 ) -> Result<ChatCompletionsOutput> {
     if ctx.dry_run {
-        let content = crate::config::input::echo_messages(&input, config)?;
+        let content = crate::config::input::echo_messages(&mut input, config)?;
         return Ok(ChatCompletionsOutput::new(&content));
     }
     let data = crate::config::input::prepare_completion_data(
-        &input,
+        &mut input,
         config,
         client.model(),
         false,
@@ -55,7 +55,7 @@ pub async fn chat_completions_with_input(
 /// caller's abort signal attached to `handler`.
 pub async fn chat_completions_streaming_with_input(
     client: &dyn Client,
-    input: &Input,
+    input: &mut Input,
     config: &GlobalConfig,
     handler: &mut SseHandler,
     ctx: &ClientCallContext<'_>,
@@ -107,7 +107,7 @@ fn spinner_label(config: &GlobalConfig) -> String {
 }
 
 pub async fn call_chat_completions(
-    input: &Input,
+    input: &mut Input,
     print: bool,
     extract_code: bool,
     client: &dyn Client,
@@ -180,7 +180,7 @@ pub async fn call_chat_completions(
 }
 
 pub async fn call_chat_completions_streaming(
-    input: &Input,
+    input: &mut Input,
     client: &dyn Client,
     config: &GlobalConfig,
     abort_signal: AbortSignal,

--- a/crates/harnx-runtime/src/client/retry.rs
+++ b/crates/harnx-runtime/src/client/retry.rs
@@ -48,6 +48,7 @@ fn build_turn_context(config: &GlobalConfig) -> TurnContext {
         // `harnx_client::init_client`; in tests it short-circuits to the
         // installed `MockClient`.
         init_client_fn: Arc::new(super::init_client),
+        select_model_fn: Arc::new(|input, model| input.agent.set_model(model.clone())),
     }
 }
 
@@ -57,7 +58,7 @@ fn build_turn_context(config: &GlobalConfig) -> TurnContext {
 /// For each model, retries up to `retry_config.attempts` times on retryable errors.
 /// On exhaustion or auth errors, sets a cooldown on the model and moves to the next.
 pub async fn call_with_retry_and_fallback(
-    input: &Input,
+    input: &mut Input,
     config: &GlobalConfig,
     abort_signal: AbortSignal,
 ) -> Result<(String, Option<String>, Vec<ToolCall>, CompletionTokenUsage)> {
@@ -78,13 +79,13 @@ pub async fn call_with_retry_and_fallback(
 /// loop takes a 3-arg closure `(input, client, abort)` and this wrapper
 /// adapts by capturing `config` in the forwarded closure.
 pub async fn call_with_retry_and_fallback_custom<F>(
-    input: &Input,
+    input: &mut Input,
     config: &GlobalConfig,
     abort_signal: AbortSignal,
     call_fn: F,
 ) -> Result<(String, Option<String>, Vec<ToolCall>, CompletionTokenUsage)>
 where
-    F: for<'a> Fn(&'a Input, &'a dyn Client, &'a GlobalConfig, AbortSignal) -> CallFuture<'a>
+    F: for<'a> Fn(&'a mut Input, &'a dyn Client, &'a GlobalConfig, AbortSignal) -> CallFuture<'a>
         + Send
         + Sync
         + 'static,
@@ -115,7 +116,7 @@ where
 }
 
 async fn default_call_fn(
-    input: &Input,
+    input: &mut Input,
     client: &dyn Client,
     config: &GlobalConfig,
     abort_signal: AbortSignal,
@@ -162,7 +163,7 @@ mod tests {
     /// Arc-clone HRTB-friendly adapter pattern as
     /// [`call_with_retry_and_fallback_custom`].
     async fn try_model_with_retries(
-        input: &Input,
+        input: &mut Input,
         client: &dyn Client,
         config: &GlobalConfig,
         retry_config: &RetryConfig,
@@ -212,7 +213,7 @@ mod tests {
         let _guard = TestStateGuard::new(Some(mock)).await;
 
         let config = make_config();
-        let input = make_input(&config);
+        let mut input = make_input(&config);
         let abort = create_abort_signal();
 
         let client = crate::config::input::create_client(&input, &config).unwrap();
@@ -222,7 +223,8 @@ mod tests {
             max_delay_ms: 100,
         };
         let result =
-            try_model_with_retries(&input, client.as_ref(), &config, &retry_config, abort).await;
+            try_model_with_retries(&mut input, client.as_ref(), &config, &retry_config, abort)
+                .await;
         assert!(
             result.is_ok(),
             "Expected success after retries, got: {:?}",
@@ -244,7 +246,7 @@ mod tests {
         let _guard = TestStateGuard::new(Some(mock)).await;
 
         let config = make_config();
-        let input = make_input(&config);
+        let mut input = make_input(&config);
         let abort = create_abort_signal();
 
         let client = crate::config::input::create_client(&input, &config).unwrap();
@@ -254,7 +256,8 @@ mod tests {
             max_delay_ms: 100,
         };
         let result =
-            try_model_with_retries(&input, client.as_ref(), &config, &retry_config, abort).await;
+            try_model_with_retries(&mut input, client.as_ref(), &config, &retry_config, abort)
+                .await;
         assert!(result.is_err());
 
         let err = result.unwrap_err();
@@ -296,7 +299,7 @@ mod tests {
         let _guard = TestStateGuard::new(Some(mock)).await;
 
         let config = make_config();
-        let input = make_input(&config);
+        let mut input = make_input(&config);
         let abort = create_abort_signal();
 
         let client = crate::config::input::create_client(&input, &config).unwrap();
@@ -306,7 +309,8 @@ mod tests {
             max_delay_ms: 100,
         };
         let result =
-            try_model_with_retries(&input, client.as_ref(), &config, &retry_config, abort).await;
+            try_model_with_retries(&mut input, client.as_ref(), &config, &retry_config, abort)
+                .await;
         assert!(
             result.is_err(),
             "Expected error after all retries exhausted"
@@ -334,7 +338,7 @@ mod tests {
         let _guard = TestStateGuard::new(Some(mock)).await;
 
         let config = make_config();
-        let input = make_input(&config);
+        let mut input = make_input(&config);
         let abort = create_abort_signal();
 
         let client = crate::config::input::create_client(&input, &config).unwrap();
@@ -344,7 +348,8 @@ mod tests {
             max_delay_ms: 100,
         };
         let result =
-            try_model_with_retries(&input, client.as_ref(), &config, &retry_config, abort).await;
+            try_model_with_retries(&mut input, client.as_ref(), &config, &retry_config, abort)
+                .await;
         assert!(result.is_err());
 
         let err = result.unwrap_err();
@@ -422,12 +427,12 @@ mod tests {
         let _guard = TestStateGuard::new(Some(mock)).await;
 
         let config = make_config();
-        let input = make_input(&config);
+        let mut input = make_input(&config);
         let abort = create_abort_signal();
         let client = crate::config::input::create_client(&input, &config).unwrap();
 
         let result = try_model_with_retries(
-            &input,
+            &mut input,
             client.as_ref(),
             &config,
             &retry_after_test_config(),
@@ -465,12 +470,12 @@ mod tests {
         let _guard = TestStateGuard::new(Some(mock.clone())).await;
 
         let config = make_config();
-        let input = make_input(&config);
+        let mut input = make_input(&config);
         let abort = create_abort_signal();
         let client = crate::config::input::create_client(&input, &config).unwrap();
 
         let result = try_model_with_retries(
-            &input,
+            &mut input,
             client.as_ref(),
             &config,
             &retry_after_test_config(),
@@ -521,10 +526,11 @@ mod tests {
             .set_model_fallbacks(vec!["nonexistent-client:bogus-model".to_string()]);
 
         let abort = create_abort_signal();
-        let result = call_with_retry_and_fallback_custom(&input, &config, abort, |i, c, cfg, a| {
-            Box::pin(default_call_fn(i, c, cfg, a))
-        })
-        .await;
+        let result =
+            call_with_retry_and_fallback_custom(&mut input, &config, abort, |i, c, cfg, a| {
+                Box::pin(default_call_fn(i, c, cfg, a))
+            })
+            .await;
 
         assert!(
             result.is_err(),

--- a/crates/harnx-runtime/src/config/compaction_tests.rs
+++ b/crates/harnx-runtime/src/config/compaction_tests.rs
@@ -421,11 +421,22 @@ async fn test_compact_session_honors_compaction_keep_recent_turns() {
         "the last turn must be kept verbatim, not compacted; transcript: {transcript:?}"
     );
 
-    // The kept-verbatim suffix lands back as [summary_system, U4, A4].
-    let kept = config.read().session.as_ref().unwrap().messages.len();
+    // The kept-verbatim suffix lands back as [U4, A4]; summary stays on runtime field.
+    let guard = config.read();
+    let session = guard.session.as_ref().unwrap();
     assert_eq!(
-        kept, 3,
-        "expected the summary plus the one kept turn (2 messages)"
+        session.messages.len(),
+        2,
+        "expected one kept turn (2 messages)"
+    );
+    let summary = session
+        .compaction_summary
+        .as_deref()
+        .expect("expected runtime compaction summary to be populated");
+    assert!(!summary.is_empty(), "expected non-empty compaction summary");
+    assert!(
+        summary.contains("Compacted"),
+        "expected runtime compaction summary to contain 'Compacted', got {summary:?}"
     );
 }
 

--- a/crates/harnx-runtime/src/config/input.rs
+++ b/crates/harnx-runtime/src/config/input.rs
@@ -139,7 +139,7 @@ pub fn create_client(input: &Input, config: &GlobalConfig) -> Result<Box<dyn Cli
 
 /// Fetch chat text with retry and model fallback support.
 /// Uses the agent's configured fallback models if the primary model fails.
-pub async fn fetch_chat_text(input: &Input, config: &GlobalConfig) -> Result<String> {
+pub async fn fetch_chat_text(input: &mut Input, config: &GlobalConfig) -> Result<String> {
     let abort_signal = create_abort_signal();
     let (text, _, _, _) =
         crate::client::retry::call_with_retry_and_fallback(input, config, abort_signal).await?;
@@ -148,17 +148,18 @@ pub async fn fetch_chat_text(input: &Input, config: &GlobalConfig) -> Result<Str
 }
 
 pub fn prepare_completion_data(
-    input: &Input,
+    input: &mut Input,
     config: &GlobalConfig,
     model: &Model,
     stream: bool,
     client: &dyn Client,
 ) -> Result<ChatCompletionsData> {
+    let functions = config.read().select_tools(input.agent());
+    input.resolved_tools = functions.clone();
     let mut messages = build_messages(input, config)?;
     patch_messages(&mut messages, model);
     model.guard_max_input_tokens(&messages)?;
     let (temperature, top_p) = (input.agent().temperature(), input.agent().top_p());
-    let functions = config.read().select_tools(input.agent());
 
     // Clients either expand attachments internally (Gemini native) or rely on
     // the runtime base64 pre-pass (all other providers).
@@ -219,7 +220,9 @@ pub fn build_messages(input: &Input, config: &GlobalConfig) -> Result<Vec<Messag
     Ok(messages)
 }
 
-pub fn echo_messages(input: &Input, config: &GlobalConfig) -> anyhow::Result<String> {
+pub fn echo_messages(input: &mut Input, config: &GlobalConfig) -> anyhow::Result<String> {
+    let functions = config.read().select_tools(input.agent());
+    input.resolved_tools = functions;
     if let Some(session) = session_of(input, &config.read().session) {
         Ok(crate::config::session::echo_messages(session, input))
     } else {
@@ -539,7 +542,7 @@ mod tests {
 
         // Call prepare_completion_data
         let data = prepare_completion_data(
-            &input,
+            &mut input,
             &global_config,
             mock_client.model(),
             false,
@@ -608,7 +611,7 @@ mod tests {
             .expands_attachments_internally(false)
             .build();
         let data = prepare_completion_data(
-            &input,
+            &mut input,
             &global_config,
             mock_client.model(),
             false,
@@ -672,7 +675,7 @@ mod tests {
 
         // Call prepare_completion_data
         let data = prepare_completion_data(
-            &input,
+            &mut input,
             &global_config,
             mock_client.model(),
             false,

--- a/crates/harnx-runtime/src/config/remote_session_ops.rs
+++ b/crates/harnx-runtime/src/config/remote_session_ops.rs
@@ -321,6 +321,7 @@ async fn remote_thin_session(
 pub struct RemoteTranscriptState {
     pub compressed_messages: Vec<harnx_core::message::Message>,
     pub messages: Vec<harnx_core::message::Message>,
+    pub compaction_summary: Option<String>,
 }
 
 fn renumber_remote_messages_for_window(
@@ -420,6 +421,7 @@ pub async fn load_remote_transcript_for_render(
         return Ok(RemoteTranscriptState {
             compressed_messages: vec![],
             messages: vec![],
+            compaction_summary: None,
         });
     }
 
@@ -445,6 +447,7 @@ pub async fn load_remote_transcript_for_render(
     Ok(RemoteTranscriptState {
         compressed_messages: session.compressed_messages,
         messages: session.messages,
+        compaction_summary: session.compaction_summary,
     })
 }
 

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -233,6 +233,9 @@ pub(crate) fn replay_log_entries_for_external(
 
                     );
                 }
+                if role == MessageRole::System && !session.agent_instructions.is_empty() {
+                    continue;
+                }
                 let mut message = Message::new(role, content).with_log_seq(seq);
                 if let Some(id) = id {
                     message = message.with_id(id);
@@ -292,10 +295,7 @@ pub(crate) fn replay_log_entries_for_external(
                         .push(repair_orphan_tool_calls(pending, name)?);
                 }
                 session.compressed_messages.append(&mut session.messages);
-                session.messages.push(Message::new(
-                    MessageRole::System,
-                    MessageContent::Text(prompt),
-                ));
+                session.compaction_summary = Some(prompt);
             }
             SessionLogEntry::Clear => {
                 pending = None;
@@ -870,23 +870,9 @@ pub fn to_agent(session: &Session) -> Agent {
     )
 }
 
-pub fn compress(session: &mut Session, mut prompt: String) {
-    if let Some(system_prompt) = session.messages.first().and_then(|v| {
-        if MessageRole::System == v.role {
-            let content = v.content.to_text();
-            if !content.is_empty() {
-                return Some(content);
-            }
-        }
-        None
-    }) {
-        prompt = format!("{system_prompt}\n\n{prompt}",);
-    }
+pub fn compress(session: &mut Session, prompt: String) {
     session.compressed_messages.append(&mut session.messages);
-    session.messages.push(Message::new(
-        MessageRole::System,
-        MessageContent::Text(prompt.clone()),
-    ));
+    session.compaction_summary = Some(prompt.clone());
     session.update_tokens();
     if !append_event(session, &SessionLogEntry::Compress { prompt }) {
         session.dirty = true;
@@ -895,31 +881,16 @@ pub fn compress(session: &mut Session, mut prompt: String) {
 
 /// Compact only the prefix `messages[..keep_from]`, keeping `messages[keep_from..]`
 /// verbatim. The prefix moves to `compressed_messages`; the new message list is
-/// `[summary system message, ...kept suffix]`. The original leading system
-/// prompt (if any) is folded into the summary, matching `compress`.
-pub fn compress_keeping_recent(session: &mut Session, mut prompt: String, keep_from: usize) {
+/// just preserved suffix, while summary stays in `session.compaction_summary`.
+pub fn compress_keeping_recent(session: &mut Session, prompt: String, keep_from: usize) {
     let keep_from = keep_from.min(session.messages.len());
-    if let Some(system_prompt) = session.messages.first().and_then(|v| {
-        if MessageRole::System == v.role {
-            let content = v.content.to_text();
-            if !content.is_empty() {
-                return Some(content);
-            }
-        }
-        None
-    }) {
-        prompt = format!("{system_prompt}\n\n{prompt}",);
-    }
     // Split off the recent suffix to keep verbatim; the remainder is the prefix.
     let suffix: Vec<Message> = session.messages.split_off(keep_from);
     session.compressed_messages.append(&mut session.messages);
     // Hard-cut log layout: the Compress event archives the prefix and carries
     // the summary; the preserved suffix is then re-logged as fresh entries so
-    // replay reproduces `[summary, ...suffix]` without any stored index.
-    session.messages.push(Message::new(
-        MessageRole::System,
-        MessageContent::Text(prompt.clone()),
-    ));
+    // replay reproduces active suffix without any stored index.
+    session.compaction_summary = Some(prompt.clone());
     if !append_event(session, &SessionLogEntry::Compress { prompt }) {
         session.dirty = true;
     }
@@ -1362,6 +1333,9 @@ fn append_initial_agent_messages(session: &mut Session, input: &Input) -> Result
     let mut cid_urls = std::collections::HashMap::new();
 
     for mut msg in agent_messages {
+        if msg.role == MessageRole::System {
+            continue;
+        }
         // `externalize_content` only writes files + rewrites `content` in
         // memory (takes `&Session`, cannot append), so `seq` stays correct.
         let seq = session.next_seq();
@@ -1560,21 +1534,29 @@ fn build_messages_inner(session: &Session, input: &Input) -> Result<Vec<Message>
     if need_add_msg && is_tool_continuation(input, &messages) {
         need_add_msg = false;
     }
-    if need_add_msg {
-        // When the agent was swapped after construction (e.g. compaction),
-        // inject_system_prompt is true and we must prepend the agent's
-        // system prompt — session messages won't already contain it.
-        // On normal session turns the system prompt was stored on turn 1
-        // by save_message(), so inject_system_prompt stays false.
-        if input.inject_system_prompt() {
-            let system_text = input.agent().system_text()?;
-            if !system_text.is_empty() {
-                messages.insert(
-                    0,
-                    Message::new(MessageRole::System, MessageContent::Text(system_text)),
-                );
-            }
+    // System prompt is no longer persisted in session transcript.
+    // Inject it fresh here so each turn sees current agent variables,
+    // resolved tools, and active model selection (including fallbacks).
+    // Agent swaps after construction (e.g. compaction) also flow through
+    // this path via inject_system_prompt.
+    if input.inject_system_prompt() {
+        let system_text = input
+            .agent()
+            .system_text_with_tools(input.resolved_tools.as_deref().unwrap_or_default())?;
+        // Drop any leading system message(s) so only the freshly rendered
+        // prompt survives — including the case where a legacy transcript
+        // stored one but the current render is empty.
+        while matches!(messages.first().map(|m| m.role), Some(MessageRole::System)) {
+            messages.remove(0);
         }
+        if !system_text.is_empty() {
+            messages.insert(
+                0,
+                Message::new(MessageRole::System, MessageContent::Text(system_text)),
+            );
+        }
+    }
+    if need_add_msg {
         messages.push(Message::new(MessageRole::User, input.message_content()));
     }
     Ok(messages)
@@ -1702,17 +1684,17 @@ content: recent answer
 
         let session = super::load_from_log_for_test(content);
 
-        // Live messages: summary system message followed by the kept suffix.
+        // Live messages: kept suffix only; summary stays on runtime field.
         assert_eq!(
             message_view(&session.messages),
             vec![
-                (
-                    MessageRole::System,
-                    "summary of earlier conversation".to_string()
-                ),
                 (MessageRole::User, "recent question".to_string()),
                 (MessageRole::Assistant, "recent answer".to_string()),
             ]
+        );
+        assert_eq!(
+            session.compaction_summary.as_deref(),
+            Some("summary of earlier conversation")
         );
 
         // The prefix entries before the compress event must have been archived.
@@ -1749,10 +1731,8 @@ prompt: summary
 
         let session = super::load_from_log_for_test(content);
 
-        assert_eq!(
-            message_view(&session.messages),
-            vec![(MessageRole::System, "summary".to_string())]
-        );
+        assert!(session.messages.is_empty());
+        assert_eq!(session.compaction_summary.as_deref(), Some("summary"));
         assert_eq!(
             message_view(&session.compressed_messages),
             vec![
@@ -3397,11 +3377,278 @@ content: second
         super::compress_keeping_recent(&mut session, "SUMMARY".to_string(), 3);
 
         assert_eq!(session.compressed_messages.len(), 3);
-        assert_eq!(session.messages.len(), 3);
-        assert_eq!(session.messages[0].role, MessageRole::System);
-        assert!(session.messages[0].content.to_text().contains("SUMMARY"));
-        assert!(session.messages[0].content.to_text().contains("sys"));
-        assert_eq!(session.messages[1].content.to_text(), "recent u");
-        assert_eq!(session.messages[2].content.to_text(), "recent a");
+        assert_eq!(session.compaction_summary.as_deref(), Some("SUMMARY"));
+        assert_eq!(session.messages.len(), 2);
+        assert!(session
+            .messages
+            .iter()
+            .all(|message| message.role != MessageRole::System));
+        assert_eq!(session.messages[0].content.to_text(), "recent u");
+        assert_eq!(session.messages[1].content.to_text(), "recent a");
+    }
+
+    #[test]
+    fn first_turn_persists_user_only_and_no_stored_system_message() {
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let mut session = test_session();
+        session.set_sessions_dir(tmp.path().to_path_buf());
+
+        let config = Config::default();
+        let agent = config.extract_agent();
+        let global_config = std::sync::Arc::new(parking_lot::RwLock::new(config));
+        let input = crate::config::input::from_str(&global_config, "hello world", Some(agent));
+
+        super::add_assistant_text(&mut session, &input, "hi there", None).unwrap();
+
+        assert!(
+            session
+                .messages
+                .iter()
+                .all(|message| message.role != MessageRole::System),
+            "session transcript should not store a system message: {:#?}",
+            session.messages
+        );
+        let persisted = std::fs::read_to_string(session.path.as_ref().unwrap()).unwrap();
+        assert!(
+            !persisted.contains("role: system"),
+            "persisted log should not contain a stored system message: {persisted}"
+        );
+    }
+
+    #[test]
+    fn compress_keeping_recent_log_stores_summary_only_and_runtime_tracks_it() {
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let mut session = test_session();
+        session.set_sessions_dir(tmp.path().to_path_buf());
+        session.messages = vec![
+            Message::new(
+                MessageRole::System,
+                MessageContent::Text("agent instructions".to_string()),
+            ),
+            Message::new(MessageRole::User, MessageContent::Text("old u".to_string())),
+            Message::new(
+                MessageRole::Assistant,
+                MessageContent::Text("old a".to_string()),
+            ),
+            Message::new(
+                MessageRole::User,
+                MessageContent::Text("recent u".to_string()),
+            ),
+            Message::new(
+                MessageRole::Assistant,
+                MessageContent::Text("recent a".to_string()),
+            ),
+        ];
+        super::save(&mut session, "test", &tmp.path().join("test.yaml"), false).unwrap();
+
+        super::compress_keeping_recent(&mut session, "LLM summary only".to_string(), 3);
+
+        let persisted = std::fs::read_to_string(session.path.as_ref().unwrap()).unwrap();
+        assert!(persisted.contains("type: compress\nprompt: LLM summary only"));
+        assert!(!persisted.contains("prompt: agent instructions"));
+        assert!(session
+            .messages
+            .iter()
+            .all(|message| message.role != MessageRole::System));
+        assert_eq!(
+            session.compaction_summary.as_deref(),
+            Some("LLM summary only")
+        );
+    }
+
+    #[test]
+    fn build_messages_reinjects_system_prompt_after_compaction() {
+        let mut session = test_session();
+        session.agent_instructions = "Agent prompt with {{ agent.model }}".to_string();
+        session.model_id = "openai:gpt-4o-mini".to_string();
+        session.model = harnx_core::model::Model::new("openai", "gpt-4o-mini");
+        session.messages = vec![Message::new(
+            MessageRole::User,
+            MessageContent::Text("recent question".to_string()),
+        )];
+        session.compaction_summary = Some("summary".to_string());
+
+        let input = Input::new(
+            "next question".to_string(),
+            ("next question".to_string(), vec![]),
+            to_agent(&session).into_config(),
+        );
+        let messages = super::build_messages(&session, &input).unwrap();
+
+        assert_eq!(messages[0].role, MessageRole::System);
+        assert_eq!(
+            messages[0].content.to_text(),
+            "Agent prompt with openai:gpt-4o-mini"
+        );
+    }
+
+    #[test]
+    fn to_agent_prefers_raw_agent_instructions_over_stale_agent_prompt_on_resume() {
+        let mut session = test_session();
+        session.agent_instructions = "Model={{ agent.model }}".to_string();
+        session.agent_prompt = "Model=openai:gpt-4o-mini".to_string();
+        session.model_id = "openai:gpt-4o-mini".to_string();
+        session.model = harnx_core::model::Model::new("openai", "gpt-4o-mini");
+
+        let input = Input::new(
+            "question".to_string(),
+            ("question".to_string(), vec![]),
+            to_agent(&session).into_config(),
+        );
+        let messages = super::build_messages(&session, &input).unwrap();
+        assert_eq!(messages[0].content.to_text(), "Model=openai:gpt-4o-mini");
+
+        session.model_id = "openai:gpt-4o".to_string();
+        session.model = harnx_core::model::Model::new("openai", "gpt-4o");
+        let input = Input::new(
+            "question".to_string(),
+            ("question".to_string(), vec![]),
+            to_agent(&session).into_config(),
+        );
+        let messages = super::build_messages(&session, &input).unwrap();
+        assert_eq!(messages[0].content.to_text(), "Model=openai:gpt-4o");
+    }
+
+    #[test]
+    fn load_from_log_drops_legacy_stored_system_message_and_reinjects_prompt() {
+        let content = r#"---
+type: header
+model: openai:gpt-4o
+agent_instructions: Agent prompt for openai:gpt-4o
+agent_prompt: Agent prompt for openai:gpt-4o
+---
+type: message
+role: system
+content: old stored system prompt
+---
+type: message
+role: user
+content: hi
+---
+type: message
+role: assistant
+content: hello
+"#;
+
+        let session = super::load_from_log_for_test(content);
+
+        assert!(
+            session
+                .messages
+                .iter()
+                .all(|message| message.role != MessageRole::System),
+            "legacy stored system message should be dropped: {:#?}",
+            session.messages
+        );
+
+        let input = Input::new(
+            "follow up".to_string(),
+            ("follow up".to_string(), vec![]),
+            to_agent(&session).into_config(),
+        );
+        let messages = super::build_messages(&session, &input).unwrap();
+
+        assert_eq!(messages[0].role, MessageRole::System);
+        assert_eq!(
+            messages[0].content.to_text(),
+            "Agent prompt for openai:gpt-4o"
+        );
+    }
+
+    #[test]
+    fn build_messages_replaces_legacy_stored_system_prompt_with_fresh_render() {
+        let mut session = test_session();
+        session.agent_instructions = String::new();
+        session.agent_name = Some("legacy-agent".to_string());
+        session.messages = vec![
+            Message::new(
+                MessageRole::System,
+                MessageContent::Text("old stored prompt".to_string()),
+            ),
+            Message::new(
+                MessageRole::User,
+                MessageContent::Text("earlier user".to_string()),
+            ),
+        ];
+
+        let mut agent = harnx_core::agent_config::AgentConfig::from_prompt("fresh rendered prompt");
+        agent.set_name("legacy-agent");
+        let input = Input::new(
+            "follow up".to_string(),
+            ("follow up".to_string(), vec![]),
+            agent,
+        );
+        let messages = super::build_messages(&session, &input).unwrap();
+
+        let system_messages: Vec<_> = messages
+            .iter()
+            .enumerate()
+            .filter(|(_, message)| message.role == MessageRole::System)
+            .collect();
+        assert_eq!(system_messages.len(), 1, "messages: {messages:#?}");
+        assert_eq!(system_messages[0].0, 0, "messages: {messages:#?}");
+        assert_eq!(messages[0].content.to_text(), "fresh rendered prompt");
+    }
+
+    #[test]
+    fn build_messages_tool_continuation_still_injects_system_prompt() {
+        use crate::tool::{ToolCall, ToolResult};
+        use serde_json::json;
+
+        let mut session = test_session();
+        session.messages = vec![
+            Message::new(MessageRole::User, MessageContent::Text("q".to_string())),
+            Message::new(
+                MessageRole::Tool,
+                MessageContent::ToolCalls(crate::client::MessageContentToolCalls::new(
+                    vec![ToolResult::new(
+                        ToolCall::new(
+                            "fs_read".to_string(),
+                            json!({"path": "README.md"}),
+                            Some("call_1".to_string()),
+                            None,
+                        ),
+                        json!({"content": "ok"}),
+                    )],
+                    "tool round".to_string(),
+                    None,
+                )),
+            ),
+        ];
+
+        let mut input = Input::new(
+            "follow up".to_string(),
+            ("follow up".to_string(), vec![]),
+            harnx_core::agent_config::AgentConfig::from_prompt("fresh tool continuation prompt"),
+        );
+        input.tool_calls = Some(crate::client::MessageContentToolCalls::new(
+            vec![],
+            "continuation".to_string(),
+            None,
+        ));
+
+        let messages = super::build_messages(&session, &input).unwrap();
+        assert_eq!(
+            messages[0].role,
+            MessageRole::System,
+            "messages: {messages:#?}"
+        );
+        assert_eq!(
+            messages[0].content.to_text(),
+            "fresh tool continuation prompt"
+        );
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|message| message.role == MessageRole::User)
+                .count(),
+            1,
+            "messages: {messages:#?}"
+        );
+        assert_eq!(messages[1].content.to_text(), "q");
     }
 }

--- a/crates/harnx-runtime/src/config/session_ops_compaction.rs
+++ b/crates/harnx-runtime/src/config/session_ops_compaction.rs
@@ -94,7 +94,7 @@ impl Config {
         input.with_session = false;
         input.with_agent = true;
 
-        let summary = crate::config::input::fetch_chat_text(&input, config).await?;
+        let summary = crate::config::input::fetch_chat_text(&mut input, config).await?;
 
         let summary_with_note = append_recovery_note(summary, covered);
         Self::apply_compaction_summary(config, &session_id, summary_with_note, split);

--- a/crates/harnx-runtime/src/nats_worker/tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests.rs
@@ -2323,10 +2323,16 @@ async fn load_remote_transcript_for_render_keeps_tool_rows_and_compressed_prefix
         "compressed prefix must retain assembled tool message rows"
     );
     assert!(
-        transcript.messages.iter().any(|message| message.role
-            == harnx_core::message::MessageRole::System
-            && message.content.to_text() == "summary prompt"),
-        "active transcript must include summary prompt after Compress"
+        transcript
+            .messages
+            .iter()
+            .all(|message| message.role != harnx_core::message::MessageRole::System),
+        "active transcript must not include a synthetic System message after Compress"
+    );
+    assert_eq!(
+        transcript.compaction_summary.as_deref(),
+        Some("summary prompt"),
+        "compaction summary must carry the summary text after Compress"
     );
 
     let active_rows: Vec<(harnx_core::message::MessageRole, String, Option<usize>)> = transcript
@@ -2336,18 +2342,11 @@ async fn load_remote_transcript_for_render_keeps_tool_rows_and_compressed_prefix
         .collect();
     assert_eq!(
         active_rows,
-        vec![
-            (
-                harnx_core::message::MessageRole::System,
-                "summary prompt".to_string(),
-                None,
-            ),
-            (
-                harnx_core::message::MessageRole::User,
-                "after compress user".to_string(),
-                Some(0),
-            ),
-        ]
+        vec![(
+            harnx_core::message::MessageRole::User,
+            "after compress user".to_string(),
+            Some(0),
+        ),]
     );
 
     worker.abort();

--- a/crates/harnx-serve/src/bin/harnx-serve.rs
+++ b/crates/harnx-serve/src/bin/harnx-serve.rs
@@ -7,6 +7,7 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use harnx_core::agent_config::collect_agent_variables;
 use harnx_render::render_error;
 use harnx_runtime::bootstrap::setup_logger;
 use harnx_runtime::config::{load_env_file, Config, WorkingMode};
@@ -32,6 +33,9 @@ struct Cli {
     /// (default: ~/.local/share/harnx/web-assets, XDG-aware)
     #[clap(long, value_name = "PATH")]
     web_assets: Option<PathBuf>,
+    /// Set agent variable pairs (format: --agent-variable key value or -x key value); can be repeated
+    #[clap(short = 'x', long, value_names = ["KEY", "VALUE"], num_args = 2, action = clap::ArgAction::Append)]
+    pub agent_variable: Vec<String>,
 }
 
 #[tokio::main]
@@ -53,10 +57,35 @@ async fn main() -> Result<()> {
     if let Some(model_id) = &cli.model {
         config.write().set_model(model_id)?;
     }
+    config.write().agent_variables = collect_agent_variables(&cli.agent_variable)?;
 
     if let Err(err) = harnx_serve::run(config, cli.addr, cli.web_assets).await {
         render_error(err);
         std::process::exit(1);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+    use clap::Parser;
+
+    #[test]
+    fn parses_agent_variables_flag() {
+        let cli = Cli::try_parse_from([
+            "harnx-serve",
+            "--agent-variable",
+            "cloud_env",
+            "true",
+            "--agent-variable",
+            "debug",
+            "false",
+        ])
+        .unwrap();
+        assert_eq!(
+            cli.agent_variable,
+            vec!["cloud_env", "true", "debug", "false"]
+        );
+    }
 }

--- a/crates/harnx-serve/src/session_actor.rs
+++ b/crates/harnx-serve/src/session_actor.rs
@@ -2074,7 +2074,7 @@ mod tests {
             Some(&serde_json::json!({
                 "content": [{
                     "type": "text",
-                    "text": "[{\"seq\":0,\"type\":\"header\",\"text\":\"model: openai:gpt-4o\"},{\"seq\":1,\"type\":\"message\",\"text\":\"You are plain.\",\"role\":\"system\"},{\"seq\":2,\"type\":\"message\",\"text\":\"batch interrupt\",\"role\":\"user\"},{\"seq\":3,\"type\":\"tool_calls\",\"text\":\"batch approval needed\\nharnx_agent_session_history_read({})\\nharnx_agent_session_history_read({})\",\"tool_names\":[\"harnx_agent_session_history_read\",\"harnx_agent_session_history_read\"]}]"
+                    "text": "[{\"seq\":0,\"type\":\"header\",\"text\":\"model: openai:gpt-4o\"},{\"seq\":1,\"type\":\"message\",\"text\":\"batch interrupt\",\"role\":\"user\"},{\"seq\":2,\"type\":\"tool_calls\",\"text\":\"batch approval needed\\nharnx_agent_session_history_read({})\\nharnx_agent_session_history_read({})\",\"tool_names\":[\"harnx_agent_session_history_read\",\"harnx_agent_session_history_read\"]}]"
                 }]
             })),
             "auto-approved call should execute normally"

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -786,31 +786,20 @@ fn build_compaction_marker(
 ///
 /// When `compressed_messages` is non-empty the archived history is rendered
 /// inline first so it stays visible, followed by a single compaction marker
-/// carrying the summary (the leading `System` message of the active window),
-/// then the active/preserved messages. Shared by the local and remote resume
-/// paths to keep their layout in lockstep (#904).
+/// carrying summary text, then the active/preserved messages. Shared by local
+/// and remote resume paths to keep layout in lockstep (#904).
 pub(crate) fn build_transcript_with_compaction(
     compressed_messages: &[Message],
     active_messages: &[Message],
+    compaction_summary: Option<&str>,
     decl_map: &HashMap<String, ToolDeclaration>,
 ) -> Vec<TranscriptItem> {
-    use harnx_core::message::MessageRole;
-
     let mut items = Vec::new();
     if !compressed_messages.is_empty() {
         items.extend(messages_to_transcript_items(compressed_messages, decl_map));
-        // Invariant: `compress_keeping_recent` prepends the compaction summary as
-        // the leading `System` message of the active window, so the summary (when
-        // present) is `active_messages[0]`. If that contract changes, the summary
-        // would silently render empty rather than showing wrong content.
-        let summary_text = active_messages
-            .first()
-            .filter(|msg| msg.role == MessageRole::System)
-            .map(|msg| msg.content.to_text())
-            .unwrap_or_default();
         items.push(build_compaction_marker(
             compressed_messages,
-            summary_text,
+            compaction_summary.unwrap_or_default().to_string(),
             decl_map,
         ));
     }
@@ -885,12 +874,18 @@ pub(crate) fn session_history_transcript_items(config: &GlobalConfig) -> Vec<Tra
         return build_transcript_with_compaction(
             &state.compressed_messages,
             &state.messages,
+            state.compaction_summary.as_deref(),
             &decl_map,
         );
     }
 
     let session = cfg.session.as_ref().expect("checked above");
-    build_transcript_with_compaction(&session.compressed_messages, &session.messages, &decl_map)
+    build_transcript_with_compaction(
+        &session.compressed_messages,
+        &session.messages,
+        session.compaction_summary.as_deref(),
+        &decl_map,
+    )
 }
 
 /// Compact one-line preview of a tool call's arguments for the confirmation

--- a/crates/harnx-tui/src/prompt.rs
+++ b/crates/harnx-tui/src/prompt.rs
@@ -62,14 +62,13 @@ impl Tui {
         let call_fn: harnx_runtime::AgentCallFn = {
             let config = ctx.config.clone();
             Arc::new(
-                move |input: &harnx_runtime::config::Input,
+                move |input: &mut harnx_runtime::config::Input,
                       _config: &harnx_runtime::config::GlobalConfig,
                       abort: harnx_runtime::utils::AbortSignal| {
-                    let input = input.clone();
                     let config = config.clone();
                     Box::pin(async move {
                         harnx_runtime::client::retry::call_with_retry_and_fallback_custom(
-                            &input,
+                            input,
                             &config,
                             abort,
                             |inp, client, cfg, abort_signal| {
@@ -231,7 +230,7 @@ impl Tui {
     }
 
     async fn call_chat_completions_streaming_tui(
-        input: &Input,
+        input: &mut Input,
         client: &dyn harnx_runtime::client::Client,
         config: &GlobalConfig,
         abort_signal: AbortSignal,

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -109,9 +109,11 @@ fn seed_compressed_session(config: &GlobalConfig) {
     guard.session = Some(session);
 }
 
-/// Like `seed_compressed_session`, but the active window begins with a
-/// `System` compaction summary message (as produced by `compress_keeping_recent`),
-/// so the compaction marker carries a non-empty `summary_text`.
+/// Like `seed_compressed_session`, but carries a compaction summary on the
+/// runtime `compaction_summary` field (as produced by `compress_keeping_recent`),
+/// so the compaction marker carries a non-empty `summary_text`. The active
+/// window contains only preserved conversation turns — no synthetic `System`
+/// summary message.
 fn seed_compressed_session_with_summary(config: &GlobalConfig) {
     let mut guard = config.write();
     let mut session =
@@ -128,20 +130,12 @@ fn seed_compressed_session_with_summary(config: &GlobalConfig) {
             1,
         ),
     ];
-    session.messages = vec![
-        make_compacted_message(
-            harnx_core::message::MessageRole::System,
-            harnx_core::message::MessageContent::Text(
-                "Prior conversation summary line".to_string(),
-            ),
-            2,
-        ),
-        make_compacted_message(
-            harnx_core::message::MessageRole::User,
-            harnx_core::message::MessageContent::Text("Current question".to_string()),
-            3,
-        ),
-    ];
+    session.compaction_summary = Some("Prior conversation summary line".to_string());
+    session.messages = vec![make_compacted_message(
+        harnx_core::message::MessageRole::User,
+        harnx_core::message::MessageContent::Text("Current question".to_string()),
+        3,
+    )];
     guard.session = Some(session);
 }
 
@@ -8597,20 +8591,18 @@ fn build_transcript_with_compaction_orders_history_marker_and_suffix() {
             1,
         ),
     ];
-    let active = vec![
-        make_compacted_message(
-            MessageRole::System,
-            MessageContent::Text("Summary of the past".to_string()),
-            2,
-        ),
-        make_compacted_message(
-            MessageRole::User,
-            MessageContent::Text("Fresh question".to_string()),
-            3,
-        ),
-    ];
+    let active = vec![make_compacted_message(
+        MessageRole::User,
+        MessageContent::Text("Fresh question".to_string()),
+        3,
+    )];
 
-    let items = crate::lifecycle::build_transcript_with_compaction(&compressed, &active, &decl_map);
+    let items = crate::lifecycle::build_transcript_with_compaction(
+        &compressed,
+        &active,
+        Some("Summary of the past"),
+        &decl_map,
+    );
 
     let archived_q = items
         .iter()
@@ -8654,7 +8646,12 @@ fn build_transcript_with_compaction_orders_history_marker_and_suffix() {
     }
 
     // No archived messages => no marker, only the active messages render.
-    let no_compaction = crate::lifecycle::build_transcript_with_compaction(&[], &active, &decl_map);
+    let no_compaction = crate::lifecycle::build_transcript_with_compaction(
+        &[],
+        &active,
+        Some("Summary of the past"),
+        &decl_map,
+    );
     assert!(!no_compaction
         .iter()
         .any(|item| matches!(item, TranscriptItem::CompactionMarker { .. })));

--- a/crates/harnx/src/cli.rs
+++ b/crates/harnx/src/cli.rs
@@ -113,6 +113,9 @@ pub struct WorkerArgs {
     /// Defaults to a generated id if omitted.
     #[arg(long)]
     pub worker_id: Option<String>,
+    /// Set agent variable pairs (format: --agent-variable key value or -x key value); can be repeated
+    #[arg(short = 'x', long, value_names = ["KEY", "VALUE"], num_args = 2, action = clap::ArgAction::Append)]
+    pub agent_variable: Vec<String>,
 }
 
 #[derive(Args, Debug, PartialEq, Eq)]
@@ -196,7 +199,7 @@ impl Cli {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Commands, InfoSubcommands, SessionSubcommands};
+    use super::{Cli, Commands, InfoSubcommands, SessionSubcommands, WorkerArgs};
     use clap::Parser;
 
     #[test]
@@ -231,6 +234,35 @@ mod tests {
                     assert_eq!(delete.cluster, "local");
                 }
             },
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_worker_agent_variables() {
+        let cli = Cli::try_parse_from([
+            "harnx",
+            "worker",
+            "--cluster",
+            "prod",
+            "--agent-variable",
+            "cloud_env",
+            "true",
+            "--agent-variable",
+            "debug",
+            "false",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(Commands::Worker(WorkerArgs {
+                cluster,
+                worker_id,
+                agent_variable,
+            })) => {
+                assert_eq!(cluster, "prod");
+                assert_eq!(worker_id, None);
+                assert_eq!(agent_variable, vec!["cloud_env", "true", "debug", "false"]);
+            }
             other => panic!("unexpected command: {other:?}"),
         }
     }

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -29,6 +29,7 @@ use crate::config::{
     render_session_dump, Config, GlobalConfig, Input, WorkingMode,
 };
 use crate::tui::{TranscriptItem, Tui};
+use harnx_core::agent_config::collect_agent_variables;
 use harnx_core::event::{AgentEvent, AgentSource, NoticeEvent};
 use harnx_hooks::{
     dispatch_hooks_with_count_and_manager, dispatch_hooks_with_managers, drain_async_results,
@@ -191,6 +192,7 @@ async fn run_worker_command(worker_args: &WorkerArgs) -> Result<()> {
     let config = Arc::new(RwLock::new(
         Config::init(WorkingMode::Cmd, true, vec![]).await?,
     ));
+    config.write().agent_variables = collect_agent_variables(&worker_args.agent_variable)?;
     let worker_id = worker_args
         .worker_id
         .clone()
@@ -285,14 +287,7 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
             }
             Some(Some(s)) => Some(s.as_str()),
         };
-        if !cli.agent_variable.is_empty() {
-            config.write().agent_variables = Some(
-                cli.agent_variable
-                    .chunks(2)
-                    .map(|v| (v[0].to_string(), v[1].to_string()))
-                    .collect(),
-            );
-        }
+        config.write().agent_variables = collect_agent_variables(&cli.agent_variable)?;
 
         let ret = Config::use_agent(&config, agent, session, abort_signal.clone()).await;
         config.write().agent_variables = None;
@@ -743,7 +738,7 @@ async fn start_directive_inner(
         HookResultControl::Continue => {}
     }
     let (output, thought, tool_calls, usage) =
-        match call_with_retry_and_fallback(&input, config, abort_signal.clone()).await {
+        match call_with_retry_and_fallback(&mut input, config, abort_signal.clone()).await {
             Ok(result) => result,
             Err(err) => {
                 let event = HookEvent::StopFailure {

--- a/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap1_baseline_three_turns.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap1_baseline_three_turns.snap
@@ -39,7 +39,7 @@ THIRD_RESPONSE_SENTINEL
 
 
 
-* 🤖 mutation-test-agent ▸ mock-llm:test ▸ mutation-e2e-session   Context: 57(0%)
+* 🤖 mutation-test-agent ▸ mock-llm:test ▸ mutation-e2e-session   Context: 40(0%)
 
 
 # snap: 1-baseline-three-turns

--- a/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap2_after_delete.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap2_after_delete.snap
@@ -12,7 +12,7 @@ FIRST_RESPONSE_SENTINEL
 THIRD_RESPONSE_SENTINEL
 
 🤖 mutation-test-agent ▸ mock-llm:test ▸ mutation-e2e-session
-Deleted entries 4-5.
+Deleted entries 3-4.
 
 
 
@@ -39,7 +39,7 @@ Deleted entries 4-5.
 
 
 
-* 🤖 mutation-test-agent ▸ mock-llm:test ▸ mutation-e2e-session   Context: 42(0%)
+* 🤖 mutation-test-agent ▸ mock-llm:test ▸ mutation-e2e-session   Context: 25(0%)
 
 
 # snap: 2-after-delete

--- a/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap3_after_rewind.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap3_after_rewind.snap
@@ -8,7 +8,7 @@ Welcome to harnx [VERSION]  *  Type .help for commands, Tab to complete.
 FIRST_RESPONSE_SENTINEL
 
 🤖 mutation-test-agent ▸ mock-llm:test ▸ mutation-e2e-session
-↩ Rewound session to entry 3.
+↩ Rewound session to entry 2.
 
 
 
@@ -39,7 +39,7 @@ FIRST_RESPONSE_SENTINEL
 
 
 
-* 🤖 mutation-test-agent ▸ mock-llm:test ▸ mutation-e2e-session   Context: 27(0%)
+* 🤖 mutation-test-agent ▸ mock-llm:test ▸ mutation-e2e-session   Context: 10(0%)
 
 
 # snap: 3-after-rewind

--- a/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap4_after_edit.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap4_after_edit.snap
@@ -39,7 +39,7 @@ EDITED_RESPONSE_SENTINEL
 
 
 
-* 🤖 mutation-test-agent ▸ mock-llm:test ▸ mutation-e2e-session   Context: 42(0%)
+* 🤖 mutation-test-agent ▸ mock-llm:test ▸ mutation-e2e-session   Context: 25(0%)
 
 
 # snap: 4-after-edit

--- a/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap5_session2_loaded.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__mutation_snap5_session2_loaded.snap
@@ -39,7 +39,7 @@ EDITED_RESPONSE_SENTINEL
 
 
 
-* 🤖 mutation-test-agent ▸ mock-llm:test ▸ mutation-e2e-session   Context: 42(0%)
+* 🤖 mutation-test-agent ▸ mock-llm:test ▸ mutation-e2e-session   Context: 25(0%)
 
 
 # snap: 5-session2-loaded

--- a/crates/harnx/tests/snapshots/tmux_e2e__retry_all_fail_shows_warnings_in_tui.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__retry_all_fail_shows_warnings_in_tui.snap
@@ -49,4 +49,4 @@ Caused by:
 
 
 
-* 🤖 retry-agent ▸ mock-llm:primary ▸ [SID]   Context: 19(0%)
+* 🤖 retry-agent ▸ mock-llm:primary ▸ [SID]   Context: 7(0%)

--- a/crates/harnx/tests/snapshots/tmux_e2e__retry_succeed_after_fallback_shows_transition.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__retry_succeed_after_fallback_shows_transition.snap
@@ -49,4 +49,4 @@ FALLBACK_SUCCESS: The fallback model handled it!
 
 
 
-* 🤖 retry-agent ▸ mock-llm:primary ▸ [SID]   Context: 27(0%)
+* 🤖 retry-agent ▸ mock-llm:primary ▸ [SID]   Context: 15(0%)

--- a/crates/harnx/tests/snapshots/tmux_e2e__retry_succeed_after_retry_shows_warning_then_response.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__retry_succeed_after_retry_shows_warning_then_response.snap
@@ -49,4 +49,4 @@ RETRY_SUCCESS_RESPONSE: Hello from the retried model!
 
 
 
-* 🤖 retry-agent ▸ mock-llm:primary ▸ [SID]   Context: 27(0%)
+* 🤖 retry-agent ▸ mock-llm:primary ▸ [SID]   Context: 15(0%)

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -386,6 +386,15 @@ You are a project assistant. Answer questions using the provided
 documentation. If the docs don't cover something, say so clearly.
 ```
 
+
+### Dynamic Variables in Prompts
+
+Agent prompts are rendered using [MiniJinja](https://github.com/mitsuhiko/minijinja). In addition to the custom variables defined in front-matter, several dynamic variables are available:
+
+- `{{ agent.model }}`: The active model ID (e.g., `openai:gpt-4o`). This updates automatically if the agent falls back to a different model.
+- `{{ tools }}`: A list of available tools. You can iterate over them: `{% for t in tools %}- {{ t.name }}: {{ t.description }}{% endfor %}`.
+- `{{ __os__ }}`, `{{ __arch__ }}`, `{{ __shell__ }}`, `{{ __cwd__ }}`, `{{ __now__ }}`, `{{ __locale__ }}`: Environment and system information.
+
 ## Built-in Agents
 
 Harnx includes one internal agent:

--- a/docs/command-line-guide.md
+++ b/docs/command-line-guide.md
@@ -109,6 +109,7 @@ harnx-serve --addr 0.0.0.0:8000
 harnx-serve --model claude:claude-3-5-sonnet-20240620
 harnx-serve --mcp-root /path/to/project --mcp-root /path/to/other/project
 harnx-serve --dry-run
+harnx-serve --agent-variable env production --agent-variable debug true
 ```
 
 ## Inspect Agents and Sessions

--- a/docs/solutions/logic-errors/system-prompt-request-time-rendering-2026-07-14.md
+++ b/docs/solutions/logic-errors/system-prompt-request-time-rendering-2026-07-14.md
@@ -1,0 +1,269 @@
+---
+title: "System prompt rendered at request time with model/tool/env awareness"
+date: 2026-07-14
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-core agent system, harnx-runtime session handling"
+root_cause: "stored rendered prompt in transcript prevented dynamic re-rendering after model fallback or tool changes"
+resolution_type: code_fix
+severity: medium
+tags:
+  - system-prompt
+  - minijinja
+  - compaction
+  - session-transcript
+  - model-fallback
+  - tools
+plan_ref: "harnx-system-prompt-refactor"
+---
+## Problem
+
+Agent system prompts were persisted in session transcripts as rendered text. This prevented prompts from adapting to model fallback, tool changes, or environment variable updates during resumed sessions. Compaction baked the full system prompt into summary markers, polluting TUI display.
+
+## Symptoms
+
+```
+- `session.yaml` contains `role: system` entries with frozen prompt text
+- After model fallback, `{{ agent.model }}` in prompt still shows original model
+- Compaction markers in TUI show full system prompt text, obscuring the summary
+- Resumed sessions cannot render `{{ tools }}` because tool list resolved at session creation
+- Issues: #1024 (compaction marker noise), #487 (model-aware prompt customization)
+```
+
+## Investigation Steps
+
+1. Traced `append_initial_agent_messages` → `build_messages` → stored System message in transcript
+2. Found `compress` and `compress_keeping_recent` prepend system prompt to summary and push synthetic System message to `session.messages`
+3. Identified TUI assumed `session.messages[0].role == System` for compaction marker
+4. Verified `build_messages` rendered prompt once at session creation, not per-request
+5. Discovered `prepare_completion_data` called `select_tools` AFTER `build_messages`, so `{{ tools }}` was always empty
+
+## Root Cause
+
+The system prompt was rendered once during session initialization and persisted to the `SessionLogEntry::Message { role: System }` transcript entry. Subsequent LLM requests used the stored text, not re-rendering from the template. This architecture:
+
+- Locked `{{ agent.model }}` to the initial model name
+- Prevented `{{ tools }}` from reflecting runtime tool selection
+- Required compaction to preserve the system prompt as a synthetic `Message { role: System }` at `session.messages[0]`
+- Created a positional TUI assumption that `active_messages[0]` was the compaction summary
+
+## Solution
+
+### Core architectural change: render at request time, never store
+
+**1. Stop persisting System messages in transcript**
+
+```rust
+// append_initial_agent_messages now filters System:
+for mut msg in agent_messages {
+    if msg.role == MessageRole::System {
+        continue; // don't log to session
+    }
+    // ... append user/assistant messages
+}
+```
+
+**2. Replay skips legacy stored System when raw template present**
+
+```rust
+// replay_log_entries_for_external
+SessionLogEntry::Message { role, .. } if role == MessageRole::System => {
+    if !session.agent_instructions.is_empty() {
+        // have raw template → skip stored render, inject fresh later
+        continue;
+    }
+    // legacy fallback: load as-is
+}
+```
+
+**3. `inject_system_prompt` defaults true**
+
+```rust
+// Input::new
+inject_system_prompt: true,  // was false
+```
+
+Every request path goes through `build_messages_inner`, which injects a fresh render at index 0.
+
+**4. Compaction: runtime-only `compaction_summary` replaces synthetic System message**
+
+```rust
+// Session struct
+#[serde(skip)]
+pub compaction_summary: Option<String>,
+
+// compress/compress_keeping_recent
+session.compaction_summary = Some(prompt.clone());  // no System message push
+
+// TUI build_transcript_with_compaction
+fn build_transcript_with_compaction(
+    compaction_summary: Option<&str>,  // explicit param, not positional lookup
+    ...
+) -> Vec<TranscriptItem>
+```
+
+**5. Tools + model in Jinja context**
+
+```rust
+// render_template signature
+pub fn render_template(
+    template: &str,
+    agent: &AgentConfig,
+    tools: Option<&[ToolDeclaration]>,  // ToolDeclaration already derives Serialize
+) -> Result<String>
+
+// Input gains field
+#[serde(skip)]
+pub resolved_tools: Option<Vec<ToolDeclaration>>,
+
+// prepare_completion_data: select_tools BEFORE build_messages
+let functions = config.read().select_tools(input.agent());
+input.resolved_tools = functions.clone();
+let messages = build_messages(input, config)?;
+
+// build_messages_inner
+let system_text = input.agent().system_text_with_tools(
+    input.resolved_tools.as_deref().unwrap_or_default()
+)?;
+```
+
+**6. Model fallback: update before prompt render**
+
+```rust
+// retry.rs: call_with_retry_and_fallback_custom
+let selected_model = client.model().clone();
+// ordering: model updated before prompt render so {{ agent.model }} reflects fallback
+(ctx.select_model_fn)(input, &selected_model);
+// NOW call prepare_completion_data → build_messages → render
+```
+
+## Pitfalls Discovered
+
+### 1. Store RAW template in `agent_instructions`, not rendered prompt
+
+**Bug:** `Session::set_agent` and `sync_agent` stored `agent.interpolated_instructions()` (rendered text) in `agent_instructions`, defeating future re-render.
+
+**Fix:** Store `agent.instructions_template()` (raw template string).
+
+```rust
+fn set_agent(&mut self, agent: &AgentConfig) {
+    self.agent_instructions = agent.instructions_template().to_string();  // raw, not rendered
+}
+```
+
+**Why it matters:** If `agent_instructions` holds rendered text, `{{ agent.model }}` is frozen to the model name at session creation, not re-evaluated after model change.
+
+### 2. Legacy sessions: strip stored System before fresh injection
+
+**Bug:** Legacy sessions (empty `agent_instructions`, named agent retrievable) have a stored `role: system` entry. With `inject_system_prompt` defaulting to true, `build_messages_inner` would prepend a fresh System message, yielding `[fresh System, stored System, ...User]` to the LLM.
+
+**Fix:** Strip leading `MessageRole::System` entries before injecting fresh prompt:
+
+```rust
+if input.inject_system_prompt() {
+    let system_text = input.agent().system_text_with_tools(...)?;
+    if !system_text.is_empty() {
+        // strip legacy stored System messages
+        while matches!(messages.first().map(|m| m.role), Some(MessageRole::System)) {
+            messages.remove(0);
+        }
+        messages.insert(0, Message::new(MessageRole::System, ...));
+    }
+}
+```
+
+### 3. `to_agent_config` must use `from_prompt`, not `from_markdown`
+
+**Bug:** Raw templates starting with `---` (common in frontmatter-like instructions) were misparsed by `AgentConfig::from_markdown`, which interpreted `---` as YAML frontmatter delimiter.
+
+**Fix:** Use `from_prompt` for session-resume path, which treats the input as verbatim prompt text:
+
+```rust
+pub fn to_agent_config(&self) -> Result<AgentConfig> {
+    let prompt = if self.agent_instructions.is_empty() {
+        self.agent_prompt.as_str()
+    } else {
+        self.agent_instructions.as_str()  // prefer raw template
+    };
+    let mut config = AgentConfig::from_prompt(prompt);  // not from_markdown
+    config.set_name(agent_name);
+    // ... restore other fields from session metadata
+}
+```
+
+### 4. `system_text` must honor `instructions` override
+
+**Bug:** Early implementation rendered `self.prompt` directly, ignoring `self.instructions` frontmatter override. Agents with `instructions:` field in agent markdown had that content ignored.
+
+**Fix:** Use `instructions_template()` helper that returns `self.instructions.as_deref().unwrap_or(&self.prompt)`.
+
+### 5. Workspace test runner OOM in constrained environments
+
+**Observation:** `cargo nextest run --workspace` compiles all test binaries in parallel. Large crates (harnx-runtime e2e tests) cause linker OOM in memory-constrained sandboxes.
+
+**Workaround:** Run tests per-crate: `cargo nextest run -p harnx-core`, `cargo nextest run -p harnx-runtime`, etc.
+
+**Pre-existing test hang:** `harnx-tui::guard_drop_during_panic_does_not_double_panic` hangs in sandbox environments lacking a real TTY. Exclude with `-E 'not test(guard_drop_during_panic_does_not_double_panic)'`.
+
+## Why This Works
+
+**Request-time rendering:** Each LLM call renders the prompt from the raw template with current context. Model changes, tool updates, and environment variables always reflect current state.
+
+**Single source of truth:** `agent_instructions` stores raw template; `AgentConfig` receives it via `to_agent_config`; `build_messages_inner` renders with current `agent.model` and `resolved_tools`.
+
+**Explicit threading:** `compaction_summary` passed as explicit parameter, eliminating positional `session.messages[0]` assumption. Backward compat achieved via conditional replay logic.
+
+**No mirror struct needed:** `ToolDeclaration` already derives `Serialize`. Skipped fields (`mcp_tool_name`, `call_template`) don't appear in Jinja context, matching intended design.
+
+## Prevention Strategies
+
+**Test Cases:**
+```rust
+// New session: no role:system stored
+#[test]
+fn first_turn_persists_user_only_and_no_stored_system_message()
+
+// Compaction: summary only, compaction_summary set
+#[test]
+fn compress_keeping_recent_log_stores_summary_only_and_runtime_tracks_it()
+
+// Legacy session: stored System replaced, not duplicated
+#[test]
+fn build_messages_replaces_legacy_stored_system_prompt_with_fresh_render()
+
+// Raw template stored for re-render fidelity
+#[test]
+fn to_agent_prefers_raw_agent_instructions_over_stale_agent_prompt_on_resume()
+
+// Model-change triggers re-render
+#[test]
+fn interpolated_instructions_renders_current_model_id_after_model_change()
+
+// Tools in Jinja
+#[test]
+fn system_text_with_tools_renders_tool_names_in_jinja()
+
+// Template with --- preserved
+#[test]
+fn to_agent_config_preserves_prompt_starting_with_frontmatter_delimiter()
+```
+
+**Code Review Checklist:**
+- [ ] `agent_instructions` stores raw template, not rendered output
+- [ ] `to_agent_config` uses `from_prompt`, not `from_markdown`
+- [ ] Legacy System message stripping before fresh injection
+- [ ] `system_text`/`system_text_with_tools` use `instructions_template()` helper
+- [ ] `prepare_completion_data` calls `select_tools` before `build_messages`
+- [ ] Model update callback occurs before prompt render in retry loop
+- [ ] `compaction_summary` threaded explicitly, not via positional assumption
+
+**Monitoring:**
+- Log template render errors during request preparation
+- Track `{{ agent.model }}` mismatches between prompt and actual model on fallback
+- Alert on empty system prompts (would indicate injection path failure)
+
+## Related Issues
+
+- **Issues:** [#1024](https://github.com/dobesv/harnx/issues/1024), [#487](https://github.com/dobesv/harnx/issues/487)
+- **Prior solution:** [minijinja-system-prompt-templating-2026-04-25.md](./minijinja-system-prompt-templating-2026-04-25.md) — MiniJinja migration foundation
+- **Changeset:** `.changeset/system-prompt-runtime-rendering.md`

--- a/web/package.json
+++ b/web/package.json
@@ -43,7 +43,7 @@
     "vite": "^8.1.1",
     "vitest": "^4.1.10"
   },
-  "packageManager": "pnpm@11.12.0",
+  "packageManager": "pnpm@11.11.0",
   "msw": {
     "workerDirectory": [
       "public"


### PR DESCRIPTION
…l awareness

Refactor system prompt handling to render prompts at request time instead of storing rendered text in transcripts. This ensures prompts always reflect the current state of the session, including the active model (enabling model-specific instructions) and resolved tool declarations.

Key changes:
- Remove system prompt from session transcripts and compaction storage.
- Render system prompt fresh from raw AgentConfig template at every LLM request.
- Expose resolved tools and active model ID into the Jinja render context.
- Support --agent-variable in harnx-serve and harnx-worker.
- Introduce session.compaction_summary to store LLM summaries separately from the system prompt.
- Ensure backward compatibility for old sessions by stripping legacy system messages on replay.
- Update TUI to handle the new compaction storage format without positional assumptions.

Refs #1024, #487

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System prompts are rendered at request time, reflecting the active model, available tools, and current environment.
  * Added `--agent-variable`/`-x` CLI options for supplying custom prompt variables.
  * Tool declarations can now be referenced in prompt templates.
* **Bug Fixes**
  * Prevented stale or duplicated system prompts in resumed sessions and transcripts.
  * Improved session compaction summaries and transcript display.
* **Documentation**
  * Added guidance for dynamic prompt variables and command-line configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->