### PR TITLE
feat(hooks): launch and dispatch hooks over NATS

### DIFF
--- a/.changeset/hooks-over-nats-launch-dispatch.md
+++ b/.changeset/hooks-over-nats-launch-dispatch.md
@@ -1,0 +1,5 @@
+---
+harnx: minor
+---
+
+Run configured hooks fully over NATS. Adds a generic `harnx-claude-compatible-hook-server` that runs `claude-command` and `claude-command-persistent` hooks over NATS, a native NATS hook mode for `harnx-proxy-auth`, a `hooks:` field on tool-server configs, and a worker-side supervisor that launches configured hooks scoped by where they're defined (global, tool-server, or agent). NATS now dispatches lifecycle, prompt, stop, and tool-use events that have runtime call sites; `InstructionsLoaded` and `CwdChanged` are supported by the protocol but aren't fired by the runtime yet. PreToolUse context injection and Ask approvals work over NATS. The inline dispatch path remains as a fallback for now.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3500,6 +3500,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "harnx-claude-compatible-hook-server"
+version = "0.33.4"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "async-trait",
+ "clap",
+ "harnx-core",
+ "harnx-hooks",
+ "harnx-hookset",
+ "harnx-hookset-server",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "which",
+]
+
+[[package]]
 name = "harnx-client"
 version = "0.33.4"
 dependencies = [
@@ -3937,11 +3955,15 @@ name = "harnx-proxy-auth"
 version = "0.33.4"
 dependencies = [
  "anyhow",
+ "async-nats",
+ "async-trait",
  "base64 0.23.0",
  "clap",
  "harnx-core",
  "harnx-engine",
  "harnx-hooks",
+ "harnx-hookset",
+ "harnx-hookset-server",
  "harnx-mcp",
  "harnx-runtime",
  "http 1.4.2",
@@ -3966,6 +3988,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "which",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "crates/harnx-time-server",
     "crates/harnx-hookset",
     "crates/harnx-hookset-server",
+    "crates/harnx-claude-compatible-hook-server",
     "crates/harnx-toolset",
     "crates/harnx-toolset-server",
     "crates/harnx-tui",

--- a/crates/harnx-claude-compatible-hook-server/Cargo.toml
+++ b/crates/harnx-claude-compatible-hook-server/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "harnx-claude-compatible-hook-server"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "NATS server for Claude Code-compatible command hooks"
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+clap = { workspace = true }
+harnx-core = { path = "../harnx-core" }
+harnx-hooks = { path = "../harnx-hooks" }
+harnx-hookset = { path = "../harnx-hookset" }
+harnx-hookset-server = { path = "../harnx-hookset-server" }
+tokio = { workspace = true, features = ["sync"] }
+
+[dev-dependencies]
+async-nats = { workspace = true }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+which = { workspace = true }

--- a/crates/harnx-claude-compatible-hook-server/src/lib.rs
+++ b/crates/harnx-claude-compatible-hook-server/src/lib.rs
@@ -1,0 +1,276 @@
+//! NATS hook server for Claude Code-compatible command hooks.
+
+use anyhow::{bail, Result};
+use async_trait::async_trait;
+use clap::{Parser, ValueEnum};
+use harnx_core::hooks::{HookOutcome, HookPayload};
+use harnx_hooks::{execute_command_hook, HookCommand, PersistentHookManager};
+use harnx_hookset::{FailPolicy, Hook, HookSpec};
+use std::path::PathBuf;
+use tokio::sync::Mutex;
+
+/// Command-line settings for one hook server.
+#[derive(Clone, Debug, Parser)]
+#[command(about = "Serve a Claude Code-compatible command hook over NATS")]
+pub struct Args {
+    /// Stable hook server name used in NATS subjects and registration.
+    #[arg(long)]
+    pub name: String,
+
+    /// Hook event to register, such as PreToolUse or PostToolUse.
+    #[arg(long)]
+    pub event: String,
+
+    /// Optional regular expression matched against the bare tool name.
+    #[arg(long)]
+    pub matcher: Option<String>,
+
+    /// Dispatch priority. Lower values run first.
+    #[arg(long, default_value_t = 0)]
+    pub priority: i32,
+
+    /// Hook execution timeout in seconds.
+    #[arg(long)]
+    pub timeout: Option<u64>,
+
+    /// Failure policy advertised to dispatchers.
+    #[arg(long, value_enum, default_value_t = CliFailPolicy::Closed)]
+    pub fail_policy: CliFailPolicy,
+
+    /// Claude-compatible hook process type.
+    #[arg(long = "type", value_enum, default_value_t = HookType::ClaudeCommand)]
+    pub hook_type: HookType,
+
+    /// Shell command run for hook requests.
+    #[arg(long)]
+    pub command: String,
+
+    /// Package directory exposed to the command as HARNX_PACKAGE_DIR.
+    #[arg(long)]
+    pub package_dir: Option<PathBuf>,
+}
+
+/// Supported Claude-compatible subprocess protocols.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum HookType {
+    #[value(name = "claude-command")]
+    ClaudeCommand,
+    #[value(name = "claude-command-persistent")]
+    ClaudeCommandPersistent,
+}
+
+/// Hook dispatch behavior when the server fails.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum CliFailPolicy {
+    Closed,
+    Open,
+}
+
+impl From<CliFailPolicy> for FailPolicy {
+    fn from(value: CliFailPolicy) -> Self {
+        match value {
+            CliFailPolicy::Closed => Self::Closed,
+            CliFailPolicy::Open => Self::Open,
+        }
+    }
+}
+
+/// One configured command hook hosted over NATS.
+pub struct ClaudeCompatibleHook {
+    name: String,
+    spec: HookSpec,
+    hook_type: HookType,
+    command: HookCommand,
+    persistent: Mutex<PersistentHookManager>,
+}
+
+impl TryFrom<Args> for ClaudeCompatibleHook {
+    type Error = anyhow::Error;
+
+    fn try_from(args: Args) -> Result<Self> {
+        if args.name.trim().is_empty() {
+            bail!("hook server name must not be empty");
+        }
+        if args.event.trim().is_empty() {
+            bail!("hook event must not be empty");
+        }
+        if args.command.trim().is_empty() {
+            bail!("hook command must not be empty");
+        }
+
+        Ok(Self {
+            name: args.name,
+            spec: HookSpec {
+                event: args.event,
+                matcher: args.matcher,
+                priority: args.priority,
+                timeout_secs: args.timeout,
+                fail_policy: args.fail_policy.into(),
+            },
+            hook_type: args.hook_type,
+            command: HookCommand {
+                command: args.command,
+                timeout: args.timeout,
+                package_dir: args.package_dir,
+            },
+            persistent: Mutex::new(PersistentHookManager::new()),
+        })
+    }
+}
+
+#[async_trait]
+impl Hook for ClaudeCompatibleHook {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn hooks(&self) -> Vec<HookSpec> {
+        vec![self.spec.clone()]
+    }
+
+    async fn handle_hook(&self, payload: HookPayload) -> HookOutcome {
+        match self.hook_type {
+            HookType::ClaudeCommand => execute_command_hook(&payload, &self.command).await,
+            HookType::ClaudeCommandPersistent => {
+                self.persistent
+                    .lock()
+                    .await
+                    .send_event(&payload, &self.command)
+                    .await
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(unix)]
+    use harnx_core::hooks::{HookEvent, HookResultControl};
+    #[cfg(unix)]
+    use serde_json::json;
+    #[cfg(unix)]
+    use std::path::Path;
+
+    #[cfg(unix)]
+    fn payload(cwd: &Path, value: u64) -> HookPayload {
+        HookPayload {
+            session_id: format!("session-{value}"),
+            cwd: cwd.to_path_buf(),
+            resume_count: 0,
+            hook_event: HookEvent::PreToolUse {
+                tool_name: "exec".to_string(),
+                tool_input: json!({"value": value}),
+                tool_use_id: format!("tool-use-{value}"),
+            },
+        }
+    }
+
+    fn hook(command: &str, hook_type: HookType) -> ClaudeCompatibleHook {
+        Args {
+            name: "test-hook".to_string(),
+            event: "PreToolUse".to_string(),
+            matcher: Some("exec".to_string()),
+            priority: 7,
+            timeout: Some(5),
+            fail_policy: CliFailPolicy::Closed,
+            hook_type,
+            command: command.to_string(),
+            package_dir: None,
+        }
+        .try_into()
+        .expect("valid test hook")
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn one_shot_exit_zero_parses_hook_result() {
+        let cwd = tempfile::tempdir().expect("temp dir");
+        let runner = hook(
+            r#"printf '%s' '{"additionalContext":"from-hook"}'"#,
+            HookType::ClaudeCommand,
+        );
+
+        let outcome = runner.handle_hook(payload(cwd.path(), 1)).await;
+
+        assert_eq!(outcome.control, HookResultControl::Continue);
+        assert_eq!(
+            outcome.result.additional_context.as_deref(),
+            Some("from-hook")
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn one_shot_exit_two_blocks_with_stderr() {
+        let cwd = tempfile::tempdir().expect("temp dir");
+        let runner = hook(
+            "printf '%s' 'denied by test' >&2; exit 2",
+            HookType::ClaudeCommand,
+        );
+
+        let outcome = runner.handle_hook(payload(cwd.path(), 1)).await;
+
+        assert_eq!(
+            outcome.control,
+            HookResultControl::Block {
+                reason: "denied by test".to_string()
+            }
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn one_shot_returns_mutated_tool_input() {
+        let cwd = tempfile::tempdir().expect("temp dir");
+        let runner = hook(
+            r#"printf '%s' '{"mutatedToolInput":{"command":"safe"}}'"#,
+            HookType::ClaudeCommand,
+        );
+
+        let outcome = runner.handle_hook(payload(cwd.path(), 1)).await;
+
+        assert_eq!(
+            outcome.result.mutated_tool_input,
+            Some(json!({"command": "safe"}))
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn persistent_process_routes_two_id_framed_round_trips() {
+        let cwd = tempfile::tempdir().expect("temp dir");
+        let runner = hook(
+            r#"count=0; while IFS= read -r line; do count=$((count + 1)); id=$(printf '%s' "$line" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p'); printf '{"id":"%s","mutatedToolInput":{"sequence":%s}}\n' "$id" "$count"; done"#,
+            HookType::ClaudeCommandPersistent,
+        );
+
+        let first = runner.handle_hook(payload(cwd.path(), 1)).await;
+        let second = runner.handle_hook(payload(cwd.path(), 2)).await;
+
+        assert_eq!(
+            first.result.mutated_tool_input,
+            Some(json!({"sequence": 1}))
+        );
+        assert_eq!(
+            second.result.mutated_tool_input,
+            Some(json!({"sequence": 2}))
+        );
+    }
+
+    #[test]
+    fn hook_metadata_comes_from_configuration() {
+        let runner = hook("true", HookType::ClaudeCommand);
+        assert_eq!(runner.name(), "test-hook");
+        assert_eq!(
+            runner.hooks(),
+            vec![HookSpec {
+                event: "PreToolUse".to_string(),
+                matcher: Some("exec".to_string()),
+                priority: 7,
+                timeout_secs: Some(5),
+                fail_policy: FailPolicy::Closed,
+            }]
+        );
+    }
+}

--- a/crates/harnx-claude-compatible-hook-server/src/main.rs
+++ b/crates/harnx-claude-compatible-hook-server/src/main.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+use clap::Parser;
+use harnx_claude_compatible_hook_server::{Args, ClaudeCompatibleHook};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let hook = ClaudeCompatibleHook::try_from(Args::parse())?;
+    harnx_hookset_server::run_hookset_main(hook).await
+}

--- a/crates/harnx-claude-compatible-hook-server/tests/nats_runner.rs
+++ b/crates/harnx-claude-compatible-hook-server/tests/nats_runner.rs
@@ -1,0 +1,168 @@
+#![cfg(unix)]
+
+use anyhow::{Context, Result};
+use harnx_claude_compatible_hook_server::{Args, ClaudeCompatibleHook, CliFailPolicy, HookType};
+use harnx_core::hooks::{HookEvent, HookOutcome, HookPayload, HookResultControl};
+use harnx_core::instance::InstanceId;
+use harnx_hookset::HookRegistration;
+use harnx_hookset_server::{hook_registration_key, serve_over_nats, HOOK_REGISTRY_BUCKET};
+use serde_json::json;
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+const TOKEN: &str = "claude-hook-runner-test-token";
+const SERVER_NAME: &str = "command-runner";
+
+struct NatsServerHandle {
+    url: String,
+    _store_dir: TempDir,
+    child: Child,
+}
+
+impl Drop for NatsServerHandle {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn nats_server_binary() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("NATS_SERVER_BIN") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    which::which("nats-server").ok()
+}
+
+async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
+    let Some(binary) = nats_server_binary() else {
+        eprintln!("skipping NATS integration test: nats-server binary not found");
+        return Ok(None);
+    };
+
+    let listener = TcpListener::bind("127.0.0.1:0").context("allocate NATS test port")?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    let store_dir = tempfile::tempdir().context("create NATS test store")?;
+    let mut child = Command::new(binary)
+        .arg("-js")
+        .arg("-sd")
+        .arg(store_dir.path())
+        .arg("-p")
+        .arg(port.to_string())
+        .arg("--auth")
+        .arg(TOKEN)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("spawn nats-server")?;
+    let url = format!("nats://127.0.0.1:{port}");
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        match async_nats::ConnectOptions::new()
+            .token(TOKEN.to_string())
+            .connect(&url)
+            .await
+        {
+            Ok(client) => {
+                client.flush().await.context("flush NATS test client")?;
+                return Ok(Some(NatsServerHandle {
+                    url,
+                    _store_dir: store_dir,
+                    child,
+                }));
+            }
+            Err(error) if child.try_wait()?.is_some() => {
+                anyhow::bail!("nats-server exited during startup: {error}");
+            }
+            Err(_) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Err(error) => return Err(error).context("wait for nats-server readiness"),
+        }
+    }
+}
+
+async fn wait_for_registration(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+) -> Result<HookRegistration> {
+    let jetstream = async_nats::jetstream::new(client.clone());
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(store) = jetstream.get_key_value(HOOK_REGISTRY_BUCKET).await {
+            let key = hook_registration_key(instance_id, SERVER_NAME);
+            if let Some(value) = store.get(&key).await? {
+                return serde_json::from_slice(&value).context("decode hook registration");
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("timed out waiting for command runner registration");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn command_hook_registers_and_answers_over_nats() -> Result<()> {
+    harnx_core::require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        return Ok(());
+    };
+    let runner = ClaudeCompatibleHook::try_from(Args {
+        name: SERVER_NAME.to_string(),
+        event: "PreToolUse".to_string(),
+        matcher: Some("exec".to_string()),
+        priority: 3,
+        timeout: Some(5),
+        fail_policy: CliFailPolicy::Closed,
+        hook_type: HookType::ClaudeCommand,
+        command: r#"printf '%s' '{"mutatedToolInput":{"overNats":true}}'"#.to_string(),
+        package_dir: None,
+    })?;
+    let instance_id = InstanceId::new();
+    let server_instance_id = instance_id.clone();
+    let server_url = server.url.clone();
+    let server_task = tokio::spawn(async move {
+        serve_over_nats(runner, server_instance_id, &server_url, TOKEN).await
+    });
+    let client = async_nats::ConnectOptions::new()
+        .token(TOKEN.to_string())
+        .connect(&server.url)
+        .await?;
+
+    let registration = wait_for_registration(&client, &instance_id).await?;
+    assert_eq!(registration.server, SERVER_NAME);
+    assert_eq!(registration.hooks[0].matcher.as_deref(), Some("exec"));
+
+    let payload = HookPayload {
+        session_id: "nats-test".to_string(),
+        cwd: std::env::current_dir()?,
+        resume_count: 0,
+        hook_event: HookEvent::PreToolUse {
+            tool_name: "exec".to_string(),
+            tool_input: json!({"command": "true"}),
+            tool_use_id: "tool-use-1".to_string(),
+        },
+    };
+    let message = client
+        .request(
+            instance_id.hook_subject(SERVER_NAME, "PreToolUse"),
+            serde_json::to_vec(&payload)?.into(),
+        )
+        .await?;
+    let outcome: HookOutcome = serde_json::from_slice(&message.payload)?;
+    assert_eq!(outcome.control, HookResultControl::Continue);
+    assert_eq!(
+        outcome.result.mutated_tool_input,
+        Some(json!({"overNats": true}))
+    );
+
+    server_task.abort();
+    Ok(())
+}

--- a/crates/harnx-core/src/hooks.rs
+++ b/crates/harnx-core/src/hooks.rs
@@ -33,6 +33,15 @@ pub enum HookEvent {
         error: String,
         error_type: String,
     },
+    InstructionsLoaded {
+        file_path: PathBuf,
+        memory_type: String,
+        load_reason: String,
+    },
+    CwdChanged {
+        old_cwd: PathBuf,
+        new_cwd: PathBuf,
+    },
     PreToolUse {
         tool_name: String,
         tool_input: Value,
@@ -60,6 +69,8 @@ impl HookEvent {
             Self::UserPromptSubmit { .. } => "UserPromptSubmit",
             Self::Stop { .. } => "Stop",
             Self::StopFailure { .. } => "StopFailure",
+            Self::InstructionsLoaded { .. } => "InstructionsLoaded",
+            Self::CwdChanged { .. } => "CwdChanged",
             Self::PreToolUse { .. } => "PreToolUse",
             Self::PostToolUse { .. } => "PostToolUse",
             Self::PostToolUseFailure { .. } => "PostToolUseFailure",
@@ -542,9 +553,20 @@ entries:
         assert!(result.resume.is_none());
     }
 
+    fn assert_event_names(events: Vec<(HookEvent, &str)>) {
+        for (event, expected_name) in events {
+            assert_eq!(event.event_name(), expected_name);
+            let serialized = serde_json::to_value(&event).expect("serialize hook event");
+            assert_eq!(serialized["hook_event_name"], expected_name);
+            let decoded: HookEvent =
+                serde_json::from_value(serialized).expect("deserialize hook event");
+            assert_eq!(decoded.event_name(), expected_name);
+        }
+    }
+
     #[test]
-    fn test_event_name() {
-        let events = vec![
+    fn lifecycle_event_names_round_trip() {
+        assert_event_names(vec![
             (
                 HookEvent::SessionStart {
                     source: "cli".to_string(),
@@ -578,6 +600,27 @@ entries:
                 },
                 "StopFailure",
             ),
+        ]);
+    }
+
+    #[test]
+    fn file_and_tool_event_names_round_trip() {
+        assert_event_names(vec![
+            (
+                HookEvent::InstructionsLoaded {
+                    file_path: PathBuf::from("/tmp/CLAUDE.md"),
+                    memory_type: "Project".to_string(),
+                    load_reason: "session_start".to_string(),
+                },
+                "InstructionsLoaded",
+            ),
+            (
+                HookEvent::CwdChanged {
+                    old_cwd: PathBuf::from("/tmp/old"),
+                    new_cwd: PathBuf::from("/tmp/new"),
+                },
+                "CwdChanged",
+            ),
             (
                 HookEvent::PreToolUse {
                     tool_name: "shell".to_string(),
@@ -604,11 +647,7 @@ entries:
                 },
                 "PostToolUseFailure",
             ),
-        ];
-
-        for (event, expected_name) in events {
-            assert_eq!(event.event_name(), expected_name);
-        }
+        ]);
     }
 
     #[test]

--- a/crates/harnx-hookset/src/lib.rs
+++ b/crates/harnx-hookset/src/lib.rs
@@ -36,6 +36,16 @@ pub enum FailPolicy {
     Open,
 }
 
+impl FailPolicy {
+    /// Lowercase value accepted by hook-server command-line arguments.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Closed => "closed",
+            Self::Open => "open",
+        }
+    }
+}
+
 /// Hook implementation served by a transport adapter.
 #[async_trait]
 pub trait Hook: Send + Sync {
@@ -85,6 +95,8 @@ mod tests {
 
         assert_eq!(decoded, registration);
         assert_eq!(FailPolicy::default(), FailPolicy::Closed);
+        assert_eq!(FailPolicy::Closed.as_str(), "closed");
+        assert_eq!(FailPolicy::Open.as_str(), "open");
         Ok(())
     }
 }

--- a/crates/harnx-proxy-auth/Cargo.toml
+++ b/crates/harnx-proxy-auth/Cargo.toml
@@ -16,8 +16,12 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 base64.workspace = true
 clap.workspace = true
+harnx-core = { path = "../harnx-core" }
+harnx-hookset = { path = "../harnx-hookset" }
+harnx-hookset-server = { path = "../harnx-hookset-server" }
 hudsucker = { workspace = true, features = ["rustls-client"] }
 hyper.workspace = true
 hyper-rustls = { workspace = true }
@@ -37,7 +41,7 @@ jaq-core.workspace = true
 jaq-std.workspace = true
 
 [dev-dependencies]
-harnx-core = { path = "../harnx-core" }
+async-nats.workspace = true
 harnx-engine = { path = "../harnx-engine" }
 harnx-hooks = { path = "../harnx-hooks" }
 harnx-mcp = { path = "../harnx-mcp" }
@@ -53,3 +57,4 @@ tokio-rustls = { workspace = true }
 serde_json.workspace = true
 serde_yaml.workspace = true
 tokio = { workspace = true, features = ["macros", "net", "process", "rt-multi-thread", "time", "io-util"] }
+which.workspace = true

--- a/crates/harnx-proxy-auth/src/hook.rs
+++ b/crates/harnx-proxy-auth/src/hook.rs
@@ -1,9 +1,14 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
+use async_trait::async_trait;
+use harnx_core::hooks::{HookEvent, HookOutcome, HookPayload, HookResult, HookResultControl};
+use harnx_hookset::{FailPolicy, Hook, HookSpec};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+pub const SERVER_NAME: &str = "proxy-auth";
 
 #[derive(Deserialize)]
 struct HookRequest {
@@ -24,6 +29,60 @@ struct HookResponse {
 struct HookSpecificOutput {
     #[serde(rename = "toolInput")]
     tool_input: Value,
+}
+
+/// Persistent proxy and startup environment exposed as a NATS PreToolUse hook.
+pub struct ProxyAuthHook {
+    proxy_port: u16,
+    ca_cert_path: String,
+    extra_env: Map<String, Value>,
+}
+
+impl ProxyAuthHook {
+    pub fn new(proxy_port: u16, ca_cert_path: PathBuf, extra_env: Map<String, Value>) -> Self {
+        Self {
+            proxy_port,
+            ca_cert_path: ca_cert_path.to_string_lossy().into_owned(),
+            extra_env,
+        }
+    }
+}
+
+#[async_trait]
+impl Hook for ProxyAuthHook {
+    fn name(&self) -> &str {
+        SERVER_NAME
+    }
+
+    fn hooks(&self) -> Vec<HookSpec> {
+        vec![HookSpec {
+            event: "PreToolUse".to_string(),
+            matcher: Some("exec|spawn".to_string()),
+            priority: 0,
+            timeout_secs: None,
+            fail_policy: FailPolicy::Closed,
+        }]
+    }
+
+    async fn handle_hook(&self, payload: HookPayload) -> HookOutcome {
+        let mutated_tool_input = match payload.hook_event {
+            HookEvent::PreToolUse { tool_input, .. } => Some(augment_tool_input(
+                Some(tool_input),
+                self.proxy_port,
+                &self.ca_cert_path,
+                &self.extra_env,
+            )),
+            _ => None,
+        };
+
+        HookOutcome {
+            control: HookResultControl::Continue,
+            result: HookResult {
+                mutated_tool_input,
+                ..HookResult::default()
+            },
+        }
+    }
 }
 
 pub async fn run_jsonl_loop(

--- a/crates/harnx-proxy-auth/src/main.rs
+++ b/crates/harnx-proxy-auth/src/main.rs
@@ -23,12 +23,7 @@ async fn main() -> Result<()> {
     // surface structured notices that the JSONL loop drains to stdout.
     let notice_rx = notice::init_channel();
     let sentinels = Arc::new(sentinel::Sentinels::generate());
-    let load_specs = load::parse_load_specs(&args.load_yaml, &args.load_json, &args.load_raw)?;
-    let loaded_vars: Vec<(String, jaq_all::json::Val)> = load_specs
-        .iter()
-        .map(|spec| (spec.name.clone(), load::load_value(spec)))
-        .collect();
-
+    let loaded_vars = load_variables(&args)?;
     let fs_temp_dir = if args.fs.is_empty() {
         None
     } else {
@@ -38,22 +33,6 @@ async fn main() -> Result<()> {
         .as_ref()
         .map(|dir| dir.path().to_string_lossy().into_owned())
         .unwrap_or_default();
-
-    let mut loaded_vars = loaded_vars
-        .into_iter()
-        .map(|(name, value)| Ok((name, filter::jaq_value_to_json(value)?)))
-        .collect::<Result<Vec<_>>>()?;
-    let exec_specs = exec_load::parse_exec_specs(
-        &args.load_exec,
-        &loaded_vars
-            .iter()
-            .map(|(name, _)| name.clone())
-            .collect::<Vec<_>>(),
-    )?;
-    for spec in &exec_specs {
-        let value = exec_load::run_exec_value(spec, &exec_load::ShellRunner);
-        loaded_vars.push((spec.name.clone(), value));
-    }
 
     let jaq_vars = Arc::new(filter::JaqVars::new_from_values(
         &sentinels,
@@ -96,32 +75,98 @@ async fn main() -> Result<()> {
         extra_env.insert(key, value);
     }
 
-    // Write readiness lines then explicitly drop the lock before entering the
-    // async JSONL loop. Holding a std::io::StdoutLock across an .await would
-    // deadlock: tokio's async stdout shares the same fd and any tracing output
-    // or response write that tries to acquire the lock would block forever.
-    {
-        let mut stdout = std::io::stdout().lock();
-        writeln!(stdout, "PROXY_PORT={port}")?;
-        writeln!(stdout, "CA_CERT_PATH={}", ca_cert_path.display())?;
-        use base64::Engine as _;
-        let ca_cert_b64 = base64::engine::general_purpose::STANDARD.encode(ca_cert_pem.as_bytes());
-        writeln!(stdout, "CA_CERT_PEM_B64={ca_cert_b64}")?;
-        stdout.flush()?;
-    } // lock dropped here
+    write_readiness(port, &ca_cert_path, &ca_cert_pem)?;
 
+    run_dispatch_mode(DispatchRuntime {
+        port,
+        ca_cert_path,
+        extra_env,
+        notice_rx,
+        fs_temp_dir,
+    })
+    .await
+}
+
+fn load_variables(args: &cli::Args) -> Result<Vec<(String, serde_json::Value)>> {
+    let load_specs = load::parse_load_specs(&args.load_yaml, &args.load_json, &args.load_raw)?;
+    let loaded_vars: Vec<(String, jaq_all::json::Val)> = load_specs
+        .iter()
+        .map(|spec| (spec.name.clone(), load::load_value(spec)))
+        .collect();
+    let mut loaded_vars = loaded_vars
+        .into_iter()
+        .map(|(name, value)| Ok((name, filter::jaq_value_to_json(value)?)))
+        .collect::<Result<Vec<_>>>()?;
+    let names = loaded_vars
+        .iter()
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    for spec in exec_load::parse_exec_specs(&args.load_exec, &names)? {
+        let value = exec_load::run_exec_value(&spec, &exec_load::ShellRunner);
+        loaded_vars.push((spec.name, value));
+    }
+    Ok(loaded_vars)
+}
+
+fn write_readiness(port: u16, ca_cert_path: &std::path::Path, ca_cert_pem: &str) -> Result<()> {
+    // Drop stdout lock before async dispatch; Tokio stdout uses same descriptor.
+    let mut stdout = std::io::stdout().lock();
+    writeln!(stdout, "PROXY_PORT={port}")?;
+    writeln!(stdout, "CA_CERT_PATH={}", ca_cert_path.display())?;
+    use base64::Engine as _;
+    let ca_cert_b64 = base64::engine::general_purpose::STANDARD.encode(ca_cert_pem.as_bytes());
+    writeln!(stdout, "CA_CERT_PEM_B64={ca_cert_b64}")?;
+    stdout.flush()?;
+    Ok(())
+}
+
+struct DispatchRuntime {
+    port: u16,
+    ca_cert_path: std::path::PathBuf,
+    extra_env: serde_json::Map<String, serde_json::Value>,
+    notice_rx: notice::HookNoticeReceiver,
+    fs_temp_dir: Option<tempfile::TempDir>,
+}
+
+async fn run_dispatch_mode(runtime: DispatchRuntime) -> Result<()> {
+    let DispatchRuntime {
+        port,
+        ca_cert_path,
+        extra_env,
+        notice_rx,
+        fs_temp_dir,
+    } = runtime;
+    if nats_mode_enabled() {
+        // Keep generated credentials and notice channel alive for hook-server lifetime.
+        let _temp_dir_guard = fs_temp_dir;
+        let _notice_rx_guard = notice_rx;
+        return harnx_hookset_server::run_hookset_main(hook::ProxyAuthHook::new(
+            port,
+            ca_cert_path,
+            extra_env,
+        ))
+        .await;
+    }
     if let Some(temp_dir) = fs_temp_dir {
-        tokio::select! {
+        return tokio::select! {
             result = hook::run_jsonl_loop(port, ca_cert_path, extra_env, notice_rx) => result,
             _ = shutdown_signal() => {
-                // `TempDir`'s Drop removes the directory on the way out.
                 drop(temp_dir);
                 Ok(())
             }
-        }
-    } else {
-        hook::run_jsonl_loop(port, ca_cert_path, extra_env, notice_rx).await
+        };
     }
+    hook::run_jsonl_loop(port, ca_cert_path, extra_env, notice_rx).await
+}
+
+fn nats_mode_enabled() -> bool {
+    [
+        harnx_core::instance::HARNX_INSTANCE_ID,
+        "HARNX_NATS_URL",
+        "HARNX_NATS_TOKEN",
+    ]
+    .iter()
+    .all(|name| std::env::var_os(name).is_some())
 }
 
 async fn shutdown_signal() {

--- a/crates/harnx-proxy-auth/tests/nats_hook.rs
+++ b/crates/harnx-proxy-auth/tests/nats_hook.rs
@@ -1,0 +1,178 @@
+#![cfg(unix)]
+
+use anyhow::{Context, Result};
+use harnx_core::hooks::{HookEvent, HookOutcome, HookPayload, HookResultControl};
+use harnx_core::instance::InstanceId;
+use harnx_hookset::{FailPolicy, HookRegistration};
+use harnx_hookset_server::{hook_registration_key, serve_over_nats, HOOK_REGISTRY_BUCKET};
+use harnx_proxy_auth::hook::{ProxyAuthHook, SERVER_NAME};
+use serde_json::{json, Map};
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+const TOKEN: &str = "proxy-auth-hook-test-token";
+
+struct NatsServerHandle {
+    url: String,
+    _store_dir: TempDir,
+    child: Child,
+}
+
+impl Drop for NatsServerHandle {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn nats_server_binary() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("NATS_SERVER_BIN") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    which::which("nats-server").ok()
+}
+
+async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
+    let Some(binary) = nats_server_binary() else {
+        eprintln!("skipping NATS integration test: nats-server binary not found");
+        return Ok(None);
+    };
+
+    let listener = TcpListener::bind("127.0.0.1:0").context("allocate NATS test port")?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    let store_dir = tempfile::tempdir().context("create NATS test store")?;
+    let mut child = Command::new(binary)
+        .arg("-js")
+        .arg("-sd")
+        .arg(store_dir.path())
+        .arg("-p")
+        .arg(port.to_string())
+        .arg("--auth")
+        .arg(TOKEN)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("spawn nats-server")?;
+    let url = format!("nats://127.0.0.1:{port}");
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        match async_nats::ConnectOptions::new()
+            .token(TOKEN.to_string())
+            .connect(&url)
+            .await
+        {
+            Ok(client) => {
+                client.flush().await.context("flush NATS test client")?;
+                return Ok(Some(NatsServerHandle {
+                    url,
+                    _store_dir: store_dir,
+                    child,
+                }));
+            }
+            Err(error) if child.try_wait()?.is_some() => {
+                anyhow::bail!("nats-server exited during startup: {error}");
+            }
+            Err(_) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Err(error) => return Err(error).context("wait for nats-server readiness"),
+        }
+    }
+}
+
+async fn wait_for_registration(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+) -> Result<HookRegistration> {
+    let jetstream = async_nats::jetstream::new(client.clone());
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(store) = jetstream.get_key_value(HOOK_REGISTRY_BUCKET).await {
+            let key = hook_registration_key(instance_id, SERVER_NAME);
+            if let Some(value) = store.get(&key).await? {
+                return serde_json::from_slice(&value).context("decode hook registration");
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("timed out waiting for proxy-auth registration");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn proxy_auth_registers_and_mutates_tool_env_over_nats() -> Result<()> {
+    harnx_core::require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        return Ok(());
+    };
+
+    let proxy_port = 4312;
+    let ca_cert_path = PathBuf::from("/tmp/proxy-auth-nats-test-ca.pem");
+    let extra_env = Map::from_iter([("ACLI_CONFIG_DIR".to_string(), json!("/tmp/acli-config"))]);
+    let hook = ProxyAuthHook::new(proxy_port, ca_cert_path.clone(), extra_env);
+    let instance_id = InstanceId::new();
+    let server_instance_id = instance_id.clone();
+    let server_url = server.url.clone();
+    let server_task =
+        tokio::spawn(
+            async move { serve_over_nats(hook, server_instance_id, &server_url, TOKEN).await },
+        );
+    let client = async_nats::ConnectOptions::new()
+        .token(TOKEN.to_string())
+        .connect(&server.url)
+        .await?;
+
+    let registration = wait_for_registration(&client, &instance_id).await?;
+    assert_eq!(registration.server, SERVER_NAME);
+    assert_eq!(registration.hooks.len(), 1);
+    assert_eq!(registration.hooks[0].event, "PreToolUse");
+    assert_eq!(registration.hooks[0].matcher.as_deref(), Some("exec|spawn"));
+    assert_eq!(registration.hooks[0].fail_policy, FailPolicy::Closed);
+
+    let payload = HookPayload {
+        session_id: "proxy-auth-nats-test".to_string(),
+        cwd: std::env::current_dir()?,
+        resume_count: 0,
+        hook_event: HookEvent::PreToolUse {
+            tool_name: "exec".to_string(),
+            tool_input: json!({"command": "true", "env": {"EXISTING": "kept"}}),
+            tool_use_id: "tool-use-1".to_string(),
+        },
+    };
+    let message = client
+        .request(
+            instance_id.hook_subject(SERVER_NAME, "PreToolUse"),
+            serde_json::to_vec(&payload)?.into(),
+        )
+        .await?;
+    let outcome: HookOutcome = serde_json::from_slice(&message.payload)?;
+    assert_eq!(outcome.control, HookResultControl::Continue);
+    let mutated = outcome
+        .result
+        .mutated_tool_input
+        .context("proxy-auth must return mutated tool input")?;
+    let env = mutated["env"].as_object().context("mutated env object")?;
+    assert_eq!(
+        env["HTTP_PROXY"],
+        json!(format!("http://127.0.0.1:{proxy_port}"))
+    );
+    assert_eq!(
+        env["HTTPS_PROXY"],
+        json!(format!("http://127.0.0.1:{proxy_port}"))
+    );
+    assert_eq!(env["SSL_CERT_FILE"], json!(ca_cert_path));
+    assert_eq!(env["NODE_EXTRA_CA_CERTS"], json!(ca_cert_path));
+    assert_eq!(env["ACLI_CONFIG_DIR"], json!("/tmp/acli-config"));
+    assert_eq!(env["EXISTING"], json!("kept"));
+
+    server_task.abort();
+    Ok(())
+}

--- a/crates/harnx-runtime/src/agent_loop.rs
+++ b/crates/harnx-runtime/src/agent_loop.rs
@@ -13,14 +13,14 @@
 
 use crate::{
     config::{session_lock::SessionLock, Config, GlobalConfig, Input},
+    nats_hook_provider::{dispatch_hook_event, HookDispatchMeta, HookEventDispatch},
     tool::{execute_tool_round, CompletionText, ToolResult},
     utils::dimmed_text,
 };
 use anyhow::{bail, Context, Result};
 use harnx_hooks::{
-    dispatch_hooks_with_count_and_manager, dispatch_hooks_with_managers, drain_async_results,
-    inject_pending_async_context, AsyncHookManager, HookEvent, HookResultControl,
-    PersistentHookManager,
+    dispatch_hooks_with_count_and_manager, drain_async_results, inject_pending_async_context,
+    AsyncHookManager, HookEvent, HookResultControl, PersistentHookManager,
 };
 use std::{future::Future, path::PathBuf, pin::Pin, sync::Arc};
 
@@ -349,6 +349,51 @@ async fn apply_local_handoff(
     Ok(())
 }
 
+struct AgentHookDispatch<'a> {
+    ctx: &'a AgentLoopContext,
+    event: HookEvent,
+    hooks: &'a harnx_hooks::HooksConfig,
+    session_id: &'a str,
+    cwd: &'a std::path::Path,
+    resume_count: u32,
+}
+
+async fn dispatch_agent_loop_hook(params: AgentHookDispatch<'_>) -> harnx_core::hooks::HookOutcome {
+    let AgentHookDispatch {
+        ctx,
+        event,
+        hooks,
+        session_id,
+        cwd,
+        resume_count,
+    } = params;
+    let async_guard = ctx.async_manager.lock().await;
+    let inline_event = event.clone();
+    let inline_fallback = dispatch_hooks_with_count_and_manager(
+        &inline_event,
+        &hooks.entries,
+        session_id,
+        cwd,
+        resume_count,
+        Some(&async_guard),
+        Some(&ctx.persistent_manager),
+    );
+    dispatch_hook_event(
+        HookEventDispatch {
+            event,
+            provider: ctx.nats_hook_provider.as_deref(),
+            meta: HookDispatchMeta {
+                session_id: session_id.to_string(),
+                cwd: cwd.to_path_buf(),
+                resume_count,
+            },
+            pending_async_context: ctx.pending_async_context.clone(),
+        },
+        inline_fallback,
+    )
+    .await
+}
+
 async fn run_agent_loop_inner(
     ctx: &AgentLoopContext,
     initial_input: Input,
@@ -417,16 +462,14 @@ async fn run_agent_loop_inner(
             let event = HookEvent::UserPromptSubmit {
                 prompt: input.text().to_string(),
             };
-            let async_guard = ctx.async_manager.lock().await;
-            let outcome = dispatch_hooks_with_count_and_manager(
-                &event,
-                &hooks.entries,
-                &session_id,
-                &cwd,
+            let outcome = dispatch_agent_loop_hook(AgentHookDispatch {
+                ctx,
+                event,
+                hooks: &hooks,
+                session_id: &session_id,
+                cwd: &cwd,
                 resume_count,
-                Some(&async_guard),
-                Some(&ctx.persistent_manager),
-            )
+            })
             .await;
             if matches!(outcome.control, HookResultControl::Block { .. }) {
                 break;
@@ -455,18 +498,15 @@ async fn run_agent_loop_inner(
                     error: err.to_string(),
                     error_type: "api_error".to_string(),
                 };
-                {
-                    let async_guard = ctx.async_manager.lock().await;
-                    let _ = dispatch_hooks_with_managers(
-                        &event,
-                        &hooks.entries,
-                        &session_id,
-                        &cwd,
-                        Some(&async_guard),
-                        Some(&ctx.persistent_manager),
-                    )
-                    .await;
-                }
+                let _ = dispatch_agent_loop_hook(AgentHookDispatch {
+                    ctx,
+                    event,
+                    hooks: &hooks,
+                    session_id: &session_id,
+                    cwd: &cwd,
+                    resume_count,
+                })
+                .await;
                 let _ = config.write().after_chat_completion(
                     &input,
                     "",
@@ -562,16 +602,14 @@ async fn run_agent_loop_inner(
                 stop_hook_active: true,
                 last_assistant_message: Some(output.clone()),
             };
-            let async_guard = ctx.async_manager.lock().await;
-            let outcome = dispatch_hooks_with_count_and_manager(
-                &event,
-                &hooks.entries,
-                &session_id,
-                &cwd,
+            let outcome = dispatch_agent_loop_hook(AgentHookDispatch {
+                ctx,
+                event,
+                hooks: &hooks,
+                session_id: &session_id,
+                cwd: &cwd,
                 resume_count,
-                Some(&async_guard),
-                Some(&ctx.persistent_manager),
-            )
+            })
             .await;
             if let Some(additional_context) = outcome
                 .result

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -5,6 +5,9 @@ use syntect::highlighting::{Color, Theme};
 use crate::config::{
     macro_execute, remote_session_ops, AgentVariables, Config, GlobalConfig, Input, LastMessage,
 };
+use crate::nats_hook_provider::{
+    discover_process_nats_hook_provider, dispatch_hook_event, HookDispatchMeta, HookEventDispatch,
+};
 use crate::utils::{dimmed_text, set_text, AbortSignal};
 use harnx_hooks::{
     dispatch_hooks_with_managers, AsyncHookManager, HookEvent, HookResultControl,
@@ -1068,7 +1071,7 @@ Commands:
             _ => unknown_command()?,
         },
         None => {
-            let (hooks, session_id) = {
+            let (hooks, session_id, config_snapshot) = {
                 let config = config.read();
                 (
                     config.resolved_hooks(),
@@ -1078,19 +1081,36 @@ Commands:
                         .map(|session| session.id())
                         .unwrap_or("default")
                         .to_string(),
+                    config.clone(),
                 )
             };
+            let nats_hook_provider =
+                discover_process_nats_hook_provider(&config_snapshot).await;
             let cwd = env::current_dir().unwrap_or_default();
             let event = HookEvent::UserPromptSubmit {
                 prompt: line.to_string(),
             };
-            let outcome = dispatch_hooks_with_managers(
-                &event,
+            let inline_event = event.clone();
+            let inline_fallback = dispatch_hooks_with_managers(
+                &inline_event,
                 &hooks.entries,
                 &session_id,
                 &cwd,
                 Some(async_manager),
                 Some(persistent_manager),
+            );
+            let outcome = dispatch_hook_event(
+                HookEventDispatch {
+                    event,
+                    provider: nats_hook_provider.as_deref(),
+                    meta: HookDispatchMeta {
+                        session_id: session_id.clone(),
+                        cwd: cwd.clone(),
+                        resume_count: 0,
+                    },
+                    pending_async_context: None,
+                },
+                inline_fallback,
             )
             .await;
             match outcome.control {

--- a/crates/harnx-runtime/src/config/tool_servers_split.rs
+++ b/crates/harnx-runtime/src/config/tool_servers_split.rs
@@ -2,7 +2,7 @@
 //!
 //! These configs specify which NATS tool servers to spawn as separate processes.
 //! Similar in shape to `McpServerConfig` but without MCP-specific fields like
-//! `rename_tools`, `tool_templates`, `hooks`, and `roots`.
+//! `rename_tools`, `tool_templates`, and `roots`.
 
 use super::*;
 use anyhow::Context as _;
@@ -50,6 +50,13 @@ pub struct ToolServerConfig {
     /// installed from packages.
     #[serde(skip)]
     pub package: Option<String>,
+
+    /// Per-tool-server hooks configuration.
+    ///
+    /// Hooks defined here apply only to tools provided by this tool server.
+    /// Merged with global and agent hooks at runtime.
+    #[serde(default)]
+    pub hooks: Option<HooksConfig>,
 }
 
 impl Config {
@@ -103,6 +110,33 @@ command: harnx-time-server
         assert!(config.enabled);
         assert!(config.description.is_none());
         assert!(config.package.is_none());
+        assert!(config.hooks.is_none());
+    }
+
+    #[test]
+    fn deserializes_config_with_hooks() {
+        let yaml = r#"
+command: harnx-time-server
+hooks:
+  max_resume: 3
+  entries:
+    - event: PreToolUse
+      matcher: "time"
+      command: "/path/to/hook.sh"
+      timeout: 30
+      type: claude-command
+"#;
+        let config: ToolServerConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.command, "harnx-time-server");
+        let hooks = config.hooks.as_ref().expect("hooks should be parsed");
+        assert_eq!(hooks.max_resume, Some(3));
+        assert_eq!(hooks.entries.len(), 1);
+        let entry = &hooks.entries[0];
+        assert_eq!(entry.event, "PreToolUse");
+        assert_eq!(entry.matcher, Some("time".to_string()));
+        assert_eq!(entry.command, "/path/to/hook.sh");
+        assert_eq!(entry.timeout, Some(30));
+        assert_eq!(entry.hook_type, "claude-command");
     }
 
     #[test]

--- a/crates/harnx-runtime/src/nats_hook_provider.rs
+++ b/crates/harnx-runtime/src/nats_hook_provider.rs
@@ -7,6 +7,7 @@ use harnx_core::hooks::{HookEvent, HookOutcome, HookPayload, HookResult, HookRes
 use harnx_core::instance::InstanceId;
 use harnx_hookset::{FailPolicy, HookRegistration, HookSpec, HOOK_REGISTRY_BUCKET};
 use harnx_hookset_server::hook_registration_key;
+use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -19,6 +20,45 @@ const DEFAULT_HOOK_TIMEOUT: Duration = Duration::from_secs(30);
 pub struct HookDispatchMeta {
     pub session_id: String,
     pub cwd: PathBuf,
+    pub resume_count: u32,
+}
+
+/// Parameters for one unified hook dispatch.
+pub struct HookEventDispatch<'a> {
+    pub event: HookEvent,
+    pub provider: Option<&'a NatsHookProvider>,
+    pub meta: HookDispatchMeta,
+    pub pending_async_context: Option<Arc<Mutex<Option<String>>>>,
+}
+
+/// Dispatch one hook event through NATS, or use the inline runtime while no
+/// NATS provider is available. The inline future is lazy and isn't polled when
+/// NATS owns dispatch.
+pub async fn dispatch_hook_event<F>(
+    params: HookEventDispatch<'_>,
+    inline_fallback: F,
+) -> HookOutcome
+where
+    F: Future<Output = HookOutcome>,
+{
+    match params.provider {
+        Some(provider) => {
+            provider
+                .dispatch_event(params.event, params.pending_async_context, params.meta)
+                .await
+        }
+        None => inline_fallback.await,
+    }
+}
+
+/// Discover hooks for binaries launched inside a worker process tree.
+/// Frontends without `HARNX_INSTANCE_ID` keep the inline fallback.
+pub async fn discover_process_nats_hook_provider(config: &Config) -> Option<Arc<NatsHookProvider>> {
+    let instance_id = std::env::var(harnx_core::instance::HARNX_INSTANCE_ID).ok()?;
+    NatsHookProvider::discover(config, InstanceId::from_string(instance_id))
+        .await
+        .ok()
+        .map(Arc::new)
 }
 
 /// One hook route flattened from a hook server registration.
@@ -59,7 +99,7 @@ impl HookRequestDispatcher for NatsHookRequester {
 
 /// Discovers and dispatches hooks registered for one worker instance.
 pub struct NatsHookProvider {
-    client: async_nats::Client,
+    client: Option<async_nats::Client>,
     instance_id: InstanceId,
     hooks: Vec<DiscoveredHook>,
     dispatcher: Arc<dyn HookRequestDispatcher>,
@@ -88,7 +128,7 @@ impl NatsHookProvider {
             client: client.clone(),
         });
         Self {
-            client,
+            client: Some(client),
             instance_id,
             hooks,
             dispatcher,
@@ -101,7 +141,66 @@ impl NatsHookProvider {
 
     /// Returns the client used for discovery and requests.
     pub fn client(&self) -> &async_nats::Client {
-        &self.client
+        self.client
+            .as_ref()
+            .expect("production NATS hook providers always carry a client")
+    }
+
+    #[cfg(test)]
+    fn from_dispatcher(
+        instance_id: InstanceId,
+        hooks: Vec<DiscoveredHook>,
+        dispatcher: Arc<dyn HookRequestDispatcher>,
+    ) -> Self {
+        Self {
+            client: None,
+            instance_id,
+            hooks,
+            dispatcher,
+        }
+    }
+
+    /// Dispatches any hook event using its event-specific blocking policy.
+    ///
+    /// PreToolUse, session boundary, and turn-control events run sequentially.
+    /// File-change and post-tool events start in background and return immediately.
+    pub async fn dispatch_event(
+        &self,
+        event: HookEvent,
+        pending: Option<Arc<Mutex<Option<String>>>>,
+        meta: HookDispatchMeta,
+    ) -> HookOutcome {
+        match event {
+            HookEvent::PreToolUse { .. } => {
+                let outcome = self.dispatch_pre_tool_use(&event, meta).await;
+                append_outcome_context(pending.as_ref(), &outcome).await;
+                outcome
+            }
+            HookEvent::SessionStart { .. }
+            | HookEvent::SessionEnd { .. }
+            | HookEvent::UserPromptSubmit { .. }
+            | HookEvent::Stop { .. }
+            | HookEvent::StopFailure { .. } => {
+                dispatch_blocking_event_with(
+                    EventDispatch {
+                        dispatcher: self.dispatcher.as_ref(),
+                        instance_id: &self.instance_id,
+                        hooks: &self.hooks,
+                        meta: &meta,
+                        pending,
+                    },
+                    &event,
+                )
+                .await
+            }
+            HookEvent::InstructionsLoaded { .. }
+            | HookEvent::CwdChanged { .. }
+            | HookEvent::PostToolUse { .. }
+            | HookEvent::PostToolUseFailure { .. } => {
+                self.dispatch_best_effort(event, pending, meta);
+                continue_outcome(None)
+            }
+        }
     }
 
     pub async fn dispatch_pre_tool_use(
@@ -128,6 +227,15 @@ impl NatsHookProvider {
         pending: Option<Arc<Mutex<Option<String>>>>,
         meta: HookDispatchMeta,
     ) {
+        self.dispatch_best_effort(event, pending, meta);
+    }
+
+    fn dispatch_best_effort(
+        &self,
+        event: HookEvent,
+        pending: Option<Arc<Mutex<Option<String>>>>,
+        meta: HookDispatchMeta,
+    ) {
         for hook in matching_hooks(&self.hooks, event.event_name(), event.matcher_text()) {
             let dispatcher = Arc::clone(&self.dispatcher);
             let subject = self
@@ -136,16 +244,16 @@ impl NatsHookProvider {
             let payload = HookPayload {
                 session_id: meta.session_id.clone(),
                 cwd: meta.cwd.clone(),
-                resume_count: 0,
+                resume_count: meta.resume_count,
                 hook_event: event.clone(),
             };
-            let params = PostHookDispatch {
+            let params = BestEffortHookDispatch {
                 subject,
                 payload,
                 hook: hook.clone(),
                 pending: pending.clone(),
             };
-            tokio::spawn(dispatch_one_post_hook(dispatcher, params));
+            tokio::spawn(dispatch_one_best_effort_hook(dispatcher, params));
         }
     }
 }
@@ -186,6 +294,45 @@ struct PreHookDispatch<'a> {
     meta: &'a HookDispatchMeta,
 }
 
+#[derive(Default)]
+struct ContinueResultAccumulator {
+    additional_contexts: Vec<String>,
+    system_messages: Vec<String>,
+    resume: bool,
+}
+
+impl ContinueResultAccumulator {
+    fn push(&mut self, result: &HookResult) {
+        if let Some(context) = result
+            .additional_context
+            .as_ref()
+            .filter(|context| !context.is_empty())
+        {
+            self.additional_contexts.push(context.clone());
+        }
+        if let Some(message) = result
+            .system_message
+            .as_ref()
+            .filter(|message| !message.is_empty())
+        {
+            self.system_messages.push(message.clone());
+        }
+        self.resume |= result.resume.unwrap_or(false);
+    }
+
+    fn into_result(self, mutated_tool_input: Option<serde_json::Value>) -> HookResult {
+        HookResult {
+            additional_context: (!self.additional_contexts.is_empty())
+                .then(|| self.additional_contexts.join("\n")),
+            system_message: (!self.system_messages.is_empty())
+                .then(|| self.system_messages.join("\n")),
+            mutated_tool_input,
+            resume: self.resume.then_some(true),
+            ..HookResult::default()
+        }
+    }
+}
+
 async fn dispatch_pre_tool_use_with(params: PreHookDispatch<'_>, event: &HookEvent) -> HookOutcome {
     if !matches!(event, HookEvent::PreToolUse { .. }) {
         return continue_outcome(None);
@@ -193,11 +340,12 @@ async fn dispatch_pre_tool_use_with(params: PreHookDispatch<'_>, event: &HookEve
 
     let mut running_event = event.clone();
     let mut final_mutation = None;
+    let mut accumulated = ContinueResultAccumulator::default();
     for hook in matching_hooks(params.hooks, event.event_name(), event.matcher_text()) {
         let payload = HookPayload {
             session_id: params.meta.session_id.clone(),
             cwd: params.meta.cwd.clone(),
-            resume_count: 0,
+            resume_count: params.meta.resume_count,
             hook_event: running_event.clone(),
         };
         let payload = match serde_json::to_vec(&payload) {
@@ -224,6 +372,7 @@ async fn dispatch_pre_tool_use_with(params: PreHookDispatch<'_>, event: &HookEve
         match outcome.control {
             HookResultControl::Block { .. } | HookResultControl::Ask { .. } => return outcome,
             HookResultControl::Continue => {
+                accumulated.push(&outcome.result);
                 if let Some(tool_input) = outcome.result.mutated_tool_input {
                     running_event = with_pre_tool_input(&running_event, tool_input.clone());
                     final_mutation = Some(tool_input);
@@ -231,21 +380,84 @@ async fn dispatch_pre_tool_use_with(params: PreHookDispatch<'_>, event: &HookEve
             }
         }
     }
-    continue_outcome(final_mutation)
+    HookOutcome {
+        control: HookResultControl::Continue,
+        result: accumulated.into_result(final_mutation),
+    }
 }
 
-struct PostHookDispatch {
+struct EventDispatch<'a> {
+    dispatcher: &'a dyn HookRequestDispatcher,
+    instance_id: &'a InstanceId,
+    hooks: &'a [DiscoveredHook],
+    meta: &'a HookDispatchMeta,
+    pending: Option<Arc<Mutex<Option<String>>>>,
+}
+
+async fn dispatch_blocking_event_with(params: EventDispatch<'_>, event: &HookEvent) -> HookOutcome {
+    let mut accumulated = ContinueResultAccumulator::default();
+    for hook in matching_hooks(params.hooks, event.event_name(), event.matcher_text()) {
+        let payload = HookPayload {
+            session_id: params.meta.session_id.clone(),
+            cwd: params.meta.cwd.clone(),
+            resume_count: params.meta.resume_count,
+            hook_event: event.clone(),
+        };
+        let payload = match serde_json::to_vec(&payload) {
+            Ok(payload) => payload,
+            Err(error) => {
+                return unavailable_outcome(&hook.server, hook.spec.fail_policy, error);
+            }
+        };
+        let subject = params
+            .instance_id
+            .hook_subject(&hook.server, event.event_name());
+        let timeout = hook
+            .spec
+            .timeout_secs
+            .map(Duration::from_secs)
+            .unwrap_or(DEFAULT_HOOK_TIMEOUT);
+        let outcome = match params.dispatcher.request(subject, payload, timeout).await {
+            Ok(outcome) => outcome,
+            Err(error) if hook.spec.fail_policy == FailPolicy::Open => {
+                log::warn!("{} hook unavailable; continuing: {error:#}", hook.server);
+                continue;
+            }
+            Err(error) => return unavailable_outcome(&hook.server, FailPolicy::Closed, error),
+        };
+
+        let texts = [
+            outcome.result.additional_context.clone(),
+            outcome.result.system_message.clone(),
+        ];
+        if let Some(pending) = params.pending.as_deref() {
+            append_pending_context(pending, texts).await;
+        }
+        match outcome.control {
+            HookResultControl::Block { .. } | HookResultControl::Ask { .. } => return outcome,
+            HookResultControl::Continue => accumulated.push(&outcome.result),
+        }
+    }
+
+    HookOutcome {
+        control: HookResultControl::Continue,
+        result: accumulated.into_result(None),
+    }
+}
+
+struct BestEffortHookDispatch {
     subject: String,
     payload: HookPayload,
     hook: DiscoveredHook,
     pending: Option<Arc<Mutex<Option<String>>>>,
 }
 
-async fn dispatch_one_post_hook(
+async fn dispatch_one_best_effort_hook(
     dispatcher: Arc<dyn HookRequestDispatcher>,
-    params: PostHookDispatch,
+    params: BestEffortHookDispatch,
 ) {
     let server = &params.hook.server;
+    let event_name = params.payload.hook_event.event_name();
     let timeout = params
         .hook
         .spec
@@ -275,12 +487,13 @@ async fn dispatch_one_post_hook(
 
     if !matches!(outcome.control, HookResultControl::Continue) {
         emit_post_notice(format!(
-            "{server} hook returned {:?} after tool completion",
+            "{server} hook returned {:?} during best-effort {event_name} dispatch",
             outcome.control
         ));
     }
-    if outcome.result.mutated_tool_response.is_some() {
-        log::debug!("ignoring mutated tool response from asynchronous {server} hook");
+    if outcome.result.mutated_tool_input.is_some() || outcome.result.mutated_tool_response.is_some()
+    {
+        log::debug!("ignoring mutation from asynchronous {server} {event_name} hook");
     }
     if let Some(pending) = params.pending {
         append_pending_context(
@@ -305,6 +518,22 @@ async fn append_pending_context(pending: &Mutex<Option<String>>, texts: [Option<
     }
     if !accumulated.is_empty() {
         *guard = Some(accumulated);
+    }
+}
+
+async fn append_outcome_context(
+    pending: Option<&Arc<Mutex<Option<String>>>>,
+    outcome: &HookOutcome,
+) {
+    if let Some(pending) = pending {
+        append_pending_context(
+            pending.as_ref(),
+            [
+                outcome.result.additional_context.clone(),
+                outcome.result.system_message.clone(),
+            ],
+        )
+        .await;
     }
 }
 
@@ -401,6 +630,8 @@ mod tests {
     struct StubDispatcher {
         outcomes: Mutex<VecDeque<HookOutcome>>,
         seen_inputs: Mutex<Vec<Value>>,
+        seen_subjects: Mutex<Vec<String>>,
+        seen_resume_counts: Mutex<Vec<u32>>,
         delay: Option<Duration>,
         completed: Option<Arc<Notify>>,
         calls: AtomicUsize,
@@ -410,12 +641,17 @@ mod tests {
     impl HookRequestDispatcher for StubDispatcher {
         async fn request(
             &self,
-            _subject: String,
+            subject: String,
             payload: Vec<u8>,
             _timeout: Duration,
         ) -> Result<HookOutcome> {
             self.calls.fetch_add(1, Ordering::SeqCst);
+            self.seen_subjects.lock().await.push(subject);
             let payload: HookPayload = serde_json::from_slice(&payload)?;
+            self.seen_resume_counts
+                .lock()
+                .await
+                .push(payload.resume_count);
             if let HookEvent::PreToolUse { tool_input, .. } = payload.hook_event {
                 self.seen_inputs.lock().await.push(tool_input);
             }
@@ -464,10 +700,44 @@ mod tests {
         Arc::new(StubDispatcher {
             outcomes: Mutex::new(outcomes.into()),
             seen_inputs: Mutex::new(Vec::new()),
+            seen_subjects: Mutex::new(Vec::new()),
+            seen_resume_counts: Mutex::new(Vec::new()),
             delay: None,
             completed: None,
             calls: AtomicUsize::new(0),
         })
+    }
+
+    fn non_tool_events() -> Vec<HookEvent> {
+        vec![
+            HookEvent::SessionStart {
+                source: "cli".to_string(),
+                model: "model".to_string(),
+            },
+            HookEvent::SessionEnd {
+                reason: "exit".to_string(),
+            },
+            HookEvent::UserPromptSubmit {
+                prompt: "hello".to_string(),
+            },
+            HookEvent::Stop {
+                stop_hook_active: true,
+                last_assistant_message: Some("done".to_string()),
+            },
+            HookEvent::StopFailure {
+                error: "failed".to_string(),
+                error_type: "api_error".to_string(),
+            },
+            HookEvent::InstructionsLoaded {
+                file_path: PathBuf::from("/tmp/CLAUDE.md"),
+                memory_type: "Project".to_string(),
+                load_reason: "session_start".to_string(),
+            },
+            HookEvent::CwdChanged {
+                old_cwd: PathBuf::from("/tmp/old"),
+                new_cwd: PathBuf::from("/tmp/new"),
+            },
+        ]
     }
 
     #[test]
@@ -482,7 +752,14 @@ mod tests {
         let selected = matching_hooks(&hooks, "PreToolUse", Some("exec"));
         let servers: Vec<_> = selected.iter().map(|hook| hook.server.as_str()).collect();
         assert_eq!(servers, ["all-tools", "exact"]);
-        assert!(matching_hooks(&hooks, "SessionStart", None).is_empty());
+
+        let non_tool_hooks = vec![
+            hook("unmatched", "SessionStart", Some("cli"), 0),
+            hook("matched", "SessionStart", None, 0),
+        ];
+        let selected = matching_hooks(&non_tool_hooks, "SessionStart", None);
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].server, "matched");
     }
 
     #[test]
@@ -533,6 +810,7 @@ mod tests {
         let meta = HookDispatchMeta {
             session_id: "session".to_string(),
             cwd: PathBuf::from("/tmp"),
+            resume_count: 0,
         };
         let outcome = dispatch_pre_tool_use_with(
             PreHookDispatch {
@@ -568,6 +846,7 @@ mod tests {
         let meta = HookDispatchMeta {
             session_id: "session".to_string(),
             cwd: PathBuf::from("/tmp"),
+            resume_count: 0,
         };
         let outcome = dispatch_pre_tool_use_with(
             PreHookDispatch {
@@ -591,6 +870,157 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn every_non_tool_event_dispatches_to_its_nats_subject() {
+        let instance_id = InstanceId::from_string("test");
+        let meta = HookDispatchMeta {
+            session_id: "session".to_string(),
+            cwd: PathBuf::from("/tmp"),
+            resume_count: 0,
+        };
+
+        for event in non_tool_events() {
+            let event_name = event.event_name();
+            let dispatcher = stub(vec![continue_outcome(None)]);
+            let hooks = vec![hook("server", event_name, None, 0)];
+            let outcome = dispatch_blocking_event_with(
+                EventDispatch {
+                    dispatcher: dispatcher.as_ref(),
+                    instance_id: &instance_id,
+                    hooks: &hooks,
+                    meta: &meta,
+                    pending: None,
+                },
+                &event,
+            )
+            .await;
+
+            assert!(matches!(outcome.control, HookResultControl::Continue));
+            assert_eq!(dispatcher.calls.load(Ordering::SeqCst), 1, "{event_name}");
+            let subjects = dispatcher.seen_subjects.lock().await;
+            assert_eq!(subjects.len(), 1);
+            assert!(subjects[0].ends_with(&format!(".hook.server.{event_name}")));
+        }
+    }
+
+    #[tokio::test]
+    async fn blocking_event_block_short_circuits_later_hooks() {
+        let dispatcher = stub(vec![HookOutcome {
+            control: HookResultControl::Block {
+                reason: "denied".to_string(),
+            },
+            result: HookResult::default(),
+        }]);
+        let hooks = vec![
+            hook("one", "UserPromptSubmit", None, 0),
+            hook("two", "UserPromptSubmit", None, 1),
+        ];
+        let instance_id = InstanceId::from_string("test");
+        let meta = HookDispatchMeta {
+            session_id: "session".to_string(),
+            cwd: PathBuf::from("/tmp"),
+            resume_count: 0,
+        };
+
+        let outcome = dispatch_blocking_event_with(
+            EventDispatch {
+                dispatcher: dispatcher.as_ref(),
+                instance_id: &instance_id,
+                hooks: &hooks,
+                meta: &meta,
+                pending: None,
+            },
+            &HookEvent::UserPromptSubmit {
+                prompt: "hello".to_string(),
+            },
+        )
+        .await;
+
+        assert!(matches!(outcome.control, HookResultControl::Block { .. }));
+        assert_eq!(dispatcher.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn blocking_event_preserves_context_channels_and_appends_both_to_pending() {
+        let dispatcher = stub(vec![HookOutcome {
+            control: HookResultControl::Continue,
+            result: HookResult {
+                additional_context: Some("context".to_string()),
+                system_message: Some("system".to_string()),
+                ..HookResult::default()
+            },
+        }]);
+        let hooks = vec![hook("server", "Stop", None, 0)];
+        let instance_id = InstanceId::from_string("test");
+        let meta = HookDispatchMeta {
+            session_id: "session".to_string(),
+            cwd: PathBuf::from("/tmp"),
+            resume_count: 0,
+        };
+        let pending = Arc::new(Mutex::new(Some("existing".to_string())));
+
+        let outcome = dispatch_blocking_event_with(
+            EventDispatch {
+                dispatcher: dispatcher.as_ref(),
+                instance_id: &instance_id,
+                hooks: &hooks,
+                meta: &meta,
+                pending: Some(Arc::clone(&pending)),
+            },
+            &HookEvent::Stop {
+                stop_hook_active: true,
+                last_assistant_message: Some("done".to_string()),
+            },
+        )
+        .await;
+
+        assert_eq!(
+            outcome.result.additional_context.as_deref(),
+            Some("context")
+        );
+        assert_eq!(outcome.result.system_message.as_deref(), Some("system"));
+        assert_eq!(
+            pending.lock().await.as_deref(),
+            Some("existing\ncontext\nsystem")
+        );
+    }
+
+    #[tokio::test]
+    async fn lifecycle_event_fires_without_blocking() {
+        let completed = Arc::new(Notify::new());
+        let dispatcher = Arc::new(StubDispatcher {
+            outcomes: Mutex::new(vec![continue_outcome(None)].into()),
+            seen_inputs: Mutex::new(Vec::new()),
+            seen_subjects: Mutex::new(Vec::new()),
+            seen_resume_counts: Mutex::new(Vec::new()),
+            delay: Some(Duration::from_millis(100)),
+            completed: Some(Arc::clone(&completed)),
+            calls: AtomicUsize::new(0),
+        });
+        let payload = HookPayload {
+            session_id: "session".to_string(),
+            cwd: PathBuf::from("/tmp"),
+            resume_count: 0,
+            hook_event: HookEvent::SessionStart {
+                source: "cli".to_string(),
+                model: "model".to_string(),
+            },
+        };
+
+        let started = tokio::time::Instant::now();
+        tokio::spawn(dispatch_one_best_effort_hook(
+            dispatcher,
+            BestEffortHookDispatch {
+                subject: "test.hook.server.SessionStart".to_string(),
+                payload,
+                hook: hook("server", "SessionStart", None, 0),
+                pending: None,
+            },
+        ));
+        assert!(started.elapsed() < Duration::from_millis(50));
+        completed.notified().await;
+    }
+
+    #[tokio::test]
     async fn post_dispatch_returns_before_hook_and_appends_shared_context() {
         let completed = Arc::new(Notify::new());
         let dispatcher = Arc::new(StubDispatcher {
@@ -606,6 +1036,8 @@ mod tests {
                 .into(),
             ),
             seen_inputs: Mutex::new(Vec::new()),
+            seen_subjects: Mutex::new(Vec::new()),
+            seen_resume_counts: Mutex::new(Vec::new()),
             delay: Some(Duration::from_millis(100)),
             completed: Some(Arc::clone(&completed)),
             calls: AtomicUsize::new(0),
@@ -624,9 +1056,9 @@ mod tests {
         };
 
         let started = tokio::time::Instant::now();
-        tokio::spawn(dispatch_one_post_hook(
+        tokio::spawn(dispatch_one_best_effort_hook(
             dispatcher,
-            PostHookDispatch {
+            BestEffortHookDispatch {
                 subject: "subject".to_string(),
                 payload,
                 hook: hook("server", "PostToolUse", None, 0),
@@ -641,5 +1073,201 @@ mod tests {
             pending.lock().await.as_deref(),
             Some("existing\ncontext\nsystem")
         );
+    }
+
+    #[tokio::test]
+    async fn unified_entrypoint_uses_inline_fallback_without_provider() {
+        let outcome = HookOutcome {
+            control: HookResultControl::Block {
+                reason: "inline".to_string(),
+            },
+            result: HookResult::default(),
+        };
+        let actual = dispatch_hook_event(
+            HookEventDispatch {
+                event: HookEvent::SessionEnd {
+                    reason: "test".to_string(),
+                },
+                provider: None,
+                meta: HookDispatchMeta {
+                    session_id: "session".to_string(),
+                    cwd: PathBuf::from("/tmp"),
+                    resume_count: 0,
+                },
+                pending_async_context: None,
+            },
+            std::future::ready(outcome.clone()),
+        )
+        .await;
+        assert_eq!(
+            serde_json::to_value(actual).unwrap(),
+            serde_json::to_value(outcome).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_event_queues_aggregated_pre_tool_context_for_next_turn() {
+        let dispatcher = stub(vec![
+            HookOutcome {
+                control: HookResultControl::Continue,
+                result: HookResult {
+                    additional_context: Some("context-one".to_string()),
+                    system_message: Some("system-one".to_string()),
+                    mutated_tool_input: Some(json!({"step": 1})),
+                    resume: Some(true),
+                    ..HookResult::default()
+                },
+            },
+            HookOutcome {
+                control: HookResultControl::Continue,
+                result: HookResult {
+                    additional_context: Some("context-two".to_string()),
+                    system_message: Some("system-two".to_string()),
+                    mutated_tool_input: Some(json!({"step": 2})),
+                    ..HookResult::default()
+                },
+            },
+        ]);
+        let provider = NatsHookProvider::from_dispatcher(
+            InstanceId::from_string("test"),
+            vec![
+                hook("first", "PreToolUse", Some("exec"), 0),
+                hook("second", "PreToolUse", Some("exec"), 1),
+            ],
+            dispatcher.clone(),
+        );
+        let pending = Arc::new(Mutex::new(Some("existing".to_string())));
+
+        let outcome = provider
+            .dispatch_event(
+                pre_event(json!({"initial": true})),
+                Some(Arc::clone(&pending)),
+                HookDispatchMeta {
+                    session_id: "session".to_string(),
+                    cwd: PathBuf::from("/tmp"),
+                    resume_count: 0,
+                },
+            )
+            .await;
+
+        assert_eq!(
+            outcome.result.additional_context.as_deref(),
+            Some("context-one\ncontext-two")
+        );
+        assert_eq!(
+            outcome.result.system_message.as_deref(),
+            Some("system-one\nsystem-two")
+        );
+        assert_eq!(outcome.result.mutated_tool_input, Some(json!({"step": 2})));
+        assert_eq!(outcome.result.resume, Some(true));
+        assert_eq!(
+            dispatcher.seen_inputs.lock().await.as_slice(),
+            [json!({"initial": true}), json!({"step": 1})]
+        );
+        assert_eq!(
+            pending.lock().await.as_deref(),
+            Some("existing\ncontext-one\ncontext-two\nsystem-one\nsystem-two")
+        );
+    }
+
+    #[tokio::test]
+    async fn session_end_is_delivered_before_dispatch_returns() {
+        let dispatcher = Arc::new(StubDispatcher {
+            outcomes: Mutex::new(vec![continue_outcome(None)].into()),
+            seen_inputs: Mutex::new(Vec::new()),
+            seen_subjects: Mutex::new(Vec::new()),
+            seen_resume_counts: Mutex::new(Vec::new()),
+            delay: Some(Duration::from_millis(100)),
+            completed: None,
+            calls: AtomicUsize::new(0),
+        });
+        let provider = NatsHookProvider::from_dispatcher(
+            InstanceId::from_string("test"),
+            vec![hook("lifecycle", "SessionEnd", None, 0)],
+            dispatcher.clone(),
+        );
+
+        let started = tokio::time::Instant::now();
+        let outcome = provider
+            .dispatch_event(
+                HookEvent::SessionEnd {
+                    reason: "exit".to_string(),
+                },
+                None,
+                HookDispatchMeta {
+                    session_id: "session".to_string(),
+                    cwd: PathBuf::from("/tmp"),
+                    resume_count: 4,
+                },
+            )
+            .await;
+
+        assert!(matches!(outcome.control, HookResultControl::Continue));
+        assert!(started.elapsed() >= Duration::from_millis(75));
+        assert_eq!(dispatcher.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            dispatcher.seen_subjects.lock().await.as_slice(),
+            ["harnx.v1.test.hook.lifecycle.SessionEnd"]
+        );
+        assert_eq!(dispatcher.seen_resume_counts.lock().await.as_slice(), [4]);
+    }
+
+    #[tokio::test]
+    async fn resume_count_is_serialized_for_pre_tool_dispatch() {
+        let dispatcher = stub(vec![continue_outcome(None)]);
+        let instance_id = InstanceId::from_string("test");
+        let hooks = vec![hook("server", "PreToolUse", Some("exec"), 0)];
+        let meta = HookDispatchMeta {
+            session_id: "session".to_string(),
+            cwd: PathBuf::from("/tmp"),
+            resume_count: 7,
+        };
+
+        dispatch_pre_tool_use_with(
+            PreHookDispatch {
+                dispatcher: dispatcher.as_ref(),
+                instance_id: &instance_id,
+                hooks: &hooks,
+                meta: &meta,
+            },
+            &pre_event(json!({})),
+        )
+        .await;
+
+        assert_eq!(dispatcher.seen_resume_counts.lock().await.as_slice(), [7]);
+    }
+
+    #[tokio::test]
+    async fn pre_tool_ask_survives_nats_dispatch_for_approval_flow() {
+        let dispatcher = stub(vec![HookOutcome {
+            control: HookResultControl::Ask {
+                reason: Some("approval needed".to_string()),
+            },
+            result: HookResult::default(),
+        }]);
+        let hooks = vec![hook("approval", "PreToolUse", Some("exec"), 0)];
+        let instance_id = InstanceId::from_string("test");
+        let meta = HookDispatchMeta {
+            session_id: "session".to_string(),
+            cwd: PathBuf::from("/tmp"),
+            resume_count: 0,
+        };
+
+        let outcome = dispatch_pre_tool_use_with(
+            PreHookDispatch {
+                dispatcher: dispatcher.as_ref(),
+                instance_id: &instance_id,
+                hooks: &hooks,
+                meta: &meta,
+            },
+            &pre_event(json!({})),
+        )
+        .await;
+
+        assert!(matches!(
+            outcome.control,
+            HookResultControl::Ask { reason }
+                if reason.as_deref() == Some("approval needed")
+        ));
     }
 }

--- a/crates/harnx-runtime/src/nats_worker/agent_loop.rs
+++ b/crates/harnx-runtime/src/nats_worker/agent_loop.rs
@@ -1,12 +1,14 @@
 //! Agent loop entrypoint for NATS-backed sessions.
 
 use super::backend::{FencedSessionLogSink, NatsSessionLogBackend};
+use super::hook_supervisor::{HookServerStartConfig, HookServerSupervisor};
 use crate::agent_loop::OnToolRoundFn;
-use crate::config::{GlobalConfig, Input};
+use crate::config::{resolve_local_nats_server_config, GlobalConfig, Input, LOCAL_CLUSTER_KEY};
 use crate::nats_event_sink::NatsEventSink;
 use crate::nats_lease::{NatsLeaseAcquireParams, NatsLeaseConfig, NatsSessionLease};
 use crate::nats_metrics;
 use crate::nats_session_index::{put_record, SessionIndexRecord};
+use crate::tool_context::discover_nats_hook_provider_cached;
 use crate::utils::AbortSignal;
 use anyhow::{Context, Result};
 use async_nats::jetstream;
@@ -198,57 +200,41 @@ pub async fn run_agent_loop_with_nats_inner(args: RunAgentLoopArgs<'_>) -> Resul
         on_tool_round,
         working_dir,
     } = args;
-    // Get JetStream context from config (extract URL before await)
-    // Connect through the config-driven helper so per-cluster auth/TLS
-    // (token, require_tls, client cert, custom CA) is applied. Connecting with
-    // a bare `async_nats::connect(url)` here would silently drop all auth/TLS
-    // settings, breaking secure clusters. Snapshot the Config first so we don't
-    // hold the lock across the await.
-    let cfg_snapshot = config.read().clone();
-    let jetstream_ctx = cfg_snapshot.nats_jetstream(cluster_key).await?;
-
-    // Load or create session from NATS
-    let mut backend = NatsSessionLogBackend::new(jetstream_ctx.clone(), session_id);
-    if let Some(observer) = after_seq_observer {
-        backend = backend.with_after_seq_observer(observer);
-    }
-
-    abort_resume_if_fenced(&backend, lease.as_deref())?;
-
-    let session = load_or_repair_session(LoadOrRepairSessionParams {
-        backend: &backend,
+    let jetstream_ctx = prepare_agent_session(PrepareAgentSessionParams {
+        cluster_key,
+        session_id,
         config: &config,
         instance_id: &instance_id,
-        input: &initial_input,
-        lease: lease.as_deref(),
-        session_index,
-        session_id,
-        working_dir: working_dir.as_deref(),
+        initial_input: &initial_input,
         abort_signal: &abort_signal,
+        lease: lease.as_ref(),
+        after_seq_observer,
         header_insert_observer: header_insert_observer.as_ref(),
+        session_index,
+        working_dir: working_dir.as_deref(),
     })
     .await?;
 
-    attach_session_to_config(&config, session, &backend, lease.as_ref());
+    let hook_start_config =
+        agent_hook_start_config(cluster_key, &jetstream_ctx, &instance_id).await;
+    let mut hook_supervisor = None;
+    reconcile_agent_hooks(
+        &mut hook_supervisor,
+        hook_start_config.as_ref(),
+        &config,
+        session_id,
+    )
+    .await;
 
-    // Build AgentLoopContext
-    let ctx = crate::agent_loop::AgentLoopContext {
+    let ctx = build_agent_loop_context(AgentContextParams {
         config: config.clone(),
         instance_id,
         abort_signal: abort_signal.clone(),
-        async_manager: Arc::new(tokio::sync::Mutex::new(AsyncHookManager::new())),
-        persistent_manager: Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new())),
         call_fn,
         on_tool_round,
-        on_text_response: None,
-        initial_with_embeddings: false,
-        initial_resume_count: 0,
-        max_resume: None,
-        nats_hook_provider: None,
-        pending_async_context: Some(Arc::new(tokio::sync::Mutex::new(None))),
         working_dir,
-        session_lock: None,
-    };
+    })
+    .await;
 
     // Run unified agent loop
     // Persistence goes through shared Config.save_message entry construction; append_event routes sink
@@ -261,8 +247,85 @@ pub async fn run_agent_loop_with_nats_inner(args: RunAgentLoopArgs<'_>) -> Resul
         lease,
         lease_config,
         session_index: session_index.cloned(),
+        hook_start_config,
+        hook_supervisor,
     })
     .await
+}
+
+struct PrepareAgentSessionParams<'a> {
+    cluster_key: &'a str,
+    session_id: &'a str,
+    config: &'a GlobalConfig,
+    instance_id: &'a harnx_core::instance::InstanceId,
+    initial_input: &'a Input,
+    abort_signal: &'a AbortSignal,
+    lease: Option<&'a Arc<NatsSessionLease>>,
+    after_seq_observer: Option<Arc<AtomicU64>>,
+    header_insert_observer: Option<&'a Arc<AtomicU64>>,
+    session_index: Option<&'a async_nats::jetstream::kv::Store>,
+    working_dir: Option<&'a std::path::Path>,
+}
+
+async fn prepare_agent_session(
+    params: PrepareAgentSessionParams<'_>,
+) -> Result<jetstream::Context> {
+    let cfg_snapshot = params.config.read().clone();
+    let jetstream = cfg_snapshot.nats_jetstream(params.cluster_key).await?;
+    let mut backend = NatsSessionLogBackend::new(jetstream.clone(), params.session_id);
+    if let Some(observer) = params.after_seq_observer {
+        backend = backend.with_after_seq_observer(observer);
+    }
+    abort_resume_if_fenced(&backend, params.lease.map(Arc::as_ref))?;
+    let session = load_or_repair_session(LoadOrRepairSessionParams {
+        backend: &backend,
+        config: params.config,
+        instance_id: params.instance_id,
+        input: params.initial_input,
+        lease: params.lease.map(Arc::as_ref),
+        session_index: params.session_index,
+        session_id: params.session_id,
+        working_dir: params.working_dir,
+        abort_signal: params.abort_signal,
+        header_insert_observer: params.header_insert_observer,
+    })
+    .await?;
+    attach_session_to_config(params.config, session, &backend, params.lease);
+    Ok(jetstream)
+}
+
+struct AgentContextParams {
+    config: GlobalConfig,
+    instance_id: harnx_core::instance::InstanceId,
+    abort_signal: AbortSignal,
+    call_fn: Option<crate::agent_loop::AgentCallFn>,
+    on_tool_round: Option<OnToolRoundFn>,
+    working_dir: Option<std::path::PathBuf>,
+}
+
+async fn build_agent_loop_context(
+    params: AgentContextParams,
+) -> crate::agent_loop::AgentLoopContext {
+    let config_snapshot = params.config.read().clone();
+    let nats_hook_provider =
+        discover_nats_hook_provider_cached(&config_snapshot, &params.instance_id).await;
+    crate::agent_loop::AgentLoopContext {
+        config: params.config,
+        instance_id: params.instance_id,
+        abort_signal: params.abort_signal,
+        async_manager: Arc::new(tokio::sync::Mutex::new(AsyncHookManager::new())),
+        persistent_manager: Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new())),
+        call_fn: params.call_fn,
+        on_tool_round: params.on_tool_round,
+        on_text_response: None,
+        initial_with_embeddings: false,
+        initial_resume_count: 0,
+        max_resume: None,
+        nats_hook_provider,
+        pending_async_context: Some(Arc::new(tokio::sync::Mutex::new(None))),
+        working_dir: params.working_dir,
+        session_lock: None,
+    }
 }
 
 struct AgentLoopSegmentArgs {
@@ -274,6 +337,38 @@ struct AgentLoopSegmentArgs {
     lease: Option<Arc<NatsSessionLease>>,
     lease_config: NatsLeaseConfig,
     session_index: Option<async_nats::jetstream::kv::Store>,
+    hook_start_config: Option<HookServerStartConfig>,
+    hook_supervisor: Option<HookServerSupervisor>,
+}
+
+async fn agent_hook_start_config(
+    cluster_key: &str,
+    jetstream: &jetstream::Context,
+    instance_id: &harnx_core::instance::InstanceId,
+) -> Option<HookServerStartConfig> {
+    if cluster_key != LOCAL_CLUSTER_KEY {
+        return None;
+    }
+    let result = async {
+        let server = resolve_local_nats_server_config().await?;
+        let token = server
+            .token
+            .context("local NATS agent hooks require HARNX_NATS_TOKEN")?;
+        Result::<_>::Ok(HookServerStartConfig::new(
+            jetstream.client().clone(),
+            instance_id.clone(),
+            server.url,
+            token,
+        ))
+    }
+    .await;
+    match result {
+        Ok(config) => Some(config),
+        Err(error) => {
+            log::warn!("session NATS hook servers disabled: {error:#}");
+            None
+        }
+    }
 }
 
 fn run_agent_loop_segment(
@@ -289,6 +384,8 @@ fn run_agent_loop_segment(
             lease,
             lease_config,
             session_index,
+            hook_start_config,
+            hook_supervisor,
         } = args;
         let loop_result = crate::agent_loop::run_agent_loop(&ctx, input).await?;
         match loop_result {
@@ -308,6 +405,8 @@ fn run_agent_loop_segment(
                     lease,
                     lease_config,
                     session_index,
+                    hook_start_config,
+                    hook_supervisor,
                 };
                 let (handoff_args, new_event_sink) =
                     prepare_nats_handoff(handoff_args, agent, session_id).await?;
@@ -378,7 +477,59 @@ async fn prepare_nats_handoff(
         .context("NATS handoff missing session after activation")?;
     attach_session_to_config(&args.config, new_session, &new_backend, Some(&new_lease));
     args.lease = Some(new_lease);
+    reconcile_agent_hooks(
+        &mut args.hook_supervisor,
+        args.hook_start_config.as_ref(),
+        &args.config,
+        &new_session_id,
+    )
+    .await;
     Ok((args, new_event_sink))
+}
+
+fn agent_resolved_hooks(config: &GlobalConfig) -> harnx_core::hooks::HooksConfig {
+    config
+        .read()
+        .agent
+        .as_ref()
+        .and_then(|agent| agent.hooks().cloned())
+        .unwrap_or_default()
+}
+
+async fn reconcile_agent_hooks(
+    current: &mut Option<HookServerSupervisor>,
+    start: Option<&HookServerStartConfig>,
+    config: &GlobalConfig,
+    session_id: &str,
+) {
+    let hooks = agent_resolved_hooks(config);
+    let scope = format!("session-{session_id}");
+    reconcile_hook_supervisor(current, start, &hooks, &scope).await;
+}
+
+/// Replace one session's hook processes only after its previous registrations
+/// have been removed. Public for lifecycle integration coverage.
+#[doc(hidden)]
+pub async fn reconcile_hook_supervisor(
+    current: &mut Option<HookServerSupervisor>,
+    start: Option<&HookServerStartConfig>,
+    hooks: &harnx_core::hooks::HooksConfig,
+    scope: &str,
+) {
+    // Stop first so old registrations and processes are gone before new hooks register.
+    if let Some(mut previous) = current.take() {
+        previous.shutdown().await;
+    }
+    let Some(start) = start else {
+        return;
+    };
+    if hooks.entries.is_empty() {
+        return;
+    }
+    match HookServerSupervisor::start_local(start.clone(), hooks, scope).await {
+        Ok(supervisor) => *current = Some(supervisor),
+        Err(error) => log::warn!("session NATS hook servers disabled: {error:#}"),
+    }
 }
 
 /// Fence-on-resume fail-safe: if the persisted tail carries a worker fence
@@ -1044,7 +1195,8 @@ pub(crate) async fn write_header_and_load_session(
 
 #[cfg(test)]
 mod tests {
-    use super::fold_new_user_messages_since;
+    use super::{agent_resolved_hooks, fold_new_user_messages_since};
+    use crate::config::Config;
     use chrono::{TimeZone, Utc};
     use harnx_core::message::{MessageContent, MessageRole};
     use harnx_core::session::SessionLogEntry;
@@ -1057,6 +1209,67 @@ mod tests {
             timestamp: Some(timestamp),
             fence_token: None,
         }
+    }
+
+    #[test]
+    fn session_hook_resolution_excludes_instance_hooks() {
+        let config = Config {
+            data: harnx_core::config_data::ConfigData {
+                hooks: Some(harnx_core::hooks::HooksConfig {
+                    max_resume: None,
+                    entries: vec![harnx_core::hooks::HookConfig {
+                        event: "SessionStart".to_string(),
+                        matcher: None,
+                        command: "echo global".to_string(),
+                        timeout: Some(30),
+                        status_message: None,
+                        async_hook: None,
+                        hook_type: "claude-command".to_string(),
+                        package_dir: None,
+                    }],
+                }),
+                ..harnx_core::config_data::ConfigData::default()
+            },
+            ..Config::default()
+        };
+        let config = std::sync::Arc::new(parking_lot::RwLock::new(config));
+
+        assert!(agent_resolved_hooks(&config).entries.is_empty());
+    }
+
+    #[test]
+    fn session_hook_resolution_keeps_agent_override_of_global_hook() {
+        let global_hook = harnx_core::hooks::HookConfig {
+            event: "SessionStart".to_string(),
+            matcher: None,
+            command: "echo global".to_string(),
+            timeout: Some(30),
+            status_message: None,
+            async_hook: None,
+            hook_type: "claude-command".to_string(),
+            package_dir: None,
+        };
+        let agent_config = harnx_core::agent_config::AgentConfig::from_markdown(
+            "override-agent",
+            "---\nhooks:\n  entries:\n    - event: SessionStart\n      command: echo agent\n      type: claude-command\n---\nprompt",
+        )
+        .expect("agent config");
+        let config = Config {
+            data: harnx_core::config_data::ConfigData {
+                hooks: Some(harnx_core::hooks::HooksConfig {
+                    max_resume: None,
+                    entries: vec![global_hook],
+                }),
+                ..harnx_core::config_data::ConfigData::default()
+            },
+            agent: Some(crate::config::Agent::new(agent_config)),
+            ..Config::default()
+        };
+        let config = std::sync::Arc::new(parking_lot::RwLock::new(config));
+
+        let hooks = agent_resolved_hooks(&config);
+        assert_eq!(hooks.entries.len(), 1);
+        assert_eq!(hooks.entries[0].command, "echo agent");
     }
 
     #[test]

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -6,6 +6,7 @@ use super::agent_loop::{
 };
 use super::backend::NatsSessionLogBackend;
 use super::control::{control_subject, ControlCommand};
+use super::hook_supervisor::{HookServerStartConfig, HookServerSupervisor};
 use super::subagent_toolset::SubagentToolset;
 use super::tool_supervisor::{ToolServerStartConfig, ToolServerSupervisor};
 use crate::config::{
@@ -316,6 +317,36 @@ async fn start_local_tool_servers(
     optional_tool_server(result)
 }
 
+async fn start_global_hooks(
+    daemon: &WorkerDaemonConfig,
+    client: async_nats::Client,
+    instance_id: &harnx_core::instance::InstanceId,
+    hooks: &harnx_core::hooks::HooksConfig,
+) -> Option<HookServerSupervisor> {
+    if daemon.cluster != LOCAL_CLUSTER_KEY || hooks.entries.is_empty() {
+        return None;
+    }
+    let result = async {
+        let server = resolve_local_nats_server_config().await?;
+        let token = server
+            .token
+            .as_deref()
+            .context("local NATS hook servers require HARNX_NATS_TOKEN")?;
+        let start = HookServerStartConfig::new(client, instance_id.clone(), &server.url, token);
+        HookServerSupervisor::start_local(start, hooks, "global")
+            .await
+            .context("start global NATS hook servers")
+    }
+    .await;
+    match result {
+        Ok(supervisor) => Some(supervisor),
+        Err(error) => {
+            log::warn!("global NATS hook servers disabled: {error:#}");
+            None
+        }
+    }
+}
+
 fn optional_tool_server<T>(result: Result<T>) -> Option<T> {
     match result {
         Ok(supervisor) => Some(supervisor),
@@ -378,61 +409,56 @@ async fn start_subagent_toolset(
     }
 }
 
-/// Run a worker daemon: pull `SessionActivate` notifications, claim each via a
-/// KV lease, and execute the session (exactly one worker per session).
-pub async fn run_worker_daemon(
-    config: GlobalConfig,
-    daemon: WorkerDaemonConfig,
-    call_fn: Option<crate::agent_loop::AgentCallFn>,
-) -> Result<()> {
-    let instance_id = harnx_core::instance::InstanceId::new();
-    let startup = prepare_worker_startup(&config, &daemon).await?;
-    let (tool_servers, agent_package, namespaced_use_tools) = {
-        let config = config.read();
-        let agent_package = config
-            .agent
-            .as_ref()
-            .and_then(|agent| harnx_core::package_namespace::pkg_from_qualified(agent.name()))
-            .map(str::to_string);
-        let mut namespaced_use_tools = Vec::new();
-        // Same-package servers use bare MCP display names; retain bare selectors
-        // while also adding package-qualified forms for cross-package matching.
-        for selector in config
-            .agent
-            .as_ref()
-            .and_then(|agent| agent.use_tools())
-            .unwrap_or_default()
-        {
-            namespaced_use_tools.push(selector.clone());
-            if selector != "*" {
-                if let Some(package) = agent_package.as_deref() {
-                    let namespaced = harnx_core::package_namespace::namespace_use_tools_entry(
-                        package, &selector,
-                    );
-                    if namespaced != selector {
-                        namespaced_use_tools.push(namespaced);
-                    }
-                }
-            }
+struct WorkerServices {
+    tool_supervisor: Option<ToolServerSupervisor>,
+    global_hook_supervisor: Option<HookServerSupervisor>,
+    subagent_tool_servers: Vec<JoinHandle<Result<()>>>,
+    session_index: Option<async_nats::jetstream::kv::Store>,
+}
+
+fn configured_worker_services(
+    config: &GlobalConfig,
+) -> (Vec<ToolServerConfig>, harnx_core::hooks::HooksConfig) {
+    let config = config.read();
+    let agent_package = config
+        .agent
+        .as_ref()
+        .and_then(|agent| harnx_core::package_namespace::pkg_from_qualified(agent.name()));
+    let mut selectors = Vec::new();
+    for selector in config
+        .agent
+        .as_ref()
+        .and_then(|agent| agent.use_tools())
+        .unwrap_or_default()
+    {
+        if let Some(namespaced) = namespaced_selector(&selector, agent_package) {
+            selectors.push(namespaced);
         }
-        (
-            config.tool_servers.clone(),
-            agent_package,
-            namespaced_use_tools,
-        )
-    };
-    let matching_tool_servers = tool_servers_matching_use_tools(
-        &tool_servers,
-        agent_package.as_deref(),
-        &namespaced_use_tools,
-    );
-    let tool_supervisor = start_local_tool_servers(
-        &daemon,
-        startup.client.clone(),
-        &instance_id,
-        &matching_tool_servers,
-    )
-    .await;
+        selectors.push(selector);
+    }
+    let servers = tool_servers_matching_use_tools(&config.tool_servers, agent_package, &selectors);
+    (servers, config.hooks.clone().unwrap_or_default())
+}
+
+fn namespaced_selector(selector: &str, package: Option<&str>) -> Option<String> {
+    if selector == "*" {
+        return None;
+    }
+    let namespaced = harnx_core::package_namespace::namespace_use_tools_entry(package?, selector);
+    (namespaced != selector).then_some(namespaced)
+}
+
+async fn launch_worker_services(
+    config: &GlobalConfig,
+    daemon: &WorkerDaemonConfig,
+    startup: &WorkerStartup,
+    instance_id: &harnx_core::instance::InstanceId,
+) -> Result<WorkerServices> {
+    let (tool_servers, global_hooks) = configured_worker_services(config);
+    let tool_supervisor =
+        start_local_tool_servers(daemon, startup.client.clone(), instance_id, &tool_servers).await;
+    let global_hook_supervisor =
+        start_global_hooks(daemon, startup.client.clone(), instance_id, &global_hooks).await;
     let mut subagent_tool_servers = Vec::new();
     for agent in list_agents() {
         subagent_tool_servers.push(
@@ -447,19 +473,37 @@ pub async fn run_worker_daemon(
             .context("start sub-agent toolset")?,
         );
     }
-    // Attempt optional tool startup before readiness so successful pilots are available on turn one.
-    spawn_readiness_publisher(startup.client.clone(), &daemon);
+    spawn_readiness_publisher(startup.client.clone(), daemon);
     let session_index = optional_session_index(&startup.jetstream).await;
+    Ok(WorkerServices {
+        tool_supervisor,
+        global_hook_supervisor,
+        subagent_tool_servers,
+        session_index,
+    })
+}
+
+/// Run a worker daemon: pull `SessionActivate` notifications, claim each via a
+/// KV lease, and execute the session (exactly one worker per session).
+pub async fn run_worker_daemon(
+    config: GlobalConfig,
+    daemon: WorkerDaemonConfig,
+    call_fn: Option<crate::agent_loop::AgentCallFn>,
+) -> Result<()> {
+    let instance_id = harnx_core::instance::InstanceId::new();
+    let startup = prepare_worker_startup(&config, &daemon).await?;
+    let services = launch_worker_services(&config, &daemon, &startup, &instance_id).await?;
     let runtime = Arc::new(WorkerRuntime {
         config,
         instance_id,
-        _tool_supervisor: tool_supervisor,
-        _subagent_tool_servers: subagent_tool_servers,
+        _tool_supervisor: services.tool_supervisor,
+        _global_hook_supervisor: services.global_hook_supervisor,
+        _subagent_tool_servers: services.subagent_tool_servers,
         cluster: daemon.cluster.clone(),
         worker_id: daemon.worker_id.clone(),
         lease: daemon.lease,
         jetstream: startup.jetstream,
-        session_index,
+        session_index: services.session_index,
         client: startup.client,
         call_fn,
         generation: AtomicU64::new(1),
@@ -493,6 +537,7 @@ struct WorkerRuntime {
     config: GlobalConfig,
     instance_id: harnx_core::instance::InstanceId,
     _tool_supervisor: Option<ToolServerSupervisor>,
+    _global_hook_supervisor: Option<HookServerSupervisor>,
     _subagent_tool_servers: Vec<JoinHandle<Result<()>>>,
     #[allow(dead_code)]
     cluster: String,
@@ -1091,6 +1136,7 @@ mod tests {
             enabled: true,
             description: None,
             package: None,
+            hooks: None,
         }
     }
 

--- a/crates/harnx-runtime/src/nats_worker/hook_supervisor.rs
+++ b/crates/harnx-runtime/src/nats_worker/hook_supervisor.rs
@@ -1,0 +1,439 @@
+use crate::config::{HARNX_NATS_TOKEN_ENV, HARNX_NATS_URL_ENV};
+use anyhow::{bail, Context, Result};
+use async_nats::jetstream::{self, kv, stream};
+use futures_util::StreamExt;
+use harnx_core::hooks::{HookConfig, HooksConfig};
+use harnx_core::instance::{InstanceId, HARNX_INSTANCE_ID};
+use harnx_hooks::executor::HARNX_PACKAGE_DIR_ENV;
+use harnx_hookset::{FailPolicy, HookRegistration, HOOK_REGISTRY_BUCKET};
+use harnx_hookset_server::hook_registration_key;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+const HOOK_STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
+const GENERIC_HOOK_BINARY: &str = "harnx-claude-compatible-hook-server";
+const PROXY_AUTH_BINARY: &str = "harnx-proxy-auth";
+
+/// Connection and identity shared by hook servers spawned for one worker.
+#[derive(Clone)]
+pub struct HookServerStartConfig {
+    client: async_nats::Client,
+    instance_id: InstanceId,
+    nats_url: String,
+    token: String,
+}
+
+impl HookServerStartConfig {
+    pub fn new(
+        client: async_nats::Client,
+        instance_id: InstanceId,
+        nats_url: impl Into<String>,
+        token: impl Into<String>,
+    ) -> Self {
+        Self {
+            client,
+            instance_id,
+            nats_url: nats_url.into(),
+            token: token.into(),
+        }
+    }
+}
+
+/// Owns one child process per configured hook and removes registrations on exit.
+pub struct HookServerSupervisor {
+    processes: Arc<Mutex<HashMap<u32, String>>>,
+    tasks: Vec<JoinHandle<()>>,
+    client: async_nats::Client,
+    instance_id: InstanceId,
+    registrations: Vec<String>,
+}
+
+impl HookServerSupervisor {
+    pub async fn start_local(
+        config: HookServerStartConfig,
+        hooks: &HooksConfig,
+        scope: &str,
+    ) -> Result<Self> {
+        Self::start_local_with_timeout(config, hooks, scope, HOOK_STARTUP_TIMEOUT).await
+    }
+
+    pub async fn start_local_with_timeout(
+        config: HookServerStartConfig,
+        hooks: &HooksConfig,
+        scope: &str,
+        readiness_timeout: Duration,
+    ) -> Result<Self> {
+        let processes = Arc::new(Mutex::new(HashMap::new()));
+        let mut supervisor = Self {
+            processes: Arc::clone(&processes),
+            tasks: Vec::new(),
+            client: config.client.clone(),
+            instance_id: config.instance_id.clone(),
+            registrations: Vec::new(),
+        };
+        let enabled: Vec<_> = hooks
+            .entries
+            .iter()
+            .enumerate()
+            .filter(|(_, hook)| hook.is_supported_type())
+            .collect();
+        if enabled.is_empty() {
+            return Ok(supervisor);
+        }
+
+        let registry = ensure_registry_bucket(&config.client).await?;
+        let mut watches = Vec::new();
+        for (index, hook) in &enabled {
+            let name = hook_server_name(scope, *index, hook);
+            let key = hook_registration_key(&config.instance_id, &name);
+            let _ = registry.delete(&key).await;
+            let watch = registry
+                .watch_with_history(&key)
+                .await
+                .with_context(|| format!("watch hook registration '{key}'"))?;
+            supervisor.registrations.push(name.clone());
+            watches.push((name, key, watch));
+        }
+
+        for (index, hook) in enabled {
+            let name = hook_server_name(scope, index, hook);
+            let child = spawn_hook_server(&config, hook, &name)?;
+            let pid = child
+                .id()
+                .with_context(|| format!("hook server '{name}' has no process ID"))?;
+            processes.lock().await.insert(pid, name.clone());
+            supervisor.tasks.push(spawn_child_monitor(
+                child,
+                pid,
+                name,
+                config.instance_id.clone(),
+                config.client.clone(),
+                Arc::clone(&processes),
+            ));
+        }
+
+        let deadline = Instant::now() + readiness_timeout;
+        for (name, key, mut watch) in watches {
+            wait_for_registration(
+                &mut watch,
+                &processes,
+                &name,
+                &key,
+                deadline,
+                readiness_timeout,
+            )
+            .await?;
+        }
+        Ok(supervisor)
+    }
+
+    pub async fn server_pids(&self) -> HashMap<u32, String> {
+        self.processes.lock().await.clone()
+    }
+
+    /// Stop all children and remove their registry entries before returning.
+    pub async fn shutdown(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+        for server in std::mem::take(&mut self.registrations) {
+            remove_registration(&self.client, &self.instance_id, &server).await;
+        }
+    }
+}
+
+impl Drop for HookServerSupervisor {
+    fn drop(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+        let client = self.client.clone();
+        let instance_id = self.instance_id.clone();
+        let registrations = std::mem::take(&mut self.registrations);
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                for server in registrations {
+                    remove_registration(&client, &instance_id, &server).await;
+                }
+            });
+        }
+    }
+}
+
+fn hook_server_name(scope: &str, index: usize, hook: &HookConfig) -> String {
+    if is_proxy_auth_command(&hook.command) {
+        return "proxy-auth".to_string();
+    }
+    let scope = sanitize_name(scope);
+    let event = sanitize_name(&hook.event);
+    format!("{scope}-{event}-{index}")
+}
+
+fn sanitize_name(value: &str) -> String {
+    let value: String = value
+        .chars()
+        .map(|ch| if is_server_name_char(ch) { ch } else { '-' })
+        .collect();
+    value.trim_matches('-').to_string()
+}
+
+fn is_server_name_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_')
+}
+
+fn spawn_hook_server(
+    config: &HookServerStartConfig,
+    hook: &HookConfig,
+    name: &str,
+) -> Result<Child> {
+    let package_dir = hook
+        .package_dir
+        .clone()
+        .unwrap_or_else(harnx_core::config_paths::config_dir);
+    let mut command = if let Some(args) = proxy_auth_args(&hook.command)? {
+        let binary = resolve_binary(PROXY_AUTH_BINARY)?;
+        let mut command = Command::new(&binary);
+        command.args(args);
+        command
+    } else {
+        let binary = resolve_binary(GENERIC_HOOK_BINARY)?;
+        let mut command = Command::new(&binary);
+        command
+            .arg("--name")
+            .arg(name)
+            .arg("--event")
+            .arg(&hook.event)
+            .arg("--priority")
+            .arg("0")
+            .arg("--fail-policy")
+            .arg(FailPolicy::Closed.as_str())
+            .arg("--type")
+            .arg(&hook.hook_type)
+            .arg("--command")
+            .arg(&hook.command)
+            .arg("--package-dir")
+            .arg(&package_dir);
+        if let Some(matcher) = &hook.matcher {
+            command.arg("--matcher").arg(matcher);
+        }
+        if let Some(timeout) = hook.timeout {
+            command.arg("--timeout").arg(timeout.to_string());
+        }
+        command
+    };
+
+    command
+        .env(HARNX_PACKAGE_DIR_ENV, package_dir)
+        .env(HARNX_INSTANCE_ID, config.instance_id.as_str())
+        .env(HARNX_NATS_URL_ENV, &config.nats_url)
+        .env(HARNX_NATS_TOKEN_ENV, &config.token)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    configure_hook_process(&mut command);
+    command
+        .spawn()
+        .with_context(|| format!("spawn hook server '{name}'"))
+}
+
+/// A command whose executable basename is `harnx-proxy-auth` is already a
+/// native hook server. Its remaining words are forwarded as normal CLI flags.
+fn proxy_auth_args(command: &str) -> Result<Option<Vec<String>>> {
+    let words = shell_words::split(command).context("parse hook command")?;
+    Ok(is_proxy_auth_words(&words).then(|| words.into_iter().skip(1).collect()))
+}
+
+fn is_proxy_auth_command(command: &str) -> bool {
+    shell_words::split(command).is_ok_and(|words| is_proxy_auth_words(&words))
+}
+
+fn is_proxy_auth_words(words: &[String]) -> bool {
+    words
+        .first()
+        .and_then(|program| Path::new(program).file_name())
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == PROXY_AUTH_BINARY || name == "harnx-proxy-auth.exe")
+}
+
+fn resolve_binary(binary: &str) -> Result<PathBuf> {
+    let current = std::env::current_exe().context("resolve current worker executable")?;
+    let directory = current
+        .parent()
+        .context("current worker executable has no parent directory")?;
+    let directory = if directory.file_name().is_some_and(|name| name == "deps") {
+        directory
+            .parent()
+            .context("test executable deps directory has no parent")?
+    } else {
+        directory
+    };
+    let next_to_worker = directory.join(binary);
+    #[cfg(windows)]
+    let next_to_worker = next_to_worker.with_extension("exe");
+    if next_to_worker.is_file() {
+        return Ok(next_to_worker);
+    }
+    which::which(binary).with_context(|| {
+        format!(
+            "hook-server command '{binary}' not found next to worker at {} or on PATH",
+            next_to_worker.display()
+        )
+    })
+}
+
+fn spawn_child_monitor(
+    mut child: Child,
+    pid: u32,
+    server: String,
+    instance_id: InstanceId,
+    client: async_nats::Client,
+    processes: Arc<Mutex<HashMap<u32, String>>>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let status = child.wait().await;
+        processes.lock().await.remove(&pid);
+        remove_registration(&client, &instance_id, &server).await;
+        match status {
+            Ok(status) if status.success() => log::debug!("hook server '{server}' exited"),
+            Ok(status) => log::warn!("hook server '{server}' exited with {status}"),
+            Err(error) => log::warn!("hook server '{server}' wait failed: {error}"),
+        }
+    })
+}
+
+async fn wait_for_registration(
+    watch: &mut kv::Watch,
+    processes: &Arc<Mutex<HashMap<u32, String>>>,
+    server: &str,
+    key: &str,
+    deadline: Instant,
+    timeout: Duration,
+) -> Result<()> {
+    loop {
+        if !processes.lock().await.values().any(|name| name == server) {
+            bail!("hook server '{server}' exited before registering at '{key}'");
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            bail!(
+                "hook server '{server}' did not register at '{key}' within {}s",
+                timeout.as_secs_f64()
+            );
+        }
+        let poll = deadline
+            .saturating_duration_since(now)
+            .min(Duration::from_millis(100));
+        match tokio::time::timeout(poll, watch.next()).await {
+            Ok(Some(Ok(entry))) if entry.operation == kv::Operation::Put => {
+                let registration: HookRegistration = serde_json::from_slice(&entry.value)
+                    .with_context(|| format!("decode hook registration '{key}'"))?;
+                if registration.server == server {
+                    return Ok(());
+                }
+            }
+            Ok(Some(Ok(_))) => {}
+            Ok(Some(Err(error))) => {
+                return Err(error).with_context(|| format!("watch hook registration '{key}'"));
+            }
+            Ok(None) => bail!("hook registration watch closed for '{key}'"),
+            Err(_) => continue,
+        }
+    }
+}
+
+async fn ensure_registry_bucket(client: &async_nats::Client) -> Result<kv::Store> {
+    let jetstream = jetstream::new(client.clone());
+    match jetstream
+        .create_key_value(kv::Config {
+            bucket: HOOK_REGISTRY_BUCKET.to_string(),
+            history: 1,
+            num_replicas: 1,
+            storage: stream::StorageType::File,
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(store) => Ok(store),
+        Err(_) => jetstream
+            .get_key_value(HOOK_REGISTRY_BUCKET)
+            .await
+            .map_err(anyhow::Error::from)
+            .context("open hook registry bucket"),
+    }
+}
+
+async fn remove_registration(client: &async_nats::Client, instance_id: &InstanceId, server: &str) {
+    let jetstream = jetstream::new(client.clone());
+    let Ok(store) = jetstream.get_key_value(HOOK_REGISTRY_BUCKET).await else {
+        return;
+    };
+    let _ = store
+        .delete(hook_registration_key(instance_id, server))
+        .await;
+}
+
+#[cfg(unix)]
+fn configure_hook_process(command: &mut Command) {
+    #[cfg(target_os = "linux")]
+    let parent_pid = std::process::id() as libc::pid_t;
+    // SAFETY: pre_exec invokes only async-signal-safe libc calls.
+    unsafe {
+        command.pre_exec(move || {
+            if libc::setpgid(0, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            #[cfg(target_os = "linux")]
+            {
+                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::getppid() != parent_pid {
+                    libc::raise(libc::SIGTERM);
+                }
+            }
+            Ok(())
+        });
+    }
+}
+
+#[cfg(not(unix))]
+fn configure_hook_process(_command: &mut Command) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_proxy_auth_and_forwards_flags() {
+        assert_eq!(
+            proxy_auth_args("harnx-proxy-auth --hook 'token helper'").unwrap(),
+            Some(vec!["--hook".to_string(), "token helper".to_string()])
+        );
+        assert_eq!(proxy_auth_args("echo hello").unwrap(), None);
+    }
+
+    #[test]
+    fn names_are_stable_and_nats_safe() {
+        let hook = HookConfig {
+            event: "PreToolUse".to_string(),
+            matcher: None,
+            command: "echo".to_string(),
+            timeout: Some(30),
+            status_message: None,
+            async_hook: None,
+            hook_type: "claude-command".to_string(),
+            package_dir: None,
+        };
+        assert_eq!(
+            hook_server_name("agent:review", 2, &hook),
+            "agent-review-PreToolUse-2"
+        );
+    }
+}

--- a/crates/harnx-runtime/src/nats_worker/mod.rs
+++ b/crates/harnx-runtime/src/nats_worker/mod.rs
@@ -25,6 +25,7 @@ mod agent_loop;
 mod backend;
 mod control;
 mod daemon;
+mod hook_supervisor;
 mod subagent_toolset;
 mod tool_supervisor;
 
@@ -32,11 +33,15 @@ mod tool_supervisor;
 mod tests;
 
 // Re-export public items to preserve the `crate::nats_worker::X` path
-pub use agent_loop::{run_agent_loop_with_nats, run_agent_loop_with_nats_inner, RunAgentLoopArgs};
+pub use agent_loop::{
+    reconcile_hook_supervisor, run_agent_loop_with_nats, run_agent_loop_with_nats_inner,
+    RunAgentLoopArgs,
+};
 pub use backend::{FencedSessionLogSink, NatsSessionLogBackend};
 pub use control::{control_subject, publish_control_command, ControlCommand};
 pub use daemon::{
     new_remote_session_id, notify_subject, publish_session_activate, run_worker_daemon,
     worker_ready_subject, SessionActivate, WorkerDaemonConfig,
 };
+pub use hook_supervisor::{HookServerStartConfig, HookServerSupervisor};
 pub use tool_supervisor::{ToolServerStartConfig, ToolServerSupervisor};

--- a/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
+++ b/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
@@ -1,3 +1,4 @@
+use super::hook_supervisor::{HookServerStartConfig, HookServerSupervisor};
 use crate::config::{ToolServerConfig, HARNX_NATS_TOKEN_ENV, HARNX_NATS_URL_ENV};
 use crate::nats_tool_provider::NatsInFlightCalls;
 use anyhow::{bail, Context, Result};
@@ -42,12 +43,22 @@ impl ToolServerStartConfig {
             token: token.into(),
         }
     }
+
+    fn hook_start_config(&self) -> HookServerStartConfig {
+        HookServerStartConfig::new(
+            self.client.clone(),
+            self.instance_id.clone(),
+            self.nats_url.clone(),
+            self.token.clone(),
+        )
+    }
 }
 
 /// Owns local tool-server children for one worker process.
 pub struct ToolServerSupervisor {
     processes: Arc<Mutex<HashMap<u32, String>>>,
     tasks: Vec<JoinHandle<()>>,
+    hook_supervisors: Vec<HookServerSupervisor>,
 }
 
 impl ToolServerSupervisor {
@@ -69,6 +80,7 @@ impl ToolServerSupervisor {
         let mut supervisor = Self {
             processes: Arc::clone(&processes),
             tasks: Vec::new(),
+            hook_supervisors: Vec::new(),
         };
         let enabled: Vec<_> = servers.iter().filter(|server| server.enabled).collect();
         if enabled.is_empty() {
@@ -98,28 +110,7 @@ impl ToolServerSupervisor {
             }
         }
 
-        let in_flight = NatsInFlightCalls::for_instance(&config.instance_id);
-        for server in enabled {
-            match spawn_tool_server(&config, server) {
-                Ok(child) => {
-                    let Some(pid) = child.id() else {
-                        warn_server_failure(&server.name, "spawned child has no process ID");
-                        continue;
-                    };
-                    processes.lock().await.insert(pid, server.name.clone());
-                    supervisor.tasks.push(spawn_child_monitor(
-                        child,
-                        pid,
-                        server.name.clone(),
-                        config.instance_id.clone(),
-                        config.client.clone(),
-                        Arc::clone(&processes),
-                        in_flight.clone(),
-                    ));
-                }
-                Err(error) => warn_server_failure(&server.name, format!("{error:#}")),
-            }
-        }
+        spawn_enabled_tool_servers(&mut supervisor, &config, &enabled, &processes).await;
 
         let deadline = Instant::now() + readiness_timeout;
         let readiness = watches.into_iter().map(|(server, key, mut watch)| {
@@ -140,11 +131,70 @@ impl ToolServerSupervisor {
             }
         });
         futures_util::future::join_all(readiness).await;
+
+        start_co_located_hooks(&mut supervisor, &config, enabled).await;
         Ok(supervisor)
     }
 
     pub async fn server_pids(&self) -> HashMap<u32, String> {
         self.processes.lock().await.clone()
+    }
+}
+
+async fn spawn_enabled_tool_servers(
+    supervisor: &mut ToolServerSupervisor,
+    config: &ToolServerStartConfig,
+    servers: &[&ToolServerConfig],
+    processes: &Arc<Mutex<HashMap<u32, String>>>,
+) {
+    let in_flight = NatsInFlightCalls::for_instance(&config.instance_id);
+    for server in servers {
+        match spawn_tool_server(config, server) {
+            Ok(child) => {
+                let Some(pid) = child.id() else {
+                    warn_server_failure(&server.name, "spawned child has no process ID");
+                    continue;
+                };
+                processes.lock().await.insert(pid, server.name.clone());
+                supervisor.tasks.push(spawn_child_monitor(
+                    child,
+                    pid,
+                    server.name.clone(),
+                    config.instance_id.clone(),
+                    config.client.clone(),
+                    Arc::clone(processes),
+                    in_flight.clone(),
+                ));
+            }
+            Err(error) => warn_server_failure(&server.name, format!("{error:#}")),
+        }
+    }
+}
+
+async fn start_co_located_hooks(
+    supervisor: &mut ToolServerSupervisor,
+    config: &ToolServerStartConfig,
+    servers: Vec<&ToolServerConfig>,
+) {
+    for server in servers {
+        let Some(hooks) = &server.hooks else {
+            continue;
+        };
+        let mut hooks = hooks.clone();
+        let package_dir = tool_server_package_dir(server);
+        for hook in &mut hooks.entries {
+            if hook.package_dir.is_none() {
+                hook.package_dir = Some(package_dir.clone());
+            }
+        }
+        let scope = format!("tool-{}", server.name);
+        match HookServerSupervisor::start_local(config.hook_start_config(), &hooks, &scope).await {
+            Ok(hooks) => supervisor.hook_supervisors.push(hooks),
+            Err(error) => warn_server_failure(
+                &server.name,
+                format!("start co-located hook servers: {error:#}"),
+            ),
+        }
     }
 }
 
@@ -381,6 +431,7 @@ mod tests {
             enabled: true,
             description: None,
             package: package.map(str::to_string),
+            hooks: None,
         }
     }
 

--- a/crates/harnx-runtime/src/tool.rs
+++ b/crates/harnx-runtime/src/tool.rs
@@ -1,6 +1,8 @@
 use crate::{
     config::{Config, GlobalConfig},
-    nats_hook_provider::{HookDispatchMeta, NatsHookProvider},
+    nats_hook_provider::{
+        dispatch_hook_event, HookDispatchMeta, HookEventDispatch, NatsHookProvider,
+    },
     utils::*,
 };
 use anyhow::Result;
@@ -210,35 +212,6 @@ async fn dispatch_inline_hooks(
     .await
 }
 
-fn with_pre_tool_input(event: &HookEvent, tool_input: Value) -> HookEvent {
-    match event {
-        HookEvent::PreToolUse {
-            tool_name,
-            tool_input: _,
-            tool_use_id,
-        } => HookEvent::PreToolUse {
-            tool_name: tool_name.clone(),
-            tool_input,
-            tool_use_id: tool_use_id.clone(),
-        },
-        _ => event.clone(),
-    }
-}
-
-fn compose_pre_tool_use_outcome(
-    nats_mutated_tool_input: Option<Value>,
-    mut inline_outcome: harnx_core::hooks::HookOutcome,
-) -> harnx_core::hooks::HookOutcome {
-    if matches!(
-        inline_outcome.control,
-        harnx_core::hooks::HookResultControl::Continue
-    ) && inline_outcome.result.mutated_tool_input.is_none()
-    {
-        inline_outcome.result.mutated_tool_input = nats_mutated_tool_input;
-    }
-    inline_outcome
-}
-
 fn build_dispatch_hook_fn(
     hooks: &harnx_hooks::HooksConfig,
     // Value is (bare_server_tool_name, hook_entries). The matcher in each entry is
@@ -269,72 +242,31 @@ fn build_dispatch_hook_fn(
             let meta = HookDispatchMeta {
                 session_id: session_id.clone(),
                 cwd: cwd.clone(),
+                resume_count: 0,
             };
-            match &event {
-                HookEvent::PreToolUse { .. } => {
-                    let Some(provider) = nats_hook_provider else {
-                        return dispatch_inline_hooks(
-                            &event,
-                            &hooks_entries,
-                            &per_tool_hooks,
-                            &session_id,
-                            &cwd,
-                            &persistent_manager,
-                        )
-                        .await;
-                    };
-                    let nats_outcome = provider.dispatch_pre_tool_use(&event, meta).await;
-                    match &nats_outcome.control {
-                        harnx_core::hooks::HookResultControl::Block { .. } => return nats_outcome,
-                        harnx_core::hooks::HookResultControl::Ask { .. } => {
-                            // NOTE: Ask follows the existing ToolApprovalRequiredError path.
-                            // Headless-worker resolution over NATS is deferred to a later slice.
-                            return nats_outcome;
-                        }
-                        harnx_core::hooks::HookResultControl::Continue => {}
-                    }
-                    let nats_mutation = nats_outcome.result.mutated_tool_input;
-                    let inline_event = nats_mutation
-                        .clone()
-                        .map(|input| with_pre_tool_input(&event, input))
-                        .unwrap_or(event);
-                    let inline_outcome = dispatch_inline_hooks(
-                        &inline_event,
-                        &hooks_entries,
-                        &per_tool_hooks,
-                        &session_id,
-                        &cwd,
-                        &persistent_manager,
-                    )
-                    .await;
-                    compose_pre_tool_use_outcome(nats_mutation, inline_outcome)
-                }
-                HookEvent::PostToolUse { .. } => {
-                    if let Some(provider) = nats_hook_provider {
-                        provider.dispatch_post_tool_use(event.clone(), pending_async_context, meta);
-                    }
-                    dispatch_inline_hooks(
-                        &event,
-                        &hooks_entries,
-                        &per_tool_hooks,
-                        &session_id,
-                        &cwd,
-                        &persistent_manager,
-                    )
-                    .await
-                }
-                _ => {
-                    dispatch_inline_hooks(
-                        &event,
-                        &hooks_entries,
-                        &per_tool_hooks,
-                        &session_id,
-                        &cwd,
-                        &persistent_manager,
-                    )
-                    .await
-                }
-            }
+            let inline_event = event.clone();
+            let inline_fallback = dispatch_inline_hooks(
+                &inline_event,
+                &hooks_entries,
+                &per_tool_hooks,
+                &session_id,
+                &cwd,
+                &persistent_manager,
+            );
+            // Ask is returned unchanged. eval_tool_calls turns a deferred
+            // confirmation into ToolApprovalRequiredError. Headless workers
+            // can't prompt, so their existing confirmation callback decides
+            // whether the error is surfaced or the call is denied.
+            dispatch_hook_event(
+                HookEventDispatch {
+                    event,
+                    provider: nats_hook_provider.as_deref(),
+                    meta,
+                    pending_async_context,
+                },
+                inline_fallback,
+            )
+            .await
         })
     })
 }
@@ -1264,39 +1196,6 @@ mod tests {
         let dispatch_fn =
             build_dispatch_hook_fn(&hooks_config, per_tool_hooks, None, &pm, None, None, None);
         (dispatch_fn)(event).await
-    }
-
-    fn continue_outcome(mutated_tool_input: Option<Value>) -> harnx_core::hooks::HookOutcome {
-        harnx_core::hooks::HookOutcome {
-            control: harnx_core::hooks::HookResultControl::Continue,
-            result: harnx_core::hooks::HookResult {
-                mutated_tool_input,
-                ..Default::default()
-            },
-        }
-    }
-
-    #[test]
-    fn compose_pre_tool_use_outcome_preserves_nats_then_inline_mutation() {
-        let nats_mutation = json!({"nats": true});
-        let nats_only =
-            compose_pre_tool_use_outcome(Some(nats_mutation.clone()), continue_outcome(None));
-        assert_eq!(
-            nats_only.result.mutated_tool_input,
-            Some(nats_mutation),
-            "NATS mutation must survive when inline hooks don't mutate"
-        );
-
-        let inline_mutation = json!({"nats": true, "inline": true});
-        let inline_wins = compose_pre_tool_use_outcome(
-            Some(json!({"nats": true})),
-            continue_outcome(Some(inline_mutation.clone())),
-        );
-        assert_eq!(
-            inline_wins.result.mutated_tool_input,
-            Some(inline_mutation),
-            "inline mutation already includes its NATS-mutated starting input"
-        );
     }
 
     #[tokio::test]

--- a/crates/harnx-runtime/tests/hook_supervisor.rs
+++ b/crates/harnx-runtime/tests/hook_supervisor.rs
@@ -1,0 +1,227 @@
+#[allow(dead_code)]
+mod common;
+
+use anyhow::{Context, Result};
+use harnx_core::hooks::{HookConfig, HooksConfig};
+use harnx_core::instance::InstanceId;
+use harnx_hookset::HOOK_REGISTRY_BUCKET;
+use harnx_hookset_server::hook_registration_key;
+use harnx_runtime::nats_worker::{
+    reconcile_hook_supervisor, HookServerStartConfig, HookServerSupervisor,
+};
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+const TOKEN: &str = "hook-supervisor-test-token";
+
+fn hook_config(event: &str) -> HooksConfig {
+    HooksConfig {
+        max_resume: None,
+        entries: vec![HookConfig {
+            event: event.to_string(),
+            matcher: Some("exec".to_string()),
+            command: "cat".to_string(),
+            timeout: Some(5),
+            status_message: None,
+            async_hook: None,
+            hook_type: "claude-command".to_string(),
+            package_dir: None,
+        }],
+    }
+}
+
+fn ensure_hook_server_binary() -> Result<PathBuf> {
+    let mut path = std::env::current_exe().context("resolve test executable")?;
+    path.pop();
+    if path.file_name().is_some_and(|name| name == "deps") {
+        path.pop();
+    }
+    path.push(if cfg!(windows) {
+        "harnx-claude-compatible-hook-server.exe"
+    } else {
+        "harnx-claude-compatible-hook-server"
+    });
+    if path.is_file() {
+        return Ok(path);
+    }
+    let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .context("resolve workspace root")?
+        .to_path_buf();
+    let status = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
+        .args(["build", "-p", "harnx-claude-compatible-hook-server"])
+        .current_dir(workspace)
+        .status()
+        .context("build hook server for supervisor test")?;
+    anyhow::ensure!(status.success(), "building hook server failed");
+    anyhow::ensure!(
+        path.is_file(),
+        "hook server not found at {}",
+        path.display()
+    );
+    Ok(path)
+}
+
+async fn wait_until_removed(store: &async_nats::jetstream::kv::Store, key: &str) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if store.get(key).await?.is_none() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("hook registration '{key}' was not removed");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn run_scope_transitions(
+    start: &HookServerStartConfig,
+    store: &async_nats::jetstream::kv::Store,
+    instance_id: &InstanceId,
+) -> Result<()> {
+    let scopes = [
+        ("global", "PreToolUse"),
+        ("tool-time", "PostToolUse"),
+        ("session-old", "SessionStart"),
+        ("session-new", "Stop"),
+    ];
+    let mut active: Option<HookServerSupervisor> = None;
+    for (scope, event) in scopes {
+        if let Some(previous) = active.take() {
+            let previous_name = previous
+                .server_pids()
+                .await
+                .into_values()
+                .next()
+                .context("previous hook process")?;
+            let previous_key = hook_registration_key(instance_id, &previous_name);
+            drop(previous);
+            wait_until_removed(store, &previous_key).await?;
+        }
+        let supervisor = HookServerSupervisor::start_local_with_timeout(
+            start.clone(),
+            &hook_config(event),
+            scope,
+            Duration::from_secs(5),
+        )
+        .await?;
+        let name = supervisor
+            .server_pids()
+            .await
+            .into_values()
+            .next()
+            .context("hook process")?;
+        let key = hook_registration_key(instance_id, &name);
+        assert!(store.get(&key).await?.is_some(), "missing {scope} hook");
+        active = Some(supervisor);
+    }
+    let final_supervisor = active.context("final hook supervisor")?;
+    let final_name = final_supervisor
+        .server_pids()
+        .await
+        .into_values()
+        .next()
+        .context("final hook process")?;
+    let final_key = hook_registration_key(instance_id, &final_name);
+    drop(final_supervisor);
+    wait_until_removed(store, &final_key).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scoped_hooks_register_and_unregister_across_lifecycle_transitions() -> Result<()> {
+    harnx_core::require_nextest();
+    ensure_hook_server_binary()?;
+    let Some(server) = common::spawn_nats_server_with_options(common::SpawnNatsServerOptions {
+        auth_token: Some(TOKEN.to_string()),
+    })
+    .await?
+    else {
+        return Ok(());
+    };
+    let client = async_nats::ConnectOptions::new()
+        .token(TOKEN.to_string())
+        .connect(server.url())
+        .await?;
+    let instance_id = InstanceId::new();
+    let start =
+        HookServerStartConfig::new(client.clone(), instance_id.clone(), server.url(), TOKEN);
+
+    let store = async_nats::jetstream::new(client.clone())
+        .create_key_value(async_nats::jetstream::kv::Config {
+            bucket: HOOK_REGISTRY_BUCKET.to_string(),
+            ..Default::default()
+        })
+        .await?;
+
+    run_scope_transitions(&start, &store, &instance_id).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reconcile_hook_supervisor_replaces_old_agent_registration() -> Result<()> {
+    harnx_core::require_nextest();
+    ensure_hook_server_binary()?;
+    let Some(server) = common::spawn_nats_server_with_options(common::SpawnNatsServerOptions {
+        auth_token: Some(TOKEN.to_string()),
+    })
+    .await?
+    else {
+        return Ok(());
+    };
+    let client = async_nats::ConnectOptions::new()
+        .token(TOKEN.to_string())
+        .connect(server.url())
+        .await?;
+    let instance_id = InstanceId::new();
+    let start =
+        HookServerStartConfig::new(client.clone(), instance_id.clone(), server.url(), TOKEN);
+    let store = async_nats::jetstream::new(client)
+        .create_key_value(async_nats::jetstream::kv::Config {
+            bucket: HOOK_REGISTRY_BUCKET.to_string(),
+            ..Default::default()
+        })
+        .await?;
+
+    let old_supervisor = HookServerSupervisor::start_local_with_timeout(
+        start.clone(),
+        &hook_config("SessionStart"),
+        "session-old-agent",
+        Duration::from_secs(5),
+    )
+    .await?;
+    let old_name = old_supervisor
+        .server_pids()
+        .await
+        .into_values()
+        .next()
+        .context("old-agent hook process")?;
+    let old_key = hook_registration_key(&instance_id, &old_name);
+    assert!(store.get(&old_key).await?.is_some());
+
+    let mut active = Some(old_supervisor);
+    reconcile_hook_supervisor(
+        &mut active,
+        Some(&start),
+        &hook_config("Stop"),
+        "session-new-agent",
+    )
+    .await;
+
+    wait_until_removed(&store, &old_key).await?;
+    let new_supervisor = active.context("new-agent hook supervisor")?;
+    let new_name = new_supervisor
+        .server_pids()
+        .await
+        .into_values()
+        .next()
+        .context("new-agent hook process")?;
+    let new_key = hook_registration_key(&instance_id, &new_name);
+    assert_ne!(old_key, new_key);
+    assert!(store.get(&new_key).await?.is_some());
+
+    drop(new_supervisor);
+    wait_until_removed(&store, &new_key).await?;
+    Ok(())
+}

--- a/crates/harnx-runtime/tests/nats_hooks_e2e.rs
+++ b/crates/harnx-runtime/tests/nats_hooks_e2e.rs
@@ -162,6 +162,7 @@ async fn nats_hooks_deny_mutate_and_deliver_post_results() -> Result<()> {
     let meta = HookDispatchMeta {
         session_id: "nats-hooks-e2e".to_string(),
         cwd: std::env::current_dir()?,
+        resume_count: 0,
     };
 
     let denied = provider

--- a/crates/harnx-runtime/tests/tool_supervisor.rs
+++ b/crates/harnx-runtime/tests/tool_supervisor.rs
@@ -30,6 +30,7 @@ fn time_server_config(command: impl Into<String>) -> ToolServerConfig {
         enabled: true,
         description: None,
         package: None,
+        hooks: None,
     }
 }
 const TOKEN: &str = "tool-supervisor-test-token";

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -34,6 +34,9 @@ use harnx_hooks::{
 };
 use harnx_render::{render_error, MarkdownRender};
 use harnx_runtime::config::SessionMeta;
+use harnx_runtime::nats_hook_provider::{
+    discover_process_nats_hook_provider, dispatch_hook_event, HookDispatchMeta, HookEventDispatch,
+};
 use harnx_runtime::utils::*;
 
 use anyhow::{bail, Context, Result};
@@ -510,18 +513,34 @@ async fn dispatch_session_start(
     persistent_manager: &Arc<tokio::sync::Mutex<PersistentHookManager>>,
 ) {
     let (hooks, session_id, cwd) = hook_dispatch_context(config);
+    let config_snapshot = config.read().clone();
+    let nats_hook_provider = discover_process_nats_hook_provider(&config_snapshot).await;
     let model_id = config.read().current_model().id().to_string();
     let event = HookEvent::SessionStart {
         source: source.to_string(),
         model: model_id,
     };
-    let _ = dispatch_hooks_with_managers(
-        &event,
+    let inline_event = event.clone();
+    let inline_fallback = dispatch_hooks_with_managers(
+        &inline_event,
         &hooks.entries,
         &session_id,
         &cwd,
         Some(async_manager),
         Some(persistent_manager),
+    );
+    let _ = dispatch_hook_event(
+        HookEventDispatch {
+            event,
+            provider: nats_hook_provider.as_deref(),
+            meta: HookDispatchMeta {
+                session_id: session_id.clone(),
+                cwd: cwd.clone(),
+                resume_count: 0,
+            },
+            pending_async_context: None,
+        },
+        inline_fallback,
     )
     .await;
 }
@@ -645,19 +664,35 @@ async fn exit_session_with_hook(
 ) -> Result<()> {
     let resume_cmd = session_resume_command(config);
     let (hooks, session_id, cwd) = hook_dispatch_context(config);
+    let config_snapshot = config.read().clone();
+    let nats_hook_provider = discover_process_nats_hook_provider(&config_snapshot).await;
     config.write().exit_session()?;
     let event = HookEvent::SessionEnd {
         reason: "session_exit".to_string(),
     };
+    let inline_event = event.clone();
+    let inline_fallback = dispatch_hooks_with_managers(
+        &inline_event,
+        &hooks.entries,
+        &session_id,
+        &cwd,
+        Some(async_manager),
+        Some(persistent_manager),
+    );
     let _ = tokio::time::timeout(
         Duration::from_secs(5),
-        dispatch_hooks_with_managers(
-            &event,
-            &hooks.entries,
-            &session_id,
-            &cwd,
-            Some(async_manager),
-            Some(persistent_manager),
+        dispatch_hook_event(
+            HookEventDispatch {
+                event,
+                provider: nats_hook_provider.as_deref(),
+                meta: HookDispatchMeta {
+                    session_id: session_id.clone(),
+                    cwd: cwd.clone(),
+                    resume_count: 0,
+                },
+                pending_async_context: None,
+            },
+            inline_fallback,
         ),
     )
     .await;

--- a/docs/solutions/hooks-over-nats-core-2026-07-31.md
+++ b/docs/solutions/hooks-over-nats-core-2026-07-31.md
@@ -14,6 +14,7 @@ tags:
   - fire-and-forget
   - testing
 plan_ref: "hooks-over-nats-core"
+last_updated: 2026-08-01
 ---
 
 # Solution: Hooks over NATS Core

--- a/docs/solutions/integration-issues/hooks-nats-launch-dispatch-complete-2026-08-01.md
+++ b/docs/solutions/integration-issues/hooks-nats-launch-dispatch-complete-2026-08-01.md
@@ -1,0 +1,262 @@
+---
+title: "Hooks over NATS Launch and Dispatch — Supervisor Lifecycle, Unified Entrypoint, and Context Aggregation"
+date: 2026-08-01
+category: "integration-issues"
+problem_type: integration_issue
+component: "harnx-runtime, harnx-hookset, harnx-proxy-auth"
+root_cause: "hooks only partially dispatched over NATS; no worker-side launch/lifecycle management for hook servers; PreToolUse context aggregation silently dropped across multi-hook sequential dispatch"
+resolution_type: code_fix
+severity: high
+tags:
+  - nats
+  - hooks
+  - lifecycle
+  - supervisor
+  - context-aggregation
+  - handoff
+plan_ref: "hooks-config-migration"
+---
+
+# Solution: Hooks over NATS Launch and Dispatch
+
+## Problem
+
+Hooks over NATS were incomplete: only PreToolUse/PostToolUse dispatched over NATS, other events fired inline directly. No worker-side launch mechanism existed for hook servers — global, tool-server, and agent hooks had no lifecycle management. PreToolUse `additional_context`/`system_message` were silently dropped when multiple hooks chained sequentially because the dispatch loop only accumulated `mutated_tool_input`.
+
+## Symptoms
+
+- `SessionStart`, `SessionEnd`, `UserPromptSubmit`, `Stop`, `StopFailure` events never reached NATS hooks
+- Mid-session agent handoff (`/agent` switch) kept old agent's hooks registered, new agent's hooks never started
+- PreToolUse hooks returning `additional_context` or `system_message` had those fields silently discarded
+- No tests caught the context-drop bug because tests bypassed the public `dispatch_event` entrypoint
+- `FailPolicy::Closed` hooks that crashed or failed to start were removed from registry, dispatch treated "no matching hooks" as Continue (fail-open for security hooks)
+
+## Investigation Steps
+
+1. Traced `dispatch_hook_event` call sites: `tool.rs`, `agent_loop.rs`, `commands.rs`, `main.rs` — only some called NATS dispatch, others fired inline directly.
+
+2. Found `HookServerSupervisor` mirrored `ToolServerSupervisor` correctly, but no code started it at the right lifecycle seams:
+   - Global hooks needed startup in `run_worker_daemon`
+   - Tool-server hooks needed co-launch with their parent tool server
+   - Agent hooks needed session bind and handoff reconciliation
+
+3. Traced `dispatch_pre_tool_use_with` (the multi-hook sequential loop): Continue arm accumulated `mutated_tool_input` but ignored `additional_context`/`system_message`/`resume`. The helper `continue_outcome(mutated_tool_input)` returned a `HookOutcome` with all context fields defaulted to `None`.
+
+4. Verified `reconcile_agent_hooks` (handoff hook swap) had zero test coverage — no test ever produced a `HandoffRequested` result.
+
+5. Confirmed that `pending_async_context` is a standalone `Arc<Mutex<Option<String>>>` owned by agent loop, NOT tied to `AsyncHookManager`. This independence is why NATS context injection works without the inline async manager.
+
+## Root Cause
+
+**PreToolUse context drop:** `dispatch_pre_tool_use_with` returned `continue_outcome(final_mutation)` which hardcodes `..HookResult::default()` for all fields except `mutated_tool_input`. Context fields were discarded before `append_outcome_context` ever saw them.
+
+**Launch seams wrong:** Developers assumed `use_agent`/`exit_agent` (frontend operations) were the hook launch seams. In a NATS worker, those run in the frontend. The actual seams are:
+- `run_worker_daemon` for global hooks (instance lifetime)
+- `ToolServerSupervisor::start_local` for tool-server hooks (co-launched, co-dropped)
+- `load_or_repair_session` / `attach_session_to_config` for agent hooks (session bind)
+- `prepare_nats_handoff` for agent swap (must explicitly reconcile)
+
+**Handoff gap:** `prepare_nats_handoff` lacked a reconcile step, so a handed-off session retained old agent's hook registrations while new agent's hooks never started.
+
+## Solution
+
+### 1. Unified `dispatch_hook_event` Entrypoint
+
+All hook events now route through a single entrypoint:
+
+```rust
+pub async fn dispatch_hook_event<F>(
+    event: HookEvent,
+    provider: Option<&NatsHookProvider>,
+    meta: HookDispatchMeta,
+    pending_async_context: Option<Arc<Mutex<Option<String>>>>,
+    inline_fallback: F,
+) -> HookOutcome
+where
+    F: Future<Output = HookOutcome>,
+```
+
+When `provider` exists, NATS dispatch runs. When `None`, inline fallback runs. This covers:
+- Tool dispatch (`tool.rs`)
+- Agent-loop events (`agent_loop.rs`: UserPromptSubmit, Stop, StopFailure)
+- CLI commands (`commands.rs`: `/hook` command)
+- Session lifecycle (`main.rs`: SessionStart, SessionEnd)
+
+### 2. HookServerSupervisor Lifecycle Scopes
+
+`HookServerSupervisor` mirrors `ToolServerSupervisor`:
+
+```rust
+pub struct HookServerSupervisor {
+    handles: Vec<HookServerHandle>,
+    instance_id: InstanceId,
+    jetstream_ctx: jetstream::Context,
+    client: async_nats::Client,
+}
+
+pub struct HookServerStartConfig {
+    nats_url: String,
+    token: String,
+}
+```
+
+**Launch routing:**
+- Global hooks: `run_worker_daemon` starts from `config.hooks`, retained in `WorkerRuntime._global_hook_supervisor`
+- Tool-server hooks: `ToolServerSupervisor` owns `hook_supervisors` map, co-launched with tool server, same package dir, drop together
+- Agent hooks: Session bind (`attach_session_to_config`) starts from `agent_resolved_hooks` (strips global prefix to avoid duplicates), stored in `AgentLoopSegmentArgs.hook_supervisor`
+
+**Native proxy-auth routing:** Command basename check — if `harnx-proxy-auth`, launch that binary directly with remaining CLI flags. Fixed server name `proxy-auth`. All other commands route to `harnx-claude-compatible-hook-server`.
+
+### 3. ContinueResultAccumulator Pattern
+
+Fixed PreToolUse context drop with explicit aggregation:
+
+```rust
+struct ContinueResultAccumulator {
+    additional_contexts: Vec<String>,
+    system_messages: Vec<String>,
+    resume: Option<bool>,
+}
+
+impl ContinueResultAccumulator {
+    fn push(&mut self, result: &HookResult) {
+        if let Some(ctx) = &result.additional_context {
+            if !ctx.is_empty() {
+                self.additional_contexts.push(ctx.clone());
+            }
+        }
+        if let Some(msg) = &result.system_message {
+            if !msg.is_empty() {
+                self.system_messages.push(msg.clone());
+            }
+        }
+        self.resume = Some(self.resume.unwrap_or(false) || result.resume.unwrap_or(false));
+    }
+
+    fn into_result(self, mutated_tool_input: Option<serde_json::Value>) -> HookResult {
+        HookResult {
+            mutated_tool_input,
+            additional_context: if self.additional_contexts.is_empty() {
+                None
+            } else {
+                Some(self.additional_contexts.join("\n"))
+            },
+            system_message: if self.system_messages.is_empty() {
+                None
+            } else {
+                Some(self.system_messages.join("\n"))
+            },
+            resume: self.resume,
+            ..HookResult::default()
+        }
+    }
+}
+```
+
+`dispatch_pre_tool_use_with` now calls `accumulated.push(&outcome.result)` for each Continue outcome and returns `accumulated.into_result(final_mutation)`.
+
+Block/Ask short-circuit unchanged (`return outcome` immediately).
+
+### 4. Handoff Hook Reconciliation
+
+`prepare_nats_handoff` now calls `reconcile_agent_hooks` immediately before returning:
+
+```rust
+pub async fn reconcile_agent_hooks(
+    old_supervisor: Option<HookServerSupervisor>,
+    new_hooks: Vec<HookConfig>,
+    start_config: &HookServerStartConfig,
+    scope: &str,
+) -> Option<HookServerSupervisor> {
+    // Stop old supervisor, await registry deletion
+    if let Some(sup) = old_supervisor {
+        sup.shutdown().await;
+    }
+    // Start new supervisor with new agent's hooks
+    if new_hooks.is_empty() {
+        return None;
+    }
+    HookServerSupervisor::start_local(start_config, &new_hooks, scope).await.ok()
+}
+```
+
+Sequential stop-then-start prevents old/new overlap. Brief fail-open window exists between stop and start — acceptable for atomic swap semantics.
+
+### 5. pending_async_context Architecture
+
+`pending_async_context` is a standalone `Arc<Mutex<Option<String>>>` owned by agent loop:
+
+- NATS PreToolUse appends via `append_outcome_context`
+- NATS PostToolUse appends via `append_pending_context` (fire-and-forget, spawned)
+- Inline async manager removed in Phase 4 won't break context injection — the Arc is independent
+
+This separation allows inline path removal without breaking async context flow.
+
+### 6. Ask-over-NATS Behavior
+
+Ask returns as `HookResultControl::Ask`. Engine's `confirm_tool_use_fn` converts to `ToolApprovalRequiredError`. Headless workers cannot prompt — the existing confirmation callback decides whether to surface or deny. Ask does not silently proceed.
+
+### 7. proxy-auth NATS Mode
+
+`harnx-proxy-auth` selects NATS mode only when all three of `HARNX_INSTANCE_ID`, `HARNX_NATS_URL`, and `HARNX_NATS_TOKEN` are present. A partial NATS environment falls back to the stdin-JSONL loop instead of returning a configuration error:
+
+- `ProxyAuthHook` implements `Hook` trait
+- Registration: `PreToolUse` with matcher `exec|spawn`, priority 0, `FailPolicy::Closed`
+- `handle_hook` calls existing `augment_tool_input`, returns mutation
+- Process must stay alive for proxy port + TempDir-backed CA/creds lifetime
+- Local-only: injected proxy URL is `127.0.0.1:<ephemeral-port>`, requires co-location
+
+## Why This Works
+
+**Unified entrypoint simplifies all call sites:** One function (`dispatch_hook_event`) handles NATS/inline routing. Phase 4 inline removal is straightforward: delete the `inline_fallback` parameter and branch.
+
+**Lifecycle scopes match ownership:** Global = instance, tool-server = tool server, agent = session. Hook processes die with their owner.
+
+**Context aggregation preserves multi-hook guidance:** `ContinueResultAccumulator` joins non-empty strings with newline across all matching hooks in priority order. Each hook's contribution survives the chain.
+
+**pending_async_context independence enables Phase 4:** Inline async manager removal won't break context flow because NATS writes directly to the Arc.
+
+**Handoff reconcile prevents stale registrations:** Old agent's hooks stop and unregister before new agent's start, preventing stale responses.
+
+## Accepted Behavior Changes / Known Gaps
+
+1. **FailPolicy::Closed crash/startup handling:** This branch can treat a missing Closed-policy hook as no match. The Phase 4 follow-up closes that gap with the `harnx_hook_expectations` manifest, which tracks required hooks when registrations disappear.
+
+2. **Handoff stop-then-start window:** Brief gap where zero agent hooks registered. Sequential stop-then-start is atomic for swap semantics. Acceptable.
+
+3. **Ask headless limitation:** Headless workers surface Ask via `ToolApprovalRequiredError` but cannot interactively prompt. Confirmation callback decides denial/surface.
+
+4. **InstructionsLoaded/CwdChanged defined but not fired:** Variants exist in enum and dispatch match, but no call site constructs them. Deferred wiring.
+
+5. **proxy-auth localhost-only:** Ephemeral port on `127.0.0.1` requires hook and tool servers on same host. Local deployment by design.
+
+## Prevention Strategies
+
+**Test coverage:**
+- `dispatch_event_queues_aggregated_pre_tool_context_for_next_turn`: Drives public `dispatch_event` entrypoint with 2 hooks, asserts joined context/system fields and pending_async_context
+- `dispatch_event_runs_best_effort_session_start`: Drives `dispatch_event` for SessionStart, asserts dispatcher called
+- `reconcile_hook_supervisor_replaces_old_agent_registration`: Live NATS test of handoff reconcile — old gone, new present
+
+**Code patterns:**
+- Always aggregate across Continue outcomes — never hardcode `..HookResult::default()` on returned outcome
+- Test the public entrypoint, not just internal helpers
+- Launch seams are worker-side (daemon, tool supervisor, session bind, handoff), not frontend (`use_agent`)
+
+**Code review checklist:**
+- [ ] Does `dispatch_pre_tool_use_with` accumulate `additional_context`/`system_message`?
+- [ ] Does handoff path call `reconcile_agent_hooks`?
+- [ ] Are agent hooks started at session bind, not frontend agent switch?
+- [ ] Is `pending_async_context` allocated before NATS dispatch called?
+- [ ] Do multi-hook tests assert on aggregated context, not just mutation?
+
+**Monitoring:**
+- Hook registry bucket size/entries
+- Hook server crashes (log warning)
+- PreToolUse context reaching pending_async_context
+- Agent handoff hook reconciliation completion
+
+## Related Issues
+
+- **GitHub:** [#1224](https://github.com/dobesv/harnx/issues/1224) — Umbrella issue
+- **Prior solution:** `hooks-over-nats-core-2026-07-31.md` — Initial NATS dispatch path
+- **Deferred:** Phase 4 inline removal, InstructionsLoaded/CwdChanged firing, native proxy-auth config migration


### PR DESCRIPTION
Add NATS-based hook launching and event dispatch across the runtime while keeping inline hook execution as a fallback.

Changes:
- Add `harnx-claude-compatible-hook-server` runner binary for executing one-shot and persistent Claude command hooks over NATS.
- Add native NATS PreToolUse hook support in `harnx-proxy-auth` to inject proxy and CA environment variables into tool executions.
- Add `hooks` configuration support to `ToolServerConfig` for tool-server-scoped hooks.
- Implement worker-side `HookServerSupervisor` to manage hook process lifecycles scoped by global, tool-server, and session agent boundaries, including agent handoff reconciliation.
- Extend `NatsHookProvider` to handle all `HookEvent` variants.
- Unify hook dispatch across `tool.rs`, `agent_loop.rs`, slash commands, and CLI through a single `dispatch_hook_event` entrypoint.
- Aggregate NATS PreToolUse `additional_context` and `system_message` into session async context, and handle `Ask` decision responses.

Issue: #1224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NATS-based hook execution for lifecycle, tool, approval, and context-injection events.
  * Added Claude-compatible hook server support, including one-shot and persistent commands.
  * Added hook configuration for individual tool servers and agent scopes.
  * Added native NATS support for proxy authentication hooks.
  * Added instruction-loaded and working-directory-changed events.
* **Improvements**
  * Hooks now support centralized dispatch with inline execution as a fallback.
  * Hook processes are supervised, reconciled during handoffs, and cleaned up reliably.
* **Documentation**
  * Added comprehensive documentation for NATS hook integration and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->