### PR TITLE
fix(acp): forward model errors via harnx:error meta instead of plain text

### DIFF
--- a/.changeset/acp-error-notification-964.md
+++ b/.changeset/acp-error-notification-964.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Forward nested ACP model errors with a `harnx:error` marker so clients render them as errors without feeding them into downstream agent context.

--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -39,6 +39,10 @@ const SESSION_IDLE_TTL: Duration = Duration::from_secs(15 * 60);
 enum AcpForward {
     /// Text chunk for `SessionUpdate::AgentMessageChunk`.
     Text(String, Option<AgentSource>),
+    /// Error chunk for `SessionUpdate::AgentMessageChunk`, flagged via
+    /// `harnx:error` meta so ACP clients can render it without accumulating it
+    /// into `response_text`.
+    Error(String, Option<AgentSource>),
     /// User-turn text for `SessionUpdate::UserMessageChunk`. Kept separate
     /// from `Text` so replayed/attached user turns are NOT mixed into the
     /// parent's accumulated `response_text` (which forms the next agent's
@@ -118,7 +122,7 @@ pub(crate) fn event_to_forward(
             Some(AcpForward::Text(output, source))
         }
         AgentEvent::Model(ModelEvent::Error(err)) if !err.is_empty() => {
-            Some(AcpForward::Text(format!("error: {err}"), source))
+            Some(AcpForward::Error(err, source))
         }
         AgentEvent::User(UserEvent::Message { content }) if !content.is_empty() => {
             Some(AcpForward::UserText(content, source))
@@ -442,6 +446,31 @@ impl HarnxAgent {
             }
         }
 
+        fn send_notify_error(
+            conn: &Option<acp::ConnectionTo<acp::Client>>,
+            session_key: &str,
+            err: String,
+            source: Option<AgentSource>,
+        ) {
+            if err.is_empty() {
+                return;
+            }
+            if let Some(conn) = conn.as_ref() {
+                let sid = session_key.to_string();
+                let mut meta = source
+                    .as_ref()
+                    .and_then(meta_from_source)
+                    .unwrap_or_default();
+                meta.insert("harnx:error".to_string(), serde_json::Value::Bool(true));
+                let chunk = ContentChunk::new(format!("error: {err}").into()).meta(meta);
+                let notification = SessionNotification::new(
+                    SessionId::new(sid),
+                    SessionUpdate::AgentMessageChunk(chunk),
+                );
+                let _ = conn.send_notification(notification);
+            }
+        }
+
         fn send_notify_user_text(
             conn: &Option<acp::ConnectionTo<acp::Client>>,
             session_key: &str,
@@ -572,6 +601,9 @@ impl HarnxAgent {
             match forward {
                 AcpForward::Text(text, source) => {
                     send_notify_text(conn, session_key, text, source);
+                }
+                AcpForward::Error(err, source) => {
+                    send_notify_error(conn, session_key, err, source);
                 }
                 AcpForward::UserText(text, source) => {
                     send_notify_user_text(conn, session_key, text, source);

--- a/crates/harnx-acp-server/src/lib_tests.rs
+++ b/crates/harnx-acp-server/src/lib_tests.rs
@@ -446,11 +446,11 @@ mod tests {
         );
 
         match rx.try_recv().expect("should forward error text") {
-            AcpForward::Text(text, source) => {
-                assert_eq!(text, "error: Internal server error");
+            AcpForward::Error(text, source) => {
+                assert_eq!(text, "Internal server error");
                 assert!(source.is_none());
             }
-            _ => panic!("expected Text forward"),
+            _ => panic!("expected Error forward"),
         }
     }
 

--- a/crates/harnx-acp/src/client.rs
+++ b/crates/harnx-acp/src/client.rs
@@ -162,19 +162,26 @@ impl AcpNotificationClient {
             return Ok(());
         }
 
-        let is_agent_message = matches!(args.update, SessionUpdate::AgentMessageChunk(_));
+        let mut accumulate_response_text = false;
         let mut message_text: Option<String> = None;
         let event: Option<AgentEvent> = match args.update {
             SessionUpdate::AgentMessageChunk(chunk) => {
                 let text = chunk_text(&chunk.content);
+                let meta = chunk.meta.as_ref().map(|meta| json!(meta));
+                let is_error = meta.as_ref().is_some_and(is_error_from_meta_value);
                 // Only drop genuinely empty chunks. Whitespace-only chunks
                 // (e.g. a lone "\n" between streamed list items or paragraphs)
                 // are meaningful: stripping them concatenates adjacent chunks
-                // and corrupts the rendered markdown (see issue #862, where
+                // and corrupts rendered markdown (see issue #862, where
                 // "1. Confirm\n2. Confirm" rendered as "1. Confirm2. Confirm").
                 if text.is_empty() {
                     None
+                } else if is_error {
+                    Some(AgentEvent::Model(ModelEvent::Error(
+                        strip_error_prefix(&text).to_string(),
+                    )))
                 } else {
+                    accumulate_response_text = true;
                     message_text = Some(text.clone());
                     Some(AgentEvent::Model(ModelEvent::MessageChunk {
                         blocks: vec![ContentBlock::Text(text)],
@@ -265,8 +272,8 @@ impl AcpNotificationClient {
             SessionUpdate::UserMessageChunk(chunk) => {
                 // User turns (e.g. from remote attach/resume history replay)
                 // are rendered as user transcript entries and deliberately
-                // NOT accumulated into `response_text` (`is_agent_message` is
-                // only set for `AgentMessageChunk`).
+                // NOT accumulated into `response_text` (`accumulate_response_text`
+                // is only set for non-error `AgentMessageChunk`s).
                 let text = chunk_text(&chunk.content);
                 if text.is_empty() {
                     None
@@ -284,7 +291,7 @@ impl AcpNotificationClient {
         };
 
         if let Some(event) = event {
-            if is_agent_message {
+            if accumulate_response_text {
                 if let Some(ref chunk) = message_text {
                     let mut sessions = self.sessions.write().await;
                     let state = sessions.entry(session_id).or_default();
@@ -1085,6 +1092,17 @@ fn markdown_from_meta_value(value: &serde_json::Value) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+fn is_error_from_meta_value(value: &serde_json::Value) -> bool {
+    value
+        .get("harnx:error")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn strip_error_prefix(text: &str) -> &str {
+    text.strip_prefix("error: ").unwrap_or(text)
+}
+
 fn resolve_notification_source(
     fallback_agent: &str,
     notification: &SessionNotification,
@@ -1811,6 +1829,161 @@ mod tests {
         }
 
         assert_eq!(received, "Step one\nStep two");
+    }
+
+    /// Error chunks from nested ACP agents must surface as `ModelEvent::Error`
+    /// without being accumulated into `response_text`, which becomes next
+    /// agent input.
+    #[tokio::test]
+    async fn error_message_chunk_forwards_error_event_without_polluting_response_text() {
+        let sessions = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let chunk_forwarder = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel();
+        chunk_forwarder.write().await.insert(1, chunk_tx);
+        let (activity_tx, _) = tokio::sync::broadcast::channel(8);
+        let client = AcpNotificationClient::new(
+            "working".to_string(),
+            sessions.clone(),
+            chunk_forwarder,
+            activity_tx,
+        );
+
+        let notification = SessionNotification::new(
+            SessionId::new("outer-session"),
+            SessionUpdate::AgentMessageChunk(
+                ContentChunk::new("error: upstream failed".into()).meta(
+                    serde_json::Map::from_iter([("harnx:error".to_string(), json!(true))]),
+                ),
+            ),
+        );
+        client.session_notification(notification).await.unwrap();
+
+        let forwarded = chunk_rx.recv().await.expect("forwarded error chunk");
+        match forwarded {
+            NestedAcpEvent::Agent(AgentEvent::Model(ModelEvent::Error(message)), _) => {
+                assert_eq!(message, "upstream failed");
+            }
+            other => panic!("unexpected nested ACP event: {other:?}"),
+        }
+
+        let sessions = sessions.read().await;
+        if let Some(state) = sessions.get("outer-session") {
+            assert!(
+                state.response_text.is_empty(),
+                "error message chunk must not accumulate into response_text"
+            );
+        }
+    }
+
+    /// A chunk with `harnx:error = false` is a normal message chunk: it must
+    /// forward a `MessageChunk` event and DO accumulate into `response_text`.
+    #[tokio::test]
+    async fn message_chunk_with_error_meta_false_is_treated_as_normal_message() {
+        let sessions = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let chunk_forwarder = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel();
+        chunk_forwarder.write().await.insert(1, chunk_tx);
+        let (activity_tx, _) = tokio::sync::broadcast::channel(8);
+        let client = AcpNotificationClient::new(
+            "working".to_string(),
+            sessions.clone(),
+            chunk_forwarder,
+            activity_tx,
+        );
+
+        let notification = SessionNotification::new(
+            SessionId::new("outer-session"),
+            SessionUpdate::AgentMessageChunk(ContentChunk::new("hello".into()).meta(
+                serde_json::Map::from_iter([("harnx:error".to_string(), json!(false))]),
+            )),
+        );
+        client.session_notification(notification).await.unwrap();
+
+        let forwarded = chunk_rx.recv().await.expect("forwarded message chunk");
+        match forwarded {
+            NestedAcpEvent::Agent(AgentEvent::Model(ModelEvent::MessageChunk { .. }), _) => {}
+            other => panic!("unexpected nested ACP event: {other:?}"),
+        }
+
+        let sessions = sessions.read().await;
+        let state = sessions.get("outer-session").expect("session state");
+        assert_eq!(
+            state.response_text, "hello",
+            "non-error message chunk must accumulate into response_text"
+        );
+    }
+
+    /// A `harnx:error` meta with a non-boolean value falls back to normal
+    /// message handling (fails open safely, not treated as an error).
+    #[tokio::test]
+    async fn message_chunk_with_non_bool_error_meta_is_treated_as_normal_message() {
+        let sessions = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let chunk_forwarder = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel();
+        chunk_forwarder.write().await.insert(1, chunk_tx);
+        let (activity_tx, _) = tokio::sync::broadcast::channel(8);
+        let client = AcpNotificationClient::new(
+            "working".to_string(),
+            sessions.clone(),
+            chunk_forwarder,
+            activity_tx,
+        );
+
+        let notification = SessionNotification::new(
+            SessionId::new("outer-session"),
+            SessionUpdate::AgentMessageChunk(ContentChunk::new("hi".into()).meta(
+                serde_json::Map::from_iter([("harnx:error".to_string(), json!("yes"))]),
+            )),
+        );
+        client.session_notification(notification).await.unwrap();
+
+        let forwarded = chunk_rx.recv().await.expect("forwarded message chunk");
+        match forwarded {
+            NestedAcpEvent::Agent(AgentEvent::Model(ModelEvent::MessageChunk { .. }), _) => {}
+            other => panic!("unexpected nested ACP event: {other:?}"),
+        }
+
+        let sessions = sessions.read().await;
+        let state = sessions.get("outer-session").expect("session state");
+        assert_eq!(state.response_text, "hi");
+    }
+
+    /// An error-flagged chunk WITHOUT the legacy `error: ` prefix still surfaces
+    /// as a `ModelEvent::Error` carrying the raw text, and is not accumulated.
+    #[tokio::test]
+    async fn error_chunk_without_prefix_forwards_raw_error_text() {
+        let sessions = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let chunk_forwarder = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel();
+        chunk_forwarder.write().await.insert(1, chunk_tx);
+        let (activity_tx, _) = tokio::sync::broadcast::channel(8);
+        let client = AcpNotificationClient::new(
+            "working".to_string(),
+            sessions.clone(),
+            chunk_forwarder,
+            activity_tx,
+        );
+
+        let notification = SessionNotification::new(
+            SessionId::new("outer-session"),
+            SessionUpdate::AgentMessageChunk(ContentChunk::new("bare failure".into()).meta(
+                serde_json::Map::from_iter([("harnx:error".to_string(), json!(true))]),
+            )),
+        );
+        client.session_notification(notification).await.unwrap();
+
+        let forwarded = chunk_rx.recv().await.expect("forwarded error chunk");
+        match forwarded {
+            NestedAcpEvent::Agent(AgentEvent::Model(ModelEvent::Error(message)), _) => {
+                assert_eq!(message, "bare failure");
+            }
+            other => panic!("unexpected nested ACP event: {other:?}"),
+        }
+
+        let sessions = sessions.read().await;
+        if let Some(state) = sessions.get("outer-session") {
+            assert!(state.response_text.is_empty());
+        }
     }
 
     /// A genuinely empty thought chunk ("") is still dropped.

--- a/docs/solutions/integration-issues/acp-error-notification-meta-marker-2026-07-21.md
+++ b/docs/solutions/integration-issues/acp-error-notification-meta-marker-2026-07-21.md
@@ -1,0 +1,158 @@
+---
+title: "ACP: Forward model errors via harnx:error meta marker to prevent response_text pollution"
+date: 2026-07-21
+category: "integration-issues"
+problem_type: integration_issue
+component: "harnx-acp, harnx-acp-server"
+root_cause: "ACP SessionUpdate enum lacks dedicated error variant; errors forwarded as plain text accumulated into parent agent's response_text"
+resolution_type: code_fix
+severity: medium
+tags:
+  - acp
+  - error-handling
+  - meta-marker
+  - sub-agent
+  - protocol-extension
+plan_ref: "acp-error-notification-964"
+---
+
+## Problem
+
+Sub-agent model errors forwarded through ACP accumulated into the parent agent's `response_text`, polluting downstream LLM input and potentially confusing later turns. The external `agent-client-protocol` `SessionUpdate` enum has no dedicated error variant, so `harnx-acp-server` previously forwarded `ModelEvent::Error` as plain `AgentMessageChunk` text with `error: {err}` prefix. Parent client accumulated all chunks into `response_text`, unaware the content was an error.
+
+## Symptoms
+
+- Sub-agent errors appeared in parent agent's next-turn prompt context
+- TUI rendered errors correctly (without accumulation), but ACP path behaved differently
+- Error text like `error: upstream failed` mixed with legitimate response content
+- Downstream LLM could misinterpret error text as part of conversation
+
+## Investigation Steps
+
+1. Traced `ModelEvent::Error` handling in `harnx-acp-server` — mapped to `AcpForward::Text` with `error: ` prefix
+2. Identified `AcpNotificationClient::session_notification` accumulated all `AgentMessageChunk` into `response_text`
+3. Noted `is_agent_message` bool controlled accumulation — no differentiation for error chunks
+4. Discovered existing `harnx:*` meta-marker convention (`harnx:model`, `harnx:markdown`, `harnx:usage`)
+5. Recognized pattern: meta markers convey harnx-specific semantics over ACP wire without protocol fork
+
+## Root Cause
+
+**Protocol gap**: External `SessionUpdate` enum lacks error variant. Server code forced all forwarded content through `AgentMessageChunk`, conflating errors with genuine message text.
+
+**Accumulation logic flaw**: Client accumulated all `AgentMessageChunk` chunks into `response_text` based on a single `is_agent_message` flag, with no condition to exclude error content.
+
+## Solution
+
+### 1. Server: Add `AcpForward::Error` variant and `send_notify_error`
+
+Added internal `AcpForward::Error(String, Option<AgentSource>)` variant:
+
+```rust
+// crates/harnx-acp-server/src/lib.rs
+enum AcpForward {
+    Text(String, Option<AgentSource>),
+    Error(String, Option<AgentSource>),  // NEW
+    UserText(String, Option<AgentSource>),
+    // ...
+}
+
+// Map ModelEvent::Error to AcpForward::Error
+AgentEvent::Model(ModelEvent::Error(err)) if !err.is_empty() => {
+    Some(AcpForward::Error(err, source))  // was: AcpForward::Text(format!("error: {err}"), source))
+}
+```
+
+`send_notify_error` emits `AgentMessageChunk` with `harnx:error: true` in meta:
+
+```rust
+fn send_notify_error(
+    conn: &Option<acp::ConnectionTo<acp::Client>>,
+    session_key: &str,
+    err: String,
+    source: Option<AgentSource>,
+) {
+    let mut meta = source.as_ref().and_then(meta_from_source).unwrap_or_default();
+    meta.insert("harnx:error".to_string(), serde_json::Value::Bool(true));
+    let chunk = ContentChunk::new(format!("error: {err}").into()).meta(meta);
+    let notification = SessionNotification::new(
+        SessionId::new(session_key.to_string()),
+        SessionUpdate::AgentMessageChunk(chunk),
+    );
+    let _ = conn.send_notification(notification);
+}
+```
+
+### 2. Client: Check meta for error flag, exclude from accumulation
+
+Added `is_error_from_meta_value` helper and `accumulate_response_text` flag:
+
+```rust
+// crates/harnx-acp/src/client.rs
+fn is_error_from_meta_value(value: &serde_json::Value) -> bool {
+    value
+        .get("harnx:error")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)  // fails open: missing/non-bool = not error
+}
+
+fn strip_error_prefix(text: &str) -> &str {
+    text.strip_prefix("error: ").unwrap_or(text)
+}
+
+// In session_notification:
+let mut accumulate_response_text = false;
+match args.update {
+    SessionUpdate::AgentMessageChunk(chunk) => {
+        let is_error = meta.as_ref().is_some_and(is_error_from_meta_value);
+        if is_error {
+            Some(AgentEvent::Model(ModelEvent::Error(
+                strip_error_prefix(&text).to_string(),
+            )))
+        } else {
+            accumulate_response_text = true;  // only set for non-error
+            Some(AgentEvent::Model(ModelEvent::MessageChunk { ... }))
+        }
+    }
+    // ...
+}
+```
+
+## Why This Works
+
+**Meta marker pattern**: Embeds harnx-specific semantics in existing ACP chunk type via namespaced `harnx:<key>` meta. External protocol remains unchanged; unaware clients still render the human-readable `error: {err}` text.
+
+**Fail-open design**: `is_error_from_meta_value` uses strict bool check with `unwrap_or(false)`. Missing key, non-bool values, or malformed meta all fall back to normal message handling. No silent breakage.
+
+**Backward compatibility**: Both directions preserved:
+- Old server → new client: No `harnx:error` meta, falls back to normal message accumulation (old behavior)
+- New server → old client: Chunk renders as text with `error: ` prefix (old behavior), no meta extraction
+
+## Prevention Strategies
+
+**Test coverage**:
+- Error chunk surfaces as `ModelEvent::Error`, NOT accumulated into `response_text`
+- `harnx:error: false` treated as normal message, DOES accumulate
+- Non-bool `harnx:error` value falls back to normal message handling
+- Error without `error: ` prefix still surfaces raw text
+
+**Verification**:
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run  # NOT cargo test
+```
+
+**Code review checklist**:
+- [ ] New ACP extensions use `harnx:*` namespaced meta keys
+- [ ] Meta extraction functions fail open (default to safe behavior)
+- [ ] Tests cover both error and non-error cases
+- [ ] Backward compatibility preserved in both directions
+
+## Related Issues
+
+- **GitHub:** [#964](https://github.com/dobesv/harnx/issues/964) — ACP: forward ModelEvent::Error as dedicated error notification
+- **Related Solution:** [mcp-tool-template-acp-propagation-2026-04-30.md](./mcp-tool-template-acp-propagation-2026-04-30.md) — Establishes `harnx:markdown` meta marker pattern
+
+## Out of Scope
+
+`NoticeEvent::Error`/`Warning` still forwarded as plain text and can pollute `response_text` — same class of issue, could reuse `harnx:error` path in future.


### PR DESCRIPTION
Fixes #964

Forward ModelEvent::Error events structurally via a harnx:error meta marker instead of accumulating them as plain text into response_text. This prevents model errors from polluting downstream agent input while allowing clients to distinguish errors from normal message text.

Changes include:
- Updated harnx-acp-server to emit harnx:error meta marker for model errors.
- Updated harnx-acp client to detect and extract harnx:error markers into structural errors.
- Regression and edge-case tests in lib_tests.rs.
- Solution documentation for the acp-error-notification pattern.
- Changeset for the harnx workspace.

Issue: #964
References: #905
Plan: acp-error-notification-964