### PR TITLE
Use a stronger model for daedalus agent

### DIFF
--- a/packages/pantheon/agents/daedalus.md
+++ b/packages/pantheon/agents/daedalus.md
@@ -1,9 +1,9 @@
 ---
 role: assistant
-model: claude:claude-sonnet-5
+model: openai:gpt-5.6-sol
 compaction_agent: compact-researcher
 model_fallbacks:
-- openai:gpt-5.6-sol
+- claude:claude-opus-4-8
 use_tools:
 - atlas_session_handoff
 - librarian_session_prompt


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * The Daedalus agent now uses OpenAI GPT-5.6 Sol as its primary language model.
  * Updated fallback behavior now uses Claude Opus 4.8 when the primary model is unavailable.
  * No other agent configuration settings were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->