### PR TITLE
Roll back GPT version

### DIFF
--- a/packages/coding/agents/coder.md
+++ b/packages/coding/agents/coder.md
@@ -4,7 +4,7 @@ model: claude:claude-sonnet-5
 compaction_agent: compact-coder
 model_fallbacks:
   - claude:claude-opus-4-8
-  - openai:gpt-5.6-sol
+  - openai:gpt-5.5
 
 use_tools:
   - bash_exec

--- a/packages/pantheon/agents/aeacus.md
+++ b/packages/pantheon/agents/aeacus.md
@@ -1,6 +1,6 @@
 ---
 role: subagent
-model: openai:gpt-5.6-sol
+model: openai:gpt-5.5
 compaction_agent: compact-reviewer
 use_tools:
 - bash_exec

--- a/packages/pantheon/agents/atlas.md
+++ b/packages/pantheon/agents/atlas.md
@@ -3,7 +3,7 @@ role: assistant
 model: claude:claude-opus-4-8
 model_fallbacks:
 - claude:claude-sonnet-5
-- openai:gpt-5.6-terra
+- openai:gpt-5.4
 compaction_agent: compact-planner
 use_tools:
 - bash_exec

--- a/packages/pantheon/agents/daedalus.md
+++ b/packages/pantheon/agents/daedalus.md
@@ -1,6 +1,6 @@
 ---
 role: assistant
-model: openai:gpt-5.6-sol
+model: openai:gpt-5.5
 compaction_agent: compact-researcher
 model_fallbacks:
 - claude:claude-opus-4-8

--- a/packages/pantheon/agents/hephaestus.md
+++ b/packages/pantheon/agents/hephaestus.md
@@ -1,6 +1,6 @@
 ---
 role: subagent
-model: openai:gpt-5.6-sol
+model: openai:gpt-5.5
 compaction_agent: compact-dev
 use_tools:
 - bash_exec

--- a/packages/pantheon/agents/melpomene.md
+++ b/packages/pantheon/agents/melpomene.md
@@ -1,6 +1,6 @@
 ---
 role: subagent
-model: openai:gpt-5.6-sol
+model: openai:gpt-5.5
 compaction_agent: compact-reviewer
 use_tools:
 - bash_exec

--- a/packages/pantheon/agents/momus.md
+++ b/packages/pantheon/agents/momus.md
@@ -1,6 +1,6 @@
 ---
 role: subagent
-model: openai:gpt-5.6-terra
+model: openai:gpt-5.4
 compaction_agent: compact-planner
 use_tools:
 - bash_exec

--- a/packages/pantheon/agents/plato.md
+++ b/packages/pantheon/agents/plato.md
@@ -1,6 +1,6 @@
 ---
 role: subagent
-model: openai:gpt-5.6-sol
+model: openai:gpt-5.5
 compaction_agent: compact-dev
 use_tools:
 - bash_exec

--- a/packages/pantheon/agents/polyhymnia.md
+++ b/packages/pantheon/agents/polyhymnia.md
@@ -1,6 +1,6 @@
 ---
 role: subagent
-model: openai:gpt-5.6-sol
+model: openai:gpt-5.5
 compaction_agent: compact-reviewer
 use_tools:
 - bash_exec

--- a/packages/pantheon/agents/sisyphus.md
+++ b/packages/pantheon/agents/sisyphus.md
@@ -3,7 +3,7 @@ role: assistant
 model: claude:claude-opus-4-8
 compaction_agent: compact-dev
 model_fallbacks:
-- openai:gpt-5.6-terra
+- openai:gpt-5.4
 use_tools:
 - bash_exec
 - bash_read_exec_log

--- a/packages/pantheon/agents/zosimus.md
+++ b/packages/pantheon/agents/zosimus.md
@@ -1,6 +1,6 @@
 ---
 role: subagent
-model: openai:gpt-5.6-sol
+model: openai:gpt-5.5
 compaction_agent: compact-researcher
 use_tools:
 - bash_exec


### PR DESCRIPTION
Need to switch to new API to use GPT 5.6 with tools and reasoning