### PR TITLE
fix(runtime): resolve title agent at top level for package agents (#103)

### DIFF
--- a/.changeset/surface-title-generation-failures.md
+++ b/.changeset/surface-title-generation-failures.md
@@ -1,0 +1,9 @@
+---
+harnx: patch
+---
+
+Fix automatic session-title generation when running a package agent (e.g. `pantheon/sisyphus`).
+
+A globally-configured `title_agent` was resolved relative to the active agent's package, so a top-level `title-agent` was looked up as `<package>/title-agent` and never found — title generation was silently disabled. Global title agents now resolve at the top level, while an agent's own `title_agent` frontmatter still resolves package-relative.
+
+Also surface title-generation failures instead of failing silently: a new `TitleGenerationFailed` event is shown in the TUI, CLI, server (AG-UI), and web client, carrying the full error chain. Background title-agent output is isolated from the main transcript. Adds a `.title` command to view the current title and guard state and `.title generate` to (re)generate on demand, shows the title in `.info session`, and adds logging to the title-generation path.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5332,9 +5332,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.188"
+version = "0.2.187"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
+checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
 
 [[package]]
 name = "libm"

--- a/crates/harnx-core/src/event.rs
+++ b/crates/harnx-core/src/event.rs
@@ -144,6 +144,9 @@ pub enum SessionEvent {
     /// Emitted after a session title has been generated or manually set.
     /// Carries the new title text.
     TitleUpdated(String),
+    /// Emitted when automatic session-title generation fails. Carries the
+    /// full error chain for display.
+    TitleGenerationFailed(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -30,7 +30,7 @@ pub enum CommandOutcome {
     OpenSessionPicker,
 }
 
-pub static COMMANDS: LazyLock<[Command; 49]> = LazyLock::new(|| {
+pub static COMMANDS: LazyLock<[Command; 50]> = LazyLock::new(|| {
     [
         Command::new(".help", "Show this help guide"),
         Command::new(".info", "Show system info"),
@@ -101,6 +101,7 @@ pub static COMMANDS: LazyLock<[Command; 49]> = LazyLock::new(|| {
         Command::new(".regenerate", "Regenerate last response"),
         Command::new(".copy", "Copy last response"),
         Command::new(".set", "Modify runtime settings"),
+        Command::new(".title", "Show or (re)generate the session title"),
         Command::new(
             ".set show_sequence_numbers",
             "Toggle [n] prefix in transcript (on/off)",
@@ -313,6 +314,74 @@ pub async fn run_command_with_output(
             ".help" => {
                 dump_help(output)?;
             }
+            ".title" => match args {
+                None => {
+                    let conf = config.read();
+                    let Some(session) = conf.session.as_ref() else {
+                        writeln!(output, "No session")?;
+                        return Ok(CommandOutcome::Continue);
+                    };
+                    let title = session.title().unwrap_or("(none — not generated yet)");
+                    // Report the configured name AND how it resolves for the
+                    // active agent (which may be a package agent). Resolving
+                    // here mirrors what `resolve_title_agent` actually looks up,
+                    // so the display matches real behavior (#103).
+                    let active_agent = conf.extract_agent();
+                    let active_pkg =
+                        harnx_core::package_namespace::pkg_from_qualified(active_agent.name());
+                    let title_agent = match crate::config::session_ops_title::resolve_title_agent_name(
+                        active_agent.title_agent(),
+                        conf.title_agent.as_deref(),
+                        active_pkg,
+                    ) {
+                        Some((name, resolved)) if resolved == name => name,
+                        Some((name, resolved)) => format!("{name} (resolves to {resolved})"),
+                        None => "(not configured)".to_string(),
+                    };
+                    let last_updated = if session.title_last_updated_tokens() == usize::MAX {
+                        "(frozen/manual)".to_string()
+                    } else {
+                        session.title_last_updated_tokens().to_string()
+                    };
+                    writeln!(output, "title: {title}")?;
+                    writeln!(
+                        output,
+                        "title_update_threshold: {}",
+                        conf.title_update_threshold
+                    )?;
+                    writeln!(output, "title_agent: {title_agent}")?;
+                    writeln!(output, "session.tokens: {}", session.tokens())?;
+                    writeln!(output, "title_last_updated_tokens: {last_updated}")?;
+                }
+                Some("generate" | "now") => {
+                    // Generate synchronously so the user sees the outcome right
+                    // here. Isolate the title-agent's own model/retry events
+                    // from the transcript via NullSink.
+                    let result = harnx_core::sink::with_agent_event_sink(
+                        Arc::new(harnx_core::event::NullSink),
+                        Config::generate_title(config),
+                    )
+                    .await;
+                    // Report the outcome directly as command output. On success
+                    // also emit `TitleUpdated` (updates the terminal title and
+                    // any UI listeners). Do NOT emit `TitleGenerationFailed` on
+                    // error — the error is already shown here, and emitting it
+                    // would double-render the failure in the TUI transcript.
+                    match result {
+                        Ok(Some(title)) => {
+                            writeln!(output, "title: {title}")?;
+                            harnx_core::sink::emit_agent_event(
+                                harnx_core::event::AgentEvent::Session(
+                                    harnx_core::event::SessionEvent::TitleUpdated(title),
+                                ),
+                            );
+                        }
+                        Ok(None) => writeln!(output, "(nothing to title)")?,
+                        Err(err) => writeln!(output, "title generation failed: {err:#}")?,
+                    }
+                }
+                _ => writeln!(output, "Usage: .title [generate|now]")?,
+            },
             ".info" => match args {
                 Some("session") => {
                     let info = config.read().session_info()?;
@@ -1460,6 +1529,169 @@ hooks:
         let mut out = Vec::new();
         write_env_info(&mut out, Some("HARNX_DEFINITELY_UNSET_XYZ")).expect("show unset");
         assert!(String::from_utf8(out).unwrap().contains("is not set"));
+    }
+
+    #[tokio::test]
+    async fn title_command_shows_current_title_and_guard_state() {
+        let mut config = Config {
+            data: ConfigData {
+                title_agent: Some("title-agent".to_string()),
+                title_update_threshold: 12_345,
+                ..Default::default()
+            },
+            working_mode: WorkingMode::Cmd,
+            ..Default::default()
+        };
+        let mut session = config::session::new(&config, "test", None).expect("test session");
+        session.set_title("Inspect title generation".to_string());
+        session.set_title_last_updated_tokens(42);
+        config.session = Some(session);
+        let config = Arc::new(RwLock::new(config));
+        let mut output = Vec::new();
+        let abort_signal = crate::utils::create_abort_signal();
+        let mut async_manager = AsyncHookManager::default();
+        let persistent_manager = Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new()));
+        let mut pending_async_context = None;
+
+        let outcome = run_command_with_output(
+            &config,
+            abort_signal,
+            ".title",
+            &mut async_manager,
+            &persistent_manager,
+            &mut pending_async_context,
+            &mut output,
+        )
+        .await
+        .expect("command succeeds");
+
+        assert_eq!(outcome, CommandOutcome::Continue);
+        assert_eq!(
+            String::from_utf8(output).expect("utf8 output"),
+            "title: Inspect title generation\ntitle_update_threshold: 12345\ntitle_agent: title-agent\nsession.tokens: 0\ntitle_last_updated_tokens: 42\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn title_command_shows_frozen_manual_without_sentinel_value() {
+        // A manually set title freezes regeneration by setting
+        // title_last_updated_tokens to usize::MAX; the display must show only
+        // "(frozen/manual)", not the raw sentinel integer.
+        let mut config = Config {
+            data: ConfigData {
+                title_agent: Some("title-agent".to_string()),
+                title_update_threshold: 12_345,
+                ..Default::default()
+            },
+            working_mode: WorkingMode::Cmd,
+            ..Default::default()
+        };
+        let mut session = config::session::new(&config, "test", None).expect("test session");
+        session.set_title("Manual title".to_string());
+        session.set_title_last_updated_tokens(usize::MAX);
+        config.session = Some(session);
+        let config = Arc::new(RwLock::new(config));
+        let mut output = Vec::new();
+        let abort_signal = crate::utils::create_abort_signal();
+        let mut async_manager = AsyncHookManager::default();
+        let persistent_manager = Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new()));
+        let mut pending_async_context = None;
+
+        run_command_with_output(
+            &config,
+            abort_signal,
+            ".title",
+            &mut async_manager,
+            &persistent_manager,
+            &mut pending_async_context,
+            &mut output,
+        )
+        .await
+        .expect("command succeeds");
+
+        let out = String::from_utf8(output).expect("utf8 output");
+        assert!(
+            out.contains("title_last_updated_tokens: (frozen/manual)\n"),
+            "expected frozen/manual annotation without sentinel, got: {out:?}"
+        );
+        assert!(
+            !out.contains(&usize::MAX.to_string()),
+            "raw usize::MAX sentinel must not appear, got: {out:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn title_generate_without_a_loadable_agent_reports_failure() {
+        // Hermetic: `title_agent` names an agent that isn't present on disk, so
+        // `generate_title` fails at agent resolution. Exercises the command's
+        // `Err` branch deterministically (no LLM/network) and asserts the error
+        // is surfaced directly as command output (not double-rendered).
+        let mut config = Config {
+            data: ConfigData {
+                title_agent: Some("definitely-missing-title-agent".to_string()),
+                ..Default::default()
+            },
+            working_mode: WorkingMode::Cmd,
+            ..Default::default()
+        };
+        let session = config::session::new(&config, "test", None).expect("test session");
+        config.session = Some(session);
+        let config = Arc::new(RwLock::new(config));
+        let mut output = Vec::new();
+        let abort_signal = crate::utils::create_abort_signal();
+        let mut async_manager = AsyncHookManager::default();
+        let persistent_manager = Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new()));
+        let mut pending_async_context = None;
+
+        let outcome = run_command_with_output(
+            &config,
+            abort_signal,
+            ".title generate",
+            &mut async_manager,
+            &persistent_manager,
+            &mut pending_async_context,
+            &mut output,
+        )
+        .await
+        .expect("command succeeds");
+
+        assert_eq!(outcome, CommandOutcome::Continue);
+        let out = String::from_utf8(output).expect("utf8 output");
+        assert!(
+            out.starts_with("title generation failed:"),
+            "expected a failure line, got: {out:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn title_command_rejects_unknown_subcommand() {
+        let config = Config {
+            working_mode: WorkingMode::Cmd,
+            ..Default::default()
+        };
+        let config = Arc::new(RwLock::new(config));
+        let mut output = Vec::new();
+        let abort_signal = crate::utils::create_abort_signal();
+        let mut async_manager = AsyncHookManager::default();
+        let persistent_manager = Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new()));
+        let mut pending_async_context = None;
+
+        run_command_with_output(
+            &config,
+            abort_signal,
+            ".title bogus",
+            &mut async_manager,
+            &persistent_manager,
+            &mut pending_async_context,
+            &mut output,
+        )
+        .await
+        .expect("command succeeds");
+
+        assert_eq!(
+            String::from_utf8(output).expect("utf8 output"),
+            "Usage: .title [generate|now]\n"
+        );
     }
 
     fn model_with_data(

--- a/crates/harnx-runtime/src/config/completion_split.rs
+++ b/crates/harnx-runtime/src/config/completion_split.rs
@@ -32,6 +32,7 @@ impl Config {
                     "add-root",
                     "remove-root",
                 ]),
+                ".title" => map_completion_values(vec!["generate", "now"]),
                 ".use" => map_completion_values(vec!["tool"]),
                 ".drop" => map_completion_values(vec!["tool"]),
                 ".starter" => match &self.agent {

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -721,6 +721,15 @@ pub fn render(session: &Session) -> Result<String> {
         ),
     ));
 
+    let title = match session.title() {
+        Some(title) if session.title_last_updated_tokens() == usize::MAX => {
+            format!("{title} (manual)")
+        }
+        Some(title) => title.to_string(),
+        None => "(none)".to_string(),
+    };
+    items.push(("title", title));
+
     if let Some(temperature) = session.temperature() {
         items.push(("temperature", temperature.to_string()));
     }
@@ -3179,6 +3188,22 @@ content: second
         assert!(appended);
         assert_eq!(session.log_entry_count, 4);
         assert_eq!(session.next_seq(), 4);
+    }
+
+    #[test]
+    fn render_shows_session_title_and_manual_state() {
+        let mut session = test_session();
+
+        let output = super::render(&session).unwrap();
+        assert!(output.contains("title               (none)"), "{output}");
+
+        session.set_title("User chosen title".to_string());
+        session.set_title_last_updated_tokens(usize::MAX);
+        let output = super::render(&session).unwrap();
+        assert!(
+            output.contains("title               User chosen title (manual)"),
+            "{output}"
+        );
     }
 
     #[test]

--- a/crates/harnx-runtime/src/config/session_ops_title.rs
+++ b/crates/harnx-runtime/src/config/session_ops_title.rs
@@ -13,6 +13,66 @@ use crate::config::session_lock::SessionLock;
 
 use harnx_core::message::MessageRole;
 
+/// Result of attempting to resolve a title agent from configuration.
+///
+/// Distinguishes three error cases that were previously collapsed into one
+/// generic "no title agent configured" message:
+///
+/// - `NotConfigured`: Neither `AgentConfig.title_agent` nor global `ConfigData.title_agent`
+///   is set. The error message MUST be exactly "no title agent configured".
+/// - `NotFound`: A title-agent name is configured but no such agent file exists.
+///   The error includes the configured name.
+/// - `LoadError`: Agent file exists but fails to load/parse. The underlying error
+///   is surfaced with the agent name in context.
+#[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum TitleAgentResolution {
+    /// Title agent is not configured (neither agent frontmatter nor global config).
+    NotConfigured,
+    /// Title agent name is configured but the agent file was not found.
+    NotFound {
+        /// The configured title agent name.
+        name: String,
+    },
+    /// Title agent file exists but failed to load or parse.
+    LoadError {
+        /// The configured title agent name.
+        name: String,
+        /// The underlying error from `retrieve_agent` or `resolve_variables`.
+        source: anyhow::Error,
+    },
+    /// Title agent resolved successfully.
+    Ok(crate::config::agent::Agent),
+}
+
+impl TitleAgentResolution {
+    /// Returns `true` if this represents a successfully resolved agent.
+    pub(crate) fn is_ok(&self) -> bool {
+        matches!(self, Self::Ok(_))
+    }
+
+    /// Convert to `Result<Option<Agent>>` for callers that need Result-based
+    /// error handling.
+    ///
+    /// - `Ok(Some(agent))` = successfully resolved
+    /// - `Ok(None)` = not configured
+    /// - `Err(..)` = configured but broken (precise error with agent name)
+    ///
+    /// The `NotConfigured` → `Ok(None)` mapping lets callers attach their own
+    /// context message (e.g. `generate_title` turns it into a hard error, while
+    /// background generation silently skips).
+    pub(crate) fn into_result(self) -> Result<Option<crate::config::agent::Agent>> {
+        match self {
+            Self::NotConfigured => Ok(None),
+            Self::NotFound { name } => Err(anyhow::anyhow!("title agent '{}' not found", name)),
+            Self::LoadError { name, source } => {
+                Err(source.context(format!("title agent '{}' failed to load", name)))
+            }
+            Self::Ok(agent) => Ok(Some(agent)),
+        }
+    }
+}
+
 /// System prompt used when no explicit title agent is configured. Produces a
 /// short natural-language title (not a slug) suitable for session listings.
 pub const DEFAULT_TITLE_SYSTEM_PROMPT: &str = r#"Generate a concise session title (10 words or fewer).
@@ -151,16 +211,87 @@ fn post_process_title(raw: &str) -> String {
 }
 
 /// Handle the outcome of a spawned `generate_title`: emit `TitleUpdated` on a
-/// new title, warn on error, ignore the "nothing to title" case.
-fn handle_title_result(result: anyhow::Result<Option<String>>) {
+/// new title, emit `TitleGenerationFailed` and warn on error, and ignore the
+/// "nothing to title" case.
+pub(crate) fn handle_title_result(result: anyhow::Result<Option<String>>) {
     match result {
         Ok(Some(title)) => {
+            info!("session title generated: {title:?}");
             harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
                 harnx_core::event::SessionEvent::TitleUpdated(title),
             ));
         }
-        Ok(None) => {}
-        Err(err) => warn!("Failed to generate session title: {err}"),
+        Ok(None) => debug!("title generation produced nothing"),
+        Err(err) => {
+            warn!("Failed to generate session title: {err:#}");
+            harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Session(
+                harnx_core::event::SessionEvent::TitleGenerationFailed(format!("{err:#}")),
+            ));
+        }
+    }
+}
+
+/// Decide which title-agent name to look up and how to qualify it, given the
+/// active agent's own `title_agent` frontmatter, the global
+/// `ConfigData.title_agent`, and the active agent's package.
+///
+/// The name can come from two sources, which resolve differently:
+///   1. The active agent's own `title_agent` frontmatter — a bare peer name
+///      means a peer *within the active agent's package*, so it resolves
+///      package-relative.
+///   2. The global `ConfigData.title_agent` — this refers to a *top-level*
+///      agent, so a bare name must resolve at the top level (NOT prefixed with
+///      whatever package agent happens to be active). Resolving it
+///      package-relative was the bug behind #103: running a package agent (e.g.
+///      `pantheon/sisyphus`) rewrote `title-agent` into `pantheon/title-agent`,
+///      which does not exist.
+///
+/// Returns `(name, resolved_name)` where `name` is the bare configured name and
+/// `resolved_name` is the (possibly package-qualified) name to look up first.
+/// Returns `None` when no title agent is configured from either source.
+pub(crate) fn resolve_title_agent_name(
+    agent_title_agent: Option<&str>,
+    global_title_agent: Option<&str>,
+    active_pkg: Option<&str>,
+) -> Option<(String, String)> {
+    if let Some(name) = agent_title_agent {
+        // Source 1: active agent frontmatter → package-relative.
+        let resolved =
+            harnx_core::package_namespace::resolve_package_relative_name(name, active_pkg);
+        Some((name.to_string(), resolved))
+    } else {
+        // Source 2: global config → resolve at top level. Passing `None` still
+        // honors an explicitly qualified `pkg/foo` or `/foo`, but keeps a bare
+        // name top-level.
+        let name = global_title_agent?;
+        let resolved = harnx_core::package_namespace::resolve_package_relative_name(name, None);
+        Some((name.to_string(), resolved))
+    }
+}
+
+/// Choose which name to look up for the title agent, given the bare configured
+/// `name`, its (possibly package-qualified) `resolved_name`, and whether an
+/// agent file exists at `resolved_name`.
+///
+/// When a package prefix was applied (`resolved_name != name`) but no agent
+/// file exists at that package path, fall back to the bare top-level name.
+/// Otherwise use `resolved_name` as-is — crucially, this means a package agent
+/// file that EXISTS but fails to load surfaces its own error rather than being
+/// masked by a top-level agent of the same name (#103 follow-up).
+///
+/// The fallback strips a leading `/` from `name` (an explicit "top-level"
+/// escape such as `/foo` resolves to the file `foo`), so we never fall back to
+/// a literal slash-prefixed name that no agent file would match.
+fn title_agent_lookup_name<'a>(
+    name: &'a str,
+    resolved_name: &'a str,
+    resolved_file_exists: bool,
+) -> &'a str {
+    let package_prefix_applied = resolved_name != name;
+    if package_prefix_applied && !resolved_file_exists {
+        name.strip_prefix('/').unwrap_or(name)
+    } else {
+        resolved_name
     }
 }
 
@@ -180,24 +311,49 @@ impl Config {
     /// `maybe_compact_session`.
     pub fn maybe_generate_title(config: GlobalConfig) {
         if !Self::claim_titling(&config) {
+            let guard = config.read();
+            let session_state = guard.session.as_ref().map(|session| {
+                (
+                    session.tokens(),
+                    session.title().map(str::to_owned),
+                    session.title_last_updated_tokens(),
+                )
+            });
+            debug!(
+                "title generation: guard not met; threshold={}, session_state={session_state:?}",
+                guard.title_update_threshold
+            );
             return;
         }
 
-        // Only proceed if a title agent is actually configured; otherwise clear
-        // the flag we just set and bail (no fallback title generation).
-        if Self::resolve_title_agent(&config).is_none() {
-            Self::clear_titling(&config, None);
-            return;
-        }
-
+        // Capture the id of the session whose titling flag we just claimed, so
+        // every cleanup path (including the no-agent early return) targets that
+        // exact session even if the active session were to change.
         let titling_session_id = config
             .read()
             .session
             .as_ref()
             .map(|session| session.id.clone());
 
+        // Only proceed if a title agent is actually configured; otherwise clear
+        // the flag we just set and bail (no fallback title generation).
+        let resolution = Self::resolve_title_agent(&config);
+        if !resolution.is_ok() {
+            debug!("title generation: no title agent configured; skipping");
+            Self::clear_titling(&config, titling_session_id.as_deref());
+            return;
+        }
+
+        if let Some(id) = titling_session_id.as_deref() {
+            info!("title generation: starting for session {id}");
+        }
+
         tokio::spawn(async move {
-            let result = Self::generate_title(&config).await;
+            let result = harnx_core::sink::with_agent_event_sink(
+                Arc::new(harnx_core::event::NullSink),
+                Self::generate_title(&config),
+            )
+            .await;
             Self::clear_titling(&config, titling_session_id.as_deref());
             handle_title_result(result);
         });
@@ -230,32 +386,57 @@ impl Config {
     }
 
     /// Resolve the configured title agent: `AgentConfig.title_agent` first, then
-    /// the global `ConfigData.title_agent`. Returns `None` when neither is set
-    /// (no title generation). Mirrors `resolve_compaction_agent`.
-    fn resolve_title_agent(config: &GlobalConfig) -> Option<crate::config::agent::Agent> {
+    /// the global `ConfigData.title_agent`. Returns a `TitleAgentResolution`
+    /// distinguishing between not configured, not found, load error, and success.
+    pub(crate) fn resolve_title_agent(config: &GlobalConfig) -> TitleAgentResolution {
         let active_agent_name = config.read().extract_agent().name().to_string();
         let active_pkg = harnx_core::package_namespace::pkg_from_qualified(&active_agent_name);
-        let name = {
+
+        let (name, resolved_name) = {
             let guard = config.read();
             let agent = guard.extract_agent();
-            agent
-                .title_agent()
-                .map(str::to_owned)
-                .or_else(|| guard.title_agent.clone())?
+            let Some((name, resolved_name)) = resolve_title_agent_name(
+                agent.title_agent(),
+                guard.title_agent.as_deref(),
+                active_pkg,
+            ) else {
+                return TitleAgentResolution::NotConfigured;
+            };
+            (name, resolved_name)
         };
 
-        let resolved_name =
-            harnx_core::package_namespace::resolve_package_relative_name(&name, active_pkg);
-        match config.read().retrieve_agent(&resolved_name) {
+        // Try the resolved name first; if a package prefix was applied and the
+        // package-qualified agent FILE DOES NOT EXIST, fall back to the bare
+        // top-level name. The decision is gated on file existence (not on
+        // `retrieve_agent` erroring) so that a package agent file which *exists
+        // but fails to load* (malformed frontmatter, unknown model, …) surfaces
+        // its real error instead of being masked by a top-level agent of the
+        // same name. See `title_agent_lookup_name`.
+        let resolved_exists = Self::agent_file(&resolved_name).exists();
+        let lookup_name = title_agent_lookup_name(&name, &resolved_name, resolved_exists);
+        let lookup_path = Self::agent_file(lookup_name);
+        let lookup_exists = lookup_path.exists();
+
+        match config.read().retrieve_agent(lookup_name) {
             Ok(mut title_agent) => {
                 if let Err(e) = self::agent::resolve_variables(&mut title_agent) {
                     warn!("Failed to resolve variables for title_agent '{name}': {e}");
+                    return TitleAgentResolution::LoadError { name, source: e };
                 }
-                Some(title_agent)
+                TitleAgentResolution::Ok(title_agent)
             }
             Err(e) => {
                 warn!("Failed to load title_agent '{name}': {e}; skipping title generation");
-                None
+                // Distinguish between "not found" and other errors based on file existence.
+                // retrieve_agent checks both file existence and builtin agents, so we need
+                // to check file existence ourselves to correctly categorize this.
+                if lookup_exists {
+                    // File exists but failed to load - this is a load/parse error
+                    TitleAgentResolution::LoadError { name, source: e }
+                } else {
+                    // File doesn't exist - this is "not found"
+                    TitleAgentResolution::NotFound { name }
+                }
             }
         }
     }
@@ -263,10 +444,19 @@ impl Config {
     /// Perform the actual title generation. Returns `Ok(Some(title))` on success,
     /// `Ok(None)` when there is nothing to title (empty transcript / model
     /// returned an empty string), and `Err` on LLM/model failure.
-    async fn generate_title(config: &GlobalConfig) -> Result<Option<String>> {
+    pub(crate) async fn generate_title(config: &GlobalConfig) -> Result<Option<String>> {
+        // `into_result` maps NotFound/LoadError to precise errors and
+        // NotConfigured to `Ok(None)`; turn the latter into the hard
+        // "no title agent configured" error specific to explicit generation.
         let title_agent = Self::resolve_title_agent(config)
+            .into_result()?
             .context("no title agent configured")?
             .into_config();
+        info!(
+            "title generation: using agent '{}' with model '{}'",
+            title_agent.name(),
+            title_agent.model().id()
+        );
 
         let (transcript, session_id, tokens) = {
             let guard = config.read();
@@ -277,6 +467,7 @@ impl Config {
                 session.tokens,
             )
         };
+        debug!("title generation: transcript length={}", transcript.len());
         if transcript.trim().is_empty() {
             return Ok(None);
         }
@@ -408,8 +599,138 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource, NoticeEvent, SessionEvent};
     use harnx_core::message::{Message, MessageContent};
     use harnx_core::session::Session;
+    use std::sync::Mutex;
+
+    // --- title-agent name resolution (#103) ---
+
+    #[test]
+    fn global_title_agent_resolves_top_level_even_inside_a_package_agent() {
+        // Regression for #103: running a package agent (e.g. `pantheon/sisyphus`)
+        // must NOT rewrite a globally-configured bare `title-agent` into
+        // `pantheon/title-agent`. The global title agent is a top-level agent.
+        let (name, resolved) = resolve_title_agent_name(
+            None,                // active agent has no title_agent frontmatter
+            Some("title-agent"), // global ConfigData.title_agent
+            Some("pantheon"),    // active package
+        )
+        .expect("global title agent should resolve");
+        assert_eq!(name, "title-agent");
+        assert_eq!(resolved, "title-agent", "global name must stay top-level");
+    }
+
+    #[test]
+    fn agent_frontmatter_title_agent_resolves_package_relative() {
+        // A bare title_agent in an agent's own frontmatter refers to a peer in
+        // the same package, so it resolves package-relative.
+        let (name, resolved) = resolve_title_agent_name(
+            Some("peer"), // active agent frontmatter
+            None,
+            Some("pkg"), // active package
+        )
+        .expect("frontmatter title agent should resolve");
+        assert_eq!(name, "peer");
+        assert_eq!(resolved, "pkg/peer");
+    }
+
+    #[test]
+    fn agent_frontmatter_takes_precedence_over_global() {
+        // When both are set, the active agent's own frontmatter wins.
+        let (name, resolved) =
+            resolve_title_agent_name(Some("peer"), Some("title-agent"), Some("pkg")).unwrap();
+        assert_eq!(name, "peer");
+        assert_eq!(resolved, "pkg/peer");
+    }
+
+    #[test]
+    fn explicitly_qualified_global_title_agent_is_preserved() {
+        // An explicitly qualified global name keeps its qualification and is not
+        // re-prefixed with the active package.
+        let (name, resolved) =
+            resolve_title_agent_name(None, Some("otherpkg/foo"), Some("pkg")).unwrap();
+        assert_eq!(name, "otherpkg/foo");
+        assert_eq!(resolved, "otherpkg/foo");
+    }
+
+    #[test]
+    fn leading_slash_global_title_agent_escapes_to_top_level() {
+        let (name, resolved) = resolve_title_agent_name(None, Some("/foo"), Some("pkg")).unwrap();
+        assert_eq!(name, "/foo");
+        assert_eq!(resolved, "foo");
+    }
+
+    #[test]
+    fn no_title_agent_configured_returns_none() {
+        assert!(resolve_title_agent_name(None, None, Some("pkg")).is_none());
+        assert!(resolve_title_agent_name(None, None, None).is_none());
+    }
+
+    #[test]
+    fn top_level_active_agent_keeps_global_name_bare() {
+        // No active package → bare global name stays bare.
+        let (name, resolved) = resolve_title_agent_name(None, Some("title-agent"), None).unwrap();
+        assert_eq!(name, "title-agent");
+        assert_eq!(resolved, "title-agent");
+    }
+
+    // --- fallback lookup gating (#103 follow-up) ---
+
+    #[test]
+    fn lookup_name_falls_back_to_bare_when_package_agent_file_missing() {
+        // Package prefix applied AND the package file doesn't exist → fall back
+        // to the bare top-level name.
+        assert_eq!(
+            title_agent_lookup_name("title-agent", "pantheon/title-agent", false),
+            "title-agent"
+        );
+    }
+
+    #[test]
+    fn lookup_name_strips_leading_slash_when_falling_back() {
+        // A global `/foo` resolves to file `foo`. When that file is missing, the
+        // fallback must return the stripped `foo`, never the literal `/foo`
+        // (which no agent file would match).
+        assert_eq!(title_agent_lookup_name("/foo", "foo", false), "foo");
+        // When the file exists, use the resolved (stripped) name as-is.
+        assert_eq!(title_agent_lookup_name("/foo", "foo", true), "foo");
+    }
+
+    #[test]
+    fn lookup_name_keeps_package_name_when_package_agent_file_exists() {
+        // Package prefix applied and the package file EXISTS → use the package
+        // name so a broken package file surfaces its own error (not masked).
+        assert_eq!(
+            title_agent_lookup_name("title-agent", "pantheon/title-agent", true),
+            "pantheon/title-agent"
+        );
+    }
+
+    #[test]
+    fn lookup_name_uses_resolved_when_no_package_prefix_applied() {
+        // No package prefix (resolved == name) → never falls back, regardless
+        // of the existence flag (short-circuits before the file check).
+        assert_eq!(
+            title_agent_lookup_name("title-agent", "title-agent", false),
+            "title-agent"
+        );
+        assert_eq!(
+            title_agent_lookup_name("title-agent", "title-agent", true),
+            "title-agent"
+        );
+    }
+
+    #[derive(Default)]
+    struct CollectingSink {
+        events: Mutex<Vec<AgentEvent>>,
+    }
+
+    impl AgentEventSink for CollectingSink {
+        fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
 
     fn user(text: &str) -> Message {
         Message::new(MessageRole::User, MessageContent::Text(text.to_string()))
@@ -424,6 +745,37 @@ mod tests {
         Session {
             messages,
             ..Session::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn title_failure_emits_full_error_after_isolated_generation_events() {
+        let sink = Arc::new(CollectingSink::default());
+
+        harnx_core::sink::with_agent_event_sink(sink.clone(), async {
+            let result = harnx_core::sink::with_agent_event_sink(
+                Arc::new(harnx_core::event::NullSink),
+                async {
+                    harnx_core::sink::emit_agent_event(AgentEvent::Notice(NoticeEvent::Info(
+                        "title-agent output".to_string(),
+                    )));
+                    Err(anyhow::Error::msg("Miss 'api_key'")
+                        .context("Failed to call chat-completions api"))
+                },
+            )
+            .await;
+
+            handle_title_result(result);
+        })
+        .await;
+
+        let events = sink.events.lock().unwrap();
+        assert_eq!(events.len(), 1, "title-agent events must stay isolated");
+        match &events[0] {
+            AgentEvent::Session(SessionEvent::TitleGenerationFailed(error)) => {
+                assert_eq!(error, "Failed to call chat-completions api: Miss 'api_key'");
+            }
+            other => panic!("unexpected event: {other:?}"),
         }
     }
 
@@ -492,6 +844,80 @@ mod tests {
         assert_eq!(post_process_title("Configuring CI!"), "Configuring CI");
         assert_eq!(post_process_title("**Bold title**"), "Bold title");
         assert_eq!(post_process_title("`code title`"), "code title");
+    }
+
+    // --- TitleAgentResolution error cases ---
+
+    #[test]
+    fn resolution_not_configured_when_no_title_agent_set() {
+        // Neither agent frontmatter nor global config has title_agent
+        let resolution = resolve_title_agent_name(
+            None, // agent frontmatter
+            None, // global config
+            None, // active package
+        );
+        assert!(
+            resolution.is_none(),
+            "expected None when no title agent configured"
+        );
+    }
+
+    #[test]
+    fn resolution_not_found_message_includes_agent_name() {
+        use super::*;
+        // When a title agent name is configured but doesn't exist,
+        // the error message should include the name
+        let resolution = TitleAgentResolution::NotFound {
+            name: "missing-title-agent".to_string(),
+        };
+        let result: Result<Option<_>> = resolution.into_result();
+        let err = result.expect_err("should be error for NotFound");
+        // The error message must contain both "not found" and the agent name
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("not found"),
+            "error message should contain 'not found': {msg}"
+        );
+        assert!(
+            msg.contains("missing-title-agent"),
+            "error message should contain agent name: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolution_load_error_surfaces_underlying_error() {
+        use super::*;
+        // When a title agent exists but fails to load, the underlying error
+        // should be surfaced with the agent name in context
+        let underlying = anyhow::anyhow!("parse error: invalid frontmatter");
+        let resolution = TitleAgentResolution::LoadError {
+            name: "malformed-title-agent".to_string(),
+            source: underlying,
+        };
+        let result: Result<Option<_>> = resolution.into_result();
+        let err = result.expect_err("should be error for LoadError");
+        let msg = format!("{err:#}");
+        // The error message must include both the agent name and the underlying error
+        assert!(
+            msg.contains("malformed-title-agent"),
+            "error should contain agent name: {msg}"
+        );
+        assert!(
+            msg.contains("parse error"),
+            "error should contain underlying error: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolution_not_configured_is_ok_none() {
+        use super::*;
+        let resolution = TitleAgentResolution::NotConfigured;
+        let result: Result<Option<_>> = resolution.into_result();
+        assert!(result.is_ok(), "NotConfigured should resolve to Ok(None)");
+        assert!(
+            result.unwrap().is_none(),
+            "NotConfigured should resolve to Ok(None)"
+        );
     }
 
     #[test]

--- a/crates/harnx-serve/README.md
+++ b/crates/harnx-serve/README.md
@@ -159,6 +159,7 @@ Cross-process live synchronization via NATS and distributed persistence (Issue #
 | `Turn::Started` / `Turn::Ended` | `STEP_STARTED` / `STEP_FINISHED` | Step names use `turn-N`. |
 | `Turn::RetryAttempt` / `ModelFallback` / `HandoffRequested` | `CUSTOM` | Names: `turn_retry_attempt`, `turn_model_fallback`, `turn_handoff_requested`. |
 | `Session::Compacting*` | `CUSTOM` (+ `MESSAGES_SNAPSHOT` on completed) | Names: `session_compacting_started`, `session_compacting_completed`, `session_compacting_failed`. Completion re-snapshots transcript because compaction mutates history. |
+| `Session::TitleUpdated` / `TitleGenerationFailed` | `CUSTOM` | Names: `session_title_updated`, `session_title_generation_failed`. |
 | `Session::Saved` / `AgentInitializing` / `ModelChanged` / `RagIndexing` / `Generic` | `CUSTOM` | Stable names prefixed with `session_...`. |
 | `Session::LogSeqAssigned` | dropped | Persistence bookkeeping for local transcript patching; not useful on AG-UI wire. |
 | `Plan { entries }` | `CUSTOM` | Name: `plan`. Carries serialized plan entries for plan/todo panels. |

--- a/crates/harnx-serve/src/ag_ui.rs
+++ b/crates/harnx-serve/src/ag_ui.rs
@@ -632,6 +632,9 @@ impl harnx_core::event::AgentEventSink for AgUiSink {
             AgentEvent::Session(SessionEvent::CompactingFailed(error)) => {
                 self.emit_custom("session_compacting_failed", json!({ "error": error }));
             }
+            AgentEvent::Session(SessionEvent::TitleGenerationFailed(error)) => {
+                self.emit_custom("session_title_generation_failed", json!({ "error": error }));
+            }
             AgentEvent::Session(SessionEvent::Saved { path }) => {
                 self.emit_custom("session_saved", json!({ "path": path }));
             }

--- a/crates/harnx-serve/src/ag_ui_tests.rs
+++ b/crates/harnx-serve/src/ag_ui_tests.rs
@@ -136,6 +136,29 @@ fn ag_ui_sink_emits_run_error_for_model_error() {
 }
 
 #[test]
+fn ag_ui_sink_emits_custom_for_title_generation_failed() {
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
+    let message_id = MessageId::from(uuid::Uuid::new_v4());
+    let sink = super::AgUiSink::new(tx, message_id);
+
+    sink.emit(
+        AgentEvent::Session(SessionEvent::TitleGenerationFailed(
+            "Miss 'api_key'".to_string(),
+        )),
+        None,
+    );
+
+    let event = rx.try_recv().expect("should receive event");
+    match event {
+        Event::Custom(CustomEvent { name, value, .. }) => {
+            assert_eq!(name, "session_title_generation_failed");
+            assert_eq!(value["error"], json!("Miss 'api_key'"));
+        }
+        _ => panic!("expected Custom event, got: {:?}", event),
+    }
+}
+
+#[test]
 fn ag_ui_sink_emits_run_error_for_notice_error() {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
     let message_id = MessageId::from(uuid::Uuid::new_v4());

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1344,9 +1344,13 @@ impl Tui {
                     "Compaction failed: {err}"
                 ))]
             }
+            AgentEvent::Session(SessionEvent::TitleGenerationFailed(err)) => {
+                vec![TranscriptItem::ErrorText(format!(
+                    "Title generation failed: {err}"
+                ))]
+            }
             AgentEvent::Session(SessionEvent::TitleUpdated(title)) => {
-                let _ = std::io::stdout()
-                    .execute(crossterm::terminal::SetTitle(format!("harnx — {title}")));
+                let _ = std::io::stdout().execute(crossterm::terminal::SetTitle(&title));
                 vec![]
             }
             _ => vec![],

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -356,8 +356,7 @@ impl Tui {
         let mut terminal = Self::setup_terminal()?;
 
         if let Some(title) = self.config.read().session.as_ref().and_then(|s| s.title()) {
-            let _ = std::io::stdout()
-                .execute(crossterm::terminal::SetTitle(format!("harnx — {title}")));
+            let _ = std::io::stdout().execute(crossterm::terminal::SetTitle(title));
         }
 
         let mut event_source = CrosstermEventSource;

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__help_in_tui.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__help_in_tui.snap
@@ -2,7 +2,6 @@
 source: crates/harnx-tui/src/tests.rs
 expression: rendered
 ---
-.exit rag                Leave RAG
 .attach                  Attach a file to the next message
 .detach                  Remove attached files
 .macro                   Execute a macro
@@ -12,6 +11,7 @@ expression: rendered
 .regenerate              Regenerate last response
 .copy                    Copy last response
 .set                     Modify runtime settings
+.title                   Show or (re)generate the session title
 .set show_sequence_numbers Toggle [n] prefix in transcript (on/off)
 .set show_timestamps     Toggle timestamp in transcript (on/off)
 .delete                  Delete agents, sessions, RAGs, or macros

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -806,6 +806,58 @@ async fn compute_completions_appends_space_for_command_matches() {
 }
 
 #[tokio::test]
+async fn compute_completions_title_offers_subcommands_not_usage_brackets() {
+    // Regression: `.title` was registered with the name ".title [generate|now]",
+    // so tab-completing `.title ` produced the literal usage string
+    // "[generate|now]" instead of the real subcommands.
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    // Completing the command name must not carry a usage suffix.
+    let name_completions = tui.compute_completions(".title", 6).await;
+    assert!(
+        name_completions.iter().any(|(value, _)| value == ".title "),
+        "expected bare \".title \" command completion, got: {name_completions:?}"
+    );
+    assert!(
+        !name_completions
+            .iter()
+            .any(|(value, _)| value.contains('[') || value.contains(']')),
+        "command completion must not contain usage brackets, got: {name_completions:?}"
+    );
+
+    // Completing the argument after `.title ` must offer exactly the real
+    // subcommands — no usage brackets, no extraneous candidates.
+    let line = ".title ";
+    let arg_completions = tui.compute_completions(line, line.len()).await;
+    let values: Vec<&str> = arg_completions
+        .iter()
+        .map(|(value, _)| value.as_str())
+        .collect();
+    assert_eq!(
+        values,
+        vec!["generate", "now"],
+        "expected exactly the \"generate\"/\"now\" subcommands, got: {values:?}"
+    );
+
+    // A partial subcommand prefix must narrow to the matching subcommand.
+    let line = ".title g";
+    let prefix_completions = tui.compute_completions(line, line.len()).await;
+    let prefix_values: Vec<&str> = prefix_completions
+        .iter()
+        .map(|(value, _)| value.as_str())
+        .collect();
+    assert_eq!(
+        prefix_values,
+        vec!["generate"],
+        "expected \".title g\" to complete to \"generate\", got: {prefix_values:?}"
+    );
+}
+
+#[tokio::test]
 async fn apply_completion_preserves_text_after_cursor() {
     let config = test_config();
     let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
@@ -8452,6 +8504,30 @@ async fn render_agent_event_title_updated_executes_without_panic() {
     .await
     .unwrap();
 }
+#[tokio::test]
+async fn render_agent_event_title_generation_failed_produces_error_transcript_entry() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    tui.handle_tui_event(TuiEvent::Agent(
+        AgentEvent::Session(SessionEvent::TitleGenerationFailed(
+            "Miss 'api_key'".to_string(),
+        )),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    assert!(tui.app.transcript.iter().any(|item| matches!(
+        item,
+        TranscriptItem::ErrorText(text)
+            if text == "Title generation failed: Miss 'api_key'"
+    )));
+}
+
 #[tokio::test]
 async fn render_agent_event_compacting_started_produces_transcript_entry() {
     let config = test_config();

--- a/crates/harnx/src/cli_event_sink.rs
+++ b/crates/harnx/src/cli_event_sink.rs
@@ -434,6 +434,12 @@ impl AgentEventSink for CliAgentEventSink {
                 }
                 eprintln!("{}", warning_text(&format!("compaction failed: {err}")));
             }
+            AgentEvent::Session(SessionEvent::TitleGenerationFailed(err)) => {
+                eprintln!(
+                    "{}",
+                    warning_text(&format!("title generation failed: {err}"))
+                );
+            }
             // Every other variant — Session (other), Status, Plan — still gets
             // captured so nothing silently disappears. These receive dedicated
             // renderers in a future plan.
@@ -524,6 +530,14 @@ mod tests {
                 input: serde_json::Value::Null,
                 reason: "hook denied".into(),
             }),
+            None,
+        );
+        sink.emit(
+            AgentEvent::Session(SessionEvent::TitleUpdated("A title".into())),
+            None,
+        );
+        sink.emit(
+            AgentEvent::Session(SessionEvent::TitleGenerationFailed("Miss 'api_key'".into())),
             None,
         );
     }

--- a/docs/solutions/logic-errors/background-task-failure-surface-title-generation-2026-07-23.md
+++ b/docs/solutions/logic-errors/background-task-failure-surface-title-generation-2026-07-23.md
@@ -1,0 +1,164 @@
+---
+title: "Surface background task failures in title generation (silent API key error)"
+date: 2026-07-23
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-runtime, harnx-core, harnx-tui"
+root_cause: "Silently swallowed error in spawned background task — warn! log invisible in TUI"
+resolution_type: code_fix
+severity: medium
+tags:
+  - background-task
+  - event-sink
+  - title-generation
+  - error-handling
+  - NullSink
+  - diagnostics
+plan_ref: "terminal-title-update"
+---
+
+## Problem
+
+Configured title generation never updated terminal title. Static plumbing verified correct (config → agent file → runtime → `maybe_generate_title` → `SessionEvent::TitleUpdated` → crossterm `SetTitle`). Root cause: title agent's API call failed with `Miss 'api_key'`, but failure was logged via `warn!(...)` — invisible to TUI users. No visible error, no title, no diagnostics.
+
+## Symptoms
+
+- Terminal title remains unchanged despite correct `title_agent` config
+- No error message visible in TUI, CLI, or web frontend
+- `harnx info agent title-agent` resolves correctly, model valid
+- Tmux/mock-server E2E with mock LLM: title pipeline works when credentials present
+- Log file shows: `[WARN] Failed to generate session title: Failed to call chat-completions api (client: gemini, model: gemini:gemini-3.1-flash-lite)`
+
+## Investigation Steps
+
+1. Static traced plumbing: `Config::run_post_turn_maintenance` → `maybe_generate_title` → `claim_titling` → `resolve_title_agent` → `generate_title` → `handle_title_result` → `emit_agent_event(TitleUpdated)`. All present.
+2. Suspected `SetTitle` lost under ratatui alternate-screen/raw-mode — ruled out via tmux E2E: title updates observed under raw mode, alternate screen, and after redraws.
+3. Built mock-LLM E2E: normal turn + title-model request → mock returns title → pane title updated within 1s. Pipeline functional.
+4. Reproduced failure: same flow with unauthenticated Gemini client. Main turn succeeded; title generation failed with `Miss 'api_key'`.
+5. Found: `handle_title_result` called `warn!("Failed...")` but emitted NO event. User saw nothing.
+
+**Key insight**: When all static plumbing is correct but a feature "does nothing," suspect silently swallowed errors in spawned/background tasks.
+
+## Root Cause
+
+Two-part bug:
+
+1. **Invisible failure**: `handle_title_result` logged error with `warn!` but never emitted a `SessionEvent`. TUI has no access to log crate output unless explicit event path fires.
+
+2. **Event pollution**: Background title generation runs the title agent through normal chat path, leaking model/streaming/retry events into main transcript. Observed in E2E: title-agent completions rendered in user-visible output.
+
+```rust
+// Before (in session_ops_title.rs)
+fn handle_title_result(result: anyhow::Result<Option<String>>) {
+    match result {
+        Ok(Some(title)) => { /* emit TitleUpdated */ }
+        Ok(None) => {}
+        Err(err) => {
+            warn!("Failed to generate session title: {err}");
+            // Nothing else — user never sees this
+        }
+    }
+}
+```
+
+## Solution
+
+### Fix A — Surface background failures with dedicated event
+
+Added `SessionEvent::TitleGenerationFailed(String)` (mirrors existing `CompactingFailed`):
+
+```rust
+// In harnx-core/src/event.rs
+pub enum SessionEvent {
+    // ... existing variants ...
+    TitleGenerationFailed(String),
+}
+```
+
+Emit with FULL anyhow chain via `format!("{err:#}")` (not just top-level message):
+
+```rust
+// In session_ops_title.rs
+fn handle_title_result(result: anyhow::Result<Option<String>>) {
+    match result {
+        Ok(Some(title)) => {
+            emit_agent_event(AgentEvent::Session(SessionEvent::TitleUpdated(title)));
+        }
+        Ok(None) => {}
+        Err(err) => {
+            warn!("Failed to generate session title: {err}");
+            emit_agent_event(AgentEvent::Session(
+                SessionEvent::TitleGenerationFailed(format!("{err:#}")),
+            ));
+        }
+    }
+}
+```
+
+Sweep every `AgentEventSink` consumer:
+
+- **TUI** (`input.rs`): `ErrorText("Title generation failed: {err}")`
+- **CLI** (`cli_event_sink.rs`): `eprintln!(warning_text("title generation failed: {err}"))`
+- **serve/ag_ui** (`ag_ui.rs`): `emit_custom("session_title_generation_failed", json!({ "error": error }))`
+- **Web frontend**: must handle `onStatus` callback for the new event type
+
+**Discipline**: Every `SessionEvent` enum variant must have explicit handling in every sink implementation.
+
+### Fix B — Isolate background-task events with `NullSink`
+
+Wrap spawned generation to suppress intermediate events:
+
+```rust
+tokio::spawn(async move {
+    let result = harnx_core::sink::with_agent_event_sink(
+        Arc::new(harnx_core::event::NullSink),  // Swallow model/streaming/retry events
+        Self::generate_title(&config),
+    ).await;
+    Self::clear_titling(&config, session_id.as_deref());
+    handle_title_result(result);  // FINAL result emitted AFTER scope closes
+});
+```
+
+`with_agent_event_sink` sets a task-local sink override. Events emitted inside `generate_title` go to `NullSink` (dropped). After the scope closes, `handle_title_result` emits the final `TitleUpdated` or `TitleGenerationFailed` to the real global sink.
+
+This is the reusable pattern for "run an LLM sub-call in background without polluting user's UI."
+
+## Why This Works
+
+1. **Dedicated event**: `TitleGenerationFailed` surfaces via existing event infrastructure. Every sink already knows how to render `SessionEvent` variants. Full anyhow chain via `{err:#}` includes root cause (`Miss 'api_key'`).
+
+2. **NullSink isolation**: Task-local sink (`SCOPED_SINK` in `harnx_core::sink`) shadows the global sink for the duration of `with_agent_event_sink`. Title agent's internal completions never reach TUI. After scope exits, global sink restored; final result event reaches user.
+
+3. **Exhaustive match discipline**: Adding a new `SessionEvent` forced inspection of every sink. Compilation fails if match is non-exhaustive.
+
+## Prevention Strategies
+
+**Test Cases:**
+- Add E2E test for title generation failure with missing API key
+- Verify `TitleGenerationFailed` event content includes root cause
+- Verify TUI renders error as `ErrorText`, CLI as warning, web via custom event
+
+**Best Practices:**
+- Never rely on `warn!`/`error!` logs for user-visible diagnostics in background tasks
+- Mirror the `CompactingFailed` pattern for any new background operation that can fail
+- Use `with_agent_event_sink(Arc::new(NullSink), fut)` for background LLM sub-calls
+- Emit final result AFTER the NullSink scope closes, not inside
+
+**Code Review Checklist:**
+- [ ] New `SessionEvent` variants have handler in every `AgentEventSink`
+- [ ] Background tasks emit failure events, not just log messages
+- [ ] Error strings include full anyhow chain (`{err:#}`) for root cause visibility
+- [ ] Task-local sink override used for background LLM calls that shouldn't pollute UI
+
+**Known Debt:**
+`sessions_ops_title.rs` notes that `maybe_compact_session` still lacks this isolation — title-agent events are suppressed but compaction events may still leak. Follow-up candidate.
+
+## Verified Non-Issue
+
+Crossterm `SetTitle` (OSC `ESC]0;...BEL`) reaches terminal under ratatui alternate-screen + raw mode. Written via fresh `std::io::stdout()`. Ratatui redraws do not reset OSC title. No need to route through ratatui backend or re-emit each frame.
+
+## Related Issues
+
+- **GitHub:** [issue #103](https://github.com/dobesv/harnx/issues/103) — Terminal title not updating
+- **Related Solution:** [feature-implementation/session-title-generation-pipeline-2026-07-15.md](../feature-implementation/session-title-generation-pipeline-2026-07-15.md) — Original title generation feature implementation
+- **Related Solution:** [async-patterns/acp-io-task-supervision-2026-05-07.md](../async-patterns/acp-io-task-supervision-2026-05-07.md) — Supervision for spawned background tasks

--- a/web/src/ChatProvider.tsx
+++ b/web/src/ChatProvider.tsx
@@ -125,6 +125,10 @@ export class HarnxHttpAgent extends HttpAgent {
       usage: (v) => this.onUsageCb(v),
       tool_summary: (v) => this.onToolSummaryCb(v?.tool_call_id, v?.markdown),
       session_title_updated: (v) => setDocumentTitle(v?.title),
+      session_title_generation_failed: (v) => {
+        console.error('session_title_generation_failed:', v?.error);
+        this.onStatus(v?.error || null);
+      },
       session_handoff: (v) => {
         if (this.isRunActive) {
           this.onHandoff?.(v?.agent, v?.session_id ?? null);


### PR DESCRIPTION
Fix automatic session-title generation when running a package agent (e.g. `pantheon/sisyphus`). A globally-configured `title_agent` was resolved relative to the active agent's package, so top-level `title-agent` was looked up as `<package>/title-agent` and never found. Global title agents now resolve at the top level; an agent's own `title_agent` frontmatter still resolves package-relative; a package-qualified lookup that finds no file falls back to the bare name (but a package file that exists but fails to load surfaces its real error).

Surface title-generation failures via a new `TitleGenerationFailed` event (shown in TUI, CLI, server AG-UI, and web client) with the full error chain instead of a silent `warn!`. Isolate background title-agent output from the main transcript via a task-local NullSink.

Add `.title` command to view current title and guard state, `.title generate` and `.title now` to (re)generate on demand and view errors immediately. Show title in `.info session` and add logging to title path. Include tests and patch changeset.

Issue: #103
Plan: terminal-title-update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `.title [generate|now]` command to view current title/guard state and trigger synchronous regeneration.
  * Session rendering now includes the title (or “(none)”) and marks manually set titles as “(manual)”.
* **Bug Fixes**
  * Automatic title-generation failures are now surfaced everywhere with detailed error messages.
  * Improved title-agent resolution behavior and prevented background title-agent output from polluting the main transcript.
* **Documentation**
  * Added a troubleshooting guide for background title-generation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->