### PR TITLE
feat(grep): add native harnx-vercel-grep-server MCP server

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Keep grep-server golden test fixtures as LF so byte-exact output asserts pass on Windows
+crates/harnx-vercel-grep-server/tests/fixtures/** text eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4379,6 +4379,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "harnx-vercel-grep-server"
+version = "0.33.4"
+dependencies = [
+ "anyhow",
+ "fancy-regex 0.18.0",
+ "log",
+ "reqwest",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "tokio",
+ "wiremock",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/harnx-mcp-hooks-proxy",
     "crates/harnx-mcp-fs",
     "crates/harnx-mcp-time",
+    "crates/harnx-vercel-grep-server",
     "crates/harnx-mcp-remote",
     "crates/harnx-mcp-plans",
     "crates/harnx-mcp-plans-core",

--- a/crates/harnx-vercel-grep-server/Cargo.toml
+++ b/crates/harnx-vercel-grep-server/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "harnx-vercel-grep-server"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "MCP server for GitHub code search through grep.app"
+
+[dependencies]
+rmcp = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true, features = ["query"] }
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+fancy-regex = { workspace = true }
+log = { workspace = true }
+
+[dev-dependencies]
+wiremock = { workspace = true }
+tokio = { workspace = true }
+
+[[bin]]
+name = "harnx-vercel-grep-server"
+path = "src/main.rs"

--- a/crates/harnx-vercel-grep-server/README.md
+++ b/crates/harnx-vercel-grep-server/README.md
@@ -1,0 +1,96 @@
+# harnx-vercel-grep-server
+
+Native Rust MCP server exposing a single `grep_query` tool that searches GitHub code via the grep.app API.
+
+This replaces the external `grep-mcp` (uvx) package for GitHub issue #1268, providing a 1:1 behavior port of [galprz/grep-mcp](https://github.com/galprz/grep-mcp). Used by Pytheas, Sisyphus, and Zosimus to find real-world usage examples of APIs and patterns in public repos.
+
+## Install
+
+From the repo root:
+
+```bash
+cargo install --path crates/harnx-vercel-grep-server
+```
+
+The resulting binary is `harnx-vercel-grep-server` — a stdio MCP server. No external runtime (Python, uvx) needed.
+
+## Tool
+
+### `grep_query`
+
+Search GitHub code via grep.app.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `query` | Yes | Search query string. Max 1000 characters. |
+| `language` | No | Filter by programming language. Max 50 characters. |
+| `repo` | No | Filter by repository in `owner/repo` format. Must contain exactly one `/`. Max 100 characters. |
+| `path` | No | Filter by file path. Max 200 characters. |
+
+## Smoke Test
+
+Run the server:
+
+```bash
+harnx-vercel-grep-server
+```
+
+Send an MCP `tools/call` request (via an MCP client or manually via stdin):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "grep_query",
+    "arguments": {
+      "query": "FastAPI",
+      "language": "Python"
+    }
+  }
+}
+```
+
+Expected output shape (formatted as 2-space-indented JSON):
+
+```json
+{
+  "query": "FastAPI",
+  "summary": {
+    "total_results": 12345,
+    "results_shown": 10,
+    "repositories_found": 42,
+    "top_languages": [
+      { "language": "Python", "count": 500 }
+    ],
+    "top_repositories": [
+      { "repository": "owner/repo", "count": 100 }
+    ]
+  },
+  "results_by_repository": [
+    {
+      "repository": "owner/repo",
+      "matches_count": 5,
+      "files": [
+        {
+          "file_path": "src/main.py",
+          "branch": "main",
+          "total_matches": 3,
+          "line_numbers": [10, 25, 42],
+          "language": "python",
+          "code_snippet": "..."
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Note:** grep.app is currently behind a Vercel bot-challenge that returns HTTP 429 to some automated/datacenter clients. Depending on your network environment, a live query may return:
+
+```
+❌ Error: Rate limit exceeded. Please wait before making another request.
+```
+
+This is expected behavior — the server correctly surfaces the rate limit. The tool behavior is correct; it's grep.app rate-limiting requests from certain environments.

--- a/crates/harnx-vercel-grep-server/README.md
+++ b/crates/harnx-vercel-grep-server/README.md
@@ -89,7 +89,7 @@ Expected output shape (formatted as 2-space-indented JSON):
 
 **Note:** grep.app is currently behind a Vercel bot-challenge that returns HTTP 429 to some automated/datacenter clients. Depending on your network environment, a live query may return:
 
-```
+```text
 ❌ Error: Rate limit exceeded. Please wait before making another request.
 ```
 

--- a/crates/harnx-vercel-grep-server/src/client.rs
+++ b/crates/harnx-vercel-grep-server/src/client.rs
@@ -13,6 +13,7 @@ pub enum SearchOutcome {
     RateLimited,
     HttpStatus(u16),
     Timeout,
+    Malformed(String),
     Network(String),
 }
 
@@ -46,6 +47,7 @@ pub async fn search(
     match response.status().as_u16() {
         200 => match response.json::<Value>().await {
             Ok(body) => SearchOutcome::Ok(body),
+            Err(error) if error.is_decode() => SearchOutcome::Malformed(error.to_string()),
             Err(error) => classify_error(error),
         },
         429 => SearchOutcome::RateLimited,

--- a/crates/harnx-vercel-grep-server/src/client.rs
+++ b/crates/harnx-vercel-grep-server/src/client.rs
@@ -1,0 +1,63 @@
+use std::time::Duration;
+
+use serde_json::Value;
+
+use crate::server::GrepQueryParams;
+
+pub const DEFAULT_SEARCH_URL: &str = "https://grep.app/api/search";
+
+#[derive(Debug, PartialEq)]
+pub enum SearchOutcome {
+    Ok(Value),
+    NotFound,
+    RateLimited,
+    HttpStatus(u16),
+    Timeout,
+    Network(String),
+}
+
+pub async fn search(
+    client: &reqwest::Client,
+    base_url: &str,
+    params: &GrepQueryParams,
+) -> SearchOutcome {
+    let mut query = vec![("q", params.query.trim())];
+    if let Some(language) = &params.language {
+        query.push(("f.lang", language.trim()));
+    }
+    if let Some(repo) = &params.repo {
+        query.push(("f.repo", repo.trim()));
+    }
+    if let Some(path) = &params.path {
+        query.push(("f.path", path.trim()));
+    }
+
+    let response = match client
+        .get(base_url)
+        .query(&query)
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => return classify_error(error),
+    };
+
+    match response.status().as_u16() {
+        200 => match response.json::<Value>().await {
+            Ok(body) => SearchOutcome::Ok(body),
+            Err(error) => classify_error(error),
+        },
+        429 => SearchOutcome::RateLimited,
+        404 => SearchOutcome::NotFound,
+        status => SearchOutcome::HttpStatus(status),
+    }
+}
+
+fn classify_error(error: reqwest::Error) -> SearchOutcome {
+    if error.is_timeout() {
+        SearchOutcome::Timeout
+    } else {
+        SearchOutcome::Network(error.to_string())
+    }
+}

--- a/crates/harnx-vercel-grep-server/src/format.rs
+++ b/crates/harnx-vercel-grep-server/src/format.rs
@@ -1,0 +1,525 @@
+use std::sync::OnceLock;
+
+use fancy_regex::Regex;
+use serde::Serialize;
+
+use crate::server::model::SearchResponse;
+
+static HTML_TAG_REGEX: OnceLock<Result<Regex, fancy_regex::Error>> = OnceLock::new();
+static LINE_NUMBER_REGEX: OnceLock<Result<Regex, fancy_regex::Error>> = OnceLock::new();
+
+pub fn extract_text_from_html(html: &str) -> String {
+    let without_tags = match HTML_TAG_REGEX.get_or_init(|| Regex::new(r"<[^>]+>")) {
+        Ok(regex) => regex.replace_all(html, "").into_owned(),
+        Err(error) => {
+            log::error!("failed to compile HTML tag regex: {error}");
+            html.to_owned()
+        }
+    };
+
+    without_tags
+        .replace("&quot;", "\"")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .trim()
+        .to_owned()
+}
+
+pub fn extract_line_numbers(html: &str) -> Vec<u32> {
+    let regex = match LINE_NUMBER_REGEX.get_or_init(|| Regex::new(r#"data-line="(\d+)""#)) {
+        Ok(regex) => regex,
+        Err(error) => {
+            log::error!("failed to compile line number regex: {error}");
+            return Vec::new();
+        }
+    };
+
+    regex
+        .captures_iter(html)
+        .filter_map(|captures| match captures {
+            Ok(captures) => captures
+                .get(1)
+                .and_then(|capture| capture.as_str().parse::<u32>().ok()),
+            Err(error) => {
+                log::error!("failed to extract line number: {error}");
+                None
+            }
+        })
+        .collect()
+}
+
+pub fn language_from_extension(extension: &str) -> &'static str {
+    match extension {
+        "py" => "python",
+        "js" | "jsx" => "javascript",
+        "ts" | "tsx" => "typescript",
+        "java" => "java",
+        "c" | "h" => "c",
+        "cpp" | "cc" | "cxx" | "hpp" => "cpp",
+        "cs" => "csharp",
+        "php" => "php",
+        "rb" => "ruby",
+        "go" => "go",
+        "rs" => "rust",
+        "swift" => "swift",
+        "kt" => "kotlin",
+        "scala" => "scala",
+        "sh" | "bash" | "zsh" | "fish" => "bash",
+        "ps1" => "powershell",
+        "sql" => "sql",
+        "html" | "htm" => "html",
+        "xml" => "xml",
+        "css" => "css",
+        "scss" => "scss",
+        "sass" => "sass",
+        "less" => "less",
+        "json" => "json",
+        "yaml" | "yml" => "yaml",
+        "toml" => "toml",
+        "ini" | "cfg" | "conf" => "ini",
+        "md" | "markdown" => "markdown",
+        "tex" => "latex",
+        "r" => "r",
+        "matlab" | "m" => "matlab",
+        "pl" => "perl",
+        "lua" => "lua",
+        "vim" => "vim",
+        "dockerfile" => "dockerfile",
+        "makefile" | "make" => "makefile",
+        _ => "text",
+    }
+}
+
+pub fn format_code_snippet(text: &str, language: &str) -> String {
+    if text.trim().is_empty() {
+        return String::new();
+    }
+
+    let snippet = if text.chars().count() > 400 {
+        let mut truncated = text.chars().take(400).collect::<String>();
+        truncated.push_str("...");
+        truncated
+    } else {
+        text.to_owned()
+    };
+
+    let lines = snippet.split('\n').collect::<Vec<_>>();
+    let mut formatted_lines = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        let cleaned = line.trim_end();
+        if !cleaned.is_empty() {
+            formatted_lines.push(cleaned);
+        }
+        if formatted_lines.len() >= 8 {
+            if index < lines.len() - 1 {
+                formatted_lines.push("... (truncated)");
+            }
+            break;
+        }
+    }
+
+    let joined = formatted_lines.join("\n");
+    if !language.is_empty() && language != "text" {
+        format!("```{language}\n{joined}\n```")
+    } else {
+        joined
+    }
+}
+
+pub fn build_output(query: &str, response: &SearchResponse) -> String {
+    let top_languages = response
+        .facets
+        .lang
+        .buckets
+        .iter()
+        .take(5)
+        .map(|bucket| TopLanguage {
+            language: if bucket.val.is_empty() {
+                "Unknown"
+            } else {
+                &bucket.val
+            },
+            count: bucket.count,
+        })
+        .collect();
+    let top_repositories = response
+        .facets
+        .repo
+        .buckets
+        .iter()
+        .take(5)
+        .map(|bucket| TopRepository {
+            repository: if bucket.val.is_empty() {
+                "Unknown"
+            } else {
+                &bucket.val
+            },
+            count: bucket.count,
+        })
+        .collect();
+
+    let mut results_by_repository: Vec<RepositoryResult> = Vec::new();
+    for hit in response.hits.hits.iter().take(10) {
+        let repository = hit.repo();
+        let path = hit.path();
+        let raw_total_matches = hit.total_matches();
+        let total_matches = if !raw_total_matches.is_empty()
+            && raw_total_matches
+                .chars()
+                .all(|character| character.is_ascii_digit())
+        {
+            raw_total_matches.parse::<u64>().unwrap_or(0)
+        } else {
+            0
+        };
+        let raw_snippet = hit.snippet();
+        let clean_snippet = extract_text_from_html(raw_snippet);
+        let line_numbers = extract_line_numbers(raw_snippet);
+        let extension = if path.contains('.') {
+            path.rsplit('.').next().unwrap_or("txt").to_lowercase()
+        } else {
+            "txt".to_owned()
+        };
+        let language = language_from_extension(&extension);
+        let file = FileResult {
+            file_path: path.to_owned(),
+            branch: hit.branch().to_owned(),
+            total_matches,
+            line_numbers,
+            language,
+            code_snippet: format_code_snippet(&clean_snippet, language),
+        };
+
+        if let Some(group) = results_by_repository
+            .iter_mut()
+            .find(|group| group.repository == repository)
+        {
+            group.matches_count = group.matches_count.saturating_add(total_matches);
+            group.files.push(file);
+        } else {
+            results_by_repository.push(RepositoryResult {
+                repository: repository.to_owned(),
+                matches_count: total_matches,
+                files: vec![file],
+            });
+        }
+    }
+
+    results_by_repository.sort_by_key(|repository| std::cmp::Reverse(repository.matches_count));
+    let results_shown = results_by_repository
+        .iter()
+        .map(|repository| repository.files.len())
+        .sum();
+    let repositories_found = results_by_repository.len();
+    let output = SearchOutput {
+        query,
+        summary: Summary {
+            total_results: response.facets.count,
+            results_shown,
+            repositories_found,
+            top_languages,
+            top_repositories,
+        },
+        results_by_repository,
+    };
+
+    serialize_pretty(&output)
+}
+
+pub fn build_not_found_output(query: &str) -> String {
+    serialize_pretty(&NotFoundOutput {
+        query,
+        summary: NotFoundSummary {
+            total_results: 0,
+            message: "No results found for this query",
+        },
+        results: Vec::new(),
+    })
+}
+
+fn serialize_pretty<T: Serialize>(value: &T) -> String {
+    match serde_json::to_string_pretty(value) {
+        Ok(output) => output,
+        Err(error) => {
+            log::error!("failed to serialize grep output: {error}");
+            String::new()
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct SearchOutput<'a> {
+    query: &'a str,
+    summary: Summary<'a>,
+    results_by_repository: Vec<RepositoryResult>,
+}
+
+#[derive(Serialize)]
+struct Summary<'a> {
+    total_results: u64,
+    results_shown: usize,
+    repositories_found: usize,
+    top_languages: Vec<TopLanguage<'a>>,
+    top_repositories: Vec<TopRepository<'a>>,
+}
+
+#[derive(Serialize)]
+struct TopLanguage<'a> {
+    language: &'a str,
+    count: u64,
+}
+
+#[derive(Serialize)]
+struct TopRepository<'a> {
+    repository: &'a str,
+    count: u64,
+}
+
+#[derive(Serialize)]
+struct RepositoryResult {
+    repository: String,
+    matches_count: u64,
+    files: Vec<FileResult>,
+}
+
+#[derive(Serialize)]
+struct FileResult {
+    file_path: String,
+    branch: String,
+    total_matches: u64,
+    line_numbers: Vec<u32>,
+    language: &'static str,
+    code_snippet: String,
+}
+
+#[derive(Serialize)]
+struct NotFoundOutput<'a> {
+    query: &'a str,
+    summary: NotFoundSummary,
+    results: Vec<serde_json::Value>,
+}
+
+#[derive(Serialize)]
+struct NotFoundSummary {
+    total_results: u64,
+    message: &'static str,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::{
+        build_not_found_output, build_output, extract_line_numbers, extract_text_from_html,
+        format_code_snippet, language_from_extension,
+    };
+    use crate::server::model::SearchResponse;
+
+    const GOLDEN_SUCCESS: &str = r#"{
+  "query": "FastAPI",
+  "summary": {
+    "total_results": 1234,
+    "results_shown": 1,
+    "repositories_found": 1,
+    "top_languages": [
+      {
+        "language": "Python",
+        "count": 500
+      }
+    ],
+    "top_repositories": [
+      {
+        "repository": "fastapi/fastapi",
+        "count": 100
+      }
+    ]
+  },
+  "results_by_repository": [
+    {
+      "repository": "fastapi/fastapi",
+      "matches_count": 5,
+      "files": [
+        {
+          "file_path": "src/main.py",
+          "branch": "main",
+          "total_matches": 5,
+          "line_numbers": [
+            10,
+            11
+          ],
+          "language": "python",
+          "code_snippet": "```python\nimport fastapi\napp = FastAPI()\n```"
+        }
+      ]
+    }
+  ]
+}"#;
+
+    const GOLDEN_NOT_FOUND: &str = r#"{
+  "query": "somequery",
+  "summary": {
+    "total_results": 0,
+    "message": "No results found for this query"
+  },
+  "results": []
+}"#;
+
+    #[test]
+    fn strips_tags_decodes_entities_in_reference_order_and_trims() {
+        assert_eq!(
+            extract_text_from_html("  <span>&quot;x&quot; &amp; &lt;y&gt; &amp;lt;</span>  "),
+            "\"x\" & <y> <"
+        );
+    }
+
+    #[test]
+    fn extracts_only_well_formed_numeric_line_numbers() {
+        let html = r#"<span data-line="7">a</span><i data-line="42">b</i>"#;
+        assert_eq!(extract_line_numbers(html), vec![7, 42]);
+        assert!(extract_line_numbers("<span>none</span>").is_empty());
+        assert!(extract_line_numbers(r#"data-line="12x" data-line="abc""#).is_empty());
+    }
+
+    #[test]
+    fn maps_extensions_and_defaults_to_text() {
+        assert_eq!(language_from_extension("py"), "python");
+        assert_eq!(language_from_extension("rs"), "rust");
+        assert_eq!(language_from_extension("ts"), "typescript");
+        assert_eq!(language_from_extension("unknown"), "text");
+        assert_eq!(language_from_extension("txt"), "text");
+    }
+
+    #[test]
+    fn formats_empty_plain_and_fenced_snippets() {
+        assert_eq!(format_code_snippet(" \n\t", "rust"), "");
+        assert_eq!(format_code_snippet("one\n\ntwo  ", "text"), "one\ntwo");
+        assert_eq!(
+            format_code_snippet("fn main() {}", "rust"),
+            "```rust\nfn main() {}\n```"
+        );
+    }
+
+    #[test]
+    fn truncates_to_400_characters_before_splitting_lines() {
+        let long = "x".repeat(401);
+        assert_eq!(
+            format_code_snippet(&long, "text"),
+            format!("{}...", "x".repeat(400))
+        );
+
+        let split_after_boundary = format!("{}\nsecond line", "a".repeat(399));
+        assert_eq!(
+            format_code_snippet(&split_after_boundary, "text"),
+            format!("{}\n...", "a".repeat(399))
+        );
+    }
+
+    #[test]
+    fn keeps_eight_non_empty_lines_then_marks_truncation() {
+        let snippet = "one\n\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine";
+        assert_eq!(
+            format_code_snippet(snippet, "text"),
+            "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\n... (truncated)"
+        );
+    }
+
+    #[test]
+    fn golden_success_output_is_byte_exact() {
+        let response: SearchResponse =
+            serde_json::from_str(include_str!("../tests/fixtures/search_golden_single.json"))
+                .expect("golden fixture must deserialize");
+        assert_eq!(build_output("FastAPI", &response), GOLDEN_SUCCESS);
+    }
+
+    #[test]
+    fn basic_output_groups_sorts_and_summarizes_results() {
+        let response: SearchResponse =
+            serde_json::from_str(include_str!("../tests/fixtures/search_basic.json"))
+                .expect("basic fixture must deserialize");
+        let output: Value =
+            serde_json::from_str(&build_output("FastAPI", &response)).expect("valid output JSON");
+
+        assert_eq!(output["summary"]["total_results"], 1234);
+        assert_eq!(output["summary"]["results_shown"], 3);
+        assert_eq!(output["summary"]["repositories_found"], 2);
+        assert_eq!(
+            output["summary"]["top_languages"].as_array().unwrap().len(),
+            3
+        );
+        assert_eq!(
+            output["summary"]["top_repositories"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            output["results_by_repository"][0]["repository"],
+            "fastapi/fastapi"
+        );
+        assert_eq!(output["results_by_repository"][0]["matches_count"], 15);
+        assert_eq!(
+            output["results_by_repository"][1]["repository"],
+            "tiangolo/full-stack-fastapi-template"
+        );
+        assert_eq!(output["results_by_repository"][1]["matches_count"], 5);
+    }
+
+    #[test]
+    fn no_extension_path_uses_plain_text_snippet() {
+        let response: SearchResponse = serde_json::from_value(serde_json::json!({
+            "hits": { "hits": [{
+                "repo": { "raw": "owner/repo" },
+                "path": { "raw": "README" },
+                "content": { "snippet": "<span data-line=\"1\">plain text</span>" }
+            }] }
+        }))
+        .expect("response must deserialize");
+        let output: Value =
+            serde_json::from_str(&build_output("plain", &response)).expect("valid output JSON");
+        let file = &output["results_by_repository"][0]["files"][0];
+        assert_eq!(file["language"], "text");
+        assert_eq!(file["code_snippet"], "plain text");
+    }
+
+    #[test]
+    fn limits_summary_facets_to_top_five_buckets() {
+        let response: SearchResponse = serde_json::from_value(serde_json::json!({
+            "facets": {
+                "lang": { "buckets": [
+                    {"val": "one"}, {"val": "two"}, {"val": "three"},
+                    {"val": "four"}, {"val": "five"}, {"val": "six"}
+                ]},
+                "repo": { "buckets": [
+                    {"val": "r/1"}, {"val": "r/2"}, {"val": "r/3"},
+                    {"val": "r/4"}, {"val": "r/5"}, {"val": "r/6"}
+                ]}
+            }
+        }))
+        .expect("response must deserialize");
+        let output: Value =
+            serde_json::from_str(&build_output("query", &response)).expect("valid output JSON");
+        assert_eq!(
+            output["summary"]["top_languages"].as_array().unwrap().len(),
+            5
+        );
+        assert_eq!(
+            output["summary"]["top_repositories"]
+                .as_array()
+                .unwrap()
+                .len(),
+            5
+        );
+        assert_eq!(output["summary"]["top_languages"][4]["language"], "five");
+        assert_eq!(
+            output["summary"]["top_repositories"][4]["repository"],
+            "r/5"
+        );
+    }
+
+    #[test]
+    fn not_found_output_is_byte_exact() {
+        assert_eq!(build_not_found_output("somequery"), GOLDEN_NOT_FOUND);
+    }
+}

--- a/crates/harnx-vercel-grep-server/src/format.rs
+++ b/crates/harnx-vercel-grep-server/src/format.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 use fancy_regex::Regex;
 use serde::Serialize;
 
-use crate::server::model::SearchResponse;
+use crate::server::model::{Hit, SearchResponse};
 
 static HTML_TAG_REGEX: OnceLock<Result<Regex, fancy_regex::Error>> = OnceLock::new();
 static LINE_NUMBER_REGEX: OnceLock<Result<Regex, fancy_regex::Error>> = OnceLock::new();
@@ -96,15 +96,27 @@ pub fn format_code_snippet(text: &str, language: &str) -> String {
         return String::new();
     }
 
-    let snippet = if text.chars().count() > 400 {
+    let snippet = truncate_snippet(text);
+    let capped = cap_snippet_lines(&snippet);
+    if !language.is_empty() && language != "text" {
+        format!("```{language}\n{capped}\n```")
+    } else {
+        capped
+    }
+}
+
+fn truncate_snippet(text: &str) -> String {
+    if text.chars().count() > 400 {
         let mut truncated = text.chars().take(400).collect::<String>();
         truncated.push_str("...");
         truncated
     } else {
         text.to_owned()
-    };
+    }
+}
 
-    let lines = snippet.split('\n').collect::<Vec<_>>();
+fn cap_snippet_lines(text: &str) -> String {
+    let lines = text.split('\n').collect::<Vec<_>>();
     let mut formatted_lines = Vec::new();
     for (index, line) in lines.iter().enumerate() {
         let cleaned = line.trim_end();
@@ -118,17 +130,33 @@ pub fn format_code_snippet(text: &str, language: &str) -> String {
             break;
         }
     }
-
-    let joined = formatted_lines.join("\n");
-    if !language.is_empty() && language != "text" {
-        format!("```{language}\n{joined}\n```")
-    } else {
-        joined
-    }
+    formatted_lines.join("\n")
 }
 
 pub fn build_output(query: &str, response: &SearchResponse) -> String {
-    let top_languages = response
+    let mut results_by_repository = group_hits_by_repository(&response.hits.hits);
+    results_by_repository.sort_by_key(|repository| std::cmp::Reverse(repository.matches_count));
+
+    let output = SearchOutput {
+        query,
+        summary: Summary {
+            total_results: response.facets.count,
+            results_shown: results_by_repository
+                .iter()
+                .map(|repository| repository.files.len())
+                .sum(),
+            repositories_found: results_by_repository.len(),
+            top_languages: top_language_summaries(response),
+            top_repositories: top_repository_summaries(response),
+        },
+        results_by_repository,
+    };
+
+    serialize_pretty(&output)
+}
+
+fn top_language_summaries(response: &SearchResponse) -> Vec<TopLanguage<'_>> {
+    response
         .facets
         .lang
         .buckets
@@ -142,8 +170,11 @@ pub fn build_output(query: &str, response: &SearchResponse) -> String {
             },
             count: bucket.count,
         })
-        .collect();
-    let top_repositories = response
+        .collect()
+}
+
+fn top_repository_summaries(response: &SearchResponse) -> Vec<TopRepository<'_>> {
+    response
         .facets
         .repo
         .buckets
@@ -157,74 +188,59 @@ pub fn build_output(query: &str, response: &SearchResponse) -> String {
             },
             count: bucket.count,
         })
-        .collect();
+        .collect()
+}
 
-    let mut results_by_repository: Vec<RepositoryResult> = Vec::new();
-    for hit in response.hits.hits.iter().take(10) {
+fn group_hits_by_repository(hits: &[Hit]) -> Vec<RepositoryResult> {
+    let mut groups: Vec<RepositoryResult> = Vec::new();
+    for hit in hits.iter().take(10) {
         let repository = hit.repo();
-        let path = hit.path();
-        let raw_total_matches = hit.total_matches();
-        let total_matches = if !raw_total_matches.is_empty()
-            && raw_total_matches
-                .chars()
-                .all(|character| character.is_ascii_digit())
-        {
-            raw_total_matches.parse::<u64>().unwrap_or(0)
-        } else {
-            0
-        };
-        let raw_snippet = hit.snippet();
-        let clean_snippet = extract_text_from_html(raw_snippet);
-        let line_numbers = extract_line_numbers(raw_snippet);
-        let extension = if path.contains('.') {
-            path.rsplit('.').next().unwrap_or("txt").to_lowercase()
-        } else {
-            "txt".to_owned()
-        };
-        let language = language_from_extension(&extension);
-        let file = FileResult {
-            file_path: path.to_owned(),
-            branch: hit.branch().to_owned(),
-            total_matches,
-            line_numbers,
-            language,
-            code_snippet: format_code_snippet(&clean_snippet, language),
-        };
-
-        if let Some(group) = results_by_repository
+        let file = file_result(hit);
+        if let Some(group) = groups
             .iter_mut()
             .find(|group| group.repository == repository)
         {
-            group.matches_count = group.matches_count.saturating_add(total_matches);
+            group.matches_count = group.matches_count.saturating_add(file.total_matches);
             group.files.push(file);
         } else {
-            results_by_repository.push(RepositoryResult {
+            groups.push(RepositoryResult {
                 repository: repository.to_owned(),
-                matches_count: total_matches,
+                matches_count: file.total_matches,
                 files: vec![file],
             });
         }
     }
+    groups
+}
 
-    results_by_repository.sort_by_key(|repository| std::cmp::Reverse(repository.matches_count));
-    let results_shown = results_by_repository
-        .iter()
-        .map(|repository| repository.files.len())
-        .sum();
-    let repositories_found = results_by_repository.len();
-    let output = SearchOutput {
-        query,
-        summary: Summary {
-            total_results: response.facets.count,
-            results_shown,
-            repositories_found,
-            top_languages,
-            top_repositories,
-        },
-        results_by_repository,
+fn file_result(hit: &Hit) -> FileResult {
+    let path = hit.path();
+    let total_matches = parse_total_matches(hit.total_matches());
+    let raw_snippet = hit.snippet();
+    let clean_snippet = extract_text_from_html(raw_snippet);
+    let extension = if path.contains('.') {
+        path.rsplit('.').next().unwrap_or("txt").to_lowercase()
+    } else {
+        "txt".to_owned()
     };
+    let language = language_from_extension(&extension);
 
-    serialize_pretty(&output)
+    FileResult {
+        file_path: path.to_owned(),
+        branch: hit.branch().to_owned(),
+        total_matches,
+        line_numbers: extract_line_numbers(raw_snippet),
+        language,
+        code_snippet: format_code_snippet(&clean_snippet, language),
+    }
+}
+
+fn parse_total_matches(raw: &str) -> u64 {
+    if !raw.is_empty() && raw.chars().all(|character| character.is_ascii_digit()) {
+        raw.parse::<u64>().unwrap_or(0)
+    } else {
+        0
+    }
 }
 
 pub fn build_not_found_output(query: &str) -> String {
@@ -243,7 +259,7 @@ fn serialize_pretty<T: Serialize>(value: &T) -> String {
         Ok(output) => output,
         Err(error) => {
             log::error!("failed to serialize grep output: {error}");
-            String::new()
+            format!("❌ Error: Failed to serialize grep output: {error}")
         }
     }
 }

--- a/crates/harnx-vercel-grep-server/src/format.rs
+++ b/crates/harnx-vercel-grep-server/src/format.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 use fancy_regex::Regex;
 use serde::Serialize;
 
-use crate::server::model::{Hit, SearchResponse};
+use crate::server::model::{Bucket, Hit, SearchResponse};
 
 static HTML_TAG_REGEX: OnceLock<Result<Regex, fancy_regex::Error>> = OnceLock::new();
 static LINE_NUMBER_REGEX: OnceLock<Result<Regex, fancy_regex::Error>> = OnceLock::new();
@@ -124,9 +124,7 @@ fn cap_snippet_lines(text: &str) -> String {
             formatted_lines.push(cleaned);
         }
         if formatted_lines.len() >= 8 {
-            if index < lines.len() - 1 {
-                formatted_lines.push("... (truncated)");
-            }
+            formatted_lines.extend((index < lines.len() - 1).then_some("... (truncated)"));
             break;
         }
     }
@@ -155,40 +153,38 @@ pub fn build_output(query: &str, response: &SearchResponse) -> String {
     serialize_pretty(&output)
 }
 
-fn top_language_summaries(response: &SearchResponse) -> Vec<TopLanguage<'_>> {
-    response
-        .facets
-        .lang
-        .buckets
+fn top_summaries<'a, T>(
+    buckets: &'a [Bucket],
+    make_summary: impl Fn(FacetSummary<'a>) -> T,
+) -> Vec<T> {
+    buckets
         .iter()
         .take(5)
-        .map(|bucket| TopLanguage {
-            language: if bucket.val.is_empty() {
-                "Unknown"
-            } else {
-                &bucket.val
-            },
-            count: bucket.count,
+        .map(|bucket| {
+            make_summary(FacetSummary {
+                value: if bucket.val.is_empty() {
+                    "Unknown"
+                } else {
+                    &bucket.val
+                },
+                count: bucket.count,
+            })
         })
         .collect()
 }
 
+fn top_language_summaries(response: &SearchResponse) -> Vec<TopLanguage<'_>> {
+    top_summaries(&response.facets.lang.buckets, |summary| TopLanguage {
+        language: summary.value,
+        count: summary.count,
+    })
+}
+
 fn top_repository_summaries(response: &SearchResponse) -> Vec<TopRepository<'_>> {
-    response
-        .facets
-        .repo
-        .buckets
-        .iter()
-        .take(5)
-        .map(|bucket| TopRepository {
-            repository: if bucket.val.is_empty() {
-                "Unknown"
-            } else {
-                &bucket.val
-            },
-            count: bucket.count,
-        })
-        .collect()
+    top_summaries(&response.facets.repo.buckets, |summary| TopRepository {
+        repository: summary.value,
+        count: summary.count,
+    })
 }
 
 fn group_hits_by_repository(hits: &[Hit]) -> Vec<RepositoryResult> {
@@ -309,6 +305,11 @@ struct FileResult {
     code_snippet: String,
 }
 
+struct FacetSummary<'a> {
+    value: &'a str,
+    count: u64,
+}
+
 #[derive(Serialize)]
 struct NotFoundOutput<'a> {
     query: &'a str,
@@ -398,10 +399,14 @@ mod tests {
     }
 
     #[test]
-    fn maps_extensions_and_defaults_to_text() {
+    fn maps_known_extensions() {
         assert_eq!(language_from_extension("py"), "python");
         assert_eq!(language_from_extension("rs"), "rust");
         assert_eq!(language_from_extension("ts"), "typescript");
+    }
+
+    #[test]
+    fn defaults_unknown_extensions_to_text() {
         assert_eq!(language_from_extension("unknown"), "text");
         assert_eq!(language_from_extension("txt"), "text");
     }

--- a/crates/harnx-vercel-grep-server/src/lib.rs
+++ b/crates/harnx-vercel-grep-server/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod client;
+pub mod format;
+pub mod server;

--- a/crates/harnx-vercel-grep-server/src/main.rs
+++ b/crates/harnx-vercel-grep-server/src/main.rs
@@ -1,0 +1,50 @@
+use anyhow::Context;
+use harnx_vercel_grep_server::server::GrepServer;
+use rmcp::ServiceExt;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    if parse_args()? {
+        print_help();
+        return Ok(());
+    }
+
+    eprintln!(
+        "harnx-vercel-grep-server v{}: starting",
+        env!("CARGO_PKG_VERSION")
+    );
+
+    let server = GrepServer::new();
+    let service = server
+        .serve(rmcp::transport::stdio())
+        .await
+        .context("harnx-vercel-grep-server: failed to start stdio service")?;
+    service
+        .waiting()
+        .await
+        .context("harnx-vercel-grep-server: stdio service failed")?;
+
+    Ok(())
+}
+
+fn parse_args() -> anyhow::Result<bool> {
+    let mut help = false;
+
+    for arg in std::env::args().skip(1) {
+        match arg.as_str() {
+            "--help" | "-h" => help = true,
+            _ => anyhow::bail!("harnx-vercel-grep-server: unknown argument: {arg}"),
+        }
+    }
+
+    Ok(help)
+}
+
+fn print_help() {
+    eprintln!("harnx-vercel-grep-server - GitHub code search MCP server");
+    eprintln!();
+    eprintln!("Usage: harnx-vercel-grep-server [--help]");
+    eprintln!();
+    eprintln!("Options:");
+    eprintln!("  --help, -h          Show this help message");
+}

--- a/crates/harnx-vercel-grep-server/src/server/handler.rs
+++ b/crates/harnx-vercel-grep-server/src/server/handler.rs
@@ -1,0 +1,146 @@
+use rmcp::model::{
+    CallToolRequestMethod, CallToolRequestParams, CallToolResult, ContentBlock, ErrorData,
+    Implementation, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+    ToolAnnotations,
+};
+use rmcp::service::{RequestContext, RoleServer};
+use rmcp::ServerHandler;
+use serde_json::{Map, Value};
+
+use crate::client::{self, SearchOutcome};
+use crate::format;
+
+use super::model::SearchResponse;
+use super::{GrepQueryParams, GrepServer};
+
+const QUERY_REQUIRED_ERROR: &str =
+    "❌ Error: 'query' parameter is required and must be a non-empty string";
+const RATE_LIMIT_ERROR: &str =
+    "❌ Error: Rate limit exceeded. Please wait before making another request.";
+const TIMEOUT_ERROR: &str =
+    "❌ Error: Request timed out. The grep.app API may be experiencing issues.";
+
+impl ServerHandler for GrepServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new(
+                "harnx-vercel-grep-server",
+                env!("CARGO_PKG_VERSION"),
+            ))
+            .with_instructions("Search GitHub code through the grep.app search index.")
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        let grep_query = Tool::new(
+            "grep_query",
+            "Search GitHub code using grep.app API. This tool enables AI assistants to search through GitHub repositories for specific code patterns using grep.app's powerful search index. It returns formatted results with repository information, file paths, and code snippets.",
+            grep_query_schema(),
+        )
+        .annotate(
+            ToolAnnotations::new()
+                .read_only(true)
+                .destructive(false)
+                .idempotent(true)
+                .open_world(true),
+        );
+
+        Ok(ListToolsResult {
+            meta: None,
+            tools: vec![grep_query],
+            next_cursor: None,
+        })
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if request.name.as_ref() != "grep_query" {
+            return Err(ErrorData::method_not_found::<CallToolRequestMethod>());
+        }
+
+        let params = match serde_json::from_value::<GrepQueryParams>(Value::Object(
+            request.arguments.unwrap_or_default(),
+        )) {
+            Ok(params) => params,
+            Err(_) => return Ok(text_result(QUERY_REQUIRED_ERROR)),
+        };
+
+        if let Err(message) = params.validate() {
+            return Ok(text_result(message));
+        }
+
+        let query = params.query.trim();
+        let output = match client::search(&self.client, &self.base_url, &params).await {
+            SearchOutcome::Ok(value) => match serde_json::from_value::<SearchResponse>(value) {
+                Ok(response) => format::build_output(query, &response),
+                Err(error) => {
+                    format!("❌ Error: Network error while contacting grep.app API: {error}")
+                }
+            },
+            SearchOutcome::NotFound => format::build_not_found_output(query),
+            SearchOutcome::RateLimited => RATE_LIMIT_ERROR.to_string(),
+            SearchOutcome::HttpStatus(status) => {
+                format!("❌ Error: API request failed with status {status}")
+            }
+            SearchOutcome::Timeout => TIMEOUT_ERROR.to_string(),
+            SearchOutcome::Network(details) => {
+                format!("❌ Error: Network error while contacting grep.app API: {details}")
+            }
+        };
+
+        Ok(text_result(output))
+    }
+}
+
+fn text_result(text: impl Into<String>) -> CallToolResult {
+    CallToolResult::success(vec![ContentBlock::text(text.into())])
+}
+
+fn grep_query_schema() -> Map<String, Value> {
+    let mut properties = Map::new();
+    properties.insert(
+        "query".to_string(),
+        string_property("The search query string to find in GitHub repositories"),
+    );
+    properties.insert(
+        "language".to_string(),
+        string_property("Optional programming language filter (e.g., \"Python\", \"JavaScript\")"),
+    );
+    properties.insert(
+        "repo".to_string(),
+        string_property(
+            "Optional repository filter in format \"owner/repo\" (e.g., \"fastapi/fastapi\")",
+        ),
+    );
+    properties.insert(
+        "path".to_string(),
+        string_property(
+            "Optional path filter to search within specific directories (e.g., \"src/\")",
+        ),
+    );
+
+    let mut schema = Map::new();
+    schema.insert("type".to_string(), Value::String("object".to_string()));
+    schema.insert("properties".to_string(), Value::Object(properties));
+    schema.insert(
+        "required".to_string(),
+        Value::Array(vec![Value::String("query".to_string())]),
+    );
+    schema
+}
+
+fn string_property(description: &str) -> Value {
+    let mut property = Map::new();
+    property.insert("type".to_string(), Value::String("string".to_string()));
+    property.insert(
+        "description".to_string(),
+        Value::String(description.to_string()),
+    );
+    Value::Object(property)
+}

--- a/crates/harnx-vercel-grep-server/src/server/handler.rs
+++ b/crates/harnx-vercel-grep-server/src/server/handler.rs
@@ -79,9 +79,7 @@ impl ServerHandler for GrepServer {
         let output = match client::search(&self.client, &self.base_url, &params).await {
             SearchOutcome::Ok(value) => match serde_json::from_value::<SearchResponse>(value) {
                 Ok(response) => format::build_output(query, &response),
-                Err(error) => {
-                    format!("❌ Error: Network error while contacting grep.app API: {error}")
-                }
+                Err(error) => unexpected_response_error(error),
             },
             SearchOutcome::NotFound => format::build_not_found_output(query),
             SearchOutcome::RateLimited => RATE_LIMIT_ERROR.to_string(),
@@ -89,6 +87,7 @@ impl ServerHandler for GrepServer {
                 format!("❌ Error: API request failed with status {status}")
             }
             SearchOutcome::Timeout => TIMEOUT_ERROR.to_string(),
+            SearchOutcome::Malformed(error) => unexpected_response_error(error),
             SearchOutcome::Network(details) => {
                 format!("❌ Error: Network error while contacting grep.app API: {details}")
             }
@@ -96,6 +95,10 @@ impl ServerHandler for GrepServer {
 
         Ok(text_result(output))
     }
+}
+
+fn unexpected_response_error(error: impl std::fmt::Display) -> String {
+    format!("❌ Error: Unexpected response format from grep.app API: {error}")
 }
 
 fn text_result(text: impl Into<String>) -> CallToolResult {

--- a/crates/harnx-vercel-grep-server/src/server/mod.rs
+++ b/crates/harnx-vercel-grep-server/src/server/mod.rs
@@ -1,0 +1,33 @@
+mod handler;
+pub mod model;
+mod params;
+
+pub use params::GrepQueryParams;
+
+#[derive(Clone)]
+pub struct GrepServer {
+    pub(super) client: reqwest::Client,
+    pub(super) base_url: String,
+}
+
+impl GrepServer {
+    pub fn new() -> Self {
+        Self::with_base_url(crate::client::DEFAULT_SEARCH_URL)
+    }
+
+    /// Creates a server targeting a custom grep.app-compatible endpoint.
+    ///
+    /// This is primarily useful for exercising the full handler against a mock server.
+    pub fn with_base_url(base_url: impl Into<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            base_url: base_url.into(),
+        }
+    }
+}
+
+impl Default for GrepServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/harnx-vercel-grep-server/src/server/model.rs
+++ b/crates/harnx-vercel-grep-server/src/server/model.rs
@@ -1,0 +1,173 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct SearchResponse {
+    pub facets: Facets,
+    pub hits: Hits,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct Facets {
+    pub count: u64,
+    pub lang: BucketFacet,
+    pub repo: BucketFacet,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct BucketFacet {
+    pub buckets: Vec<Bucket>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct Bucket {
+    pub val: String,
+    pub count: u64,
+}
+
+impl Default for Bucket {
+    fn default() -> Self {
+        Self {
+            val: "Unknown".to_owned(),
+            count: 0,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct Hits {
+    pub hits: Vec<Hit>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct Hit {
+    pub repo: Option<RawString>,
+    pub path: Option<RawString>,
+    pub branch: Option<RawString>,
+    pub total_matches: Option<RawTotalMatches>,
+    pub content: Option<Content>,
+}
+
+impl Hit {
+    pub fn repo(&self) -> &str {
+        self.repo
+            .as_ref()
+            .and_then(|value| value.raw.as_deref())
+            .unwrap_or("Unknown")
+    }
+
+    pub fn path(&self) -> &str {
+        self.path
+            .as_ref()
+            .and_then(|value| value.raw.as_deref())
+            .unwrap_or("Unknown")
+    }
+
+    pub fn branch(&self) -> &str {
+        self.branch
+            .as_ref()
+            .and_then(|value| value.raw.as_deref())
+            .unwrap_or("main")
+    }
+
+    pub fn total_matches(&self) -> &str {
+        self.total_matches
+            .as_ref()
+            .map_or("0", |value| value.raw.as_str())
+    }
+
+    pub fn snippet(&self) -> &str {
+        self.content
+            .as_ref()
+            .and_then(|content| content.snippet.as_deref())
+            .unwrap_or("")
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct RawString {
+    pub raw: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct RawTotalMatches {
+    #[serde(deserialize_with = "deserialize_string_or_integer")]
+    pub raw: String,
+}
+
+impl Default for RawTotalMatches {
+    fn default() -> Self {
+        Self {
+            raw: "0".to_owned(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct Content {
+    pub snippet: Option<String>,
+}
+
+fn deserialize_string_or_integer<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<Value>::deserialize(deserializer)?;
+    Ok(match value {
+        Some(Value::String(value)) => value,
+        Some(Value::Number(value)) => value.to_string(),
+        _ => "0".to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::SearchResponse;
+
+    #[test]
+    fn deserializes_captured_fixture() {
+        let response: SearchResponse =
+            serde_json::from_str(include_str!("../../tests/fixtures/search_basic.json"))
+                .expect("fixture must deserialize");
+        assert_eq!(response.facets.count, 1234);
+        assert_eq!(response.hits.hits.len(), 3);
+        assert_eq!(response.hits.hits[0].repo(), "fastapi/fastapi");
+        assert_eq!(response.hits.hits[0].total_matches(), "12");
+    }
+
+    #[test]
+    fn total_matches_accepts_string_and_integer_raw_values() {
+        for (raw, expected) in [(json!("5"), "5"), (json!(5), "5")] {
+            let response: SearchResponse = serde_json::from_value(json!({
+                "hits": { "hits": [{ "total_matches": { "raw": raw } }] }
+            }))
+            .expect("response must deserialize");
+            assert_eq!(response.hits.hits[0].total_matches(), expected);
+        }
+    }
+
+    #[test]
+    fn missing_nested_fields_use_reference_defaults() {
+        let response: SearchResponse = serde_json::from_value(json!({
+            "hits": { "hits": [{}] }
+        }))
+        .expect("response must deserialize");
+        let hit = &response.hits.hits[0];
+        assert_eq!(hit.repo(), "Unknown");
+        assert_eq!(hit.path(), "Unknown");
+        assert_eq!(hit.branch(), "main");
+        assert_eq!(hit.total_matches(), "0");
+        assert_eq!(hit.snippet(), "");
+    }
+}

--- a/crates/harnx-vercel-grep-server/src/server/params.rs
+++ b/crates/harnx-vercel-grep-server/src/server/params.rs
@@ -1,0 +1,192 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct GrepQueryParams {
+    pub query: String,
+    pub language: Option<String>,
+    pub repo: Option<String>,
+    pub path: Option<String>,
+}
+
+impl GrepQueryParams {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.query.is_empty() {
+            return Err(
+                "❌ Error: 'query' parameter is required and must be a non-empty string".into(),
+            );
+        }
+        if self.query.trim().is_empty() {
+            return Err("❌ Error: 'query' cannot be empty or only whitespace".into());
+        }
+        if self.query.chars().count() > 1000 {
+            return Err(
+                "❌ Error: 'query' is too long (max 1000 characters). Please use a shorter query."
+                    .into(),
+            );
+        }
+
+        if let Some(language) = &self.language {
+            if language.trim().is_empty() {
+                return Err(
+                    "❌ Error: 'language' parameter must be a non-empty string when provided"
+                        .into(),
+                );
+            }
+            if language.chars().count() > 50 {
+                return Err(
+                    "❌ Error: 'language' parameter is too long (max 50 characters)".into(),
+                );
+            }
+        }
+
+        if let Some(repo) = &self.repo {
+            if repo.trim().is_empty() {
+                return Err(
+                    "❌ Error: 'repo' parameter must be a non-empty string when provided".into(),
+                );
+            }
+            if repo.matches('/').count() != 1 {
+                return Err(
+                    "❌ Error: 'repo' parameter must be in format 'owner/repository' (e.g., 'fastapi/fastapi')"
+                        .into(),
+                );
+            }
+            if repo.chars().count() > 100 {
+                return Err("❌ Error: 'repo' parameter is too long (max 100 characters)".into());
+            }
+        }
+
+        if let Some(path) = &self.path {
+            if path.trim().is_empty() {
+                return Err(
+                    "❌ Error: 'path' parameter must be a non-empty string when provided".into(),
+                );
+            }
+            if path.chars().count() > 200 {
+                return Err("❌ Error: 'path' parameter is too long (max 200 characters)".into());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GrepQueryParams;
+
+    fn params(query: impl Into<String>) -> GrepQueryParams {
+        GrepQueryParams {
+            query: query.into(),
+            language: None,
+            repo: None,
+            path: None,
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_query_with_exact_messages() {
+        assert_eq!(
+            params("").validate(),
+            Err("❌ Error: 'query' parameter is required and must be a non-empty string".into())
+        );
+        assert_eq!(
+            params(" \t\n").validate(),
+            Err("❌ Error: 'query' cannot be empty or only whitespace".into())
+        );
+        assert_eq!(
+            params("q".repeat(1001)).validate(),
+            Err(
+                "❌ Error: 'query' is too long (max 1000 characters). Please use a shorter query."
+                    .into()
+            )
+        );
+    }
+
+    #[test]
+    fn query_length_uses_characters_and_accepts_boundary() {
+        assert!(params("é".repeat(1000)).validate().is_ok());
+        assert_eq!(
+            params("é".repeat(1001)).validate(),
+            Err(
+                "❌ Error: 'query' is too long (max 1000 characters). Please use a shorter query."
+                    .into()
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_language_with_exact_messages_and_accepts_boundary() {
+        let mut value = params("query");
+        value.language = Some("  ".into());
+        assert_eq!(
+            value.validate(),
+            Err("❌ Error: 'language' parameter must be a non-empty string when provided".into())
+        );
+        value.language = Some("l".repeat(50));
+        assert!(value.validate().is_ok());
+        value.language = Some("l".repeat(51));
+        assert_eq!(
+            value.validate(),
+            Err("❌ Error: 'language' parameter is too long (max 50 characters)".into())
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_repo_with_exact_messages_and_checks_slashes() {
+        let mut value = params("query");
+        value.repo = Some(" \t".into());
+        assert_eq!(
+            value.validate(),
+            Err("❌ Error: 'repo' parameter must be a non-empty string when provided".into())
+        );
+
+        let format_error = Err("❌ Error: 'repo' parameter must be in format 'owner/repository' (e.g., 'fastapi/fastapi')".into());
+        value.repo = Some("owner-repo".into());
+        assert_eq!(value.validate(), format_error);
+        value.repo = Some("owner/repo/extra".into());
+        assert_eq!(value.validate(), format_error);
+        value.repo = Some("owner/repo".into());
+        assert!(value.validate().is_ok());
+    }
+
+    #[test]
+    fn repo_length_accepts_100_and_rejects_101_characters() {
+        let mut value = params("query");
+        value.repo = Some(format!("{}/r", "o".repeat(98)));
+        assert!(value.validate().is_ok());
+        value.repo = Some(format!("{}/r", "o".repeat(99)));
+        assert_eq!(
+            value.validate(),
+            Err("❌ Error: 'repo' parameter is too long (max 100 characters)".into())
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_path_with_exact_messages_and_accepts_boundary() {
+        let mut value = params("query");
+        value.path = Some("\n ".into());
+        assert_eq!(
+            value.validate(),
+            Err("❌ Error: 'path' parameter must be a non-empty string when provided".into())
+        );
+        value.path = Some("p".repeat(200));
+        assert!(value.validate().is_ok());
+        value.path = Some("p".repeat(201));
+        assert_eq!(
+            value.validate(),
+            Err("❌ Error: 'path' parameter is too long (max 200 characters)".into())
+        );
+    }
+
+    #[test]
+    fn valid_filters_pass_validation() {
+        let value = GrepQueryParams {
+            query: " FastAPI ".into(),
+            language: Some(" Python ".into()),
+            repo: Some("fastapi/fastapi".into()),
+            path: Some("src/".into()),
+        };
+        assert!(value.validate().is_ok());
+    }
+}

--- a/crates/harnx-vercel-grep-server/src/server/params.rs
+++ b/crates/harnx-vercel-grep-server/src/server/params.rs
@@ -126,20 +126,32 @@ mod tests {
         );
     }
 
+    /// Helper to test optional string param validation with:
+    /// - whitespace-only → empty error
+    /// - exact max length → ok
+    /// - one over max → too-long error
+    fn assert_param_empty_and_length_checks(
+        set_param: impl Fn(&mut GrepQueryParams, Option<String>),
+        empty_error: &str,
+        max_len: usize,
+        too_long_error: &str,
+    ) {
+        let mut value = params("query");
+        set_param(&mut value, Some("  ".into()));
+        assert_eq!(value.validate(), Err(empty_error.into()));
+        set_param(&mut value, Some("x".repeat(max_len)));
+        assert!(value.validate().is_ok());
+        set_param(&mut value, Some("x".repeat(max_len + 1)));
+        assert_eq!(value.validate(), Err(too_long_error.into()));
+    }
+
     #[test]
     fn rejects_invalid_language_with_exact_messages_and_accepts_boundary() {
-        let mut value = params("query");
-        value.language = Some("  ".into());
-        assert_eq!(
-            value.validate(),
-            Err("❌ Error: 'language' parameter must be a non-empty string when provided".into())
-        );
-        value.language = Some("l".repeat(50));
-        assert!(value.validate().is_ok());
-        value.language = Some("l".repeat(51));
-        assert_eq!(
-            value.validate(),
-            Err("❌ Error: 'language' parameter is too long (max 50 characters)".into())
+        assert_param_empty_and_length_checks(
+            |p, v| p.language = v,
+            "❌ Error: 'language' parameter must be a non-empty string when provided",
+            50,
+            "❌ Error: 'language' parameter is too long (max 50 characters)",
         );
     }
 
@@ -175,18 +187,11 @@ mod tests {
 
     #[test]
     fn rejects_invalid_path_with_exact_messages_and_accepts_boundary() {
-        let mut value = params("query");
-        value.path = Some("\n ".into());
-        assert_eq!(
-            value.validate(),
-            Err("❌ Error: 'path' parameter must be a non-empty string when provided".into())
-        );
-        value.path = Some("p".repeat(200));
-        assert!(value.validate().is_ok());
-        value.path = Some("p".repeat(201));
-        assert_eq!(
-            value.validate(),
-            Err("❌ Error: 'path' parameter is too long (max 200 characters)".into())
+        assert_param_empty_and_length_checks(
+            |p, v| p.path = v,
+            "❌ Error: 'path' parameter must be a non-empty string when provided",
+            200,
+            "❌ Error: 'path' parameter is too long (max 200 characters)",
         );
     }
 

--- a/crates/harnx-vercel-grep-server/src/server/params.rs
+++ b/crates/harnx-vercel-grep-server/src/server/params.rs
@@ -10,65 +10,76 @@ pub struct GrepQueryParams {
 
 impl GrepQueryParams {
     pub fn validate(&self) -> Result<(), String> {
-        if self.query.is_empty() {
-            return Err(
-                "❌ Error: 'query' parameter is required and must be a non-empty string".into(),
-            );
-        }
-        if self.query.trim().is_empty() {
-            return Err("❌ Error: 'query' cannot be empty or only whitespace".into());
-        }
-        if self.query.chars().count() > 1000 {
-            return Err(
-                "❌ Error: 'query' is too long (max 1000 characters). Please use a shorter query."
-                    .into(),
-            );
-        }
-
-        if let Some(language) = &self.language {
-            if language.trim().is_empty() {
-                return Err(
-                    "❌ Error: 'language' parameter must be a non-empty string when provided"
-                        .into(),
-                );
-            }
-            if language.chars().count() > 50 {
-                return Err(
-                    "❌ Error: 'language' parameter is too long (max 50 characters)".into(),
-                );
-            }
-        }
-
-        if let Some(repo) = &self.repo {
-            if repo.trim().is_empty() {
-                return Err(
-                    "❌ Error: 'repo' parameter must be a non-empty string when provided".into(),
-                );
-            }
-            if repo.matches('/').count() != 1 {
-                return Err(
-                    "❌ Error: 'repo' parameter must be in format 'owner/repository' (e.g., 'fastapi/fastapi')"
-                        .into(),
-                );
-            }
-            if repo.chars().count() > 100 {
-                return Err("❌ Error: 'repo' parameter is too long (max 100 characters)".into());
-            }
-        }
-
-        if let Some(path) = &self.path {
-            if path.trim().is_empty() {
-                return Err(
-                    "❌ Error: 'path' parameter must be a non-empty string when provided".into(),
-                );
-            }
-            if path.chars().count() > 200 {
-                return Err("❌ Error: 'path' parameter is too long (max 200 characters)".into());
-            }
-        }
-
-        Ok(())
+        validate_query(&self.query)?;
+        validate_language(self.language.as_deref())?;
+        validate_repo(self.repo.as_deref())?;
+        validate_path(self.path.as_deref())
     }
+}
+
+fn validate_query(query: &str) -> Result<(), String> {
+    if query.is_empty() {
+        return Err(
+            "❌ Error: 'query' parameter is required and must be a non-empty string".into(),
+        );
+    }
+    if query.trim().is_empty() {
+        return Err("❌ Error: 'query' cannot be empty or only whitespace".into());
+    }
+    if query.chars().count() > 1000 {
+        return Err(
+            "❌ Error: 'query' is too long (max 1000 characters). Please use a shorter query."
+                .into(),
+        );
+    }
+    Ok(())
+}
+
+fn validate_language(language: Option<&str>) -> Result<(), String> {
+    let Some(language) = language else {
+        return Ok(());
+    };
+    if language.trim().is_empty() {
+        return Err(
+            "❌ Error: 'language' parameter must be a non-empty string when provided".into(),
+        );
+    }
+    if language.chars().count() > 50 {
+        return Err("❌ Error: 'language' parameter is too long (max 50 characters)".into());
+    }
+    Ok(())
+}
+
+fn validate_repo(repo: Option<&str>) -> Result<(), String> {
+    let Some(repo) = repo else {
+        return Ok(());
+    };
+    if repo.trim().is_empty() {
+        return Err("❌ Error: 'repo' parameter must be a non-empty string when provided".into());
+    }
+    if repo.matches('/').count() != 1 {
+        return Err(
+            "❌ Error: 'repo' parameter must be in format 'owner/repository' (e.g., 'fastapi/fastapi')"
+                .into(),
+        );
+    }
+    if repo.chars().count() > 100 {
+        return Err("❌ Error: 'repo' parameter is too long (max 100 characters)".into());
+    }
+    Ok(())
+}
+
+fn validate_path(path: Option<&str>) -> Result<(), String> {
+    let Some(path) = path else {
+        return Ok(());
+    };
+    if path.trim().is_empty() {
+        return Err("❌ Error: 'path' parameter must be a non-empty string when provided".into());
+    }
+    if path.chars().count() > 200 {
+        return Err("❌ Error: 'path' parameter is too long (max 200 characters)".into());
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/harnx-vercel-grep-server/tests/fixtures/search_basic.json
+++ b/crates/harnx-vercel-grep-server/tests/fixtures/search_basic.json
@@ -1,0 +1,49 @@
+{
+  "facets": {
+    "count": 1234,
+    "lang": {
+      "buckets": [
+        { "val": "Python", "count": 500 },
+        { "val": "JavaScript", "count": 210 },
+        { "val": "TypeScript", "count": 130 }
+      ]
+    },
+    "repo": {
+      "buckets": [
+        { "val": "fastapi/fastapi", "count": 100 },
+        { "val": "tiangolo/full-stack-fastapi-template", "count": 40 }
+      ]
+    }
+  },
+  "hits": {
+    "hits": [
+      {
+        "repo": { "raw": "fastapi/fastapi" },
+        "path": { "raw": "fastapi/applications.py" },
+        "branch": { "raw": "master" },
+        "total_matches": { "raw": "12" },
+        "content": {
+          "snippet": "<div class=\"highlight\"><span data-line=\"20\">from fastapi import FastAPI</span>\n<span data-line=\"21\">app = FastAPI()</span></div>"
+        }
+      },
+      {
+        "repo": { "raw": "fastapi/fastapi" },
+        "path": { "raw": "docs_src/first_steps/tutorial001.py" },
+        "branch": { "raw": "master" },
+        "total_matches": { "raw": "3" },
+        "content": {
+          "snippet": "<span data-line=\"1\">from fastapi import FastAPI</span>\n<span data-line=\"3\">app = FastAPI()</span>"
+        }
+      },
+      {
+        "repo": { "raw": "tiangolo/full-stack-fastapi-template" },
+        "path": { "raw": "backend/app/main.py" },
+        "branch": { "raw": "master" },
+        "total_matches": { "raw": "5" },
+        "content": {
+          "snippet": "<span data-line=\"7\">app = FastAPI(title=settings.PROJECT_NAME)</span>"
+        }
+      }
+    ]
+  }
+}

--- a/crates/harnx-vercel-grep-server/tests/fixtures/search_filtered.json
+++ b/crates/harnx-vercel-grep-server/tests/fixtures/search_filtered.json
@@ -1,0 +1,28 @@
+{
+  "facets": {
+    "count": 42,
+    "lang": {
+      "buckets": [
+        { "val": "Python", "count": 42 }
+      ]
+    },
+    "repo": {
+      "buckets": [
+        { "val": "fastapi/fastapi", "count": 42 }
+      ]
+    }
+  },
+  "hits": {
+    "hits": [
+      {
+        "repo": { "raw": "fastapi/fastapi" },
+        "path": { "raw": "fastapi/routing.py" },
+        "branch": { "raw": "master" },
+        "total_matches": { "raw": "8" },
+        "content": {
+          "snippet": "<span data-line=\"55\">class APIRouter(routing.Router):</span>\n<span data-line=\"56\">    def __init__(self) -&gt; None:</span>"
+        }
+      }
+    ]
+  }
+}

--- a/crates/harnx-vercel-grep-server/tests/fixtures/search_golden_single.json
+++ b/crates/harnx-vercel-grep-server/tests/fixtures/search_golden_single.json
@@ -1,0 +1,28 @@
+{
+  "facets": {
+    "count": 1234,
+    "lang": {
+      "buckets": [
+        { "val": "Python", "count": 500 }
+      ]
+    },
+    "repo": {
+      "buckets": [
+        { "val": "fastapi/fastapi", "count": 100 }
+      ]
+    }
+  },
+  "hits": {
+    "hits": [
+      {
+        "repo": { "raw": "fastapi/fastapi" },
+        "path": { "raw": "src/main.py" },
+        "branch": { "raw": "main" },
+        "total_matches": { "raw": "5" },
+        "content": {
+          "snippet": "<span data-line=\"10\">import fastapi</span>\n<span data-line=\"11\">app = FastAPI()</span>"
+        }
+      }
+    ]
+  }
+}

--- a/crates/harnx-vercel-grep-server/tests/fixtures/search_golden_single_output.txt
+++ b/crates/harnx-vercel-grep-server/tests/fixtures/search_golden_single_output.txt
@@ -1,0 +1,39 @@
+{
+  "query": "FastAPI",
+  "summary": {
+    "total_results": 1234,
+    "results_shown": 1,
+    "repositories_found": 1,
+    "top_languages": [
+      {
+        "language": "Python",
+        "count": 500
+      }
+    ],
+    "top_repositories": [
+      {
+        "repository": "fastapi/fastapi",
+        "count": 100
+      }
+    ]
+  },
+  "results_by_repository": [
+    {
+      "repository": "fastapi/fastapi",
+      "matches_count": 5,
+      "files": [
+        {
+          "file_path": "src/main.py",
+          "branch": "main",
+          "total_matches": 5,
+          "line_numbers": [
+            10,
+            11
+          ],
+          "language": "python",
+          "code_snippet": "```python\nimport fastapi\napp = FastAPI()\n```"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/harnx-vercel-grep-server/tests/fixtures/search_nofilters.json
+++ b/crates/harnx-vercel-grep-server/tests/fixtures/search_nofilters.json
@@ -1,0 +1,39 @@
+{
+  "facets": {
+    "count": 987,
+    "lang": {
+      "buckets": [
+        { "val": "Rust", "count": 300 },
+        { "val": "Go", "count": 120 }
+      ]
+    },
+    "repo": {
+      "buckets": [
+        { "val": "tokio-rs/tokio", "count": 80 },
+        { "val": "hyperium/hyper", "count": 25 }
+      ]
+    }
+  },
+  "hits": {
+    "hits": [
+      {
+        "repo": { "raw": "tokio-rs/tokio" },
+        "path": { "raw": "tokio/src/runtime/mod.rs" },
+        "branch": { "raw": "master" },
+        "total_matches": { "raw": "9" },
+        "content": {
+          "snippet": "<span data-line=\"100\">pub fn spawn(future: F) -&gt; JoinHandle&lt;F::Output&gt;</span>"
+        }
+      },
+      {
+        "repo": { "raw": "hyperium/hyper" },
+        "path": { "raw": "src/client/mod.rs" },
+        "branch": { "raw": "master" },
+        "total_matches": { "raw": "4" },
+        "content": {
+          "snippet": "<span data-line=\"12\">let client = Client::new();</span>"
+        }
+      }
+    ]
+  }
+}

--- a/crates/harnx-vercel-grep-server/tests/search_integration.rs
+++ b/crates/harnx-vercel-grep-server/tests/search_integration.rs
@@ -24,6 +24,11 @@ const NOT_FOUND_OUTPUT: &str = r#"{
   "results": []
 }"#;
 
+/// Normalize CRLF to LF so byte-exact asserts pass on Windows (where git checks out .txt fixtures as CRLF)
+fn golden_output() -> String {
+    GOLDEN_OUTPUT.replace("\r\n", "\n")
+}
+
 fn endpoint(server: &MockServer) -> String {
     format!("{}/api/search", server.uri())
 }
@@ -62,7 +67,7 @@ async fn client_sends_all_filters_and_formats_success_response() {
         panic!("expected successful search outcome");
     };
     let response: SearchResponse = serde_json::from_value(value).expect("fixture must deserialize");
-    assert_eq!(build_output("FastAPI", &response), GOLDEN_OUTPUT);
+    assert_eq!(build_output("FastAPI", &response), golden_output());
 }
 
 #[tokio::test]
@@ -199,5 +204,5 @@ async fn grep_query_handler_runs_full_pipeline_over_rmcp() {
         .expect("tool call must succeed");
 
     assert_eq!(result.is_error, Some(false));
-    assert_eq!(text_content(&result), GOLDEN_OUTPUT);
+    assert_eq!(text_content(&result), golden_output());
 }

--- a/crates/harnx-vercel-grep-server/tests/search_integration.rs
+++ b/crates/harnx-vercel-grep-server/tests/search_integration.rs
@@ -1,0 +1,203 @@
+use harnx_vercel_grep_server::client::{self, SearchOutcome};
+use harnx_vercel_grep_server::format::{build_not_found_output, build_output};
+use harnx_vercel_grep_server::server::model::SearchResponse;
+use harnx_vercel_grep_server::server::{GrepQueryParams, GrepServer};
+use rmcp::handler::client::ClientHandler;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, ClientCapabilities, Implementation,
+    InitializeRequestParams,
+};
+use rmcp::service::{serve_client, serve_server, RoleClient, RoleServer, RunningService};
+use serde_json::{Map, Value};
+use tokio::io::duplex;
+use wiremock::matchers::{method, path, query_param, query_param_is_missing};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const GOLDEN_RESPONSE: &str = include_str!("fixtures/search_golden_single.json");
+const GOLDEN_OUTPUT: &str = include_str!("fixtures/search_golden_single_output.txt");
+const NOT_FOUND_OUTPUT: &str = r#"{
+  "query": "somequery",
+  "summary": {
+    "total_results": 0,
+    "message": "No results found for this query"
+  },
+  "results": []
+}"#;
+
+fn endpoint(server: &MockServer) -> String {
+    format!("{}/api/search", server.uri())
+}
+
+fn params(query: &str) -> GrepQueryParams {
+    GrepQueryParams {
+        query: query.into(),
+        language: None,
+        repo: None,
+        path: None,
+    }
+}
+
+#[tokio::test]
+async fn client_sends_all_filters_and_formats_success_response() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("q", "FastAPI"))
+        .and(query_param("f.lang", "Python"))
+        .and(query_param("f.repo", "fastapi/fastapi"))
+        .and(query_param("f.path", "src/"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(GOLDEN_RESPONSE, "application/json"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let request = GrepQueryParams {
+        query: " FastAPI ".into(),
+        language: Some(" Python ".into()),
+        repo: Some(" fastapi/fastapi ".into()),
+        path: Some(" src/ ".into()),
+    };
+    let outcome = client::search(&reqwest::Client::new(), &endpoint(&server), &request).await;
+    let SearchOutcome::Ok(value) = outcome else {
+        panic!("expected successful search outcome");
+    };
+    let response: SearchResponse = serde_json::from_value(value).expect("fixture must deserialize");
+    assert_eq!(build_output("FastAPI", &response), GOLDEN_OUTPUT);
+}
+
+#[tokio::test]
+async fn client_omits_all_optional_filters() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("q", "rust async"))
+        .and(query_param_is_missing("f.lang"))
+        .and(query_param_is_missing("f.repo"))
+        .and(query_param_is_missing("f.path"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            include_str!("fixtures/search_nofilters.json"),
+            "application/json",
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let outcome = client::search(
+        &reqwest::Client::new(),
+        &endpoint(&server),
+        &params("rust async"),
+    )
+    .await;
+    assert!(matches!(outcome, SearchOutcome::Ok(_)));
+}
+
+#[tokio::test]
+async fn client_maps_404_429_and_500_to_exact_contract_outputs() {
+    for (status, expected) in [
+        (404, NOT_FOUND_OUTPUT),
+        (
+            429,
+            "❌ Error: Rate limit exceeded. Please wait before making another request.",
+        ),
+        (500, "❌ Error: API request failed with status 500"),
+    ] {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/search"))
+            .and(query_param("q", "somequery"))
+            .respond_with(ResponseTemplate::new(status))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let outcome = client::search(
+            &reqwest::Client::new(),
+            &endpoint(&server),
+            &params("somequery"),
+        )
+        .await;
+        let output = match outcome {
+            SearchOutcome::NotFound => build_not_found_output("somequery"),
+            SearchOutcome::RateLimited => {
+                "❌ Error: Rate limit exceeded. Please wait before making another request.".into()
+            }
+            SearchOutcome::HttpStatus(code) => {
+                format!("❌ Error: API request failed with status {code}")
+            }
+            other => panic!("unexpected search outcome for status {status}: {other:?}"),
+        };
+        assert_eq!(output, expected);
+    }
+}
+
+#[derive(Clone, Default)]
+struct TestClientHandler;
+
+impl ClientHandler for TestClientHandler {
+    fn get_info(&self) -> InitializeRequestParams {
+        InitializeRequestParams::new(
+            ClientCapabilities::builder().build(),
+            Implementation::new("grep-integration-test", "0.1"),
+        )
+    }
+}
+
+struct TestConnection {
+    _server_service: RunningService<RoleServer, GrepServer>,
+    client_service: RunningService<RoleClient, TestClientHandler>,
+}
+
+async fn connect_server(server: GrepServer) -> TestConnection {
+    let (client_transport, server_transport) = duplex(65_536);
+    let (server_result, client_result) = tokio::join!(
+        serve_server(server, server_transport),
+        serve_client(TestClientHandler, client_transport)
+    );
+    TestConnection {
+        _server_service: server_result.expect("server must initialize"),
+        client_service: client_result.expect("client must initialize"),
+    }
+}
+
+fn tool_args(value: Value) -> Map<String, Value> {
+    value
+        .as_object()
+        .expect("tool args must be an object")
+        .clone()
+}
+
+fn text_content(result: &CallToolResult) -> &str {
+    result
+        .content
+        .iter()
+        .find_map(|content| content.as_text().map(|text| text.text.as_str()))
+        .expect("tool result must contain text")
+}
+
+#[tokio::test]
+async fn grep_query_handler_runs_full_pipeline_over_rmcp() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search"))
+        .and(query_param("q", "FastAPI"))
+        .and(query_param_is_missing("f.lang"))
+        .and(query_param_is_missing("f.repo"))
+        .and(query_param_is_missing("f.path"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(GOLDEN_RESPONSE, "application/json"))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let connection = connect_server(GrepServer::with_base_url(endpoint(&mock_server))).await;
+    let peer = connection.client_service.peer().clone();
+    let result = peer
+        .call_tool(
+            CallToolRequestParams::new("grep_query")
+                .with_arguments(tool_args(serde_json::json!({ "query": "FastAPI" }))),
+        )
+        .await
+        .expect("tool call must succeed");
+
+    assert_eq!(result.is_error, Some(false));
+    assert_eq!(text_content(&result), GOLDEN_OUTPUT);
+}

--- a/docs/solutions/integration-issues/python-to-rust-byte-exact-port-2026-07-29.md
+++ b/docs/solutions/integration-issues/python-to-rust-byte-exact-port-2026-07-29.md
@@ -27,7 +27,7 @@ A "strict 1:1 port" of a Python MCP server to Rust requires matching not just th
 
 ## Symptoms
 
-```
+```text
 - JSON output key order differs from Python reference
 - Snippet truncation splits multi-byte UTF-8 characters
 - Sorting ties produce different ordering on repeated runs
@@ -198,7 +198,7 @@ Include test cases for `total_matches.raw` as both numeric strings (`"5"`) and n
 - Multi-byte UTF-8 truncation fixture (assert no character splitting)
 
 **Best Practices:**
-- Always fetch the verbatim upstream source when porting; plans can parphrase incorrectly
+- Always fetch the verbatim upstream source when porting; plans can paraphrase incorrectly
 - Use `.chars()` for any Python string length/slice operation
 - Use stable sorts (`sort_by_key`, `sort_by`) when Python uses `sorted()`
 - Test with golden fixtures for byte-exact contracts

--- a/docs/solutions/integration-issues/python-to-rust-byte-exact-port-2026-07-29.md
+++ b/docs/solutions/integration-issues/python-to-rust-byte-exact-port-2026-07-29.md
@@ -1,0 +1,221 @@
+---
+title: "Python-to-Rust byte-exact port: fidelity traps and patterns"
+date: 2026-07-29
+category: "integration-issues"
+problem_type: integration_issue
+component: "harnx-vercel-grep-server"
+root_cause: "Python and Rust have divergent semantics for string operations, sorting stability, and JSON key ordering"
+resolution_type: code_fix
+severity: medium
+tags:
+  - python
+  - rust
+  - porting
+  - byte-exact
+  - serde
+  - unicode
+  - sorting
+  - rmcp
+plan_ref: "harnx-vercel-grep-server"
+---
+
+# Python-to-Rust byte-exact port: fidelity traps and patterns
+
+## Problem
+
+A "strict 1:1 port" of a Python MCP server to Rust requires matching not just the logic, but exact byte output including JSON key order, truncation behavior, sorting stability, and error formatting. Several Python semantics have no direct Rust equivalent and require explicit handling.
+
+## Symptoms
+
+```
+- JSON output key order differs from Python reference
+- Snippet truncation splits multi-byte UTF-8 characters
+- Sorting ties produce different ordering on repeated runs
+- `total_matches` string "100+" parses as 100 instead of 0
+- `str.isdigit()` behavior differs between Python and Rust
+- Golden fixture byte comparison fails despite "equivalent" logic
+```
+
+## Investigation Steps
+
+1. Fetched the verbatim upstream source (galprz/grep-mcp `server.py` at SHA 97300fc) to resolve ambiguities in the plan's paraphrase
+2. Discovered the plan contradicted itself on which string gets truncated: raw HTML vs cleaned text — the reference code showed `_format_code_snippet` receives already-extracted text
+3. Built a golden fixture with expected output and compared byte-by-byte
+4. Traced Python `str.isdigit()` semantics: True only if non-empty and ALL characters are ASCII digits
+5. Verified Python `sorted()` is stable; Rust's `sort_by_key` is also stable but `sort_unstable_by` is not
+6. Confirmed Python `len()` and slicing operate on Unicode code points, not bytes
+
+## Root Cause
+
+### 1. JSON key ordering
+
+Python `json.dumps` preserves dict insertion order (Python 3.7+). Rust `serde_json` preserves struct field declaration order only when `preserve_order` feature is enabled, which this workspace has.
+
+### 2. String length and slicing
+
+Python `len(s)` counts Unicode code points. Rust `s.len()` counts bytes. For truncation at 400 characters, Rust must use `s.chars().count()` and `s.chars().take(400).collect()`.
+
+### 3. Sorting stability
+
+Python `sorted(..., reverse=True)` is stable — ties preserve first-seen order. Rust provides both stable (`sort_by`, `sort_by_key`) and unstable (`sort_unstable_by`) sorts. Using unstable sort breaks tie-ordering guarantees.
+
+### 4. isdigit semantics
+
+Python `str.isdigit()` returns True only if the string is non-empty and every character is an ASCII digit. Strings like `"100+"`, `""`, `"-3"` all return False. Rust's `s.chars().all(|c| c.is_ascii_digit())` plus an emptiness check replicates this.
+
+### 5. Error return contract
+
+The Python reference returns errors as plain text content, not HTTP errors or JSON-RPC errors. The handler must return `CallToolResult::success` with a text block containing "`❌ Error: ...`", not a JSON-RPC error.
+
+### 6. External API unreachability
+
+grep.app returns HTTP 429 with a Vercel bot-challenge HTML page from CI/datacenter IPs. Live capture is impossible; synthetic fixtures modeling the actual shape are required.
+
+## Solution
+
+### JSON key ordering
+
+Enable `preserve_order` on `serde_json` (already set workspace-wide) and declare struct fields in exact contract order:
+
+```rust
+#[derive(Serialize)]
+struct Output {
+    query: String,
+    summary: Summary,
+    results_by_repository: Vec<RepositoryResult>,
+}
+
+#[derive(Serialize)]
+struct Summary {
+    total_results: u64,
+    results_shown: usize,
+    repositories_found: usize,
+    top_languages: Vec<LanguageCount>,
+    top_repositories: Vec<RepositoryCount>,
+}
+```
+
+Serialize with `serde_json::to_string_pretty(&output)` for 2-space indentation.
+
+### Character-aware truncation
+
+Use `.chars()` for all length checks and slicing:
+
+```rust
+let snippet = if text.chars().count() > 400 {
+    let mut truncated = text.chars().take(400).collect::<String>();
+    truncated.push_str("...");
+    truncated
+} else {
+    text.to_owned()
+};
+```
+
+### Stable descending sort
+
+Use `sort_by_key` with `Reverse` for stable descending order:
+
+```rust
+results_by_repository.sort_by_key(|repo| std::cmp::Reverse(repo.matches_count));
+```
+
+Do NOT use `sort_unstable_by` — it does not preserve first-seen order on ties.
+
+### isdigit-equivalent check
+
+Match Python semantics exactly:
+
+```rust
+let total_matches = if !raw_string.is_empty()
+    && raw_string.chars().all(|c| c.is_ascii_digit())
+{
+    raw_string.parse::<u64>().unwrap_or(0)
+} else {
+    0
+};
+```
+
+This correctly maps `"5"` → 5, `"100+"` → 0, `""` → 0, `"-3"` → 0.
+
+### Handler error return contract
+
+Return all validation and runtime errors as successful tool results:
+
+```rust
+impl ServerHandler for GrepServer {
+    async fn call_tool(&self, request: CallToolRequestParams, _context: RequestContext<RoleServer>) -> Result<CallToolResult, ErrorData> {
+        // Validation errors → success with error text
+        if let Err(message) = params.validate() {
+            return Ok(CallToolResult::success(vec![ContentBlock::text(message)]));
+        }
+
+        // Runtime errors → success with error text  
+        match outcome {
+            SearchOutcome::RateLimited => Ok(text_result("❌ Error: Rate limit exceeded...")),
+            SearchOutcome::NotFound => Ok(text_result(build_not_found_output(query))),
+            // ...
+        }
+    }
+}
+```
+
+Only unknown tool names return JSON-RPC `ErrorData::method_not_found`.
+
+### rmcp 2.0 patterns
+
+- STDERR-only logging; STDOUT reserved for JSON-RPC
+- `GrepServer::with_base_url(base_url)` for wiremock injection
+- In-memory duplex for e2e: `tokio::io::duplex(64)` → `serve_server` + `serve_client`
+
+### Synthetic fixtures when live capture fails
+
+When grep.app returns 429/Vercel-challenge, craft fixtures matching the reference's expected shape:
+
+```json
+{
+  "facets": {"count": 1234, "lang": {"buckets": [...]}, "repo": {"buckets": [...]}},
+  "hits": {"hits": [{"repo": {"raw": "owner/repo"}, "path": {"raw": "src/main.py"}, ...}]}
+}
+```
+
+Include test cases for `total_matches.raw` as both numeric strings (`"5"`) and non-numeric (`"100+"`) to cover isdigit semantics.
+
+## Why This Works
+
+- `preserve_order` + field declaration order = deterministic JSON key order matching Python's dict insertion order
+- `.chars().count()`/`.chars().take(n)` operate on Unicode code points like Python's `len()` and slicing
+- `sort_by_key` with `Reverse` is stable, preserving first-seen order for ties like Python's `sorted(..., reverse=True)`
+- Explicit emptiness check + `all(|c| c.is_ascii_digit())` matches Python's `str.isdigit()` exactly
+- Success-tool-text for errors matches the Python contract; agents consuming this output need no changes
+- Synthetic fixtures with golden output enable byte-exact assertion without live API access
+
+## Prevention Strategies
+
+**Test Cases:**
+- Golden fixture with byte-exact expected output (use `include_str!` and assert equality)
+- Multi-repo fixture exercising descending sort with ties (verify stable ordering)
+- `total_matches` fixture with `"100+"` (assert parses to 0) and `"5"` (assert parses to 5)
+- Multi-byte UTF-8 truncation fixture (assert no character splitting)
+
+**Best Practices:**
+- Always fetch the verbatim upstream source when porting; plans can parphrase incorrectly
+- Use `.chars()` for any Python string length/slice operation
+- Use stable sorts (`sort_by_key`, `sort_by`) when Python uses `sorted()`
+- Test with golden fixtures for byte-exact contracts
+- Use `preserve_order` feature and declare struct fields in contract order
+- Return errors as success-tool-text when the reference does — not JSON-RPC errors
+
+**Code Review Checklist:**
+- [ ] Are struct fields declared in exact JSON output order?
+- [ ] Is `.chars().count()` used instead of `.len()` for Python-compatible length?
+- [ ] Is the sort stable if Python's `sorted()` is used?
+- [ ] Does isdigit-equivalent check for non-empty first, then all-ASCII-digits?
+- [ ] Are runtime/validation errors returned as success-tool-text, not JSON-RPC errors?
+- [ ] Is there a golden fixture with byte-exact expected output?
+
+## Related Issues
+
+- **Plan:** [harnx-vercel-grep-server](plan:harnx-vercel-grep-server) — native Rust grep.app MCP server
+- **GitHub:** [#1268](https://github.com/dobesv/harnx/issues/1268) — original issue
+- **Reference:** [galprz/grep-mcp](https://github.com/galprz/grep-mcp) — Python implementation ported
+- **Related Solution:** [rmcp/mcp-proxy-stdio-pattern-2026-05-19.md](../rmcp/mcp-proxy-stdio-pattern-2026-05-19.md) — rmcp stdio patterns

--- a/packages/coding/mcp_servers/grep.yaml
+++ b/packages/coding/mcp_servers/grep.yaml
@@ -1,9 +1,7 @@
-command: uvx
-args:
-  - "grep-mcp"
+command: harnx-vercel-grep-server
 description: >-
   GitHub code search via grep.app. Used by Pytheas, Sisyphus, and Zosimus
   to find real-world usage examples of APIs and patterns in public repos.
 
-# Requires: uv / uvx  (https://docs.astral.sh/uv/)
+# Native harnx binary — no external runtime needed.
 # No API key needed.

--- a/packages/pantheon/mcp_servers/grep.yaml
+++ b/packages/pantheon/mcp_servers/grep.yaml
@@ -1,9 +1,7 @@
-command: uvx
-args:
-  - "grep-mcp"
+command: harnx-vercel-grep-server
 description: >-
   GitHub code search via grep.app. Used by Pytheas, Sisyphus, and Zosimus
   to find real-world usage examples of APIs and patterns in public repos.
 
-# Requires: uv / uvx  (https://docs.astral.sh/uv/)
+# Native harnx binary — no external runtime needed.
 # No API key needed.


### PR DESCRIPTION
Add native Rust workspace crate `crates/harnx-vercel-grep-server` exposing a `grep_query` MCP tool that searches GitHub code via the grep.app API. This replaces the external `uvx grep-mcp` dependency with a strict 1:1 behavior port.

Includes unit and wiremock integration tests, synthetic reference fixtures, rmcp ServerHandler wiring, YAML configurations in packages/coding and packages/pantheon, crate documentation, and a solution note in docs/solutions.

Fixes #1268
Plan: harnx-vercel-grep-server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a native grep search MCP server with the `grep_query` tool.
  * Supports searching by query, language, repository, and file path.
  * Returns structured results with match counts, repositories, file paths, branches, languages, and code snippets.
  * Provides clear responses for no results, rate limits, timeouts, and API failures.
* **Improvements**
  * MCP configurations now use the native server without requiring an external runtime.
* **Documentation**
  * Added installation, usage, parameter, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->