### PR TITLE
feat(events): introduce AgentEvent::SubAgent for structural routing

### DIFF
--- a/.changeset/tui_sub_agent_events_no_longer_clear_busy_state.md
+++ b/.changeset/tui_sub_agent_events_no_longer_clear_busy_state.md
@@ -1,0 +1,5 @@
+---
+harnx: patch
+---
+
+Fix the TUI incorrectly switching to idle state while a prompt task is still active. Sub-agent events are now represented using a structural `AgentEvent::SubAgent` variant, replacing out-of-band source tracking. When a nested sub-agent completes or fails, its output is rendered under its own source heading without clearing the main task's busy spinner.

--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -86,7 +86,7 @@ struct AcpChunkSink {
 }
 
 impl harnx_core::event::AgentEventSink for AcpChunkSink {
-    fn emit(&self, event: AgentEvent, source: Option<AgentSource>) {
+    fn emit(&self, event: AgentEvent) {
         // Source headings are NOT injected into the chunk stream here.
         // Sending `> agent ▸ session` as an `AgentMessageChunk` would
         // pollute the parent's accumulated `response_text` (which forms
@@ -94,7 +94,7 @@ impl harnx_core::event::AgentEventSink for AcpChunkSink {
         // notification`). The parent's UI reconstructs source from the
         // chunk's `meta` (set by `send_notify_text` /
         // `send_notify_tool_call`) and renders the heading itself.
-        if let Some(forward) = event_to_forward(event, source) {
+        if let Some(forward) = event_to_forward(event, None) {
             let _ = self.tx.send(forward);
         }
     }
@@ -176,6 +176,10 @@ pub(crate) fn event_to_forward(
             };
             forwarded.map(|(prefix, msg)| AcpForward::Text(format!("{prefix} {msg}"), source))
         }
+        AgentEvent::SubAgent {
+            source: sub_source,
+            event,
+        } => event_to_forward(*event, Some(sub_source)),
         _ => None,
     }
 }

--- a/crates/harnx-acp-server/src/lib_tests.rs
+++ b/crates/harnx-acp-server/src/lib_tests.rs
@@ -356,24 +356,18 @@ mod tests {
         let (tx, mut rx) = unbounded_channel::<AcpForward>();
         let sink = AcpChunkSink { tx };
 
-        sink.emit(
-            AgentEvent::Tool(ToolEvent::Completed {
-                id: "call-1".to_string(),
-                output: serde_json::json!({"text": "result"}),
-                markdown: Some("**result**".to_string()),
-            }),
-            None,
-        );
+        sink.emit(AgentEvent::Tool(ToolEvent::Completed {
+            id: "call-1".to_string(),
+            output: serde_json::json!({"text": "result"}),
+            markdown: Some("**result**".to_string()),
+        }));
 
-        sink.emit(
-            AgentEvent::Tool(ToolEvent::Update {
-                id: "call-1".to_string(),
-                markdown: None,
-                status: Some(ToolStatus::InProgress),
-                content: None,
-            }),
-            None,
-        );
+        sink.emit(AgentEvent::Tool(ToolEvent::Update {
+            id: "call-1".to_string(),
+            markdown: None,
+            status: Some(ToolStatus::InProgress),
+            content: None,
+        }));
 
         let completed = rx.try_recv().expect("should have ToolCompleted");
         let update = rx.try_recv().expect("should have ToolUpdate");
@@ -405,12 +399,9 @@ mod tests {
         let (tx, mut rx) = unbounded_channel::<AcpForward>();
         let sink = AcpChunkSink { tx };
 
-        sink.emit(
-            AgentEvent::User(UserEvent::Message {
-                content: "hello user".to_string(),
-            }),
-            None,
-        );
+        sink.emit(AgentEvent::User(UserEvent::Message {
+            content: "hello user".to_string(),
+        }));
 
         match rx.try_recv().expect("should forward user text") {
             AcpForward::UserText(text, source) => {
@@ -420,12 +411,9 @@ mod tests {
             _ => panic!("expected UserText forward"),
         }
 
-        sink.emit(
-            AgentEvent::User(UserEvent::Message {
-                content: String::new(),
-            }),
-            None,
-        );
+        sink.emit(AgentEvent::User(UserEvent::Message {
+            content: String::new(),
+        }));
 
         assert!(
             rx.try_recv().is_err(),
@@ -438,12 +426,9 @@ mod tests {
         let (tx, mut rx) = unbounded_channel::<AcpForward>();
         let sink = AcpChunkSink { tx };
 
-        sink.emit(
-            AgentEvent::Model(harnx_core::event::ModelEvent::Error(
-                "Internal server error".to_string(),
-            )),
-            None,
-        );
+        sink.emit(AgentEvent::Model(harnx_core::event::ModelEvent::Error(
+            "Internal server error".to_string(),
+        )));
 
         match rx.try_recv().expect("should forward error text") {
             AcpForward::Error(text, source) => {

--- a/crates/harnx-acp/src/client.rs
+++ b/crates/harnx-acp/src/client.rs
@@ -131,21 +131,21 @@ impl AcpNotificationClient {
     }
 
     async fn forward_agent_event(&self, event: AgentEvent, source: AgentSource) {
+        let event = AgentEvent::sub_agent(source.clone(), event);
         let mut forwarders = self.chunk_forwarder.write().await;
         let mut forwarded_to_chunk = false;
-        forwarders.retain(|_, tx| {
-            match tx.send(NestedAcpEvent::Agent(event.clone(), Some(source.clone()))) {
+        forwarders.retain(
+            |_, tx| match tx.send(NestedAcpEvent::Agent(event.clone())) {
                 Ok(()) => {
                     forwarded_to_chunk = true;
                     true
                 }
                 Err(_) => false,
-            }
-        });
+            },
+        );
 
         if !forwarded_to_chunk {
-            use harnx_core::sink::emit_agent_event_with_source;
-            emit_agent_event_with_source(event, Some(source));
+            harnx_core::sink::emit_agent_event(event);
         }
     }
 
@@ -1244,6 +1244,15 @@ mod tests {
     };
     use serde_json::json;
 
+    fn unwrap_sub_agent_event(event: NestedAcpEvent) -> NestedAcpEvent {
+        match event {
+            NestedAcpEvent::Agent(AgentEvent::SubAgent { event, .. }) => {
+                NestedAcpEvent::Agent(*event)
+            }
+            event => event,
+        }
+    }
+
     #[test]
     fn session_info_update_event_emits_usage_model_event() {
         let info = SessionInfoUpdate::new().meta(serde_json::Map::from_iter([(
@@ -1425,8 +1434,14 @@ mod tests {
         client.session_notification(notification).await.unwrap();
 
         let forwarded = chunk_rx.recv().await.expect("forwarded nested ACP event");
-        let (forwarded_event, forwarded_source) = match forwarded {
-            NestedAcpEvent::Agent(event, source) => (event, source),
+
+        let forwarded_source = match &forwarded {
+            NestedAcpEvent::Agent(AgentEvent::SubAgent { source, .. }) => Some(source.clone()),
+            _ => None,
+        };
+        let forwarded = unwrap_sub_agent_event(forwarded);
+        let forwarded_event = match forwarded {
+            NestedAcpEvent::Agent(event) => event,
             other => panic!("unexpected nested ACP event: {other:?}"),
         };
 
@@ -1498,8 +1513,14 @@ mod tests {
         client.session_notification(notification).await.unwrap();
 
         let forwarded = chunk_rx.recv().await.expect("forwarded nested ACP event");
-        let (forwarded_event, forwarded_source) = match forwarded {
-            NestedAcpEvent::Agent(event, source) => (event, source),
+
+        let forwarded_source = match &forwarded {
+            NestedAcpEvent::Agent(AgentEvent::SubAgent { source, .. }) => Some(source.clone()),
+            _ => None,
+        };
+        let forwarded = unwrap_sub_agent_event(forwarded);
+        let forwarded_event = match forwarded {
+            NestedAcpEvent::Agent(event) => event,
             other => panic!("unexpected nested ACP event: {other:?}"),
         };
 
@@ -1557,8 +1578,14 @@ mod tests {
         client.session_notification(notification).await.unwrap();
 
         let forwarded = chunk_rx.recv().await.expect("forwarded nested ACP event");
-        let (forwarded_event, forwarded_source) = match forwarded {
-            NestedAcpEvent::Agent(event, source) => (event, source),
+
+        let forwarded_source = match &forwarded {
+            NestedAcpEvent::Agent(AgentEvent::SubAgent { source, .. }) => Some(source.clone()),
+            _ => None,
+        };
+        let forwarded = unwrap_sub_agent_event(forwarded);
+        let forwarded_event = match forwarded {
+            NestedAcpEvent::Agent(event) => event,
             other => panic!("unexpected nested ACP event: {other:?}"),
         };
 
@@ -1619,9 +1646,8 @@ mod tests {
             .await
             .expect("session notification should succeed");
 
-        let NestedAcpEvent::Agent(forwarded_event, _) =
-            chunk_rx.recv().await.expect("forwarded nested ACP event")
-        else {
+        let forwarded = chunk_rx.recv().await.expect("forwarded nested ACP event");
+        let NestedAcpEvent::Agent(forwarded_event) = unwrap_sub_agent_event(forwarded) else {
             panic!("unexpected nested ACP event");
         };
 
@@ -1666,8 +1692,10 @@ mod tests {
         client.session_notification(notification).await.unwrap();
 
         let forwarded = chunk_rx.recv().await.expect("forwarded nested ACP event");
-        let (forwarded_event, _) = match forwarded {
-            NestedAcpEvent::Agent(event, source) => (event, source),
+
+        let forwarded = unwrap_sub_agent_event(forwarded);
+        let forwarded_event = match forwarded {
+            NestedAcpEvent::Agent(event) => event,
             other => panic!("unexpected nested ACP event: {other:?}"),
         };
 
@@ -1716,11 +1744,10 @@ mod tests {
         let mut received = String::new();
         for _ in 0..pieces.len() {
             let forwarded = chunk_rx.recv().await.expect("forwarded chunk");
+
+            let forwarded = unwrap_sub_agent_event(forwarded);
             match forwarded {
-                NestedAcpEvent::Agent(
-                    AgentEvent::Model(ModelEvent::MessageChunk { blocks }),
-                    _,
-                ) => {
+                NestedAcpEvent::Agent(AgentEvent::Model(ModelEvent::MessageChunk { blocks })) => {
                     for b in &blocks {
                         if let ContentBlock::Text(t) = b {
                             received.push_str(t);
@@ -1768,8 +1795,10 @@ mod tests {
         client.session_notification(notification).await.unwrap();
 
         let forwarded = chunk_rx.recv().await.expect("forwarded user chunk");
+
+        let forwarded = unwrap_sub_agent_event(forwarded);
         match forwarded {
-            NestedAcpEvent::Agent(AgentEvent::User(UserEvent::Message { content }), _) => {
+            NestedAcpEvent::Agent(AgentEvent::User(UserEvent::Message { content })) => {
                 assert_eq!(content, "hello from attach");
             }
             other => panic!("unexpected nested ACP event: {other:?}"),
@@ -1813,11 +1842,10 @@ mod tests {
         let mut received = String::new();
         for _ in 0..3 {
             let forwarded = chunk_rx.recv().await.expect("forwarded thought chunk");
+
+            let forwarded = unwrap_sub_agent_event(forwarded);
             match forwarded {
-                NestedAcpEvent::Agent(
-                    AgentEvent::Model(ModelEvent::ThoughtChunk { blocks }),
-                    _,
-                ) => {
+                NestedAcpEvent::Agent(AgentEvent::Model(ModelEvent::ThoughtChunk { blocks })) => {
                     for b in &blocks {
                         if let ContentBlock::Text(t) = b {
                             received.push_str(t);
@@ -1859,8 +1887,10 @@ mod tests {
         client.session_notification(notification).await.unwrap();
 
         let forwarded = chunk_rx.recv().await.expect("forwarded error chunk");
+
+        let forwarded = unwrap_sub_agent_event(forwarded);
         match forwarded {
-            NestedAcpEvent::Agent(AgentEvent::Model(ModelEvent::Error(message)), _) => {
+            NestedAcpEvent::Agent(AgentEvent::Model(ModelEvent::Error(message))) => {
                 assert_eq!(message, "upstream failed");
             }
             other => panic!("unexpected nested ACP event: {other:?}"),
@@ -1900,8 +1930,10 @@ mod tests {
         client.session_notification(notification).await.unwrap();
 
         let forwarded = chunk_rx.recv().await.expect("forwarded message chunk");
+
+        let forwarded = unwrap_sub_agent_event(forwarded);
         match forwarded {
-            NestedAcpEvent::Agent(AgentEvent::Model(ModelEvent::MessageChunk { .. }), _) => {}
+            NestedAcpEvent::Agent(AgentEvent::Model(ModelEvent::MessageChunk { .. })) => {}
             other => panic!("unexpected nested ACP event: {other:?}"),
         }
 
@@ -1938,8 +1970,10 @@ mod tests {
         client.session_notification(notification).await.unwrap();
 
         let forwarded = chunk_rx.recv().await.expect("forwarded message chunk");
+
+        let forwarded = unwrap_sub_agent_event(forwarded);
         match forwarded {
-            NestedAcpEvent::Agent(AgentEvent::Model(ModelEvent::MessageChunk { .. }), _) => {}
+            NestedAcpEvent::Agent(AgentEvent::Model(ModelEvent::MessageChunk { .. })) => {}
             other => panic!("unexpected nested ACP event: {other:?}"),
         }
 
@@ -1973,8 +2007,10 @@ mod tests {
         client.session_notification(notification).await.unwrap();
 
         let forwarded = chunk_rx.recv().await.expect("forwarded error chunk");
+
+        let forwarded = unwrap_sub_agent_event(forwarded);
         match forwarded {
-            NestedAcpEvent::Agent(AgentEvent::Model(ModelEvent::Error(message)), _) => {
+            NestedAcpEvent::Agent(AgentEvent::Model(ModelEvent::Error(message))) => {
                 assert_eq!(message, "bare failure");
             }
             other => panic!("unexpected nested ACP event: {other:?}"),

--- a/crates/harnx-acp/src/client.rs
+++ b/crates/harnx-acp/src/client.rs
@@ -131,7 +131,7 @@ impl AcpNotificationClient {
     }
 
     async fn forward_agent_event(&self, event: AgentEvent, source: AgentSource) {
-        let event = AgentEvent::sub_agent(source.clone(), event);
+        let event = AgentEvent::sub_agent(source, event);
         let mut forwarders = self.chunk_forwarder.write().await;
         let mut forwarded_to_chunk = false;
         forwarders.retain(

--- a/crates/harnx-acp/src/event.rs
+++ b/crates/harnx-acp/src/event.rs
@@ -1,8 +1,8 @@
-use harnx_core::event::{AgentEvent, AgentSource};
+use harnx_core::event::AgentEvent;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum NestedAcpEvent {
     Text(String),
-    Agent(AgentEvent, Option<AgentSource>),
+    Agent(AgentEvent),
 }

--- a/crates/harnx-acp/src/manager.rs
+++ b/crates/harnx-acp/src/manager.rs
@@ -530,17 +530,17 @@ pub async fn forward_acp_chunks(
     spinner_msg: String,
 ) {
     use harnx_core::event::{AgentEvent, NoticeEvent};
-    use harnx_core::sink::emit_agent_event_with_source;
+    use harnx_core::sink::emit_agent_event;
 
     while let Some(chunk) = chunk_rx.recv().await {
         if let Some(ref s) = spinner {
             s.pause();
         }
-        let (event, source) = match chunk {
-            NestedAcpEvent::Agent(event, source) => (event, source),
-            NestedAcpEvent::Text(text) => (AgentEvent::Notice(NoticeEvent::Info(text)), None),
+        let event = match chunk {
+            NestedAcpEvent::Agent(event) => event,
+            NestedAcpEvent::Text(text) => AgentEvent::Notice(NoticeEvent::Info(text)),
         };
-        emit_agent_event_with_source(event, source);
+        emit_agent_event(event);
         if let Some(ref s) = spinner {
             let _ = s.set_message(spinner_msg.clone());
         }
@@ -1166,7 +1166,11 @@ enabled: false
             events: Mutex<Vec<(AgentEvent, Option<AgentSource>)>>,
         }
         impl AgentEventSink for CollectingSink {
-            fn emit(&self, event: AgentEvent, source: Option<AgentSource>) {
+            fn emit(&self, event: AgentEvent) {
+                let (event, source) = match event {
+                    AgentEvent::SubAgent { source, event } => (*event, Some(source)),
+                    event => (event, None),
+                };
                 self.events.lock().unwrap().push((event, source));
             }
         }
@@ -1187,32 +1191,32 @@ enabled: false
         let _cleanup = SinkCleanupGuard;
 
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        tx.send(NestedAcpEvent::Agent(
+        tx.send(NestedAcpEvent::Agent(AgentEvent::sub_agent(
+            AgentSource {
+                agent: "sub-agent".to_string(),
+                session_id: Some("session-1".to_string()),
+                model: None,
+            },
             AgentEvent::Tool(ToolEvent::Completed {
                 id: "call-1".to_string(),
                 output: json!({"text": "done"}),
                 markdown: None,
             }),
-            Some(AgentSource {
+        )))
+        .expect("send tool completed event");
+        tx.send(NestedAcpEvent::Agent(AgentEvent::sub_agent(
+            AgentSource {
                 agent: "sub-agent".to_string(),
                 session_id: Some("session-1".to_string()),
                 model: None,
-            }),
-        ))
-        .expect("send tool completed event");
-        tx.send(NestedAcpEvent::Agent(
+            },
             AgentEvent::Tool(ToolEvent::Update {
                 id: "call-1".to_string(),
                 markdown: None,
                 status: Some(ToolStatus::InProgress),
                 content: None,
             }),
-            Some(AgentSource {
-                agent: "sub-agent".to_string(),
-                session_id: Some("session-1".to_string()),
-                model: None,
-            }),
-        ))
+        )))
         .expect("send tool update event");
         drop(tx);
 
@@ -1251,7 +1255,11 @@ enabled: false
             events: Mutex<Vec<(AgentEvent, Option<AgentSource>)>>,
         }
         impl AgentEventSink for CollectingSink {
-            fn emit(&self, event: AgentEvent, source: Option<AgentSource>) {
+            fn emit(&self, event: AgentEvent) {
+                let (event, source) = match event {
+                    AgentEvent::SubAgent { source, event } => (*event, Some(source)),
+                    event => (event, None),
+                };
                 self.events.lock().unwrap().push((event, source));
             }
         }
@@ -1264,7 +1272,12 @@ enabled: false
 
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
-        tx.send(NestedAcpEvent::Agent(
+        tx.send(NestedAcpEvent::Agent(AgentEvent::sub_agent(
+            AgentSource {
+                agent: "argus".to_string(),
+                session_id: Some("sub-session-1".to_string()),
+                model: None,
+            },
             AgentEvent::Tool(ToolEvent::Started {
                 id: String::new(),
                 name: "read_file".to_string(),
@@ -1273,12 +1286,7 @@ enabled: false
                 input: serde_json::json!({"path": "/tmp/x.txt"}),
                 locations: vec![],
             }),
-            Some(AgentSource {
-                agent: "argus".to_string(),
-                session_id: Some("sub-session-1".to_string()),
-                model: None,
-            }),
-        ))
+        )))
         .unwrap();
         tx.send(NestedAcpEvent::Text("plain text notification".to_string()))
             .unwrap();
@@ -1324,7 +1332,11 @@ enabled: false
             events: Mutex<Vec<(AgentEvent, Option<AgentSource>)>>,
         }
         impl AgentEventSink for CollectingSink {
-            fn emit(&self, event: AgentEvent, source: Option<AgentSource>) {
+            fn emit(&self, event: AgentEvent) {
+                let (event, source) = match event {
+                    AgentEvent::SubAgent { source, event } => (*event, Some(source)),
+                    event => (event, None),
+                };
                 self.events.lock().unwrap().push((event, source));
             }
         }
@@ -1345,10 +1357,10 @@ enabled: false
             model: None,
         };
 
-        tx.send(NestedAcpEvent::Agent(
+        tx.send(NestedAcpEvent::Agent(AgentEvent::sub_agent(
+            source.clone(),
             AgentEvent::Model(ModelEvent::Error(formatted_error.to_string())),
-            Some(source.clone()),
-        ))
+        )))
         .unwrap();
         drop(tx);
 
@@ -1401,12 +1413,9 @@ enabled: false
             .await;
 
         // Send one event through alpha's forwarder.
-        let event = NestedAcpEvent::Agent(
-            harnx_core::event::AgentEvent::Notice(harnx_core::event::NoticeEvent::Info(
-                "from alpha".to_string(),
-            )),
-            None,
-        );
+        let event = NestedAcpEvent::Agent(harnx_core::event::AgentEvent::Notice(
+            harnx_core::event::NoticeEvent::Info("from alpha".to_string()),
+        ));
         send_tx
             .send(event)
             .expect("send event into alpha forwarder");
@@ -1418,12 +1427,9 @@ enabled: false
             .await
             .expect("alpha_rx must receive the injected event");
         match received {
-            NestedAcpEvent::Agent(
-                harnx_core::event::AgentEvent::Notice(harnx_core::event::NoticeEvent::Info(
-                    ref msg,
-                )),
-                None,
-            ) => assert_eq!(msg, "from alpha"),
+            NestedAcpEvent::Agent(harnx_core::event::AgentEvent::Notice(
+                harnx_core::event::NoticeEvent::Info(ref msg),
+            )) => assert_eq!(msg, "from alpha"),
             other => panic!("unexpected event in alpha_rx: {other:?}"),
         }
 
@@ -1471,7 +1477,6 @@ enabled: false
                 harnx_core::event::AgentEvent::Notice(harnx_core::event::NoticeEvent::Info(
                     "from alpha-broad".to_string(),
                 )),
-                None,
             ))
             .expect("send alpha broad event");
         drop(alpha_send);
@@ -1481,12 +1486,9 @@ enabled: false
             .await
             .expect("alpha entry must deliver event")
         {
-            NestedAcpEvent::Agent(
-                harnx_core::event::AgentEvent::Notice(harnx_core::event::NoticeEvent::Info(
-                    ref msg,
-                )),
-                None,
-            ) => assert_eq!(msg, "from alpha-broad"),
+            NestedAcpEvent::Agent(harnx_core::event::AgentEvent::Notice(
+                harnx_core::event::NoticeEvent::Info(ref msg),
+            )) => assert_eq!(msg, "from alpha-broad"),
             other => panic!("unexpected alpha-broad event: {other:?}"),
         }
 
@@ -1500,18 +1502,14 @@ enabled: false
                 harnx_core::event::AgentEvent::Notice(harnx_core::event::NoticeEvent::Info(
                     "from beta-broad".to_string(),
                 )),
-                None,
             ))
             .expect("send beta broad event");
         drop(beta_send);
 
         match beta_rx.recv().await.expect("beta entry must deliver event") {
-            NestedAcpEvent::Agent(
-                harnx_core::event::AgentEvent::Notice(harnx_core::event::NoticeEvent::Info(
-                    ref msg,
-                )),
-                None,
-            ) => assert_eq!(msg, "from beta-broad"),
+            NestedAcpEvent::Agent(harnx_core::event::AgentEvent::Notice(
+                harnx_core::event::NoticeEvent::Info(ref msg),
+            )) => assert_eq!(msg, "from beta-broad"),
             other => panic!("unexpected beta-broad event: {other:?}"),
         }
 

--- a/crates/harnx-core/src/event.rs
+++ b/crates/harnx-core/src/event.rs
@@ -24,7 +24,33 @@ pub enum AgentEvent {
     Notice(NoticeEvent),
     User(UserEvent),
     Status(StatusLine),
-    Plan { entries: Vec<PlanEntry> },
+    Plan {
+        entries: Vec<PlanEntry>,
+    },
+    SubAgent {
+        source: AgentSource,
+        event: Box<AgentEvent>,
+    },
+}
+
+impl AgentEvent {
+    /// Wraps an event from a sub-agent, preserving the innermost existing source.
+    pub fn sub_agent(source: AgentSource, event: AgentEvent) -> AgentEvent {
+        let mut source = source;
+        let mut event = event;
+        while let AgentEvent::SubAgent {
+            source: existing,
+            event: inner,
+        } = event
+        {
+            source = existing;
+            event = *inner;
+        }
+        AgentEvent::SubAgent {
+            source,
+            event: Box::new(event),
+        }
+    }
 }
 
 // --- sub-enums ---------------------------------------------------------------
@@ -253,7 +279,7 @@ pub struct AgentHandoff {
 /// and installed on the `SessionCtx`. The trait is object-safe so the
 /// sink can be held as `Arc<dyn AgentEventSink>`.
 pub trait AgentEventSink: Send + Sync {
-    fn emit(&self, event: AgentEvent, source: Option<AgentSource>);
+    fn emit(&self, event: AgentEvent);
 }
 
 /// A no-op sink useful for tests or code paths that run before a real sink
@@ -262,7 +288,7 @@ pub trait AgentEventSink: Send + Sync {
 pub struct NullSink;
 
 impl AgentEventSink for NullSink {
-    fn emit(&self, _event: AgentEvent, _source: Option<AgentSource>) {}
+    fn emit(&self, _event: AgentEvent) {}
 }
 
 impl AgentSource {
@@ -295,9 +321,94 @@ mod tests {
     }
 
     #[test]
+    fn sub_agent_wraps_bare_event() {
+        let source = AgentSource {
+            agent: "argus".into(),
+            session_id: Some("session-1".into()),
+            model: None,
+        };
+
+        match AgentEvent::sub_agent(
+            source.clone(),
+            AgentEvent::Model(ModelEvent::Error("failed".into())),
+        ) {
+            AgentEvent::SubAgent {
+                source: actual,
+                event,
+            } => {
+                assert_eq!(actual, source);
+                assert!(matches!(*event, AgentEvent::Model(ModelEvent::Error(_))));
+            }
+            other => panic!("expected sub-agent event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sub_agent_flattens_repeated_wrapping_preserving_innermost_source() {
+        let inner_source = AgentSource {
+            agent: "inner".into(),
+            session_id: None,
+            model: None,
+        };
+        let outer_source = AgentSource {
+            agent: "outer".into(),
+            session_id: Some("session-2".into()),
+            model: Some("model".into()),
+        };
+        let model_event = AgentEvent::Model(ModelEvent::Error("failed".into()));
+        let event = AgentEvent::sub_agent(
+            outer_source,
+            AgentEvent::sub_agent(inner_source.clone(), model_event),
+        );
+
+        match event {
+            AgentEvent::SubAgent { source, event } => {
+                assert_eq!(source, inner_source);
+                assert!(matches!(*event, AgentEvent::Model(ModelEvent::Error(_))));
+            }
+            other => panic!("expected flattened sub-agent event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sub_agent_preserves_analyst_source_when_researcher_wraps_final() {
+        let analyst_source = AgentSource {
+            agent: "analyst".into(),
+            session_id: Some("analyst-session".into()),
+            model: None,
+        };
+        let researcher_source = AgentSource {
+            agent: "researcher".into(),
+            session_id: Some("researcher-session".into()),
+            model: None,
+        };
+        let event = AgentEvent::sub_agent(
+            researcher_source,
+            AgentEvent::sub_agent(
+                analyst_source.clone(),
+                AgentEvent::Model(ModelEvent::Final {
+                    output: "Analyst complete".into(),
+                    usage: CompletionTokenUsage::default(),
+                }),
+            ),
+        );
+
+        match event {
+            AgentEvent::SubAgent { source, event } => {
+                assert_eq!(source, analyst_source);
+                assert!(matches!(
+                    *event,
+                    AgentEvent::Model(ModelEvent::Final { .. })
+                ));
+            }
+            other => panic!("expected flattened analyst event, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn null_sink_accepts_events() {
         let sink: Box<dyn AgentEventSink> = Box::new(NullSink);
-        sink.emit(AgentEvent::Turn(TurnEvent::Started), None);
+        sink.emit(AgentEvent::Turn(TurnEvent::Started));
     }
 
     #[test]
@@ -334,18 +445,6 @@ mod tests {
         let decoded: AgentSource = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.agent, "argus");
         assert_eq!(decoded.session_id.as_deref(), Some("session-1"));
-    }
-
-    #[test]
-    fn null_sink_accepts_source() {
-        let sink: Box<dyn AgentEventSink> = Box::new(NullSink);
-        let source = AgentSource {
-            agent: "argus".to_string(),
-            session_id: None,
-            model: None,
-        };
-        sink.emit(AgentEvent::Turn(TurnEvent::Started), Some(source));
-        sink.emit(AgentEvent::Turn(TurnEvent::Started), None);
     }
 
     #[test]

--- a/crates/harnx-core/src/sink.rs
+++ b/crates/harnx-core/src/sink.rs
@@ -20,7 +20,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use crate::event::{AgentEvent, AgentEventSink, AgentSource};
+use crate::event::{AgentEvent, AgentEventSink};
 
 tokio::task_local! {
     static SCOPED_SINK: Arc<dyn AgentEventSink>;
@@ -35,7 +35,7 @@ const PENDING_EVENTS_CAP: usize = 64;
 
 struct SinkState {
     sink: Option<Arc<dyn AgentEventSink>>,
-    pending: Vec<(AgentEvent, Option<AgentSource>)>,
+    pending: Vec<AgentEvent>,
 }
 
 impl SinkState {
@@ -61,8 +61,8 @@ pub fn install_agent_event_sink(sink: Arc<dyn AgentEventSink>) {
         guard.sink = Some(sink.clone());
         std::mem::take(&mut guard.pending)
     };
-    for (event, source) in pending {
-        sink.emit(event, source);
+    for event in pending {
+        sink.emit(event);
     }
 }
 
@@ -88,12 +88,8 @@ pub fn current_agent_event_sink() -> Option<Arc<dyn AgentEventSink>> {
 }
 
 pub fn emit_agent_event(event: AgentEvent) -> bool {
-    emit_agent_event_with_source(event, None)
-}
-
-pub fn emit_agent_event_with_source(event: AgentEvent, source: Option<AgentSource>) -> bool {
     if SCOPED_SINK
-        .try_with(|sink| sink.emit(event.clone(), source.clone()))
+        .try_with(|sink| sink.emit(event.clone()))
         .is_ok()
     {
         return true;
@@ -108,12 +104,12 @@ pub fn emit_agent_event_with_source(event: AgentEvent, source: Option<AgentSourc
                 if guard.pending.len() == PENDING_EVENTS_CAP {
                     guard.pending.remove(0);
                 }
-                guard.pending.push((event, source));
+                guard.pending.push(event);
                 return true;
             }
         }
     };
-    sink.emit(event, source);
+    sink.emit(event);
     true
 }
 
@@ -161,7 +157,7 @@ mod tests {
     }
 
     impl AgentEventSink for CollectingSink {
-        fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+        fn emit(&self, event: AgentEvent) {
             self.events.lock().unwrap().push(event);
         }
     }
@@ -205,30 +201,34 @@ mod tests {
         clear_agent_event_sink();
 
         emit_agent_event(AgentEvent::Notice(NoticeEvent::Warning("first".into())));
-        emit_agent_event_with_source(
-            AgentEvent::Notice(NoticeEvent::Warning("second".into())),
-            Some(AgentSource {
+        emit_agent_event(AgentEvent::sub_agent(
+            AgentSource {
                 agent: "argus".into(),
                 session_id: None,
                 model: None,
-            }),
-        );
+            },
+            AgentEvent::Notice(NoticeEvent::Warning("second".into())),
+        ));
 
         let sink = Arc::new(SourceRecordingSink::default());
         install_agent_event_sink(sink.clone());
 
         let events = sink.events.lock().unwrap();
         assert_eq!(events.len(), 2);
-        match &events[0].0 {
+        match &events[0] {
             AgentEvent::Notice(NoticeEvent::Warning(msg)) => assert_eq!(msg, "first"),
             other => panic!("unexpected first event: {other:?}"),
         }
-        assert!(events[0].1.is_none());
-        match &events[1].0 {
-            AgentEvent::Notice(NoticeEvent::Warning(msg)) => assert_eq!(msg, "second"),
+        match &events[1] {
+            AgentEvent::SubAgent { source, event } => {
+                assert_eq!(source.agent, "argus");
+                assert!(matches!(
+                    &**event,
+                    AgentEvent::Notice(NoticeEvent::Warning(msg)) if msg == "second"
+                ));
+            }
             other => panic!("unexpected second event: {other:?}"),
         }
-        assert_eq!(events[1].1.as_ref().unwrap().agent, "argus");
         drop(events);
         clear_agent_event_sink();
     }
@@ -264,17 +264,17 @@ mod tests {
 
     #[derive(Default)]
     struct SourceRecordingSink {
-        events: Mutex<Vec<(AgentEvent, Option<AgentSource>)>>,
+        events: Mutex<Vec<AgentEvent>>,
     }
 
     impl AgentEventSink for SourceRecordingSink {
-        fn emit(&self, event: AgentEvent, source: Option<AgentSource>) {
-            self.events.lock().unwrap().push((event, source));
+        fn emit(&self, event: AgentEvent) {
+            self.events.lock().unwrap().push(event);
         }
     }
 
     #[test]
-    fn emit_with_source_preserves_source() {
+    fn sub_agent_event_preserves_source() {
         use crate::event::AgentSource;
         let _guard = lock_sink_tests();
         clear_agent_event_sink();
@@ -282,22 +282,27 @@ mod tests {
         install_agent_event_sink(sink.clone());
 
         emit_agent_event(AgentEvent::Notice(NoticeEvent::Info("no-source".into())));
-        emit_agent_event_with_source(
-            AgentEvent::Notice(NoticeEvent::Info("with-source".into())),
-            Some(AgentSource {
+        emit_agent_event(AgentEvent::sub_agent(
+            AgentSource {
                 agent: "argus".into(),
                 session_id: Some("s1".into()),
                 model: None,
-            }),
-        );
+            },
+            AgentEvent::Notice(NoticeEvent::Info("with-source".into())),
+        ));
 
         let events = sink.events.lock().unwrap();
         assert_eq!(events.len(), 2);
-        assert!(events[0].1.is_none());
-        let (_, s1) = &events[1];
-        let source = s1.as_ref().expect("second event carries source");
+        assert!(matches!(events[0], AgentEvent::Notice(_)));
+        let AgentEvent::SubAgent { source, event } = &events[1] else {
+            panic!("second event should carry sub-agent source");
+        };
         assert_eq!(source.agent, "argus");
         assert_eq!(source.session_id.as_deref(), Some("s1"));
+        assert!(matches!(
+            &**event,
+            AgentEvent::Notice(NoticeEvent::Info(msg)) if msg == "with-source"
+        ));
         drop(events);
         clear_agent_event_sink();
     }

--- a/crates/harnx-engine/src/chat_completions.rs
+++ b/crates/harnx-engine/src/chat_completions.rs
@@ -209,7 +209,7 @@ mod tests {
     use super::run_chat_completion_streaming;
     use harnx_client::{ChatCompletionsData, ClientCallContext, CompletionTokenUsage, SseHandler};
     use harnx_core::abort::create_abort_signal;
-    use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource, ModelEvent};
+    use harnx_core::event::{AgentEvent, AgentEventSink, ModelEvent};
     use harnx_core::sink::{clear_agent_event_sink, install_agent_event_sink};
     use harnx_runtime::test_utils::{MockClient, MockTurnBuilder};
     use parking_lot::Mutex;
@@ -253,7 +253,7 @@ mod tests {
     }
 
     impl AgentEventSink for CollectingSink {
-        fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+        fn emit(&self, event: AgentEvent) {
             self.events.lock().push(event);
         }
     }

--- a/crates/harnx-engine/src/engine.rs
+++ b/crates/harnx-engine/src/engine.rs
@@ -48,7 +48,7 @@ impl Engine {
         let ctx_for_task = Arc::clone(&ctx);
         tokio::spawn(async move {
             let emit = |event: AgentEvent| {
-                ctx_for_task.sink.emit(event.clone(), None);
+                ctx_for_task.sink.emit(event.clone());
                 let _ = tx.send(event);
             };
 

--- a/crates/harnx-engine/tests/run_turn.rs
+++ b/crates/harnx-engine/tests/run_turn.rs
@@ -24,7 +24,7 @@ impl RecordingSink {
 }
 
 impl AgentEventSink for RecordingSink {
-    fn emit(&self, event: AgentEvent, _source: Option<harnx_core::event::AgentSource>) {
+    fn emit(&self, event: AgentEvent) {
         self.events.lock().expect("sink mutex").push(event);
     }
 }

--- a/crates/harnx-hooks/src/persistent.rs
+++ b/crates/harnx-hooks/src/persistent.rs
@@ -581,7 +581,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn test_failing_persistent_hook_surfaces_notice() {
-        use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource, NoticeEvent};
+        use harnx_core::event::{AgentEvent, AgentEventSink, NoticeEvent};
         use std::sync::{Arc, Mutex};
 
         #[derive(Default)]
@@ -589,7 +589,7 @@ mod tests {
             events: Mutex<Vec<AgentEvent>>,
         }
         impl AgentEventSink for CollectingSink {
-            fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+            fn emit(&self, event: AgentEvent) {
                 self.events.lock().unwrap().push(event);
             }
         }
@@ -626,7 +626,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn test_persistent_hook_stdout_notice_surfaces() {
-        use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource, NoticeEvent};
+        use harnx_core::event::{AgentEvent, AgentEventSink, NoticeEvent};
         use std::sync::{Arc, Mutex};
 
         #[derive(Default)]
@@ -634,7 +634,7 @@ mod tests {
             events: Mutex<Vec<AgentEvent>>,
         }
         impl AgentEventSink for CollectingSink {
-            fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+            fn emit(&self, event: AgentEvent) {
                 self.events.lock().unwrap().push(event);
             }
         }

--- a/crates/harnx-runtime/src/agent_loop.rs
+++ b/crates/harnx-runtime/src/agent_loop.rs
@@ -610,15 +610,15 @@ async fn run_agent_loop_inner(
                     session_id: switch.session_id.clone(),
                     model: ctx.config.read().current_model_id(),
                 };
-                harnx_core::sink::emit_agent_event_with_source(
+                harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::sub_agent(
+                    source,
                     harnx_core::event::AgentEvent::Turn(
                         harnx_core::event::TurnEvent::HandoffRequested {
                             agent: switch.agent.clone(),
                             session_id: switch.session_id.clone(),
                         },
                     ),
-                    Some(source),
-                );
+                ));
                 return Ok(LoopResult::HandoffRequested {
                     agent: switch.agent.clone(),
                     session_id: switch.session_id.clone(),
@@ -709,7 +709,11 @@ mod tests {
     }
 
     impl AgentEventSink for CollectingSink {
-        fn emit(&self, event: AgentEvent, source: Option<AgentSource>) {
+        fn emit(&self, event: AgentEvent) {
+            let (event, source) = match event {
+                AgentEvent::SubAgent { source, event } => (*event, Some(source)),
+                event => (event, None),
+            };
             self.events.lock().unwrap().push((event, source));
         }
     }

--- a/crates/harnx-runtime/src/client/common.rs
+++ b/crates/harnx-runtime/src/client/common.rs
@@ -219,22 +219,10 @@ pub async fn call_chat_completions_streaming(
         }));
     }
 
-    // Emit Turn::Started with source so the CLI sink shows agent+session heading.
-    {
-        use harnx_core::event::{AgentEvent, AgentSource, TurnEvent};
-        let agent_source = {
-            let cfg = config.read();
-            AgentSource {
-                agent: cfg.extract_agent().name().to_string(),
-                session_id: cfg.session.as_ref().map(|s| s.id().to_string()),
-                model: cfg.current_model_id(),
-            }
-        };
-        harnx_core::sink::emit_agent_event_with_source(
-            AgentEvent::Turn(TurnEvent::Started),
-            Some(agent_source),
-        );
-    }
+    // Turn::Started belongs to the direct agent handling this request.
+    harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Turn(
+        harnx_core::event::TurnEvent::Started,
+    ));
 
     // Drain the SseHandler's channel — chunk display is now driven by
     // AgentEvent::Model::MessageChunk/ThoughtChunk emitted by SseHandler,

--- a/crates/harnx-runtime/src/config/session_ops_title.rs
+++ b/crates/harnx-runtime/src/config/session_ops_title.rs
@@ -597,7 +597,7 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource, NoticeEvent, SessionEvent};
+    use harnx_core::event::{AgentEvent, AgentEventSink, NoticeEvent, SessionEvent};
     use harnx_core::message::{Message, MessageContent};
     use harnx_core::session::Session;
     use std::sync::Mutex;
@@ -725,7 +725,7 @@ mod tests {
     }
 
     impl AgentEventSink for CollectingSink {
-        fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+        fn emit(&self, event: AgentEvent) {
             self.events.lock().unwrap().push(event);
         }
     }

--- a/crates/harnx-runtime/src/nats_client_session.rs
+++ b/crates/harnx-runtime/src/nats_client_session.rs
@@ -578,10 +578,9 @@ fn render_log_entry_to_sink(
     // has a boundary and numbers replayed rows immediately here.
     if rendered && history_window.boundary_index().is_some() {
         for logical_index in logical_indices_for_entry(physical_seq, entry, history_window) {
-            sink.emit(
-                AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: logical_index }),
-                None,
-            );
+            sink.emit(AgentEvent::Session(SessionEvent::LogSeqAssigned {
+                seq: logical_index,
+            }));
         }
     }
     // Note: ToolResults fence_token is not currently exposed in the entry type
@@ -627,7 +626,7 @@ fn flush_pending_advisories(
             envelope.event,
             AgentEvent::Session(SessionEvent::LogSeqAssigned { .. })
         ) {
-            sink.emit(envelope.event, None);
+            sink.emit(envelope.event);
         }
     }
 }
@@ -682,10 +681,9 @@ fn emit_deduped_logical_seq(
     emitted_logical_seqs: &mut HashSet<usize>,
 ) {
     if emitted_logical_seqs.insert(logical_index) {
-        sink.emit(
-            AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: logical_index }),
-            None,
-        );
+        sink.emit(AgentEvent::Session(SessionEvent::LogSeqAssigned {
+            seq: logical_index,
+        }));
     }
 }
 
@@ -713,20 +711,14 @@ fn render_message_entry(
 ) {
     if role.is_assistant() {
         use harnx_core::event::ModelEvent;
-        sink.emit(
-            AgentEvent::Model(ModelEvent::Final {
-                output: content.to_text(),
-                usage: Default::default(),
-            }),
-            None,
-        );
+        sink.emit(AgentEvent::Model(ModelEvent::Final {
+            output: content.to_text(),
+            usage: Default::default(),
+        }));
     } else if role.is_user() {
-        sink.emit(
-            AgentEvent::User(UserEvent::Message {
-                content: content.to_text(),
-            }),
-            None,
-        );
+        sink.emit(AgentEvent::User(UserEvent::Message {
+            content: content.to_text(),
+        }));
     }
 }
 
@@ -738,26 +730,20 @@ fn render_tool_calls_entry(
     use harnx_core::event::{ContentBlock, ModelEvent, ToolEvent, ToolKind};
 
     for call in calls {
-        sink.emit(
-            AgentEvent::Tool(ToolEvent::Started {
-                id: call.id.clone().unwrap_or_default(),
-                name: call.name.clone(),
-                kind: ToolKind::Other,
-                markdown: None,
-                input: call.arguments.clone(),
-                locations: vec![],
-            }),
-            None,
-        );
+        sink.emit(AgentEvent::Tool(ToolEvent::Started {
+            id: call.id.clone().unwrap_or_default(),
+            name: call.name.clone(),
+            kind: ToolKind::Other,
+            markdown: None,
+            input: call.arguments.clone(),
+            locations: vec![],
+        }));
     }
 
     if !text.is_empty() {
-        sink.emit(
-            AgentEvent::Model(ModelEvent::MessageChunk {
-                blocks: vec![ContentBlock::Text(text.to_string())],
-            }),
-            None,
-        );
+        sink.emit(AgentEvent::Model(ModelEvent::MessageChunk {
+            blocks: vec![ContentBlock::Text(text.to_string())],
+        }));
     }
 }
 
@@ -768,24 +754,20 @@ fn render_tool_results_entry(
     use harnx_core::event::ToolEvent;
 
     for result in results {
-        sink.emit(
-            AgentEvent::Tool(ToolEvent::Completed {
-                id: result.id.clone().unwrap_or_default(),
-                output: result.output.clone(),
-                markdown: result.markdown.clone(),
-            }),
-            None,
-        );
+        sink.emit(AgentEvent::Tool(ToolEvent::Completed {
+            id: result.id.clone().unwrap_or_default(),
+            output: result.output.clone(),
+            markdown: result.markdown.clone(),
+        }));
     }
 }
 
 fn render_cancel_entry(sink: &Arc<dyn AgentEventSink>) {
     use harnx_core::event::NoticeEvent;
 
-    sink.emit(
-        AgentEvent::Notice(NoticeEvent::Warning("Session cancelled".to_string())),
-        None,
-    );
+    sink.emit(AgentEvent::Notice(NoticeEvent::Warning(
+        "Session cancelled".to_string(),
+    )));
 }
 
 /// Send a control command to a remote session.
@@ -802,7 +784,6 @@ pub async fn send_control_command(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use harnx_core::event::AgentSource;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
 
@@ -811,7 +792,7 @@ mod tests {
         events: Mutex<Vec<AgentEvent>>,
     }
     impl AgentEventSink for TestSink {
-        fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+        fn emit(&self, event: AgentEvent) {
             self.count.fetch_add(1, Ordering::SeqCst);
             self.events.lock().unwrap().push(event);
         }

--- a/crates/harnx-runtime/src/nats_event_sink.rs
+++ b/crates/harnx-runtime/src/nats_event_sink.rs
@@ -18,7 +18,7 @@
 
 use anyhow::Result;
 use async_nats::jetstream;
-use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource};
+use harnx_core::event::{AgentEvent, AgentEventSink};
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -153,7 +153,7 @@ impl NatsEventSink {
 }
 
 impl AgentEventSink for NatsEventSink {
-    fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+    fn emit(&self, event: AgentEvent) {
         // The trait method is sync but publish is async. Fire-and-forget onto
         // the current runtime so the agent loop is never blocked, and so this
         // works on any runtime flavor (block_in_place would panic on a

--- a/crates/harnx-runtime/src/nats_worker/tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests.rs
@@ -16,7 +16,7 @@ use anyhow::{bail, Context};
 use futures_util::StreamExt;
 use harnx_core::agent_config::AgentConfig;
 use harnx_core::config_data::ConfigData;
-use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource, SessionEvent};
+use harnx_core::event::{AgentEvent, AgentEventSink, SessionEvent};
 use harnx_core::session::{SessionLogEntry, ToolOutput};
 use harnx_core::session_reconstruct::{
     active_context_window, reconstruct_state_from_nats, TurnStatus,
@@ -786,7 +786,7 @@ async fn control_log_append_requires_live_lease() {
 struct NoopEventSink;
 
 impl AgentEventSink for NoopEventSink {
-    fn emit(&self, _event: AgentEvent, _source: Option<AgentSource>) {}
+    fn emit(&self, _event: AgentEvent) {}
 }
 
 #[derive(Default)]
@@ -801,7 +801,7 @@ impl RecordingEventSink {
 }
 
 impl AgentEventSink for RecordingEventSink {
-    fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+    fn emit(&self, event: AgentEvent) {
         self.events.lock().unwrap().push(event);
     }
 }

--- a/crates/harnx-runtime/src/tool.rs
+++ b/crates/harnx-runtime/src/tool.rs
@@ -789,7 +789,7 @@ mod tests {
     // populated, the consumer-side rendering has nothing to display.
     // ----------------------------------------------------------------
 
-    use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource, ToolEvent};
+    use harnx_core::event::{AgentEvent, AgentEventSink, ToolEvent};
     use std::sync::Mutex as StdMutex;
 
     #[derive(Default)]
@@ -797,7 +797,7 @@ mod tests {
         events: StdMutex<Vec<AgentEvent>>,
     }
     impl AgentEventSink for RecordingSink {
-        fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+        fn emit(&self, event: AgentEvent) {
             self.events.lock().unwrap().push(event);
         }
     }

--- a/crates/harnx-runtime/tests/nats_thin_client.rs
+++ b/crates/harnx-runtime/tests/nats_thin_client.rs
@@ -92,7 +92,7 @@ async fn append_new_reply_after_current_turn_user(
 struct NoopEventSink;
 
 impl AgentEventSink for NoopEventSink {
-    fn emit(&self, _event: AgentEvent, _source: Option<harnx_core::event::AgentSource>) {}
+    fn emit(&self, _event: AgentEvent) {}
 }
 
 /// Test that control commands are sent correctly

--- a/crates/harnx-serve/src/ag_ui.rs
+++ b/crates/harnx-serve/src/ag_ui.rs
@@ -34,8 +34,7 @@ use bytes::Bytes;
 use harnx_core::{
     agent_config::AgentConfig,
     event::{
-        AgentEvent, AgentSource, ContentBlock, ModelEvent, NoticeEvent, SessionEvent, ToolEvent,
-        TurnEvent,
+        AgentEvent, ContentBlock, ModelEvent, NoticeEvent, SessionEvent, ToolEvent, TurnEvent,
     },
     message::{Message as HistoryMsg, MessageContent, MessageRole},
 };
@@ -531,7 +530,11 @@ impl AgUiSink {
 }
 
 impl harnx_core::event::AgentEventSink for AgUiSink {
-    fn emit(&self, event: AgentEvent, _source: Option<AgentSource>) {
+    fn emit(&self, event: AgentEvent) {
+        let event = match event {
+            AgentEvent::SubAgent { event, .. } => *event,
+            event => event,
+        };
         match event {
             AgentEvent::Model(ModelEvent::MessageChunk { blocks }) => {
                 let delta: String = blocks

--- a/crates/harnx-serve/src/ag_ui_tests.rs
+++ b/crates/harnx-serve/src/ag_ui_tests.rs
@@ -82,6 +82,94 @@ fn ag_ui_sink_emits_text_message_content_for_chunk() {
 }
 
 #[test]
+fn ag_ui_sink_unwraps_sub_agent_message_chunk() {
+    // SubAgent wrapper is transparently unwrapped at the top of emit.
+    // The resulting AG-UI events should match the bare MessageChunk path.
+    use harnx_core::event::AgentSource;
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
+    let message_id =
+        MessageId::from(uuid::Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap());
+    let sink = super::AgUiSink::with_snapshot(tx, message_id.clone(), false, None);
+
+    let source = AgentSource {
+        agent: "sub".into(),
+        session_id: None,
+        model: None,
+    };
+    sink.emit(AgentEvent::sub_agent(
+        source,
+        AgentEvent::Model(ModelEvent::MessageChunk {
+            blocks: vec![ContentBlock::Text("hello".into())],
+        }),
+    ));
+
+    let opened_message_id = match rx.try_recv().expect("text start") {
+        Event::TextMessageStart(event) => {
+            assert_eq!(event.role, Role::Assistant);
+            event.message_id
+        }
+        other => panic!("expected TextMessageStart event, got: {other:?}"),
+    };
+    match rx.try_recv().expect("text content") {
+        Event::TextMessageContent(TextMessageContentEvent {
+            base,
+            message_id: mid,
+            delta,
+        }) => {
+            assert_eq!(base.timestamp, None);
+            assert_eq!(base.raw_event, None);
+            assert_eq!(mid, opened_message_id);
+            assert_eq!(delta, "hello");
+        }
+        other => panic!("expected TextMessageContent event, got: {other:?}"),
+    }
+
+    assert!(rx.try_recv().is_err(), "no additional events expected");
+}
+
+#[test]
+fn ag_ui_sink_unwraps_sub_agent_error() {
+    // SubAgent wrapper around Model::Error should produce the same RunError
+    // event as the bare error path after unwrapping at the top of emit.
+    use harnx_core::event::AgentSource;
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
+    let message_id =
+        MessageId::from(uuid::Uuid::parse_str("33333333-3333-3333-3333-333333333333").unwrap());
+    // Use `new` (not with_snapshot) for error path — finish_turn is not called
+    // unless a message was already started, so we expect RunError directly.
+    let sink = super::AgUiSink::new(tx, message_id.clone());
+
+    let source = AgentSource {
+        agent: "sub".into(),
+        session_id: None,
+        model: None,
+    };
+    sink.emit(AgentEvent::sub_agent(
+        source,
+        AgentEvent::Model(ModelEvent::Error("boom".into())),
+    ));
+
+    // RunError with the wrapped message
+    match rx.try_recv().expect("run error") {
+        Event::RunError(RunErrorEvent {
+            base,
+            message,
+            code,
+        }) => {
+            assert_eq!(base.timestamp, None);
+            assert_eq!(base.raw_event, None);
+            assert_eq!(message, "boom");
+            assert!(code.is_none());
+        }
+        other => panic!("expected RunError event, got: {other:?}"),
+    }
+
+    assert!(rx.try_recv().is_err(), "no additional events expected");
+}
+
+#[test]
 fn ag_ui_sink_skips_empty_chunk() {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
     let message_id = MessageId::from(uuid::Uuid::new_v4());

--- a/crates/harnx-serve/src/ag_ui_tests.rs
+++ b/crates/harnx-serve/src/ag_ui_tests.rs
@@ -53,12 +53,9 @@ fn ag_ui_sink_emits_text_message_content_for_chunk() {
         MessageId::from(uuid::Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap());
     let sink = super::AgUiSink::with_snapshot(tx, message_id.clone(), false, None);
 
-    sink.emit(
-        AgentEvent::Model(ModelEvent::MessageChunk {
-            blocks: vec![ContentBlock::Text("hello".to_string())],
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Model(ModelEvent::MessageChunk {
+        blocks: vec![ContentBlock::Text("hello".to_string())],
+    }));
 
     let opened_message_id = match rx.try_recv().expect("text start") {
         Event::TextMessageStart(event) => {
@@ -90,21 +87,17 @@ fn ag_ui_sink_skips_empty_chunk() {
     let message_id = MessageId::from(uuid::Uuid::new_v4());
     let sink = super::AgUiSink::new(tx, message_id);
 
-    sink.emit(
-        AgentEvent::Model(ModelEvent::MessageChunk { blocks: vec![] }),
-        None,
-    );
+    sink.emit(AgentEvent::Model(ModelEvent::MessageChunk {
+        blocks: vec![],
+    }));
     assert!(rx.try_recv().is_err());
 
-    sink.emit(
-        AgentEvent::Model(ModelEvent::MessageChunk {
-            blocks: vec![ContentBlock::Image {
-                data: vec![],
-                mime: "image/png".to_string(),
-            }],
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Model(ModelEvent::MessageChunk {
+        blocks: vec![ContentBlock::Image {
+            data: vec![],
+            mime: "image/png".to_string(),
+        }],
+    }));
     assert!(rx.try_recv().is_err());
 }
 
@@ -114,10 +107,7 @@ fn ag_ui_sink_emits_run_error_for_model_error() {
     let message_id = MessageId::from(uuid::Uuid::new_v4());
     let sink = super::AgUiSink::new(tx, message_id);
 
-    sink.emit(
-        AgentEvent::Model(ModelEvent::Error("boom".to_string())),
-        None,
-    );
+    sink.emit(AgentEvent::Model(ModelEvent::Error("boom".to_string())));
 
     let event = rx.try_recv().expect("should receive event");
     match event {
@@ -141,12 +131,9 @@ fn ag_ui_sink_emits_custom_for_title_generation_failed() {
     let message_id = MessageId::from(uuid::Uuid::new_v4());
     let sink = super::AgUiSink::new(tx, message_id);
 
-    sink.emit(
-        AgentEvent::Session(SessionEvent::TitleGenerationFailed(
-            "Miss 'api_key'".to_string(),
-        )),
-        None,
-    );
+    sink.emit(AgentEvent::Session(SessionEvent::TitleGenerationFailed(
+        "Miss 'api_key'".to_string(),
+    )));
 
     let event = rx.try_recv().expect("should receive event");
     match event {
@@ -164,10 +151,9 @@ fn ag_ui_sink_emits_run_error_for_notice_error() {
     let message_id = MessageId::from(uuid::Uuid::new_v4());
     let sink = super::AgUiSink::new(tx, message_id);
 
-    sink.emit(
-        AgentEvent::Notice(NoticeEvent::Error("fatal error".to_string())),
-        None,
-    );
+    sink.emit(AgentEvent::Notice(NoticeEvent::Error(
+        "fatal error".to_string(),
+    )));
 
     let event = rx.try_recv().expect("should receive event");
     match event {
@@ -184,12 +170,9 @@ fn ag_ui_sink_emits_custom_status_event() {
     let message_id = MessageId::from(uuid::Uuid::new_v4());
     let sink = super::AgUiSink::new(tx, message_id);
 
-    sink.emit(
-        AgentEvent::Status(harnx_core::event::StatusLine {
-            text: "working...".to_string(),
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Status(harnx_core::event::StatusLine {
+        text: "working...".to_string(),
+    }));
 
     let event = rx.try_recv().expect("should receive status event");
     match event {
@@ -211,13 +194,10 @@ fn ag_ui_sink_emits_final_as_content_when_non_empty() {
     let sink = super::AgUiSink::with_snapshot(tx, message_id.clone(), false, None);
 
     let usage = CompletionTokenUsage::new(Some(10), Some(5), Some(0));
-    sink.emit(
-        AgentEvent::Model(ModelEvent::Final {
-            output: "final text".to_string(),
-            usage,
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Model(ModelEvent::Final {
+        output: "final text".to_string(),
+        usage,
+    }));
 
     let opened_message_id = match rx.try_recv().expect("text start") {
         Event::TextMessageStart(event) => {
@@ -247,13 +227,10 @@ fn ag_ui_sink_skips_final_when_empty() {
     let sink = super::AgUiSink::new(tx, message_id);
 
     let usage = CompletionTokenUsage::new(Some(10), Some(5), Some(0));
-    sink.emit(
-        AgentEvent::Model(ModelEvent::Final {
-            output: String::new(),
-            usage,
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Model(ModelEvent::Final {
+        output: String::new(),
+        usage,
+    }));
 
     assert!(rx.try_recv().is_err());
 }
@@ -264,25 +241,16 @@ fn ag_ui_sink_maps_thought_then_text_and_closes_thinking_before_text() {
     let message_id = MessageId::from(uuid::Uuid::new_v4());
     let sink = super::AgUiSink::with_snapshot(tx, message_id.clone(), false, None);
 
-    sink.emit(
-        AgentEvent::Model(ModelEvent::ThoughtChunk {
-            blocks: vec![ContentBlock::Text("thinking...".to_string())],
-        }),
-        None,
-    );
-    sink.emit(
-        AgentEvent::Model(ModelEvent::MessageChunk {
-            blocks: vec![ContentBlock::Text("answer".to_string())],
-        }),
-        None,
-    );
-    sink.emit(
-        AgentEvent::Model(ModelEvent::Final {
-            output: String::new(),
-            usage: CompletionTokenUsage::default(),
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Model(ModelEvent::ThoughtChunk {
+        blocks: vec![ContentBlock::Text("thinking...".to_string())],
+    }));
+    sink.emit(AgentEvent::Model(ModelEvent::MessageChunk {
+        blocks: vec![ContentBlock::Text("answer".to_string())],
+    }));
+    sink.emit(AgentEvent::Model(ModelEvent::Final {
+        output: String::new(),
+        usage: CompletionTokenUsage::default(),
+    }));
 
     assert!(matches!(
         rx.try_recv().expect("thinking start"),
@@ -327,23 +295,17 @@ fn ag_ui_sink_closes_thinking_before_tool_events() {
     let message_id = MessageId::from(uuid::Uuid::new_v4());
     let sink = super::AgUiSink::with_snapshot(tx, message_id.clone(), false, None);
 
-    sink.emit(
-        AgentEvent::Model(ModelEvent::ThoughtChunk {
-            blocks: vec![ContentBlock::Text("planning".to_string())],
-        }),
-        None,
-    );
-    sink.emit(
-        AgentEvent::Tool(ToolEvent::Started {
-            id: "tool-1".to_string(),
-            name: "read_history".to_string(),
-            kind: harnx_core::event::ToolKind::Other,
-            markdown: None,
-            input: json!({"limit": 1}),
-            locations: vec![],
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Model(ModelEvent::ThoughtChunk {
+        blocks: vec![ContentBlock::Text("planning".to_string())],
+    }));
+    sink.emit(AgentEvent::Tool(ToolEvent::Started {
+        id: "tool-1".to_string(),
+        name: "read_history".to_string(),
+        kind: harnx_core::event::ToolKind::Other,
+        markdown: None,
+        input: json!({"limit": 1}),
+        locations: vec![],
+    }));
 
     assert!(matches!(
         rx.try_recv().expect("thinking start"),
@@ -385,30 +347,18 @@ fn ag_ui_sink_keeps_thinking_open_across_background_session_event() {
     let message_id = MessageId::from(uuid::Uuid::new_v4());
     let sink = super::AgUiSink::with_snapshot(tx, message_id, false, None);
 
-    sink.emit(
-        AgentEvent::Model(ModelEvent::ThoughtChunk {
-            blocks: vec![ContentBlock::Text("thinking one".to_string())],
-        }),
-        None,
-    );
-    sink.emit(
-        AgentEvent::Session(SessionEvent::Saved {
-            path: "/tmp/session.json".into(),
-        }),
-        None,
-    );
-    sink.emit(
-        AgentEvent::Model(ModelEvent::ThoughtChunk {
-            blocks: vec![ContentBlock::Text(" thinking two".to_string())],
-        }),
-        None,
-    );
-    sink.emit(
-        AgentEvent::Turn(TurnEvent::Ended {
-            outcome: harnx_core::event::TurnOutcome::default(),
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Model(ModelEvent::ThoughtChunk {
+        blocks: vec![ContentBlock::Text("thinking one".to_string())],
+    }));
+    sink.emit(AgentEvent::Session(SessionEvent::Saved {
+        path: "/tmp/session.json".into(),
+    }));
+    sink.emit(AgentEvent::Model(ModelEvent::ThoughtChunk {
+        blocks: vec![ContentBlock::Text(" thinking two".to_string())],
+    }));
+    sink.emit(AgentEvent::Turn(TurnEvent::Ended {
+        outcome: harnx_core::event::TurnOutcome::default(),
+    }));
 
     assert!(matches!(
         rx.try_recv().expect("thinking start"),
@@ -453,25 +403,19 @@ fn ag_ui_sink_maps_tool_started_completed_to_ag_ui_events() {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
     let message_id = MessageId::from(uuid::Uuid::new_v4());
     let sink = super::AgUiSink::with_snapshot(tx, message_id.clone(), false, None);
-    sink.emit(
-        AgentEvent::Tool(ToolEvent::Started {
-            id: "history-1".to_string(),
-            name: "read_history".to_string(),
-            kind: harnx_core::event::ToolKind::Other,
-            markdown: None,
-            input: json!({"limit": 5, "entry_type": "message"}),
-            locations: vec![],
-        }),
-        None,
-    );
-    sink.emit(
-        AgentEvent::Tool(ToolEvent::Completed {
-            id: "history-1".to_string(),
-            output: json!("history checked"),
-            markdown: None,
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Tool(ToolEvent::Started {
+        id: "history-1".to_string(),
+        name: "read_history".to_string(),
+        kind: harnx_core::event::ToolKind::Other,
+        markdown: None,
+        input: json!({"limit": 5, "entry_type": "message"}),
+        locations: vec![],
+    }));
+    sink.emit(AgentEvent::Tool(ToolEvent::Completed {
+        id: "history-1".to_string(),
+        output: json!("history checked"),
+        markdown: None,
+    }));
 
     match rx.try_recv().expect("tool start") {
         Event::ToolCallStart(event) => {
@@ -530,37 +474,25 @@ fn ag_ui_sink_segments_text_around_tool_calls() {
     let message_id = MessageId::from(uuid::Uuid::new_v4());
     let sink = super::AgUiSink::with_snapshot(tx, message_id.clone(), false, None);
 
-    sink.emit(
-        AgentEvent::Model(ModelEvent::MessageChunk {
-            blocks: vec![ContentBlock::Text("A".to_string())],
-        }),
-        None,
-    );
-    sink.emit(
-        AgentEvent::Tool(ToolEvent::Started {
-            id: "history-3".to_string(),
-            name: "read_history".to_string(),
-            kind: harnx_core::event::ToolKind::Other,
-            markdown: None,
-            input: json!({"limit": 1}),
-            locations: vec![],
-        }),
-        None,
-    );
-    sink.emit(
-        AgentEvent::Tool(ToolEvent::Completed {
-            id: "history-3".to_string(),
-            output: json!("done"),
-            markdown: None,
-        }),
-        None,
-    );
-    sink.emit(
-        AgentEvent::Model(ModelEvent::MessageChunk {
-            blocks: vec![ContentBlock::Text("B".to_string())],
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Model(ModelEvent::MessageChunk {
+        blocks: vec![ContentBlock::Text("A".to_string())],
+    }));
+    sink.emit(AgentEvent::Tool(ToolEvent::Started {
+        id: "history-3".to_string(),
+        name: "read_history".to_string(),
+        kind: harnx_core::event::ToolKind::Other,
+        markdown: None,
+        input: json!({"limit": 1}),
+        locations: vec![],
+    }));
+    sink.emit(AgentEvent::Tool(ToolEvent::Completed {
+        id: "history-3".to_string(),
+        output: json!("done"),
+        markdown: None,
+    }));
+    sink.emit(AgentEvent::Model(ModelEvent::MessageChunk {
+        blocks: vec![ContentBlock::Text("B".to_string())],
+    }));
 
     let first_id = match rx.try_recv().expect("first text start") {
         Event::TextMessageStart(event) => {
@@ -633,23 +565,17 @@ fn ag_ui_sink_does_not_emit_orphan_text_end_after_tool_only_tail() {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
     let sink = super::AgUiSink::with_snapshot(tx, MessageId::random(), false, None);
 
-    sink.emit(
-        AgentEvent::Model(ModelEvent::MessageChunk {
-            blocks: vec![ContentBlock::Text("A".to_string())],
-        }),
-        None,
-    );
-    sink.emit(
-        AgentEvent::Tool(ToolEvent::Started {
-            id: "history-4".to_string(),
-            name: "read_history".to_string(),
-            kind: harnx_core::event::ToolKind::Other,
-            markdown: None,
-            input: json!({"limit": 1}),
-            locations: vec![],
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Model(ModelEvent::MessageChunk {
+        blocks: vec![ContentBlock::Text("A".to_string())],
+    }));
+    sink.emit(AgentEvent::Tool(ToolEvent::Started {
+        id: "history-4".to_string(),
+        name: "read_history".to_string(),
+        kind: harnx_core::event::ToolKind::Other,
+        markdown: None,
+        input: json!({"limit": 1}),
+        locations: vec![],
+    }));
 
     while let Ok(_event) = rx.try_recv() {}
     assert!(sink.close_text_segment().is_none());
@@ -662,17 +588,14 @@ fn ag_ui_sink_emits_tool_summary_custom_event_and_preserves_start_args() {
     let message_id = MessageId::from(uuid::Uuid::new_v4());
     let sink = super::AgUiSink::with_snapshot(tx, message_id.clone(), false, None);
 
-    sink.emit(
-        AgentEvent::Tool(ToolEvent::Started {
-            id: "history-2".to_string(),
-            name: "read_history".to_string(),
-            kind: harnx_core::event::ToolKind::Other,
-            markdown: Some("### Summary\n- item".to_string()),
-            input: json!({"limit": 2}),
-            locations: vec![],
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Tool(ToolEvent::Started {
+        id: "history-2".to_string(),
+        name: "read_history".to_string(),
+        kind: harnx_core::event::ToolKind::Other,
+        markdown: Some("### Summary\n- item".to_string()),
+        input: json!({"limit": 2}),
+        locations: vec![],
+    }));
 
     match rx.try_recv().expect("tool start") {
         Event::ToolCallStart(event) => {
@@ -728,15 +651,12 @@ fn ag_ui_sink_usage_event_includes_context_fields_and_legacy_fields() {
     let sink =
         super::AgUiSink::with_snapshot_and_context(tx, message_id, true, None, Some(context));
 
-    sink.emit(
-        AgentEvent::Model(ModelEvent::Usage {
-            input: 12,
-            output: 34,
-            cached: 5,
-            session_label: Some("sess-a".to_string()),
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Model(ModelEvent::Usage {
+        input: 12,
+        output: 34,
+        cached: 5,
+        session_label: Some("sess-a".to_string()),
+    }));
 
     match rx.try_recv().expect("usage event") {
         Event::Custom(CustomEvent { name, value, .. }) => {
@@ -764,22 +684,16 @@ fn ag_ui_sink_maps_tool_failures_and_blocked_to_results() {
     let message_id = MessageId::from(uuid::Uuid::new_v4());
     let sink = super::AgUiSink::new(tx, message_id);
 
-    sink.emit(
-        AgentEvent::Tool(ToolEvent::Failed {
-            id: "tool-fail".to_string(),
-            error: "boom".to_string(),
-        }),
-        None,
-    );
-    sink.emit(
-        AgentEvent::Tool(ToolEvent::Blocked {
-            id: "tool-blocked".to_string(),
-            name: "danger".to_string(),
-            input: json!({"path": "/tmp"}),
-            reason: "blocked by policy".to_string(),
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Tool(ToolEvent::Failed {
+        id: "tool-fail".to_string(),
+        error: "boom".to_string(),
+    }));
+    sink.emit(AgentEvent::Tool(ToolEvent::Blocked {
+        id: "tool-blocked".to_string(),
+        name: "danger".to_string(),
+        input: json!({"path": "/tmp"}),
+        reason: "blocked by policy".to_string(),
+    }));
 
     for (expected_id, expected_content) in
         [("tool-fail", "boom"), ("tool-blocked", "blocked by policy")]
@@ -866,13 +780,10 @@ fn ag_ui_sink_maps_turn_started_and_ended_to_step_events() {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
     let sink = super::AgUiSink::with_snapshot(tx, MessageId::random(), true, None);
 
-    sink.emit(AgentEvent::Turn(TurnEvent::Started), None);
-    sink.emit(
-        AgentEvent::Turn(TurnEvent::Ended {
-            outcome: harnx_core::event::TurnOutcome::default(),
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Turn(TurnEvent::Started));
+    sink.emit(AgentEvent::Turn(TurnEvent::Ended {
+        outcome: harnx_core::event::TurnOutcome::default(),
+    }));
 
     match rx.try_recv().expect("step started") {
         Event::StepStarted(event) => assert_eq!(event.step_name, "turn-1"),
@@ -890,15 +801,12 @@ fn ag_ui_sink_maps_plan_event_to_custom() {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
     let sink = super::AgUiSink::with_snapshot(tx, MessageId::random(), true, None);
 
-    sink.emit(
-        AgentEvent::Plan {
-            entries: vec![harnx_core::event::PlanEntry {
-                status: "in_progress".to_string(),
-                content: "check logs".to_string(),
-            }],
-        },
-        None,
-    );
+    sink.emit(AgentEvent::Plan {
+        entries: vec![harnx_core::event::PlanEntry {
+            status: "in_progress".to_string(),
+            content: "check logs".to_string(),
+        }],
+    });
 
     match rx.try_recv().expect("plan custom") {
         Event::Custom(event) => {
@@ -948,21 +856,15 @@ fn ag_ui_sink_emits_session_handoff_custom_event_on_handoff_requested() {
     let sink = super::AgUiSink::with_snapshot(tx, message_id.clone(), false, None);
 
     // Emit the handoff event
-    sink.emit(
-        AgentEvent::Turn(TurnEvent::HandoffRequested {
-            agent: "target-agent".to_string(),
-            session_id: Some("target-session-123".to_string()),
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Turn(TurnEvent::HandoffRequested {
+        agent: "target-agent".to_string(),
+        session_id: Some("target-session-123".to_string()),
+    }));
 
     // Emit a step finished event (simulating turn end after handoff)
-    sink.emit(
-        AgentEvent::Turn(TurnEvent::Ended {
-            outcome: harnx_core::event::TurnOutcome::default(),
-        }),
-        None,
-    );
+    sink.emit(AgentEvent::Turn(TurnEvent::Ended {
+        outcome: harnx_core::event::TurnOutcome::default(),
+    }));
 
     // Collect all events in order
     let mut events: Vec<Event> = Vec::new();
@@ -1025,7 +927,7 @@ fn ag_ui_sink_maps_compaction_completed_to_custom_and_snapshot() {
     });
     let sink = super::AgUiSink::with_snapshot(tx, MessageId::random(), true, Some(snapshot));
 
-    sink.emit(AgentEvent::Session(SessionEvent::CompactingCompleted), None);
+    sink.emit(AgentEvent::Session(SessionEvent::CompactingCompleted));
 
     match rx.try_recv().expect("compaction custom") {
         Event::Custom(event) => {

--- a/crates/harnx-serve/src/session_actor.rs
+++ b/crates/harnx-serve/src/session_actor.rs
@@ -1050,12 +1050,8 @@ impl SessionActor {
 }
 
 impl harnx_core::event::AgentEventSink for BroadcastEventSender {
-    fn emit(
-        &self,
-        event: harnx_core::event::AgentEvent,
-        source: Option<harnx_core::event::AgentSource>,
-    ) {
-        self.sink.emit(event, source);
+    fn emit(&self, event: harnx_core::event::AgentEvent) {
+        self.sink.emit(event);
     }
 }
 

--- a/crates/harnx-tui/src/agent_event_sink.rs
+++ b/crates/harnx-tui/src/agent_event_sink.rs
@@ -1,16 +1,16 @@
 //! TUI-side `AgentEventSink` implementation. Moved from `harnx::agent_event_sink`
 //! (plan P49). The `TuiAgentEventSink` is a pure forwarder that pushes
-//! `TuiEvent::Agent(event, source)` directly into the TUI event loop.
+//! `TuiEvent::Agent(event)` directly into the TUI event loop.
 
 use std::sync::Arc;
 
-use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource};
+use harnx_core::event::{AgentEvent, AgentEventSink};
 use harnx_core::sink::install_agent_event_sink;
 
 use crate::types::TuiEvent;
 
 /// Sink used by the interactive TUI mode. Pure forwarder: carries an
-/// `UnboundedSender<TuiEvent>` and pushes `TuiEvent::Agent(event, source)`
+/// `UnboundedSender<TuiEvent>` and pushes `TuiEvent::Agent(event)`
 /// directly into the TUI event loop where `render_agent_event` dispatches
 /// on the structured `AgentEvent` variants. No translation happens here.
 pub(crate) struct TuiAgentEventSink {
@@ -24,8 +24,8 @@ impl TuiAgentEventSink {
 }
 
 impl AgentEventSink for TuiAgentEventSink {
-    fn emit(&self, event: AgentEvent, source: Option<AgentSource>) {
-        let _ = self.tx.send(TuiEvent::Agent(event, source));
+    fn emit(&self, event: AgentEvent) {
+        let _ = self.tx.send(TuiEvent::Agent(event));
     }
 }
 
@@ -61,22 +61,22 @@ mod tests {
     async fn source_propagates_through_message_chunk() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<TuiEvent>();
         let sink = TuiAgentEventSink::new(tx);
-        sink.emit(
-            AgentEvent::Model(ModelEvent::MessageChunk {
-                blocks: vec![ContentBlock::Text("hello".into())],
-            }),
-            Some(AgentSource {
+        sink.emit(AgentEvent::sub_agent(
+            AgentSource {
                 model: None,
                 agent: "argus".into(),
                 session_id: Some("session-1".into()),
+            },
+            AgentEvent::Model(ModelEvent::MessageChunk {
+                blocks: vec![ContentBlock::Text("hello".into())],
             }),
-        );
+        ));
         let ev = rx.try_recv().expect("tui event");
         match ev {
-            TuiEvent::Agent(
-                AgentEvent::Model(ModelEvent::MessageChunk { blocks }),
-                Some(source),
-            ) => {
+            TuiEvent::Agent(AgentEvent::SubAgent { source, event }) => {
+                let AgentEvent::Model(ModelEvent::MessageChunk { blocks }) = *event else {
+                    panic!("unexpected nested AgentEvent");
+                };
                 assert_eq!(blocks.len(), 1);
                 match &blocks[0] {
                     ContentBlock::Text(t) => assert_eq!(t, "hello"),
@@ -93,10 +93,10 @@ mod tests {
     async fn none_source_yields_none_source() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<TuiEvent>();
         let sink = TuiAgentEventSink::new(tx);
-        sink.emit(AgentEvent::Notice(NoticeEvent::Info("hi".into())), None);
+        sink.emit(AgentEvent::Notice(NoticeEvent::Info("hi".into())));
         let ev = rx.try_recv().expect("tui event");
         match ev {
-            TuiEvent::Agent(AgentEvent::Notice(NoticeEvent::Info(msg)), None) => {
+            TuiEvent::Agent(AgentEvent::Notice(NoticeEvent::Info(msg))) => {
                 assert_eq!(msg, "hi");
             }
             _ => panic!("unexpected TuiEvent"),
@@ -107,21 +107,25 @@ mod tests {
     async fn source_propagates_through_tool_completed() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<TuiEvent>();
         let sink = TuiAgentEventSink::new(tx);
-        sink.emit(
+        sink.emit(AgentEvent::sub_agent(
+            AgentSource {
+                agent: "hephaestus".into(),
+                session_id: None,
+                model: None,
+            },
             AgentEvent::Tool(ToolEvent::Completed {
                 id: String::new(),
                 output: serde_json::Value::String("ok".into()),
                 markdown: None,
             }),
-            Some(AgentSource {
-                agent: "hephaestus".into(),
-                session_id: None,
-                model: None,
-            }),
-        );
+        ));
         let ev = rx.try_recv().expect("tui event");
         match ev {
-            TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Completed { .. }), Some(source)) => {
+            TuiEvent::Agent(AgentEvent::SubAgent { source, event }) => {
+                assert!(matches!(
+                    *event,
+                    AgentEvent::Tool(ToolEvent::Completed { .. })
+                ));
                 assert_eq!(source.agent, "hephaestus");
                 assert!(source.session_id.is_none());
             }

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -807,8 +807,8 @@ impl Tui {
 
     async fn handle_tui_event_inner(&mut self, event: TuiEvent) -> Result<()> {
         match event {
-            TuiEvent::Agent(event, source) => {
-                self.render_agent_event(event, source).await;
+            TuiEvent::Agent(event) => {
+                self.render_agent_event(event).await;
             }
             TuiEvent::ToolRoundComplete => {
                 // Intermediate tool round — prompt loop continues, don't clear llm_busy.
@@ -957,11 +957,15 @@ impl Tui {
         self.flush_pending_thought();
     }
 
-    async fn render_agent_event(&mut self, event: AgentEvent, source: Option<AgentSource>) {
+    async fn render_agent_event(&mut self, event: AgentEvent) {
         use harnx_core::event::{
             ModelEvent, NoticeEvent, SessionEvent, ToolEvent, TurnEvent, UserEvent,
         };
 
+        let (source, event, is_sub_agent) = match event {
+            AgentEvent::SubAgent { source, event } => (Some(source), *event, true),
+            event => (None, event, false),
+        };
         let is_thought = matches!(&event, AgentEvent::Model(ModelEvent::ThoughtChunk { .. }));
         let is_usage = matches!(&event, AgentEvent::Model(ModelEvent::Usage { .. }));
         // No streaming-run bookkeeping is needed here: any event that renders a
@@ -1093,126 +1097,21 @@ impl Tui {
                     vec![]
                 }
             }
+            AgentEvent::SubAgent { .. } => unreachable!("sub-agent event flattened above"),
             AgentEvent::Model(ModelEvent::Final { output, usage }) => {
-                self.flush_pending_thought();
-                self.app.llm_busy = false;
-                self.active_remote_session = None;
-                // The task that emitted Final has signalled it is exiting.
-                // Drop our reference to its abort signal — the next Ctrl+C
-                // should not target a task that's already gone. We keep
-                // the JoinHandle until the next `start_prompt` so the
-                // drain step has something to await on (already-completed
-                // handles resolve immediately).
-                self.current_prompt_abort = None;
-                // Defensive cleanup of the pending-message channel: the
-                // normal mid-tool-round consumption already clears it,
-                // but a text-only response path leaves it set, where it
-                // would otherwise leak into the NEXT prompt task and be
-                // re-injected as a duplicate user message.
-                *self.shared_pending_message.lock().await = None;
-                self.app.last_ui_output_source = None;
-                let usage_str = format_usage(&usage);
-                if !output.is_empty() {
-                    if self.app.streamed_text_this_turn {
-                        // We streamed this turn, so the streamed run is the
-                        // trailing block of AssistantText items. Replace it
-                        // with the model's canonical final `output` (collapsing
-                        // any trailing run to a single block) so streamed text
-                        // is never duplicated by the final message.
-                        let tail_start = self
-                            .app
-                            .transcript
-                            .iter()
-                            .rposition(|item| !matches!(item, TranscriptItem::AssistantText { .. }))
-                            .map_or(0, |idx| idx + 1);
-
-                        if tail_start < self.app.transcript.len() {
-                            let mut tail = self.app.transcript.split_off(tail_start);
-                            if let Some(TranscriptItem::AssistantText {
-                                text,
-                                rendered_cache,
-                                ..
-                            }) = tail.first_mut()
-                            {
-                                *text = output;
-                                *rendered_cache = None;
-                            }
-                            tail.truncate(1);
-                            self.app.transcript.extend(tail);
-                        } else {
-                            self.app.transcript.push(TranscriptItem::AssistantText {
-                                text: output,
-                                seq: None,
-                                timestamp: Some(chrono::Utc::now()),
-                                rendered_cache: None,
-                            });
-                        }
-                    } else {
-                        // Nothing streamed this turn (non-streaming client, or
-                        // an empty stream): append the final text as a fresh
-                        // block.
-                        self.app.transcript.push(TranscriptItem::AssistantText {
-                            text: output,
-                            seq: None,
-                            timestamp: Some(chrono::Utc::now()),
-                            rendered_cache: None,
-                        });
-                    }
-                    self.pin_transcript_to_bottom();
-                }
-                self.app.streaming_open = false;
-                self.app.streamed_text_this_turn = false;
-                if !usage_str.is_empty() {
-                    self.app
-                        .transcript
-                        .push(TranscriptItem::SystemText(format!("Usage: {usage_str}")));
-                    self.pin_transcript_to_bottom();
-                }
-                self.refresh_input_chrome();
-
-                if let Some(pending) = self.app.pending_message.take() {
-                    if let Err(err) = self.submit_pending_message(pending).await {
-                        self.app
-                            .transcript
-                            .push(TranscriptItem::ErrorText(pretty_error_string(&err)));
-                        self.pin_transcript_to_bottom();
-                    }
+                if is_sub_agent {
+                    self.render_sub_agent_final(output, &usage);
+                } else {
+                    self.finish_main_prompt_final(output, &usage).await;
                 }
                 vec![]
             }
             AgentEvent::Model(ModelEvent::Error(err)) => {
-                self.flush_pending_thought();
-                self.app.llm_busy = false;
-                self.active_remote_session = None;
-                // Mirrors the Final cleanup: drop the per-task abort
-                // signal (task has exited) and clear the shared pending
-                // channel so its content can't leak into the next task.
-                self.current_prompt_abort = None;
-                *self.shared_pending_message.lock().await = None;
-                self.app.streaming_open = false;
-                // Symmetric with the Final handler: reset the per-turn
-                // streamed-text flag so a streamed chunk before an error
-                // can't suppress a later turn's final text.
-                self.app.streamed_text_this_turn = false;
-                self.app.last_ui_output_source = None;
-                self.app.transcript.push(TranscriptItem::ErrorText(err));
-
-                // Do NOT auto-replay the pending message on error. Replaying the
-                // exact input that just failed would loop forever for persistent
-                // failures (invalid input, repeated network errors). Instead,
-                // restore it as an editable draft so the user can review/edit and
-                // resubmit it with Enter, breaking the retry loop (issue #199).
-                if let Some(pending) = self.app.pending_message.take() {
-                    self.set_input_text(&pending.text);
-                    self.app.attachments = pending.attachments;
-                    self.app.attachment_dir = pending.attachment_dir;
-                    self.app.paste_count = pending.paste_count;
-                    self.app.transcript.push(TranscriptItem::SystemText(
-                        "Queued message not sent due to error. Press Enter to retry.".to_string(),
-                    ));
+                if is_sub_agent {
+                    self.render_sub_agent_error(err);
+                } else {
+                    self.finish_main_prompt_error(err).await;
                 }
-                self.pin_transcript_to_bottom();
-                self.refresh_input_chrome();
                 vec![]
             }
             AgentEvent::Model(ModelEvent::ThoughtChunk { blocks }) => {
@@ -1371,6 +1270,147 @@ impl Tui {
         }
     }
 
+    async fn finish_main_prompt_final(
+        &mut self,
+        output: String,
+        usage: &harnx_core::api_types::CompletionTokenUsage,
+    ) {
+        self.flush_pending_thought();
+        self.app.llm_busy = false;
+        self.active_remote_session = None;
+        // Final means this task is exiting. Keep its completed JoinHandle for
+        // the next start_prompt drain, but drop the obsolete abort signal.
+        self.current_prompt_abort = None;
+        // Prevent a text-only response from leaking a queued message into the
+        // next prompt task as a duplicate user message.
+        *self.shared_pending_message.lock().await = None;
+        self.app.last_ui_output_source = None;
+        let usage_str = format_usage(usage);
+        if !output.is_empty() {
+            if self.app.streamed_text_this_turn {
+                // Replace the trailing streamed run with canonical final output.
+                let tail_start = self
+                    .app
+                    .transcript
+                    .iter()
+                    .rposition(|item| !matches!(item, TranscriptItem::AssistantText { .. }))
+                    .map_or(0, |idx| idx + 1);
+
+                if tail_start < self.app.transcript.len() {
+                    let mut tail = self.app.transcript.split_off(tail_start);
+                    if let Some(TranscriptItem::AssistantText {
+                        text,
+                        rendered_cache,
+                        ..
+                    }) = tail.first_mut()
+                    {
+                        *text = output;
+                        *rendered_cache = None;
+                    }
+                    tail.truncate(1);
+                    self.app.transcript.extend(tail);
+                } else {
+                    self.app.transcript.push(TranscriptItem::AssistantText {
+                        text: output,
+                        seq: None,
+                        timestamp: Some(chrono::Utc::now()),
+                        rendered_cache: None,
+                    });
+                }
+            } else {
+                self.app.transcript.push(TranscriptItem::AssistantText {
+                    text: output,
+                    seq: None,
+                    timestamp: Some(chrono::Utc::now()),
+                    rendered_cache: None,
+                });
+            }
+            self.pin_transcript_to_bottom();
+        }
+        self.app.streaming_open = false;
+        self.app.streamed_text_this_turn = false;
+        if !usage_str.is_empty() {
+            self.app
+                .transcript
+                .push(TranscriptItem::SystemText(format!("Usage: {usage_str}")));
+            self.pin_transcript_to_bottom();
+        }
+        self.refresh_input_chrome();
+
+        if let Some(pending) = self.app.pending_message.take() {
+            if let Err(err) = self.submit_pending_message(pending).await {
+                self.app
+                    .transcript
+                    .push(TranscriptItem::ErrorText(pretty_error_string(&err)));
+                self.pin_transcript_to_bottom();
+            }
+        }
+    }
+
+    async fn finish_main_prompt_error(&mut self, err: String) {
+        self.flush_pending_thought();
+        self.app.llm_busy = false;
+        self.active_remote_session = None;
+        self.current_prompt_abort = None;
+        *self.shared_pending_message.lock().await = None;
+        self.app.streaming_open = false;
+        self.app.streamed_text_this_turn = false;
+        self.app.last_ui_output_source = None;
+        self.app.transcript.push(TranscriptItem::ErrorText(err));
+
+        // Do not replay input that failed. Restore it as editable draft so user
+        // can change it before resubmitting, avoiding persistent retry loops.
+        if let Some(pending) = self.app.pending_message.take() {
+            self.set_input_text(&pending.text);
+            self.app.attachments = pending.attachments;
+            self.app.attachment_dir = pending.attachment_dir;
+            self.app.paste_count = pending.paste_count;
+            self.app.transcript.push(TranscriptItem::SystemText(
+                "Queued message not sent due to error. Press Enter to retry.".to_string(),
+            ));
+        }
+        self.pin_transcript_to_bottom();
+        self.refresh_input_chrome();
+    }
+
+    /// Render a nested sub-agent's final turn text under its source heading.
+    /// Deliberately touches no main-task state (busy flag, abort signal,
+    /// pending message): the tool call that delegated to the sub-agent is
+    /// still in flight, so the main prompt task is not done.
+    fn render_sub_agent_final(
+        &mut self,
+        output: String,
+        usage: &harnx_core::api_types::CompletionTokenUsage,
+    ) {
+        if !output.is_empty() {
+            self.app.transcript.push(TranscriptItem::AssistantText {
+                text: output,
+                seq: None,
+                timestamp: Some(chrono::Utc::now()),
+                rendered_cache: None,
+            });
+        }
+        // Close any open streaming run so a later chunk from the same source
+        // starts a fresh block instead of appending to this final text.
+        self.app.streaming_open = false;
+        let usage_str = format_usage(usage);
+        if !usage_str.is_empty() {
+            self.app
+                .transcript
+                .push(TranscriptItem::SystemText(format!("Usage: {usage_str}")));
+        }
+        self.pin_transcript_to_bottom();
+    }
+
+    /// Render a nested sub-agent's error. Like `render_sub_agent_final`,
+    /// this only surfaces the text — the main prompt task keeps running,
+    /// so busy state and the queued pending message stay untouched.
+    fn render_sub_agent_error(&mut self, err: String) {
+        self.app.transcript.push(TranscriptItem::ErrorText(err));
+        self.app.streaming_open = false;
+        self.pin_transcript_to_bottom();
+    }
+
     fn render_ui_output_heading(&mut self, source: Option<&AgentSource>, is_usage: bool) {
         let source = source.cloned();
         if source != self.app.last_ui_output_source {
@@ -1489,10 +1529,9 @@ impl Tui {
 
             if let Err(err) = result {
                 use harnx_core::event::{AgentEvent, ModelEvent};
-                let _ = event_tx.send(TuiEvent::Agent(
-                    AgentEvent::Model(ModelEvent::Error(pretty_error_string(&err))),
-                    None,
-                ));
+                let _ = event_tx.send(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Error(
+                    pretty_error_string(&err),
+                ))));
             }
         });
         self.current_prompt_handle = Some(handle);

--- a/crates/harnx-tui/src/prompt.rs
+++ b/crates/harnx-tui/src/prompt.rs
@@ -130,10 +130,10 @@ impl Tui {
                 let event_tx = event_tx.clone();
                 Box::pin(async move {
                     use harnx_core::event::{AgentEvent, ModelEvent};
-                    let _ = event_tx.send(TuiEvent::Agent(
-                        AgentEvent::Model(ModelEvent::Final { output, usage }),
-                        None,
-                    ));
+                    let _ = event_tx.send(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Final {
+                        output,
+                        usage,
+                    })));
                 })
             },
         );

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -250,13 +250,10 @@ async fn pending_message_is_auto_sent_after_finish() {
     tui.app.llm_busy = true;
     tui.queue_pending_message("follow up".to_string()).await;
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Model(ModelEvent::Final {
-            output: "done".to_string(),
-            usage: Default::default(),
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Final {
+        output: "done".to_string(),
+        usage: Default::default(),
+    })))
     .await
     .unwrap();
 
@@ -267,6 +264,107 @@ async fn pending_message_is_auto_sent_after_finish() {
             |entry| matches!(entry, TranscriptItem::UserText { text, .. } if text == "follow up"),
         );
     assert!(has_user_entry);
+}
+
+fn sub_agent_source() -> AgentSource {
+    AgentSource {
+        agent: "aristarchus".to_string(),
+        session_id: Some("sub-session-1".to_string()),
+        model: None,
+    }
+}
+
+/// A nested sub-agent's error (e.g. a transient LLM failure inside a
+/// delegated ACP session) arrives as a `SubAgent`-wrapped `ModelEvent::Error`.
+/// It must NOT be mistaken for the end of the main prompt task: the
+/// delegating tool call is still in flight, so busy state and the queued
+/// pending message must survive. Otherwise the TUI shows idle (no spinner)
+/// while the agent loop is still running and output keeps streaming.
+#[tokio::test]
+async fn sub_agent_error_does_not_clear_llm_busy() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+    tui.app.llm_busy = true;
+    tui.queue_pending_message("follow up".to_string()).await;
+
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        sub_agent_source(),
+        AgentEvent::Model(ModelEvent::Error("sub-agent exploded".to_string())),
+    )))
+    .await
+    .unwrap();
+
+    assert!(
+        tui.app.llm_busy,
+        "sub-agent error must not clear the main busy flag"
+    );
+    // The queued message still belongs to the (still running) main task.
+    assert!(tui.app.pending_message.is_some());
+    assert!(tui.shared_pending_message.lock().await.is_some());
+    // The error itself is still surfaced in the transcript.
+    assert!(tui.app.transcript.iter().any(
+        |entry| matches!(entry, TranscriptItem::ErrorText(text) if text == "sub-agent exploded")
+    ));
+}
+
+/// Same as above for `ModelEvent::Final`: only a bare main-task Final may
+/// flip the TUI back to idle.
+#[tokio::test]
+async fn sub_agent_final_does_not_clear_llm_busy() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+    tui.app.llm_busy = true;
+    tui.queue_pending_message("follow up".to_string()).await;
+
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        sub_agent_source(),
+        AgentEvent::Model(ModelEvent::Final {
+            output: "sub-agent final text".to_string(),
+            usage: Default::default(),
+        }),
+    )))
+    .await
+    .unwrap();
+
+    assert!(
+        tui.app.llm_busy,
+        "sub-agent Final must not clear the main busy flag"
+    );
+    // The pending message must not be auto-submitted by a sub-agent Final.
+    assert!(tui.app.pending_message.is_some());
+    assert!(tui.shared_pending_message.lock().await.is_some());
+    // The sub-agent's final text is still rendered.
+    assert!(tui.app.transcript.iter().any(
+        |entry| matches!(entry, TranscriptItem::AssistantText { text, .. } if text == "sub-agent final text")
+    ));
+}
+
+#[tokio::test]
+async fn bare_final_clears_llm_busy() {
+    let config = test_config();
+    let persistent = Arc::new(Mutex::new(PersistentHookManager::new()));
+    let mut tui = Tui::init(&config, AsyncHookManager::new(), persistent)
+        .await
+        .unwrap();
+    tui.app.llm_busy = true;
+
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Final {
+        output: "main final text".to_string(),
+        usage: Default::default(),
+    })))
+    .await
+    .unwrap();
+
+    assert!(
+        !tui.app.llm_busy,
+        "bare Final must clear the main busy flag"
+    );
 }
 
 #[tokio::test]
@@ -297,13 +395,10 @@ async fn pending_dot_command_restores_attachments_before_running() {
     });
     tui.set_input_text(".info attachments");
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Model(ModelEvent::Final {
-            output: "done".to_string(),
-            usage: Default::default(),
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Final {
+        output: "done".to_string(),
+        usage: Default::default(),
+    })))
     .await
     .unwrap();
 
@@ -373,13 +468,10 @@ async fn pending_message_not_double_submitted_after_consumed() {
     .unwrap();
 
     // Now LlmFinal arrives.
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Model(ModelEvent::Final {
-            output: "final answer".to_string(),
-            usage: Default::default(),
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Final {
+        output: "final answer".to_string(),
+        usage: Default::default(),
+    })))
     .await
     .unwrap();
 
@@ -474,26 +566,23 @@ async fn streaming_chunks_accumulate_across_interleaved_ui_output() {
         .await
         .unwrap();
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Model(ModelEvent::MessageChunk {
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+        ModelEvent::MessageChunk {
             blocks: vec![ContentBlock::Text("Hello\nworld".to_string())],
-        }),
-        None,
-    ))
+        },
+    )))
     .await
     .unwrap();
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Notice(NoticeEvent::Info("tool output".to_string())),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Notice(NoticeEvent::Info(
+        "tool output".to_string(),
+    ))))
     .await
     .unwrap();
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Model(ModelEvent::MessageChunk {
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+        ModelEvent::MessageChunk {
             blocks: vec![ContentBlock::Text("\nAgain".to_string())],
-        }),
-        None,
-    ))
+        },
+    )))
     .await
     .unwrap();
 
@@ -528,23 +617,19 @@ async fn final_coalesces_streamed_multiline_assistant_text() {
     tui.app.streamed_text_this_turn = false;
 
     for chunk in ["Hello\n", "world\n", "Again"] {
-        tui.handle_tui_event(TuiEvent::Agent(
-            AgentEvent::Model(ModelEvent::MessageChunk {
+        tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+            ModelEvent::MessageChunk {
                 blocks: vec![ContentBlock::Text(chunk.to_string())],
-            }),
-            None,
-        ))
+            },
+        )))
         .await
         .unwrap();
     }
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Model(ModelEvent::Final {
-            output: "Hello\nworld\nAgain".to_string(),
-            usage: Default::default(),
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Final {
+        output: "Hello\nworld\nAgain".to_string(),
+        usage: Default::default(),
+    })))
     .await
     .unwrap();
 
@@ -579,24 +664,20 @@ async fn final_coalesces_streamed_fenced_code_block_into_one_entry() {
         "```\n",
     ];
     for chunk in chunks {
-        tui.handle_tui_event(TuiEvent::Agent(
-            AgentEvent::Model(ModelEvent::MessageChunk {
+        tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+            ModelEvent::MessageChunk {
                 blocks: vec![ContentBlock::Text(chunk.to_string())],
-            }),
-            None,
-        ))
+            },
+        )))
         .await
         .unwrap();
     }
 
     let full_block = "```rust\nfn main() {\n    println!(\"hi\");\n}\n```\n";
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Model(ModelEvent::Final {
-            output: full_block.to_string(),
-            usage: Default::default(),
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Final {
+        output: full_block.to_string(),
+        usage: Default::default(),
+    })))
     .await
     .unwrap();
 
@@ -623,42 +704,36 @@ async fn final_only_coalesces_trailing_streamed_run_after_interruption() {
     tui.app.llm_busy = true;
 
     for chunk in ["```rust\n", "fn first() {}\n"] {
-        tui.handle_tui_event(TuiEvent::Agent(
-            AgentEvent::Model(ModelEvent::MessageChunk {
+        tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+            ModelEvent::MessageChunk {
                 blocks: vec![ContentBlock::Text(chunk.to_string())],
-            }),
-            None,
-        ))
+            },
+        )))
         .await
         .unwrap();
     }
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Notice(NoticeEvent::Info("tool output".to_string())),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Notice(NoticeEvent::Info(
+        "tool output".to_string(),
+    ))))
     .await
     .unwrap();
 
     for chunk in ["fn second() {}\n", "```\n"] {
-        tui.handle_tui_event(TuiEvent::Agent(
-            AgentEvent::Model(ModelEvent::MessageChunk {
+        tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+            ModelEvent::MessageChunk {
                 blocks: vec![ContentBlock::Text(chunk.to_string())],
-            }),
-            None,
-        ))
+            },
+        )))
         .await
         .unwrap();
     }
 
     let full_block = "```rust\nfn first() {}\nfn second() {}\n```\n";
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Model(ModelEvent::Final {
-            output: full_block.to_string(),
-            usage: Default::default(),
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Final {
+        output: full_block.to_string(),
+        usage: Default::default(),
+    })))
     .await
     .unwrap();
 
@@ -691,13 +766,10 @@ async fn final_without_chunks_renders_assistant_text_once() {
 
     tui.app.llm_busy = true;
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Model(ModelEvent::Final {
-            output: "Hello\nworld\nAgain".to_string(),
-            usage: Default::default(),
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Final {
+        output: "Hello\nworld\nAgain".to_string(),
+        usage: Default::default(),
+    })))
     .await
     .unwrap();
 
@@ -727,26 +799,26 @@ async fn ui_output_inserts_heading_when_source_changes() {
         model: None,
     };
 
-    tui.handle_tui_event(TuiEvent::Agent(
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        source.clone(),
         AgentEvent::Notice(NoticeEvent::Info("first chunk".to_string())),
-        Some(source.clone()),
-    ))
+    )))
     .await
     .unwrap();
-    tui.handle_tui_event(TuiEvent::Agent(
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        source,
         AgentEvent::Notice(NoticeEvent::Info("second chunk".to_string())),
-        Some(source),
-    ))
+    )))
     .await
     .unwrap();
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Notice(NoticeEvent::Info("other chunk".to_string())),
-        Some(AgentSource {
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        AgentSource {
             model: None,
             agent: "hephaestus".to_string(),
             session_id: Some("session-2".to_string()),
-        }),
-    ))
+        },
+        AgentEvent::Notice(NoticeEvent::Info("other chunk".to_string())),
+    )))
     .await
     .unwrap();
 
@@ -1099,62 +1171,60 @@ async fn sub_agent_heading_transitions_render_in_tui_snapshot() {
 
     harness
         .tui()
-        .handle_tui_event(TuiEvent::Agent(
-            AgentEvent::Model(ModelEvent::MessageChunk {
+        .handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+            ModelEvent::MessageChunk {
                 blocks: vec![ContentBlock::Text(
                     "Top-level assistant opening response.".to_string(),
                 )],
-            }),
-            None,
-        ))
+            },
+        )))
         .await
         .unwrap();
     harness
         .tui()
-        .handle_tui_event(TuiEvent::Agent(
+        .handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+            AgentSource {
+                model: None,
+                agent: "argus".to_string(),
+                session_id: Some("session-1".to_string()),
+            },
             AgentEvent::Notice(NoticeEvent::Info("sub-agent tool call".to_string())),
-            Some(AgentSource {
-                model: None,
-                agent: "argus".to_string(),
-                session_id: Some("session-1".to_string()),
-            }),
-        ))
+        )))
         .await
         .unwrap();
     harness
         .tui()
-        .handle_tui_event(TuiEvent::Agent(
+        .handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+            AgentSource {
+                model: None,
+                agent: "argus".to_string(),
+                session_id: Some("session-1".to_string()),
+            },
             AgentEvent::Notice(NoticeEvent::Info("sub-agent follow-up output".to_string())),
-            Some(AgentSource {
-                model: None,
-                agent: "argus".to_string(),
-                session_id: Some("session-1".to_string()),
-            }),
-        ))
+        )))
         .await
         .unwrap();
     harness
         .tui()
-        .handle_tui_event(TuiEvent::Agent(
-            AgentEvent::Notice(NoticeEvent::Info("other sub-agent output".to_string())),
-            Some(AgentSource {
+        .handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+            AgentSource {
                 model: None,
                 agent: "hephaestus".to_string(),
                 session_id: Some("session-2".to_string()),
-            }),
-        ))
+            },
+            AgentEvent::Notice(NoticeEvent::Info("other sub-agent output".to_string())),
+        )))
         .await
         .unwrap();
     harness
         .tui()
-        .handle_tui_event(TuiEvent::Agent(
-            AgentEvent::Model(ModelEvent::MessageChunk {
+        .handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+            ModelEvent::MessageChunk {
                 blocks: vec![ContentBlock::Text(
                     "Top-level assistant closes response.".to_string(),
                 )],
-            }),
-            None,
-        ))
+            },
+        )))
         .await
         .unwrap();
 
@@ -1175,7 +1245,12 @@ async fn structured_system_entries_do_not_insert_blank_lines_between_each_line()
 
     harness
         .tui()
-        .handle_tui_event(TuiEvent::Agent(
+        .handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+            AgentSource {
+                model: None,
+                agent: "argus".to_string(),
+                session_id: Some("session-1".to_string()),
+            },
             AgentEvent::Tool(ToolEvent::Started {
                 id: String::new(),
                 name: "argus_session_prompt".to_string(),
@@ -1184,26 +1259,21 @@ async fn structured_system_entries_do_not_insert_blank_lines_between_each_line()
                 input: yaml_to_json("message: hello\nsession_id: abc123"),
                 locations: vec![],
             }),
-            Some(AgentSource {
-                model: None,
-                agent: "argus".to_string(),
-                session_id: Some("session-1".to_string()),
-            }),
-        ))
+        )))
         .await
         .unwrap();
     harness
         .tui()
-        .handle_tui_event(TuiEvent::Agent(
-            AgentEvent::Model(ModelEvent::ThoughtChunk {
-                blocks: vec![ContentBlock::Text("thinking hard\nstep two".to_string())],
-            }),
-            Some(AgentSource {
+        .handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+            AgentSource {
                 model: None,
                 agent: "argus".to_string(),
                 session_id: Some("session-1".to_string()),
+            },
+            AgentEvent::Model(ModelEvent::ThoughtChunk {
+                blocks: vec![ContentBlock::Text("thinking hard\nstep two".to_string())],
             }),
-        ))
+        )))
         .await
         .unwrap();
 
@@ -1222,37 +1292,32 @@ async fn top_level_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         .unwrap();
 
     for chunk in ["thinking ", "before ", "tool"] {
-        tui.handle_tui_event(TuiEvent::Agent(
-            AgentEvent::Model(ModelEvent::ThoughtChunk {
+        tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+            ModelEvent::ThoughtChunk {
                 blocks: vec![ContentBlock::Text(chunk.to_string())],
-            }),
-            None,
-        ))
+            },
+        )))
         .await
         .unwrap();
     }
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Started {
-            id: String::new(),
-            name: "argus_session_prompt".to_string(),
-            kind: ToolKind::Other,
-            markdown: None,
-            input: yaml_to_json("message: delegate"),
-            locations: vec![],
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Started {
+        id: String::new(),
+        name: "argus_session_prompt".to_string(),
+        kind: ToolKind::Other,
+        markdown: None,
+        input: yaml_to_json("message: delegate"),
+        locations: vec![],
+    })))
     .await
     .unwrap();
 
     for chunk in ["thinking ", "after ", "tool"] {
-        tui.handle_tui_event(TuiEvent::Agent(
-            AgentEvent::Model(ModelEvent::ThoughtChunk {
+        tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+            ModelEvent::ThoughtChunk {
                 blocks: vec![ContentBlock::Text(chunk.to_string())],
-            }),
-            None,
-        ))
+            },
+        )))
         .await
         .unwrap();
     }
@@ -1297,24 +1362,25 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
         .await
         .unwrap();
 
-    let source = Some(AgentSource {
+    let source = AgentSource {
         agent: "argus".to_string(),
         session_id: Some("session-1".to_string()),
         model: None,
-    });
+    };
 
     for chunk in ["thinking ", "before ", "tool"] {
-        tui.handle_tui_event(TuiEvent::Agent(
+        tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+            source.clone(),
             AgentEvent::Model(ModelEvent::ThoughtChunk {
                 blocks: vec![ContentBlock::Text(chunk.to_string())],
             }),
-            source.clone(),
-        ))
+        )))
         .await
         .unwrap();
     }
 
-    tui.handle_tui_event(TuiEvent::Agent(
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        source.clone(),
         AgentEvent::Tool(ToolEvent::Started {
             id: String::new(),
             name: "argus_session_prompt".to_string(),
@@ -1323,18 +1389,17 @@ async fn sub_agent_thinking_stream_coalesces_into_paragraphs_around_tool_calls()
             input: yaml_to_json("message: delegate"),
             locations: vec![],
         }),
-        source.clone(),
-    ))
+    )))
     .await
     .unwrap();
 
     for chunk in ["thinking ", "after ", "tool"] {
-        tui.handle_tui_event(TuiEvent::Agent(
+        tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+            source.clone(),
             AgentEvent::Model(ModelEvent::ThoughtChunk {
                 blocks: vec![ContentBlock::Text(chunk.to_string())],
             }),
-            source.clone(),
-        ))
+        )))
         .await
         .unwrap();
     }
@@ -1383,12 +1448,11 @@ async fn whitespace_only_thought_chunk_is_preserved_in_tui() {
         .unwrap();
 
     // Send a thought chunk with only a newline
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Model(ModelEvent::ThoughtChunk {
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+        ModelEvent::ThoughtChunk {
             blocks: vec![ContentBlock::Text("\n".to_string())],
-        }),
-        None,
-    ))
+        },
+    )))
     .await
     .unwrap();
 
@@ -1406,12 +1470,11 @@ async fn thought_chunk_with_think_tags_is_stripped_and_dropped_if_empty() {
         .unwrap();
 
     // Send a thought chunk with only <think> tags
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Model(ModelEvent::ThoughtChunk {
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+        ModelEvent::ThoughtChunk {
             blocks: vec![ContentBlock::Text("<think></think>".to_string())],
-        }),
-        None,
-    ))
+        },
+    )))
     .await
     .unwrap();
 
@@ -1428,14 +1491,13 @@ async fn llm_multiline_text_renders_without_extra_blank_lines() {
 
     harness
         .tui()
-        .handle_tui_event(TuiEvent::Agent(
-            AgentEvent::Model(ModelEvent::MessageChunk {
+        .handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+            ModelEvent::MessageChunk {
                 blocks: vec![ContentBlock::Text(
                     "line one\nline two\nline three".to_string(),
                 )],
-            }),
-            None,
-        ))
+            },
+        )))
         .await
         .unwrap();
 
@@ -1459,22 +1521,27 @@ async fn thinking_stream_coalescing_around_tool_calls_snapshot() {
     for chunk in ["thinking ", "before ", "tool"] {
         harness
             .tui()
-            .handle_tui_event(TuiEvent::Agent(
-                AgentEvent::Model(ModelEvent::ThoughtChunk {
-                    blocks: vec![ContentBlock::Text(chunk.to_string())],
-                }),
-                Some(AgentSource {
+            .handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+                AgentSource {
                     model: None,
                     agent: "argus".to_string(),
                     session_id: Some("session-1".to_string()),
+                },
+                AgentEvent::Model(ModelEvent::ThoughtChunk {
+                    blocks: vec![ContentBlock::Text(chunk.to_string())],
                 }),
-            ))
+            )))
             .await
             .unwrap();
     }
     harness
         .tui()
-        .handle_tui_event(TuiEvent::Agent(
+        .handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+            AgentSource {
+                model: None,
+                agent: "argus".to_string(),
+                session_id: Some("session-1".to_string()),
+            },
             AgentEvent::Tool(ToolEvent::Started {
                 id: String::new(),
                 name: "argus_session_prompt".to_string(),
@@ -1483,27 +1550,22 @@ async fn thinking_stream_coalescing_around_tool_calls_snapshot() {
                 input: yaml_to_json("message: delegate"),
                 locations: vec![],
             }),
-            Some(AgentSource {
-                model: None,
-                agent: "argus".to_string(),
-                session_id: Some("session-1".to_string()),
-            }),
-        ))
+        )))
         .await
         .unwrap();
     for chunk in ["thinking ", "after ", "tool"] {
         harness
             .tui()
-            .handle_tui_event(TuiEvent::Agent(
-                AgentEvent::Model(ModelEvent::ThoughtChunk {
-                    blocks: vec![ContentBlock::Text(chunk.to_string())],
-                }),
-                Some(AgentSource {
+            .handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+                AgentSource {
                     model: None,
                     agent: "argus".to_string(),
                     session_id: Some("session-1".to_string()),
+                },
+                AgentEvent::Model(ModelEvent::ThoughtChunk {
+                    blocks: vec![ContentBlock::Text(chunk.to_string())],
                 }),
-            ))
+            )))
             .await
             .unwrap();
     }
@@ -1522,7 +1584,12 @@ async fn structured_ui_output_variants_render_in_transcript() {
         .await
         .unwrap();
 
-    tui.handle_tui_event(TuiEvent::Agent(
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        AgentSource {
+            agent: "argus".to_string(),
+            session_id: Some("session-1".to_string()),
+            model: None,
+        },
         AgentEvent::Tool(ToolEvent::Started {
             id: String::new(),
             name: "argus_session_prompt".to_string(),
@@ -1531,42 +1598,42 @@ async fn structured_ui_output_variants_render_in_transcript() {
             input: yaml_to_json("message: hello\nsession_id: abc123"),
             locations: vec![],
         }),
-        Some(AgentSource {
+    )))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        AgentSource {
             agent: "argus".to_string(),
             session_id: Some("session-1".to_string()),
             model: None,
-        }),
-    ))
-    .await
-    .unwrap();
-    tui.handle_tui_event(TuiEvent::Agent(
+        },
         AgentEvent::Model(ModelEvent::ThoughtChunk {
             blocks: vec![ContentBlock::Text("thinking hard".to_string())],
         }),
-        Some(AgentSource {
+    )))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        AgentSource {
             agent: "argus".to_string(),
             session_id: Some("session-1".to_string()),
             model: None,
-        }),
-    ))
-    .await
-    .unwrap();
-    tui.handle_tui_event(TuiEvent::Agent(
+        },
         AgentEvent::Tool(ToolEvent::Update {
             id: "call-1".to_string(),
             markdown: Some("argus_session_prompt".to_string()),
             status: Some(ToolStatus::Completed),
             content: None,
         }),
-        Some(AgentSource {
+    )))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        AgentSource {
             agent: "argus".to_string(),
             session_id: Some("session-1".to_string()),
             model: None,
-        }),
-    ))
-    .await
-    .unwrap();
-    tui.handle_tui_event(TuiEvent::Agent(
+        },
         AgentEvent::Plan {
             entries: vec![
                 PlanEntry {
@@ -1579,50 +1646,39 @@ async fn structured_ui_output_variants_render_in_transcript() {
                 },
             ],
         },
-        Some(AgentSource {
+    )))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        AgentSource {
             agent: "argus".to_string(),
             session_id: Some("session-1".to_string()),
             model: None,
-        }),
-    ))
-    .await
-    .unwrap();
-    tui.handle_tui_event(TuiEvent::Agent(
+        },
         AgentEvent::Model(ModelEvent::Usage {
             input: 12,
             output: 34,
             cached: 5,
             session_label: Some("> argus ▸ session-1".to_string()),
         }),
-        Some(AgentSource {
-            agent: "argus".to_string(),
-            session_id: Some("session-1".to_string()),
-            model: None,
-        }),
-    ))
+    )))
     .await
     .unwrap();
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Started {
-            id: String::new(),
-            name: "bash".to_string(),
-            kind: ToolKind::Other,
-            markdown: None,
-            input: yaml_to_json("command: ls"),
-            locations: vec![],
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Started {
+        id: String::new(),
+        name: "bash".to_string(),
+        kind: ToolKind::Other,
+        markdown: None,
+        input: yaml_to_json("command: ls"),
+        locations: vec![],
+    })))
     .await
     .unwrap();
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Completed {
-            id: String::new(),
-            output: serde_json::Value::String("\u{1b}[2mline one\nline two\u{1b}[0m\n".to_string()),
-            markdown: None,
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Completed {
+        id: String::new(),
+        output: serde_json::Value::String("\u{1b}[2mline one\nline two\u{1b}[0m\n".to_string()),
+        markdown: None,
+    })))
     .await
     .unwrap();
 
@@ -1663,21 +1719,23 @@ async fn nested_subagent_tool_call_renders_with_heading_and_usage() {
         .await
         .unwrap();
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Started {
-            id: String::new(),
-            name: "pytheas_session_prompt".to_string(),
-            kind: ToolKind::Other,
-            markdown: None,
-            input: yaml_to_json("message: Count files in /tmp"),
-            locations: vec![],
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Started {
+        id: String::new(),
+        name: "pytheas_session_prompt".to_string(),
+        kind: ToolKind::Other,
+        markdown: None,
+        input: yaml_to_json("message: Count files in /tmp"),
+        locations: vec![],
+    })))
     .await
     .unwrap();
 
-    tui.handle_tui_event(TuiEvent::Agent(
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        AgentSource {
+            agent: "pytheas".to_string(),
+            session_id: Some("session-nested".to_string()),
+            model: None,
+        },
         AgentEvent::Tool(ToolEvent::Started {
             id: String::new(),
             name: "bash".to_string(),
@@ -1686,28 +1744,23 @@ async fn nested_subagent_tool_call_renders_with_heading_and_usage() {
             input: yaml_to_json("command: ls -1 /tmp | wc -l"),
             locations: vec![],
         }),
-        Some(AgentSource {
-            agent: "pytheas".to_string(),
-            session_id: Some("session-nested".to_string()),
-            model: None,
-        }),
-    ))
+    )))
     .await
     .unwrap();
 
-    tui.handle_tui_event(TuiEvent::Agent(
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        AgentSource {
+            agent: "pytheas".to_string(),
+            session_id: Some("session-nested".to_string()),
+            model: None,
+        },
         AgentEvent::Model(ModelEvent::Usage {
             input: 10,
             output: 20,
             cached: 0,
             session_label: Some("> pytheas ▸ session-nested".to_string()),
         }),
-        Some(AgentSource {
-            agent: "pytheas".to_string(),
-            session_id: Some("session-nested".to_string()),
-            model: None,
-        }),
-    ))
+    )))
     .await
     .unwrap();
 
@@ -1750,26 +1803,26 @@ async fn consecutive_usage_updates_replace_previous_usage_row_for_same_source() 
         model: None,
     };
 
-    tui.handle_tui_event(TuiEvent::Agent(
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        source.clone(),
         AgentEvent::Model(ModelEvent::Usage {
             input: 10,
             output: 1,
             cached: 0,
             session_label: None,
         }),
-        Some(source.clone()),
-    ))
+    )))
     .await
     .unwrap();
-    tui.handle_tui_event(TuiEvent::Agent(
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        source.clone(),
         AgentEvent::Model(ModelEvent::Usage {
             input: 20,
             output: 2,
             cached: 0,
             session_label: None,
         }),
-        Some(source.clone()),
-    ))
+    )))
     .await
     .unwrap();
 
@@ -1831,12 +1884,12 @@ async fn acp_message_chunks_coalesce_like_direct_llm_streaming() {
         "information to ",
         "complete my review.",
     ] {
-        tui.handle_tui_event(TuiEvent::Agent(
+        tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+            source.clone(),
             AgentEvent::Model(ModelEvent::MessageChunk {
                 blocks: vec![ContentBlock::Text(chunk.to_string())],
             }),
-            Some(source.clone()),
-        ))
+        )))
         .await
         .unwrap();
     }
@@ -2143,10 +2196,9 @@ async fn live_log_seq_assignment_patches_latest_unsequenced_transcript_items() {
         seq: None,
     });
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 2 }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Session(
+        SessionEvent::LogSeqAssigned { seq: 2 },
+    )))
     .await
     .unwrap();
 
@@ -2157,10 +2209,9 @@ async fn live_log_seq_assignment_patches_latest_unsequenced_transcript_items() {
         rendered_cache: None,
     });
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 3 }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Session(
+        SessionEvent::LogSeqAssigned { seq: 3 },
+    )))
     .await
     .unwrap();
 
@@ -2190,24 +2241,20 @@ async fn live_log_seq_assignment_applies_to_tool_calls_started_after_seq_event()
         .await
         .unwrap();
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 5 }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Session(
+        SessionEvent::LogSeqAssigned { seq: 5 },
+    )))
     .await
     .unwrap();
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Started {
-            id: "call-1".into(),
-            name: "bash_exec".into(),
-            kind: ToolKind::Other,
-            markdown: None,
-            input: yaml_to_json("command: echo hi"),
-            locations: vec![],
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Started {
+        id: "call-1".into(),
+        name: "bash_exec".into(),
+        kind: ToolKind::Other,
+        markdown: None,
+        input: yaml_to_json("command: echo hi"),
+        locations: vec![],
+    })))
     .await
     .unwrap();
 
@@ -2246,20 +2293,18 @@ async fn log_seq_backfill_clears_pending_tool_seq() {
         .unwrap();
 
     // First add an AssistantText with seq=None so backfill can find it.
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Model(ModelEvent::MessageChunk {
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+        ModelEvent::MessageChunk {
             blocks: vec![ContentBlock::Text("assistant reply".to_string())],
-        }),
-        None,
-    ))
+        },
+    )))
     .await
     .unwrap();
 
     // Now LogSeqAssigned should backfill the AssistantText and NOT set pending_tool_seq.
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 3 }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Session(
+        SessionEvent::LogSeqAssigned { seq: 3 },
+    )))
     .await
     .unwrap();
 
@@ -2279,22 +2324,18 @@ async fn live_log_seq_assignment_applies_to_blocked_tool_calls() {
         .await
         .unwrap();
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 7 }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Session(
+        SessionEvent::LogSeqAssigned { seq: 7 },
+    )))
     .await
     .unwrap();
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Blocked {
-            id: "call-2".into(),
-            name: "dangerous_tool".into(),
-            input: yaml_to_json("target: /etc"),
-            reason: "hook denied".into(),
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Blocked {
+        id: "call-2".into(),
+        name: "dangerous_tool".into(),
+        input: yaml_to_json("target: /etc"),
+        reason: "hook denied".into(),
+    })))
     .await
     .unwrap();
 
@@ -3099,10 +3140,9 @@ async fn test_streaming_error_shows_full_cause_chain_in_transcript() {
     harness
         .tui()
         .event_tx
-        .send(TuiEvent::Agent(
-            AgentEvent::Model(ModelEvent::Error(formatted.clone())),
-            None,
-        ))
+        .send(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Error(
+            formatted.clone(),
+        ))))
         .unwrap();
 
     // Drain the single queued event into the transcript.
@@ -3175,10 +3215,9 @@ async fn test_pending_message_not_replayed_on_error() {
     harness
         .tui()
         .event_tx
-        .send(TuiEvent::Agent(
-            AgentEvent::Model(ModelEvent::Error("boom".to_string())),
-            None,
-        ))
+        .send(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Error(
+            "boom".to_string(),
+        ))))
         .unwrap();
     harness.drain_and_settle().await.unwrap();
 
@@ -4200,22 +4239,21 @@ async fn sub_agent_activity_no_duplicates_snapshot() {
     harness.tui().persistent_manager = persistent;
     harness.tui().clear_transcript();
 
-    let sub_source = Some(AgentSource {
+    let sub_source = AgentSource {
         agent: "researcher".to_string(),
         session_id: Some("research-session-1".to_string()),
         model: None,
-    });
+    };
 
     // ── Phase 1: Top-level agent streams opening message ─────────────
     for chunk in ["I'll look into ", "that for you. ", "Delegating now."] {
         harness
             .tui()
-            .handle_tui_event(TuiEvent::Agent(
-                AgentEvent::Model(ModelEvent::MessageChunk {
+            .handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+                ModelEvent::MessageChunk {
                     blocks: vec![ContentBlock::Text(chunk.to_string())],
-                }),
-                None,
-            ))
+                },
+            )))
             .await
             .unwrap();
     }
@@ -4223,17 +4261,14 @@ async fn sub_agent_activity_no_duplicates_snapshot() {
     // ── Phase 2: Top-level delegation tool call ──────────────────────
     harness
         .tui()
-        .handle_tui_event(TuiEvent::Agent(
-            AgentEvent::Tool(ToolEvent::Started {
-                id: String::new(),
-                name: "researcher_session_prompt".to_string(),
-                kind: ToolKind::Other,
-                markdown: None,
-                input: yaml_to_json("message: investigate the data"),
-                locations: vec![],
-            }),
-            None,
-        ))
+        .handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Started {
+            id: String::new(),
+            name: "researcher_session_prompt".to_string(),
+            kind: ToolKind::Other,
+            markdown: None,
+            input: yaml_to_json("message: investigate the data"),
+            locations: vec![],
+        })))
         .await
         .unwrap();
 
@@ -4241,12 +4276,12 @@ async fn sub_agent_activity_no_duplicates_snapshot() {
     for chunk in ["Let me ", "analyze ", "the situation ", "carefully."] {
         harness
             .tui()
-            .handle_tui_event(TuiEvent::Agent(
+            .handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+                sub_source.clone(),
                 AgentEvent::Model(ModelEvent::ThoughtChunk {
                     blocks: vec![ContentBlock::Text(chunk.to_string())],
                 }),
-                sub_source.clone(),
-            ))
+            )))
             .await
             .unwrap();
     }
@@ -4254,7 +4289,8 @@ async fn sub_agent_activity_no_duplicates_snapshot() {
     // ── Phase 4: Sub-agent makes two tool calls ──────────────────────
     harness
         .tui()
-        .handle_tui_event(TuiEvent::Agent(
+        .handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+            sub_source.clone(),
             AgentEvent::Tool(ToolEvent::Started {
                 id: String::new(),
                 name: "bash".to_string(),
@@ -4263,13 +4299,13 @@ async fn sub_agent_activity_no_duplicates_snapshot() {
                 input: yaml_to_json("command: find /data -name '*.csv'"),
                 locations: vec![],
             }),
-            sub_source.clone(),
-        ))
+        )))
         .await
         .unwrap();
     harness
         .tui()
