### PR TITLE
feat(session): add automatic LLM-driven session title generation

### DIFF
--- a/.changeset/session-title-generation.md
+++ b/.changeset/session-title-generation.md
@@ -1,0 +1,14 @@
+---
+harnx: minor
+---
+
+feat(session): automatic session title generation
+
+Sessions now get a short, LLM-generated title after the first exchange and
+periodically as they grow (every `title_update_threshold` tokens, default
+50,000). Configure the generator via `title_agent` (global in `config.yaml` or
+per-agent in front matter); leave it unset to disable. Titles are stored as
+append-only `Title` log entries, surfaced in local and remote (NATS) session
+listings and the serve API, and can be set manually with `.set title <text>`
+(which freezes automatic regeneration). Do not use a reasoning model as the
+title agent.

--- a/.changeset/session-title-ui.md
+++ b/.changeset/session-title-ui.md
@@ -1,0 +1,11 @@
+---
+harnx: minor
+---
+
+feat(ui): show the generated session title in the terminal and browser tab
+
+The automatically generated session title now sets the terminal window title in
+the TUI and the browser tab title in the web UI (as `harnx — <title>`), updating
+live as the title is (re)generated or set with `.set title`. Adds an
+`example-title-agent` and `title_agent` / `title_update_threshold` settings to
+the example configuration.

--- a/crates/harnx-core/src/agent_config.rs
+++ b/crates/harnx-core/src/agent_config.rs
@@ -18,21 +18,6 @@ use std::sync::LazyLock;
 /// Agent name used for transient prompts that aren't loaded from disk.
 pub const TEMP_AGENT_NAME: &str = "%%";
 
-const CREATE_TITLE_PROMPT: &str = r#"Create a concise, 3-6 word title.
-
-**Notes**:
-- Avoid quotation marks or emojis
-- RESPOND ONLY WITH TITLE SLUG TEXT
-
-**Examples**:
-stock-market-trends
-perfect-chocolate-chip-recipe
-remote-work-productivity-tips
-video-game-development-insights"#;
-
-/// Built-in agent name: routes to the title-creation prompt.
-pub const CREATE_TITLE_AGENT_NAME: &str = "%create-title%";
-
 pub type AgentVariables = IndexMap<String, String>;
 
 /// Collect flat `[KEY, VALUE, KEY, VALUE, ...]` CLI pairs (as produced by the
@@ -163,6 +148,8 @@ pub struct AgentConfig {
     compaction_keep_recent_tokens: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     compaction_tool_output_max_chars: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    title_agent: Option<String>,
     #[serde(default)]
     pub role: AgentRole,
     #[serde(default)]
@@ -214,6 +201,7 @@ impl AgentConfig {
             compaction_keep_recent_turns: frontmatter.compaction_keep_recent_turns,
             compaction_keep_recent_tokens: frontmatter.compaction_keep_recent_tokens,
             compaction_tool_output_max_chars: frontmatter.compaction_tool_output_max_chars,
+            title_agent: frontmatter.title_agent,
             role: frontmatter.role,
             prompt,
             ..Default::default()
@@ -233,13 +221,8 @@ impl AgentConfig {
         &self.description
     }
 
-    /// Markdown body for the built-in `%create-title%` agent, or `None`
-    /// if `name` is not a recognised built-in.
-    pub fn builtin_markdown(name: &str) -> Option<&'static str> {
-        match name {
-            CREATE_TITLE_AGENT_NAME => Some(CREATE_TITLE_PROMPT),
-            _ => None,
-        }
+    pub fn builtin_markdown(_name: &str) -> Option<&'static str> {
+        None
     }
 
     pub fn export(&self) -> Result<String> {
@@ -351,6 +334,10 @@ impl AgentConfig {
         self.compaction_agent = value;
     }
 
+    pub fn set_title_agent(&mut self, value: Option<String>) {
+        self.title_agent = value;
+    }
+
     pub fn use_tools(&self) -> Option<Vec<String>> {
         self.use_tools.clone()
     }
@@ -361,6 +348,10 @@ impl AgentConfig {
 
     pub fn compaction_agent(&self) -> Option<&str> {
         self.compaction_agent.as_deref()
+    }
+
+    pub fn title_agent(&self) -> Option<&str> {
+        self.title_agent.as_deref()
     }
 
     pub fn compaction_keep_recent_turns(&self) -> Option<usize> {
@@ -574,6 +565,8 @@ struct AgentFrontMatter {
     compaction_keep_recent_tokens: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     compaction_tool_output_max_chars: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    title_agent: Option<String>,
     #[serde(default)]
     role: AgentRole,
 }
@@ -598,6 +591,7 @@ impl AgentFrontMatter {
             compaction_keep_recent_turns: config.compaction_keep_recent_turns,
             compaction_keep_recent_tokens: config.compaction_keep_recent_tokens,
             compaction_tool_output_max_chars: config.compaction_tool_output_max_chars,
+            title_agent: config.title_agent.clone(),
             role: config.role,
         }
     }
@@ -628,10 +622,15 @@ impl AgentFrontMatter {
             && self.compaction_tool_output_max_chars.is_none()
     }
 
+    fn title_is_empty(&self) -> bool {
+        self.title_agent.is_none()
+    }
+
     fn is_empty(&self) -> bool {
         self.model_is_empty()
             && self.content_is_empty()
             && self.compaction_is_empty()
+            && self.title_is_empty()
             && self.role == AgentRole::Assistant
     }
 }
@@ -920,6 +919,30 @@ You are a compaction agent.\n";
         // Completely empty frontmatter — AgentRole::Assistant is the serde default
         let agent = AgentConfig::from_markdown("plain", "You are plain.").unwrap();
         assert_eq!(agent.role, AgentRole::Assistant);
+    }
+
+    #[test]
+    fn title_agent_roundtrip() {
+        // Round-trip an AgentConfig with title_agent set and assert it survives serialize→deserialize
+        let mut agent = AgentConfig::from_markdown(
+            "title-test",
+            "---\nmodel: openai:gpt-4o\ntitle_agent: claude-sonnet-4-6\n---\nYou are an agent.",
+        )
+        .unwrap();
+        assert_eq!(agent.title_agent(), Some("claude-sonnet-4-6"));
+
+        // Clear and set via setter
+        agent.set_title_agent(None);
+        assert!(agent.title_agent().is_none());
+
+        // Set it back
+        agent.set_title_agent(Some("title-generator-v2".to_string()));
+        assert_eq!(agent.title_agent(), Some("title-generator-v2"));
+
+        // Export and reparse
+        let exported = agent.export().unwrap();
+        let reparsed = AgentConfig::from_markdown("title-test", &exported).unwrap();
+        assert_eq!(reparsed.title_agent(), Some("title-generator-v2"));
     }
 }
 

--- a/crates/harnx-core/src/config_data.rs
+++ b/crates/harnx-core/src/config_data.rs
@@ -82,6 +82,10 @@ pub struct ConfigData {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hooks: Option<HooksConfig>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title_agent: Option<String>,
+    pub title_update_threshold: usize,
 }
 
 impl Default for ConfigData {
@@ -129,6 +133,9 @@ impl Default for ConfigData {
             sync_models_url: None,
 
             hooks: None,
+
+            title_agent: None,
+            title_update_threshold: 50_000,
         }
     }
 }
@@ -202,5 +209,24 @@ hooks:
             got.toolsets.get("demo"),
             Some(&vec!["fs_read".to_string(), "fs_write".to_string()])
         );
+    }
+
+    #[test]
+    fn empty_yaml_has_default_title_update_threshold() {
+        // Empty YAML must deserialize to the default 50000
+        let got: ConfigData = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(got.title_update_threshold, 50_000);
+        assert!(got.title_agent.is_none());
+    }
+
+    #[test]
+    fn title_agent_and_threshold_roundtrip() {
+        let yaml = r#"
+title_agent: claude-sonnet-4-6
+title_update_threshold: 25000
+"#;
+        let got: ConfigData = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(got.title_agent, Some("claude-sonnet-4-6".to_string()));
+        assert_eq!(got.title_update_threshold, 25_000);
     }
 }

