### PR TITLE
feat(hooks): add core hooks-over-NATS infrastructure and dual dispatch

### DIFF
--- a/.changeset/hooks-over-nats-core.md
+++ b/.changeset/hooks-over-nats-core.md
@@ -1,0 +1,7 @@
+---
+harnx: minor
+---
+
+feat(nats): introduce core hooks-over-NATS protocol and worker dual dispatch.
+
+Adds the `harnx-hookset` protocol crate and `harnx-hookset-server` daemon for NATS hook registration and request/reply execution. Worker dual dispatch runs NATS hooks alongside existing inline hooks, while hook supervision and config migration are deferred to future slices. References #1224.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3654,6 +3654,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "harnx-hookset"
+version = "0.33.4"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "harnx-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "harnx-hookset-server"
+version = "0.33.4"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "async-trait",
+ "futures-util",
+ "harnx-core",
+ "harnx-hookset",
+ "log",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "which",
+]
+
+[[package]]
 name = "harnx-k8s-creds"
 version = "0.33.4"
 dependencies = [
@@ -4009,6 +4037,8 @@ dependencies = [
  "harnx-engine",
  "harnx-fetch",
  "harnx-hooks",
+ "harnx-hookset",
+ "harnx-hookset-server",
  "harnx-mcp",
  "harnx-rag",
  "harnx-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ members = [
     "crates/harnx-spinner",
     "crates/harnx-test-bins",
     "crates/harnx-time-server",
+    "crates/harnx-hookset",
+    "crates/harnx-hookset-server",
     "crates/harnx-toolset",
     "crates/harnx-toolset-server",
     "crates/harnx-tui",

--- a/crates/harnx-core/src/hooks.rs
+++ b/crates/harnx-core/src/hooks.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HookPayload {
     pub session_id: String,
     pub cwd: PathBuf,
@@ -12,7 +12,7 @@ pub struct HookPayload {
     pub hook_event: HookEvent,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "hook_event_name", rename_all = "PascalCase")]
 pub enum HookEvent {
     SessionStart {
@@ -76,14 +76,14 @@ impl HookEvent {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum HookResultControl {
     Continue,
     Block { reason: String },
     Ask { reason: Option<String> },
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HookSpecificOutput {
     #[serde(default)]
@@ -96,7 +96,7 @@ pub struct HookSpecificOutput {
     pub tool_response: Option<Value>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HookResult {
     #[serde(default)]
@@ -113,7 +113,7 @@ pub struct HookResult {
     pub mutated_tool_response: Option<Value>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HookOutcome {
     pub control: HookResultControl,
     pub result: HookResult,
@@ -226,7 +226,10 @@ impl HooksConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{HookConfig, HookEvent, HookPayload, HookResult, HookSpecificOutput, HooksConfig};
+    use super::{
+        HookConfig, HookEvent, HookOutcome, HookPayload, HookResult, HookResultControl,
+        HookSpecificOutput, HooksConfig,
+    };
     use serde_json::{json, Value};
     use std::path::PathBuf;
 
@@ -446,6 +449,79 @@ entries:
         );
         assert_eq!(value["cwd"], Value::String("/tmp/project".to_string()));
         assert_eq!(value["resume_count"], Value::from(2));
+    }
+
+    #[test]
+    fn test_hook_payload_json_round_trip() {
+        let payload = HookPayload {
+            session_id: "session-123".to_string(),
+            cwd: PathBuf::from("/tmp/project"),
+            resume_count: 2,
+            hook_event: HookEvent::PreToolUse {
+                tool_name: "shell".to_string(),
+                tool_input: json!({"command": "echo hi"}),
+                tool_use_id: "call-1".to_string(),
+            },
+        };
+
+        let json = serde_json::to_string(&payload).expect("serialize hook payload");
+        let decoded: HookPayload = serde_json::from_str(&json).expect("deserialize hook payload");
+
+        assert_eq!(decoded.session_id, payload.session_id);
+        assert_eq!(decoded.cwd, payload.cwd);
+        assert_eq!(decoded.resume_count, payload.resume_count);
+        match decoded.hook_event {
+            HookEvent::PreToolUse {
+                tool_name,
+                tool_input,
+                tool_use_id,
+            } => {
+                assert_eq!(tool_name, "shell");
+                assert_eq!(tool_input, json!({"command": "echo hi"}));
+                assert_eq!(tool_use_id, "call-1");
+            }
+            event => panic!("expected PreToolUse, got {event:?}"),
+        }
+    }
+
+    #[test]
+    fn test_hook_outcome_json_round_trip() {
+        let outcome = HookOutcome {
+            control: HookResultControl::Block {
+                reason: "dangerous command".to_string(),
+            },
+            result: HookResult {
+                mutated_tool_input: Some(json!({"command": "echo safe"})),
+                ..HookResult::default()
+            },
+        };
+
+        let json = serde_json::to_string(&outcome).expect("serialize hook outcome");
+        let decoded: HookOutcome = serde_json::from_str(&json).expect("deserialize hook outcome");
+
+        assert_eq!(decoded.control, outcome.control);
+        assert_eq!(
+            decoded.result.mutated_tool_input,
+            Some(json!({"command": "echo safe"}))
+        );
+    }
+
+    #[test]
+    fn test_hook_result_control_json_round_trip() {
+        let controls = [
+            HookResultControl::Continue,
+            HookResultControl::Block {
+                reason: "blocked".to_string(),
+            },
+            HookResultControl::Ask { reason: None },
+        ];
+
+        for control in controls {
+            let json = serde_json::to_string(&control).expect("serialize hook result control");
+            let decoded: HookResultControl =
+                serde_json::from_str(&json).expect("deserialize hook result control");
+            assert_eq!(decoded, control);
+        }
     }
 
     #[test]

--- a/crates/harnx-core/src/instance.rs
+++ b/crates/harnx-core/src/instance.rs
@@ -32,6 +32,11 @@ impl InstanceId {
     pub fn control_subject(&self) -> String {
         format!("harnx.v1.{self}.tools.control")
     }
+
+    /// Build the Core NATS subject for a hook event.
+    pub fn hook_subject(&self, server: &str, event: &str) -> String {
+        format!("harnx.v1.{self}.hook.{server}.{event}")
+    }
 }
 
 impl Default for InstanceId {
@@ -72,6 +77,10 @@ mod tests {
         assert_eq!(
             instance_id.control_subject(),
             format!("harnx.v1.{instance_id}.tools.control")
+        );
+        assert_eq!(
+            instance_id.hook_subject("proxy-auth", "PreToolUse"),
+            format!("harnx.v1.{instance_id}.hook.proxy-auth.PreToolUse")
         );
     }
 }

--- a/crates/harnx-hookset-server/Cargo.toml
+++ b/crates/harnx-hookset-server/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "harnx-hookset-server"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "NATS server runtime for harnx hooks"
+
+[dependencies]
+anyhow = { workspace = true }
+async-nats = { workspace = true }
+futures-util = { workspace = true }
+harnx-core = { path = "../harnx-core" }
+harnx-hookset = { path = "../harnx-hookset" }
+log = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+async-trait = { workspace = true }
+tempfile = { workspace = true }
+which = { workspace = true }

--- a/crates/harnx-hookset-server/src/lib.rs
+++ b/crates/harnx-hookset-server/src/lib.rs
@@ -1,0 +1,211 @@
+//! Server-side adapter for hosting a [`harnx_hookset::Hook`] over Core NATS.
+
+use anyhow::{Context, Result};
+use async_nats::jetstream::{self, kv, stream};
+use futures_util::{stream::select_all, StreamExt};
+use harnx_core::hooks::{HookOutcome, HookPayload, HookResult, HookResultControl};
+use harnx_core::instance::{InstanceId, HARNX_INSTANCE_ID};
+use harnx_hookset::{Hook, HookRegistration, HookSpec, HOOK_PROTOCOL_VERSION, HOOK_SCHEMA_VERSION};
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+pub use harnx_hookset::HOOK_REGISTRY_BUCKET;
+
+const HARNX_NATS_URL: &str = "HARNX_NATS_URL";
+const HARNX_NATS_TOKEN: &str = "HARNX_NATS_TOKEN";
+const REGISTRATION_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+const DEFAULT_HOOK_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// KV key for one worker instance's hook server registration.
+pub fn hook_registration_key(instance_id: &InstanceId, server: &str) -> String {
+    format!("{instance_id}.{server}")
+}
+
+/// Host a hook over Core NATS request-reply and publish its KV registration.
+pub async fn serve_over_nats<H: Hook + 'static>(
+    hook: H,
+    instance_id: InstanceId,
+    nats_url: &str,
+    token: &str,
+) -> Result<()> {
+    let client = async_nats::ConnectOptions::new()
+        .token(token.to_owned())
+        .connect(nats_url)
+        .await
+        .with_context(|| format!("connect to NATS at {nats_url}"))?;
+    serve_with_client(Arc::new(hook), instance_id, client).await
+}
+
+/// Serve a hook using an existing NATS client.
+pub async fn serve_with_client(
+    hook: Arc<dyn Hook>,
+    instance_id: InstanceId,
+    client: async_nats::Client,
+) -> Result<()> {
+    let server = hook.name().to_owned();
+    let hooks = hook.hooks();
+    let mut events = HashSet::new();
+    let mut subscribers = Vec::new();
+
+    for event in hooks.iter().map(|spec| &spec.event) {
+        if !events.insert(event.clone()) {
+            continue;
+        }
+        let subject = instance_id.hook_subject(&server, event);
+        let subscriber = client
+            .subscribe(subject.clone())
+            .await
+            .with_context(|| format!("subscribe to hook requests on {subject}"))?;
+        subscribers.push(subscriber);
+    }
+    let mut requests = select_all(subscribers);
+
+    // Subscriptions must be active before registration makes this server discoverable.
+    client.flush().await.context("flush hook subscriptions")?;
+
+    let registration = HookRegistration {
+        server: server.clone(),
+        hooks,
+        schema_version: HOOK_SCHEMA_VERSION,
+        proto_version: HOOK_PROTOCOL_VERSION,
+    };
+    let jetstream = jetstream::new(client.clone());
+    let registry = ensure_hook_registry_bucket(&jetstream).await?;
+    publish_hook_registration(&registry, &instance_id, &registration).await?;
+
+    let mut refresh = tokio::time::interval(REGISTRATION_REFRESH_INTERVAL);
+    refresh.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    refresh.tick().await;
+
+    loop {
+        tokio::select! {
+            request = requests.next() => {
+                let Some(request) = request else {
+                    anyhow::bail!("hook request subscriptions closed");
+                };
+                let client = client.clone();
+                let hook = Arc::clone(&hook);
+                let specs = registration.hooks.clone();
+                tokio::spawn(async move {
+                    if let Err(error) = handle_hook_request(client, hook, &specs, request).await {
+                        log::warn!("handle hook request failed: {error:#}");
+                    }
+                });
+            }
+            _ = refresh.tick() => {
+                if let Err(error) = publish_hook_registration(&registry, &instance_id, &registration).await {
+                    log::warn!("refresh hook registration failed; retrying next interval: {error:#}");
+                }
+            }
+        }
+    }
+}
+
+fn continue_outcome() -> HookOutcome {
+    HookOutcome {
+        control: HookResultControl::Continue,
+        result: HookResult::default(),
+    }
+}
+
+async fn handle_hook_request(
+    client: async_nats::Client,
+    hook: Arc<dyn Hook>,
+    specs: &[HookSpec],
+    message: async_nats::Message,
+) -> Result<()> {
+    let Some(reply_subject) = message.reply else {
+        log::warn!("hook request missing reply subject");
+        return Ok(());
+    };
+
+    let outcome = match serde_json::from_slice::<HookPayload>(&message.payload) {
+        Ok(payload) => {
+            let event = payload.hook_event.event_name();
+            let timeout = specs
+                .iter()
+                .find(|spec| spec.event == event)
+                .and_then(|spec| spec.timeout_secs)
+                .map(Duration::from_secs)
+                .unwrap_or(DEFAULT_HOOK_TIMEOUT);
+            match tokio::time::timeout(timeout, hook.handle_hook(payload)).await {
+                Ok(outcome) => outcome,
+                Err(_) => {
+                    log::warn!(
+                        "{event} hook timed out after {}s; replying with Continue",
+                        timeout.as_secs()
+                    );
+                    continue_outcome()
+                }
+            }
+        }
+        Err(error) => {
+            log::warn!("decode hook request failed; replying with Continue: {error}");
+            continue_outcome()
+        }
+    };
+    let payload = serde_json::to_vec(&outcome).context("encode hook outcome")?;
+    client
+        .publish(reply_subject, payload.into())
+        .await
+        .context("publish hook outcome")?;
+    client.flush().await.context("flush hook outcome")
+}
+
+/// Create or open the hook registration KV bucket.
+pub async fn ensure_hook_registry_bucket(jetstream: &jetstream::Context) -> Result<kv::Store> {
+    match jetstream
+        .create_key_value(kv::Config {
+            bucket: HOOK_REGISTRY_BUCKET.to_string(),
+            history: 1,
+            num_replicas: 1,
+            storage: stream::StorageType::File,
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(store) => Ok(store),
+        Err(create_error) => jetstream
+            .get_key_value(HOOK_REGISTRY_BUCKET)
+            .await
+            .map_err(anyhow::Error::from)
+            .with_context(|| {
+                format!(
+                    "open hook registry bucket '{HOOK_REGISTRY_BUCKET}' after create failed: {create_error}"
+                )
+            }),
+    }
+}
+
+/// Publish one hook server registration.
+pub async fn publish_hook_registration(
+    registry: &kv::Store,
+    instance_id: &InstanceId,
+    registration: &HookRegistration,
+) -> Result<u64> {
+    let key = hook_registration_key(instance_id, &registration.server);
+    let payload = serde_json::to_vec(registration).context("encode hook registration")?;
+    registry
+        .put(&key, payload.into())
+        .await
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("publish hook registration '{key}'"))
+}
+
+/// Read hook server settings from the environment and serve over NATS.
+pub async fn run_hookset_main<H: Hook + 'static>(hook: H) -> Result<()> {
+    let instance_id = std::env::var(HARNX_INSTANCE_ID)
+        .with_context(|| format!("{HARNX_INSTANCE_ID} is required"))?;
+    let nats_url =
+        std::env::var(HARNX_NATS_URL).with_context(|| format!("{HARNX_NATS_URL} is required"))?;
+    let token = std::env::var(HARNX_NATS_TOKEN)
+        .with_context(|| format!("{HARNX_NATS_TOKEN} is required"))?;
+    serve_over_nats(
+        hook,
+        InstanceId::from_string(instance_id),
+        &nats_url,
+        &token,
+    )
+    .await
+}

--- a/crates/harnx-hookset-server/tests/nats_hookset.rs
+++ b/crates/harnx-hookset-server/tests/nats_hookset.rs
@@ -1,0 +1,225 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use harnx_core::hooks::{HookEvent, HookOutcome, HookPayload, HookResult, HookResultControl};
+use harnx_core::instance::InstanceId;
+use harnx_hookset::{
+    FailPolicy, Hook, HookRegistration, HookSpec, HOOK_PROTOCOL_VERSION, HOOK_SCHEMA_VERSION,
+};
+use harnx_hookset_server::{hook_registration_key, serve_over_nats, HOOK_REGISTRY_BUCKET};
+use serde_json::json;
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+const TOKEN: &str = "hookset-server-test-token";
+
+struct NatsServerHandle {
+    url: String,
+    _store_dir: TempDir,
+    child: Child,
+}
+
+impl Drop for NatsServerHandle {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
+    let Some(binary) = nats_server_binary() else {
+        eprintln!("skipping NATS integration test: nats-server binary not found");
+        return Ok(None);
+    };
+
+    const MAX_START_ATTEMPTS: usize = 5;
+    for attempt in 1..=MAX_START_ATTEMPTS {
+        let listener = TcpListener::bind("127.0.0.1:0").context("allocate NATS test port")?;
+        let port = listener.local_addr()?.port();
+        drop(listener);
+        let store_dir = tempfile::tempdir().context("create NATS test store")?;
+        let mut child = Command::new(&binary)
+            .arg("-js")
+            .arg("-sd")
+            .arg(store_dir.path())
+            .arg("-p")
+            .arg(port.to_string())
+            .arg("--auth")
+            .arg(TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .context("spawn nats-server")?;
+        let url = format!("nats://127.0.0.1:{port}");
+
+        match wait_for_nats_ready(&mut child, &url).await {
+            Ok(()) => {
+                return Ok(Some(NatsServerHandle {
+                    url,
+                    _store_dir: store_dir,
+                    child,
+                }));
+            }
+            Err(error) => {
+                let exited_during_startup = child.try_wait()?.is_some();
+                let _ = child.kill();
+                let _ = child.wait();
+                if exited_during_startup && attempt < MAX_START_ATTEMPTS {
+                    eprintln!(
+                        "nats-server exited during startup attempt {attempt}; retrying with a new port: {error:#}"
+                    );
+                    continue;
+                }
+                return Err(error).context(format!(
+                    "start nats-server after {attempt} attempt{}",
+                    if attempt == 1 { "" } else { "s" }
+                ));
+            }
+        }
+    }
+
+    unreachable!("NATS startup loop always returns")
+}
+
+async fn wait_for_nats_ready(child: &mut Child, url: &str) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let result = async_nats::ConnectOptions::new()
+            .token(TOKEN.to_string())
+            .connect(url)
+            .await;
+        match result {
+            Ok(client) => return client.flush().await.context("flush NATS test client"),
+            Err(error) if child.try_wait()?.is_some() => {
+                anyhow::bail!("nats-server exited during startup: {error}");
+            }
+            Err(_) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Err(error) => return Err(error).context("wait for nats-server readiness"),
+        }
+    }
+}
+
+fn nats_server_binary() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("NATS_SERVER_BIN") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    which::which("nats-server").ok()
+}
+
+async fn wait_for_registration(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+) -> Result<HookRegistration> {
+    let jetstream = async_nats::jetstream::new(client.clone());
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(store) = jetstream.get_key_value(HOOK_REGISTRY_BUCKET).await {
+            let key = hook_registration_key(instance_id, "echo");
+            if let Some(value) = store.get(&key).await? {
+                return serde_json::from_slice(&value).context("decode hook registration");
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("timed out waiting for echo hook registration");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+struct EchoHook;
+
+#[async_trait]
+impl Hook for EchoHook {
+    fn name(&self) -> &str {
+        "echo"
+    }
+
+    fn hooks(&self) -> Vec<HookSpec> {
+        vec![HookSpec {
+            event: "PreToolUse".to_string(),
+            matcher: None,
+            priority: 0,
+            timeout_secs: None,
+            fail_policy: FailPolicy::Closed,
+        }]
+    }
+
+    async fn handle_hook(&self, _payload: HookPayload) -> HookOutcome {
+        HookOutcome {
+            control: HookResultControl::Continue,
+            result: HookResult {
+                mutated_tool_input: Some(json!({"seen": true})),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn hookset_registers_and_serves_hook_over_nats() -> Result<()> {
+    harnx_core::require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        return Ok(());
+    };
+    let instance_id = InstanceId::new();
+    let server_instance_id = instance_id.clone();
+    let server_url = server.url.clone();
+    let server_task = tokio::spawn(async move {
+        serve_over_nats(EchoHook, server_instance_id, &server_url, TOKEN).await
+    });
+    let client = async_nats::ConnectOptions::new()
+        .token(TOKEN.to_string())
+        .connect(&server.url)
+        .await?;
+
+    let registration = match wait_for_registration(&client, &instance_id).await {
+        Ok(registration) => registration,
+        Err(error) if server_task.is_finished() => {
+            return Err(anyhow::anyhow!(
+                "hook server exited before registration ({error:#}): {:?}",
+                server_task.await
+            ));
+        }
+        Err(error) => return Err(error),
+    };
+    assert_eq!(registration.server, "echo");
+    assert_eq!(registration.hooks.len(), 1);
+    assert_eq!(registration.hooks[0].event, "PreToolUse");
+    assert_eq!(registration.schema_version, HOOK_SCHEMA_VERSION);
+    assert_eq!(registration.proto_version, HOOK_PROTOCOL_VERSION);
+
+    let payload = HookPayload {
+        session_id: "test-session".to_string(),
+        cwd: std::env::current_dir()?,
+        resume_count: 0,
+        hook_event: HookEvent::PreToolUse {
+            tool_name: "example".to_string(),
+            tool_input: json!({"input": true}),
+            tool_use_id: "tool-use-1".to_string(),
+        },
+    };
+    let message = client
+        .request(
+            instance_id.hook_subject("echo", "PreToolUse"),
+            serde_json::to_vec(&payload)?.into(),
+        )
+        .await?;
+    let outcome: HookOutcome =
+        serde_json::from_slice(&message.payload).context("decode hook outcome")?;
+    assert_eq!(outcome.control, HookResultControl::Continue);
+    assert_eq!(
+        outcome.result.mutated_tool_input,
+        Some(json!({"seen": true}))
+    );
+
+    server_task.abort();
+    drop(server);
+    Ok(())
+}

--- a/crates/harnx-hookset/Cargo.toml
+++ b/crates/harnx-hookset/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "harnx-hookset"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Transport-independent hook contract and wire types for harnx hook servers"
+
+[dependencies]
+async-trait = { workspace = true }
+harnx-core = { path = "../harnx-core" }
+serde = { workspace = true }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/harnx-hookset/src/lib.rs
+++ b/crates/harnx-hookset/src/lib.rs
@@ -1,0 +1,90 @@
+//! Shared hook contract and transport-independent protocol types.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// JetStream KV bucket containing hook server registrations.
+pub const HOOK_REGISTRY_BUCKET: &str = "harnx_hook_registry";
+/// Current hook registration schema version.
+pub const HOOK_SCHEMA_VERSION: u32 = 1;
+/// Current hook request protocol version.
+pub const HOOK_PROTOCOL_VERSION: u32 = 1;
+
+/// A hook event subscription advertised by a hook server.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HookSpec {
+    /// Hook event name, such as `PreToolUse` or `PostToolUse`.
+    pub event: String,
+    /// Optional regular expression matched against the bare tool name.
+    pub matcher: Option<String>,
+    /// Dispatch priority. Lower values run first.
+    pub priority: i32,
+    /// Optional execution timeout in seconds.
+    pub timeout_secs: Option<u64>,
+    /// Behavior to apply when hook execution fails.
+    pub fail_policy: FailPolicy,
+}
+
+/// Behavior to apply when a hook can't produce an outcome.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FailPolicy {
+    /// Reject the operation when the hook fails.
+    #[default]
+    Closed,
+    /// Continue the operation when the hook fails.
+    Open,
+}
+
+/// Hook implementation served by a transport adapter.
+#[async_trait]
+pub trait Hook: Send + Sync {
+    /// Stable server name used in registration and transport subjects.
+    fn name(&self) -> &str;
+
+    /// Hook event subscriptions exposed by this server.
+    fn hooks(&self) -> Vec<HookSpec>;
+
+    /// Handles one hook event.
+    async fn handle_hook(
+        &self,
+        payload: harnx_core::hooks::HookPayload,
+    ) -> harnx_core::hooks::HookOutcome;
+}
+
+/// Hook server metadata stored in KV for discovery.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HookRegistration {
+    pub server: String,
+    pub hooks: Vec<HookSpec>,
+    pub schema_version: u32,
+    pub proto_version: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hook_registration_round_trips_through_serde() -> anyhow::Result<()> {
+        let registration = HookRegistration {
+            server: "test-hooks".to_string(),
+            hooks: vec![HookSpec {
+                event: "PreToolUse".to_string(),
+                matcher: Some("exec".to_string()),
+                priority: 10,
+                timeout_secs: Some(5),
+                fail_policy: FailPolicy::default(),
+            }],
+            schema_version: HOOK_SCHEMA_VERSION,
+            proto_version: HOOK_PROTOCOL_VERSION,
+        };
+
+        let encoded = serde_json::to_vec(&registration)?;
+        let decoded: HookRegistration = serde_json::from_slice(&encoded)?;
+
+        assert_eq!(decoded, registration);
+        assert_eq!(FailPolicy::default(), FailPolicy::Closed);
+        Ok(())
+    }
+}

--- a/crates/harnx-proxy-auth/tests/hook_e2e.rs
+++ b/crates/harnx-proxy-auth/tests/hook_e2e.rs
@@ -297,6 +297,8 @@ async fn hook_injected_env_reaches_bash_exec_command() {
         current_agent_package: None,
         persistent_manager: &persistent_manager,
         working_dir: None,
+        nats_hook_provider: None,
+        pending_async_context: None,
     })
     .await;
 

--- a/crates/harnx-runtime/Cargo.toml
+++ b/crates/harnx-runtime/Cargo.toml
@@ -33,6 +33,8 @@ harnx-core = { path = "../harnx-core" }
 harnx-engine = { path = "../harnx-engine" }
 harnx-fetch = { path = "../harnx-fetch" }
 harnx-hooks = { path = "../harnx-hooks" }
+harnx-hookset = { path = "../harnx-hookset" }
+harnx-hookset-server = { path = "../harnx-hookset-server" }
 harnx-toolset = { path = "../harnx-toolset" }
 harnx-toolset-server = { path = "../harnx-toolset-server" }
 harnx-mcp = { path = "../harnx-mcp" }

--- a/crates/harnx-runtime/src/agent_loop.rs
+++ b/crates/harnx-runtime/src/agent_loop.rs
@@ -106,6 +106,7 @@ pub struct AgentLoopContext {
     pub initial_with_embeddings: bool,
     pub initial_resume_count: u32,
     pub max_resume: Option<u32>,
+    pub nats_hook_provider: Option<Arc<crate::nats_hook_provider::NatsHookProvider>>,
     pub pending_async_context: Option<Arc<tokio::sync::Mutex<Option<String>>>>,
     /// Optional per-session working directory. When unset, runtime falls back
     /// to process cwd for CLI compatibility.
@@ -735,9 +736,7 @@ mod tests {
     async fn injected_user_text_is_not_replayed_across_rounds() {
         let _guard = crate::client::TestStateGuard::new(None).await;
         let tmp = TempDir::new().unwrap();
-
         let global_config = replay_test_config(&tmp);
-
         // Mock LLM: round 1 → tool call, round 2 → tool call, round 3 → text-only.
         // No real tool provider is registered, so eval_tool_calls returns
         // is_error results. That's fine — the loop still proceeds round by
@@ -785,22 +784,7 @@ mod tests {
             })
         });
 
-        let ctx = AgentLoopContext {
-            instance_id: harnx_core::instance::InstanceId::new(),
-            config: global_config.clone(),
-            abort_signal: create_abort_signal(),
-            async_manager: Arc::new(tokio::sync::Mutex::new(AsyncHookManager::new())),
-            persistent_manager: Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new())),
-            call_fn: Some(call_fn),
-            on_tool_round: Some(on_tool_round),
-            on_text_response: None,
-            working_dir: None,
-            initial_with_embeddings: false,
-            initial_resume_count: 0,
-            max_resume: Some(0),
-            pending_async_context: None,
-            session_lock: None,
-        };
+        let ctx = make_test_context(global_config.clone(), call_fn, on_tool_round);
 
         let input = crate::config::input::from_str(&global_config, "do work", None);
         run_agent_loop(&ctx, input).await.unwrap();
@@ -833,9 +817,10 @@ mod tests {
         })
     }
 
-    fn make_handoff_test_context(
+    fn make_test_context(
         global_config: GlobalConfig,
         call_fn: AgentCallFn,
+        on_tool_round: OnToolRoundFn,
     ) -> AgentLoopContext {
         AgentLoopContext {
             instance_id: harnx_core::instance::InstanceId::new(),
@@ -844,12 +829,13 @@ mod tests {
             async_manager: Arc::new(tokio::sync::Mutex::new(AsyncHookManager::new())),
             persistent_manager: Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new())),
             call_fn: Some(call_fn),
-            on_tool_round: Some(handoff_on_tool_round()),
+            on_tool_round: Some(on_tool_round),
             on_text_response: None,
             working_dir: None,
             initial_with_embeddings: false,
             initial_resume_count: 0,
             max_resume: Some(0),
+            nats_hook_provider: None,
             pending_async_context: None,
             session_lock: None,
         }
@@ -969,7 +955,7 @@ mod tests {
             })
         });
 
-        let ctx = make_handoff_test_context(global_config.clone(), call_fn);
+        let ctx = make_test_context(global_config.clone(), call_fn, handoff_on_tool_round());
 
         assert!(!global_config.read().is_compacting_session());
         let sink = Arc::new(CollectingSink::default());

--- a/crates/harnx-runtime/src/lib.rs
+++ b/crates/harnx-runtime/src/lib.rs
@@ -20,6 +20,7 @@ pub mod local_orchestrator;
 pub mod nats_admin;
 pub mod nats_client_session;
 pub mod nats_event_sink;
+pub mod nats_hook_provider;
 pub mod nats_lease;
 pub mod nats_local_server;
 pub mod nats_metrics;

--- a/crates/harnx-runtime/src/nats_hook_provider.rs
+++ b/crates/harnx-runtime/src/nats_hook_provider.rs
@@ -1,0 +1,645 @@
+use crate::config::{Config, LOCAL_CLUSTER_KEY};
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use futures_util::TryStreamExt;
+use harnx_core::event::{AgentEvent, NoticeEvent};
+use harnx_core::hooks::{HookEvent, HookOutcome, HookPayload, HookResult, HookResultControl};
+use harnx_core::instance::InstanceId;
+use harnx_hookset::{FailPolicy, HookRegistration, HookSpec, HOOK_REGISTRY_BUCKET};
+use harnx_hookset_server::hook_registration_key;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+
+const DEFAULT_HOOK_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Session data needed to serialize a hook event for a remote hook server.
+#[derive(Clone, Debug)]
+pub struct HookDispatchMeta {
+    pub session_id: String,
+    pub cwd: PathBuf,
+}
+
+/// One hook route flattened from a hook server registration.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiscoveredHook {
+    pub server: String,
+    pub spec: HookSpec,
+}
+
+#[async_trait]
+trait HookRequestDispatcher: Send + Sync {
+    async fn request(
+        &self,
+        subject: String,
+        payload: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<HookOutcome>;
+}
+
+struct NatsHookRequester {
+    client: async_nats::Client,
+}
+
+#[async_trait]
+impl HookRequestDispatcher for NatsHookRequester {
+    async fn request(
+        &self,
+        subject: String,
+        payload: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<HookOutcome> {
+        let message = tokio::time::timeout(timeout, self.client.request(subject, payload.into()))
+            .await
+            .context("hook request timed out")??;
+        serde_json::from_slice(&message.payload).context("deserialize hook reply")
+    }
+}
+
+/// Discovers and dispatches hooks registered for one worker instance.
+pub struct NatsHookProvider {
+    client: async_nats::Client,
+    instance_id: InstanceId,
+    hooks: Vec<DiscoveredHook>,
+    dispatcher: Arc<dyn HookRequestDispatcher>,
+}
+
+impl NatsHookProvider {
+    pub async fn discover(config: &Config, instance_id: InstanceId) -> Result<Self> {
+        let client = config.nats_client(LOCAL_CLUSTER_KEY).await?;
+        let hooks = match registration_snapshot(&client, &instance_id).await {
+            Ok(hooks) => hooks,
+            Err(error) => {
+                // Hook servers create the registry lazily, so a fresh instance has no bucket.
+                log::debug!("NATS hook registry is not available yet: {error:#}");
+                Vec::new()
+            }
+        };
+        Ok(Self::from_hooks(client, instance_id, hooks))
+    }
+
+    pub fn from_hooks(
+        client: async_nats::Client,
+        instance_id: InstanceId,
+        hooks: Vec<DiscoveredHook>,
+    ) -> Self {
+        let dispatcher = Arc::new(NatsHookRequester {
+            client: client.clone(),
+        });
+        Self {
+            client,
+            instance_id,
+            hooks,
+            dispatcher,
+        }
+    }
+
+    pub fn hooks(&self) -> &[DiscoveredHook] {
+        &self.hooks
+    }
+
+    /// Returns the client used for discovery and requests.
+    pub fn client(&self) -> &async_nats::Client {
+        &self.client
+    }
+
+    pub async fn dispatch_pre_tool_use(
+        &self,
+        event: &HookEvent,
+        meta: HookDispatchMeta,
+    ) -> HookOutcome {
+        dispatch_pre_tool_use_with(
+            PreHookDispatch {
+                dispatcher: self.dispatcher.as_ref(),
+                instance_id: &self.instance_id,
+                hooks: &self.hooks,
+                meta: &meta,
+            },
+            event,
+        )
+        .await
+    }
+
+    /// Starts all matching PostToolUse hooks without waiting for their replies.
+    pub fn dispatch_post_tool_use(
+        &self,
+        event: HookEvent,
+        pending: Option<Arc<Mutex<Option<String>>>>,
+        meta: HookDispatchMeta,
+    ) {
+        for hook in matching_hooks(&self.hooks, event.event_name(), event.matcher_text()) {
+            let dispatcher = Arc::clone(&self.dispatcher);
+            let subject = self
+                .instance_id
+                .hook_subject(&hook.server, event.event_name());
+            let payload = HookPayload {
+                session_id: meta.session_id.clone(),
+                cwd: meta.cwd.clone(),
+                resume_count: 0,
+                hook_event: event.clone(),
+            };
+            let params = PostHookDispatch {
+                subject,
+                payload,
+                hook: hook.clone(),
+                pending: pending.clone(),
+            };
+            tokio::spawn(dispatch_one_post_hook(dispatcher, params));
+        }
+    }
+}
+
+/// Filters hooks for an event and matcher, then orders them by dispatch precedence.
+pub fn matching_hooks<'a>(
+    hooks: &'a [DiscoveredHook],
+    event_name: &str,
+    tool_name: Option<&str>,
+) -> Vec<&'a DiscoveredHook> {
+    let mut matches: Vec<_> = hooks
+        .iter()
+        .enumerate()
+        .filter(|(_, hook)| {
+            hook.spec.event == event_name
+                && match tool_name {
+                    Some(tool_name) => harnx_hooks::CompiledMatcher::compile(&hook.spec.matcher)
+                        .map(|matcher| matcher.matches_str(tool_name))
+                        .unwrap_or(false),
+                    None => hook.spec.matcher.is_none(),
+                }
+        })
+        .collect();
+    matches.sort_by(|(left_index, left), (right_index, right)| {
+        left.spec
+            .priority
+            .cmp(&right.spec.priority)
+            .then_with(|| left.server.cmp(&right.server))
+            .then_with(|| left_index.cmp(right_index))
+    });
+    matches.into_iter().map(|(_, hook)| hook).collect()
+}
+
+struct PreHookDispatch<'a> {
+    dispatcher: &'a dyn HookRequestDispatcher,
+    instance_id: &'a InstanceId,
+    hooks: &'a [DiscoveredHook],
+    meta: &'a HookDispatchMeta,
+}
+
+async fn dispatch_pre_tool_use_with(params: PreHookDispatch<'_>, event: &HookEvent) -> HookOutcome {
+    if !matches!(event, HookEvent::PreToolUse { .. }) {
+        return continue_outcome(None);
+    }
+
+    let mut running_event = event.clone();
+    let mut final_mutation = None;
+    for hook in matching_hooks(params.hooks, event.event_name(), event.matcher_text()) {
+        let payload = HookPayload {
+            session_id: params.meta.session_id.clone(),
+            cwd: params.meta.cwd.clone(),
+            resume_count: 0,
+            hook_event: running_event.clone(),
+        };
+        let payload = match serde_json::to_vec(&payload) {
+            Ok(payload) => payload,
+            Err(error) => {
+                return unavailable_outcome(&hook.server, hook.spec.fail_policy, error);
+            }
+        };
+        let subject = params.instance_id.hook_subject(&hook.server, "PreToolUse");
+        let timeout = hook
+            .spec
+            .timeout_secs
+            .map(Duration::from_secs)
+            .unwrap_or(DEFAULT_HOOK_TIMEOUT);
+        let outcome = match params.dispatcher.request(subject, payload, timeout).await {
+            Ok(outcome) => outcome,
+            Err(error) if hook.spec.fail_policy == FailPolicy::Open => {
+                log::warn!("{} hook unavailable; continuing: {error:#}", hook.server);
+                continue;
+            }
+            Err(error) => return unavailable_outcome(&hook.server, FailPolicy::Closed, error),
+        };
+
+        match outcome.control {
+            HookResultControl::Block { .. } | HookResultControl::Ask { .. } => return outcome,
+            HookResultControl::Continue => {
+                if let Some(tool_input) = outcome.result.mutated_tool_input {
+                    running_event = with_pre_tool_input(&running_event, tool_input.clone());
+                    final_mutation = Some(tool_input);
+                }
+            }
+        }
+    }
+    continue_outcome(final_mutation)
+}
+
+struct PostHookDispatch {
+    subject: String,
+    payload: HookPayload,
+    hook: DiscoveredHook,
+    pending: Option<Arc<Mutex<Option<String>>>>,
+}
+
+async fn dispatch_one_post_hook(
+    dispatcher: Arc<dyn HookRequestDispatcher>,
+    params: PostHookDispatch,
+) {
+    let server = &params.hook.server;
+    let timeout = params
+        .hook
+        .spec
+        .timeout_secs
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_HOOK_TIMEOUT);
+    let payload = match serde_json::to_vec(&params.payload) {
+        Ok(payload) => payload,
+        Err(error) => {
+            emit_post_notice(format!(
+                "{server} hook request could not be serialized: {error}"
+            ));
+            return;
+        }
+    };
+    let outcome = match dispatcher.request(params.subject, payload, timeout).await {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            let policy = match params.hook.spec.fail_policy {
+                FailPolicy::Closed => "fail-closed",
+                FailPolicy::Open => "fail-open",
+            };
+            emit_post_notice(format!("{server} hook unavailable ({policy}): {error:#}"));
+            return;
+        }
+    };
+
+    if !matches!(outcome.control, HookResultControl::Continue) {
+        emit_post_notice(format!(
+            "{server} hook returned {:?} after tool completion",
+            outcome.control
+        ));
+    }
+    if outcome.result.mutated_tool_response.is_some() {
+        log::debug!("ignoring mutated tool response from asynchronous {server} hook");
+    }
+    if let Some(pending) = params.pending {
+        append_pending_context(
+            pending.as_ref(),
+            [
+                outcome.result.additional_context,
+                outcome.result.system_message,
+            ],
+        )
+        .await;
+    }
+}
+
+async fn append_pending_context(pending: &Mutex<Option<String>>, texts: [Option<String>; 2]) {
+    let mut guard = pending.lock().await;
+    let mut accumulated = guard.take().unwrap_or_default();
+    for text in texts.into_iter().flatten().filter(|text| !text.is_empty()) {
+        if !accumulated.is_empty() {
+            accumulated.push('\n');
+        }
+        accumulated.push_str(&text);
+    }
+    if !accumulated.is_empty() {
+        *guard = Some(accumulated);
+    }
+}
+
+fn with_pre_tool_input(event: &HookEvent, tool_input: serde_json::Value) -> HookEvent {
+    match event {
+        HookEvent::PreToolUse {
+            tool_name,
+            tool_use_id,
+            ..
+        } => HookEvent::PreToolUse {
+            tool_name: tool_name.clone(),
+            tool_input,
+            tool_use_id: tool_use_id.clone(),
+        },
+        _ => event.clone(),
+    }
+}
+
+fn continue_outcome(mutated_tool_input: Option<serde_json::Value>) -> HookOutcome {
+    HookOutcome {
+        control: HookResultControl::Continue,
+        result: HookResult {
+            mutated_tool_input,
+            ..HookResult::default()
+        },
+    }
+}
+
+fn unavailable_outcome(
+    server: &str,
+    fail_policy: FailPolicy,
+    error: impl std::fmt::Display,
+) -> HookOutcome {
+    if fail_policy == FailPolicy::Open {
+        log::warn!("{server} hook unavailable; continuing: {error}");
+        return continue_outcome(None);
+    }
+    log::warn!("{server} hook unavailable; blocking: {error}");
+    HookOutcome {
+        control: HookResultControl::Block {
+            reason: format!("{server} hook unavailable"),
+        },
+        result: HookResult::default(),
+    }
+}
+
+fn emit_post_notice(message: String) {
+    log::warn!("{message}");
+    harnx_core::sink::emit_agent_event(AgentEvent::Notice(NoticeEvent::Error(message)));
+}
+
+async fn registration_snapshot(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+) -> Result<Vec<DiscoveredHook>> {
+    let jetstream = async_nats::jetstream::new(client.clone());
+    let store = jetstream.get_key_value(HOOK_REGISTRY_BUCKET).await?;
+    let mut keys = store.keys().await?;
+    let prefix = format!("{instance_id}.");
+    let mut hooks = Vec::new();
+    while let Some(key) = keys.try_next().await? {
+        if !key.starts_with(&prefix) {
+            continue;
+        }
+        let Some(value) = store.get(&key).await? else {
+            continue;
+        };
+        let registration = match serde_json::from_slice::<HookRegistration>(&value) {
+            Ok(registration) => registration,
+            Err(error) => {
+                log::warn!("ignoring invalid NATS hook registration '{key}': {error}");
+                continue;
+            }
+        };
+        if key != hook_registration_key(instance_id, &registration.server) {
+            continue;
+        }
+        hooks.extend(registration.hooks.into_iter().map(|spec| DiscoveredHook {
+            server: registration.server.clone(),
+            spec,
+        }));
+    }
+    Ok(hooks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Value};
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Notify;
+
+    struct StubDispatcher {
+        outcomes: Mutex<VecDeque<HookOutcome>>,
+        seen_inputs: Mutex<Vec<Value>>,
+        delay: Option<Duration>,
+        completed: Option<Arc<Notify>>,
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl HookRequestDispatcher for StubDispatcher {
+        async fn request(
+            &self,
+            _subject: String,
+            payload: Vec<u8>,
+            _timeout: Duration,
+        ) -> Result<HookOutcome> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let payload: HookPayload = serde_json::from_slice(&payload)?;
+            if let HookEvent::PreToolUse { tool_input, .. } = payload.hook_event {
+                self.seen_inputs.lock().await.push(tool_input);
+            }
+            if let Some(delay) = self.delay {
+                tokio::time::sleep(delay).await;
+            }
+            let outcome = self
+                .outcomes
+                .lock()
+                .await
+                .pop_front()
+                .context("stub outcome queue exhausted")?;
+            if let Some(completed) = &self.completed {
+                completed.notify_one();
+            }
+            Ok(outcome)
+        }
+    }
+
+    fn hook(server: &str, event: &str, matcher: Option<&str>, priority: i32) -> DiscoveredHook {
+        DiscoveredHook {
+            server: server.to_string(),
+            spec: HookSpec {
+                event: event.to_string(),
+                matcher: matcher.map(str::to_string),
+                priority,
+                timeout_secs: None,
+                fail_policy: FailPolicy::Closed,
+            },
+        }
+    }
+
+    fn pre_event(input: Value) -> HookEvent {
+        HookEvent::PreToolUse {
+            tool_name: "exec".to_string(),
+            tool_input: input,
+            tool_use_id: "tool-1".to_string(),
+        }
+    }
+
+    fn mutate(value: Value) -> HookOutcome {
+        continue_outcome(Some(value))
+    }
+
+    fn stub(outcomes: Vec<HookOutcome>) -> Arc<StubDispatcher> {
+        Arc::new(StubDispatcher {
+            outcomes: Mutex::new(outcomes.into()),
+            seen_inputs: Mutex::new(Vec::new()),
+            delay: None,
+            completed: None,
+            calls: AtomicUsize::new(0),
+        })
+    }
+
+    #[test]
+    fn matcher_filter_selects_event_and_bare_tool_name() {
+        let hooks = vec![
+            hook("exact", "PreToolUse", Some("^exec$"), 0),
+            hook("prefixed", "PreToolUse", Some("^mcp__exec$"), 0),
+            hook("other-event", "PostToolUse", Some("^exec$"), 0),
+            hook("all-tools", "PreToolUse", None, 0),
+        ];
+
+        let selected = matching_hooks(&hooks, "PreToolUse", Some("exec"));
+        let servers: Vec<_> = selected.iter().map(|hook| hook.server.as_str()).collect();
+        assert_eq!(servers, ["all-tools", "exact"]);
+        assert!(matching_hooks(&hooks, "SessionStart", None).is_empty());
+    }
+
+    #[test]
+    fn priority_sort_uses_server_then_registry_order_as_tiebreakers() {
+        let hooks = vec![
+            hook("zeta", "PreToolUse", None, 10),
+            hook("alpha", "PreToolUse", None, 10),
+            hook("alpha", "PreToolUse", None, 10),
+            hook("later", "PreToolUse", None, 20),
+            hook("first", "PreToolUse", None, -1),
+        ];
+
+        let selected = matching_hooks(&hooks, "PreToolUse", Some("exec"));
+        let positions: Vec<_> = selected
+            .iter()
+            .map(|hook| (hook.server.as_str(), hook.spec.priority))
+            .collect();
+        assert_eq!(
+            positions,
+            [
+                ("first", -1),
+                ("alpha", 10),
+                ("alpha", 10),
+                ("zeta", 10),
+                ("later", 20),
+            ]
+        );
+        assert!(std::ptr::eq(selected[1], &hooks[1]));
+        assert!(std::ptr::eq(selected[2], &hooks[2]));
+    }
+
+    #[tokio::test]
+    async fn pre_chain_applies_mutation_before_block_and_short_circuits() {
+        let blocked = HookOutcome {
+            control: HookResultControl::Block {
+                reason: "denied".to_string(),
+            },
+            result: HookResult::default(),
+        };
+        let dispatcher = stub(vec![mutate(json!({"step": 1})), blocked]);
+        let hooks = vec![
+            hook("one", "PreToolUse", None, 0),
+            hook("two", "PreToolUse", None, 1),
+            hook("three", "PreToolUse", None, 2),
+        ];
+
+        let instance_id = InstanceId::from_string("test");
+        let meta = HookDispatchMeta {
+            session_id: "session".to_string(),
+            cwd: PathBuf::from("/tmp"),
+        };
+        let outcome = dispatch_pre_tool_use_with(
+            PreHookDispatch {
+                dispatcher: dispatcher.as_ref(),
+                instance_id: &instance_id,
+                hooks: &hooks,
+                meta: &meta,
+            },
+            &pre_event(json!({"step": 0})),
+        )
+        .await;
+
+        assert!(matches!(outcome.control, HookResultControl::Block { .. }));
+        assert_eq!(dispatcher.calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            *dispatcher.seen_inputs.lock().await,
+            vec![json!({"step": 0}), json!({"step": 1})]
+        );
+    }
+
+    #[tokio::test]
+    async fn pre_chain_returns_last_of_composed_mutations() {
+        let dispatcher = stub(vec![
+            mutate(json!({"step": "a"})),
+            mutate(json!({"step": "b"})),
+        ]);
+        let hooks = vec![
+            hook("one", "PreToolUse", None, 0),
+            hook("two", "PreToolUse", None, 1),
+        ];
+
+        let instance_id = InstanceId::from_string("test");
+        let meta = HookDispatchMeta {
+            session_id: "session".to_string(),
+            cwd: PathBuf::from("/tmp"),
+        };
+        let outcome = dispatch_pre_tool_use_with(
+            PreHookDispatch {
+                dispatcher: dispatcher.as_ref(),
+                instance_id: &instance_id,
+                hooks: &hooks,
+                meta: &meta,
+            },
+            &pre_event(json!({"step": "initial"})),
+        )
+        .await;
+
+        assert_eq!(
+            outcome.result.mutated_tool_input,
+            Some(json!({"step": "b"}))
+        );
+        assert_eq!(
+            *dispatcher.seen_inputs.lock().await,
+            vec![json!({"step": "initial"}), json!({"step": "a"})]
+        );
+    }
+
+    #[tokio::test]
+    async fn post_dispatch_returns_before_hook_and_appends_shared_context() {
+        let completed = Arc::new(Notify::new());
+        let dispatcher = Arc::new(StubDispatcher {
+            outcomes: Mutex::new(
+                vec![HookOutcome {
+                    control: HookResultControl::Continue,
+                    result: HookResult {
+                        additional_context: Some("context".to_string()),
+                        system_message: Some("system".to_string()),
+                        ..HookResult::default()
+                    },
+                }]
+                .into(),
+            ),
+            seen_inputs: Mutex::new(Vec::new()),
+            delay: Some(Duration::from_millis(100)),
+            completed: Some(Arc::clone(&completed)),
+            calls: AtomicUsize::new(0),
+        });
+        let pending = Arc::new(Mutex::new(Some("existing".to_string())));
+        let payload = HookPayload {
+            session_id: "session".to_string(),
+            cwd: PathBuf::from("/tmp"),
+            resume_count: 0,
+            hook_event: HookEvent::PostToolUse {
+                tool_name: "exec".to_string(),
+                tool_input: json!({}),
+                tool_response: json!({}),
+                tool_use_id: "tool-1".to_string(),
+            },
+        };
+
+        let started = tokio::time::Instant::now();
+        tokio::spawn(dispatch_one_post_hook(
+            dispatcher,
+            PostHookDispatch {
+                subject: "subject".to_string(),
+                payload,
+                hook: hook("server", "PostToolUse", None, 0),
+                pending: Some(Arc::clone(&pending)),
+            },
+        ));
+        assert!(started.elapsed() < Duration::from_millis(50));
+
+        completed.notified().await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            pending.lock().await.as_deref(),
+            Some("existing\ncontext\nsystem")
+        );
+    }
+}