-        .handle_tui_event(TuiEvent::Agent(
+        .handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+            sub_source.clone(),
             AgentEvent::Tool(ToolEvent::Started {
                 id: String::new(),
                 name: "read_file".to_string(),
@@ -4278,8 +4314,7 @@ async fn sub_agent_activity_no_duplicates_snapshot() {
                 input: yaml_to_json("path: /data/results.csv"),
                 locations: vec![],
             }),
-            sub_source.clone(),
-        ))
+        )))
         .await
         .unwrap();
 
@@ -4293,12 +4328,12 @@ async fn sub_agent_activity_no_duplicates_snapshot() {
     for chunk in ["Now I see ", "the pattern ", "in the data."] {
         harness
             .tui()
-            .handle_tui_event(TuiEvent::Agent(
+            .handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+                sub_source.clone(),
                 AgentEvent::Model(ModelEvent::ThoughtChunk {
                     blocks: vec![ContentBlock::Text(chunk.to_string())],
                 }),
-                sub_source.clone(),
-            ))
+            )))
             .await
             .unwrap();
     }
@@ -4306,7 +4341,8 @@ async fn sub_agent_activity_no_duplicates_snapshot() {
     // ── Phase 6: Sub-agent makes one more tool call ──────────────────
     harness
         .tui()
-        .handle_tui_event(TuiEvent::Agent(
+        .handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+            sub_source.clone(),
             AgentEvent::Tool(ToolEvent::Started {
                 id: String::new(),
                 name: "write_file".to_string(),
@@ -4315,8 +4351,7 @@ async fn sub_agent_activity_no_duplicates_snapshot() {
                 input: yaml_to_json("path: /data/summary.md"),
                 locations: vec![],
             }),
-            sub_source.clone(),
-        ))
+        )))
         .await
         .unwrap();
 
