### PR TITLE
Add harnx-mcp-remote stdio→HTTP MCP proxy binary

### DIFF
--- a/.changeset/harnx-mcp-remote-initial.md
+++ b/.changeset/harnx-mcp-remote-initial.md
@@ -4,4 +4,4 @@
 
 feat(mcp-remote): add stdio→HTTP MCP proxy binary
 
-Add `harnx-mcp-remote` — a stdio-based MCP server that transparently proxies all MCP traffic to a remote HTTP MCP server. Supports both streamable HTTP (MCP 2025-03) and legacy SSE (MCP 2024-11) transports via rmcp's unified StreamableHttpClientTransport. Auth via bearer token, custom headers, and mTLS, configurable through CLI flags or env vars.
+Add `harnx-mcp-remote` — a stdio-based MCP proxy for remote HTTP MCP servers. Supports forwarding negotiated MCP capabilities such as tools, prompts, and resources over both streamable HTTP (MCP 2025-03) and legacy SSE (MCP 2024-11) transports via rmcp's unified StreamableHttpClientTransport. Auth via bearer token, custom headers, and mTLS, configurable through CLI flags and most settings via env vars.

--- a/.changeset/harnx-mcp-remote-initial.md
+++ b/.changeset/harnx-mcp-remote-initial.md
@@ -1,0 +1,7 @@
+---
+"harnx": minor
+---
+
+feat(mcp-remote): add stdio→HTTP MCP proxy binary
+
+Add `harnx-mcp-remote` — a stdio-based MCP server that transparently proxies all MCP traffic to a remote HTTP MCP server. Supports both streamable HTTP (MCP 2025-03) and legacy SSE (MCP 2024-11) transports via rmcp's unified StreamableHttpClientTransport. Auth via bearer token, custom headers, and mTLS, configurable through CLI flags or env vars.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3969,6 +3969,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "harnx-mcp-remote"
+version = "0.33.3"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "parking_lot",
+ "reqwest",
+ "rmcp",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "harnx-mcp-time"
 version = "0.33.3"
 dependencies = [
@@ -7155,6 +7172,7 @@ dependencies = [
  "pin-project-lite",
  "process-wrap",
  "rand 0.10.2",
+ "reqwest",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
@@ -7960,9 +7978,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3983,6 +3983,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/harnx-mcp-hooks-proxy",
     "crates/harnx-mcp-fs",
     "crates/harnx-mcp-time",
+    "crates/harnx-mcp-remote",
     "crates/harnx-mcp-plans",
     "crates/harnx-mcp-plans-core",
     "crates/harnx-mcp-plans-github",
@@ -144,7 +145,7 @@ which = "8.0.0"
 fuzzy-matcher = "0.3.7"
 terminal-colorsaurus = "1.0.3"
 duct = "1.0.0"
-rmcp = { version = "2.0", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "2.0", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server", "transport-streamable-http-client-reqwest"] }
 process-wrap = { version = "9", features = ["tokio1"] }
 libc = "0.2"
 agent-client-protocol = { git = "https://github.com/agentclientprotocol/rust-sdk", rev = "e410bada56f868f70c25b9a29567cece7d89d201" }

--- a/crates/harnx-mcp-remote/Cargo.toml
+++ b/crates/harnx-mcp-remote/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 reqwest = { workspace = true }
 parking_lot = { workspace = true }
+url = "2"
 
 [[bin]]
 name = "harnx-mcp-remote"

--- a/crates/harnx-mcp-remote/Cargo.toml
+++ b/crates/harnx-mcp-remote/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "harnx-mcp-remote"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "stdio MCP proxy that forwards to remote HTTP MCP servers"
+
+[dependencies]
+rmcp = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive", "env"] }
+reqwest = { workspace = true }
+parking_lot = { workspace = true }
+
+[[bin]]
+name = "harnx-mcp-remote"
+path = "src/main.rs"
+
+[dev-dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true }
+rmcp = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true }

--- a/crates/harnx-mcp-remote/README.md
+++ b/crates/harnx-mcp-remote/README.md
@@ -1,0 +1,84 @@
+# harnx-mcp-remote
+
+`harnx-mcp-remote` is a high-performance stdio-to-HTTP proxy for the Model Context Protocol (MCP). It bridges the gap between MCP hosts that communicate via standard I/O (such as Claude Desktop or various LLM harnesses) and remote MCP servers hosted over HTTP.
+
+## Overview
+
+This binary acts as a transparent proxy, allowing you to treat a remote HTTP-based MCP server as if it were running locally via stdio. It handles all necessary transport negotiation and authentication, providing a seamless integration for tools and services that require a remote backend.
+
+Key capabilities include:
+- **Unified Transport Support**: Automatically handles both modern streamable HTTP (MCP 2025-03) and legacy SSE (MCP 2024-11) transports.
+- **Flexible Authentication**: Support for Bearer tokens, custom HTTP headers, and mutual TLS (mTLS).
+- **Environment-First Configuration**: All settings can be provided via CLI flags or environment variables for easy deployment.
+
+## Installation
+
+To install `harnx-mcp-remote` from the `harnx` workspace:
+
+```sh
+cargo install --path crates/harnx-mcp-remote
+```
+
+Alternatively, build it from the repository root:
+
+```sh
+cargo build -p harnx-mcp-remote --release
+```
+
+## Usage Examples
+
+### Basic Proxying
+Point the proxy to a remote URL. The proxy will automatically negotiate the best available transport.
+
+```sh
+harnx-mcp-remote --url https://mcp.example.com/api
+```
+
+### Authentication with Bearer Tokens
+Secure your connection using a standard `Authorization: Bearer <token>` header.
+
+```sh
+harnx-mcp-remote --url https://mcp.example.com/api --bearer-token "secret-session-token"
+```
+
+### Custom Headers
+Provide additional headers required by your infrastructure. This flag can be repeated multiple times.
+
+```sh
+harnx-mcp-remote \
+  --url https://mcp.example.com/api \
+  --header "X-Project-ID: internal-77" \
+  --header "X-Client-Version: 1.2.0"
+```
+
+### Mutual TLS (mTLS)
+For environments requiring client certificate authentication:
+
+```sh
+harnx-mcp-remote \
+  --url https://mcp.example.com/api \
+  --tls-cert /path/to/cert.pem \
+  --tls-key /path/to/key.pem \
+  --tls-ca /path/to/ca.pem
+```
+
+## Transport Notes
+
+`harnx-mcp-remote` utilizes `rmcp`'s `StreamableHttpClientTransport`, which unifies support for both SSE and streamable HTTP.
+
+- **Stateless Fallback**: By default, the proxy allows stateless HTTP sessions, matching the behavior of legacy SSE (2024-11) servers.
+- **Strict Sessions**: Use the `--strict-session` flag to disable stateless fallback. This requires the remote server to support stateful MCP sessions (2025-03 spec).
+
+## Environment Variables
+
+All command-line flags (except `--header`) have corresponding environment variables:
+
+| Flag | Environment Variable | Description |
+| :--- | :--- | :--- |
+| `--url <URL>` | `MCP_REMOTE_URL` | **Required.** The URL of the remote MCP server. |
+| `--bearer-token <TOKEN>` | `MCP_REMOTE_BEARER_TOKEN` | Token for the `Authorization: Bearer` header. |
+| `--header <NAME:VALUE>` | (None) | Repeatable flag for custom HTTP headers. |
+| `--tls-cert <PATH>` | `MCP_REMOTE_TLS_CERT` | Path to the client's PEM certificate. |
+| `--tls-key <PATH>` | `MCP_REMOTE_TLS_KEY` | Path to the client's PEM private key. |
+| `--tls-ca <PATH>` | `MCP_REMOTE_TLS_CA` | Path to a custom CA certificate bundle (PEM). |
+| `--strict-session` | `MCP_REMOTE_STRICT_SESSION` | Require stateful sessions; disable stateless fallback. |

--- a/crates/harnx-mcp-remote/README.md
+++ b/crates/harnx-mcp-remote/README.md
@@ -4,12 +4,12 @@
 
 ## Overview
 
-This binary acts as a transparent proxy, allowing you to treat a remote HTTP-based MCP server as if it were running locally via stdio. It handles all necessary transport negotiation and authentication, providing a seamless integration for tools and services that require a remote backend.
+This binary acts as a stdio-to-HTTP proxy, allowing you to treat a remote HTTP-based MCP server as if it were running locally via stdio. It handles transport negotiation and authentication for forwarded MCP capabilities such as tools, prompts, and resources.
 
 Key capabilities include:
 - **Unified Transport Support**: Automatically handles both modern streamable HTTP (MCP 2025-03) and legacy SSE (MCP 2024-11) transports.
 - **Flexible Authentication**: Support for Bearer tokens, custom HTTP headers, and mutual TLS (mTLS).
-- **Environment-First Configuration**: All settings can be provided via CLI flags or environment variables for easy deployment.
+- **Environment-First Configuration**: Most settings can be provided via CLI flags or environment variables for easy deployment (`--header` remains CLI-only).
 
 ## Installation
 
@@ -76,7 +76,8 @@ All command-line flags (except `--header`) have corresponding environment variab
 | Flag | Environment Variable | Description |
 | :--- | :--- | :--- |
 | `--url <URL>` | `MCP_REMOTE_URL` | **Required.** The URL of the remote MCP server. |
-| `--bearer-token <TOKEN>` | `MCP_REMOTE_BEARER_TOKEN` | Token for the `Authorization: Bearer` header. |
+| `--bearer-token <TOKEN>` | `MCP_REMOTE_BEARER_TOKEN` | Token for the `Authorization: Bearer` header. HTTPS required unless loopback or `--insecure` is set. |
+| `--insecure` | `MCP_REMOTE_INSECURE` | Allow bearer tokens over plaintext HTTP for non-loopback hosts. |
 | `--header <NAME:VALUE>` | (None) | Repeatable flag for custom HTTP headers. |
 | `--tls-cert <PATH>` | `MCP_REMOTE_TLS_CERT` | Path to the client's PEM certificate. |
 | `--tls-key <PATH>` | `MCP_REMOTE_TLS_KEY` | Path to the client's PEM private key. |

--- a/crates/harnx-mcp-remote/src/cli.rs
+++ b/crates/harnx-mcp-remote/src/cli.rs
@@ -12,6 +12,13 @@ pub struct Cli {
     #[arg(long, env = "MCP_REMOTE_BEARER_TOKEN", hide_env_values = true)]
     pub bearer_token: Option<String>,
 
+    #[arg(
+        long,
+        env = "MCP_REMOTE_INSECURE",
+        help = "Allow bearer tokens over non-HTTPS transport for non-loopback hosts"
+    )]
+    pub insecure: bool,
+
     #[arg(long, action = ArgAction::Append)]
     pub header: Vec<String>,
 

--- a/crates/harnx-mcp-remote/src/cli.rs
+++ b/crates/harnx-mcp-remote/src/cli.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+
+use clap::{ArgAction, Parser};
+
+#[derive(Debug, Clone, Parser)]
+#[command(name = "harnx-mcp-remote")]
+#[command(about = "Stdio MCP proxy for remote HTTP MCP servers")]
+pub struct Cli {
+    #[arg(long, env = "MCP_REMOTE_URL", required = true)]
+    pub url: String,
+
+    #[arg(long, env = "MCP_REMOTE_BEARER_TOKEN", hide_env_values = true)]
+    pub bearer_token: Option<String>,
+
+    #[arg(long, action = ArgAction::Append)]
+    pub header: Vec<String>,
+
+    #[arg(long, env = "MCP_REMOTE_TLS_CERT")]
+    pub tls_cert: Option<PathBuf>,
+
+    #[arg(long, env = "MCP_REMOTE_TLS_KEY")]
+    pub tls_key: Option<PathBuf>,
+
+    #[arg(long, env = "MCP_REMOTE_TLS_CA")]
+    pub tls_ca: Option<PathBuf>,
+
+    #[arg(
+        long,
+        env = "MCP_REMOTE_STRICT_SESSION",
+        help = "Require stateful remote MCP sessions and disable stateless fallback"
+    )]
+    pub strict_session: bool,
+}