--- a/crates/harnx-runtime/src/nats_worker/agent_loop.rs
+++ b/crates/harnx-runtime/src/nats_worker/agent_loop.rs
@@ -244,7 +244,8 @@ pub async fn run_agent_loop_with_nats_inner(args: RunAgentLoopArgs<'_>) -> Resul
         initial_with_embeddings: false,
         initial_resume_count: 0,
         max_resume: None,
-        pending_async_context: None,
+        nats_hook_provider: None,
+        pending_async_context: Some(Arc::new(tokio::sync::Mutex::new(None))),
         working_dir,
         session_lock: None,
     };
@@ -727,6 +728,8 @@ async fn build_orphan_tool_eval_context(
         current_agent_package: repair.current_agent_package.clone(),
         persistent_manager: &repair.persistent_manager,
         working_dir: None,
+        nats_hook_provider: None,
+        pending_async_context: None,
     })
     .await
 }

--- a/crates/harnx-runtime/src/tool.rs
+++ b/crates/harnx-runtime/src/tool.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::{Config, GlobalConfig},
+    nats_hook_provider::{HookDispatchMeta, NatsHookProvider},
     utils::*,
 };
 use anyhow::Result;
@@ -30,7 +31,8 @@ pub struct CompletionText<'a> {
     pub thought: Option<&'a str>,
 }
 