@@ -4334,12 +4369,12 @@ async fn sub_agent_activity_no_duplicates_snapshot() {
     ] {
         harness
             .tui()
-            .handle_tui_event(TuiEvent::Agent(
+            .handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+                sub_source.clone(),
                 AgentEvent::Model(ModelEvent::MessageChunk {
                     blocks: vec![ContentBlock::Text(chunk.to_string())],
                 }),
-                sub_source.clone(),
-            ))
+            )))
             .await
             .unwrap();
     }
@@ -4347,15 +4382,15 @@ async fn sub_agent_activity_no_duplicates_snapshot() {
     // ── Phase 8: Sub-agent usage line ────────────────────────────────
     harness
         .tui()
-        .handle_tui_event(TuiEvent::Agent(
+        .handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+            sub_source.clone(),
             AgentEvent::Model(ModelEvent::Usage {
                 input: 500,
                 output: 200,
                 cached: 100,
                 session_label: Some("> researcher ▸ research-session-1".to_string()),
             }),
-            sub_source.clone(),
-        ))
+        )))
         .await
         .unwrap();
 
@@ -4368,12 +4403,11 @@ async fn sub_agent_activity_no_duplicates_snapshot() {
     ] {
         harness
             .tui()
-            .handle_tui_event(TuiEvent::Agent(
-                AgentEvent::Model(ModelEvent::MessageChunk {
+            .handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+                ModelEvent::MessageChunk {
                     blocks: vec![ContentBlock::Text(chunk.to_string())],
-                }),
-                None,
-            ))
+                },
+            )))
             .await
             .unwrap();
     }
