### PR TITLE
Only convert large pastes into attachments

### DIFF
--- a/.changeset/paste-attachment-size-threshold.md
+++ b/.changeset/paste-attachment-size-threshold.md
@@ -1,0 +1,15 @@
+---
+"harnx": patch
+---
+
+fix(tui): only convert large pastes into attachments
+
+Previously any multi-line paste was turned into a text attachment, which was
+annoying for small pastes of just a few lines. A paste now becomes an
+attachment only when it is large — more than 8 lines or more than 512
+characters. Smaller multi-line pastes are inserted inline into the input.
+
+- Line counting uses `str::lines()` so a single trailing newline does not
+  inflate the count.
+- Character counting uses `chars().count()`, so the limit is measured in
+  characters rather than bytes (multibyte text is counted correctly).

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -27,6 +27,24 @@ const ATTACHMENT_PREVIEW_HEAD_LINES: usize = ATTACHMENT_PREVIEW_MAX_LINES / 2;
 const ATTACHMENT_PREVIEW_TAIL_LINES: usize =
     ATTACHMENT_PREVIEW_MAX_LINES - ATTACHMENT_PREVIEW_HEAD_LINES;
 
+/// A multi-line paste is only converted into an attachment when it is "large".
+/// Small pastes (a handful of short lines) are inserted inline instead, so
+/// pasting a couple of lines is not needlessly turned into a file.
+///
+/// A paste becomes an attachment when it exceeds EITHER of these limits.
+const PASTE_ATTACHMENT_MAX_LINES: usize = 8;
+const PASTE_ATTACHMENT_MAX_CHARS: usize = 512;
+
+/// Returns true when a normalized (LF-only) paste is large enough to warrant
+/// being stored as an attachment rather than inserted inline.
+///
+/// Line counting uses `str::lines()` so a single trailing newline does not
+/// inflate the count (an 8-line paste ending in `\n` still counts as 8 lines).
+fn paste_should_attach(text: &str) -> bool {
+    let line_count = text.lines().count();
+    line_count > PASTE_ATTACHMENT_MAX_LINES || text.chars().count() > PASTE_ATTACHMENT_MAX_CHARS
+}
+
 /// How long `start_prompt` waits for a prior prompt task to finish
 /// cooperatively (after signalling its abort) before force-cancelling it
 /// via `JoinHandle::abort`. Long enough for `bash_wait` and similar
@@ -710,8 +728,8 @@ impl Tui {
         }
         // Normalize line endings: \r\n -> \n, then \r -> \n
         let text = text.replace("\r\n", "\n").replace('\r', "\n");