-use crate::tool_context::discover_nats_tool_provider;
+use crate::nats_tool_provider::NatsToolProvider;
+use crate::tool_context::{discover_nats_hook_provider_cached, discover_nats_tool_provider};
 pub use crate::tool_context::{BuildToolEvalContextParams, ToolRoundParams};
 
 #[derive(Debug, Clone)]
@@ -92,6 +94,8 @@ pub async fn execute_tool_round_with_persistence(
         abort_signal,
         persistent_manager,
         working_dir,
+        nats_hook_provider,
+        pending_async_context,
     } = params;
     let dry_run = config.read().dry_run;
 
@@ -116,6 +120,8 @@ pub async fn execute_tool_round_with_persistence(
         current_agent_package,
         persistent_manager,
         working_dir,
+        nats_hook_provider,
+        pending_async_context,
     })
     .await;
     let results = match eval_tool_calls(&eval_ctx, tool_calls.clone(), abort_signal).await {
@@ -149,22 +155,90 @@ pub async fn execute_tool_round_with_persistence(
     Ok(results)
 }
 
-/// Build a `ToolEvalContext` from the harnx `GlobalConfig`. Replaces the
-/// old inherent `ToolEvalContext::from_config` method — the struct lives
-/// in `harnx-engine::tool` now (orphan rules forbid adding inherent
-/// methods on a cross-crate type). Snapshots Config fields and the instance's
-/// NATS registrations, constructs the provider list (NATS first, then MCP),
-/// builds the dispatch hook closure over captured `hooks.entries`, `session_id`,
-/// and `cwd`, and wires in harnx-side default UI/prompt callbacks.
-///
-/// `agent_use_tools` is the active agent's `use_tools` whitelist. The
-/// CLI/TUI flow stores the agent on the Config (via `use_agent`), so
-/// `Config::extract_agent()` would yield the right value, but the previous frontend
-/// server holds the agent only on the per-prompt `Input` (because each
-/// `prompt` call may target a different agent on the same Config).
-/// Passing the use_tools list explicitly keeps both paths correct.
-/// Build the hook dispatch closure, capturing hooks config and the persistent
-/// manager so `ToolEvalContext` can fire PreToolUse/PostToolUse hooks.
+/// Run configured inline hooks for one event.
+async fn dispatch_inline_hooks(
+    event: &HookEvent,
+    hooks_entries: &[HookConfig],
+    per_tool_hooks: &HashMap<String, (String, Vec<HookConfig>)>,
+    session_id: &str,
+    cwd: &std::path::Path,
+    persistent_manager: &Arc<tokio::sync::Mutex<PersistentHookManager>>,
+) -> harnx_core::hooks::HookOutcome {
+    let display_tool_name = match event {
+        HookEvent::PreToolUse { tool_name, .. }
+        | HookEvent::PostToolUse { tool_name, .. }
+        | HookEvent::PostToolUseFailure { tool_name, .. } => Some(tool_name.as_str()),
+        _ => None,
+    };
+
+    // For server-scoped hooks, match the hook's `matcher` against the bare
+    // (unprefixed) tool name. Strip the matcher from entries we add to the
+    // merged list so the global dispatcher doesn't re-check against the
+    // prefixed display name and accidentally reject them.
+    let mut merged_entries: Vec<HookConfig> = if let Some(display_name) = display_tool_name {
+        per_tool_hooks
+            .get(display_name)
+            .map(|(bare_name, entries)| {
+                entries
+                    .iter()
+                    .filter(|hook| {
+                        harnx_hooks::CompiledMatcher::compile(&hook.matcher)
+                            .map(|m| m.matches_str(bare_name))
+                            .unwrap_or(false)
+                    })
+                    .map(|hook| HookConfig {
+                        matcher: None,
+                        ..hook.clone()
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    merged_entries.extend_from_slice(hooks_entries);
+
+    harnx_hooks::dispatch::dispatch_hooks_with_count_and_manager(
+        event,
+        &merged_entries,
+        session_id,
+        cwd,
+        0,
+        None,
+        Some(persistent_manager),
+    )
+    .await
+}
+
+fn with_pre_tool_input(event: &HookEvent, tool_input: Value) -> HookEvent {
+    match event {
+        HookEvent::PreToolUse {
+            tool_name,
+            tool_input: _,
+            tool_use_id,
+        } => HookEvent::PreToolUse {
+            tool_name: tool_name.clone(),
+            tool_input,
+            tool_use_id: tool_use_id.clone(),
+        },
+        _ => event.clone(),
+    }
+}
+
+fn compose_pre_tool_use_outcome(
+    nats_mutated_tool_input: Option<Value>,
+    mut inline_outcome: harnx_core::hooks::HookOutcome,
+) -> harnx_core::hooks::HookOutcome {
+    if matches!(
+        inline_outcome.control,
+        harnx_core::hooks::HookResultControl::Continue
+    ) && inline_outcome.result.mutated_tool_input.is_none()
+    {
+        inline_outcome.result.mutated_tool_input = nats_mutated_tool_input;
+    }
+    inline_outcome
+}
+
 fn build_dispatch_hook_fn(
     hooks: &harnx_hooks::HooksConfig,
     // Value is (bare_server_tool_name, hook_entries). The matcher in each entry is
@@ -172,8 +246,10 @@ fn build_dispatch_hook_fn(
     // an MCP server doesn't require updating hook matchers.
     per_tool_hooks: HashMap<String, (String, Vec<HookConfig>)>,
     session_name: Option<&str>,
-    persistent_manager: &std::sync::Arc<tokio::sync::Mutex<PersistentHookManager>>,
+    persistent_manager: &Arc<tokio::sync::Mutex<PersistentHookManager>>,
     working_dir: Option<&std::path::Path>,
+    nats_hook_provider: Option<Arc<NatsHookProvider>>,
+    pending_async_context: Option<Arc<tokio::sync::Mutex<Option<String>>>>,
 ) -> Arc<DispatchHookFn> {
     let hooks_entries = hooks.entries.clone();
     let session_id = session_name.unwrap_or("cmd").to_string();
@@ -187,52 +263,78 @@ fn build_dispatch_hook_fn(
         let session_id = session_id.clone();
         let cwd = cwd.clone();
         let persistent_manager = persistent_manager.clone();
+        let nats_hook_provider = nats_hook_provider.clone();
+        let pending_async_context = pending_async_context.clone();
         Box::pin(async move {
-            let display_tool_name = match &event {
-                HookEvent::PreToolUse { tool_name, .. }
-                | HookEvent::PostToolUse { tool_name, .. }
-                | HookEvent::PostToolUseFailure { tool_name, .. } => Some(tool_name.as_str()),
-                _ => None,
+            let meta = HookDispatchMeta {
+                session_id: session_id.clone(),
+                cwd: cwd.clone(),
             };
-
-            // For server-scoped hooks, match the hook's `matcher` against the bare
-            // (unprefixed) tool name. Strip the matcher from entries we add to the
-            // merged list so the global dispatcher doesn't re-check against the
-            // prefixed display name and accidentally reject them.
-            let mut merged_entries: Vec<HookConfig> = if let Some(display_name) = display_tool_name
-            {
-                per_tool_hooks
-                    .get(display_name)
-                    .map(|(bare_name, entries)| {
-                        entries
-                            .iter()
-                            .filter(|hook| {
-                                harnx_hooks::CompiledMatcher::compile(&hook.matcher)
-                                    .map(|m| m.matches_str(bare_name))
-                                    .unwrap_or(false)
-                            })
-                            .map(|hook| HookConfig {
-                                matcher: None,
-                                ..hook.clone()
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default()
-            } else {
-                Vec::new()
-            };
-            merged_entries.extend(hooks_entries.clone());
-
-            harnx_hooks::dispatch::dispatch_hooks_with_count_and_manager(
-                &event,
-                &merged_entries,
-                &session_id,
-                &cwd,
-                0,
-                None,
-                Some(&persistent_manager),
-            )
-            .await
+            match &event {
+                HookEvent::PreToolUse { .. } => {
+                    let Some(provider) = nats_hook_provider else {
+                        return dispatch_inline_hooks(
+                            &event,
+                            &hooks_entries,
+                            &per_tool_hooks,
+                            &session_id,
+                            &cwd,
+                            &persistent_manager,
+                        )
+                        .await;
+                    };
+                    let nats_outcome = provider.dispatch_pre_tool_use(&event, meta).await;
+                    match &nats_outcome.control {
+                        harnx_core::hooks::HookResultControl::Block { .. } => return nats_outcome,
+                        harnx_core::hooks::HookResultControl::Ask { .. } => {
+                            // NOTE: Ask follows the existing ToolApprovalRequiredError path.
+                            // Headless-worker resolution over NATS is deferred to a later slice.
+                            return nats_outcome;
+                        }
+                        harnx_core::hooks::HookResultControl::Continue => {}
+                    }
+                    let nats_mutation = nats_outcome.result.mutated_tool_input;
+                    let inline_event = nats_mutation
+                        .clone()
+                        .map(|input| with_pre_tool_input(&event, input))
+                        .unwrap_or(event);
+                    let inline_outcome = dispatch_inline_hooks(
+                        &inline_event,
+                        &hooks_entries,
+                        &per_tool_hooks,
+                        &session_id,
+                        &cwd,
+                        &persistent_manager,
+                    )
+                    .await;
+                    compose_pre_tool_use_outcome(nats_mutation, inline_outcome)
+                }
+                HookEvent::PostToolUse { .. } => {
+                    if let Some(provider) = nats_hook_provider {
+                        provider.dispatch_post_tool_use(event.clone(), pending_async_context, meta);
+                    }
+                    dispatch_inline_hooks(
+                        &event,
+                        &hooks_entries,
+                        &per_tool_hooks,
+                        &session_id,
+                        &cwd,
+                        &persistent_manager,
+                    )
+                    .await
+                }
+                _ => {
+                    dispatch_inline_hooks(
+                        &event,
+                        &hooks_entries,
+                        &per_tool_hooks,
+                        &session_id,
+                        &cwd,
+                        &persistent_manager,
+                    )
+                    .await
+                }
+            }
         })
     })
 }
@@ -263,6 +365,20 @@ fn build_emit_fns(
     (emit_tool_call_fn, emit_tool_result_fn, emit_tool_blocked_fn)
 }
 
+async fn resolve_nats_providers(
+    config: &Config,
+    instance_id: &harnx_core::instance::InstanceId,
+    injected_hook_provider: Option<Arc<NatsHookProvider>>,
+) -> (Option<Arc<NatsToolProvider>>, Option<Arc<NatsHookProvider>>) {
+    let tool_provider = discover_nats_tool_provider(config, instance_id).await;
+    let hook_provider = match injected_hook_provider {
+        Some(provider) => Some(provider),
+        None => discover_nats_hook_provider_cached(config, instance_id).await,
+    };
+    (tool_provider, hook_provider)
+}
+
+/// Build tool providers, hook dispatch, and rendering state for one tool round.
 pub async fn build_tool_eval_context(params: BuildToolEvalContextParams<'_>) -> ToolEvalContext {
     let BuildToolEvalContextParams {
         config,
@@ -271,6 +387,8 @@ pub async fn build_tool_eval_context(params: BuildToolEvalContextParams<'_>) -> 
         current_agent_package,
         persistent_manager,
         working_dir,
+        nats_hook_provider,
+        pending_async_context,
     } = params;
     let (
         mut tool_declarations,
@@ -295,7 +413,8 @@ pub async fn build_tool_eval_context(params: BuildToolEvalContextParams<'_>) -> 
         )
     };
 
-    let nats_provider = discover_nats_tool_provider(&config_snapshot, instance_id).await;
+    let (nats_provider, nats_hook_provider) =
+        resolve_nats_providers(&config_snapshot, instance_id, nats_hook_provider).await;
     if let Some(provider) = &nats_provider {
         tool_declarations.extend(provider.declarations_for_use_tools(agent_use_tools));
     }
@@ -310,6 +429,8 @@ pub async fn build_tool_eval_context(params: BuildToolEvalContextParams<'_>) -> 
         session_name.as_deref(),
         persistent_manager,
         working_dir,
+        nats_hook_provider,
+        pending_async_context,
     );
     let (emit_tool_call_fn, emit_tool_result_fn, emit_tool_blocked_fn) = build_emit_fns(&decl_map);
     ToolEvalContext {
@@ -1140,8 +1261,94 @@ mod tests {
         let pm = Arc::new(tokio::sync::Mutex::new(
             harnx_hooks::PersistentHookManager::new(),
         ));
-        let dispatch_fn = build_dispatch_hook_fn(&hooks_config, per_tool_hooks, None, &pm, None);
+        let dispatch_fn =
+            build_dispatch_hook_fn(&hooks_config, per_tool_hooks, None, &pm, None, None, None);
         (dispatch_fn)(event).await
+    }
+
+    fn continue_outcome(mutated_tool_input: Option<Value>) -> harnx_core::hooks::HookOutcome {
+        harnx_core::hooks::HookOutcome {
+            control: harnx_core::hooks::HookResultControl::Continue,
+            result: harnx_core::hooks::HookResult {
+                mutated_tool_input,
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn compose_pre_tool_use_outcome_preserves_nats_then_inline_mutation() {
+        let nats_mutation = json!({"nats": true});
+        let nats_only =
+            compose_pre_tool_use_outcome(Some(nats_mutation.clone()), continue_outcome(None));
+        assert_eq!(
+            nats_only.result.mutated_tool_input,
+            Some(nats_mutation),
+            "NATS mutation must survive when inline hooks don't mutate"
+        );
+
+        let inline_mutation = json!({"nats": true, "inline": true});
+        let inline_wins = compose_pre_tool_use_outcome(
+            Some(json!({"nats": true})),
+            continue_outcome(Some(inline_mutation.clone())),
+        );
+        assert_eq!(
+            inline_wins.result.mutated_tool_input,
+            Some(inline_mutation),
+            "inline mutation already includes its NATS-mutated starting input"
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_none_matches_pure_inline_for_pre_and_post_tool_use() {
+        let hooks = harnx_hooks::HooksConfig {
+            entries: Vec::new(),
+            max_resume: None,
+        };
+        let per_tool_hooks = HashMap::new();
+        let persistent_manager = Arc::new(tokio::sync::Mutex::new(
+            harnx_hooks::PersistentHookManager::new(),
+        ));
+        let cwd = std::env::current_dir().unwrap();
+        let dispatch = build_dispatch_hook_fn(
+            &hooks,
+            per_tool_hooks.clone(),
+            Some("session"),
+            &persistent_manager,
+            Some(&cwd),
+            None,
+            None,
+        );
+        let events = [
+            HookEvent::PreToolUse {
+                tool_name: "tool".to_string(),
+                tool_input: json!({"input": true}),
+                tool_use_id: "pre".to_string(),
+            },
+            HookEvent::PostToolUse {
+                tool_name: "tool".to_string(),
+                tool_input: json!({"input": true}),
+                tool_response: json!({"output": true}),
+                tool_use_id: "post".to_string(),
+            },
+        ];
+
+        for event in events {
+            let expected = dispatch_inline_hooks(
+                &event,
+                &hooks.entries,
+                &per_tool_hooks,
+                "session",
+                &cwd,
+                &persistent_manager,
+            )
+            .await;
+            let actual = dispatch(event).await;
+            assert_eq!(
+                serde_json::to_value(actual).unwrap(),
+                serde_json::to_value(expected).unwrap()
+            );
+        }
     }
 
     /// A no-matcher server hook applies to all tools on that server.
@@ -1316,6 +1523,8 @@ mod tests {
             Some("session-a"),
             &persistent_manager,
             Some(root_a.path()),
+            None,
+            None,
         );
         let dispatch_b = build_dispatch_hook_fn(
             &hooks,
@@ -1323,6 +1532,8 @@ mod tests {
             Some("session-b"),
             &persistent_manager,
             Some(root_b.path()),
+            None,
+            None,
         );
 
         let (outcome_a, outcome_b) = tokio::join!(

--- a/crates/harnx-runtime/src/tool_context.rs
+++ b/crates/harnx-runtime/src/tool_context.rs
@@ -1,12 +1,15 @@
 use crate::agent_loop::AgentLoopContext;
 use crate::config::{Config, GlobalConfig, Input};
+use crate::nats_hook_provider::NatsHookProvider;
 use crate::nats_tool_provider::{NatsInFlightCalls, NatsToolProvider};
 use crate::tool::CompletionText;
 use crate::utils::AbortSignal;
 use harnx_core::instance::InstanceId;
 use harnx_hooks::PersistentHookManager;
+use std::collections::HashMap;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
 /// Shared runtime state for one tool-evaluation round.
@@ -18,6 +21,8 @@ pub struct ToolRoundParams<'a> {
     pub abort_signal: &'a AbortSignal,
     pub persistent_manager: &'a Arc<Mutex<PersistentHookManager>>,
     pub working_dir: Option<&'a Path>,
+    pub nats_hook_provider: Option<Arc<NatsHookProvider>>,
+    pub pending_async_context: Option<Arc<Mutex<Option<String>>>>,
 }
 
 /// Inputs used to assemble the provider and rendering context for a tool round.
@@ -28,6 +33,8 @@ pub struct BuildToolEvalContextParams<'a> {
     pub current_agent_package: Option<String>,
     pub persistent_manager: &'a Arc<Mutex<PersistentHookManager>>,
     pub working_dir: Option<&'a Path>,
+    pub nats_hook_provider: Option<Arc<NatsHookProvider>>,
+    pub pending_async_context: Option<Arc<Mutex<Option<String>>>>,
 }
 
 impl<'a> BuildToolEvalContextParams<'a> {
@@ -43,6 +50,8 @@ impl<'a> BuildToolEvalContextParams<'a> {
             current_agent_package: None,
             persistent_manager,
             working_dir: None,
+            nats_hook_provider: None,
+            pending_async_context: None,
         }
     }
 
@@ -72,8 +81,71 @@ impl AgentLoopContext {
             abort_signal: &self.abort_signal,
             persistent_manager: &self.persistent_manager,
             working_dir: self.working_dir.as_deref(),
+            nats_hook_provider: self.nats_hook_provider.clone(),
+            pending_async_context: self.pending_async_context.clone(),
         }
     }
+}
+
+const NATS_HOOK_DISCOVERY_TTL: Duration = Duration::from_secs(30);
+
+type HookDiscoveryCache = std::sync::Mutex<HashMap<InstanceId, CachedDiscovery<NatsHookProvider>>>;
+static NATS_HOOK_DISCOVERY_CACHE: OnceLock<HookDiscoveryCache> = OnceLock::new();
+
+struct CachedDiscovery<T> {
+    provider: Option<Arc<T>>,
+    discovered_at: Instant,
+}
+
+fn cached_discovery<T>(
+    cache: &std::sync::Mutex<HashMap<InstanceId, CachedDiscovery<T>>>,
+    instance_id: &InstanceId,
+    now: Instant,
+    ttl: Duration,
+) -> Option<Option<Arc<T>>> {
+    let mut cache = cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    cache.retain(|_, entry| now.saturating_duration_since(entry.discovered_at) < ttl);
+    cache.get(instance_id).map(|entry| entry.provider.clone())
+}
+
+fn cache_discovery<T>(
+    cache: &std::sync::Mutex<HashMap<InstanceId, CachedDiscovery<T>>>,
+    instance_id: InstanceId,
+    provider: Option<Arc<T>>,
+    discovered_at: Instant,
+) {
+    cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(
+            instance_id,
+            CachedDiscovery {
+                provider,
+                discovered_at,
+            },
+        );
+}
+
+/// Discover NATS hooks at most once per instance during each refresh interval.
+pub async fn discover_nats_hook_provider_cached(
+    config: &Config,
+    instance_id: &InstanceId,
+) -> Option<Arc<NatsHookProvider>> {
+    let cache = NATS_HOOK_DISCOVERY_CACHE.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
+    let now = Instant::now();
+    if let Some(provider) = cached_discovery(cache, instance_id, now, NATS_HOOK_DISCOVERY_TTL) {
+        return provider;
+    }
+
+    // Don't hold the process-wide lock while connecting to NATS or scanning KV.
+    let provider = NatsHookProvider::discover(config, instance_id.clone())
+        .await
+        .ok()
+        .map(Arc::new);
+    cache_discovery(cache, instance_id.clone(), provider.clone(), Instant::now());
+    provider
 }
 
 pub async fn discover_nats_tool_provider(
@@ -88,4 +160,76 @@ pub async fn discover_nats_tool_provider(
     .await
     .ok()
     .map(Arc::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hook_discovery_cache_reuses_arc_until_ttl_expires() {
+        let cache = std::sync::Mutex::new(HashMap::new());
+        let instance_id = InstanceId::from_string("cache-test");
+        let discovered_at = Instant::now();
+        let first = Arc::new(());
+        cache_discovery(
+            &cache,
+            instance_id.clone(),
+            Some(Arc::clone(&first)),
+            discovered_at,
+        );
+
+        let cached = cached_discovery(
+            &cache,
+            &instance_id,
+            discovered_at + Duration::from_secs(29),
+            Duration::from_secs(30),
+        )
+        .flatten()
+        .expect("fresh provider cached");
+        assert!(Arc::ptr_eq(&first, &cached));
+
+        assert!(cached_discovery(
+            &cache,
+            &instance_id,
+            discovered_at + Duration::from_secs(30),
+            Duration::from_secs(30),
+        )
+        .is_none());
+        let refreshed = Arc::new(());
+        cache_discovery(
+            &cache,
+            instance_id.clone(),
+            Some(Arc::clone(&refreshed)),
+            discovered_at + Duration::from_secs(30),
+        );
+        let cached = cached_discovery(
+            &cache,
+            &instance_id,
+            discovered_at + Duration::from_secs(31),
+            Duration::from_secs(30),
+        )
+        .flatten()
+        .expect("refreshed provider cached");
+        assert!(Arc::ptr_eq(&refreshed, &cached));
+        assert!(!Arc::ptr_eq(&first, &cached));
+    }
+
+    #[test]
+    fn hook_discovery_cache_preserves_none_until_ttl_expires() {
+        let cache = std::sync::Mutex::new(HashMap::<InstanceId, CachedDiscovery<()>>::new());
+        let instance_id = InstanceId::from_string("none-cache-test");
+        let discovered_at = Instant::now();
+        cache_discovery(&cache, instance_id.clone(), None, discovered_at);
+
+        assert!(matches!(
+            cached_discovery(
+                &cache,
+                &instance_id,
+                discovered_at + Duration::from_secs(1),
+                Duration::from_secs(30),
+            ),
+            Some(None)
+        ));
+    }
 }

--- a/crates/harnx-runtime/tests/nats_hooks_e2e.rs
+++ b/crates/harnx-runtime/tests/nats_hooks_e2e.rs
@@ -1,0 +1,365 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use harnx_core::event::{AgentEvent, AgentEventSink, NoticeEvent};
+use harnx_core::hooks::{HookEvent, HookOutcome, HookPayload, HookResult, HookResultControl};
+use harnx_core::instance::InstanceId;
+use harnx_hookset::{FailPolicy, Hook, HookRegistration, HookSpec};
+use harnx_hookset_server::{hook_registration_key, serve_over_nats, HOOK_REGISTRY_BUCKET};
+use harnx_runtime::config::Config;
+use harnx_runtime::nats_hook_provider::{HookDispatchMeta, NatsHookProvider};
+use serde_json::{json, Value};
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+use tokio::sync::Mutex;
+
+const TOKEN: &str = "nats-hooks-e2e-token";
+const TEST_TOOL: &str = "test_tool";
+
+struct NatsServerHandle {
+    url: String,
+    _store_dir: TempDir,
+    child: Child,
+}
+
+impl Drop for NatsServerHandle {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+struct TestHook;
+
+#[async_trait]
+impl Hook for TestHook {
+    fn name(&self) -> &str {
+        "testhook"
+    }
+
+    fn hooks(&self) -> Vec<HookSpec> {
+        vec![
+            HookSpec {
+                event: "PreToolUse".to_string(),
+                matcher: Some(TEST_TOOL.to_string()),
+                priority: 10,
+                timeout_secs: Some(2),
+                fail_policy: FailPolicy::Closed,
+            },
+            HookSpec {
+                event: "PostToolUse".to_string(),
+                matcher: Some(TEST_TOOL.to_string()),
+                priority: 10,
+                timeout_secs: Some(2),
+                fail_policy: FailPolicy::Closed,
+            },
+        ]
+    }
+
+    async fn handle_hook(&self, payload: HookPayload) -> HookOutcome {
+        match payload.hook_event {
+            HookEvent::PreToolUse { mut tool_input, .. } => {
+                if tool_input.get("deny_me") == Some(&Value::Bool(true)) {
+                    return HookOutcome {
+                        control: HookResultControl::Block {
+                            reason: "denied by test hook".to_string(),
+                        },
+                        result: HookResult::default(),
+                    };
+                }
+                tool_input
+                    .as_object_mut()
+                    .expect("test tool input must be an object")
+                    .insert("nats_hook_seen".to_string(), Value::Bool(true));
+                HookOutcome {
+                    control: HookResultControl::Continue,
+                    result: HookResult {
+                        mutated_tool_input: Some(tool_input),
+                        ..HookResult::default()
+                    },
+                }
+            }
+            HookEvent::PostToolUse { tool_input, .. }
+                if tool_input.get("post_error") == Some(&Value::Bool(true)) =>
+            {
+                HookOutcome {
+                    control: HookResultControl::Block {
+                        reason: "post hook cannot block completed tool".to_string(),
+                    },
+                    result: HookResult::default(),
+                }
+            }
+            HookEvent::PostToolUse { .. } => HookOutcome {
+                control: HookResultControl::Continue,
+                result: HookResult {
+                    additional_context: Some("post-hook-context".to_string()),
+                    ..HookResult::default()
+                },
+            },
+            _ => HookOutcome {
+                control: HookResultControl::Continue,
+                result: HookResult::default(),
+            },
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+struct CollectingSink {
+    events: Arc<StdMutex<Vec<AgentEvent>>>,
+}
+
+impl AgentEventSink for CollectingSink {
+    fn emit(&self, event: AgentEvent) {
+        self.events
+            .lock()
+            .expect("event mutex poisoned")
+            .push(event);
+    }
+}
+
+impl CollectingSink {
+    fn error_notices(&self) -> Vec<String> {
+        self.events
+            .lock()
+            .expect("event mutex poisoned")
+            .iter()
+            .filter_map(|event| match event {
+                AgentEvent::Notice(NoticeEvent::Error(message)) => Some(message.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn nats_hooks_deny_mutate_and_deliver_post_results() -> Result<()> {
+    harnx_core::require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        return Ok(());
+    };
+    let instance_id = InstanceId::new();
+    let server_url = server.url.clone();
+    let hook_instance_id = instance_id.clone();
+    let hook_task = tokio::spawn(async move {
+        serve_over_nats(TestHook, hook_instance_id, &server_url, TOKEN).await
+    });
+    let client = async_nats::ConnectOptions::new()
+        .token(TOKEN.to_string())
+        .connect(&server.url)
+        .await?;
+    wait_for_registration(&client, &instance_id).await?;
+
+    // NatsHookProvider reserves __local__ for the worker's environment handoff.
+    unsafe {
+        std::env::set_var("HARNX_NATS_URL", &server.url);
+        std::env::set_var("HARNX_NATS_TOKEN", TOKEN);
+    }
+    let provider = NatsHookProvider::discover(&Config::default(), instance_id).await?;
+    let meta = HookDispatchMeta {
+        session_id: "nats-hooks-e2e".to_string(),
+        cwd: std::env::current_dir()?,
+    };
+
+    let denied = provider
+        .dispatch_pre_tool_use(&pre_event(json!({"deny_me": true})), meta.clone())
+        .await;
+    assert_eq!(
+        denied.control,
+        HookResultControl::Block {
+            reason: "denied by test hook".to_string()
+        }
+    );
+
+    let mutated = provider
+        .dispatch_pre_tool_use(&pre_event(json!({"value": 42})), meta.clone())
+        .await;
+    assert_eq!(mutated.control, HookResultControl::Continue);
+    assert_eq!(
+        mutated.result.mutated_tool_input,
+        Some(json!({"value": 42, "nats_hook_seen": true}))
+    );
+
+    let pending = Arc::new(Mutex::new(None));
+    provider.dispatch_post_tool_use(
+        post_event(json!({"value": 42})),
+        Some(Arc::clone(&pending)),
+        meta.clone(),
+    );
+    wait_for_pending_context(&pending, "post-hook-context").await?;
+
+    let sink = CollectingSink::default();
+    harnx_core::sink::clear_agent_event_sink();
+    harnx_core::sink::install_agent_event_sink(Arc::new(sink.clone()));
+    provider.dispatch_post_tool_use(post_event(json!({"post_error": true})), Some(pending), meta);
+    let errors = wait_for_error_notice(&sink).await?;
+    assert!(
+        errors.iter().any(|message| {
+            message.contains("testhook hook returned Block")
+                && message.contains("post hook cannot block completed tool")
+        }),
+        "expected post-hook Block Error Notice, got {errors:?}"
+    );
+    harnx_core::sink::clear_agent_event_sink();
+
+    hook_task.abort();
+    drop(server);
+    Ok(())
+}
+
+fn pre_event(tool_input: Value) -> HookEvent {
+    HookEvent::PreToolUse {
+        tool_name: TEST_TOOL.to_string(),
+        tool_input,
+        tool_use_id: "pre-tool-use-id".to_string(),
+    }
+}
+
+fn post_event(tool_input: Value) -> HookEvent {
+    HookEvent::PostToolUse {
+        tool_name: TEST_TOOL.to_string(),
+        tool_input,
+        tool_response: json!({"ok": true}),
+        tool_use_id: "post-tool-use-id".to_string(),
+    }
+}
+
+async fn wait_for_registration(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+) -> Result<HookRegistration> {
+    let jetstream = async_nats::jetstream::new(client.clone());
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(store) = jetstream.get_key_value(HOOK_REGISTRY_BUCKET).await {
+            let key = hook_registration_key(instance_id, "testhook");
+            if let Some(value) = store.get(&key).await? {
+                return serde_json::from_slice(&value).context("decode hook registration");
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("timed out waiting for test hook registration");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn wait_for_pending_context(
+    pending: &Arc<Mutex<Option<String>>>,
+    expected: &str,
+) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if pending.lock().await.as_deref() == Some(expected) {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for pending hook context; got {:?}",
+                pending.lock().await.as_deref()
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+async fn wait_for_error_notice(sink: &CollectingSink) -> Result<Vec<String>> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let errors = sink.error_notices();
+        if !errors.is_empty() {
+            return Ok(errors);
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("timed out waiting for post-hook Error Notice");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
+    let Some(binary) = nats_server_binary() else {
+        eprintln!("skipping NATS integration test: nats-server binary not found");
+        return Ok(None);
+    };
+
+    const MAX_START_ATTEMPTS: usize = 5;
+    for attempt in 1..=MAX_START_ATTEMPTS {
+        let listener = TcpListener::bind("127.0.0.1:0").context("allocate NATS test port")?;
+        let port = listener.local_addr()?.port();
+        drop(listener);
+        let store_dir = tempfile::tempdir().context("create NATS test store")?;
+        let mut child = Command::new(&binary)
+            .arg("-js")
+            .arg("-sd")
+            .arg(store_dir.path())
+            .arg("-p")
+            .arg(port.to_string())
+            .arg("--auth")
+            .arg(TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .context("spawn nats-server")?;
+        let url = format!("nats://127.0.0.1:{port}");
+
+        match wait_for_nats_ready(&mut child, &url).await {
+            Ok(()) => {
+                return Ok(Some(NatsServerHandle {
+                    url,
+                    _store_dir: store_dir,
+                    child,
+                }));
+            }
+            Err(error) => {
+                let exited_during_startup = child.try_wait()?.is_some();
+                let _ = child.kill();
+                let _ = child.wait();
+                if exited_during_startup && attempt < MAX_START_ATTEMPTS {
+                    eprintln!(
+                        "nats-server exited during startup attempt {attempt}; retrying with a new port: {error:#}"
+                    );
+                    continue;
+                }
+                return Err(error).context(format!(
+                    "start nats-server after {attempt} attempt{}",
+                    if attempt == 1 { "" } else { "s" }
+                ));
+            }
+        }
+    }
+    unreachable!("NATS startup loop always returns")
+}
+
+async fn wait_for_nats_ready(child: &mut Child, url: &str) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let result = async_nats::ConnectOptions::new()
+            .token(TOKEN.to_string())
+            .connect(url)
+            .await;
+        match result {
+            Ok(client) => return client.flush().await.context("flush NATS test client"),
+            Err(error) if child.try_wait()?.is_some() => {
+                anyhow::bail!("nats-server exited during startup: {error}");
+            }
+            Err(_) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Err(error) => return Err(error).context("wait for nats-server readiness"),
+        }
+    }
+}
+
+fn nats_server_binary() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("NATS_SERVER_BIN") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    which::which("nats-server").ok()
+}

--- a/crates/harnx-session/src/lib.rs
+++ b/crates/harnx-session/src/lib.rs
@@ -42,6 +42,7 @@ pub fn build_context(
         initial_with_embeddings: true,
         initial_resume_count: 0,
         max_resume: None,
+        nats_hook_provider: None,
         pending_async_context: None,
         working_dir,
         session_lock: None,

--- a/crates/harnx-tui/src/prompt.rs
+++ b/crates/harnx-tui/src/prompt.rs
@@ -116,9 +116,8 @@ impl Tui {
 
         let event_tx = ctx.event_tx.clone();
         let shared_pending = ctx.shared_pending_message.clone();
-        let on_tool_round: harnx_runtime::OnToolRoundFn = Arc::new(
-            move |merged_input: &mut harnx_runtime::config::Input,
-                  _tool_results: &[harnx_runtime::tool::ToolResult]| {
+        let on_tool_round: harnx_runtime::OnToolRoundFn =
+            Arc::new(move |merged_input, _tool_results| {
                 let event_tx = event_tx.clone();
                 let shared_pending = shared_pending.clone();
                 Box::pin(async move {
@@ -134,8 +133,7 @@ impl Tui {
                         }
                     }
                 })
-            },
-        );
+            });
 
         let event_tx = ctx.event_tx.clone();
         let on_text_response: harnx_runtime::OnTextResponseFn = Arc::new(
@@ -150,7 +148,6 @@ impl Tui {
                 })
             },
         );
-
         let loop_ctx = harnx_runtime::AgentLoopContext {
             instance_id: harnx_core::instance::InstanceId::new(),
             config: ctx.config.clone(),
@@ -163,6 +160,7 @@ impl Tui {
             initial_with_embeddings: true,
             initial_resume_count: 0,
             max_resume: None,
+            nats_hook_provider: None,
             pending_async_context: None,
             working_dir: None,
             session_lock: None,

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -611,3 +611,55 @@ When the hook runs, it injects the following variables into the tool's environme
 *   **User Precedence**: If the agent or user already defined any of these environment variables in the tool call, `harnx-proxy-auth` will **not** overwrite them. This allows for manual overrides.
 *   **Ephemeral CA**: The proxy CA certificate is generated on startup and deleted immediately upon the hook's exit. It is only trusted by the processes spawned during a single harnx run.
 *   **Scoped Injection**: Request mutation scope is defined by your jaq filter. Requests that do not match your condition should return `.`, leaving traffic unchanged.
+
+
+## 12. Serving Hooks over NATS (experimental)
+
+Harnx supports running hook handlers as decoupled NATS microservices using the `harnx-hookset` and `harnx-hookset-server` crates.
+
+### Architecture and Discovery
+
+NATS hook servers register their capabilities in a JetStream Key-Value bucket and handle hook invocation requests over NATS subjects.
+
+* **Registry Bucket**: `harnx_hook_registry` (constant `HOOK_REGISTRY_BUCKET`).
+* **Registration**: On startup, hook servers publish a `HookRegistration` payload containing `server` ID, `hooks` list (`Vec<HookSpec>`), `schema_version`, and `proto_version`. The registration is refreshed every 30 seconds (TTL).
+* **Subject Scheme**: Hook servers subscribe to `harnx.v1.{instance}.hook.{server}.{event}` subjects.
+* **Request/Reply**: The worker posts a `HookPayload` request and awaits a `HookOutcome` reply.
+
+### Hook Specifications and Fail Policy
+
+Each hook registers one or more `HookSpec` structures:
+
+* `event`: Triggering event type (e.g., `PreToolUse`, `PostToolUse`).
+* `matcher`: Regex matched against the bare tool name (for example, `bash_exec` or `fs_read`).
+* `priority`: Integer priority (lower values execute first).
+* `timeout_secs`: Execution timeout in seconds.
+* `fail_policy`: Determines behavior if the hook times out or returns an error.
+  * `Closed` (default, serialized as `"closed"`): Treats hook failure as a blocking error.
+  * `Open` (serialized as `"open"`): Logs the error and continues execution.
+
+### Worker Discovery and Execution
+
+The worker's `NatsHookProvider` reads active registrations from `harnx_hook_registry`, filters hooks matching the event and bare tool name, and orders them by priority ascending.
+
+* **`PreToolUse` Hooks**: Executed sequentially. Output mutations (`mutated_tool_input`) chain from one hook to the next. If any hook returns a `Block` or `Ask` outcome, execution short-circuits immediately.
+* **`PostToolUse` Hooks**: Executed asynchronously (`tokio::spawn` fire-and-forget). Errors emit an `AgentEvent::Notice(Error)`. Returned `additional_context` or `system_message` values route to the shared `pending_async_context` and inject into the next agent turn. Tool response mutations (`mutated_tool_response`) are dropped in this slice.
+
+### Dual Dispatch
+
+The worker's hook dispatcher (`build_dispatch_hook_fn`) executes NATS hooks first, followed sequentially by existing inline hooks:
+
+1. NATS hooks run sequentially.
+2. If a NATS hook blocks or requests approval (`Ask`), the request short-circuits.
+3. If NATS hooks pass, the resulting mutated payload passes to the inline hook runner.
+4. NATS and inline mutations are composed together.
+
+Inline hooks still run after NATS hooks, ensuring existing configurations (such as `harnx-proxy-auth`) function without modification. Non-NATS callers fall back to inline-only dispatch.
+
+### Known Edges and Deferred Items
+
+* **`Ask` Outcome over NATS**: A `PreToolUse` hook returning `Ask` routes through the worker's existing `ToolApprovalRequiredError` path. Interactive resolution of `Ask` outcomes over NATS for headless workers is deferred to a future slice.
+* **`PreToolUse` context injection**: In this slice the worker composes only `mutated_tool_input` from NATS `PreToolUse` hooks. `additional_context` and `system_message` returned by a NATS `PreToolUse` hook are not yet injected (unlike `PostToolUse`, which routes them to `pending_async_context`). Deferred to a future slice.
+* **Deferred Goals**: Hook process supervision, config-driven `hooks/*.yaml` loading, migrating existing inline hooks to NATS, converting `harnx-proxy-auth` to a native NATS hook, and restoring `PostToolUse` response mutations will be implemented in subsequent slices.
+
+References #1224.

--- a/docs/solutions/hooks-over-nats-core-2026-07-31.md
+++ b/docs/solutions/hooks-over-nats-core-2026-07-31.md
@@ -1,0 +1,229 @@
+---
+title: "Hooks over NATS Core — Dual Dispatch, Fire-and-Forget Context, and Fork vs Share"
+date: 2026-07-31
+category: "integration-issues"
+problem_type: integration_issue
+component: "harnx-runtime/harnx-hookset"
+root_cause: "hooks only ran inline; no NATS dispatch path existed and inline hooks could not be bypassed without breaking proxy-auth"
+resolution_type: code_fix
+severity: high
+tags:
+  - nats
+  - hooks
+  - dual-dispatch
+  - fire-and-forget
+  - testing
+plan_ref: "hooks-over-nats-core"
+---
+
+# Solution: Hooks over NATS Core
+
+## Problem
+
+Hooks ran only through the inline `harnx_hooks` dispatcher. Adding a NATS dispatch path risked breaking existing inline hooks (notably `harnx-proxy-auth`, which injects GitHub/Atlassian credentials for `bash_exec`) if inline dispatch was removed or bypassed. PostToolUse context injection from async hooks had no path into the agent's turn-local state.
+
+## Symptoms
+
+- No NATS hook registry or dispatch mechanism existed.
+- `build_dispatch_hook_fn` called only `dispatch_hooks_with_count_and_manager` (inline).
+- `AgentLoopContext` allocated `pending_async_context: None` in the nats_worker path, leaving detached PostToolUse tasks no handle to inject context.
+- Hook wire types (`HookPayload`, `HookOutcome`, etc.) were one-directional (Serialize-only or Deserialize-only) and could not round-trip through NATS.
+
+## Investigation Steps
+
+Verified the seam in `crates/harnx-runtime/src/tool.rs`:
+
+- Engine (`harnx-engine/src/tool.rs`) calls `ctx.dispatch_hook_fn` for Pre/Post hooks — unchanged.
+- `build_dispatch_hook_fn` builds the closure that calls inline dispatch.
+- The closure takes `event: HookEvent` **by value** — essential for mutation composition.
+
+Inspected toolset-server for forking:
+
+- `harnx-toolset-server` implements idempotency-cache, cancellation, control subject, reply-cache.
+- Hooks don't need these — they're single-shot dispatch, no retry semantics.
+
+Analyzed context handle issues:
+
+- `AgentLoopContext.pending_async_context: Option<Arc<Mutex<Option<String>>>>` is drained at turn start.
+- Detached `tokio::spawn` tasks from PostToolUse cannot reach turn-local `&mut Option<String>` — must use the Arc.
+
+Aristarchus multi-agent review confirmed:
+- Engine diff empty (hard constraint holds).
+- Dual dispatch preserves proxy-auth.
+- Fork decision clean.
+- Discovery-error → inline-only fail-open is acceptable (no NATS-only security hook exists yet).
+
+## Root Cause
+
+1. **Missing NATS path**: No registry, no discovery, no dispatch to remote hooks.
+2. **Serde gap**: Wire types couldn't serialize + deserialize for round-trip over NATS.
+3. **Context unreachable from detached task**: Turn-local async_manager is inaccessible from `tokio::spawn` — only the shared Arc works.
+
+## Solution
+
+### Serde Round-Trip Derives (Task 1)
+
+Added `Deserialize` to `HookPayload`, `HookEvent`; added `Serialize`+`Deserialize` to `HookResultControl`, `HookOutcome`; added `Serialize` to `HookResult`, `HookSpecificOutput`. Kept `HookEvent`'s `#[serde(tag="hook_event_name", rename_all="PascalCase")]` unchanged.
+
+`HookResultControl` uses serde's default externally tagged enum representation:
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HookResultControl {
+    Continue,
+    Block { reason: String },
+    Ask { reason: Option<String> },
+}
+```
+
+`FailPolicy` serializes lowercase (`#[serde(rename_all = "lowercase")]`) and defaults to `Closed`:
+```rust
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FailPolicy {
+    #[default]
+    Closed,
+    Open,
+}
+```
+
+### FORK vs SHARE: harnx-hookset-server (Task 2-3)
+
+Forked `harnx-toolset-server` into `harnx-hookset-server` rather than extracting shared code:
+
+- **Why fork**: Tool-serving carries idempotency-cache, cancellation, control-subject, reply-cache — none of which hooks need.
+- **HookRegistration mirrors Registration**: Server name + hooks list + schema/proto versions.
+- **Subject**: `harnx.v1.{instance}.hook.{server}.{event}` (parallel to tool subject pattern).
+- **Registry**: Separate `harnx_hook_registry` KV bucket.
+- **Refresh**: 30-second TTL (same pattern as tool registry).
+
+Shared KV/registration utilities could be extracted later at the config-migration slice, but forking keeps the walking skeleton simple.
+
+### Dual Dispatch Pattern (Task 4-5)
+
+Added NATS dispatch to `build_dispatch_hook_fn` without breaking inline hooks:
+
+**PreToolUse (sequential, mutation-chained):**
+1. Run NATS hooks first.
+2. If NATS returns `Block` or `Ask`, short-circuit — return that outcome. Inline hooks **do not run** (inline proxy-auth can't override NATS denial).
+3. If NATS returns `Continue` with `mutated_tool_input`, rebuild the `HookEvent::PreToolUse` with the mutated input.
+4. Feed the NATS-mutated event into the existing inline `dispatch_inline_hooks`.
+5. Compose outcomes: if inline's mutation is `None`, use NATS mutation; otherwise inline's mutation wins (inline saw NATS-mutated input).
+
+**Why closure by value matters:** The dispatch closure takes `event: HookEvent` by value, which lets us construct a fresh `HookEvent` from the NATS outcome and pass it to inline dispatch. This is the key enabler for NATS-then-inline composition.
+
+**PostToolUse (fire-and-forget):**
+1. NATS dispatch spawns `tokio::spawn` per matching hook — returns immediately.
+2. Inline hooks run against the original event (no mutation from NATS to apply).
+3. NATS outcomes:
+   - Errors emit `AgentEvent::Notice(NoticeEvent::Error)`.
+   - `mutated_tool_response` is **dropped** (acceptable behavior change).
+   - `additional_context`/`system_message` append to `pending_async_context`.
+
+**Shared context handle routing:**
+```rust
+// crates/harnx-runtime/src/nats_worker/agent_loop.rs
+pending_async_context: Some(Arc::new(tokio::sync::Mutex::new(None))),
+```
+
+The Arc flows through:
+- `ToolRoundParams.pending_async_context`
+- `BuildToolEvalContextParams.pending_async_context`
+- `build_dispatch_hook_fn` captures it
+- `dispatch_post_tool_use` passes it to `dispatch_one_post_hook`
+- Detached task calls `pending.lock().await` to append
+
+**No NATS client fallback:**
+If `nats_hook_provider` is `None`, `build_dispatch_hook_fn` falls back to inline-only. Non-NATS callers (tests) continue working without NATS setup.
+
+### Registry/Discovery Mirror (Task 4)
+
+`NatsHookProvider::discover` mirrors `NatsToolProvider::registration_snapshot`:
+- Query `harnx_hook_registry` for `{instance}.*` keys.
+- Filter: `event` matches event name, `matcher` (regex) matches **bare tool name**.
+- Sort: `priority` ascending, then server name (deterministic tiebreak).
+
+```rust
+// crates/harnx-runtime/src/nats_hook_provider.rs
+fn matching_hooks<'a>(
+    hooks: &'a [DiscoveredHook],
+    event_name: &str,
+    tool_name: Option<&str>,
+) -> Vec<DiscoveredHook> {
+    // ... filter by event + matcher ...
+    matches.sort_by(|(left_index, left), (right_index, right)| {
+        left.spec.priority.cmp(&right.spec.priority)
+            .then_with(|| left.server.cmp(&right.server))
+            .then_with(|| left_index.cmp(right_index))
+    });
+    matches.into_iter().map(|(_, hook)| hook).collect()
+}
+```
+
+### Injectable Dispatch Seam (Task 4)
+
+The `HookRequestDispatcher` trait enables unit tests without a live NATS server:
+
+```rust
+#[async_trait]
+trait HookRequestDispatcher: Send + Sync {
+    async fn request(&self, subject: String, payload: Vec<u8>, timeout: Duration) -> Result<HookOutcome>;
+}
+```
+
+Production: `NatsHookRequester` wraps `async_nats::Client`.
+Tests: `StubDispatcher` returns queued outcomes and records seen inputs.
+
+## Why This Works
+
+**Dual dispatch preserves proxy-auth:** NATS hooks run first, but inline hooks still run after NATS passes. Proxy-auth (an inline hook) continues to receive events and can mutate or block. NATS can't silently bypass the security layer.
+
+**Fire-and-forget doesn't block tool completion:** `dispatch_post_tool_use` spawns detached tasks and returns immediately. The tool round completes without waiting for PostToolUse hooks.
+
+**Shared Arc enables context injection:** The `Arc<Mutex<Option<String>>>` is reachable from any spawned task. The take-then-put pattern preserves existing context:
+
+```rust
+let mut guard = pending.lock().await;
+let mut accumulated = guard.take().unwrap_or_default();
+// ... append new context ...
+*guard = Some(accumulated);
+```
+
+**Discovery fail-open is safe:** If the hook registry bucket doesn't exist, discovery returns an empty list and the worker runs inline-only. This mirrors the tool registry posture.
+
+## Accepted Behavior Changes / Known Gaps
+
+1. **PostToolUse mutated_tool_response dropped**: NATS PostToolUse hooks cannot mutate the tool response. Logged and ignored. Restoring this is deferred.
+
+2. **PreToolUse additional_context/system_message not yet injected**: NATS PreToolUse hooks can return these fields, but they're not routed. PostToolUse is. Deferred to config-migration slice.
+
+3. **Ask-over-NATS headless edge**: `Ask` routes through `ToolApprovalRequiredError`, but headless-worker resolution needs design. Deferred.
+
+4. **Discovery-error → inline-only**: If registry read fails, worker continues with inline hooks only. Safe because no NATS-only security hook exists yet.
+
+5. **Registry trust model**: Mirrors tool registry — any process with the NATS token can register. Trust is per-broker, not per-hook.
+
+6. **Matcher uses bare tool name**: Hook specs match `bash_exec` or `fs_read`, not prefixed display names. Renaming an MCP server doesn't require updating matchers.
+
+## Prevention Strategies
+
+**Test coverage:**
+- `nats_hooks_e2e.rs`: end-to-end with spawned NATS, test hook, and worker dispatch.
+- Unit tests for mutation-chaining, Block short-circuit, Post fire-and-forget context append.
+- `HookRequestDispatcher` trait enables tests without NATS binary.
+
+**Code review checklist:**
+- [ ] Are shared contexts (`Arc<Mutex<...>>`) allocated before dispatch?
+- [ ] Does the NATS client have a fallback path for non-NATS callers?
+- [ ] Does NATS dispatch preserve inline hook execution?
+- [ ] Are matcher comparisons against bare tool names?
+
+**Monitoring:**
+- Hook registry bucket exists and contains expected keys.
+- Hook timeouts and fail_policy surfaces correctly.
+- PostToolUse context reaches pending_async_context.
+
+## Related Issues
+
+- **GitHub:** [#1224](https://github.com/dobesv/harnx/issues/1224) — Native migration umbrella.
+- **Prior solution:** `nats-instance-scoped-tool-servers-2026-07-29.md` — Instance-scoped tool servers and registration pattern.
+- **Deferred:** `HookServerSupervisor`, `hooks/*.yaml` config loading, proxy-auth → NATS, bash native (S4).


### PR DESCRIPTION
Adds the hooks-over-NATS walking skeleton for native hook serving and dispatch. Introduces the harnx-hookset protocol crate and harnx-hookset-server for registering and serving hooks over NATS.

Adds NatsHookProvider to discover registered hooks from the harnx_hook_registry KV store, dispatching PreToolUse hooks sequentially with mutation chaining and PostToolUse hooks as background tasks. Wires NATS hook dispatch into build_dispatch_hook_fn alongside inline hook dispatch in a dual-dispatch design that preserves inline hook support for proxy-auth. Includes round-trip serde derives for hook wire types, end-to-end integration tests, and documentation. Config migration, supervisor management, and proxy-auth transition to NATS remain deferred to subsequent slices.

Issue: #1224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental NATS-served hooks with registration, discovery, and worker dispatch.
  * Supports synchronous pre-tool hooks with input mutation, approvals, blocking, and failure policies.
  * Supports asynchronous post-tool hooks with accumulated context and notices.
  * Added dual dispatch alongside existing inline hooks.

* **Documentation**
  * Added setup and behavior guidance for NATS hooks, including current limitations.

* **Tests**
  * Added end-to-end coverage for registration, discovery, mutations, denials, context delivery, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->