@@ -5473,17 +5507,14 @@ async fn tui_renders_started_title_when_template_provides_it() {
     // "```sh\n$ {{ args.command }}\n```" produces this `markdown`. The raw
     // `input` JSON is also kept on the event for transcript serialization,
     // but the user-facing rendering must prefer the rendered title.
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Started {
-            id: "call-1".into(),
-            name: "bash_exec".into(),
-            kind: ToolKind::Other,
-            markdown: Some("```sh\n$ ls -la /tmp\n```".into()),
-            input: yaml_to_json("command: ls -la /tmp"),
-            locations: vec![],
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Started {
+        id: "call-1".into(),
+        name: "bash_exec".into(),
+        kind: ToolKind::Other,
+        markdown: Some("```sh\n$ ls -la /tmp\n```".into()),
+        input: yaml_to_json("command: ls -la /tmp"),
+        locations: vec![],
+    })))
     .await
     .unwrap();
 
@@ -5516,15 +5547,12 @@ async fn tui_renders_blocked_tool_call_in_transcript() {
     .await
     .unwrap();
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Blocked {
-            id: "call-1".into(),
-            name: "bash_exec".into(),
-            input: yaml_to_json("command: rm -rf /tmp/demo"),
-            reason: "hook denied".into(),
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Blocked {
+        id: "call-1".into(),
+        name: "bash_exec".into(),
+        input: yaml_to_json("command: rm -rf /tmp/demo"),
+        reason: "hook denied".into(),
+    })))
     .await
     .unwrap();
 
