### PR TITLE
feat(mcp-fs): serialize concurrent file mutations to prevent corruption

### DIFF
--- a/.changeset/fs-server-per-file-locking.md
+++ b/.changeset/fs-server-per-file-locking.md
@@ -1,0 +1,5 @@
+---
+harnx: minor
+---
+
+Serialize concurrent mutations in the filesystem MCP server to prevent corruption from parallel edits. Same-file edits (write, edit, insert, re_replace) are now serialized via per-file locks, while `rollback_file` takes an exclusive repository-wide lock so it cannot interleave with concurrent edits to other files in the same repository.

--- a/crates/harnx-mcp-fs/src/server/handlers.rs
+++ b/crates/harnx-mcp-fs/src/server/handlers.rs
@@ -15,10 +15,67 @@ impl FsServer {
             roots: Arc::new(RwLock::new(initial_roots.clone())),
             roots_initialized: Arc::new(AtomicBool::new(false)),
             history: Arc::new(HistoryManager::new(&initial_roots)),
+            repo_locks: Arc::new(Mutex::new(HashMap::new())),
+            file_locks: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    async fn snapshot_before(&self, path: &Path, label: &str) -> Option<gix::ObjectId> {
+    fn repo_lock_key_for_path(path: &Path) -> PathBuf {
+        harnx_mcp_history::discover::find_repo_for_path(path)
+            .or_else(|| path.parent().map(Path::to_path_buf))
+            .unwrap_or_else(|| path.to_path_buf())
+    }
+
+    fn repo_lock_for_path(&self, path: &Path) -> Arc<RwLock<()>> {
+        let key = Self::repo_lock_key_for_path(path);
+        let mut locks = self
+            .repo_locks
+            .lock()
+            .expect("repo lock registry mutex poisoned");
+        locks.retain(|_, weak| weak.strong_count() > 0);
+
+        if let Some(lock) = locks.get(&key).and_then(Weak::upgrade) {
+            return lock;
+        }
+
+        let lock = Arc::new(RwLock::new(()));
+        locks.insert(key, Arc::downgrade(&lock));
+        lock
+    }
+
+    fn lock_for_path(&self, path: &Path) -> Arc<AsyncMutex<()>> {
+        let mut locks = self
+            .file_locks
+            .lock()
+            .expect("per-file lock registry mutex poisoned");
+        locks.retain(|_, weak| weak.strong_count() > 0);
+
+        if let Some(lock) = locks.get(path).and_then(Weak::upgrade) {
+            return lock;
+        }
+
+        let lock = Arc::new(AsyncMutex::new(()));
+        locks.insert(path.to_path_buf(), Arc::downgrade(&lock));
+        lock
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn repo_read_guard_for_path(
+        &self,
+        path: &Path,
+    ) -> tokio::sync::OwnedRwLockReadGuard<()> {
+        self.repo_lock_for_path(path).read_owned().await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn repo_write_guard_for_path(
+        &self,
+        path: &Path,
+    ) -> tokio::sync::OwnedRwLockWriteGuard<()> {
+        self.repo_lock_for_path(path).write_owned().await
+    }
+
+    pub(crate) async fn snapshot_before(&self, path: &Path, label: &str) -> Option<gix::ObjectId> {
         self.history
             .snapshot_file(path, label)
             .await
@@ -28,7 +85,7 @@ impl FsServer {
             .ok()
     }
 
-    async fn snapshot_after_diff(
+    pub(crate) async fn snapshot_after_diff(
         &self,
         path: &Path,
         before: Option<gix::ObjectId>,
@@ -467,6 +524,10 @@ impl FsServer {
         let roots = self.roots.read().await;
         let path = validate_write_path(&params.path, &roots).map_err(invalid_params)?;
         drop(roots);
+        let repo_lock = self.repo_lock_for_path(&path);
+        let _repo_guard = repo_lock.read().await;
+        let file_lock = self.lock_for_path(&path);
+        let _file_guard = file_lock.lock().await;
 
         if params.content.len() > WRITE_MAX_BYTES {
             return tool_error(format!(
@@ -512,6 +573,10 @@ impl FsServer {
         let roots = self.roots.read().await;
         let path = validate_write_path(&params.path, &roots).map_err(invalid_params)?;
         drop(roots);
+        let repo_lock = self.repo_lock_for_path(&path);
+        let _repo_guard = repo_lock.read().await;
+        let file_lock = self.lock_for_path(&path);
+        let _file_guard = file_lock.lock().await;
 
         let before_snap = self.snapshot_before(&path, "before insert").await;
 
@@ -564,6 +629,10 @@ impl FsServer {
         let roots = self.roots.read().await;
         let path = validate_write_path(&params.path, &roots).map_err(invalid_params)?;
         drop(roots);
+        let repo_lock = self.repo_lock_for_path(&path);
+        let _repo_guard = repo_lock.read().await;
+        let file_lock = self.lock_for_path(&path);
+        let _file_guard = file_lock.lock().await;
 
         let before_snap = self.snapshot_before(&path, "before re_replace").await;
 
@@ -635,6 +704,10 @@ impl FsServer {
         let roots = self.roots.read().await;
         let path = validate_write_path(&params.path, &roots).map_err(invalid_params)?;
         drop(roots);
+        let repo_lock = self.repo_lock_for_path(&path);
+        let _repo_guard = repo_lock.read().await;
+        let file_lock = self.lock_for_path(&path);
+        let _file_guard = file_lock.lock().await;
 
         let before_snap = self.snapshot_before(&path, "before edit_file").await;
 
@@ -906,12 +979,18 @@ impl FsServer {
         let path = validate_path(&params.repo_path, &roots).map_err(invalid_params)?;
         drop(roots);
 
+        // Validate inputs and resolve the repository root *before* taking the
+        // exclusive repo lock, so invalid requests fail fast without blocking
+        // concurrent edits, and so the lock is keyed on the real repo root.
         let commit_id = gix::ObjectId::from_hex(params.commit_id.as_bytes())
             .map_err(|e| ErrorData::invalid_params(format!("invalid commit_id: {e}"), None))?;
 
         let repo_dir = harnx_mcp_history::discover::find_repo_for_path(&path).ok_or_else(|| {
             ErrorData::invalid_params("path is not inside a git repository".to_string(), None)
         })?;
+
+        let repo_lock = self.repo_lock_for_path(&repo_dir);
+        let _repo_guard = repo_lock.write().await;
 
         let new_commit_id = self
             .history

--- a/crates/harnx-mcp-fs/src/server/mod.rs
+++ b/crates/harnx-mcp-fs/src/server/mod.rs
@@ -26,12 +26,13 @@ use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use tokio::sync::RwLock;
+use std::sync::{Arc, Mutex, Weak};
+use tokio::sync::{Mutex as AsyncMutex, RwLock};
 
 mod handler;
 mod handlers;
@@ -48,6 +49,8 @@ pub struct FsServer {
     roots: Arc<RwLock<Vec<PathBuf>>>,
     roots_initialized: Arc<AtomicBool>,
     history: Arc<HistoryManager>,
+    repo_locks: Arc<Mutex<HashMap<PathBuf, Weak<RwLock<()>>>>>,
+    file_locks: Arc<Mutex<HashMap<PathBuf, Weak<AsyncMutex<()>>>>>,
 }
 
 /// Build a `_meta` block with only the call template. We deliberately

--- a/crates/harnx-mcp-fs/src/server/tests.rs
+++ b/crates/harnx-mcp-fs/src/server/tests.rs
@@ -115,6 +115,21 @@ fn path_string(path: &Path) -> String {
     path.to_string_lossy().into_owned()
 }
 
+fn git(dir: &Path, args: &[&str]) {
+    let status = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .status()
+        .unwrap();
+    assert!(status.success(), "git {:?} failed with {status}", args);
+}
+
+fn init_git_repo(dir: &Path) {
+    git(dir, &["init"]);
+    git(dir, &["config", "user.name", "harnx test"]);
+    git(dir, &["config", "user.email", "harnx@example.com"]);
+}
+
 fn user_summary(result: &CallToolResult) -> String {
     result
         .content
@@ -1479,4 +1494,141 @@ async fn test_re_replace_invalid_pattern() {
         .unwrap_err();
 
     assert!(err.message.contains("invalid regex pattern"));
+}
+
+#[tokio::test]
+async fn test_insert_impl_serializes_concurrent_same_file_updates() {
+    let temp_dir = TestDir::new();
+    let file_path = write_fixture(&temp_dir, "concurrent_insert.txt", "start\n");
+    let server = FsServer::new(vec![temp_dir.path().to_path_buf()]);
+
+    let task_count = 32usize;
+    let mut tasks = tokio::task::JoinSet::new();
+    for index in 0..task_count {
+        let server = server.clone();
+        let path = path_string(&file_path);
+        tasks.spawn(async move {
+            server
+                .insert_impl(InsertParams {
+                    path,
+                    insert_line: None,
+                    insert_text: format!("task-{index}\n"),
+                    column: None,
+                })
+                .await
+        });
+    }
+
+    while let Some(result) = tasks.join_next().await {
+        let result = result.unwrap().unwrap();
+        assert_eq!(result.is_error, Some(false));
+    }
+
+    let content = std::fs::read_to_string(&file_path).unwrap();
+    let lines = content.lines().collect::<Vec<_>>();
+    assert_eq!(lines.len(), task_count + 1);
+    assert_eq!(lines[0], "start");
+
+    for index in 0..task_count {
+        assert!(
+            lines.contains(&format!("task-{index}").as_str()),
+            "missing task-{index} in final file: {content:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_repo_lock_for_paths_in_same_repo_share_lock() {
+    let temp_dir = TestDir::new();
+    init_git_repo(temp_dir.path());
+    let repo_root = temp_dir.path().canonicalize().unwrap();
+    let file_a = repo_root.join("a.txt");
+    std::fs::write(&file_a, "a\n").unwrap();
+    let nested_dir = repo_root.join("nested");
+    std::fs::create_dir_all(&nested_dir).unwrap();
+    let file_b = repo_root.join("nested/b.txt");
+    std::fs::write(&file_b, "b\n").unwrap();
+    let server = FsServer::new(vec![repo_root.clone()]);
+
+    let repo_guard = server.repo_write_guard_for_path(&file_a).await;
+    let same_repo_try = tokio::time::timeout(
+        std::time::Duration::from_millis(50),
+        server.repo_read_guard_for_path(&file_b),
+    )
+    .await;
+
+    assert!(
+        same_repo_try.is_err(),
+        "same repo lock should block readers while write held"
+    );
+    drop(repo_guard);
+
+    server.repo_read_guard_for_path(&file_b).await;
+}
+
+/// Gated to Unix because `std::env::temp_dir()` on Windows runners
+/// yields an 8.3 short-name path (`C:\\Users\\RUNNER~1\\...`); the
+/// canonicalize-then-`gix::open` flow inside `HistoryManager::new`
+/// then fails to register the repo, leaving the production code
+/// without a base to diff against. That's a pre-existing Windows
+/// limitation in `harnx-mcp-history`, not something this regression
+/// test introduces.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_rollback_excludes_concurrent_edits_in_same_repo() {
+    let temp_dir = TestDir::new();
+    init_git_repo(temp_dir.path());
+    let repo_root = temp_dir.path().canonicalize().unwrap();
+
+    let tracked_path = repo_root.join("tracked.txt");
+    std::fs::write(&tracked_path, "tracked-v1\n").unwrap();
+    let server = FsServer::new(vec![repo_root.clone()]);
+
+    let tracked_before = server
+        .snapshot_before(&tracked_path, "before tracked change")
+        .await
+        .unwrap();
+    std::fs::write(&tracked_path, "tracked-v2\n").unwrap();
+    let rollback_diff = server
+        .snapshot_after_diff(&tracked_path, Some(tracked_before), "after tracked change")
+        .await
+        .unwrap();
+    let rollback_commit = rollback_diff
+        .lines()
+        .next()
+        .unwrap()
+        .strip_prefix("commit ")
+        .unwrap()
+        .to_string();
+
+    let repo_guard = server.repo_write_guard_for_path(&tracked_path).await;
+    let edit_server = server.clone();
+    let edit_path = path_string(&repo_root.join("other.txt"));
+    let blocked_edit = tokio::spawn(async move {
+        tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            edit_server.write_file_impl(WriteFileParams {
+                path: edit_path,
+                content: "blocked\n".to_string(),
+            }),
+        )
+        .await
+    });
+
+    assert!(blocked_edit.await.unwrap().is_err());
+    drop(repo_guard);
+
+    let rollback_server = server.clone();
+    let rollback_path = path_string(&repo_root);
+    let rollback_task = tokio::spawn(async move {
+        rollback_server
+            .rollback_file_impl(RollbackParams {
+                commit_id: rollback_commit,
+                repo_path: rollback_path,
+            })
+            .await
+    });
+
+    let rollback_result = rollback_task.await.unwrap().unwrap();
+    assert_eq!(rollback_result.is_error, Some(false));
 }

--- a/docs/solutions/async-patterns/hierarchical-lock-concurrent-file-mutations-2026-07-20.md
+++ b/docs/solutions/async-patterns/hierarchical-lock-concurrent-file-mutations-2026-07-20.md
@@ -1,0 +1,161 @@
+---
+title: "Hierarchical two-level locking for concurrent file mutations in MCP filesystem server"
+date: 2026-07-20
+category: async-patterns
+problem_type: logic_error
+component: harnx-mcp-fs
+root_cause: "non-atomic read-modify-write with no serialization across concurrent tool calls"
+resolution_type: code_fix
+severity: high
+tags:
+  - tokio
+  - concurrency
+  - locking
+  - mcp-server
+  - deadlock-prevention
+  - rwlock
+  - weak-references
+plan_ref: issue-1101-fs-edit-serialization
+---
+
+## Problem
+
+Filesystem MCP server's mutating tools (`write`, `edit`, `insert`, `re_replace`, `rollback_file`) each performed non-atomic read-modify-write plus git history snapshots without locking. On a multi-threaded tokio runtime, concurrent `call_tool` invocations interleaved → file corruption, lost updates, truncated content. GitHub issue #1101.
+
+## Symptoms
+
+- Parallel edits to same file caused content corruption (truncation, mangling)
+- Lost updates when multiple handlers read-modify-wrote concurrently
+- `rollback_file` could interleave with edits to other files in same repo, corrupting working tree
+- Only manifested under actual concurrent agent tool batches; not reliably reproducible in sequential tests
+
+## Investigation Steps
+
+1. Identified all mutating handlers shared common pattern: validate → read file → modify → write → git snapshot
+2. Traced handler invocations through `rmcp` service layer → each `call_tool` runs concurrently on tokio runtime
+3. Recognized `rollback_file` as special case: mutates entire repo working tree, not just single file
+4. Initial per-file lock approach failed review: rollback keyed on `path` argument, but concurrent edits to OTHER files in same repo took different locks → could interleave
+5. Designed hierarchical two-level lock: repo-level RwLock (shared for file edits, exclusive for rollback) + per-file Mutex
+
+## Root Cause
+
+`FsServer` was Clone with shared state behind Arc, but no synchronization primitives. Each concurrent tool handler ran independently. The read-modify-write sequence is not atomic, so interleaving produced conflicts. `rollback_file` was especially problematic because it discovers repo root internally and mutates the whole working tree, but had no way to exclude concurrent file edits in the same repo.
+
+## Solution
+
+Added two lock registries to `FsServer`:
+
+```rust
+pub struct FsServer {
+    // ...existing fields...
+    repo_locks: Arc<std::sync::Mutex<HashMap<PathBuf, Weak<tokio::sync::RwLock<()>>>>>,
+    file_locks: Arc<std::sync::Mutex<HashMap<PathBuf, Weak<tokio::sync::Mutex<()>>>>>,
+}
+```
+
+### Lock Registry Helpers
+
+```rust
+fn repo_lock_key_for_path(path: &Path) -> PathBuf {
+    harnx_mcp_history::discover::find_repo_for_path(path)
+        .or_else(|| path.parent().map(Path::to_path_buf))
+        .unwrap_or_else(|| path.to_path_buf())
+}
+
+fn repo_lock_for_path(&self, path: &Path) -> Arc<RwLock<()>> {
+    let key = Self::repo_lock_key_for_path(path);
+    let mut locks = self.repo_locks.lock().expect("...");
+    locks.retain(|_, weak| weak.strong_count() > 0);  // prune dead entries
+    
+    if let Some(lock) = locks.get(&key).and_then(Weak::upgrade) {
+        return lock;
+    }
+    
+    let lock = Arc::new(RwLock::new(()));
+    locks.insert(key, Arc::downgrade(&lock));
+    lock
+}
+
+fn lock_for_path(&self, path: &Path) -> Arc<AsyncMutex<()>> {
+    // Same pattern for per-file locks
+}
+```
+
+### Lock Protocol (Uniform Order → Deadlock-Free)
+
+**File mutators** (write/insert/re_replace/edit):
+1. Acquire repo `RwLock` in READ (shared) mode
+2. Acquire per-file `Mutex` (exclusive)
+3. Hold both guards for entire handler via RAII
+
+**Rollback** (repo-wide operation):
+1. Validate repo root BEFORE taking lock (fail fast)
+2. Acquire repo `RwLock` in WRITE (exclusive) mode only
+3. No per-file lock needed — write lock excludes all file editors
+
+```rust
+// File mutator pattern
+let repo_lock = self.repo_lock_for_path(&path);
+let file_lock = self.lock_for_path(&path);
+let _repo_guard = repo_lock.read().await;
+let _file_guard = file_lock.lock().await;
+// ... perform mutation ...
+
+// Rollback pattern
+let repo_lock = self.repo_lock_for_path(&repo_dir);
+let _repo_guard = repo_lock.write().await;
+// ... rollback entire working tree ...
+```
+
+### Semantics
+
+- Different files, same repo → concurrent (each holds repo READ + different file Mutex)
+- Same file → serialized (same file Mutex)
+- Rollback vs any edit in same repo → mutually exclusive (repo WRITE blocks all READs)
+
+## Why This Works
+
+1. **Hierarchical ordering ensures deadlock prevention**: All handlers acquire repo lock first, then file lock. Rollback skips file lock. No cycles possible.
+
+2. **Weak-valued registry with retain prevents unbounded growth**: Each lookup prunes dead entries. No background task needed. Locks freed when last Arc dropped.
+
+3. **std::sync::Mutex guards never held across .await**: Registry mutex protects only the HashMap lookup/insert synchronously. Async locks acquired after releasing std guard.
+
+4. **Repo lock keyed on discovered root**: All path variants within same repo map to same repo lock. Uses `find_repo_for_path` to resolve canonical repo root.
+
+5. **Fail-fast before exclusive hold**: Rollback validates repo existence BEFORE acquiring write lock, minimizing time spent with writers blocked.
+
+## Prevention Strategies
+
+**Test Cases:**
+- Stress test with 32 concurrent inserts to one file → all survive (no lost updates)
+- Verify rollback excludes concurrent edits to different file in same repo
+- Verify same-repo paths share one repo lock; different repos get different locks
+- Run under `cargo nextest run -p harnx-mcp-fs --stress-count=5`
+
+**Code Review Checklist:**
+- [ ] Is lock acquisition order consistent across ALL handlers?
+- [ ] Are std::sync::Mutex guards NEVER held across .await points?
+- [ ] Does repo-wide operation acquire repo write lock before any mutation?
+- [ ] Is validation performed BEFORE taking exclusive locks (fail fast)?
+
+**Best Practices:**
+- Use hierarchical locks (coarse + fine-grained) to allow parallelism where possible
+- Key locks on canonical/discovered values, not user-provided paths
+- Prune weak-valued registries on lookup to prevent memory leaks
+- Document accepted edge cases and residual risks explicitly
+
+## Known Limitations
+
+1. **File creation path aliasing**: For non-existent write targets, `validate_write_path` returns non-canonical path. Path aliases (case differences) can key different file locks, bypassing same-file serialization for *creation*. Accepted as low-risk edge case.
+
+2. **Read-only tools don't lock**: Can observe transient state during rollback. Acceptable for current use case; read consistency would require repo read lock on all reads.
+
+3. **Poison propagation**: If a handler panics holding a lock, subsequent acquisitions unwrap poison. Could use `into_inner()` for recovery if needed.
+
+## Related Issues
+
+- **GitHub:** [#1101](https://github.com/dobesv/harnx/issues/1101) — Original issue
+- **Changeset:** `.changeset/fs-server-per-file-locking.md`
+- **Related:** [session-actor-concurrency-invariants-2026-07-04.md](../async-patterns/session-actor-concurrency-invariants-2026-07-04.md) — Actor concurrency patterns
+- **Related:** [mcp-server-background-task-supervision-2026-05-25.md](../async-patterns/mcp-server-background-task-supervision-2026-05-25.md) — spawn_blocking for fs I/O


### PR DESCRIPTION
Agents that fire multiple edits in parallel to the same file could corrupt it: the filesystem MCP server's mutating tools did a non-atomic read-modify-write plus git-history snapshots with no locking, so concurrent tool calls on the tokio runtime interleaved.

Add hierarchical in-memory locking to FsServer:
- per-file async mutex serializes edits to the same path
- repository-level RwLock: file mutators take it shared (read), rollback_file takes it exclusive (write), so a repo-wide rollback cannot interleave with edits to other files in the same repo
- Weak-valued self-pruning lock registries; std registry mutex is never held across .await; uniform roots -> repo -> file acquisition order avoids deadlock

Covered by concurrency stress tests (same-file serialization, rollback exclusion, repo-lock sharing).

Closes #1101

Plan: issue-1101-fs-edit-serialization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent edits to the same file from overwriting changes or corrupting filesystem state.
  * Improved rollback reliability by preventing it from interleaving with edits elsewhere in the same repository.
  * Preserved parallel editing for separate files when safe.

* **Documentation**
  * Added guidance on filesystem mutation concurrency, locking behavior, and related limitations.

* **Tests**
  * Added coverage for concurrent inserts, repository-level locking, and rollback interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->