### PR TITLE
fix(models): set require_max_tokens for adaptive-only Opus base models

### DIFF
--- a/scripts/update_models.py
+++ b/scripts/update_models.py
@@ -581,6 +581,8 @@ def apply_base_thinking(model: dict[str, Any], provider: str) -> None:
         return
     if name.startswith("claude-") and is_adaptive_only_opus(name):
         model["patches"] = [claude_adaptive_patch(BASE_EFFORT)]
+        # Adaptive-only Opus rejects requests without an explicit max_tokens.
+        model["require_max_tokens"] = True
     # Modern Claude models reject requests without an explicit max_tokens,
     # regardless of the adaptive-thinking patch above.
     if claude_requires_max_tokens(name):


### PR DESCRIPTION
Restore model["require_max_tokens"] = True inside the adaptive-only Opus branch in apply_base_thinking().

Refactoring in #1131 moved the flag setting behind claude_requires_max_tokens(name), which by design only matches Sonnet/Haiku and excludes Opus. This caused adaptive-only Opus base models to omit require_max_tokens=True, breaking CI tests in the update-models.yml workflow.