--- a/crates/harnx-core/src/event.rs
+++ b/crates/harnx-core/src/event.rs
@@ -141,6 +141,9 @@ pub enum SessionEvent {
     LogSeqAssigned {
         seq: usize,
     },
+    /// Emitted after a session title has been generated or manually set.
+    /// Carries the new title text.
+    TitleUpdated(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/harnx-core/src/session.rs
+++ b/crates/harnx-core/src/session.rs
@@ -26,6 +26,10 @@ use std::path::PathBuf;
 // The Header variant is intentionally large — it holds all session-level metadata
 // fields. Boxing would require pervasive refactoring; the allocation cost is acceptable
 // since Headers are only created/read at session boundaries.
+fn is_zero_usize(value: &usize) -> bool {
+    *value == 0
+}
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type")]
@@ -123,6 +127,21 @@ pub enum SessionLogEntry {
     Rewind {
         /// All entries with seq > after_seq are excluded from context on replay.
         after_seq: usize,
+    },
+    #[serde(rename = "title")]
+    Title {
+        title: String,
+        /// `true` when the title was set manually (`.set title`). A manual title
+        /// freezes automatic regeneration across reloads. Defaults to `false`
+        /// so auto-generated and legacy title entries deserialize cleanly.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        manual: bool,
+        /// Session token count when this title was generated. Persisted so that
+        /// on reload `title_last_updated_tokens` can be restored exactly instead
+        /// of being derived from a mid-replay (still-zero) token count. Defaults
+        /// to `0` for legacy entries that predate this field.
+        #[serde(default, skip_serializing_if = "is_zero_usize")]
+        tokens: usize,
     },
     #[serde(other)]
     Unknown,
@@ -247,6 +266,12 @@ pub struct Session {
     pub save_session_this_time: bool,
     #[serde(skip)]
     pub compressing: bool,
+    #[serde(skip)]
+    pub title: Option<String>,
+    #[serde(skip)]
+    pub titling: bool,
+    #[serde(skip)]
+    pub title_last_updated_tokens: usize,
     #[serde(skip)]
     pub sessions_dir: Option<PathBuf>,
     #[serde(skip)]
@@ -482,6 +507,48 @@ impl Session {
 
     pub fn set_compressing(&mut self, compressing: bool) {
         self.compressing = compressing;
+    }
+
+    pub fn need_generate_title(&self, threshold: usize) -> bool {
+        if self.titling {
+            return false;
+        }
+        if threshold == 0 {
+            return false;
+        }
+        // First title: as soon as the session has any content and no title yet,
+        // generate one (don't wait for a full threshold of growth). A manually
+        // set title freezes `title_last_updated_tokens` at `usize::MAX`, so this
+        // branch does not fire once a title exists.
+        if self.title.is_none() {
+            return self.tokens > 0;
+        }
+        // Subsequent regeneration: only after another `threshold` tokens of growth.
+        self.tokens.saturating_sub(self.title_last_updated_tokens) >= threshold
+    }
+
+    pub fn titling(&self) -> bool {
+        self.titling
+    }
+
+    pub fn set_titling(&mut self, v: bool) {
+        self.titling = v;
+    }
+
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    pub fn set_title(&mut self, t: String) {
+        self.title = Some(t);
+    }
+
+    pub fn title_last_updated_tokens(&self) -> usize {
+        self.title_last_updated_tokens
+    }
+
+    pub fn set_title_last_updated_tokens(&mut self, t: usize) {
+        self.title_last_updated_tokens = t;
     }
 
     pub fn guard_empty(&self) -> Result<()> {
@@ -896,6 +963,46 @@ field: value
         let entry: SessionLogEntry = serde_yaml::from_str(yaml).unwrap();
 
         assert!(matches!(entry, SessionLogEntry::Unknown));
+    }
+
+    #[test]
+    fn need_generate_title_uses_titling_threshold_and_token_delta() {
+        // First-title branch: no title yet and some content -> generate.
+        let mut session = Session {
+            tokens: 20,
+            title_last_updated_tokens: 10,
+            titling: true,
+            ..Default::default()
+        };
+
+        // While titling is in progress, never trigger.
+        assert!(!session.need_generate_title(5));
+
+        session.titling = false;
+        // Threshold 0 disables generation entirely.
+        assert!(!session.need_generate_title(0));
+        // No title yet + tokens > 0 -> first title fires regardless of delta.
+        assert!(session.need_generate_title(10));
+        assert!(session.need_generate_title(usize::MAX));
+
+        // Empty session (no tokens) never generates a first title.
+        let empty = Session::default();
+        assert!(!empty.need_generate_title(10));
+
+        // Regeneration branch: once a title exists, only token growth beyond the
+        // threshold triggers again.
+        let mut titled = Session {
+            tokens: 20,
+            title_last_updated_tokens: 10,
+            title: Some("Existing title".to_string()),
+            ..Default::default()
+        };
+        assert!(titled.need_generate_title(10)); // delta 10 >= 10
+        assert!(!titled.need_generate_title(11)); // delta 10 < 11
+
+        // A frozen (manual) title uses usize::MAX and never regenerates.
+        titled.title_last_updated_tokens = usize::MAX;
+        assert!(!titled.need_generate_title(1));
     }
 
     #[test]

--- a/crates/harnx-runtime/src/agent_loop.rs
+++ b/crates/harnx-runtime/src/agent_loop.rs
@@ -603,7 +603,7 @@ pub async fn run_agent_loop(ctx: &AgentLoopContext, initial_input: Input) -> Res
     if abort_signal.aborted() {
         bail!("interrupted by user");
     }
-    Config::maybe_compact_session(config.clone());
+    Config::run_post_turn_maintenance(config.clone());
     Ok(())
 }
 

--- a/crates/harnx-runtime/src/config/agent_dump_tests.rs
+++ b/crates/harnx-runtime/src/config/agent_dump_tests.rs
@@ -203,20 +203,6 @@ fn render_agent_dump_errors_cleanly_for_unknown_agent() {
 }
 
 #[test]
-fn render_agent_dump_works_for_builtin_agent() {
-    let config = Config::default();
-
-    let result = render_agent_dump(&config, "%create-title%");
-
-    let rendered = result.expect("should work for builtin agent");
-    assert!(rendered.contains("---"), "should have front-matter");
-    assert!(
-        rendered.contains("title") || rendered.contains("Title"),
-        "should contain title-related content"
-    );
-}
-
-#[test]
 fn render_agent_dump_handles_package_qualified_agent() {
     let _guard = TEST_CONFIG_DIR_LOCK.lock().unwrap();
     let config_dir = unique_test_config_dir();

--- a/crates/harnx-runtime/src/config/agent_tests.rs
+++ b/crates/harnx-runtime/src/config/agent_tests.rs
@@ -56,7 +56,11 @@ fn spawn_log_lines(path: &Path) -> Vec<String> {
 fn wait_for_spawn_count(path: &Path, min_lines: usize) -> Vec<String> {
     use std::time::{Duration, Instant};
 
-    let deadline = Instant::now() + Duration::from_secs(5);
+    // Poll returns as soon as the expected lines appear; the deadline only
+    // guards against a genuine hang. Keep it generous so CI (which runs 2000+
+    // tests in parallel and can starve freshly spawned MCP servers) doesn't
+    // flake on a too-tight timeout.
+    let deadline = Instant::now() + Duration::from_secs(30);
     loop {
         let lines = spawn_log_lines(path);
         if lines.len() >= min_lines {
@@ -273,17 +277,6 @@ fn test_agent_from_prompt() {
         .contains("You are a pirate"));
     assert!(agent.model_id().is_none());
     assert!(agent.temperature().is_none());
-}
-
-#[test]
-fn test_agent_builtin_create_title() {
-    let agent = super::builtin("%create-title%").unwrap();
-    assert_eq!(agent.name(), "%create-title%");
-    assert!(!agent.interpolated_instructions().unwrap().is_empty());
-    assert!(agent
-        .interpolated_instructions()
-        .unwrap()
-        .contains("concise"));
 }
 
 #[test]

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -22,6 +22,7 @@ pub mod session_meta;
 mod session_ops_compaction;
 mod session_ops_core;
 mod session_ops_split;
+pub mod session_ops_title;
 mod settings_split;
 
 pub use self::env_split::load_env_file;

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -297,6 +297,18 @@ pub(crate) fn replay_log_entries_for_external(
                 session.compressed_messages.append(&mut session.messages);
                 session.compaction_summary = Some(prompt);
             }
+            SessionLogEntry::Title {
+                title,
+                manual,
+                tokens,
+            } => {
+                session.title = Some(title);
+                // A manually set title freezes automatic regeneration across
+                // reloads; auto-generated titles restore the exact token count
+                // recorded in the entry (session.tokens is still 0 mid-replay,
+                // so we must NOT derive it from session state here).
+                session.title_last_updated_tokens = if manual { usize::MAX } else { tokens };
+            }
             SessionLogEntry::Clear => {
                 pending = None;
                 session.messages.clear();
@@ -617,6 +629,24 @@ pub fn append_event(session: &mut Session, entry: &SessionLogEntry) -> bool {
         }
         Err(_) => false,
     }
+}
+
+/// Append a `Title` log entry and update the in-memory session title state.
+/// Shared by automatic generation (`manual = false`) and the `.set title`
+/// command (`manual = true`). A manual title freezes automatic regeneration by
+/// setting `title_last_updated_tokens` to `usize::MAX`; an automatic title
+/// records the token count it was generated at so reloads restore it exactly.
+pub fn record_title(session: &mut Session, title: String, manual: bool, tokens: usize) {
+    let entry = SessionLogEntry::Title {
+        title: title.clone(),
+        manual,
+        tokens,
+    };
+    if !append_event(session, &entry) {
+        session.dirty = true;
+    }
+    session.set_title(title);
+    session.set_title_last_updated_tokens(if manual { usize::MAX } else { tokens });
 }
 
 pub fn render(session: &Session) -> Result<String> {
@@ -1740,6 +1770,32 @@ prompt: summary
                 (MessageRole::Assistant, "second".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn replay_auto_title_restores_token_count_from_entry_not_session_state() {
+        // Regression: title_last_updated_tokens must come from the Title entry's
+        // recorded token count, NOT session.tokens (which is 0 mid-replay). If
+        // derived from session state, large auto-titled sessions would re-title
+        // on every reload.
+        let content = "type: header\nmodel: openai:gpt-4o\nsession_id: sess-a\n---\ntype: message\nrole: user\ncontent: hello\n---\ntype: title\ntitle: Some generated title\ntokens: 30000\n";
+        let session = super::load_from_log_for_test(content);
+
+        assert_eq!(session.title.as_deref(), Some("Some generated title"));
+        assert_eq!(session.title_last_updated_tokens, 30000);
+        // With a 50k threshold and ~30k baseline, a freshly loaded session does
+        // not immediately re-title unless it has grown 50k tokens past 30k.
+        assert!(!session.need_generate_title(50_000));
+    }
+
+    #[test]
+    fn replay_manual_title_freezes_regeneration_across_reload() {
+        let content = "type: header\nmodel: openai:gpt-4o\nsession_id: sess-b\n---\ntype: message\nrole: user\ncontent: hello\n---\ntype: title\ntitle: My Manual Title\nmanual: true\n";
+        let session = super::load_from_log_for_test(content);
+
+        assert_eq!(session.title.as_deref(), Some("My Manual Title"));
+        assert_eq!(session.title_last_updated_tokens, usize::MAX);
+        assert!(!session.need_generate_title(1));
     }
 
     #[test]

--- a/crates/harnx-runtime/src/config/session_meta.rs
+++ b/crates/harnx-runtime/src/config/session_meta.rs
@@ -12,6 +12,7 @@ pub struct SessionMeta {
     pub git_remote: Option<String>,
     pub terminal_session_id: Option<String>,
     pub agent_name: Option<String>,
+    pub title: Option<String>,
     pub modified: Option<SystemTime>,
 }
 
@@ -205,6 +206,39 @@ fn read_session_header_bytes(path: &Path) -> Option<String> {
     String::from_utf8(content[..boundary].to_vec()).ok()
 }
 
+/// The title text of a document, if it parses as a `SessionLogEntry::Title`.
+fn title_of_doc(doc: &str) -> Option<String> {
+    let doc = doc
+        .trim_start_matches("---\n")
+        .trim_start_matches("---\r\n");
+    match serde_yaml::from_str::<SessionLogEntry>(doc) {
+        Ok(SessionLogEntry::Title { title, .. }) => Some(title),
+        _ => None,
+    }
+}
+
+/// Return the text of the LAST parseable `SessionLogEntry::Title` document in a
+/// buffer of concatenated YAML documents. Malformed documents are skipped.
+fn last_title_in_buffer(buffer: &str) -> Option<String> {
+    buffer
+        .split("\n---\n")
+        .flat_map(|d| d.split("\n---\r\n"))
+        .filter_map(title_of_doc)
+        .last()
+}
+
+/// Find the most recent session title. Title events are small and rare, so we
+/// scan the whole log for the LAST `Title` document rather than a fixed prefix
+/// window — a bounded window would miss titles written past the window in long
+/// sessions (regenerations and manual overrides late in the session). The file
+/// is read as UTF-8 (lossy) and only string-split; no full YAML parse of the
+/// transcript occurs, keeping listing cheap.
+fn scan_latest_title(path: &Path) -> Option<String> {
+    let bytes = std::fs::read(path).ok()?;
+    let text = String::from_utf8_lossy(&bytes);
+    last_title_in_buffer(&text)
+}
+
 pub fn parse_session_meta(name: &str, path: &Path) -> Option<SessionMeta> {
     let header_str = read_session_header_bytes(path)?;
     let modified = std::fs::metadata(path).ok()?.modified().ok();
@@ -226,6 +260,7 @@ pub fn parse_session_meta(name: &str, path: &Path) -> Option<SessionMeta> {
             git_remote,
             terminal_session_id,
             agent_name,
+            title: scan_latest_title(path),
             modified,
         }),
         _ => None,
@@ -251,8 +286,38 @@ mod tests {
             git_remote: None,
             terminal_session_id: None,
             agent_name: None,
+            title: None,
             modified: None,
         }
+    }
+
+    #[test]
+    fn parse_session_meta_populates_latest_title_event() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("titled.yaml");
+        fs::write(
+            &path,
+            "type: header\nmodel: test-model\nsession_id: sess-t\n---\ntype: message\nrole: user\ncontent: hi\n---\ntype: title\ntitle: An earlier title\n---\ntype: title\ntitle: The latest title\n",
+        )
+        .unwrap();
+
+        // The most recent title wins so manual overrides / regenerations show.
+        let meta = parse_session_meta("titled", &path).unwrap();
+        assert_eq!(meta.title.as_deref(), Some("The latest title"));
+    }
+
+    #[test]
+    fn parse_session_meta_title_is_none_without_title_event() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("untitled.yaml");
+        fs::write(
+            &path,
+            "type: header\nmodel: test-model\nsession_id: sess-u\n---\ntype: message\nrole: user\ncontent: hi\n",
+        )
+        .unwrap();
+
+        let meta = parse_session_meta("untitled", &path).unwrap();
+        assert_eq!(meta.title, None);
     }
 
     #[test]

--- a/crates/harnx-runtime/src/config/session_meta_test_extra.rs
+++ b/crates/harnx-runtime/src/config/session_meta_test_extra.rs
@@ -14,6 +14,7 @@ mod tests {
             git_remote: None,
             terminal_session_id: None,
             agent_name: None,
+            title: None,
             modified: None,
         }
     }

--- a/crates/harnx-runtime/src/config/session_ops_split.rs
+++ b/crates/harnx-runtime/src/config/session_ops_split.rs
@@ -17,6 +17,7 @@ fn session_index_record_to_meta(record: &SessionIndexRecord) -> SessionMeta {
         git_remote: record.git_remote.clone(),
         terminal_session_id: None,
         agent_name: Some(record.agent_name.clone()),
+        title: record.title.clone(),
         modified: UNIX_EPOCH.checked_add(Duration::from_secs(record.last_activity)),
     }
 }
@@ -504,6 +505,7 @@ mod tests_remote_sessions {
             working_dir: Some("/home/user/project".to_string()),
             git_branch: Some("feature-branch".to_string()),
             git_remote: Some("git@github.com:org/repo.git".to_string()),
+            title: None,
             last_activity: 1_719_531_234,
         };
 
@@ -536,6 +538,7 @@ mod tests_remote_sessions {
             working_dir: None,
             git_branch: None,
             git_remote: None,
+            title: None,
             last_activity: 0,
         };
 
@@ -566,6 +569,7 @@ mod tests_remote_sessions {
             working_dir: None,
             git_branch: None,
             git_remote: None,
+            title: None,
             last_activity: u64::MAX,
         };
 

--- a/crates/harnx-runtime/src/config/session_ops_title.rs
+++ b/crates/harnx-runtime/src/config/session_ops_title.rs
@@ -1,0 +1,406 @@
+//! Automatic session title generation.
+//!
+//! Mirrors the compaction pipeline (`session_ops_compaction.rs`): a cheap
+//! guard (`need_generate_title`) decides when to (re)generate, a title agent
+//! is resolved from config, and the actual LLM call runs on a spawned task so
+//! the agent loop is never blocked. The generated title is appended to the
+//! session log as `SessionLogEntry::Title`, stored on the in-memory session,
+//! and surfaced via a `TitleUpdated` event. There is no fallback: if
+//! generation fails or no title agent is configured, the title is left unset.
+
+use super::*;
+
+use harnx_core::message::MessageRole;
+
+/// System prompt used when no explicit title agent is configured. Produces a
+/// short natural-language title (not a slug) suitable for session listings.
+pub const DEFAULT_TITLE_SYSTEM_PROMPT: &str = r#"Generate a concise session title (10 words or fewer).
+
+Rules:
+- Plain text only — no quotes, no punctuation at the end, no markdown
+- Natural language (not slug/kebab-case)
+- Capture the main topic or goal
+- RESPOND WITH THE TITLE ONLY
+
+Examples:
+Debugging Rust async lifetime errors
+Setting up PostgreSQL connection pooling
+Planning a hiking trip to Patagonia"#;
+
+/// Maximum characters kept from the transcript sent to the title model. Keeps
+/// the prompt cheap (~2000 tokens) regardless of how long the exchange grew.
+const MAX_TRANSCRIPT_CHARS: usize = 8000;
+/// Maximum characters kept from a single message when assembling the transcript.
+const MAX_SECTION_CHARS: usize = 4000;
+/// Hard cap on the stored title length.
+const MAX_TITLE_CHARS: usize = 200;
+
+fn truncate_chars(text: &str, max: usize) -> String {
+    let trimmed = text.trim();
+    if trimmed.chars().count() <= max {
+        return trimmed.to_string();
+    }
+    let truncated: String = trimmed.chars().take(max).collect();
+    format!("{truncated}…")
+}
+
+/// Format a `label:\n<text>` section, truncated, or `None` when `text` is blank.
+fn labeled_section(label: &str, text: &str) -> Option<String> {
+    let text = text.trim();
+    (!text.is_empty()).then(|| format!("{label}:\n{}", truncate_chars(text, MAX_SECTION_CHARS)))
+}
+
+/// The first user message text, and (only if different) the last user message.
+fn first_and_last_user_text(session: &Session) -> (String, Option<String>) {
+    let messages = &session.messages;
+    let first = messages.iter().position(|m| m.role == MessageRole::User);
+    let last = messages.iter().rposition(|m| m.role == MessageRole::User);
+    let first_text = first
+        .map(|i| messages[i].content.to_text())
+        .unwrap_or_default();
+    let last_text = match (first, last) {
+        (Some(f), Some(l)) if l != f => Some(messages[l].content.to_text()),
+        _ => None,
+    };
+    (first_text, last_text)
+}
+
+/// The concatenated assistant replies that follow the last user message.
+fn assistant_after_last_user(session: &Session) -> String {
+    let messages = &session.messages;
+    let Some(last) = messages.iter().rposition(|m| m.role == MessageRole::User) else {
+        return String::new();
+    };
+    messages
+        .iter()
+        .skip(last + 1)
+        .filter(|m| m.role == MessageRole::Assistant)
+        .map(|m| m.content.to_text())
+        .filter(|t| !t.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+/// Build a compact transcript for title generation. Mirrors the TUI exit
+/// summary heuristic (`select_breakdown_sections` in `crates/harnx/src/main.rs`):
+/// first user message + last user message (if different) + assistant replies
+/// after the last user message. Deterministic and cheap — no extra LLM call.
+pub fn build_title_transcript(session: &Session) -> String {
+    let (first_user, last_user) = first_and_last_user_text(session);
+    let assistant = assistant_after_last_user(session);
+
+    let sections: Vec<String> = [
+        labeled_section("First user message", &first_user),
+        labeled_section("Latest user message", last_user.as_deref().unwrap_or("")),
+        labeled_section("Latest assistant response", &assistant),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    truncate_chars(&sections.join("\n\n"), MAX_TRANSCRIPT_CHARS)
+}
+
+/// First non-empty line, trimmed — reasoning models sometimes emit extra
+/// commentary on later lines.
+fn first_line(text: &str) -> &str {
+    text.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("")
+}
+
+/// Drop a leading `Title:` label (any case).
+fn strip_title_label(text: &str) -> &str {
+    for prefix in ["Title:", "title:", "TITLE:"] {
+        if let Some(rest) = text.strip_prefix(prefix) {
+            return rest.trim();
+        }
+    }
+    text
+}
+
+/// Strip one layer of matching surrounding single or double quotes.
+fn strip_surrounding_quotes(text: &str) -> &str {
+    let mut chars = text.chars();
+    let Some(first) = chars.next() else {
+        return text;
+    };
+    let is_quote = first == '"' || first == '\'';
+    if is_quote && chars.next_back() == Some(first) {
+        return text[first.len_utf8()..text.len() - first.len_utf8()].trim();
+    }
+    text
+}
+
+/// Clean the raw model output into a stored title: collapse to one line, drop a
+/// leading `Title:` label, strip surrounding quotes/markdown emphasis and any
+/// trailing sentence punctuation, then cap length.
+fn post_process_title(raw: &str) -> String {
+    let title = first_line(raw.trim());
+    let title = strip_title_label(title);
+    let title = strip_surrounding_quotes(title);
+    let title = title
+        .trim_matches(|c| c == '*' || c == '_' || c == '`')
+        .trim();
+    let title = title
+        .trim_end_matches(['.', ',', ';', ':', '!', '?'])
+        .trim_end();
+    truncate_chars(title, MAX_TITLE_CHARS)
+}
+
+/// Handle the outcome of a spawned `generate_title`: emit `TitleUpdated` on a
+/// new title, warn on error, ignore the "nothing to title" case.
+fn handle_title_result(result: anyhow::Result<Option<String>>) {
+    match result {
+        Ok(Some(title)) => {
+            harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
+                harnx_core::event::SessionEvent::TitleUpdated(title),
+            ));
+        }
+        Ok(None) => {}
+        Err(err) => warn!("Failed to generate session title: {err}"),
+    }
+}
+
+impl Config {
+    /// Run the periodic, best-effort session maintenance that fires after each
+    /// completed turn: threshold-triggered compaction, then title (re)generation.
+    /// Both are internally guarded and spawn their own work, so this returns
+    /// immediately.
+    pub fn run_post_turn_maintenance(config: GlobalConfig) {
+        Self::maybe_compact_session(config.clone());
+        Self::maybe_generate_title(config);
+    }
+
+    /// Fire-and-forget title generation. Checks the threshold guard, resolves a
+    /// title agent (returning early if none is configured), marks the session as
+    /// `titling`, and spawns the generation on a background task. Mirrors
+    /// `maybe_compact_session`.
+    pub fn maybe_generate_title(config: GlobalConfig) {
+        if !Self::claim_titling(&config) {
+            return;
+        }
+
+        // Only proceed if a title agent is actually configured; otherwise clear
+        // the flag we just set and bail (no fallback title generation).
+        if Self::resolve_title_agent(&config).is_none() {
+            Self::clear_titling(&config, None);
+            return;
+        }
+
+        let titling_session_id = config
+            .read()
+            .session
+            .as_ref()
+            .map(|session| session.id.clone());
+
+        tokio::spawn(async move {
+            let result = Self::generate_title(&config).await;
+            Self::clear_titling(&config, titling_session_id.as_deref());
+            handle_title_result(result);
+        });
+    }
+
+    /// Under the write lock: if the active session needs a title, set its
+    /// `titling` flag and return `true`. Returns `false` (no-op) otherwise.
+    fn claim_titling(config: &GlobalConfig) -> bool {
+        let mut guard = config.write();
+        let threshold = guard.title_update_threshold;
+        let Some(session) = guard.session.as_mut() else {
+            return false;
+        };
+        if !session.need_generate_title(threshold) {
+            return false;
+        }
+        session.set_titling(true);
+        true
+    }
+
+    /// Clear the `titling` flag on the active session. When `session_id` is
+    /// `Some`, only clear if the active session still matches (guards against
+    /// session swaps during the spawned task).
+    fn clear_titling(config: &GlobalConfig, session_id: Option<&str>) {
+        if let Some(session) = config.write().session.as_mut() {
+            if session_id.is_none_or(|id| session.id == id) {
+                session.set_titling(false);
+            }
+        }
+    }
+
+    /// Resolve the configured title agent: `AgentConfig.title_agent` first, then
+    /// the global `ConfigData.title_agent`. Returns `None` when neither is set
+    /// (no title generation). Mirrors `resolve_compaction_agent`.
+    fn resolve_title_agent(config: &GlobalConfig) -> Option<crate::config::agent::Agent> {
+        let active_agent_name = config.read().extract_agent().name().to_string();
+        let active_pkg = harnx_core::package_namespace::pkg_from_qualified(&active_agent_name);
+        let name = {
+            let guard = config.read();
+            let agent = guard.extract_agent();
+            agent
+                .title_agent()
+                .map(str::to_owned)
+                .or_else(|| guard.title_agent.clone())?
+        };
+
+        let resolved_name =
+            harnx_core::package_namespace::resolve_package_relative_name(&name, active_pkg);
+        match config.read().retrieve_agent(&resolved_name) {
+            Ok(mut title_agent) => {
+                if let Err(e) = self::agent::resolve_variables(&mut title_agent) {
+                    warn!("Failed to resolve variables for title_agent '{name}': {e}");
+                }
+                Some(title_agent)
+            }
+            Err(e) => {
+                warn!("Failed to load title_agent '{name}': {e}; skipping title generation");
+                None
+            }
+        }
+    }
+
+    /// Perform the actual title generation. Returns `Ok(Some(title))` on success,
+    /// `Ok(None)` when there is nothing to title (empty transcript / model
+    /// returned an empty string), and `Err` on LLM/model failure.
+    async fn generate_title(config: &GlobalConfig) -> Result<Option<String>> {
+        let title_agent = Self::resolve_title_agent(config)
+            .context("no title agent configured")?
+            .into_config();
+
+        let (transcript, session_id, tokens) = {
+            let guard = config.read();
+            let session = guard.session.as_ref().context("No session")?;
+            (
+                build_title_transcript(session),
+                session.id.clone(),
+                session.tokens,
+            )
+        };
+        if transcript.trim().is_empty() {
+            return Ok(None);
+        }
+
+        let mut input =
+            harnx_core::input::Input::new(transcript.clone(), (transcript, vec![]), title_agent);
+        input.with_session = false;
+        input.with_agent = true;
+
+        let raw = crate::config::input::fetch_chat_text(&mut input, config).await?;
+        let title = post_process_title(&raw);
+        if title.is_empty() {
+            return Ok(None);
+        }
+
+        // Persist to the session log + in-memory session, but only if the active
+        // session is still the one we titled (it may have been swapped).
+        {
+            let mut guard = config.write();
+            let Some(session) = guard.session.as_mut() else {
+                return Ok(None);
+            };
+            if session.id != session_id {
+                return Ok(None);
+            }
+            crate::config::session::record_title(session, title.clone(), false, tokens);
+        }
+
+        Ok(Some(title))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harnx_core::message::{Message, MessageContent};
+    use harnx_core::session::Session;
+
+    fn user(text: &str) -> Message {
+        Message::new(MessageRole::User, MessageContent::Text(text.to_string()))
+    }
+    fn assistant(text: &str) -> Message {
+        Message::new(
+            MessageRole::Assistant,
+            MessageContent::Text(text.to_string()),
+        )
+    }
+    fn session_with(messages: Vec<Message>) -> Session {
+        Session {
+            messages,
+            ..Session::default()
+        }
+    }
+
+    #[test]
+    fn transcript_single_exchange_has_first_user_and_assistant() {
+        let session = session_with(vec![
+            user("How do I fix async lifetimes?"),
+            assistant("Use owned data."),
+        ]);
+        let t = build_title_transcript(&session);
+        assert!(t.contains("How do I fix async lifetimes?"));
+        assert!(t.contains("Use owned data."));
+        // Only one user message: no separate "Latest user message" section.
+        assert!(!t.contains("Latest user message:"));
+    }
+
+    #[test]
+    fn transcript_multi_exchange_includes_first_and_last_user() {
+        let session = session_with(vec![
+            user("first question about postgres"),
+            assistant("answer one"),
+            user("later question about pooling"),
+            assistant("answer two"),
+        ]);
+        let t = build_title_transcript(&session);
+        assert!(t.contains("first question about postgres"));
+        assert!(t.contains("later question about pooling"));
+        assert!(t.contains("answer two"));
+        // Assistant reply before the last user message is not the "latest response".
+        assert!(!t.contains("answer one"));
+    }
+
+    #[test]
+    fn transcript_empty_session_is_empty() {
+        let session = Session::default();
+        assert!(build_title_transcript(&session).trim().is_empty());
+    }
+
+    #[test]
+    fn post_process_strips_quotes_prefix_and_extra_lines() {
+        assert_eq!(
+            post_process_title("  Debugging async errors  "),
+            "Debugging async errors"
+        );
+        assert_eq!(
+            post_process_title("\"Setting up Postgres\""),
+            "Setting up Postgres"
+        );
+        assert_eq!(post_process_title("'Planning a trip'"), "Planning a trip");
+        assert_eq!(
+            post_process_title("Title: Fix the parser"),
+            "Fix the parser"
+        );
+        assert_eq!(
+            post_process_title("Rust ownership refactor\n\nHere is why..."),
+            "Rust ownership refactor"
+        );
+    }
+
+    #[test]
+    fn post_process_strips_trailing_punctuation_and_markdown() {
+        assert_eq!(
+            post_process_title("Fixing the login bug."),
+            "Fixing the login bug"
+        );
+        assert_eq!(post_process_title("Configuring CI!"), "Configuring CI");
+        assert_eq!(post_process_title("**Bold title**"), "Bold title");
+        assert_eq!(post_process_title("`code title`"), "code title");
+    }
+
+    #[test]
+    fn post_process_caps_length() {
+        let long = "word ".repeat(200);
+        let out = post_process_title(&long);
+        assert!(out.chars().count() <= MAX_TITLE_CHARS + 1); // +1 for the ellipsis
+    }
+}

--- a/crates/harnx-runtime/src/config/settings_split.rs
+++ b/crates/harnx-runtime/src/config/settings_split.rs
@@ -5,6 +5,13 @@ use anyhow::{anyhow, bail, Context, Result};
 
 impl Config {
     pub fn update(config: &GlobalConfig, data: &str) -> Result<()> {
+        // `title` takes a free-form, possibly multi-word value: everything
+        // after the key is the title text (not split on whitespace).
+        if let Some(rest) = data.trim_start().strip_prefix("title") {
+            if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+                return Self::apply_update(config, "title", rest.trim());
+            }
+        }
         let parts: Vec<&str> = data.split_whitespace().collect();
         if parts.len() != 2 {
             bail!("Usage: .set <key> <value>. If value is null, unset key.");
@@ -46,8 +53,35 @@ impl Config {
             "highlight" => {
                 Self::update_bool_field(config, value, |cfg, value| cfg.highlight = value)
             }
+            "title" => Self::set_session_title(config, value),
             _ => bail!("Unknown key '{key}'"),
         }
+    }
+
+    /// Manually set the session title via `.set title <text>`. Appends a
+    /// `SessionLogEntry::Title` to the log, updates the in-memory session, and
+    /// freezes automatic regeneration by setting `title_last_updated_tokens`
+    /// to `usize::MAX`. Emits `TitleUpdated`. An empty value is rejected.
+    fn set_session_title(config: &GlobalConfig, value: &str) -> Result<()> {
+        let title = value.trim().to_string();
+        if title.is_empty() {
+            bail!("Usage: .set title <text>");
+        }
+        {
+            let mut guard = config.write();
+            let session = guard
+                .session
+                .as_mut()
+                .context("No active session to set a title on")?;
+            // Manual title: record the current token count for provenance;
+            // `record_title` freezes regeneration (usize::MAX) for manual titles.
+            let tokens = session.tokens;
+            crate::config::session::record_title(session, title.clone(), true, tokens);
+        }
+        harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
+            harnx_core::event::SessionEvent::TitleUpdated(title),
+        ));
+        Ok(())
     }
 
     fn update_optional_f64(
@@ -308,5 +342,56 @@ where
         Ok(None)
     } else {
         Ok(Some(value.parse().with_context(|| "Invalid value")?))
+    }
+}
+
+#[cfg(test)]
+mod title_command_tests {
+    use super::super::*;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn config_with_session(dir: &std::path::Path) -> GlobalConfig {
+        let mut config = Config::default();
+        let mut session = crate::config::session::new(&config, "title-test", None).unwrap();
+        session.set_sessions_dir(dir.to_path_buf());
+        crate::config::session::save(
+            &mut session,
+            "title-test",
+            &dir.join("title-test.yaml"),
+            false,
+        )
+        .unwrap();
+        config.session = Some(session);
+        Arc::new(RwLock::new(config))
+    }
+
+    #[test]
+    fn set_title_multiword_updates_session_and_freezes_regeneration() {
+        let tmp = TempDir::new().unwrap();
+        let config = config_with_session(tmp.path());
+
+        Config::update(&config, "title My Custom Session Title").unwrap();
+
+        let guard = config.read();
+        let session = guard.session.as_ref().unwrap();
+        assert_eq!(session.title(), Some("My Custom Session Title"));
+        // Frozen: auto-regeneration is disabled after a manual title.
+        assert_eq!(session.title_last_updated_tokens(), usize::MAX);
+        assert!(!session.need_generate_title(50_000));
+
+        // The manual title is persisted to the log with manual: true.
+        let persisted = std::fs::read_to_string(session.path.as_ref().unwrap()).unwrap();
+        assert!(persisted.contains("type: title"));
+        assert!(persisted.contains("title: My Custom Session Title"));
+        assert!(persisted.contains("manual: true"));
+    }
+
+    #[test]
+    fn set_title_empty_value_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let config = config_with_session(tmp.path());
+        assert!(Config::update(&config, "title   ").is_err());
     }
 }

--- a/crates/harnx-runtime/src/nats_client_session.rs
+++ b/crates/harnx-runtime/src/nats_client_session.rs
@@ -562,6 +562,7 @@ fn render_log_entry_to_sink(
         SessionLogEntry::Header { .. }
         | SessionLogEntry::DataUrls { .. }
         | SessionLogEntry::Compress { .. }
+        | SessionLogEntry::Title { .. }
         | SessionLogEntry::Clear
         | SessionLogEntry::EditEntries { .. }
         | SessionLogEntry::Rewind { .. }

--- a/crates/harnx-runtime/src/nats_lease.rs
+++ b/crates/harnx-runtime/src/nats_lease.rs
@@ -494,6 +494,7 @@ mod tests {
             working_dir: None,
             git_branch: None,
             git_remote: None,
+            title: None,
             last_activity: u64::MAX,
         };
 

--- a/crates/harnx-runtime/src/nats_session_index.rs
+++ b/crates/harnx-runtime/src/nats_session_index.rs
@@ -21,6 +21,8 @@ pub struct SessionIndexRecord {
     pub working_dir: Option<String>,
     pub git_branch: Option<String>,
     pub git_remote: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     pub last_activity: u64,
 }
 
@@ -159,6 +161,20 @@ pub async fn update_record_with_revision(
         })
 }
 
+/// Update just the `title` field of an existing session index record via a
+/// compare-and-swap read/modify/write. If the record doesn't exist yet (e.g.
+/// the header hasn't been indexed), this is a no-op that logs a warning and
+/// returns `Ok(())` — the title will be picked up on the next header write.
+pub async fn update_session_title(store: &kv::Store, session_id: &str, title: &str) -> Result<()> {
+    let Some((mut record, revision)) = get_record_with_revision(store, session_id).await? else {
+        warn!("session index record not found; skipping title update for session_id={session_id}");
+        return Ok(());
+    };
+    record.title = Some(title.to_owned());
+    update_record_with_revision(store, &record, revision).await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -170,6 +186,40 @@ mod tests {
     // =============================================================================
     // Test helpers for NATS integration tests
     // =============================================================================
+
+    #[test]
+    fn old_json_record_without_title_deserializes_with_none() {
+        // Backward compatibility: records written before the `title` field
+        // existed must still deserialize cleanly (serde default -> None).
+        let json = r#"{
+            "session_id": "sess-legacy",
+            "agent_name": "hephaestus",
+            "working_dir": "/tmp/project",
+            "git_branch": "main",
+            "git_remote": null,
+            "last_activity": 1719531234
+        }"#;
+        let record: SessionIndexRecord = serde_json::from_str(json).unwrap();
+        assert_eq!(record.session_id, "sess-legacy");
+        assert_eq!(record.title, None);
+    }
+
+    #[test]
+    fn record_with_title_round_trips_through_json() {
+        let json = r#"{
+            "session_id": "sess-titled",
+            "agent_name": "hephaestus",
+            "working_dir": null,
+            "git_branch": null,
+            "git_remote": null,
+            "title": "Debugging async lifetimes",
+            "last_activity": 1
+        }"#;
+        let record: SessionIndexRecord = serde_json::from_str(json).unwrap();
+        assert_eq!(record.title.as_deref(), Some("Debugging async lifetimes"));
+        let reserialized = serde_json::to_string(&record).unwrap();
+        assert!(reserialized.contains("\"title\":\"Debugging async lifetimes\""));
+    }
 
     /// Get NATS test URL from environment, returning None if not set.
     /// Tests should skip gracefully when this returns None.
@@ -200,6 +250,7 @@ mod tests {
             working_dir: Some("/tmp/project".to_string()),
             git_branch: Some("main".to_string()),
             git_remote: Some("git@github.com:dobesv/harnx.git".to_string()),
+            title: None,
             last_activity: 1_719_531_234,
         }
     }

--- a/crates/harnx-runtime/src/nats_worker/agent_loop.rs
+++ b/crates/harnx-runtime/src/nats_worker/agent_loop.rs
@@ -319,64 +319,18 @@ async fn load_or_repair_session(
     let mut entries_vec = entries;
     let mut effective_entries =
         harnx_core::session_reconstruct::apply_log_mutations_nats(&entries_vec)?;
-    if should_insert_remote_header(&effective_entries) {
-        if let Some((first_user_seq, last_user_seq, replacements)) =
-            build_remote_header_insert_replacements(
-                &entries_vec,
-                &effective_entries,
-                config,
-                input,
-                session_id,
-                working_dir,
-            )?
-        {
-            let edit_entry = SessionLogEntry::EditEntries {
-                from: first_user_seq,
-                to: last_user_seq,
-                replacements,
-            };
-            let message_id = remote_header_insert_message_id(session_id, first_user_seq);
-            let insert_seq = crate::nats_session_log::NatsSessionLog::new(
-                backend.jetstream(),
-                session_id.to_string(),
-            )
-            .append_event_with_message_id_async(&edit_entry, message_id)
-            .await?;
-            debug!("inserted header via EditEntries js{insert_seq}");
-            // Publish the migration seq so the daemon advances its activation
-            // high-water cursor past the re-mapped leading-user block. The
-            // migration re-maps those users onto `insert_seq`; the turn that
-            // runs this activation answers them, so without this the drain would
-            // re-fold them (seq > pre-migration cursor) and re-run the turn (S3).
-            if let Some(observer) = header_insert_observer {
-                observer.fetch_max(insert_seq, std::sync::atomic::Ordering::Relaxed);
-            }
-            entries_vec = backend.load_events_blocking()?;
-            effective_entries =
-                harnx_core::session_reconstruct::apply_log_mutations_nats(&entries_vec)?;
-        }
-    }
-    // Keep the session index current on every activation that takes the
-    // existing-session path. Brand-new (empty-log) sessions register their
-    // index in `write_header_and_load_session`; but headerless sessions
-    // migrated here (S2) and normal resumes take THIS path, so upsert from the
-    // effective `Header` — otherwise the session never appears in
-    // `list_remote_sessions_with_meta` (breaks resume/picker) and its
-    // `last_activity` is never refreshed. Best-effort: warn on failure, never
-    // fail activation. Idempotent (`put_record` upserts).
-    if let Some(store) = session_index {
-        if let Some((_, header)) = effective_entries
-            .iter()
-            .find(|(_, entry)| matches!(entry, SessionLogEntry::Header { .. }))
-        {
-            if let Err(err) = upsert_session_index_record(store, header).await {
-                log::warn!(
-                    "failed to upsert remote session index during activation: \
-                     session_id={session_id} err={err:#}"
-                );
-            }
-        }
-    }
+    maybe_insert_remote_header(MaybeInsertRemoteHeaderArgs {
+        backend,
+        config,
+        input,
+        session_id,
+        working_dir,
+        header_insert_observer,
+        entries_vec: &mut entries_vec,
+        effective_entries: &mut effective_entries,
+    })
+    .await?;
+    refresh_session_index_on_activation(session_index, &effective_entries, session_id).await;
     let orphan_calls = find_orphan_tool_calls(&effective_entries);
     if !orphan_calls.is_empty() {
         nats_metrics::resume_detected();
@@ -766,6 +720,7 @@ fn build_remote_session_header(
 
 fn build_session_index_record_from_header(
     header: &harnx_core::session::SessionLogEntry,
+    title: Option<String>,
 ) -> Result<SessionIndexRecord> {
     let harnx_core::session::SessionLogEntry::Header {
         session_id,
@@ -789,6 +744,7 @@ fn build_session_index_record_from_header(
         working_dir: working_dir.clone(),
         git_branch: git_branch.clone(),
         git_remote: git_remote.clone(),
+        title,
         last_activity: SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .context("system clock before unix epoch")?
@@ -796,14 +752,125 @@ fn build_session_index_record_from_header(
     })
 }
 
+/// Scan effective log entries for the most recent `Title` event so the session
+/// index reflects the latest generated/manual title on activation upsert.
+fn latest_title_from_entries(
+    entries: &[(u64, harnx_core::session::SessionLogEntry)],
+) -> Option<String> {
+    entries.iter().rev().find_map(|(_, entry)| match entry {
+        harnx_core::session::SessionLogEntry::Title { title, .. } => Some(title.clone()),
+        _ => None,
+    })
+}
+
 async fn upsert_session_index_record(
     store: &async_nats::jetstream::kv::Store,
     header: &harnx_core::session::SessionLogEntry,
+    title: Option<String>,
 ) -> Result<u64> {
-    let record = build_session_index_record_from_header(header)?;
+    let record = build_session_index_record_from_header(header, title)?;
     put_record(store, &record)
         .await
         .with_context(|| format!("put session index record for {}", record.session_id))
+}
+
+/// Keep the session index current on every activation that takes the
+/// existing-session path. Brand-new (empty-log) sessions register their index in
+/// `write_header_and_load_session`; but headerless sessions migrated here (S2)
+/// and normal resumes take THIS path, so we upsert from the effective `Header`
+/// (carrying the latest `Title`) — otherwise the session never appears in
+/// `list_remote_sessions_with_meta` (breaks resume/picker) and its
+/// `last_activity` is never refreshed. Best-effort: warn on failure, never fail
+/// activation. Idempotent (`put_record` upserts).
+async fn refresh_session_index_on_activation(
+    session_index: Option<&async_nats::jetstream::kv::Store>,
+    effective_entries: &[(u64, SessionLogEntry)],
+    session_id: &str,
+) {
+    let Some(store) = session_index else {
+        return;
+    };
+    let Some((_, header)) = effective_entries
+        .iter()
+        .find(|(_, entry)| matches!(entry, SessionLogEntry::Header { .. }))
+    else {
+        return;
+    };
+    let title = latest_title_from_entries(effective_entries);
+    if let Err(err) = upsert_session_index_record(store, header, title).await {
+        log::warn!(
+            "failed to upsert remote session index during activation: \
+             session_id={session_id} err={err:#}"
+        );
+    }
+}
+
+struct MaybeInsertRemoteHeaderArgs<'a> {
+    backend: &'a NatsSessionLogBackend,
+    config: &'a GlobalConfig,
+    input: &'a Input,
+    session_id: &'a str,
+    working_dir: Option<&'a std::path::Path>,
+    header_insert_observer: Option<&'a Arc<AtomicU64>>,
+    entries_vec: &'a mut Vec<(u64, SessionLogEntry)>,
+    effective_entries: &'a mut Vec<(u64, SessionLogEntry)>,
+}
+
+/// Headerless sessions migrated in (S2) need a `Header` synthesized from the
+/// leading user block. When required, this appends an `EditEntries` migration,
+/// publishes the resulting seq to the daemon's high-water observer, and reloads
+/// `entries_vec` / `effective_entries` so the caller sees the repaired log.
+/// No-op when the effective log already has a header.
+async fn maybe_insert_remote_header(args: MaybeInsertRemoteHeaderArgs<'_>) -> Result<()> {
+    let MaybeInsertRemoteHeaderArgs {
+        backend,
+        config,
+        input,
+        session_id,
+        working_dir,
+        header_insert_observer,
+        entries_vec,
+        effective_entries,
+    } = args;
+
+    if !should_insert_remote_header(effective_entries) {
+        return Ok(());
+    }
+    let Some((first_user_seq, last_user_seq, replacements)) =
+        build_remote_header_insert_replacements(
+            entries_vec,
+            effective_entries,
+            config,
+            input,
+            session_id,
+            working_dir,
+        )?
+    else {
+        return Ok(());
+    };
+
+    let edit_entry = SessionLogEntry::EditEntries {
+        from: first_user_seq,
+        to: last_user_seq,
+        replacements,
+    };
+    let message_id = remote_header_insert_message_id(session_id, first_user_seq);
+    let insert_seq =
+        crate::nats_session_log::NatsSessionLog::new(backend.jetstream(), session_id.to_string())
+            .append_event_with_message_id_async(&edit_entry, message_id)
+            .await?;
+    debug!("inserted header via EditEntries js{insert_seq}");
+    // Publish the migration seq so the daemon advances its activation high-water
+    // cursor past the re-mapped leading-user block. The migration re-maps those
+    // users onto `insert_seq`; the turn that runs this activation answers them,
+    // so without this the drain would re-fold them (seq > pre-migration cursor)
+    // and re-run the turn (S3).
+    if let Some(observer) = header_insert_observer {
+        observer.fetch_max(insert_seq, std::sync::atomic::Ordering::Relaxed);
+    }
+    *entries_vec = backend.load_events_blocking()?;
+    *effective_entries = harnx_core::session_reconstruct::apply_log_mutations_nats(entries_vec)?;
+    Ok(())
 }
 
 /// Write a new session header and load the session.
@@ -818,7 +885,7 @@ pub(crate) async fn write_header_and_load_session(
     let header = build_remote_session_header(config, input, session_id, working_dir)?;
     backend.append_event_blocking(&header)?;
     if let Some(store) = session_index {
-        if let Err(err) = upsert_session_index_record(store, &header).await {
+        if let Err(err) = upsert_session_index_record(store, &header, None).await {
             log::warn!(
                 "failed to upsert remote session index after header write: session_id={} err={err:#}",
                 session_id

--- a/crates/harnx-runtime/src/nats_worker/tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests.rs
@@ -449,6 +449,15 @@ fn run_git(temp_repo: &Path, args: &[&str]) {
     );
 }
 
+/// Drop the `session_id:` line from a serialized header so two independently
+/// built headers can be compared ignoring their random session ids.
+fn strip_session_id_line(yaml: &str) -> String {
+    yaml.lines()
+        .filter(|line| !line.trim_start().starts_with("session_id:"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 fn create_test_git_repo() -> tempfile::TempDir {
     let temp_dir = tempfile::tempdir().expect("temp dir must be created");
     let repo = temp_dir.path();
@@ -700,12 +709,16 @@ async fn remote_header_matches_local_header_source_of_truth() {
         actual_header_yaml.contains(&expected_working_dir),
         "actual header must use hermetic working dir: {actual_header_yaml}"
     );
-    assert!(expected_header_yaml.contains("git_branch: test-branch"));
-    assert!(expected_header_yaml.contains("git_remote: https://example.com/test/repo.git"));
-    assert!(expected_header_yaml.contains(&expected_working_dir));
+    // Each header is built from an INDEPENDENT `session::new` call, so each
+    // generates its own random `session_id`. Normalize that legitimately
+    // non-deterministic line out before comparing the rest (which must match
+    // exactly) — otherwise the test is flaky under nextest parallelism. This
+    // equality also covers the git_branch/git_remote/working_dir fields, so no
+    // separate `expected_header_yaml.contains(...)` assertions are needed.
     assert_eq!(
-        actual_header_yaml, expected_header_yaml,
-        "remote header must match locally built header"
+        strip_session_id_line(&actual_header_yaml),
+        strip_session_id_line(&expected_header_yaml),
+        "remote header must match locally built header (ignoring random session_id)"
     );
     let loaded_header_yaml = serde_yaml::to_string(&session.build_header_entry()).unwrap();
     assert!(loaded_header_yaml.contains("agent_name: pkg/main"));

--- a/crates/harnx-runtime/src/remote_session_cleanup.rs
+++ b/crates/harnx-runtime/src/remote_session_cleanup.rs
@@ -266,6 +266,7 @@ mod tests {
             working_dir: Some("/tmp/project".to_string()),
             git_branch: Some("main".to_string()),
             git_remote: Some("git@github.com:dobesv/harnx.git".to_string()),
+            title: None,
             last_activity,
         }
     }

--- a/crates/harnx-runtime/src/session_history.rs
+++ b/crates/harnx-runtime/src/session_history.rs
@@ -41,6 +41,7 @@ pub fn entry_type(entry: &SessionLogEntry) -> &'static str {
         SessionLogEntry::Cancel { .. } => "cancel",
         SessionLogEntry::EditEntries { .. } => "edit_entries",
         SessionLogEntry::Rewind { .. } => "rewind",
+        SessionLogEntry::Title { .. } => "title",
         SessionLogEntry::Unknown => "unknown",
     }
 }
@@ -63,6 +64,7 @@ fn entry_searchable_text(entry: &SessionLogEntry) -> String {
             .collect::<Vec<_>>()
             .join("\n"),
         SessionLogEntry::Compress { prompt } => prompt.clone(),
+        SessionLogEntry::Title { title, .. } => title.clone(),
         SessionLogEntry::Header { model_id, .. } => format!("model: {model_id}"),
         _ => String::new(),
     }

--- a/crates/harnx-runtime/tests/nats_session_delete.rs
+++ b/crates/harnx-runtime/tests/nats_session_delete.rs
@@ -74,6 +74,7 @@ async fn session_delete_removes_stream_and_lease_and_is_idempotent() -> Result<(
         working_dir: Some("/tmp".to_string()),
         git_branch: Some("main".to_string()),
         git_remote: Some("origin".to_string()),
+        title: None,
         last_activity: 1_700_000_000,
     };
     put_record(&index_store, &index_record).await?;

--- a/crates/harnx-runtime/tests/title_generation.rs
+++ b/crates/harnx-runtime/tests/title_generation.rs
@@ -1,0 +1,180 @@
+//! Integration tests for session title generation: log-entry serde, meta
+//! extraction, backward compatibility with pre-title session files, and the
+//! deterministic transcript builder.
+
+use anyhow::Result;
+use harnx_core::message::{Message, MessageContent, MessageRole};
+use harnx_core::require_nextest;
+use harnx_core::session::{Session, SessionLogEntry};
+use harnx_runtime::config::parse_session_meta;
+use harnx_runtime::config::session_ops_title::{
+    build_title_transcript, DEFAULT_TITLE_SYSTEM_PROMPT,
+};
+use std::fs;
+use tempfile::TempDir;
+
+/// A `Title` log entry round-trips through YAML and is NOT treated as Unknown.
+#[test]
+fn title_log_entry_round_trips() -> Result<()> {
+    require_nextest();
+
+    let yaml = "type: title\ntitle: Debugging async lifetimes\n";
+    let entry: SessionLogEntry = serde_yaml::from_str(yaml)?;
+    match &entry {
+        SessionLogEntry::Title { title, .. } => assert_eq!(title, "Debugging async lifetimes"),
+        other => panic!("expected Title, got {other:?}"),
+    }
+    let reserialized = serde_yaml::to_string(&entry)?;
+    assert!(reserialized.contains("type: title"));
+    assert!(reserialized.contains("title: Debugging async lifetimes"));
+    Ok(())
+}
+
+/// Write a session log file with the given body and return the title that
+/// `parse_session_meta` extracts from it.
+fn title_from_session_log(body: &str) -> Option<String> {
+    let tmp = TempDir::new().expect("temp dir");
+    let path = tmp.path().join("session.yaml");
+    fs::write(&path, body).expect("write session file");
+    parse_session_meta("session", &path)
+        .expect("meta should parse")
+        .title
+}
+
+/// A session file that contains a `Title` event surfaces it in `SessionMeta`.
+#[test]
+fn session_meta_reads_generated_title() {
+    require_nextest();
+    let title = title_from_session_log(concat!(
+        "type: header\nmodel: test-model\nsession_id: sess-1\n",
+        "---\ntype: message\nrole: user\ncontent: how do I fix this bug\n",
+        "---\ntype: title\ntitle: Fixing the bug\n",
+    ));
+    assert_eq!(title.as_deref(), Some("Fixing the bug"));
+}
+
+/// An OLD session file with NO `Title` event must load cleanly with `title == None`.
+#[test]
+fn old_session_file_without_title_loads_with_none() {
+    require_nextest();
+    let title = title_from_session_log(concat!(
+        "type: header\nmodel: test-model\nsession_id: sess-legacy\nagent_instructions: You are Oracle\n",
+        "---\ntype: message\nrole: user\ncontent: hello\n",
+        "---\ntype: message\nrole: assistant\ncontent: hi there\n",
+    ));
+    assert_eq!(title, None);
+}
+
+/// The LATEST title event is used when several are present, so regenerated and
+/// manual titles are reflected in listings.
+#[test]
+fn session_meta_uses_latest_title_event() {
+    require_nextest();
+    let title = title_from_session_log(concat!(
+        "type: header\nmodel: test-model\nsession_id: sess-multi\n",
+        "---\ntype: title\ntitle: First Title\n",
+        "---\ntype: title\ntitle: Second Title\n",
+    ));
+    assert_eq!(title.as_deref(), Some("Second Title"));
+}
+
+/// A manual title (`.set title`) written as a `Title { manual: true }` entry is
+/// reflected in `SessionMeta` and replays with the freeze semantics.
+#[test]
+fn session_meta_reads_manual_title() {
+    require_nextest();
+    let title = title_from_session_log(concat!(
+        "type: header\nmodel: test-model\nsession_id: sess-manual\n",
+        "---\ntype: title\ntitle: My Custom Title\nmanual: true\n",
+    ));
+    assert_eq!(title.as_deref(), Some("My Custom Title"));
+}
+
+/// A title event past the first 64KB of a large session file is still found
+/// (the scan covers the whole log, not a fixed prefix window).
+#[test]
+fn session_meta_finds_title_in_large_file() -> Result<()> {
+    require_nextest();
+
+    let tmp = TempDir::new()?;
+    let path = tmp.path().join("huge.yaml");
+
+    let mut content = String::from("type: header\nmodel: test-model\nsession_id: sess-huge\n");
+    // Pad with many message documents so the title lands well past 128KB.
+    let filler = "x".repeat(200);
+    for i in 0..1500 {
+        content.push_str("---\ntype: message\nrole: user\ncontent: ");
+        content.push_str(&filler);
+        content.push_str(&format!("{i}\n"));
+    }
+    // Title appears deep in the file, then more messages follow after it so the
+    // title is neither in the first nor last 64KB window.
+    content.push_str("---\ntype: title\ntitle: Deep Title\n");
+    for i in 0..1500 {
+        content.push_str("---\ntype: message\nrole: assistant\ncontent: ");
+        content.push_str(&filler);
+        content.push_str(&format!("{i}\n"));
+    }
+    fs::write(&path, &content)?;
+    assert!(content.len() > 256 * 1024, "fixture must exceed 256KB");
+
+    let meta = parse_session_meta("huge", &path).expect("meta should parse");
+    assert_eq!(meta.title.as_deref(), Some("Deep Title"));
+    Ok(())
+}
+
+/// The transcript builder captures the first user message, the last user
+/// message (when different), and the assistant response after the last user
+/// message — mirroring the TUI exit-summary heuristic.
+#[test]
+fn transcript_builder_selects_expected_sections() {
+    require_nextest();
+
+    let session = Session {
+        messages: vec![
+            Message::new(
+                MessageRole::User,
+                MessageContent::Text("set up postgres pooling".to_string()),
+            ),
+            Message::new(
+                MessageRole::Assistant,
+                MessageContent::Text("first answer".to_string()),
+            ),
+            Message::new(
+                MessageRole::User,
+                MessageContent::Text("now tune the pool size".to_string()),
+            ),
+            Message::new(
+                MessageRole::Assistant,
+                MessageContent::Text("final answer".to_string()),
+            ),
+        ],
+        ..Session::default()
+    };
+
+    let transcript = build_title_transcript(&session);
+    assert!(transcript.contains("set up postgres pooling"));
+    assert!(transcript.contains("now tune the pool size"));
+    assert!(transcript.contains("final answer"));
+    // Assistant reply preceding the last user message is excluded.
+    assert!(!transcript.contains("first answer"));
+}
+
+/// The default title prompt is natural-language guidance (not a slug prompt).
+#[test]
+fn default_title_prompt_is_natural_language() {
+    require_nextest();
+    assert!(DEFAULT_TITLE_SYSTEM_PROMPT.contains("title"));
+    assert!(
+        DEFAULT_TITLE_SYSTEM_PROMPT
+            .to_lowercase()
+            .contains("no quotes")
+            || DEFAULT_TITLE_SYSTEM_PROMPT
+                .to_lowercase()
+                .contains("plain text")
+    );
+    // Should discourage slug/kebab output.
+    assert!(DEFAULT_TITLE_SYSTEM_PROMPT
+        .to_lowercase()
+        .contains("natural language"));
+}

--- a/crates/harnx-serve/src/ag_ui.rs
+++ b/crates/harnx-serve/src/ag_ui.rs
@@ -653,6 +653,9 @@ impl harnx_core::event::AgentEventSink for AgUiSink {
             AgentEvent::Status(status) => {
                 self.emit_custom("status", json!({ "text": status.text }));
             }
+            AgentEvent::Session(SessionEvent::TitleUpdated(title)) => {
+                self.emit_custom("session_title_updated", json!({ "title": title }))
+            }
             AgentEvent::Session(SessionEvent::Generic { text }) => {
                 self.finish_turn();
                 self.emit_custom("session_generic", json!({ "text": text }));

--- a/crates/harnx-serve/src/lib.rs
+++ b/crates/harnx-serve/src/lib.rs
@@ -1239,6 +1239,10 @@ fn agent_sessions_json(config: &Config, agent: &str) -> Result<Vec<Value>> {
                 String::from("session_id"),
                 Value::String(session_id),
             )]);
+            value.insert(
+                String::from("title"),
+                session.title.map(Value::String).unwrap_or(Value::Null),
+            );
             if let Some(modified) = session.modified {
                 value.insert(
                     String::from("updated_at"),
@@ -1702,6 +1706,7 @@ mod tests {
                 git_remote: None,
                 terminal_session_id: None,
                 agent_name: Some("plain".into()),
+                title: None,
                 modified: None,
             },
             SessionMeta {
@@ -1712,6 +1717,7 @@ mod tests {
                 git_remote: None,
                 terminal_session_id: None,
                 agent_name: Some("other".into()),
+                title: None,
                 modified: None,
             },
             SessionMeta {
@@ -1722,6 +1728,7 @@ mod tests {
                 git_remote: None,
                 terminal_session_id: None,
                 agent_name: None,
+                title: None,
                 modified: None,
             },
         ];
@@ -1900,6 +1907,7 @@ mod tests {
             git_remote: None,
             terminal_session_id: None,
             agent_name: Some("plain".into()),
+            title: None,
             modified,
         };
 

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -5,6 +5,7 @@ use crate::types::Tui;
 use crate::types::{TranscriptItem, TuiEvent};
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
+use crossterm::ExecutableCommand;
 use harnx_core::event::{AgentEvent, AgentSource};
 use harnx_render::pretty_error_string;
 use harnx_runtime::config::{
@@ -1324,6 +1325,11 @@ impl Tui {
                 vec![TranscriptItem::ErrorText(format!(
                     "Compaction failed: {err}"
                 ))]
+            }
+            AgentEvent::Session(SessionEvent::TitleUpdated(title)) => {
+                let _ = std::io::stdout()
+                    .execute(crossterm::terminal::SetTitle(format!("harnx — {title}")));
+                vec![]
             }
             _ => vec![],
         };

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -354,6 +354,12 @@ impl Tui {
     pub async fn run(&mut self) -> Result<()> {
         let _panic_terminal_hook = PanicTerminalHookGuard::install();
         let mut terminal = Self::setup_terminal()?;
+
+        if let Some(title) = self.config.read().session.as_ref().and_then(|s| s.title()) {
+            let _ = std::io::stdout()
+                .execute(crossterm::terminal::SetTitle(format!("harnx — {title}")));
+        }
+
         let mut event_source = CrosstermEventSource;
         let result = self.run_loop_inner(&mut terminal, &mut event_source).await;
         Self::restore_terminal(&mut terminal)?;

--- a/crates/harnx-tui/src/terminal.rs
+++ b/crates/harnx-tui/src/terminal.rs
@@ -25,6 +25,7 @@ pub(super) fn cleanup_terminal_state() {
     }
     let _ = stdout.execute(DisableBracketedPaste);
     let _ = stdout.execute(DisableMouseCapture);
+    let _ = stdout.execute(crossterm::terminal::SetTitle("harnx"));
     let _ = stdout.execute(LeaveAlternateScreen);
     let _ = stdout.flush();
 }

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -7631,6 +7631,7 @@ async fn session_picker_enter_loads_selected_session() {
         git_remote: None,
         session_id: None,
         terminal_session_id: None,
+        title: None,
         modified: None,
     };
 
@@ -7720,6 +7721,7 @@ async fn session_picker_enter_reconciles_from_origin_not_current_agent() {
         git_remote: None,
         session_id: None,
         terminal_session_id: None,
+        title: None,
         modified: None,
     };
 
@@ -8316,6 +8318,24 @@ async fn render_agent_event_user_message_produces_user_transcript_entry() {
     ));
 }
 
+#[tokio::test]
+async fn render_agent_event_title_updated_executes_without_panic() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    // Verify handling a TitleUpdated event does not crash
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(harnx_core::event::SessionEvent::TitleUpdated(
+            "Test Title".to_string(),
+        )),
+        None,
+    ))
+    .await
+    .unwrap();
+}
 #[tokio::test]
 async fn render_agent_event_compacting_started_produces_transcript_entry() {
     let config = test_config();

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -1287,6 +1287,7 @@ mod tests_list_sessions_routing {
                 git_remote: None,
                 terminal_session_id: None,
                 agent_name: None,
+                title: None,
                 modified: None,
             },
             SessionMeta {
@@ -1297,6 +1298,7 @@ mod tests_list_sessions_routing {
                 git_remote: None,
                 terminal_session_id: None,
                 agent_name: None,
+                title: None,
                 modified: None,
             },
         ];
@@ -1323,6 +1325,7 @@ mod tests_list_sessions_routing {
             git_remote: None,
             terminal_session_id: None,
             agent_name: None,
+            title: None,
             modified: None,
         }];
         let output = format_sessions_for_output(&sessions);
@@ -1350,6 +1353,7 @@ mod tests_list_sessions_routing {
                 git_remote: None,
                 terminal_session_id: None,
                 agent_name: None,
+                title: None,
                 modified: None,
             },
             SessionMeta {
@@ -1360,6 +1364,7 @@ mod tests_list_sessions_routing {
                 git_remote: None,
                 terminal_session_id: None,
                 agent_name: None,
+                title: None,
                 modified: None,
             },
         ];

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -395,8 +395,3 @@ Agent prompts are rendered using [MiniJinja](https://github.com/mitsuhiko/miniji
 - `{{ tools }}`: A list of available tools. You can iterate over them: `{% for t in tools %}- {{ t.name }}: {{ t.description }}{% endfor %}`.
 - `{{ __os__ }}`, `{{ __arch__ }}`, `{{ __shell__ }}`, `{{ __cwd__ }}`, `{{ __now__ }}`, `{{ __locale__ }}`: Environment and system information.
 
-## Built-in Agents
-
-Harnx includes one internal agent:
-
-- `%create-title%`: Generates session titles automatically. This is internal and not intended for direct use.

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -200,3 +200,44 @@ See the [RAG Guide](rag-guide.md) for detailed setup instructions.
 
 - **highlight**: Whether to enable syntax highlighting.
 - **light_theme**: Whether to use the light theme.
+
+### Session Titles
+
+Harnx can automatically generate a short, human-readable title for each session
+using an LLM. Titles are stored in the session log and shown in session
+listings (local and remote). The active title is also used to set the terminal
+window title in the TUI and the browser tab title in the web UI (as
+`harnx — <title>`).
+
+- **title_agent**: Name of the agent used to generate titles. When unset, no
+  titles are generated. Can be set globally in `config.yaml` or per-agent in an
+  agent's front matter (the agent-level value takes precedence). Point it at a
+  small, fast chat model.
+- **title_update_threshold**: Number of tokens of growth after which the title
+  is regenerated. Defaults to `50000`. The first title is generated on the first
+  exchange (growth from 0 crosses any non-zero threshold). Set to `0` to disable
+  automatic title generation entirely.
+
+Example `config.yaml`:
+
+```yaml
+title_agent: title-writer      # an agent configured with a small, fast model
+title_update_threshold: 50000
+```
+
+You can also override the title agent for a specific agent in its front matter:
+
+```yaml
+---
+model: openai:gpt-4o
+title_agent: title-writer
+---
+```
+
+**Do not configure a reasoning model** (e.g. OpenAI `o1`/`o3`, DeepSeek-R1) as
+the `title_agent`. Such models spend their token budget on internal reasoning
+and often return an empty or truncated title. Use a standard chat model.
+
+To set a title manually, use the [`.set title`](tui-guide.md) command in the
+TUI. A manually set title freezes automatic regeneration for the rest of the
+session.

--- a/docs/solutions/feature-implementation/session-title-generation-pipeline-2026-07-15.md
+++ b/docs/solutions/feature-implementation/session-title-generation-pipeline-2026-07-15.md
@@ -1,0 +1,201 @@
+---
+title: "Session title generation pipeline with LLM-driven auto-titling"
+date: 2026-07-15
+category: "feature-implementation"
+problem_type: logic_error
+component: "harnx-core, harnx-runtime"
+root_cause: "Non-obvious edge cases in first-title trigger, replay token derivation, and title extraction for large logs"
+resolution_type: code_fix
+severity: medium
+tags:
+  - session-management
+  - title-generation
+  - replay-state
+  - async-pipeline
+  - nats-index
+  - backward-compatibility
+plan_ref: "session-title-generation"
+---
+
+## Problem
+
+Implementing automatic LLM-driven session title generation required mirroring the compaction pipeline's async pattern while handling non-obvious edge cases: first-title triggering, replay token state derivation, title extraction from large logs, manual title freeze, and NATS index propagation.
+
+## Symptoms
+
+Several design bugs emerged during review:
+
+- First title never generated — pure token-delta check (`tokens - last_updated >= 50000`) stays false for normal sessions
+- Large auto-titled sessions re-titled on every reload — `session.tokens` is 0 mid-replay, so deriving `title_last_updated_tokens` from it produces 0 baseline
+- Manual `.set title` not reflected in local listing after reload
+- Titles in middle of >128KB logs missed by bounded prefix scan
+- Remote listing title lags behind local
+
+## Investigation Steps
+
+### 1. First-Title Trigger
+
+`need_generate_title` checked only `tokens.saturating_sub(title_last_updated_tokens) >= threshold`. For new sessions (`tokens=1000`, `last=0`), `1000 >= 50000` is false. Fix: add `title.is_none() && tokens > 0` check first.
+
+### 2. Mid-Replay Token State
+
+Session log replay runs BEFORE `update_tokens()` computes the cumulative count. Any `session.tokens` read during replay is stale (0 at start, partial during iteration). Deriving `title_last_updated_tokens = session.tokens` at replay time sets it to 0 for large auto-titled sessions, causing re-generation on every reload.
+
+Fix: persist the token count directly in the `Title` log entry:
+```rust
+#[serde(rename = "title")]
+Title {
+    title: String,
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    tokens: usize,
+    #[serde(default, skip_serializing_if = "Not::not")]
+    manual: bool,
+},
+```
+
+Replay restores `title_last_updated_tokens = entry.tokens` (or `usize::MAX` for manual titles).
+
+### 3. Manual Title Freeze Across Reload
+
+`.set title` sets `manual: true` and `tokens: usize::MAX`. Replay recognizes manual titles and sets `title_last_updated_tokens = usize::MAX` — a sentinel that never crosses the regeneration threshold.
+
+### 4. Latest Title Extraction
+
+Initially `scan_first_title` returned the first `Title` in 64KB prefix. This hid regeneration events and manual overrides appending later.
+
+Fix: `scan_latest_title` reads the whole file (lossy utf8), string-splits on `---` doc boundaries, parses each chunk, returns the LAST `Title` found. A bounded window is insufficient — titles can land in the middle of large logs.
+
+### 5. NATS Index Propagation (Option A)
+
+`generate_title` is NATS-free — no kv::Store plumbing. The worker's existing per-activation `upsert_session_index_record` carries the latest `Title` from `effective_entries`. Tradeoff: remote listing title lags by one activation. The `update_session_title` CAS helper exists but has no caller — kept as tested public API for future use.
+
+## Solution
+
+### Async Title Pipeline (mirrors compaction)
+
+```rust
+// session_ops_title.rs — fire-and-forget spawn pattern
+pub fn maybe_generate_title(config: GlobalConfig) {
+    let threshold = config.read().data.title_update_threshold;
+    let need = config.read().session.as_ref()
+        .map(|s| s.need_generate_title(threshold))
+        .unwrap_or(false);
+    if !need { return; }
+    
+    config.write().session.as_mut().map(|s| s.set_titling(true));
+    let session_id = config.read().session.as_ref().map(|s| s.id.clone());
+    
+    tokio::spawn(async move {
+        let result = generate_title(&config).await;
+        // Session-swap guard before mutation
+        if config.read().session.as_ref().map(|s| &s.id) != session_id.as_ref() {
+            return; // session swapped, abort
+        }
+        config.write().session.as_mut().map(|s| s.set_titling(false));
+        if let Some(title) = result.ok().flatten() {
+            emit_agent_event(AgentEvent::Session(SessionEvent::TitleUpdated(title)));
+        }
+    });
+}
+```
+
+### First-Title Trigger Logic
+
+```rust
+pub fn need_generate_title(&self, threshold: usize) -> bool {
+    if self.titling { return false; }
+    if threshold == 0 { return false; }
+    // First title: no title yet but tokens exist
+    if self.title.is_none() && self.tokens > 0 { return true; }
+    // Regeneration: token delta exceeds threshold
+    self.tokens.saturating_sub(self.title_last_updated_tokens) >= threshold
+}
+```
+
+### Title Log Entry with Token Persistence
+
+```rust
+// Generation writes tokens = session.tokens, manual = false
+SessionLogEntry::Title {
+    title: cleaned_title,
+    tokens: session.tokens(),
+    manual: false,
+}
+
+// Manual set writes tokens = session.tokens, manual = true
+SessionLogEntry::Title {
+    title: user_title,
+    tokens: session.tokens(),
+    manual: true,
+}
+
+// Replay restores state from entry, NOT from session.tokens
+SessionLogEntry::Title { title, tokens, manual } => {
+    session.title = Some(title);
+    session.title_last_updated_tokens = if manual { usize::MAX } else { tokens };
+}
+```
+
+### Latest Title Scanning
+
+```rust
+pub fn scan_latest_title(path: &Path) -> Option<String> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    last_title_in_buffer(&contents)
+}
+
+fn last_title_in_buffer(contents: &str) -> Option<String> {
+    let mut last: Option<String> = None;
+    for doc in contents.split("\n---").flat_map(|d| d.split("\n---\r\n")) {
+        if let Ok(SessionLogEntry::Title { title, .. }) = serde_yaml::from_str(doc) {
+            last = Some(title);
+        }
+    }
+    last
+}
+```
+
+### Backward Compatibility
+
+`SessionLogEntry::Title` placed before `#[serde(other)] Unknown`. New fields use `#[serde(default)]`. Old entries without `tokens`/`manual` deserialize with defaults (0/false). `SessionIndexRecord.title` uses `#[serde(default, skip_serializing_if)]`.
+
+## Why This Works
+
+1. **First-title check**: Explicit `title.is_none()` triggers generation after first exchange regardless of threshold
+2. **Token persistence**: `Title.tokens` captures the actual count at generation time, replay restores it directly without relying on `session.tokens` (which is stale during replay)
+3. **Manual sentinel**: `usize::MAX` makes regeneration mathematically impossible — `tokens.saturating_sub(usize::MAX) >= threshold` is always false
+4. **Whole-file scan**: Titles can appear mid-log; bounded windows miss them. Reading whole file is correct; perf cost is acceptable for sessions (files are session logs, not arbitrary large data)
+5. **Option A propagation**: Simple — no NATS plumbing on generation path, worker handles propagation on next activation. Log is source of truth.
+
+## Prevention Strategies
+
+### Replay State Rules
+
+- Never derive replay-able state from `session.tokens`, `session.modified`, or any field computed post-replay
+- Persist required values directly in log entries with `#[serde(default)]` for backward compat
+- Test: reload a session with many tokens, verify `title_last_updated_tokens` matches generation time not 0
+
+### Async Pipeline Patterns
+
+- Mirror compaction: `titling` flag, `tokio::spawn`, session-id guard against swap, flag clear in spawn
+- Re-entrancy guard (`titling`) checked BEFORE spawn
+- Session-swap check AFTER spawn, BEFORE mutation
+
+### Enumeration Extraction
+
+- Append-only events require LATEST semantics, not FIRST
+- Bounded prefix scans are insufficient for events that can appear mid-file
+- Test with >128KB fixture, event placed past prefix boundary
+
+### Concurrency Safety (WORKFLOW)
+
+- Multiple editing agents on shared working tree caused mass file deletion via git checkout/restore
+- **Edit strictly serially** — one agent at a time on the same checkout
+- Recover with `git reset --hard HEAD` after verified commit
+
+## Related Issues
+
+- **GitHub:** [Issue #103](https://github.com/dobesv/harnx/issues/103)
+- **Prior removal:** [temp-session-title-removal-2026-05-12.md](../workflow-issues/temp-session-title-removal-2026-05-12.md) — explains why the earlier title system was removed
+- **NATS index pattern:** [nats-kv-session-index-enumeration-2026-06-27.md](../integration-issues/nats-kv-session-index-enumeration-2026-06-27.md) — index read/write pattern
+- **Async pattern:** [session-actor-concurrency-invariants-2026-07-04.md](../async-patterns/session-actor-concurrency-invariants-2026-07-04.md) — spawn/flag/guard patterns

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -118,7 +118,13 @@ If the response is interrupted or unsatisfactory, you can regenerate it with `.r
 .set rag_reranker_model <tab>
 .set rag_top_k 4
 .set highlight true
+.set title My Custom Session Title
 ```
+
+`.set title <text>` sets a title for the current session. The text may contain
+spaces. Setting a title manually freezes automatic title regeneration for the
+rest of the session. See the [Configuration Guide](configuration-guide.md#session-titles)
+for automatic title generation (`title_agent`, `title_update_threshold`).
 
 ### `.edit` - modify config/session/agent/rag-docs
 

--- a/example_config/agents/example-title-agent.md
+++ b/example_config/agents/example-title-agent.md
@@ -1,0 +1,16 @@
+---
+model: openai:gpt-4o-mini
+description: "Example session title agent — generates a short, human-readable title"
+---
+Generate a concise session title (10 words or fewer).
+
+Rules:
+- Plain text only — no quotes, no punctuation at the end, no markdown
+- Natural language (not slug/kebab-case)
+- Capture the main topic or goal
+- RESPOND WITH THE TITLE ONLY
+
+Examples:
+Debugging Rust async lifetime errors
+Setting up PostgreSQL connection pooling
+Planning a hiking trip to Patagonia

--- a/example_config/config.yaml
+++ b/example_config/config.yaml
@@ -10,6 +10,19 @@ save_session: true
 cleanup_inactive_sessions_days: 14
 keybindings: emacs
 
+# ---- session titles ----
+# Auto-generate a short, human-readable title for each session using an LLM.
+# Titles appear in session listings and set the terminal / browser tab title.
+# `title_agent` names an agent (see agents/example-title-agent.md); leave it
+# unset to disable title generation. Point it at a small, fast chat model —
+# NOT a reasoning model (o1/o3/DeepSeek-R1), which exhaust the token budget on
+# internal reasoning and return empty/truncated titles.
+title_agent: example-title-agent
+# Regenerate the title after this many additional tokens of conversation
+# (default 50000). The first title is generated on the first exchange. Set to 0
+# to disable automatic generation entirely.
+title_update_threshold: 50000
+
 # ---- tool-use ----
 tool_use: true
 use_tools: '*'

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>web</title>
+    <title>harnx</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/ChatProvider.tsx
+++ b/web/src/ChatProvider.tsx
@@ -7,6 +7,7 @@ import type { AgentSubscriber, Message } from '@ag-ui/client';
 import { PendingContext } from './PendingContext';
 import { UsageContext, type UsageData } from './UsageContext';
 import { uploadAttachment } from './api';
+import { setDocumentTitle } from './sessionTitle';
 
 export interface ChatProviderProps {
   agentName: string;
@@ -114,13 +115,13 @@ export class HarnxHttpAgent extends HttpAgent {
   }
 
   private handleCustomEvent(name: string, value: any) {
-    if (name === 'status') {
-      this.onStatus(value?.text || null);
-    } else if (name === 'usage') {
-      this.onUsageCb(value);
-    } else if (name === 'tool_summary') {
-      this.onToolSummaryCb(value?.tool_call_id, value?.markdown);
-    }
+    const handlers: Record<string, (v: any) => void> = {
+      status: (v) => this.onStatus(v?.text || null),
+      usage: (v) => this.onUsageCb(v),
+      tool_summary: (v) => this.onToolSummaryCb(v?.tool_call_id, v?.markdown),
+      session_title_updated: (v) => setDocumentTitle(v?.title),
+    };
+    handlers[name]?.(value);
   }
 
   override async runAgent(params: any, subscriber?: AgentSubscriber) {

--- a/web/src/__tests__/ChatProvider.test.ts
+++ b/web/src/__tests__/ChatProvider.test.ts
@@ -218,6 +218,25 @@ describe('toAgUiMessages', () => {
       });
       expect(onStatus).toHaveBeenCalledWith('Running');
 
+      // Simulate onEvent CUSTOM session_title_updated
+      await subscriber.onEvent({
+        event: {
+          type: 'CUSTOM',
+          name: 'session_title_updated',
+          value: { title: 'New Test Title' }
+        }
+      });
+      expect(document.title).toBe('harnx — New Test Title');
+
+      await subscriber.onEvent({
+        event: {
+          type: 'CUSTOM',
+          name: 'session_title_updated',
+          value: { title: '' }
+        }
+      });
+      expect(document.title).toBe('harnx');
+
       // Test missing fields tolerance (e.g. older server without context_tokens)
       await subscriber.onEvent({
         event: {

--- a/web/src/sessionTitle.ts
+++ b/web/src/sessionTitle.ts
@@ -1,0 +1,12 @@
+/** Base document/tab title used when no session title is present. */
+export const DEFAULT_DOCUMENT_TITLE = 'harnx';
+
+/** Format a session title for display in the browser tab. */
+export function formatDocumentTitle(title?: string | null): string {
+  return title ? `${DEFAULT_DOCUMENT_TITLE} — ${title}` : DEFAULT_DOCUMENT_TITLE;
+}
+
+/** Set the browser tab title from an optional session title. */
+export function setDocumentTitle(title?: string | null): void {
+  document.title = formatDocumentTitle(title);
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -8,6 +8,7 @@ export interface Agent {
 
 export interface SessionRef {
   session_id: string;
+  title?: string | null;
   updated_at?: string | number | null;
   [key: string]: unknown;
 }

--- a/web/src/useAgentSessions.ts
+++ b/web/src/useAgentSessions.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { listAgents, listSessions, newSessionId } from './api';
 import type { Agent, SessionRef } from './types';
+import { setDocumentTitle } from './sessionTitle';
 
 export function useAgentSessions() {
   const getInitialState = () => {
@@ -91,6 +92,13 @@ export function useAgentSessions() {
     setSelectedSessionId('');
   }, []);
 
+
+  useEffect(() => {
+    const session = selectedSessionId
+      ? sessions.find(s => s.session_id === selectedSessionId)
+      : undefined;
+    setDocumentTitle(session?.title);
+  }, [selectedSessionId, sessions]);
   return {
     agents,
     agentsError,


### PR DESCRIPTION
Implements automatic session title generation triggered by token usage thresholds. Titles are generated using a configurable LLM agent and stored as append-only SessionLogEntry::Title events in the session log. These titles are indexed in SessionMeta and SessionIndexRecord for fast listing in local, remote (NATS), and serve API contexts.

Key features:
- Periodic auto-generation (default every 50,000 tokens)
- Immediate generation after the first exchange
- Manual override via `.set title <text>` command, which freezes regeneration
- Efficient title propagation to NATS KV session indices
- Integration with the serve API for remote session discovery
- Comprehensive documentation and integration tests

Issue: #103
Plan: session-title-generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic AI-generated session titles (after the first exchange and then as sessions grow), configurable via `title_agent` and `title_update_threshold`.
  * Titles now appear in local listings, remote listings, the serve API, and can be matched in session history search.
  * Added live UI updates: the TUI window title and browser tab title update whenever titles are generated or changed.
  * Added `.set title <text>` to set a manual title and stop further automatic regeneration for that session.
* **Documentation**
  * Added “Session Titles” documentation, including configuration examples and manual-title behavior.
  * Updated TUI docs and removed internal built-in-agent documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->