### PR TITLE
Add per-call repo targeting and non-fatal startup for plans-github

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3938,6 +3938,7 @@ dependencies = [
  "serde_yaml",
  "similar 3.1.1",
  "thiserror 2.0.19",
+ "tokio",
  "uuid",
 ]
 

--- a/crates/harnx-mcp-plans-core/Cargo.toml
+++ b/crates/harnx-mcp-plans-core/Cargo.toml
@@ -24,4 +24,4 @@ thiserror = "2"
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["io-util", "macros", "rt"] }

--- a/crates/harnx-mcp-plans-core/Cargo.toml
+++ b/crates/harnx-mcp-plans-core/Cargo.toml
@@ -22,3 +22,6 @@ serde_yaml = { workspace = true }
 similar = { workspace = true }
 thiserror = "2"
 uuid = { workspace = true, features = ["v4"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/harnx-mcp-plans-core/src/conformance.rs
+++ b/crates/harnx-mcp-plans-core/src/conformance.rs
@@ -122,7 +122,7 @@ async fn assert_deleted_plan_contract<S: PlanStore>(
 ) {
     if caps.deletes_permanently {
         let err = store
-            .get_plan(&id.to_string())
+            .get_plan(&crate::model::Target::Local, &id.to_string())
             .await
             .expect_err("get_plan on deleted plan should fail");
         assert!(
@@ -146,7 +146,11 @@ async fn assert_deleted_task_contract<S: PlanStore>(
 ) {
     if caps.deletes_permanently {
         let err = store
-            .get_task(&plan_id.to_string(), &task_id.to_string())
+            .get_task(
+                &crate::model::Target::Local,
+                &plan_id.to_string(),
+                &task_id.to_string(),
+            )
             .await
             .expect_err("get_task on deleted task should fail");
         assert!(
@@ -167,7 +171,7 @@ async fn collect_all_plans<S: PlanStore>(store: &Arc<S>) -> Vec<Plan> {
     let mut next: Option<PageToken> = None;
     loop {
         let page = store
-            .list_plans(next.clone())
+            .list_plans(&crate::model::Target::Local, next.clone())
             .await
             .expect("list_plans should succeed");
         items.extend(page.items);
@@ -184,7 +188,12 @@ async fn collect_all_tasks<S: PlanStore>(store: &Arc<S>, plan_id: &str) -> Vec<T
     let mut next: Option<PageToken> = None;
     loop {
         let page = store
-            .list_tasks(&plan_id.to_string(), TaskFilter::default(), next.clone())
+            .list_tasks(
+                &crate::model::Target::Local,
+                &plan_id.to_string(),
+                TaskFilter::default(),
+                next.clone(),
+            )
             .await
             .expect("list_tasks should succeed");
         items.extend(page.items);
@@ -198,16 +207,19 @@ async fn collect_all_tasks<S: PlanStore>(store: &Arc<S>, plan_id: &str) -> Vec<T
 
 async fn test_plan_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities) {
     let plan1 = store
-        .add_plan(NewPlan {
-            id: "auto-gen-test-plan".to_string(),
-            title: Some("Auto-generated ID plan".to_string()),
-            summary: None,
-            author: None,
-            assignee: None,
-            executor: None,
-            git_branch: None,
-            github_owner_repo: None,
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: "auto-gen-test-plan".to_string(),
+                title: Some("Auto-generated ID plan".to_string()),
+                summary: None,
+                author: None,
+                assignee: None,
+                executor: None,
+                git_branch: None,
+                github_owner_repo: None,
+            },
+        )
         .await
         .expect("add_plan with provided ID should succeed");
     assert!(!plan1.id.is_empty(), "plan ID should be non-empty");
@@ -215,16 +227,19 @@ async fn test_plan_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities)
 
     let client_id = "custom-plan-id";
     let plan2 = store
-        .add_plan(NewPlan {
-            id: client_id.to_string(),
-            title: Some("Custom ID plan".to_string()),
-            summary: Some("Plan summary".to_string()),
-            author: Some("hestia".to_string()),
-            assignee: None,
-            executor: None,
-            git_branch: None,
-            github_owner_repo: None,
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: client_id.to_string(),
+                title: Some("Custom ID plan".to_string()),
+                summary: Some("Plan summary".to_string()),
+                author: Some("hestia".to_string()),
+                assignee: None,
+                executor: None,
+                git_branch: None,
+                github_owner_repo: None,
+            },
+        )
         .await
         .expect("add_plan with custom ID should succeed");
     assert_preserved_id(caps, &plan2.id, client_id, "plan");
@@ -232,14 +247,14 @@ async fn test_plan_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities)
     assert_eq!(plan2.author.as_deref(), Some("hestia"));
 
     let fetched = store
-        .get_plan(&plan2.id)
+        .get_plan(&crate::model::Target::Local, &plan2.id)
         .await
         .expect("get_plan should succeed");
     assert_eq!(fetched.id, plan2.id);
     assert_eq!(fetched.title, plan2.title);
     if caps.preserves_client_id {
         let fetched_by_client_id = store
-            .get_plan(&client_id.to_string())
+            .get_plan(&crate::model::Target::Local, &client_id.to_string())
             .await
             .expect("get_plan by client-provided ID should succeed when IDs are preserved");
         assert_eq!(fetched_by_client_id.id, client_id);
@@ -247,6 +262,7 @@ async fn test_plan_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities)
 
     let updated = store
         .update_plan_meta(
+            &crate::model::Target::Local,
             &plan2.id,
             PlanMetaUpdate {
                 title: Some("Updated title".to_string()),
@@ -264,11 +280,11 @@ async fn test_plan_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities)
     assert_eq!(updated.assignee.as_deref(), Some("atlas"));
 
     store
-        .write_plan_body(&plan2.id, "Plan body content")
+        .write_plan_body(&crate::model::Target::Local, &plan2.id, "Plan body content")
         .await
         .expect("write_plan_body should succeed");
     let body = store
-        .read_plan_body(&plan2.id)
+        .read_plan_body(&crate::model::Target::Local, &plan2.id)
         .await
         .expect("read_plan_body should succeed");
     assert!(
@@ -277,46 +293,51 @@ async fn test_plan_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities)
     );
 
     store
-        .delete_plan(&plan2.id)
+        .delete_plan(&crate::model::Target::Local, &plan2.id)
         .await
         .expect("delete_plan should succeed");
     assert_deleted_plan_contract(store, &plan2.id, caps).await;
 
-    let _ = store.delete_plan(&plan1.id).await;
+    let _ = store
+        .delete_plan(&crate::model::Target::Local, &plan1.id)
+        .await;
 }
 
 async fn test_plan_list_pagination<S: PlanStore>(store: &Arc<S>) {
     let ids: Vec<_> = (0..5).map(|i| format!("pagination-plan-{}", i)).collect();
 
     for id in &ids {
-        let _ = store.delete_plan(id).await;
+        let _ = store.delete_plan(&crate::model::Target::Local, id).await;
     }
 
     for id in &ids {
         store
-            .add_plan(NewPlan {
-                id: id.clone(),
-                title: Some(format!("Plan {}", id)),
-                summary: None,
-                author: None,
-                assignee: None,
-                executor: None,
-                git_branch: None,
-                github_owner_repo: None,
-            })
+            .add_plan(
+                &crate::model::Target::Local,
+                NewPlan {
+                    id: id.clone(),
+                    title: Some(format!("Plan {}", id)),
+                    summary: None,
+                    author: None,
+                    assignee: None,
+                    executor: None,
+                    git_branch: None,
+                    github_owner_repo: None,
+                },
+            )
             .await
             .expect("add_plan should succeed");
     }
 
     let page1 = store
-        .list_plans(None)
+        .list_plans(&crate::model::Target::Local, None)
         .await
         .expect("list_plans should succeed");
     assert!(!page1.items.is_empty(), "page 1 should have items");
 
     if let Some(next) = page1.next {
         let page2 = store
-            .list_plans(Some(next))
+            .list_plans(&crate::model::Target::Local, Some(next))
             .await
             .expect("list_plans page 2 should succeed");
         let page1_ids: std::collections::HashSet<_> = page1.items.iter().map(|p| &p.id).collect();
@@ -330,27 +351,35 @@ async fn test_plan_list_pagination<S: PlanStore>(store: &Arc<S>) {
 
     for plan in collect_all_plans(store).await {
         if plan.id.starts_with("pagination-plan-") {
-            let _ = store.delete_plan(&plan.id).await;
+            let _ = store
+                .delete_plan(&crate::model::Target::Local, &plan.id)
+                .await;
         }
     }
 }
 
 async fn test_plan_duplicate_id<S: PlanStore>(store: &Arc<S>) {
     let plan = store
-        .add_plan(NewPlan {
-            id: "duplicate-plan-id".to_string(),
-            title: Some("First plan".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: "duplicate-plan-id".to_string(),
+                title: Some("First plan".to_string()),
+                ..Default::default()
+            },
+        )
         .await
         .expect("first add_plan should succeed");
 
     let result = store
-        .add_plan(NewPlan {
-            id: "duplicate-plan-id".to_string(),
-            title: Some("Second plan".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: "duplicate-plan-id".to_string(),
+                title: Some("Second plan".to_string()),
+                ..Default::default()
+            },
+        )
         .await;
 
     if let Err(err) = result {
@@ -361,21 +390,27 @@ async fn test_plan_duplicate_id<S: PlanStore>(store: &Arc<S>) {
         );
     }
 
-    let _ = store.delete_plan(&plan.id).await;
+    let _ = store
+        .delete_plan(&crate::model::Target::Local, &plan.id)
+        .await;
 }
 
 async fn test_task_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities) {
     let plan = store
-        .add_plan(NewPlan {
-            id: "task-crud-plan".to_string(),
-            title: Some("Task CRUD plan".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: "task-crud-plan".to_string(),
+                title: Some("Task CRUD plan".to_string()),
+                ..Default::default()
+            },
+        )
         .await
         .expect("add_plan should succeed");
 
     let task1 = store
         .add_task(
+            &crate::model::Target::Local,
             &plan.id,
             NewTask {
                 id: "auto-gen-test-task".to_string(),
@@ -397,6 +432,7 @@ async fn test_task_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities)
     let client_id = "custom-task-id";
     let task2 = store
         .add_task(
+            &crate::model::Target::Local,
             &plan.id,
             NewTask {
                 id: client_id.to_string(),
@@ -417,13 +453,17 @@ async fn test_task_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities)
     assert_eq!(task2.author.as_deref(), Some("apollo"));
 
     let fetched = store
-        .get_task(&plan.id, &task2.id)
+        .get_task(&crate::model::Target::Local, &plan.id, &task2.id)
         .await
         .expect("get_task should succeed");
     assert_eq!(fetched.id, task2.id);
     if caps.preserves_client_id {
         let fetched_by_client_id = store
-            .get_task(&plan.id, &client_id.to_string())
+            .get_task(
+                &crate::model::Target::Local,
+                &plan.id,
+                &client_id.to_string(),
+            )
             .await
             .expect("get_task by client-provided ID should succeed when IDs are preserved");
         assert_eq!(fetched_by_client_id.id, client_id);
@@ -431,6 +471,7 @@ async fn test_task_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities)
 
     let updated = store
         .update_task_meta(
+            &crate::model::Target::Local,
             &plan.id,
             &task2.id,
             TaskMetaUpdate {
@@ -451,11 +492,16 @@ async fn test_task_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities)
     assert_eq!(updated.status, "in_progress");
 
     store
-        .write_task_body(&plan.id, &task2.id, "Task body")
+        .write_task_body(
+            &crate::model::Target::Local,
+            &plan.id,
+            &task2.id,
+            "Task body",
+        )
         .await
         .expect("write_task_body should succeed");
     let body = store
-        .read_task_body(&plan.id, &task2.id)
+        .read_task_body(&crate::model::Target::Local, &plan.id, &task2.id)
         .await
         .expect("read_task_body should succeed");
     assert!(
@@ -464,27 +510,35 @@ async fn test_task_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities)
     );
 
     store
-        .delete_task(&plan.id, &task2.id)
+        .delete_task(&crate::model::Target::Local, &plan.id, &task2.id)
         .await
         .expect("delete_task should succeed");
     assert_deleted_task_contract(store, &plan.id, &task2.id, caps).await;
 
-    let _ = store.delete_task(&plan.id, &task1.id).await;
-    let _ = store.delete_plan(&plan.id).await;
+    let _ = store
+        .delete_task(&crate::model::Target::Local, &plan.id, &task1.id)
+        .await;
+    let _ = store
+        .delete_plan(&crate::model::Target::Local, &plan.id)
+        .await;
 }
 
 async fn test_task_filtering<S: PlanStore>(store: &Arc<S>) {
     let plan = store
-        .add_plan(NewPlan {
-            id: "task-filter-plan".to_string(),
-            title: Some("Task filter plan".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: "task-filter-plan".to_string(),
+                title: Some("Task filter plan".to_string()),
+                ..Default::default()
+            },
+        )
         .await
         .expect("add_plan should succeed");
 
     store
         .add_task(
+            &crate::model::Target::Local,
             &plan.id,
             NewTask {
                 id: "task-open".to_string(),
@@ -499,6 +553,7 @@ async fn test_task_filtering<S: PlanStore>(store: &Arc<S>) {
 
     store
         .add_task(
+            &crate::model::Target::Local,
             &plan.id,
             NewTask {
                 id: "task-done".to_string(),
@@ -513,6 +568,7 @@ async fn test_task_filtering<S: PlanStore>(store: &Arc<S>) {
 
     let open_tasks = store
         .list_tasks(
+            &crate::model::Target::Local,
             &plan.id,
             TaskFilter {
                 status: Some("open".to_string()),
@@ -526,6 +582,7 @@ async fn test_task_filtering<S: PlanStore>(store: &Arc<S>) {
 
     let backend_tasks = store
         .list_tasks(
+            &crate::model::Target::Local,
             &plan.id,
             TaskFilter {
                 status: None,
@@ -540,22 +597,28 @@ async fn test_task_filtering<S: PlanStore>(store: &Arc<S>) {
         .iter()
         .all(|t| t.tags.contains(&"backend".to_string())));
 
-    let _ = store.delete_plan(&plan.id).await;
+    let _ = store
+        .delete_plan(&crate::model::Target::Local, &plan.id)
+        .await;
 }
 
 async fn test_task_list_pagination<S: PlanStore>(store: &Arc<S>) {
     let plan = store
-        .add_plan(NewPlan {
-            id: "task-pag-plan".to_string(),
-            title: Some("Task pagination plan".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: "task-pag-plan".to_string(),
+                title: Some("Task pagination plan".to_string()),
+                ..Default::default()
+            },
+        )
         .await
         .expect("add_plan should succeed");
 
     for i in 0..5 {
         store
             .add_task(
+                &crate::model::Target::Local,
                 &plan.id,
                 NewTask {
                     id: format!("task-pag-{}", i),
@@ -568,14 +631,24 @@ async fn test_task_list_pagination<S: PlanStore>(store: &Arc<S>) {
     }
 
     let page1 = store
-        .list_tasks(&plan.id, TaskFilter::default(), None)
+        .list_tasks(
+            &crate::model::Target::Local,
+            &plan.id,
+            TaskFilter::default(),
+            None,
+        )
         .await
         .expect("list_tasks should succeed");
     assert!(!page1.items.is_empty(), "page 1 should have items");
 
     if let Some(next) = page1.next {
         let page2 = store
-            .list_tasks(&plan.id, TaskFilter::default(), Some(next))
+            .list_tasks(
+                &crate::model::Target::Local,
+                &plan.id,
+                TaskFilter::default(),
+                Some(next),
+            )
             .await
             .expect("list_tasks page 2 should succeed");
         let page1_ids: std::collections::HashSet<_> = page1.items.iter().map(|t| &t.id).collect();
@@ -587,21 +660,27 @@ async fn test_task_list_pagination<S: PlanStore>(store: &Arc<S>) {
         }
     }
 
-    let _ = store.delete_plan(&plan.id).await;
+    let _ = store
+        .delete_plan(&crate::model::Target::Local, &plan.id)
+        .await;
 }
 
 async fn test_task_dependencies<S: PlanStore>(store: &Arc<S>) {
     let plan = store
-        .add_plan(NewPlan {
-            id: "task-deps-plan".to_string(),
-            title: Some("Task deps plan".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: "task-deps-plan".to_string(),
+                title: Some("Task deps plan".to_string()),
+                ..Default::default()
+            },
+        )
         .await
         .expect("add_plan should succeed");
 
     let task1 = store
         .add_task(
+            &crate::model::Target::Local,
             &plan.id,
             NewTask {
                 id: "dep-task-1".to_string(),
@@ -614,6 +693,7 @@ async fn test_task_dependencies<S: PlanStore>(store: &Arc<S>) {
 
     let task2 = store
         .add_task(
+            &crate::model::Target::Local,
             &plan.id,
             NewTask {
                 id: "dep-task-2".to_string(),
@@ -627,29 +707,38 @@ async fn test_task_dependencies<S: PlanStore>(store: &Arc<S>) {
 
     assert_eq!(task2.dependencies, vec![task1.id.clone()]);
 
-    let _ = store.delete_plan(&plan.id).await;
+    let _ = store
+        .delete_plan(&crate::model::Target::Local, &plan.id)
+        .await;
 }
 
 async fn test_cross_plan_isolation<S: PlanStore>(store: &Arc<S>) {
     let plan_a = store
-        .add_plan(NewPlan {
-            id: "cross-plan-a".to_string(),
-            title: Some("Cross plan A".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: "cross-plan-a".to_string(),
+                title: Some("Cross plan A".to_string()),
+                ..Default::default()
+            },
+        )
         .await
         .expect("add_plan A should succeed");
     let plan_b = store
-        .add_plan(NewPlan {
-            id: "cross-plan-b".to_string(),
-            title: Some("Cross plan B".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: "cross-plan-b".to_string(),
+                title: Some("Cross plan B".to_string()),
+                ..Default::default()
+            },
+        )
         .await
         .expect("add_plan B should succeed");
 
     let task = store
         .add_task(
+            &crate::model::Target::Local,
             &plan_a.id,
             NewTask {
                 id: "cross-task".to_string(),
@@ -661,13 +750,14 @@ async fn test_cross_plan_isolation<S: PlanStore>(store: &Arc<S>) {
         .expect("add_task should succeed");
 
     let err = store
-        .get_task(&plan_b.id, &task.id)
+        .get_task(&crate::model::Target::Local, &plan_b.id, &task.id)
         .await
         .expect_err("get_task with wrong plan should fail");
     assert!(matches!(err, StoreError::NotFound));
 
     let note = store
         .add_note(
+            &crate::model::Target::Local,
             &plan_a.id,
             NewNote {
                 id: "cross-note".to_string(),
@@ -679,27 +769,35 @@ async fn test_cross_plan_isolation<S: PlanStore>(store: &Arc<S>) {
         .expect("add_note should succeed");
 
     let err = store
-        .get_note(&plan_b.id, &note.id)
+        .get_note(&crate::model::Target::Local, &plan_b.id, &note.id)
         .await
         .expect_err("get_note with wrong plan should fail");
     assert!(matches!(err, StoreError::NotFound));
 
-    let _ = store.delete_plan(&plan_a.id).await;
-    let _ = store.delete_plan(&plan_b.id).await;
+    let _ = store
+        .delete_plan(&crate::model::Target::Local, &plan_a.id)
+        .await;
+    let _ = store
+        .delete_plan(&crate::model::Target::Local, &plan_b.id)
+        .await;
 }
 
 async fn test_note_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities) {
     let plan = store
-        .add_plan(NewPlan {
-            id: "note-crud-plan".to_string(),
-            title: Some("Note CRUD plan".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: "note-crud-plan".to_string(),
+                title: Some("Note CRUD plan".to_string()),
+                ..Default::default()
+            },
+        )
         .await
         .expect("add_plan should succeed");
 
     let note1 = store
         .add_note(
+            &crate::model::Target::Local,
             &plan.id,
             NewNote {
                 id: "auto-gen-test-note".to_string(),
@@ -714,6 +812,7 @@ async fn test_note_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities)
     let client_id = "custom-note-id";
     let note2 = store
         .add_note(
+            &crate::model::Target::Local,
             &plan.id,
             NewNote {
                 id: client_id.to_string(),
@@ -727,13 +826,17 @@ async fn test_note_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities)
     assert_eq!(note2.summary.as_deref(), Some("Note summary"));
 
     let fetched = store
-        .get_note(&plan.id, &note2.id)
+        .get_note(&crate::model::Target::Local, &plan.id, &note2.id)
         .await
         .expect("get_note should succeed");
     assert_eq!(fetched.id, note2.id);
     if caps.preserves_client_id {
         let fetched_by_client_id = store
-            .get_note(&plan.id, &client_id.to_string())
+            .get_note(
+                &crate::model::Target::Local,
+                &plan.id,
+                &client_id.to_string(),
+            )
             .await
             .expect("get_note by client-provided ID should succeed when IDs are preserved");
         assert_eq!(fetched_by_client_id.id, client_id);
@@ -741,6 +844,7 @@ async fn test_note_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities)
 
     let updated = store
         .update_note_meta(
+            &crate::model::Target::Local,
             &plan.id,
             &note2.id,
             NoteMetaUpdate {
@@ -754,11 +858,16 @@ async fn test_note_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities)
     assert_eq!(updated.author.as_deref(), Some("atlas"));
 
     store
-        .write_note_body(&plan.id, &note2.id, "Note body")
+        .write_note_body(
+            &crate::model::Target::Local,
+            &plan.id,
+            &note2.id,
+            "Note body",
+        )
         .await
         .expect("write_note_body should succeed");
     let body = store
-        .read_note_body(&plan.id, &note2.id)
+        .read_note_body(&crate::model::Target::Local, &plan.id, &note2.id)
         .await
         .expect("read_note_body should succeed");
     assert!(
@@ -767,32 +876,40 @@ async fn test_note_crud<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities)
     );
 
     store
-        .delete_note(&plan.id, &note2.id)
+        .delete_note(&crate::model::Target::Local, &plan.id, &note2.id)
         .await
         .expect("delete_note should succeed");
     let err = store
-        .get_note(&plan.id, &note2.id)
+        .get_note(&crate::model::Target::Local, &plan.id, &note2.id)
         .await
         .expect_err("get_note on deleted note should fail");
     assert!(matches!(err, StoreError::NotFound));
 
-    let _ = store.delete_note(&plan.id, &note1.id).await;
-    let _ = store.delete_plan(&plan.id).await;
+    let _ = store
+        .delete_note(&crate::model::Target::Local, &plan.id, &note1.id)
+        .await;
+    let _ = store
+        .delete_plan(&crate::model::Target::Local, &plan.id)
+        .await;
 }
 
 async fn test_note_list_pagination<S: PlanStore>(store: &Arc<S>) {
     let plan = store
-        .add_plan(NewPlan {
-            id: "note-pag-plan".to_string(),
-            title: Some("Note pagination plan".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: "note-pag-plan".to_string(),
+                title: Some("Note pagination plan".to_string()),
+                ..Default::default()
+            },
+        )
         .await
         .expect("add_plan should succeed");
 
     for i in 0..5 {
         store
             .add_note(
+                &crate::model::Target::Local,
                 &plan.id,
                 NewNote {
                     id: format!("note-pag-{}", i),
@@ -805,14 +922,14 @@ async fn test_note_list_pagination<S: PlanStore>(store: &Arc<S>) {
     }
 
     let page1 = store
-        .list_notes(&plan.id, None)
+        .list_notes(&crate::model::Target::Local, &plan.id, None)
         .await
         .expect("list_notes should succeed");
     assert!(!page1.items.is_empty(), "page 1 should have items");
 
     if let Some(next) = page1.next {
         let page2 = store
-            .list_notes(&plan.id, Some(next))
+            .list_notes(&crate::model::Target::Local, &plan.id, Some(next))
             .await
             .expect("list_notes page 2 should succeed");
         let page1_ids: std::collections::HashSet<_> = page1.items.iter().map(|n| &n.id).collect();
@@ -824,51 +941,69 @@ async fn test_note_list_pagination<S: PlanStore>(store: &Arc<S>) {
         }
     }
 
-    let _ = store.delete_plan(&plan.id).await;
+    let _ = store
+        .delete_plan(&crate::model::Target::Local, &plan.id)
+        .await;
 }
 
 async fn test_body_edits<S: PlanStore>(store: &Arc<S>) {
     let plan = store
-        .add_plan(NewPlan {
-            id: "body-edits-plan".to_string(),
-            title: Some("Body edits plan".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: "body-edits-plan".to_string(),
+                title: Some("Body edits plan".to_string()),
+                ..Default::default()
+            },
+        )
         .await
         .expect("add_plan should succeed");
 
     store
-        .write_plan_body(&plan.id, "line1\nline2\nline3")
+        .write_plan_body(
+            &crate::model::Target::Local,
+            &plan.id,
+            "line1\nline2\nline3",
+        )
         .await
         .expect("write_plan_body should succeed");
     let body = store
-        .read_plan_body(&plan.id)
+        .read_plan_body(&crate::model::Target::Local, &plan.id)
         .await
         .expect("read_plan_body should succeed");
     assert!(body.ends_with("line1\nline2\nline3"));
 
     store
-        .write_plan_body(&plan.id, "line1\nREPLACED\nline3")
+        .write_plan_body(
+            &crate::model::Target::Local,
+            &plan.id,
+            "line1\nREPLACED\nline3",
+        )
         .await
         .expect("write_plan_body replace should succeed");
     let body = store
-        .read_plan_body(&plan.id)
+        .read_plan_body(&crate::model::Target::Local, &plan.id)
         .await
         .expect("read_plan_body should succeed");
     assert!(body.ends_with("line1\nREPLACED\nline3"));
 
     store
-        .write_plan_body(&plan.id, "line1\nREPLACED\nline3\nappended")
+        .write_plan_body(
+            &crate::model::Target::Local,
+            &plan.id,
+            "line1\nREPLACED\nline3\nappended",
+        )
         .await
         .expect("write_plan_body append should succeed");
     let body = store
-        .read_plan_body(&plan.id)
+        .read_plan_body(&crate::model::Target::Local, &plan.id)
         .await
         .expect("read_plan_body should succeed");
     assert!(body.ends_with("line1\nREPLACED\nline3\nappended"));
 
     let task = store
         .add_task(
+            &crate::model::Target::Local,
             &plan.id,
             NewTask {
                 id: "body-task".to_string(),
@@ -879,17 +1014,23 @@ async fn test_body_edits<S: PlanStore>(store: &Arc<S>) {
         .await
         .expect("add_task should succeed");
     store
-        .write_task_body(&plan.id, &task.id, "Task body content")
+        .write_task_body(
+            &crate::model::Target::Local,
+            &plan.id,
+            &task.id,
+            "Task body content",
+        )
         .await
         .expect("write_task_body should succeed");
     let task_body = store
-        .read_task_body(&plan.id, &task.id)
+        .read_task_body(&crate::model::Target::Local, &plan.id, &task.id)
         .await
         .expect("read_task_body should succeed");
     assert!(task_body.ends_with("Task body content"));
 
     let note = store
         .add_note(
+            &crate::model::Target::Local,
             &plan.id,
             NewNote {
                 id: "body-note".to_string(),
@@ -900,27 +1041,38 @@ async fn test_body_edits<S: PlanStore>(store: &Arc<S>) {
         .await
         .expect("add_note should succeed");
     store
-        .write_note_body(&plan.id, &note.id, "Note body content")
+        .write_note_body(
+            &crate::model::Target::Local,
+            &plan.id,
+            &note.id,
+            "Note body content",
+        )
         .await
         .expect("write_note_body should succeed");
     let note_body = store
-        .read_note_body(&plan.id, &note.id)
+        .read_note_body(&crate::model::Target::Local, &plan.id, &note.id)
         .await
         .expect("read_note_body should succeed");
     assert!(note_body.ends_with("Note body content"));
 
-    let _ = store.delete_plan(&plan.id).await;
+    let _ = store
+        .delete_plan(&crate::model::Target::Local, &plan.id)
+        .await;
 }
 
 async fn test_not_found_errors<S: PlanStore>(store: &Arc<S>) {
     let err = store
-        .get_plan(&"nonexistent-plan".to_string())
+        .get_plan(
+            &crate::model::Target::Local,
+            &"nonexistent-plan".to_string(),
+        )
         .await
         .expect_err("get_plan should fail for nonexistent ID");
     assert!(matches!(err, StoreError::NotFound) || matches!(err, StoreError::InvalidParams(_)));
 
     let err = store
         .get_task(
+            &crate::model::Target::Local,
             &"nonexistent-plan".to_string(),
             &"nonexistent-task".to_string(),
         )
@@ -930,6 +1082,7 @@ async fn test_not_found_errors<S: PlanStore>(store: &Arc<S>) {
 
     let err = store
         .get_note(
+            &crate::model::Target::Local,
             &"nonexistent-plan".to_string(),
             &"nonexistent-note".to_string(),
         )
@@ -940,20 +1093,26 @@ async fn test_not_found_errors<S: PlanStore>(store: &Arc<S>) {
 
 async fn test_already_exists_errors<S: PlanStore>(store: &Arc<S>) {
     let plan = store
-        .add_plan(NewPlan {
-            id: "already-exists-plan".to_string(),
-            title: Some("Existing plan".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: "already-exists-plan".to_string(),
+                title: Some("Existing plan".to_string()),
+                ..Default::default()
+            },
+        )
         .await
         .expect("first add_plan should succeed");
 
     let result = store
-        .add_plan(NewPlan {
-            id: "already-exists-plan".to_string(),
-            title: Some("Duplicate plan".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: "already-exists-plan".to_string(),
+                title: Some("Duplicate plan".to_string()),
+                ..Default::default()
+            },
+        )
         .await;
 
     if let Err(err) = result {
@@ -964,17 +1123,22 @@ async fn test_already_exists_errors<S: PlanStore>(store: &Arc<S>) {
         );
     }
 
-    let _ = store.delete_plan(&plan.id).await;
+    let _ = store
+        .delete_plan(&crate::model::Target::Local, &plan.id)
+        .await;
 }
 
 async fn test_invalid_id_errors<S: PlanStore>(store: &Arc<S>, caps: BackendCapabilities) {
     if caps.rejects_invalid_create_ids {
         let err = store
-            .add_plan(NewPlan {
-                id: "invalid/plan/id".to_string(),
-                title: Some("Invalid ID".to_string()),
-                ..Default::default()
-            })
+            .add_plan(
+                &crate::model::Target::Local,
+                NewPlan {
+                    id: "invalid/plan/id".to_string(),
+                    title: Some("Invalid ID".to_string()),
+                    ..Default::default()
+                },
+            )
             .await
             .expect_err("add_plan should fail for invalid ID");
         assert!(
@@ -985,16 +1149,20 @@ async fn test_invalid_id_errors<S: PlanStore>(store: &Arc<S>, caps: BackendCapab
     }
 
     let plan = store
-        .add_plan(NewPlan {
-            id: "plan-invalid-task".to_string(),
-            ..Default::default()
-        })
+        .add_plan(
+            &crate::model::Target::Local,
+            NewPlan {
+                id: "plan-invalid-task".to_string(),
+                ..Default::default()
+            },
+        )
         .await
         .expect("add_plan should succeed");
 
     if caps.rejects_invalid_create_ids {
         let err = store
             .add_task(
+                &crate::model::Target::Local,
                 &plan.id,
                 NewTask {
                     id: "invalid/task/id".to_string(),
@@ -1011,7 +1179,9 @@ async fn test_invalid_id_errors<S: PlanStore>(store: &Arc<S>, caps: BackendCapab
         );
     }
 
-    let _ = store.delete_plan(&plan.id).await;
+    let _ = store
+        .delete_plan(&crate::model::Target::Local, &plan.id)
+        .await;
 }
 
 #[cfg(test)]

--- a/crates/harnx-mcp-plans-core/src/lib.rs
+++ b/crates/harnx-mcp-plans-core/src/lib.rs
@@ -7,6 +7,6 @@ pub mod conformance;
 
 pub use model::{
     NewNote, NewPlan, NewTask, Note, NoteId, NoteMetaUpdate, Page, PageToken, Plan, PlanId,
-    PlanMetaUpdate, Task, TaskFilter, TaskId, TaskMetaUpdate,
+    PlanMetaUpdate, RepoTarget, Target, Task, TaskFilter, TaskId, TaskMetaUpdate,
 };
 pub use store::{PlanStore, StoreError};

--- a/crates/harnx-mcp-plans-core/src/model.rs
+++ b/crates/harnx-mcp-plans-core/src/model.rs
@@ -5,6 +5,72 @@ pub type PlanId = String;
 pub type TaskId = String;
 pub type NoteId = String;
 
+/// GitHub repository target for one plan store operation.
+///
+/// Values must be GitHub path slugs: non-empty ASCII letters, digits, `.`, `_`, or `-`,
+/// excluding `.` and `..`. This deliberately rejects path separators, whitespace, and
+/// control characters before values can be used in GitHub REST paths.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoTarget {
+    pub owner: String,
+    pub repo: String,
+}
+
+impl RepoTarget {
+    /// Build a validated GitHub repository target from caller or startup-detected values.
+    pub fn new(owner: impl Into<String>, repo: impl Into<String>) -> Result<Self, String> {
+        let owner = owner.into();
+        let repo = repo.into();
+        validate_github_slug("owner", &owner)?;
+        validate_github_slug("repo", &repo)?;
+        Ok(Self { owner, repo })
+    }
+
+    /// Validate this target's owner and repository slug values.
+    pub fn validate(&self) -> Result<(), String> {
+        validate_github_slug("owner", &self.owner)?;
+        validate_github_slug("repo", &self.repo)
+    }
+}
+
+/// Storage target resolved for a single tool call.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Target {
+    /// Local filesystem backend target; remote owner/repo params are ignored.
+    Local,
+    /// GitHub repository backend target.
+    GitHub(RepoTarget),
+}
+
+fn validate_github_slug(kind: &str, value: &str) -> Result<(), String> {
+    if value.is_empty() {
+        return Err(format!("GitHub {kind} must not be empty"));
+    }
+    if value == "." || value == ".." {
+        return Err(format!("GitHub {kind} must not be '.' or '..'"));
+    }
+    if value.contains('/') || value.contains('\\') {
+        return Err(format!("GitHub {kind} must not contain path separators"));
+    }
+    if value
+        .chars()
+        .any(|ch| ch.is_whitespace() || ch.is_control())
+    {
+        return Err(format!(
+            "GitHub {kind} must not contain whitespace or control characters"
+        ));
+    }
+    if !value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
+    {
+        return Err(format!(
+            "GitHub {kind} must contain only ASCII letters, digits, '.', '_', or '-'"
+        ));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PageToken(pub String);
 

--- a/crates/harnx-mcp-plans-core/src/server/handler.rs
+++ b/crates/harnx-mcp-plans-core/src/server/handler.rs
@@ -15,10 +15,10 @@ impl<S: PlanStore + 'static> ServerHandler for PlansServer<S> {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new(
-                self.meta.name,
+                self.meta.name.clone(),
                 env!("CARGO_PKG_VERSION"),
             ))
-            .with_instructions(self.meta.instructions)
+            .with_instructions(self.meta.instructions.clone())
     }
 
     async fn list_tools(
@@ -26,9 +26,7 @@ impl<S: PlanStore + 'static> ServerHandler for PlansServer<S> {
         _pagination: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
-        Ok(ListToolsResult {
-            meta: None,
-            tools: vec![
+        let mut tools = vec![
                 Tool::new("list_plans", "List all plans with metadata and task/note counts.", Map::new())
                     .with_input_schema::<ListPlansParams>()
                     .with_meta(Meta(json!({"call_template": "list plans", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
@@ -74,7 +72,13 @@ impl<S: PlanStore + 'static> ServerHandler for PlansServer<S> {
                 Tool::new("delete_note", "Delete a note from a plan.", Map::new())
                     .with_input_schema::<DeleteNoteParams>()
                     .with_meta(Meta(json!({"call_template": "delete note {{ args.plan }}/{{ args.note_id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
-            ],
+            ];
+        for tool in &mut tools {
+            self.meta.target_policy.apply_to_tool_schema(tool);
+        }
+        Ok(ListToolsResult {
+            meta: None,
+            tools,
             next_cursor: None,
         })
     }
@@ -86,8 +90,8 @@ impl<S: PlanStore + 'static> ServerHandler for PlansServer<S> {
     ) -> Result<CallToolResult, ErrorData> {
         match request.name.as_ref() {
             "list_plans" => {
-                let _params = parse_arguments::<ListPlansParams>(request.arguments)?;
-                self.handle_list_plans().await
+                let params = parse_arguments::<ListPlansParams>(request.arguments)?;
+                self.handle_list_plans(params).await
             }
             "add_plan" => {
                 let params = parse_arguments::<AddPlanParams>(request.arguments)?;
@@ -150,5 +154,298 @@ impl<S: PlanStore + 'static> ServerHandler for PlansServer<S> {
                 None,
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Page, PageToken, RepoTarget};
+    use rmcp::handler::client::ClientHandler;
+    use rmcp::model::{ClientCapabilities, InitializeRequestParams};
+    use rmcp::service::{serve_client, serve_server, RoleClient, RoleServer, RunningService};
+    use tokio::io::duplex;
+
+    #[derive(Clone, Default)]
+    struct TestClientHandler;
+
+    impl ClientHandler for TestClientHandler {
+        fn get_info(&self) -> InitializeRequestParams {
+            InitializeRequestParams::new(
+                ClientCapabilities::builder().build(),
+                Implementation::new("test", "0.1"),
+            )
+        }
+    }
+
+    struct EmptyStore;
+
+    #[async_trait::async_trait]
+    impl PlanStore for EmptyStore {
+        async fn list_plans(
+            &self,
+            _target: &Target,
+            _page: Option<PageToken>,
+        ) -> Result<Page<Plan>, StoreError> {
+            unreachable!()
+        }
+        async fn get_plan(&self, _target: &Target, _plan: &PlanId) -> Result<Plan, StoreError> {
+            unreachable!()
+        }
+        async fn add_plan(&self, _target: &Target, _new_plan: NewPlan) -> Result<Plan, StoreError> {
+            unreachable!()
+        }
+        async fn update_plan_meta(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _update: PlanMetaUpdate,
+        ) -> Result<Plan, StoreError> {
+            unreachable!()
+        }
+        async fn delete_plan(&self, _target: &Target, _plan: &PlanId) -> Result<(), StoreError> {
+            unreachable!()
+        }
+        async fn read_plan_body(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+        ) -> Result<String, StoreError> {
+            unreachable!()
+        }
+        async fn write_plan_body(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _body: &str,
+        ) -> Result<(), StoreError> {
+            unreachable!()
+        }
+        async fn list_tasks(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _filter: TaskFilter,
+            _page: Option<PageToken>,
+        ) -> Result<Page<Task>, StoreError> {
+            unreachable!()
+        }
+        async fn get_task(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _task: &crate::model::TaskId,
+        ) -> Result<Task, StoreError> {
+            unreachable!()
+        }
+        async fn add_task(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _new_task: NewTask,
+        ) -> Result<Task, StoreError> {
+            unreachable!()
+        }
+        async fn update_task_meta(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _task: &crate::model::TaskId,
+            _update: TaskMetaUpdate,
+        ) -> Result<Task, StoreError> {
+            unreachable!()
+        }
+        async fn delete_task(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _task: &crate::model::TaskId,
+        ) -> Result<(), StoreError> {
+            unreachable!()
+        }
+        async fn read_task_body(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _task: &crate::model::TaskId,
+        ) -> Result<String, StoreError> {
+            unreachable!()
+        }
+        async fn write_task_body(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _task: &crate::model::TaskId,
+            _body: &str,
+        ) -> Result<(), StoreError> {
+            unreachable!()
+        }
+        async fn list_notes(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _page: Option<PageToken>,
+        ) -> Result<Page<Note>, StoreError> {
+            unreachable!()
+        }
+        async fn get_note(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _note: &crate::model::NoteId,
+        ) -> Result<Note, StoreError> {
+            unreachable!()
+        }
+        async fn add_note(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _new_note: NewNote,
+        ) -> Result<Note, StoreError> {
+            unreachable!()
+        }
+        async fn update_note_meta(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _note: &crate::model::NoteId,
+            _update: NoteMetaUpdate,
+        ) -> Result<Note, StoreError> {
+            unreachable!()
+        }
+        async fn delete_note(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _note: &crate::model::NoteId,
+        ) -> Result<(), StoreError> {
+            unreachable!()
+        }
+        async fn read_note_body(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _note: &crate::model::NoteId,
+        ) -> Result<String, StoreError> {
+            unreachable!()
+        }
+        async fn write_note_body(
+            &self,
+            _target: &Target,
+            _plan: &PlanId,
+            _note: &crate::model::NoteId,
+            _body: &str,
+        ) -> Result<(), StoreError> {
+            unreachable!()
+        }
+    }
+
+    async fn list_tools_for(default_repo: Option<RepoTarget>) -> ListToolsResult {
+        let (client_transport, server_transport) = duplex(65_536);
+        let server = PlansServer::with_meta(
+            Arc::new(EmptyStore),
+            ServerMeta {
+                name: "test".into(),
+                instructions: "test".into(),
+                target_policy: TargetPolicy::GitHub { default_repo },
+            },
+        );
+        let server_fut = serve_server(server, server_transport);
+        let client_fut = serve_client(TestClientHandler, client_transport);
+        type TestServerService = RunningService<RoleServer, PlansServer<EmptyStore>>;
+        type TestClientService = RunningService<RoleClient, TestClientHandler>;
+        let (server_res, client_res): (Result<TestServerService, _>, Result<TestClientService, _>) =
+            tokio::join!(server_fut, client_fut);
+        let _server = server_res.unwrap();
+        let client = client_res.unwrap();
+        let peer = client.peer().clone();
+        let _client_task = tokio::spawn(async move {
+            let _ = client.waiting().await;
+        });
+        peer.list_tools(Default::default()).await.unwrap()
+    }
+
+    fn required_for(tool: &Tool) -> Vec<String> {
+        tool.input_schema
+            .get("required")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|value| value.as_str().map(str::to_string))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn github_tool_schema_owner_repo_requiredness_tracks_default_repo() {
+        let with_default = list_tools_for(Some(RepoTarget {
+            owner: "acme".to_string(),
+            repo: "plans".to_string(),
+        }))
+        .await;
+        let list_plans = with_default
+            .tools
+            .iter()
+            .find(|tool| tool.name == "list_plans")
+            .unwrap();
+        let required = required_for(list_plans);
+        assert!(!required.contains(&"owner".to_string()));
+        assert!(!required.contains(&"repo".to_string()));
+
+        let without_default = list_tools_for(None).await;
+        let list_plans = without_default
+            .tools
+            .iter()
+            .find(|tool| tool.name == "list_plans")
+            .unwrap();
+        let required = required_for(list_plans);
+        assert!(required.contains(&"owner".to_string()));
+        assert!(required.contains(&"repo".to_string()));
+    }
+
+    #[tokio::test]
+    async fn resolve_target_rejects_path_traversal_owner_and_repo() {
+        let server = PlansServer::with_meta(
+            Arc::new(EmptyStore),
+            ServerMeta {
+                name: "test".into(),
+                instructions: "test".into(),
+                target_policy: TargetPolicy::GitHub { default_repo: None },
+            },
+        );
+
+        let repo_err = server
+            .resolve_target(Some("acme"), Some("../../../user"))
+            .expect_err("repo traversal should be rejected");
+        assert!(repo_err.message.contains("GitHub repo"));
+        assert!(repo_err.message.contains("path separators"));
+
+        let owner_err = server
+            .resolve_target(Some("../../../user"), Some("plans"))
+            .expect_err("owner traversal should be rejected");
+        assert!(owner_err.message.contains("GitHub owner"));
+        assert!(owner_err.message.contains("path separators"));
+    }
+
+    #[tokio::test]
+    async fn resolve_target_accepts_normal_repo_slug_with_dot() {
+        let server = PlansServer::with_meta(
+            Arc::new(EmptyStore),
+            ServerMeta {
+                name: "test".into(),
+                instructions: "test".into(),
+                target_policy: TargetPolicy::GitHub { default_repo: None },
+            },
+        );
+        let target = server
+            .resolve_target(Some("acme"), Some("plans.rs"))
+            .expect("normal repo target should resolve");
+
+        assert_eq!(
+            target,
+            Target::GitHub(RepoTarget {
+                owner: "acme".to_string(),
+                repo: "plans.rs".to_string(),
+            })
+        );
     }
 }

--- a/crates/harnx-mcp-plans-core/src/server/handlers.rs
+++ b/crates/harnx-mcp-plans-core/src/server/handlers.rs
@@ -146,12 +146,14 @@ fn map_note_not_found(plan_name: &str, note_id: &str, err: StoreError) -> ErrorD
 
 async fn validate_batch_task_specs<S: PlanStore>(
     store: &S,
+    target: &Target,
     name: &str,
     plan_id: &PlanId,
     task_specs: &[TaskSpec],
 ) -> Result<(), ErrorData> {
     let existing_tasks = store
         .list_tasks(
+            target,
             plan_id,
             TaskFilter {
                 status: None,
@@ -209,19 +211,20 @@ impl<S: PlanStore> PlansServer<S> {
         &self,
         params: ListTasksParams,
     ) -> Result<CallToolResult, ErrorData> {
+        let target = self.resolve_target(params.owner.as_deref(), params.repo.as_deref())?;
         let plan_name =
             validate_plan_name(&params.plan).map_err(|err| ErrorData::invalid_params(err, None))?;
         let plan_id: PlanId = plan_name.clone();
         let tasks = self
             .store
-            .list_tasks(&plan_id, task_filter_from_params(&params), None)
+            .list_tasks(&target, &plan_id, task_filter_from_params(&params), None)
             .await
             .map_err(store_error_to_error_data)?;
         let mut tasks_json = Vec::new();
         for task in tasks.items {
             let body = self
                 .store
-                .read_task_body(&plan_id, &task.id)
+                .read_task_body(&target, &plan_id, &task.id)
                 .await
                 .map_err(|err| map_task_not_found(&plan_name, &task.id, err))?;
             tasks_json.push(task_to_json(task, body));
@@ -233,6 +236,7 @@ impl<S: PlanStore> PlansServer<S> {
         &self,
         params: GetTaskParams,
     ) -> Result<CallToolResult, ErrorData> {
+        let target = self.resolve_target(params.owner.as_deref(), params.repo.as_deref())?;
         let plan_name =
             validate_plan_name(&params.plan).map_err(|err| ErrorData::invalid_params(err, None))?;
         let task_id =
@@ -240,12 +244,12 @@ impl<S: PlanStore> PlansServer<S> {
         let plan_id: PlanId = plan_name.clone();
         let task = self
             .store
-            .get_task(&plan_id, &task_id)
+            .get_task(&target, &plan_id, &task_id)
             .await
             .map_err(|err| map_task_not_found(&plan_name, &task_id, err))?;
         let body = self
             .store
-            .read_task_body(&plan_id, &task_id)
+            .read_task_body(&target, &plan_id, &task_id)
             .await
             .map_err(|err| map_task_not_found(&plan_name, &task_id, err))?;
         result_json(task_to_json(task, body))
@@ -255,6 +259,7 @@ impl<S: PlanStore> PlansServer<S> {
         &self,
         params: AddTaskParams,
     ) -> Result<CallToolResult, ErrorData> {
+        let target = self.resolve_target(params.owner.as_deref(), params.repo.as_deref())?;
         let plan_name =
             validate_plan_name(&params.plan).map_err(|err| ErrorData::invalid_params(err, None))?;
         let plan_id: PlanId = plan_name.clone();
@@ -278,7 +283,7 @@ impl<S: PlanStore> PlansServer<S> {
         };
         let task = self
             .store
-            .add_task(&plan_id, new_task)
+            .add_task(&target, &plan_id, new_task)
             .await
             .map_err(|err| match err {
                 StoreError::AlreadyExists => ErrorData::invalid_params(
@@ -292,7 +297,7 @@ impl<S: PlanStore> PlansServer<S> {
                 other => store_error_to_error_data(other),
             })?;
         self.store
-            .write_task_body(&plan_id, &task.id, &body)
+            .write_task_body(&target, &plan_id, &task.id, &body)
             .await
             .map_err(store_error_to_error_data)?;
         let serialized = serde_yaml::to_string(&task_to_json(task.clone(), body.clone()))
@@ -310,6 +315,7 @@ impl<S: PlanStore> PlansServer<S> {
         &self,
         params: UpdateTaskParams,
     ) -> Result<CallToolResult, ErrorData> {
+        let target = self.resolve_target(params.owner.as_deref(), params.repo.as_deref())?;
         let plan_name =
             validate_plan_name(&params.plan).map_err(|err| ErrorData::invalid_params(err, None))?;
         let task_id =
@@ -317,12 +323,12 @@ impl<S: PlanStore> PlansServer<S> {
         let plan_id: PlanId = plan_name.clone();
         let task = self
             .store
-            .get_task(&plan_id, &task_id)
+            .get_task(&target, &plan_id, &task_id)
             .await
             .map_err(|err| map_task_not_found(&plan_name, &task_id, err))?;
         let before_body = self
             .store
-            .read_task_body(&plan_id, &task_id)
+            .read_task_body(&target, &plan_id, &task_id)
             .await
             .map_err(|err| map_task_not_found(&plan_name, &task_id, err))?;
         let body = apply_body_edit(
@@ -343,11 +349,11 @@ impl<S: PlanStore> PlansServer<S> {
             dependencies: params.dependencies,
         };
         self.store
-            .update_task_meta(&plan_id, &task_id, update)
+            .update_task_meta(&target, &plan_id, &task_id, update)
             .await
             .map_err(|err| map_task_not_found(&plan_name, &task_id, err))?;
         self.store
-            .write_task_body(&plan_id, &task_id, &body)
+            .write_task_body(&target, &plan_id, &task_id, &body)
             .await
             .map_err(|err| map_task_not_found(&plan_name, &task_id, err))?;
         let diff = diff_text(
@@ -363,6 +369,7 @@ impl<S: PlanStore> PlansServer<S> {
         &self,
         params: DeleteTaskParams,
     ) -> Result<CallToolResult, ErrorData> {
+        let target = self.resolve_target(params.owner.as_deref(), params.repo.as_deref())?;
         let plan_name =
             validate_plan_name(&params.plan).map_err(|err| ErrorData::invalid_params(err, None))?;
         let task_id =
@@ -370,14 +377,18 @@ impl<S: PlanStore> PlansServer<S> {
         let plan_id: PlanId = plan_name.clone();
         let before_body = self
             .store
-            .read_task_body(&plan_id, &task_id)
+            .read_task_body(&target, &plan_id, &task_id)
             .await
             .map_err(|err| map_task_not_found(&plan_name, &task_id, err))?;
         self.store
-            .delete_task(&plan_id, &task_id)
+            .delete_task(&target, &plan_id, &task_id)
             .await
             .map_err(|err| map_task_not_found(&plan_name, &task_id, err))?;
-        let after_body = self.store.read_task_body(&plan_id, &task_id).await.ok();
+        let after_body = self
+            .store
+            .read_task_body(&target, &plan_id, &task_id)
+            .await
+            .ok();
         match after_body {
             Some(_current_body) => result_text(format!(
                 "left task {} unchanged (delete behavior is leave)",
@@ -394,24 +405,28 @@ impl<S: PlanStore> PlansServer<S> {
         }
     }
 
-    pub async fn handle_list_plans(&self) -> Result<CallToolResult, ErrorData> {
+    pub async fn handle_list_plans(
+        &self,
+        params: ListPlansParams,
+    ) -> Result<CallToolResult, ErrorData> {
+        let target = self.resolve_target(params.owner.as_deref(), params.repo.as_deref())?;
         let plans = self
             .store
-            .list_plans(None)
+            .list_plans(&target, None)
             .await
             .map_err(store_error_to_error_data)?;
         let mut result = Vec::new();
         for plan in plans.items {
             let task_count = self
                 .store
-                .list_tasks(&plan.id, TaskFilter::default(), None)
+                .list_tasks(&target, &plan.id, TaskFilter::default(), None)
                 .await
                 .map_err(store_error_to_error_data)?
                 .items
                 .len();
             let note_count = self
                 .store
-                .list_notes(&plan.id, None)
+                .list_notes(&target, &plan.id, None)
                 .await
                 .map_err(store_error_to_error_data)?
                 .items
@@ -425,22 +440,26 @@ impl<S: PlanStore> PlansServer<S> {
         &self,
         params: AddPlanParams,
     ) -> Result<CallToolResult, ErrorData> {
+        let target = self.resolve_target(params.owner.as_deref(), params.repo.as_deref())?;
         let name =
             validate_plan_name(&params.name).map_err(|err| ErrorData::invalid_params(err, None))?;
         let plan_id: PlanId = name.clone();
         let body = params.body.unwrap_or_default();
         let plan = self
             .store
-            .add_plan(NewPlan {
-                id: plan_id.clone(),
-                title: params.title,
-                summary: params.summary,
-                author: params.author,
-                assignee: params.assignee,
-                executor: params.executor,
-                git_branch: params.git_branch,
-                github_owner_repo: params.github_owner_repo,
-            })
+            .add_plan(
+                &target,
+                NewPlan {
+                    id: plan_id.clone(),
+                    title: params.title,
+                    summary: params.summary,
+                    author: params.author,
+                    assignee: params.assignee,
+                    executor: params.executor,
+                    git_branch: params.git_branch,
+                    github_owner_repo: params.github_owner_repo,
+                },
+            )
             .await
             .map_err(|err| match err {
                 StoreError::AlreadyExists => {
@@ -449,36 +468,39 @@ impl<S: PlanStore> PlansServer<S> {
                 other => store_error_to_error_data(other),
             })?;
         self.store
-            .write_plan_body(&plan_id, &body)
+            .write_plan_body(&target, &plan_id, &body)
             .await
             .map_err(store_error_to_error_data)?;
 
         let task_specs = params.tasks.unwrap_or_default();
-        validate_batch_task_specs(self.store.as_ref(), &name, &plan_id, &task_specs).await?;
+        validate_batch_task_specs(self.store.as_ref(), &target, &name, &plan_id, &task_specs)
+            .await?;
         let mut created_task_ids = Vec::new();
         let mut task_failures = Vec::new();
         for spec in task_specs {
             match build_new_task(&name, spec) {
-                Ok((new_task, task_body)) => match self.store.add_task(&plan_id, new_task).await {
-                    Ok(task) => {
-                        if let Err(err) = self
-                            .store
-                            .write_task_body(&plan_id, &task.id, &task_body)
-                            .await
-                        {
-                            task_failures.push(format!(
-                                "{}: {}",
-                                display_id(&task.id),
-                                store_error_to_error_data(err).message
-                            ));
-                        } else {
-                            created_task_ids.push(display_id(&task.id));
+                Ok((new_task, task_body)) => {
+                    match self.store.add_task(&target, &plan_id, new_task).await {
+                        Ok(task) => {
+                            if let Err(err) = self
+                                .store
+                                .write_task_body(&target, &plan_id, &task.id, &task_body)
+                                .await
+                            {
+                                task_failures.push(format!(
+                                    "{}: {}",
+                                    display_id(&task.id),
+                                    store_error_to_error_data(err).message
+                                ));
+                            } else {
+                                created_task_ids.push(display_id(&task.id));
+                            }
+                        }
+                        Err(err) => {
+                            task_failures.push(store_error_to_error_data(err).message.to_string())
                         }
                     }
-                    Err(err) => {
-                        task_failures.push(store_error_to_error_data(err).message.to_string())
-                    }
-                },
+                }
                 Err(err) => task_failures.push(err.message.to_string()),
             }
         }
@@ -502,12 +524,13 @@ impl<S: PlanStore> PlansServer<S> {
         &self,
         params: GetPlanParams,
     ) -> Result<CallToolResult, ErrorData> {
+        let target = self.resolve_target(params.owner.as_deref(), params.repo.as_deref())?;
         let name =
             validate_plan_name(&params.name).map_err(|err| ErrorData::invalid_params(err, None))?;
         let plan_id: PlanId = name.clone();
         let plan = self
             .store
-            .get_plan(&plan_id)
+            .get_plan(&target, &plan_id)
             .await
             .map_err(|err| match err {
                 StoreError::NotFound => {
@@ -517,12 +540,12 @@ impl<S: PlanStore> PlansServer<S> {
             })?;
         let body = self
             .store
-            .read_plan_body(&plan_id)
+            .read_plan_body(&target, &plan_id)
             .await
             .map_err(store_error_to_error_data)?;
         let task_ids = self
             .store
-            .list_tasks(&plan_id, TaskFilter::default(), None)
+            .list_tasks(&target, &plan_id, TaskFilter::default(), None)
             .await
             .map_err(store_error_to_error_data)?
             .items
@@ -531,7 +554,7 @@ impl<S: PlanStore> PlansServer<S> {
             .collect();
         let note_ids = self
             .store
-            .list_notes(&plan_id, None)
+            .list_notes(&target, &plan_id, None)
             .await
             .map_err(store_error_to_error_data)?
             .items
@@ -545,33 +568,37 @@ impl<S: PlanStore> PlansServer<S> {
         &self,
         params: UpdatePlanParams,
     ) -> Result<CallToolResult, ErrorData> {
+        let target = self.resolve_target(params.owner.as_deref(), params.repo.as_deref())?;
         let name =
             validate_plan_name(&params.name).map_err(|err| ErrorData::invalid_params(err, None))?;
         let plan_id: PlanId = name.clone();
 
-        let existing = match self.store.get_plan(&plan_id).await {
+        let existing = match self.store.get_plan(&target, &plan_id).await {
             Ok(plan) => Some(plan),
             Err(StoreError::NotFound) => None,
             Err(err) => return Err(store_error_to_error_data(err)),
         };
         if existing.is_none() {
             self.store
-                .add_plan(NewPlan {
-                    id: plan_id.clone(),
-                    title: None,
-                    summary: None,
-                    author: None,
-                    assignee: None,
-                    executor: None,
-                    git_branch: None,
-                    github_owner_repo: None,
-                })
+                .add_plan(
+                    &target,
+                    NewPlan {
+                        id: plan_id.clone(),
+                        title: None,
+                        summary: None,
+                        author: None,
+                        assignee: None,
+                        executor: None,
+                        git_branch: None,
+                        github_owner_repo: None,
+                    },
+                )
                 .await
                 .map_err(store_error_to_error_data)?;
         }
         let before_body = self
             .store
-            .read_plan_body(&plan_id)
+            .read_plan_body(&target, &plan_id)
             .await
             .unwrap_or_default();
         let new_body = apply_body_edit(
@@ -583,6 +610,7 @@ impl<S: PlanStore> PlansServer<S> {
         )?;
         self.store
             .update_plan_meta(
+                &target,
                 &plan_id,
                 PlanMetaUpdate {
                     title: params
@@ -611,39 +639,42 @@ impl<S: PlanStore> PlansServer<S> {
             .await
             .map_err(store_error_to_error_data)?;
         self.store
-            .write_plan_body(&plan_id, &new_body)
+            .write_plan_body(&target, &plan_id, &new_body)
             .await
             .map_err(store_error_to_error_data)?;
 
         let task_specs = params.tasks.unwrap_or_default();
-        validate_batch_task_specs(self.store.as_ref(), &name, &plan_id, &task_specs).await?;
+        validate_batch_task_specs(self.store.as_ref(), &target, &name, &plan_id, &task_specs)
+            .await?;
         let mut created_task_ids = Vec::new();
         let mut task_failures = Vec::new();
         for spec in task_specs {
             match build_new_task(&name, spec) {
-                Ok((new_task, task_body)) => match self.store.add_task(&plan_id, new_task).await {
-                    Ok(task) => {
-                        if let Err(err) = self
-                            .store
-                            .write_task_body(&plan_id, &task.id, &task_body)
-                            .await
-                        {
-                            task_failures.push(format!(
-                                "{}: {}",
-                                display_id(&task.id),
-                                store_error_to_error_data(err).message
-                            ));
-                        } else {
-                            created_task_ids.push(display_id(&task.id));
+                Ok((new_task, task_body)) => {
+                    match self.store.add_task(&target, &plan_id, new_task).await {
+                        Ok(task) => {
+                            if let Err(err) = self
+                                .store
+                                .write_task_body(&target, &plan_id, &task.id, &task_body)
+                                .await
+                            {
+                                task_failures.push(format!(
+                                    "{}: {}",
+                                    display_id(&task.id),
+                                    store_error_to_error_data(err).message
+                                ));
+                            } else {
+                                created_task_ids.push(display_id(&task.id));
+                            }
+                        }
+                        Err(StoreError::AlreadyExists) => {
+                            task_failures.push(format!("task already exists in plan '{}'", name))
+                        }
+                        Err(err) => {
+                            task_failures.push(store_error_to_error_data(err).message.to_string())
                         }
                     }
-                    Err(StoreError::AlreadyExists) => {
-                        task_failures.push(format!("task already exists in plan '{}'", name))
-                    }
-                    Err(err) => {
-                        task_failures.push(store_error_to_error_data(err).message.to_string())
-                    }
-                },
+                }
                 Err(err) => task_failures.push(err.message.to_string()),
             }
         }
@@ -673,23 +704,25 @@ impl<S: PlanStore> PlansServer<S> {
         &self,
         params: DeletePlanParams,
     ) -> Result<CallToolResult, ErrorData> {
+        let target = self.resolve_target(params.owner.as_deref(), params.repo.as_deref())?;
         let name =
             validate_plan_name(&params.name).map_err(|err| ErrorData::invalid_params(err, None))?;
         let plan_id: PlanId = name.clone();
-        let plan_body = self
-            .store
-            .read_plan_body(&plan_id)
-            .await
-            .map_err(|err| match err {
-                StoreError::NotFound => {
-                    ErrorData::invalid_params(format!("plan '{}' not found", name), None)
-                }
-                other => store_error_to_error_data(other),
-            })?;
+        let plan_body =
+            self.store
+                .read_plan_body(&target, &plan_id)
+                .await
+                .map_err(|err| match err {
+                    StoreError::NotFound => {
+                        ErrorData::invalid_params(format!("plan '{}' not found", name), None)
+                    }
+                    other => store_error_to_error_data(other),
+                })?;
         let mut diffs = vec![diff_text(&plan_body, "", &format!("{name}/plan.md"))];
         let tasks = self
             .store
             .list_tasks(
+                &target,
                 &plan_id,
                 TaskFilter {
                     status: None,
@@ -702,7 +735,7 @@ impl<S: PlanStore> PlansServer<S> {
         for task in tasks.items {
             let body = self
                 .store
-                .read_task_body(&plan_id, &task.id)
+                .read_task_body(&target, &plan_id, &task.id)
                 .await
                 .map_err(store_error_to_error_data)?;
             let diff = diff_text(&body, "", &format!("{name}/tasks/{}.md", task.id));
@@ -712,13 +745,13 @@ impl<S: PlanStore> PlansServer<S> {
         }
         let notes = self
             .store
-            .list_notes(&plan_id, None)
+            .list_notes(&target, &plan_id, None)
             .await
             .map_err(store_error_to_error_data)?;
         for note in notes.items {
             let body = self
                 .store
-                .read_note_body(&plan_id, &note.id)
+                .read_note_body(&target, &plan_id, &note.id)
                 .await
                 .map_err(store_error_to_error_data)?;
             let diff = diff_text(&body, "", &format!("{name}/notes/{}.md", note.id));
@@ -727,7 +760,7 @@ impl<S: PlanStore> PlansServer<S> {
             }
         }
         self.store
-            .delete_plan(&plan_id)
+            .delete_plan(&target, &plan_id)
             .await
             .map_err(|err| match err {
                 StoreError::NotFound => {
@@ -735,7 +768,7 @@ impl<S: PlanStore> PlansServer<S> {
                 }
                 other => store_error_to_error_data(other),
             })?;
-        let after_body = self.store.read_plan_body(&plan_id).await.ok();
+        let after_body = self.store.read_plan_body(&target, &plan_id).await.ok();
         if after_body.is_some() {
             result_text(format!(
                 "left plan {} unchanged (delete behavior is leave)",
@@ -763,19 +796,20 @@ impl<S: PlanStore> PlansServer<S> {
         &self,
         params: ListNotesParams,
     ) -> Result<CallToolResult, ErrorData> {
+        let target = self.resolve_target(params.owner.as_deref(), params.repo.as_deref())?;
         let plan =
             validate_plan_name(&params.plan).map_err(|err| ErrorData::invalid_params(err, None))?;
         let plan_id: PlanId = plan.clone();
         let notes = self
             .store
-            .list_notes(&plan_id, None)
+            .list_notes(&target, &plan_id, None)
             .await
             .map_err(store_error_to_error_data)?;
         let mut result = Vec::new();
         for note in notes.items {
             let body = self
                 .store
-                .read_note_body(&plan_id, &note.id)
+                .read_note_body(&target, &plan_id, &note.id)
                 .await
                 .map_err(|err| map_note_not_found(&plan, &note.id, err))?;
             result.push(note_to_json(note, body));
@@ -787,6 +821,7 @@ impl<S: PlanStore> PlansServer<S> {
         &self,
         params: AddNoteParams,
     ) -> Result<CallToolResult, ErrorData> {
+        let target = self.resolve_target(params.owner.as_deref(), params.repo.as_deref())?;
         let plan =
             validate_plan_name(&params.plan).map_err(|err| ErrorData::invalid_params(err, None))?;
         let plan_id: PlanId = plan.clone();
@@ -799,6 +834,7 @@ impl<S: PlanStore> PlansServer<S> {
         let note = self
             .store
             .add_note(
+                &target,
                 &plan_id,
                 NewNote {
                     id: id.unwrap_or_else(|| {
@@ -817,7 +853,7 @@ impl<S: PlanStore> PlansServer<S> {
                 other => store_error_to_error_data(other),
             })?;
         self.store
-            .write_note_body(&plan_id, &note.id, &params.body)
+            .write_note_body(&target, &plan_id, &note.id, &params.body)
             .await
             .map_err(store_error_to_error_data)?;
         let diff = diff_text(
@@ -833,6 +869,7 @@ impl<S: PlanStore> PlansServer<S> {
         &self,
         params: GetNoteParams,
     ) -> Result<CallToolResult, ErrorData> {
+        let target = self.resolve_target(params.owner.as_deref(), params.repo.as_deref())?;
         let plan =
             validate_plan_name(&params.plan).map_err(|err| ErrorData::invalid_params(err, None))?;
         let note_id =
@@ -840,12 +877,12 @@ impl<S: PlanStore> PlansServer<S> {
         let plan_id: PlanId = plan.clone();
         let note = self
             .store
-            .get_note(&plan_id, &note_id)
+            .get_note(&target, &plan_id, &note_id)
             .await
             .map_err(|err| map_note_not_found(&plan, &note_id, err))?;
         let body = self
             .store
-            .read_note_body(&plan_id, &note_id)
+            .read_note_body(&target, &plan_id, &note_id)
             .await
             .map_err(|err| map_note_not_found(&plan, &note_id, err))?;
         result_json(note_to_json(note, body))
@@ -855,6 +892,7 @@ impl<S: PlanStore> PlansServer<S> {
         &self,
         params: DeleteNoteParams,
     ) -> Result<CallToolResult, ErrorData> {
+        let target = self.resolve_target(params.owner.as_deref(), params.repo.as_deref())?;
         let plan =
             validate_plan_name(&params.plan).map_err(|err| ErrorData::invalid_params(err, None))?;
         let note_id =
@@ -862,14 +900,18 @@ impl<S: PlanStore> PlansServer<S> {
         let plan_id: PlanId = plan.clone();
         let before_body = self
             .store
-            .read_note_body(&plan_id, &note_id)
+            .read_note_body(&target, &plan_id, &note_id)
             .await
             .map_err(|err| map_note_not_found(&plan, &note_id, err))?;
         self.store
-            .delete_note(&plan_id, &note_id)
+            .delete_note(&target, &plan_id, &note_id)
             .await
             .map_err(|err| map_note_not_found(&plan, &note_id, err))?;
-        let after_body = self.store.read_note_body(&plan_id, &note_id).await.ok();
+        let after_body = self
+            .store
+            .read_note_body(&target, &plan_id, &note_id)
+            .await
+            .ok();
         match after_body {
             Some(_) => result_text(format!(
                 "left note {} unchanged (delete behavior is leave)",
@@ -886,6 +928,7 @@ impl<S: PlanStore> PlansServer<S> {
         &self,
         params: UpdateNoteParams,
     ) -> Result<CallToolResult, ErrorData> {
+        let target = self.resolve_target(params.owner.as_deref(), params.repo.as_deref())?;
         let plan =
             validate_plan_name(&params.plan).map_err(|err| ErrorData::invalid_params(err, None))?;
         let note_id =
@@ -893,12 +936,12 @@ impl<S: PlanStore> PlansServer<S> {
         let plan_id: PlanId = plan.clone();
         let note = self
             .store
-            .get_note(&plan_id, &note_id)
+            .get_note(&target, &plan_id, &note_id)
             .await
             .map_err(|err| map_note_not_found(&plan, &note_id, err))?;
         let before_body = self
             .store
-            .read_note_body(&plan_id, &note_id)
+            .read_note_body(&target, &plan_id, &note_id)
             .await
             .map_err(|err| map_note_not_found(&plan, &note_id, err))?;
         let body = apply_body_edit(
@@ -910,6 +953,7 @@ impl<S: PlanStore> PlansServer<S> {
         )?;
         self.store
             .update_note_meta(
+                &target,
                 &plan_id,
                 &note_id,
                 NoteMetaUpdate {
@@ -920,7 +964,7 @@ impl<S: PlanStore> PlansServer<S> {
             .await
             .map_err(|err| map_note_not_found(&plan, &note_id, err))?;
         self.store
-            .write_note_body(&plan_id, &note_id, &body)
+            .write_note_body(&target, &plan_id, &note_id, &body)
             .await
             .map_err(|err| map_note_not_found(&plan, &note_id, err))?;
         let diff = diff_text(

--- a/crates/harnx-mcp-plans-core/src/server/mod.rs
+++ b/crates/harnx-mcp-plans-core/src/server/mod.rs
@@ -14,8 +14,8 @@ use serde_json::{json, Map, Value};
 use similar::{ChangeTag, TextDiff};
 
 use crate::model::{
-    NewNote, NewPlan, NewTask, Note, NoteMetaUpdate, Plan, PlanId, PlanMetaUpdate, Task,
-    TaskFilter, TaskMetaUpdate,
+    NewNote, NewPlan, NewTask, Note, NoteMetaUpdate, Plan, PlanId, PlanMetaUpdate, RepoTarget,
+    Target, Task, TaskFilter, TaskMetaUpdate,
 };
 use crate::store::{PlanStore, StoreError};
 
@@ -26,15 +26,85 @@ mod params;
 pub use handler::{serve_plans_server, serve_plans_server_with_meta};
 pub use params::*;
 
+/// Repository targeting policy exposed by a plans server.
+#[derive(Debug, Clone, Default)]
+pub enum TargetPolicy {
+    /// Backend has no remote repository target; owner/repo params are ignored.
+    #[default]
+    None,
+    /// GitHub backend with an optional startup-detected default repository.
+    GitHub { default_repo: Option<RepoTarget> },
+}
+
 #[derive(Debug, Clone)]
 pub struct ServerMeta {
-    pub name: &'static str,
-    pub instructions: &'static str,
+    pub name: Cow<'static, str>,
+    pub instructions: Cow<'static, str>,
+    pub target_policy: TargetPolicy,
 }
 
 impl ServerMeta {
     pub const fn new(name: &'static str, instructions: &'static str) -> Self {
-        Self { name, instructions }
+        Self {
+            name: Cow::Borrowed(name),
+            instructions: Cow::Borrowed(instructions),
+            target_policy: TargetPolicy::None,
+        }
+    }
+
+    pub fn with_target_policy(mut self, target_policy: TargetPolicy) -> Self {
+        self.target_policy = target_policy;
+        self
+    }
+}
+
+impl TargetPolicy {
+    fn apply_to_tool_schema(&self, tool: &mut Tool) {
+        let Self::GitHub { default_repo } = self else {
+            return;
+        };
+
+        let mut schema = tool.input_schema.as_ref().clone();
+        let properties = schema
+            .entry("properties".to_string())
+            .or_insert_with(|| Value::Object(Map::new()));
+        let Value::Object(properties) = properties else {
+            return;
+        };
+
+        let description = match default_repo {
+            Some(default_repo) => format!(
+                "Optional. Defaults to {}/{} detected at startup.",
+                default_repo.owner, default_repo.repo
+            ),
+            None => "Required. No default repository was detected at startup.".to_string(),
+        };
+        let property_schema = |description: &str| {
+            let mut property = Map::new();
+            property.insert("type".to_string(), Value::String("string".to_string()));
+            property.insert(
+                "description".to_string(),
+                Value::String(description.to_string()),
+            );
+            Value::Object(property)
+        };
+        properties.insert("owner".to_string(), property_schema(&description));
+        properties.insert("repo".to_string(), property_schema(&description));
+
+        if default_repo.is_none() {
+            let required = schema
+                .entry("required".to_string())
+                .or_insert_with(|| Value::Array(Vec::new()));
+            if let Value::Array(required) = required {
+                for name in ["owner", "repo"] {
+                    if !required.iter().any(|value| value.as_str() == Some(name)) {
+                        required.push(Value::String(name.to_string()));
+                    }
+                }
+            }
+        }
+
+        tool.input_schema = Arc::new(schema);
     }
 }
 
@@ -56,6 +126,47 @@ impl<S: PlanStore> PlansServer<S> {
     pub fn with_meta(store: Arc<S>, meta: ServerMeta) -> Self {
         Self { store, meta }
     }
+
+    /// Resolve and validate one per-call storage target from tool arguments and server defaults.
+    pub(crate) fn resolve_target(
+        &self,
+        owner: Option<&str>,
+        repo: Option<&str>,
+    ) -> Result<Target, ErrorData> {
+        match &self.meta.target_policy {
+            TargetPolicy::None => Ok(Target::Local),
+            TargetPolicy::GitHub { default_repo } => {
+                let owner = owner.and_then(non_empty_trimmed);
+                let repo = repo.and_then(non_empty_trimmed);
+                match (owner, repo) {
+                    (Some(owner), Some(repo)) => RepoTarget::new(owner, repo)
+                        .map(Target::GitHub)
+                        .map_err(|message| ErrorData::invalid_params(message, None)),
+                    (Some(_), None) | (None, Some(_)) => Err(ErrorData::invalid_params(
+                        "owner and repo must be provided together",
+                        None,
+                    )),
+                    (None, None) => {
+                        let default_repo = default_repo.clone().ok_or_else(|| {
+                            ErrorData::invalid_params(
+                                "owner and repo are required because no default GitHub repository was detected at startup",
+                                None,
+                            )
+                        })?;
+                        default_repo
+                            .validate()
+                            .map_err(|message| ErrorData::invalid_params(message, None))?;
+                        Ok(Target::GitHub(default_repo))
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn non_empty_trimmed(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
 }
 
 fn default_open_status() -> String {

--- a/crates/harnx-mcp-plans-core/src/server/params.rs
+++ b/crates/harnx-mcp-plans-core/src/server/params.rs
@@ -2,6 +2,10 @@ use super::*;
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct ListTasksParams {
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
     pub plan: String,
     #[serde(default = "default_open_status")]
     pub filter: String,
@@ -11,12 +15,20 @@ pub struct ListTasksParams {
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct GetTaskParams {
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
     pub plan: String,
     pub id: String,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct AddTaskParams {
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
     pub plan: String,
     pub title: String,
     #[serde(default)]
@@ -41,6 +53,10 @@ pub struct AddTaskParams {
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct UpdateTaskParams {
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
     pub plan: String,
     pub id: String,
     #[serde(default)]
@@ -77,15 +93,28 @@ pub struct ReplaceInContent {
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct DeleteTaskParams {
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
     pub plan: String,
     pub id: String,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
-pub struct ListPlansParams {}
+pub struct ListPlansParams {
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
+}
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct AddPlanParams {
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
     pub name: String,
     #[serde(default)]
     pub title: Option<String>,
@@ -109,11 +138,19 @@ pub struct AddPlanParams {
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct GetPlanParams {
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
     pub name: String,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct UpdatePlanParams {
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
     pub name: String,
     #[serde(default)]
     pub replace_content: Option<String>,
@@ -141,16 +178,28 @@ pub struct UpdatePlanParams {
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct DeletePlanParams {
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
     pub name: String,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct ListNotesParams {
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
     pub plan: String,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct AddNoteParams {
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
     pub plan: String,
     #[serde(default)]
     pub id: Option<String>,
@@ -163,18 +212,30 @@ pub struct AddNoteParams {
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct GetNoteParams {
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
     pub plan: String,
     pub note_id: String,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct DeleteNoteParams {
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
     pub plan: String,
     pub note_id: String,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct UpdateNoteParams {
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
     pub plan: String,
     pub note_id: String,
     #[serde(default)]

--- a/crates/harnx-mcp-plans-core/src/store.rs
+++ b/crates/harnx-mcp-plans-core/src/store.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use crate::model::{
     NewNote, NewPlan, NewTask, Note, NoteId, NoteMetaUpdate, Page, PageToken, Plan, PlanId,
-    PlanMetaUpdate, Task, TaskFilter, TaskId, TaskMetaUpdate,
+    PlanMetaUpdate, Target, Task, TaskFilter, TaskId, TaskMetaUpdate,
 };
 
 #[derive(Debug, Error)]
@@ -25,38 +25,71 @@ pub enum StoreError {
 
 #[async_trait]
 pub trait PlanStore: Send + Sync {
-    async fn list_plans(&self, page: Option<PageToken>) -> Result<Page<Plan>, StoreError>;
-    async fn get_plan(&self, plan: &PlanId) -> Result<Plan, StoreError>;
-    async fn add_plan(&self, new_plan: NewPlan) -> Result<Plan, StoreError>;
+    async fn list_plans(
+        &self,
+        target: &Target,
+        page: Option<PageToken>,
+    ) -> Result<Page<Plan>, StoreError>;
+    async fn get_plan(&self, target: &Target, plan: &PlanId) -> Result<Plan, StoreError>;
+    async fn add_plan(&self, target: &Target, new_plan: NewPlan) -> Result<Plan, StoreError>;
     async fn update_plan_meta(
         &self,
+        target: &Target,
         plan: &PlanId,
         update: PlanMetaUpdate,
     ) -> Result<Plan, StoreError>;
-    async fn delete_plan(&self, plan: &PlanId) -> Result<(), StoreError>;
+    async fn delete_plan(&self, target: &Target, plan: &PlanId) -> Result<(), StoreError>;
 
-    async fn read_plan_body(&self, plan: &PlanId) -> Result<String, StoreError>;
-    async fn write_plan_body(&self, plan: &PlanId, body: &str) -> Result<(), StoreError>;
+    async fn read_plan_body(&self, target: &Target, plan: &PlanId) -> Result<String, StoreError>;
+    async fn write_plan_body(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        body: &str,
+    ) -> Result<(), StoreError>;
 
     async fn list_tasks(
         &self,
+        target: &Target,
         plan: &PlanId,
         filter: TaskFilter,
         page: Option<PageToken>,
     ) -> Result<Page<Task>, StoreError>;
-    async fn get_task(&self, plan: &PlanId, task: &TaskId) -> Result<Task, StoreError>;
-    async fn add_task(&self, plan: &PlanId, new_task: NewTask) -> Result<Task, StoreError>;
+    async fn get_task(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        task: &TaskId,
+    ) -> Result<Task, StoreError>;
+    async fn add_task(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        new_task: NewTask,
+    ) -> Result<Task, StoreError>;
     async fn update_task_meta(
         &self,
+        target: &Target,
         plan: &PlanId,
         task: &TaskId,
         update: TaskMetaUpdate,
     ) -> Result<Task, StoreError>;
-    async fn delete_task(&self, plan: &PlanId, task: &TaskId) -> Result<(), StoreError>;
+    async fn delete_task(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        task: &TaskId,
+    ) -> Result<(), StoreError>;
 
-    async fn read_task_body(&self, plan: &PlanId, task: &TaskId) -> Result<String, StoreError>;
+    async fn read_task_body(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        task: &TaskId,
+    ) -> Result<String, StoreError>;
     async fn write_task_body(
         &self,
+        target: &Target,
         plan: &PlanId,
         task: &TaskId,
         body: &str,
@@ -64,22 +97,45 @@ pub trait PlanStore: Send + Sync {
 
     async fn list_notes(
         &self,
+        target: &Target,
         plan: &PlanId,
         page: Option<PageToken>,
     ) -> Result<Page<Note>, StoreError>;
-    async fn get_note(&self, plan: &PlanId, note: &NoteId) -> Result<Note, StoreError>;
-    async fn add_note(&self, plan: &PlanId, new_note: NewNote) -> Result<Note, StoreError>;
+    async fn get_note(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        note: &NoteId,
+    ) -> Result<Note, StoreError>;
+    async fn add_note(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        new_note: NewNote,
+    ) -> Result<Note, StoreError>;
     async fn update_note_meta(
         &self,
+        target: &Target,
         plan: &PlanId,
         note: &NoteId,
         update: NoteMetaUpdate,
     ) -> Result<Note, StoreError>;
-    async fn delete_note(&self, plan: &PlanId, note: &NoteId) -> Result<(), StoreError>;
+    async fn delete_note(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        note: &NoteId,
+    ) -> Result<(), StoreError>;
 
-    async fn read_note_body(&self, plan: &PlanId, note: &NoteId) -> Result<String, StoreError>;
+    async fn read_note_body(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        note: &NoteId,
+    ) -> Result<String, StoreError>;
     async fn write_note_body(
         &self,
+        target: &Target,
         plan: &PlanId,
         note: &NoteId,
         body: &str,

--- a/crates/harnx-mcp-plans-github/README.md
+++ b/crates/harnx-mcp-plans-github/README.md
@@ -11,11 +11,20 @@ This MCP server provides a persistent storage backend for plans and todo lists u
 - **Note**: Represented as a **Comment** on the parent plan issue.
 - **Metadata**: Plan/Task metadata (ID, status, tags, dependencies) is stored as YAML front-matter within the issue or comment body, mirroring the format used by the filesystem backend.
 
+## Repository Targeting
+
+The server targets a GitHub repository (`owner`/`repo`) for plan, task, and note operations:
+
+- **Startup Auto-Detection**: At startup, the server attempts to detect a default GitHub repository from the `origin` remote of the current working directory. Only `github.com` origins are recognized.
+- **Non-Fatal Startup**: Detection is non-fatal. If the working directory is not a git repository, has no `origin`, uses a non-GitHub origin, or the origin URL cannot be parsed, a warning is logged and the server starts with no default repository. Startup performs no GitHub repository or label API validation — it never fails to start for those reasons.
+- **Per-Call Target Parameters**: Every plan, task, and note tool accepts per-call `owner` and `repo` target parameters:
+  - **With Default Repo**: When a default repository was detected at startup, `owner` and `repo` are optional and default to `<owner>/<repo>`.
+  - **Without Default Repo**: When no default repository was detected, `owner` and `repo` are required on every tool call (and `tools/list` schemas mark them required accordingly).
+- **Storage Target vs. Plan Metadata**: On `add_plan` and `update_plan`, the existing `github_owner_repo` parameter remains plan metadata only (stored in the plan's YAML front-matter) and is **never** used to select the storage target repository. Storage target selection is handled exclusively by the `owner` and `repo` parameters.
+
 ## Configuration
 
 The server can be configured via command-line flags or environment variables. CLI flags take precedence.
-
-Target repository is auto-detected from the `origin` remote of process current working directory. Only `github.com` origins are accepted. Startup fails fast if current directory is not a git repo, has no `origin`, uses a non-`github.com` origin, or origin URL cannot be parsed.
 
 ### Configuration Options
 
@@ -48,8 +57,13 @@ If both PAT and App credentials are provided, the PAT takes precedence.
 ### JIRA Cross-Referencing
 If a plan or task has a JIRA key associated with it, the server automatically prefixes the GitHub Issue title with `[KEY-123]`.
 
+### Label Handling
+The plan label (default: `harnx-plan`) is ensured and applied at write time when creating a plan (`add_plan`), not at server startup. Label operations are warning-only and non-fatal:
+- If label creation or application fails (e.g. due to permissions), a warning is logged and plan creation proceeds.
+- If GitHub rejects issue creation with a label validation error, the server automatically retries creating the plan issue without the label and logs a warning.
+
 ### Retention
-A background loop runs every hour to close plan issues that have not been updated for more than the configured retention period (default 14 days). Retention math uses a fixed 86,400 seconds per day.
+A background loop runs every hour to close plan issues that have not been updated for more than the configured retention period (default 14 days). Retention math uses a fixed 86,400 seconds per day. Retention runs against the default repository when detected at startup; if no default repository was detected, background retention is disabled.
 
 ### Rate Limiting
 The server handles GitHub API rate limits gracefully:

--- a/crates/harnx-mcp-plans-github/src/auth.rs
+++ b/crates/harnx-mcp-plans-github/src/auth.rs
@@ -70,7 +70,6 @@ pub enum AuthSource {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuthConfig {
     pub base_url: String,
-    pub repo: RepoConfig,
     pub source: AuthSource,
 }
 
@@ -358,7 +357,6 @@ se1WmgkjgdgmMWBVaajht3Y=
         let auth = GitHubAuth::with_clock(
             AuthConfig {
                 base_url,
-                repo: RepoConfig::parse("acme/plans").expect("repo"),
                 source: AuthSource::GitHubApp(AppAuthConfig {
                     app_id: "1".to_owned(),
                     private_key_pem: TEST_PRIVATE_KEY.to_owned(),
@@ -395,7 +393,6 @@ se1WmgkjgdgmMWBVaajht3Y=
         let auth = GitHubAuth::with_clock(
             AuthConfig {
                 base_url: base_url.clone(),
-                repo: RepoConfig::parse("acme/plans").expect("repo"),
                 source: AuthSource::GitHubApp(AppAuthConfig {
                     app_id: "1".to_owned(),
                     private_key_pem: TEST_PRIVATE_KEY.to_owned(),

--- a/crates/harnx-mcp-plans-github/src/client.rs
+++ b/crates/harnx-mcp-plans-github/src/client.rs
@@ -162,12 +162,22 @@ struct CreateLabelRequest<'a> {
 
 impl From<GitHubClient> for GitHubClientFactory {
     fn from(client: GitHubClient) -> Self {
+        let default_repo = match RepoTarget::new(client.owner.clone(), client.repo.clone()) {
+            Ok(target) => Some(target),
+            Err(err) => {
+                eprintln!(
+                    "harnx-mcp-plans-github: ignoring invalid default repository {}/{}: {err}",
+                    client.owner, client.repo
+                );
+                None
+            }
+        };
         Self {
             auth: client.auth,
             base_url: client.base_url,
             raw_http: client.raw_http,
             ratelimit: client.ratelimit,
-            default_repo: RepoTarget::new(client.owner, client.repo).ok(),
+            default_repo,
         }
     }
 }
@@ -656,8 +666,24 @@ impl GitHubClient {
         .await
     }
 
+    /// Percent-encode a single URL path segment.
+    ///
+    /// Passes through RFC 3986 unreserved characters (`A-Z a-z 0-9 - . _ ~`) and
+    /// percent-encodes everything else — including path separators (`/`, `\`) and
+    /// reserved characters such as `#`, `?`, `%`, and spaces — so that
+    /// caller-configurable values (e.g. the plan label) cannot alter the request
+    /// path or introduce a query/fragment.
     fn encode_path_segment(value: &str) -> String {
-        value.replace('/', "%2F").replace('\\', "%5C")
+        let mut encoded = String::with_capacity(value.len());
+        for byte in value.bytes() {
+            match byte {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                    encoded.push(byte as char);
+                }
+                _ => encoded.push_str(&format!("%{byte:02X}")),
+            }
+        }
+        encoded
     }
 
     fn absolute_url(&self, endpoint: &str) -> String {
@@ -794,4 +820,33 @@ struct IssueCommentWire {
     created_at: Option<String>,
     #[serde(default)]
     updated_at: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_path_segment_escapes_reserved_characters() {
+        // Path separators must not survive.
+        assert_eq!(GitHubClient::encode_path_segment("a/b"), "a%2Fb");
+        assert_eq!(GitHubClient::encode_path_segment("a\\b"), "a%5Cb");
+        // Reserved URL characters that could alter the request path or start a
+        // query/fragment must be percent-encoded.
+        assert_eq!(GitHubClient::encode_path_segment("a#b"), "a%23b");
+        assert_eq!(GitHubClient::encode_path_segment("a?b"), "a%3Fb");
+        assert_eq!(GitHubClient::encode_path_segment("100%"), "100%25");
+        assert_eq!(
+            GitHubClient::encode_path_segment("needs review"),
+            "needs%20review"
+        );
+    }
+
+    #[test]
+    fn encode_path_segment_preserves_unreserved_characters() {
+        assert_eq!(
+            GitHubClient::encode_path_segment("harnx-plan_v1.0~beta"),
+            "harnx-plan_v1.0~beta"
+        );
+    }
 }

--- a/crates/harnx-mcp-plans-github/src/client.rs
+++ b/crates/harnx-mcp-plans-github/src/client.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use harnx_mcp_plans_core::RepoTarget;
 use reqwest::Client;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -13,6 +14,16 @@ use crate::auth::{GitHubAuth, SystemClock, GITHUB_ACCEPT, GITHUB_API_VERSION, US
 use crate::ratelimit::{
     send_rate_limited, RateLimitConfig, RateLimitExecutor, RequestContext, TokioSleeper,
 };
+
+/// Factory for cheap per-repository GitHub clients sharing auth, HTTP, and rate limits.
+#[derive(Debug, Clone)]
+pub struct GitHubClientFactory {
+    auth: GitHubAuth,
+    base_url: String,
+    raw_http: Client,
+    ratelimit: Arc<RateLimitExecutor>,
+    default_repo: Option<RepoTarget>,
+}
 
 #[derive(Debug, Clone)]
 pub struct GitHubClient {
@@ -149,6 +160,54 @@ struct CreateLabelRequest<'a> {
     description: &'a str,
 }
 
+impl From<GitHubClient> for GitHubClientFactory {
+    fn from(client: GitHubClient) -> Self {
+        Self {
+            auth: client.auth,
+            base_url: client.base_url,
+            raw_http: client.raw_http,
+            ratelimit: client.ratelimit,
+            default_repo: RepoTarget::new(client.owner, client.repo).ok(),
+        }
+    }
+}
+
+impl GitHubClientFactory {
+    /// Create a factory with no implicit default repository fallback.
+    pub fn new(auth: GitHubAuth, ratelimit: Arc<RateLimitExecutor>) -> Result<Self> {
+        let base_url = auth.base_url().to_owned();
+        let raw_http = Client::builder()
+            .user_agent(USER_AGENT)
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .build()
+            .context("build raw GitHub client")?;
+        Ok(Self {
+            auth,
+            base_url,
+            raw_http,
+            ratelimit,
+            default_repo: None,
+        })
+    }
+
+    /// Return a repo-bound client for a validated target repository.
+    pub fn client_for(&self, target: &RepoTarget) -> GitHubClient {
+        GitHubClient {
+            auth: self.auth.clone(),
+            owner: target.owner.clone(),
+            repo: target.repo.clone(),
+            base_url: self.base_url.clone(),
+            raw_http: self.raw_http.clone(),
+            ratelimit: self.ratelimit.clone(),
+        }
+    }
+
+    pub fn default_repo(&self) -> Option<&RepoTarget> {
+        self.default_repo.as_ref()
+    }
+}
+
 impl GitHubClient {
     pub async fn new(
         auth: GitHubAuth,
@@ -208,7 +267,7 @@ impl GitHubClient {
     }
 
     pub async fn create_issue(&self, input: CreateIssue) -> Result<IssueRecord> {
-        let endpoint = format!("/repos/{}/{}/issues", self.owner, self.repo);
+        let endpoint = self.repo_endpoint("/issues");
         let issue: IssueRecordWire = self
             .post_json(
                 &endpoint,
@@ -227,19 +286,13 @@ impl GitHubClient {
     }
 
     pub async fn get_issue(&self, issue_number: u64) -> Result<IssueRecord> {
-        let endpoint = format!(
-            "/repos/{}/{}/issues/{}",
-            self.owner, self.repo, issue_number
-        );
+        let endpoint = self.repo_endpoint(&format!("/issues/{issue_number}"));
         let issue: IssueRecordWire = self.get_json(&endpoint).await?;
         Ok(map_issue(issue))
     }
 
     pub async fn update_issue(&self, issue_number: u64, input: UpdateIssue) -> Result<IssueRecord> {
-        let endpoint = format!(
-            "/repos/{}/{}/issues/{}",
-            self.owner, self.repo, issue_number
-        );
+        let endpoint = self.repo_endpoint(&format!("/issues/{issue_number}"));
         let issue: IssueRecordWire = self
             .patch_json(
                 &endpoint,
@@ -266,7 +319,7 @@ impl GitHubClient {
 
     pub async fn list_issues(&self, params: ListIssuesParams) -> Result<GhPage<IssueRecord>> {
         let endpoint = with_query(
-            format!("/repos/{}/{}/issues", self.owner, self.repo),
+            self.repo_endpoint("/issues"),
             params
                 .state
                 .into_iter()
@@ -296,10 +349,7 @@ impl GitHubClient {
         issue_number: u64,
         input: CreateComment,
     ) -> Result<IssueComment> {
-        let endpoint = format!(
-            "/repos/{}/{}/issues/{}/comments",
-            self.owner, self.repo, issue_number
-        );
+        let endpoint = self.repo_endpoint(&format!("/issues/{issue_number}/comments"));
         let comment: IssueCommentWire = self
             .post_json(&endpoint, &CreateCommentRequest { body: &input.body })
             .await?;
@@ -307,10 +357,7 @@ impl GitHubClient {
     }
 
     pub async fn get_comment(&self, comment_id: u64) -> Result<IssueComment> {
-        let endpoint = format!(
-            "/repos/{}/{}/issues/comments/{}",
-            self.owner, self.repo, comment_id
-        );
+        let endpoint = self.repo_endpoint(&format!("/issues/comments/{comment_id}"));
         let comment: IssueCommentWire = self.get_json(&endpoint).await?;
         Ok(map_comment(comment))
     }
@@ -320,10 +367,7 @@ impl GitHubClient {
         comment_id: u64,
         input: UpdateComment,
     ) -> Result<IssueComment> {
-        let endpoint = format!(
-            "/repos/{}/{}/issues/comments/{}",
-            self.owner, self.repo, comment_id
-        );
+        let endpoint = self.repo_endpoint(&format!("/issues/comments/{comment_id}"));
         let comment: IssueCommentWire = self
             .patch_json(&endpoint, &CreateCommentRequest { body: &input.body })
             .await?;
@@ -336,10 +380,7 @@ impl GitHubClient {
         per_page: Option<u8>,
     ) -> Result<GhPage<IssueComment>> {
         let endpoint = with_query(
-            format!(
-                "/repos/{}/{}/issues/{}/comments",
-                self.owner, self.repo, issue_number
-            ),
+            self.repo_endpoint(&format!("/issues/{issue_number}/comments")),
             per_page
                 .map(|value| vec![("per_page", value.to_string())])
                 .unwrap_or_default(),
@@ -362,10 +403,7 @@ impl GitHubClient {
     /// Delete a comment.
     /// DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}
     pub async fn delete_comment(&self, comment_id: u64) -> Result<()> {
-        let endpoint = format!(
-            "/repos/{}/{}/issues/comments/{}",
-            self.owner, self.repo, comment_id
-        );
+        let endpoint = self.repo_endpoint(&format!("/issues/comments/{comment_id}"));
         let url = self.absolute_url(&endpoint);
         self.request_json_empty::<()>(reqwest::Method::DELETE, &url, None)
             .await
@@ -384,10 +422,7 @@ impl GitHubClient {
         parent_issue_number: u64,
         sub_issue_internal_id: u64,
     ) -> Result<()> {
-        let endpoint = format!(
-            "/repos/{}/{}/issues/{}/sub_issues",
-            self.owner, self.repo, parent_issue_number
-        );
+        let endpoint = self.repo_endpoint(&format!("/issues/{parent_issue_number}/sub_issues"));
         let _: Value = self
             .post_json(
                 &endpoint,
@@ -406,10 +441,7 @@ impl GitHubClient {
         parent_issue_number: u64,
         sub_issue_internal_id: u64,
     ) -> Result<()> {
-        let endpoint = format!(
-            "/repos/{}/{}/issues/{}/sub_issue",
-            self.owner, self.repo, parent_issue_number
-        );
+        let endpoint = self.repo_endpoint(&format!("/issues/{parent_issue_number}/sub_issue"));
         self.request_json::<Value, _>(
             reqwest::Method::DELETE,
             &endpoint,
@@ -421,19 +453,17 @@ impl GitHubClient {
     }
 
     pub async fn get_repository(&self) -> Result<RepoRecord> {
-        let endpoint = format!("/repos/{}/{}", self.owner, self.repo);
+        let endpoint = self.repo_endpoint("");
         self.get_json(&endpoint)
             .await
             .context("get GitHub repository")
     }
 
     pub async fn get_label(&self, label_name: &str) -> Result<LabelRecord> {
-        let endpoint = format!(
-            "/repos/{}/{}/labels/{}",
-            self.owner,
-            self.repo,
+        let endpoint = self.repo_endpoint(&format!(
+            "/labels/{}",
             Self::encode_path_segment(label_name)
-        );
+        ));
         self.get_json(&endpoint).await.context("get GitHub label")
     }
 
@@ -443,7 +473,7 @@ impl GitHubClient {
         color: &str,
         description: &str,
     ) -> Result<LabelRecord> {
-        let endpoint = format!("/repos/{}/{}/labels", self.owner, self.repo);
+        let endpoint = self.repo_endpoint("/labels");
         self.post_json(
             &endpoint,
             &CreateLabelRequest {
@@ -484,10 +514,7 @@ impl GitHubClient {
         }
     }
     pub async fn list_sub_issues(&self, parent_issue_number: u64) -> Result<GhPage<Value>> {
-        let endpoint = format!(
-            "/repos/{}/{}/issues/{}/sub_issues",
-            self.owner, self.repo, parent_issue_number
-        );
+        let endpoint = self.repo_endpoint(&format!("/issues/{parent_issue_number}/sub_issues"));
         self.get_page_json(&endpoint)
             .await
             .context("list GitHub sub-issues")
@@ -630,11 +657,20 @@ impl GitHubClient {
     }
 
     fn encode_path_segment(value: &str) -> String {
-        value.replace('/', "%2F")
+        value.replace('/', "%2F").replace('\\', "%5C")
     }
 
     fn absolute_url(&self, endpoint: &str) -> String {
         format!("{}{}", self.base_url, endpoint)
+    }
+
+    fn repo_endpoint(&self, suffix: &str) -> String {
+        format!(
+            "/repos/{}/{}{}",
+            Self::encode_path_segment(&self.owner),
+            Self::encode_path_segment(&self.repo),
+            suffix
+        )
     }
 }
 

--- a/crates/harnx-mcp-plans-github/src/config.rs
+++ b/crates/harnx-mcp-plans-github/src/config.rs
@@ -19,6 +19,7 @@ const GIT_DETECTION_TIMEOUT: Duration = Duration::from_secs(5);
 #[derive(Debug, Clone)]
 pub struct AppConfig {
     pub auth: AuthConfig,
+    pub default_repo: Option<RepoConfig>,
     pub store: GitHubStoreConfig,
     pub rate_limit: RateLimitConfig,
     pub retention_days: u64,
@@ -105,7 +106,15 @@ impl AppConfig {
             }
         }
 
-        let repo = parse_github_origin(&origin_provider()?)?;
+        let default_repo = match origin_provider().and_then(|origin| parse_github_origin(&origin)) {
+            Ok(repo) => Some(repo),
+            Err(err) => {
+                eprintln!(
+                    "harnx-mcp-plans-github: warning: could not detect default GitHub repository from git origin: {err}"
+                );
+                None
+            }
+        };
 
         let base_url = first_non_empty(base_url_arg, env("GITHUB_API_URL"))
             .unwrap_or_else(|| DEFAULT_GITHUB_API_URL.to_string())
@@ -155,9 +164,13 @@ impl AppConfig {
         Ok(Self {
             auth: AuthConfig {
                 base_url,
-                repo,
+                repo: default_repo.clone().unwrap_or_else(|| RepoConfig {
+                    owner: String::new(),
+                    repo: String::new(),
+                }),
                 source: auth_source,
             },
+            default_repo,
             store: GitHubStoreConfig {
                 plan_label,
                 delete_is_close,

--- a/crates/harnx-mcp-plans-github/src/config.rs
+++ b/crates/harnx-mcp-plans-github/src/config.rs
@@ -164,10 +164,6 @@ impl AppConfig {
         Ok(Self {
             auth: AuthConfig {
                 base_url,
-                repo: default_repo.clone().unwrap_or_else(|| RepoConfig {
-                    owner: String::new(),
-                    repo: String::new(),
-                }),
                 source: auth_source,
             },
             default_repo,
@@ -409,8 +405,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(cfg.auth.repo.owner, "acme");
-        assert_eq!(cfg.auth.repo.repo, "plans");
+        let default_repo = cfg.default_repo.as_ref().expect("default repo detected");
+        assert_eq!(default_repo.owner, "acme");
+        assert_eq!(default_repo.repo, "plans");
         assert!(matches!(
             cfg.auth.source,
             AuthSource::PersonalAccessToken(_)

--- a/crates/harnx-mcp-plans-github/src/runtime.rs
+++ b/crates/harnx-mcp-plans-github/src/runtime.rs
@@ -3,31 +3,42 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use axum::Router;
-use harnx_mcp_plans_core::server::{PlansServer, ServerMeta};
-use harnx_mcp_plans_core::{PageToken, Plan, PlanStore};
+use harnx_mcp_plans_core::server::{PlansServer, ServerMeta, TargetPolicy};
+use harnx_mcp_plans_core::{PageToken, Plan, PlanStore, RepoTarget, Target};
 use rmcp::transport::streamable_http_server::session::never::NeverSessionManager;
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 use rmcp::ServiceExt;
 use tokio_util::sync::CancellationToken;
 
 use crate::auth::{GitHubAuth, SystemClock};
+use crate::client::GitHubClientFactory;
 use crate::config::AppConfig;
 use crate::ratelimit::{RateLimitExecutor, TokioSleeper};
 use crate::store_github::GitHubPlanStore;
 
-const LABEL_COLOR: &str = "5319e7";
-const LABEL_DESCRIPTION: &str = "harnx plans root issue";
 const RETENTION_SCAN_INTERVAL: Duration = Duration::from_secs(60 * 60);
 const BASE_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_BACKOFF: Duration = Duration::from_secs(300);
-const GITHUB_SERVER_META: ServerMeta = ServerMeta::new(
-    "harnx-mcp-plans-github",
-    "GitHub Issues-backed plan/task/note management server using issue bodies and comment front matter",
-);
+fn github_server_meta(default_repo: Option<RepoTarget>) -> ServerMeta {
+    let target_note = match &default_repo {
+        Some(default_repo) => format!(
+            " Target repository defaults to {}/{} detected at startup; owner/repo tool args may override it.",
+            default_repo.owner, default_repo.repo
+        ),
+        None => " No default repository was detected at startup; owner and repo tool args are required.".to_string(),
+    };
+    ServerMeta {
+        name: "harnx-mcp-plans-github".into(),
+        instructions: format!(
+            "GitHub Issues-backed plan/task/note management server using issue bodies and comment front matter.{target_note}"
+        )
+        .into(),
+        target_policy: TargetPolicy::GitHub { default_repo },
+    }
+}
 
 pub async fn run(config: AppConfig) -> Result<()> {
     let store = build_store(&config).await?;
-    validate_startup(store.as_ref(), &config.store.plan_label).await?;
 
     if config.http {
         run_http(store, config).await
@@ -43,39 +54,19 @@ pub async fn build_store(config: &AppConfig) -> Result<Arc<GitHubPlanStore>> {
         Arc::new(TokioSleeper),
         config.rate_limit.clone(),
     ));
-    let client = crate::client::GitHubClient::with_ratelimit(
-        auth,
-        config.auth.repo.owner.clone(),
-        config.auth.repo.repo.clone(),
-        ratelimit,
-    )
-    .await
-    .context("build GitHub API client")?;
+    let client_factory =
+        GitHubClientFactory::new(auth, ratelimit).context("build GitHub API client factory")?;
     Ok(Arc::new(GitHubPlanStore::with_config(
-        client,
+        client_factory,
         config.store.clone(),
     )))
 }
 
-pub async fn validate_startup(store: &GitHubPlanStore, plan_label: &str) -> Result<()> {
-    store
-        .client_ref()
-        .get_repository()
-        .await
-        .map_err(sanitize_github_error)
-        .context("startup validation failed: cannot access configured repository")?;
-    store
-        .client_ref()
-        .ensure_label(plan_label, LABEL_COLOR, LABEL_DESCRIPTION)
-        .await
-        .map_err(sanitize_github_error)
-        .with_context(|| {
-            format!("startup validation failed: cannot ensure label '{plan_label}'")
-        })?;
-    Ok(())
-}
-
-pub async fn run_retention_pass(store: &GitHubPlanStore, retention_days: u64) -> Result<()> {
+pub async fn run_retention_pass(
+    store: &GitHubPlanStore,
+    target: &Target,
+    retention_days: u64,
+) -> Result<()> {
     if retention_days == 0 {
         return Ok(());
     }
@@ -85,10 +76,10 @@ pub async fn run_retention_pass(store: &GitHubPlanStore, retention_days: u64) ->
 
     let mut page: Option<PageToken> = None;
     loop {
-        let response = store.list_plans(page.clone()).await?;
+        let response = store.list_plans(target, page.clone()).await?;
         for plan in response.items {
             if plan.updated_at.unwrap_or(plan.created_at) < cutoff {
-                close_stale_plan(store, &plan).await?;
+                close_stale_plan(store, target, &plan).await?;
             }
         }
         if response.next.is_none() {
@@ -111,17 +102,37 @@ fn redact_bearer_tokens(input: &str) -> String {
         .into_owned()
 }
 
+fn default_repo_target(config: &AppConfig) -> Option<RepoTarget> {
+    config.default_repo.as_ref().map(|repo| RepoTarget {
+        owner: repo.owner.clone(),
+        repo: repo.repo.clone(),
+    })
+}
+
+fn log_startup_target(default_repo: Option<&RepoTarget>) {
+    match default_repo {
+        Some(default_repo) => eprintln!(
+            "harnx-mcp-plans-github: default repository detected: {}/{}",
+            default_repo.owner, default_repo.repo
+        ),
+        None => eprintln!(
+            "harnx-mcp-plans-github: no default repository detected; owner/repo are required per tool call"
+        ),
+    }
+}
+
 async fn run_stdio(store: Arc<GitHubPlanStore>, config: AppConfig) -> Result<()> {
+    let default_repo = default_repo_target(&config);
+    log_startup_target(default_repo.as_ref());
+
     eprintln!(
-        "harnx-mcp-plans-github v{}: starting (repo: {}/{}, label: {}, retention: {} days)",
+        "harnx-mcp-plans-github v{}: starting (label: {}, retention: {} days)",
         env!("CARGO_PKG_VERSION"),
-        config.auth.repo.owner,
-        config.auth.repo.repo,
         config.store.plan_label,
         config.retention_days
     );
 
-    let server = PlansServer::with_meta(store.clone(), GITHUB_SERVER_META);
+    let server = PlansServer::with_meta(store.clone(), github_server_meta(default_repo.clone()));
     let transport = rmcp::transport::stdio();
     let service = server.serve(transport).await?;
 
@@ -131,7 +142,11 @@ async fn run_stdio(store: Arc<GitHubPlanStore>, config: AppConfig) -> Result<()>
         return Ok(());
     }
 
-    let mut retention_handle = tokio::spawn(retention_loop(store.clone(), config.retention_days));
+    let mut retention_handle = tokio::spawn(retention_loop(
+        store.clone(),
+        default_repo.clone(),
+        config.retention_days,
+    ));
     let service_handle = tokio::spawn(async move { service.waiting().await });
     tokio::pin!(service_handle);
     let mut backoff = BASE_BACKOFF;
@@ -152,7 +167,7 @@ async fn run_stdio(store: Arc<GitHubPlanStore>, config: AppConfig) -> Result<()>
                     }
                     Ok(()) => backoff = BASE_BACKOFF,
                 }
-                retention_handle = tokio::spawn(retention_loop(store.clone(), config.retention_days));
+                retention_handle = tokio::spawn(retention_loop(store.clone(), default_repo.clone(), config.retention_days));
             }
         }
     }
@@ -161,17 +176,21 @@ async fn run_stdio(store: Arc<GitHubPlanStore>, config: AppConfig) -> Result<()>
 }
 
 async fn run_http(store: Arc<GitHubPlanStore>, config: AppConfig) -> Result<()> {
+    let default_repo = default_repo_target(&config);
+    log_startup_target(default_repo.as_ref());
+
     let ct = CancellationToken::new();
     let factory_store = store.clone();
     let server_config = StreamableHttpServerConfig::default()
         .with_stateful_mode(false)
         .with_json_response(true)
         .with_cancellation_token(ct.child_token());
+    let service_default_repo = default_repo.clone();
     let mcp_service = StreamableHttpService::new(
         move || {
             Ok(PlansServer::with_meta(
                 factory_store.clone(),
-                GITHUB_SERVER_META,
+                github_server_meta(service_default_repo.clone()),
             ))
         },
         Arc::new(NeverSessionManager::default()),
@@ -190,12 +209,10 @@ async fn run_http(store: Arc<GitHubPlanStore>, config: AppConfig) -> Result<()> 
     spawn_shutdown_handler(ct.clone());
 
     eprintln!(
-        "harnx-mcp-plans-github v{}: listening on http://{}:{}/mcp (repo: {}/{}, label: {}, retention: {} days)",
+        "harnx-mcp-plans-github v{}: listening on http://{}:{}/mcp (label: {}, retention: {} days)",
         env!("CARGO_PKG_VERSION"),
         config.host,
         config.port,
-        config.auth.repo.owner,
-        config.auth.repo.repo,
         config.store.plan_label,
         config.retention_days
     );
@@ -214,7 +231,11 @@ async fn run_http(store: Arc<GitHubPlanStore>, config: AppConfig) -> Result<()> 
         return Ok(());
     }
 
-    let mut retention_handle = tokio::spawn(retention_loop(store.clone(), config.retention_days));
+    let mut retention_handle = tokio::spawn(retention_loop(
+        store.clone(),
+        default_repo.clone(),
+        config.retention_days,
+    ));
     let mut backoff = BASE_BACKOFF;
 
     loop {
@@ -233,7 +254,7 @@ async fn run_http(store: Arc<GitHubPlanStore>, config: AppConfig) -> Result<()> 
                     }
                     Ok(()) => backoff = BASE_BACKOFF,
                 }
-                retention_handle = tokio::spawn(retention_loop(store.clone(), config.retention_days));
+                retention_handle = tokio::spawn(retention_loop(store.clone(), default_repo.clone(), config.retention_days));
             }
         }
     }
@@ -241,22 +262,36 @@ async fn run_http(store: Arc<GitHubPlanStore>, config: AppConfig) -> Result<()> 
     Ok(())
 }
 
-async fn retention_loop(store: Arc<GitHubPlanStore>, retention_days: u64) {
+async fn retention_loop(
+    store: Arc<GitHubPlanStore>,
+    default_repo: Option<RepoTarget>,
+    retention_days: u64,
+) {
+    let Some(default_repo) = default_repo else {
+        eprintln!(
+            "[retention] disabled because no default GitHub repository was detected at startup"
+        );
+        return;
+    };
+    let target = Target::GitHub(default_repo);
     loop {
-        if let Err(err) = run_retention_pass(store.as_ref(), retention_days).await {
+        if let Err(err) = run_retention_pass(store.as_ref(), &target, retention_days).await {
             eprintln!("[retention] pass failed: {}", sanitize_github_error(err));
         }
         tokio::time::sleep(RETENTION_SCAN_INTERVAL).await;
     }
 }
 
-async fn close_stale_plan(store: &GitHubPlanStore, plan: &Plan) -> Result<()> {
+async fn close_stale_plan(store: &GitHubPlanStore, target: &Target, plan: &Plan) -> Result<()> {
     if !store.config_ref().delete_is_close {
         return Ok(());
     }
 
+    let Target::GitHub(repo) = target else {
+        return Ok(());
+    };
     store
-        .client_ref()
+        .client_for(repo)
         .close_issue(parse_issue_number(&plan.id)?)
         .await
         .map_err(sanitize_github_error)

--- a/crates/harnx-mcp-plans-github/src/runtime.rs
+++ b/crates/harnx-mcp-plans-github/src/runtime.rs
@@ -291,7 +291,7 @@ async fn close_stale_plan(store: &GitHubPlanStore, target: &Target, plan: &Plan)
         return Ok(());
     };
     store
-        .client_for(repo)
+        .client_for(repo)?
         .close_issue(parse_issue_number(&plan.id)?)
         .await
         .map_err(sanitize_github_error)

--- a/crates/harnx-mcp-plans-github/src/store_github.rs
+++ b/crates/harnx-mcp-plans-github/src/store_github.rs
@@ -26,13 +26,14 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use harnx_mcp_plans_core::{
     NewNote, NewPlan, NewTask, Note, NoteId, NoteMetaUpdate, Page, PageToken, Plan, PlanId,
-    PlanMetaUpdate, PlanStore, StoreError, Task, TaskFilter, TaskId, TaskMetaUpdate,
+    PlanMetaUpdate, PlanStore, RepoTarget, StoreError, Target, Task, TaskFilter, TaskId,
+    TaskMetaUpdate,
 };
 use jiff::Timestamp;
 
 use crate::client::{
-    CreateComment, CreateIssue, GitHubClient, IssueRecord, ListIssuesParams, UpdateComment,
-    UpdateIssue,
+    CreateComment, CreateIssue, GitHubClient, GitHubClientFactory, IssueRecord, ListIssuesParams,
+    UpdateComment, UpdateIssue,
 };
 use crate::codec::{
     comment_to_note, issue_to_plan, issue_to_task, new_note_to_comment, new_plan_to_issue,
@@ -42,6 +43,8 @@ use crate::codec::{
 
 /// Maximum number of sub-issues allowed per parent issue.
 const MAX_SUB_ISSUES: usize = 100;
+const LABEL_COLOR: &str = "5319e7";
+const LABEL_DESCRIPTION: &str = "harnx plans root issue";
 
 /// Configuration for `GitHubPlanStore`.
 #[derive(Debug, Clone)]
@@ -66,26 +69,43 @@ impl Default for GitHubStoreConfig {
 /// GitHub-backed `PlanStore` implementation.
 #[derive(Debug, Clone)]
 pub struct GitHubPlanStore {
-    client: GitHubClient,
+    client_factory: GitHubClientFactory,
     config: GitHubStoreConfig,
 }
 
 impl GitHubPlanStore {
     /// Create a new store with default configuration.
-    pub fn new(client: GitHubClient) -> Self {
+    pub fn new(client_factory: impl Into<GitHubClientFactory>) -> Self {
         Self {
-            client,
+            client_factory: client_factory.into(),
             config: GitHubStoreConfig::default(),
         }
     }
 
-    /// Create a new store with the given client and config.
-    pub fn with_config(client: GitHubClient, config: GitHubStoreConfig) -> Self {
-        Self { client, config }
+    /// Create a new store with the given client factory and config.
+    pub fn with_config(
+        client_factory: impl Into<GitHubClientFactory>,
+        config: GitHubStoreConfig,
+    ) -> Self {
+        Self {
+            client_factory: client_factory.into(),
+            config,
+        }
     }
 
-    pub fn client_ref(&self) -> &GitHubClient {
-        &self.client
+    pub fn client_for(&self, target: &RepoTarget) -> GitHubClient {
+        self.client_factory.client_for(target)
+    }
+
+    fn client_for_store_target(&self, target: &Target) -> Result<GitHubClient, StoreError> {
+        let repo = match target {
+            Target::GitHub(repo) => repo,
+            Target::Local => self.client_factory.default_repo().ok_or_else(|| {
+                StoreError::InvalidParams("GitHub plan store requires a GitHub target".to_string())
+            })?,
+        };
+        repo.validate().map_err(StoreError::InvalidParams)?;
+        Ok(self.client_for(repo))
     }
 
     pub fn config_ref(&self) -> &GitHubStoreConfig {
@@ -161,9 +181,12 @@ impl GitHubPlanStore {
         }
     }
 
-    async fn ensure_issue_is_plan(&self, plan_number: u64) -> Result<IssueRecord, StoreError> {
-        let issue = self
-            .client
+    async fn ensure_issue_is_plan(
+        &self,
+        client: &GitHubClient,
+        plan_number: u64,
+    ) -> Result<IssueRecord, StoreError> {
+        let issue = client
             .get_issue(plan_number)
             .await
             .map_err(map_github_error)?;
@@ -178,10 +201,13 @@ impl GitHubPlanStore {
         }
     }
 
-    async fn count_sub_issues(&self, plan_number: u64) -> Result<usize, StoreError> {
+    async fn count_sub_issues(
+        &self,
+        client: &GitHubClient,
+        plan_number: u64,
+    ) -> Result<usize, StoreError> {
         let mut total = 0usize;
-        let mut page = self
-            .client
+        let mut page = client
             .list_sub_issues(plan_number)
             .await
             .map_err(map_github_error)?;
@@ -190,8 +216,7 @@ impl GitHubPlanStore {
             let Some(next) = page.next.take() else {
                 break;
             };
-            page = self
-                .client
+            page = client
                 .list_sub_issues_next(&next)
                 .await
                 .map_err(map_github_error)?;
@@ -201,11 +226,11 @@ impl GitHubPlanStore {
 
     async fn find_task_membership(
         &self,
+        client: &GitHubClient,
         plan_number: u64,
         task_number: u64,
     ) -> Result<bool, StoreError> {
-        let mut page = self
-            .client
+        let mut page = client
             .list_sub_issues(plan_number)
             .await
             .map_err(map_github_error)?;
@@ -221,8 +246,7 @@ impl GitHubPlanStore {
             let Some(next) = page.next.take() else {
                 return Ok(false);
             };
-            page = self
-                .client
+            page = client
                 .list_sub_issues_next(&next)
                 .await
                 .map_err(map_github_error)?;
@@ -231,11 +255,11 @@ impl GitHubPlanStore {
 
     async fn find_note_membership(
         &self,
+        client: &GitHubClient,
         plan_number: u64,
         comment_id: u64,
     ) -> Result<bool, StoreError> {
-        let mut page = self
-            .client
+        let mut page = client
             .list_comments(plan_number, Some(100))
             .await
             .map_err(map_github_error)?;
@@ -246,8 +270,7 @@ impl GitHubPlanStore {
             let Some(next) = page.next.take() else {
                 return Ok(false);
             };
-            page = self
-                .client
+            page = client
                 .list_comments_next(&next)
                 .await
                 .map_err(map_github_error)?;
@@ -354,14 +377,18 @@ impl GitHubPlanStore {
 
     async fn ensure_task_belongs_to_plan(
         &self,
+        client: &GitHubClient,
         plan: &PlanId,
         task: &TaskId,
     ) -> Result<u64, StoreError> {
         let plan_number = Self::parse_plan_id(plan)?;
-        self.ensure_issue_is_plan(plan_number).await?;
+        self.ensure_issue_is_plan(client, plan_number).await?;
         let task_number = Self::parse_task_id(task)?;
 
-        if self.find_task_membership(plan_number, task_number).await? {
+        if self
+            .find_task_membership(client, plan_number, task_number)
+            .await?
+        {
             Ok(task_number)
         } else {
             Err(StoreError::NotFound)
@@ -370,19 +397,22 @@ impl GitHubPlanStore {
 
     async fn ensure_note_belongs_to_plan(
         &self,
+        client: &GitHubClient,
         plan: &PlanId,
         note: &NoteId,
     ) -> Result<crate::client::IssueComment, StoreError> {
         let plan_number = Self::parse_plan_id(plan)?;
-        self.ensure_issue_is_plan(plan_number).await?;
+        self.ensure_issue_is_plan(client, plan_number).await?;
         let comment_id = Self::parse_note_id(note)?;
-        let comment = self
-            .client
+        let comment = client
             .get_comment(comment_id)
             .await
             .map_err(map_github_error)?;
 
-        if self.find_note_membership(plan_number, comment_id).await? {
+        if self
+            .find_note_membership(client, plan_number, comment_id)
+            .await?
+        {
             Ok(comment)
         } else {
             Err(StoreError::NotFound)
@@ -394,6 +424,31 @@ impl GitHubPlanStore {
 fn parse_github_timestamp(s: &str) -> Result<Timestamp, StoreError> {
     s.parse::<Timestamp>()
         .map_err(|e| StoreError::Backend(anyhow!("failed to parse timestamp '{}': {}", s, e)))
+}
+
+fn is_label_validation_error(err: &StoreError) -> bool {
+    match err {
+        StoreError::InvalidParams(message) => {
+            let message = message.to_lowercase();
+            message.contains("422")
+                || message.contains("validation")
+                || message.contains("unprocessable entity")
+        }
+        _ => false,
+    }
+}
+
+async fn ensure_plan_label_warning_only(client: &GitHubClient, label: &str) {
+    if let Err(err) = client
+        .ensure_label(label, LABEL_COLOR, LABEL_DESCRIPTION)
+        .await
+        .map_err(map_github_error)
+    {
+        eprintln!(
+            "[github] warning: could not ensure label '{}' before plan creation: {}",
+            label, err
+        );
+    }
 }
 
 /// Map GitHub client errors to StoreError.
@@ -415,11 +470,16 @@ fn map_github_error(e: anyhow::Error) -> StoreError {
 
 #[async_trait]
 impl PlanStore for GitHubPlanStore {
-    async fn list_plans(&self, page: Option<PageToken>) -> Result<Page<Plan>, StoreError> {
+    async fn list_plans(
+        &self,
+        target: &Target,
+        page: Option<PageToken>,
+    ) -> Result<Page<Plan>, StoreError> {
+        let client = self.client_for_store_target(target)?;
         let gh_page = match page {
-            Some(token) => self.client.list_issues_next(&token.0).await,
+            Some(token) => client.list_issues_next(&token.0).await,
             None => {
-                self.client
+                client
                     .list_issues(ListIssuesParams {
                         state: Some("open".to_string()),
                         labels: Some(self.config.plan_label.clone()),
@@ -467,26 +527,51 @@ impl PlanStore for GitHubPlanStore {
         })
     }
 
-    async fn get_plan(&self, plan: &PlanId) -> Result<Plan, StoreError> {
+    async fn get_plan(&self, target: &Target, plan: &PlanId) -> Result<Plan, StoreError> {
+        let client = self.client_for_store_target(target)?;
         let issue_number = Self::parse_plan_id(plan)?;
-        let issue = self.ensure_issue_is_plan(issue_number).await?;
+        let issue = self.ensure_issue_is_plan(&client, issue_number).await?;
 
         let decoded = Self::decode_issue_to_plan(issue)?;
         Ok(decoded.plan)
     }
 
-    async fn add_plan(&self, new_plan: NewPlan) -> Result<Plan, StoreError> {
+    async fn add_plan(&self, target: &Target, new_plan: NewPlan) -> Result<Plan, StoreError> {
+        let client = self.client_for_store_target(target)?;
         let (title, body) = new_plan_to_issue(&new_plan, None, "");
 
-        let issue = self
-            .client
-            .create_issue(CreateIssue {
-                title,
-                body: Some(body),
-                labels: vec![self.config.plan_label.clone()],
-            })
+        ensure_plan_label_warning_only(&client, &self.config.plan_label).await;
+
+        // Label application is best-effort: GitHub can reject create-with-label when
+        // label creation/visibility races or repository label permissions fail. Retry
+        // without labels and return the plan so write-time label problems remain warning-only.
+        let create_with_label = CreateIssue {
+            title: title.clone(),
+            body: Some(body.clone()),
+            labels: vec![self.config.plan_label.clone()],
+        };
+        let issue = match client
+            .create_issue(create_with_label)
             .await
-            .map_err(map_github_error)?;
+            .map_err(map_github_error)
+        {
+            Ok(issue) => issue,
+            Err(err) if is_label_validation_error(&err) => {
+                eprintln!(
+                    "[github] warning: plan label '{}' was rejected during issue creation; retrying without label: {}",
+                    self.config.plan_label, err
+                );
+                client
+                    .create_issue(CreateIssue {
+                        title,
+                        body: Some(body),
+                        labels: Vec::new(),
+                    })
+                    .await
+                    .map_err(map_github_error)?
+            }
+            Err(err) => return Err(err),
+        };
 
         Ok(Plan {
             id: issue.number.to_string(),
@@ -504,17 +589,18 @@ impl PlanStore for GitHubPlanStore {
 
     async fn update_plan_meta(
         &self,
+        target: &Target,
         plan: &PlanId,
         update: PlanMetaUpdate,
     ) -> Result<Plan, StoreError> {
+        let client = self.client_for_store_target(target)?;
         let issue_number = Self::parse_plan_id(plan)?;
-        let issue = self.ensure_issue_is_plan(issue_number).await?;
+        let issue = self.ensure_issue_is_plan(&client, issue_number).await?;
         let decoded = Self::decode_issue_to_plan(issue)?;
 
         let (new_title_opt, new_body) = plan_meta_update_to_issue_body(&decoded, &update);
 
-        let updated = self
-            .client
+        let updated = client
             .update_issue(
                 issue_number,
                 UpdateIssue {
@@ -530,11 +616,12 @@ impl PlanStore for GitHubPlanStore {
         Ok(decoded.plan)
     }
 
-    async fn delete_plan(&self, plan: &PlanId) -> Result<(), StoreError> {
+    async fn delete_plan(&self, target: &Target, plan: &PlanId) -> Result<(), StoreError> {
+        let client = self.client_for_store_target(target)?;
         if self.config.delete_is_close {
             let issue_number = Self::parse_plan_id(plan)?;
-            self.ensure_issue_is_plan(issue_number).await?;
-            self.client
+            self.ensure_issue_is_plan(&client, issue_number).await?;
+            client
                 .close_issue(issue_number)
                 .await
                 .map_err(map_github_error)?;
@@ -546,16 +633,23 @@ impl PlanStore for GitHubPlanStore {
         }
     }
 
-    async fn read_plan_body(&self, plan: &PlanId) -> Result<String, StoreError> {
+    async fn read_plan_body(&self, target: &Target, plan: &PlanId) -> Result<String, StoreError> {
+        let client = self.client_for_store_target(target)?;
         let issue_number = Self::parse_plan_id(plan)?;
-        let issue = self.ensure_issue_is_plan(issue_number).await?;
+        let issue = self.ensure_issue_is_plan(&client, issue_number).await?;
         let decoded = Self::decode_issue_to_plan(issue)?;
         Ok(decoded.body)
     }
 
-    async fn write_plan_body(&self, plan: &PlanId, body: &str) -> Result<(), StoreError> {
+    async fn write_plan_body(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        body: &str,
+    ) -> Result<(), StoreError> {
+        let client = self.client_for_store_target(target)?;
         let issue_number = Self::parse_plan_id(plan)?;
-        let issue = self.ensure_issue_is_plan(issue_number).await?;
+        let issue = self.ensure_issue_is_plan(&client, issue_number).await?;
         let decoded = Self::decode_issue_to_plan(issue)?;
 
         let (title_opt, final_body) = plan_meta_update_to_issue_body(
@@ -568,7 +662,7 @@ impl PlanStore for GitHubPlanStore {
             &PlanMetaUpdate::default(),
         );
 
-        self.client
+        client
             .update_issue(
                 issue_number,
                 UpdateIssue {
@@ -585,15 +679,17 @@ impl PlanStore for GitHubPlanStore {
 
     async fn list_tasks(
         &self,
+        target: &Target,
         plan: &PlanId,
         filter: TaskFilter,
         page: Option<PageToken>,
     ) -> Result<Page<Task>, StoreError> {
+        let client = self.client_for_store_target(target)?;
         let plan_number = Self::parse_plan_id(plan)?;
 
         let gh_page = match page {
-            Some(token) => self.client.list_sub_issues_next(&token.0).await,
-            None => self.client.list_sub_issues(plan_number).await,
+            Some(token) => client.list_sub_issues_next(&token.0).await,
+            None => client.list_sub_issues(plan_number).await,
         }
         .map_err(map_github_error)?;
 
@@ -636,11 +732,18 @@ impl PlanStore for GitHubPlanStore {
         })
     }
 
-    async fn get_task(&self, plan: &PlanId, task: &TaskId) -> Result<Task, StoreError> {
-        let task_number = self.ensure_task_belongs_to_plan(plan, task).await?;
+    async fn get_task(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        task: &TaskId,
+    ) -> Result<Task, StoreError> {
+        let client = self.client_for_store_target(target)?;
+        let task_number = self
+            .ensure_task_belongs_to_plan(&client, plan, task)
+            .await?;
 
-        let issue = self
-            .client
+        let issue = client
             .get_issue(task_number)
             .await
             .map_err(map_github_error)?;
@@ -649,11 +752,17 @@ impl PlanStore for GitHubPlanStore {
         Ok(decoded.task)
     }
 
-    async fn add_task(&self, plan: &PlanId, new_task: NewTask) -> Result<Task, StoreError> {
+    async fn add_task(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        new_task: NewTask,
+    ) -> Result<Task, StoreError> {
+        let client = self.client_for_store_target(target)?;
         let plan_number = Self::parse_plan_id(plan)?;
 
-        self.ensure_issue_is_plan(plan_number).await?;
-        let current_sub_count = self.count_sub_issues(plan_number).await?;
+        self.ensure_issue_is_plan(&client, plan_number).await?;
+        let current_sub_count = self.count_sub_issues(&client, plan_number).await?;
         if current_sub_count >= MAX_SUB_ISSUES {
             return Err(StoreError::InvalidParams(format!(
                 "plan {} already has maximum number of sub-issues ({})",
@@ -663,8 +772,7 @@ impl PlanStore for GitHubPlanStore {
 
         let (title, body) = new_task_to_issue(plan, &new_task, None, "");
 
-        let issue = self
-            .client
+        let issue = client
             .create_issue(CreateIssue {
                 title,
                 body: Some(body),
@@ -676,7 +784,7 @@ impl PlanStore for GitHubPlanStore {
         let task_number = issue.number;
         let task_internal_id = issue.id;
 
-        self.client
+        client
             .add_sub_issue(plan_number, task_internal_id)
             .await
             .map_err(map_github_error)?;
@@ -699,14 +807,17 @@ impl PlanStore for GitHubPlanStore {
 
     async fn update_task_meta(
         &self,
+        target: &Target,
         plan: &PlanId,
         task: &TaskId,
         update: TaskMetaUpdate,
     ) -> Result<Task, StoreError> {
-        let task_number = self.ensure_task_belongs_to_plan(plan, task).await?;
+        let client = self.client_for_store_target(target)?;
+        let task_number = self
+            .ensure_task_belongs_to_plan(&client, plan, task)
+            .await?;
 
-        let issue = self
-            .client
+        let issue = client
             .get_issue(task_number)
             .await
             .map_err(map_github_error)?;
@@ -714,8 +825,7 @@ impl PlanStore for GitHubPlanStore {
 
         let (new_title_opt, new_body) = task_meta_update_to_issue_body(&decoded, &update);
 
-        let updated = self
-            .client
+        let updated = client
             .update_issue(
                 task_number,
                 UpdateIssue {
@@ -731,10 +841,18 @@ impl PlanStore for GitHubPlanStore {
         Ok(decoded.task)
     }
 
-    async fn delete_task(&self, plan: &PlanId, task: &TaskId) -> Result<(), StoreError> {
+    async fn delete_task(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        task: &TaskId,
+    ) -> Result<(), StoreError> {
+        let client = self.client_for_store_target(target)?;
         if self.config.delete_is_close {
-            let task_number = self.ensure_task_belongs_to_plan(plan, task).await?;
-            self.client
+            let task_number = self
+                .ensure_task_belongs_to_plan(&client, plan, task)
+                .await?;
+            client
                 .close_issue(task_number)
                 .await
                 .map_err(map_github_error)?;
@@ -746,10 +864,17 @@ impl PlanStore for GitHubPlanStore {
         }
     }
 
-    async fn read_task_body(&self, plan: &PlanId, task: &TaskId) -> Result<String, StoreError> {
-        let task_number = self.ensure_task_belongs_to_plan(plan, task).await?;
-        let issue = self
-            .client
+    async fn read_task_body(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        task: &TaskId,
+    ) -> Result<String, StoreError> {
+        let client = self.client_for_store_target(target)?;
+        let task_number = self
+            .ensure_task_belongs_to_plan(&client, plan, task)
+            .await?;
+        let issue = client
             .get_issue(task_number)
             .await
             .map_err(map_github_error)?;
@@ -759,14 +884,17 @@ impl PlanStore for GitHubPlanStore {
 
     async fn write_task_body(
         &self,
+        target: &Target,
         plan: &PlanId,
         task: &TaskId,
         body: &str,
     ) -> Result<(), StoreError> {
-        let task_number = self.ensure_task_belongs_to_plan(plan, task).await?;
+        let client = self.client_for_store_target(target)?;
+        let task_number = self
+            .ensure_task_belongs_to_plan(&client, plan, task)
+            .await?;
 
-        let issue = self
-            .client
+        let issue = client
             .get_issue(task_number)
             .await
             .map_err(map_github_error)?;
@@ -782,7 +910,7 @@ impl PlanStore for GitHubPlanStore {
             &TaskMetaUpdate::default(),
         );
 
-        self.client
+        client
             .update_issue(
                 task_number,
                 UpdateIssue {
@@ -799,14 +927,16 @@ impl PlanStore for GitHubPlanStore {
 
     async fn list_notes(
         &self,
+        target: &Target,
         plan: &PlanId,
         page: Option<PageToken>,
     ) -> Result<Page<Note>, StoreError> {
+        let client = self.client_for_store_target(target)?;
         let plan_number = Self::parse_plan_id(plan)?;
 
         let gh_page = match page {
-            Some(token) => self.client.list_comments_next(&token.0).await,
-            None => self.client.list_comments(plan_number, Some(100)).await,
+            Some(token) => client.list_comments_next(&token.0).await,
+            None => client.list_comments(plan_number, Some(100)).await,
         }
         .map_err(map_github_error)?;
 
@@ -824,19 +954,32 @@ impl PlanStore for GitHubPlanStore {
         })
     }
 
-    async fn get_note(&self, plan: &PlanId, note: &NoteId) -> Result<Note, StoreError> {
-        let comment = self.ensure_note_belongs_to_plan(plan, note).await?;
+    async fn get_note(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        note: &NoteId,
+    ) -> Result<Note, StoreError> {
+        let client = self.client_for_store_target(target)?;
+        let comment = self
+            .ensure_note_belongs_to_plan(&client, plan, note)
+            .await?;
         let decoded = Self::decode_comment_to_note(comment)?;
         Ok(decoded.note)
     }
 
-    async fn add_note(&self, plan: &PlanId, new_note: NewNote) -> Result<Note, StoreError> {
+    async fn add_note(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        new_note: NewNote,
+    ) -> Result<Note, StoreError> {
+        let client = self.client_for_store_target(target)?;
         let plan_number = Self::parse_plan_id(plan)?;
 
         let body = new_note_to_comment(&new_note, "");
 
-        let comment = self
-            .client
+        let comment = client
             .create_comment(plan_number, CreateComment { body })
             .await
             .map_err(map_github_error)?;
@@ -852,18 +995,21 @@ impl PlanStore for GitHubPlanStore {
 
     async fn update_note_meta(
         &self,
+        target: &Target,
         plan: &PlanId,
         note: &NoteId,
         update: NoteMetaUpdate,
     ) -> Result<Note, StoreError> {
-        let comment = self.ensure_note_belongs_to_plan(plan, note).await?;
+        let client = self.client_for_store_target(target)?;
+        let comment = self
+            .ensure_note_belongs_to_plan(&client, plan, note)
+            .await?;
         let decoded = Self::decode_comment_to_note(comment)?;
         let comment_id = Self::parse_note_id(note)?;
 
         let new_body = note_meta_update_to_comment_body(&decoded, &update);
 
-        let updated = self
-            .client
+        let updated = client
             .update_comment(comment_id, UpdateComment { body: new_body })
             .await
             .map_err(map_github_error)?;
@@ -872,9 +1018,17 @@ impl PlanStore for GitHubPlanStore {
         Ok(decoded.note)
     }
 
-    async fn delete_note(&self, plan: &PlanId, note: &NoteId) -> Result<(), StoreError> {
-        let comment = self.ensure_note_belongs_to_plan(plan, note).await?;
-        self.client
+    async fn delete_note(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        note: &NoteId,
+    ) -> Result<(), StoreError> {
+        let client = self.client_for_store_target(target)?;
+        let comment = self
+            .ensure_note_belongs_to_plan(&client, plan, note)
+            .await?;
+        client
             .delete_comment(comment.id)
             .await
             .map_err(map_github_error)?;
@@ -882,19 +1036,31 @@ impl PlanStore for GitHubPlanStore {
         Ok(())
     }
 
-    async fn read_note_body(&self, plan: &PlanId, note: &NoteId) -> Result<String, StoreError> {
-        let comment = self.ensure_note_belongs_to_plan(plan, note).await?;
+    async fn read_note_body(
+        &self,
+        target: &Target,
+        plan: &PlanId,
+        note: &NoteId,
+    ) -> Result<String, StoreError> {
+        let client = self.client_for_store_target(target)?;
+        let comment = self
+            .ensure_note_belongs_to_plan(&client, plan, note)
+            .await?;
         let decoded = Self::decode_comment_to_note(comment)?;
         Ok(decoded.body)
     }
 
     async fn write_note_body(
         &self,
+        target: &Target,
         plan: &PlanId,
         note: &NoteId,
         body: &str,
     ) -> Result<(), StoreError> {
-        let comment = self.ensure_note_belongs_to_plan(plan, note).await?;
+        let client = self.client_for_store_target(target)?;
+        let comment = self
+            .ensure_note_belongs_to_plan(&client, plan, note)
+            .await?;
         let decoded = Self::decode_comment_to_note(comment)?;
         let comment_id = Self::parse_note_id(note)?;
 
@@ -907,7 +1073,7 @@ impl PlanStore for GitHubPlanStore {
             &NoteMetaUpdate::default(),
         );
 
-        self.client
+        client
             .update_comment(comment_id, UpdateComment { body: final_body })
             .await
             .map_err(map_github_error)?;

--- a/crates/harnx-mcp-plans-github/src/store_github.rs
+++ b/crates/harnx-mcp-plans-github/src/store_github.rs
@@ -93,8 +93,9 @@ impl GitHubPlanStore {
         }
     }
 
-    pub fn client_for(&self, target: &RepoTarget) -> GitHubClient {
-        self.client_factory.client_for(target)
+    pub fn client_for(&self, target: &RepoTarget) -> Result<GitHubClient, StoreError> {
+        target.validate().map_err(StoreError::InvalidParams)?;
+        Ok(self.client_factory.client_for(target))
     }
 
     fn client_for_store_target(&self, target: &Target) -> Result<GitHubClient, StoreError> {
@@ -104,8 +105,8 @@ impl GitHubPlanStore {
                 StoreError::InvalidParams("GitHub plan store requires a GitHub target".to_string())
             })?,
         };
-        repo.validate().map_err(StoreError::InvalidParams)?;
-        Ok(self.client_for(repo))
+        let client = self.client_for(repo)?;
+        Ok(client)
     }
 
     pub fn config_ref(&self) -> &GitHubStoreConfig {

--- a/crates/harnx-mcp-plans-github/src/store_github/tests.rs
+++ b/crates/harnx-mcp-plans-github/src/store_github/tests.rs
@@ -12,7 +12,7 @@ use wiremock::{
 use harnx_mcp_plans_core::{NewPlan, NewTask, PageToken, PlanStore, StoreError, TaskFilter};
 
 use crate::auth::SystemClock;
-use crate::auth::{AuthConfig, AuthSource, GitHubAuth, RepoConfig};
+use crate::auth::{AuthConfig, AuthSource, GitHubAuth};
 use crate::client::{GitHubClient, GitHubClientFactory};
 use crate::ratelimit::{RateLimitConfig, RateLimitExecutor, TokioSleeper};
 use std::sync::Arc;
@@ -22,10 +22,6 @@ use super::*;
 async fn create_test_store(server: &MockServer) -> GitHubPlanStore {
     let config = AuthConfig {
         base_url: server.uri(),
-        repo: RepoConfig {
-            owner: "test-owner".to_string(),
-            repo: "test-repo".to_string(),
-        },
         source: AuthSource::PersonalAccessToken("test-token".to_string()),
     };
 
@@ -49,10 +45,6 @@ async fn create_test_store_with_config(
 ) -> GitHubPlanStore {
     let auth_config = AuthConfig {
         base_url: server.uri(),
-        repo: RepoConfig {
-            owner: "test-owner".to_string(),
-            repo: "test-repo".to_string(),
-        },
         source: AuthSource::PersonalAccessToken("test-token".to_string()),
     };
 
@@ -84,10 +76,6 @@ async fn create_store_with_default(
 ) -> GitHubPlanStore {
     let config = AuthConfig {
         base_url: server.uri(),
-        repo: RepoConfig {
-            owner: owner.to_string(),
-            repo: repo.to_string(),
-        },
         source: AuthSource::PersonalAccessToken("test-token".to_string()),
     };
 
@@ -144,6 +132,26 @@ fn mock_comment_json(id: u64, body: &str) -> serde_json::Value {
     })
 }
 
+#[tokio::test]
+async fn client_for_rejects_path_traversal_without_request() {
+    let server = MockServer::start().await;
+    let store = create_test_store(&server).await;
+    let traversal = RepoTarget {
+        owner: "acme".to_string(),
+        repo: "../../../user".to_string(),
+    };
+
+    let err = store
+        .client_for(&traversal)
+        .expect_err("repo traversal should be rejected");
+    assert!(matches!(err, StoreError::InvalidParams(_)));
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        requests.is_empty(),
+        "invalid target made GitHub API requests: {requests:?}"
+    );
+}
 #[tokio::test]
 async fn explicit_target_rejects_path_traversal_without_request() {
     let server = MockServer::start().await;

--- a/crates/harnx-mcp-plans-github/src/store_github/tests.rs
+++ b/crates/harnx-mcp-plans-github/src/store_github/tests.rs
@@ -5,14 +5,17 @@
 
 use jiff::Timestamp;
 use wiremock::{
-    matchers::{body_json, method, path, query_param},
+    matchers::{body_json, body_partial_json, method, path, query_param},
     Mock, MockServer, ResponseTemplate,
 };
 
 use harnx_mcp_plans_core::{NewPlan, NewTask, PageToken, PlanStore, StoreError, TaskFilter};
 
+use crate::auth::SystemClock;
 use crate::auth::{AuthConfig, AuthSource, GitHubAuth, RepoConfig};
-use crate::client::GitHubClient;
+use crate::client::{GitHubClient, GitHubClientFactory};
+use crate::ratelimit::{RateLimitConfig, RateLimitExecutor, TokioSleeper};
+use std::sync::Arc;
 
 use super::*;
 
@@ -27,11 +30,17 @@ async fn create_test_store(server: &MockServer) -> GitHubPlanStore {
     };
 
     let auth = GitHubAuth::new(config).unwrap();
-    let client = GitHubClient::new(auth, "test-owner", "test-repo")
-        .await
-        .unwrap();
+    let factory = GitHubClientFactory::new(
+        auth,
+        Arc::new(RateLimitExecutor::new(
+            Arc::new(SystemClock),
+            Arc::new(TokioSleeper),
+            RateLimitConfig::default(),
+        )),
+    )
+    .unwrap();
 
-    GitHubPlanStore::new(client)
+    GitHubPlanStore::new(factory)
 }
 
 async fn create_test_store_with_config(
@@ -48,13 +57,44 @@ async fn create_test_store_with_config(
     };
 
     let auth = GitHubAuth::new(auth_config).unwrap();
-    let client = GitHubClient::new(auth, "test-owner", "test-repo")
-        .await
-        .unwrap();
+    let factory = GitHubClientFactory::new(
+        auth,
+        Arc::new(RateLimitExecutor::new(
+            Arc::new(SystemClock),
+            Arc::new(TokioSleeper),
+            RateLimitConfig::default(),
+        )),
+    )
+    .unwrap();
 
-    GitHubPlanStore::with_config(client, config)
+    GitHubPlanStore::with_config(factory, config)
 }
 
+fn target(owner: &str, repo: &str) -> harnx_mcp_plans_core::Target {
+    harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+    })
+}
+
+async fn create_store_with_default(
+    server: &MockServer,
+    owner: &str,
+    repo: &str,
+) -> GitHubPlanStore {
+    let config = AuthConfig {
+        base_url: server.uri(),
+        repo: RepoConfig {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+        },
+        source: AuthSource::PersonalAccessToken("test-token".to_string()),
+    };
+
+    let auth = GitHubAuth::new(config).unwrap();
+    let client = GitHubClient::new(auth, owner, repo).await.unwrap();
+    GitHubPlanStore::new(client)
+}
 fn mock_issue_json(id: u64, number: u64, title: &str, body: &str) -> serde_json::Value {
     let created = Timestamp::now().to_string();
     serde_json::json!({
@@ -81,6 +121,7 @@ fn mock_issue_with_labels_json(
     let created = Timestamp::now().to_string();
     serde_json::json!({
         "id": id,
+
         "number": number,
         "title": title,
         "body": body,
@@ -104,6 +145,254 @@ fn mock_comment_json(id: u64, body: &str) -> serde_json::Value {
 }
 
 #[tokio::test]
+async fn explicit_target_rejects_path_traversal_without_request() {
+    let server = MockServer::start().await;
+    let store = create_test_store(&server).await;
+
+    let repo_err = store
+        .list_plans(&target("acme", "../../../user"), None)
+        .await
+        .expect_err("repo traversal should be rejected");
+    assert!(matches!(repo_err, StoreError::InvalidParams(_)));
+
+    let owner_err = store
+        .list_plans(&target("../../../user", "plans"), None)
+        .await
+        .expect_err("owner traversal should be rejected");
+    assert!(matches!(owner_err, StoreError::InvalidParams(_)));
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        requests.is_empty(),
+        "invalid targets made GitHub API requests: {requests:?}"
+    );
+}
+
+#[tokio::test]
+async fn explicit_target_routes_requests_to_requested_repo() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/target-owner/target-repo/issues"))
+        .and(query_param("labels", "harnx-plan"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let store = create_test_store(&server).await;
+    let page = store
+        .list_plans(&target("target-owner", "target-repo"), None)
+        .await
+        .unwrap();
+    assert!(page.items.is_empty());
+}
+
+#[tokio::test]
+async fn explicit_target_accepts_repo_slug_with_dot() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/plans.rs/issues"))
+        .and(query_param("labels", "harnx-plan"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let store = create_test_store(&server).await;
+    let page = store
+        .list_plans(&target("acme", "plans.rs"), None)
+        .await
+        .unwrap();
+    assert!(page.items.is_empty());
+}
+
+#[tokio::test]
+async fn local_target_falls_back_to_default_repo_for_requests() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/default-owner/default-repo/issues"))
+        .and(query_param("labels", "harnx-plan"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let store = create_store_with_default(&server, "default-owner", "default-repo").await;
+    let page = store
+        .list_plans(&harnx_mcp_plans_core::Target::Local, None)
+        .await
+        .unwrap();
+    assert!(page.items.is_empty());
+}
+
+#[tokio::test]
+async fn constructing_store_does_not_call_github_api() {
+    let server = MockServer::start().await;
+    let _store = create_test_store(&server).await;
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        requests.is_empty(),
+        "store construction made GitHub API requests: {requests:?}"
+    );
+}
+
+#[tokio::test]
+async fn ensure_label_failure_still_creates_plan() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/test-owner/test-repo/labels/harnx-plan"))
+        .respond_with(ResponseTemplate::new(400).set_body_string("boom"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/test-owner/test-repo/issues"))
+        .and(body_partial_json(
+            serde_json::json!({ "labels": ["harnx-plan"] }),
+        ))
+        .respond_with(
+            ResponseTemplate::new(201).set_body_json(mock_issue_with_labels_json(
+                1002,
+                2,
+                "Plan B",
+                "---\nclient_id: plan-b\n---\n",
+                &["harnx-plan"],
+            )),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let store = create_test_store(&server).await;
+    let plan = store
+        .add_plan(
+            &target("test-owner", "test-repo"),
+            NewPlan {
+                id: "plan-b".to_string(),
+                title: Some("Plan B".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(plan.id, "2");
+}
+
+#[tokio::test]
+async fn create_label_conflict_is_handled_when_ensuring_plan_label() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/test-owner/test-repo/labels/harnx-plan"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/test-owner/test-repo/labels"))
+        .respond_with(ResponseTemplate::new(422).set_body_string("already_exists"))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/test-owner/test-repo/issues"))
+        .and(body_partial_json(
+            serde_json::json!({ "labels": ["harnx-plan"] }),
+        ))
+        .respond_with(
+            ResponseTemplate::new(201).set_body_json(mock_issue_with_labels_json(
+                1003,
+                3,
+                "Plan C",
+                "---\nclient_id: plan-c\n---\n",
+                &["harnx-plan"],
+            )),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let store = create_test_store(&server).await;
+    let plan = store
+        .add_plan(
+            &target("test-owner", "test-repo"),
+            NewPlan {
+                id: "plan-c".to_string(),
+                title: Some("Plan C".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(plan.id, "3");
+}
+
+#[tokio::test]
+async fn create_with_label_validation_failure_retries_without_label() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/test-owner/test-repo/labels/harnx-plan"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": 1,
+            "name": "harnx-plan"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/test-owner/test-repo/issues"))
+        .and(body_partial_json(
+            serde_json::json!({ "labels": ["harnx-plan"] }),
+        ))
+        .respond_with(
+            ResponseTemplate::new(422).set_body_string("Validation Failed: invalid label"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/test-owner/test-repo/issues"))
+        .and(body_partial_json(serde_json::json!({
+            "title": "Plan D"
+        })))
+        .respond_with(
+            ResponseTemplate::new(201).set_body_json(mock_issue_with_labels_json(
+                1004,
+                4,
+                "Plan D",
+                "---\nclient_id: plan-d\n---\n",
+                &[],
+            )),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let store = create_test_store(&server).await;
+    let plan = store
+        .add_plan(
+            &target("test-owner", "test-repo"),
+            NewPlan {
+                id: "plan-d".to_string(),
+                title: Some("Plan D".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(plan.id, "4");
+}
+
+#[tokio::test]
 async fn add_plan_applies_plan_label() {
     let server = MockServer::start().await;
 
@@ -123,11 +412,17 @@ async fn add_plan_applies_plan_label() {
 
     let store = create_test_store(&server).await;
     let plan = store
-        .add_plan(NewPlan {
-            id: "plan-a".to_string(),
-            title: Some("Plan A".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            NewPlan {
+                id: "plan-a".to_string(),
+                title: Some("Plan A".to_string()),
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
 
@@ -153,7 +448,16 @@ async fn get_plan_unlabeled_issue_returns_not_found() {
         .await;
 
     let store = create_test_store(&server).await;
-    let err = store.get_plan(&"7".to_string()).await.unwrap_err();
+    let err = store
+        .get_plan(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"7".to_string(),
+        )
+        .await
+        .unwrap_err();
     assert!(matches!(err, StoreError::NotFound));
 }
 
@@ -176,7 +480,16 @@ async fn delete_plan_unlabeled_issue_returns_not_found() {
         .await;
 
     let store = create_test_store(&server).await;
-    let err = store.delete_plan(&"7".to_string()).await.unwrap_err();
+    let err = store
+        .delete_plan(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"7".to_string(),
+        )
+        .await
+        .unwrap_err();
     assert!(matches!(err, StoreError::NotFound));
 }
 
@@ -219,7 +532,16 @@ async fn list_plans_filters_non_plan_issues_and_dedupes() {
         .await;
 
     let store = create_test_store(&server).await;
-    let page = store.list_plans(None).await.unwrap();
+    let page = store
+        .list_plans(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            None,
+        )
+        .await
+        .unwrap();
 
     assert_eq!(page.items.len(), 1);
     assert_eq!(page.items[0].id, "12");
@@ -251,7 +573,17 @@ async fn list_notes_dedupes_by_client_id_keeps_most_recent() {
         .await;
 
     let store = create_test_store(&server).await;
-    let page = store.list_notes(&"1".to_string(), None).await.unwrap();
+    let page = store
+        .list_notes(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"1".to_string(),
+            None,
+        )
+        .await
+        .unwrap();
 
     assert_eq!(page.items.len(), 1);
     assert_eq!(page.items[0].id, "5002");
@@ -294,7 +626,16 @@ async fn dedupe_tie_break_prefers_higher_issue_number() {
         .await;
 
     let store = create_test_store(&server).await;
-    let page = store.list_plans(None).await.unwrap();
+    let page = store
+        .list_plans(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            None,
+        )
+        .await
+        .unwrap();
     assert_eq!(page.items.len(), 1);
     assert_eq!(page.items[0].id, "22");
 }
@@ -350,6 +691,10 @@ async fn add_task_sends_correct_internal_id_in_post_body() {
 
     let result = store
         .add_task(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
             &"1".to_string(),
             NewTask {
                 id: "task-1".to_string(),
@@ -414,6 +759,10 @@ async fn add_task_returns_error_when_cap_reached_without_creating_issue() {
 
     let result = store
         .add_task(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
             &"1".to_string(),
             NewTask {
                 id: "task-overflow".to_string(),
@@ -471,7 +820,14 @@ async fn get_task_wrong_plan_returns_not_found() {
 
     let store = create_test_store(&server).await;
     let err = store
-        .get_task(&"2".to_string(), &"42".to_string())
+        .get_task(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"2".to_string(),
+            &"42".to_string(),
+        )
         .await
         .unwrap_err();
     assert!(matches!(err, StoreError::NotFound));
@@ -545,7 +901,14 @@ async fn get_task_on_second_page_succeeds() {
 
     let store = create_test_store(&server).await;
     let task = store
-        .get_task(&"1".to_string(), &"31".to_string())
+        .get_task(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"1".to_string(),
+            &"31".to_string(),
+        )
         .await
         .unwrap();
     assert_eq!(task.id, "31");
@@ -577,7 +940,14 @@ async fn delete_task_wrong_plan_returns_not_found() {
 
     let store = create_test_store(&server).await;
     let err = store
-        .delete_task(&"2".to_string(), &"42".to_string())
+        .delete_task(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"2".to_string(),
+            &"42".to_string(),
+        )
         .await
         .unwrap_err();
     assert!(matches!(err, StoreError::NotFound));
@@ -623,7 +993,14 @@ async fn get_note_wrong_plan_returns_not_found() {
 
     let store = create_test_store(&server).await;
     let err = store
-        .get_note(&"2".to_string(), &"5001".to_string())
+        .get_note(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"2".to_string(),
+            &"5001".to_string(),
+        )
         .await
         .unwrap_err();
     assert!(matches!(err, StoreError::NotFound));
@@ -689,7 +1066,14 @@ async fn get_note_on_second_page_succeeds() {
 
     let store = create_test_store(&server).await;
     let note = store
-        .get_note(&"1".to_string(), &"7001".to_string())
+        .get_note(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"1".to_string(),
+            &"7001".to_string(),
+        )
         .await
         .unwrap();
     assert_eq!(note.id, "7001");
@@ -730,7 +1114,14 @@ async fn delete_note_wrong_plan_returns_not_found() {
 
     let store = create_test_store(&server).await;
     let err = store
-        .delete_note(&"2".to_string(), &"5001".to_string())
+        .delete_note(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"2".to_string(),
+            &"5001".to_string(),
+        )
         .await
         .unwrap_err();
     assert!(matches!(err, StoreError::NotFound));
@@ -766,7 +1157,16 @@ async fn delete_plan_closes_issue() {
         .await;
 
     let store = create_test_store(&server).await;
-    assert!(store.delete_plan(&"123".to_string()).await.is_ok());
+    assert!(store
+        .delete_plan(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string()
+            }),
+            &"123".to_string()
+        )
+        .await
+        .is_ok());
 }
 
 #[tokio::test]
@@ -816,7 +1216,14 @@ async fn delete_task_closes_issue() {
 
     let store = create_test_store(&server).await;
     assert!(store
-        .delete_task(&"1".to_string(), &"456".to_string())
+        .delete_task(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string()
+            }),
+            &"1".to_string(),
+            &"456".to_string()
+        )
         .await
         .is_ok());
 }
@@ -833,7 +1240,16 @@ async fn delete_leave_mode_is_honest() {
     )
     .await;
 
-    let err = store.delete_plan(&"123".to_string()).await.unwrap_err();
+    let err = store
+        .delete_plan(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"123".to_string(),
+        )
+        .await
+        .unwrap_err();
     assert!(matches!(err, StoreError::InvalidParams(_)));
 }
 
@@ -879,7 +1295,14 @@ async fn delete_note_deletes_comment() {
 
     let store = create_test_store(&server).await;
     assert!(store
-        .delete_note(&"1".to_string(), &"789".to_string())
+        .delete_note(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string()
+            }),
+            &"1".to_string(),
+            &"789".to_string()
+        )
         .await
         .is_ok());
 }
@@ -928,7 +1351,15 @@ async fn list_tasks_dedupes_by_client_id_keeps_most_recent() {
 
     let store = create_test_store(&server).await;
     let page = store
-        .list_tasks(&"1".to_string(), TaskFilter::default(), None)
+        .list_tasks(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"1".to_string(),
+            TaskFilter::default(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -976,7 +1407,16 @@ async fn list_plans_encodes_link_header_in_page_token() {
         .await;
 
     let store = create_test_store(&server).await;
-    let page = store.list_plans(None).await.unwrap();
+    let page = store
+        .list_plans(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            None,
+        )
+        .await
+        .unwrap();
 
     assert!(page.next.is_some());
     let token = page.next.unwrap();
@@ -1003,7 +1443,13 @@ async fn list_plans_uses_token_for_next_page() {
 
     let store = create_test_store(&server).await;
     let page = store
-        .list_plans(Some(PageToken(format!("{}/page2", server.uri()))))
+        .list_plans(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            Some(PageToken(format!("{}/page2", server.uri()))),
+        )
         .await
         .unwrap();
 
@@ -1047,24 +1493,14 @@ async fn retention_pass_closes_stale_plan() {
         .await;
 
     let store = create_test_store(&server).await;
-    crate::runtime::run_retention_pass(&store, 14)
-        .await
-        .unwrap();
-}
-
-#[tokio::test]
-async fn startup_validation_fails_for_missing_repo() {
-    let server = MockServer::start().await;
-
-    Mock::given(method("GET"))
-        .and(path("/repos/test-owner/test-repo"))
-        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
-        .mount(&server)
-        .await;
-
-    let store = create_test_store(&server).await;
-    let err = crate::runtime::validate_startup(&store, "harnx-plan")
-        .await
-        .expect_err("missing repo should fail");
-    assert!(err.to_string().contains("startup validation failed"));
+    crate::runtime::run_retention_pass(
+        &store,
+        &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+            owner: "test-owner".to_string(),
+            repo: "test-repo".to_string(),
+        }),
+        14,
+    )
+    .await
+    .unwrap();
 }

--- a/crates/harnx-mcp-plans-github/tests/conformance_github.rs
+++ b/crates/harnx-mcp-plans-github/tests/conformance_github.rs
@@ -11,7 +11,7 @@ use jiff::Timestamp;
 use wiremock::{matchers::method, Mock, MockServer, Request, ResponseTemplate};
 
 use harnx_mcp_plans_core::conformance::{run_conformance, BackendCapabilities};
-use harnx_mcp_plans_github::auth::{AuthConfig, AuthSource, GitHubAuth, RepoConfig};
+use harnx_mcp_plans_github::auth::{AuthConfig, AuthSource, GitHubAuth};
 use harnx_mcp_plans_github::client::GitHubClient;
 use harnx_mcp_plans_github::store_github::GitHubPlanStore;
 
@@ -239,10 +239,6 @@ async fn create_mock_store_and_server() -> GitHubPlanStore {
 async fn create_test_store_with_server(server: &MockServer) -> GitHubPlanStore {
     let config = AuthConfig {
         base_url: server.uri(),
-        repo: RepoConfig {
-            owner: "test-owner".to_string(),
-            repo: "test-repo".to_string(),
-        },
         source: AuthSource::PersonalAccessToken("test-token".to_string()),
     };
 

--- a/crates/harnx-mcp-plans-github/tests/github_specific.rs
+++ b/crates/harnx-mcp-plans-github/tests/github_specific.rs
@@ -16,7 +16,7 @@ use wiremock::{
 };
 
 use harnx_mcp_plans_core::{NewTask, PageToken, PlanStore, StoreError, TaskFilter};
-use harnx_mcp_plans_github::auth::{AuthConfig, AuthSource, GitHubAuth, RepoConfig};
+use harnx_mcp_plans_github::auth::{AuthConfig, AuthSource, GitHubAuth};
 use harnx_mcp_plans_github::client::GitHubClient;
 use harnx_mcp_plans_github::store_github::GitHubPlanStore;
 
@@ -24,10 +24,6 @@ use harnx_mcp_plans_github::store_github::GitHubPlanStore;
 async fn create_test_store(server: &MockServer) -> GitHubPlanStore {
     let config = AuthConfig {
         base_url: server.uri(),
-        repo: RepoConfig {
-            owner: "test-owner".to_string(),
-            repo: "test-repo".to_string(),
-        },
         source: AuthSource::PersonalAccessToken("test-token".to_string()),
     };
 

--- a/crates/harnx-mcp-plans-github/tests/github_specific.rs
+++ b/crates/harnx-mcp-plans-github/tests/github_specific.rs
@@ -150,7 +150,16 @@ async fn add_task_sends_correct_internal_id_in_post_body() {
         dependencies: vec![],
     };
 
-    let result = store.add_task(&"1".to_string(), new_task).await;
+    let result = store
+        .add_task(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"1".to_string(),
+            new_task,
+        )
+        .await;
     assert!(result.is_ok(), "add_task should succeed");
 }
 
@@ -211,7 +220,16 @@ async fn add_task_returns_error_when_cap_reached() {
         dependencies: vec![],
     };
 
-    let result = store.add_task(&"1".to_string(), new_task).await;
+    let result = store
+        .add_task(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"1".to_string(),
+            new_task,
+        )
+        .await;
     assert!(result.is_err());
     match result.unwrap_err() {
         StoreError::InvalidParams(msg) => {
@@ -258,7 +276,15 @@ async fn delete_plan_closes_issue() {
         .await;
 
     let store = create_test_store(&server).await;
-    let result = store.delete_plan(&"123".to_string()).await;
+    let result = store
+        .delete_plan(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"123".to_string(),
+        )
+        .await;
     assert!(result.is_ok());
 }
 
@@ -311,7 +337,14 @@ async fn delete_task_closes_issue() {
 
     let store = create_test_store(&server).await;
     let result = store
-        .delete_task(&"1".to_string(), &"456".to_string())
+        .delete_task(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"1".to_string(),
+            &"456".to_string(),
+        )
         .await;
     assert!(result.is_ok());
 }
@@ -355,7 +388,15 @@ async fn list_tasks_dedupes_by_client_id_keeps_most_recent() {
 
     let store = create_test_store(&server).await;
     let page = store
-        .list_tasks(&"1".to_string(), TaskFilter::default(), None)
+        .list_tasks(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &"1".to_string(),
+            TaskFilter::default(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -392,7 +433,16 @@ async fn list_plans_encodes_link_header_in_page_token() {
         .await;
 
     let store = create_test_store(&server).await;
-    let page = store.list_plans(None).await.unwrap();
+    let page = store
+        .list_plans(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            None,
+        )
+        .await
+        .unwrap();
 
     assert!(page.next.is_some(), "should have next page token");
     let token = page.next.unwrap();
@@ -416,7 +466,13 @@ async fn list_plans_uses_token_for_next_page() {
 
     let store = create_test_store(&server).await;
     let page = store
-        .list_plans(Some(PageToken(format!("{}/page2", server.uri()))))
+        .list_plans(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            Some(PageToken(format!("{}/page2", server.uri()))),
+        )
         .await
         .unwrap();
 
@@ -453,11 +509,17 @@ async fn jira_key_round_trips_in_title() {
 
     use harnx_mcp_plans_core::NewPlan;
     let plan = store
-        .add_plan(NewPlan {
-            id: "plan-1".to_string(),
-            title: Some("[PROJ-123] Test Plan".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            NewPlan {
+                id: "plan-1".to_string(),
+                title: Some("[PROJ-123] Test Plan".to_string()),
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
 
@@ -488,7 +550,15 @@ async fn rate_limit_headers_handled() {
         .await;
 
     let store = create_test_store(&server).await;
-    let result = store.list_plans(None).await;
+    let result = store
+        .list_plans(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            None,
+        )
+        .await;
     assert!(
         result.is_ok(),
         "request should succeed with rate-limit headers"

--- a/crates/harnx-mcp-plans-github/tests/live_e2e.rs
+++ b/crates/harnx-mcp-plans-github/tests/live_e2e.rs
@@ -19,8 +19,8 @@
 use std::env;
 use std::sync::Arc;
 
-use harnx_mcp_plans_core::{NewNote, NewPlan, NewTask, PlanStore, TaskFilter};
-use harnx_mcp_plans_github::auth::{AuthConfig, AuthSource, GitHubAuth, RepoConfig};
+use harnx_mcp_plans_core::{NewNote, NewPlan, NewTask, PlanStore, RepoTarget, Target, TaskFilter};
+use harnx_mcp_plans_github::auth::{AuthConfig, AuthSource, GitHubAuth};
 use harnx_mcp_plans_github::client::GitHubClient;
 use harnx_mcp_plans_github::store_github::GitHubPlanStore;
 
@@ -52,27 +52,24 @@ fn check_live_tests() -> bool {
     live_tests_enabled() && get_test_repo().is_some() && get_test_token().is_some()
 }
 
-async fn create_live_store() -> Option<GitHubPlanStore> {
+async fn create_live_store() -> Option<(GitHubPlanStore, Target)> {
     if !live_tests_enabled() {
         return None;
     }
 
     let (owner, repo) = get_test_repo()?;
     let token = get_test_token()?;
+    let target = Target::GitHub(RepoTarget::new(owner.clone(), repo.clone()).ok()?);
 
     let config = AuthConfig {
         base_url: "https://api.github.com".to_string(),
-        repo: RepoConfig {
-            owner: owner.clone(),
-            repo: repo.clone(),
-        },
         source: AuthSource::PersonalAccessToken(token),
     };
 
     let auth = GitHubAuth::new(config).ok()?;
     let client = GitHubClient::new(auth, &owner, &repo).await.ok()?;
 
-    Some(GitHubPlanStore::new(client))
+    Some((GitHubPlanStore::new(client), target))
 }
 
 /// Generate a unique test plan ID.
@@ -97,7 +94,7 @@ fn unique_note_id() -> String {
 #[tokio::test]
 #[ignore]
 async fn live_e2e_create_plan() {
-    let Some(store) = create_live_store().await else {
+    let Some((store, target)) = create_live_store().await else {
         eprintln!("SKIPPED: Live tests not enabled (set HARNX_GH_LIVE_TEST=1, GITHUB_OWNER_REPO [test-only harness], GITHUB_TOKEN)");
         return;
     };
@@ -108,10 +105,7 @@ async fn live_e2e_create_plan() {
     // Create a plan
     let plan = store
         .add_plan(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
+            &target,
             NewPlan {
                 id: plan_id.clone(),
                 title: Some(format!("[TEST] {}", plan_id)),
@@ -130,29 +124,13 @@ async fn live_e2e_create_plan() {
             );
 
             // Read it back
-            let fetched = store
-                .get_plan(
-                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                        owner: "test-owner".to_string(),
-                        repo: "test-repo".to_string(),
-                    }),
-                    &plan.id,
-                )
-                .await;
+            let fetched = store.get_plan(&target, &plan.id).await;
             assert!(fetched.is_ok(), "should be able to fetch created plan");
             let fetched = fetched.unwrap();
             assert_eq!(fetched.id, plan.id);
 
             // Clean up: close the issue
-            let _ = store
-                .delete_plan(
-                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                        owner: "test-owner".to_string(),
-                        repo: "test-repo".to_string(),
-                    }),
-                    &plan.id,
-                )
-                .await;
+            let _ = store.delete_plan(&target, &plan.id).await;
         }
         Err(e) => {
             eprintln!("Failed to create plan: {:?}", e);
@@ -164,7 +142,7 @@ async fn live_e2e_create_plan() {
 #[tokio::test]
 #[ignore]
 async fn live_e2e_create_task() {
-    let Some(store) = create_live_store().await else {
+    let Some((store, target)) = create_live_store().await else {
         eprintln!("SKIPPED: Live tests not enabled");
         return;
     };
@@ -176,10 +154,7 @@ async fn live_e2e_create_task() {
     // Create a plan first
     let plan = store
         .add_plan(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
+            &target,
             NewPlan {
                 id: plan_id.clone(),
                 title: Some(format!("[TEST] Task container {}", plan_id)),
@@ -192,10 +167,7 @@ async fn live_e2e_create_task() {
     // Create a task
     let task = store
         .add_task(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
+            &target,
             &plan.id,
             NewTask {
                 id: task_id.clone(),
@@ -211,50 +183,16 @@ async fn live_e2e_create_task() {
             println!("Created task: {} (ID: {})", task.title, task.id);
 
             // Read it back
-            let fetched = store
-                .get_task(
-                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                        owner: "test-owner".to_string(),
-                        repo: "test-repo".to_string(),
-                    }),
-                    &plan.id,
-                    &task.id,
-                )
-                .await;
+            let fetched = store.get_task(&target, &plan.id, &task.id).await;
             assert!(fetched.is_ok(), "should be able to fetch created task");
 
             // Clean up
-            let _ = store
-                .delete_task(
-                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                        owner: "test-owner".to_string(),
-                        repo: "test-repo".to_string(),
-                    }),
-                    &plan.id,
-                    &task.id,
-                )
-                .await;
-            let _ = store
-                .delete_plan(
-                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                        owner: "test-owner".to_string(),
-                        repo: "test-repo".to_string(),
-                    }),
-                    &plan.id,
-                )
-                .await;
+            let _ = store.delete_task(&target, &plan.id, &task.id).await;
+            let _ = store.delete_plan(&target, &plan.id).await;
         }
         Err(e) => {
             eprintln!("Failed to create task: {:?}", e);
-            let _ = store
-                .delete_plan(
-                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                        owner: "test-owner".to_string(),
-                        repo: "test-repo".to_string(),
-                    }),
-                    &plan.id,
-                )
-                .await;
+            let _ = store.delete_plan(&target, &plan.id).await;
             panic!("Live test failed");
         }
     }
@@ -263,7 +201,7 @@ async fn live_e2e_create_task() {
 #[tokio::test]
 #[ignore]
 async fn live_e2e_create_note() {
-    let Some(store) = create_live_store().await else {
+    let Some((store, target)) = create_live_store().await else {
         eprintln!("SKIPPED: Live tests not enabled");
         return;
     };
@@ -275,10 +213,7 @@ async fn live_e2e_create_note() {
     // Create a plan first
     let plan = store
         .add_plan(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
+            &target,
             NewPlan {
                 id: plan_id.clone(),
                 title: Some(format!("[TEST] Note container {}", plan_id)),
@@ -291,10 +226,7 @@ async fn live_e2e_create_note() {
     // Create a note
     let note = store
         .add_note(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
+            &target,
             &plan.id,
             NewNote {
                 id: note_id.clone(),
@@ -309,50 +241,16 @@ async fn live_e2e_create_note() {
             println!("Created note: ID {})", note.id);
 
             // Read it back
-            let fetched = store
-                .get_note(
-                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                        owner: "test-owner".to_string(),
-                        repo: "test-repo".to_string(),
-                    }),
-                    &plan.id,
-                    &note.id,
-                )
-                .await;
+            let fetched = store.get_note(&target, &plan.id, &note.id).await;
             assert!(fetched.is_ok(), "should be able to fetch created note");
 
             // Clean up
-            let _ = store
-                .delete_note(
-                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                        owner: "test-owner".to_string(),
-                        repo: "test-repo".to_string(),
-                    }),
-                    &plan.id,
-                    &note.id,
-                )
-                .await;
-            let _ = store
-                .delete_plan(
-                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                        owner: "test-owner".to_string(),
-                        repo: "test-repo".to_string(),
-                    }),
-                    &plan.id,
-                )
-                .await;
+            let _ = store.delete_note(&target, &plan.id, &note.id).await;
+            let _ = store.delete_plan(&target, &plan.id).await;
         }
         Err(e) => {
             eprintln!("Failed to create note: {:?}", e);
-            let _ = store
-                .delete_plan(
-                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                        owner: "test-owner".to_string(),
-                        repo: "test-repo".to_string(),
-                    }),
-                    &plan.id,
-                )
-                .await;
+            let _ = store.delete_plan(&target, &plan.id).await;
             panic!("Live test failed");
         }
     }
@@ -361,7 +259,7 @@ async fn live_e2e_create_note() {
 #[tokio::test]
 #[ignore]
 async fn live_e2e_pagination() {
-    let Some(store) = create_live_store().await else {
+    let Some((store, target)) = create_live_store().await else {
         eprintln!("SKIPPED: Live tests not enabled");
         return;
     };
@@ -370,13 +268,7 @@ async fn live_e2e_pagination() {
 
     // List plans (should return at least an empty page)
     let page = store
-        .list_plans(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
-            None,
-        )
+        .list_plans(&target, None)
         .await
         .expect("list plans should succeed");
 
@@ -385,13 +277,7 @@ async fn live_e2e_pagination() {
     // If there's a next page, fetch it
     if let Some(token) = page.next {
         let next_page = store
-            .list_plans(
-                &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                    owner: "test-owner".to_string(),
-                    repo: "test-repo".to_string(),
-                }),
-                Some(token),
-            )
+            .list_plans(&target, Some(token))
             .await
             .expect("next page should succeed");
         println!("Next page has {} plans", next_page.items.len());
@@ -401,7 +287,7 @@ async fn live_e2e_pagination() {
 #[tokio::test]
 #[ignore]
 async fn live_e2e_full_crud_cycle() {
-    let Some(store) = create_live_store().await else {
+    let Some((store, target)) = create_live_store().await else {
         eprintln!("SKIPPED: Live tests not enabled");
         return;
     };
@@ -414,10 +300,7 @@ async fn live_e2e_full_crud_cycle() {
     // 1. Create plan
     let plan = store
         .add_plan(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
+            &target,
             NewPlan {
                 id: plan_id.clone(),
                 title: Some(format!("[TEST] Full CRUD {}", plan_id)),
@@ -434,10 +317,7 @@ async fn live_e2e_full_crud_cycle() {
     // 2. Write body
     store
         .write_plan_body(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
+            &target,
             &plan.id,
             "# Test Plan\n\nThis is a test plan body.",
         )
@@ -446,13 +326,7 @@ async fn live_e2e_full_crud_cycle() {
 
     // 3. Read body
     let body = store
-        .read_plan_body(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
-            &plan.id,
-        )
+        .read_plan_body(&target, &plan.id)
         .await
         .expect("read body");
     assert!(body.contains("Test Plan"), "body should contain title");
@@ -460,10 +334,7 @@ async fn live_e2e_full_crud_cycle() {
     // 4. Create task
     let task = store
         .add_task(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
+            &target,
             &plan.id,
             NewTask {
                 id: task_id.clone(),
@@ -480,10 +351,7 @@ async fn live_e2e_full_crud_cycle() {
     // 5. Create note
     let note = store
         .add_note(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
+            &target,
             &plan.id,
             NewNote {
                 id: note_id.clone(),
@@ -498,15 +366,7 @@ async fn live_e2e_full_crud_cycle() {
 
     // 6. List tasks
     let tasks = store
-        .list_tasks(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
-            &plan.id,
-            TaskFilter::default(),
-            None,
-        )
+        .list_tasks(&target, &plan.id, TaskFilter::default(), None)
         .await
         .expect("list tasks");
     assert!(
@@ -516,14 +376,7 @@ async fn live_e2e_full_crud_cycle() {
 
     // 7. List notes
     let notes = store
-        .list_notes(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
-            &plan.id,
-            None,
-        )
+        .list_notes(&target, &plan.id, None)
         .await
         .expect("list notes");
     assert!(
@@ -533,35 +386,15 @@ async fn live_e2e_full_crud_cycle() {
 
     // 8. Cleanup
     store
-        .delete_note(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
-            &plan.id,
-            &note.id,
-        )
+        .delete_note(&target, &plan.id, &note.id)
         .await
         .expect("delete note");
     store
-        .delete_task(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
-            &plan.id,
-            &task.id,
-        )
+        .delete_task(&target, &plan.id, &task.id)
         .await
         .expect("delete task");
     store
-        .delete_plan(
-            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
-                owner: "test-owner".to_string(),
-                repo: "test-repo".to_string(),
-            }),
-            &plan.id,
-        )
+        .delete_plan(&target, &plan.id)
         .await
         .expect("delete plan");
 

--- a/crates/harnx-mcp-plans-github/tests/live_e2e.rs
+++ b/crates/harnx-mcp-plans-github/tests/live_e2e.rs
@@ -107,12 +107,18 @@ async fn live_e2e_create_plan() {
 
     // Create a plan
     let plan = store
-        .add_plan(NewPlan {
-            id: plan_id.clone(),
-            title: Some(format!("[TEST] {}", plan_id)),
-            summary: Some("Created by live e2e test".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            NewPlan {
+                id: plan_id.clone(),
+                title: Some(format!("[TEST] {}", plan_id)),
+                summary: Some("Created by live e2e test".to_string()),
+                ..Default::default()
+            },
+        )
         .await;
 
     match plan {
@@ -124,13 +130,29 @@ async fn live_e2e_create_plan() {
             );
 
             // Read it back
-            let fetched = store.get_plan(&plan.id).await;
+            let fetched = store
+                .get_plan(
+                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                        owner: "test-owner".to_string(),
+                        repo: "test-repo".to_string(),
+                    }),
+                    &plan.id,
+                )
+                .await;
             assert!(fetched.is_ok(), "should be able to fetch created plan");
             let fetched = fetched.unwrap();
             assert_eq!(fetched.id, plan.id);
 
             // Clean up: close the issue
-            let _ = store.delete_plan(&plan.id).await;
+            let _ = store
+                .delete_plan(
+                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                        owner: "test-owner".to_string(),
+                        repo: "test-repo".to_string(),
+                    }),
+                    &plan.id,
+                )
+                .await;
         }
         Err(e) => {
             eprintln!("Failed to create plan: {:?}", e);
@@ -153,17 +175,27 @@ async fn live_e2e_create_task() {
 
     // Create a plan first
     let plan = store
-        .add_plan(NewPlan {
-            id: plan_id.clone(),
-            title: Some(format!("[TEST] Task container {}", plan_id)),
-            ..Default::default()
-        })
+        .add_plan(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            NewPlan {
+                id: plan_id.clone(),
+                title: Some(format!("[TEST] Task container {}", plan_id)),
+                ..Default::default()
+            },
+        )
         .await
         .expect("create plan");
 
     // Create a task
     let task = store
         .add_task(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
             &plan.id,
             NewTask {
                 id: task_id.clone(),
@@ -179,16 +211,50 @@ async fn live_e2e_create_task() {
             println!("Created task: {} (ID: {})", task.title, task.id);
 
             // Read it back
-            let fetched = store.get_task(&plan.id, &task.id).await;
+            let fetched = store
+                .get_task(
+                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                        owner: "test-owner".to_string(),
+                        repo: "test-repo".to_string(),
+                    }),
+                    &plan.id,
+                    &task.id,
+                )
+                .await;
             assert!(fetched.is_ok(), "should be able to fetch created task");
 
             // Clean up
-            let _ = store.delete_task(&plan.id, &task.id).await;
-            let _ = store.delete_plan(&plan.id).await;
+            let _ = store
+                .delete_task(
+                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                        owner: "test-owner".to_string(),
+                        repo: "test-repo".to_string(),
+                    }),
+                    &plan.id,
+                    &task.id,
+                )
+                .await;
+            let _ = store
+                .delete_plan(
+                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                        owner: "test-owner".to_string(),
+                        repo: "test-repo".to_string(),
+                    }),
+                    &plan.id,
+                )
+                .await;
         }
         Err(e) => {
             eprintln!("Failed to create task: {:?}", e);
-            let _ = store.delete_plan(&plan.id).await;
+            let _ = store
+                .delete_plan(
+                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                        owner: "test-owner".to_string(),
+                        repo: "test-repo".to_string(),
+                    }),
+                    &plan.id,
+                )
+                .await;
             panic!("Live test failed");
         }
     }
@@ -208,17 +274,27 @@ async fn live_e2e_create_note() {
 
     // Create a plan first
     let plan = store
-        .add_plan(NewPlan {
-            id: plan_id.clone(),
-            title: Some(format!("[TEST] Note container {}", plan_id)),
-            ..Default::default()
-        })
+        .add_plan(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            NewPlan {
+                id: plan_id.clone(),
+                title: Some(format!("[TEST] Note container {}", plan_id)),
+                ..Default::default()
+            },
+        )
         .await
         .expect("create plan");
 
     // Create a note
     let note = store
         .add_note(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
             &plan.id,
             NewNote {
                 id: note_id.clone(),
@@ -233,16 +309,50 @@ async fn live_e2e_create_note() {
             println!("Created note: ID {})", note.id);
 
             // Read it back
-            let fetched = store.get_note(&plan.id, &note.id).await;
+            let fetched = store
+                .get_note(
+                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                        owner: "test-owner".to_string(),
+                        repo: "test-repo".to_string(),
+                    }),
+                    &plan.id,
+                    &note.id,
+                )
+                .await;
             assert!(fetched.is_ok(), "should be able to fetch created note");
 
             // Clean up
-            let _ = store.delete_note(&plan.id, &note.id).await;
-            let _ = store.delete_plan(&plan.id).await;
+            let _ = store
+                .delete_note(
+                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                        owner: "test-owner".to_string(),
+                        repo: "test-repo".to_string(),
+                    }),
+                    &plan.id,
+                    &note.id,
+                )
+                .await;
+            let _ = store
+                .delete_plan(
+                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                        owner: "test-owner".to_string(),
+                        repo: "test-repo".to_string(),
+                    }),
+                    &plan.id,
+                )
+                .await;
         }
         Err(e) => {
             eprintln!("Failed to create note: {:?}", e);
-            let _ = store.delete_plan(&plan.id).await;
+            let _ = store
+                .delete_plan(
+                    &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                        owner: "test-owner".to_string(),
+                        repo: "test-repo".to_string(),
+                    }),
+                    &plan.id,
+                )
+                .await;
             panic!("Live test failed");
         }
     }
@@ -260,7 +370,13 @@ async fn live_e2e_pagination() {
 
     // List plans (should return at least an empty page)
     let page = store
-        .list_plans(None)
+        .list_plans(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            None,
+        )
         .await
         .expect("list plans should succeed");
 
@@ -269,7 +385,13 @@ async fn live_e2e_pagination() {
     // If there's a next page, fetch it
     if let Some(token) = page.next {
         let next_page = store
-            .list_plans(Some(token))
+            .list_plans(
+                &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                    owner: "test-owner".to_string(),
+                    repo: "test-repo".to_string(),
+                }),
+                Some(token),
+            )
             .await
             .expect("next page should succeed");
         println!("Next page has {} plans", next_page.items.len());
@@ -291,13 +413,19 @@ async fn live_e2e_full_crud_cycle() {
 
     // 1. Create plan
     let plan = store
-        .add_plan(NewPlan {
-            id: plan_id.clone(),
-            title: Some(format!("[TEST] Full CRUD {}", plan_id)),
-            summary: Some("Full CRUD test".to_string()),
-            author: Some("live_e2e_test".to_string()),
-            ..Default::default()
-        })
+        .add_plan(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            NewPlan {
+                id: plan_id.clone(),
+                title: Some(format!("[TEST] Full CRUD {}", plan_id)),
+                summary: Some("Full CRUD test".to_string()),
+                author: Some("live_e2e_test".to_string()),
+                ..Default::default()
+            },
+        )
         .await
         .expect("create plan");
 
@@ -305,17 +433,37 @@ async fn live_e2e_full_crud_cycle() {
 
     // 2. Write body
     store
-        .write_plan_body(&plan.id, "# Test Plan\n\nThis is a test plan body.")
+        .write_plan_body(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &plan.id,
+            "# Test Plan\n\nThis is a test plan body.",
+        )
         .await
         .expect("write body");
 
     // 3. Read body
-    let body = store.read_plan_body(&plan.id).await.expect("read body");
+    let body = store
+        .read_plan_body(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &plan.id,
+        )
+        .await
+        .expect("read body");
     assert!(body.contains("Test Plan"), "body should contain title");
 
     // 4. Create task
     let task = store
         .add_task(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
             &plan.id,
             NewTask {
                 id: task_id.clone(),
@@ -332,6 +480,10 @@ async fn live_e2e_full_crud_cycle() {
     // 5. Create note
     let note = store
         .add_note(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
             &plan.id,
             NewNote {
                 id: note_id.clone(),
@@ -346,7 +498,15 @@ async fn live_e2e_full_crud_cycle() {
 
     // 6. List tasks
     let tasks = store
-        .list_tasks(&plan.id, TaskFilter::default(), None)
+        .list_tasks(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &plan.id,
+            TaskFilter::default(),
+            None,
+        )
         .await
         .expect("list tasks");
     assert!(
@@ -355,7 +515,17 @@ async fn live_e2e_full_crud_cycle() {
     );
 
     // 7. List notes
-    let notes = store.list_notes(&plan.id, None).await.expect("list notes");
+    let notes = store
+        .list_notes(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &plan.id,
+            None,
+        )
+        .await
+        .expect("list notes");
     assert!(
         notes.items.iter().any(|n| n.id == note.id),
         "should find created note"
@@ -363,14 +533,37 @@ async fn live_e2e_full_crud_cycle() {
 
     // 8. Cleanup
     store
-        .delete_note(&plan.id, &note.id)
+        .delete_note(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &plan.id,
+            &note.id,
+        )
         .await
         .expect("delete note");
     store
-        .delete_task(&plan.id, &task.id)
+        .delete_task(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &plan.id,
+            &task.id,
+        )
         .await
         .expect("delete task");
-    store.delete_plan(&plan.id).await.expect("delete plan");
+    store
+        .delete_plan(
+            &harnx_mcp_plans_core::Target::GitHub(harnx_mcp_plans_core::RepoTarget {
+                owner: "test-owner".to_string(),
+                repo: "test-repo".to_string(),
+            }),
+            &plan.id,
+        )
+        .await
+        .expect("delete plan");
 
     println!("Cleaned up plan: {}", plan.id);
 }

--- a/docs/solutions/integration-issues/github-issues-storage-backend-2026-07-08.md
+++ b/docs/solutions/integration-issues/github-issues-storage-backend-2026-07-08.md
@@ -506,6 +506,7 @@ Error paths: non-git-dir, repo-without-origin.
 ## Related Issues
 
 - **GitHub:** [#949](https://github.com/dobesv/harnx/issues/949) — Original issue
+- **Related Solution:** [github-per-call-target-mcp-schema-2026-07-22.md](github-per-call-target-mcp-schema-2026-07-22.md) — Per-call repository targeting, non-fatal startup, dynamic schema, path-traversal fix (supersedes fail-fast startup from this doc)
 - **Related Solution:** [api-design/mcp-plans-surgical-edit-api-2026-05-11.md](../api-design/mcp-plans-surgical-edit-api-2026-05-11.md) — Body-edit mutual exclusion, diff output
 - **Related Solution:** [logic-errors/mcp-plans-rewrite-patterns-2026-05-04.md](../logic-errors/mcp-plans-rewrite-patterns-2026-05-04.md) — Atomic writes, ID normalization
 - **Related Solution:** [integration-issues/plan-note-file-storage-2026-05-03.md](../integration-issues/plan-note-file-storage-2026-05-03.md) — Per-file notes, JSON overview

--- a/docs/solutions/integration-issues/github-per-call-target-mcp-schema-2026-07-22.md
+++ b/docs/solutions/integration-issues/github-per-call-target-mcp-schema-2026-07-22.md
@@ -1,0 +1,291 @@
+---
+title: "Per-call repository targeting and dynamic MCP schema requiredness for GitHub plans backend"
+date: 2026-07-22
+category: "integration-issues"
+problem_type: integration_issue
+component: "harnx-mcp-plans-github"
+root_cause: "Fixed startup detection and single-repo constraint prevented operation outside git repos and per-call repository targeting"
+resolution_type: code_fix
+severity: high
+tags:
+  - mcp
+  - github
+  - plans
+  - storage-backend
+  - rust
+  - json-schema
+  - security
+  - path-traversal
+  - validation
+plan_ref: "harnx-1137-github-plans-startup-and-targeting"
+---
+
+## Problem
+
+GitHub plans MCP server required startup inside a git repo with GitHub origin and bound all operations to a single fixed repository. Per-call repository selection was impossible, and startup failed outside git repos or without GitHub origin. Label validation at startup blocked server initialization even when labels were optional.
+
+## Symptoms
+
+```
+Error: current working directory is not inside a git repository
+```
+
+```
+startup validation failed: cannot ensure label 'harnx-plan'
+```
+
+- MCP tool callers could not specify target repository per call
+- Server unusable outside git repos or in repos without GitHub remote
+- Label validation blocked startup even though labels are best-effort metadata
+- Schema showed `owner`/`repo` as required or absent based on compile-time config, not runtime detection
+
+## Investigation Steps
+
+Reviewed existing `PlanStore` trait (21 methods across plans/tasks/notes) and `GitHubPlanStore` design. Found single `GitHubClient` owner/repo bound at startup. Evaluated two options:
+
+1. **StoreManager layer above server** — duplicate handlers for validation, error mapping, body diffs
+2. **Target parameter on trait methods** — clean seam, factory produces per-target clients
+
+Chose option 2. Traced proposed `owner`/`repo` params through handlers → store methods → client construction. Identified security gap: caller-controlled path segments concatenated into GitHub API URLs without validation. `url` crate performs RFC 3986 dot-segment normalization — `repo="../../../user"` escapes `/repos/{owner}/{repo}` prefix.
+
+Pre-diff, owner/repo were fixed at startup from git-origin detection. This diff introduces caller-controlled targeting, creating new attack surface requiring validation at trust boundary.
+
+## Root Cause
+
+### Architecture Constraint
+
+Single `GitHubClient` instance bound to one repo at construction. No per-call target parameter on `PlanStore` trait. Handlers had no mechanism to resolve or pass target context.
+
+### Security Vulnerability
+
+Caller-supplied `owner`/`repo` interpolated into URL paths via `format!("/repos/{}/{}/...", self.owner, self.repo)`. No validation at `resolve_target()`. `url` 2.5.8 normalizes `../` segments per RFC 3986, escaping `/repos/{owner}/{repo}` prefix. Attacker could reach arbitrary GitHub API endpoints (`/user`, `/orgs/{org}/members`, `/app/installations`) using server's credential.
+
+Example exploit: `owner="foo", repo="../../../user"` → `https://api.github.com/user` (escapes repo path).
+
+### Schema Static Generation
+
+`impl_json_schema!` macro produced static schemas at compile time. MCP `tools/list` had no mechanism to mark `owner`/`repo` as required only when no default repo detected at runtime.
+
+## Solution
+
+### 1. Target Threading Through Shared Trait
+
+Added `target: &Target` as first argument after `&self` on all 21 `PlanStore` methods:
+
+```rust
+pub enum Target {
+    Local,
+    GitHub(RepoTarget),
+}
+
+pub struct RepoTarget {
+    pub owner: String,
+    pub repo: String,
+}
+
+pub trait PlanStore: Send + Sync {
+    async fn list_plans(&self, target: &Target, page: Option<PageToken>) -> Result<...>;
+    async fn get_plan(&self, target: &Target, name: &str) -> Result<...>;
+    // ... 19 more methods
+}
+```
+
+Filesystem backend ignores `_target`. GitHub backend uses factory to produce repo-bound clients:
+
+```rust
+pub struct GitHubClientFactory {
+    auth: GitHubAuth,              // Arc-wrapped token cache
+    raw_http: Client,              // Arc-wrapped connection pool
+    ratelimit: Arc<RateLimitExecutor>, // Shared rate limiter
+    base_url: String,
+    default_repo: Option<RepoTarget>,
+}
+
+impl GitHubClientFactory {
+    pub fn client_for(&self, target: &RepoTarget) -> GitHubClient {
+        GitHubClient {
+            auth: self.auth.clone(),
+            owner: target.owner.clone(),
+            repo: target.repo.clone(),
+            raw_http: self.raw_http.clone(),
+            ratelimit: self.ratelimit.clone(),
+            base_url: self.base_url.clone(),
+        }
+    }
+}
+```
+
+Client construction is cheap (Arc clones + string clones). No HTTP client rebuild, no token re-fetch.
+
+### 2. Target Validation at Trust Boundary
+
+Critical: validate caller-controlled `owner`/`repo` before constructing URLs.
+
+**Validation rule** (both owner and repo):
+- Non-empty
+- Explicit rejection of `.` and `..` (equality check, not substring)
+- No `/` or `\`
+- No whitespace or control characters
+- ASCII allowlist: `[A-Za-z0-9._-]`
+
+```rust
+impl RepoTarget {
+    pub fn validate(value: &str) -> Result<(), String> {
+        if value.is_empty() {
+            return Err("cannot be empty".into());
+        }
+        if value == "." || value == ".." {
+            return Err("cannot be '.' or '..'".into());
+        }
+        if value.contains('/') || value.contains('\\') {
+            return Err("cannot contain path separators".into());
+        }
+        if value.chars().any(|c| c.is_whitespace() || c.is_control()) {
+            return Err("cannot contain whitespace or control characters".into());
+        }
+        if !value.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')) {
+            return Err("must contain only alphanumeric, '.', '_', or '-'".into());
+        }
+        Ok(())
+    }
+}
+```
+
+**Why explicit `.`/`..` rejection is necessary**: The allowlist includes `.`. A naive `^[A-Za-z0-9._-]+$` regex would accept `..` because each `.` is individually valid. The explicit equality check closes this gap.
+
+**Defense in depth**:
+1. Core `resolve_target()` validates explicit params and default-repo fallback
+2. GitHub store `client_for_store_target()` re-validates before client creation
+3. Client `repo_endpoint()` percent-encodes owner/repo path segments
+
+```rust
+fn repo_endpoint(&self, suffix: &str) -> String {
+    format!("/repos/{}/{}/{}",
+        encode_path_segment(&self.owner),
+        encode_path_segment(&self.repo),
+        suffix
+    )
+}
+
+fn encode_path_segment(segment: &str) -> String {
+    segment.chars().flat_map(|c| {
+        if c.is_alphanumeric() || matches!(c, '-' | '_' | '.') {
+            vec![c]
+        } else {
+            format!("%{:02X}", c as u8).chars().collect()
+        }
+    }).collect()
+}
+```
+
+### 3. Dynamic MCP Schema Requiredness
+
+Post-process static schemars schemas in `list_tools` based on server-held `TargetPolicy`:
+
+```rust
+pub enum TargetPolicy {
+    #[default]
+    None,  // Filesystem — no owner/repo params
+    GitHub { default_repo: Option<RepoTarget> },
+}
+
+impl TargetPolicy {
+    pub fn apply_to_tool_schema(&self, tool: &mut Tool) {
+        match self {
+            TargetPolicy::None => {}
+            TargetPolicy::GitHub { default_repo } => {
+                // Inject owner/repo into properties
+                // If default_repo is None, add to required array
+            }
+        }
+    }
+}
+```
+
+**With default repo detected**: `owner`/`repo` not in `required`, descriptions say "Optional. Defaults to `<owner>/<repo>` detected at startup."
+
+**Without default repo**: `owner`/`repo` in `required`, descriptions say "Required. No default repository was detected at startup."
+
+Test proves both cases:
+
+```rust
+#[test]
+fn github_tool_schema_owner_repo_requiredness_tracks_default_repo() {
+    // With default_repo → owner/repo NOT in required
+    // Without default_repo → owner/repo IN required
+}
+```
+
+### 4. Non-Fatal Startup Detection
+
+Startup attempts cwd git-origin detection. On failure, logs warning and continues with `default_repo: None`. No GitHub API validation at startup. Label ensure moved to `add_plan()` with warning-only behavior.
+
+```rust
+let default_repo = match origin_provider().and_then(|origin| parse_github_origin(&origin)) {
+    Ok(repo) => Some(repo),
+    Err(err) => {
+        eprintln!("warning: could not detect default GitHub repository: {err}");
+        None
+    }
+};
+```
+
+## Why This Works
+
+**Target threading** keeps `PlanStore` stateless relative to repos. Factory pattern avoids expensive per-call client reconstruction while enabling per-call target selection. Filesystem backend unchanged (zero diff).
+
+**Validation at trust boundary** prevents path traversal. Explicit `.`/`..` check closes allowlist gap. Percent-encoding provides defense-in-depth. Regression test verifies zero HTTP requests for traversal payloads.
+
+**Dynamic schema injection** occurs once per `tools/list` call (MCP protocol), not per `call_tool`. Schema reflects actual server state (detected repo or not).
+
+**Non-fatal startup** gracefully degrades: auto-detect if available, explicit params otherwise. Label failures logged as warnings, operations proceed.
+
+## Prevention Strategies
+
+### Security
+
+- **Validate at trust boundary**: Caller-supplied path segments must be validated before reaching URL construction
+- **Explicit `.`/`..` rejection**: Allowlist alone is insufficient when `.` is a valid character
+- **Regression test for path traversal**: Assert zero HTTP requests when traversal payloads provided
+
+```rust
+#[test]
+fn explicit_target_rejects_path_traversal_without_request() {
+    let mock = Wiremock::start();
+    let store = build_store(mock.uri());
+    
+    // Attempt traversal payload
+    let result = store.get_plan(
+        &Target::GitHub(RepoTarget { owner: "../../../user".into(), repo: "repo".into() }),
+        "plan-name"
+    ).await;
+    
+    assert!(result.is_err());
+    // Critical: assert ZERO requests made
+    assert_eq!(mock.received_requests().await.len(), 0);
+}
+```
+
+### Architecture
+
+- **Thread target/context through shared trait**: Prefer single clean seam over manager layers duplicating handler logic
+- **Factory for per-call resources**: Clone Arc-wrapped state (auth, HTTP client, rate limiter) rather than rebuild
+- **Separate storage target from plan metadata**: `owner`/`repo` params for storage selection, `github_owner_repo` field for plan metadata — never conflate
+
+### Schema
+
+- **Post-process static schemas rather than generate dynamically**: Static `impl_json_schema!` for base, policy-driven injection for conditional fields
+- **Test both branches**: Verify schema with and without default repo
+
+### Test Coverage
+
+- **Test coverage signal**: Modified test files in PR exercising changed code satisfies policy
+- **Wiremock for HTTP assertions**: Mock server verifies request paths match expected targets
+- **Zero-request assertion**: For security tests, verify malicious payloads never reach the network
+
+## Related Issues
+
+- **GitHub:** [#1137](https://github.com/dobesv/harnx/issues/1137) — Per-call repository targeting and non-fatal startup
+- **Related Solution:** [github-issues-storage-backend-2026-07-08.md](github-issues-storage-backend-2026-07-08.md) — Original GitHub backend, superseded fail-fast startup
+- **Related Solution:** [mcp-tool-template-design-guidelines-2026-05-08.md](mcp-tool-template-design-guidelines-2026-05-08.md) — MCP tool schema design
+- **Related Solution:** [api-design/per-call-env-param-bash-mcp-2026-05-13.md](../api-design/per-call-env-param-bash-mcp-2026-05-13.md) — Per-call parameter pattern


### PR DESCRIPTION
Make harnx-mcp-plans-github startup non-fatal outside a GitHub repo by making default repo detection optional and eliminating startup GitHub API validation. Add Target enum to PlanStore and thread per-call owner and repo parameters across plan, task, and note tools, falling back to the detected repo when parameters are omitted.

Validate target owner/repo parameters to reject path traversal attempts before making network calls. Dynamically update MCP tool schemas during tools/list so owner/repo are required only when no default repo exists. Move label creation to plan insertion time with warning-only fallbacks on failure.

Issue: #1137

Plan: harnx-1137-github-plans-startup-and-targeting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-call GitHub repository targeting with optional owner and repository fields.
  * Added validation to reject unsafe repository names and path traversal attempts.
  * Updated tool schemas to reflect whether repository details are required.
  * GitHub origin detection is now non-blocking at startup.
  * Plan creation continues when label setup fails, with a fallback retry.

* **Documentation**
  * Documented repository targeting, startup behavior, label handling, and retention updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->