@@ -5559,17 +5587,14 @@ async fn tui_falls_back_to_yaml_when_no_template_title() {
     .await
     .unwrap();
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Started {
-            id: "call-1".into(),
-            name: "no_template_tool".into(),
-            kind: ToolKind::Other,
-            markdown: None,
-            input: yaml_to_json("command: ls"),
-            locations: vec![],
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Started {
+        id: "call-1".into(),
+        name: "no_template_tool".into(),
+        kind: ToolKind::Other,
+        markdown: None,
+        input: yaml_to_json("command: ls"),
+        locations: vec![],
+    })))
     .await
     .unwrap();
 
@@ -5606,14 +5631,11 @@ async fn tui_renders_completed_template_title_when_provided() {
         "content": [{"type": "text", "text": "hello"}],
         "isError": false,
     });
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Completed {
-            id: "call-1".into(),
-            output: raw_output,
-            markdown: Some("OK: hello".into()),
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Completed {
+        id: "call-1".into(),
+        output: raw_output,
+        markdown: Some("OK: hello".into()),
+    })))
     .await
     .unwrap();
 
@@ -5656,14 +5678,11 @@ async fn tui_renders_fenced_diff_tool_result_with_per_line_syntect_styling() {
         "content": [{"type": "text", "text": result_text}],
         "isError": false,
     });
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Completed {
-            id: "call-1".into(),
-            output,
-            markdown: None,
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Completed {
+        id: "call-1".into(),
+        output,
+        markdown: None,
+    })))
     .await
     .unwrap();
 
