### PR TITLE
Add session variable dot-commands and TUI dump truncation

### DIFF
--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -30,7 +30,7 @@ pub enum CommandOutcome {
     OpenSessionPicker,
 }
 
-pub static COMMANDS: LazyLock<[Command; 50]> = LazyLock::new(|| {
+pub static COMMANDS: LazyLock<[Command; 55]> = LazyLock::new(|| {
     [
         Command::new(".help", "Show this help guide"),
         Command::new(".info", "Show system info"),
@@ -43,12 +43,24 @@ pub static COMMANDS: LazyLock<[Command; 50]> = LazyLock::new(|| {
             ".info env [name]",
             "List harnx process env var names (or show one var's value)",
         ),
+        Command::new(
+            ".info variables",
+            "List session variables (values truncated)",
+        ),
+        Command::new(
+            ".info variable <name>",
+            "Show one session variable's full value",
+        ),
         Command::new(".use tool", "Add a tool or toolset to the active tools"),
         Command::new(
             ".drop tool",
             "Remove a tool or toolset from the active tools",
         ),
         Command::new(".edit config", "Modify configuration file"),
+        Command::new(
+            ".edit variable <name>",
+            "Edit a session variable in $EDITOR",
+        ),
         Command::new(".model", "Switch LLM model"),
         Command::new(".prompt", "Set a temporary agent using a prompt"),
         Command::new(".edit agent", "Modify current agent"),
@@ -101,6 +113,11 @@ pub static COMMANDS: LazyLock<[Command; 50]> = LazyLock::new(|| {
         Command::new(".regenerate", "Regenerate last response"),
         Command::new(".copy", "Copy last response"),
         Command::new(".set", "Modify runtime settings"),
+        Command::new(".set variable <name> <value>", "Set a session variable"),
+        Command::new(
+            ".load variable <name> <file>",
+            "Load a session variable value from a file",
+        ),
         Command::new(".title", "Show or (re)generate the session title"),
         Command::new(
             ".set show_sequence_numbers",
@@ -414,6 +431,19 @@ pub async fn run_command_with_output_and_local_worker(
                     let info = config.read().session_info()?;
                     write!(output, "{info}")?;
                 }
+                Some("variables") => {
+                    write!(output, "{}", config.read().list_variables()?)?;
+                }
+                Some("variable") => {
+                    bail!("Usage: .info variable <name>");
+                }
+                Some(rest) if rest.starts_with("variable ") => {
+                    let name = rest["variable ".len()..].trim();
+                    if name.is_empty() {
+                        bail!("Usage: .info variable <name>");
+                    }
+                    write!(output, "{}", config.read().get_variable(name)?)?;
+                }
                 Some("model") => {
                     let conf = config.read();
                     write_model_info_block(output, &conf, conf.current_model())?;
@@ -627,6 +657,16 @@ pub async fn run_command_with_output_and_local_worker(
                     }
                     Some("session") => {
                         config.write().edit_session()?;
+                    }
+                    Some("variable") => {
+                        bail!("Usage: .edit variable <name>");
+                    }
+                    Some(rest) if rest.starts_with("variable ") => {
+                        let name = rest["variable ".len()..].trim();
+                        if name.is_empty() {
+                            bail!("Usage: .edit variable <name>");
+                        }
+                        config.write().edit_variable(name)?;
                     }
                     Some("rag-docs") => {
                         Config::edit_rag_docs(config, abort_signal.clone()).await?;
@@ -1003,10 +1043,41 @@ Commands:
                 _ => writeln!(output, "Usage: .drop tool <name>")?,
             },
             ".set" => match args {
+                Some("variable") => {
+                    bail!("Usage: .set variable <name> <value>");
+                }
+                Some(rest) if rest.starts_with("variable ") => {
+                    let variable_args = rest["variable ".len()..].trim_start();
+                    let Some((name, value)) = variable_args.split_once(' ') else {
+                        bail!("Usage: .set variable <name> <value>");
+                    };
+                    if name.is_empty() || value.is_empty() {
+                        bail!("Usage: .set variable <name> <value>");
+                    }
+                    config.write().set_variable(name, value)?;
+                }
                 Some(args) => {
                     Config::update(config, args)?;
                 }
                 _ => writeln!(output, "Usage: .set <key> <value>...")?,
+            },
+            ".load" => match args {
+                Some("variable") => {
+                    bail!("Usage: .load variable <name> <file>");
+                }
+                Some(rest) if rest.starts_with("variable ") => {
+                    let variable_args = rest["variable ".len()..].trim_start();
+                    let Some((name, file)) = variable_args.split_once(' ') else {
+                        bail!("Usage: .load variable <name> <file>");
+                    };
+                    let file = file.trim();
+                    if name.is_empty() || file.is_empty() {
+                        bail!("Usage: .load variable <name> <file>");
+                    }
+                    config.write().load_variable(name, file)?;
+                    writeln!(output, "Loaded variable '{name}' from '{file}'")?;
+                }
+                _ => bail!("Usage: .load variable <name> <file>"),
             },
             ".delete" => match args {
                 Some(args) if args.starts_with("message ") => {

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -25,6 +25,7 @@ mod session_ops_core;
 mod session_ops_split;
 pub mod session_ops_title;
 mod settings_split;
+mod variable_split;
 
 pub use self::env_split::load_env_file;
 pub use self::macros_split::macro_execute;

--- a/crates/harnx-runtime/src/config/session_dump.rs
+++ b/crates/harnx-runtime/src/config/session_dump.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use super::compaction::truncate_middle;
 use crate::client::{Message, MessageRole};
 use anyhow::{bail, Context, Result};
 use std::path::PathBuf;
@@ -58,9 +59,14 @@ fn build_session_dump(session: &Session) -> Result<String> {
         "tokens".to_string(),
         serde_json::Value::Object(build_session_tokens(session)),
     );
+    let agent_variables: IndexMap<String, String> = session
+        .agent_variables()
+        .iter()
+        .map(|(name, value)| (name.clone(), truncate_middle(value, 200)))
+        .collect();
     data.insert(
         "agent_variables".to_string(),
-        serde_json::to_value(session.agent_variables())?,
+        serde_json::to_value(agent_variables)?,
     );
     data.insert(
         "messages".to_string(),
@@ -312,6 +318,27 @@ content: hi there
         assert!(dump.contains("content: hi there"));
         assert!(dump.contains("snapshot:"));
         assert!(!dump.contains("SECRET SYSTEM PROMPT"));
+    }
+
+    #[test]
+    fn render_session_dump_truncates_long_agent_variables() {
+        let _lock = env_lock();
+        let env = SessionDumpTestEnv::new(SessionScope::RequestedAgent("smith"));
+        let long_value = "x".repeat(260);
+        env.write_session(
+            "variables",
+            &format!(
+                "---\ntype: header\nmodel: openai:test-model\nsession_id: variables\nworking_dir: /tmp/work\nagent_name: smith\nagent_variables:\n  long: {long_value}\n  short: forge\n",
+            ),
+        );
+
+        let dump = render_session_dump(Some("smith"), "variables").unwrap();
+        let rendered: serde_yaml::Value = serde_yaml::from_str(&dump).unwrap();
+        let truncated = rendered["agent_variables"]["long"].as_str().unwrap();
+
+        assert!(truncated.contains("…[truncated]…"));
+        assert_eq!(truncated.chars().count(), 200);
+        assert_eq!(rendered["agent_variables"]["short"], "forge");
     }
 
     #[test]

--- a/crates/harnx-runtime/src/config/session_edit_tests.rs
+++ b/crates/harnx-runtime/src/config/session_edit_tests.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 use harnx_core::{
-    message::{MessageContent, MessageRole},
+    message::{Message, MessageContent, MessageRole},
     session::ToolOutput,
     tool::ToolCall,
 };
@@ -101,6 +101,177 @@ fn editor_test_config(sessions_dir: std::path::PathBuf) -> Config {
     config.model = harnx_client::Model::new("test", "model");
     config.model_id = "test:model".to_string();
     config
+}
+
+fn variable_test_config(sessions_dir: std::path::PathBuf) -> Config {
+    let mut config = editor_test_config(sessions_dir);
+    let mut agent = Agent::new(AgentConfig::from_prompt(""));
+    agent.set_model(config.model.clone());
+    config.agent = Some(agent);
+    config
+}
+
+#[test]
+fn set_variable_persists_and_creates_empty_key() -> Result<()> {
+    let sessions = tempfile::TempDir::new()?;
+    let mut config = variable_test_config(sessions.path().to_path_buf());
+    config.use_session(Some("variable-persistence"))?;
+    config
+        .session
+        .as_mut()
+        .context("No active session")?
+        .messages
+        .push(Message::new(
+            MessageRole::User,
+            MessageContent::Text("keep session active".to_string()),
+        ));
+
+    config.set_variable("persisted", "saved value")?;
+    config.set_variable("empty", "")?;
+    config.save_session(None)?;
+    drop(config);
+
+    let mut reloaded = variable_test_config(sessions.path().to_path_buf());
+    reloaded.use_session(Some("variable-persistence"))?;
+    assert_eq!(reloaded.get_variable("persisted")?, "saved value");
+    assert_eq!(reloaded.get_variable("empty")?, "");
+
+    Ok(())
+}
+
+#[test]
+fn get_variable_returns_full_long_value() -> Result<()> {
+    let sessions = tempfile::TempDir::new()?;
+    let mut config = variable_test_config(sessions.path().to_path_buf());
+    config.use_session(Some("variable-get"))?;
+    let long_value = "x".repeat(250);
+
+    config.set_variable("long", &long_value)?;
+
+    assert_eq!(config.get_variable("long")?, long_value);
+    Ok(())
+}
+
+#[test]
+fn list_variables_truncates_long_values_and_preserves_short_values() -> Result<()> {
+    let sessions = tempfile::TempDir::new()?;
+    let mut config = variable_test_config(sessions.path().to_path_buf());
+    config.use_session(Some("variable-list"))?;
+    config.set_variable("short", "small")?;
+    config.set_variable("long", &"x".repeat(250))?;
+
+    let listed = config.list_variables()?;
+    let short_line = listed
+        .lines()
+        .find(|line| line.starts_with("short = "))
+        .context("short variable missing from list")?;
+    let long_rendered = listed
+        .split_once("long = ")
+        .map(|(_, value)| value)
+        .context("long variable missing from list")?;
+
+    assert_eq!(short_line, "short = small");
+    assert!(long_rendered.contains("…[truncated]…"));
+    assert!(long_rendered.chars().count() <= 200);
+    Ok(())
+}
+
+#[test]
+fn load_variable_reads_file_and_missing_file_does_not_mutate() -> Result<()> {
+    let sessions = tempfile::TempDir::new()?;
+    let files = tempfile::TempDir::new()?;
+    let mut config = variable_test_config(sessions.path().to_path_buf());
+    config.use_session(Some("variable-load"))?;
+    config.set_variable("loaded", "original")?;
+
+    let value_path = files.path().join("value.txt");
+    std::fs::write(&value_path, "loaded from file\n")?;
+    config.load_variable(
+        "loaded",
+        value_path.to_str().context("non-UTF-8 temp path")?,
+    )?;
+    assert_eq!(config.get_variable("loaded")?, "loaded from file\n");
+
+    let before = config
+        .session
+        .as_ref()
+        .context("No active session")?
+        .agent_variables()
+        .clone();
+    let missing_path = files.path().join("missing.txt");
+    let error = config
+        .load_variable(
+            "new-key",
+            missing_path.to_str().context("non-UTF-8 temp path")?,
+        )
+        .expect_err("missing variable file should fail");
+    assert!(error.to_string().contains("Failed to read variable file"));
+    assert_eq!(
+        config
+            .session
+            .as_ref()
+            .context("No active session")?
+            .agent_variables(),
+        &before
+    );
+
+    Ok(())
+}
+
+#[test]
+fn edit_variable_round_trip_supports_content_and_empty_edits() {
+    use tempfile::TempDir;
+
+    let sessions = TempDir::new().unwrap();
+    let editor_tmp = TempDir::new().unwrap();
+    let original_editor = std::env::var_os("EDITOR");
+    std::env::set_var("EDITOR", "true");
+
+    let result = (|| -> Result<()> {
+        let mut config = variable_test_config(sessions.path().to_path_buf());
+        config.use_session(Some("variable-edit"))?;
+        config.set_variable("draft", "initial")?;
+
+        let editor_tmp_path = editor_tmp.path().to_path_buf();
+        config.temp_dir_override = Some(editor_tmp_path.clone());
+        let mut edit_count = 0;
+        config.set_tui_editor_hooks(
+            None,
+            Some(Box::new(move || {
+                let temp_path = std::fs::read_dir(&editor_tmp_path)
+                    .unwrap()
+                    .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+                    .find(|path| {
+                        path.file_name()
+                            .and_then(|name| name.to_str())
+                            .is_some_and(|name| name.starts_with("variable-edit-"))
+                            && path.extension().and_then(|ext| ext.to_str()) == Some("txt")
+                    })
+                    .expect("variable edit temp file");
+                let content = if edit_count == 0 {
+                    "edited variable content\n"
+                } else {
+                    ""
+                };
+                edit_count += 1;
+                std::fs::write(&temp_path, content).unwrap();
+            })),
+        );
+
+        config.edit_variable("draft")?;
+        assert_eq!(config.get_variable("draft")?, "edited variable content\n");
+        config.edit_variable("draft")?;
+        assert_eq!(config.get_variable("draft")?, "");
+
+        Ok(())
+    })();
+
+    match original_editor {
+        Some(value) => std::env::set_var("EDITOR", value),
+        None => std::env::remove_var("EDITOR"),
+    }
+
+    result.unwrap();
 }
 
 #[test]

--- a/crates/harnx-runtime/src/config/variable_split.rs
+++ b/crates/harnx-runtime/src/config/variable_split.rs
@@ -1,0 +1,91 @@
+use super::{compaction::truncate_middle, session_lock::SessionLock, Config};
+use crate::utils::{edit_file, temp_file};
+use anyhow::{bail, Context, Result};
+
+impl Config {
+    pub fn list_variables(&self) -> Result<String> {
+        let session = self.session.as_ref().context("No active session")?;
+        if session.agent_variables().is_empty() {
+            return Ok("No session variables".to_string());
+        }
+
+        Ok(session
+            .agent_variables()
+            .iter()
+            .map(|(name, value)| format!("{name} = {}", truncate_middle(value, 200)))
+            .collect::<Vec<_>>()
+            .join("\n"))
+    }
+
+    pub fn get_variable(&self, name: &str) -> Result<String> {
+        let session = self.session.as_ref().context("No active session")?;
+        session
+            .agent_variables()
+            .get(name)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Variable '{name}' not set"))
+    }
+
+    pub fn set_variable(&mut self, name: &str, value: &str) -> Result<()> {
+        let session_name = self
+            .session
+            .as_ref()
+            .context("No active session")?
+            .id()
+            .to_string();
+        let lock = SessionLock::acquire(&self.session_file(&session_name))?;
+
+        let (agent, session) = match (self.agent.as_mut(), self.session.as_mut()) {
+            (Some(agent), Some(session)) => (agent, session),
+            (None, _) => bail!("No active agent"),
+            (_, None) => bail!("No active session"),
+        };
+        let mut variables = session.agent_variables().clone();
+        variables.insert(name.to_string(), value.to_string());
+        agent.set_session_variables(variables);
+        session.sync_agent(agent)?;
+
+        // save_session acquires this same non-reentrant lock internally.
+        drop(lock);
+        self.save_session(None)
+    }
+
+    pub fn edit_variable(&mut self, name: &str) -> Result<()> {
+        let current_value = self
+            .session
+            .as_ref()
+            .context("No active session")?
+            .agent_variables()
+            .get(name)
+            .cloned()
+            .unwrap_or_default();
+        let temp_file = if let Some(ref dir) = self.temp_dir_override {
+            dir.join(format!("variable-edit-{}.txt", uuid::Uuid::new_v4()))
+        } else {
+            temp_file("variable-edit", ".txt")
+        };
+
+        std::fs::write(&temp_file, current_value)
+            .with_context(|| format!("Failed to write to '{}'", temp_file.display()))?;
+
+        let edit_result = self.edit_with_tui_hooks(|this| {
+            let editor = this.editor()?;
+            edit_file(&editor, &temp_file).with_context(|| {
+                format!("Failed to edit '{}' with '{}'", temp_file.display(), editor)
+            })
+        });
+        let edited_content = std::fs::read_to_string(&temp_file)
+            .with_context(|| format!("Failed to read '{}'", temp_file.display()));
+        let _ = std::fs::remove_file(&temp_file);
+        edit_result?;
+        let edited_content = edited_content?;
+
+        self.set_variable(name, &edited_content)
+    }
+
+    pub fn load_variable(&mut self, name: &str, path: &str) -> Result<()> {
+        let value = std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read variable file '{path}'"))?;
+        self.set_variable(name, &value)
+    }
+}

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -2177,8 +2177,17 @@ impl Tui {
             line_cmd.starts_with(".info agent") || line_cmd.starts_with("/info agent");
         let is_info_session =
             line_cmd.starts_with(".info session") || line_cmd.starts_with("/info session");
+        let is_info_variables = line_cmd == ".info variables"
+            || line_cmd == "/info variables"
+            || line_cmd.starts_with(".info variables ")
+            || line_cmd.starts_with("/info variables ");
+        let is_info_variable = !is_info_variables
+            && (line_cmd == ".info variable"
+                || line_cmd == "/info variable"
+                || line_cmd.starts_with(".info variable ")
+                || line_cmd.starts_with("/info variable "));
 
-        if !is_info_agent && !is_info_session {
+        if !is_info_agent && !is_info_session && !is_info_variables && !is_info_variable {
             return false;
         }
 
@@ -2189,25 +2198,36 @@ impl Tui {
             return true;
         };
 
-        let result = if is_info_agent {
-            self.resolve_info_agent_target(&tokens)
+        let (result, title) = if is_info_agent {
+            let res = self
+                .resolve_info_agent_target(&tokens)
                 .and_then(|agent_name| {
                     let cfg = self.config.read();
                     harnx_runtime::config::render_agent_dump(&cfg, &agent_name)
-                })
+                });
+            (res, "Agent Info")
+        } else if is_info_session {
+            let res =
+                self.resolve_info_session_target(&tokens)
+                    .and_then(|(agent_name, session_id)| {
+                        harnx_runtime::config::render_session_dump(
+                            agent_name.as_deref(),
+                            &session_id,
+                        )
+                    });
+            (res, "Session Info")
+        } else if is_info_variables {
+            (self.config.read().list_variables(), "Session Variables")
         } else {
-            self.resolve_info_session_target(&tokens)
-                .and_then(|(agent_name, session_id)| {
-                    harnx_runtime::config::render_session_dump(agent_name.as_deref(), &session_id)
-                })
+            let res = if tokens.len() > 2 {
+                self.config.read().get_variable(&tokens[2])
+            } else {
+                Err(anyhow::anyhow!("Usage: .info variable <name>"))
+            };
+            (res, "Session Variable")
         };
 
         let display_text = result.unwrap_or_else(|err| format!("Error: {}", err));
-        let title = if is_info_agent {
-            "Agent Info"
-        } else {
-            "Session Info"
-        };
         self.open_info_overlay(display_text, title);
         true
     }

--- a/crates/harnx-tui/src/snapshots/harnx_tui__tests__help_in_tui.snap
+++ b/crates/harnx-tui/src/snapshots/harnx_tui__tests__help_in_tui.snap
@@ -2,8 +2,6 @@
 source: crates/harnx-tui/src/tests.rs
 expression: rendered
 ---
-.attach                  Attach a file to the next message
-.detach                  Remove attached files
 .macro                   Execute a macro
 .mcp                     Manage MCP servers
 .file                    Include files, directories, URLs or commands
@@ -11,6 +9,8 @@ expression: rendered
 .regenerate              Regenerate last response
 .copy                    Copy last response
 .set                     Modify runtime settings
+.set variable <name> <value> Set a session variable
+.load variable <name> <file> Load a session variable value from a file
 .title                   Show or (re)generate the session title
 .set show_sequence_numbers Toggle [n] prefix in transcript (on/off)
 .set show_timestamps     Toggle timestamp in transcript (on/off)

--- a/docs/solutions/feature-implementation/session-variable-dot-commands-2026-07-29.md
+++ b/docs/solutions/feature-implementation/session-variable-dot-commands-2026-07-29.md
@@ -1,0 +1,170 @@
+---
+title: "Session variable dot-commands: verb-first convention, 3-layer dispatch, and persistence path"
+date: 2026-07-29
+category: "feature-implementation"
+problem_type: logic_error
+component: "harnx-runtime, harnx-tui"
+root_cause: "n/a — feature implementation pattern documentation"
+resolution_type: code_fix
+severity: medium
+tags:
+  - dot-commands
+  - session-variables
+  - tui-overlay
+  - session-lock
+  - verb-first
+  - dispatch-routing
+  - editor-integration
+plan_ref: "session-variables-tui"
+---
+
+## Problem
+
+Adding new dot-commands for session variable management required understanding three distinct architectural layers: (1) command registry, (2) CLI dispatch routing, and (3) TUI overlay intercept. Additionally, the variable mutation+persistence path needed to correctly coordinate SessionLock acquisition with `save_session` re-entrancy semantics.
+
+## Symptoms
+
+N/A — feature implementation.
+
+## Key Architectural Patterns
+
+### 1. Dot-Command Convention and 3-Layer Architecture
+
+Harnx uses a **verb-first** naming convention for dot-commands (`.info session`, `.edit config`, `.set model`). When adding new commands, three layers must be updated:
+
+1. **Registry** (`crates/harnx-runtime/src/commands.rs`):
+   - Static array `COMMANDS: [Command; N]` holds help text entries
+   - **N must be bumped manually** when adding commands (compile-time count)
+   - Location: `commands.rs:33`
+
+2. **CLI Dispatch** (`run_command_with_output` in `commands.rs`):
+   - `match parse_command(line)` branches route to handler methods
+   - Command-specific parsing (`starts_with`, `split_once`) lives inline
+   - `.set` and `.load` use `split_once(' ')` to allow values with spaces
+
+3. **TUI Overlay Intercept** (`harnx-tui/src/input.rs`):
+   - `try_handle_info_overlay` handles `.info` subcommands that open modals
+   - Disambiguation via boolean prefix checks (plural `.info variables` vs singular `.info variable`)
+   - Calls `config.read().method()` directly, wraps result in overlay
+
+**Example**: For `.info variable <name>`:
+- Registry: `Command::new(".info variable <name>", "Show one session variable's full value")`
+- Dispatch: `rest.starts_with("variable ")` → `config.read().get_variable(name)?`
+- TUI: `is_info_variable` check → `config.read().get_variable(&tokens[2])` → `open_info_overlay`
+
+### 2. Session Variable Mutation + Persistence Path
+
+Variable mutation follows a specific sequence:
+
+```rust
+let lock = SessionLock::acquire(&self.session_file(&session_name))?;
+let mut variables = session.agent_variables().clone();
+variables.insert(name.to_string(), value.to_string());
+agent.set_session_variables(variables);
+session.sync_agent(agent)?;
+drop(lock);  // save_session re-acquires this same non-reentrant lock
+self.save_session(None)?;
+```
+
+**Key points**:
+
+- `SessionLock` is file-based (`flock`) and **non-reentrant within a process**
+- Must drop lock before `save_session` because `save_session` acquires it internally
+- Pattern matches sibling modules (`settings_split.rs`, `session_ops_split.rs`)
+- Background: [local-session-cross-process-locking-2026-07-17.md](../integration-issues/local-session-cross-process-locking-2026-07-17.md)
+
+### 3. Truncation Reuse (`truncate_middle`)
+
+The `compaction::truncate_middle(text, max_chars)` helper at `compaction.rs:63` is reused for:
+
+- `.info variables` — bulk display truncated to 200 chars
+- `.info session` TUI dump — agent_variables truncated in `session_dump.rs`
+- `.info variable <name>` — **full value, no truncation**
+
+**Budget**: 200 chars for bulk; distinction enforced at call site.
+
+Import via `use super::compaction::truncate_middle;` in handler module.
+
+### 4. `$EDITOR` Round-Trip Pattern
+
+Temp file editing uses a consistent pattern (precedent: `session_ops_split.rs:278-297`):
+
+```rust
+let temp_file = if let Some(ref dir) = self.temp_dir_override {
+    dir.join(format!("variable-edit-{}.txt", uuid::Uuid::new_v4()))
+} else {
+    temp_file("variable-edit", ".txt")
+};
+std::fs::write(&temp_file, current_value)?;
+
+let edit_result = self.edit_with_tui_hooks(|this| {
+    let editor = this.editor()?;
+    edit_file(&editor, &temp_file)
+});
+let edited_content = std::fs::read_to_string(&temp_file);
+let _ = std::fs::remove_file(&temp_file);  // best-effort cleanup
+edit_result?;
+let edited_content = edited_content?;
+
+self.set_variable(name, &edited_content)?
+```
+
+**Gotcha**: `edit_with_tui_hooks` installed via `set_tui_editor_hooks` at TUI lifecycle (`lifecycle.rs`) to suspend/resume alt-screen.
+
+### 5. Test Bootstrap for Variable Mutations
+
+Variable mutation tests need **both** an active agent **and** a non-empty session:
+
+```rust
+fn variable_test_config(sessions_dir: PathBuf) -> Config {
+    let mut config = editor_test_config(sessions_dir);
+    let mut agent = Agent::new(AgentConfig::from_prompt(""));
+    agent.set_model(config.model.clone());
+    config.agent = Some(agent);
+    config
+}
+```
+
+Persistence tests must add at least one `Message` to `session.messages` before saving. `use_session` treats empty-sessions as new, triggering `init_agent_variables` which may reset variables from defaults.
+
+**Fake editor pattern** (for testing `edit_variable`):
+
+```rust
+let _env_lock = ENV_MUTEX.lock().unwrap();  // serialize EDITOR manipulations
+let original_editor = std::env::var("EDITOR").ok();
+std::env::set_var("EDITOR", "true");  // no-op editor
+
+let mut config = variable_test_config(temp.path().to_path_buf());
+config.temp_dir_override = Some(temp.path().to_path_buf());
+config.set_tui_editor_hooks(Arc::new(|| {}), Arc::new(|_success| {}));
+
+// ... test code ...
+
+if let Some(val) = original_editor {
+    std::env::set_var("EDITOR", val);
+} else {
+    std::env::remove_var("EDITOR");
+}
+```
+
+Reference: `session_edit_tests.rs` for complete examples.
+
+### 6. TUI Help Snapshot Gotcha
+
+Adding commands changes the help snapshot:
+
+- File: `crates/harnx-tui/src/snapshots/harnx_tui__tests__help_in_tui.snap`
+- Expect snapshot diff when adding new commands
+- Column alignment may break if command names exceed hardcoded padding width (24 chars)
+
+## Related Issues
+
+- GitHub: [#1254](https://github.com/dobesv/harnx/issues/1254) — Session Variable Management via dot-commands
+- GitHub: [#1163](https://github.com/dobesv/harnx/issues/1163) — Truncate large variable values in session dump
+
+## Related Solutions
+
+- [local-session-cross-process-locking-2026-07-17.md](../integration-issues/local-session-cross-process-locking-2026-07-17.md) — SessionLock and re-entrancy semantics
+- [restored-session-agent-variable-defaults-2026-07-28.md](restored-session-agent-variable-defaults-2026-07-28.md) — Variable defaults on session restore
+- [info-session-compact-summary-2026-05-22.md](info-session-compact-summary-2026-05-22.md) — CLI vs TUI info paths
+- [dot-commands-picker-signals-2026-05-10.md](dot-commands-picker-signals-2026-05-10.md) — CommandOutcome for TUI modal signals


### PR DESCRIPTION
Add verb-first dot-commands (.info variables, .info variable, .set variable, .edit variable, .load variable) to manage session variables across CLI and TUI modes. Implement variable handlers in Config (variable_split.rs), register commands in commands.rs, and wire overlay rendering in input.rs.

Truncate large variable values to 200 characters in the TUI session info dump (session_dump.rs) and bulk variable listing while preserving full values for single-variable lookup. Include unit tests for persistence, truncation, and editor integration, along with solution documentation.

#1254
#1163