### PR TITLE
Migrate MCP servers to tool servers

### DIFF
--- a/.changeset/nats-mcp-bridge-s2-config-migration.md
+++ b/.changeset/nats-mcp-bridge-s2-config-migration.md
@@ -1,0 +1,5 @@
+---
+harnx: minor
+---
+
+feat(nats): migrate roots-free MCP servers (`context7`, `exa`, `fetch`, `grep`, `plans-github`, `wet`, `dev`) to run over NATS via `harnx-mcp-bridge`. Their configurations move from `mcp_servers/` to `tool_servers/`; `fs` and `bash` remain stdio pending roots support. References #1224.

--- a/demos/README.md
+++ b/demos/README.md
@@ -25,7 +25,7 @@ demos/
 │   ├── agents/                 Demo agent definitions (demo/code/tool-confirm)
 │   ├── clients/                openai-compatible client pointed at :3829
 │   │   └── mock.yaml
-│   └── mcp_servers/
+│   └── tool_servers/
 │       ├── dev.yaml            Wires harnx-mock-mcp for the agent demo
 │       └── time.yaml           Time MCP server (tool-confirm demo)
 └── scripts/                    Mock-LLM turns (*-flow) + mock-MCP results (*-tools)
@@ -59,7 +59,7 @@ On Linux you'll also need `ttyd` and `ffmpeg`.
 2. To show tool use without running anything real, have the mock LLM emit tool
    calls and serve faked results from `harnx-mock-mcp`: add a
    `demos/scripts/<name>-tools.yaml` (tools + ordered `responses`, see
-   `agent-tools.yaml`), wire it via a `demos/config/mcp_servers/<server>.yaml`
+   `agent-tools.yaml`), wire it via a `demos/config/tool_servers/<server>.yaml`
    (`command: harnx-mock-mcp`, `args: [--script, demos/scripts/<name>-tools.yaml]`),
    and list the `<server>_<tool>` names in the agent's `use_tools`. Schema lives
    in `crates/harnx-test-bins/src/bin/harnx-mock-mcp/server.rs`.

--- a/demos/config/tool_servers/dev.yaml
+++ b/demos/config/tool_servers/dev.yaml
@@ -1,9 +1,13 @@
-command: harnx-mock-mcp
-args:
-  - --script
-  - demos/scripts/agent-tools.yaml
+command: harnx-mcp-bridge
 description: >-
   Deterministic mock dev tools (read_file / apply_edit / run) for the agent
   coding-session demo. Returns canned results — nothing actually executes.
   Paths are resolved from the repo root, which render.sh cd's into before
   launching harnx.
+args:
+  - --name
+  - dev
+  - --
+  - harnx-mock-mcp
+  - --script
+  - demos/scripts/agent-tools.yaml

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -29,7 +29,7 @@ If an MCP server — e.g. the Exa web-search server run via `npx` — reports a 
 Forward the specific variable through the sandbox from the server's config:
 
 ```yaml
-# mcp_servers/exa.yaml
+# tool_servers/exa.yaml
 env:
   HARNX_BASH_ENV_PASSTHROUGH: EXA_API_KEY
 ```

--- a/example_config/tool_servers/exa.yaml
+++ b/example_config/tool_servers/exa.yaml
@@ -1,11 +1,13 @@
 # Note: set EXA_API_KEY in ~/.local/share/harnx/.env
-command: npx
-args:
-  - "-y"
-  - "exa-mcp-server"
+command: harnx-mcp-bridge
 enabled: true
 description: "Web search via Exa API"
-# If you've wrapped npx/node with a harnx sandbox, this allows the EXA_API_KEY to pass through
+args:
+  - --name
+  - exa
+  - --
+  - npx
+  - "-y"
+  - exa-mcp-server
 env:
   HARNX_BASH_ENV_PASSTHROUGH: EXA_API_KEY
-

--- a/example_config/tool_servers/plans-github.yaml
+++ b/example_config/tool_servers/plans-github.yaml
@@ -1,21 +1,20 @@
-command: harnx-mcp-plans-github
+command: harnx-mcp-bridge
 enabled: false # Requires GitHub repository and auth setup
 description: >-
   GitHub Issues-backed plan/task/note management. Stores plans as issues,
   tasks as sub-issues, and notes as comments. Supports PAT and GitHub App auth.
 args:
-  # Repository auto-detected from git origin of working directory (github.com required)
-  - "--plan-label"
-  - "harnx-plan"
-  # Optional: bind HTTP mode to all interfaces only when intentionally exposing server
-  # - "--http"
-  # - "--host"
-  # - "0.0.0.0"
+  - --name
+  - plans-github
+  - --
+  - harnx-mcp-plans-github
+  - --plan-label
+  - harnx-plan
 env:
   # Use EITHER GITHUB_TOKEN for PAT:
   # Provide GITHUB_TOKEN via your environment / secrets manager (do not hardcode here).
   # GITHUB_TOKEN: "${GITHUB_TOKEN}"