@@ -5716,14 +5735,11 @@ async fn tui_falls_back_to_output_when_no_template_title() {
     )
     .await
     .unwrap();
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Completed {
-            id: "call-1".into(),
-            output: serde_json::Value::String("plain output line".into()),
-            markdown: None,
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Completed {
+        id: "call-1".into(),
+        output: serde_json::Value::String("plain output line".into()),
+        markdown: None,
+    })))
     .await
     .unwrap();
     let lines: Vec<String> = tui
@@ -5826,17 +5842,14 @@ async fn tui_started_template_strips_markers_and_styles_spans() {
     .unwrap();
 
     // Producer-side render of "```sh\n$ {{ args.command }}\n```".
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Started {
-            id: "call-1".into(),
-            name: "bash_exec".into(),
-            kind: ToolKind::Other,
-            markdown: Some("```sh\n$ ls -la /tmp\n```".into()),
-            input: yaml_to_json("command: ls -la /tmp"),
-            locations: vec![],
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Started {
+        id: "call-1".into(),
+        name: "bash_exec".into(),
+        kind: ToolKind::Other,
+        markdown: Some("```sh\n$ ls -la /tmp\n```".into()),
+        input: yaml_to_json("command: ls -la /tmp"),
+        locations: vec![],
+    })))
     .await
     .unwrap();
 
