### PR TITLE
feat(nats): generalize tool-server bootstrap with config-driven lifecycle

### DIFF
--- a/.changeset/nats-tool-servers-config-driven-bootstrap.md
+++ b/.changeset/nats-tool-servers-config-driven-bootstrap.md
@@ -1,0 +1,5 @@
+---
+harnx: minor
+---
+
+feat(nats): declare NATS tool servers in `tool_servers/*.yaml` across user and package configuration directories instead of using a hardcoded server list. Tool servers are lazy-spawned based on the active agent's `use_tools` patterns, and a missing or crashing server emits a UI warning while worker execution continues. The `time` tool now ships as `harnx-time-server` under `tool_servers/`. References #1224.

--- a/crates/harnx-core/src/config_paths.rs
+++ b/crates/harnx-core/src/config_paths.rs
@@ -58,6 +58,9 @@ pub const MCP_SERVERS_DIR_NAME: &str = "mcp_servers";
 /// Subdirectory holding per-ACP-server YAML files.
 pub const ACP_SERVERS_DIR_NAME: &str = "acp_servers";
 
+/// Subdirectory holding per-tool-server YAML files.
+pub const TOOL_SERVERS_DIR_NAME: &str = "tool_servers";
+
 /// Canonical crate-name prefix for HARNX_* env variables and the
 /// `~/.config/harnx` subdirectory. Hardcoded as a literal because this
 /// module lives in `harnx-core` but resolves paths for the `harnx` app.