--- a/crates/harnx-mcp-remote/src/client_handler.rs
+++ b/crates/harnx-mcp-remote/src/client_handler.rs
@@ -1,0 +1,29 @@
+// rmcp deprecated MCP Roots (SEP-2577); proxy still must return method_not_found
+// here to avoid overwriting remote roots.
+#![allow(deprecated)]
+
+use rmcp::handler::client::ClientHandler;
+use rmcp::model::{
+    ClientCapabilities, ErrorData, Implementation, InitializeRequestParams, ListRootsResult,
+};
+use rmcp::service::{RequestContext, RoleClient};
+
+pub struct RemoteClientHandler;
+
+impl ClientHandler for RemoteClientHandler {
+    fn get_info(&self) -> InitializeRequestParams {
+        InitializeRequestParams::new(
+            ClientCapabilities::default(),
+            Implementation::new("harnx-mcp-remote", env!("CARGO_PKG_VERSION")),
+        )
+    }
+
+    async fn list_roots(
+        &self,
+        _context: RequestContext<RoleClient>,
+    ) -> Result<ListRootsResult, ErrorData> {
+        Err(ErrorData::method_not_found::<
+            rmcp::model::ListRootsRequestMethod,
+        >())
+    }
+}

--- a/crates/harnx-mcp-remote/src/main.rs
+++ b/crates/harnx-mcp-remote/src/main.rs
@@ -1,0 +1,67 @@
+mod cli;
+mod client_handler;
+mod server;
+mod transport;
+
+use std::time::Duration;
+
+use clap::Parser;
+use rmcp::ServiceExt;
+use server::RemoteProxyServer;
+use tokio_util::sync::CancellationToken;
+
+fn main() -> anyhow::Result<()> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    let result = rt.block_on(async_main());
+    // Tokio stdio can leave a blocking read alive; bound runtime shutdown.
+    rt.shutdown_timeout(Duration::from_secs(1));
+    result
+}
+
+async fn async_main() -> anyhow::Result<()> {
+    let cli = cli::Cli::parse();
+    eprintln!(
+        "harnx-mcp-remote v{}: starting, proxying to {}",
+        env!("CARGO_PKG_VERSION"),
+        cli.url
+    );
+
+    #[cfg(unix)]
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+    #[cfg(not(unix))]
+    let mut sigterm = ();
+
+    let server = RemoteProxyServer::new(cli);
+    let transport = rmcp::transport::stdio();
+    let serve_ct = CancellationToken::new();
+
+    tokio::select! {
+        service = server.serve_with_ct(transport, serve_ct.clone()) => {
+            let service = service?;
+            wait_for_shutdown(&mut sigterm).await;
+            service.service().shutdown_remote().await?;
+            service.cancel().await?;
+        }
+        _ = wait_for_shutdown(&mut sigterm) => {
+            // SIGTERM/SIGINT before initialize completes: cancel the in-progress
+            // rmcp initialize wait and exit cleanly.
+            serve_ct.cancel();
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn wait_for_shutdown(sigterm: &mut tokio::signal::unix::Signal) {
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {}
+        _ = sigterm.recv() => {}
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_shutdown(_sigterm: &mut ()) {
+    let _ = tokio::signal::ctrl_c().await;
+}

--- a/crates/harnx-mcp-remote/src/server.rs
+++ b/crates/harnx-mcp-remote/src/server.rs
@@ -58,10 +58,8 @@ impl ServerHandler for RemoteProxyServer {
                 .enable_resources()
                 .build(),
         );
-        info.server_info = rmcp::model::Implementation::new(
-            "harnx-mcp-remote",
-            env!("CARGO_PKG_VERSION"),
-        );
+        info.server_info =
+            rmcp::model::Implementation::new("harnx-mcp-remote", env!("CARGO_PKG_VERSION"));
         info
     }
 
@@ -71,6 +69,7 @@ impl ServerHandler for RemoteProxyServer {
         _context: RequestContext<RoleServer>,
     ) -> Result<rmcp::model::InitializeResult, ErrorData> {
         let transport = build_transport(&self.cli)
+            .await
             .map_err(|err| ErrorData::internal_error(err.to_string(), None))?;
         let service = rmcp::service::serve_client(RemoteClientHandler, transport)
             .await
@@ -80,10 +79,8 @@ impl ServerHandler for RemoteProxyServer {
             .peer_info()
             .map(|info| (*info).clone())
             .unwrap_or_else(|| self.get_info());
-        info.server_info = rmcp::model::Implementation::new(
-            "harnx-mcp-remote",
-            env!("CARGO_PKG_VERSION"),
-        );
+        info.server_info =
+            rmcp::model::Implementation::new("harnx-mcp-remote", env!("CARGO_PKG_VERSION"));
         *self.peer.write() = Some(peer);
         *self.client_service.write() = Some(service);
         Ok(info)

--- a/crates/harnx-mcp-remote/src/server.rs
+++ b/crates/harnx-mcp-remote/src/server.rs
@@ -1,0 +1,127 @@
+use parking_lot::RwLock;
+use rmcp::handler::server::ServerHandler;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, ErrorData, InitializeRequestParams, ListPromptsResult,
+    ListResourcesResult, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo,
+};
+use rmcp::service::{RequestContext, RoleClient, RoleServer, RunningService};
+use rmcp::Peer;
+
+use crate::cli::Cli;
+use crate::client_handler::RemoteClientHandler;
+use crate::transport::build_transport;
+
+fn proxy_error(err: rmcp::service::ServiceError) -> ErrorData {
+    // rmcp ServiceError in 2.2.0 does not expose structured remote ErrorData
+    // here, so fall back to internal_error while preserving message text.
+    ErrorData::internal_error(err.to_string(), None)
+}
+
+pub struct RemoteProxyServer {
+    cli: Cli,
+    peer: RwLock<Option<Peer<RoleClient>>>,
+    client_service: RwLock<Option<RunningService<RoleClient, RemoteClientHandler>>>,
+}
+
+impl RemoteProxyServer {
+    pub fn new(cli: Cli) -> Self {
+        Self {
+            cli,
+            peer: RwLock::new(None),
+            client_service: RwLock::new(None),
+        }
+    }
+
+    pub async fn shutdown_remote(&self) -> Result<(), tokio::task::JoinError> {
+        *self.peer.write() = None;
+        let service = { self.client_service.write().take() };
+        if let Some(service) = service {
+            service.cancel().await?;
+        }
+        Ok(())
+    }
+
+    fn peer(&self) -> Result<Peer<RoleClient>, ErrorData> {
+        self.peer
+            .read()
+            .clone()
+            .ok_or_else(|| ErrorData::internal_error("remote MCP peer not initialized", None))
+    }
+}
+
+impl ServerHandler for RemoteProxyServer {
+    fn get_info(&self) -> ServerInfo {
+        let mut info = ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .enable_prompts()
+                .enable_resources()
+                .build(),
+        );
+        info.server_info = rmcp::model::Implementation::new(
+            "harnx-mcp-remote",
+            env!("CARGO_PKG_VERSION"),
+        );
+        info
+    }
+
+    async fn initialize(
+        &self,
+        _request: InitializeRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<rmcp::model::InitializeResult, ErrorData> {
+        let transport = build_transport(&self.cli)
+            .map_err(|err| ErrorData::internal_error(err.to_string(), None))?;
+        let service = rmcp::service::serve_client(RemoteClientHandler, transport)
+            .await
+            .map_err(|err| ErrorData::internal_error(err.to_string(), None))?;
+        let peer = service.peer().clone();
+        let mut info = peer
+            .peer_info()
+            .map(|info| (*info).clone())
+            .unwrap_or_else(|| self.get_info());
+        info.server_info = rmcp::model::Implementation::new(
+            "harnx-mcp-remote",
+            env!("CARGO_PKG_VERSION"),
+        );
+        *self.peer.write() = Some(peer);
+        *self.client_service.write() = Some(service);
+        Ok(info)
+    }
+
+    async fn list_tools(
+        &self,
+        request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        let peer = self.peer()?;
+        peer.list_tools(request).await.map_err(proxy_error)
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let peer = self.peer()?;
+        peer.call_tool(request).await.map_err(proxy_error)
+    }
+
+    async fn list_prompts(
+        &self,
+        request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListPromptsResult, ErrorData> {
+        let peer = self.peer()?;
+        peer.list_prompts(request).await.map_err(proxy_error)
+    }
+
+    async fn list_resources(
+        &self,
+        request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, ErrorData> {
+        let peer = self.peer()?;
+        peer.list_resources(request).await.map_err(proxy_error)
+    }
+}

--- a/crates/harnx-mcp-remote/src/transport.rs
+++ b/crates/harnx-mcp-remote/src/transport.rs
@@ -1,14 +1,27 @@
-use std::fs;
-
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use reqwest::header::{HeaderName, HeaderValue};
 use rmcp::transport::streamable_http_client::{
     StreamableHttpClientTransport, StreamableHttpClientTransportConfig,
 };
+use url::Url;
 
 use crate::cli::Cli;
 
 fn config_from_cli(cli: &Cli) -> Result<StreamableHttpClientTransportConfig> {
+    let parsed_url = Url::parse(cli.url.as_str())
+        .with_context(|| format!("invalid remote MCP URL: {}", cli.url))?;
+
+    if cli.bearer_token.is_some()
+        && parsed_url.scheme() != "https"
+        && !is_loopback_host(&parsed_url)
+        && !cli.insecure
+    {
+        anyhow::bail!(
+            "refusing to send bearer token over non-HTTPS URL {}; use HTTPS, loopback, or --insecure",
+            cli.url
+        );
+    }
+
     let mut config = StreamableHttpClientTransportConfig::with_uri(cli.url.as_str());
     config.auth_header = cli.bearer_token.clone();
 
@@ -28,30 +41,41 @@ fn config_from_cli(cli: &Cli) -> Result<StreamableHttpClientTransportConfig> {
     Ok(config)
 }
 
-pub fn build_transport(
-    cli: &Cli,
-) -> Result<StreamableHttpClientTransport<reqwest::Client>> {
+fn is_loopback_host(url: &Url) -> bool {
+    match url.host_str() {
+        Some("localhost") => true,
+        Some(host) => host == "127.0.0.1" || host == "::1",
+        None => false,
+    }
+}
+
+pub async fn build_transport(cli: &Cli) -> Result<StreamableHttpClientTransport<reqwest::Client>> {
     let mut client_builder = reqwest::Client::builder();
 
     match (&cli.tls_cert, &cli.tls_key) {
         (Some(cert_path), Some(key_path)) => {
-            let cert = fs::read(cert_path)
-                .with_context(|| format!("failed to read TLS cert PEM from {}", cert_path.display()))?;
-            let key = fs::read(key_path)
-                .with_context(|| format!("failed to read TLS key PEM from {}", key_path.display()))?;
+            let cert = tokio::fs::read(cert_path).await.with_context(|| {
+                format!("failed to read TLS cert PEM from {}", cert_path.display())
+            })?;
+            let key = tokio::fs::read(key_path).await.with_context(|| {
+                format!("failed to read TLS key PEM from {}", key_path.display())
+            })?;
             let mut identity_pem = cert;
             identity_pem.extend_from_slice(&key);
             let identity = reqwest::Identity::from_pem(&identity_pem)?;
             client_builder = client_builder.identity(identity);
         }
         (Some(_), None) | (None, Some(_)) => {
-            return Err(anyhow!("--tls-cert and --tls-key must be provided together"));
+            return Err(anyhow!(
+                "--tls-cert and --tls-key must be provided together"
+            ));
         }
         (None, None) => {}
     }
 
     if let Some(ca_path) = &cli.tls_ca {
-        let ca = fs::read(ca_path)
+        let ca = tokio::fs::read(ca_path)
+            .await
             .with_context(|| format!("failed to read TLS CA PEM from {}", ca_path.display()))?;
         let certificate = reqwest::Certificate::from_pem(&ca)?;
         client_builder = client_builder.add_root_certificate(certificate);
@@ -78,13 +102,25 @@ mod tests {
 
     #[test]
     fn bearer_token_sets_auth_header() {
-        let config = config_from_args(&["harnx-mcp-remote", "--url", "https://example.com", "--bearer-token", "mytoken"]);
+        let config = config_from_args(&[
+            "harnx-mcp-remote",
+            "--url",
+            "https://example.com",
+            "--bearer-token",
+            "mytoken",
+        ]);
         assert_eq!(config.auth_header.as_deref(), Some("mytoken"));
     }
 
     #[test]
     fn custom_header_populates_custom_headers() {
-        let config = config_from_args(&["harnx-mcp-remote", "--url", "https://example.com", "--header", "Foo:bar"]);
+        let config = config_from_args(&[
+            "harnx-mcp-remote",
+            "--url",
+            "https://example.com",
+            "--header",
+            "Foo:bar",
+        ]);
         assert_eq!(
             config
                 .custom_headers
@@ -101,8 +137,51 @@ mod tests {
 
     #[test]
     fn strict_session_disables_stateless_mode() {
-        let config = config_from_args(&["harnx-mcp-remote", "--url", "https://example.com", "--strict-session"]);
+        let config = config_from_args(&[
+            "harnx-mcp-remote",
+            "--url",
+            "https://example.com",
+            "--strict-session",
+        ]);
         assert!(!config.allow_stateless);
+    }
+
+    #[test]
+    fn bearer_token_over_http_non_loopback_is_rejected() {
+        let cli = Cli::parse_from([
+            "harnx-mcp-remote",
+            "--url",
+            "http://example.com",
+            "--bearer-token",
+            "secret",
+        ]);
+        let err = super::config_from_cli(&cli).expect_err("plaintext bearer token should fail");
+        assert!(err.to_string().contains("refusing to send bearer token"));
+    }
+
+    #[test]
+    fn bearer_token_over_http_loopback_is_allowed() {
+        let config = config_from_args(&[
+            "harnx-mcp-remote",
+            "--url",
+            "http://127.0.0.1:8000",
+            "--bearer-token",
+            "secret",
+        ]);
+        assert_eq!(config.auth_header.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn bearer_token_over_http_non_loopback_is_allowed_with_insecure() {
+        let config = config_from_args(&[
+            "harnx-mcp-remote",
+            "--url",
+            "http://example.com",
+            "--bearer-token",
+            "secret",
+            "--insecure",
+        ]);
+        assert_eq!(config.auth_header.as_deref(), Some("secret"));
     }
 
     #[test]

--- a/crates/harnx-mcp-remote/src/transport.rs
+++ b/crates/harnx-mcp-remote/src/transport.rs
@@ -24,7 +24,7 @@ fn config_from_cli(cli: &Cli) -> Result<StreamableHttpClientTransportConfig> {
 }
 
 fn ensure_bearer_transport_is_secure(url: &Url, has_bearer: bool, insecure: bool) -> Result<()> {
-    if !has_bearer || insecure || uses_https(url) || is_loopback_url(url) {
+    if bearer_transport_is_secure(url, has_bearer, insecure) {
         return Ok(());
     }
 
@@ -32,6 +32,17 @@ fn ensure_bearer_transport_is_secure(url: &Url, has_bearer: bool, insecure: bool
         "refusing to send bearer token over non-HTTPS URL {}; use HTTPS, loopback, or --insecure",
         url
     );
+}
+
+/// A bearer token may be sent when there is no token, when the caller opts out
+/// of the check, or when the endpoint is already safe (HTTPS or loopback).
+fn bearer_transport_is_secure(url: &Url, has_bearer: bool, insecure: bool) -> bool {
+    let bearer_check_waived = !has_bearer || insecure;
+    bearer_check_waived || endpoint_is_safe(url)
+}
+
+fn endpoint_is_safe(url: &Url) -> bool {
+    uses_https(url) || is_loopback_url(url)
 }
 
 fn uses_https(url: &Url) -> bool {

--- a/crates/harnx-mcp-remote/src/transport.rs
+++ b/crates/harnx-mcp-remote/src/transport.rs
@@ -10,29 +10,11 @@ use crate::cli::Cli;
 fn config_from_cli(cli: &Cli) -> Result<StreamableHttpClientTransportConfig> {
     let parsed_url = Url::parse(cli.url.as_str())
         .with_context(|| format!("invalid remote MCP URL: {}", cli.url))?;
-
-    if cli.bearer_token.is_some()
-        && parsed_url.scheme() != "https"
-        && !is_loopback_host(&parsed_url)
-        && !cli.insecure
-    {
-        anyhow::bail!(
-            "refusing to send bearer token over non-HTTPS URL {}; use HTTPS, loopback, or --insecure",
-            cli.url
-        );
-    }
+    ensure_bearer_transport_is_secure(&parsed_url, cli.bearer_token.is_some(), cli.insecure)?;
 
     let mut config = StreamableHttpClientTransportConfig::with_uri(cli.url.as_str());
     config.auth_header = cli.bearer_token.clone();
-
-    for header in &cli.header {
-        let (name, value) = header
-            .split_once(':')
-            .ok_or_else(|| anyhow!("invalid header '{header}': expected NAME:VALUE"))?;
-        let header_name: HeaderName = name.trim().parse()?;
-        let header_value = HeaderValue::from_str(value.trim())?;
-        config.custom_headers.insert(header_name, header_value);
-    }
+    config.custom_headers = parse_custom_headers(&cli.header)?;
 
     if cli.strict_session {
         config.allow_stateless = false;
@@ -41,12 +23,44 @@ fn config_from_cli(cli: &Cli) -> Result<StreamableHttpClientTransportConfig> {
     Ok(config)
 }
 
-fn is_loopback_host(url: &Url) -> bool {
-    match url.host_str() {
-        Some("localhost") => true,
-        Some(host) => host == "127.0.0.1" || host == "::1",
-        None => false,
+fn ensure_bearer_transport_is_secure(url: &Url, has_bearer: bool, insecure: bool) -> Result<()> {
+    if !has_bearer || insecure || uses_https(url) || is_loopback_url(url) {
+        return Ok(());
     }
+
+    anyhow::bail!(
+        "refusing to send bearer token over non-HTTPS URL {}; use HTTPS, loopback, or --insecure",
+        url
+    );
+}
+
+fn uses_https(url: &Url) -> bool {
+    url.scheme() == "https"
+}
+
+fn is_loopback_url(url: &Url) -> bool {
+    url.host_str().is_some_and(is_loopback_host)
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    matches!(host, "localhost" | "127.0.0.1" | "::1")
+}
+
+fn parse_custom_headers(
+    headers: &[String],
+) -> Result<std::collections::HashMap<HeaderName, HeaderValue>> {
+    let mut parsed = std::collections::HashMap::new();
+
+    for header in headers {
+        let (name, value) = header
+            .split_once(':')
+            .ok_or_else(|| anyhow!("invalid header '{header}': expected NAME:VALUE"))?;
+        let header_name: HeaderName = name.trim().parse()?;
+        let header_value = HeaderValue::from_str(value.trim())?;
+        parsed.insert(header_name, header_value);
+    }
+
+    Ok(parsed)
 }
 
 pub async fn build_transport(cli: &Cli) -> Result<StreamableHttpClientTransport<reqwest::Client>> {

--- a/crates/harnx-mcp-remote/src/transport.rs
+++ b/crates/harnx-mcp-remote/src/transport.rs
@@ -125,25 +125,31 @@ mod tests {
         super::config_from_cli(&cli).expect("valid transport config")
     }
 
-    /// Asserts that the given CLI args produce a config whose bearer auth header
-    /// matches `expected`. Shared by the several "token is accepted" cases.
-    fn assert_auth_header(args: &[&str], expected: &str) {
-        let config = config_from_args(args);
-        assert_eq!(config.auth_header.as_deref(), Some(expected));
-    }
-
+    /// Table-driven coverage of the cases where a bearer token is accepted and
+    /// forwarded verbatim as the auth header: HTTPS, loopback HTTP, and
+    /// non-loopback HTTP with `--insecure`.
     #[test]
-    fn bearer_token_sets_auth_header() {
-        assert_auth_header(
-            &[
-                "harnx-mcp-remote",
-                "--url",
-                "https://example.com",
-                "--bearer-token",
-                "mytoken",
-            ],
-            "mytoken",
-        );
+    fn bearer_token_is_forwarded_for_allowed_endpoints() {
+        let cases: &[(&str, &[&str])] = &[
+            ("https endpoint", &["--url", "https://example.com"]),
+            ("loopback http", &["--url", "http://127.0.0.1:8000"]),
+            (
+                "insecure http",
+                &["--url", "http://example.com", "--insecure"],
+            ),
+        ];
+
+        for (label, url_args) in cases {
+            let mut args = vec!["harnx-mcp-remote"];
+            args.extend_from_slice(url_args);
+            args.extend_from_slice(&["--bearer-token", "secret"]);
+            let config = config_from_args(&args);
+            assert_eq!(
+                config.auth_header.as_deref(),
+                Some("secret"),
+                "auth header should be forwarded for {label}"
+            );
+        }
     }
 
     #[test]
@@ -191,35 +197,6 @@ mod tests {
         ]);
         let err = super::config_from_cli(&cli).expect_err("plaintext bearer token should fail");
         assert!(err.to_string().contains("refusing to send bearer token"));
-    }
-
-    #[test]
-    fn bearer_token_over_http_loopback_is_allowed() {
-        assert_auth_header(
-            &[
-                "harnx-mcp-remote",
-                "--url",
-                "http://127.0.0.1:8000",
-                "--bearer-token",
-                "secret",
-            ],
-            "secret",
-        );
-    }
-
-    #[test]
-    fn bearer_token_over_http_non_loopback_is_allowed_with_insecure() {
-        assert_auth_header(
-            &[
-                "harnx-mcp-remote",
-                "--url",
-                "http://example.com",
-                "--bearer-token",
-                "secret",
-                "--insecure",
-            ],
-            "secret",
-        );
     }
 
     #[test]

--- a/crates/harnx-mcp-remote/src/transport.rs
+++ b/crates/harnx-mcp-remote/src/transport.rs
@@ -125,16 +125,25 @@ mod tests {
         super::config_from_cli(&cli).expect("valid transport config")
     }
 
+    /// Asserts that the given CLI args produce a config whose bearer auth header
+    /// matches `expected`. Shared by the several "token is accepted" cases.
+    fn assert_auth_header(args: &[&str], expected: &str) {
+        let config = config_from_args(args);
+        assert_eq!(config.auth_header.as_deref(), Some(expected));
+    }
+
     #[test]
     fn bearer_token_sets_auth_header() {
-        let config = config_from_args(&[
-            "harnx-mcp-remote",
-            "--url",
-            "https://example.com",
-            "--bearer-token",
+        assert_auth_header(
+            &[
+                "harnx-mcp-remote",
+                "--url",
+                "https://example.com",
+                "--bearer-token",
+                "mytoken",
+            ],
             "mytoken",
-        ]);
-        assert_eq!(config.auth_header.as_deref(), Some("mytoken"));
+        );
     }
 
     #[test]
@@ -186,27 +195,31 @@ mod tests {
 
     #[test]
     fn bearer_token_over_http_loopback_is_allowed() {
-        let config = config_from_args(&[
-            "harnx-mcp-remote",
-            "--url",
-            "http://127.0.0.1:8000",
-            "--bearer-token",
+        assert_auth_header(
+            &[
+                "harnx-mcp-remote",
+                "--url",
+                "http://127.0.0.1:8000",
+                "--bearer-token",
+                "secret",
+            ],
             "secret",
-        ]);
-        assert_eq!(config.auth_header.as_deref(), Some("secret"));
+        );
     }
 
     #[test]
     fn bearer_token_over_http_non_loopback_is_allowed_with_insecure() {
-        let config = config_from_args(&[
-            "harnx-mcp-remote",
-            "--url",
-            "http://example.com",
-            "--bearer-token",
+        assert_auth_header(
+            &[
+                "harnx-mcp-remote",
+                "--url",
+                "http://example.com",
+                "--bearer-token",
+                "secret",
+                "--insecure",
+            ],
             "secret",
-            "--insecure",
-        ]);
-        assert_eq!(config.auth_header.as_deref(), Some("secret"));
+        );
     }
 
     #[test]

--- a/crates/harnx-mcp-remote/src/transport.rs
+++ b/crates/harnx-mcp-remote/src/transport.rs
@@ -1,0 +1,113 @@
+use std::fs;
+
+use anyhow::{Context, Result, anyhow};
+use reqwest::header::{HeaderName, HeaderValue};
+use rmcp::transport::streamable_http_client::{
+    StreamableHttpClientTransport, StreamableHttpClientTransportConfig,
+};
+
+use crate::cli::Cli;
+
+fn config_from_cli(cli: &Cli) -> Result<StreamableHttpClientTransportConfig> {
+    let mut config = StreamableHttpClientTransportConfig::with_uri(cli.url.as_str());
+    config.auth_header = cli.bearer_token.clone();
+
+    for header in &cli.header {
+        let (name, value) = header
+            .split_once(':')
+            .ok_or_else(|| anyhow!("invalid header '{header}': expected NAME:VALUE"))?;
+        let header_name: HeaderName = name.trim().parse()?;
+        let header_value = HeaderValue::from_str(value.trim())?;
+        config.custom_headers.insert(header_name, header_value);
+    }
+
+    if cli.strict_session {
+        config.allow_stateless = false;
+    }
+
+    Ok(config)
+}
+
+pub fn build_transport(
+    cli: &Cli,
+) -> Result<StreamableHttpClientTransport<reqwest::Client>> {
+    let mut client_builder = reqwest::Client::builder();
+
+    match (&cli.tls_cert, &cli.tls_key) {
+        (Some(cert_path), Some(key_path)) => {
+            let cert = fs::read(cert_path)
+                .with_context(|| format!("failed to read TLS cert PEM from {}", cert_path.display()))?;
+            let key = fs::read(key_path)
+                .with_context(|| format!("failed to read TLS key PEM from {}", key_path.display()))?;
+            let mut identity_pem = cert;
+            identity_pem.extend_from_slice(&key);
+            let identity = reqwest::Identity::from_pem(&identity_pem)?;
+            client_builder = client_builder.identity(identity);
+        }
+        (Some(_), None) | (None, Some(_)) => {
+            return Err(anyhow!("--tls-cert and --tls-key must be provided together"));
+        }
+        (None, None) => {}
+    }
+
+    if let Some(ca_path) = &cli.tls_ca {
+        let ca = fs::read(ca_path)
+            .with_context(|| format!("failed to read TLS CA PEM from {}", ca_path.display()))?;
+        let certificate = reqwest::Certificate::from_pem(&ca)?;
+        client_builder = client_builder.add_root_certificate(certificate);
+    }
+
+    let client = client_builder.build()?;
+    let config = config_from_cli(cli)?;
+
+    Ok(StreamableHttpClientTransport::with_client(client, config))
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+    use reqwest::header::{HeaderName, HeaderValue};
+    use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+
+    use crate::cli::Cli;
+
+    fn config_from_args(args: &[&str]) -> StreamableHttpClientTransportConfig {
+        let cli = Cli::parse_from(args);
+        super::config_from_cli(&cli).expect("valid transport config")
+    }
+
+    #[test]
+    fn bearer_token_sets_auth_header() {
+        let config = config_from_args(&["harnx-mcp-remote", "--url", "https://example.com", "--bearer-token", "mytoken"]);
+        assert_eq!(config.auth_header.as_deref(), Some("mytoken"));
+    }
+
+    #[test]
+    fn custom_header_populates_custom_headers() {
+        let config = config_from_args(&["harnx-mcp-remote", "--url", "https://example.com", "--header", "Foo:bar"]);
+        assert_eq!(
+            config
+                .custom_headers
+                .get(&"foo".parse::<HeaderName>().expect("header name")),
+            Some(&HeaderValue::from_static("bar"))
+        );
+    }
+
+    #[test]
+    fn stateless_allowed_by_default() {
+        let config = config_from_args(&["harnx-mcp-remote", "--url", "https://example.com"]);
+        assert!(config.allow_stateless);
+    }
+
+    #[test]
+    fn strict_session_disables_stateless_mode() {
+        let config = config_from_args(&["harnx-mcp-remote", "--url", "https://example.com", "--strict-session"]);
+        assert!(!config.allow_stateless);
+    }
+
+    #[test]
+    fn missing_url_is_parse_error() {
+        let err = Cli::try_parse_from(["harnx-mcp-remote"]).expect_err("missing url should fail");
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+}

--- a/crates/harnx-mcp-remote/tests/auth.rs
+++ b/crates/harnx-mcp-remote/tests/auth.rs
@@ -1,0 +1,46 @@
+mod common;
+
+use anyhow::Result;
+use common::{spawn_auth_guard_server, spawn_proxy_client, text_content, tool_args};
+use rmcp::model::CallToolRequestParams;
+use serde_json::json;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_bearer_token_surfaces_remote_401() -> Result<()> {
+    let server = spawn_auth_guard_server("Bearer test-token").await?;
+    let url = format!("http://127.0.0.1:{}/mcp", server.port);
+    let err = spawn_proxy_client(&["--url", &url])
+        .await
+        .expect_err("expected unauthorized remote initialize to fail");
+    let message = err.to_string();
+    assert!(
+        message.contains("401") || message.contains("unauthorized"),
+        "expected 401/unauthorized in error, got: {message}"
+    );
+
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn bearer_token_allows_proxy_calls() -> Result<()> {
+    let server = spawn_auth_guard_server("Bearer test-token").await?;
+    let url = format!("http://127.0.0.1:{}/mcp", server.port);
+    let (proxy, _stderr) =
+        spawn_proxy_client(&["--url", &url, "--bearer-token", "test-token"]).await?;
+    let peer = proxy.peer().clone();
+
+    let tools = peer.list_tools(None).await?;
+    assert!(tools.tools.iter().any(|tool| tool.name.as_ref() == "echo"));
+
+    let result = peer
+        .call_tool(
+            CallToolRequestParams::new("echo").with_arguments(tool_args(json!({ "text": "auth ok" }))),
+        )
+        .await?;
+    assert_eq!(serde_json::from_str::<serde_json::Value>(&text_content(&result))?["text"], "auth ok");
+
+    proxy.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}

--- a/crates/harnx-mcp-remote/tests/auth.rs
+++ b/crates/harnx-mcp-remote/tests/auth.rs
@@ -26,8 +26,7 @@ async fn missing_bearer_token_surfaces_remote_401() -> Result<()> {
 async fn bearer_token_allows_proxy_calls() -> Result<()> {
     let server = spawn_auth_guard_server("Bearer test-token").await?;
     let url = format!("http://127.0.0.1:{}/mcp", server.port);
-    let (proxy, _stderr) =
-        spawn_proxy_client(&["--url", &url, "--bearer-token", "test-token"]).await?;
+    let proxy = spawn_proxy_client(&["--url", &url, "--bearer-token", "test-token"]).await?;
     let peer = proxy.peer().clone();
 
     let tools = peer.list_tools(None).await?;
@@ -35,10 +34,14 @@ async fn bearer_token_allows_proxy_calls() -> Result<()> {
 
     let result = peer
         .call_tool(
-            CallToolRequestParams::new("echo").with_arguments(tool_args(json!({ "text": "auth ok" }))),
+            CallToolRequestParams::new("echo")
+                .with_arguments(tool_args(json!({ "text": "auth ok" }))),
         )
         .await?;
-    assert_eq!(serde_json::from_str::<serde_json::Value>(&text_content(&result))?["text"], "auth ok");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&text_content(&result))?["text"],
+        "auth ok"
+    );
 
     proxy.cancel().await?;
     server.shutdown().await;

--- a/crates/harnx-mcp-remote/tests/common.rs
+++ b/crates/harnx-mcp-remote/tests/common.rs
@@ -3,9 +3,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use axum::Router;
 use axum::extract::Request;
 use axum::middleware::Next;
+use axum::Router;
 use rmcp::handler::client::ClientHandler;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
@@ -13,11 +13,11 @@ use rmcp::model::{
     InitializeRequestParams, ServerInfo,
 };
 use rmcp::service::{RequestContext, RoleClient, RoleServer};
-use rmcp::transport::TokioChildProcess;
 use rmcp::transport::streamable_http_server::session::never::NeverSessionManager;
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
-use rmcp::{ServerHandler, tool, tool_handler, tool_router};
-use serde_json::{Map, Value, json};
+use rmcp::transport::TokioChildProcess;
+use rmcp::{tool, tool_handler, tool_router, ServerHandler};
+use serde_json::{json, Map, Value};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -89,7 +89,11 @@ impl TestHttpServer {
 #[tool_handler]
 impl ServerHandler for TestHttpServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(rmcp::model::ServerCapabilities::builder().enable_tools().build())
+        ServerInfo::new(
+            rmcp::model::ServerCapabilities::builder()
+                .enable_tools()
+                .build(),
+        )
     }
 }
 
@@ -102,7 +106,7 @@ pub struct HttpTestServerHandle {
 impl HttpTestServerHandle {
     pub async fn shutdown(self) {
         self.shutdown.cancel();
-        let _ = self.join.await;
+        self.join.await.expect("test HTTP server task panicked");
     }
 }
 
@@ -166,22 +170,27 @@ pub async fn spawn_auth_guard_server(expected_auth: &'static str) -> Result<Http
         Arc::new(NeverSessionManager::default()),
         config,
     );
-    let app = Router::new().nest_service("/mcp", mcp_service).route_layer(
-        axum::middleware::from_fn(move |req: Request, next: Next| async move {
-            let authorized = req
-                .headers()
-                .get(axum::http::header::AUTHORIZATION)
-                .and_then(|value| value.to_str().ok())
-                == Some(expected_auth);
-            if !authorized {
-                return Ok::<_, std::convert::Infallible>(axum::http::Response::builder()
-                    .status(axum::http::StatusCode::UNAUTHORIZED)
-                    .body(axum::body::Body::from("unauthorized"))
-                    .expect("response"));
-            }
-            Ok::<_, std::convert::Infallible>(next.run(req).await)
-        }),
-    );
+    let app =
+        Router::new()
+            .nest_service("/mcp", mcp_service)
+            .route_layer(axum::middleware::from_fn(
+                move |req: Request, next: Next| async move {
+                    let authorized = req
+                        .headers()
+                        .get(axum::http::header::AUTHORIZATION)
+                        .and_then(|value| value.to_str().ok())
+                        == Some(expected_auth);
+                    if !authorized {
+                        return Ok::<_, std::convert::Infallible>(
+                            axum::http::Response::builder()
+                                .status(axum::http::StatusCode::UNAUTHORIZED)
+                                .body(axum::body::Body::from("unauthorized"))
+                                .expect("response"),
+                        );
+                    }
+                    Ok::<_, std::convert::Infallible>(next.run(req).await)
+                },
+            ));
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await?;
     let port = listener.local_addr()?.port();
     let shutdown_wait = shutdown.clone();
@@ -204,10 +213,7 @@ pub async fn spawn_auth_guard_server(expected_auth: &'static str) -> Result<Http
 
 pub async fn spawn_proxy_client(
     args: &[&str],
-) -> Result<(
-    rmcp::service::RunningService<RoleClient, TestClientHandler>,
-    tokio::process::ChildStderr,
-)> {
+) -> Result<rmcp::service::RunningService<RoleClient, TestClientHandler>> {
     let bin = proxy_binary_path().context("harnx-mcp-remote binary not found")?;
     let mut command = tokio::process::Command::new(bin);
     command.args(args);
@@ -216,19 +222,27 @@ pub async fn spawn_proxy_client(
         .spawn()
         .context("spawn harnx-mcp-remote")?;
     let mut stderr = stderr.expect("proxy stderr should be piped");
-    let service = match rmcp::service::serve_client(TestClientHandler, transport).await {
-        Ok(service) => service,
+    let stderr_task = tokio::spawn(async move {
+        use tokio::io::AsyncReadExt;
+        let mut stderr_buf = String::new();
+        let _ = stderr.read_to_string(&mut stderr_buf).await;
+        stderr_buf
+    });
+    match rmcp::service::serve_client(TestClientHandler, transport).await {
+        Ok(service) => {
+            std::mem::drop(stderr_task);
+            Ok(service)
+        }
         Err(err) => {
-            let mut stderr_buf = String::new();
-            use tokio::io::AsyncReadExt;
-            let _ = stderr.read_to_string(&mut stderr_buf).await;
-            return Err(anyhow::anyhow!(
+            let stderr_buf = stderr_task
+                .await
+                .unwrap_or_else(|_| String::from("<stderr task panicked>"));
+            Err(anyhow::anyhow!(
                 "connect MCP client to proxy stdio: {err}; proxy stderr: {}",
                 stderr_buf.trim()
-            ));
+            ))
         }
-    };
-    Ok((service, stderr))
+    }
 }
 
 pub fn text_content(result: &CallToolResult) -> String {

--- a/crates/harnx-mcp-remote/tests/common.rs
+++ b/crates/harnx-mcp-remote/tests/common.rs
@@ -1,0 +1,301 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use axum::Router;
+use axum::extract::Request;
+use axum::middleware::Next;
+use rmcp::handler::client::ClientHandler;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{
+    CallToolResult, ClientCapabilities, ContentBlock, ErrorData, Implementation,
+    InitializeRequestParams, ServerInfo,
+};
+use rmcp::service::{RequestContext, RoleClient, RoleServer};
+use rmcp::transport::TokioChildProcess;
+use rmcp::transport::streamable_http_server::session::never::NeverSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use rmcp::{ServerHandler, tool, tool_handler, tool_router};
+use serde_json::{Map, Value, json};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Clone, serde::Deserialize, rmcp::schemars::JsonSchema)]
+pub struct EchoArgs {
+    pub text: String,
+}
+
+#[derive(Debug)]
+pub struct TestClientHandler;
+
+impl ClientHandler for TestClientHandler {
+    fn get_info(&self) -> InitializeRequestParams {
+        InitializeRequestParams::new(
+            ClientCapabilities::default(),
+            Implementation::new("harnx-mcp-remote-test-client", "0.1.0"),
+        )
+    }
+}
+
+#[derive(Clone)]
+pub struct TestHttpServer {
+    expected_auth: Option<String>,
+    include_headers: bool,
+    #[allow(dead_code)]
+    tool_router: rmcp::handler::server::tool::ToolRouter<Self>,
+}
+
+#[tool_router]
+impl TestHttpServer {
+    #[tool(description = "Echo input text")]
+    async fn echo(
+        &self,
+        Parameters(args): Parameters<EchoArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Some(expected) = &self.expected_auth {
+            let actual = context
+                .extensions
+                .get::<axum::http::request::Parts>()
+                .and_then(|parts| parts.headers.get(axum::http::header::AUTHORIZATION))
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_owned);
+            if actual.as_deref() != Some(expected.as_str()) {
+                return Err(ErrorData::internal_error(
+                    format!("unexpected authorization header: {actual:?}"),
+                    None,
+                ));
+            }
+        }
+
+        let mut payload = json!({ "text": args.text });
+
+        if self.include_headers {
+            let headers = context
+                .extensions
+                .get::<axum::http::request::Parts>()
+                .map(|parts| header_map_to_json(&parts.headers))
+                .unwrap_or_default();
+            payload["headers"] = Value::Object(headers);
+        }
+
+        Ok(CallToolResult::success(vec![ContentBlock::text(
+            payload.to_string(),
+        )]))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for TestHttpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(rmcp::model::ServerCapabilities::builder().enable_tools().build())
+    }
+}
+
+pub struct HttpTestServerHandle {
+    pub port: u16,
+    shutdown: CancellationToken,
+    join: JoinHandle<()>,
+}
+
+impl HttpTestServerHandle {
+    pub async fn shutdown(self) {
+        self.shutdown.cancel();
+        let _ = self.join.await;
+    }
+}
+
+#[allow(dead_code)]
+pub async fn spawn_http_test_server(
+    expected_auth: Option<String>,
+    include_headers: bool,
+) -> Result<HttpTestServerHandle> {
+    let shutdown = CancellationToken::new();
+    let config = StreamableHttpServerConfig::default()
+        .with_stateful_mode(false)
+        .with_json_response(true)
+        .with_cancellation_token(shutdown.child_token())
+        .disable_allowed_hosts();
+    let server = TestHttpServer {
+        expected_auth,
+        include_headers,
+        tool_router: TestHttpServer::tool_router(),
+    };
+    let mcp_service = StreamableHttpService::new(
+        move || Ok(server.clone()),
+        Arc::new(NeverSessionManager::default()),
+        config,
+    );
+    let app = Router::new().nest_service("/mcp", mcp_service);
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await?;
+    let port = listener.local_addr()?.port();
+    let shutdown_wait = shutdown.clone();
+    let join = tokio::spawn(async move {
+        let result = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                shutdown_wait.cancelled().await;
+            })
+            .await;
+        if let Err(err) = result {
+            panic!("test HTTP server failed: {err}");
+        }
+    });
+    Ok(HttpTestServerHandle {
+        port,
+        shutdown,
+        join,
+    })
+}
+
+#[allow(dead_code)]
+pub async fn spawn_auth_guard_server(expected_auth: &'static str) -> Result<HttpTestServerHandle> {
+    let shutdown = CancellationToken::new();
+    let config = StreamableHttpServerConfig::default()
+        .with_stateful_mode(false)
+        .with_json_response(true)
+        .with_cancellation_token(shutdown.child_token())
+        .disable_allowed_hosts();
+    let server = TestHttpServer {
+        expected_auth: None,
+        include_headers: false,
+        tool_router: TestHttpServer::tool_router(),
+    };
+    let mcp_service = StreamableHttpService::new(
+        move || Ok(server.clone()),
+        Arc::new(NeverSessionManager::default()),
+        config,
+    );
+    let app = Router::new().nest_service("/mcp", mcp_service).route_layer(
+        axum::middleware::from_fn(move |req: Request, next: Next| async move {
+            let authorized = req
+                .headers()
+                .get(axum::http::header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                == Some(expected_auth);
+            if !authorized {
+                return Ok::<_, std::convert::Infallible>(axum::http::Response::builder()
+                    .status(axum::http::StatusCode::UNAUTHORIZED)
+                    .body(axum::body::Body::from("unauthorized"))
+                    .expect("response"));
+            }
+            Ok::<_, std::convert::Infallible>(next.run(req).await)
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await?;
+    let port = listener.local_addr()?.port();
+    let shutdown_wait = shutdown.clone();
+    let join = tokio::spawn(async move {
+        let result = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                shutdown_wait.cancelled().await;
+            })
+            .await;
+        if let Err(err) = result {
+            panic!("test auth server failed: {err}");
+        }
+    });
+    Ok(HttpTestServerHandle {
+        port,
+        shutdown,
+        join,
+    })
+}
+
+pub async fn spawn_proxy_client(
+    args: &[&str],
+) -> Result<(
+    rmcp::service::RunningService<RoleClient, TestClientHandler>,
+    tokio::process::ChildStderr,
+)> {
+    let bin = proxy_binary_path().context("harnx-mcp-remote binary not found")?;
+    let mut command = tokio::process::Command::new(bin);
+    command.args(args);
+    let (transport, stderr) = TokioChildProcess::builder(command)
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .context("spawn harnx-mcp-remote")?;
+    let mut stderr = stderr.expect("proxy stderr should be piped");
+    let service = match rmcp::service::serve_client(TestClientHandler, transport).await {
+        Ok(service) => service,
+        Err(err) => {
+            let mut stderr_buf = String::new();
+            use tokio::io::AsyncReadExt;
+            let _ = stderr.read_to_string(&mut stderr_buf).await;
+            return Err(anyhow::anyhow!(
+                "connect MCP client to proxy stdio: {err}; proxy stderr: {}",
+                stderr_buf.trim()
+            ));
+        }
+    };
+    Ok((service, stderr))
+}
+
+pub fn text_content(result: &CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .filter_map(|content| content.as_text().map(|text| text.text.clone()))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn tool_args(value: Value) -> Map<String, Value> {
+    value.as_object().expect("tool args object").clone()
+}
+
+pub fn proxy_binary_path() -> Option<PathBuf> {
+    find_binary(
+        std::option_env!("CARGO_BIN_EXE_harnx-mcp-remote"),
+        "harnx-mcp-remote",
+    )
+}
+
+fn find_binary(env_path: Option<&str>, name: &str) -> Option<PathBuf> {
+    if let Some(path) = env_path {
+        let p = PathBuf::from(path);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    let candidate = target_dir().join(binary_name(name));
+    candidate.is_file().then_some(candidate)
+}
+
+fn target_dir() -> PathBuf {
+    let mut exe = std::env::current_exe().expect("current_exe");
+    exe.pop();
+    if exe.ends_with("deps") {
+        exe.pop();
+    }
+    exe
+}
+
+fn binary_name(base: &str) -> String {
+    if cfg!(windows) {
+        format!("{base}.exe")
+    } else {
+        base.to_string()
+    }
+}
+
+fn header_map_to_json(headers: &axum::http::HeaderMap) -> Map<String, Value> {
+    let mut grouped: HashMap<String, Vec<String>> = HashMap::new();
+    for (name, value) in headers {
+        let key = name.as_str().to_ascii_lowercase();
+        let val = value.to_str().unwrap_or_default().to_string();
+        grouped.entry(key).or_default().push(val);
+    }
+
+    grouped
+        .into_iter()
+        .map(|(key, values)| {
+            let value = if values.len() == 1 {
+                Value::String(values.into_iter().next().expect("one value"))
+            } else {
+                Value::Array(values.into_iter().map(Value::String).collect())
+            };
+            (key, value)
+        })
+        .collect()
+}

--- a/crates/harnx-mcp-remote/tests/headers.rs
+++ b/crates/harnx-mcp-remote/tests/headers.rs
@@ -9,13 +9,13 @@ use serde_json::json;
 async fn custom_headers_are_forwarded_to_remote_server() -> Result<()> {
     let server = spawn_http_test_server(None, true).await?;
     let url = format!("http://127.0.0.1:{}/mcp", server.port);
-    let (proxy, _stderr) =
-        spawn_proxy_client(&["--url", &url, "--header", "X-Custom:myvalue"]).await?;
+    let proxy = spawn_proxy_client(&["--url", &url, "--header", "X-Custom:myvalue"]).await?;
     let peer = proxy.peer().clone();
 
     let result = peer
         .call_tool(
-            CallToolRequestParams::new("echo").with_arguments(tool_args(json!({ "text": "header check" }))),
+            CallToolRequestParams::new("echo")
+                .with_arguments(tool_args(json!({ "text": "header check" }))),
         )
         .await?;
     let payload: serde_json::Value = serde_json::from_str(&text_content(&result))?;

--- a/crates/harnx-mcp-remote/tests/headers.rs
+++ b/crates/harnx-mcp-remote/tests/headers.rs
@@ -1,0 +1,27 @@
+mod common;
+
+use anyhow::Result;
+use common::{spawn_http_test_server, spawn_proxy_client, text_content, tool_args};
+use rmcp::model::CallToolRequestParams;
+use serde_json::json;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn custom_headers_are_forwarded_to_remote_server() -> Result<()> {
+    let server = spawn_http_test_server(None, true).await?;
+    let url = format!("http://127.0.0.1:{}/mcp", server.port);
+    let (proxy, _stderr) =
+        spawn_proxy_client(&["--url", &url, "--header", "X-Custom:myvalue"]).await?;
+    let peer = proxy.peer().clone();
+
+    let result = peer
+        .call_tool(
+            CallToolRequestParams::new("echo").with_arguments(tool_args(json!({ "text": "header check" }))),
+        )
+        .await?;
+    let payload: serde_json::Value = serde_json::from_str(&text_content(&result))?;
+    assert_eq!(payload["headers"]["x-custom"], "myvalue");
+
+    proxy.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}

--- a/crates/harnx-mcp-remote/tests/streamable_http.rs
+++ b/crates/harnx-mcp-remote/tests/streamable_http.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 async fn proxies_streamable_http_tools_and_calls() -> Result<()> {
     let server = spawn_http_test_server(None, false).await?;
     let url = format!("http://127.0.0.1:{}/mcp", server.port);
-    let (proxy, _stderr) = spawn_proxy_client(&["--url", &url]).await?;
+    let proxy = spawn_proxy_client(&["--url", &url]).await?;
     let peer = proxy.peer().clone();
 
     let proxy_info = peer
@@ -21,7 +21,11 @@ async fn proxies_streamable_http_tools_and_calls() -> Result<()> {
     assert!(
         tools.tools.iter().any(|tool| tool.name.as_ref() == "echo"),
         "expected echo tool in proxied list, got {:?}",
-        tools.tools.iter().map(|tool| tool.name.as_ref()).collect::<Vec<_>>()
+        tools
+            .tools
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>()
     );
 
     let result = peer
@@ -31,7 +35,10 @@ async fn proxies_streamable_http_tools_and_calls() -> Result<()> {
         )
         .await?;
     let text = text_content(&result);
-    assert_eq!(serde_json::from_str::<serde_json::Value>(&text)?["text"], "hello through proxy");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&text)?["text"],
+        "hello through proxy"
+    );
 
     proxy.cancel().await?;
     server.shutdown().await;

--- a/crates/harnx-mcp-remote/tests/streamable_http.rs
+++ b/crates/harnx-mcp-remote/tests/streamable_http.rs
@@ -1,0 +1,39 @@
+mod common;
+
+use anyhow::Result;
+use common::{spawn_http_test_server, spawn_proxy_client, text_content, tool_args};
+use rmcp::model::CallToolRequestParams;
+use serde_json::json;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn proxies_streamable_http_tools_and_calls() -> Result<()> {
+    let server = spawn_http_test_server(None, false).await?;
+    let url = format!("http://127.0.0.1:{}/mcp", server.port);
+    let (proxy, _stderr) = spawn_proxy_client(&["--url", &url]).await?;
+    let peer = proxy.peer().clone();
+
+    let proxy_info = peer
+        .peer_info()
+        .expect("proxy initialize result should be cached after handshake");
+    assert!(proxy_info.capabilities.tools.is_some());
+
+    let tools = peer.list_tools(None).await?;
+    assert!(
+        tools.tools.iter().any(|tool| tool.name.as_ref() == "echo"),
+        "expected echo tool in proxied list, got {:?}",
+        tools.tools.iter().map(|tool| tool.name.as_ref()).collect::<Vec<_>>()
+    );
+
+    let result = peer
+        .call_tool(
+            CallToolRequestParams::new("echo")
+                .with_arguments(tool_args(json!({ "text": "hello through proxy" }))),
+        )
+        .await?;
+    let text = text_content(&result);
+    assert_eq!(serde_json::from_str::<serde_json::Value>(&text)?["text"], "hello through proxy");
+
+    proxy.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}

--- a/docs/solutions/rmcp/mcp-stdio-to-http-proxy-2026-07-21.md
+++ b/docs/solutions/rmcp/mcp-stdio-to-http-proxy-2026-07-21.md
@@ -58,7 +58,7 @@ One rmcp 2.2.0 type handles both MCP 2024-11 SSE and 2025-03 streamable HTTP. En
 
 ```toml
 # Cargo.toml root
-rmcp = { version = "0.2", features = [
+rmcp = { version = "2.0", features = [ # Resolves to 2.2.0+
     "client",
     "server",
     "transport-streamable-http-client-reqwest",  # ADD THIS
@@ -116,25 +116,24 @@ config.auth_header = cli.bearer_token.clone();
 Combine cert+key PEM bytes into one buffer; use `from_pem` (not `from_pem_parts` on rustls backend):
 
 ```rust
-fn build_identity(cert_pem: &[u8], key_pem: &[u8]) -> reqwest::Identity {
+fn build_identity(cert_pem: &[u8], key_pem: &[u8]) -> anyhow::Result<reqwest::Identity> {
     let mut combined = Vec::with_capacity(cert_pem.len() + key_pem.len());
     combined.extend_from_slice(cert_pem);
     combined.extend_from_slice(key_pem);
-    reqwest::Identity::from_pem(&combined)
-        .expect("invalid cert/key PEM")
+    Ok(reqwest::Identity::from_pem(&combined)?)
 }
 
-fn build_client(cert_path: &Path, key_path: &Path, ca_path: Option<&Path>) -> anyhow::Result<reqwest::Client> {
+async fn build_client(cert_path: &Path, key_path: &Path, ca_path: Option<&Path>) -> anyhow::Result<reqwest::Client> {
     let mut builder = reqwest::Client::builder();
     
     // mTLS identity
-    let cert = std::fs::read(cert_path)?;
-    let key = std::fs::read(key_path)?;
-    builder = builder.identity(build_identity(&cert, &key));
+    let cert = tokio::fs::read(cert_path).await?;
+    let key = tokio::fs::read(key_path).await?;
+    builder = builder.identity(build_identity(&cert, &key)?);
     
     // Custom CA (optional)
     if let Some(ca) = ca_path {
-        let ca_pem = std::fs::read(ca)?;
+        let ca_pem = tokio::fs::read(ca).await?;
         let cert = reqwest::Certificate::from_pem(&ca_pem)?;
         builder = builder.add_root_certificate(cert);
     }
@@ -172,6 +171,7 @@ fn main() -> anyhow::Result<()> {
 
 async fn async_main() -> anyhow::Result<()> {
     let mut sigterm = signal(SignalKind::terminate())?;
+    let transport = rmcp::transport::stdio();
     let serve_ct = CancellationToken::new();
     
     tokio::select! {
@@ -197,34 +197,31 @@ Key points:
 - Create `Signal` before `serve_with_ct` — installs OS handler immediately
 - Use `serve_with_ct` + `tokio::select!` to handle pre-initialize SIGTERM
 - Manual runtime + `shutdown_timeout(1s)` guarantees exit (blocked stdio thread)
-- Take `RunningService` out of `RwLock` before `.await` — no lock held across await
 
-### 7. Transparent capability reflection
+### 7. Capability reflection via peer_info()
 
-After `serve_client()` completes handshake, read cached remote capabilities via `peer.peer_info()`:
+When `harnx-mcp-remote` initializes, it connects to the remote server first. Instead of hardcoding capabilities, reflect the remote's actual capabilities:
 
 ```rust
 async fn initialize(
     &self,
-    request: InitializeRequestParams,
-    context: RequestContext<RoleServer>,
-) -> Result<InitializeResult, ErrorData> {
-    // Connect to remote
-    let transport = build_transport(&self.cli)?;
-    let service = rmcp::service::serve_client(RemoteClientHandler, transport).await
-        .map_err(proxy_error)?;
+    _request: InitializeRequestParams,
+    _context: RequestContext<RoleServer>,
+) -> Result<rmcp::model::InitializeResult, ErrorData> {
+    // 1. Connect to remote
+    let transport = build_transport(&self.cli).await?;
+    let service = rmcp::service::serve_client(RemoteClientHandler, transport).await?;
     let peer = service.peer().clone();
     
-    // Store state
-    *self.peer.write().await = Some(peer.clone());
-    *self.client_service.write().await = Some(service);
+    // 2. Extract remote capabilities
+    let remote_info = peer.peer_info().expect("handshake must be complete");
     
-    // Reflect remote capabilities + instructions, rebrand server_info
-    let remote_info = peer.peer_info()
-        .ok_or_else(|| ErrorData::internal_error("remote info unavailable", None))?;
+    // 3. Store for proxying
+    *self.peer.write() = Some(peer);
+    *self.client_service.write() = Some(service);
     
-    let mut result = InitializeResult::default();
-    result.capabilities = remote_info.capabilities.clone();
+    // 4. Return remote info + proxy's own name/version
+    let mut result = remote_info.clone();
     result.instructions = remote_info.instructions.clone();
     result.server_info = ServerInfo {
         name: "harnx-mcp-remote".into(),

--- a/docs/solutions/rmcp/mcp-stdio-to-http-proxy-2026-07-21.md
+++ b/docs/solutions/rmcp/mcp-stdio-to-http-proxy-2026-07-21.md
@@ -1,0 +1,302 @@
+---
+title: "MCP stdio-to-HTTP proxy using rmcp StreamableHttpClientTransport"
+date: 2026-07-21
+category: "rmcp"
+problem_type: integration_issue
+component: "rmcp-transport"
+root_cause: "non-obvious rmcp defaults and API behaviors when building HTTP MCP proxies"
+resolution_type: code_fix
+severity: high
+tags:
+  - mcp
+  - rmcp
+  - proxy
+  - http
+  - streamable-http
+  - sse
+  - graceful-shutdown
+  - mtls
+  - auth
+plan_ref: "harnx-mcp-remote"
+---
+
+# MCP stdio-to-HTTP proxy using rmcp StreamableHttpClientTransport
+
+## Problem
+
+Building a stdio-to-HTTP MCP proxy that transparently bridges an LLM harness (stdio) to a remote HTTP MCP server requires handling rmcp's unified transport, preserving default behaviors, avoiding auth header bugs, wiring graceful shutdown correctly, and reflecting remote capabilities accurately.
+
+## Symptoms
+
+- **SSE servers disconnect immediately**: Proxy works against streamable HTTP servers but fails against stateless SSE (2024-11) servers with `connection closed: initialize response` — no meaningful error
+- **401 on valid bearer tokens**: Auth header set as `Bearer <token>` produces HTTP 401; server logs show `Authorization: Bearer Bearer <token>`
+- **SIGTERM exits 143**: Process exits with code 143 in idle/pre-initialize state instead of graceful exit 0
+- **Process hangs after cancel**: Service cancellation returns but process never exits (blocked in runtime drop)
+- **Capability mismatch**: Host cannot call `list_prompts`/`list_resources` despite proxy implementing them
+
+## Investigation Steps
+
+1. Traced `allow_stateless` default through rmcp source: `StreamableHttpClientTransportConfig::default()` sets `true`; proxy overwrites with `clap` bool defaulting to `false`
+2. Probed auth header handling: rmcp's reqwest transport calls `.bearer_auth(auth_header)` which prepends `"Bearer "`; setting header to full `"Bearer <token>"` doubles it
+3. Instrumented SIGTERM handling: probe showed signal handler not installed before `serve()`; rmcp `serve()` blocks on `expect_next_message("initialize request")` — never reaches handler registration in idle state
+4. Tested runtime shutdown: `#[tokio::main]` drop hangs on blocking stdio read thread; explicit runtime + `shutdown_timeout(1s)` exits cleanly
+5. Verified capability reflection: `Peer::peer_info()` returns cached `ServerInfo` from handshake — safe to read in `initialize` after `serve_client` completes (no deadlock)
+
+## Root Cause
+
+1. **`allow_stateless` default overwritten**: rmcp 2.2.0 defaults `allow_stateless = true` for SSE compatibility; clap bool default `false` breaks stateless servers
+2. **Double Bearer**: rmcp's transport prepends `"Bearer "`; setting full header value doubles it
+3. **Pre-initialize SIGTERM**: rmcp `serve()` blocks until initialize; signal handler installed after cannot fire in idle state
+4. **Blocking stdio thread**: `#[tokio::main]` runtime drop waits on blocking tasks
+5. **Static capabilities**: Hardcoded capabilities exclude methods the proxy actually forwards
+
+## Solution
+
+### 1. StreamableHttpClientTransport unifies SSE + streamable HTTP
+
+One rmcp 2.2.0 type handles both MCP 2024-11 SSE and 2025-03 streamable HTTP. Enable workspace feature:
+
+```toml
+# Cargo.toml root
+rmcp = { version = "0.2", features = [
+    "client",
+    "server",
+    "transport-streamable-http-client-reqwest",  # ADD THIS
+] }
+```
+
+Build transport with config:
+
+```rust
+use rmcp::transport::streamable_http_client::{
+    StreamableHttpClientTransport, StreamableHttpClientTransportConfig,
+};
+
+let mut config = StreamableHttpClientTransportConfig::with_uri(&url);
+config.auth_header = bearer_token;  // RAW token, no "Bearer " prefix
+config.custom_headers = headers;    // HashMap<HeaderName, HeaderValue>
+// allow_stateless defaults to true — preserve it for SSE compat
+
+let transport = StreamableHttpClientTransport::with_client(reqwest_client, config);
+```
+
+### 2. Preserve allow_stateless default — expose opt-OUT
+
+rmcp's default `true` supports stateless HTTP servers. Overwriting with clap bool (default false) is a silent regression. Expose an opt-OUT flag:
+
+```rust
+#[derive(Parser)]
+struct Cli {
+    /// Require stateful session; disable SSE fallback
+    #[arg(long, env = "MCP_REMOTE_STRICT_SESSION")]
+    strict_session: bool,
+}
+
+// In transport builder:
+if cli.strict_session {
+    config.allow_stateless = false;
+}
+// Else: preserve rmcp default (true)
+```
+
+### 3. Set raw token, not "Bearer <token>"
+
+rmcp passes `auth_header` to reqwest's `.bearer_auth()` which prepends `"Bearer "`:
+
+```rust
+// WRONG — doubles "Bearer "
+config.auth_header = Some(format!("Bearer {token}"));
+
+// CORRECT — raw token only
+config.auth_header = cli.bearer_token.clone();
+```
+
+### 4. mTLS with rustls reqwest
+
+Combine cert+key PEM bytes into one buffer; use `from_pem` (not `from_pem_parts` on rustls backend):
+
+```rust
+fn build_identity(cert_pem: &[u8], key_pem: &[u8]) -> reqwest::Identity {
+    let mut combined = Vec::with_capacity(cert_pem.len() + key_pem.len());
+    combined.extend_from_slice(cert_pem);
+    combined.extend_from_slice(key_pem);
+    reqwest::Identity::from_pem(&combined)
+        .expect("invalid cert/key PEM")
+}
+
+fn build_client(cert_path: &Path, key_path: &Path, ca_path: Option<&Path>) -> anyhow::Result<reqwest::Client> {
+    let mut builder = reqwest::Client::builder();
+    
+    // mTLS identity
+    let cert = std::fs::read(cert_path)?;
+    let key = std::fs::read(key_path)?;
+    builder = builder.identity(build_identity(&cert, &key));
+    
+    // Custom CA (optional)
+    if let Some(ca) = ca_path {
+        let ca_pem = std::fs::read(ca)?;
+        let cert = reqwest::Certificate::from_pem(&ca_pem)?;
+        builder = builder.add_root_certificate(cert);
+    }
+    
+    Ok(builder.build()?)
+}
+```
+
+### 5. Dependency: rmcp 2.2.0 requires sse-stream >= 0.2.4
+
+rmcp 2.2.0 calls `SseStream::from_bytes_stream`; sse-stream 0.2.3 only has `from_byte_stream`. Fix:
+
+```bash
+cargo update -p sse-stream --precise 0.2.4
+```
+
+Cargo.lock-only change; rmcp requires `^0.2`, so no manifest edit needed.
+
+### 6. Graceful shutdown: register signal BEFORE serve, use serve_with_ct
+
+rmcp `serve()` blocks until initialize arrives. Signal handler must be registered BEFORE calling serve:
+
+```rust
+use tokio::signal::unix::{signal, SignalKind};
+use tokio_util::sync::CancellationToken;
+
+fn main() -> anyhow::Result<()> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    let result = rt.block_on(async_main());
+    rt.shutdown_timeout(std::time::Duration::from_secs(1));  // Guarantees exit
+    result
+}
+
+async fn async_main() -> anyhow::Result<()> {
+    let mut sigterm = signal(SignalKind::terminate())?;
+    let serve_ct = CancellationToken::new();
+    
+    tokio::select! {
+        // Post-initialize path
+        service = server.serve_with_ct(transport, serve_ct.clone()) => {
+            // Wait for shutdown signal
+            sigterm.recv().await;
+            // Ordered teardown: remote first, then local
+            service.service().shutdown_remote().await?;
+            service.cancel().await?;
+        }
+        // Pre-initialize path: signal wins before serve completes
+        _ = sigterm.recv() => {
+            serve_ct.cancel();  // Cancel pending serve
+        }
+    }
+    
+    Ok(())
+}
+```
+
+Key points:
+- Create `Signal` before `serve_with_ct` — installs OS handler immediately
+- Use `serve_with_ct` + `tokio::select!` to handle pre-initialize SIGTERM
+- Manual runtime + `shutdown_timeout(1s)` guarantees exit (blocked stdio thread)
+- Take `RunningService` out of `RwLock` before `.await` — no lock held across await
+
+### 7. Transparent capability reflection
+
+After `serve_client()` completes handshake, read cached remote capabilities via `peer.peer_info()`:
+
+```rust
+async fn initialize(
+    &self,
+    request: InitializeRequestParams,
+    context: RequestContext<RoleServer>,
+) -> Result<InitializeResult, ErrorData> {
+    // Connect to remote
+    let transport = build_transport(&self.cli)?;
+    let service = rmcp::service::serve_client(RemoteClientHandler, transport).await
+        .map_err(proxy_error)?;
+    let peer = service.peer().clone();
+    
+    // Store state
+    *self.peer.write().await = Some(peer.clone());
+    *self.client_service.write().await = Some(service);
+    
+    // Reflect remote capabilities + instructions, rebrand server_info
+    let remote_info = peer.peer_info()
+        .ok_or_else(|| ErrorData::internal_error("remote info unavailable", None))?;
+    
+    let mut result = InitializeResult::default();
+    result.capabilities = remote_info.capabilities.clone();
+    result.instructions = remote_info.instructions.clone();
+    result.server_info = ServerInfo {
+        name: "harnx-mcp-remote".into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+    };
+    
+    Ok(result)
+}
+```
+
+This is safe because `peer_info()` returns cached handshake state — no extra round-trip, no deadlock.
+
+### 8. Prior-art patterns apply
+
+From `mcp-proxy-stdio-pattern-2026-05-19.md`:
+
+1. **Store BOTH Peer and RunningService**:
+```rust
+struct RemoteProxyServer {
+    peer: RwLock<Option<Peer<RoleClient>>>,
+    client_service: RwLock<Option<RunningService<RoleClient, RemoteClientHandler>>>,
+}
+```
+Dropping `RunningService` closes connection.
+
+2. **ClientHandler::list_roots returns method_not_found**:
+```rust
+async fn list_roots(&self, _: RequestContext<RoleClient>) -> Result<ListRootsResult, ErrorData> {
+    Err(ErrorData::method_not_found::<rmcp::model::ListRootsRequestMethod>())
+}
+```
+
+3. **Never call peer methods inside initialize**. The peer methods (e.g., `list_tools`) are only safe to call after handshake completes. In this implementation, `peer.peer_info()` is safe because it reads cached state.
+
+## Why This Works
+
+1. **Unified transport**: `StreamableHttpClientTransport` auto-negotiates SSE vs streamable HTTP via `allow_stateless`; preserves SSE compatibility by default
+2. **Default preservation**: Opt-out flag avoids invalidating rmcp's sensible defaults for SSE servers
+3. **Raw token**: rmcp's request builder handles `Authorization` header construction; caller provides token only
+4. **Pre-initialize shutdown**: Signal registered before serve can fire; `serve_with_ct` + `select!` handles both timing windows
+5. **Manual runtime**: `shutdown_timeout()` forces exit without waiting for blocked stdio thread
+6. **Capability reflection**: `peer_info()` returns handshake result — no new request, usable immediately
+
+## Prevention Strategies
+
+**Tests:**
+- Unit test: verify `auth_header` receives raw token (not `"Bearer <token>"`) 
+- Unit test: verify `allow_stateless` defaults to `true` without `--strict-session`
+- Integration test: SIGTERM in idle state exits 0 (not 143)
+- Integration test: SIGTERM after initialize exits 0 with remote shutdown
+- Integration test: initialize response reflects remote capabilities
+
+**Code Review Checklist:**
+- [ ] `transport-streamable-http-client-reqwest` feature enabled in root `Cargo.toml`
+- [ ] `allow_stateless` NOT overwritten to `false` by default
+- [ ] `auth_header` set to raw token (no `"Bearer "` prefix)
+- [ ] mTLS uses `Identity::from_pem` with combined cert+key
+- [ ] SIGTERM `Signal` created before `serve_with_ct`
+- [ ] `tokio::select!` between serve and shutdown signal
+- [ ] Manual runtime with `shutdown_timeout(1s)` 
+- [ ] `initialize` returns remote capabilities (or minimal static set)
+- [ ] BOTH `Peer` and `RunningService` stored in `RwLock<Option<...>>`
+- [ ] `list_roots` returns `method_not_found`
+
+**Best Practices:**
+- Use `--strict-session` opt-OUT flag for stateless mode (preserve rmcp default)
+- Test against stateless SSE servers (`with_stateful_mode(false)`)
+- Log startup URL but never log secrets
+- Ordered shutdown: remote service first, then local stdio
+
+## Related Issues
+
+- **GitHub:** [#1076](https://github.com/dobesv/harnx/issues/1076) — harnx-mcp-remote proxy
+- **Related Solution:** [mcp-proxy-stdio-pattern-2026-05-19.md](mcp-proxy-stdio-pattern-2026-05-19.md) — RunningService lifetime, method_not_found
+- **Related Solution:** [streamable-http-server-setup-2026-05-29.md](streamable-http-server-setup-2026-05-29.md) — HTTP server config patterns


### PR DESCRIPTION
Adds the harnx-mcp-remote crate, a stdio-based MCP server that proxies traffic to remote HTTP MCP servers. It supports both streamable HTTP (MCP 2025-03) and legacy SSE (MCP 2024-11) transports using rmcp's unified StreamableHttpClientTransport.

Key features:
- Authentication via bearer token, custom headers, and mTLS (configured via CLI flags or MCP_REMOTE_* environment variables).
- Graceful shutdown handling for SIGTERM and Ctrl-C, ensuring remote connections are closed.
- Automatic capability reflection, advertising the remote server's tools, prompts, and resources.
- Support for stateless legacy SSE servers via a --strict-session opt-out flag.
- Comprehensive integration test suite covering auth, headers, and transport modes.

Includes a solution document for stdio-to-HTTP proxy patterns and a required workspace dependency bump for sse-stream to 0.2.4.

#1076

Plan: harnx-mcp-remote

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `harnx-mcp-remote`, a stdio-to-HTTP proxy for remote MCP servers.
  * Supports streamable HTTP and legacy SSE transports.
  * Added bearer-token authentication, custom headers, and mTLS configuration.
  * Supports CLI flags and environment variables, with optional strict session handling.
  * Proxies remote tools, prompts, and resources through the local MCP connection.

* **Documentation**
  * Added installation, configuration, usage examples, and troubleshooting guidance.

* **Tests**
  * Added coverage for authentication, headers, tool calls, and streamable HTTP proxying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->