@@ -5881,17 +5894,14 @@ async fn tui_started_multiline_command_renders_without_fence_markers() {
 
     let multiline_cmd = "cat <<EOF\nline1\nEOF";
     let markdown = format!("```sh\n$ {multiline_cmd}\n```");
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Started {
-            id: "call-1".into(),
-            name: "bash_exec".into(),
-            kind: ToolKind::Other,
-            markdown: Some(markdown),
-            input: yaml_to_json(&format!("command: '{multiline_cmd}'")),
-            locations: vec![],
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Started {
+        id: "call-1".into(),
+        name: "bash_exec".into(),
+        kind: ToolKind::Other,
+        markdown: Some(markdown),
+        input: yaml_to_json(&format!("command: '{multiline_cmd}'")),
+        locations: vec![],
+    })))
     .await
     .unwrap();
 
@@ -5926,17 +5936,14 @@ async fn tui_started_no_template_keeps_yaml_unstyled() {
     )
     .await
     .unwrap();
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Started {
-            id: "call-1".into(),
-            name: "no_template_tool".into(),
-            kind: ToolKind::Other,
-            markdown: None,
-            input: yaml_to_json("flag: _priv_value"),
-            locations: vec![],
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Started {
+        id: "call-1".into(),
+        name: "no_template_tool".into(),
+        kind: ToolKind::Other,
+        markdown: None,
+        input: yaml_to_json("flag: _priv_value"),
+        locations: vec![],
+    })))
     .await
     .unwrap();
 
@@ -5977,14 +5984,11 @@ async fn tui_completed_template_styles_spans() {
     .await
     .unwrap();
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Tool(ToolEvent::Completed {
-            id: "call-1".into(),
-            output: serde_json::json!({"content": [{"type": "text", "text": "hello"}]}),
-            markdown: Some("**OK**: `hello`".into()),
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Tool(ToolEvent::Completed {
+        id: "call-1".into(),
+        output: serde_json::json!({"content": [{"type": "text", "text": "hello"}]}),
+        markdown: Some("**OK**: `hello`".into()),
+    })))
     .await
     .unwrap();
 
@@ -8454,12 +8458,9 @@ async fn render_agent_event_user_message_produces_user_transcript_entry() {
         .await
         .unwrap();
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::User(UserEvent::Message {
-            content: "hello from attach".to_string(),
-        }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::User(UserEvent::Message {
+        content: "hello from attach".to_string(),
+    })))
     .await
     .unwrap();
 
@@ -8474,10 +8475,9 @@ async fn render_agent_event_user_message_produces_user_transcript_entry() {
     ));
 
     // A subsequent LogSeqAssigned must NOT backfill into the replayed row.
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Session(SessionEvent::LogSeqAssigned { seq: 42 }),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Session(
+        SessionEvent::LogSeqAssigned { seq: 42 },
+    )))
     .await
     .unwrap();
     assert!(matches!(
@@ -8495,12 +8495,9 @@ async fn render_agent_event_title_updated_executes_without_panic() {
         .unwrap();
 
     // Verify handling a TitleUpdated event does not crash
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Session(harnx_core::event::SessionEvent::TitleUpdated(
-            "Test Title".to_string(),
-        )),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Session(
+        harnx_core::event::SessionEvent::TitleUpdated("Test Title".to_string()),
+    )))
     .await
     .unwrap();
 }
@@ -8512,12 +8509,9 @@ async fn render_agent_event_title_generation_failed_produces_error_transcript_en
         .await
         .unwrap();
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Session(SessionEvent::TitleGenerationFailed(
-            "Miss 'api_key'".to_string(),
-        )),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Session(
+        SessionEvent::TitleGenerationFailed("Miss 'api_key'".to_string()),
+    )))
     .await
     .unwrap();
 
@@ -8537,10 +8531,9 @@ async fn render_agent_event_compacting_started_produces_transcript_entry() {
         .unwrap();
 
     // Emit CompactingStarted event
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Session(SessionEvent::CompactingStarted),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Session(
+        SessionEvent::CompactingStarted,
+    )))
     .await
     .unwrap();
 
@@ -8593,19 +8586,17 @@ async fn render_agent_event_compacting_completed_reconciles_live_transcript() {
     tui.app.transcript_focus = Some(99);
     tui.app.transcript_selection_anchor = Some(88);
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Session(SessionEvent::CompactingStarted),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Session(
+        SessionEvent::CompactingStarted,
+    )))
     .await
     .unwrap();
 
     seed_compressed_session(&config);
 
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Session(SessionEvent::CompactingCompleted),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Session(
+        SessionEvent::CompactingCompleted,
+    )))
     .await
     .unwrap();
 
@@ -8902,18 +8893,16 @@ async fn render_agent_event_compacting_failed_produces_error_transcript_entry() 
         .unwrap();
 
     // First emit CompactingStarted
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Session(SessionEvent::CompactingStarted),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Session(
+        SessionEvent::CompactingStarted,
+    )))
     .await
     .unwrap();
 
     // Then emit CompactingFailed
-    tui.handle_tui_event(TuiEvent::Agent(
-        AgentEvent::Session(SessionEvent::CompactingFailed("test error".to_string())),
-        None,
-    ))
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Session(
+        SessionEvent::CompactingFailed("test error".to_string()),
+    )))
     .await
     .unwrap();
 
