### PR TITLE
Treat blank session_id as new session and return actionable errors

### DIFF
--- a/.changeset/acp-session-prompt-blank-session-id.md
+++ b/.changeset/acp-session-prompt-blank-session-id.md
@@ -1,0 +1,7 @@
+---
+harnx: patch
+---
+
+Fix ACP `session_prompt` failing with a bare "Invalid params" when a sub-agent model passes an empty or made-up `session_id`.
+
+Empty or whitespace-only `session_id` values are now treated as omitted and start a new session instead of being forwarded verbatim. Unknown session IDs (in both `prompt` and `cancel`) now return an actionable error telling the model to use a real ID or omit it to start a new session. The `session_prompt` tool and `session_id` parameter descriptions now spell out how to continue a conversation versus start a new one, and warn against inventing session IDs.

--- a/crates/harnx-acp-server/src/lib.rs
+++ b/crates/harnx-acp-server/src/lib.rs
@@ -747,7 +747,7 @@ impl HarnxAgent {
         let sessions = self.sessions.lock().await;
         let session = sessions
             .get(session_id.as_ref())
-            .ok_or_else(acp::Error::invalid_params)?;
+            .ok_or_else(|| unknown_session_error(session_id.as_ref()))?;
         // A cancel is direct user interaction — count it as activity so the
         // idle reaper doesn't evict a session the user is actively steering.
         session.touch();
@@ -771,7 +771,7 @@ impl HarnxAgent {
         // Session not in memory. Check if it exists on disk.
         let session_path = self.base_config.read().session_file(session_id);
         if !tokio::fs::try_exists(&session_path).await.unwrap_or(false) {
-            return Err(acp::Error::invalid_params());
+            return Err(unknown_session_error(session_id));
         }
 
         // Lazy rebuild: fork config, load session from disk.
@@ -841,6 +841,18 @@ impl HarnxAgent {
             }
         });
     }
+}
+
+/// Build the actionable ACP error returned when a caller references a session
+/// ID that isn't in memory or on disk. The message tells the calling model how
+/// to recover (use a real ID or omit it) instead of a bare "Invalid params".
+fn unknown_session_error(session_id: &str) -> acp::Error {
+    acp::Error::new(
+        -32602,
+        format!(
+            "Unknown session ID '{session_id}'. Use a session_id returned by session_new or session_prompt; omit it to start a new session."
+        ),
+    )
 }
 
 /// Build the `meta` map that `AcpNotificationClient::resolve_notification_source`

--- a/crates/harnx-acp-server/src/lib_tests.rs
+++ b/crates/harnx-acp-server/src/lib_tests.rs
@@ -149,7 +149,41 @@ mod tests {
             })
             .await;
 
