### PR TITLE
Support combining offset and tail in read tools

### DIFF
--- a/crates/harnx-fs-tools/src/server/handlers.rs
+++ b/crates/harnx-fs-tools/src/server/handlers.rs
@@ -128,29 +128,16 @@ impl FsServer {
         notices: &mut Vec<String>,
     ) -> Result<ReadLinesPage<'a>, ErrorData> {
         let total_matching_lines = numbered_lines.len();
-        if let Some(tail) = params.tail {
-            if tail == 0 {
-                return Err(ErrorData::internal_error(
-                    "tail must be at least 1".to_string(),
-                    None,
-                ));
-            }
 
-            if tail < total_matching_lines {
-                notices.push(format!(
-                    "showing last {} of {} matching lines",
-                    tail, total_matching_lines
-                ));
-            }
-
-            let start = total_matching_lines.saturating_sub(tail);
-            numbered_lines = numbered_lines.into_iter().skip(start).collect();
-            return Ok((numbered_lines, start + 1, total_matching_lines));
+        // `offset` is 1-indexed. Reject an explicit 0 rather than silently
+        // coercing it, matching read_exec_log's contract.
+        if params.offset == Some(0) {
+            return Err(ErrorData::invalid_params("offset must be >= 1", None));
         }
+        let offset = params.offset.unwrap_or(1);
 
-        let offset = params.offset.unwrap_or(1).max(1);
-        let limit = params.limit.unwrap_or(DEFAULT_MAX_LINES);
-
+        // Validate the offset once, regardless of whether `tail` is also set,
+        // so both code paths reject an offset past the end of the result set.
         if offset > total_matching_lines {
             return Err(ErrorData::internal_error(
                 format!(
@@ -160,6 +147,33 @@ impl FsServer {
                 None,
             ));
         }
+
+        if let Some(tail) = params.tail {
+            if tail == 0 {
+                return Err(ErrorData::internal_error(
+                    "tail must be at least 1".to_string(),
+                    None,
+                ));
+            }
+
+            // When combined with `offset`, first skip to the offset line, then
+            // tail the remaining window. `offset` is 1-indexed; offset=1 (or
+            // absent) means "no skip".
+            let skip = offset - 1;
+            let window_len = total_matching_lines - skip;
+            if tail < window_len {
+                notices.push(format!(
+                    "showing last {} of {} matching lines",
+                    tail, window_len
+                ));
+            }
+
+            let start = total_matching_lines.saturating_sub(tail).max(skip);
+            numbered_lines = numbered_lines.into_iter().skip(start).collect();
+            return Ok((numbered_lines, start + 1, total_matching_lines));
+        }
+
+        let limit = params.limit.unwrap_or(DEFAULT_MAX_LINES);
 
         if limit == 0 {
             return Err(ErrorData::internal_error(
@@ -454,13 +468,6 @@ impl FsServer {
         &self,
         params: ReadFileParams,
     ) -> Result<CallToolResult, ErrorData> {
-        if params.offset.is_some() && params.tail.is_some() {
-            return Err(ErrorData::invalid_params(
-                "offset and tail are mutually exclusive",
-                None,
-            ));
-        }
-
         let roots = self.roots.read().await;
         let path = validate_path(&params.path, &roots).map_err(invalid_params)?;
         drop(roots);

--- a/crates/harnx-fs-tools/src/server/params.rs
+++ b/crates/harnx-fs-tools/src/server/params.rs
@@ -110,7 +110,7 @@ impl JsonSchema for ReadFileParams {
                 ("path", "Absolute path to the file to read. Prefer this tool over shell commands like sed, cat, head, tail for reading files. If the path is an image file (PNG/JPEG/GIF/WebP), it is returned as viewable image content.", path),
                 ("offset", "Start reading at this line number (1-indexed). Use to read a specific line range instead of `sed -n 'N,Mp'`.", offset),
                 ("limit", "Maximum number of lines to return from offset. Combine with offset to read a range.", limit),
-                ("tail", "Return only the last N lines of the file.", tail),
+                ("tail", "Return only the last N lines of the file. Can be combined with offset to tail from a starting line (skip to offset, then take the last N lines after it).", tail),
                 ("grep", "Filter lines by regex pattern before returning.", grep),
                 ("head_lines", "Return only the first N lines. Prefer this over piping through head.", head_lines),
                 ("tail_lines", "Return only the last N lines. Prefer this over piping through tail.", tail_lines),

--- a/crates/harnx-fs-tools/src/server/tests.rs
+++ b/crates/harnx-fs-tools/src/server/tests.rs
@@ -772,6 +772,119 @@ async fn test_read_file_with_tail() {
     assert!(text.contains("showing last 2 of 4 matching lines"));
 }
 
+/// Read `content` with combined `offset`+`tail` and return the rendered text.
+async fn read_offset_tail(content: &str, offset: usize, tail: usize) -> String {
+    let temp_dir = TestDir::new();
+    let file_path = temp_dir.path().join("offset_tail.txt");
+    std::fs::write(&file_path, content).unwrap();
+    let server = make_server(temp_dir.path());
+
+    let result = server
+        .read_file_impl(ReadFileParams {
+            path: path_string(&file_path),
+            offset: Some(offset),
+            limit: None,
+            tail: Some(tail),
+            grep: None,
+            head_lines: None,
+            tail_lines: None,
+            max_output_bytes: None,
+        })
+        .await
+        .unwrap();
+
+    text_content(&result)
+}
+
+#[tokio::test]
+async fn test_read_file_offset_and_tail_combinations() {
+    let six = "one\ntwo\nthree\nfour\nfive\nsix\n";
+
+    // Skip to line 3, then tail the last 2 lines of the remaining window
+    // (lines 3..6) → lines 5 and 6. Tail is anchored to the end, so no
+    // forward "more matching lines" notice.
+    let text = read_offset_tail(six, 3, 2).await;
+    for expect in ["5: five", "6: six", "showing last 2 of 4 matching lines"] {
+        assert!(text.contains(expect), "expected {expect:?} in: {text}");
+    }
+    for absent in ["4: four", "more matching lines"] {
+        assert!(!text.contains(absent), "unexpected {absent:?} in: {text}");
+    }
+
+    // tail == window_len (offset=3 leaves a 4-line window): whole window, no
+    // "showing last" notice.
+    let text = read_offset_tail(six, 3, 4).await;
+    assert_window_without_notice(&text);
+
+    // tail > window_len (offset=3 leaves a 2-line window on a 4-line file):
+    // whole window, no notice.
+    let text = read_offset_tail("one\ntwo\nthree\nfour\n", 3, 5).await;
+    assert_window_without_notice(&text);
+}
+
+/// Asserts a post-offset window starting at line 3 was returned in full with
+/// no truncation notice.
+fn assert_window_without_notice(text: &str) {
+    assert!(text.contains("3: three"), "got: {text}");
+    assert!(!text.contains("2: two"), "got: {text}");
+    assert!(!text.contains("showing last"), "got: {text}");
+}
+
+#[tokio::test]
+async fn test_read_file_offset_beyond_eof_with_tail_errors() {
+    let temp_dir = TestDir::new();
+    let file_path = temp_dir.path().join("offset_tail_eof.txt");
+    std::fs::write(&file_path, "one\ntwo\nthree\n").unwrap();
+    let server = make_server(temp_dir.path());
+
+    // offset one past EOF (total=3, offset=4) with tail must error, matching
+    // the non-tail path.
+    let result = server
+        .read_file_impl(ReadFileParams {
+            path: path_string(&file_path),
+            offset: Some(4),
+            limit: None,
+            tail: Some(2),
+            grep: None,
+            head_lines: None,
+            tail_lines: None,
+            max_output_bytes: None,
+        })
+        .await;
+
+    let message = result.expect_err("expected error").message;
+    assert!(
+        message.contains("beyond end of result set"),
+        "got: {message}"
+    );
+}
+
+#[tokio::test]
+async fn test_read_file_offset_zero_rejected() {
+    let temp_dir = TestDir::new();
+    let file_path = temp_dir.path().join("offset_zero.txt");
+    std::fs::write(&file_path, "one\ntwo\n").unwrap();
+    let server = make_server(temp_dir.path());
+
+    // Explicit offset=0 is invalid (offset is 1-indexed), matching
+    // read_exec_log's contract rather than silently coercing to 1.
+    let result = server
+        .read_file_impl(ReadFileParams {
+            path: path_string(&file_path),
+            offset: Some(0),
+            limit: None,
+            tail: None,
+            grep: None,
+            head_lines: None,
+            tail_lines: None,
+            max_output_bytes: None,
+        })
+        .await;
+
+    let message = result.expect_err("expected error").message;
+    assert!(message.contains("offset must be >= 1"), "got: {message}");
+}
+
 #[tokio::test]
 async fn test_read_file_binary_detection() {
     let temp_dir = TestDir::new();

--- a/crates/harnx-mcp-bash/src/server/exec_log.rs
+++ b/crates/harnx-mcp-bash/src/server/exec_log.rs
@@ -12,17 +12,21 @@ impl BashServer {
         let total_lines = line_matches.len();
         let mut notices = Vec::new();
         let selected = if let Some(tail_n) = tail {
-            if tail_n < total_lines {
+            // When combined with `offset`, first skip to the offset line, then
+            // tail the remaining window. `offset` is 1-indexed; offset=1 (or
+            // absent) means "no skip".
+            let skip = offset.unwrap_or(1).saturating_sub(1).min(total_lines);
+            let window_len = total_lines - skip;
+            if tail_n < window_len {
                 notices.push(format!(
                     "showing last {} of {} matching lines",
-                    tail_n, total_lines
+                    tail_n, window_len
                 ));
-                line_matches[total_lines - tail_n..].to_vec()
-            } else {
-                line_matches
             }
+            let start = total_lines.saturating_sub(tail_n).max(skip);
+            line_matches[start..].to_vec()
         } else {
-            let start = offset.unwrap_or(1).saturating_sub(1);
+            let start = offset.unwrap_or(1).saturating_sub(1).min(total_lines);
             let end = (start + limit).min(total_lines);
             line_matches[start..end].to_vec()
         };
@@ -131,12 +135,6 @@ impl BashServer {
     pub(crate) fn validate_read_exec_log_params(
         params: &ReadExecLogParams,
     ) -> Result<(), ErrorData> {
-        if params.offset.is_some() && params.tail.is_some() {
-            return Err(ErrorData::invalid_params(
-                "offset and tail are mutually exclusive",
-                None,
-            ));
-        }
         if params.stream != "stdout" && params.stream != "stderr" {
             return Err(ErrorData::invalid_params(
                 format!(
@@ -218,7 +216,10 @@ impl BashServer {
         let limit = params.limit.unwrap_or(200).max(1);
         let (lines, mut notices) =
             Self::select_log_lines(numbered_lines, params.offset, limit, params.tail);
-        if let Some(offset) = params.offset {
+        // The offset-based "more lines" pagination notice only applies to
+        // forward reads. When `tail` is set the selection is anchored to the
+        // end of the window, so there are never more lines after it.
+        if let (Some(offset), None) = (params.offset, params.tail) {
             let shown_count = lines.len();
             let end = (offset - 1 + shown_count).min(total_matching_lines);
             if end < total_matching_lines {

--- a/crates/harnx-mcp-bash/src/server/params.rs
+++ b/crates/harnx-mcp-bash/src/server/params.rs
@@ -96,7 +96,7 @@ impl JsonSchema for ReadExecLogParams {
                     offset,
                 ),
                 ("limit", "Return at most N lines.", limit),
-                ("tail", "Return only the last N lines.", tail),
+                ("tail", "Return only the last N lines. Can be combined with offset to tail from a starting line (skip to offset, then take the last N lines after it).", tail),
                 ("grep", "Filter lines by regex before truncating.", grep),
                 ("head_lines", "Return only the first N lines.", head_lines),
                 ("tail_lines", "Return only the last N lines.", tail_lines),

--- a/crates/harnx-mcp-bash/src/server/tests.rs
+++ b/crates/harnx-mcp-bash/src/server/tests.rs
@@ -1609,6 +1609,79 @@ async fn test_read_exec_log_rejects_invalid_stream() {
 }
 
 #[tokio::test]
+async fn test_read_exec_log_offset_and_tail_combined() {
+    let temp_dir = TestDir::new();
+    let server = BashServer::new(vec![temp_dir.path().to_path_buf()]);
+
+    let result = server
+        .exec_command_impl(ExecCommandParams {
+            command: "printf 'l1\\nl2\\nl3\\nl4\\nl5\\nl6\\n'".to_string(),
+            working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
+            timeout_secs: Some(5),
+            head_lines: None,
+            tail_lines: None,
+            max_output_bytes: None,
+            env: None,
+        })
+        .await
+        .unwrap();
+
+    let execution_id = extract_field(&text_content(&result), "execution_id");
+
+    // Skip to line 3, then tail the last 2 lines of the remaining window
+    // (lines 3..6) → lines 5 and 6.
+    let read = server
+        .read_exec_log_impl(ReadExecLogParams {
+            execution_id,
+            stream: "stdout".to_string(),
+            offset: Some(3),
+            limit: None,
+            tail: Some(2),
+            grep: None,
+            head_lines: None,
+            tail_lines: None,
+            max_output_bytes: None,
+        })
+        .await
+        .unwrap();
+
+    let text = text_content(&read);
+    assert!(text.contains("5: l5"), "got: {text}");
+    assert!(text.contains("6: l6"), "got: {text}");
+    assert!(!text.contains("4: l4"), "got: {text}");
+    // Window after offset is 4 lines (3..6), tail 2 of those.
+    assert!(
+        text.contains("showing last 2 of 4 matching lines"),
+        "got: {text}"
+    );
+    // Tail is anchored to the end, so no "more matching lines" pagination notice.
+    assert!(!text.contains("more matching lines"), "got: {text}");
+}
+
+#[test]
+fn test_select_log_lines_offset_and_tail() {
+    let lines: Vec<(usize, String)> = (1..=6).map(|n| (n, format!("line{n}"))).collect();
+
+    // offset=3 (skip 2), tail=2 → last 2 of window [3..6] = lines 5,6.
+    let (selected, notices) = BashServer::select_log_lines(lines.clone(), Some(3), 200, Some(2));
+    assert_eq!(
+        selected,
+        vec![(5, "line5".to_string()), (6, "line6".to_string())]
+    );
+    assert!(notices
+        .iter()
+        .any(|n| n.contains("showing last 2 of 4 matching lines")));
+
+    // tail larger than the post-offset window returns the whole window.
+    let (selected, notices) = BashServer::select_log_lines(lines, Some(5), 200, Some(10));
+    assert_eq!(
+        selected,
+        vec![(5, "line5".to_string()), (6, "line6".to_string())]
+    );
+    assert!(notices.is_empty());
+}
+
+#[tokio::test]
 async fn test_cleanup_log_dir_removes_temp_logs() {
     let temp_dir = TestDir::new();
     let server = BashServer::new(vec![temp_dir.path().to_path_buf()]);

--- a/docs/solutions/logic-errors/offset-tail-mutual-exclusion-2026-07-31.md
+++ b/docs/solutions/logic-errors/offset-tail-mutual-exclusion-2026-07-31.md
@@ -1,0 +1,123 @@
+---
+title: "Removed offset+tail mutual exclusion in read tools, fixed off-by-one validation bug"
+date: 2026-07-31
+category: "logic-errors"
+problem_type: logic_error
+component: "harnx-fs-tools, harnx-mcp-bash"
+root_cause: "unnecessary mutual exclusion between parameters; duplicated validation with inconsistent boundary check"
+resolution_type: code_fix
+severity: medium
+tags:
+  - api-ergonomics
+  - off-by-one
+  - parameter-validation
+  - pagination
+plan_ref: "harnx-1312-offset-tail-combine"
+---
+
+## Problem
+
+The `read` tool (harnx-fs-tools) and `read_exec_log` tool (harnx-mcp-bash) rejected `offset` + `tail` together with error "offset and tail are mutually exclusive". Agents hit this frequently. No fundamental conflict exists — the parameters compose naturally.
+
+## Symptoms
+
+- Error: `offset and tail are mutually exclusive` when both parameters provided
+- Workaround: agents manually combined semantics by reading entire file then post-processing
+- Friction in pagination flows where skip-to-line + tail-from-end is a natural operation
+
+## Investigation Steps
+
+Reviewed the validation logic in both crates:
+- `handlers.rs` in harnx-fs-tools (`read_file_impl`) had a guard returning error if both `offset` and `tail` were set
+- `exec_log.rs` in harnx-mcp-bash (`validate_read_exec_log_params`) had an identical guard
+- Neither tool had a semantic reason for the exclusion — the combination is well-defined
+
+Traced through the implementation path to design the combined semantics:
+1. Skip to line `offset` (1-indexed, so skip `offset - 1` lines)
+2. On the remaining window (lines `offset..end`), return the last `tail` lines
+
+## Root Cause
+
+Two issues:
+
+1. **Unnecessary mutual exclusion**: The original implementation treated `offset` and `tail` as competing ways to define a read window, but they actually compose: offset defines the window start, tail defines how much of that window to return from the end.
+
+2. **Off-by-one validation bug**: When implementing the tail branch, the check used `skip > total` instead of `offset > total`. This let `offset = total+1` slip through and return `Ok(empty)` instead of erroring — inconsistent with the non-tail branch which correctly rejected `offset > total`.
+
+## Solution
+
+Removed the mutual exclusion guard and unified the calculation:
+
+**Shared math (both crates):**
+```
+skip = offset - 1
+window_len = total - skip
+start = max(total - tail, skip)
+return lines[start..]
+```
+
+**Boundary validation:** hoisted to run once before branching on tail:
+```rust
+if offset > total {
+    return Err("offset beyond end of file");
+}
+```
+
+Both paths now share identical offset validation semantics.
+
+**Files changed:**
+- `crates/harnx-fs-tools/src/server/handlers.rs` — removed the mutual-exclusion guard in `read_file_impl`; combined offset+tail logic in `paginate_read_lines`
+- `crates/harnx-fs-tools/src/server/params.rs` — updated the `tail` schema description
+- `crates/harnx-fs-tools/src/server/tests.rs` — new test cases for combined params
+- `crates/harnx-mcp-bash/src/server/exec_log.rs` — removed the guard in `validate_read_exec_log_params`; combined offset+tail logic in `select_log_lines`
+- `crates/harnx-mcp-bash/src/server/params.rs` — updated the `tail` schema description
+- `crates/harnx-mcp-bash/src/server/tests.rs` — new test cases
+
+**Additional fixes:**
+- "Showing last N of M matching lines" notice reports `window_len` (post-offset window), not total
+- When `tail` is set, suppress the forward "more matching lines" pagination notice — tail anchors to end, nothing follows
+
+## Why This Works
+
+The parameters express orthogonal concepts:
+- `offset`: where to start reading (absolute position from file start)
+- `tail`: how much to return from the window's end (relative to the window defined by offset)
+
+For a 100-line file with `offset=20, tail=10`:
+- Window becomes lines 20..100 (81 lines)
+- Return last 10 of that window: lines 91..100
+
+The validation bug was caught because the duplicated check used different boundary logic (`skip > total` vs `offset > total`). Since `skip = offset - 1`, `skip > total` is equivalent to `offset > total + 1`, allowing the off-by-one slip.
+
+## Prevention Strategies
+
+**When duplicating a check across branches, validate BEFORE branching:**
+
+```rust
+// BAD: duplicated check with subtle difference
+if tail.is_some() {
+    if skip > total { return Err(...); }  // off-by-one!
+    // tail path
+} else {
+    if offset > total { return Err(...); }
+    // non-tail path
+}
+
+// GOOD: validate once, then branch
+if offset > total { return Err(...); }
+if tail.is_some() {
+    // tail path
+} else {
+    // non-tail path
+}
+```
+
+**Test boundary cases explicitly:**
+- `offset = total` (last line) — should succeed
+- `offset = total + 1` — should error, not return empty
+- `offset + tail` where tail exceeds window — return entire window
+
+**Code review checklist:**
+- [ ] When adding a branch, check if validation is duplicated
+- [ ] Hoist shared validation above the branch point
+- [ ] Compare boundary conditions letter-for-letter between branches


### PR DESCRIPTION
The `read` tool (harnx-fs-tools) and `read_exec_log` tool (harnx-mcp-bash) rejected offset+tail together with "offset and tail are mutually exclusive". They express orthogonal concepts, so combine them: skip to line `offset` (1-indexed), then return the last `tail` lines of the remaining window.

- Remove the mutual-exclusion guards in both crates.
- Share offset-skip + tail-window math: skip=offset-1, window_len=total-skip, start=max(total-tail, skip).
- Report window_len (not total) in the "showing last N of M" notice, and suppress the forward pagination notice when tailing.
- Validate offset-vs-EOF once before branching on tail so both paths reject offsets past the end of the result set.
- Update the tail param descriptions and add regression tests covering combined offset+tail, exact/oversized tail windows, and the EOF boundary.

#1312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-file and execution-log pagination now supports combining `offset` with `tail`.
  * Tail results correctly begin after the specified offset and report the remaining window size.
* **Bug Fixes**
  * Improved validation for offsets beyond available content and rejected invalid zero offsets.
  * Corrected pagination notices and off-by-one behavior for combined pagination.
* **Documentation**
  * Updated parameter guidance and added examples describing combined `offset` and `tail` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->