### PR TITLE
Fix model update script

### DIFF
--- a/scripts/test_update_models.py
+++ b/scripts/test_update_models.py
@@ -426,6 +426,20 @@ class TestMergeOldFields(unittest.TestCase):
         merged = um.merge_old_fields(new, None)
         self.assertEqual(merged, new)
 
+    def test_endpoint_preserved(self) -> None:
+        # GPT models pinned to the responses endpoint must keep the field when
+        # regenerated from the LiteLLM registry (which does not carry it).
+        old = {"name": "gpt-5", "endpoint": "responses"}
+        new = {"name": "gpt-5", "max_input_tokens": 400000}
+        merged = um.merge_old_fields(new, old)
+        self.assertEqual(merged["endpoint"], "responses")
+
+    def test_endpoint_survives_ordered_model(self) -> None:
+        # ordered_model only emits fields in FIELD_ORDER; endpoint must be there
+        # so the preserved value is not dropped during serialization.
+        ordered = um.ordered_model({"name": "gpt-5", "endpoint": "responses"})
+        self.assertEqual(ordered["endpoint"], "responses")
+
 
 class TestRenderProviderBlock(unittest.TestCase):
     """Tests for YAML output formatting."""

--- a/scripts/test_update_models.py
+++ b/scripts/test_update_models.py
@@ -441,6 +441,47 @@ class TestMergeOldFields(unittest.TestCase):
         self.assertEqual(ordered["endpoint"], "responses")
 
 
+class TestOpenAIEndpointDefault(unittest.TestCase):
+    """OpenAI chat models are routed to the responses endpoint when the LiteLLM
+    registry's supported_endpoints signals it."""
+
+    _RESP = ["/v1/chat/completions", "/v1/batch", "/v1/responses"]
+
+    def test_responses_capable_gets_endpoint(self) -> None:
+        model = {"name": "gpt-5.7"}
+        um.apply_openai_endpoint_default(model, "openai", {"supported_endpoints": self._RESP})
+        self.assertEqual(model["endpoint"], "responses")
+
+    def test_no_signal_leaves_chat_completions(self) -> None:
+        # Legacy models (gpt-4o, gpt-4, ...) have no supported_endpoints field.
+        model = {"name": "gpt-4o"}
+        um.apply_openai_endpoint_default(model, "openai", {})
+        self.assertNotIn("endpoint", model)
+
+    def test_endpoints_without_responses_left_alone(self) -> None:
+        model = {"name": "weird"}
+        um.apply_openai_endpoint_default(
+            model, "openai", {"supported_endpoints": ["/v1/chat/completions"]}
+        )
+        self.assertNotIn("endpoint", model)
+
+    def test_human_override_not_clobbered(self) -> None:
+        # A value already on the (merged) model wins over the registry signal.
+        model = {"name": "gpt-4o", "endpoint": "chat/completions"}
+        um.apply_openai_endpoint_default(model, "openai", {"supported_endpoints": self._RESP})
+        self.assertEqual(model["endpoint"], "chat/completions")
+
+    def test_non_openai_provider_unaffected(self) -> None:
+        model = {"name": "claude-x"}
+        um.apply_openai_endpoint_default(model, "claude", {"supported_endpoints": self._RESP})
+        self.assertNotIn("endpoint", model)
+
+    def test_embedding_model_unaffected(self) -> None:
+        model = {"name": "text-embedding-3-large", "type": "embedding"}
+        um.apply_openai_endpoint_default(model, "openai", {"supported_endpoints": self._RESP})
+        self.assertNotIn("endpoint", model)
+
+
 class TestRenderProviderBlock(unittest.TestCase):
     """Tests for YAML output formatting."""
 

--- a/scripts/update_models.py
+++ b/scripts/update_models.py
@@ -581,6 +581,8 @@ def apply_base_thinking(model: dict[str, Any], provider: str) -> None:
         return
     if name.startswith("claude-") and is_adaptive_only_opus(name):
         model["patches"] = [claude_adaptive_patch(BASE_EFFORT)]
+        # Adaptive-only Opus rejects requests without an explicit max_tokens.
+        model["require_max_tokens"] = True
     # Modern Claude models reject requests without an explicit max_tokens,
     # regardless of the adaptive-thinking patch above.
     if claude_requires_max_tokens(name):

--- a/scripts/update_models.py
+++ b/scripts/update_models.py
@@ -336,6 +336,35 @@ def is_variant_name(name: str) -> bool:
     return ":" in name and name.rsplit(":", 1)[1] in VARIANT_SUFFIXES
 
 
+def apply_openai_endpoint_default(
+    model: dict[str, Any], provider: str, payload: dict[str, Any]
+) -> None:
+    """Route OpenAI chat models to the `responses` endpoint when the LiteLLM
+    registry says they support it.
+
+    OpenAI's Responses API (`/v1/responses`) is the path forward for chat models
+    (starting with gpt-5.4, tool calling is unsupported on Chat Completions with
+    `reasoning: none`). The registry's per-model `supported_endpoints` array is a
+    machine-readable capability signal — when it lists `/v1/responses` we set
+    `endpoint: responses`, so new model families pick this up automatically
+    without a hand-maintained version list. Legacy models whose registry entry
+    omits the field (gpt-4o, gpt-4, gpt-3.5-turbo, o1, ...) are left on Chat
+    Completions.
+
+    A human choice recorded in models.yaml wins: an already-present `endpoint`
+    (preserved via merge_old_fields) is never overwritten.
+    """
+    if provider != "openai":
+        return
+    if model.get("type") is not None:  # non-chat (embedding/reranker) models
+        return
+    if "endpoint" in model:  # preserve any human-curated value
+        return
+    supported = payload.get("supported_endpoints")
+    if isinstance(supported, list) and "/v1/responses" in supported:
+        model["endpoint"] = "responses"
+
+
 def claude_adaptive_patch(effort: str) -> str:
     """Request-body patch enabling adaptive thinking at a given effort level for
     the Claude/Vertex AI body shape. Sampling params are stripped because they
@@ -752,6 +781,7 @@ def main() -> int:
         model = build_model_from_litellm(model_name, payload, mode)
         old_model = old_by_provider.get(provider, {}).get(model_name)
         model = merge_old_fields(model, old_model)
+        apply_openai_endpoint_default(model, provider, payload)
         new_provider_models[provider][model_name] = model
 
     final_provider_models: OrderedDict[str, list[dict[str, Any]]] = OrderedDict()

--- a/scripts/update_models.py
+++ b/scripts/update_models.py
@@ -31,6 +31,7 @@ FIELD_ORDER = [
     "supports_vision",
     "supports_tool_use",
     "patches",
+    "endpoint",
     "type",
     "max_tokens_per_chunk",
     "default_chunk_size",
@@ -40,6 +41,7 @@ FIELD_ORDER = [
 
 HARNX_ONLY_FIELDS = [
     "patches",
+    "endpoint",
     "require_max_tokens",
     "real_name",
     "system_prompt_prefix",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAI chat models now default to the Responses endpoint when supported.
  * Existing manually configured endpoints are preserved.
  * Model updates now retain endpoint settings during merging and regeneration.
  * Adaptive-thinking Opus models now consistently require maximum token settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->