### PR TITLE
feat(pantheon): add natural-writing style guidance to agent prompts

### DIFF
--- a/.changeset/natural-writing-prompts.md
+++ b/.changeset/natural-writing-prompts.md
@@ -1,0 +1,9 @@
+---
+"pantheon": minor
+"coding": minor
+---
+
+Add natural-writing style guidance to agent prompts to reduce AI-tell phrasing in code comments, documentation, commit messages, and PR text (#1248).
+
+- New shared prompt fragment `agents/shared/natural-writing.md`, wired into the prose-writing pantheon agents (peitho, clio, mnemosyne, aristarchus, atlas, daedalus, sisyphus, and the coder specialists).
+- Inline `## Natural Writing` section added to the `coding` package coder prompt.

--- a/crates/harnx-runtime/tests/agent_prompt_rendering.rs
+++ b/crates/harnx-runtime/tests/agent_prompt_rendering.rs
@@ -1,0 +1,102 @@
+use std::{ffi::OsStr, fs, path::Path};
+
+use harnx_core::agent_config::{AgentConfig, AgentVariables};
+
+#[test]
+fn agent_prompt_rendering_renders_all_shipped_agents() {
+    let Some(workspace_root) = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .find(|ancestor| ancestor.join("packages").is_dir())
+    else {
+        // Published crates do not include workspace package assets.
+        return;
+    };
+
+    let agent_dirs = [
+        workspace_root.join("packages/pantheon/agents"),
+        workspace_root.join("packages/coding/agents"),
+    ];
+    let mut failures = Vec::new();
+
+    for agent_dir in agent_dirs {
+        let entries = match fs::read_dir(&agent_dir) {
+            Ok(entries) => entries,
+            Err(error) => {
+                failures.push(format!("{}: {error}", agent_dir.display()));
+                continue;
+            }
+        };
+        let mut agent_paths = entries
+            .filter_map(|entry| match entry {
+                Ok(entry) => {
+                    let path = entry.path();
+                    (path.is_file() && path.extension() == Some(OsStr::new("md"))).then_some(path)
+                }
+                Err(error) => {
+                    failures.push(format!("{}: {error}", agent_dir.display()));
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        agent_paths.sort();
+
+        for agent_path in agent_paths {
+            let content = match fs::read_to_string(&agent_path) {
+                Ok(content) => content,
+                Err(error) => {
+                    failures.push(format!("{}: {error}", agent_path.display()));
+                    continue;
+                }
+            };
+            let Some(stem) = agent_path.file_stem().and_then(OsStr::to_str) else {
+                failures.push(format!("{}: invalid UTF-8 file stem", agent_path.display()));
+                continue;
+            };
+            let mut agent = match AgentConfig::from_markdown(stem, &content) {
+                Ok(agent) => agent,
+                Err(error) => {
+                    failures.push(format!("{}: {error:#}", agent_path.display()));
+                    continue;
+                }
+            };
+
+            let mut variables = AgentVariables::new();
+            let mut variable_loading_failed = false;
+            for variable in agent.defined_variables() {
+                if let Some(relative_path) = &variable.path {
+                    let variable_path = agent_dir.join(relative_path);
+                    match fs::read_to_string(&variable_path) {
+                        Ok(value) => {
+                            variables.insert(variable.name.clone(), value);
+                        }
+                        Err(error) => {
+                            failures.push(format!(
+                                "{}: failed to load variable '{}' from {}: {error}",
+                                agent_path.display(),
+                                variable.name,
+                                variable_path.display()
+                            ));
+                            variable_loading_failed = true;
+                        }
+                    }
+                } else if let Some(default) = &variable.default {
+                    variables.insert(variable.name.clone(), default.clone());
+                }
+            }
+            if variable_loading_failed {
+                continue;
+            }
+
+            agent.set_shared_variables(variables);
+            if let Err(error) = agent.system_text() {
+                failures.push(format!("{}: {error:#}", agent_path.display()));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "failed to load or render shipped agent prompts:\n{}",
+        failures.join("\n")
+    );
+}

--- a/docs/solutions/testing-issues/prompt-template-rendering-regression-test-2026-07-27.md
+++ b/docs/solutions/testing-issues/prompt-template-rendering-regression-test-2026-07-27.md
@@ -1,0 +1,148 @@
+---
+title: "Regression test for prompt-template rendering across shipped agents"
+date: 2026-07-27
+category: "testing-issues"
+problem_type: test_failure
+component: "harnx-runtime, pantheon-agents"
+root_cause: "no CI verification that markdown agent prompts render without undefined variable errors"
+resolution_type: test_fix
+severity: medium
+tags:
+  - rendering
+  - prompt-templates
+  - minijinja
+  - regression-test
+  - agent-config
+  - shared-variables
+plan_ref: "natural-writing-prompts"
+---
+
+## Problem
+
+Agent prompts under `packages/*/agents/` use MiniJinja templates with `{{variable}}` placeholders backed by `variables:` frontmatter entries. No CI test verified that all shipped agent markdown files render successfully. A missing `variables:` entry or typo in a placeholder name caused load-time failures discovered only at runtime.
+
+## Symptoms
+
+```
+- MiniJinja `UndefinedBehavior::Strict` panics when rendering agent system prompt with undefined variable
+- Missing `path:` file for a variable causes load failure
+- Typos in `{{placeholder}}` names not caught until agent instantiated in a session
+- Changes to shared prompt fragments could break multiple agents silently
+```
+
+## Investigation Steps
+
+1. Reviewed `AgentConfig::from_markdown` — parses frontmatter `variables:` into `AgentVariables`
+2. Traced `system_text()` — renders template with MiniJinja `UndefinedBehavior::Strict`, fails fast on undefined
+3. Identified two agent sources: `packages/pantheon/agents/` (uses `shared/` fragments) and `packages/coding/agents/` (inlines)
+4. Noted repo's Test Coverage Policy treats prompt markdown as executable behavior requiring verification
+5. Designed test to iterate all `.md` agents, parse, resolve `path:` files, set shared variables, and assert render succeeds
+
+## Root Cause
+
+**No render verification in CI.** Agents declare variables in frontmatter and reference them in body:
+
+```yaml
+---
+variables:
+  - name: natural_writing
+    path: shared/natural-writing.md
+---
+```
+
+Body:
+```markdown
+{{natural_writing}}
+```
+
+If `natural_writing` is misspelled, the `path:` file doesn't exist, or the placeholder name doesn't match, `system_text()` fails. Without a test, broken prompts reached main.
+
+## Solution
+
+Added `crates/harnx-runtime/tests/agent_prompt_rendering.rs`:
+
+```rust
+#[test]
+fn agent_prompt_rendering_renders_all_shipped_agents() {
+    let Some(workspace_root) = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .find(|ancestor| ancestor.join("packages").is_dir())
+    else {
+        // Published crates do not include workspace package assets.
+        return;
+    };
+
+    let agent_dirs = [
+        workspace_root.join("packages/pantheon/agents"),
+        workspace_root.join("packages/coding/agents"),
+    ];
+    let mut failures = Vec::new();
+
+    for agent_dir in agent_dirs {
+        // Iterate all .md files in agent directory
+        for agent_path in /* sorted .md entries */ {
+            // Parse markdown to AgentConfig
+            let agent = AgentConfig::from_markdown(stem, &content)?;
+            
+            // Resolve path:-backed variables from disk
+            let mut variables = AgentVariables::new();
+            for variable in agent.defined_variables() {
+                if let Some(relative_path) = &variable.path {
+                    let value = fs::read_to_string(agent_dir.join(relative_path))?;
+                    variables.insert(variable.name.clone(), value);
+                }
+            }
+            
+            // Set shared variables and render
+            agent.set_shared_variables(variables);
+            agent.system_text()?; // fails if any {{var}} undefined
+        }
+    }
+    
+    assert!(failures.is_empty(), "failed to render: {}", failures.join("\n"));
+}
+```
+
+Key behaviors:
+- Iterates every top-level `.md` under `packages/pantheon/agents/` and `packages/coding/agents/`
+- Parses via `AgentConfig::from_markdown`, resolves `path:` files from disk
+- Sets resolved values as `shared_variables`
+- Asserts `system_text()` renders Ok (collects all failures before asserting)
+- Skips gracefully when `packages/` isn't present (published-crate builds)
+
+## Why This Works
+
+**Fail-fast at load time.** The test runs in CI and catches:
+- Missing `variables:` entry for a `{{placeholder}}` used in body
+- Missing `path:` file for a declared variable
+- Typos in variable names (either in frontmatter or placeholder)
+
+UndefinedBehavior::Strict means any unreferenced context variable is ignored (MiniJinja doesn't error), but any referenced `{{var}}` without a value fails immediately.
+
+**Known blind spot:** A variable declared in `variables:` but never referenced in the body still passes. The test only catches missing definitions for referenced placeholders, not unused declarations. This is acceptable — unused declarations waste space but don't break rendering.
+
+## Prevention Strategies
+
+**Test coverage requirement:**
+- Any new agent markdown under `packages/*/agents/` automatically covered
+- Any new `shared/*.md` fragment wired via `variables:` automatically exercised
+- CI fails fast on template wiring regressions
+
+**Adding cross-cutting prompt guidance:**
+1. Create `packages/pantheon/agents/shared/<name>.md` with the guidance
+2. Add `variables:` entry to each agent needing it:
+   ```yaml
+   variables:
+     - name: <name>
+       path: shared/<name>.md
+   ```
+3. Add `{{<name>}}` placeholder in agent body at desired position
+4. Test will verify render succeeds
+
+**For `coding` package:** Prompts are inlined (no `shared/` directory). Cross-package guidance must be duplicated inline in `packages/coding/agents/coder.md`.
+
+## Related Issues
+
+- **Issue:** #1248 — Add natural-writing style guidance to sample prompts
+- **Related Solution:** [workflow-issues/dual-repo-pantheon-prompt-architecture-2026-07-18.md](../workflow-issues/dual-repo-pantheon-prompt-architecture-2026-07-18.md) — MiniJinja template composition rules
+- **Related Solution:** [logic-errors/minijinja-system-prompt-templating-2026-04-25.md](../logic-errors/minijinja-system-prompt-templating-2026-04-25.md) — MiniJinja context construction

--- a/packages/coding/agents/coder.md
+++ b/packages/coding/agents/coder.md
@@ -120,6 +120,16 @@ rule:
 - Keep changes minimal. Do what was asked, not more.
 - If blocked, say why specifically and what information you need.
 
+## Natural Writing
+
+For prose you write for humans (code comments, docs, commit messages, PR descriptions, review comments):
+
+Don't use AI-tell words: delve, leverage, utilize, harness, seamless, boasts, testament to, tapestry, paramount, streamline, facilitate. Say "use" not "utilize", "is/has" not "boasts". ("robust" is fine as a real technical term, not as vague praise.)
+Don't use filler transitions (furthermore, moreover, additionally, notably) or formulaic openers/closers ("It's worth noting", "In conclusion"). Cut them.
+Don't use "not just X, but Y" constructions, rule-of-three padding, or em-dash pileups. Don't hedge every sentence.
+Do use plain verbs, varied sentence length, contractions, and concrete names/IDs. Fragments fine.
+Code comments: explain WHY not WHAT — don't restate code. Docs: open with what it does, task-oriented, runnable examples. Commit subjects: imperative ("add retry"), body says what/why not a diff recap. PR descriptions: lead with what and why, don't restate the diff. Review comments: point at the line, concrete fix, skip praise padding. No AI-generated footers. Say only what you verified.
+
 ## Output Style
 
 Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries, hedging. Fragments OK. Technical terms exact. Code blocks unchanged. Errors quoted exact.

--- a/packages/pantheon/README.md
+++ b/packages/pantheon/README.md
@@ -169,8 +169,8 @@ agents via the `variables` system. These cover:
 
 - Agent identity/instructions for each specialist
 - Tool usage guides (ast-grep search, ast-grep rewrite)
-- Cross-cutting protocols (output style, repo documentation discovery, quality
-  review gate, Clio delegation, Jira/GitHub lookup)
+- Cross-cutting protocols (output style, natural writing style, repo documentation
+  discovery, quality review gate, Clio delegation, Jira/GitHub lookup)
 
 You can override individual shared files by creating matching files in your
 local `~/.config/harnx/agents/shared/` directory.

--- a/packages/pantheon/agents/apollo.md
+++ b/packages/pantheon/agents/apollo.md
@@ -46,6 +46,9 @@ variables:
 - name: output_style
   description: Output style rules for concise, low-verbosity responses
   path: shared/output-style.md
+- name: natural_writing
+  description: Natural writing style rules for prose (comments, docs, commits, PRs)
+  path: shared/natural-writing.md
 ---
 
 {{apollo_core}}
@@ -79,5 +82,7 @@ You are a worker agent delegated to by Sisyphus or Atlas. The local repo and bra
 already set up for you. Focus on doing the work and reporting results — the orchestrator
 handles git operations.
 </context>
+
+{{natural_writing}}
 
 {{output_style}}

--- a/packages/pantheon/agents/aristarchus.md
+++ b/packages/pantheon/agents/aristarchus.md
@@ -60,6 +60,9 @@ variables:
 - name: output_style
   description: Output style rules for concise, low-verbosity responses
   path: shared/output-style.md
+- name: natural_writing
+  description: Natural writing style rules for prose (comments, docs, commits, PRs)
+  path: shared/natural-writing.md
 - name: policy_test_coverage
   description: Test coverage policy — trigger, exemptions, opt-out rules
   path: shared/policy-test-coverage.md
@@ -68,5 +71,7 @@ variables:
 {{aristarchus_core}}
 
 {{policy_test_coverage}}
+
+{{natural_writing}}
 
 {{output_style}}

--- a/packages/pantheon/agents/athena.md
+++ b/packages/pantheon/agents/athena.md
@@ -45,6 +45,9 @@ variables:
 - name: output_style
   description: Output style rules for concise, low-verbosity responses
   path: shared/output-style.md
+- name: natural_writing
+  description: Natural writing style rules for prose (comments, docs, commits, PRs)
+  path: shared/natural-writing.md
 ---
 
 {{athena_core}}
@@ -78,5 +81,7 @@ You are a worker agent delegated to by Sisyphus or Atlas. The local repo and bra
 already set up for you. Focus on doing the work and reporting results — the orchestrator
 handles git operations.
 </context>
+
+{{natural_writing}}
 
 {{output_style}}

--- a/packages/pantheon/agents/atlas.md
+++ b/packages/pantheon/agents/atlas.md
@@ -83,6 +83,9 @@ variables:
 - name: output_style
   description: Output style rules for concise, low-verbosity responses
   path: shared/output-style.md
+- name: natural_writing
+  description: Natural writing style rules for prose (comments, docs, commits, PRs)
+  path: shared/natural-writing.md
 ---
 
 {{atlas_core}}
@@ -98,5 +101,7 @@ variables:
 {{ast_grep_search}}
 
 {{quality_review}}
+
+{{natural_writing}}
 
 {{output_style}}

--- a/packages/pantheon/agents/clio.md
+++ b/packages/pantheon/agents/clio.md
@@ -37,6 +37,9 @@ variables:
 - name: output_style
   description: Output style rules for concise, low-verbosity responses
   path: shared/output-style.md
+- name: natural_writing
+  description: Natural writing style rules for prose (comments, docs, commits, PRs)
+  path: shared/natural-writing.md
 ---
 
 {{clio_core}}
@@ -46,5 +49,7 @@ Use `bash_exec` to run local git commands (`git status`, `git add`, `git commit`
 Use the filesystem read tools (`fs_read`, `fs_ls`, `fs_grep`, `fs_find`) or `plans_get_plan` to inspect plan notes for JIRA ticket context when needed.
 
 {{repo_docs}}
+
+{{natural_writing}}
 
 {{output_style}}

--- a/packages/pantheon/agents/daedalus.md
+++ b/packages/pantheon/agents/daedalus.md
@@ -49,6 +49,9 @@ variables:
 - name: output_style
   description: Output style rules for concise, low-verbosity responses
   path: shared/output-style.md
+- name: natural_writing
+  description: Natural writing style rules for prose (comments, docs, commits, PRs)
+  path: shared/natural-writing.md
 ---
 
 {{daedalus_core}}
@@ -58,5 +61,7 @@ variables:
 {{github_gh_lookup}}
 
 {{learnings_search}}
+
+{{natural_writing}}
 
 {{output_style}}

--- a/packages/pantheon/agents/hephaestus.md
+++ b/packages/pantheon/agents/hephaestus.md
@@ -45,6 +45,9 @@ variables:
 - name: output_style
   description: Output style rules for concise, low-verbosity responses
   path: shared/output-style.md
+- name: natural_writing
+  description: Natural writing style rules for prose (comments, docs, commits, PRs)
+  path: shared/natural-writing.md
 ---
 
 {{hephaestus_core}}
@@ -78,5 +81,7 @@ You are a worker agent delegated to by Sisyphus or Atlas. The local repo and bra
 already set up for you. Focus on doing the work and reporting results — the orchestrator
 handles git operations.
 </context>
+
+{{natural_writing}}
 
 {{output_style}}

--- a/packages/pantheon/agents/hermes.md
+++ b/packages/pantheon/agents/hermes.md
@@ -45,6 +45,9 @@ variables:
 - name: output_style
   description: Output style rules for concise, low-verbosity responses
   path: shared/output-style.md
+- name: natural_writing
+  description: Natural writing style rules for prose (comments, docs, commits, PRs)
+  path: shared/natural-writing.md
 ---
 
 {{hermes_core}}
@@ -78,5 +81,7 @@ You are a worker agent delegated to by Sisyphus or Atlas. The local repo and bra
 already set up for you. Focus on doing the work and reporting results — the orchestrator
 handles git operations.
 </context>
+
+{{natural_writing}}
 
 {{output_style}}

--- a/packages/pantheon/agents/hestia.md
+++ b/packages/pantheon/agents/hestia.md
@@ -45,6 +45,9 @@ variables:
 - name: output_style
   description: Output style rules for concise, low-verbosity responses
   path: shared/output-style.md
+- name: natural_writing
+  description: Natural writing style rules for prose (comments, docs, commits, PRs)
+  path: shared/natural-writing.md
 ---
 
 {{hestia_core}}
@@ -78,5 +81,7 @@ You are a worker agent delegated to by Sisyphus or Atlas. The local repo and bra
 already set up for you. Focus on doing the work and reporting results — the orchestrator
 handles git operations.
 </context>
+
+{{natural_writing}}
 
 {{output_style}}

--- a/packages/pantheon/agents/iris.md
+++ b/packages/pantheon/agents/iris.md
@@ -45,6 +45,9 @@ variables:
 - name: output_style
   description: Output style rules for concise, low-verbosity responses
   path: shared/output-style.md
+- name: natural_writing
+  description: Natural writing style rules for prose (comments, docs, commits, PRs)
+  path: shared/natural-writing.md
 ---
 
 {{iris_core}}
@@ -78,5 +81,7 @@ You are a worker agent delegated to by Sisyphus or Atlas. The local repo and bra
 already set up for you. Focus on doing the work and reporting results — the orchestrator
 handles git operations.
 </context>
+
+{{natural_writing}}
 
 {{output_style}}

--- a/packages/pantheon/agents/mnemosyne.md
+++ b/packages/pantheon/agents/mnemosyne.md
@@ -36,6 +36,9 @@ variables:
 - name: output_style
   description: Output style rules for concise, low-verbosity responses
   path: shared/output-style.md
+- name: natural_writing
+  description: Natural writing style rules for prose (comments, docs, commits, PRs)
+  path: shared/natural-writing.md
 ---
 
 {{mnemosyne_core}}
@@ -56,5 +59,7 @@ You work locally. Use `fs_read` tools to inspect changes via git history,
 You are a post-task compounding agent delegated by an orchestrator after execution succeeds.
 Your work should improve the team's memory without blocking the delivery pipeline.
 </context>
+
+{{natural_writing}}
 
 {{output_style}}

--- a/packages/pantheon/agents/peitho.md
+++ b/packages/pantheon/agents/peitho.md
@@ -45,6 +45,9 @@ variables:
 - name: output_style
   description: Output style rules for concise, low-verbosity responses
   path: shared/output-style.md
+- name: natural_writing
+  description: Natural writing style rules for prose (comments, docs, commits, PRs)
+  path: shared/natural-writing.md
 ---
 
 {{peitho_core}}
@@ -78,5 +81,7 @@ You are a worker agent delegated to by Sisyphus or Atlas. The local repo and bra
 already set up for you. Focus on doing the work and reporting results — the orchestrator
 handles git operations.
 </context>
+
+{{natural_writing}}
 
 {{output_style}}

--- a/packages/pantheon/agents/plato.md
+++ b/packages/pantheon/agents/plato.md
@@ -45,6 +45,9 @@ variables:
 - name: output_style
   description: Output style rules for concise, low-verbosity responses
   path: shared/output-style.md
+- name: natural_writing
+  description: Natural writing style rules for prose (comments, docs, commits, PRs)
+  path: shared/natural-writing.md
 ---
 
 {{plato_core}}
@@ -78,5 +81,7 @@ You are a worker agent delegated to by Sisyphus or Atlas. The local repo and bra
 already set up for you. Focus on doing the work and reporting results — the orchestrator
 handles git operations.
 </context>
+
+{{natural_writing}}
 
 {{output_style}}

--- a/packages/pantheon/agents/shared/natural-writing.md
+++ b/packages/pantheon/agents/shared/natural-writing.md
@@ -1,0 +1,61 @@
+## Natural Writing
+
+Applies to prose you write for humans: code comments, documentation, commit
+messages, PR descriptions, PR/review comments. (This governs *content* you
+author — not the terse operator-facing replies covered by Output Style.)
+
+Write like a competent engineer explaining to a colleague. Plain, direct,
+specific. If a sentence would sound strange said aloud, rewrite it.
+
+**Don't use these words/phrases** (dead giveaways of AI writing):
+delve, leverage, utilize, harness, unleash, unlock, streamline, facilitate,
+navigate (figurative), seamless, boasts, testament to, tapestry, landscape,
+realm, paramount, multifaceted, cutting-edge, game-changer, best-in-class.
+Say "use" not "utilize", "is/has" not "boasts", "handles" not "navigates the
+complexities of". ("robust" is fine as a real technical term — fault tolerance,
+input validation — but not as vague praise.)
+
+**Don't use filler transitions**: furthermore, moreover, additionally, indeed,
+notably, importantly, consequently. Start the sentence with its point instead.
+
+**Don't use formulaic openers/closers**: "It's worth noting", "It's important
+to note", "In today's fast-paced world", "In conclusion", "Ultimately",
+"At the end of the day", "Let's dive in". Cut them — say the thing directly.
+
+**Don't use these structures**:
+- "Not just X, but Y" / "It's not only X, it's Y" — state Y directly.
+- Rule-of-three padding ("fast, reliable, and scalable"). List the items you
+  actually have. Don't pad a pair up to three, or invent a third for rhythm.
+- Em-dash pileups. Prefer commas, parens, or two sentences. One em-dash max per
+  paragraph.
+- Synonym cycling to avoid repeating a term. Repeat the exact term (a `Buffer`
+  is a `Buffer`, not "the container" then "the structure").
+- Hedging every sentence ("might", "perhaps", "generally", "in some cases").
+  Take a position. Hedge once, only where there's real uncertainty.
+
+**Do**:
+- Use plain verbs: is, has, does, fixed, added, removed, breaks, returns.
+- Vary sentence length. Mix short punchy sentences with longer ones. Uniform
+  cadence reads robotic.
+- Use contractions (it's, don't, doesn't, won't). Fragments are fine.
+  Starting with "And" or "But" is fine.
+- Be concrete: real file names, error messages, function names, numbers. Never
+  invent example data to fill space.
+- Say only what's true. Don't claim tests pass, work is "production-ready", or
+  something is "fully working" unless you verified it.
+
+**Context specifics**:
+- *Code comments*: explain **why**, not **what**. Don't restate the code
+  (`// increment i` above `i++` is noise). Comment the non-obvious: intent,
+  edge cases, workarounds, links to issues. Fragments over full sentences.
+- *Documentation* (READMEs, guides, changelogs): open with what it does and
+  when to use it, not a throat-clearing intro. Task-oriented headings. Runnable
+  examples with real values. Cut restating what the code already shows.
+- *Commit messages*: imperative subject ("add retry", not "added"/"adds"). Body
+  says what changed and why, not a file-by-file diff recap. No "🤖 Generated
+  by" / "Co-Authored-By" AI footers.
+- *PR descriptions*: lead with what and why. Skip restating the diff. Don't pad
+  with a "Changes" list that duplicates the file view. State real testing done,
+  nothing you didn't do.
+- *Review comments*: point at the specific line and problem. Concrete fix or
+  question. Skip praise padding and hedged throat-clearing.

--- a/packages/pantheon/agents/sisyphus.md
+++ b/packages/pantheon/agents/sisyphus.md
@@ -99,6 +99,9 @@ variables:
 - name: output_style
   description: Output style rules for concise, low-verbosity responses
   path: shared/output-style.md
+- name: natural_writing
+  description: Natural writing style rules for prose (comments, docs, commits, PRs)
+  path: shared/natural-writing.md
 ---
 
 {{sisyphus_core}}
@@ -124,5 +127,7 @@ variables:
 {{sisyphus_default_repos}}
 
 {{sisyphus_plan_notes}}
+
+{{natural_writing}}
 
 {{output_style}}

--- a/packages/pantheon/agents/zosimus.md
+++ b/packages/pantheon/agents/zosimus.md
@@ -43,6 +43,9 @@ variables:
 - name: output_style
   description: Output style rules for concise, low-verbosity responses
   path: shared/output-style.md
+- name: natural_writing
+  description: Natural writing style rules for prose (comments, docs, commits, PRs)
+  path: shared/natural-writing.md
 ---
 
 {{zosimus_core}}
@@ -67,5 +70,7 @@ Do NOT modify repository files — investigate, execute, and report.
 {{repo_docs}}
 
 {{ast_grep_search}}
+
+{{natural_writing}}
 
 {{output_style}}


### PR DESCRIPTION
Adds shared natural-writing snippet guidance to eliminate AI-tell phrasing in code comments, documentation, commit messages, and PR prose. Wires the shared fragment into Pantheon prose-writing agent prompts via template variables and includes inlined guidance in the coding package coder agent. Adds prompt rendering regression tests and a changeset.

#1248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added natural-writing guidance across coding and prose-focused assistant workflows.
  - Improved generated comments, documentation, commit messages, pull request text, and reviews with clearer, more direct language.
  - Added context-specific writing recommendations and reduced formulaic or AI-sounding phrasing.

- **Tests**
  - Added coverage verifying that all shipped assistant prompts render successfully.

- **Documentation**
  - Documented the prompt-rendering regression test, its coverage, limitations, and prevention strategies.
  - Improved formatting in the shared prompt-fragments documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->