-  
+
   # OR GitHub App credentials:
   # GITHUB_APP_ID: "123456"
   # GITHUB_APP_PRIVATE_KEY: "/path/to/app-private-key.pem"
@@ -23,6 +22,6 @@ env:
 
   # Optional: API base URL (e.g. for caching proxy)
   # GITHUB_API_URL: "https://api.github.com"
-  
+
   # Optional: Retention (days to close stale plans)
   # AGENT_PLANS_RETENTION_DAYS: "14"

--- a/example_config/tool_servers/wet.yaml
+++ b/example_config/tool_servers/wet.yaml
@@ -1,10 +1,14 @@
-command: uvx
-args:
-  - "--python"
-  - "3.13"
-  - "wet-mcp"
+command: harnx-mcp-bridge
 enabled: true
-description: >
+description: >-
   Web Extended Toolkit. Uses SearXNG to aggregate results from Google, Bing,
   DuckDuckGo, and Brave. Converts web pages into clean Markdown/Text.
   Performs multi-page BFS crawling with depth control.
+args:
+  - --name
+  - wet
+  - --
+  - uvx
+  - --python
+  - "3.13"
+  - wet-mcp

--- a/packages/coding/README.md
+++ b/packages/coding/README.md
@@ -82,14 +82,14 @@ or symlink anything.
 | `plans.yaml` | `plans_*` | Plan/task tracking, stored in `.agent/plans/` relative to the working directory. |
 | `time.yaml` | `time_*` | Current time and wait utilities. |
 
-### External servers (require install)
+### Tool servers (bridge-run, under tool_servers/)
 
 | Server | Namespace | Requires | Notes |
 |--------|-----------|----------|-------|
 | `fetch.yaml` | `fetch_*` | Node.js / npx | Fetches URLs as markdown or text. No API key. |
 | `exa.yaml` | `exa_*` | Node.js / npx | Web search via Exa. Requires `EXA_API_KEY`. |
 | `context7.yaml` | `context7_*` | Node.js / npx | Library docs lookup. No API key. |
-| `grep.yaml` | `grep_*` | uv / uvx | GitHub code search via grep.app. No API key. |
+| `grep.yaml` | `grep_*` | None (bundled binary) | GitHub code search via grep.app. No API key. |
 
 Add your Exa key to `~/.local/share/harnx/.env`:
 

--- a/packages/coding/tool_servers/context7.yaml
+++ b/packages/coding/tool_servers/context7.yaml
@@ -1,10 +1,12 @@
-command: npx
-args:
-  - "-y"
-  - "@upstash/context7-mcp@2.1.6"
+command: harnx-mcp-bridge
 description: >-
   Library and framework documentation lookup via Context7. Used by
   Librarian and Sisyphus to answer API and usage questions without
   hallucinating.
-
-# Requires: Node.js / npx. No API key needed.
+args:
+  - --name
+  - context7
+  - --
+  - npx
+  - "-y"
+  - "@upstash/context7-mcp@2.1.6"

--- a/packages/coding/tool_servers/exa.yaml
+++ b/packages/coding/tool_servers/exa.yaml
@@ -1,11 +1,13 @@
 # Note: set EXA_API_KEY in ~/.local/share/harnx/.env
-command: npx
-args:
-  - "-y"
-  - "exa-mcp-server"
+command: harnx-mcp-bridge
 enabled: true
 description: "Web search via Exa API"
-# If you've wrapped npx/node with a harnx sandbox, this allows the EXA_API_KEY to pass through
+args:
+  - --name
+  - exa
+  - --
+  - npx
+  - "-y"
+  - exa-mcp-server
 env:
   HARNX_BASH_ENV_PASSTHROUGH: EXA_API_KEY
-

--- a/packages/coding/tool_servers/fetch.yaml
+++ b/packages/coding/tool_servers/fetch.yaml
@@ -1,9 +1,11 @@
-command: npx
-args:
-  - "-y"
-  - "mcp-fetch-server"
+command: harnx-mcp-bridge
 description: >-
   Fetch web pages as markdown, plain text, or JSON. Used by Pytheas,
   Zosimus, Hephaestus, and other agents to read documentation and URLs.
-
-# Requires: Node.js / npx
+args:
+  - --name
+  - fetch
+  - --
+  - npx
+  - "-y"
+  - mcp-fetch-server

--- a/packages/coding/tool_servers/grep.yaml
+++ b/packages/coding/tool_servers/grep.yaml
@@ -1,7 +1,9 @@
-command: harnx-vercel-grep-server
+command: harnx-mcp-bridge
 description: >-
   GitHub code search via grep.app. Used by Pytheas, Sisyphus, and Zosimus
   to find real-world usage examples of APIs and patterns in public repos.
