### PR TITLE
harnx-mcp-bridge

### DIFF
--- a/.changeset/nats-mcp-bridge.md
+++ b/.changeset/nats-mcp-bridge.md
@@ -1,0 +1,5 @@
+---
+harnx: minor
+---
+
+feat(nats): add `harnx-mcp-bridge`, a generic MCP→NATS bridge that wraps any stdio MCP server and re-exposes its tools over NATS. Migrate the `plans` tool server to run over NATS via the bridge; the `harnx-mcp-plans` binary still works standalone as an MCP server (`--mcp-stdio`) for external MCP clients. References #1224.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3910,6 +3910,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "harnx-mcp-bridge"
+version = "0.33.4"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "async-trait",
+ "clap",
+ "harnx-core",
+ "harnx-toolset",
+ "harnx-toolset-server",
+ "libc",
+ "log",
+ "process-wrap",
+ "rmcp",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "which",
+]
+
+[[package]]
 name = "harnx-mcp-fs"
 version = "0.33.4"
 dependencies = [
@@ -3971,6 +3993,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "similar 3.1.1",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/harnx-hooks",
     "crates/harnx-mcp",
     "crates/harnx-mcp-bash",
+    "crates/harnx-mcp-bridge",
     "crates/harnx-sandbox-common",
     "crates/harnx-sandbox-run",
     "crates/harnx-mcp-hooks-proxy",

--- a/crates/harnx-mcp-bridge/Cargo.toml
+++ b/crates/harnx-mcp-bridge/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "harnx-mcp-bridge"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Generic MCP to NATS toolset bridge"
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+clap = { workspace = true }
+harnx-core = { path = "../harnx-core" }
+harnx-toolset = { path = "../harnx-toolset" }
+harnx-toolset-server = { path = "../harnx-toolset-server" }
+libc = { workspace = true }
+log = { workspace = true }
+process-wrap = { workspace = true }
+rmcp = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+
+[dev-dependencies]
+async-nats = { workspace = true }
+tempfile = { workspace = true }
+which = { workspace = true }
+
+[[bin]]
+name = "harnx-mcp-bridge"
+path = "src/main.rs"

--- a/crates/harnx-mcp-bridge/src/lib.rs
+++ b/crates/harnx-mcp-bridge/src/lib.rs
@@ -21,7 +21,7 @@ use rmcp::model::{
 use rmcp::service::{Peer, RequestContext, RoleClient, ServiceError};
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Command;
+use tokio::process::{ChildStderr, ChildStdin, ChildStdout, Command};
 use tokio_util::sync::CancellationToken;
 
 const STDERR_TAIL_LINES: usize = 50;
@@ -29,6 +29,12 @@ const INITIALIZE_TIMEOUT: Duration = Duration::from_secs(30);
 const LIST_TOOLS_TIMEOUT: Duration = Duration::from_secs(10);
 
 type StderrTail = Arc<Mutex<VecDeque<String>>>;
+type SpawnedChild = (
+    Box<dyn ChildWrapper>,
+    ChildStdin,
+    ChildStdout,
+    Option<ChildStderr>,
+);
 
 /// Command-line arguments for the MCP-to-NATS bridge.
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
@@ -70,6 +76,122 @@ pub struct BridgeToolset {
     stderr_tail: StderrTail,
 }
 
+fn spawn_child(server_name: &str, program: &str, args: &[String]) -> anyhow::Result<SpawnedChild> {
+    let mut command = Command::new(program);
+    command
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    configure_child_process(&mut command);
+
+    // A separate process group prevents terminal SIGINT from reaching the child.
+    #[allow(unused_mut)]
+    let mut wrap = CommandWrap::from(command);
+    #[cfg(unix)]
+    wrap.wrap(ProcessGroup::leader());
+
+    let mut child = wrap
+        .spawn()
+        .with_context(|| format!("Failed to spawn MCP server '{server_name}'"))?;
+    let stdin = child
+        .stdin()
+        .take()
+        .ok_or_else(|| anyhow!("MCP server '{server_name}' stdin not piped"))?;
+    let stdout = child
+        .stdout()
+        .take()
+        .ok_or_else(|| anyhow!("MCP server '{server_name}' stdout not piped"))?;
+    let stderr = child.stderr().take();
+    Ok((child, stdin, stdout, stderr))
+}
+
+fn spawn_stderr_reader(server_name: &str, stderr: Option<ChildStderr>) -> StderrTail {
+    let stderr_tail = Arc::new(Mutex::new(VecDeque::with_capacity(STDERR_TAIL_LINES)));
+    if let Some(stderr) = stderr {
+        let reader_server_name = server_name.to_owned();
+        let reader_tail = Arc::clone(&stderr_tail);
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                log::debug!("[mcp:{reader_server_name}] {line}");
+                let mut tail = reader_tail.lock().unwrap_or_else(|err| err.into_inner());
+                if tail.len() == STDERR_TAIL_LINES {
+                    tail.pop_front();
+                }
+                tail.push_back(line);
+            }
+        });
+    }
+    stderr_tail
+}
+
+async fn connect_and_list_tools(
+    server_name: &str,
+    stdin: ChildStdin,
+    stdout: ChildStdout,
+    stderr_tail: &StderrTail,
+) -> anyhow::Result<(
+    rmcp::service::RunningService<RoleClient, BridgeClientHandler>,
+    Vec<ToolSpec>,
+)> {
+    let transport =
+        rmcp::transport::async_rw::AsyncRwTransport::<RoleClient, _, _>::new(stdout, stdin);
+    let service = match tokio::time::timeout(
+        INITIALIZE_TIMEOUT,
+        rmcp::service::serve_client(BridgeClientHandler, transport),
+    )
+    .await
+    {
+        Err(_) => bail!(
+            "MCP server '{}' timed out during initialization (30s){}",
+            server_name,
+            render_stderr_tail(stderr_tail)
+        ),
+        Ok(Err(err)) => {
+            return Err(anyhow::Error::from(err)).with_context(|| {
+                format!(
+                    "Failed to initialize MCP client for server '{}'{}",
+                    server_name,
+                    render_stderr_tail(stderr_tail)
+                )
+            });
+        }
+        Ok(Ok(service)) => service,
+    };
+
+    let listed = match tokio::time::timeout(
+        LIST_TOOLS_TIMEOUT,
+        service.peer().list_tools(Default::default()),
+    )
+    .await
+    {
+        Err(_) => bail!(
+            "MCP server '{}' timed out listing tools (10s){}",
+            server_name,
+            render_stderr_tail(stderr_tail)
+        ),
+        Ok(Err(err)) => {
+            return Err(anyhow::Error::from(err)).with_context(|| {
+                format!(
+                    "Failed to list tools for MCP server '{}'{}",
+                    server_name,
+                    render_stderr_tail(stderr_tail)
+                )
+            });
+        }
+        Ok(Ok(result)) => result,
+    };
+    let cached_tools = listed
+        .tools
+        .into_iter()
+        .map(|tool| map_tool(server_name, tool))
+        .collect();
+
+    Ok((service, cached_tools))
+}
+
 impl BridgeToolset {
     /// Spawns a stdio MCP server, initializes its client connection, and lists tools once.
     pub async fn new(
@@ -80,105 +202,11 @@ impl BridgeToolset {
         let (program, args) = child_argv
             .split_first()
             .ok_or_else(|| anyhow!("MCP server '{}' command is empty", server_name))?;
+        let (child, stdin, stdout, stderr) = spawn_child(&server_name, program, args)?;
+        let stderr_tail = spawn_stderr_reader(&server_name, stderr);
+        let (service, cached_tools) =
+            connect_and_list_tools(&server_name, stdin, stdout, &stderr_tail).await?;
 
-        let mut command = Command::new(program);
-        command
-            .args(args)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true);
-        configure_child_process(&mut command);
-
-        // A separate process group prevents terminal SIGINT from reaching the child.
-        #[allow(unused_mut)]
-        let mut wrap = CommandWrap::from(command);
-        #[cfg(unix)]
-        wrap.wrap(ProcessGroup::leader());
-
-        let mut child = wrap
-            .spawn()
-            .with_context(|| format!("Failed to spawn MCP server '{server_name}'"))?;
-        let stdin = child
-            .stdin()
-            .take()
-            .ok_or_else(|| anyhow!("MCP server '{server_name}' stdin not piped"))?;
-        let stdout = child
-            .stdout()
-            .take()
-            .ok_or_else(|| anyhow!("MCP server '{server_name}' stdout not piped"))?;
-        let stderr = child.stderr().take();
-
-        let stderr_tail = Arc::new(Mutex::new(VecDeque::with_capacity(STDERR_TAIL_LINES)));
-        if let Some(stderr) = stderr {
-            let reader_server_name = server_name.clone();
-            let reader_tail = Arc::clone(&stderr_tail);
-            tokio::spawn(async move {
-                let mut lines = BufReader::new(stderr).lines();
-                while let Ok(Some(line)) = lines.next_line().await {
-                    log::debug!("[mcp:{reader_server_name}] {line}");
-                    let mut tail = reader_tail.lock().unwrap_or_else(|err| err.into_inner());
-                    if tail.len() == STDERR_TAIL_LINES {
-                        tail.pop_front();
-                    }
-                    tail.push_back(line);
-                }
-            });
-        }
-
-        let transport =
-            rmcp::transport::async_rw::AsyncRwTransport::<RoleClient, _, _>::new(stdout, stdin);
-        let service = match tokio::time::timeout(
-            INITIALIZE_TIMEOUT,
-            rmcp::service::serve_client(BridgeClientHandler, transport),
-        )
-        .await
-        {
-            Err(_) => bail!(
-                "MCP server '{}' timed out during initialization (30s){}",
-                server_name,
-                render_stderr_tail(&stderr_tail)
-            ),
-            Ok(Err(err)) => {
-                return Err(anyhow::Error::from(err)).with_context(|| {
-                    format!(
-                        "Failed to initialize MCP client for server '{}'{}",
-                        server_name,
-                        render_stderr_tail(&stderr_tail)
-                    )
-                });
-            }
-            Ok(Ok(service)) => service,
-        };
-
-        let listed = match tokio::time::timeout(
-            LIST_TOOLS_TIMEOUT,
-            service.peer().list_tools(Default::default()),
-        )
-        .await
-        {
-            Err(_) => bail!(
-                "MCP server '{}' timed out listing tools (10s){}",
-                server_name,
-                render_stderr_tail(&stderr_tail)
-            ),
-            Ok(Err(err)) => {
-                return Err(anyhow::Error::from(err)).with_context(|| {
-                    format!(
-                        "Failed to list tools for MCP server '{}'{}",
-                        server_name,
-                        render_stderr_tail(&stderr_tail)
-                    )
-                });
-            }
-            Ok(Ok(result)) => result,
-        };
-
-        let cached_tools = listed
-            .tools
-            .into_iter()
-            .map(|tool| map_tool(&server_name, tool))
-            .collect();
         let peer = service.peer().clone();
         let child_died = CancellationToken::new();
         let watch_token = child_died.clone();

--- a/crates/harnx-mcp-bridge/src/lib.rs
+++ b/crates/harnx-mcp-bridge/src/lib.rs
@@ -1,0 +1,577 @@
+// rmcp deprecated MCP Roots (SEP-2577); bridge still returns method_not_found.
+#![allow(deprecated)]
+
+use std::collections::VecDeque;
+use std::process::Stdio;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context};
+use async_trait::async_trait;
+use clap::Parser;
+use harnx_toolset::{ToolInvokeError, ToolSpec, Toolset};
+#[cfg(unix)]
+use process_wrap::tokio::ProcessGroup;
+use process_wrap::tokio::{ChildWrapper, CommandWrap};
+use rmcp::handler::client::ClientHandler;
+use rmcp::model::{
+    CallToolRequestParams, ClientCapabilities, ErrorData, Implementation, InitializeRequestParams,
+    ListRootsResult, Tool,
+};
+use rmcp::service::{Peer, RequestContext, RoleClient, ServiceError};
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio_util::sync::CancellationToken;
+
+const STDERR_TAIL_LINES: usize = 50;
+const INITIALIZE_TIMEOUT: Duration = Duration::from_secs(30);
+const LIST_TOOLS_TIMEOUT: Duration = Duration::from_secs(10);
+
+type StderrTail = Arc<Mutex<VecDeque<String>>>;
+
+/// Command-line arguments for the MCP-to-NATS bridge.
+#[derive(Debug, Clone, PartialEq, Eq, Parser)]
+#[command(trailing_var_arg = true)]
+pub struct Args {
+    /// Server name used for registration and tool-name prefixes.
+    #[arg(long)]
+    pub name: String,
+
+    /// Wrapped MCP command followed by its arguments.
+    #[arg(required = true, allow_hyphen_values = true)]
+    pub child: Vec<String>,
+}
+
+impl Args {
+    /// Parses bridge arguments from the process command line.
+    pub fn parse() -> Self {
+        <Self as Parser>::parse()
+    }
+
+    /// Parses bridge arguments from an argument iterator.
+    pub fn parse_from<I, T>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<std::ffi::OsString> + Clone,
+    {
+        <Self as Parser>::parse_from(iter)
+    }
+}
+
+/// Connected stdio MCP server and its tool metadata cached at startup.
+pub struct BridgeToolset {
+    server_name: String,
+    cached_tools: Vec<ToolSpec>,
+    peer: Peer<RoleClient>,
+    child_died: CancellationToken,
+    _service_watch: tokio::task::JoinHandle<()>,
+    _child: Box<dyn ChildWrapper>,
+    stderr_tail: StderrTail,
+}
+
+impl BridgeToolset {
+    /// Spawns a stdio MCP server, initializes its client connection, and lists tools once.
+    pub async fn new(
+        server_name: impl Into<String>,
+        child_argv: Vec<String>,
+    ) -> anyhow::Result<Self> {
+        let server_name = server_name.into();
+        let (program, args) = child_argv
+            .split_first()
+            .ok_or_else(|| anyhow!("MCP server '{}' command is empty", server_name))?;
+
+        let mut command = Command::new(program);
+        command
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        configure_child_process(&mut command);
+
+        // A separate process group prevents terminal SIGINT from reaching the child.
+        #[allow(unused_mut)]
+        let mut wrap = CommandWrap::from(command);
+        #[cfg(unix)]
+        wrap.wrap(ProcessGroup::leader());
+
+        let mut child = wrap
+            .spawn()
+            .with_context(|| format!("Failed to spawn MCP server '{server_name}'"))?;
+        let stdin = child
+            .stdin()
+            .take()
+            .ok_or_else(|| anyhow!("MCP server '{server_name}' stdin not piped"))?;
+        let stdout = child
+            .stdout()
+            .take()
+            .ok_or_else(|| anyhow!("MCP server '{server_name}' stdout not piped"))?;
+        let stderr = child.stderr().take();
+
+        let stderr_tail = Arc::new(Mutex::new(VecDeque::with_capacity(STDERR_TAIL_LINES)));
+        if let Some(stderr) = stderr {
+            let reader_server_name = server_name.clone();
+            let reader_tail = Arc::clone(&stderr_tail);
+            tokio::spawn(async move {
+                let mut lines = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    log::debug!("[mcp:{reader_server_name}] {line}");
+                    let mut tail = reader_tail.lock().unwrap_or_else(|err| err.into_inner());
+                    if tail.len() == STDERR_TAIL_LINES {
+                        tail.pop_front();
+                    }
+                    tail.push_back(line);
+                }
+            });
+        }
+
+        let transport =
+            rmcp::transport::async_rw::AsyncRwTransport::<RoleClient, _, _>::new(stdout, stdin);
+        let service = match tokio::time::timeout(
+            INITIALIZE_TIMEOUT,
+            rmcp::service::serve_client(BridgeClientHandler, transport),
+        )
+        .await
+        {
+            Err(_) => bail!(
+                "MCP server '{}' timed out during initialization (30s){}",
+                server_name,
+                render_stderr_tail(&stderr_tail)
+            ),
+            Ok(Err(err)) => {
+                return Err(anyhow::Error::from(err)).with_context(|| {
+                    format!(
+                        "Failed to initialize MCP client for server '{}'{}",
+                        server_name,
+                        render_stderr_tail(&stderr_tail)
+                    )
+                });
+            }
+            Ok(Ok(service)) => service,
+        };
+
+        let listed = match tokio::time::timeout(
+            LIST_TOOLS_TIMEOUT,
+            service.peer().list_tools(Default::default()),
+        )
+        .await
+        {
+            Err(_) => bail!(
+                "MCP server '{}' timed out listing tools (10s){}",
+                server_name,
+                render_stderr_tail(&stderr_tail)
+            ),
+            Ok(Err(err)) => {
+                return Err(anyhow::Error::from(err)).with_context(|| {
+                    format!(
+                        "Failed to list tools for MCP server '{}'{}",
+                        server_name,
+                        render_stderr_tail(&stderr_tail)
+                    )
+                });
+            }
+            Ok(Ok(result)) => result,
+        };
+
+        let cached_tools = listed
+            .tools
+            .into_iter()
+            .map(|tool| map_tool(&server_name, tool))
+            .collect();
+        let peer = service.peer().clone();
+        let child_died = CancellationToken::new();
+        let watch_token = child_died.clone();
+        let watch_name = server_name.clone();
+        let watch_stderr = Arc::clone(&stderr_tail);
+        // RunningService owns the transport loop, so its completion reports child stdio closure
+        // without moving the process handle needed for kill_on_drop out of BridgeToolset.
+        let service_watch = tokio::spawn(async move {
+            let reason = service.waiting().await;
+            log::warn!(
+                "MCP server '{watch_name}' connection closed ({reason:?}){}",
+                render_stderr_tail(&watch_stderr)
+            );
+            watch_token.cancel();
+        });
+
+        Ok(Self {
+            server_name,
+            cached_tools,
+            peer,
+            child_died,
+            _service_watch: service_watch,
+            _child: child,
+            stderr_tail,
+        })
+    }
+
+    /// Server name used to prefix cached tool names.
+    pub fn server_name(&self) -> &str {
+        &self.server_name
+    }
+
+    /// Tool metadata returned by the child's initial tools/list response.
+    pub fn cached_tools(&self) -> &[ToolSpec] {
+        &self.cached_tools
+    }
+
+    /// Client peer connected to the wrapped MCP server.
+    pub fn peer(&self) -> &Peer<RoleClient> {
+        &self.peer
+    }
+
+    /// Current bounded tail of child stderr, oldest line first.
+    pub fn stderr_tail(&self) -> Vec<String> {
+        self.stderr_tail
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Process ID of the wrapped MCP server, when available.
+    pub fn child_id(&self) -> Option<u32> {
+        self._child.id()
+    }
+
+    /// Token cancelled when the wrapped server's MCP transport closes.
+    pub fn child_died_token(&self) -> CancellationToken {
+        self.child_died.clone()
+    }
+}
+
+#[async_trait]
+impl Toolset for BridgeToolset {
+    fn name(&self) -> &str {
+        &self.server_name
+    }
+
+    fn tools(&self) -> Vec<ToolSpec> {
+        self.cached_tools.clone()
+    }
+
+    async fn invoke(
+        &self,
+        tool: &str,
+        args: Value,
+        cancel: CancellationToken,
+    ) -> Result<Value, ToolInvokeError> {
+        let prefix = format!("{}_", self.server_name);
+        let mcp_tool = tool
+            .strip_prefix(&prefix)
+            .ok_or_else(|| ToolInvokeError::Recoverable(format!("bad tool name {tool}")))?;
+        let arguments = match args {
+            Value::Object(arguments) => Some(arguments),
+            Value::Null => None,
+            _ => {
+                return Err(ToolInvokeError::Recoverable(
+                    "MCP tool arguments must be a JSON object or null".into(),
+                ));
+            }
+        };
+        let mut params = CallToolRequestParams::new(mcp_tool.to_owned());
+        if let Some(arguments) = arguments {
+            params = params.with_arguments(arguments);
+        }
+
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {
+                Err(ToolInvokeError::Recoverable("call cancelled".into()))
+            }
+            result = self.peer.call_tool(params) => match result {
+                Ok(result) => serde_json::to_value(result)
+                    .map_err(|err| ToolInvokeError::Fatal(err.to_string())),
+                Err(ServiceError::TransportClosed | ServiceError::TransportSend(_)) => {
+                    Err(ToolInvokeError::Fatal(format!(
+                        "MCP server '{}' exited during call",
+                        self.server_name
+                    )))
+                }
+                Err(err) => Err(ToolInvokeError::Recoverable(err.to_string())),
+            },
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn configure_child_process(command: &mut Command) {
+    let parent_pid = std::process::id() as libc::pid_t;
+    // SAFETY: pre_exec invokes only async-signal-safe libc calls. ProcessGroup configures setpgid.
+    unsafe {
+        command.pre_exec(move || {
+            if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::getppid() != parent_pid {
+                libc::raise(libc::SIGTERM);
+            }
+            Ok(())
+        });
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn configure_child_process(_command: &mut Command) {}
+
+fn map_tool(server_name: &str, tool: Tool) -> ToolSpec {
+    let annotations = tool.annotations.as_ref();
+    ToolSpec {
+        name: format!("{server_name}_{}", tool.name),
+        description: tool
+            .description
+            .map_or_else(String::new, |value| value.into_owned()),
+        input_schema: Value::Object((*tool.input_schema).clone()),
+        idempotent_hint: annotations
+            .and_then(|value| value.idempotent_hint)
+            .unwrap_or(false),
+        read_only_hint: annotations
+            .and_then(|value| value.read_only_hint)
+            .unwrap_or(false),
+        timeout_secs: None,
+    }
+}
+
+fn render_stderr_tail(stderr_tail: &StderrTail) -> String {
+    let tail = stderr_tail.lock().unwrap_or_else(|err| err.into_inner());
+    if tail.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "\nChild stderr tail:\n{}",
+            tail.iter().cloned().collect::<Vec<_>>().join("\n")
+        )
+    }
+}
+
+/// Client handler for wrapped servers. S1 doesn't expose roots to children.
+pub struct BridgeClientHandler;
+
+impl ClientHandler for BridgeClientHandler {
+    fn get_info(&self) -> InitializeRequestParams {
+        InitializeRequestParams::new(
+            ClientCapabilities::default(),
+            Implementation::new("harnx-mcp-bridge", env!("CARGO_PKG_VERSION")),
+        )
+    }
+
+    async fn list_roots(
+        &self,
+        _context: RequestContext<RoleClient>,
+    ) -> Result<ListRootsResult, ErrorData> {
+        Err(ErrorData::method_not_found::<
+            rmcp::model::ListRootsRequestMethod,
+        >())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Args, BridgeToolset};
+
+    #[test]
+    fn arg_parses_child_command_and_flags_after_separator() {
+        let args = Args::parse_from([
+            "harnx-mcp-bridge",
+            "--name",
+            "plans",
+            "--",
+            "harnx-mcp-plans",
+            "--mcp-stdio",
+            "--dir",
+            ".agent/plans",
+        ]);
+
+        assert_eq!(args.name, "plans");
+        assert_eq!(
+            args.child,
+            ["harnx-mcp-plans", "--mcp-stdio", "--dir", ".agent/plans"]
+        );
+    }
+
+    #[test]
+    fn arg_parses_child_command_without_child_arguments() {
+        let args = Args::parse_from([
+            "harnx-mcp-bridge",
+            "--name",
+            "plans",
+            "--",
+            "harnx-mcp-plans",
+        ]);
+
+        assert_eq!(args.name, "plans");
+        assert_eq!(args.child, ["harnx-mcp-plans"]);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn caches_prefixed_plans_tool_specs() {
+        let plans_dir = tempfile::tempdir().expect("create temporary plans directory");
+        let plans_binary = option_env!("CARGO_BIN_EXE_harnx-mcp-plans")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| {
+                let mut path = std::env::current_exe().expect("locate current test executable");
+                path.pop();
+                if path.ends_with("deps") {
+                    path.pop();
+                }
+                path.join("harnx-mcp-plans")
+            });
+        assert!(
+            plans_binary.is_file(),
+            "harnx-mcp-plans binary missing at {}; build it before this test",
+            plans_binary.display()
+        );
+        let bridge = BridgeToolset::new(
+            "plans",
+            vec![
+                plans_binary.display().to_string(),
+                "--mcp-stdio".to_owned(),
+                "--dir".to_owned(),
+                plans_dir.path().display().to_string(),
+            ],
+        )
+        .await
+        .expect("connect to plans MCP server");
+
+        assert_eq!(bridge.cached_tools().len(), 15);
+        assert!(bridge.cached_tools().iter().all(|tool| {
+            tool.name.starts_with("plans_")
+                && tool
+                    .input_schema
+                    .as_object()
+                    .is_some_and(|schema| !schema.is_empty())
+        }));
+    }
+
+    #[cfg(unix)]
+    fn plans_command(dir: &std::path::Path) -> Vec<String> {
+        let plans_binary = option_env!("CARGO_BIN_EXE_harnx-mcp-plans")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| {
+                let mut path = std::env::current_exe().expect("locate current test executable");
+                path.pop();
+                if path.ends_with("deps") {
+                    path.pop();
+                }
+                path.join("harnx-mcp-plans")
+            });
+        assert!(
+            plans_binary.is_file(),
+            "harnx-mcp-plans binary missing at {}; build it before this test",
+            plans_binary.display()
+        );
+        vec![
+            plans_binary.display().to_string(),
+            "--mcp-stdio".to_owned(),
+            "--dir".to_owned(),
+            dir.display().to_string(),
+        ]
+    }
+
+    #[cfg(unix)]
+    fn process_exists(pid: u32) -> bool {
+        // SAFETY: signal 0 only checks whether the process exists.
+        let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        result == 0 || std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dropping_bridge_terminates_child() {
+        let plans_dir = tempfile::tempdir().expect("create temporary plans directory");
+        let bridge = BridgeToolset::new("plans", plans_command(plans_dir.path()))
+            .await
+            .expect("connect to plans MCP server");
+        let pid = bridge.child_id().expect("child process ID");
+
+        drop(bridge);
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while process_exists(pid) {
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("child should exit after bridge drop");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn child_death_cancels_token() {
+        let plans_dir = tempfile::tempdir().expect("create temporary plans directory");
+        let bridge = BridgeToolset::new("plans", plans_command(plans_dir.path()))
+            .await
+            .expect("connect to plans MCP server");
+        let pid = bridge.child_id().expect("child process ID");
+        let child_died = bridge.child_died_token();
+
+        // SAFETY: pid belongs to the child held by bridge.
+        assert_eq!(unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) }, 0);
+        tokio::time::timeout(std::time::Duration::from_secs(5), child_died.cancelled())
+            .await
+            .expect("child death token should fire");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn invokes_child_tools_and_validates_name_and_cancellation() {
+        use harnx_toolset::{ToolInvokeError, Toolset};
+        use tokio_util::sync::CancellationToken;
+
+        let plans_dir = tempfile::tempdir().expect("create temporary plans directory");
+        let bridge = BridgeToolset::new("plans", plans_command(plans_dir.path()))
+            .await
+            .expect("connect to plans MCP server");
+
+        let result = bridge
+            .invoke(
+                "plans_list_plans",
+                serde_json::json!({}),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("invoke plans list_plans");
+        assert!(result
+            .get("content")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|content| !content.is_empty()));
+
+        let bad_name = bridge
+            .invoke(
+                "wrongname_foo",
+                serde_json::json!({}),
+                CancellationToken::new(),
+            )
+            .await;
+        assert!(matches!(
+            bad_name,
+            Err(ToolInvokeError::Recoverable(message)) if message == "bad tool name wrongname_foo"
+        ));
+
+        let bad_arguments = bridge
+            .invoke(
+                "plans_list_plans",
+                serde_json::json!([]),
+                CancellationToken::new(),
+            )
+            .await;
+        assert!(matches!(
+            bad_arguments,
+            Err(ToolInvokeError::Recoverable(message))
+                if message == "MCP tool arguments must be a JSON object or null"
+        ));
+
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let cancelled = bridge
+            .invoke("plans_list_plans", serde_json::json!({}), cancel)
+            .await;
+        assert!(matches!(
+            cancelled,
+            Err(ToolInvokeError::Recoverable(message)) if message == "call cancelled"
+        ));
+    }
+}

--- a/crates/harnx-mcp-bridge/src/lib.rs
+++ b/crates/harnx-mcp-bridge/src/lib.rs
@@ -397,7 +397,9 @@ impl ClientHandler for BridgeClientHandler {
 
 #[cfg(test)]
 mod tests {
-    use super::{Args, BridgeToolset};
+    use super::Args;
+    #[cfg(unix)]
+    use super::BridgeToolset;
 
     #[test]
     fn arg_parses_child_command_and_flags_after_separator() {

--- a/crates/harnx-mcp-bridge/src/main.rs
+++ b/crates/harnx-mcp-bridge/src/main.rs
@@ -1,0 +1,23 @@
+use anyhow::Context;
+use harnx_core::instance::{InstanceId, HARNX_INSTANCE_ID};
+use harnx_mcp_bridge::{Args, BridgeToolset};
+use harnx_toolset_server::serve_over_nats;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let bridge = BridgeToolset::new(args.name, args.child).await?;
+    let child_died = bridge.child_died_token();
+    let instance_id = std::env::var(HARNX_INSTANCE_ID)
+        .with_context(|| format!("{HARNX_INSTANCE_ID} is required"))?;
+    let nats_url = std::env::var("HARNX_NATS_URL").context("HARNX_NATS_URL is required")?;
+    let token = std::env::var("HARNX_NATS_TOKEN").context("HARNX_NATS_TOKEN is required")?;
+
+    tokio::select! {
+        result = serve_over_nats(bridge, InstanceId::from_string(instance_id), &nats_url, &token) => result,
+        _ = child_died.cancelled() => {
+            log::warn!("wrapped MCP child exited; shutting down bridge");
+            anyhow::bail!("wrapped MCP child exited")
+        }
+    }
+}

--- a/crates/harnx-mcp-bridge/tests/bridge_roundtrip.rs
+++ b/crates/harnx-mcp-bridge/tests/bridge_roundtrip.rs
@@ -1,0 +1,327 @@
+#![cfg(unix)]
+
+use anyhow::{Context, Result};
+use harnx_core::instance::InstanceId;
+use harnx_mcp_bridge::BridgeToolset;
+use harnx_toolset::{Registration, ToolReply, ToolRequest, HDR_CALL_ID, HDR_IDEMPOTENCY_KEY};
+use harnx_toolset_server::{
+    registration_key, serve_over_nats, TOOL_REGISTRY_BUCKET, TOOL_SCHEMA_VERSION,
+};
+use serde_json::json;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+const TOKEN: &str = "mcp-bridge-roundtrip-token";
+
+struct NatsServerHandle {
+    url: String,
+    _store_dir: TempDir,
+    child: Child,
+}
+
+impl Drop for NatsServerHandle {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn nats_server_binary() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("NATS_SERVER_BIN") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    which::which("nats-server").ok()
+}
+
+async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
+    let Some(binary) = nats_server_binary() else {
+        eprintln!("skipping NATS integration test: nats-server binary not found");
+        return Ok(None);
+    };
+
+    let mut last_error = None;
+    for _ in 0..5 {
+        match try_spawn_nats_server(&binary).await {
+            Ok(server) => return Ok(Some(server)),
+            Err(error) => last_error = Some(error),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| anyhow::anyhow!("failed to spawn nats-server")))
+}
+
+async fn try_spawn_nats_server(binary: &Path) -> Result<NatsServerHandle> {
+    let listener = TcpListener::bind("127.0.0.1:0").context("allocate NATS test port")?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+
+    let store_dir = tempfile::tempdir().context("create NATS test store")?;
+    let mut child = Command::new(binary)
+        .arg("-js")
+        .arg("-sd")
+        .arg(store_dir.path())
+        .arg("-p")
+        .arg(port.to_string())
+        .arg("--auth")
+        .arg(TOKEN)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("spawn {}", binary.display()))?;
+    let url = format!("nats://127.0.0.1:{port}");
+
+    if let Err(error) = wait_for_nats_ready(&url).await {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
+    Ok(NatsServerHandle {
+        url,
+        _store_dir: store_dir,
+        child,
+    })
+}
+
+async fn wait_for_nats_ready(url: &str) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let connection = tokio::time::timeout(
+            Duration::from_secs(1),
+            async_nats::ConnectOptions::new()
+                .token(TOKEN.to_string())
+                .connect(url),
+        )
+        .await;
+        match connection {
+            Ok(Ok(client)) => return client.flush().await.context("flush NATS test client"),
+            Ok(Err(_)) | Err(_) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            Ok(Err(error)) => return Err(error).context("wait for nats-server readiness"),
+            Err(_) => anyhow::bail!("timed out waiting for nats-server readiness"),
+        }
+    }
+}
+
+fn plans_binary() -> Result<PathBuf> {
+    // Cargo's compile-time binary path is preferred. Cross-crate test builds don't always set it,
+    // so the fallback resolves the sibling binary next to the test executable's deps directory.
+    let (path, mechanism) = if let Some(path) = option_env!("CARGO_BIN_EXE_harnx-mcp-plans") {
+        (PathBuf::from(path), "CARGO_BIN_EXE_harnx-mcp-plans")
+    } else {
+        let mut path = std::env::current_exe().context("locate current test executable")?;
+        path.pop();
+        if path.ends_with("deps") {
+            path.pop();
+        }
+        (path.join("harnx-mcp-plans"), "test executable sibling")
+    };
+    anyhow::ensure!(
+        path.is_file(),
+        "harnx-mcp-plans binary missing at {} (resolved via {mechanism})",
+        path.display()
+    );
+    eprintln!(
+        "resolved harnx-mcp-plans via {mechanism}: {}",
+        path.display()
+    );
+    Ok(path)
+}
+
+async fn wait_for_registration(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+) -> Result<Registration> {
+    let jetstream = async_nats::jetstream::new(client.clone());
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(store) = jetstream.get_key_value(TOOL_REGISTRY_BUCKET).await {
+            if let Some(value) = store.get(registration_key(instance_id, "plans")).await? {
+                return serde_json::from_slice(&value).context("decode plans registration");
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("timed out waiting for plans tool registration");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn bridge_registers_plans_and_round_trips_an_invoke() -> Result<()> {
+    let Some(server) = spawn_nats_server().await? else {
+        return Ok(());
+    };
+    let plans_dir = tempfile::tempdir().context("create temporary plans directory")?;
+    let bridge = BridgeToolset::new(
+        "plans",
+        vec![
+            plans_binary()?.display().to_string(),
+            "--mcp-stdio".to_owned(),
+            "--dir".to_owned(),
+            plans_dir.path().display().to_string(),
+        ],
+    )
+    .await?;
+    let instance_id = InstanceId::new();
+    let server_instance_id = instance_id.clone();
+    let nats_url = server.url.clone();
+    let server_task =
+        tokio::spawn(
+            async move { serve_over_nats(bridge, server_instance_id, &nats_url, TOKEN).await },
+        );
+
+    let client = async_nats::ConnectOptions::new()
+        .token(TOKEN.to_string())
+        .connect(&server.url)
+        .await?;
+    let registration = wait_for_registration(&client, &instance_id).await?;
+    assert_eq!(registration.server, "plans");
+    assert_eq!(registration.schema_version, TOOL_SCHEMA_VERSION);
+    assert_eq!(registration.tools.len(), 15);
+    assert!(registration
+        .tools
+        .iter()
+        .all(|tool| tool.name.starts_with("plans_")));
+
+    let call_id = "bridge-plans-list";
+    let request = ToolRequest {
+        call_id: call_id.to_owned(),
+        tool: "plans_list_plans".to_owned(),
+        args: json!({}),
+    };
+    let mut headers = async_nats::HeaderMap::new();
+    headers.insert(HDR_CALL_ID, call_id);
+    headers.insert(HDR_IDEMPOTENCY_KEY, "bridge-plans-list-idempotency");
+    let message = client
+        .request_with_headers(
+            instance_id.tool_subject("plans", "plans_list_plans"),
+            headers,
+            serde_json::to_vec(&request)?.into(),
+        )
+        .await?;
+    let reply: ToolReply = serde_json::from_slice(&message.payload)?;
+    assert_eq!(reply.call_id, call_id);
+    let value = reply.result.expect("plans_list_plans should succeed");
+    assert!(value.is_object());
+    assert!(value
+        .get("content")
+        .is_some_and(|content| content.is_array()));
+
+    server_task.abort();
+    let _ = server_task.await;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn direct_child_pid(parent_pid: u32) -> Result<u32> {
+    // /proc avoids depending on pgrep in minimal Linux test environments.
+    for entry in std::fs::read_dir("/proc").context("scan /proc for bridge child")? {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        let status = match std::fs::read_to_string(entry.path().join("status")) {
+            Ok(status) => status,
+            Err(_) => continue,
+        };
+        let is_child = status.lines().any(|line| {
+            line.strip_prefix("PPid:")
+                .and_then(|value| value.trim().parse::<u32>().ok())
+                == Some(parent_pid)
+        });
+        if is_child {
+            return Ok(pid);
+        }
+    }
+    anyhow::bail!("no direct child found for bridge process {parent_pid}")
+}
+
+#[cfg(not(target_os = "linux"))]
+fn direct_child_pid(parent_pid: u32) -> Result<u32> {
+    // pgrep -P is available on the BSD and macOS Unix hosts covered by this test.
+    let output = Command::new("pgrep")
+        .arg("-P")
+        .arg(parent_pid.to_string())
+        .output()
+        .context("run pgrep to find bridge child")?;
+    anyhow::ensure!(
+        output.status.success(),
+        "pgrep found no direct child for bridge process {parent_pid}"
+    );
+    let stdout = String::from_utf8(output.stdout).context("decode pgrep output")?;
+    stdout
+        .lines()
+        .next()
+        .context("pgrep returned empty output")?
+        .trim()
+        .parse()
+        .context("parse bridge child process ID")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn bridge_binary_exits_when_wrapped_child_dies() -> Result<()> {
+    let Some(server) = spawn_nats_server().await? else {
+        return Ok(());
+    };
+    let plans_dir = tempfile::tempdir().context("create temporary plans directory")?;
+    let instance_id = InstanceId::new();
+    let mut bridge = tokio::process::Command::new(env!("CARGO_BIN_EXE_harnx-mcp-bridge"));
+    bridge
+        .arg("--name")
+        .arg("plans")
+        .arg("--")
+        .arg(plans_binary()?)
+        .arg("--mcp-stdio")
+        .arg("--dir")
+        .arg(plans_dir.path())
+        .env("HARNX_INSTANCE_ID", instance_id.as_str())
+        .env("HARNX_NATS_URL", &server.url)
+        .env("HARNX_NATS_TOKEN", TOKEN)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .kill_on_drop(true);
+    let mut bridge = bridge.spawn().context("spawn harnx-mcp-bridge binary")?;
+    let bridge_pid = bridge.id().context("get bridge process ID")?;
+
+    let client = async_nats::ConnectOptions::new()
+        .token(TOKEN.to_string())
+        .connect(&server.url)
+        .await?;
+    wait_for_registration(&client, &instance_id).await?;
+
+    let wrapped_child_pid = direct_child_pid(bridge_pid)?;
+    // SAFETY: wrapped_child_pid was read from the bridge process's direct children.
+    anyhow::ensure!(
+        unsafe { libc::kill(wrapped_child_pid as libc::pid_t, libc::SIGKILL) } == 0,
+        "kill wrapped MCP child {wrapped_child_pid}: {}",
+        std::io::Error::last_os_error()
+    );
+
+    let status = match tokio::time::timeout(Duration::from_secs(10), bridge.wait()).await {
+        Ok(status) => status.context("wait for bridge binary")?,
+        Err(_) => {
+            let _ = bridge.kill().await;
+            let _ = bridge.wait().await;
+            anyhow::bail!("bridge binary did not exit after wrapped MCP child died");
+        }
+    };
+    anyhow::ensure!(
+        !status.success(),
+        "bridge binary exited successfully after wrapped MCP child died"
+    );
+    Ok(())
+}

--- a/crates/harnx-mcp-plans/Cargo.toml
+++ b/crates/harnx-mcp-plans/Cargo.toml
@@ -23,6 +23,7 @@ similar = { workspace = true }
 
 [dev-dependencies]
 filetime = "0.2"
+tempfile = "3"
 
 [[bin]]
 name = "harnx-mcp-plans"

--- a/crates/harnx-mcp-plans/src/main.rs
+++ b/crates/harnx-mcp-plans/src/main.rs
@@ -98,6 +98,25 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
+fn print_help() {
+    eprintln!("harnx-mcp-plans: File-based todo/plan management MCP server");
+    eprintln!();
+    eprintln!("Usage: harnx-mcp-plans [OPTIONS]");
+    eprintln!();
+    eprintln!("Options:");
+    eprintln!("  --dir, -d <path>           Set the plans directory (default: .agent/plans)");
+    eprintln!("  --retention-days, -r <N>   Set retention period in days (default: 14)");
+    eprintln!("  --http                     Serve MCP over Streamable HTTP at /mcp");
+    eprintln!("  --mcp-stdio                Serve MCP over stdio (default when --http is absent)");
+    eprintln!("  --host <addr>              Bind address for HTTP mode (default: 0.0.0.0)");
+    eprintln!("  --port <N>                 Bind port for HTTP mode (default: 3000)");
+    eprintln!("  --help, -h                 Show this help message");
+    eprintln!();
+    eprintln!("Env:");
+    eprintln!("  AGENT_PLANS_PATH         Overrides the default directory.");
+    eprintln!("  AGENT_PLANS_RETENTION_DAYS  Overrides the default retention days.");
+}
+
 fn parse_args() -> anyhow::Result<Args> {
     let args: Vec<String> = std::env::args().collect();
     let mut plans_dir: Option<PathBuf> = None;
@@ -171,27 +190,7 @@ fn parse_args() -> anyhow::Result<Args> {
                 }
             }
             "--help" | "-h" => {
-                eprintln!("harnx-mcp-plans: File-based todo/plan management MCP server");
-                eprintln!();
-                eprintln!("Usage: harnx-mcp-plans [OPTIONS]");
-                eprintln!();
-                eprintln!("Options:");
-                eprintln!(
-                    "  --dir, -d <path>           Set the plans directory (default: .agent/plans)"
-                );
-                eprintln!(
-                    "  --retention-days, -r <N>   Set retention period in days (default: 14)"
-                );
-                eprintln!("  --http                     Serve MCP over Streamable HTTP at /mcp");
-                eprintln!(
-                    "  --host <addr>              Bind address for HTTP mode (default: 0.0.0.0)"
-                );
-                eprintln!("  --port <N>                 Bind port for HTTP mode (default: 3000)");
-                eprintln!("  --help, -h                 Show this help message");
-                eprintln!();
-                eprintln!("Env:");
-                eprintln!("  AGENT_PLANS_PATH         Overrides the default directory.");
-                eprintln!("  AGENT_PLANS_RETENTION_DAYS  Overrides the default retention days.");
+                print_help();
                 std::process::exit(0);
             }
             other => {

--- a/crates/harnx-mcp-plans/src/main.rs
+++ b/crates/harnx-mcp-plans/src/main.rs
@@ -139,6 +139,11 @@ fn parse_args() -> anyhow::Result<Args> {
                 http = true;
                 i += 1;
             }
+            "--mcp-stdio" => {
+                // No-op: stdio MCP mode is the default behavior when --http is absent.
+                // This flag exists so external callers can make stdio mode explicit.
+                i += 1;
+            }
             "--host" => {
                 if i + 1 < args.len() {
                     host = Some(args[i + 1].clone());

--- a/crates/harnx-mcp-plans/tests/mcp_stdio_client.rs
+++ b/crates/harnx-mcp-plans/tests/mcp_stdio_client.rs
@@ -1,0 +1,83 @@
+#![cfg(unix)]
+// rmcp deprecated MCP Roots (SEP-2577); this raw client still returns method_not_found.
+#![allow(deprecated)]
+
+use std::process::Stdio;
+
+use rmcp::handler::client::ClientHandler;
+use rmcp::model::{
+    CallToolRequestParams, ClientCapabilities, ErrorData, Implementation, InitializeRequestParams,
+    ListRootsResult,
+};
+use rmcp::service::{RequestContext, RoleClient};
+use rmcp::transport::async_rw::AsyncRwTransport;
+use tokio::process::Command;
+
+struct RawClientHandler;
+
+impl ClientHandler for RawClientHandler {
+    fn get_info(&self) -> InitializeRequestParams {
+        InitializeRequestParams::new(
+            ClientCapabilities::default(),
+            Implementation::new("raw-rmcp-test-client", env!("CARGO_PKG_VERSION")),
+        )
+    }
+
+    async fn list_roots(
+        &self,
+        _context: RequestContext<RoleClient>,
+    ) -> Result<ListRootsResult, ErrorData> {
+        Err(ErrorData::method_not_found::<
+            rmcp::model::ListRootsRequestMethod,
+        >())
+    }
+}
+
+#[tokio::test]
+async fn raw_rmcp_client_drives_plans_server_over_stdio() {
+    let plans_dir = tempfile::tempdir().expect("create temporary plans directory");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_harnx-mcp-plans"))
+        .arg("--mcp-stdio")
+        .arg("--dir")
+        .arg(plans_dir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("spawn harnx-mcp-plans");
+
+    let child_stdin = child.stdin.take().expect("take child stdin");
+    let child_stdout = child.stdout.take().expect("take child stdout");
+    let transport = AsyncRwTransport::<RoleClient, _, _>::new(child_stdout, child_stdin);
+    let service = rmcp::service::serve_client(RawClientHandler, transport)
+        .await
+        .expect("initialize raw rmcp client");
+    let peer = service.peer().clone();
+
+    let tools = peer
+        .list_tools(Default::default())
+        .await
+        .expect("list plans tools");
+    assert_eq!(tools.tools.len(), 15);
+    assert!(tools.tools.iter().all(|tool| !tool.input_schema.is_empty()));
+
+    let tool_names = tools
+        .tools
+        .iter()
+        .map(|tool| tool.name.as_ref())
+        .collect::<Vec<_>>();
+    for expected in ["list_plans", "add_plan", "add_note"] {
+        assert!(tool_names.contains(&expected), "missing tool {expected}");
+    }
+
+    let result = peer
+        .call_tool(CallToolRequestParams::new("list_plans"))
+        .await
+        .expect("call list_plans");
+    assert_ne!(result.is_error, Some(true));
+    assert!(!result.content.is_empty());
+
+    service.cancel().await.expect("close raw rmcp client");
+    child.kill().await.expect("stop harnx-mcp-plans");
+}

--- a/crates/harnx-runtime/src/config/tool_servers_split.rs
+++ b/crates/harnx-runtime/src/config/tool_servers_split.rs
@@ -44,13 +44,6 @@ pub struct ToolServerConfig {
     #[serde(default)]
     pub description: Option<String>,
 
-    /// Optional environment variable naming an override path for the server binary.
-    ///
-    /// This provides a test/dev seam for substituting a different binary.
-    /// Replaces the older per-server override constants like `HARNX_TIME_SERVER_BIN`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub bin_override_env: Option<String>,
-
     /// Package this server belongs to, set at runtime by the package loader.
     ///
     /// `None` for user-provided configs; `Some(package_name)` for servers
@@ -109,7 +102,6 @@ command: harnx-time-server
         assert!(config.env.is_empty());
         assert!(config.enabled);
         assert!(config.description.is_none());
-        assert!(config.bin_override_env.is_none());
         assert!(config.package.is_none());
     }
 

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -1021,7 +1021,6 @@ mod tests {
             env: Default::default(),
             enabled: true,
             description: None,
-            bin_override_env: None,
             package: None,
         }
     }
@@ -1089,8 +1088,13 @@ mod tests {
     #[test]
     fn worker_startup_continues_when_configured_binary_is_missing() {
         harnx_core::require_nextest();
+        let missing_dir = tempfile::tempdir().expect("create missing-binary test directory");
         let mut missing_server = tool_server("time");
-        missing_server.bin_override_env = Some("HARNX_MISSING_TOOL_SERVER_BIN_TEST".to_string());
+        missing_server.command = missing_dir
+            .path()
+            .join("harnx-missing-tool-server")
+            .to_string_lossy()
+            .into_owned();
         let filtered = tool_servers_matching_use_tools(
             &[missing_server],
             None,

--- a/crates/harnx-runtime/src/nats_worker/mod.rs
+++ b/crates/harnx-runtime/src/nats_worker/mod.rs
@@ -38,4 +38,4 @@ pub use daemon::{
     new_remote_session_id, notify_subject, publish_session_activate, run_worker_daemon,
     worker_ready_subject, SessionActivate, WorkerDaemonConfig,
 };
-pub use tool_supervisor::{ToolServerStartConfig, ToolServerSupervisor, HARNX_TIME_SERVER_BIN};
+pub use tool_supervisor::{ToolServerStartConfig, ToolServerSupervisor};

--- a/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
+++ b/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
@@ -17,7 +17,6 @@ use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
-pub const HARNX_TIME_SERVER_BIN: &str = "HARNX_TIME_SERVER_BIN";
 const TOOL_STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Connection and identity shared by all tool servers spawned for one worker.
@@ -157,19 +156,6 @@ impl Drop for ToolServerSupervisor {
 }
 
 fn resolve_tool_binary(server: &ToolServerConfig) -> Result<PathBuf> {
-    if let Some(override_env) = &server.bin_override_env {
-        if let Some(path) = std::env::var_os(override_env) {
-            let path = PathBuf::from(path);
-            if path.is_file() {
-                return Ok(path);
-            }
-            bail!(
-                "{override_env} points to a missing tool-server binary: {}",
-                path.display()
-            );
-        }
-    }
-
     let current = std::env::current_exe().context("resolve current worker executable")?;
     let directory = current
         .parent()

--- a/crates/harnx-runtime/tests/tool_supervisor.rs
+++ b/crates/harnx-runtime/tests/tool_supervisor.rs
@@ -355,8 +355,22 @@ async fn time_over_nats_pilot_e2e_mixed_stdio_cancel_and_crash() -> Result<()> {
 }
 
 #[cfg(unix)]
-#[tokio::test(flavor = "multi_thread")]
-async fn tool_server_readiness_failure_warns_and_continues() -> Result<()> {
+struct ReadinessTestFixture {
+    _server: common::NatsServerHandle,
+    _directory: tempfile::TempDir,
+    client: async_nats::Client,
+    instance_id: InstanceId,
+    sink: Arc<RecordingEventSink>,
+    supervisor: ToolServerSupervisor,
+}
+
+#[cfg(unix)]
+async fn start_readiness_test(
+    fake_binary_name: &str,
+    fake_server_name: &str,
+    healthy_binary: Option<String>,
+    timeout: Duration,
+) -> Result<Option<ReadinessTestFixture>> {
     use std::os::unix::fs::PermissionsExt;
 
     let Some(server) = common::spawn_nats_server_with_options(common::SpawnNatsServerOptions {
@@ -364,13 +378,12 @@ async fn tool_server_readiness_failure_warns_and_continues() -> Result<()> {
     })
     .await?
     else {
-        return Ok(());
+        return Ok(None);
     };
     let directory = tempfile::tempdir()?;
-    let binary = directory.path().join("never-registers");
-    std::fs::write(&binary, "#!/bin/sh\nsleep 10\n")?;
-    std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755))?;
-    let binary = binary.to_string_lossy().into_owned();
+    let fake_binary = directory.path().join(fake_binary_name);
+    std::fs::write(&fake_binary, "#!/bin/sh\nsleep 10\n")?;
+    std::fs::set_permissions(&fake_binary, std::fs::Permissions::from_mode(0o755))?;
     let client = async_nats::ConnectOptions::new()
         .token(TOKEN.to_string())
         .connect(server.url())
@@ -378,90 +391,91 @@ async fn tool_server_readiness_failure_warns_and_continues() -> Result<()> {
     let instance_id = InstanceId::new();
     let start =
         ToolServerStartConfig::new(client.clone(), instance_id.clone(), server.url(), TOKEN);
-    let servers = [time_server_config(binary)];
+    let mut fake_server = time_server_config(fake_binary.to_string_lossy().into_owned());
+    fake_server.name = fake_server_name.to_string();
+    let mut servers = vec![fake_server];
+    if let Some(healthy_binary) = healthy_binary {
+        servers.push(time_server_config(healthy_binary));
+    }
     let sink = Arc::new(RecordingEventSink::default());
     let supervisor = harnx_core::sink::with_agent_event_sink(sink.clone(), async {
-        ToolServerSupervisor::start_local_with_timeout(start, &servers, Duration::from_millis(250))
-            .await
+        ToolServerSupervisor::start_local_with_timeout(start, &servers, timeout).await
     })
     .await?;
 
-    let store = async_nats::jetstream::new(client)
+    Ok(Some(ReadinessTestFixture {
+        _server: server,
+        _directory: directory,
+        client,
+        instance_id,
+        sink,
+        supervisor,
+    }))
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn tool_server_readiness_failure_warns_and_continues() -> Result<()> {
+    let Some(fixture) =
+        start_readiness_test("never-registers", "time", None, Duration::from_millis(250)).await?
+    else {
+        return Ok(());
+    };
+
+    let store = async_nats::jetstream::new(fixture.client.clone())
         .get_key_value(TOOL_REGISTRY_BUCKET)
         .await?;
     assert!(
         store
-            .get(registration_key(&instance_id, "time"))
+            .get(registration_key(&fixture.instance_id, "time"))
             .await?
             .is_none(),
         "non-registering server must not become available"
     );
     assert!(
-        sink.warning_messages().iter().any(|message| {
+        fixture.sink.warning_messages().iter().any(|message| {
             message.contains("tool server 'time' failed to start")
                 && message.contains("did not register")
         }),
         "readiness failure must emit a warning: {:?}",
-        sink.warning_messages()
+        fixture.sink.warning_messages()
     );
-    drop(supervisor);
+    drop(fixture.supervisor);
     Ok(())
 }
 
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread")]
 async fn readiness_waits_for_servers_concurrently() -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
-    let Some(server) = common::spawn_nats_server_with_options(common::SpawnNatsServerOptions {
-        auth_token: Some(TOKEN.to_string()),
-    })
+    let time_binary = time_server_binary()?.to_string_lossy().into_owned();
+    let Some(fixture) = start_readiness_test(
+        "stall-server",
+        "stall",
+        Some(time_binary),
+        Duration::from_secs(1),
+    )
     .await?
     else {
         return Ok(());
     };
-    let directory = tempfile::tempdir()?;
-    let stall_binary = directory.path().join("stall-server");
-    std::fs::write(&stall_binary, "#!/bin/sh\nsleep 10\n")?;
-    std::fs::set_permissions(&stall_binary, std::fs::Permissions::from_mode(0o755))?;
-    let stall_binary = stall_binary.to_string_lossy().into_owned();
-    let time_binary = time_server_binary()?.to_string_lossy().into_owned();
-    let client = async_nats::ConnectOptions::new()
-        .token(TOKEN.to_string())
-        .connect(server.url())
-        .await?;
-    let instance_id = InstanceId::new();
-    let start =
-        ToolServerStartConfig::new(client.clone(), instance_id.clone(), server.url(), TOKEN);
-    let stall = ToolServerConfig {
-        name: "stall".to_string(),
-        ..time_server_config(stall_binary)
-    };
-    let servers = [stall, time_server_config(time_binary)];
-    let sink = Arc::new(RecordingEventSink::default());
-    let supervisor = harnx_core::sink::with_agent_event_sink(sink.clone(), async {
-        ToolServerSupervisor::start_local_with_timeout(start, &servers, Duration::from_secs(1))
-            .await
-    })
-    .await?;
 
-    let store = async_nats::jetstream::new(client)
+    let store = async_nats::jetstream::new(fixture.client.clone())
         .get_key_value(TOOL_REGISTRY_BUCKET)
         .await?;
     assert!(
         store
-            .get(registration_key(&instance_id, "time"))
+            .get(registration_key(&fixture.instance_id, "time"))
             .await?
             .is_some(),
         "healthy server must register while another server stalls"
     );
-    let warnings = sink.warning_messages();
+    let warnings = fixture.sink.warning_messages();
     assert!(warnings.iter().any(|message| message.contains("'stall'")));
     assert!(
         warnings.iter().all(|message| !message.contains("'time'")),
         "healthy server must not receive a readiness warning: {warnings:?}"
     );
-    drop(supervisor);
+    drop(fixture.supervisor);
     Ok(())
 }
 

--- a/crates/harnx-runtime/tests/tool_supervisor.rs
+++ b/crates/harnx-runtime/tests/tool_supervisor.rs
@@ -10,9 +10,7 @@ use harnx_core::tool::{ToolCall, ToolError, ToolProvider};
 use harnx_mcp::{McpManager, McpServerConfig};
 use harnx_runtime::config::{Config, ToolServerConfig, HARNX_NATS_TOKEN_ENV, HARNX_NATS_URL_ENV};
 use harnx_runtime::nats_tool_provider::{NatsInFlightCalls, NatsToolProvider};
-use harnx_runtime::nats_worker::{
-    ToolServerStartConfig, ToolServerSupervisor, HARNX_TIME_SERVER_BIN,
-};
+use harnx_runtime::nats_worker::{ToolServerStartConfig, ToolServerSupervisor};
 use harnx_toolset::{ControlKind, ControlMessage};
 use harnx_toolset_server::{registration_key, TOOL_REGISTRY_BUCKET};
 use parking_lot::RwLock;
@@ -23,15 +21,14 @@ use std::process::Command;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-fn time_server_config() -> ToolServerConfig {
+fn time_server_config(command: impl Into<String>) -> ToolServerConfig {
     ToolServerConfig {
         name: "time".to_string(),
-        command: "harnx-time-server".to_string(),
+        command: command.into(),
         args: Vec::new(),
         env: Default::default(),
         enabled: true,
         description: None,
-        bin_override_env: Some(HARNX_TIME_SERVER_BIN.to_string()),
         package: None,
     }
 }
@@ -330,7 +327,6 @@ async fn time_over_nats_pilot_e2e_mixed_stdio_cancel_and_crash() -> Result<()> {
     };
     let binary = time_server_binary()?.to_string_lossy().into_owned();
     let _env = EnvGuard::install(&[
-        (HARNX_TIME_SERVER_BIN, &binary),
         (HARNX_NATS_URL_ENV, server.url()),
         (HARNX_NATS_TOKEN_ENV, TOKEN),
     ]);
@@ -341,7 +337,7 @@ async fn time_over_nats_pilot_e2e_mixed_stdio_cancel_and_crash() -> Result<()> {
     let instance_id = InstanceId::new();
     let start =
         ToolServerStartConfig::new(client.clone(), instance_id.clone(), server.url(), TOKEN);
-    let servers = [time_server_config()];
+    let servers = [time_server_config(&binary)];
     let supervisor =
         ToolServerSupervisor::start_local_with_timeout(start, &servers, Duration::from_secs(5))
             .await?;
@@ -375,7 +371,6 @@ async fn tool_server_readiness_failure_warns_and_continues() -> Result<()> {
     std::fs::write(&binary, "#!/bin/sh\nsleep 10\n")?;
     std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755))?;
     let binary = binary.to_string_lossy().into_owned();
-    let _env = EnvGuard::install(&[(HARNX_TIME_SERVER_BIN, &binary)]);
     let client = async_nats::ConnectOptions::new()
         .token(TOKEN.to_string())
         .connect(server.url())
@@ -383,7 +378,7 @@ async fn tool_server_readiness_failure_warns_and_continues() -> Result<()> {
     let instance_id = InstanceId::new();
     let start =
         ToolServerStartConfig::new(client.clone(), instance_id.clone(), server.url(), TOKEN);
-    let servers = [time_server_config()];
+    let servers = [time_server_config(binary)];
     let sink = Arc::new(RecordingEventSink::default());
     let supervisor = harnx_core::sink::with_agent_event_sink(sink.clone(), async {
         ToolServerSupervisor::start_local_with_timeout(start, &servers, Duration::from_millis(250))
@@ -418,7 +413,6 @@ async fn tool_server_readiness_failure_warns_and_continues() -> Result<()> {
 async fn readiness_waits_for_servers_concurrently() -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
-    const STALL_BIN_ENV: &str = "HARNX_STALL_TOOL_SERVER_BIN_TEST";
     let Some(server) = common::spawn_nats_server_with_options(common::SpawnNatsServerOptions {
         auth_token: Some(TOKEN.to_string()),
     })
@@ -432,10 +426,6 @@ async fn readiness_waits_for_servers_concurrently() -> Result<()> {
     std::fs::set_permissions(&stall_binary, std::fs::Permissions::from_mode(0o755))?;
     let stall_binary = stall_binary.to_string_lossy().into_owned();
     let time_binary = time_server_binary()?.to_string_lossy().into_owned();
-    let _env = EnvGuard::install(&[
-        (STALL_BIN_ENV, &stall_binary),
-        (HARNX_TIME_SERVER_BIN, &time_binary),
-    ]);
     let client = async_nats::ConnectOptions::new()
         .token(TOKEN.to_string())
         .connect(server.url())
@@ -445,11 +435,9 @@ async fn readiness_waits_for_servers_concurrently() -> Result<()> {
         ToolServerStartConfig::new(client.clone(), instance_id.clone(), server.url(), TOKEN);
     let stall = ToolServerConfig {
         name: "stall".to_string(),
-        command: "stall-server".to_string(),
-        bin_override_env: Some(STALL_BIN_ENV.to_string()),
-        ..time_server_config()
+        ..time_server_config(stall_binary)
     };
-    let servers = [stall, time_server_config()];
+    let servers = [stall, time_server_config(time_binary)];
     let sink = Arc::new(RecordingEventSink::default());
     let supervisor = harnx_core::sink::with_agent_event_sink(sink.clone(), async {
         ToolServerSupervisor::start_local_with_timeout(start, &servers, Duration::from_secs(1))
@@ -479,8 +467,6 @@ async fn readiness_waits_for_servers_concurrently() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn missing_tool_server_binary_warns_and_continues() -> Result<()> {
-    const MISSING_BIN_ENV: &str = "HARNX_MISSING_TOOL_SERVER_BIN_TEST";
-
     let Some(server) = common::spawn_nats_server_with_options(common::SpawnNatsServerOptions {
         auth_token: Some(TOKEN.to_string()),
     })
@@ -491,17 +477,13 @@ async fn missing_tool_server_binary_warns_and_continues() -> Result<()> {
     let missing_dir = tempfile::tempdir()?;
     let missing = missing_dir.path().join("does-not-exist");
     let missing = missing.to_string_lossy().into_owned();
-    let _env = EnvGuard::install(&[(MISSING_BIN_ENV, &missing)]);
     let client = async_nats::ConnectOptions::new()
         .token(TOKEN.to_string())
         .connect(server.url())
         .await?;
     let instance_id = InstanceId::new();
     let start = ToolServerStartConfig::new(client, instance_id, server.url(), TOKEN);
-    let servers = [ToolServerConfig {
-        bin_override_env: Some(MISSING_BIN_ENV.to_string()),
-        ..time_server_config()
-    }];
+    let servers = [time_server_config(missing)];
     let sink = Arc::new(RecordingEventSink::default());
     let supervisor = harnx_core::sink::with_agent_event_sink(sink.clone(), async {
         ToolServerSupervisor::start_local_with_timeout(start, &servers, Duration::from_millis(250))
@@ -513,7 +495,7 @@ async fn missing_tool_server_binary_warns_and_continues() -> Result<()> {
     assert!(
         sink.warning_messages().iter().any(|message| {
             message.contains("tool server 'time' failed to start")
-                && message.contains("points to a missing tool-server binary")
+                && message.contains("not found next to worker")
         }),
         "missing binary must emit a warning: {:?}",
         sink.warning_messages()

--- a/demos/config/tool_servers/time.yaml
+++ b/demos/config/tool_servers/time.yaml
@@ -1,3 +1,2 @@
 command: harnx-time-server
 description: Time and timezone utilities — lets agents check the current time and wait.
-bin_override_env: HARNX_TIME_SERVER_BIN

--- a/docker/harnx.Dockerfile
+++ b/docker/harnx.Dockerfile
@@ -14,6 +14,7 @@ COPY linux-${TARGETARCH}/harnx-mcp-fs /usr/local/bin/harnx-mcp-fs
 COPY linux-${TARGETARCH}/harnx-mcp-plans /usr/local/bin/harnx-mcp-plans
 COPY linux-${TARGETARCH}/harnx-mcp-time /usr/local/bin/harnx-mcp-time
 COPY linux-${TARGETARCH}/harnx-time-server /usr/local/bin/harnx-time-server
+COPY linux-${TARGETARCH}/harnx-mcp-bridge /usr/local/bin/harnx-mcp-bridge
 COPY linux-${TARGETARCH}/harnx-aws-creds /usr/local/bin/harnx-aws-creds
 COPY linux-${TARGETARCH}/harnx-k8s-creds /usr/local/bin/harnx-k8s-creds
 COPY linux-${TARGETARCH}/harnx-pkg /usr/local/bin/harnx-pkg

--- a/docs/solutions/nats-instance-scoped-tool-servers-2026-07-29.md
+++ b/docs/solutions/nats-instance-scoped-tool-servers-2026-07-29.md
@@ -77,7 +77,7 @@ async fn invoke(
 
 ## Worker bootstrap and coexistence
 
-Phase 2a initially used a private built-in bootstrap list (`LOCAL_BOOTSTRAP_SERVERS`). In Phase 2b (slice a), this hardcoded list was replaced with generalized, config-driven tool-server declarations loaded from `tool_servers/*.yaml` (across user config and package directories). The `time` tool server now ships via `tool_servers/time.yaml`, with `HARNX_TIME_SERVER_BIN` retained as a per-server binary override seam for integration testing.
+Phase 2a initially used a private built-in bootstrap list (`LOCAL_BOOTSTRAP_SERVERS`). In Phase 2b (slice a), this hardcoded list was replaced with generalized, config-driven tool-server declarations loaded from `tool_servers/*.yaml` (across user config and package directories). The `time` tool server now ships via `tool_servers/time.yaml`.
 
 The local worker spawns tool servers lazy-on-demand only when their tool-name prefix could match the active agent's `use_tools` selectors. Servers receive `HARNX_INSTANCE_ID`, `HARNX_NATS_URL`, and `HARNX_NATS_TOKEN`. If a declared tool-server binary is missing or exits prematurely, the worker emits a UI warning (`AgentEvent::Notice(Warning)`) and continues running rather than failing hard. Non-local workers do not start local tool servers, preserving remote `agent@cluster` behavior.
 

--- a/docs/solutions/nats-mcp-bridge-2026-07-30.md
+++ b/docs/solutions/nats-mcp-bridge-2026-07-30.md
@@ -1,0 +1,67 @@
+---
+title: "Generic MCP→NATS Bridge (S1)"
+date: 2026-07-30
+category: "integration-issues"
+problem_type: integration_issue
+component: "harnx-mcp-bridge"
+root_cause: "stdio MCP servers could not run over NATS without a native per-server rewrite"
+resolution_type: code_fix
+severity: medium
+tags:
+  - nats
+  - tool-servers
+  - mcp
+  - bridge
+plan_ref: "nats-mcp-bridge-s1"
+last_updated: 2026-07-30
+---
+
+# Solution: Generic MCP→NATS Bridge
+
+## Problem
+
+stdio MCP servers could not join the NATS tool-server path without being rewritten as native `Toolset` implementations. That approach also could not cover third-party MCP servers.
+
+## Solution
+
+`harnx-mcp-bridge` spawns a wrapped stdio MCP server as an rmcp-client child (`AsyncRwTransport::<RoleClient, _, _>` with `serve_client`, 30s init / 10s list_tools timeouts), caches its tool list, implements the `Toolset` trait, and serves over NATS.
+
+The bridge registers each tool as `{server}_{tool}`, such as `plans_add_note`. On invocation, it validates and strips the `{server}_` prefix before calling the child tool. Result mapping uses bare `serde_json::to_value(CallToolResult)` — byte-identical to the direct MCP path in `harnx-mcp/src/client.rs:651` — so existing `extract_image_parts` and text handling stay compatible.
+
+## Child Lifecycle
+
+The child uses `kill_on_drop(true)`, runs as a `ProcessGroup::leader()`, and sets Linux `PR_SET_PDEATHSIG` (via `pre_exec`) to prevent orphaned processes. A watcher task awaits the `RunningService`'s `waiting()` future and fires a `child_died` `CancellationToken` when the transport closes. The bridge's main loop exits on child death, and the worker supervisor reports its existing soft warning instead of leaving a registered but unusable tool server.
+
+## Error Mapping
+
+Caller-input errors return `ToolInvokeError::Recoverable` so the LLM can self-correct:
+
+- Bad tool-name prefix: `Recoverable("bad tool name {tool}")`
+- Non-object / non-null args: `Recoverable("MCP tool arguments must be a JSON object or null")`
+- Cancellation: `Recoverable("call cancelled")`
+
+Genuine transport death (`ServiceError::TransportClosed` / `TransportSend(_)`) returns `ToolInvokeError::Fatal` since retry won't help.
+
+## Pitfall: Wrapper Binaries Cannot Use Argv-Sniffing Mode Selection
+
+`run_toolset_main` (harnx-toolset-server) inspects `std::env::args_os()` for `--mcp-stdio` to decide stdio-vs-NATS mode. For a wrapper binary like the bridge, the wrapped child's argv (everything after `--`, e.g. `-- harnx-mcp-plans --mcp-stdio ...`) is part of the wrapper process's own argv.
+
+However, the initial implementation called `run_toolset_main(bridge)`. When the child's `--mcp-stdio` flag was present in argv, `run_toolset_main` matched it and put the bridge itself into MCP-stdio mode instead of NATS mode — the bridge would hang waiting for MCP client input rather than serving NATS requests.
+
+**Fix**: The bridge's `main.rs` does NOT use `run_toolset_main`. It reads `HARNX_INSTANCE_ID` / `HARNX_NATS_URL` / `HARNX_NATS_TOKEN` directly and calls `harnx_toolset_server::serve_over_nats(bridge, ...)` inside a `tokio::select!` racing `child_died.cancelled()`. This bypasses argv-sniffing entirely.
+
+**Lesson**: Any wrapper/passthrough binary must avoid argv-sniffing mode-selection like `run_toolset_main`'s `--mcp-stdio` check. Select mode explicitly — read env vars or config — not by inspecting a potentially-polluted argv.
+
+**Detection**: This bug was only caught by a BINARY-LEVEL test (`bridge_binary_exits_when_wrapped_child_dies` spawning the compiled binary), not by in-process tests that called `serve_over_nats` directly. In-process unit tests masked the collision because they bypassed arg parsing.
+
+## Verification with Plans
+
+S1 migrates `plans` as the first bridge-backed tool server. Tests:
+
+- **integration test**: starts the bridge around `harnx-mcp-plans`, verifies its `plans_*` NATS registration, completes an invocation round trip
+- **binary-level child-death test**: kills the wrapped child, asserts bridge exits non-zero
+- **raw rmcp-client test**: drives `harnx-mcp-plans --mcp-stdio` directly, proving the plans binary remains available to any MCP client
+
+## Roadmap
+
+This is S1 of issue #1224 (hybrid bridge-first strategy). S2 migrates more roots-free and third-party server configs. S3 adds a roots-over-NATS protocol, S4 passes roots through the bridge, and S5 adds native fs/bash toolsets and deletes `McpManager`. `McpManager` is unchanged in S1.

--- a/docs/solutions/nats-tool-servers-config-driven-bootstrap-2026-07-29.md
+++ b/docs/solutions/nats-tool-servers-config-driven-bootstrap-2026-07-29.md
@@ -32,7 +32,7 @@ Phase 2b generalizes tool-server bootstrap into declarative configuration:
 
 3. **Resilient process supervision**: Missing binaries or crashing tool servers emit a UI warning (`AgentEvent::Notice(Warning)`) while worker execution continues.
 
-4. **Time tool migration**: The hardcoded `LOCAL_BOOTSTRAP_SERVERS` constant and `BootstrapServer` struct were removed. `time` now ships as `harnx-time-server` in `tool_servers/time.yaml`. The `HARNX_TIME_SERVER_BIN` environment variable remains as a per-server binary override seam for integration tests.
+4. **Time tool migration**: The hardcoded `LOCAL_BOOTSTRAP_SERVERS` constant and `BootstrapServer` struct were removed. `time` now ships as `harnx-time-server` in `tool_servers/time.yaml`.
 
 ## Key Learning: KV-Key Name Collision Requires Pre-Spawn Deduplication
 

--- a/example_config/mcp_servers/plans.yaml
+++ b/example_config/mcp_servers/plans.yaml
@@ -1,9 +1,0 @@
-command: harnx-mcp-plans
-enabled: true
-description: >-
-  File-based plan/task/note management. Provides list_plans, add_plan, get_plan,
-  update_plan, delete_plan, list_tasks, add_task, get_task, update_task,
-  append_task, delete_task, list_notes, add_note, get_note, delete_note.
-args:
-  - "--dir"
-  - ".agent/plans"

--- a/example_config/tool_servers/plans.yaml
+++ b/example_config/tool_servers/plans.yaml
@@ -2,7 +2,6 @@ command: harnx-mcp-bridge
 description: >-
   File-based plan/task/note management (MCP→NATS bridge) — used by orchestrator
   agents to track multi-step work across sessions.
-bin_override_env: HARNX_MCP_BRIDGE_BIN
 args:
   - --name
   - plans

--- a/example_config/tool_servers/plans.yaml
+++ b/example_config/tool_servers/plans.yaml
@@ -1,0 +1,13 @@
+command: harnx-mcp-bridge
+description: >-
+  File-based plan/task/note management (MCP→NATS bridge) — used by orchestrator
+  agents to track multi-step work across sessions.
+bin_override_env: HARNX_MCP_BRIDGE_BIN
+args:
+  - --name
+  - plans
+  - --
+  - harnx-mcp-plans
+  - --mcp-stdio
+  - --dir
+  - .agent/plans

--- a/example_config/tool_servers/time.yaml
+++ b/example_config/tool_servers/time.yaml
@@ -1,3 +1,2 @@
 command: harnx-time-server
 description: Time and timezone utilities — lets agents check the current time and wait.
-bin_override_env: HARNX_TIME_SERVER_BIN

--- a/packages/coding/mcp_servers/plans.yaml
+++ b/packages/coding/mcp_servers/plans.yaml
@@ -1,7 +1,0 @@
-command: harnx-mcp-plans
-description: >-
-  File-based plan/task/note management — used by orchestrator agents
-  (Sisyphus, Atlas, Daedalus) to track multi-step work across sessions.
-args:
-  - --dir
-  - .agent/plans   # plans are stored relative to the working directory

--- a/packages/coding/tool_servers/plans.yaml
+++ b/packages/coding/tool_servers/plans.yaml
@@ -2,7 +2,6 @@ command: harnx-mcp-bridge
 description: >-
   File-based plan/task/note management (MCP→NATS bridge) — used by orchestrator
   agents to track multi-step work across sessions.
-bin_override_env: HARNX_MCP_BRIDGE_BIN
 args:
   - --name
   - plans

--- a/packages/coding/tool_servers/plans.yaml
+++ b/packages/coding/tool_servers/plans.yaml
@@ -1,0 +1,13 @@
+command: harnx-mcp-bridge
+description: >-
+  File-based plan/task/note management (MCP→NATS bridge) — used by orchestrator
+  agents to track multi-step work across sessions.
+bin_override_env: HARNX_MCP_BRIDGE_BIN
+args:
+  - --name
+  - plans
+  - --
+  - harnx-mcp-plans
+  - --mcp-stdio
+  - --dir
+  - .agent/plans

--- a/packages/coding/tool_servers/time.yaml
+++ b/packages/coding/tool_servers/time.yaml
@@ -1,3 +1,2 @@
 command: harnx-time-server
 description: Time and timezone utilities — lets agents check the current time and wait.
-bin_override_env: HARNX_TIME_SERVER_BIN

--- a/packages/pantheon/mcp_servers/plans.yaml
+++ b/packages/pantheon/mcp_servers/plans.yaml
@@ -1,7 +1,0 @@
-command: harnx-mcp-plans
-description: >-
-  File-based plan/task/note management — used by orchestrator agents
-  (Sisyphus, Atlas, Daedalus) to track multi-step work across sessions.
-args:
-  - --dir
-  - .agent/plans   # plans are stored relative to the working directory

--- a/packages/pantheon/tool_servers/plans.yaml
+++ b/packages/pantheon/tool_servers/plans.yaml
@@ -2,7 +2,6 @@ command: harnx-mcp-bridge
 description: >-
   File-based plan/task/note management (MCP→NATS bridge) — used by orchestrator
   agents to track multi-step work across sessions.
-bin_override_env: HARNX_MCP_BRIDGE_BIN
 args:
   - --name
   - plans

--- a/packages/pantheon/tool_servers/plans.yaml
+++ b/packages/pantheon/tool_servers/plans.yaml
@@ -1,0 +1,13 @@
+command: harnx-mcp-bridge
+description: >-
+  File-based plan/task/note management (MCP→NATS bridge) — used by orchestrator
+  agents to track multi-step work across sessions.
+bin_override_env: HARNX_MCP_BRIDGE_BIN
+args:
+  - --name
+  - plans
+  - --
+  - harnx-mcp-plans
+  - --mcp-stdio
+  - --dir
+  - .agent/plans

--- a/packages/pantheon/tool_servers/time.yaml
+++ b/packages/pantheon/tool_servers/time.yaml
@@ -1,3 +1,2 @@
 command: harnx-time-server
 description: Time and timezone utilities — lets agents check the current time and wait.
-bin_override_env: HARNX_TIME_SERVER_BIN


### PR DESCRIPTION
add `harnx-mcp-bridge`, a generic MCP→NATS bridge that wraps any stdio MCP server and re-exposes its tools over NATS. Migrate the `plans` tool server to run over NATS via the bridge; the `harnx-mcp-plans` binary still works standalone as an MCP server (`--mcp-stdio`) for external MCP clients. References #1224.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an MCP-to-NATS bridge that exposes tools from stdio-based MCP servers over NATS.
  * Migrated plans tooling to use the bridge while preserving standalone MCP stdio support.
  * Added plans tool-server configuration and included the bridge binary in Docker images.

* **Improvements**
  * Simplified tool-server binary discovery by removing environment-variable overrides.
  * Added lifecycle handling so bridge shutdown follows the wrapped MCP process.

* **Documentation**
  * Added guidance covering bridge usage, configuration, errors, and process management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->