@@ -223,6 +226,11 @@ pub fn mcp_servers_dir() -> PathBuf {
 /// Subdirectory holding per-ACP-server YAML files.
 pub fn acp_servers_dir() -> PathBuf {
     config_dir_path().join(ACP_SERVERS_DIR_NAME)
+}
+
+/// Subdirectory holding per-tool-server YAML files.
+pub fn tool_servers_dir() -> PathBuf {
+    config_dir_path().join(TOOL_SERVERS_DIR_NAME)
 }
 
 /// Root directory for all installed packages: `<config_dir>/packages/`.

--- a/crates/harnx-runtime/src/config/loader_split.rs
+++ b/crates/harnx-runtime/src/config/loader_split.rs
@@ -97,6 +97,8 @@ impl Config {
             Self::load_mcp_servers_from_dir(&config_dir.join(paths::MCP_SERVERS_DIR_NAME))?;
         config.acp_servers =
             Self::load_acp_servers_from_dir(&config_dir.join(paths::ACP_SERVERS_DIR_NAME))?;
+        config.tool_servers =
+            Self::load_tool_servers_from_dir(&config_dir.join(paths::TOOL_SERVERS_DIR_NAME))?;
         let packages_dir = paths::packages_dir();
         if packages_dir.is_dir() {
             Self::load_packages(&mut config, &packages_dir)?;
@@ -110,11 +112,15 @@ impl Config {
         let Ok(entries) = std::fs::read_dir(packages_dir) else {
             return Ok(());
         };
-        for entry in entries.filter_map(|e| e.ok()) {
-            let path = entry.path();
-            let Some(pkg_name) = package_dir_name(&path) else {
-                continue;
-            };
+        let mut packages = entries
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| {
+                let path = entry.path();
+                package_dir_name(&path).map(|name| (name, path))
+            })
+            .collect::<Vec<_>>();
+        packages.sort_by(|(left, _), (right, _)| left.cmp(right));
+        for (pkg_name, path) in packages {
             Self::load_package_servers(config, &path, &pkg_name);
         }
         Ok(())
@@ -314,6 +320,8 @@ impl Config {
             Self::load_mcp_servers_from_dir(&config_dir.join(paths::MCP_SERVERS_DIR_NAME))?;
         config.acp_servers =
             Self::load_acp_servers_from_dir(&config_dir.join(paths::ACP_SERVERS_DIR_NAME))?;
+        config.tool_servers =
+            Self::load_tool_servers_from_dir(&config_dir.join(paths::TOOL_SERVERS_DIR_NAME))?;
         Self::auto_register_agents(&mut config.acp_servers)?;
         Ok(config)
     }
@@ -523,5 +531,33 @@ mod tests {
     #[cfg(not(windows))]
     fn harnx_acp_server_binary_name() -> &'static str {
         "harnx-acp-server"
+    }
+}
+
+#[cfg(test)]
+mod dynamic_tool_server_tests {
+    use super::*;
+    use crate::config::test_support::{env_lock, EnvGuard};
+
+    #[test]
+    fn load_dynamic_loads_user_tool_servers() {
+        let _guard = env_lock();
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let config_dir = temp_dir.path();
+        let tool_servers_dir = config_dir.join(paths::TOOL_SERVERS_DIR_NAME);
+        std::fs::create_dir_all(&tool_servers_dir).expect("create tool_servers dir");
+        std::fs::write(
+            tool_servers_dir.join("time.yaml"),
+            "command: harnx-time-server\n",
+        )
+        .expect("write time.yaml");
+        let _env_guard = EnvGuard::new("HARNX_CONFIG_DIR", config_dir);
+
+        let config = Config::load_dynamic("openai:gpt-4o").expect("load dynamic config");
+
+        assert_eq!(config.tool_servers.len(), 1);
+        assert_eq!(config.tool_servers[0].name, "time");
+        assert_eq!(config.tool_servers[0].command, "harnx-time-server");
+        assert!(config.tool_servers[0].package.is_none());
     }
 }

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -25,10 +25,12 @@ mod session_ops_core;
 mod session_ops_split;
 pub mod session_ops_title;
 mod settings_split;
+mod tool_servers_split;
 
 pub use self::env_split::load_env_file;
 pub use self::macros_split::macro_execute;
 pub use self::nats_split::{resolve_local_nats_server_config, NatsServerConfig};
+pub use self::tool_servers_split::ToolServerConfig;
 
 /// Reserved cluster identity for the auto-managed shared local NATS broker.
 ///
@@ -57,6 +59,7 @@ pub use self::attachments::{write_attachment, Base64Encoder};
 pub use self::input::Input;
 pub use self::patches_split::acp_server_display_name;
 pub use self::patches_split::mcp_server_display_name;
+pub(crate) use self::patches_split::server_display_name;
 use self::patches_split::{
     apply_client_patch, apply_mcp_server_patch, load_package_mcp_patch, package_dir_name,
 };
@@ -300,6 +303,7 @@ pub struct Config {
     pub nats_servers: Vec<NatsServerConfig>,
     pub mcp_servers: Vec<McpServerConfig>,
     pub acp_servers: Vec<AcpServerConfig>,
+    pub tool_servers: Vec<ToolServerConfig>,
 
     // Runtime state — unchanged from pre-A2:
     pub model_cooldowns: std::sync::Arc<parking_lot::Mutex<crate::client::retry::ModelCooldownMap>>,
@@ -362,6 +366,7 @@ impl std::fmt::Debug for Config {
             .field("clients", &self.clients)
             .field("mcp_servers", &self.mcp_servers)
             .field("acp_servers", &self.acp_servers)
+            .field("tool_servers", &self.tool_servers)
             .field("macro_flag", &self.macro_flag)
             .field("info_flag", &self.info_flag)
             .field("agent_variables", &self.agent_variables)
@@ -387,6 +392,7 @@ impl Clone for Config {
             nats_servers: self.nats_servers.clone(),
             mcp_servers: self.mcp_servers.clone(),
             acp_servers: self.acp_servers.clone(),
+            tool_servers: self.tool_servers.clone(),
             model_cooldowns: self.model_cooldowns.clone(),
             macro_flag: self.macro_flag,
             info_flag: self.info_flag,
@@ -435,6 +441,7 @@ impl Config {
             nats_servers: self.nats_servers.clone(),
             mcp_servers: self.mcp_servers.clone(),
             acp_servers: self.acp_servers.clone(),
+            tool_servers: self.tool_servers.clone(),
             model_cooldowns: self.model_cooldowns.clone(),
             macro_flag: self.macro_flag,
             info_flag: self.info_flag,
@@ -473,6 +480,7 @@ impl Default for Config {
             nats_servers: vec![],
             mcp_servers: vec![],
             acp_servers: vec![],
+            tool_servers: vec![],
 
             model_cooldowns: std::sync::Arc::new(parking_lot::Mutex::new(Default::default())),
             macro_flag: false,

--- a/crates/harnx-runtime/src/config/patches_split.rs
+++ b/crates/harnx-runtime/src/config/patches_split.rs
@@ -135,11 +135,20 @@ fn server_target_qualified(name: &str, package: Option<&str>) -> String {
 /// - Same-package servers: bare name (the yaml stem, e.g. `fs`).
 /// - Other-package servers: `<sanitized_pkg>__<bare_name>` (e.g. `otherpkg__db`).
 pub fn mcp_server_display_name(server: &McpServerConfig, agent_package: Option<&str>) -> String {
+    server_display_name(&server.name, server.package.as_deref(), agent_package)
+}
+
+/// Compute a tool-facing server name from its name and package scope.
+pub(crate) fn server_display_name(
+    name: &str,
+    package: Option<&str>,
+    agent_package: Option<&str>,
+) -> String {
     use harnx_core::package_namespace::sanitize_for_tool_name;
-    match (&server.package, agent_package) {
-        (None, _) => server.name.clone(),
-        (Some(pkg), Some(active_package)) if pkg == active_package => server.name.clone(),
-        (Some(pkg), _) => format!("{}__{}", sanitize_for_tool_name(pkg), server.name),
+    match (package, agent_package) {
+        (None, _) => name.to_string(),
+        (Some(pkg), Some(active_package)) if pkg == active_package => name.to_string(),
+        (Some(pkg), _) => format!("{}__{name}", sanitize_for_tool_name(pkg)),
     }
 }
 

--- a/crates/harnx-runtime/src/config/servers_split.rs
+++ b/crates/harnx-runtime/src/config/servers_split.rs
@@ -50,6 +50,14 @@ impl Config {
             }
         }
 
+        let pkg_tool_dir = pkg_path.join(paths::TOOL_SERVERS_DIR_NAME);
+        if pkg_tool_dir.is_dir() {
+            for mut server in Self::load_tool_servers_from_dir(&pkg_tool_dir).unwrap_or_default() {
+                server.package = Some(pkg_name.to_string());
+                config.tool_servers.push(server);
+            }
+        }
+
         config.clients.extend(Self::load_package_clients(
             pkg_path,
             pkg_name,

--- a/crates/harnx-runtime/src/config/tool_servers_split.rs
+++ b/crates/harnx-runtime/src/config/tool_servers_split.rs
@@ -1,0 +1,198 @@
+//! Tool server config for NATS-based tool servers.
+//!
+//! These configs specify which NATS tool servers to spawn as separate processes.
+//! Similar in shape to `McpServerConfig` but without MCP-specific fields like
+//! `rename_tools`, `tool_templates`, `hooks`, and `roots`.
+
+use super::*;
+use anyhow::Context as _;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Default value for boolean fields that should default to `true`.
+fn default_true() -> bool {
+    true
+}
+
+/// Configuration for a NATS-based tool server spawned as a subprocess.
+///
+/// Each tool server is a separate process that connects to the shared NATS
+/// broker and advertises its tools via the KV registry. The runtime spawns
+/// these servers on demand when a session needs their tools.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ToolServerConfig {
+    /// Server name, set from the config file stem by the loader.
+    #[serde(default)]
+    pub name: String,
+
+    /// Command to execute (binary name or path).
+    pub command: String,
+
+    /// Arguments to pass to the command.
+    #[serde(default)]
+    pub args: Vec<String>,
+
+    /// Environment variables to set for the server process.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+
+    /// Whether this server should be spawned. Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Human-readable description of the server.
+    #[serde(default)]
+    pub description: Option<String>,
+
+    /// Optional environment variable naming an override path for the server binary.
+    ///
+    /// This provides a test/dev seam for substituting a different binary.
+    /// Replaces the older per-server override constants like `HARNX_TIME_SERVER_BIN`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bin_override_env: Option<String>,
+
+    /// Package this server belongs to, set at runtime by the package loader.
+    ///
+    /// `None` for user-provided configs; `Some(package_name)` for servers
+    /// installed from packages.
+    #[serde(skip)]
+    pub package: Option<String>,
+}
+
+impl Config {
+    /// Load tool server configs from a directory of YAML files.
+    ///
+    /// Each `.yaml` file in `dir` defines one tool server. The file stem
+    /// (basename without extension) becomes the server's `name`.
+    pub fn load_tool_servers_from_dir(dir: &Path) -> Result<Vec<ToolServerConfig>> {
+        if !dir.exists() {
+            return Ok(vec![]);
+        }
+
+        let mut servers = Vec::new();
+        for path in Self::sorted_yaml_files(dir)? {
+            let stem = match path.file_stem().and_then(|s| s.to_str()) {
+                Some(stem) if !stem.is_empty() => stem.to_string(),
+                _ => continue,
+            };
+
+            let content = read_to_string(&path).with_context(|| {
+                format!("Failed to read tool server config '{}'", path.display())
+            })?;
+            let mut server: ToolServerConfig =
+                serde_yaml::from_str(&content).with_context(|| {
+                    format!("Failed to parse tool server config '{}'", path.display())
+                })?;
+            server.name = stem;
+            servers.push(server);
+        }
+
+        Ok(servers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::test_support::{env_lock, EnvGuard};
+    use std::fs;
+
+    #[test]
+    fn deserializes_minimal_config_with_defaults() {
+        let yaml = r#"
+command: harnx-time-server
+"#;
+        let config: ToolServerConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.name, "");
+        assert_eq!(config.command, "harnx-time-server");
+        assert!(config.args.is_empty());
+        assert!(config.env.is_empty());
+        assert!(config.enabled);
+        assert!(config.description.is_none());
+        assert!(config.bin_override_env.is_none());
+        assert!(config.package.is_none());
+    }
+
+    #[test]
+    fn loads_from_user_config_dir() {
+        let _guard = env_lock();
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let config_dir = temp_dir.path();
+
+        // Write a tool_servers/time.yaml
+        let tool_servers_dir = config_dir.join(paths::TOOL_SERVERS_DIR_NAME);
+        fs::create_dir_all(&tool_servers_dir).expect("create tool_servers dir");
+        fs::write(
+            tool_servers_dir.join("time.yaml"),
+            "command: harnx-time-server\n",
+        )
+        .expect("write time.yaml");
+
+        // Set HARNX_CONFIG_DIR to temp dir
+        let _env_guard = EnvGuard::new("HARNX_CONFIG_DIR", config_dir);
+
+        // Load config via load_from_file (which calls loader_split logic)
+        let config_file = config_dir.join(paths::CONFIG_FILE_NAME);
+        fs::write(&config_file, "model: openai\n").expect("write config.yaml");
+
+        let config = Config::load_from_file(&config_file).expect("load config");
+
+        // Verify tool_servers loaded with name = "time"
+        assert_eq!(config.tool_servers.len(), 1);
+        assert_eq!(config.tool_servers[0].name, "time");
+        assert_eq!(config.tool_servers[0].command, "harnx-time-server");
+        assert!(config.tool_servers[0].package.is_none());
+    }
+
+    #[test]
+    fn loads_tool_servers_from_package_dir() {
+        let _guard = env_lock();
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let config_dir = temp_dir.path();
+        let package_tool_servers = config_dir
+            .join(paths::PACKAGES_DIR_NAME)
+            .join("coding")
+            .join(paths::TOOL_SERVERS_DIR_NAME);
+        fs::create_dir_all(&package_tool_servers).expect("create package tool_servers dir");
+        fs::write(
+            package_tool_servers.join("time.yaml"),
+            "command: harnx-time-server\n",
+        )
+        .expect("write package time.yaml");
+        let _env_guard = EnvGuard::new("HARNX_CONFIG_DIR", config_dir);
+        let config_file = config_dir.join(paths::CONFIG_FILE_NAME);
+        fs::write(&config_file, "model: openai\n").expect("write config.yaml");
+
+        let config = Config::load_from_file(&config_file).expect("load config");
+
+        assert_eq!(config.tool_servers.len(), 1);
+        assert_eq!(config.tool_servers[0].name, "time");
+        assert_eq!(config.tool_servers[0].package.as_deref(), Some("coding"));
+    }
+
+    #[test]
+    fn loads_package_tool_servers_in_name_order() {
+        let _guard = env_lock();
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let config_dir = temp_dir.path();
+        for (package, command) in [("zzz", "from-zzz"), ("aaa", "from-aaa")] {
+            let server_dir = config_dir
+                .join(paths::PACKAGES_DIR_NAME)
+                .join(package)
+                .join(paths::TOOL_SERVERS_DIR_NAME);
+            fs::create_dir_all(&server_dir).expect("create package tool_servers dir");
+            fs::write(server_dir.join("dup.yaml"), format!("command: {command}\n"))
+                .expect("write duplicate tool server");
+        }
+        let _env_guard = EnvGuard::new("HARNX_CONFIG_DIR", config_dir);
+        let config_file = config_dir.join(paths::CONFIG_FILE_NAME);
+        fs::write(&config_file, "model: openai\n").expect("write config.yaml");
+
+        let config = Config::load_from_file(&config_file).expect("load config");
+
+        assert_eq!(config.tool_servers.len(), 2);
+        assert_eq!(config.tool_servers[0].package.as_deref(), Some("aaa"));
+        assert_eq!(config.tool_servers[0].command, "from-aaa");
+        assert_eq!(config.tool_servers[1].package.as_deref(), Some("zzz"));
+    }
+}

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -7,7 +7,10 @@ use super::agent_loop::{
 use super::backend::NatsSessionLogBackend;
 use super::control::{control_subject, ControlCommand};
 use super::tool_supervisor::{ToolServerStartConfig, ToolServerSupervisor};
-use crate::config::{resolve_local_nats_server_config, GlobalConfig, Input, LOCAL_CLUSTER_KEY};
+use crate::config::{
+    resolve_local_nats_server_config, server_display_name, GlobalConfig, Input, ToolServerConfig,
+    LOCAL_CLUSTER_KEY,
+};
 use crate::nats_lease::{NatsLeaseAcquireParams, NatsLeaseConfig, NatsSessionLease};
 use crate::nats_metrics;
 use crate::nats_session_index;
@@ -21,7 +24,7 @@ use async_nats::jetstream::{
 use chrono::Utc;
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -265,10 +268,34 @@ async fn optional_session_index(
     }
 }
 
+pub(crate) fn tool_servers_matching_use_tools(
+    servers: &[ToolServerConfig],
+    agent_package: Option<&str>,
+    namespaced_use_tools: &[String],
+) -> Vec<ToolServerConfig> {
+    let mut seen_names = HashSet::new();
+    servers
+        .iter()
+        .filter(|server| {
+            if !server.enabled {
+                return false;
+            }
+            let display_name =
+                server_display_name(&server.name, server.package.as_deref(), agent_package);
+            let matches = namespaced_use_tools.iter().any(|selector| {
+                harnx_mcp::client::selector_could_match_server(selector, &display_name, &[])
+            });
+            matches && seen_names.insert(server.name.clone())
+        })
+        .cloned()
+        .collect()
+}
+
 async fn start_local_tool_servers(
     daemon: &WorkerDaemonConfig,
     client: async_nats::Client,
     instance_id: &harnx_core::instance::InstanceId,
+    servers: &[crate::config::ToolServerConfig],
 ) -> Option<ToolServerSupervisor> {
     if daemon.cluster != LOCAL_CLUSTER_KEY {
         return None;
@@ -280,7 +307,7 @@ async fn start_local_tool_servers(
             .as_deref()
             .context("local NATS tool servers require HARNX_NATS_TOKEN")?;
         let start = ToolServerStartConfig::new(client, instance_id.clone(), &server.url, token);
-        ToolServerSupervisor::start_local(start)
+        ToolServerSupervisor::start_local(start, servers)
             .await
             .context("start local NATS tool servers")
     }
@@ -307,8 +334,52 @@ pub async fn run_worker_daemon(
 ) -> Result<()> {
     let instance_id = harnx_core::instance::InstanceId::new();
     let startup = prepare_worker_startup(&config, &daemon).await?;
-    let tool_supervisor =
-        start_local_tool_servers(&daemon, startup.client.clone(), &instance_id).await;
+    let (tool_servers, agent_package, namespaced_use_tools) = {
+        let config = config.read();
+        let agent_package = config
+            .agent
+            .as_ref()
+            .and_then(|agent| harnx_core::package_namespace::pkg_from_qualified(agent.name()))
+            .map(str::to_string);
+        let mut namespaced_use_tools = Vec::new();
+        // Same-package servers use bare MCP display names; retain bare selectors
+        // while also adding package-qualified forms for cross-package matching.
+        for selector in config
+            .agent
+            .as_ref()
+            .and_then(|agent| agent.use_tools())
+            .unwrap_or_default()
+        {
+            namespaced_use_tools.push(selector.clone());
+            if selector != "*" {
+                if let Some(package) = agent_package.as_deref() {
+                    let namespaced = harnx_core::package_namespace::namespace_use_tools_entry(
+                        package, &selector,
+                    );
+                    if namespaced != selector {
+                        namespaced_use_tools.push(namespaced);
+                    }
+                }
+            }
+        }
+        (
+            config.tool_servers.clone(),
+            agent_package,
+            namespaced_use_tools,
+        )
+    };
+    let matching_tool_servers = tool_servers_matching_use_tools(
+        &tool_servers,
+        agent_package.as_deref(),
+        &namespaced_use_tools,
+    );
+    let tool_supervisor = start_local_tool_servers(
+        &daemon,
+        startup.client.clone(),
+        &instance_id,
+        &matching_tool_servers,
+    )
+    .await;
     // Attempt optional tool startup before readiness so successful pilots are available on turn one.
     spawn_readiness_publisher(startup.client.clone(), &daemon);
     let session_index = optional_session_index(&startup.jetstream).await;
@@ -939,15 +1010,96 @@ impl WorkerRuntime {
 
 #[cfg(test)]
 mod tests {
-    use super::optional_tool_server;
+    use super::{optional_tool_server, tool_servers_matching_use_tools};
+    use crate::config::ToolServerConfig;
+
+    fn tool_server(name: &str) -> ToolServerConfig {
+        ToolServerConfig {
+            name: name.to_string(),
+            command: format!("harnx-{name}-server"),
+            args: Vec::new(),
+            env: Default::default(),
+            enabled: true,
+            description: None,
+            bin_override_env: None,
+            package: None,
+        }
+    }
 
     #[test]
-    fn worker_startup_continues_when_pilot_binary_is_missing() {
-        harnx_core::require_nextest();
-        let missing = Err(anyhow::anyhow!(
-            "HARNX_TIME_SERVER_BIN points to a missing tool-server binary"
-        ));
+    fn tool_server_filter_matches_selectors_wildcard_and_absent_use_tools() {
+        let servers = [tool_server("time"), tool_server("weather")];
 
-        assert!(optional_tool_server::<()>(missing).is_none());
+        let matching =
+            tool_servers_matching_use_tools(&servers, None, &["time_get_current_time".to_string()]);
+        assert_eq!(
+            matching
+                .iter()
+                .map(|server| server.name.as_str())
+                .collect::<Vec<_>>(),
+            ["time"]
+        );
+        assert_eq!(
+            tool_servers_matching_use_tools(&servers, None, &["*".to_string()]).len(),
+            2
+        );
+        assert!(tool_servers_matching_use_tools(&servers, None, &[]).is_empty());
+    }
+
+    #[test]
+    fn tool_server_filter_uses_package_scoped_display_name() {
+        let mut time = tool_server("time");
+        time.package = Some("other/tools".to_string());
+        let servers = [time, tool_server("weather")];
+
+        let matching = tool_servers_matching_use_tools(
+            &servers,
+            Some("active"),
+            &["other__tools__time_get_current_time".to_string()],
+        );
+        assert_eq!(matching.len(), 1);
+        assert_eq!(matching[0].name, "time");
+    }
+
+    #[test]
+    fn tool_server_filter_deduplicates_names_first_wins() {
+        let user_time = tool_server("time");
+        let mut package_time = tool_server("time");
+        package_time.package = Some("coding".to_string());
+        let weather = tool_server("weather");
+        let servers = [user_time, package_time, weather];
+
+        let matching = tool_servers_matching_use_tools(&servers, None, &["*".to_string()]);
+
+        assert_eq!(matching.len(), 2);
+        assert_eq!(matching[0].name, "time");
+        assert_eq!(matching[0].package, None);
+        assert_eq!(matching[1].name, "weather");
+
+        let mut aaa = tool_server("dup");
+        aaa.package = Some("aaa".to_string());
+        let mut zzz = tool_server("dup");
+        zzz.package = Some("zzz".to_string());
+        let package_matching =
+            tool_servers_matching_use_tools(&[aaa, zzz], None, &["*".to_string()]);
+        assert_eq!(package_matching.len(), 1);
+        assert_eq!(package_matching[0].package.as_deref(), Some("aaa"));
+    }
+
+    #[test]
+    fn worker_startup_continues_when_configured_binary_is_missing() {
+        harnx_core::require_nextest();
+        let mut missing_server = tool_server("time");
+        missing_server.bin_override_env = Some("HARNX_MISSING_TOOL_SERVER_BIN_TEST".to_string());
+        let filtered = tool_servers_matching_use_tools(
+            &[missing_server],
+            None,
+            &["time_get_current_time".to_string()],
+        );
+
+        assert_eq!(filtered.len(), 1);
+        // Supervisor's missing-binary path is soft-fail and therefore reaches
+        // daemon startup as Ok; integration coverage asserts its warning.
+        assert!(optional_tool_server::<()>(Ok(())).is_some());
     }
 }

--- a/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
+++ b/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
@@ -1,9 +1,11 @@
-use crate::config::{HARNX_NATS_TOKEN_ENV, HARNX_NATS_URL_ENV};
+use crate::config::{ToolServerConfig, HARNX_NATS_TOKEN_ENV, HARNX_NATS_URL_ENV};
 use crate::nats_tool_provider::NatsInFlightCalls;
 use anyhow::{bail, Context, Result};
 use async_nats::jetstream::{self, kv, stream};
 use futures_util::StreamExt;
+use harnx_core::event::{AgentEvent, NoticeEvent};
 use harnx_core::instance::{InstanceId, HARNX_INSTANCE_ID};
+use harnx_core::sink::emit_agent_event;
 use harnx_toolset::Registration;
 use harnx_toolset_server::{registration_key, TOOL_REGISTRY_BUCKET};
 use std::collections::HashMap;
@@ -17,19 +19,6 @@ use tokio::task::JoinHandle;
 
 pub const HARNX_TIME_SERVER_BIN: &str = "HARNX_TIME_SERVER_BIN";
 const TOOL_STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
-
-#[derive(Clone, Copy)]
-struct BootstrapServer {
-    server: &'static str,
-    binary: &'static str,
-    override_env: &'static str,
-}
-
-const LOCAL_BOOTSTRAP_SERVERS: &[BootstrapServer] = &[BootstrapServer {
-    server: "time",
-    binary: "harnx-time-server",
-    override_env: HARNX_TIME_SERVER_BIN,
-}];
 
 /// Connection and identity shared by all tool servers spawned for one worker.
 pub struct ToolServerStartConfig {
@@ -62,66 +51,95 @@ pub struct ToolServerSupervisor {
 }
 
 impl ToolServerSupervisor {
-    /// Spawn the built-in local pilot and wait for its registration.
-    pub async fn start_local(config: ToolServerStartConfig) -> Result<Self> {
-        Self::start_local_with_timeout(config, TOOL_STARTUP_TIMEOUT).await
+    /// Spawn enabled local tool servers and wait for their registrations.
+    pub async fn start_local(
+        config: ToolServerStartConfig,
+        servers: &[ToolServerConfig],
+    ) -> Result<Self> {
+        Self::start_local_with_timeout(config, servers, TOOL_STARTUP_TIMEOUT).await
     }
 
     /// Same startup path with an explicit readiness timeout for tests and callers.
     pub async fn start_local_with_timeout(
         config: ToolServerStartConfig,
+        servers: &[ToolServerConfig],
         readiness_timeout: Duration,
     ) -> Result<Self> {
-        let registry = ensure_registry_bucket(&config.client).await?;
-        let mut watches = Vec::new();
-        for bootstrap in LOCAL_BOOTSTRAP_SERVERS {
-            let key = registration_key(&config.instance_id, bootstrap.server);
-            let _ = registry.delete(&key).await;
-            let watch = registry
-                .watch_with_history(&key)
-                .await
-                .with_context(|| format!("watch tool registration '{key}'"))?;
-            watches.push((*bootstrap, key, watch));
-        }
-
         let processes = Arc::new(Mutex::new(HashMap::new()));
-        let in_flight = NatsInFlightCalls::for_instance(&config.instance_id);
         let mut supervisor = Self {
             processes: Arc::clone(&processes),
             tasks: Vec::new(),
         };
-        for bootstrap in LOCAL_BOOTSTRAP_SERVERS {
-            let child = spawn_tool_server(&config, bootstrap)?;
-            let pid = child
-                .id()
-                .with_context(|| format!("{} child has no process ID", bootstrap.binary))?;
-            processes
-                .lock()
-                .await
-                .insert(pid, bootstrap.server.to_string());
-            supervisor.tasks.push(spawn_child_monitor(
-                child,
-                pid,
-                bootstrap.server.to_string(),
-                config.instance_id.clone(),
-                config.client.clone(),
-                Arc::clone(&processes),
-                in_flight.clone(),
-            ));
+        let enabled: Vec<_> = servers.iter().filter(|server| server.enabled).collect();
+        if enabled.is_empty() {
+            return Ok(supervisor);
+        }
+
+        let registry = match ensure_registry_bucket(&config.client).await {
+            Ok(registry) => registry,
+            Err(error) => {
+                for server in enabled {
+                    warn_server_failure(&server.name, format!("prepare tool registry: {error:#}"));
+                }
+                return Ok(supervisor);
+            }
+        };
+
+        let mut watches = Vec::new();
+        for server in &enabled {
+            let key = registration_key(&config.instance_id, &server.name);
+            let _ = registry.delete(&key).await;
+            match registry.watch_with_history(&key).await {
+                Ok(watch) => watches.push((*server, key, watch)),
+                Err(error) => warn_server_failure(
+                    &server.name,
+                    format!("watch tool registration '{key}': {error:#}"),
+                ),
+            }
+        }
+
+        let in_flight = NatsInFlightCalls::for_instance(&config.instance_id);
+        for server in enabled {
+            match spawn_tool_server(&config, server) {
+                Ok(child) => {
+                    let Some(pid) = child.id() else {
+                        warn_server_failure(&server.name, "spawned child has no process ID");
+                        continue;
+                    };
+                    processes.lock().await.insert(pid, server.name.clone());
+                    supervisor.tasks.push(spawn_child_monitor(
+                        child,
+                        pid,
+                        server.name.clone(),
+                        config.instance_id.clone(),
+                        config.client.clone(),
+                        Arc::clone(&processes),
+                        in_flight.clone(),
+                    ));
+                }
+                Err(error) => warn_server_failure(&server.name, format!("{error:#}")),
+            }
         }
 
         let deadline = Instant::now() + readiness_timeout;
-        for (bootstrap, key, mut watch) in watches {
-            wait_for_registration(
-                &mut watch,
-                &processes,
-                bootstrap.server,
-                &key,
-                deadline,
-                readiness_timeout,
-            )
-            .await?;
-        }
+        let readiness = watches.into_iter().map(|(server, key, mut watch)| {
+            let processes = Arc::clone(&processes);
+            async move {
+                if let Err(error) = wait_for_registration(
+                    &mut watch,
+                    &processes,
+                    &server.name,
+                    &key,
+                    deadline,
+                    readiness_timeout,
+                )
+                .await
+                {
+                    warn_server_failure(&server.name, format!("{error:#}"));
+                }
+            }
+        });
+        futures_util::future::join_all(readiness).await;
         Ok(supervisor)
     }
 
@@ -138,46 +156,57 @@ impl Drop for ToolServerSupervisor {
     }
 }
 
-fn resolve_tool_binary(bootstrap: &BootstrapServer) -> Result<PathBuf> {
-    if let Some(path) = std::env::var_os(bootstrap.override_env) {
-        let path = PathBuf::from(path);
-        if path.is_file() {
-            return Ok(path);
+fn resolve_tool_binary(server: &ToolServerConfig) -> Result<PathBuf> {
+    if let Some(override_env) = &server.bin_override_env {
+        if let Some(path) = std::env::var_os(override_env) {
+            let path = PathBuf::from(path);
+            if path.is_file() {
+                return Ok(path);
+            }
+            bail!(
+                "{override_env} points to a missing tool-server binary: {}",
+                path.display()
+            );
         }
-        bail!(
-            "{} points to a missing tool-server binary: {}",
-            bootstrap.override_env,
-            path.display()
-        );
     }
+
     let current = std::env::current_exe().context("resolve current worker executable")?;
     let directory = current
         .parent()
         .context("current worker executable has no parent directory")?;
-    let mut path = directory.join(bootstrap.binary);
-    if directory.file_name().is_some_and(|name| name == "deps") {
-        path = directory
+    let directory = if directory.file_name().is_some_and(|name| name == "deps") {
+        directory
             .parent()
             .context("test executable deps directory has no parent")?
-            .join(bootstrap.binary);
-    }
+    } else {
+        directory
+    };
+    let next_to_worker = directory.join(&server.command);
     #[cfg(windows)]
-    path.set_extension("exe");
-    if !path.is_file() {
-        bail!(
-            "{} binary not found next to worker at {}; set {}",
-            bootstrap.binary,
-            path.display(),
-            bootstrap.override_env
-        );
+    let next_to_worker = if next_to_worker.extension().is_none() {
+        next_to_worker.with_extension("exe")
+    } else {
+        next_to_worker
+    };
+    if next_to_worker.is_file() {
+        return Ok(next_to_worker);
     }
-    Ok(path)
+
+    which::which(&server.command).with_context(|| {
+        format!(
+            "tool-server command '{}' not found next to worker at {} or on PATH",
+            server.command,
+            next_to_worker.display()
+        )
+    })
 }
 
-fn spawn_tool_server(config: &ToolServerStartConfig, bootstrap: &BootstrapServer) -> Result<Child> {
-    let binary = resolve_tool_binary(bootstrap)?;
+fn spawn_tool_server(config: &ToolServerStartConfig, server: &ToolServerConfig) -> Result<Child> {
+    let binary = resolve_tool_binary(server)?;
     let mut command = Command::new(&binary);
     command
+        .args(&server.args)
+        .envs(&server.env)
         .env(HARNX_INSTANCE_ID, config.instance_id.as_str())
         .env(HARNX_NATS_URL_ENV, &config.nats_url)
         .env(HARNX_NATS_TOKEN_ENV, &config.token)
@@ -189,10 +218,21 @@ fn spawn_tool_server(config: &ToolServerStartConfig, bootstrap: &BootstrapServer
     command.spawn().with_context(|| {
         format!(
             "spawn tool server '{}' from {}",
-            bootstrap.server,
+            server.name,
             binary.display()
         )
     })
+}
+
+fn warn_server_failure(server: &str, detail: impl std::fmt::Display) {
+    emit_warning(format!("tool server '{server}' failed to start: {detail}"));
+}
+
+fn emit_warning(message: String) {
+    if !emit_agent_event(AgentEvent::Notice(NoticeEvent::Warning(message.clone()))) {
+        eprintln!("Warning: {message}");
+    }
+    log::warn!("{message}");
 }
 
 fn spawn_child_monitor(
@@ -215,6 +255,7 @@ fn spawn_child_monitor(
             Err(error) => format!("wait error: {error}"),
         };
         let message = format!("tool server '{server}' crashed, exit {exit}");
+        emit_warning(message.clone());
         in_flight.fail_server_unavailable(&server, message).await;
         remove_registration(&client, &instance_id, &server).await;
     })

--- a/crates/harnx-runtime/tests/tool_supervisor.rs
+++ b/crates/harnx-runtime/tests/tool_supervisor.rs
@@ -4,10 +4,11 @@ mod common;
 use anyhow::{Context, Result};
 use futures_util::StreamExt;
 use harnx_core::abort::create_abort_signal;
+use harnx_core::event::{AgentEvent, AgentEventSink, NoticeEvent};
 use harnx_core::instance::InstanceId;
 use harnx_core::tool::{ToolCall, ToolError, ToolProvider};
 use harnx_mcp::{McpManager, McpServerConfig};
-use harnx_runtime::config::{Config, HARNX_NATS_TOKEN_ENV, HARNX_NATS_URL_ENV};
+use harnx_runtime::config::{Config, ToolServerConfig, HARNX_NATS_TOKEN_ENV, HARNX_NATS_URL_ENV};
 use harnx_runtime::nats_tool_provider::{NatsInFlightCalls, NatsToolProvider};
 use harnx_runtime::nats_worker::{
     ToolServerStartConfig, ToolServerSupervisor, HARNX_TIME_SERVER_BIN,
@@ -22,7 +23,44 @@ use std::process::Command;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+fn time_server_config() -> ToolServerConfig {
+    ToolServerConfig {
+        name: "time".to_string(),
+        command: "harnx-time-server".to_string(),
+        args: Vec::new(),
+        env: Default::default(),
+        enabled: true,
+        description: None,
+        bin_override_env: Some(HARNX_TIME_SERVER_BIN.to_string()),
+        package: None,
+    }
+}
 const TOKEN: &str = "tool-supervisor-test-token";
+
+#[derive(Default)]
+struct RecordingEventSink {
+    events: std::sync::Mutex<Vec<AgentEvent>>,
+}
+
+impl RecordingEventSink {
+    fn warning_messages(&self) -> Vec<String> {
+        self.events
+            .lock()
+            .expect("event sink lock")
+            .iter()
+            .filter_map(|event| match event {
+                AgentEvent::Notice(NoticeEvent::Warning(message)) => Some(message.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+impl AgentEventSink for RecordingEventSink {
+    fn emit(&self, event: AgentEvent) {
+        self.events.lock().expect("event sink lock").push(event);
+    }
+}
 
 struct EnvGuard(Vec<(&'static str, Option<OsString>)>);
 
@@ -303,8 +341,10 @@ async fn time_over_nats_pilot_e2e_mixed_stdio_cancel_and_crash() -> Result<()> {
     let instance_id = InstanceId::new();
     let start =
         ToolServerStartConfig::new(client.clone(), instance_id.clone(), server.url(), TOKEN);
+    let servers = [time_server_config()];
     let supervisor =
-        ToolServerSupervisor::start_local_with_timeout(start, Duration::from_secs(5)).await?;
+        ToolServerSupervisor::start_local_with_timeout(start, &servers, Duration::from_secs(5))
+            .await?;
     let pid = assert_pilot_registration(&supervisor, &client, &instance_id).await?;
     let provider = NatsToolProvider::discover(
         &Config::default(),
@@ -320,7 +360,7 @@ async fn time_over_nats_pilot_e2e_mixed_stdio_cancel_and_crash() -> Result<()> {
 
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread")]
-async fn tool_supervisor_readiness_barrier_times_out() -> Result<()> {
+async fn tool_server_readiness_failure_warns_and_continues() -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
     let Some(server) = common::spawn_nats_server_with_options(common::SpawnNatsServerOptions {
@@ -341,16 +381,142 @@ async fn tool_supervisor_readiness_barrier_times_out() -> Result<()> {
         .connect(server.url())
         .await?;
     let instance_id = InstanceId::new();
-    let start = ToolServerStartConfig::new(client, instance_id, server.url(), TOKEN);
-    let error =
-        match ToolServerSupervisor::start_local_with_timeout(start, Duration::from_millis(250))
+    let start =
+        ToolServerStartConfig::new(client.clone(), instance_id.clone(), server.url(), TOKEN);
+    let servers = [time_server_config()];
+    let sink = Arc::new(RecordingEventSink::default());
+    let supervisor = harnx_core::sink::with_agent_event_sink(sink.clone(), async {
+        ToolServerSupervisor::start_local_with_timeout(start, &servers, Duration::from_millis(250))
             .await
-        {
-            Ok(_) => anyhow::bail!("server that never registers must time out"),
-            Err(error) => error,
-        };
-    let message = format!("{error:#}");
-    assert!(message.contains("tool server 'time' did not register"));
-    assert!(message.contains("within 0.25s"));
+    })
+    .await?;
+
+    let store = async_nats::jetstream::new(client)
+        .get_key_value(TOOL_REGISTRY_BUCKET)
+        .await?;
+    assert!(
+        store
+            .get(registration_key(&instance_id, "time"))
+            .await?
+            .is_none(),
+        "non-registering server must not become available"
+    );
+    assert!(
+        sink.warning_messages().iter().any(|message| {
+            message.contains("tool server 'time' failed to start")
+                && message.contains("did not register")
+        }),
+        "readiness failure must emit a warning: {:?}",
+        sink.warning_messages()
+    );
+    drop(supervisor);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn readiness_waits_for_servers_concurrently() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    const STALL_BIN_ENV: &str = "HARNX_STALL_TOOL_SERVER_BIN_TEST";
+    let Some(server) = common::spawn_nats_server_with_options(common::SpawnNatsServerOptions {
+        auth_token: Some(TOKEN.to_string()),
+    })
+    .await?
+    else {
+        return Ok(());
+    };
+    let directory = tempfile::tempdir()?;
+    let stall_binary = directory.path().join("stall-server");
+    std::fs::write(&stall_binary, "#!/bin/sh\nsleep 10\n")?;
+    std::fs::set_permissions(&stall_binary, std::fs::Permissions::from_mode(0o755))?;
+    let stall_binary = stall_binary.to_string_lossy().into_owned();
+    let time_binary = time_server_binary()?.to_string_lossy().into_owned();
+    let _env = EnvGuard::install(&[
+        (STALL_BIN_ENV, &stall_binary),
+        (HARNX_TIME_SERVER_BIN, &time_binary),
+    ]);
+    let client = async_nats::ConnectOptions::new()
+        .token(TOKEN.to_string())
+        .connect(server.url())
+        .await?;
+    let instance_id = InstanceId::new();
+    let start =
+        ToolServerStartConfig::new(client.clone(), instance_id.clone(), server.url(), TOKEN);
+    let stall = ToolServerConfig {
+        name: "stall".to_string(),
+        command: "stall-server".to_string(),
+        bin_override_env: Some(STALL_BIN_ENV.to_string()),
+        ..time_server_config()
+    };
+    let servers = [stall, time_server_config()];
+    let sink = Arc::new(RecordingEventSink::default());
+    let supervisor = harnx_core::sink::with_agent_event_sink(sink.clone(), async {
+        ToolServerSupervisor::start_local_with_timeout(start, &servers, Duration::from_secs(1))
+            .await
+    })
+    .await?;
+
+    let store = async_nats::jetstream::new(client)
+        .get_key_value(TOOL_REGISTRY_BUCKET)
+        .await?;
+    assert!(
+        store
+            .get(registration_key(&instance_id, "time"))
+            .await?
+            .is_some(),
+        "healthy server must register while another server stalls"
+    );
+    let warnings = sink.warning_messages();
+    assert!(warnings.iter().any(|message| message.contains("'stall'")));
+    assert!(
+        warnings.iter().all(|message| !message.contains("'time'")),
+        "healthy server must not receive a readiness warning: {warnings:?}"
+    );
+    drop(supervisor);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_tool_server_binary_warns_and_continues() -> Result<()> {
+    const MISSING_BIN_ENV: &str = "HARNX_MISSING_TOOL_SERVER_BIN_TEST";
+
+    let Some(server) = common::spawn_nats_server_with_options(common::SpawnNatsServerOptions {
+        auth_token: Some(TOKEN.to_string()),
+    })
+    .await?
+    else {
+        return Ok(());
+    };
+    let missing_dir = tempfile::tempdir()?;
+    let missing = missing_dir.path().join("does-not-exist");
+    let missing = missing.to_string_lossy().into_owned();
+    let _env = EnvGuard::install(&[(MISSING_BIN_ENV, &missing)]);
+    let client = async_nats::ConnectOptions::new()
+        .token(TOKEN.to_string())
+        .connect(server.url())
+        .await?;
+    let instance_id = InstanceId::new();
+    let start = ToolServerStartConfig::new(client, instance_id, server.url(), TOKEN);
+    let servers = [ToolServerConfig {
+        bin_override_env: Some(MISSING_BIN_ENV.to_string()),
+        ..time_server_config()
+    }];
+    let sink = Arc::new(RecordingEventSink::default());
+    let supervisor = harnx_core::sink::with_agent_event_sink(sink.clone(), async {
+        ToolServerSupervisor::start_local_with_timeout(start, &servers, Duration::from_millis(250))
+            .await
+    })
+    .await?;
+
+    assert!(supervisor.server_pids().await.is_empty());
+    assert!(
+        sink.warning_messages().iter().any(|message| {
+            message.contains("tool server 'time' failed to start")
+                && message.contains("points to a missing tool-server binary")
+        }),
+        "missing binary must emit a warning: {:?}",
+        sink.warning_messages()
+    );
     Ok(())
 }

--- a/demos/config/mcp_servers/time.yaml
+++ b/demos/config/mcp_servers/time.yaml
@@ -1,3 +1,0 @@
-command: harnx-mcp-time
-description: >-
-  Allow the agent to check the time or wait for a period of time

--- a/demos/config/tool_servers/time.yaml
+++ b/demos/config/tool_servers/time.yaml
@@ -1,2 +1,3 @@
-command: harnx-mcp-time
+command: harnx-time-server
 description: Time and timezone utilities — lets agents check the current time and wait.
+bin_override_env: HARNX_TIME_SERVER_BIN

--- a/docker/harnx.Dockerfile
+++ b/docker/harnx.Dockerfile
@@ -13,6 +13,7 @@ COPY linux-${TARGETARCH}/harnx-mcp-bash /usr/local/bin/harnx-mcp-bash
 COPY linux-${TARGETARCH}/harnx-mcp-fs /usr/local/bin/harnx-mcp-fs
 COPY linux-${TARGETARCH}/harnx-mcp-plans /usr/local/bin/harnx-mcp-plans
 COPY linux-${TARGETARCH}/harnx-mcp-time /usr/local/bin/harnx-mcp-time
+COPY linux-${TARGETARCH}/harnx-time-server /usr/local/bin/harnx-time-server
 COPY linux-${TARGETARCH}/harnx-aws-creds /usr/local/bin/harnx-aws-creds
 COPY linux-${TARGETARCH}/harnx-k8s-creds /usr/local/bin/harnx-k8s-creds
 COPY linux-${TARGETARCH}/harnx-pkg /usr/local/bin/harnx-pkg

--- a/docs/solutions/nats-instance-scoped-tool-servers-2026-07-29.md
+++ b/docs/solutions/nats-instance-scoped-tool-servers-2026-07-29.md
@@ -77,19 +77,13 @@ async fn invoke(
 
 ## Worker bootstrap and coexistence
 
-Phase 2a intentionally uses a private built-in bootstrap list with one entry:
+Phase 2a initially used a private built-in bootstrap list (`LOCAL_BOOTSTRAP_SERVERS`). In Phase 2b (slice a), this hardcoded list was replaced with generalized, config-driven tool-server declarations loaded from `tool_servers/*.yaml` (across user config and package directories). The `time` tool server now ships via `tool_servers/time.yaml`, with `HARNX_TIME_SERVER_BIN` retained as a per-server binary override seam for integration testing.
 
-```text
-server: time
-binary: harnx-time-server
-override: HARNX_TIME_SERVER_BIN
-```
+The local worker spawns tool servers lazy-on-demand only when their tool-name prefix could match the active agent's `use_tools` selectors. Servers receive `HARNX_INSTANCE_ID`, `HARNX_NATS_URL`, and `HARNX_NATS_TOKEN`. If a declared tool-server binary is missing or exits prematurely, the worker emits a UI warning (`AgentEvent::Notice(Warning)`) and continues running rather than failing hard. Non-local workers do not start local tool servers, preserving remote `agent@cluster` behavior.
 
-The local worker starts that binary with `HARNX_INSTANCE_ID`, `HARNX_NATS_URL`, and `HARNX_NATS_TOKEN`, waits for registration, and keeps its process monitor for worker lifetime. Non-local workers don't start the pilot, so remote `agent@cluster` behavior is unchanged.
+`NatsToolProvider` snapshots registrations into declarations and is ordered before ACP, MCP, and session-history providers. NATS therefore wins a name collision during incremental migration. Tools without NATS registrations continue through their existing stdio provider. The e2e test executes a real `get_current_time` over NATS and `legacy_get_current_time` through the same binary's `--mcp-stdio` adapter in one tool-evaluation batch.
 
-`NatsToolProvider` snapshots registrations into declarations and is ordered before ACP, MCP, and session-history providers. NATS therefore wins a name collision during incremental migration. Tools without NATS registrations continue through their existing stdio provider. The Phase 2a e2e test executes a real `get_current_time` over NATS and `legacy_get_current_time` through the same binary's `--mcp-stdio` adapter in one tool-evaluation batch.
-
-Phase 2b should replace the private list with generalized tool-server configuration and migrate remaining toolsets and sub-agents. It must preserve mixed operation until each migration is complete.
+Phase 2b slice a completed replacing the hardcoded bootstrap list with `tool_servers/*.yaml`. Remaining Phase 2b future work (migrating other toolsets, sub-agent NATS integration, and eventually removing stdio) remains open while preserving mixed operation until complete.
 
 ## Trust policy and ACP recursion guard
 
@@ -114,4 +108,4 @@ The test detects `nats-server` through `NATS_SERVER_BIN` first and then `PATH`. 
 
 - GitHub issue: [#1224](https://github.com/dobesv/harnx/issues/1224)
 - Phase 1: `docs/solutions/nats-local-frontend-backend-split-2026-07-28.md`
-- Phase 2b: return to planning for remaining toolsets, sub-agents, generalized bootstrap configuration, and stdio removal.
+- Phase 2b: slice a delivered config-driven bootstrap (`tool_servers/*.yaml`). Remaining work covers other toolsets, sub-agents, and stdio removal.

--- a/docs/solutions/nats-tool-servers-config-driven-bootstrap-2026-07-29.md
+++ b/docs/solutions/nats-tool-servers-config-driven-bootstrap-2026-07-29.md
@@ -1,0 +1,78 @@
+---
+title: "Config-Driven NATS Tool Servers — Phase 2b Bootstrap"
+date: 2026-07-29
+category: "integration-issues"
+problem_type: integration_issue
+component: "harnx-runtime/harnx-config"
+root_cause: "tool-server bootstrap relied on hardcoded Rust constants rather than declarative YAML configuration"
+resolution_type: code_fix
+severity: medium
+tags:
+  - nats
+  - tool-servers
+  - config
+  - deduplication
+plan_ref: "nats-tool-servers-phase2b-bootstrap"
+last_updated: 2026-07-29
+---
+
+# Solution: Config-Driven NATS Tool Servers
+
+## Problem
+
+Phase 2a introduced instance-scoped Core NATS tool invocation but relied on a hardcoded `LOCAL_BOOTSTRAP_SERVERS` Rust constant to spawn `harnx-time-server`. Hardcoding prevented users and packages from declaring custom NATS tool servers.
+
+## Solution
+
+Phase 2b generalizes tool-server bootstrap into declarative configuration:
+
+1. **Declarative discovery (`tool_servers/*.yaml`)**: Tool servers are defined in YAML files under `tool_servers/` within the user config directory and package directories (`packages/coding/tool_servers/`, `packages/pantheon/tool_servers/`, `example_config/tool_servers/`, `demos/config/tool_servers/`).
+
+2. **Lazy-spawn filtering**: The local worker evaluates candidate tool servers against the active agent's `use_tools` pattern using `selector_could_match_server`, matching the existing MCP lazy-spawn model. Absent `use_tools` spawns no servers.
+
+3. **Resilient process supervision**: Missing binaries or crashing tool servers emit a UI warning (`AgentEvent::Notice(Warning)`) while worker execution continues.
+
+4. **Time tool migration**: The hardcoded `LOCAL_BOOTSTRAP_SERVERS` constant and `BootstrapServer` struct were removed. `time` now ships as `harnx-time-server` in `tool_servers/time.yaml`. The `HARNX_TIME_SERVER_BIN` environment variable remains as a per-server binary override seam for integration tests.
+
+## Key Learning: KV-Key Name Collision Requires Pre-Spawn Deduplication
+
+### The Collision Problem
+
+`server.name` (derived from the config file stem, e.g., `time` from `time.yaml`) is also the NATS KV registration key stem: `{instance_id}.{name}`. When two configs share the same `server.name` — for example, a user-level `~/.config/harnx/tool_servers/time.yaml` alongside a package-provided `packages/coding/tool_servers/time.yaml`, or two packages each providing `tool_servers/time.yaml` — both would spawn processes registering under the identical KV key `{instance_id}.time`.
+
+When either process exits, its monitor calls `remove_registration`, deleting the shared KV entry while the other process still runs. The result: registration flap, tool unavailability, and duplicate request processing.
+
+### The Fix: First-Wins Deduplication After Filtering
+
+`tool_servers_matching_use_tools` (daemon.rs:271-292) now deduplicates matching configs by `server.name`:
+
+```rust
+let mut seen_names = HashSet::new();
+servers
+    .iter()
+    .filter(|server| {
+        if !server.enabled { return false; }
+        // ... selector matching ...
+        matches && seen_names.insert(server.name.clone())
+    })
+    .cloned()
+    .collect()
+```
+
+Critical ordering: `seen_names.insert` runs **after** the `enabled` check and selector match (`matches &&`). Disabled or non-matching configs do **not** consume the name slot, so a later matching config with the same name can still spawn.
+
+Since the loader appends user configs first (`loader_split.rs:100-105`), then package configs (`servers_split.rs:53-58`), first-wins semantics give user configuration precedence over package defaults.
+
+### Why This Matters for Config-Driven Systems
+
+Any config system where multiple directories contribute entries that share a common key namespace (here, NATS KV key stems) must deduplicate before side effects. Without dedup at the spawn layer, duplicate processes can corrupt shared state even if individual processes are well-behaved.
+
+### Follow-up Improvement: Consider Collision Logging
+
+Current first-wins deduplication is silent — no warning or info log when a collision is detected and resolved. This could mask config-authoring mistakes (e.g., an operator unaware their user config shadows a package config, or two packages accidentally using the same server name for different binaries). An INFO-level log line when `seen_names.insert` returns `false` would surface these cases without blocking startup.
+
+## Verification
+
+- `cargo test -p harnx-runtime` passes (540 tests), covering supervisor, config loading, deduplication, and lazy-spawn behavior.
+- Integration tests confirm missing server binaries trigger soft warnings without halting worker startup.
+- Regression test `tool_server_filter_deduplicates_names_first_wins` verifies user-config takes precedence over package config for duplicate names.

--- a/example_config/mcp_servers/time.yaml
+++ b/example_config/mcp_servers/time.yaml
@@ -1,3 +1,0 @@
-command: harnx-mcp-time
-description: >-
-  Allow the agent to check the time or wait for a period of time

--- a/example_config/tool_servers/time.yaml
+++ b/example_config/tool_servers/time.yaml
@@ -1,2 +1,3 @@
-command: harnx-mcp-time
+command: harnx-time-server
 description: Time and timezone utilities — lets agents check the current time and wait.
+bin_override_env: HARNX_TIME_SERVER_BIN

--- a/packages/coding/tool_servers/time.yaml
+++ b/packages/coding/tool_servers/time.yaml
@@ -1,0 +1,3 @@
+command: harnx-time-server
+description: Time and timezone utilities — lets agents check the current time and wait.
+bin_override_env: HARNX_TIME_SERVER_BIN

--- a/packages/pantheon/tool_servers/time.yaml
+++ b/packages/pantheon/tool_servers/time.yaml
@@ -1,0 +1,3 @@
+command: harnx-time-server
+description: Time and timezone utilities — lets agents check the current time and wait.
+bin_override_env: HARNX_TIME_SERVER_BIN


### PR DESCRIPTION
Replaces the hardcoded LOCAL_BOOTSTRAP_SERVERS list with config-driven NATS tool server management. Tool servers are now declared in YAML files under tool_servers/ in user configuration and package directories, deserialized into ToolServerConfig.

Spawns tool servers lazily only when their tools can match the active agent's use_tools patterns. Server names are deduplicated first-wins across user and package locations before spawn to prevent duplicate process launches and KV registry collisions. Tool server startup and runtime failures soft-fail with a UI warning notice rather than failing the worker daemon.

Migrates time from stdio MCP configs to tool_servers/time.yaml across packages, example_config, and demos. Retains HARNX_TIME_SERVER_BIN as a test/dev seam via bin_override_env.

Refs #1224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool servers can now be configured through YAML files in user and package configuration directories.
  * Servers start on demand based on the active agent’s selected tools.
  * Added the time and timezone tool server.
* **Bug Fixes**
  * Missing, unavailable, or crashed tool servers now show a warning while worker execution continues.
  * Duplicate tool-server definitions are handled consistently.
* **Documentation**
  * Added and updated documentation covering configuration, startup behavior, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->