### PR TITLE
Build and install web UI to serve's default assets dir

### DIFF
--- a/.changeset/xtask-install-web-assets.md
+++ b/.changeset/xtask-install-web-assets.md
@@ -1,0 +1,9 @@
+---
+"harnx": minor
+---
+
+`cargo xtask install` now builds the web UI (`pnpm install` + `pnpm build` in
+`web/`) and copies the compiled assets into the default directory `harnx serve`
+loads from (`<data_dir>/web-assets`, e.g. `~/.local/share/harnx/web-assets`), so
+a local install serves the web client out of the box. Pass `--skip-web` to
+install only the Rust binaries. Closes #1040.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
  "bytes-utils",
  "fastrand",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -708,7 +708,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
  "pin-project-lite",
@@ -788,7 +788,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
  "pin-utils",
@@ -848,7 +848,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "num-integer",
@@ -897,7 +897,7 @@ dependencies = [
  "form_urlencoded",
  "futures-util",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -928,7 +928,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -4211,7 +4211,7 @@ dependencies = [
  "harnx-runtime",
  "harnx-session",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -4517,9 +4517,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.1.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -4534,7 +4534,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -4605,7 +4605,7 @@ dependencies = [
  "futures-core",
  "h2",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -4672,7 +4672,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "hyper",
  "ipnet",
  "libc",
@@ -5247,7 +5247,7 @@ dependencies = [
  "either",
  "futures",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -7068,7 +7068,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -7149,7 +7149,7 @@ dependencies = [
  "chrono",
  "futures",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "pastey",
  "pin-project-lite",
@@ -7955,7 +7955,7 @@ checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
 dependencies = [
  "bytes",
  "futures-util",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
 ]
@@ -8613,7 +8613,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.4.2",
- "http-body 1.1.0",
+ "http-body 1.0.1",
  "mime",
  "pin-project-lite",
  "tower",

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ faster compile) and an optional list of bin names to restrict the install. It
 always builds with the committed `Cargo.lock` for a reproducible result and
 overwrites any existing bins.
 
+It also builds the web UI (via `pnpm install` + `pnpm build` in `web/`) and
+copies the compiled assets into the default directory `harnx serve` loads from
+(`<data_dir>/web-assets`, i.e. `~/.local/share/harnx/web-assets` on Linux). This
+requires [pnpm](https://pnpm.io/) on your `PATH`. Pass `--skip-web` to install
+only the Rust binaries and skip the web UI.
+
 ### Pre-built Binaries
 
 Download pre-built archives for macOS, Linux, and Windows from

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         version: 2.15.0(@types/node@24.13.3)(typescript@7.0.2)
       oxlint:
         specifier: ^1.71.0
-        version: 1.74.0
+        version: 1.73.0
       typescript:
         specifier: ~7.0.0
         version: 7.0.2
@@ -353,124 +353,124 @@ packages:
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
-  '@oxlint/binding-android-arm-eabi@1.74.0':
-    resolution: {integrity: sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw==}
+  '@oxlint/binding-android-arm-eabi@1.73.0':
+    resolution: {integrity: sha512-HZQRN/UMBu+Ut+/9MiAChkbP4qZqrNOWBcNI45vOT40GVhbGR0JgHB87L48D4iAqFQIdVmeQYtV9RF89AjTKkg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.74.0':
-    resolution: {integrity: sha512-xjKdoMB+H+RCOByv/7l7nfIGW9mlOisqYdcyC75UqYuQecLpReAeEYUf2CNeDEI3KtmUgxpRw/+c63y4AeF/Bw==}
+  '@oxlint/binding-android-arm64@1.73.0':
+    resolution: {integrity: sha512-Gp+KJRylv2aW7thRpG5p1KTxZq4ZJFbWowrKzufNq9d3ssl3r3JviYV45/+p+7CN1Nv0zDd1e8Ex0b/HUDq4TQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.74.0':
-    resolution: {integrity: sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ==}
+  '@oxlint/binding-darwin-arm64@1.73.0':
+    resolution: {integrity: sha512-3de96NdtXhxERMjIz7wsp2HYMY6pMQycGxFWac2mFecAx6VeARF/IqFb1QIaqiCRIdfzBwzTed+pCTCoiS+CYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.74.0':
-    resolution: {integrity: sha512-ggKc/tn5SJ1u2yG2izC6VKODfYKV8MQ2AicJlNzOjuyrC29udvOef6/JzK2r32xqCnBDLFouR1VCkjzEI0/N9Q==}
+  '@oxlint/binding-darwin-x64@1.73.0':
+    resolution: {integrity: sha512-5zx/uPW32TiaOeVY1dQ/H5iOf0K1HOdFKOJhLqGl4o63+i1fpzoqqu/mKtd7OFgFjNCdhlyTGgjVkQTZm1ELcg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.74.0':
-    resolution: {integrity: sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g==}
+  '@oxlint/binding-freebsd-x64@1.73.0':
+    resolution: {integrity: sha512-qNe4gKHaGnLuZJ8toUg90JAa0S2vTVvDw+0bRi3q1avXZXDT4u5mMeECf3nD4HYrbdn1O7dXqWut4onY/yx/Xg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
-    resolution: {integrity: sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.73.0':
+    resolution: {integrity: sha512-cCehYh5hTbfShm/fxTD6wwrGUWIpvX+N5OxmAMhFhDeTGXvw+BeNj889tpxsFQ9ZLatQ6wImuY8tsKLZ+FMz7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.74.0':
-    resolution: {integrity: sha512-//PKyQb/tQXcHArx2f7z+oVI/eMS2Jpv+edNuAtOrgIhWdGcpHxogveAxzmF2rpH1AIHp4Hq04RF/rgJdiICnQ==}
+  '@oxlint/binding-linux-arm-musleabihf@1.73.0':
+    resolution: {integrity: sha512-d5j5GDU/2dMgjVhw7TQT9ITrsIr1Y02KEXKyVGIXUkD+KiaxE9TP65FS2ZdgTBemQvoRL+gSBdbrIm3cQIeacg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.74.0':
-    resolution: {integrity: sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w==}
+  '@oxlint/binding-linux-arm64-gnu@1.73.0':
+    resolution: {integrity: sha512-Eyf1SrP3+yR1DI3OJgOY2Pvrr9dWP9TK37xPaDYycwTtlGlI45erJAVIfH5/m/xosDt6BupJYEFi47bvbTuuyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.74.0':
-    resolution: {integrity: sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg==}
+  '@oxlint/binding-linux-arm64-musl@1.73.0':
+    resolution: {integrity: sha512-IlT/OJApEDKaMmCooHuncgJZbbCe7T5QIWmTZBEtYscWvzPQuuEinVcid6kwQRVQOUdb7PUCz4jQHnaYXdfJXw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.74.0':
-    resolution: {integrity: sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw==}
+  '@oxlint/binding-linux-ppc64-gnu@1.73.0':
+    resolution: {integrity: sha512-L+JYcb/vdg5fmcH08V6o0YYLU28cTH1SPNulwJdvK9NK49aXSkYy6oNpKBmddArVOXYqNepriDGiZ04G54kh1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.74.0':
-    resolution: {integrity: sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg==}
+  '@oxlint/binding-linux-riscv64-gnu@1.73.0':
+    resolution: {integrity: sha512-Qtk0g3bKV6OwWjIm7R8kQN1uOZRKQt/MODK2a8QfkwhTpXBD53ozx5XLVWLGDQAVyp2otLW4D2wB98XfAfMPGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.74.0':
-    resolution: {integrity: sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw==}
+  '@oxlint/binding-linux-riscv64-musl@1.73.0':
+    resolution: {integrity: sha512-wX0NQKZVxltkAOVmzFcpOaMpdaUvsq1Eqpx9tkAfl71UdkTlSo1R4AdAnGccR1Fm2+TzFgZ22CyyGuZ41RDr/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.74.0':
-    resolution: {integrity: sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA==}
+  '@oxlint/binding-linux-s390x-gnu@1.73.0':
+    resolution: {integrity: sha512-vPe7UGBMWyiLTtnqS4xxgMQFSFGmtQwhwCxuiw6lXygaO6bVt0D8dFVg8Xv05eaiN3ybC0HXXHUAohFMFvqoCQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.74.0':
-    resolution: {integrity: sha512-+aIvJyrdeD7LwCQ2WYLMUWNmnbeDRSPb40aBYtPjD9+PTqUwgJnk+HK5yLfSMeqXrMrDhE9uTmtt2y50tvjhHw==}
+  '@oxlint/binding-linux-x64-gnu@1.73.0':
+    resolution: {integrity: sha512-2CwIWr9cemFC/CbRBWZvuk5mffz6ObmfFkfcC/9rTQ7f+icNhYr2kOjf9Rt8lLvugvkdGDOmkoVoFFHh6ClCTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.74.0':
-    resolution: {integrity: sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg==}
+  '@oxlint/binding-linux-x64-musl@1.73.0':
+    resolution: {integrity: sha512-nDadfJgg7NBBxG0N560wOe7LLX5QiYp6qBaI7viuk5EUORFBktU/NfV0MbTqU3gTqQDCh4VyxKdo5VADxk9w8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.74.0':
-    resolution: {integrity: sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg==}
+  '@oxlint/binding-openharmony-arm64@1.73.0':
+    resolution: {integrity: sha512-wGjJC+NLH9xP+IKGn9RDW94ojJR/wPbg5WCnQjj/oReaOtCQthr8ws1zICe77JFmo4ouUdeTHHZL/ESGiF6Pmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.74.0':
-    resolution: {integrity: sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA==}
+  '@oxlint/binding-win32-arm64-msvc@1.73.0':
+    resolution: {integrity: sha512-I7X47GPGljw225YUQ5SbC/rb1Kkdrd0yQf0x+hYxeKS6DpfjMbo9ccQPQ6LNY6BoJQ1sHhgDUGuMn5Vg5gHT6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.74.0':
-    resolution: {integrity: sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ==}
+  '@oxlint/binding-win32-ia32-msvc@1.73.0':
+    resolution: {integrity: sha512-5lWj+3h+74Fm1jYOO9qkJA4xkAlZA099DkXppuXsk7UpnpZLttsefrZU469vChGaG6hcSqrkKXQOvMTZtbjeNg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.74.0':
-    resolution: {integrity: sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA==}
+  '@oxlint/binding-win32-x64-msvc@1.73.0':
+    resolution: {integrity: sha512-WaNRvh4f6zY9CvUQk2YoA1O90ieWrIklI84+HXFr9Isjz9CSESrdqo/RtIYt4Dll/cAchqGDMehfaZd0vqEFZw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2089,8 +2089,8 @@ packages:
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
-  oxlint@1.74.0:
-    resolution: {integrity: sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA==}
+  oxlint@1.73.0:
+    resolution: {integrity: sha512-u91G9TJzU6yqKWNZUYprQB07W7YvntZXaRxQ6CkoytepYhLWUXWsr1M8zUJ34VatNPuUAr3Z8GH+O2A331CluQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2924,61 +2924,61 @@ snapshots:
 
   '@oxc-project/types@0.139.0': {}
 
-  '@oxlint/binding-android-arm-eabi@1.74.0':
+  '@oxlint/binding-android-arm-eabi@1.73.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.74.0':
+  '@oxlint/binding-android-arm64@1.73.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.74.0':
+  '@oxlint/binding-darwin-arm64@1.73.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.74.0':
+  '@oxlint/binding-darwin-x64@1.73.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.74.0':
+  '@oxlint/binding-freebsd-x64@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.74.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.74.0':
+  '@oxlint/binding-linux-arm64-gnu@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.74.0':
+  '@oxlint/binding-linux-arm64-musl@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.74.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.74.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.74.0':
+  '@oxlint/binding-linux-riscv64-musl@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.74.0':
+  '@oxlint/binding-linux-s390x-gnu@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.74.0':
+  '@oxlint/binding-linux-x64-gnu@1.73.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.74.0':
+  '@oxlint/binding-linux-x64-musl@1.73.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.74.0':
+  '@oxlint/binding-openharmony-arm64@1.73.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.74.0':
+  '@oxlint/binding-win32-arm64-msvc@1.73.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.74.0':
+  '@oxlint/binding-win32-ia32-msvc@1.73.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.74.0':
+  '@oxlint/binding-win32-x64-msvc@1.73.0':
     optional: true
 
   '@playwright/test@1.61.1':
@@ -4713,27 +4713,27 @@ snapshots:
 
   outvariant@1.4.3: {}
 
-  oxlint@1.74.0:
+  oxlint@1.73.0:
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.74.0
-      '@oxlint/binding-android-arm64': 1.74.0
-      '@oxlint/binding-darwin-arm64': 1.74.0
-      '@oxlint/binding-darwin-x64': 1.74.0
-      '@oxlint/binding-freebsd-x64': 1.74.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.74.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.74.0
-      '@oxlint/binding-linux-arm64-gnu': 1.74.0
-      '@oxlint/binding-linux-arm64-musl': 1.74.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.74.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.74.0
-      '@oxlint/binding-linux-riscv64-musl': 1.74.0
-      '@oxlint/binding-linux-s390x-gnu': 1.74.0
-      '@oxlint/binding-linux-x64-gnu': 1.74.0
-      '@oxlint/binding-linux-x64-musl': 1.74.0
-      '@oxlint/binding-openharmony-arm64': 1.74.0
-      '@oxlint/binding-win32-arm64-msvc': 1.74.0
-      '@oxlint/binding-win32-ia32-msvc': 1.74.0
-      '@oxlint/binding-win32-x64-msvc': 1.74.0
+      '@oxlint/binding-android-arm-eabi': 1.73.0
+      '@oxlint/binding-android-arm64': 1.73.0
+      '@oxlint/binding-darwin-arm64': 1.73.0
+      '@oxlint/binding-darwin-x64': 1.73.0
+      '@oxlint/binding-freebsd-x64': 1.73.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.73.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.73.0
+      '@oxlint/binding-linux-arm64-gnu': 1.73.0
+      '@oxlint/binding-linux-arm64-musl': 1.73.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.73.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.73.0
+      '@oxlint/binding-linux-riscv64-musl': 1.73.0
+      '@oxlint/binding-linux-s390x-gnu': 1.73.0
+      '@oxlint/binding-linux-x64-gnu': 1.73.0
+      '@oxlint/binding-linux-x64-musl': 1.73.0
+      '@oxlint/binding-openharmony-arm64': 1.73.0
+      '@oxlint/binding-win32-arm64-msvc': 1.73.0
+      '@oxlint/binding-win32-ia32-msvc': 1.73.0
+      '@oxlint/binding-win32-x64-msvc': 1.73.0
 
   parse-entities@4.0.2:
     dependencies:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::ffi::OsString;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -32,6 +32,7 @@ enum CommandLine {
 
 struct InstallArgs {
     debug: bool,
+    skip_web: bool,
     bins: Vec<String>,
 }
 
@@ -50,11 +51,13 @@ fn parse_cli(args: Vec<OsString>) -> Result<CommandLine> {
 
 fn parse_install_args(args: &[OsString]) -> Result<InstallArgs> {
     let mut debug = false;
+    let mut skip_web = false;
     let mut bins = Vec::new();
 
     for arg in args {
         match arg.to_str() {
             Some("--debug") => debug = true,
+            Some("--skip-web") => skip_web = true,
             Some("-h") | Some("--help") => {
                 print_install_help();
                 std::process::exit(0);
@@ -67,7 +70,11 @@ fn parse_install_args(args: &[OsString]) -> Result<InstallArgs> {
         }
     }
 
-    Ok(InstallArgs { debug, bins })
+    Ok(InstallArgs {
+        debug,
+        skip_web,
+        bins,
+    })
 }
 
 fn install(args: InstallArgs) -> Result<()> {
@@ -102,6 +109,220 @@ fn install(args: InstallArgs) -> Result<()> {
         install_binary(&source, &destination)?;
     }
 
+    if args.skip_web {
+        println!("==> Skipping web-ui build (--skip-web)");
+    } else {
+        install_web_assets(&metadata.workspace_root)?;
+    }
+
+    Ok(())
+}
+
+/// Build the web UI and copy the compiled assets into the directory that
+/// `harnx serve` loads from by default (`<data_dir>/web-assets`).
+///
+/// The web project lives in `web/` at the workspace root and builds with pnpm
+/// (`pnpm install` + `pnpm build`), emitting static files into `web/dist`.
+fn install_web_assets(workspace_root: &Path) -> Result<()> {
+    let web_dir = workspace_root.join("web");
+    if !web_dir.join("package.json").is_file() {
+        bail!(
+            "web project not found at {} (missing package.json); pass --skip-web to skip",
+            web_dir.display()
+        );
+    }
+
+    let pnpm = pnpm_command();
+    ensure_pnpm_available(&pnpm)?;
+
+    println!("==> Installing web-ui dependencies (pnpm install)");
+    let mut install = Command::new(&pnpm);
+    install
+        .arg("install")
+        .arg("--frozen-lockfile")
+        .current_dir(&web_dir);
+    run_command(&mut install, "pnpm install")?;
+
+    println!("==> Building web-ui (pnpm build)");
+    let mut build = Command::new(&pnpm);
+    build.arg("build").current_dir(&web_dir);
+    run_command(&mut build, "pnpm build")?;
+
+    let dist = web_dir.join("dist");
+    if !dist.is_dir() {
+        bail!(
+            "web build did not produce a dist directory at {}",
+            dist.display()
+        );
+    }
+
+    let destination = harnx_data_dir()?.join("web-assets");
+    println!("==> Installing web-ui assets -> {}", destination.display());
+    replace_dir(&dist, &destination)?;
+
+    Ok(())
+}
+
+/// Resolve the pnpm executable, honoring an override via `PNPM` for
+/// environments where pnpm is invoked through a wrapper (e.g. corepack).
+fn pnpm_command() -> OsString {
+    env::var_os("PNPM").unwrap_or_else(|| OsString::from("pnpm"))
+}
+
+/// Verify the pnpm executable can be run before we lean on it, so a missing
+/// pnpm yields an actionable message instead of a raw "No such file" IO error.
+fn ensure_pnpm_available(pnpm: &OsString) -> Result<()> {
+    match Command::new(pnpm).arg("--version").output() {
+        Ok(output) if output.status.success() => Ok(()),
+        Ok(output) => Err(command_failure(
+            "pnpm --version",
+            output.status,
+            &output.stderr,
+        )),
+        Err(err) => Err(anyhow::Error::from(err).context(format!(
+            "failed to run `{}` — install pnpm (https://pnpm.io/) or pass --skip-web \
+             to install without the web UI",
+            pnpm.to_string_lossy()
+        ))),
+    }
+}
+
+/// Root data directory, mirroring `harnx_core::config_paths::data_dir()`:
+/// 1. `HARNX_DATA_DIR` env var (literal path).
+/// 2. `XDG_DATA_HOME/harnx` (XDG override).
+/// 3. OS default (`dirs::data_dir()/harnx`).
+///
+/// Reimplemented locally to keep `xtask` free of a `harnx-core` dependency.
+fn harnx_data_dir() -> Result<PathBuf> {
+    if let Some(v) = env::var_os("HARNX_DATA_DIR") {
+        if !v.is_empty() {
+            return Ok(PathBuf::from(v));
+        }
+    }
+    if let Some(v) = env::var_os("XDG_DATA_HOME") {
+        if !v.is_empty() {
+            return Ok(PathBuf::from(v).join("harnx"));
+        }
+    }
+    dirs::data_dir()
+        .map(|dir| dir.join("harnx"))
+        .ok_or_else(|| {
+            anyhow!("failed to resolve data dir from HARNX_DATA_DIR, XDG_DATA_HOME, or OS default")
+        })
+}
+
+/// Replace `destination` with a fresh copy of `source`, keeping stale files
+/// from previous builds from lingering.
+///
+/// The copy lands in a sibling staging directory first; only once it is fully
+/// populated do we swap it into place with a double rename
+/// (`destination -> <destination>.old`, then `staging -> destination`). Renames
+/// are near-instant and, on Windows, moving a directory that holds open files
+/// tends to succeed where deleting it in place would fail — so a concurrent
+/// `harnx serve` is very unlikely to observe a missing or half-written asset
+/// directory.
+fn replace_dir(source: &Path, destination: &Path) -> Result<()> {
+    let parent = destination
+        .parent()
+        .ok_or_else(|| anyhow!("destination {} has no parent dir", destination.display()))?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create dir {}", parent.display()))?;
+
+    let file_name = destination
+        .file_name()
+        .ok_or_else(|| anyhow!("destination {} has no file name", destination.display()))?;
+    let staging = sibling_with_suffix(parent, file_name, ".new");
+    let backup = sibling_with_suffix(parent, file_name, ".old");
+
+    // Clean up leftovers from a previous interrupted run.
+    remove_dir_if_exists(&staging)
+        .with_context(|| format!("failed to clear stale staging dir {}", staging.display()))?;
+    remove_dir_if_exists(&backup)
+        .with_context(|| format!("failed to clear stale backup dir {}", backup.display()))?;
+
+    if let Err(err) = copy_dir_recursive(source, &staging) {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(err);
+    }
+
+    // Move any existing install aside first so the destination is only briefly
+    // absent (between two renames) rather than during a full delete.
+    let had_existing = destination.exists();
+    if had_existing {
+        if let Err(err) = fs::rename(destination, &backup) {
+            let _ = fs::remove_dir_all(&staging);
+            return Err(err).with_context(|| {
+                format!(
+                    "failed to move existing dir {} aside to {}",
+                    destination.display(),
+                    backup.display()
+                )
+            });
+        }
+    }
+
+    if let Err(err) = fs::rename(&staging, destination) {
+        // Roll back: restore the previous install if we moved it aside.
+        if had_existing {
+            let _ = fs::rename(&backup, destination);
+        }
+        let _ = fs::remove_dir_all(&staging);
+        return Err(err).with_context(|| {
+            format!(
+                "failed to move staged assets {} into place at {}",
+                staging.display(),
+                destination.display()
+            )
+        });
+    }
+
+    // Best-effort cleanup of the superseded install.
+    let _ = fs::remove_dir_all(&backup);
+    Ok(())
+}
+
+/// Build a sibling path in `parent` named `.<file_name><suffix>`.
+fn sibling_with_suffix(parent: &Path, file_name: &std::ffi::OsStr, suffix: &str) -> PathBuf {
+    let mut name = OsString::from(".");
+    name.push(file_name);
+    name.push(suffix);
+    parent.join(name)
+}
+
+/// Remove `dir` recursively if it exists, treating a missing dir as success.
+fn remove_dir_if_exists(dir: &Path) -> Result<()> {
+    match fs::remove_dir_all(dir) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Recursively copy the contents of `source` into `destination`.
+fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<()> {
+    fs::create_dir_all(destination)
+        .with_context(|| format!("failed to create dir {}", destination.display()))?;
+    for entry in
+        fs::read_dir(source).with_context(|| format!("failed to read dir {}", source.display()))?
+    {
+        let entry =
+            entry.with_context(|| format!("failed to read entry in {}", source.display()))?;
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("failed to stat {}", entry.path().display()))?;
+        let target = destination.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_recursive(&entry.path(), &target)?;
+        } else {
+            fs::copy(entry.path(), &target).with_context(|| {
+                format!(
+                    "failed to copy {} to {}",
+                    entry.path().display(),
+                    target.display()
+                )
+            })?;
+        }
+    }
     Ok(())
 }
 
@@ -267,6 +488,11 @@ fn parse_metadata(stdout: &[u8]) -> Result<Metadata> {
         .and_then(Value::as_str)
         .map(PathBuf::from)
         .ok_or_else(|| anyhow!("cargo metadata missing string target_directory"))?;
+    let workspace_root = root
+        .get("workspace_root")
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow!("cargo metadata missing string workspace_root"))?;
 
     let packages = root
         .get("packages")
@@ -279,6 +505,7 @@ fn parse_metadata(stdout: &[u8]) -> Result<Metadata> {
     Ok(Metadata {
         packages,
         target_directory,
+        workspace_root,
         workspace_members,
     })
 }
@@ -381,12 +608,13 @@ fn help_text() -> &'static str {
 }
 
 fn install_help_text() -> &'static str {
-    "Build and copy workspace binaries into cargo bin dir\n\nUsage: cargo xtask install [OPTIONS] [BINS]...\n\nArguments:\n  [BINS]...  Restrict install to one or more workspace binary names\n\nOptions:\n      --debug  Install debug build instead of default release build\n  -h, --help   Print help"
+    "Build and copy workspace binaries into cargo bin dir\n\nAlso builds the web UI (pnpm) and copies it to the default web-assets\ndirectory that `harnx serve` loads from (<data_dir>/web-assets).\n\nUsage: cargo xtask install [OPTIONS] [BINS]...\n\nArguments:\n  [BINS]...  Restrict install to one or more workspace binary names\n\nOptions:\n      --debug     Install debug build instead of default release build\n      --skip-web  Skip building and installing the web UI assets\n  -h, --help      Print help"
 }
 
 struct Metadata {
     packages: Vec<MetadataPackage>,
     target_directory: PathBuf,
+    workspace_root: PathBuf,
     workspace_members: BTreeSet<String>,
 }
 
@@ -400,4 +628,184 @@ struct MetadataPackage {
 struct MetadataTarget {
     name: String,
     kind: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::id;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// Serialize env-mutating tests: process-global env is shared across the
+    /// binary, so concurrent mutation would race.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn unique_tmp(label: &str) -> PathBuf {
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        env::temp_dir().join(format!("xtask-{label}-{}-{n}", id()))
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        prev: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prev = env::var_os(key);
+            env::set_var(key, value);
+            Self { key, prev }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let prev = env::var_os(key);
+            env::remove_var(key);
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => env::set_var(self.key, v),
+                None => env::remove_var(self.key),
+            }
+        }
+    }
+
+    #[test]
+    fn harnx_data_dir_prefers_explicit_env() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _xdg = EnvVarGuard::unset("XDG_DATA_HOME");
+        let _data = EnvVarGuard::set("HARNX_DATA_DIR", "/tmp/explicit-data");
+        assert_eq!(
+            harnx_data_dir().unwrap(),
+            PathBuf::from("/tmp/explicit-data")
+        );
+    }
+
+    #[test]
+    fn harnx_data_dir_uses_xdg_override() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _data = EnvVarGuard::unset("HARNX_DATA_DIR");
+        let _xdg = EnvVarGuard::set("XDG_DATA_HOME", "/tmp/xdg-data");
+        assert_eq!(
+            harnx_data_dir().unwrap(),
+            PathBuf::from("/tmp/xdg-data").join("harnx")
+        );
+    }
+
+    #[test]
+    fn copy_dir_recursive_copies_nested_tree() {
+        let src = unique_tmp("copy-src");
+        let dst = unique_tmp("copy-dst");
+        fs::create_dir_all(src.join("assets")).unwrap();
+        fs::write(src.join("index.html"), b"<html>").unwrap();
+        fs::write(src.join("assets").join("app.js"), b"console.log(1)").unwrap();
+
+        copy_dir_recursive(&src, &dst).unwrap();
+
+        assert_eq!(fs::read(dst.join("index.html")).unwrap(), b"<html>");
+        assert_eq!(
+            fs::read(dst.join("assets").join("app.js")).unwrap(),
+            b"console.log(1)"
+        );
+
+        fs::remove_dir_all(&src).ok();
+        fs::remove_dir_all(&dst).ok();
+    }
+
+    #[test]
+    fn replace_dir_clears_stale_files() {
+        let src = unique_tmp("replace-src");
+        let dst = unique_tmp("replace-dst");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("new.txt"), b"new").unwrap();
+
+        // Pre-populate destination with a stale file that must not survive.
+        fs::create_dir_all(&dst).unwrap();
+        fs::write(dst.join("stale.txt"), b"stale").unwrap();
+
+        replace_dir(&src, &dst).unwrap();
+
+        assert!(dst.join("new.txt").is_file());
+        assert!(!dst.join("stale.txt").exists());
+
+        fs::remove_dir_all(&src).ok();
+        fs::remove_dir_all(&dst).ok();
+    }
+
+    #[test]
+    fn replace_dir_swaps_over_existing_install_without_residue() {
+        let base = unique_tmp("replace-base");
+        let src = base.join("src");
+        let dst = base.join("web-assets");
+        fs::create_dir_all(src.join("assets")).unwrap();
+        fs::write(src.join("index.html"), b"v2").unwrap();
+        fs::write(src.join("assets").join("app.js"), b"v2js").unwrap();
+
+        // Existing install with a stale file that must be gone afterwards.
+        fs::create_dir_all(&dst).unwrap();
+        fs::write(dst.join("old.html"), b"v1").unwrap();
+
+        replace_dir(&src, &dst).unwrap();
+
+        assert_eq!(fs::read(dst.join("index.html")).unwrap(), b"v2");
+        assert_eq!(
+            fs::read(dst.join("assets").join("app.js")).unwrap(),
+            b"v2js"
+        );
+        assert!(!dst.join("old.html").exists());
+        // No leftover staging/backup siblings.
+        assert!(!base.join(".web-assets.new").exists());
+        assert!(!base.join(".web-assets.old").exists());
+
+        fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn harnx_data_dir_falls_back_to_os_default() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _data = EnvVarGuard::unset("HARNX_DATA_DIR");
+        let _xdg = EnvVarGuard::unset("XDG_DATA_HOME");
+        // On CI/dev hosts dirs::data_dir() resolves; assert the harnx suffix.
+        if let Some(expected) = dirs::data_dir() {
+            assert_eq!(harnx_data_dir().unwrap(), expected.join("harnx"));
+        }
+    }
+
+    #[test]
+    fn parse_install_args_accepts_skip_web() {
+        let args = parse_install_args(&[OsString::from("--skip-web")]).unwrap();
+        assert!(args.skip_web);
+        assert!(!args.debug);
+        assert!(args.bins.is_empty());
+    }
+
+    #[test]
+    fn parse_install_args_default_builds_web() {
+        let args = parse_install_args(&[]).unwrap();
+        assert!(!args.skip_web);
+    }
+
+    #[test]
+    fn parse_metadata_reads_workspace_root() {
+        let json = br#"{
+            "workspace_members": ["pkg 0.1.0 (path+file:///w)"],
+            "target_directory": "/w/target",
+            "workspace_root": "/w",
+            "packages": []
+        }"#;
+        let metadata = parse_metadata(json).unwrap();
+        assert_eq!(metadata.workspace_root, PathBuf::from("/w"));
+        assert_eq!(metadata.target_directory, PathBuf::from("/w/target"));
+    }
+
+    #[test]
+    fn install_help_mentions_web_and_skip_flag() {
+        let help = install_help_text();
+        assert!(help.contains("web UI"));
+        assert!(help.contains("--skip-web"));
+    }
 }


### PR DESCRIPTION
`cargo xtask install` now builds the web UI (pnpm install --frozen-lockfile
+ pnpm build in web/) and installs the compiled web/dist assets into the directory `harnx serve` loads from by default (<data_dir>/web-assets, i.e. ~/.local/share/harnx/web-assets). Data-dir resolution mirrors harnx-core's XDG logic (HARNX_DATA_DIR → XDG_DATA_HOME/harnx → dirs::data_dir()/harnx). Adds a --skip-web flag to install only the Rust binaries, a pnpm-availability preflight with an actionable error, and an atomic double-rename swap when replacing the installed assets. Documents the new behavior in the README and adds a changeset.

Closes #1040

Plan: xtask-install-web-assets