### PR TITLE
fix(commands): decouple Command.name from usage hints to fix tab completion

### DIFF
--- a/.changeset/command-usage-decoupling.md
+++ b/.changeset/command-usage-decoupling.md
@@ -5,7 +5,7 @@
 fix(commands): decouple `Command.name` from usage hints to fix tab-completion
 
 Commands whose registered name embedded usage syntax (e.g. `.rewind <n>`,
-`.edit message <n>`, `.info mcp [server]`) tab-completed to the literal usage
+`.edit message <n>`, `.info env [name]`) tab-completed to the literal usage
 string instead of a real command/subcommand.
 
 - Add a dedicated `Command.usage: Option<&'static str>` field plus a

--- a/.changeset/command-usage-decoupling.md
+++ b/.changeset/command-usage-decoupling.md
@@ -1,0 +1,18 @@
+---
+"harnx": patch
+---
+
+fix(commands): decouple `Command.name` from usage hints to fix tab-completion
+
+Commands whose registered name embedded usage syntax (e.g. `.rewind <n>`,
+`.edit message <n>`, `.info mcp [server]`) tab-completed to the literal usage
+string instead of a real command/subcommand.
+
+- Add a dedicated `Command.usage: Option<&'static str>` field plus a
+  `Command::with_usage()` constructor so `name` stays a clean dispatch/
+  completion key while `.help` still renders the argument syntax.
+- Split placeholder usage out of the affected command names.
+- Deduplicate first-word completions by bare name in the TUI.
+- Add real subcommand completions for `.edit` and `.delete`.
+- Add regression tests asserting completions never surface `<n>`, `[server]`,
+  `[name]`, or `<n>-<m>` literals.

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -35,8 +35,9 @@ pub static COMMANDS: LazyLock<[Command; 48]> = LazyLock::new(|| {
         Command::new(".help", "Show this help guide"),
         Command::new(".info", "Show system info"),
         Command::new(".info tools", "List all available tools and their status"),
-        Command::new(
-            ".info env [name]",
+        Command::with_usage(
+            ".info env",
+            "[name]",
             "List harnx process env var names (or show one var's value)",
         ),
         Command::new(".use tool", "Add a tool or toolset to the active tools"),
@@ -67,12 +68,14 @@ pub static COMMANDS: LazyLock<[Command; 48]> = LazyLock::new(|| {
         ),
         Command::new(".info theme", "Show active syntax-highlight theme"),
         Command::new(".edit session", "Modify current session"),
-        Command::new(
-            ".edit message <n>",
+        Command::with_usage(
+            ".edit message",
+            "<n>",
             "Edit a single log entry by sequence number",
         ),
-        Command::new(
-            ".edit message <n>-<m>",
+        Command::with_usage(
+            ".edit message",
+            "<n>-<m>",
             "Edit a range of log entries by sequence number",
         ),
         Command::new(".save session", "Save current session to file"),
@@ -106,13 +109,19 @@ pub static COMMANDS: LazyLock<[Command; 48]> = LazyLock::new(|| {
             "Toggle timestamp in transcript (on/off)",
         ),
         Command::new(".delete", "Delete agents, sessions, RAGs, or macros"),
-        Command::new(
-            ".delete message <n>",
+        Command::with_usage(
+            ".delete message",
+            "<n>",
             "Delete a log entry by sequence number",
         ),
-        Command::new(".delete message <n>-<m>", "Delete a range of log entries"),
-        Command::new(
-            ".rewind <n>",
+        Command::with_usage(
+            ".delete message",
+            "<n>-<m>",
+            "Delete a range of log entries",
+        ),
+        Command::with_usage(
+            ".rewind",
+            "<n>",
             "Rewind session context to entry N (all later entries excluded)",
         ),
         Command::new(".exit", "Exit the interactive session"),
@@ -125,6 +134,7 @@ static MULTILINE_RE: LazyLock<Regex> =
 #[derive(Debug, Clone)]
 pub struct Command {
     pub name: &'static str,
+    pub usage: Option<&'static str>,
     pub description: &'static str,
 }
 
@@ -132,6 +142,15 @@ impl Command {
     const fn new(name: &'static str, desc: &'static str) -> Self {
         Self {
             name,
+            usage: None,
+            description: desc,
+        }
+    }
+
+    const fn with_usage(name: &'static str, usage: &'static str, desc: &'static str) -> Self {
+        Self {
+            name,
+            usage: Some(usage),
             description: desc,
         }
     }
@@ -936,7 +955,13 @@ fn unknown_command() -> Result<()> {
 fn dump_help(output: &mut (dyn Write + Send)) -> Result<()> {
     let head = COMMANDS
         .iter()
-        .map(|cmd| format!("{:<24} {}", cmd.name, cmd.description))
+        .map(|cmd| {
+            let label = match cmd.usage {
+                Some(usage) => format!("{} {usage}", cmd.name),
+                None => cmd.name.to_string(),
+            };
+            format!("{label:<24} {}", cmd.description)
+        })
         .collect::<Vec<String>>()
         .join("\n");
     writeln!(

--- a/crates/harnx-runtime/src/config/completion_split.rs
+++ b/crates/harnx-runtime/src/config/completion_split.rs
@@ -1,6 +1,38 @@
 //! Command-line tab completion extracted from config/mod.rs for code health.
 use super::*;
 
+/// Commands whose second word is a fixed list.
+///
+/// Kept as data rather than match arms so `command_complete` only carries the
+/// cases that have to compute something.
+const FIXED_SUBCOMMANDS: &[(&str, &[&str])] = &[
+    (
+        ".delete",
+        &["agent", "session", "rag", "macro", "agent-data", "message"],
+    ),
+    (".drop", &["tool"]),
+    (
+        ".edit",
+        &["config", "agent", "session", "message", "rag-docs"],
+    ),
+    (
+        ".info",
+        &[
+            "session", "model", "agent", "rag", "tools", "theme", "mcp", "env",
+        ],
+    ),
+    (".mcp", &["list", "connect", "disconnect", "tools"]),
+    (".title", &["generate", "now"]),
+    (".use", &["tool"]),
+];
+
+fn fixed_subcommands(cmd: &str) -> Option<&'static [&'static str]> {
+    FIXED_SUBCOMMANDS
+        .iter()
+        .find(|(name, _)| *name == cmd)
+        .map(|(_, subcommands)| *subcommands)
+}
+
 impl Config {
     pub fn command_complete(
         &self,
@@ -20,16 +52,6 @@ impl Config {
                 ".rag" => map_completion_values(Self::list_rags()),
                 ".agent" => map_completion_values(precomputed_agents),
                 ".macro" => map_completion_values(Self::list_macros()),
-                ".info" => map_completion_values(vec![
-                    "session", "model", "agent", "rag", "tools", "theme", "mcp", "env",
-                ]),
-                ".mcp" => map_completion_values(vec!["list", "connect", "disconnect", "tools"]),
-                ".title" => map_completion_values(vec!["generate", "now"]),
-                ".use" => map_completion_values(vec!["tool"]),
-                ".drop" => map_completion_values(vec!["tool"]),
-                ".edit" => {
-                    map_completion_values(vec!["config", "agent", "session", "message", "rag-docs"])
-                }
                 ".starter" => match &self.agent {
                     Some(agent) => agent
                         .conversation_staters()
@@ -63,15 +85,9 @@ impl Config {
                         .map(|v| (format!("{v} "), None))
                         .collect()
                 }
-                ".delete" => map_completion_values(vec![
-                    "agent",
-                    "session",
-                    "rag",
-                    "macro",
-                    "agent-data",
-                    "message",
-                ]),
-                _ => vec![],
+                _ => fixed_subcommands(cmd)
+                    .map(|subcommands| map_completion_values(subcommands.to_vec()))
+                    .unwrap_or_default(),
             };
         } else if cmd == ".set" && args.len() == 2 {
             let candidates = match args[0] {

--- a/crates/harnx-runtime/src/config/completion_split.rs
+++ b/crates/harnx-runtime/src/config/completion_split.rs
@@ -27,6 +27,9 @@ impl Config {
                 ".title" => map_completion_values(vec!["generate", "now"]),
                 ".use" => map_completion_values(vec!["tool"]),
                 ".drop" => map_completion_values(vec!["tool"]),
+                ".edit" => {
+                    map_completion_values(vec!["config", "agent", "session", "message", "rag-docs"])
+                }
                 ".starter" => match &self.agent {
                     Some(agent) => agent
                         .conversation_staters()
@@ -60,9 +63,14 @@ impl Config {
                         .map(|v| (format!("{v} "), None))
                         .collect()
                 }
-                ".delete" => {
-                    map_completion_values(vec!["agent", "session", "rag", "macro", "agent-data"])
-                }
+                ".delete" => map_completion_values(vec![
+                    "agent",
+                    "session",
+                    "rag",
+                    "macro",
+                    "agent-data",
+                    "message",
+                ]),
                 _ => vec![],
             };
         } else if cmd == ".set" && args.len() == 2 {

--- a/crates/harnx-tui/src/completion.rs
+++ b/crates/harnx-tui/src/completion.rs
@@ -1,0 +1,22 @@
+//! Completion candidates for the `.`-prefixed commands.
+
+use std::collections::HashSet;
+
+/// Completions for a partial first word such as `.inf`.
+///
+/// A dispatch name can appear more than once in `COMMANDS`, since commands
+/// sharing a name differ only in the arguments they document. Offering it twice
+/// would put a duplicate in the picker, so only the first is kept.
+pub(crate) fn command_name_completions(filter: &str) -> Vec<(String, Option<String>)> {
+    let mut seen = HashSet::new();
+    harnx_runtime::commands::COMMANDS
+        .iter()
+        .filter(|command| command.name.starts_with(filter) && seen.insert(command.name))
+        .map(|command| {
+            (
+                format!("{} ", command.name),
+                Some(command.description.to_string()),
+            )
+        })
+        .collect()
+}

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -13,6 +13,7 @@ use harnx_runtime::config::{
 };
 use harnx_runtime::utils::pretty_yaml_block;
 use ratatui_textarea::{Input as TextInput, Key};
+use std::collections::HashSet;
 use std::path::Path;
 
 /// Byte budget for an attachment preview. Applied via `truncate_output`'s
@@ -1942,9 +1943,10 @@ impl Tui {
         // If we're still typing the first word starting with '.', complete commands
         if parts.len() == 1 && cmd.starts_with('.') {
             let filter = cmd;
+            let mut seen = HashSet::new();
             let commands: Vec<(String, Option<String>)> = harnx_runtime::commands::COMMANDS
                 .iter()
-                .filter(|c| c.name.starts_with(filter))
+                .filter(|c| c.name.starts_with(filter) && seen.insert(c.name))
                 .map(|c| (format!("{} ", c.name), Some(c.description.to_string())))
                 .collect();
             return commands;

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -13,7 +13,6 @@ use harnx_runtime::config::{
 };
 use harnx_runtime::utils::pretty_yaml_block;
 use ratatui_textarea::{Input as TextInput, Key};
-use std::collections::HashSet;
 use std::path::Path;
 
 /// Byte budget for an attachment preview. Applied via `truncate_output`'s
@@ -1942,14 +1941,7 @@ impl Tui {
 
         // If we're still typing the first word starting with '.', complete commands
         if parts.len() == 1 && cmd.starts_with('.') {
-            let filter = cmd;
-            let mut seen = HashSet::new();
-            let commands: Vec<(String, Option<String>)> = harnx_runtime::commands::COMMANDS
-                .iter()
-                .filter(|c| c.name.starts_with(filter) && seen.insert(c.name))
-                .map(|c| (format!("{} ", c.name), Some(c.description.to_string())))
-                .collect();
-            return commands;
+            return crate::completion::command_name_completions(cmd);
         }
 
         // For multi-part commands, delegate to config's command_complete

--- a/crates/harnx-tui/src/lib.rs
+++ b/crates/harnx-tui/src/lib.rs
@@ -16,6 +16,8 @@ pub mod terminal;
 pub mod test_utils;
 pub mod types;
 
+mod completion;
+
 #[cfg(test)]
 mod tests;
 

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -863,6 +863,70 @@ async fn compute_completions_title_offers_subcommands_not_usage_brackets() {
 }
 
 #[tokio::test]
+async fn command_completions_separate_names_from_usage_and_offer_subcommands() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+
+    for command in [".rewind", ".edit", ".delete", ".info"] {
+        let completions = tui.compute_completions(command, command.len()).await;
+        assert!(
+            completions
+                .iter()
+                .all(|(value, _)| !["<n>", "[server]", "[name]", "<n>-<m>"]
+                    .iter()
+                    .any(|usage| value.contains(usage))),
+            "{command} command completion contains a usage hint: {completions:?}"
+        );
+    }
+
+    let edit_names = tui.compute_completions(".edit", ".edit".len()).await;
+    assert_eq!(
+        edit_names
+            .iter()
+            .filter(|(value, _)| value == ".edit message ")
+            .count(),
+        1,
+        "duplicate .edit message completion: {edit_names:?}"
+    );
+    let delete_names = tui.compute_completions(".delete", ".delete".len()).await;
+    assert_eq!(
+        delete_names
+            .iter()
+            .filter(|(value, _)| value == ".delete message ")
+            .count(),
+        1,
+        "duplicate .delete message completion: {delete_names:?}"
+    );
+
+    let mut edit_subcommands: Vec<String> = tui
+        .compute_completions(".edit ", ".edit ".len())
+        .await
+        .into_iter()
+        .map(|(value, _)| value)
+        .collect();
+    edit_subcommands.sort();
+    assert_eq!(
+        edit_subcommands,
+        ["agent", "config", "message", "rag-docs", "session"]
+    );
+
+    let mut delete_subcommands: Vec<String> = tui
+        .compute_completions(".delete ", ".delete ".len())
+        .await
+        .into_iter()
+        .map(|(value, _)| value)
+        .collect();
+    delete_subcommands.sort();
+    assert_eq!(
+        delete_subcommands,
+        ["agent", "agent-data", "macro", "message", "rag", "session"]
+    );
+}
+
+#[tokio::test]
 async fn apply_completion_preserves_text_after_cursor() {
     let config = test_config();
     let mut tui = Tui::init(&config).await.unwrap();

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -17,6 +17,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Notify;
 
+mod command_completion;
+
 fn yaml_to_json(yaml: &str) -> serde_json::Value {
     serde_yaml::from_str::<serde_json::Value>(yaml)
         .unwrap_or_else(|_| serde_json::Value::String(yaml.to_string()))
@@ -859,70 +861,6 @@ async fn compute_completions_title_offers_subcommands_not_usage_brackets() {
         prefix_values,
         vec!["generate"],
         "expected \".title g\" to complete to \"generate\", got: {prefix_values:?}"
-    );
-}
-
-#[tokio::test]
-async fn command_completions_separate_names_from_usage_and_offer_subcommands() {
-    let config = test_config();
-    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
-    let tui = Tui::init(&config, AsyncHookManager::new(), persistent)
-        .await
-        .unwrap();
-
-    for command in [".rewind", ".edit", ".delete", ".info"] {
-        let completions = tui.compute_completions(command, command.len()).await;
-        assert!(
-            completions
-                .iter()
-                .all(|(value, _)| !["<n>", "[server]", "[name]", "<n>-<m>"]
-                    .iter()
-                    .any(|usage| value.contains(usage))),
-            "{command} command completion contains a usage hint: {completions:?}"
-        );
-    }
-
-    let edit_names = tui.compute_completions(".edit", ".edit".len()).await;
-    assert_eq!(
-        edit_names
-            .iter()
-            .filter(|(value, _)| value == ".edit message ")
-            .count(),
-        1,
-        "duplicate .edit message completion: {edit_names:?}"
-    );
-    let delete_names = tui.compute_completions(".delete", ".delete".len()).await;
-    assert_eq!(
-        delete_names
-            .iter()
-            .filter(|(value, _)| value == ".delete message ")
-            .count(),
-        1,
-        "duplicate .delete message completion: {delete_names:?}"
-    );
-
-    let mut edit_subcommands: Vec<String> = tui
-        .compute_completions(".edit ", ".edit ".len())
-        .await
-        .into_iter()
-        .map(|(value, _)| value)
-        .collect();
-    edit_subcommands.sort();
-    assert_eq!(
-        edit_subcommands,
-        ["agent", "config", "message", "rag-docs", "session"]
-    );
-
-    let mut delete_subcommands: Vec<String> = tui
-        .compute_completions(".delete ", ".delete ".len())
-        .await
-        .into_iter()
-        .map(|(value, _)| value)
-        .collect();
-    delete_subcommands.sort();
-    assert_eq!(
-        delete_subcommands,
-        ["agent", "agent-data", "macro", "message", "rag", "session"]
     );
 }
 

--- a/crates/harnx-tui/src/tests/command_completion.rs
+++ b/crates/harnx-tui/src/tests/command_completion.rs
@@ -1,0 +1,64 @@
+//! Tab-completion behaviour for the `.`-prefixed commands.
+
+use super::*;
+
+#[tokio::test]
+async fn command_completions_separate_names_from_usage_and_offer_subcommands() {
+    let config = test_config();
+    let tui = Tui::init(&config).await.unwrap();
+
+    for command in [".rewind", ".edit", ".delete", ".info"] {
+        let completions = tui.compute_completions(command, command.len()).await;
+        assert!(
+            completions
+                .iter()
+                .all(|(value, _)| !["<n>", "[server]", "[name]", "<n>-<m>"]
+                    .iter()
+                    .any(|usage| value.contains(usage))),
+            "{command} command completion contains a usage hint: {completions:?}"
+        );
+    }
+
+    let edit_names = tui.compute_completions(".edit", ".edit".len()).await;
+    assert_eq!(
+        edit_names
+            .iter()
+            .filter(|(value, _)| value == ".edit message ")
+            .count(),
+        1,
+        "duplicate .edit message completion: {edit_names:?}"
+    );
+    let delete_names = tui.compute_completions(".delete", ".delete".len()).await;
+    assert_eq!(
+        delete_names
+            .iter()
+            .filter(|(value, _)| value == ".delete message ")
+            .count(),
+        1,
+        "duplicate .delete message completion: {delete_names:?}"
+    );
+
+    let mut edit_subcommands: Vec<String> = tui
+        .compute_completions(".edit ", ".edit ".len())
+        .await
+        .into_iter()
+        .map(|(value, _)| value)
+        .collect();
+    edit_subcommands.sort();
+    assert_eq!(
+        edit_subcommands,
+        ["agent", "config", "message", "rag-docs", "session"]
+    );
+
+    let mut delete_subcommands: Vec<String> = tui
+        .compute_completions(".delete ", ".delete ".len())
+        .await
+        .into_iter()
+        .map(|(value, _)| value)
+        .collect();
+    delete_subcommands.sort();
+    assert_eq!(
+        delete_subcommands,
+        ["agent", "agent-data", "macro", "message", "rag", "session"]
+    );
+}

--- a/docs/solutions/logic-errors/command-usage-field-separation-2026-07-24.md
+++ b/docs/solutions/logic-errors/command-usage-field-separation-2026-07-24.md
@@ -17,7 +17,7 @@ plan_ref: "decouple-command-usage-1168"
 ---
 ## Problem
 
-`Command.name` in the `COMMANDS` table doubled as both the dispatch/completion key and the `.help` usage-hint display. Commands whose names embedded usage syntax (e.g. `.rewind <n>`, `.edit message <n>`, `.info mcp [server]`) tab-completed to the literal usage string instead of a real command.
+`Command.name` in the `COMMANDS` table doubled as both the dispatch/completion key and the `.help` usage-hint display. Commands whose names embedded usage syntax (e.g. `.rewind <n>`, `.edit message <n>`, `.info env [name]`) tab-completed to the literal usage string instead of a real command.
 
 ## Symptoms
 
@@ -65,7 +65,7 @@ impl Command {
 }
 ```
 
-Names are now bare dispatch keys (`.rewind`, `.edit message`, `.info mcp`). `dump_help` recombines:
+Names are now bare dispatch keys (`.rewind`, `.edit message`, `.info env`). `dump_help` recombines:
 
 ```rust
 fn dump_help(output: &mut (dyn Write + Send)) -> Result<()> {
@@ -102,7 +102,7 @@ This follows the earlier `.title` fix in PR #103 but solves the problem at the d
 ## Prevention Strategies
 
 **Test Cases:**
-- `command_completions_separate_names_from_usage_and_offer_subcommands` in `harnx-tui/src/tests.rs` asserts:
+- `command_completions_separate_names_from_usage_and_offer_subcommands` in `harnx-tui/src/tests/command_completion.rs` asserts:
   - Completions never contain `<n>`, `[server]`, `[name]`, `<n>-<m>`
   - Deduplication: `.edit message` and `.delete message` appear exactly once
   - Subcommand sets are exact (`.edit`, `.delete` arms)

--- a/docs/solutions/logic-errors/command-usage-field-separation-2026-07-24.md
+++ b/docs/solutions/logic-errors/command-usage-field-separation-2026-07-24.md
@@ -1,0 +1,124 @@
+---
+title: "Separate Command.name from usage hints — eliminate completion-to-literal-syntax bug"
+date: 2026-07-24
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-runtime, harnx-tui"
+root_cause: "Single Command.name field overloaded as both dispatch/completion key and help display"
+resolution_type: code_fix
+severity: medium
+tags:
+  - tui
+  - completion
+  - dot-commands
+  - data-structure-design
+  - separation-of-concerns
+plan_ref: "decouple-command-usage-1168"
+---
+## Problem
+
+`Command.name` in the `COMMANDS` table doubled as both the dispatch/completion key and the `.help` usage-hint display. Commands whose names embedded usage syntax (e.g. `.rewind <n>`, `.edit message <n>`, `.info mcp [server]`) tab-completed to the literal usage string instead of a real command.
+
+## Symptoms
+
+- Typing `.rew` and pressing TAB completed to `.rewind <n> ` instead of `.rewind ` — the `<n>` placeholder appeared in the input buffer
+- `.edit message ` and `.delete message ` appeared twice in first-word completions due to name collision
+- Subcommand completion arms for `.edit` and `.delete` were incomplete (missing `message`)
+- Help output showed correct syntax, but completions polluted with placeholder tokens
+
+## Investigation Steps
+
+1. Traced `compute_completions` in `harnx-tui/src/input.rs` — first-word completion iterated `COMMANDS` and matched on `c.name.starts_with(filter)`
+2. Found `COMMANDS` entries like `Command::new(".rewind <n>", "Rewind session...")` where the name literal included syntax
+3. Inspected `dump_help` — already formatted `name + usage` concepts but relied on string parsing
+4. Reviewed earlier PR #103 fix for `.title [generate|now]` — same bug class, patched ad-hoc in completion logic
+5. Recognized systematic issue: one field serving two roles
+
+## Root Cause
+
+`Command` struct used a single `name` field for both:
+1. **Dispatch key** — matching user input, routing to handlers
+2. **Help display** — showing argument syntax in `.help` output
+
+Overloading caused completion logic to offer literal `<n>`, `[server]`, `<n>-<m>` tokens as completions. Multiple commands sharing name prefix (`.edit message`, `.edit session`) produced duplicate entries because deduplication was on full name.
+
+## Solution
+
+Added dedicated `usage: Option<&'static str>` field to `Command` struct:
+
+```rust
+#[derive(Debug, Clone)]
+pub struct Command {
+    pub name: &'static str,
+    pub usage: Option<&'static str>,
+    pub description: &'static str,
+}
+
+impl Command {
+    const fn new(name: &'static str, desc: &'static str) -> Self {
+        Self { name, usage: None, description: desc }
+    }
+
+    const fn with_usage(name: &'static str, usage: &'static str, desc: &'static str) -> Self {
+        Self { name, usage: Some(usage), description: desc }
+    }
+}
+```
+
+Names are now bare dispatch keys (`.rewind`, `.edit message`, `.info mcp`). `dump_help` recombines:
+
+```rust
+fn dump_help(output: &mut (dyn Write + Send)) -> Result<()> {
+    let head = COMMANDS.iter().map(|cmd| {
+        let label = match cmd.usage {
+            Some(usage) => format!("{} {usage}", cmd.name),
+            None => cmd.name.to_string(),
+        };
+        format!("{label:<24} {}", cmd.description)
+    });
+    // ...
+}
+```
+
+First-word completion in `input.rs` deduplicates by bare name:
+
+```rust
+let mut seen = HashSet::new();
+let commands: Vec<_> = COMMANDS
+    .iter()
+    .filter(|c| c.name.starts_with(filter) && seen.insert(c.name))
+    .map(|c| (format!("{} ", c.name), Some(c.description.to_string())))
+    .collect();
+```
+
+Added real subcommand completion arms in `completion_split.rs` for `.edit` and `.delete` (added `message`).
+
+## Why This Works
+
+Separating the machine key (`name`) from the human display (`usage`) eliminates the entire bug class structurally. Completion logic now operates on clean keys, help formatting combines for display. The `seen` HashSet deduplication handles cases where multiple usage variants share a base command (`.edit message`, `.edit session`).
+
+This follows the earlier `.title` fix in PR #103 but solves the problem at the data-structure level instead of patching completion logic per-command.
+
+## Prevention Strategies
+
+**Test Cases:**
+- `command_completions_separate_names_from_usage_and_offer_subcommands` in `harnx-tui/src/tests.rs` asserts:
+  - Completions never contain `<n>`, `[server]`, `[name]`, `<n>-<m>`
+  - Deduplication: `.edit message` and `.delete message` appear exactly once
+  - Subcommand sets are exact (`.edit`, `.delete` arms)
+
+**Code Review Checklist:**
+- [ ] Do struct fields have single, clear purposes?
+- [ ] Is display-formatted data derived from normalized keys?
+- [ ] Are completion keys machine-friendly (no placeholders)?
+
+**Best Practices:**
+- Never overload one field as both machine key and human display
+- When `.help` shows formatted data, derive it from normalized storage
+- Regression tests for "completion never contains placeholder" patterns
+
+## Related Issues
+
+- **Issue:** [#1168](https://github.com/dobesv/harnx/issues/1168) — Command usage regression
+- **Earlier Fix:** PR #103 — `.title` command similar bug, patched ad-hoc
+- **Related Solution:** [logic-errors/dot-commands-picker-signals-2026-05-10.md](./dot-commands-picker-signals-2026-05-10.md) — Runtime-TUI command contract


### PR DESCRIPTION
Decouple `Command.name` from human-readable usage hints by adding a dedicated `usage: Option<&'static str>` field and `with_usage()` constructor. Commands whose registered names previously embedded placeholder syntax (e.g., `.rewind <n>`, `.edit message <n>`, `.info mcp [server]`) now use bare dispatch keys for `name`, preventing TUI tab-completion from inserting literal usage brackets into prompts while `dump_help()` recombines `name` and `usage` to maintain byte-identical help output formatting.

- Add `Command.usage` field, `with_usage()` constructor, and bare-name split for affected commands in `commands.rs`.
- Add `HashSet` deduplication for first-word completions in `input.rs` to filter duplicate bare command names.
- Add second-word subcommand completions for `.edit` and `.delete` in `completion_split.rs`.
- Add automated regression tests in `tests.rs` asserting bracket-free completion candidates and subcommand parity.
- Add changeset `.changeset/command-usage-decoupling.md` and solution document `docs/solutions/logic-errors/command-usage-field-separation-2026-07-24.md`.

Closes #1168
Follow-up from .title fix in #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command and subcommand tab completion.
  * Prevented usage placeholders such as `<n>` and `[name]` from appearing as completion suggestions.
  * Removed duplicate command entries from completion results.
  * Added missing subcommand suggestions for `.edit` and `.delete`.
  * Ensured completion suggestions remain accurate and consistently ordered.

* **Help**
  * Command help now displays argument and usage hints correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->