-        assert!(result.is_err());
+        let error = result.expect_err("unknown session must fail");
+        assert_eq!(error.code, (-32602).into());
+        assert_eq!(
+            error.message,
+            "Unknown session ID 'nonexistent'. Use a session_id returned by session_new or session_prompt; omit it to start a new session."
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_prompt_unknown_session_errors() {
+        let (_temp, _path) = setup_agent_env("test");
+        let _guard = TestStateGuard::new(None).await;
+        let config = test_config();
+        let agent = Arc::new(HarnxAgent::new("test".to_string(), config));
+
+        let local = tokio::task::LocalSet::new();
+        let result = local
+            .run_until(async {
+                agent
+                    .prompt(PromptRequest::new(
+                        agent_client_protocol::schema::v1::SessionId::new(
+                            "nonexistent".to_string(),
+                        ),
+                        vec![ContentBlock::from("hello".to_string())],
+                    ))
+                    .await
+            })
+            .await;
+
+        let error = result.expect_err("prompt on unknown session must fail");
+        assert_eq!(error.code, (-32602).into());
+        assert_eq!(
+            error.message,
+            "Unknown session ID 'nonexistent'. Use a session_id returned by session_new or session_prompt; omit it to start a new session."
+        );
     }
 
     /// A created session bound to its agent and on-disk log location. Holding

--- a/crates/harnx-acp/src/manager.rs
+++ b/crates/harnx-acp/src/manager.rs
@@ -210,7 +210,7 @@ impl AcpManager {
             }
             "session_prompt" => {
                 let message = required_string(&arguments, "message")?.to_owned();
-                let session_id = match optional_string(&arguments, "session_id")? {
+                let session_id = match optional_nonblank_string(&arguments, "session_id")? {
                     Some(session_id) => session_id.to_owned(),
                     None => client.session_new().await?,
                 };
@@ -347,6 +347,11 @@ fn string_prop(description: &str) -> JsonSchema {
     }
 }
 
+/// Shared guidance describing how the `session_id` argument controls session
+/// continuation. Kept as one constant so the tool description and the parameter
+/// description can't drift apart.
+const SESSION_ID_GUIDANCE: &str = "To continue a conversation, pass only the exact session_id returned by session_prompt or session_new. To start a new conversation, omit session_id; empty or whitespace-only values also start a new session. Do not invent a session ID.";
+
 /// The `session_prompt` ACP tool declaration (message + optional session_id).
 fn acp_session_prompt_tool(
     server_name: &str,
@@ -358,19 +363,12 @@ fn acp_session_prompt_tool(
         "message".to_string(),
         string_prop("The prompt message to send to the agent"),
     );
-    props.insert(
-        "session_id".to_string(),
-        string_prop(
-            "Session ID returned by a prior prompt call or by session_new. Pass it to preserve context from earlier turns; if omitted, a new empty session is created and no prior context is available.",
-        ),
-    );
+    props.insert("session_id".to_string(), string_prop(SESSION_ID_GUIDANCE));
     let description = match description {
         Some(description) => format!(
-            "Send a prompt to the '{server_name}' ACP agent. To continue a prior conversation, you must pass the session_id returned by an earlier prompt call or by session_new; the remote agent keeps context under that session_id. If you omit session_id, this starts a new empty session with no prior context. — {description}"
+            "Send a prompt to the '{server_name}' ACP agent. {SESSION_ID_GUIDANCE} — {description}"
         ),
-        None => format!(
-            "Send a prompt to the '{server_name}' ACP agent. To continue a prior conversation, you must pass the session_id returned by an earlier prompt call or by session_new; the remote agent keeps context under that session_id. If you omit session_id, this starts a new empty session with no prior context."
-        ),
+        None => format!("Send a prompt to the '{server_name}' ACP agent. {SESSION_ID_GUIDANCE}"),
     };
     ToolDeclaration {
         name: format!("{server_name}_session_prompt"),
@@ -508,11 +506,12 @@ fn required_string<'a>(
         .ok_or_else(|| anyhow!("ACP tool argument '{}' must be a string", key))
 }
 
-fn optional_string<'a>(
+fn optional_nonblank_string<'a>(
     arguments: &'a serde_json::Map<String, Value>,
     key: &str,
 ) -> Result<Option<&'a str>> {
     match arguments.get(key) {
+        Some(Value::String(value)) if value.trim().is_empty() => Ok(None),
         Some(Value::String(value)) => Ok(Some(value.as_str())),
         Some(Value::Null) | None => Ok(None),
         Some(_) => Err(anyhow!("ACP tool argument '{}' must be a string", key)),
@@ -887,7 +886,7 @@ enabled: false
         assert_eq!(
             descriptions.get("planner_session_prompt"),
             Some(
-                &"Send a prompt to the 'planner' ACP agent. To continue a prior conversation, you must pass the session_id returned by an earlier prompt call or by session_new; the remote agent keeps context under that session_id. If you omit session_id, this starts a new empty session with no prior context."
+                &"Send a prompt to the 'planner' ACP agent. To continue a conversation, pass only the exact session_id returned by session_prompt or session_new. To start a new conversation, omit session_id; empty or whitespace-only values also start a new session. Do not invent a session ID."
             )
         );
         assert_eq!(
@@ -1130,6 +1129,38 @@ enabled: false
 
         assert!(manager.get_client("disabled").is_none());
         assert_eq!(manager.get_all_tools_blocking().len(), 0);
+    }
+
+    #[test]
+    fn optional_nonblank_string_treats_blank_values_as_omitted() {
+        let empty = serde_json::Map::from_iter([(String::from("session_id"), json!(""))]);
+        let whitespace = serde_json::Map::from_iter([(String::from("session_id"), json!(" \t "))]);
+        let session =
+            serde_json::Map::from_iter([(String::from("session_id"), json!("session-1"))]);
+
+        assert_eq!(
+            optional_nonblank_string(&empty, "session_id").unwrap(),
+            None
+        );
+        assert_eq!(
+            optional_nonblank_string(&whitespace, "session_id").unwrap(),
+            None
+        );
+        assert_eq!(
+            optional_nonblank_string(&session, "session_id").unwrap(),
+            Some("session-1")
+        );
+
+        let absent = serde_json::Map::new();
+        let null = serde_json::Map::from_iter([(String::from("session_id"), Value::Null)]);
+        assert_eq!(
+            optional_nonblank_string(&absent, "session_id").unwrap(),
+            None
+        );
+        assert_eq!(optional_nonblank_string(&null, "session_id").unwrap(), None);
+
+        let wrong_type = serde_json::Map::from_iter([(String::from("session_id"), json!(123))]);
+        assert!(optional_nonblank_string(&wrong_type, "session_id").is_err());
     }
 
     #[test]

--- a/docs/solutions/integration-issues/acp-session-prompt-blank-session-id-2026-07-29.md
+++ b/docs/solutions/integration-issues/acp-session-prompt-blank-session-id-2026-07-29.md
@@ -1,0 +1,138 @@
+---
+title: "ACP session_prompt blank session_id handling and actionable error messages"
+date: 2026-07-29
+category: integration-issues
+problem_type: integration_issue
+component: harnx-acp
+root_cause: "blank strings passed verbatim to server; unactionable JSON-RPC error messages"
+resolution_type: code_fix
+severity: medium
+tags:
+  - acp
+  - sub-agent
+  - json-rpc
+  - error-messages
+  - llm-tool-design
+  - session-management
+plan_ref: issue-1282-acp-session-validation
+---
+
+## Problem
+
+ACP `session_prompt` tool failed with a bare "Invalid params" error when sub-agent models passed `session_id: ""` or invented session IDs. The error lacked context for the model to self-correct, causing repeated failed attempts.
+
+## Symptoms
+
+- `session_id: ""` forwarded verbatim to server instead of triggering session auto-creation
+- Unknown session IDs returned JSON-RPC error code `-32602` with empty message body
+- Models couldn't determine correct behavior from error — no remediation guidance
+- Delegation workflows blocked by uninformative failures
+
+## Investigation Steps
+
+1. Traced `session_prompt` handler in `harnx-acp/src/manager.rs` — `optional_string` helper returned `Some("")` for empty strings, passing them to server
+2. Checked `get_or_build_session` in `harnx-acp-server/src/lib.rs` — returned `acp::Error::invalid_params()` with no message on unknown session
+3. Confirmed the pattern: both empty strings and sentinel values like `"new"` were treated as lookup keys rather than "omit" signals
+4. Identified same bare error construction in `cancel` path (memory-only lookup, no disk check)
+
+## Root Cause
+
+Two related issues:
+
+1. **Blank-as-content problem**: `optional_string` treated empty strings as meaningful values rather than absent parameters. Models frequently send `session_id: ""` as a "no value" sentinel, but the code interpreted it as a lookup key.
+
+2. **Message-free error problem**: `acp::Error::invalid_params()` returned only the JSON-RPC error code with no explanatory message. The calling model received no context on what went wrong or how to fix it.
+
+Both issues stem from a general principle: LLM-facing tool boundaries need different error-handling semantics than human-facing APIs. Models cannot debug interactively; they need self-contained, actionable error messages.
+
+## Solution
+
+### 1. Blank string normalization
+
+Renamed `optional_string` to `optional_nonblank_string` and added whitespace check:
+
+```rust
+fn optional_nonblank_string<'a>(
+    arguments: &'a serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<&'a str>> {
+    match arguments.get(key) {
+        Some(Value::String(value)) if value.trim().is_empty() => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.as_str())),
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(anyhow!("ACP tool argument '{}' must be a string", key)),
+    }
+}
+```
+
+Empty and whitespace-only strings now map to `None`, triggering `session_new()` auto-creation per the original intent.
+
+### 2. Actionable error message
+
+Added `unknown_session_error` helper in `harnx-acp-server/src/lib.rs`:
+
+```rust
+/// Build the actionable ACP error returned when a caller references a session
+/// ID that isn't in memory or on disk. The message tells the calling model how
+/// to recover (use a real ID or omit it) instead of a bare "Invalid params".
+fn unknown_session_error(session_id: &str) -> acp::Error {
+    acp::Error::new(
+        -32602,
+        format!(
+            "Unknown session ID '{session_id}'. Use a session_id returned by session_new or session_prompt; omit it to start a new session."
+        ),
+    )
+}
+```
+
+Applied in both `cancel` (line 740) and `get_or_build_session` lazy-load (line 764) paths.
+
+### 3. Explicit tool descriptions
+
+Extracted guidance to `SESSION_ID_GUIDANCE` constant to prevent drift:
+
+```rust
+const SESSION_ID_GUIDANCE: &str = "To continue a conversation, pass only the exact session_id returned by session_prompt or session_new. To start a new conversation, omit session_id; empty or whitespace-only values also start a new session. Do not invent a session ID.";
+```
+
+Included in both parameter description and tool description.
+
+### 4. Test coverage
+
+- `test_cancel_unknown_session_errors` — verifies error code `-32602` and exact message for cancel path
+- `test_prompt_unknown_session_errors` — verifies same error for prompt/lazy-load path
+- `optional_nonblank_string_treats_blank_values_as_omitted` — covers empty, whitespace, null, absent, wrong-type cases
+
+## Why This Works
+
+**Blank normalization**: Models often use `""` as a "no value" signal when they don't have an ID to provide. Treating blank/whitespace as absent matches how models actually behave, avoiding a common failure mode without requiring models to explicitly omit the parameter.
+
+**Actionable messages**: JSON-RPC error code `-32602` alone provides nothing the model can act on. Including specific instructions ("Use a session_id returned by...; omit it to start a new session") gives the model a clear recovery path in the next turn. This is essential when the caller cannot interactively debug.
+
+**Constant guidance**: Extracting `SESSION_ID_GUIDANCE` prevents drift between parameter and tool descriptions. When guidance must stay synchronized across multiple strings, a single source of truth eliminates maintenance gaps.
+
+## Prevention Strategies
+
+**When designing LLM-facing tool parameters:**
+
+- Treat blank/whitespace strings as absent for optional ID parameters — models use `""` as a natural "no value" signal
+- Return actionable error messages with specific remediation steps, not just error codes
+- Synchronize guidance text via constants to prevent description drift
+
+**Code review checklist:**
+
+- [ ] Do optional ID params treat `""` as `None`?
+- [ ] Does every JSON-RPC error include a message explaining how to recover?
+- [ ] Are guidance strings consolidated to prevent drift?
+
+**Test coverage:**
+
+- Assert exact error code AND message text for RPC errors
+- Test blank string, whitespace, `null`, and absent key for normalization functions
+- Cover all call sites that construct errors (not just one)
+
+## Related Issues
+
+- **GitHub:** [#1282](https://github.com/dobesv/harnx/issues/1282) — ACP session_prompt empty session_id failure
+- **Related Solution:** [integration-issues/mcp-plans-silent-param-drop-deny-unknown-2026-07-24.md](./mcp-plans-silent-param-drop-deny-unknown-2026-07-24.md) — Parameter handling at tool boundaries
+- **Related Solution:** [logic-errors/xdg-directory-separation-2026-05-03.md](../logic-errors/xdg-directory-separation-2026-05-03.md) — Empty-string guards for env vars


### PR DESCRIPTION
Handle empty or whitespace-only session_id arguments as omitted in harnx-acp manager, automatically starting a new session instead of forwarding blank IDs.

Return an actionable ACP error (-32602) for unknown session IDs during prompt lazy-loading and cancellation in harnx-acp-server instead of a bare "Invalid params".

Clarify session_prompt tool and session_id parameter descriptions using a shared constant that explicitly warns models against inventing session IDs, and add regression tests.

#1282