@@ -9189,13 +9178,12 @@ async fn test_start_prompt_sets_active_remote_session() {
     // We can simulate an Error or Final event to clear it
     use harnx_core::event::{AgentEvent, ModelEvent};
     let _ = tui
-        .handle_tui_event(crate::types::TuiEvent::Agent(
-            AgentEvent::Model(ModelEvent::Final {
+        .handle_tui_event(crate::types::TuiEvent::Agent(AgentEvent::Model(
+            ModelEvent::Final {
                 output: "done".to_string(),
                 usage: Default::default(),
-            }),
-            None,
-        ))
+            },
+        )))
         .await;
 
     assert_eq!(

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -329,10 +329,7 @@ impl App {
 }
 
 pub(crate) enum TuiEvent {
-    Agent(
-        harnx_core::event::AgentEvent,
-        Option<harnx_core::event::AgentSource>,
-    ),
+    Agent(harnx_core::event::AgentEvent),
     /// Intermediate tool round completed; the prompt loop continues.
     ToolRoundComplete,
     /// The prompt task consumed the pending message during a tool round.

--- a/crates/harnx/src/cli_event_sink.rs
+++ b/crates/harnx/src/cli_event_sink.rs
@@ -938,6 +938,73 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sub_agent_final_tracks_source_and_renders() {
+        // SubAgent wrapper with Model::Final should extract the source and
+        // track it (since Final is a model-output event for source-heading).
+        // Note: Final calls cleanup(), which resets last_ui_output_source to None.
+        // We verify the event processed without panic and that cleanup ran.
+        let sink = CliAgentEventSink::new(
+            false,
+            RenderOptions::default(),
+            harnx_core::abort::create_abort_signal(),
+        );
+        let source = AgentSource {
+            agent: "sub".to_string(),
+            session_id: None,
+            model: None,
+        };
+        sink.emit(AgentEvent::sub_agent(
+            source.clone(),
+            AgentEvent::Model(ModelEvent::Final {
+                output: "done".into(),
+                usage: Default::default(),
+            }),
+        ));
+        let state = sink.state.lock().unwrap();
+        // Final triggers cleanup, which clears last_ui_output_source.
+        // We verify the event processed without panic.
+        assert!(
+            state.last_ui_output_source.is_none(),
+            "source should be cleared by cleanup after Final"
+        );
+        assert!(
+            state.buffer.is_empty(),
+            "buffer should be cleared after Final"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sub_agent_error_clears_state_without_panic() {
+        // SubAgent wrapper with Model::Error should be processed without panic.
+        // Error is NOT a model-output event, so source should NOT be tracked.
+        let sink = CliAgentEventSink::new(
+            false,
+            RenderOptions::default(),
+            harnx_core::abort::create_abort_signal(),
+        );
+        let source = AgentSource {
+            agent: "sub".to_string(),
+            session_id: None,
+            model: None,
+        };
+        sink.emit(AgentEvent::sub_agent(
+            source,
+            AgentEvent::Model(ModelEvent::Error("boom".into())),
+        ));
+        let state = sink.state.lock().unwrap();
+        // Error is NOT a model-output event, so source should be None
+        assert!(
+            state.last_ui_output_source.is_none(),
+            "source should NOT be tracked for Error event"
+        );
+        // cleanup is called for Error, so buffer should be empty
+        assert!(
+            state.buffer.is_empty(),
+            "buffer should be cleared after Error"
+        );
+    }
+
     // ----------------------------------------------------------------
     // Compaction event handling: CLI must handle Started/Completed/Failed
     // without falling into the debug catch-all.

--- a/crates/harnx/src/cli_event_sink.rs
+++ b/crates/harnx/src/cli_event_sink.rs
@@ -265,7 +265,11 @@ impl CliSinkState {
 }
 
 impl AgentEventSink for CliAgentEventSink {
-    fn emit(&self, event: AgentEvent, source: Option<harnx_core::event::AgentSource>) {
+    fn emit(&self, event: AgentEvent) {
+        let (source, event) = match event {
+            AgentEvent::SubAgent { source, event } => (Some(source), *event),
+            event => (None, event),
+        };
         let mut state = match self.state.lock() {
             Ok(g) => g,
             Err(poisoned) => poisoned.into_inner(),
@@ -490,56 +494,36 @@ mod tests {
             harnx_core::abort::create_abort_signal(),
         );
 
-        sink.emit(AgentEvent::Turn(TurnEvent::Started), None);
-        sink.emit(
-            AgentEvent::Turn(TurnEvent::Ended {
-                outcome: Default::default(),
-            }),
-            None,
-        );
-        sink.emit(AgentEvent::Notice(NoticeEvent::Info("info".into())), None);
-        sink.emit(
-            AgentEvent::Notice(NoticeEvent::Warning("warn".into())),
-            None,
-        );
-        sink.emit(AgentEvent::Notice(NoticeEvent::Error("err".into())), None);
-        sink.emit(
-            AgentEvent::Model(ModelEvent::MessageChunk {
-                blocks: vec![ContentBlock::Text("hello".into())],
-            }),
-            None,
-        );
-        sink.emit(
-            AgentEvent::Model(ModelEvent::Final {
-                output: "done".into(),
-                usage: Default::default(),
-            }),
-            None,
-        );
-        sink.emit(AgentEvent::Model(ModelEvent::Error("boom".into())), None);
-        sink.emit(
-            AgentEvent::User(UserEvent::Message {
-                content: "hello user".into(),
-            }),
-            None,
-        );
-        sink.emit(
-            AgentEvent::Tool(ToolEvent::Blocked {
-                id: String::new(),
-                name: "test_tool".into(),
-                input: serde_json::Value::Null,
-                reason: "hook denied".into(),
-            }),
-            None,
-        );
-        sink.emit(
-            AgentEvent::Session(SessionEvent::TitleUpdated("A title".into())),
-            None,
-        );
-        sink.emit(
-            AgentEvent::Session(SessionEvent::TitleGenerationFailed("Miss 'api_key'".into())),
-            None,
-        );
+        sink.emit(AgentEvent::Turn(TurnEvent::Started));
+        sink.emit(AgentEvent::Turn(TurnEvent::Ended {
+            outcome: Default::default(),
+        }));
+        sink.emit(AgentEvent::Notice(NoticeEvent::Info("info".into())));
+        sink.emit(AgentEvent::Notice(NoticeEvent::Warning("warn".into())));
+        sink.emit(AgentEvent::Notice(NoticeEvent::Error("err".into())));
+        sink.emit(AgentEvent::Model(ModelEvent::MessageChunk {
+            blocks: vec![ContentBlock::Text("hello".into())],
+        }));
+        sink.emit(AgentEvent::Model(ModelEvent::Final {
+            output: "done".into(),
+            usage: Default::default(),
+        }));
+        sink.emit(AgentEvent::Model(ModelEvent::Error("boom".into())));
+        sink.emit(AgentEvent::User(UserEvent::Message {
+            content: "hello user".into(),
+        }));
+        sink.emit(AgentEvent::Tool(ToolEvent::Blocked {
+            id: String::new(),
+            name: "test_tool".into(),
+            input: serde_json::Value::Null,
+            reason: "hook denied".into(),
+        }));
+        sink.emit(AgentEvent::Session(SessionEvent::TitleUpdated(
+            "A title".into(),
+        )));
+        sink.emit(AgentEvent::Session(SessionEvent::TitleGenerationFailed(
+            "Miss 'api_key'".into(),
+        )));
     }
 
     #[test]
@@ -558,17 +542,14 @@ mod tests {
             RenderOptions::default(),
             harnx_core::abort::create_abort_signal(),
         );
-        sink.emit(AgentEvent::Turn(TurnEvent::Started), None);
+        sink.emit(AgentEvent::Turn(TurnEvent::Started));
         {
             let state = sink.state.lock().unwrap();
             assert!(state.spinner.is_some(), "spinner should be started");
         }
-        sink.emit(
-            AgentEvent::User(UserEvent::Message {
-                content: "hello user".into(),
-            }),
-            None,
-        );
+        sink.emit(AgentEvent::User(UserEvent::Message {
+            content: "hello user".into(),
+        }));
         {
             let state = sink.state.lock().unwrap();
             assert!(
@@ -585,19 +566,13 @@ mod tests {
             RenderOptions::default(),
             harnx_core::abort::create_abort_signal(),
         );
-        sink.emit(
-            AgentEvent::Status(StatusLine {
-                text: "[test-model] generating".into(),
-            }),
-            None,
-        );
-        sink.emit(AgentEvent::Turn(TurnEvent::Started), None);
-        sink.emit(
-            AgentEvent::Turn(TurnEvent::Ended {
-                outcome: Default::default(),
-            }),
-            None,
-        );
+        sink.emit(AgentEvent::Status(StatusLine {
+            text: "[test-model] generating".into(),
+        }));
+        sink.emit(AgentEvent::Turn(TurnEvent::Started));
+        sink.emit(AgentEvent::Turn(TurnEvent::Ended {
+            outcome: Default::default(),
+        }));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -607,19 +582,13 @@ mod tests {
             RenderOptions::default(),
             harnx_core::abort::create_abort_signal(),
         );
-        sink.emit(AgentEvent::Turn(TurnEvent::Started), None);
-        sink.emit(
-            AgentEvent::Status(StatusLine {
-                text: "[rich-label] generating".into(),
-            }),
-            None,
-        );
-        sink.emit(
-            AgentEvent::Turn(TurnEvent::Ended {
-                outcome: Default::default(),
-            }),
-            None,
-        );
+        sink.emit(AgentEvent::Turn(TurnEvent::Started));
+        sink.emit(AgentEvent::Status(StatusLine {
+            text: "[rich-label] generating".into(),
+        }));
+        sink.emit(AgentEvent::Turn(TurnEvent::Ended {
+            outcome: Default::default(),
+        }));
     }
 
     // ----------------------------------------------------------------
@@ -886,12 +855,12 @@ mod tests {
             session_id: Some("s1".to_string()),
             model: None,
         };
-        sink.emit(
+        sink.emit(AgentEvent::sub_agent(
+            source.clone(),
             AgentEvent::Model(ModelEvent::MessageChunk {
                 blocks: vec![ContentBlock::Text("hello".into())],
             }),
-            Some(source.clone()),
-        );
+        ));
         let state = sink.state.lock().unwrap();
         assert_eq!(
             state.last_ui_output_source.as_ref(),
@@ -915,19 +884,16 @@ mod tests {
             model: None,
         };
         // Send a chunk to establish source.
-        sink.emit(
+        sink.emit(AgentEvent::sub_agent(
+            source,
             AgentEvent::Model(ModelEvent::MessageChunk {
                 blocks: vec![ContentBlock::Text("hello".into())],
             }),
-            Some(source),
-        );
+        ));
         // End the turn — should reset source tracking.
-        sink.emit(
-            AgentEvent::Turn(TurnEvent::Ended {
-                outcome: Default::default(),
-            }),
-            None,
-        );
+        sink.emit(AgentEvent::Turn(TurnEvent::Ended {
+            outcome: Default::default(),
+        }));
         let state = sink.state.lock().unwrap();
         assert!(
             state.last_ui_output_source.is_none(),
@@ -950,18 +916,18 @@ mod tests {
             model: None,
         };
         // Push two partial chunks without newline.  Buffer should hold both.
-        sink.emit(
+        sink.emit(AgentEvent::sub_agent(
+            source.clone(),
             AgentEvent::Model(ModelEvent::MessageChunk {
                 blocks: vec![ContentBlock::Text("hello ".into())],
             }),
-            Some(source.clone()),
-        );
-        sink.emit(
+        ));
+        sink.emit(AgentEvent::sub_agent(
+            source,
             AgentEvent::Model(ModelEvent::MessageChunk {
                 blocks: vec![ContentBlock::Text("world".into())],
             }),
-            Some(source),
-        );
+        ));
         // In non-TTY test process, handle_chunk_text uses handle_raw_chunk
         // (print!), so buffer stays empty for raw path.  We verify the
         // source hasn't reset — i.e. cleanup was NOT called between chunks.
@@ -984,9 +950,9 @@ mod tests {
             RenderOptions::default(),
             harnx_core::abort::create_abort_signal(),
         );
-        sink.emit(AgentEvent::Session(SessionEvent::CompactingStarted), None);
+        sink.emit(AgentEvent::Session(SessionEvent::CompactingStarted));
         // cleanup to close spinner
-        sink.emit(AgentEvent::Session(SessionEvent::CompactingCompleted), None);
+        sink.emit(AgentEvent::Session(SessionEvent::CompactingCompleted));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -997,19 +963,19 @@ mod tests {
             harnx_core::abort::create_abort_signal(),
         );
         // Start spinner first
-        sink.emit(AgentEvent::Turn(TurnEvent::Started), None);
+        sink.emit(AgentEvent::Turn(TurnEvent::Started));
         {
             let state = sink.state.lock().unwrap();
             assert!(state.spinner.is_some(), "spinner should be started");
         }
         // CompactingStarted should NOT replace an existing spinner
-        sink.emit(AgentEvent::Session(SessionEvent::CompactingStarted), None);
+        sink.emit(AgentEvent::Session(SessionEvent::CompactingStarted));
         {
             let state = sink.state.lock().unwrap();
             assert!(state.spinner.is_some(), "spinner should still exist");
         }
         // CompactingCompleted clears spinner
-        sink.emit(AgentEvent::Session(SessionEvent::CompactingCompleted), None);
+        sink.emit(AgentEvent::Session(SessionEvent::CompactingCompleted));
         {
             let state = sink.state.lock().unwrap();
             assert!(
@@ -1027,18 +993,15 @@ mod tests {
             harnx_core::abort::create_abort_signal(),
         );
         // Start spinner
-        sink.emit(AgentEvent::Session(SessionEvent::CompactingStarted), None);
+        sink.emit(AgentEvent::Session(SessionEvent::CompactingStarted));
         {
             let state = sink.state.lock().unwrap();
             assert!(state.spinner.is_some(), "spinner should be started");
         }
         // Failed clears spinner
-        sink.emit(
-            AgentEvent::Session(SessionEvent::CompactingFailed(
-                "something went wrong".to_string(),
-            )),
-            None,
-        );
+        sink.emit(AgentEvent::Session(SessionEvent::CompactingFailed(
+            "something went wrong".to_string(),
+        )));
         {
             let state = sink.state.lock().unwrap();
             assert!(

--- a/crates/harnx/tests/engine_smoke.rs
+++ b/crates/harnx/tests/engine_smoke.rs
@@ -40,12 +40,12 @@ impl ProxySink {
 }
 
 impl AgentEventSink for ProxySink {
-    fn emit(&self, event: AgentEvent, source: Option<harnx_core::event::AgentSource>) {
+    fn emit(&self, event: AgentEvent) {
         self.recorded
             .lock()
             .expect("proxy sink mutex")
             .push(event.clone());
-        self.inner.emit(event, source);
+        self.inner.emit(event);
     }
 }
 

--- a/docs/solutions/logic-errors/structural-variant-vs-out-of-band-discriminator-2026-07-26.md
+++ b/docs/solutions/logic-errors/structural-variant-vs-out-of-band-discriminator-2026-07-26.md
@@ -1,0 +1,195 @@
+---
+title: "Structural enum variant beats out-of-band discriminator for sub-agent provenance"
+date: 2026-07-26
+category: logic-errors
+problem_type: logic_error
+component: event-system
+root_cause: "out-of-band discriminator parallel to enum invites forgot-to-check bugs"
+resolution_type: code_fix
+severity: high
+tags:
+  - enum-design
+  - sub-agent
+  - event-routing
+  - type-safety
+  - ACP
+  - TUI
+plan_ref: subagent-event-variant-1200
+---
+
+## Problem
+
+Sub-agent events carried provenance via an out-of-band `source: Option<AgentSource>` parameter on `AgentEventSink::emit`, parallel to the `AgentEvent` enum. Consumers had to remember to check `source.is_some()` before clearing busy state; the TUI missed this, and a nested sub-agent's `ModelEvent::Final`/`Error` flipped the busy→idle spinner while the main loop still ran.
+
+## Symptoms
+
+- TUI showed as not busy while main agent loop was still running (GitHub #1200)
+- Nested sub-agent (analyst under researcher) completion events cleared main `llm_busy` flag
+- Spinner stopped prematurely during active multi-agent sessions
+- Only reproducible with nested sub-agents; single-agent workflows unaffected
+
+```
+Error: TUI `llm_busy = false` set by sub-agent Final/Error
+Behavior: Spinner stops, UI appears idle, but agent loop continues
+Frequency: Every nested sub-agent completion
+```
+
+## Investigation Steps
+
+Started by tracing TUI event handling in `input.rs`. Found `source.is_some()` check routed sub-agent events to heading render but did NOT prevent `llm_busy` clear on `Final`/`Error`. Discovered that every consumer (CLI, TUI, ACP server, AG-UI) had to remember the optional check, and the TUI path missed it.
+
+Reviewed the architecture: `AgentEventSink::emit(event, source: Option<AgentSource>)` meant sub-agent-ness was orthogonal to event type. The TUI's `render_agent_event` matched on `AgentEvent::Model(ModelEvent::Final)` directly without discriminating sub-agent vs main agent.
+
+Designed solution: encode sub-agent provenance INTO the enum as a `SubAgent { source, event }` wrapper variant. This forces every `match` site to handle it or fail to compile.
+
+## Root Cause
+
+Sub-agent-ness was carried out-of-band via an optional parameter parallel to the event enum. This architectural flaw created a "forgot to check" bug class: any match arm processing `Final`/`Error` without checking `source.is_some()` would incorrectly treat sub-agent completion as main completion. The TUI had such a path, and nested sub-agent events (analyst under researcher) triggered it.
+
+The flaw was structural: parameter-based discriminators require every consumer to remember the check, but Rust's exhaustive match already forces consumers to handle every variant. Moving the discriminator into the enum aligns the language's exhaustiveness guarantee with the correctness invariant.
+
+## Solution
+
+### 1. Add structural `AgentEvent::SubAgent` variant
+
+```rust
+pub enum AgentEvent {
+    // ... existing variants ...
+    SubAgent {
+        source: AgentSource,
+        event: Box<AgentEvent>,
+    },
+}
+```
+
+### 2. Add flatten helper with innermost-source-wins semantics
+
+```rust
+impl AgentEvent {
+    /// Wraps an event from a sub-agent, preserving the innermost existing source.
+    pub fn sub_agent(source: AgentSource, event: AgentEvent) -> AgentEvent {
+        let mut source = source;
+        let mut event = event;
+        while let AgentEvent::SubAgent {
+            source: existing,
+            event: inner,
+        } = event
+        {
+            source = existing;
+            event = *inner;
+        }
+        AgentEvent::SubAgent {
+            source,
+            event: Box::new(event),
+        }
+    }
+}
+```
+
+The while-loop strips any existing `SubAgent` wrappers and preserves the innermost (first) source. Nested sub-agents (analyst under researcher under parent) must NOT nest `SubAgent`-in-`SubAgent`.
+
+### 3. Remove out-of-band source parameter from trait
+
+```rust
+// Before
+fn emit(&self, event: AgentEvent, source: Option<AgentSource>);
+
+// After
+fn emit(&self, event: AgentEvent);
+```
+
+### 4. Add ACP server recursion for SubAgent events
+
+```rust
+AgentEvent::SubAgent {
+    source: sub_source,
+    event,
+} => event_to_forward(*event, Some(sub_source)),
+_ => None,
+```
+
+### 5. TUI structural matching at entry
+
+```rust
+let (source, event, is_sub_agent) = match event {
+    AgentEvent::SubAgent { source, event } => (Some(source), *event, true),
+    event => (None, event, false),
+};
+```
+
+Sub-agent `Final`/`Error` routes to non-mutating helpers without clearing `llm_busy`.
+
+## Why This Works
+
+**Structural variant forces exhaustiveness:** Rust requires every match to handle all variants. Adding `SubAgent` to the enum means every consumer that matches on `AgentEvent` must either handle it explicitly or use a wildcard. This eliminates the "forgot to check out-of-band param" bug class.
+
+**Innermost-source-wins preserves true origin:** Nested sub-agent chains (analyst → researcher → parent) should preserve the innermost/first source (analyst), not the most recent wrapper (researcher). The helper's while-loop unwraps existing wrappers before re-wrapping, so `sub_agent(researcher, sub_agent(analyst, raw))` yields `SubAgent { source: analyst, event: raw }`.
+
+**ACP recursion forwards embedded source:** The ACP server re-forwards sub-agent events over the wire. The explicit arm `AgentEvent::SubAgent { source, event } => event_to_forward(*event, Some(source))` extracts the embedded source and passes it downstream.
+
+## Mid-Execution Bugs and Lessons
+
+### Bug 1: ACP server dropped SubAgent events
+
+**Location:** `crates/harnx-acp-server/src/lib.rs:event_to_forward`
+
+**What:** The match had a `_ => None` catch-all that silently dropped the new `SubAgent` variant when re-forwarding nested sub-sub-agent events over the wire. Analyst events hit this wildcard and disappeared.
+
+**Fix:** Add explicit arm before the wildcard:
+```rust
+AgentEvent::SubAgent { source: sub_source, event } => event_to_forward(*event, Some(sub_source)),
+_ => None,
+```
+
+**Lesson:** When adding an enum variant, audit every wildcard `_ => None`/drop arm in forwarders, serializers, and consumers. Wildcards are maintenance traps because the compiler cannot flag missing handlers.
+
+### Bug 2: Stale binary masked the fix
+
+**What:** The ACP server is a separate binary. A stale `target/debug/harnx-acp-server` from a prior build masked the fix during e2e testing. The tmux test failed even after the code change.
+
+**Fix:** Run `cargo build --workspace` to rebuild all binaries before e2e tests.
+
+**Lesson:** Multi-process architectures (separate server binaries) require full workspace rebuild before end-to-end verification.
+
+### Bug 3: Flatten helper was "most-recent-wins" initially
+
+**What:** First implementation of `AgentEvent::sub_agent` replaced the source on outer wraps instead of preserving innermost. This contradicted the design decision and lost the innermost agent's identity.
+
+**Fix:** Change helper to while-loop that strips existing wrappers and preserves first source.
+
+**Lesson:** Flatten/unwrap semantics must be explicitly documented and tested. Add unit test asserting `sub_agent(researcher, sub_agent(analyst, raw))` yields `source == analyst`.
+
+## Prevention Strategies
+
+### Test Cases
+
+- Unit test: `sub_agent(researcher, sub_agent(analyst, Final))` yields `SubAgent { source: analyst, event: Final }`
+- TUI test: sub-agent `Final` does NOT clear `llm_busy`
+- TUI test: bare `Final` DOES clear `llm_busy`
+- ACP server test: `event_to_forward` with `SubAgent(analyst, chunk)` carries analyst source
+- E2E test: nested sub-agent output appears in TUI with correct heading
+
+### Best Practices
+
+1. **Encode discriminators into enums:** When a discriminator (like sub-agent provenance) affects behavior, make it a variant of the enum rather than a parallel parameter. Exhaustiveness checking prevents "forgot to check" bugs.
+
+2. **Audit wildcards on variant additions:** When adding an enum variant, grep for all `_ =>` wildcards in match expressions and verify each one intentionally drops the new variant.
+
+3. **Innermost-source-wins for nested wrappers:** When wrapping events from nested sources, preserve the innermost/first source, not the most recent. Use a while-loop to strip existing wrappers.
+
+4. **Rebuild all binaries before e2e:** Multi-process architectures require `cargo build --workspace` before end-to-end tests.
+
+5. **Use `cargo nextest`, never `cargo test`:** This repo uses `nextest` for process isolation. `cargo test` shares processes and can produce spurious flakes.
+
+### Code Review Checklist
+
+- [ ] Is sub-agent-ness encoded structurally (variant) rather than out-of-band (param)?
+- [ ] Does the flatten helper preserve innermost source via while-loop?
+- [ ] Are all wildcard `_` arms in forwarders audited for the new variant?
+- [ ] Are separate binaries rebuilt before e2e tests?
+- [ ] Do TUI sub-agent handlers avoid clearing main `llm_busy`?
+
+## Related Issues
+
+- **GitHub:** [#1200](https://github.com/dobesv/harnx/issues/1200) — TUI shows as not busy but agent loop is still running
+- **Related Solution:** [logic-errors/tui-event-source-propagation-2026-05-26.md](./tui-event-source-propagation-2026-05-26.md) — Fragility of optional source tracking (precursor to this structural fix)

--- a/docs/solutions/logic-errors/structural-variant-vs-out-of-band-discriminator-2026-07-26.md
+++ b/docs/solutions/logic-errors/structural-variant-vs-out-of-band-discriminator-2026-07-26.md
@@ -28,7 +28,7 @@ Sub-agent events carried provenance via an out-of-band `source: Option<AgentSour
 - Spinner stopped prematurely during active multi-agent sessions
 - Only reproducible with nested sub-agents; single-agent workflows unaffected
 
-```
+```text
 Error: TUI `llm_busy = false` set by sub-agent Final/Error
 Behavior: Spinner stops, UI appears idle, but agent loop continues
 Frequency: Every nested sub-agent completion


### PR DESCRIPTION
Introduce AgentEvent::SubAgent { source, event } to represent sub-agent events structurally rather than passing an out-of-band source parameter. Sub-agent events flatten to the innermost source when nested, avoiding recursive wrapping.

Remove the Option<AgentSource> parameter from AgentEventSink::emit across the workspace. Update all sink implementations (CLI, TUI, ACP, Nats, AG-UI, session actor) to inspect and extract provenance directly from the SubAgent variant.

In the TUI, route sub-agent events structurally so sub-agent completion or error events no longer flip the main busy indicator to idle while the primary agent loop is still running.

Include a patch changeset for harnx and solution documentation for structural variants vs out-of-band discriminators.

#1200

Plan: subagent-event-variant-1200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TUI busy/spinner lifecycle so the main task no longer switches to idle while nested agent work is still running.
  * Sub-agent finals/errors are now rendered under their correct source headings without disrupting the main task display.
  * Improved nested event forwarding for consistent presentation across the CLI and other interfaces.
* **Documentation**
  * Added guidance on structural sub-agent event handling and regression safeguards to prevent provenance/busy-state issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->