-        if text.contains('\n') {
-            // Multi-line paste: write to temp file and attach
+        if paste_should_attach(&text) {
+            // Large paste: write to temp file and attach
             match self.write_paste_to_attachment_dir(&text).await {
                 Ok(attachment) => {
                     self.app.attachments.push(attachment);
@@ -723,7 +741,7 @@ impl Tui {
                 }
             }
         } else {
-            // Single-line paste: insert inline
+            // Small paste (single line or a few short lines): insert inline
             self.app.input.insert_str(&text);
         }
     }
@@ -2848,9 +2866,54 @@ impl Tui {
 
 #[cfg(test)]
 mod tests {
+    use super::paste_should_attach;
     use super::tool_completed_to_transcript_items;
     use crate::types::TranscriptItem;
     use serde_json::json;
+
+    #[test]
+    fn paste_should_attach_thresholds() {
+        // Single line, short: inline.
+        assert!(!paste_should_attach("just one line"));
+        // A few short lines: inline.
+        assert!(!paste_should_attach("line one\nline two\nline three"));
+        // Exactly at the line limit (8 lines): still inline.
+        assert!(!paste_should_attach("1\n2\n3\n4\n5\n6\n7\n8"));
+        // 8 content lines with a trailing newline must still count as 8 lines
+        // (str::lines ignores the trailing newline): inline.
+        assert!(!paste_should_attach("1\n2\n3\n4\n5\n6\n7\n8\n"));
+        // Over the line limit (9 lines): attach.
+        assert!(paste_should_attach("1\n2\n3\n4\n5\n6\n7\n8\n9"));
+        // Two lines but over the character limit: attach.
+        let long = "a".repeat(600);
+        assert!(paste_should_attach(&format!("{long}\n{long}")));
+    }
+
+    #[test]
+    fn paste_should_attach_char_boundary() {
+        // Exactly at the char limit (512): inline.
+        let at_limit = "a".repeat(512);
+        assert_eq!(at_limit.chars().count(), 512);
+        assert!(!paste_should_attach(&at_limit));
+        // One over the char limit (513): attach.
+        let over_limit = "a".repeat(513);
+        assert!(paste_should_attach(&over_limit));
+    }
+
+    #[test]
+    fn paste_should_attach_counts_chars_not_bytes() {
+        // 300 multibyte chars (each is multiple bytes) stays under the 512-char
+        // limit even though its byte length far exceeds 512: inline.
+        let multibyte = "é".repeat(300);
+        assert_eq!(multibyte.chars().count(), 300);
+        assert!(
+            multibyte.len() > 512,
+            "byte length should exceed char limit"
+        );
+        assert!(!paste_should_attach(&multibyte));
+        // 513 multibyte chars exceeds the char limit: attach.
+        assert!(paste_should_attach(&"é".repeat(513)));
+    }
 
     #[test]
     fn tool_completed_preserves_fenced_diff_in_transcript() {

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -3269,12 +3269,17 @@ async fn paste_multiline_creates_temp_attachment() {
         .await
         .unwrap();
 
-    tui.handle_paste("line one\nline two\nline three".to_string())
-        .await;
+    // 9 lines exceeds the small-paste threshold, so this becomes an attachment.
+    let pasted =
+        "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9".to_string();
+    tui.handle_paste(pasted.clone()).await;
 
-    // Multi-line paste should NOT insert into the textarea
+    // Large multi-line paste should NOT insert into the textarea
     let text = tui.app.input.lines().join("\n");
-    assert_eq!(text, "", "Multi-line paste should not go into textarea");
+    assert_eq!(
+        text, "",
+        "Large multi-line paste should not go into textarea"
+    );
 
     // Instead it should create a temp file attachment in the attachment dir
     assert_eq!(tui.app.attachments.len(), 1, "Should create one attachment");
@@ -3292,7 +3297,7 @@ async fn paste_multiline_creates_temp_attachment() {
     let contents = tokio::fs::read_to_string(&tui.app.attachments[0].path)
         .await
         .unwrap();
-    assert_eq!(contents, "line one\nline two\nline three");
+    assert_eq!(contents, pasted);
 
     // No submission should have occurred
     let user_entries: Vec<_> = tui
@@ -3318,9 +3323,12 @@ async fn paste_multiline_with_cr_creates_temp_attachment() {
         .await
         .unwrap();
 
-    // Some terminals send \r instead of \n for newlines in paste
-    tui.handle_paste("line one\rline two\rline three".to_string())
-        .await;
+    // Some terminals send \r instead of \n for newlines in paste.
+    // 9 lines exceeds the small-paste threshold, so this becomes an attachment.
+    tui.handle_paste(
+        "line 1\rline 2\rline 3\rline 4\rline 5\rline 6\rline 7\rline 8\rline 9".to_string(),
+    )
+    .await;
 
     assert_eq!(
         tui.app.attachments.len(),
@@ -3329,7 +3337,7 @@ async fn paste_multiline_with_cr_creates_temp_attachment() {
     );
     let contents = std::fs::read_to_string(&tui.app.attachments[0].path).unwrap();
     assert_eq!(
-        contents, "line one\nline two\nline three",
+        contents, "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9",
         "CRs should be normalized to LFs"
     );
 
@@ -3344,9 +3352,13 @@ async fn paste_multiline_with_crlf_creates_temp_attachment() {
         .await
         .unwrap();
 
-    // Windows-style line endings
-    tui.handle_paste("line one\r\nline two\r\nline three".to_string())
-        .await;
+    // Windows-style line endings.
+    // 9 lines exceeds the small-paste threshold, so this becomes an attachment.
+    tui.handle_paste(
+        "line 1\r\nline 2\r\nline 3\r\nline 4\r\nline 5\r\nline 6\r\nline 7\r\nline 8\r\nline 9"
+            .to_string(),
+    )
+    .await;
 
     assert_eq!(
         tui.app.attachments.len(),
@@ -3356,7 +3368,7 @@ async fn paste_multiline_with_crlf_creates_temp_attachment() {
 
     let contents = std::fs::read_to_string(&tui.app.attachments[0].path).unwrap();
     assert_eq!(
-        contents, "line one\nline two\nline three",
+        contents, "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9",
         "CRLFs should be normalized to LFs"
     );
 
@@ -3379,6 +3391,107 @@ async fn paste_single_line_inserts_inline() {
         tui.app.attachments.is_empty(),
         "Single-line paste should not create attachment"
     );
+}
+
+#[tokio::test]
+async fn paste_small_multiline_inserts_inline() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    // A few short lines should stay inline rather than becoming an attachment.
+    tui.handle_paste("line one\nline two\nline three".to_string())
+        .await;
+
+    let text = tui.app.input.lines().join("\n");
+    assert_eq!(text, "line one\nline two\nline three");
+    assert!(
+        tui.app.attachments.is_empty(),
+        "Small multi-line paste should not create attachment"
+    );
+}
+
+#[tokio::test]
+async fn paste_small_crlf_multiline_normalizes_inline() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    // Small paste with Windows line endings stays inline and is normalized to LF.
+    tui.handle_paste("line one\r\nline two".to_string()).await;
+
+    let text = tui.app.input.lines().join("\n");
+    assert_eq!(text, "line one\nline two");
+    assert!(
+        tui.app.attachments.is_empty(),
+        "Small CRLF paste should not create attachment"
+    );
+}
+
+#[tokio::test]
+async fn paste_many_lines_creates_attachment() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    // More than the line threshold (8) of short lines becomes an attachment.
+    let pasted: String = (1..=9)
+        .map(|n| format!("line {n}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    tui.handle_paste(pasted.clone()).await;
+
+    assert_eq!(
+        tui.app.attachments.len(),
+        1,
+        "Paste over the line threshold should create attachment"
+    );
+    assert_eq!(
+        tui.app.input.lines().join("\n"),
+        "",
+        "Large paste should not go into the textarea"
+    );
+    let contents = tokio::fs::read_to_string(&tui.app.attachments[0].path)
+        .await
+        .unwrap();
+    assert_eq!(contents, pasted);
+
+    tui.cleanup_attachments();
+}
+
+#[tokio::test]
+async fn paste_long_two_line_text_creates_attachment() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    // Only two lines, but the total character count exceeds the size threshold
+    // (512), so it should still become an attachment.
+    let long_line = "x".repeat(400);
+    let pasted = format!("{long_line}\n{long_line}");
+    assert!(pasted.chars().count() > 512);
+    tui.handle_paste(pasted.clone()).await;
+
+    assert_eq!(
+        tui.app.attachments.len(),
+        1,
+        "Paste over the size threshold should create attachment"
+    );
+    assert_eq!(
+        tui.app.input.lines().join("\n"),
+        "",
+        "Large paste should not go into the textarea"
+    );
+
+    tui.cleanup_attachments();
 }
 
 #[tokio::test]
@@ -3413,8 +3526,11 @@ async fn detach_cleans_up_temp_dir() {
         .await
         .unwrap();
 
-    // Paste multi-line to create a temp attachment
-    tui.handle_paste("line one\nline two".to_string()).await;
+    // Paste large multi-line text to create a temp attachment
+    tui.handle_paste(
+        "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9".to_string(),
+    )
+    .await;
     assert_eq!(tui.app.attachments.len(), 1);
     let temp_dir = tui.app.attachment_dir.clone().unwrap();
     let temp_path = tui.app.attachments[0].path.clone();

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -17,6 +17,7 @@ There is no readline-based REPL.
 - **Multi-line input** via paste (bracketed-paste terminals) or `Shift+Enter` / `Ctrl+J` to insert a newline.
 - **History:** `↑` / `↓` to navigate prior submissions.
 - **Attachments:** `.attach <path>` to attach a file to the next message; `.detach` to remove.
+  - **Large pastes** (more than 8 lines or more than 512 characters) are automatically saved as a text attachment instead of being inserted inline. Smaller multi-line pastes are inserted directly into the input.
 
 ## Dot-Commands
 


### PR DESCRIPTION
Previously any multi-line paste was converted into a text attachment, which was annoying for small pastes of just a few lines. A paste now becomes an attachment only when it exceeds a size threshold — more than 8 lines or more than 512 characters. Smaller multi-line pastes are inserted inline into the input.

- Line counting uses str::lines() so a trailing newline does not inflate the count.
- Character counting uses chars().count() (measured in characters, not bytes; multibyte text counted correctly).
- Updated tests and docs/tui-guide.md.

Closes #1042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Small multi-line pastes (up to 8 lines and 512 characters) are inserted directly into the input.
  * Larger pastes are automatically saved as text attachments.
  * Paste handling consistently normalizes line endings.

* **Documentation**
  * Updated the TUI guide with the new large-paste thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->