-
-# Native harnx binary — no external runtime needed.
-# No API key needed.
+args:
+  - --name
+  - grep
+  - --
+  - harnx-vercel-grep-server

--- a/packages/pantheon/README.md
+++ b/packages/pantheon/README.md
@@ -197,14 +197,14 @@ or symlink anything.
 | `plans.yaml` | `plans_*` | Plan/task/note management, stored in `.agent/plans/` relative to the working directory. |
 | `time.yaml` | `time_*` | Current time and wait/sleep utilities. |
 
-### External servers (require install)
+### Tool servers (bridge-run, under tool_servers/)
 
 | Server | Namespace | Requires | Notes |
 |--------|-----------|----------|-------|
 | `fetch.yaml` | `fetch_*` | Node.js / npx | Fetches URLs as markdown or text. No API key. |
 | `exa.yaml` | `exa_*` | Node.js / npx | Web search via Exa. Requires `EXA_API_KEY`. |
 | `context7.yaml` | `context7_*` | Node.js / npx | Library docs lookup. No API key. |
-| `grep.yaml` | `grep_*` | uv / uvx | GitHub code search via grep.app. No API key. |
+| `grep.yaml` | `grep_*` | None (bundled binary) | GitHub code search via grep.app. No API key. |
 
 Add your Exa key to `~/.local/share/harnx/.env`:
 

--- a/packages/pantheon/tool_servers/context7.yaml
+++ b/packages/pantheon/tool_servers/context7.yaml
@@ -1,10 +1,12 @@
-command: npx
-args:
-  - "-y"
-  - "@upstash/context7-mcp@2.1.6"
+command: harnx-mcp-bridge
 description: >-
   Library and framework documentation lookup via Context7. Used by
   Librarian and Sisyphus to answer API and usage questions without
   hallucinating.
-
-# Requires: Node.js / npx. No API key needed.
+args:
+  - --name
+  - context7
+  - --
+  - npx
+  - "-y"
+  - "@upstash/context7-mcp@2.1.6"

--- a/packages/pantheon/tool_servers/exa.yaml
+++ b/packages/pantheon/tool_servers/exa.yaml
@@ -1,13 +1,16 @@
 # Requires: Node.js / npx and an Exa API key.
 # Set EXA_API_KEY in ~/.local/share/harnx/.env
 # Sign up at https://exa.ai to get a key.
-command: npx
-args:
-  - "-y"
-  - "exa-mcp-server@3.2.1"
+command: harnx-mcp-bridge
 description: >-
   Web search via Exa API. Used by Librarian, Sisyphus, and Zosimus for
   research and fact-finding.
-# If you've wrapped npx/node with a harnx sandbox, this allows the EXA_API_KEY to pass through
+args:
+  - --name
+  - exa
+  - --
+  - npx
+  - "-y"
+  - exa-mcp-server@3.2.1
 env:
   HARNX_BASH_ENV_PASSTHROUGH: EXA_API_KEY

--- a/packages/pantheon/tool_servers/fetch.yaml
+++ b/packages/pantheon/tool_servers/fetch.yaml
@@ -1,9 +1,11 @@
-command: npx
-args:
-  - "-y"
-  - "mcp-fetch-server@1.1.2"
+command: harnx-mcp-bridge
 description: >-
   Fetch web pages as markdown, plain text, or JSON. Used by Pytheas,
   Zosimus, Hephaestus, and other agents to read documentation and URLs.
-
-# Requires: Node.js / npx
+args:
+  - --name
+  - fetch
+  - --
+  - npx
+  - "-y"
+  - mcp-fetch-server@1.1.2

--- a/packages/pantheon/tool_servers/grep.yaml
+++ b/packages/pantheon/tool_servers/grep.yaml
@@ -1,7 +1,9 @@
-command: harnx-vercel-grep-server
+command: harnx-mcp-bridge
 description: >-
   GitHub code search via grep.app. Used by Pytheas, Sisyphus, and Zosimus
   to find real-world usage examples of APIs and patterns in public repos.
-
-# Native harnx binary — no external runtime needed.
-# No API key needed.
+args:
+  - --name
+  - grep
+  - --
+  - harnx-vercel-grep-server


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an MCP-to-NATS bridge, enabling compatible stdio-based tool servers to run over NATS.
  * Migrated plans and several external tool servers to bridge-based configurations.
  * Added bundled bridge support to container images.

* **Configuration**
  * Renamed tool-server configuration paths from `mcp_servers/` to `tool_servers/`.
  * Retained standalone stdio support for plans, filesystem, and bash tools.

* **Documentation**
  * Updated setup guides, FAQs, examples, and configuration references for the new layout and bridge usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->