### PR TITLE
feat(hooks): make hook config command-only with supervisor nonces

### DIFF
--- a/.changeset/hooks-command-only-config.md
+++ b/.changeset/hooks-command-only-config.md
@@ -1,0 +1,8 @@
+---
+pantheon: patch
+coding: patch
+---
+Convert the pantheon and coding `bash.yaml` proxy-auth hooks to the command-only
+config model. Hook entries now specify only `command` (plus optional
+`status_message` and `async`); the native `harnx-proxy-auth` hook self-declares
+its event and matcher, so those fields are no longer set in the package config.

--- a/.changeset/remove-hook-type.md
+++ b/.changeset/remove-hook-type.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+Remove hook config fields `type`, `event`, `matcher`, and `timeout`. Hooks now use a command-only model: the `command` field specifies a hook server binary (e.g., `harnx-claude-compatible-hook-server --event <E> --matcher <M> [--persistent] -- <child>` for generic hooks, or `harnx-proxy-auth ...` for native hooks that self-declare their event/matcher).

--- a/crates/harnx-aws-creds/README.md
+++ b/crates/harnx-aws-creds/README.md
@@ -38,10 +38,12 @@ Register `harnx-aws-creds` as a persistent hook in your `harnx.yaml` or agent fr
 ```yaml
 hooks:
   entries:
-    - event: PreToolUse
-      type: claude-command-persistent
-      matcher: "bash_exec|bash_spawn"
-      command: harnx-aws-creds --profile my-profile
+    - command: >-
+        harnx-claude-compatible-hook-server
+        --event PreToolUse
+        --matcher "bash_exec|bash_spawn"
+        --persistent
+        -- harnx-aws-creds --profile my-profile
 ```
 
 Replace `my-profile` with the name of the AWS profile you want to use, or omit `--profile` entirely to use the default credential chain:
@@ -49,13 +51,15 @@ Replace `my-profile` with the name of the AWS profile you want to use, or omit `
 ```yaml
 hooks:
   entries:
-    - event: PreToolUse
-      type: claude-command-persistent
-      matcher: "bash_exec|bash_spawn"
-      command: harnx-aws-creds
+    - command: >-
+        harnx-claude-compatible-hook-server
+        --event PreToolUse
+        --matcher "bash_exec|bash_spawn"
+        --persistent
+        -- harnx-aws-creds
 ```
 
-**Note**: You must use `type: claude-command-persistent` to ensure the credential server stays alive across multiple tool calls.
+**Note**: The `--persistent` flag keeps the credential server alive across multiple tool calls, avoiding the overhead of credential resolution on each request.
 
 ## CLI Flags
 

--- a/crates/harnx-claude-compatible-hook-server/Cargo.toml
+++ b/crates/harnx-claude-compatible-hook-server/Cargo.toml
@@ -10,7 +10,7 @@ description = "NATS server for Claude Code-compatible command hooks"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-clap = { workspace = true }
+clap = { workspace = true, features = ["env"] }
 harnx-core = { path = "../harnx-core" }
 harnx-hooks = { path = "../harnx-hooks" }
 harnx-hookset = { path = "../harnx-hookset" }

--- a/crates/harnx-claude-compatible-hook-server/src/lib.rs
+++ b/crates/harnx-claude-compatible-hook-server/src/lib.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use clap::{Parser, ValueEnum};
 use harnx_core::hooks::{HookOutcome, HookPayload};
 use harnx_hooks::{execute_command_hook, HookCommand, PersistentHookManager};
-use harnx_hookset::{FailPolicy, Hook, HookSpec};
+use harnx_hookset::{FailPolicy, Hook, HookSpec, HARNX_HOOK_NAME};
 use std::path::PathBuf;
 use tokio::sync::Mutex;
 
@@ -14,7 +14,7 @@ use tokio::sync::Mutex;
 #[command(about = "Serve a Claude Code-compatible command hook over NATS")]
 pub struct Args {
     /// Stable hook server name used in NATS subjects and registration.
-    #[arg(long)]
+    #[arg(long, env = HARNX_HOOK_NAME)]
     pub name: String,
 
     /// Hook event to register, such as PreToolUse or PostToolUse.
@@ -37,9 +37,9 @@ pub struct Args {
     #[arg(long, value_enum, default_value_t = CliFailPolicy::Closed)]
     pub fail_policy: CliFailPolicy,
 
-    /// Claude-compatible hook process type.
-    #[arg(long = "type", value_enum, default_value_t = HookType::ClaudeCommand)]
-    pub hook_type: HookType,
+    /// Keep one hook subprocess alive across requests.
+    #[arg(long)]
+    pub persistent: bool,
 
     /// Shell command run for hook requests.
     #[arg(long)]
@@ -48,15 +48,6 @@ pub struct Args {
     /// Package directory exposed to the command as HARNX_PACKAGE_DIR.
     #[arg(long)]
     pub package_dir: Option<PathBuf>,
-}
-
-/// Supported Claude-compatible subprocess protocols.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
-pub enum HookType {
-    #[value(name = "claude-command")]
-    ClaudeCommand,
-    #[value(name = "claude-command-persistent")]
-    ClaudeCommandPersistent,
 }
 
 /// Hook dispatch behavior when the server fails.
@@ -79,9 +70,9 @@ impl From<CliFailPolicy> for FailPolicy {
 pub struct ClaudeCompatibleHook {
     name: String,
     spec: HookSpec,
-    hook_type: HookType,
+    persistent: bool,
     command: HookCommand,
-    persistent: Mutex<PersistentHookManager>,
+    manager: Mutex<PersistentHookManager>,
 }
 
 impl TryFrom<Args> for ClaudeCompatibleHook {
@@ -107,13 +98,13 @@ impl TryFrom<Args> for ClaudeCompatibleHook {
                 timeout_secs: args.timeout,
                 fail_policy: args.fail_policy.into(),
             },
-            hook_type: args.hook_type,
+            persistent: args.persistent,
             command: HookCommand {
                 command: args.command,
                 timeout: args.timeout,
                 package_dir: args.package_dir,
             },
-            persistent: Mutex::new(PersistentHookManager::new()),
+            manager: Mutex::new(PersistentHookManager::new()),
         })
     }
 }
@@ -129,15 +120,14 @@ impl Hook for ClaudeCompatibleHook {
     }
 
     async fn handle_hook(&self, payload: HookPayload) -> HookOutcome {
-        match self.hook_type {
-            HookType::ClaudeCommand => execute_command_hook(&payload, &self.command).await,
-            HookType::ClaudeCommandPersistent => {
-                self.persistent
-                    .lock()
-                    .await
-                    .send_event(&payload, &self.command)
-                    .await
-            }
+        if self.persistent {
+            self.manager
+                .lock()
+                .await
+                .send_event(&payload, &self.command)
+                .await
+        } else {
+            execute_command_hook(&payload, &self.command).await
         }
     }
 }
@@ -166,7 +156,7 @@ mod tests {
         }
     }
 
-    fn hook(command: &str, hook_type: HookType) -> ClaudeCompatibleHook {
+    fn hook(command: &str, persistent: bool) -> ClaudeCompatibleHook {
         Args {
             name: "test-hook".to_string(),
             event: "PreToolUse".to_string(),
@@ -174,7 +164,7 @@ mod tests {
             priority: 7,
             timeout: Some(5),
             fail_policy: CliFailPolicy::Closed,
-            hook_type,
+            persistent,
             command: command.to_string(),
             package_dir: None,
         }
@@ -182,14 +172,40 @@ mod tests {
         .expect("valid test hook")
     }
 
+    #[test]
+    fn cli_uses_persistent_flag_instead_of_type() {
+        let args = Args::try_parse_from([
+            "hook-server",
+            "--name",
+            "test-hook",
+            "--event",
+            "PreToolUse",
+            "--persistent",
+            "--command",
+            "true",
+        ])
+        .expect("parse persistent hook");
+        assert!(args.persistent);
+
+        assert!(Args::try_parse_from([
+            "hook-server",
+            "--name",
+            "test-hook",
+            "--event",
+            "PreToolUse",
+            "--type",
+            "persistent",
+            "--command",
+            "true",
+        ])
+        .is_err());
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn one_shot_exit_zero_parses_hook_result() {
         let cwd = tempfile::tempdir().expect("temp dir");
-        let runner = hook(
-            r#"printf '%s' '{"additionalContext":"from-hook"}'"#,
-            HookType::ClaudeCommand,
-        );
+        let runner = hook(r#"printf '%s' '{"additionalContext":"from-hook"}'"#, false);
 
         let outcome = runner.handle_hook(payload(cwd.path(), 1)).await;
 
@@ -204,10 +220,7 @@ mod tests {
     #[tokio::test]
     async fn one_shot_exit_two_blocks_with_stderr() {
         let cwd = tempfile::tempdir().expect("temp dir");
-        let runner = hook(
-            "printf '%s' 'denied by test' >&2; exit 2",
-            HookType::ClaudeCommand,
-        );
+        let runner = hook("printf '%s' 'denied by test' >&2; exit 2", false);
 
         let outcome = runner.handle_hook(payload(cwd.path(), 1)).await;
 
@@ -225,7 +238,7 @@ mod tests {
         let cwd = tempfile::tempdir().expect("temp dir");
         let runner = hook(
             r#"printf '%s' '{"mutatedToolInput":{"command":"safe"}}'"#,
-            HookType::ClaudeCommand,
+            false,
         );
 
         let outcome = runner.handle_hook(payload(cwd.path(), 1)).await;
@@ -242,7 +255,7 @@ mod tests {
         let cwd = tempfile::tempdir().expect("temp dir");
         let runner = hook(
             r#"count=0; while IFS= read -r line; do count=$((count + 1)); id=$(printf '%s' "$line" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p'); printf '{"id":"%s","mutatedToolInput":{"sequence":%s}}\n' "$id" "$count"; done"#,
-            HookType::ClaudeCommandPersistent,
+            true,
         );
 
         let first = runner.handle_hook(payload(cwd.path(), 1)).await;
@@ -260,7 +273,7 @@ mod tests {
 
     #[test]
     fn hook_metadata_comes_from_configuration() {
-        let runner = hook("true", HookType::ClaudeCommand);
+        let runner = hook("true", false);
         assert_eq!(runner.name(), "test-hook");
         assert_eq!(
             runner.hooks(),

--- a/crates/harnx-claude-compatible-hook-server/tests/nats_runner.rs
+++ b/crates/harnx-claude-compatible-hook-server/tests/nats_runner.rs
@@ -1,10 +1,10 @@
 #![cfg(unix)]
 
 use anyhow::{Context, Result};
-use harnx_claude_compatible_hook_server::{Args, ClaudeCompatibleHook, CliFailPolicy, HookType};
+use harnx_claude_compatible_hook_server::{Args, ClaudeCompatibleHook, CliFailPolicy};
 use harnx_core::hooks::{HookEvent, HookOutcome, HookPayload, HookResultControl};
-use harnx_core::instance::InstanceId;
-use harnx_hookset::HookRegistration;
+use harnx_core::instance::{InstanceId, HARNX_INSTANCE_ID};
+use harnx_hookset::{HookRegistration, HARNX_HOOK_NAME};
 use harnx_hookset_server::{hook_registration_key, serve_over_nats, HOOK_REGISTRY_BUCKET};
 use serde_json::json;
 use std::net::TcpListener;
@@ -26,6 +26,15 @@ impl Drop for NatsServerHandle {
     fn drop(&mut self) {
         let _ = self.child.kill();
         let _ = self.child.wait();
+    }
+}
+
+struct HookServerHandle(Child);
+
+impl Drop for HookServerHandle {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
     }
 }
 
@@ -91,12 +100,13 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
 async fn wait_for_registration(
     client: &async_nats::Client,
     instance_id: &InstanceId,
+    server_name: &str,
 ) -> Result<HookRegistration> {
     let jetstream = async_nats::jetstream::new(client.clone());
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         if let Ok(store) = jetstream.get_key_value(HOOK_REGISTRY_BUCKET).await {
-            let key = hook_registration_key(instance_id, SERVER_NAME);
+            let key = hook_registration_key(instance_id, server_name);
             if let Some(value) = store.get(&key).await? {
                 return serde_json::from_slice(&value).context("decode hook registration");
             }
@@ -121,7 +131,7 @@ async fn command_hook_registers_and_answers_over_nats() -> Result<()> {
         priority: 3,
         timeout: Some(5),
         fail_policy: CliFailPolicy::Closed,
-        hook_type: HookType::ClaudeCommand,
+        persistent: false,
         command: r#"printf '%s' '{"mutatedToolInput":{"overNats":true}}'"#.to_string(),
         package_dir: None,
     })?;
@@ -136,7 +146,7 @@ async fn command_hook_registers_and_answers_over_nats() -> Result<()> {
         .connect(&server.url)
         .await?;
 
-    let registration = wait_for_registration(&client, &instance_id).await?;
+    let registration = wait_for_registration(&client, &instance_id, SERVER_NAME).await?;
     assert_eq!(registration.server, SERVER_NAME);
     assert_eq!(registration.hooks[0].matcher.as_deref(), Some("exec"));
 
@@ -164,5 +174,44 @@ async fn command_hook_registers_and_answers_over_nats() -> Result<()> {
     );
 
     server_task.abort();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn command_hook_uses_env_name_with_end_of_options_separator() -> Result<()> {
+    harnx_core::require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        return Ok(());
+    };
+    let assigned_name = "hook-env-name-000";
+    let instance_id = InstanceId::new();
+    let child = Command::new(env!("CARGO_BIN_EXE_harnx-claude-compatible-hook-server"))
+        .args([
+            "--event",
+            "PreToolUse",
+            "--matcher",
+            "exec",
+            "--command",
+            "printf '{}'",
+            "--",
+        ])
+        .env(HARNX_HOOK_NAME, assigned_name)
+        .env(HARNX_INSTANCE_ID, instance_id.as_str())
+        .env("HARNX_NATS_URL", &server.url)
+        .env("HARNX_NATS_TOKEN", TOKEN)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("spawn command hook with environment-assigned name")?;
+    let _hook_server = HookServerHandle(child);
+    let client = async_nats::ConnectOptions::new()
+        .token(TOKEN.to_string())
+        .connect(&server.url)
+        .await?;
+
+    let registration = wait_for_registration(&client, &instance_id, assigned_name).await?;
+    assert_eq!(registration.server, assigned_name);
+    assert_eq!(registration.hooks[0].matcher.as_deref(), Some("exec"));
     Ok(())
 }

--- a/crates/harnx-core/src/hooks.rs
+++ b/crates/harnx-core/src/hooks.rs
@@ -132,27 +132,11 @@ pub struct HookOutcome {
 
 // --- HookConfig / HooksConfig (serialized shape read from config.yaml) -------
 
-/// Default timeout for hook execution in seconds
-fn default_timeout() -> Option<u64> {
-    Some(30)
-}
-
 /// Configuration for a single hook entry
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct HookConfig {
-    /// Hook event name (e.g., "PreToolUse", "Stop")
-    pub event: String,
-
-    /// Optional regex pattern to match against tool_name (for tool-bearing events)
-    #[serde(default)]
-    pub matcher: Option<String>,
-
-    /// Shell command to execute
+    /// Hook server command to execute
     pub command: String,
-
-    /// Timeout in seconds (default 30)
-    #[serde(default = "default_timeout")]
-    pub timeout: Option<u64>,
 
     /// Optional status message to display
     #[serde(default)]
@@ -160,12 +144,6 @@ pub struct HookConfig {
 
     #[serde(default, rename = "async")]
     pub async_hook: Option<bool>,
-
-    /// Hook type. Determines the execution protocol.
-    /// Supported: "claude-command" (subprocess with stdin/stdout JSON).
-    /// Unknown types are silently skipped.
-    #[serde(rename = "type")]
-    pub hook_type: String,
 
     /// Directory of the package that owns this hook, set at load time when the
     /// hook was defined by a packaged MCP server. Injected into the hook
@@ -175,16 +153,6 @@ pub struct HookConfig {
     /// back to the config dir at spawn time.
     #[serde(skip)]
     pub package_dir: Option<PathBuf>,
-}
-
-impl HookConfig {
-    /// Check if the hook type is supported
-    pub fn is_supported_type(&self) -> bool {
-        matches!(
-            self.hook_type.as_str(),
-            "claude-command" | "claude-command-persistent"
-        )
-    }
 }
 
 /// Configuration for all hooks (global or per-agent)
@@ -200,37 +168,17 @@ pub struct HooksConfig {
 }
 
 impl HooksConfig {
-    /// Merge global and agent hooks
+    /// Merge global and agent hooks.
     ///
-    /// Rules:
-    /// - Agent entries extend global entries (both lists are combined)
-    /// - If agent and global have entries with the same `event` AND same `matcher`, agent takes priority (replaces)
-    /// - `max_resume`: agent value overrides global if agent value is Some
+    /// Agent entries follow global entries so declaration order remains the
+    /// dispatch tiebreak within the merged supervisor.
     pub fn merge(global: &HooksConfig, agent: &HooksConfig) -> HooksConfig {
-        // Start with global entries
-        let mut merged_entries = global.entries.clone();
-
-        // Process agent entries
-        for agent_entry in &agent.entries {
-            // Check if there's a matching entry in global (same event and matcher)
-            if let Some(pos) = merged_entries
-                .iter()
-                .position(|e| e.event == agent_entry.event && e.matcher == agent_entry.matcher)
-            {
-                // Replace the global entry with the agent entry
-                merged_entries[pos] = agent_entry.clone();
-            } else {
-                // No conflict, add the agent entry
-                merged_entries.push(agent_entry.clone());
-            }
-        }
-
-        // Determine max_resume: agent overrides global if Some
-        let max_resume = agent.max_resume.or(global.max_resume);
+        let mut entries = global.entries.clone();
+        entries.extend(agent.entries.iter().cloned());
 
         HooksConfig {
-            max_resume,
-            entries: merged_entries,
+            max_resume: agent.max_resume.or(global.max_resume),
+            entries,
         }
     }
 }
@@ -249,127 +197,52 @@ mod tests {
         let yaml = r#"
 max_resume: 3
 entries:
-  - event: Stop
-    command: "/path/to/hook.sh"
+  - command: "/path/to/hook-server --event Stop --command /path/to/hook.sh"
     async: true
-    timeout: 10
-    type: claude-command
 "#;
 
         let config: HooksConfig = serde_yaml::from_str(yaml).expect("parse hooks config");
 
         assert_eq!(config.max_resume, Some(3));
         assert_eq!(config.entries.len(), 1);
-
         let entry = &config.entries[0];
-        assert_eq!(entry.event, "Stop");
-        assert_eq!(entry.command, "/path/to/hook.sh");
-        assert_eq!(entry.timeout, Some(10));
-        assert_eq!(entry.hook_type, "claude-command");
-        assert!(entry.matcher.is_none());
+        assert_eq!(
+            entry.command,
+            "/path/to/hook-server --event Stop --command /path/to/hook.sh"
+        );
         assert!(entry.status_message.is_none());
         assert_eq!(entry.async_hook, Some(true));
+        assert!(entry.package_dir.is_none());
     }
 
     #[test]
-    fn test_hooks_config_merge() {
+    fn test_hooks_config_merge_preserves_declaration_order() {
+        let hook = |command: &str| HookConfig {
+            command: command.to_string(),
+            status_message: None,
+            async_hook: None,
+            package_dir: None,
+        };
         let global = HooksConfig {
             max_resume: Some(5),
-            entries: vec![
-                HookConfig {
-                    event: "Stop".to_string(),
-                    matcher: None,
-                    command: "global-stop.sh".to_string(),
-                    timeout: Some(30),
-                    status_message: None,
-                    async_hook: None,
-                    hook_type: "claude-command".to_string(),
-                    package_dir: None,
-                },
-                HookConfig {
-                    event: "SessionStart".to_string(),
-                    matcher: None,
-                    command: "global-start.sh".to_string(),
-                    timeout: Some(30),
-                    status_message: None,
-                    async_hook: None,
-                    hook_type: "claude-command".to_string(),
-                    package_dir: None,
-                },
-            ],
+            entries: vec![hook("global-first"), hook("global-second")],
         };
-
         let agent = HooksConfig {
             max_resume: Some(3),
-            entries: vec![HookConfig {
-                event: "PreToolUse".to_string(),
-                matcher: Some("shell".to_string()),
-                command: "agent-tool.sh".to_string(),
-                timeout: Some(15),
-                status_message: None,
-                async_hook: None,
-                hook_type: "claude-command".to_string(),
-                package_dir: None,
-            }],
+            entries: vec![hook("agent-first")],
         };
 
         let merged = HooksConfig::merge(&global, &agent);
 
-        // Agent max_resume should win
         assert_eq!(merged.max_resume, Some(3));
-
-        // Should have 3 entries: 2 from global + 1 from agent
-        assert_eq!(merged.entries.len(), 3);
-
-        // Check that all events are present
-        let events: Vec<&str> = merged.entries.iter().map(|e| e.event.as_str()).collect();
-        assert!(events.contains(&"Stop"));
-        assert!(events.contains(&"SessionStart"));
-        assert!(events.contains(&"PreToolUse"));
-    }
-
-    #[test]
-    fn test_hooks_config_merge_conflict() {
-        let global = HooksConfig {
-            max_resume: Some(5),
-            entries: vec![HookConfig {
-                event: "PreToolUse".to_string(),
-                matcher: Some("shell".to_string()),
-                command: "global-shell.sh".to_string(),
-                timeout: Some(30),
-                status_message: None,
-                async_hook: None,
-                hook_type: "claude-command".to_string(),
-                package_dir: None,
-            }],
-        };
-
-        let agent = HooksConfig {
-            max_resume: None,
-            entries: vec![HookConfig {
-                event: "PreToolUse".to_string(),
-                matcher: Some("shell".to_string()),
-                command: "agent-shell.sh".to_string(),
-                timeout: Some(10),
-                status_message: Some("Agent override".to_string()),
-                async_hook: None,
-                hook_type: "claude-command".to_string(),
-                package_dir: None,
-            }],
-        };
-
-        let merged = HooksConfig::merge(&global, &agent);
-
-        // Global max_resume should be used (agent is None)
-        assert_eq!(merged.max_resume, Some(5));
-
-        // Should have only 1 entry (agent replaced global)
-        assert_eq!(merged.entries.len(), 1);
-
-        let entry = &merged.entries[0];
-        assert_eq!(entry.command, "agent-shell.sh");
-        assert_eq!(entry.timeout, Some(10));
-        assert_eq!(entry.status_message, Some("Agent override".to_string()));
+        assert_eq!(
+            merged
+                .entries
+                .iter()
+                .map(|entry| entry.command.as_str())
+                .collect::<Vec<_>>(),
+            vec!["global-first", "global-second", "agent-first"]
+        );
     }
 
     #[test]
@@ -378,60 +251,6 @@ entries:
 
         assert!(config.max_resume.is_none());
         assert!(config.entries.is_empty());
-    }
-
-    #[test]
-    fn test_supported_type() {
-        // None should be valid (defaults to "claude-command")
-        let hook1 = HookConfig {
-            event: "Stop".to_string(),
-            matcher: None,
-            command: "test.sh".to_string(),
-            timeout: Some(30),
-            status_message: None,
-            async_hook: None,
-            hook_type: "claude-command".to_string(),
-            package_dir: None,
-        };
-        assert!(hook1.is_supported_type());
-
-        // "claude-command" should be valid
-        let hook2 = HookConfig {
-            event: "Stop".to_string(),
-            matcher: None,
-            command: "test.sh".to_string(),
-            timeout: Some(30),
-            status_message: None,
-            async_hook: None,
-            hook_type: "claude-command".to_string(),
-            package_dir: None,
-        };
-        assert!(hook2.is_supported_type());
-
-        let hook_persistent = HookConfig {
-            event: "Stop".to_string(),
-            matcher: None,
-            command: "test.sh".to_string(),
-            timeout: Some(30),
-            status_message: None,
-            async_hook: None,
-            hook_type: "claude-command-persistent".to_string(),
-            package_dir: None,
-        };
-        assert!(hook_persistent.is_supported_type());
-
-        // Unknown type should be invalid
-        let hook3 = HookConfig {
-            event: "Stop".to_string(),
-            matcher: None,
-            command: "test.sh".to_string(),
-            timeout: Some(30),
-            status_message: None,
-            async_hook: None,
-            hook_type: "future-v2".to_string(),
-            package_dir: None,
-        };
-        assert!(!hook3.is_supported_type());
     }
 
     #[test]

--- a/crates/harnx-hooks/src/dispatch.rs
+++ b/crates/harnx-hooks/src/dispatch.rs
@@ -1,5 +1,5 @@
 use crate::{
-    executor::execute_command_hook, AsyncHookManager, CompiledMatcher, HookConfig, HookEvent,
+    executor::execute_command_hook, AsyncHookManager, CompiledMatcher, HookCommand, HookEvent,
     HookOutcome, HookPayload, HookResult, HookResultControl, PersistentHookManager,
 };
 
@@ -8,219 +8,187 @@ use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Mutex as TokioMutex;
 
+/// Inline hook metadata used by sandbox-run's non-NATS dispatcher.
+#[derive(Debug, Clone)]
+pub struct InlineHookSpec {
+    pub event: String,
+    pub matcher: Option<String>,
+    pub command: HookCommand,
+    pub async_hook: Option<bool>,
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct DispatchOptions<'a> {
+    pub persistent_modes: &'a [bool],
+    pub resume_count: u32,
+    pub async_manager: Option<&'a AsyncHookManager>,
+    pub persistent_manager: Option<&'a Arc<TokioMutex<PersistentHookManager>>>,
+}
+
 pub async fn dispatch_hooks(
     event: &HookEvent,
-    hooks: &[HookConfig],
+    hooks: &[InlineHookSpec],
     session_id: &str,
     cwd: &Path,
 ) -> HookOutcome {
-    dispatch_hooks_with_count(event, hooks, session_id, cwd, 0, None).await
+    dispatch_hooks_with_options(event, hooks, session_id, cwd, DispatchOptions::default()).await
 }
 
-pub async fn dispatch_hooks_with_managers(
-    event: &HookEvent,
-    hooks: &[HookConfig],
-    session_id: &str,
-    cwd: &Path,
-    async_manager: Option<&AsyncHookManager>,
-    persistent_manager: Option<&Arc<TokioMutex<PersistentHookManager>>>,
-) -> HookOutcome {
-    dispatch_hooks_with_count_and_manager(
-        event,
-        hooks,
-        session_id,
-        cwd,
-        0,
-        async_manager,
-        persistent_manager,
-    )
-    .await
+struct DispatchState {
+    payload: HookPayload,
+    additional_contexts: Vec<String>,
+    resume: bool,
+    current_tool_input: Option<Value>,
+    current_tool_response: Option<Value>,
 }
 
-pub async fn dispatch_hooks_with_count(
-    event: &HookEvent,
-    hooks: &[HookConfig],
-    session_id: &str,
-    cwd: &Path,
-    resume_count: u32,
-    persistent_manager: Option<&Arc<TokioMutex<PersistentHookManager>>>,
-) -> HookOutcome {
-    dispatch_hooks_with_count_and_manager(
-        event,
-        hooks,
-        session_id,
-        cwd,
-        resume_count,
-        None,
-        persistent_manager,
-    )
-    .await
-}
-
-pub async fn dispatch_hooks_with_count_and_manager(
-    event: &HookEvent,
-    hooks: &[HookConfig],
-    session_id: &str,
-    cwd: &Path,
-    resume_count: u32,
-    async_manager: Option<&AsyncHookManager>,
-    persistent_manager: Option<&Arc<TokioMutex<PersistentHookManager>>>,
-) -> HookOutcome {
-    let mut payload = HookPayload {
-        session_id: session_id.to_string(),
-        cwd: cwd.to_path_buf(),
-        resume_count,
-        hook_event: event.clone(),
-    };
-
-    let mut additional_contexts = vec![];
-    let mut resume = false;
-    let mut current_tool_input: Option<Value> = None;
-    let mut current_tool_response: Option<Value> = None;
-
-    for hook in hooks {
-        if hook.event != event.event_name() || !hook.is_supported_type() {
-            continue;
+impl DispatchState {
+    fn new(event: &HookEvent, session_id: &str, cwd: &Path, resume_count: u32) -> Self {
+        Self {
+            payload: HookPayload {
+                session_id: session_id.to_string(),
+                cwd: cwd.to_path_buf(),
+                resume_count,
+                hook_event: event.clone(),
+            },
+            additional_contexts: Vec::new(),
+            resume: false,
+            current_tool_input: None,
+            current_tool_response: None,
         }
+    }
 
-        let matcher = match CompiledMatcher::compile(&hook.matcher) {
-            Ok(matcher) => matcher,
-            Err(err) => {
-                warn!(
-                    "Skipping hook `{}` for event `{}` because matcher compilation failed: {err}",
-                    hook.command, hook.event
-                );
-                continue;
-            }
-        };
-
-        if !matcher.matches(event) {
-            continue;
-        }
-
+    fn patch_payload(&mut self) {
         patch_payload_mutation(
-            &mut payload.hook_event,
-            current_tool_input.as_ref(),
-            current_tool_response.as_ref(),
+            &mut self.payload.hook_event,
+            self.current_tool_input.as_ref(),
+            self.current_tool_response.as_ref(),
         );
+    }
 
-        if hook.async_hook == Some(true) {
-            if let Some(manager) = async_manager {
-                manager.spawn_hook(payload.clone(), hook.into());
-            }
-            continue;
-        }
-
-        if hook.hook_type == "claude-command-persistent" {
-            if let Some(pm) = persistent_manager {
-                let outcome = pm.lock().await.send_event(&payload, &hook.into()).await;
-                let HookOutcome { control, result } = outcome;
-
-                // Extract mutations before branching so Ask/Block also carry them.
-                if let Some(ref hso) = result.hook_specific_output {
-                    if let Some(ref ti) = hso.tool_input {
-                        current_tool_input = Some(ti.clone());
-                    }
-                    if let Some(ref tr) = hso.tool_response {
-                        current_tool_response = Some(tr.clone());
-                    }
-                }
-
-                match control {
-                    HookResultControl::Block { reason } => {
-                        return HookOutcome {
-                            control: HookResultControl::Block { reason },
-                            result: HookResult {
-                                mutated_tool_input: current_tool_input,
-                                mutated_tool_response: current_tool_response,
-                                ..result
-                            },
-                        };
-                    }
-                    HookResultControl::Ask { reason } => {
-                        return HookOutcome {
-                            control: HookResultControl::Ask { reason },
-                            result: HookResult {
-                                mutated_tool_input: current_tool_input,
-                                mutated_tool_response: current_tool_response,
-                                ..result
-                            },
-                        };
-                    }
-                    HookResultControl::Continue => {
-                        if let Some(context) =
-                            result.additional_context.filter(|value| !value.is_empty())
-                        {
-                            additional_contexts.push(context);
-                        }
-                        if let Some(msg) = result.system_message.filter(|value| !value.is_empty()) {
-                            additional_contexts.push(msg);
-                        }
-                        resume |= result.resume.unwrap_or(false);
-                    }
-                }
-            }
-            continue;
-        }
-
-        let outcome = execute_command_hook(&payload, &hook.into()).await;
+    fn apply_outcome(&mut self, outcome: HookOutcome) -> Option<HookOutcome> {
         let HookOutcome { control, result } = outcome;
-
-        // Extract mutations from this hook before branching on control so that
-        // even Ask/Block outcomes carry the current hook's mutation forward.
-        if let Some(ref hso) = result.hook_specific_output {
-            if let Some(ref ti) = hso.tool_input {
-                current_tool_input = Some(ti.clone());
-            }
-            if let Some(ref tr) = hso.tool_response {
-                current_tool_response = Some(tr.clone());
-            }
-        }
-
+        self.capture_mutations(&result);
         match control {
-            HookResultControl::Block { reason } => {
-                return HookOutcome {
-                    control: HookResultControl::Block { reason },
-                    result: HookResult {
-                        mutated_tool_input: current_tool_input,
-                        mutated_tool_response: current_tool_response,
-                        ..result
-                    },
-                };
-            }
-            HookResultControl::Ask { reason } => {
-                return HookOutcome {
-                    control: HookResultControl::Ask { reason },
-                    result: HookResult {
-                        mutated_tool_input: current_tool_input,
-                        mutated_tool_response: current_tool_response,
-                        ..result
-                    },
-                };
-            }
             HookResultControl::Continue => {
-                if let Some(context) = result.additional_context.filter(|value| !value.is_empty()) {
-                    additional_contexts.push(context);
-                }
-                if let Some(msg) = result.system_message.filter(|value| !value.is_empty()) {
-                    additional_contexts.push(msg);
-                }
-                resume |= result.resume.unwrap_or(false);
+                self.capture_context(result);
+                None
             }
+            control => Some(HookOutcome {
+                control,
+                result: HookResult {
+                    mutated_tool_input: self.current_tool_input.clone(),
+                    mutated_tool_response: self.current_tool_response.clone(),
+                    ..result
+                },
+            }),
         }
     }
 
-    HookOutcome {
-        control: HookResultControl::Continue,
-        result: HookResult {
-            additional_context: (!additional_contexts.is_empty())
-                .then(|| additional_contexts.join("\n")),
-            resume: resume.then_some(true),
-            mutated_tool_input: current_tool_input,
-            mutated_tool_response: current_tool_response,
-            ..HookResult::default()
-        },
+    fn capture_mutations(&mut self, result: &HookResult) {
+        let Some(output) = &result.hook_specific_output else {
+            return;
+        };
+        if let Some(tool_input) = &output.tool_input {
+            self.current_tool_input = Some(tool_input.clone());
+        }
+        if let Some(tool_response) = &output.tool_response {
+            self.current_tool_response = Some(tool_response.clone());
+        }
     }
+
+    fn capture_context(&mut self, result: HookResult) {
+        self.additional_contexts.extend(
+            [result.additional_context, result.system_message]
+                .into_iter()
+                .flatten()
+                .filter(|value| !value.is_empty()),
+        );
+        self.resume |= result.resume.unwrap_or(false);
+    }
+
+    fn finish(self) -> HookOutcome {
+        HookOutcome {
+            control: HookResultControl::Continue,
+            result: HookResult {
+                additional_context: (!self.additional_contexts.is_empty())
+                    .then(|| self.additional_contexts.join("\n")),
+                resume: self.resume.then_some(true),
+                mutated_tool_input: self.current_tool_input,
+                mutated_tool_response: self.current_tool_response,
+                ..HookResult::default()
+            },
+        }
+    }
+}
+
+pub async fn dispatch_hooks_with_options(
+    event: &HookEvent,
+    hooks: &[InlineHookSpec],
+    session_id: &str,
+    cwd: &Path,
+    options: DispatchOptions<'_>,
+) -> HookOutcome {
+    let mut state = DispatchState::new(event, session_id, cwd, options.resume_count);
+    for (index, hook) in hooks.iter().enumerate() {
+        if !hook_matches_event(hook, event) {
+            continue;
+        }
+        state.patch_payload();
+        let Some(outcome) = execute_hook(index, hook, &state.payload, options).await else {
+            continue;
+        };
+        if let Some(terminal) = state.apply_outcome(outcome) {
+            return terminal;
+        }
+    }
+    state.finish()
+}
+
+fn hook_matches_event(hook: &InlineHookSpec, event: &HookEvent) -> bool {
+    if hook.event != event.event_name() {
+        return false;
+    }
+    match CompiledMatcher::compile(&hook.matcher) {
+        Ok(matcher) => matcher.matches(event),
+        Err(error) => {
+            warn!(
+                "Skipping hook `{}` for event `{}` because matcher compilation failed: {error}",
+                hook.command.command, hook.event
+            );
+            false
+        }
+    }
+}
+
+async fn execute_hook(
+    index: usize,
+    hook: &InlineHookSpec,
+    payload: &HookPayload,
+    options: DispatchOptions<'_>,
+) -> Option<HookOutcome> {
+    if hook.async_hook == Some(true) {
+        if let Some(manager) = options.async_manager {
+            manager.spawn_hook(payload.clone(), hook.command.clone());
+        }
+        return None;
+    }
+    if options
+        .persistent_modes
+        .get(index)
+        .copied()
+        .unwrap_or(false)
+    {
+        let manager = options.persistent_manager?;
+        return Some(
+            manager
+                .lock()
+                .await
+                .send_event(payload, &hook.command)
+                .await,
+        );
+    }
+    Some(execute_command_hook(payload, &hook.command).await)
 }
 
 fn patch_payload_mutation(
@@ -255,8 +223,8 @@ fn patch_payload_mutation(
 
 #[cfg(test)]
 mod tests {
-    use super::{dispatch_hooks, dispatch_hooks_with_count, dispatch_hooks_with_count_and_manager};
-    use crate::{AsyncHookManager, HookConfig, HookEvent, HookResultControl};
+    use super::{dispatch_hooks, dispatch_hooks_with_options, DispatchOptions, InlineHookSpec};
+    use crate::{AsyncHookManager, HookCommand, HookEvent, HookResultControl};
     use serde_json::json;
     use std::fs;
     #[cfg(unix)]
@@ -327,16 +295,16 @@ mod tests {
         }
     }
 
-    fn hook_config(event: &str, command: String) -> HookConfig {
-        HookConfig {
+    fn hook_config(event: &str, command: String) -> InlineHookSpec {
+        InlineHookSpec {
             event: event.to_string(),
             matcher: None,
-            command,
-            timeout: Some(5),
-            status_message: None,
+            command: HookCommand {
+                command,
+                timeout: Some(5),
+                package_dir: None,
+            },
             async_hook: None,
-            hook_type: "claude-command".to_string(),
-            package_dir: None,
         }
     }
 
@@ -822,13 +790,15 @@ mod tests {
             payload_dump_command(&cwd, &marker),
         )];
 
-        let outcome = dispatch_hooks_with_count(
+        let outcome = dispatch_hooks_with_options(
             &pre_tool_use_event("shell"),
             &hooks,
             "session-3",
             &cwd,
-            4,
-            None,
+            DispatchOptions {
+                resume_count: 4,
+                ..DispatchOptions::default()
+            },
         )
         .await;
 
@@ -840,22 +810,22 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_async_hook_does_not_block() {
         let cwd = temp_test_dir("async-no-block");
-        let hooks = vec![HookConfig {
+        let hooks = vec![InlineHookSpec {
             async_hook: Some(true),
-            command: sleep_command(5),
             ..hook_config("PreToolUse", sleep_command(5))
         }];
         let manager = AsyncHookManager::new();
         let start = tokio::time::Instant::now();
 
-        let outcome = dispatch_hooks_with_count_and_manager(
+        let outcome = dispatch_hooks_with_options(
             &pre_tool_use_event("shell"),
             &hooks,
             "session-async",
             &cwd,
-            0,
-            Some(&manager),
-            None,
+            DispatchOptions {
+                async_manager: Some(&manager),
+                ..DispatchOptions::default()
+            },
         )
         .await;
 
@@ -891,22 +861,19 @@ done"#,
 
         let cwd = temp_test_dir("persistent-hook-manager");
         let command = persistent_mutate_command(&cwd);
-        let hooks = vec![HookConfig {
-            hook_type: "claude-command-persistent".to_string(),
-            package_dir: None,
-            ..hook_config("PreToolUse", command)
-        }];
+        let hooks = vec![hook_config("PreToolUse", command)];
         let event = pre_tool_use_event("bash_exec");
 
         // With None: persistent hook is skipped — no mutation.
-        let outcome_no_pm = dispatch_hooks_with_count_and_manager(
+        let outcome_no_pm = dispatch_hooks_with_options(
             &event,
             &hooks,
             "session-no-pm",
             &cwd,
-            0,
-            None,
-            None,
+            DispatchOptions {
+                persistent_modes: &[true],
+                ..DispatchOptions::default()
+            },
         )
         .await;
         assert!(matches!(outcome_no_pm.control, HookResultControl::Continue));
@@ -917,14 +884,16 @@ done"#,
 
         // With Some(pm): persistent hook runs and mutates tool_input.
         let pm = Arc::new(Mutex::new(PersistentHookManager::new()));
-        let outcome_with_pm = dispatch_hooks_with_count_and_manager(
+        let outcome_with_pm = dispatch_hooks_with_options(
             &event,
             &hooks,
             "session-with-pm",
             &cwd,
-            0,
-            None,
-            Some(&pm),
+            DispatchOptions {
+                persistent_modes: &[true],
+                persistent_manager: Some(&pm),
+                ..DispatchOptions::default()
+            },
         )
         .await;
         assert!(matches!(

--- a/crates/harnx-hooks/src/executor.rs
+++ b/crates/harnx-hooks/src/executor.rs
@@ -1,4 +1,4 @@
-use crate::{HookConfig, HookOutcome, HookPayload, HookResult, HookResultControl};
+use crate::{HookOutcome, HookPayload, HookResult, HookResultControl};
 
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
@@ -21,16 +21,6 @@ pub struct HookCommand {
     pub command: String,
     pub timeout: Option<u64>,
     pub package_dir: Option<PathBuf>,
-}
-
-impl From<&HookConfig> for HookCommand {
-    fn from(hook: &HookConfig) -> Self {
-        Self {
-            command: hook.command.clone(),
-            timeout: hook.timeout,
-            package_dir: hook.package_dir.clone(),
-        }
-    }
 }
 
 /// Build the base shell `Command` for a hook, with `HARNX_PACKAGE_DIR` injected

--- a/crates/harnx-hooks/src/lib.rs
+++ b/crates/harnx-hooks/src/lib.rs
@@ -60,10 +60,7 @@ pub use async_manager::{
     append_pending_context, drain_async_results, inject_pending_async_context, AsyncHookManager,
 };
 #[allow(unused_imports)]
-pub use dispatch::{
-    dispatch_hooks, dispatch_hooks_with_count, dispatch_hooks_with_count_and_manager,
-    dispatch_hooks_with_managers,
-};
+pub use dispatch::{dispatch_hooks, dispatch_hooks_with_options, DispatchOptions, InlineHookSpec};
 #[allow(unused_imports)]
 pub use executor::{execute_command_hook, HookCommand};
 pub use harnx_core::hooks::*;

--- a/crates/harnx-hookset-server/src/lib.rs
+++ b/crates/harnx-hookset-server/src/lib.rs
@@ -66,6 +66,7 @@ pub async fn serve_with_client(
 
     let registration = HookRegistration {
         server: server.clone(),
+        display_label: None,
         hooks,
         schema_version: HOOK_SCHEMA_VERSION,
         proto_version: HOOK_PROTOCOL_VERSION,

--- a/crates/harnx-hookset/src/lib.rs
+++ b/crates/harnx-hookset/src/lib.rs
@@ -3,6 +3,8 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
+/// Environment variable containing the supervisor-assigned hook server name.
+pub const HARNX_HOOK_NAME: &str = "HARNX_HOOK_NAME";
 /// JetStream KV bucket containing hook server registrations.
 pub const HOOK_REGISTRY_BUCKET: &str = "harnx_hook_registry";
 /// JetStream KV bucket containing hooks local supervisors require to be available.
@@ -68,6 +70,8 @@ pub trait Hook: Send + Sync {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HookRegistration {
     pub server: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_label: Option<String>,
     pub hooks: Vec<HookSpec>,
     pub schema_version: u32,
     pub proto_version: u32,
@@ -79,8 +83,17 @@ mod tests {
 
     #[test]
     fn hook_registration_round_trips_through_serde() -> anyhow::Result<()> {
-        let registration = HookRegistration {
+        #[derive(Deserialize)]
+        struct LegacyHookRegistration {
+            server: String,
+            hooks: Vec<HookSpec>,
+            schema_version: u32,
+            proto_version: u32,
+        }
+
+        let mut registration = HookRegistration {
             server: "test-hooks".to_string(),
+            display_label: None,
             hooks: vec![HookSpec {
                 event: "PreToolUse".to_string(),
                 matcher: Some("exec".to_string()),
@@ -93,9 +106,21 @@ mod tests {
         };
 
         let encoded = serde_json::to_vec(&registration)?;
+        assert!(!encoded
+            .windows(b"display_label".len())
+            .any(|window| window == b"display_label"));
         let decoded: HookRegistration = serde_json::from_slice(&encoded)?;
-
+        assert_eq!(decoded.display_label, None);
         assert_eq!(decoded, registration);
+
+        registration.display_label = Some("Friendly hook".to_string());
+        let encoded = serde_json::to_vec(&registration)?;
+        let legacy: LegacyHookRegistration = serde_json::from_slice(&encoded)?;
+        assert_eq!(legacy.server, registration.server);
+        assert_eq!(legacy.hooks, registration.hooks);
+        assert_eq!(legacy.schema_version, registration.schema_version);
+        assert_eq!(legacy.proto_version, registration.proto_version);
+
         assert_eq!(FailPolicy::default(), FailPolicy::Closed);
         assert_eq!(FailPolicy::Closed.as_str(), "closed");
         assert_eq!(FailPolicy::Open.as_str(), "open");

--- a/crates/harnx-k8s-creds/README.md
+++ b/crates/harnx-k8s-creds/README.md
@@ -37,10 +37,12 @@ Register `harnx-k8s-creds` as a persistent hook in your `harnx.yaml` or agent fr
 ```yaml
 hooks:
   entries:
-    - event: PreToolUse
-      type: claude-command-persistent
-      matcher: "bash_exec|bash_spawn"
-      command: harnx-k8s-creds --context my-cluster
+    - command: >-
+        harnx-claude-compatible-hook-server
+        --event PreToolUse
+        --matcher "bash_exec|bash_spawn"
+        --persistent
+        -- harnx-k8s-creds --context my-cluster
 ```
 
 ### Multi-Context Example
@@ -48,13 +50,15 @@ hooks:
 ```yaml
 hooks:
   entries:
-    - event: PreToolUse
-      type: claude-command-persistent
-      matcher: "bash_exec|bash_spawn"
-      command: harnx-k8s-creds --context cluster-a --context cluster-b
+    - command: >-
+        harnx-claude-compatible-hook-server
+        --event PreToolUse
+        --matcher "bash_exec|bash_spawn"
+        --persistent
+        -- harnx-k8s-creds --context cluster-a --context cluster-b
 ```
 
-**Note**: You must use `type: claude-command-persistent` to ensure the credential server stays alive across multiple tool calls.
+**Note**: The `--persistent` flag keeps the credential server alive across multiple tool calls, avoiding the overhead of credential resolution on each request.
 
 ## CLI Flags
 

--- a/crates/harnx-proxy-auth/src/cli.rs
+++ b/crates/harnx-proxy-auth/src/cli.rs
@@ -2,6 +2,10 @@ use clap::Parser;
 
 #[derive(Debug, Parser)]
 pub struct Args {
+    /// Hook server name assigned by the supervisor.
+    #[arg(long, value_name = "NAME")]
+    pub name: Option<String>,
+
     /// jq/jaq filter or exec hook applied to each request. Input is a JSON
     /// object with fields: host, path, method, headers (object of lowercase
     /// header names). Output should be same object, optionally with headers

--- a/crates/harnx-proxy-auth/src/hook.rs
+++ b/crates/harnx-proxy-auth/src/hook.rs
@@ -10,6 +10,8 @@ use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 pub const SERVER_NAME: &str = "proxy-auth";
 
+pub use harnx_hookset::HARNX_HOOK_NAME as HARNX_HOOK_NAME_ENV;
+
 #[derive(Deserialize)]
 struct HookRequest {
     id: String,
@@ -33,14 +35,21 @@ struct HookSpecificOutput {
 
 /// Persistent proxy and startup environment exposed as a NATS PreToolUse hook.
 pub struct ProxyAuthHook {
+    name: String,
     proxy_port: u16,
     ca_cert_path: String,
     extra_env: Map<String, Value>,
 }
 
 impl ProxyAuthHook {
-    pub fn new(proxy_port: u16, ca_cert_path: PathBuf, extra_env: Map<String, Value>) -> Self {
+    pub fn new(
+        name: String,
+        proxy_port: u16,
+        ca_cert_path: PathBuf,
+        extra_env: Map<String, Value>,
+    ) -> Self {
         Self {
+            name,
             proxy_port,
             ca_cert_path: ca_cert_path.to_string_lossy().into_owned(),
             extra_env,
@@ -51,7 +60,7 @@ impl ProxyAuthHook {
 #[async_trait]
 impl Hook for ProxyAuthHook {
     fn name(&self) -> &str {
-        SERVER_NAME
+        &self.name
     }
 
     fn hooks(&self) -> Vec<HookSpec> {

--- a/crates/harnx-proxy-auth/src/main.rs
+++ b/crates/harnx-proxy-auth/src/main.rs
@@ -19,6 +19,11 @@ async fn main() -> Result<()> {
         .init();
 
     let args = <cli::Args as Parser>::parse();
+    let hook_name = args
+        .name
+        .clone()
+        .or_else(|| std::env::var(hook::HARNX_HOOK_NAME_ENV).ok())
+        .unwrap_or_else(|| hook::SERVER_NAME.to_string());
     // Register the notice channel before starting the proxy, so exec hooks can
     // surface structured notices that the JSONL loop drains to stdout.
     let notice_rx = notice::init_channel();
@@ -78,6 +83,7 @@ async fn main() -> Result<()> {
     write_readiness(port, &ca_cert_path, &ca_cert_pem)?;
 
     run_dispatch_mode(DispatchRuntime {
+        name: hook_name,
         port,
         ca_cert_path,
         extra_env,
@@ -121,6 +127,7 @@ fn write_readiness(port: u16, ca_cert_path: &std::path::Path, ca_cert_pem: &str)
 }
 
 struct DispatchRuntime {
+    name: String,
     port: u16,
     ca_cert_path: std::path::PathBuf,
     extra_env: serde_json::Map<String, serde_json::Value>,
@@ -130,6 +137,7 @@ struct DispatchRuntime {
 
 async fn run_dispatch_mode(runtime: DispatchRuntime) -> Result<()> {
     let DispatchRuntime {
+        name,
         port,
         ca_cert_path,
         extra_env,
@@ -141,6 +149,7 @@ async fn run_dispatch_mode(runtime: DispatchRuntime) -> Result<()> {
         let _temp_dir_guard = fs_temp_dir;
         let _notice_rx_guard = notice_rx;
         return harnx_hookset_server::run_hookset_main(hook::ProxyAuthHook::new(
+            name,
             port,
             ca_cert_path,
             extra_env,

--- a/crates/harnx-proxy-auth/tests/nats_hook.rs
+++ b/crates/harnx-proxy-auth/tests/nats_hook.rs
@@ -5,7 +5,7 @@ use harnx_core::hooks::{HookEvent, HookOutcome, HookPayload, HookResultControl};
 use harnx_core::instance::InstanceId;
 use harnx_hookset::{FailPolicy, HookRegistration};
 use harnx_hookset_server::{hook_registration_key, serve_over_nats, HOOK_REGISTRY_BUCKET};
-use harnx_proxy_auth::hook::{ProxyAuthHook, SERVER_NAME};
+use harnx_proxy_auth::hook::ProxyAuthHook;
 use serde_json::{json, Map};
 use std::net::TcpListener;
 use std::path::PathBuf;
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 const TOKEN: &str = "proxy-auth-hook-test-token";
+const ASSIGNED_NAME: &str = "hook-a1b2c3d4-000";
 
 struct NatsServerHandle {
     url: String,
@@ -95,7 +96,7 @@ async fn wait_for_registration(
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         if let Ok(store) = jetstream.get_key_value(HOOK_REGISTRY_BUCKET).await {
-            let key = hook_registration_key(instance_id, SERVER_NAME);
+            let key = hook_registration_key(instance_id, ASSIGNED_NAME);
             if let Some(value) = store.get(&key).await? {
                 return serde_json::from_slice(&value).context("decode hook registration");
             }
@@ -117,7 +118,12 @@ async fn proxy_auth_registers_and_mutates_tool_env_over_nats() -> Result<()> {
     let proxy_port = 4312;
     let ca_cert_path = PathBuf::from("/tmp/proxy-auth-nats-test-ca.pem");
     let extra_env = Map::from_iter([("ACLI_CONFIG_DIR".to_string(), json!("/tmp/acli-config"))]);
-    let hook = ProxyAuthHook::new(proxy_port, ca_cert_path.clone(), extra_env);
+    let hook = ProxyAuthHook::new(
+        ASSIGNED_NAME.to_string(),
+        proxy_port,
+        ca_cert_path.clone(),
+        extra_env,
+    );
     let instance_id = InstanceId::new();
     let server_instance_id = instance_id.clone();
     let server_url = server.url.clone();
@@ -131,7 +137,7 @@ async fn proxy_auth_registers_and_mutates_tool_env_over_nats() -> Result<()> {
         .await?;
 
     let registration = wait_for_registration(&client, &instance_id).await?;
-    assert_eq!(registration.server, SERVER_NAME);
+    assert_eq!(registration.server, ASSIGNED_NAME);
     assert_eq!(registration.hooks.len(), 1);
     assert_eq!(registration.hooks[0].event, "PreToolUse");
     assert_eq!(registration.hooks[0].matcher.as_deref(), Some("exec|spawn"));
@@ -149,7 +155,7 @@ async fn proxy_auth_registers_and_mutates_tool_env_over_nats() -> Result<()> {
     };
     let message = client
         .request(
-            instance_id.hook_subject(SERVER_NAME, "PreToolUse"),
+            instance_id.hook_subject(ASSIGNED_NAME, "PreToolUse"),
             serde_json::to_vec(&payload)?.into(),
         )
         .await?;

--- a/crates/harnx-runtime/src/agent_loop.rs
+++ b/crates/harnx-runtime/src/agent_loop.rs
@@ -424,12 +424,12 @@ async fn apply_round_embeddings(
     Ok(())
 }
 
-async fn user_prompt_blocked(
+async fn user_prompt_block_reason(
     ctx: &AgentLoopContext,
     input: &Input,
     turn: &TurnHookContext,
     resume_count: u32,
-) -> bool {
+) -> Option<String> {
     let outcome = dispatch_agent_loop_hook(AgentHookDispatch {
         ctx,
         event: HookEvent::UserPromptSubmit {
@@ -440,7 +440,29 @@ async fn user_prompt_blocked(
         resume_count,
     })
     .await;
-    matches!(outcome.control, HookResultControl::Block { .. })
+    match outcome.control {
+        HookResultControl::Block { reason } => Some(reason),
+        _ => None,
+    }
+}
+
+fn emit_user_prompt_block_notice(reason: String) {
+    harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Notice(
+        harnx_core::event::NoticeEvent::Error(reason),
+    ));
+}
+
+async fn user_prompt_gate_passes(
+    ctx: &AgentLoopContext,
+    input: &Input,
+    turn: &TurnHookContext,
+    resume_count: u32,
+) -> bool {
+    let Some(reason) = user_prompt_block_reason(ctx, input, turn, resume_count).await else {
+        return true;
+    };
+    emit_user_prompt_block_notice(reason);
+    false
 }
 
 type AgentModelResult = Result<(String, Option<String>, Vec<ToolCall>, CompletionTokenUsage)>;
@@ -756,7 +778,7 @@ async fn run_agent_loop_inner(
         config.write().before_chat_completion(&input)?;
 
         let turn = turn_hook_context(ctx);
-        if user_prompt_blocked(ctx, &input, &turn, resume_count).await {
+        if !user_prompt_gate_passes(ctx, &input, &turn, resume_count).await {
             break;
         }
 
@@ -869,7 +891,7 @@ mod tests {
     use super::*;
     use crate::client::MessageRole;
     use crate::utils::create_abort_signal;
-    use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource, TurnEvent};
+    use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource, NoticeEvent, TurnEvent};
     use parking_lot::RwLock;
     use serde_json::json;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -889,6 +911,24 @@ mod tests {
             };
             self.events.lock().unwrap().push((event, source));
         }
+    }
+
+    #[tokio::test]
+    async fn user_prompt_block_reason_is_emitted_as_error_notice() {
+        let _guard = SINK_LOCK.lock().await;
+        let sink = Arc::new(CollectingSink::default());
+        let reason = "hook server failed to start: Friendly safety guard hook unavailable";
+
+        harnx_core::sink::with_agent_event_sink(sink.clone(), async {
+            emit_user_prompt_block_notice(reason.to_string());
+        })
+        .await;
+
+        let events = sink.events.lock().unwrap();
+        assert!(events.iter().any(|(event, source)| {
+            source.is_none()
+                && matches!(event, AgentEvent::Notice(NoticeEvent::Error(message)) if message == reason)
+        }));
     }
 
     use tempfile::TempDir;

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -258,15 +258,7 @@ async fn write_mcp_info(
         Some(hooks) if !hooks.entries.is_empty() => {
             writeln!(output, "  hooks:")?;
             for (i, hook) in hooks.entries.iter().enumerate() {
-                writeln!(
-                    output,
-                    "    [{}] {} (type: {}, matcher: {})",
-                    i + 1,
-                    hook.event,
-                    hook.hook_type,
-                    hook.matcher.as_deref().unwrap_or("*"),
-                )?;
-                writeln!(output, "        command: {}", hook.command)?;
+                writeln!(output, "    [{}] {}", i + 1, hook.command)?;
                 writeln!(output, "        transport: NATS")?;
             }
         }
@@ -1466,10 +1458,7 @@ env:
   EDITOR: "true"
 hooks:
   entries:
-    - event: PreToolUse
-      type: claude-command-persistent
-      matcher: "exec|spawn"
-      command: "harnx-proxy-auth --hook 'if .host == \"api.github.com\" then . end'"
+    - command: "harnx-proxy-auth --hook 'if .host == \"api.github.com\" then . end'"
 "#,
         );
         let mut out: Vec<u8> = Vec::new();
@@ -1483,7 +1472,7 @@ hooks:
         assert!(text.contains("--extra-rwx"), "{text}");
         assert!(text.contains("$GIT_ROOT"), "{text}");
         assert!(text.contains("EDITOR=true"), "{text}");
-        assert!(text.contains("[1] PreToolUse"), "{text}");
+        assert!(text.contains("[1] harnx-proxy-auth --hook"), "{text}");
         // The exact hook command string is preserved — this is what reveals
         // YAML-folding/arg-dropping problems in a real config.
         assert!(text.contains("harnx-proxy-auth --hook"), "{text}");

--- a/crates/harnx-runtime/src/config/tool_servers_split.rs
+++ b/crates/harnx-runtime/src/config/tool_servers_split.rs
@@ -120,11 +120,8 @@ command: harnx-time-server
 hooks:
   max_resume: 3
   entries:
-    - event: PreToolUse
-      matcher: "time"
-      command: "/path/to/hook.sh"
-      timeout: 30
-      type: claude-command
+    - command: "harnx-claude-compatible-hook-server --event PreToolUse --matcher time --timeout 30 --command /path/to/hook.sh"
+      status_message: "Checking time tool"
 "#;
         let config: ToolServerConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(config.command, "harnx-time-server");
@@ -132,11 +129,12 @@ hooks:
         assert_eq!(hooks.max_resume, Some(3));
         assert_eq!(hooks.entries.len(), 1);
         let entry = &hooks.entries[0];
-        assert_eq!(entry.event, "PreToolUse");
-        assert_eq!(entry.matcher, Some("time".to_string()));
-        assert_eq!(entry.command, "/path/to/hook.sh");
-        assert_eq!(entry.timeout, Some(30));
-        assert_eq!(entry.hook_type, "claude-command");
+        assert_eq!(
+            entry.command,
+            "harnx-claude-compatible-hook-server --event PreToolUse --matcher time --timeout 30 --command /path/to/hook.sh"
+        );
+        assert_eq!(entry.status_message.as_deref(), Some("Checking time tool"));
+        assert!(entry.async_hook.is_none());
     }
 
     #[test]
@@ -159,9 +157,6 @@ hooks:
         let hooks = config.hooks.expect("bash hooks");
         assert_eq!(hooks.entries.len(), 1);
         let hook = &hooks.entries[0];
-        assert_eq!(hook.event, "PreToolUse");
-        assert_eq!(hook.matcher.as_deref(), Some("exec|spawn"));
-        assert_eq!(hook.hook_type, "claude-command-persistent");
         assert!(hook.command.starts_with("harnx-proxy-auth --hook "));
         assert!(hook
             .command

--- a/crates/harnx-runtime/src/nats_hook_provider.rs
+++ b/crates/harnx-runtime/src/nats_hook_provider.rs
@@ -70,7 +70,14 @@ pub async fn discover_process_nats_hook_provider(config: &Config) -> Option<Arc<
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DiscoveredHook {
     pub server: String,
+    pub display_label: Option<String>,
     pub spec: HookSpec,
+}
+
+impl DiscoveredHook {
+    fn label(&self) -> &str {
+        self.display_label.as_deref().unwrap_or(&self.server)
+    }
 }
 
 #[async_trait]
@@ -394,7 +401,7 @@ async fn dispatch_pre_tool_use_with(params: PreHookDispatch<'_>, event: &HookEve
         let payload = match serde_json::to_vec(&payload) {
             Ok(payload) => payload,
             Err(error) => {
-                return unavailable_outcome(&hook.server, hook.spec.fail_policy, error);
+                return unavailable_outcome(hook, hook.spec.fail_policy, error);
             }
         };
         let subject = params.instance_id.hook_subject(&hook.server, "PreToolUse");
@@ -406,10 +413,14 @@ async fn dispatch_pre_tool_use_with(params: PreHookDispatch<'_>, event: &HookEve
         let outcome = match params.dispatcher.request(subject, payload, timeout).await {
             Ok(outcome) => outcome,
             Err(error) if hook.spec.fail_policy == FailPolicy::Open => {
-                log::warn!("{} hook unavailable; continuing: {error:#}", hook.server);
+                log::warn!(
+                    "{} hook unavailable (route {}); continuing: {error:#}",
+                    hook.label(),
+                    hook.server
+                );
                 continue;
             }
-            Err(error) => return unavailable_outcome(&hook.server, FailPolicy::Closed, error),
+            Err(error) => return unavailable_outcome(hook, FailPolicy::Closed, error),
         };
 
         match outcome.control {
@@ -449,7 +460,7 @@ async fn dispatch_blocking_event_with(params: EventDispatch<'_>, event: &HookEve
         let payload = match serde_json::to_vec(&payload) {
             Ok(payload) => payload,
             Err(error) => {
-                return unavailable_outcome(&hook.server, hook.spec.fail_policy, error);
+                return unavailable_outcome(hook, hook.spec.fail_policy, error);
             }
         };
         let subject = params
@@ -463,10 +474,14 @@ async fn dispatch_blocking_event_with(params: EventDispatch<'_>, event: &HookEve
         let outcome = match params.dispatcher.request(subject, payload, timeout).await {
             Ok(outcome) => outcome,
             Err(error) if hook.spec.fail_policy == FailPolicy::Open => {
-                log::warn!("{} hook unavailable; continuing: {error:#}", hook.server);
+                log::warn!(
+                    "{} hook unavailable (route {}); continuing: {error:#}",
+                    hook.label(),
+                    hook.server
+                );
                 continue;
             }
-            Err(error) => return unavailable_outcome(&hook.server, FailPolicy::Closed, error),
+            Err(error) => return unavailable_outcome(hook, FailPolicy::Closed, error),
         };
 
         let texts = [
@@ -500,6 +515,7 @@ async fn dispatch_one_best_effort_hook(
     params: BestEffortHookDispatch,
 ) {
     let server = &params.hook.server;
+    let label = params.hook.label();
     let event_name = params.payload.hook_event.event_name();
     let timeout = params
         .hook
@@ -510,9 +526,10 @@ async fn dispatch_one_best_effort_hook(
     let payload = match serde_json::to_vec(&params.payload) {
         Ok(payload) => payload,
         Err(error) => {
-            emit_post_notice(format!(
-                "{server} hook request could not be serialized: {error}"
-            ));
+            emit_post_notice(
+                format!("{label} hook request could not be serialized: {error}"),
+                server,
+            );
             return;
         }
     };
@@ -523,16 +540,22 @@ async fn dispatch_one_best_effort_hook(
                 FailPolicy::Closed => "fail-closed",
                 FailPolicy::Open => "fail-open",
             };
-            emit_post_notice(format!("{server} hook unavailable ({policy}): {error:#}"));
+            emit_post_notice(
+                format!("{label} hook unavailable ({policy}): {error:#}"),
+                server,
+            );
             return;
         }
     };
 
     if !matches!(outcome.control, HookResultControl::Continue) {
-        emit_post_notice(format!(
-            "{server} hook returned {:?} during best-effort {event_name} dispatch",
-            outcome.control
-        ));
+        emit_post_notice(
+            format!(
+                "{label} hook returned {:?} during best-effort {event_name} dispatch",
+                outcome.control
+            ),
+            server,
+        );
     }
     if outcome.result.mutated_tool_input.is_some() || outcome.result.mutated_tool_response.is_some()
     {
@@ -606,25 +629,27 @@ fn continue_outcome(mutated_tool_input: Option<serde_json::Value>) -> HookOutcom
 }
 
 fn unavailable_outcome(
-    server: &str,
+    hook: &DiscoveredHook,
     fail_policy: FailPolicy,
     error: impl std::fmt::Display,
 ) -> HookOutcome {
+    let label = hook.label();
+    let server = &hook.server;
     if fail_policy == FailPolicy::Open {
-        log::warn!("{server} hook unavailable; continuing: {error}");
+        log::warn!("{label} hook unavailable (route {server}); continuing: {error}");
         return continue_outcome(None);
     }
-    log::warn!("{server} hook unavailable; blocking: {error}");
+    log::warn!("{label} hook unavailable (route {server}); blocking: {error}");
     HookOutcome {
         control: HookResultControl::Block {
-            reason: format!("{server} hook unavailable"),
+            reason: format!("{label} hook unavailable"),
         },
         result: HookResult::default(),
     }
 }
 
-fn emit_post_notice(message: String) {
-    log::warn!("{message}");
+fn emit_post_notice(message: String, server: &str) {
+    log::warn!("{message} (route {server})");
     harnx_core::sink::emit_agent_event(AgentEvent::Notice(NoticeEvent::Error(message)));
 }
 
@@ -632,19 +657,24 @@ fn hooks_or_fail_closed_guard(snapshot: Result<Vec<DiscoveredHook>>) -> Vec<Disc
     match snapshot {
         Ok(hooks) => hooks,
         Err(error) => {
-            log::warn!(
-                "NATS hook discovery failed; installing fail-closed PreToolUse guard: {error:#}"
-            );
-            vec![DiscoveredHook {
+            log::warn!("NATS hook discovery failed; installing fail-closed gate guards: {error:#}");
+            [
+                ("UserPromptSubmit", None),
+                ("PreToolUse", Some(".*".to_string())),
+            ]
+            .into_iter()
+            .map(|(event, matcher)| DiscoveredHook {
                 server: "hook-registry-unavailable".to_string(),
+                display_label: None,
                 spec: HookSpec {
-                    event: "PreToolUse".to_string(),
-                    matcher: Some(".*".to_string()),
+                    event: event.to_string(),
+                    matcher,
                     priority: i32::MIN,
                     timeout_secs: Some(1),
                     fail_policy: FailPolicy::Closed,
                 },
-            }]
+            })
+            .collect()
         }
     }
 }
@@ -727,6 +757,7 @@ async fn bucket_snapshot(
         }
         hooks.extend(registration.hooks.into_iter().map(|spec| DiscoveredHook {
             server: registration.server.clone(),
+            display_label: registration.display_label.clone(),
             spec,
         }));
     }
@@ -788,6 +819,7 @@ mod tests {
     fn hook(server: &str, event: &str, matcher: Option<&str>, priority: i32) -> DiscoveredHook {
         DiscoveredHook {
             server: server.to_string(),
+            display_label: None,
             spec: HookSpec {
                 event: event.to_string(),
                 matcher: matcher.map(str::to_string),
@@ -879,9 +911,10 @@ mod tests {
     #[test]
     fn priority_sort_uses_server_then_registry_order_as_tiebreakers() {
         let hooks = vec![
-            hook("zeta", "PreToolUse", None, 10),
-            hook("alpha", "PreToolUse", None, 10),
-            hook("alpha", "PreToolUse", None, 10),
+            hook("hook-a1b2c3d4-010", "PreToolUse", None, 10),
+            hook("hook-a1b2c3d4-002", "PreToolUse", None, 10),
+            hook("hook-a1b2c3d4-001", "PreToolUse", None, 10),
+            hook("hook-a1b2c3d4-002", "PreToolUse", None, 10),
             hook("later", "PreToolUse", None, 20),
             hook("first", "PreToolUse", None, -1),
         ];
@@ -895,14 +928,15 @@ mod tests {
             positions,
             [
                 ("first", -1),
-                ("alpha", 10),
-                ("alpha", 10),
-                ("zeta", 10),
+                ("hook-a1b2c3d4-001", 10),
+                ("hook-a1b2c3d4-002", 10),
+                ("hook-a1b2c3d4-002", 10),
+                ("hook-a1b2c3d4-010", 10),
                 ("later", 20),
             ]
         );
-        assert!(std::ptr::eq(selected[1], &hooks[1]));
-        assert!(std::ptr::eq(selected[2], &hooks[2]));
+        assert!(std::ptr::eq(selected[2], &hooks[1]));
+        assert!(std::ptr::eq(selected[3], &hooks[3]));
     }
 
     #[tokio::test]
@@ -1378,23 +1412,38 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discovery_read_failure_guard_blocks_pre_tool_use() {
+    async fn discovery_read_failure_guard_blocks_both_gate_events() {
         let hooks = hooks_or_fail_closed_guard(Err(anyhow::anyhow!("KV read failed")));
+        assert_eq!(hooks.len(), 2);
         let dispatcher = stub(Vec::new());
         let provider =
             NatsHookProvider::from_dispatcher(InstanceId::from_string("test"), hooks, dispatcher);
-        let outcome = provider
+        let meta = || HookDispatchMeta {
+            session_id: "session".to_string(),
+            cwd: PathBuf::from("/tmp"),
+            resume_count: 0,
+        };
+
+        let prompt_outcome = provider
             .dispatch_event(
-                pre_event(json!({"command": "true"})),
-                None,
-                HookDispatchMeta {
-                    session_id: "session".to_string(),
-                    cwd: PathBuf::from("/tmp"),
-                    resume_count: 0,
+                HookEvent::UserPromptSubmit {
+                    prompt: "continue?".to_string(),
                 },
+                None,
+                meta(),
             )
             .await;
+        let tool_outcome = provider
+            .dispatch_event(pre_event(json!({"command": "true"})), None, meta())
+            .await;
 
-        assert!(matches!(outcome.control, HookResultControl::Block { .. }));
+        assert!(matches!(
+            prompt_outcome.control,
+            HookResultControl::Block { .. }
+        ));
+        assert!(matches!(
+            tool_outcome.control,
+            HookResultControl::Block { .. }
+        ));
     }
 }

--- a/crates/harnx-runtime/src/nats_worker/agent_loop.rs
+++ b/crates/harnx-runtime/src/nats_worker/agent_loop.rs
@@ -525,7 +525,13 @@ pub async fn reconcile_hook_supervisor(
     }
     match HookServerSupervisor::start_local(start.clone(), hooks, scope).await {
         Ok(supervisor) => *current = Some(supervisor),
-        Err(error) => log::warn!("session NATS hook servers disabled: {error:#}"),
+        Err(error) => {
+            // Failures happen before the supervisor can own cleanup or while its KV
+            // route is unavailable. Publishing here would either reuse the failed
+            // route or leave an unowned rejector after the session ends. Registry
+            // read failures are guarded by NatsHookProvider instead.
+            log::warn!("session NATS hook servers disabled: {error:#}");
+        }
     }
 }
 
@@ -1212,13 +1218,9 @@ mod tests {
                 hooks: Some(harnx_core::hooks::HooksConfig {
                     max_resume: None,
                     entries: vec![harnx_core::hooks::HookConfig {
-                        event: "SessionStart".to_string(),
-                        matcher: None,
-                        command: "echo global".to_string(),
-                        timeout: Some(30),
+                        command: "harnx-claude-compatible-hook-server --event SessionStart --timeout 30 --command 'echo global'".to_string(),
                         status_message: None,
                         async_hook: None,
-                        hook_type: "claude-command".to_string(),
                         package_dir: None,
                     }],
                 }),
@@ -1234,18 +1236,14 @@ mod tests {
     #[test]
     fn session_hook_resolution_keeps_agent_override_of_global_hook() {
         let global_hook = harnx_core::hooks::HookConfig {
-            event: "SessionStart".to_string(),
-            matcher: None,
-            command: "echo global".to_string(),
-            timeout: Some(30),
+            command: "harnx-claude-compatible-hook-server --event SessionStart --timeout 30 --command 'echo global'".to_string(),
             status_message: None,
             async_hook: None,
-            hook_type: "claude-command".to_string(),
             package_dir: None,
         };
         let agent_config = harnx_core::agent_config::AgentConfig::from_markdown(
             "override-agent",
-            "---\nhooks:\n  entries:\n    - event: SessionStart\n      command: echo agent\n      type: claude-command\n---\nprompt",
+            "---\nhooks:\n  entries:\n    - command: harnx-claude-compatible-hook-server --event SessionStart --timeout 30 --command 'echo agent'\n---\nprompt",
         )
         .expect("agent config");
         let config = Config {
@@ -1263,7 +1261,10 @@ mod tests {
 
         let hooks = agent_resolved_hooks(&config);
         assert_eq!(hooks.entries.len(), 1);
-        assert_eq!(hooks.entries[0].command, "echo agent");
+        assert_eq!(
+            hooks.entries[0].command,
+            "harnx-claude-compatible-hook-server --event SessionStart --timeout 30 --command 'echo agent'"
+        );
     }
 
     #[test]

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -341,6 +341,10 @@ async fn start_global_hooks(
     match result {
         Ok(supervisor) => Some(supervisor),
         Err(error) => {
+            // Failures happen before the supervisor can own cleanup or while its KV
+            // route is unavailable. Publishing here would either reuse the failed
+            // route or leave an unowned rejector behind after worker shutdown. Keep
+            // the worker available; unreadable registries fail closed at discovery.
             log::warn!("global NATS hook servers disabled: {error:#}");
             None
         }

--- a/crates/harnx-runtime/src/nats_worker/hook_supervisor.rs
+++ b/crates/harnx-runtime/src/nats_worker/hook_supervisor.rs
@@ -6,22 +6,22 @@ use harnx_core::hooks::{HookConfig, HooksConfig};
 use harnx_core::instance::{InstanceId, HARNX_INSTANCE_ID};
 use harnx_hooks::executor::HARNX_PACKAGE_DIR_ENV;
 use harnx_hookset::{
-    FailPolicy, HookRegistration, HookSpec, HOOK_EXPECTATIONS_BUCKET, HOOK_PROTOCOL_VERSION,
-    HOOK_REGISTRY_BUCKET, HOOK_SCHEMA_VERSION,
+    FailPolicy, HookRegistration, HookSpec, HARNX_HOOK_NAME, HOOK_EXPECTATIONS_BUCKET,
+    HOOK_PROTOCOL_VERSION, HOOK_REGISTRY_BUCKET, HOOK_SCHEMA_VERSION,
 };
 use harnx_hookset_server::hook_registration_key;
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
+use uuid::Uuid;
 
 const HOOK_STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
-const GENERIC_HOOK_BINARY: &str = "harnx-claude-compatible-hook-server";
-const PROXY_AUTH_BINARY: &str = "harnx-proxy-auth";
+const MAX_HOOKS_PER_SUPERVISOR: usize = 999;
 
 /// Connection and identity shared by hook servers spawned for one worker.
 #[derive(Clone)]
@@ -69,9 +69,10 @@ impl HookServerSupervisor {
     pub async fn start_local_with_timeout(
         config: HookServerStartConfig,
         hooks: &HooksConfig,
-        scope: &str,
+        _scope: &str,
         readiness_timeout: Duration,
     ) -> Result<Self> {
+        let run_id = Uuid::new_v4().simple().to_string()[..8].to_string();
         let processes = Arc::new(Mutex::new(HashMap::new()));
         let mut supervisor = Self {
             processes: Arc::clone(&processes),
@@ -80,25 +81,27 @@ impl HookServerSupervisor {
             instance_id: config.instance_id.clone(),
             registrations: Vec::new(),
         };
-        let enabled: Vec<_> = hooks
-            .entries
-            .iter()
-            .enumerate()
-            .filter(|(_, hook)| hook.is_supported_type())
-            .collect();
+        let enabled: Vec<_> = hooks.entries.iter().collect();
+        validate_hook_count(enabled.len())?;
         if enabled.is_empty() {
             return Ok(supervisor);
         }
+        let launch_plan: Vec<_> = enabled
+            .into_iter()
+            .enumerate()
+            .map(|(order_index, hook)| HookLaunch {
+                order_index,
+                name: hook_server_name(&run_id, order_index),
+                hook,
+            })
+            .collect();
 
-        let watches = prepare_hook_registrations(&config, &enabled, scope, &mut supervisor).await?;
-        spawn_enabled_hooks(&config, enabled, scope, &mut supervisor).await;
-        wait_for_hook_registrations(
-            watches,
-            &processes,
-            Instant::now() + readiness_timeout,
-            readiness_timeout,
-        )
-        .await;
+        let prepared = prepare_hook_registrations(&config, &launch_plan, &mut supervisor).await?;
+        let startups = spawn_enabled_hooks(&config, prepared, &mut supervisor).await?;
+        let monitors =
+            start_hook_servers(startups, &config, Arc::clone(&processes), readiness_timeout)
+                .await?;
+        supervisor.tasks.extend(monitors);
         Ok(supervisor)
     }
 
@@ -117,130 +120,258 @@ impl HookServerSupervisor {
     }
 }
 
-type RegistrationWatch = (String, String, kv::Watch);
+fn validate_hook_count(count: usize) -> Result<()> {
+    if count > MAX_HOOKS_PER_SUPERVISOR {
+        bail!("hook supervisor supports at most {MAX_HOOKS_PER_SUPERVISOR} hooks, got {count}");
+    }
+    Ok(())
+}
+
+struct HookLaunch<'a> {
+    order_index: usize,
+    name: String,
+    hook: &'a HookConfig,
+}
+
+struct PreparedHook {
+    order_index: usize,
+    name: String,
+    key: String,
+    rejector_name: String,
+    display_label: String,
+    failure_label: String,
+    hook: HookConfig,
+    watch: kv::Watch,
+}
+
+struct HookStartup {
+    name: String,
+    key: String,
+    rejector_name: String,
+    display_label: String,
+    failure_label: String,
+    watch: kv::Watch,
+    child: Child,
+    pid: u32,
+}
+
+struct HookMonitor {
+    child: Child,
+    pid: u32,
+    server: String,
+    display_label: String,
+    registration: HookRegistration,
+    instance_id: InstanceId,
+    client: async_nats::Client,
+    processes: Arc<Mutex<HashMap<u32, String>>>,
+}
 
 async fn prepare_hook_registrations(
     config: &HookServerStartConfig,
-    enabled: &[(usize, &HookConfig)],
-    scope: &str,
+    launch_plan: &[HookLaunch<'_>],
     supervisor: &mut HookServerSupervisor,
-) -> Result<Vec<RegistrationWatch>> {
+) -> Result<Vec<PreparedHook>> {
     let registry = ensure_bucket(&config.client, HOOK_REGISTRY_BUCKET).await?;
     let expectations = ensure_bucket(&config.client, HOOK_EXPECTATIONS_BUCKET).await?;
-    let mut watches = Vec::new();
-    for (index, hook) in enabled {
-        let name = hook_server_name(scope, *index, hook);
-        let key = hook_registration_key(&config.instance_id, &name);
-        let _ = registry.delete(&key).await;
-        let watch = registry
-            .watch_with_history(&key)
-            .await
-            .with_context(|| format!("watch hook registration '{key}'"))?;
-        publish_expectation(&expectations, &key, &name, hook).await?;
-        supervisor.registrations.push(name.clone());
-        watches.push((name, key, watch));
+    let mut prepared = Vec::new();
+    for launch in launch_plan {
+        let key = hook_registration_key(&config.instance_id, &launch.name);
+        let rejector_name = format!("{}-rejector", launch.name);
+        supervisor.registrations.push(launch.name.clone());
+        supervisor.registrations.push(rejector_name.clone());
+        let display_label = hook_display_label(launch.hook);
+        let failure_label = startup_failure_label(launch.hook);
+
+        if let Err(error) = registry.delete(&key).await {
+            publish_startup_rejector(
+                &expectations,
+                &config.instance_id,
+                &rejector_name,
+                &failure_label,
+            )
+            .await?;
+            log::warn!(
+                "hook server '{}' startup rejected because stale registration '{}' could not be deleted: {error:#}",
+                launch.name,
+                key
+            );
+            continue;
+        }
+
+        let watch = match registry.watch_with_history(&key).await {
+            Ok(watch) => watch,
+            Err(error) => {
+                publish_startup_rejector(
+                    &expectations,
+                    &config.instance_id,
+                    &rejector_name,
+                    &failure_label,
+                )
+                .await?;
+                log::warn!(
+                    "hook server '{}' registration watch failed: {error:#}",
+                    launch.name
+                );
+                continue;
+            }
+        };
+        prepared.push(PreparedHook {
+            order_index: launch.order_index,
+            name: launch.name.clone(),
+            key,
+            rejector_name,
+            display_label,
+            failure_label,
+            hook: launch.hook.clone(),
+            watch,
+        });
     }
-    Ok(watches)
+    Ok(prepared)
 }
 
 async fn spawn_enabled_hooks(
     config: &HookServerStartConfig,
-    enabled: Vec<(usize, &HookConfig)>,
-    scope: &str,
+    prepared: Vec<PreparedHook>,
     supervisor: &mut HookServerSupervisor,
-) {
-    for (index, hook) in enabled {
-        let name = hook_server_name(scope, index, hook);
-        let child = match spawn_hook_server(config, hook, &name) {
+) -> Result<Vec<HookStartup>> {
+    let expectations = ensure_bucket(&config.client, HOOK_EXPECTATIONS_BUCKET).await?;
+    let mut startups = Vec::new();
+    for prepared in prepared {
+        let mut child = match spawn_hook_server(config, &prepared.hook, &prepared.name) {
             Ok(child) => child,
             Err(error) => {
+                publish_startup_rejector(
+                    &expectations,
+                    &config.instance_id,
+                    &prepared.rejector_name,
+                    &prepared.failure_label,
+                )
+                .await?;
                 log::warn!(
-                    "hook server '{name}' failed to start; fail-closed expectation remains: {error:#}"
+                    "hook server #{index} '{name}' failed to spawn: {error:#}",
+                    index = prepared.order_index,
+                    name = prepared.name
                 );
                 continue;
             }
         };
         let Some(pid) = child.id() else {
-            log::warn!("hook server '{name}' has no process ID; fail-closed expectation remains");
+            let _ = child.start_kill();
+            publish_startup_rejector(
+                &expectations,
+                &config.instance_id,
+                &prepared.rejector_name,
+                &prepared.failure_label,
+            )
+            .await?;
+            log::warn!("hook server '{}' has no process ID", prepared.name);
             continue;
         };
-        supervisor.processes.lock().await.insert(pid, name.clone());
-        supervisor.tasks.push(spawn_child_monitor(
+        supervisor
+            .processes
+            .lock()
+            .await
+            .insert(pid, prepared.name.clone());
+        startups.push(HookStartup {
+            name: prepared.name,
+            key: prepared.key,
+            rejector_name: prepared.rejector_name,
+            display_label: prepared.display_label,
+            failure_label: prepared.failure_label,
+            watch: prepared.watch,
             child,
             pid,
-            name,
-            config.instance_id.clone(),
-            config.client.clone(),
-            Arc::clone(&supervisor.processes),
-        ));
+        });
     }
+    Ok(startups)
 }
 
-async fn wait_for_hook_registrations(
-    watches: Vec<RegistrationWatch>,
-    processes: &Arc<Mutex<HashMap<u32, String>>>,
-    deadline: Instant,
+async fn start_hook_servers(
+    startups: Vec<HookStartup>,
+    config: &HookServerStartConfig,
+    processes: Arc<Mutex<HashMap<u32, String>>>,
     readiness_timeout: Duration,
-) {
-    let readiness = watches.into_iter().map(|(name, key, mut watch)| {
-        let processes = Arc::clone(processes);
-        async move {
-            if let Err(error) = wait_for_registration(
-                &mut watch,
-                &processes,
-                &name,
-                &key,
-                deadline,
-                readiness_timeout,
-            )
-            .await
-            {
-                log::warn!(
-                    "hook server '{name}' unavailable; fail-closed expectation remains: {error:#}"
-                );
-            }
-        }
+) -> Result<Vec<JoinHandle<()>>> {
+    let starts = startups.into_iter().map(|startup| {
+        let config = config.clone();
+        let processes = Arc::clone(&processes);
+        async move { start_hook_server(startup, config, processes, readiness_timeout).await }
     });
-    futures_util::future::join_all(readiness).await;
+    let mut monitors = Vec::new();
+    for result in futures_util::future::join_all(starts).await {
+        if let Some(monitor) = result? {
+            monitors.push(monitor);
+        }
+    }
+    Ok(monitors)
 }
 
-impl Drop for HookServerSupervisor {
-    fn drop(&mut self) {
-        for task in &self.tasks {
-            task.abort();
+async fn start_hook_server(
+    startup: HookStartup,
+    config: HookServerStartConfig,
+    processes: Arc<Mutex<HashMap<u32, String>>>,
+    readiness_timeout: Duration,
+) -> Result<Option<JoinHandle<()>>> {
+    let HookStartup {
+        name,
+        key,
+        rejector_name,
+        display_label,
+        failure_label,
+        mut watch,
+        mut child,
+        pid,
+    } = startup;
+
+    let readiness = tokio::select! {
+        registration = wait_for_registration(&mut watch, &name, &key) => registration,
+        status = child.wait() => match status {
+            Ok(status) => Err(anyhow::anyhow!(
+                "hook server '{name}' exited with {status} before registering at '{key}'"
+            )),
+            Err(error) => Err(error).with_context(|| format!("wait for hook server '{name}' during startup")),
+        },
+        _ = tokio::time::sleep(readiness_timeout) => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            Err(anyhow::anyhow!(
+                "hook server '{name}' did not register at '{key}' within {}s",
+                readiness_timeout.as_secs_f64()
+            ))
         }
-        let client = self.client.clone();
-        let instance_id = self.instance_id.clone();
-        let registrations = std::mem::take(&mut self.registrations);
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            handle.spawn(async move {
-                for server in registrations {
-                    remove_registration_and_expectation(&client, &instance_id, &server).await;
-                }
-            });
+    };
+
+    match readiness {
+        Ok(registration) => Ok(Some(spawn_child_monitor(HookMonitor {
+            child,
+            pid,
+            server: name,
+            display_label,
+            registration,
+            instance_id: config.instance_id,
+            client: config.client,
+            processes,
+        }))),
+        Err(error) => {
+            processes.lock().await.remove(&pid);
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            let expectations = ensure_bucket(&config.client, HOOK_EXPECTATIONS_BUCKET).await?;
+            publish_startup_rejector(
+                &expectations,
+                &config.instance_id,
+                &rejector_name,
+                &failure_label,
+            )
+            .await?;
+            log::warn!("hook server '{name}' failed during startup: {error:#}");
+            Ok(None)
         }
     }
 }
 
-fn hook_server_name(scope: &str, index: usize, hook: &HookConfig) -> String {
-    if is_proxy_auth_command(&hook.command) {
-        return "proxy-auth".to_string();
-    }
-    let scope = sanitize_name(scope);
-    let event = sanitize_name(&hook.event);
-    format!("{scope}-{event}-{index}")
-}
-
-fn sanitize_name(value: &str) -> String {
-    let value: String = value
-        .chars()
-        .map(|ch| if is_server_name_char(ch) { ch } else { '-' })
-        .collect();
-    value.trim_matches('-').to_string()
-}
-
-fn is_server_name_char(ch: char) -> bool {
-    ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_')
+fn hook_server_name(run_id: &str, order_index: usize) -> String {
+    format!("hook-{run_id}-{order_index:03}")
 }
 
 fn spawn_hook_server(
@@ -252,40 +383,23 @@ fn spawn_hook_server(
         .package_dir
         .clone()
         .unwrap_or_else(harnx_core::config_paths::config_dir);
-    let mut command = if let Some(args) = proxy_auth_args(&hook.command, &package_dir)? {
-        let binary = resolve_binary(PROXY_AUTH_BINARY)?;
-        let mut command = Command::new(&binary);
-        command.args(args);
-        command
-    } else {
-        let binary = resolve_binary(GENERIC_HOOK_BINARY)?;
-        let mut command = Command::new(&binary);
-        command
-            .arg("--name")
-            .arg(name)
-            .arg("--event")
-            .arg(&hook.event)
-            .arg("--priority")
-            .arg("0")
-            .arg("--fail-policy")
-            .arg(FailPolicy::Closed.as_str())
-            .arg("--type")
-            .arg(&hook.hook_type)
-            .arg("--command")
-            .arg(&hook.command)
-            .arg("--package-dir")
-            .arg(&package_dir);
-        if let Some(matcher) = &hook.matcher {
-            command.arg("--matcher").arg(matcher);
-        }
-        if let Some(timeout) = hook.timeout {
-            command.arg("--timeout").arg(timeout.to_string());
-        }
-        command
-    };
+    let mut words = shell_words::split(&hook.command).context("parse hook command")?;
+    if words.is_empty() {
+        bail!("hook command is empty");
+    }
+    let package_dir_value = package_dir.to_string_lossy();
+    for word in &mut words[1..] {
+        *word = word
+            .replace("${HARNX_PACKAGE_DIR}", &package_dir_value)
+            .replace("$HARNX_PACKAGE_DIR", &package_dir_value);
+    }
+    let binary = resolve_binary(&words[0])?;
+    let mut command = Command::new(binary);
+    command.args(&words[1..]);
 
     command
         .env(HARNX_PACKAGE_DIR_ENV, package_dir)
+        .env(HARNX_HOOK_NAME, name)
         .env(HARNX_INSTANCE_ID, config.instance_id.as_str())
         .env(HARNX_NATS_URL_ENV, &config.nats_url)
         .env(HARNX_NATS_TOKEN_ENV, &config.token)
@@ -297,37 +411,6 @@ fn spawn_hook_server(
     command
         .spawn()
         .with_context(|| format!("spawn hook server '{name}'"))
-}
-
-/// A command whose executable basename is `harnx-proxy-auth` is already a
-/// native hook server. Its remaining words are forwarded as normal CLI flags.
-fn proxy_auth_args(command: &str, package_dir: &Path) -> Result<Option<Vec<String>>> {
-    let words = shell_words::split(command).context("parse hook command")?;
-    if !is_proxy_auth_words(&words) {
-        return Ok(None);
-    }
-    let package_dir = package_dir.to_string_lossy();
-    let args = words
-        .into_iter()
-        .skip(1)
-        .map(|word| {
-            word.replace("${HARNX_PACKAGE_DIR}", &package_dir)
-                .replace("$HARNX_PACKAGE_DIR", &package_dir)
-        })
-        .collect();
-    Ok(Some(args))
-}
-
-fn is_proxy_auth_command(command: &str) -> bool {
-    shell_words::split(command).is_ok_and(|words| is_proxy_auth_words(&words))
-}
-
-fn is_proxy_auth_words(words: &[String]) -> bool {
-    words
-        .first()
-        .and_then(|program| Path::new(program).file_name())
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name == PROXY_AUTH_BINARY || name == "harnx-proxy-auth.exe")
 }
 
 fn resolve_binary(binary: &str) -> Result<PathBuf> {
@@ -356,66 +439,148 @@ fn resolve_binary(binary: &str) -> Result<PathBuf> {
     })
 }
 
-fn spawn_child_monitor(
-    mut child: Child,
-    pid: u32,
-    server: String,
-    instance_id: InstanceId,
-    client: async_nats::Client,
-    processes: Arc<Mutex<HashMap<u32, String>>>,
-) -> JoinHandle<()> {
+fn spawn_child_monitor(monitor: HookMonitor) -> JoinHandle<()> {
     tokio::spawn(async move {
+        let HookMonitor {
+            mut child,
+            pid,
+            server,
+            display_label,
+            registration,
+            instance_id,
+            client,
+            processes,
+        } = monitor;
         let status = child.wait().await;
         processes.lock().await.remove(&pid);
-        remove_registration(&client, &instance_id, &server).await;
-        // Keep the supervisor's expectation after an unexpected exit. Discovery
-        // will route to the absent server and apply its fail-closed policy.
-        match status {
-            Ok(status) if status.success() => log::debug!("hook server '{server}' exited"),
-            Ok(status) => log::warn!("hook server '{server}' exited with {status}"),
-            Err(error) => log::warn!("hook server '{server}' wait failed: {error}"),
-        }
+        replace_crashed_hook_route(
+            &client,
+            &instance_id,
+            &server,
+            crash_marker(registration, display_label),
+        )
+        .await;
+        log_child_exit(&server, status);
     })
+}
+
+fn crash_marker(mut registration: HookRegistration, display_label: String) -> HookRegistration {
+    registration.display_label = Some(display_label);
+    for hook in &mut registration.hooks {
+        hook.fail_policy = FailPolicy::Closed;
+    }
+    registration
+}
+
+async fn replace_crashed_hook_route(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+    server: &str,
+    marker: HookRegistration,
+) {
+    let key = hook_registration_key(instance_id, server);
+    let rejector_name = format!("{server}-rejector");
+    let rejector_label: String = format!(
+        "hook server crashed: {}",
+        marker.display_label.as_deref().unwrap_or(server)
+    )
+    .chars()
+    .take(120)
+    .collect();
+
+    // Publish before deleting the live registration so discovery never sees
+    // an empty route set. If both publications fail, retain the live route.
+    let route = publish_marker_or_rejector(
+        || async {
+            let expectations = ensure_bucket(client, HOOK_EXPECTATIONS_BUCKET).await?;
+            publish_registration(&expectations, &key, &marker).await
+        },
+        || publish_crash_rejector(client, instance_id, &rejector_name, &rejector_label),
+    )
+    .await;
+    finish_crash_route(
+        CrashRouteContext {
+            client,
+            instance_id,
+            server,
+            rejector_name: &rejector_name,
+        },
+        route,
+    )
+    .await;
+}
+
+struct CrashRouteContext<'a> {
+    client: &'a async_nats::Client,
+    instance_id: &'a InstanceId,
+    server: &'a str,
+    rejector_name: &'a str,
+}
+
+async fn finish_crash_route(context: CrashRouteContext<'_>, route: Result<CrashRoute>) {
+    let CrashRouteContext {
+        client,
+        instance_id,
+        server,
+        rejector_name,
+    } = context;
+    match route {
+        Ok(CrashRoute::Marker) => remove_registration(client, instance_id, server).await,
+        Ok(CrashRoute::Rejector) => {
+            log::warn!("hook server '{server}' crash marker failed; installed fail-closed rejector '{rejector_name}'");
+            remove_registration(client, instance_id, server).await;
+        }
+        Err(error) => {
+            log::error!("failed to install any fail-closed route for crashed hook server '{server}': {error:#}");
+        }
+    }
+}
+
+fn log_child_exit(server: &str, status: std::io::Result<std::process::ExitStatus>) {
+    match status {
+        Ok(status) if status.success() => log::debug!("hook server '{server}' exited"),
+        Ok(status) => log::warn!("hook server '{server}' exited with {status}"),
+        Err(error) => log::warn!("hook server '{server}' wait failed: {error}"),
+    }
+}
+
+struct RegistrationExpectation<'a> {
+    server: &'a str,
+    key: &'a str,
 }
 
 async fn wait_for_registration(
     watch: &mut kv::Watch,
-    processes: &Arc<Mutex<HashMap<u32, String>>>,
     server: &str,
     key: &str,
-    deadline: Instant,
-    timeout: Duration,
-) -> Result<()> {
+) -> Result<HookRegistration> {
     loop {
-        if !processes.lock().await.values().any(|name| name == server) {
-            bail!("hook server '{server}' exited before registering at '{key}'");
+        let Some(entry) = watch.next().await else {
+            bail!("hook registration watch closed for '{key}'");
+        };
+        let entry = entry.with_context(|| format!("watch hook registration '{key}'"))?;
+        if entry.operation != kv::Operation::Put {
+            continue;
         }
-        let now = Instant::now();
-        if now >= deadline {
-            bail!(
-                "hook server '{server}' did not register at '{key}' within {}s",
-                timeout.as_secs_f64()
-            );
-        }
-        let poll = deadline
-            .saturating_duration_since(now)
-            .min(Duration::from_millis(100));
-        match tokio::time::timeout(poll, watch.next()).await {
-            Ok(Some(Ok(entry))) if entry.operation == kv::Operation::Put => {
-                let registration: HookRegistration = serde_json::from_slice(&entry.value)
-                    .with_context(|| format!("decode hook registration '{key}'"))?;
-                if registration.server == server {
-                    return Ok(());
-                }
-            }
-            Ok(Some(Ok(_))) => {}
-            Ok(Some(Err(error))) => {
-                return Err(error).with_context(|| format!("watch hook registration '{key}'"));
-            }
-            Ok(None) => bail!("hook registration watch closed for '{key}'"),
-            Err(_) => continue,
-        }
+        return decode_expected_registration(&entry.value, RegistrationExpectation { server, key });
     }
+}
+
+fn decode_expected_registration(
+    value: &[u8],
+    expected: RegistrationExpectation<'_>,
+) -> Result<HookRegistration> {
+    let registration: HookRegistration = serde_json::from_slice(value)
+        .with_context(|| format!("decode hook registration '{}'", expected.key))?;
+    if registration.server != expected.server {
+        bail!(
+            "hook registration '{}' declared server '{}' instead of assigned name '{}'",
+            expected.key,
+            registration.server,
+            expected.server
+        );
+    }
+    Ok(registration)
 }
 
 async fn ensure_bucket(client: &async_nats::Client, bucket: &str) -> Result<kv::Store> {
@@ -439,25 +604,121 @@ async fn ensure_bucket(client: &async_nats::Client, bucket: &str) -> Result<kv::
     }
 }
 
-async fn publish_expectation(
-    store: &kv::Store,
-    key: &str,
-    server: &str,
-    hook: &HookConfig,
-) -> Result<()> {
-    let registration = HookRegistration {
+fn hook_display_label(hook: &HookConfig) -> String {
+    hook.status_message
+        .as_deref()
+        .unwrap_or(&hook.command)
+        .chars()
+        .take(120)
+        .collect()
+}
+
+fn startup_failure_label(hook: &HookConfig) -> String {
+    format!("hook server failed to start: {}", hook_display_label(hook))
+        .chars()
+        .take(120)
+        .collect()
+}
+
+fn fail_closed_rejector(server: &str, display_label: &str) -> HookRegistration {
+    HookRegistration {
         server: server.to_string(),
-        hooks: vec![HookSpec {
-            event: hook.event.clone(),
-            matcher: hook.matcher.clone(),
-            priority: 0,
-            timeout_secs: hook.timeout,
-            fail_policy: FailPolicy::Closed,
-        }],
+        display_label: Some(display_label.to_string()),
+        hooks: vec![
+            HookSpec {
+                event: "UserPromptSubmit".to_string(),
+                matcher: None,
+                priority: 0,
+                timeout_secs: None,
+                fail_policy: FailPolicy::Closed,
+            },
+            HookSpec {
+                event: "PreToolUse".to_string(),
+                matcher: Some(".*".to_string()),
+                priority: 0,
+                timeout_secs: None,
+                fail_policy: FailPolicy::Closed,
+            },
+        ],
         schema_version: HOOK_SCHEMA_VERSION,
         proto_version: HOOK_PROTOCOL_VERSION,
-    };
-    let payload = serde_json::to_vec(&registration).context("encode hook expectation")?;
+    }
+}
+
+async fn publish_startup_rejector(
+    store: &kv::Store,
+    instance_id: &InstanceId,
+    server: &str,
+    display_label: &str,
+) -> Result<()> {
+    let registration = fail_closed_rejector(server, display_label);
+    let key = hook_registration_key(instance_id, server);
+    publish_registration(store, &key, &registration).await
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum CrashRoute {
+    Marker,
+    Rejector,
+}
+
+async fn publish_marker_or_rejector<M, MFut, R, RFut>(
+    publish_marker: M,
+    publish_rejector: R,
+) -> Result<CrashRoute>
+where
+    M: FnOnce() -> MFut,
+    MFut: std::future::Future<Output = Result<()>>,
+    R: FnOnce() -> RFut,
+    RFut: std::future::Future<Output = Result<()>>,
+{
+    match publish_marker().await {
+        Ok(()) => Ok(CrashRoute::Marker),
+        Err(marker_error) => {
+            publish_rejector().await.with_context(|| {
+                format!("crash marker failed ({marker_error:#}); publish crash rejector")
+            })?;
+            Ok(CrashRoute::Rejector)
+        }
+    }
+}
+
+/// Publishes a synthetic fail-closed route after a hook server crash.
+///
+/// Exposed for integration testing of the live JetStream fallback paths.
+#[doc(hidden)]
+pub async fn publish_crash_rejector(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+    server: &str,
+    display_label: &str,
+) -> Result<()> {
+    let registration = fail_closed_rejector(server, display_label);
+    let key = hook_registration_key(instance_id, server);
+
+    let expectation_result = async {
+        let expectations = ensure_bucket(client, HOOK_EXPECTATIONS_BUCKET).await?;
+        publish_registration(&expectations, &key, &registration).await
+    }
+    .await;
+    if expectation_result.is_ok() {
+        return Ok(());
+    }
+
+    // If the expectations path itself is unavailable, the registry bucket is a
+    // second fail-closed publication path. The rejector still has no responder.
+    let registry = ensure_bucket(client, HOOK_REGISTRY_BUCKET).await?;
+    publish_registration(&registry, &key, &registration)
+        .await
+        .with_context(|| format!("publish crash rejector after {expectation_result:#?}"))
+}
+
+async fn publish_registration(
+    store: &kv::Store,
+    key: &str,
+    registration: &HookRegistration,
+) -> Result<()> {
+    let payload = serde_json::to_vec(registration).context("encode hook expectation")?;
     store
         .put(key.to_string(), payload.into())
         .await
@@ -520,43 +781,41 @@ fn configure_hook_process(_command: &mut Command) {}
 #[cfg(test)]
 mod tests {
     use super::*;
-
     #[test]
-    fn detects_proxy_auth_and_forwards_flags() {
-        let package_dir = Path::new("/packages/coding");
+    fn hook_count_limit_accepts_boundary_and_rejects_overflow() {
+        validate_hook_count(MAX_HOOKS_PER_SUPERVISOR).expect("999 hooks are supported");
+        let error = validate_hook_count(MAX_HOOKS_PER_SUPERVISOR + 1)
+            .expect_err("1000 hooks must be rejected");
         assert_eq!(
-            proxy_auth_args(
-                "harnx-proxy-auth --hook 'token helper' --hook '$HARNX_PACKAGE_DIR/hooks/jira.py' --env '$temp_file_root'",
-                package_dir,
-            )
-            .unwrap(),
-            Some(vec![
-                "--hook".to_string(),
-                "token helper".to_string(),
-                "--hook".to_string(),
-                "/packages/coding/hooks/jira.py".to_string(),
-                "--env".to_string(),
-                "$temp_file_root".to_string(),
-            ])
+            error.to_string(),
+            "hook supervisor supports at most 999 hooks, got 1000"
         );
-        assert_eq!(proxy_auth_args("echo hello", package_dir).unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn crash_marker_failure_invokes_fail_closed_rejector_fallback() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let rejector_called = AtomicBool::new(false);
+        let route = publish_marker_or_rejector(
+            || async { anyhow::bail!("marker unavailable") },
+            || async {
+                rejector_called.store(true, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .await
+        .expect("rejector fallback succeeds");
+
+        assert_eq!(route, CrashRoute::Rejector);
+        assert!(rejector_called.load(Ordering::SeqCst));
     }
 
     #[test]
-    fn names_are_stable_and_nats_safe() {
-        let hook = HookConfig {
-            event: "PreToolUse".to_string(),
-            matcher: None,
-            command: "echo".to_string(),
-            timeout: Some(30),
-            status_message: None,
-            async_hook: None,
-            hook_type: "claude-command".to_string(),
-            package_dir: None,
-        };
-        assert_eq!(
-            hook_server_name("agent:review", 2, &hook),
-            "agent-review-PreToolUse-2"
-        );
+    fn ordered_nonce_names_are_zero_padded() {
+        assert_eq!(hook_server_name("a1b2c3d4", 0), "hook-a1b2c3d4-000");
+        assert_eq!(hook_server_name("a1b2c3d4", 12), "hook-a1b2c3d4-012");
+        assert_eq!(hook_server_name("a1b2c3d4", 998), "hook-a1b2c3d4-998");
+        assert!(hook_server_name("a1b2c3d4", 2) < hook_server_name("a1b2c3d4", 10));
     }
 }

--- a/crates/harnx-runtime/src/nats_worker/mod.rs
+++ b/crates/harnx-runtime/src/nats_worker/mod.rs
@@ -43,5 +43,7 @@ pub use daemon::{
     new_remote_session_id, notify_subject, publish_session_activate, run_worker_daemon,
     worker_ready_subject, SessionActivate, WorkerDaemonConfig,
 };
+#[doc(hidden)]
+pub use hook_supervisor::publish_crash_rejector;
 pub use hook_supervisor::{HookServerStartConfig, HookServerSupervisor};
 pub use tool_supervisor::{ToolServerStartConfig, ToolServerSupervisor};

--- a/crates/harnx-runtime/tests/hook_supervisor.rs
+++ b/crates/harnx-runtime/tests/hook_supervisor.rs
@@ -4,30 +4,42 @@ mod common;
 use anyhow::{Context, Result};
 use harnx_core::hooks::{HookConfig, HookEvent, HookResultControl, HooksConfig};
 use harnx_core::instance::InstanceId;
-use harnx_hookset::{HOOK_EXPECTATIONS_BUCKET, HOOK_REGISTRY_BUCKET};
+use harnx_hookset::{FailPolicy, HookRegistration, HOOK_EXPECTATIONS_BUCKET, HOOK_REGISTRY_BUCKET};
 use harnx_hookset_server::hook_registration_key;
 use harnx_runtime::nats_hook_provider::{HookDispatchMeta, NatsHookProvider};
 use harnx_runtime::nats_worker::{
-    reconcile_hook_supervisor, HookServerStartConfig, HookServerSupervisor,
+    publish_crash_rejector, reconcile_hook_supervisor, HookServerStartConfig, HookServerSupervisor,
 };
 use serde_json::json;
 use std::path::PathBuf;
 use std::process::Command;
 use std::time::{Duration, Instant};
 
+#[derive(Clone, Copy)]
+struct RequestId<'a>(&'a str);
+
+impl<'a> From<&'a str> for RequestId<'a> {
+    fn from(value: &'a str) -> Self {
+        Self(value)
+    }
+}
 const TOKEN: &str = "hook-supervisor-test-token";
 
 fn hook_config(event: &str) -> HooksConfig {
+    hook_config_with_command(event, "cat")
+}
+
+fn hook_config_with_command(event: &str, child_command: &str) -> HooksConfig {
     HooksConfig {
         max_resume: None,
         entries: vec![HookConfig {
-            event: event.to_string(),
-            matcher: Some("exec".to_string()),
-            command: "cat".to_string(),
-            timeout: Some(5),
+            command: format!(
+                "harnx-claude-compatible-hook-server --event {} --matcher exec --timeout 5 --command {}",
+                shell_words::quote(event),
+                shell_words::quote(child_command)
+            ),
             status_message: None,
             async_hook: None,
-            hook_type: "claude-command".to_string(),
             package_dir: None,
         }],
     }
@@ -112,20 +124,51 @@ async fn create_store(
 async fn dispatch_pre_tool(
     client: &async_nats::Client,
     instance_id: &InstanceId,
-    request_id: &str,
+    request_id: RequestId<'_>,
+) -> Result<harnx_core::hooks::HookOutcome> {
+    dispatch_event(
+        client,
+        instance_id,
+        request_id,
+        HookEvent::PreToolUse {
+            tool_name: "exec".to_string(),
+            tool_input: json!({"command": "true"}),
+            tool_use_id: request_id.0.to_string(),
+        },
+    )
+    .await
+}
+
+async fn dispatch_user_prompt(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+    request_id: RequestId<'_>,
+) -> Result<harnx_core::hooks::HookOutcome> {
+    dispatch_event(
+        client,
+        instance_id,
+        request_id,
+        HookEvent::UserPromptSubmit {
+            prompt: "hello".to_string(),
+        },
+    )
+    .await
+}
+
+async fn dispatch_event(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+    request_id: RequestId<'_>,
+    event: HookEvent,
 ) -> Result<harnx_core::hooks::HookOutcome> {
     let provider =
         NatsHookProvider::discover_with_client(client.clone(), instance_id.clone()).await?;
     Ok(provider
         .dispatch_event(
-            HookEvent::PreToolUse {
-                tool_name: "exec".to_string(),
-                tool_input: json!({"command": "true"}),
-                tool_use_id: request_id.to_string(),
-            },
+            event,
             None,
             HookDispatchMeta {
-                session_id: request_id.to_string(),
+                session_id: request_id.0.to_string(),
                 cwd: std::env::current_dir()?,
                 resume_count: 0,
             },
@@ -159,7 +202,7 @@ async fn run_scope_transitions(
     ];
     let mut active: Option<HookServerSupervisor> = None;
     for (scope, event) in scopes {
-        if let Some(previous) = active.take() {
+        if let Some(mut previous) = active.take() {
             let previous_name = previous
                 .server_pids()
                 .await
@@ -167,7 +210,7 @@ async fn run_scope_transitions(
                 .next()
                 .context("previous hook process")?;
             let previous_key = hook_registration_key(instance_id, &previous_name);
-            drop(previous);
+            previous.shutdown().await;
             wait_until_removed(store, &previous_key).await?;
         }
         let supervisor = HookServerSupervisor::start_local_with_timeout(
@@ -187,7 +230,7 @@ async fn run_scope_transitions(
         assert!(store.get(&key).await?.is_some(), "missing {scope} hook");
         active = Some(supervisor);
     }
-    let final_supervisor = active.context("final hook supervisor")?;
+    let mut final_supervisor = active.context("final hook supervisor")?;
     let final_name = final_supervisor
         .server_pids()
         .await
@@ -195,8 +238,24 @@ async fn run_scope_transitions(
         .next()
         .context("final hook process")?;
     let final_key = hook_registration_key(instance_id, &final_name);
-    drop(final_supervisor);
+    final_supervisor.shutdown().await;
     wait_until_removed(store, &final_key).await
+}
+
+async fn wait_for_registration_value(
+    store: &async_nats::jetstream::kv::Store,
+    key: &str,
+) -> Result<HookRegistration> {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if let Some(value) = store.get(key).await? {
+            return serde_json::from_slice(&value).context("decode expected hook registration");
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("hook registration '{key}' was not published");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -257,7 +316,7 @@ async fn reconcile_hook_supervisor_replaces_old_agent_registration() -> Result<(
     .await;
 
     wait_until_removed(&store, &old_key).await?;
-    let new_supervisor = active.context("new-agent hook supervisor")?;
+    let mut new_supervisor = active.context("new-agent hook supervisor")?;
     let new_name = new_supervisor
         .server_pids()
         .await
@@ -268,13 +327,13 @@ async fn reconcile_hook_supervisor_replaces_old_agent_registration() -> Result<(
     assert_ne!(old_key, new_key);
     assert!(store.get(&new_key).await?.is_some());
 
-    drop(new_supervisor);
+    new_supervisor.shutdown().await;
     wait_until_removed(&store, &new_key).await?;
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn failed_hook_start_keeps_fail_closed_expectation() -> Result<()> {
+async fn failed_hook_start_installs_fail_closed_rejector() -> Result<()> {
     harnx_core::require_nextest();
     let Some(context) = test_nats_context().await? else {
         return Ok(());
@@ -287,8 +346,9 @@ async fn failed_hook_start_keeps_fail_closed_expectation() -> Result<()> {
     } = context;
     let mut hooks = hook_config("PreToolUse");
     hooks.entries[0].command = "harnx-proxy-auth --hook 'unterminated".to_string();
+    hooks.entries[0].status_message = Some("Friendly failure guard".to_string());
 
-    let supervisor = HookServerSupervisor::start_local_with_timeout(
+    let mut supervisor = HookServerSupervisor::start_local_with_timeout(
         start,
         &hooks,
         "tool-bash",
@@ -300,13 +360,152 @@ async fn failed_hook_start_keeps_fail_closed_expectation() -> Result<()> {
     let store = async_nats::jetstream::new(client.clone())
         .get_key_value(HOOK_EXPECTATIONS_BUCKET)
         .await?;
-    let key = hook_registration_key(&instance_id, "tool-bash-PreToolUse-0");
-    assert!(store.get(&key).await?.is_some());
+    let mut keys = store.keys().await?;
+    use futures_util::TryStreamExt as _;
+    let prefix = format!("{instance_id}.hook-");
+    let mut rejector_key = None;
+    while let Some(key) = keys.try_next().await? {
+        if key.starts_with(&prefix) && key.ends_with("-rejector") {
+            rejector_key = Some(key);
+            break;
+        }
+    }
+    let key = rejector_key.context("startup rejector key")?;
+    let rejector = wait_for_registration_value(&store, &key).await?;
+    assert_eq!(key, hook_registration_key(&instance_id, &rejector.server));
+    assert!(rejector.server.ends_with("-rejector"));
+    assert_eq!(
+        rejector.display_label.as_deref(),
+        Some("hook server failed to start: Friendly failure guard")
+    );
+    assert_eq!(rejector.hooks.len(), 2);
+    assert_eq!(rejector.hooks[0].event, "UserPromptSubmit");
+    assert!(rejector.hooks[0].matcher.is_none());
+    assert_eq!(rejector.hooks[0].fail_policy, FailPolicy::Closed);
+    assert_eq!(rejector.hooks[1].event, "PreToolUse");
+    assert_eq!(rejector.hooks[1].matcher.as_deref(), Some(".*"));
+    assert_eq!(rejector.hooks[1].fail_policy, FailPolicy::Closed);
 
-    let outcome = dispatch_pre_tool(&client, &instance_id, "failed-start").await?;
-    assert!(matches!(outcome.control, HookResultControl::Block { .. }));
+    let expected_reason = HookResultControl::Block {
+        reason: "hook server failed to start: Friendly failure guard hook unavailable".to_string(),
+    };
+    assert_eq!(
+        dispatch_pre_tool(&client, &instance_id, "failed-start".into())
+            .await?
+            .control,
+        expected_reason
+    );
+    assert_eq!(
+        dispatch_user_prompt(&client, &instance_id, "failed-prompt".into())
+            .await?
+            .control,
+        expected_reason
+    );
 
-    drop(supervisor);
+    supervisor.shutdown().await;
+    wait_until_removed(&store, &key).await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn startup_failure_blocks_user_prompt_with_friendly_label() -> Result<()> {
+    harnx_core::require_nextest();
+    let Some(context) = test_nats_context().await? else {
+        return Ok(());
+    };
+    let TestNatsContext {
+        client,
+        instance_id,
+        start,
+        _server,
+    } = context;
+    let mut hooks = hook_config("PreToolUse");
+    hooks.entries[0].command = "true".to_string();
+    hooks.entries[0].status_message = Some("Prompt safety hook".to_string());
+
+    let _supervisor = HookServerSupervisor::start_local_with_timeout(
+        start,
+        &hooks,
+        "prompt-failure",
+        Duration::from_secs(2),
+    )
+    .await?;
+    assert_eq!(
+        dispatch_user_prompt(&client, &instance_id, "failed-prompt-label".into())
+            .await?
+            .control,
+        HookResultControl::Block {
+            reason: "hook server failed to start: Prompt safety hook hook unavailable".to_string(),
+        }
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg(unix)]
+async fn readiness_timeout_installs_rejector_and_blocks_gate_events() -> Result<()> {
+    harnx_core::require_nextest();
+    let Some(context) = test_nats_context().await? else {
+        return Ok(());
+    };
+    let TestNatsContext {
+        client,
+        instance_id,
+        start,
+        _server,
+    } = context;
+    let mut hooks = hook_config("PreToolUse");
+    hooks.entries[0].command = "sh -c 'sleep 30'".to_string();
+    hooks.entries[0].status_message = Some("Timed out safety guard".to_string());
+
+    let started = Instant::now();
+    let mut supervisor = HookServerSupervisor::start_local_with_timeout(
+        start,
+        &hooks,
+        "timeout-test",
+        Duration::from_millis(100),
+    )
+    .await?;
+    assert!(started.elapsed() < Duration::from_secs(2));
+    assert!(supervisor.server_pids().await.is_empty());
+
+    let store = async_nats::jetstream::new(client.clone())
+        .get_key_value(HOOK_EXPECTATIONS_BUCKET)
+        .await?;
+    let mut keys = store.keys().await?;
+    use futures_util::TryStreamExt as _;
+    let prefix = format!("{instance_id}.hook-");
+    let mut rejector_key = None;
+    while let Some(key) = keys.try_next().await? {
+        if key.starts_with(&prefix) && key.ends_with("-rejector") {
+            rejector_key = Some(key);
+            break;
+        }
+    }
+    let key = rejector_key.context("timeout rejector key")?;
+    let rejector = wait_for_registration_value(&store, &key).await?;
+    assert_eq!(
+        rejector.display_label.as_deref(),
+        Some("hook server failed to start: Timed out safety guard")
+    );
+
+    let expected = HookResultControl::Block {
+        reason: "hook server failed to start: Timed out safety guard hook unavailable".to_string(),
+    };
+    assert_eq!(
+        dispatch_pre_tool(&client, &instance_id, "timeout-pre-tool".into())
+            .await?
+            .control,
+        expected
+    );
+    assert_eq!(
+        dispatch_user_prompt(&client, &instance_id, "timeout-prompt".into())
+            .await?
+            .control,
+        expected
+    );
+
+    supervisor.shutdown().await;
     wait_until_removed(&store, &key).await?;
     Ok(())
 }
@@ -324,9 +523,11 @@ async fn crashed_closed_hook_blocks_through_retained_expectation() -> Result<()>
         start,
         _server,
     } = context;
+    let mut hooks = hook_config("PreToolUse");
+    hooks.entries[0].command.push_str(" --fail-policy open");
     let supervisor = HookServerSupervisor::start_local_with_timeout(
         start,
-        &hook_config("PreToolUse"),
+        &hooks,
         "crash-test",
         Duration::from_secs(5),
     )
@@ -341,7 +542,15 @@ async fn crashed_closed_hook_blocks_through_retained_expectation() -> Result<()>
         .get_key_value(HOOK_REGISTRY_BUCKET)
         .await?;
     let key = hook_registration_key(&instance_id, &name);
-    assert!(registry.get(&key).await?.is_some());
+    let live = registry
+        .get(&key)
+        .await?
+        .context("live hook registration")?;
+    let live: HookRegistration = serde_json::from_slice(&live)?;
+    assert!(live
+        .hooks
+        .iter()
+        .all(|hook| hook.fail_policy == FailPolicy::Open));
 
     // SAFETY: pid belongs to child process owned by this test's supervisor.
     let result = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
@@ -349,8 +558,18 @@ async fn crashed_closed_hook_blocks_through_retained_expectation() -> Result<()>
         return Err(std::io::Error::last_os_error()).context("SIGKILL hook server");
     }
     wait_until_removed(&registry, &key).await?;
+    let expectations = async_nats::jetstream::new(client.clone())
+        .get_key_value(HOOK_EXPECTATIONS_BUCKET)
+        .await?;
+    let marker = wait_for_registration_value(&expectations, &key).await?;
+    assert_eq!(marker.server, name);
+    assert!(!marker.hooks.is_empty());
+    assert!(marker
+        .hooks
+        .iter()
+        .all(|hook| hook.fail_policy == FailPolicy::Closed));
 
-    let outcome = dispatch_pre_tool(&client, &instance_id, "crashed-hook").await?;
+    let outcome = dispatch_pre_tool(&client, &instance_id, "crashed-hook".into()).await?;
     assert!(matches!(outcome.control, HookResultControl::Block { .. }));
     drop(supervisor);
     Ok(())
@@ -368,8 +587,7 @@ async fn healthy_closed_hook_with_expectation_dispatches_normally() -> Result<()
         start,
         _server,
     } = context;
-    let mut hooks = hook_config("PreToolUse");
-    hooks.entries[0].command = "printf '{}'".to_string();
+    let hooks = hook_config_with_command("PreToolUse", "printf '{}'");
     let supervisor = HookServerSupervisor::start_local_with_timeout(
         start,
         &hooks,
@@ -401,5 +619,63 @@ async fn healthy_closed_hook_with_expectation_dispatches_normally() -> Result<()
         .await;
     assert_eq!(outcome.control, HookResultControl::Continue);
     drop(supervisor);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn crash_rejector_falls_back_to_registry_and_blocks_gate_events() -> Result<()> {
+    harnx_core::require_nextest();
+    let Some(context) = test_nats_context().await? else {
+        return Ok(());
+    };
+    let TestNatsContext {
+        client,
+        instance_id,
+        _server,
+        ..
+    } = context;
+
+    // Force the expectations publish to exceed the bucket limit while leaving
+    // the registry bucket available for the second publication attempt.
+    let expectations = async_nats::jetstream::new(client.clone())
+        .create_key_value(async_nats::jetstream::kv::Config {
+            bucket: HOOK_EXPECTATIONS_BUCKET.to_string(),
+            max_bytes: 1,
+            ..Default::default()
+        })
+        .await?;
+    let crashed_server = "hook-direct-crash";
+    let rejector_server = format!("{crashed_server}-rejector");
+    let friendly_label = "hook server crashed: Direct fallback guard";
+    let key = hook_registration_key(&instance_id, &rejector_server);
+
+    publish_crash_rejector(&client, &instance_id, &rejector_server, friendly_label).await?;
+
+    assert!(
+        expectations.get(&key).await?.is_none(),
+        "rejector unexpectedly landed in constrained expectations bucket"
+    );
+    let registry = async_nats::jetstream::new(client.clone())
+        .get_key_value(HOOK_REGISTRY_BUCKET)
+        .await?;
+    let rejector = wait_for_registration_value(&registry, &key).await?;
+    assert_eq!(rejector.server, rejector_server);
+    assert_eq!(rejector.display_label.as_deref(), Some(friendly_label));
+
+    let expected = HookResultControl::Block {
+        reason: format!("{friendly_label} hook unavailable"),
+    };
+    assert_eq!(
+        dispatch_user_prompt(&client, &instance_id, "crash-rejector-prompt".into())
+            .await?
+            .control,
+        expected
+    );
+    assert_eq!(
+        dispatch_pre_tool(&client, &instance_id, "crash-rejector-tool".into())
+            .await?
+            .control,
+        expected
+    );
     Ok(())
 }

--- a/crates/harnx-sandbox-run/src/hooks.rs
+++ b/crates/harnx-sandbox-run/src/hooks.rs
@@ -1,6 +1,6 @@
 //! Hook execution for harnx-sandbox-run.
 //!
-//! Converts CLI hook definitions into `HookConfig` and dispatches them via
+//! Converts CLI hook definitions into inline hook specs and dispatches them via
 //! the harnx-hooks crate. Extracts environment mutations from hook output.
 //!
 //! The `PersistentHookManager` is returned alongside the env map so the caller
@@ -14,8 +14,11 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{bail, Result};
-use harnx_core::hooks::{HookConfig, HookEvent, HookOutcome, HookResultControl};
-use harnx_hooks::{dispatch_hooks_with_managers, PersistentHookManager};
+use harnx_core::hooks::{HookEvent, HookOutcome, HookResultControl};
+use harnx_hooks::{
+    dispatch_hooks_with_options, DispatchOptions, HookCommand, InlineHookSpec,
+    PersistentHookManager,
+};
 use serde_json::json;
 use tokio::sync::Mutex as TokioMutex;
 
@@ -44,79 +47,94 @@ pub async fn run_hooks(
     command: &[OsString],
 ) -> Result<HookResult> {
     if hook_defs.is_empty() {
-        return Ok(HookResult {
-            env: HashMap::new(),
-            manager: Arc::new(TokioMutex::new(PersistentHookManager::new())),
-        });
+        return Ok(empty_hook_result());
     }
 
-    // Convert HookDefs to HookConfigs
-    let hooks: Vec<HookConfig> = hook_defs
-        .iter()
-        .map(|def| {
-            let full_command = build_hook_command(&def.command, &def.args);
-            HookConfig {
-                event: "PreToolUse".to_string(),
-                matcher: None,
-                command: full_command,
-                timeout: Some(30),
-                status_message: None,
-                async_hook: Some(false),
-                hook_type: def.hook_type.clone(),
-                package_dir: None,
-            }
-        })
-        .collect();
-
-    let command_str: String = command
-        .iter()
-        .map(|s| s.to_string_lossy().into_owned())
-        .collect::<Vec<_>>()
-        .join(" ");
-
-    let tool_use_id = uuid::Uuid::new_v4().to_string();
-
-    let event = HookEvent::PreToolUse {
-        tool_name: "exec".to_string(),
-        tool_use_id,
-        tool_input: json!({
-            "command": command_str,
-            "env": {},
-        }),
-    };
-
+    let (hooks, persistent_modes) = build_inline_hooks(hook_defs);
+    let event = pre_tool_event(command);
     let persistent_manager = Arc::new(TokioMutex::new(PersistentHookManager::new()));
-
-    let outcome = dispatch_hooks_with_managers(
+    let outcome = dispatch_hooks_with_options(
         &event,
         &hooks,
         session_id,
         cwd,
-        None,
-        Some(&persistent_manager),
+        DispatchOptions {
+            persistent_modes: &persistent_modes,
+            persistent_manager: Some(&persistent_manager),
+            ..DispatchOptions::default()
+        },
     )
     .await;
 
-    // Check for block — shut down before bailing
-    if matches!(outcome.control, HookResultControl::Block { .. }) {
-        persistent_manager.lock().await.shutdown();
-        bail!(
-            "hook blocked execution: {}",
-            outcome
-                .result
-                .additional_context
-                .as_deref()
-                .unwrap_or("no reason")
-        );
-    }
-
-    let env = extract_hook_env(&outcome);
-
-    // Return the manager alive — caller keeps it until the child exits.
+    reject_blocked_hook(&outcome, &persistent_manager).await?;
     Ok(HookResult {
-        env,
+        env: extract_hook_env(&outcome),
         manager: persistent_manager,
     })
+}
+
+fn empty_hook_result() -> HookResult {
+    HookResult {
+        env: HashMap::new(),
+        manager: Arc::new(TokioMutex::new(PersistentHookManager::new())),
+    }
+}
+
+fn build_inline_hooks(hook_defs: &[HookDef]) -> (Vec<InlineHookSpec>, Vec<bool>) {
+    hook_defs.iter().filter_map(build_inline_hook).unzip()
+}
+
+fn build_inline_hook(def: &HookDef) -> Option<(InlineHookSpec, bool)> {
+    let persistent = match def.hook_type.as_str() {
+        "claude-command" => false,
+        "claude-command-persistent" => true,
+        _ => return None,
+    };
+    let hook = InlineHookSpec {
+        event: "PreToolUse".to_string(),
+        matcher: None,
+        command: HookCommand {
+            command: build_hook_command(&def.command, &def.args),
+            timeout: Some(30),
+            package_dir: None,
+        },
+        async_hook: Some(false),
+    };
+    Some((hook, persistent))
+}
+
+fn pre_tool_event(command: &[OsString]) -> HookEvent {
+    let command = command
+        .iter()
+        .map(|part| part.to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join(" ");
+    HookEvent::PreToolUse {
+        tool_name: "exec".to_string(),
+        tool_use_id: uuid::Uuid::new_v4().to_string(),
+        tool_input: json!({
+            "command": command,
+            "env": {},
+        }),
+    }
+}
+
+async fn reject_blocked_hook(
+    outcome: &HookOutcome,
+    persistent_manager: &Arc<TokioMutex<PersistentHookManager>>,
+) -> Result<()> {
+    if !matches!(outcome.control, HookResultControl::Block { .. }) {
+        return Ok(());
+    }
+    persistent_manager.lock().await.shutdown();
+    bail!(
+        "hook blocked execution: {}",
+        outcome
+            .result
+            .additional_context
+            .as_deref()
+            .unwrap_or("no reason")
+    )
 }
 
 fn shell_quote(value: &str) -> String {

--- a/crates/harnx-serve/src/ag_ui_rpc.rs
+++ b/crates/harnx-serve/src/ag_ui_rpc.rs
@@ -877,7 +877,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - event: PreToolUse\n      matcher: ^harnx_agent_session_history_read$\n      type: claude-command\n      command: |\n        printf '{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval required\"}}'",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval required\"}}'\"'\"''",
             "You are plain.",
         );
 
@@ -935,7 +935,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - event: PreToolUse\n      matcher: ^harnx_agent_session_history_read$\n      type: claude-command\n      command: |\n        printf '{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval required\"}}'",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval required\"}}'\"'\"''",
             "You are plain.",
         );
 

--- a/crates/harnx-serve/src/session_actor.rs
+++ b/crates/harnx-serve/src/session_actor.rs
@@ -1234,15 +1234,26 @@ fn test_hook_provider(
     let discovered = hooks
         .into_iter()
         .enumerate()
-        .map(|(index, hook)| DiscoveredHook {
-            server: format!("test-hook-{index}"),
-            spec: HookSpec {
-                event: hook.event,
-                matcher: hook.matcher,
-                priority: index as i32,
-                timeout_secs: hook.timeout,
-                fail_policy: FailPolicy::Closed,
-            },
+        .map(|(index, hook)| {
+            let words: Vec<_> = hook.command.split_whitespace().collect();
+            let runner_arg = |name: &str| {
+                words
+                    .iter()
+                    .position(|word| *word == name)
+                    .and_then(|position| words.get(position + 1))
+                    .map(|value| value.trim_matches('\'').to_string())
+            };
+            DiscoveredHook {
+                server: format!("test-hook-{index}"),
+                display_label: hook.status_message,
+                spec: HookSpec {
+                    event: runner_arg("--event").expect("test hook command must declare --event"),
+                    matcher: runner_arg("--matcher"),
+                    priority: index as i32,
+                    timeout_secs: runner_arg("--timeout").and_then(|value| value.parse().ok()),
+                    fail_policy: FailPolicy::Closed,
+                },
+            }
         })
         .collect();
     let handler = Arc::new(move |subject: &str, _payload| {
@@ -2045,7 +2056,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - event: PreToolUse\n      matcher: ^harnx_agent_session_history_read$\n      type: claude-command\n      command: |\n        printf '{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
             "You are plain.",
         );
 
@@ -2128,7 +2139,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - event: PreToolUse\n      matcher: ^harnx_agent_session_history_read$\n      type: claude-command\n      command: |\n        printf '{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
             "You are plain.",
         );
 
@@ -2266,7 +2277,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - event: PreToolUse\n      matcher: ^harnx_agent_session_history_read$\n      type: claude-command\n      command: |\n        printf '{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"batch approval needed\"}}'",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"batch approval needed\"}}'\"'\"''",
             "You are plain.",
         );
 
@@ -2437,7 +2448,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read, harnx_agent_session_history_search\nhooks:\n  entries:\n    - event: PreToolUse\n      matcher: ^harnx_agent_session_history_search$\n      type: claude-command\n      command: |\n        printf '{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read, harnx_agent_session_history_search\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_search$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
             "You are plain.",
         );
 
@@ -2646,7 +2657,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - event: PreToolUse\n      matcher: ^harnx_agent_session_history_read$\n      type: claude-command\n      command: |\n        printf '{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
             "You are plain.",
         );
 
@@ -2727,7 +2738,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - event: PreToolUse\n      matcher: ^harnx_agent_session_history_read$\n      type: claude-command\n      command: |\n        printf '{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
             "You are plain.",
         );
 

--- a/crates/harnx/src/test_utils/interrupt.rs
+++ b/crates/harnx/src/test_utils/interrupt.rs
@@ -228,8 +228,8 @@ pub fn write_with_blocking_hook(
         paths.harnx_config_dir.join("config.yaml"),
         format!(
             "save: false\nclient: mock-llm\nmodel: mock-llm:test\ntool_use: true\nuse_tools: '*'\n\
-             hooks:\n  entries:\n    - event: PreToolUse\n      type: claude-command\n      command: {}\n      timeout: 300\n",
-            block_sh.display()
+             hooks:\n  entries:\n    - command: harnx-claude-compatible-hook-server --event PreToolUse --timeout 300 --command {}\n",
+            shell_words::quote(&block_sh.display().to_string())
         ),
     )
     .context("failed to write config.yaml with hook")?;

--- a/crates/harnx/tests/tmux_e2e.rs
+++ b/crates/harnx/tests/tmux_e2e.rs
@@ -376,10 +376,7 @@ fn write_proxy_auth_fixture_files(paths: &TestPaths, proxy_auth_bin: &Path) -> R
         &json!({
             "save": false,
             "hooks": { "entries": [{
-                "event": "PreToolUse",
-                "matcher": "bash_exec|bash_spawn",
                 "command": format!("'{bin_path}' --hook ."),
-                "type": "claude-command-persistent",
             }]},
         }),
     )?;

--- a/demos/config/agents/tool-confirm-agent.md
+++ b/demos/config/agents/tool-confirm-agent.md
@@ -5,9 +5,6 @@ use_tools:
   - time_get_current_time
 hooks:
   entries:
-    - event: PreToolUse
-      type: claude-command
-      command: "bash demos/config/ask-confirm-hook.sh"
+    - command: harnx-claude-compatible-hook-server --event PreToolUse --matcher "time_get_current_time" -- bash demos/config/ask-confirm-hook.sh
 ---
-
 You are a helpful assistant. When asked about the time, use the time tool to check it.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -49,10 +49,7 @@ documents:
 hooks:
   max_resume: 3
   entries:
-    - event: Stop
-      type: claude-command
-      command: "/path/to/hook.sh"
-      timeout: 30
+    - command: harnx-claude-compatible-hook-server --event Stop -- /path/to/hook.sh
 ---
 
 You are a helpful coding assistant working on the {{project_dir}} project.
@@ -240,15 +237,13 @@ Hooks let you run external commands at specific points during agent execution. T
 hooks:
   max_resume: 3
   entries:
-    - event: PreToolUse
-      type: claude-command
-      matcher: shell
-      command: "/path/to/approve-tool.sh"
-      timeout: 15
-      async: false
-    - event: Stop
-      type: claude-command
-      command: "/path/to/on-stop.sh"
+    - command: >-
+        harnx-claude-compatible-hook-server
+        --event PreToolUse
+        --matcher shell
+        --timeout 15
+        -- /path/to/approve-tool.sh
+    - command: harnx-claude-compatible-hook-server --event Stop -- /path/to/on-stop.sh
       status_message: "Running stop hook..."
       async: true
 ```
@@ -257,13 +252,13 @@ hooks:
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `event` | `string` | yes | — | Hook event name (e.g. `PreToolUse`, `Stop`, `SessionStart`) |
-| `type` | `string` | yes | — | Execution protocol. Supported: `claude-command`, `claude-command-persistent`. Note: `PreToolUse` hooks can return `hookSpecificOutput.toolInput` to mutate tool arguments; `PostToolUse` hooks can return `hookSpecificOutput.toolResponse` to mutate the response. |
-| `matcher` | `string` | no | none | Regex pattern to match against the tool name (for tool-related events) |
-| `command` | `string` | yes | — | Shell command to execute |
-| `timeout` | `integer` | no | `30` | Timeout in seconds |
+| `command` | `string` | yes | — | Shell command to run as a hook server. For hooks that need event/matcher, use `harnx-claude-compatible-hook-server --event <E> --matcher <M> [--persistent] -- <child-command>`. |
 | `status_message` | `string` | no | none | Message to display while the hook runs |
 | `async` | `boolean` | no | none | Whether to run the hook asynchronously |
+
+The `command` field specifies a hook server binary. Options:
+- **Generic runner**: `harnx-claude-compatible-hook-server --event <EVENT> [--matcher <REGEX>] [--persistent] [--timeout <SECS>] [--priority <N>] [--fail-policy <closed|open>] -- <child-command>`. The `--persistent` flag keeps the child process alive across requests.
+- **Native hooks** (e.g., `harnx-proxy-auth`): Self-declare their event/matcher and need no runner flags.
 
 ### Top-level Hook Settings
 

--- a/docs/aws-creds.md
+++ b/docs/aws-creds.md
@@ -41,18 +41,26 @@ In your agent's YAML config:
 
 ```yaml
 hooks:
-  - event: PreToolUse
-    type: claude-command-persistent
-    command: "harnx-aws-creds"
+  entries:
+    - command: >-
+        harnx-claude-compatible-hook-server
+        --event PreToolUse
+        --matcher "bash_exec|bash_spawn"
+        --persistent
+        -- harnx-aws-creds
 ```
 
 With a specific profile:
 
 ```yaml
 hooks:
-  - event: PreToolUse
-    type: claude-command-persistent
-    command: "harnx-aws-creds --profile my-profile"
+  entries:
+    - command: >-
+        harnx-claude-compatible-hook-server
+        --event PreToolUse
+        --matcher "bash_exec|bash_spawn"
+        --persistent
+        -- harnx-aws-creds --profile my-profile
 ```
 
 ## CLI Reference

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -24,14 +24,33 @@ Hooks can be configured in three places depending on their intended scope:
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `event` | string | **Required.** The event that triggers the hook (e.g., `PreToolUse`). |
-| `type` | string | **Required.** The execution protocol: `claude-command` or `claude-command-persistent`. |
-| `matcher` | string | **Optional.** A regex matched against the bare `tool_name` for tool-related events. |
-| `command` | string | **Required.** The shell command or path to the executable to run. |
-| `timeout` | integer | **Optional.** Execution timeout in seconds (default: 30). |
+| `command` | string | **Required.** The shell command to run as a hook server. |
 | `status_message` | string | **Optional.** A message displayed to the user while the hook is running. |
 | `async` | boolean | **Optional.** If `true`, the hook runs in the background. Async hooks cannot block or mutate. |
 | `max_resume` | integer | **Optional.** (Top-level only) Maximum number of times a `Stop` hook can request a resume. |
+
+### Command-Only Model
+
+Hook configuration uses a **command-only** model: a hook entry specifies only the `command` to run (plus optional `status_message` and `async`). The command is a hook server binary that declares its own event, matcher, and other metadata.
+
+There are two types of hook servers:
+
+1. **Generic runner** (`harnx-claude-compatible-hook-server`): Wraps a child command and exposes it as a NATS hook server. It declares the event/matcher/etc. via CLI flags:
+   ```sh
+   harnx-claude-compatible-hook-server
+     --event <EVENT>              # Hook event (e.g., PreToolUse, PostToolUse)
+     --matcher <REGEX>            # Optional regex matched against bare tool name
+     --persistent                 # Keep one process alive across requests (optional)
+     --priority <N>               # Dispatch priority, lower runs first (default: 0)
+     --timeout <SECS>             # Execution timeout in seconds (optional)
+     --fail-policy <closed|open>  # Failure behavior (default: closed)
+     -- <CHILD_COMMAND>           # The actual hook script/binary to run
+   ```
+
+2. **Native hooks** (e.g., `harnx-proxy-auth`): Specialized binaries that implement the NATS hook protocol directly and self-declare their event/matcher via `Hook::hooks()`. They need no `--event`/`--matcher` flags:
+   ```sh
+   harnx-proxy-auth --hook <FILTER> --env <JSON> ...
+   ```
 
 ### Hook Location and Merging
 
@@ -40,6 +59,7 @@ Hooks can be configured in three places depending on their intended scope:
 *   **Agent Hooks**: Defined in an agent's YAML front-matter and scoped to the active session.
 *   **Merging**: Agent hooks extend the global list. If an agent hook has the same `event` and `matcher` as a global hook, the agent hook **replaces** the global one.
 *   **max_resume**: If set in an agent's front-matter, it overrides the global `max_resume` value.
+*   **Declaration Order**: Within each scope (global, tool-server, agent), hooks dispatch in config declaration order when priorities are equal.
 
 ## 3. Event Reference
 
@@ -62,9 +82,9 @@ Harnx supports the following events. Each event sends a JSON payload to the hook
 
 Hooks run as NATS hook services launched and managed by the worker-side `HookServerSupervisor`.
 
-### `claude-command` (One-shot)
+### One-shot Hooks (Generic Runner)
 
-The default one-shot hook type. Served over NATS using the generic `harnx-claude-compatible-hook-server` binary wrapper.
+The default one-shot hook type. Served over NATS using the generic `harnx-claude-compatible-hook-server` binary wrapper. Use `--event` and `--matcher` to specify when the hook fires:
 *   **Input**: The event payload is sent to the command's `stdin` as a single JSON object.
 *   **Output**: Harnx reads `stdout` for a JSON response (see Protocol below).
 *   **Control**:
@@ -72,15 +92,18 @@ The default one-shot hook type. Served over NATS using the generic `harnx-claude
     *   Exit code `2`: Block execution (equivalent to `permissionDecision: "deny"`).
     *   Other non-zero codes: Logged as errors, but execution usually continues.
 
-### `claude-command-persistent` (Persistent)
+### Persistent Hooks (Generic Runner with `--persistent`)
 
-Useful for hooks that maintain state or have high startup overhead. The persistent process is started by `HookServerSupervisor` and served over NATS via `harnx-claude-compatible-hook-server`.
+Useful for hooks that maintain state or have high startup overhead. The persistent process is started by `HookServerSupervisor` and served over NATS via `harnx-claude-compatible-hook-server --persistent`.
 *   **Protocol**: JSONL (JSON Lines) over `stdin` and `stdout`.
 *   **Correlation**: Each request from Harnx includes a unique `id` field. The hook must include the same `id` in its response line.
 
-### Native Auth Proxy (`harnx-proxy-auth`)
+### Native Hooks (`harnx-proxy-auth`)
 
-When a persistent hook specifies `harnx-proxy-auth` as its command executable, `HookServerSupervisor` detects the binary name and launches `harnx-proxy-auth` directly as a native NATS `PreToolUse` hook (matcher `exec|spawn`, default `FailPolicy::Closed`). It serves over NATS without requiring an external proxy wrapper.
+Native hook servers implement the NATS hook protocol directly and self-declare their event/matcher via `Hook::hooks()`. They need no `--event`/`--matcher` flags:
+
+*   `harnx-proxy-auth`: Self-declares `PreToolUse` with matcher `exec|spawn`.
+*   Served over NATS without requiring an external proxy wrapper.
 
 ### Async Hooks (`async: true`)
 
@@ -151,8 +174,7 @@ echo "{\"hookSpecificOutput\": {\"toolInput\": $NEW_INPUT}}"
 
 ### Hook Process Environment: `$HARNX_PACKAGE_DIR`
 
-Every hook command (both `claude-command` and `claude-command-persistent`) runs
-through a shell, and Harnx injects one extra environment variable:
+Every hook command runs through a shell, and Harnx injects one extra environment variable:
 
 | Variable | Value |
 |---|---|
@@ -196,7 +218,7 @@ The `resume` field is primarily used with the `Stop` event. It allows a hook to 
 
 ## 9. Persistent Hooks
 
-Persistent hooks (`type: claude-command-persistent`) use a JSONL-based protocol to avoid the overhead of spawning a new process for every event.
+Persistent hooks use a JSONL-based protocol to avoid the overhead of spawning a new process for every event. Use the `--persistent` flag on `harnx-claude-compatible-hook-server` to enable this mode:
 
 ### Request Format (Harnx to Hook)
 ```json
@@ -272,10 +294,7 @@ Injects AWS credentials into any `bash_exec` call.
 # config.yaml
 hooks:
   entries:
-    - event: PreToolUse
-      type: claude-command
-      matcher: bash_exec
-      command: "inject-aws-creds.sh"
+    - command: harnx-claude-compatible-hook-server --event PreToolUse --matcher bash_exec -- inject-aws-creds.sh
 ```
 
 **inject-aws-creds.sh:**
@@ -313,10 +332,7 @@ Prevents the use of `bash_exec` for security reasons.
 ```yaml
 hooks:
   entries:
-    - event: PreToolUse
-      type: claude-command
-      matcher: bash_exec
-      command: "exit 2"
+    - command: harnx-claude-compatible-hook-server --event PreToolUse --matcher bash_exec -- exit 2
       status_message: "Blocking bash_exec for safety"
 ```
 
@@ -327,9 +343,8 @@ Requires user approval before any tool runs. See the [Tool Confirmation Guide](t
 ```yaml
 hooks:
   entries:
-    - event: PreToolUse
-      type: claude-command
-      command: >-
+    - command: >-
+        harnx-claude-compatible-hook-server --event PreToolUse --
         printf '%s\n' '{"hookSpecificOutput":{"permissionDecision":"ask","permissionDecisionReason":"Manual approval required"}}'
 ```
 
@@ -344,15 +359,12 @@ Input: {
 Allow this tool call? (y/N)
 ```
 
-The default is **No** (deny). Use `matcher` to limit confirmation to specific tools:
+The default is **No** (deny). Use `--matcher` to limit confirmation to specific tools:
 
 ```yaml
 hooks:
   entries:
-    - event: PreToolUse
-      type: claude-command
-      matcher: "bash_exec|bash_spawn"
-      command: "/path/to/ask-confirm.sh"
+    - command: harnx-claude-compatible-hook-server --event PreToolUse --matcher "bash_exec|bash_spawn" -- /path/to/ask-confirm.sh
 ```
 
 ### 5. Audit Logger (Async PostToolUse)
@@ -362,9 +374,7 @@ Logs all tool results to a file in the background.
 ```yaml
 hooks:
   entries:
-    - event: PostToolUse
-      type: claude-command
-      command: "tee -a tool_audit.log"
+    - command: harnx-claude-compatible-hook-server --event PostToolUse -- tee -a tool_audit.log
       async: true
 ```
 
@@ -374,7 +384,7 @@ The `harnx-proxy-auth` binary is a specialized persistent hook that solves the p
 
 ### Feature Overview
 
-It acts as a local HTTPS MITM (Man-in-the-Middle) proxy. When configured as a `claude-command-persistent` hook for `bash_exec` or `bash_spawn`, it:
+It acts as a local HTTPS MITM (Man-in-the-Middle) proxy. When configured as a hook for `bash_exec` or `bash_spawn`, it:
 1. Starts a local proxy server.
 2. Generates an ephemeral CA certificate.
 3. Injects proxy configuration environment variables into the tool's environment.
@@ -463,19 +473,16 @@ harnx-proxy-auth --hook '
 
 ### Hook Configuration
 
-Add it to your `config.yaml` as persistent hook for bash tools:
+Add it to your `config.yaml` as a hook for bash tools. `harnx-proxy-auth` is a native hook that self-declares `PreToolUse` with matcher `exec|spawn`:
 
 ```yaml
 hooks:
   entries:
-  - event: PreToolUse
-    type: claude-command-persistent
-    matcher: "bash_exec|bash_spawn"
-    command: >-
-      harnx-proxy-auth
-      --hook 'if (.host == "github.com" or .host == "api.github.com" or .host == "uploads.github.com" or .host == "objects.githubusercontent.com")
-          then .headers.authorization = "Bearer \(env.GITHUB_TOKEN // env.GH_TOKEN)"
-          end'
+    - command: >-
+        harnx-proxy-auth
+        --hook 'if (.host == "github.com" or .host == "api.github.com" or .host == "uploads.github.com" or .host == "objects.githubusercontent.com")
+            then .headers.authorization = "Bearer \(env.GITHUB_TOKEN // env.GH_TOKEN)"
+            end'
 ```
 
 ### Sentinel Environment Variable Injection (`--env`)
@@ -524,15 +531,12 @@ The `--env` script overrides `GITHUB_TOKEN` in the bash tool's environment with 
 ```yaml
 hooks:
   entries:
-  - event: PreToolUse
-    type: claude-command-persistent
-    matcher: "bash_exec|bash_spawn"
-    command: >-
-      harnx-proxy-auth
-      --env 'if (env.GITHUB_TOKEN // env.GH_TOKEN) then .GITHUB_TOKEN = "ghs_\($fake_base64_key)" else . end'
-      --hook 'if (.host == "api.github.com") and (.headers.authorization == "Bearer ghs_\($fake_base64_key)")
-          then .headers.authorization = bearer(env.GITHUB_TOKEN // env.GH_TOKEN)
-          else . end'
+    - command: >-
+        harnx-proxy-auth
+        --env 'if (env.GITHUB_TOKEN // env.GH_TOKEN) then .GITHUB_TOKEN = "ghs_\($fake_base64_key)" else . end'
+        --hook 'if (.host == "api.github.com") and (.headers.authorization == "Bearer ghs_\($fake_base64_key)")
+            then .headers.authorization = bearer(env.GITHUB_TOKEN // env.GH_TOKEN)
+            else . end'
 ```
 
 ### Atlassian CLI (`acli`) Example
@@ -571,14 +575,11 @@ No manual environment variables are required as long as you have logged in with 
 ```yaml
 hooks:
   entries:
-  - event: PreToolUse
-    type: claude-command-persistent
-    matcher: "exec|spawn"
-    command: >-
-      harnx-proxy-auth
-      --fs '{"harnx-fs-acli/acli/.keep": ""}'
-      --env '{"ACLI_CONFIG_DIR": "\($temp_file_root)/harnx-fs-acli"}'
-      --hook "$HARNX_PACKAGE_DIR/hooks/jira-auth-hook.py"
+    - command: >-
+        harnx-proxy-auth
+        --fs '{"harnx-fs-acli/acli/.keep": ""}'
+        --env '{"ACLI_CONFIG_DIR": "\($temp_file_root)/harnx-fs-acli"}'
+        --hook "$HARNX_PACKAGE_DIR/hooks/jira-auth-hook.py"
 ```
 
 The hook sources the token from the platform keyring automatically (`secret-tool` on Linux, `security find-generic-password` on macOS); set `HARNX_JIRA_TOKEN_CMD` to use a different secret store.
@@ -590,16 +591,13 @@ You can combine Atlassian and GitHub auth in a single `harnx-proxy-auth` invocat
 ```yaml
 hooks:
   entries:
-  - event: PreToolUse
-    type: claude-command-persistent
-    matcher: "exec|spawn"
-    command: >-
-      harnx-proxy-auth
-      --hook 'if .host == "github.com" and (env.GITHUB_TOKEN // env.GH_TOKEN) != null then .headers.authorization = "Basic \(["x-access-token", (env.GITHUB_TOKEN // env.GH_TOKEN)] | join(":") | @base64)" end'
-      --hook 'if (.host == "api.github.com" or .host == "uploads.github.com" or .host == "objects.githubusercontent.com") and (env.GITHUB_TOKEN // env.GH_TOKEN) != null then .headers.authorization = "Bearer \(env.GITHUB_TOKEN // env.GH_TOKEN)" end'
-      --fs '{"harnx-fs-acli/acli/.keep": ""}'
-      --env '{"ACLI_CONFIG_DIR": "\($temp_file_root)/harnx-fs-acli"}'
-      --hook "$HARNX_PACKAGE_DIR/hooks/jira-auth-hook.py"
+    - command: >-
+        harnx-proxy-auth
+        --hook 'if .host == "github.com" and (env.GITHUB_TOKEN // env.GH_TOKEN) != null then .headers.authorization = "Basic \(["x-access-token", (env.GITHUB_TOKEN // env.GH_TOKEN)] | join(":") | @base64)" end'
+        --hook 'if (.host == "api.github.com" or .host == "uploads.github.com" or .host == "objects.githubusercontent.com") and (env.GITHUB_TOKEN // env.GH_TOKEN) != null then .headers.authorization = "Bearer \(env.GITHUB_TOKEN // env.GH_TOKEN)" end'
+        --fs '{"harnx-fs-acli/acli/.keep": ""}'
+        --env '{"ACLI_CONFIG_DIR": "\($temp_file_root)/harnx-fs-acli"}'
+        --hook "$HARNX_PACKAGE_DIR/hooks/jira-auth-hook.py"
 ```
 
 ### Injected Environment Variables
@@ -643,7 +641,7 @@ NATS hook servers register their capabilities in a JetStream Key-Value bucket an
 * **Registry Bucket**: `harnx_hook_registry` (constant `HOOK_REGISTRY_BUCKET`).
 * **Registration**: Hook servers publish a `HookRegistration` payload containing their server ID, registered `HookSpec` list, `schema_version`, and `proto_version`. Registrations feature a 60-second TTL refreshed every 30 seconds.
 * **Subject Scheme**: `{instance}.hook.{server}.{event}`.
-* **Request/Reply**: `NatsHookProvider` queries active registrations, matches events against configured matchers (regex on bare tool names like `bash_exec`), orders matching hooks by priority ascending (with registration-timestamp tiebreaks), and posts `HookPayload` requests to collect `HookOutcome` replies.
+* **Request/Reply**: `NatsHookProvider` queries active registrations, matches events against configured matchers (regex on bare tool names like `bash_exec`), orders matching hooks by ascending priority, then by registered server name (supervisor-assigned nonce), then by discovery-list index, and posts `HookPayload` requests to collect `HookOutcome` replies.
 
 ### Event Processing and Capabilities
 
@@ -666,6 +664,17 @@ Each hook specification registers a `fail_policy`:
 * `Open` (`"open"`): Logs errors and permits execution to continue.
 
 To prevent fail-open security gaps if a required closed hook fails to start or crashes mid-session, Harnx uses an expectation manifest bucket (`harnx_hook_expectations`). `HookServerSupervisor` registers required closed hooks in the expectations manifest upon launch. If a required closed hook server process fails to start or exits unexpectedly, `NatsHookProvider` checks expectations against live registry entries and **blocks** tool execution rather than silently bypassing the missing hook.
+
+### Fail-Closed-on-Failure
+
+When a hook server with `fail_policy: closed` fails to start or crashes:
+
+* **UserPromptSubmit** and **PreToolUse** events are blocked.
+* A synthetic "rejector" server is published with the hook's name suffixed by `-rejector`.
+* The rejector's display label is prefixed with `hook server failed to start:` and includes the `status_message` (or a truncated command if no status_message).
+* This ensures security-critical hooks (like auth injection) never silently bypass.
+
+Hooks with `fail_policy: open` do not block on failure — errors are logged and execution continues.
 
 ### Standalone Utility Exception (`harnx-sandbox-run`)
 

--- a/docs/solutions/api-design/hooks-command-only-config-fail-closed-2026-08-02.md
+++ b/docs/solutions/api-design/hooks-command-only-config-fail-closed-2026-08-02.md
@@ -1,0 +1,252 @@
+---
+title: "Hook config command-only pattern — shared-struct field removal, fail-closed fallback chains, and nonce-as-name lifecycle"
+date: 2026-08-02
+category: "api-design"
+problem_type: integration_issue
+component: "harnx-runtime, harnx-hooks, harnx-sandbox-run"
+root_cause: "shared-struct field removal missed secondary consumer; fail-closed single-point-of-failure in marker publish; opaque hook names impeded readiness correlation and dispatch ordering"
+resolution_type: code_fix
+severity: high
+tags:
+  - hooks
+  - nats
+  - fail-closed
+  - lifecycle
+  - supervisor
+  - shared-struct
+  - api-design
+plan_ref: "hooks-command-only-config"
+---
+
+## Problem
+
+Refactoring hook config to "command-only" (removing `type`, `event`, `matcher`, `timeout`; the running server self-declares over NATS) broke a secondary inline dispatch consumer that recon missed, exposed subtle fail-closed invariant gaps when crash-marker publication itself failed, and required a unified naming scheme for readiness correlation and dispatch ordering.
+
+## Symptoms
+
+**Phase 3a recon gap:**
+- Build failed after removing `event`/`matcher`/`timeout` from `HookConfig`
+- `crates/harnx-hooks/src/dispatch.rs` used `.event` and compiled `.matcher` for the inline sandbox-run path
+- `crates/harnx-hooks/src/executor.rs` used `.timeout` for the inline executor
+- No test caught it because sandbox-run tests built from their own CLI `--hook` convention, not from `HookConfig`
+
+**Fail-closed review cycles:**
+- Cycle 1: crash-marker publish failure could leave a self-declared-Open crashed hook fail-open (marker publish failed → live registration retained → Open policy served)
+- Cycle 1: deleting the registration without publishing a rejector left an empty discovery snapshot (fail-open)
+- Cycle 2: the two-tier fallback (`HOOK_EXPECTATIONS_BUCKET` → `HOOK_REGISTRY_BUCKET`) had no integration test coverage
+
+**Name correlation gap:**
+- Old design passed no per-launch identifier; readiness watch couldn't distinguish "my child" from stale registry replay
+- Equal-priority dispatch order relied on registry insertion order, which wasn't deterministic across worker restarts
+
+## Investigation Steps
+
+### 1. Shared-struct field removal
+
+Searched for all readers of the fields being removed:
+```sh
+rg '\.event' crates/harnx-hooks/src/dispatch.rs
+rg '\.matcher' crates/harnx-hooks/src/dispatch.rs
+rg '\.timeout' crates/harnx-hooks/src/executor.rs
+```
+
+Found the inline sandbox-run dispatch path (`dispatch_hooks`, `dispatch_hooks_with_count_and_manager`) filtered by `hook.event != event.event_name()` and compiled `hook.matcher` into a regex. The NATS path doesn't use inline dispatch — it dispatches over NATS — but `HookConfig` was the shared source for both.
+
+Evaluated options:
+- Re-add serde-skipped fields to `HookConfig` → leaks inline concern into NATS domain model
+- Create explicit inline metadata carrier → cleanest, isolates concerns
+
+### 2. Fail-closed invariants
+
+Traced crash path in `spawn_child_monitor`:
+```rust
+// Original: marker publish failure → retain live registration (fail-open for Open hooks)
+let marker_published = publish_marker(&marker).await.is_ok();
+if !marker_published {
+    // PROBLEM: live registration stays, policy=Open means fail-open
+}
+remove_registration(&key).await;
+```
+
+Confirmed design requirement:
+- A crashed hook must block dispatch regardless of its self-declared policy
+- Empty discovery snapshot must also fail closed (no routes → reject)
+
+Two-tier fallback pattern emerged:
+1. Try `HOOK_EXPECTATIONS_BUCKET` (normal crash marker path)
+2. On failure, publish synthetic rejector to `HOOK_REGISTRY_BUCKET`
+3. Only then delete the live registration
+
+### 3. Name as correlation token
+
+Existing server comparison:
+```rust
+// In provider: tiebreak by server name when priorities equal
+servers.sort_by(|a, b| a.server.cmp(&b.server));
+```
+
+Supervisor could assign deterministic names if zero-padded:
+```rust
+fn hook_server_name(run_id: &str, order_index: usize) -> String {
+    format!("hook-{run_id}-{order_index:03}")
+}
+```
+
+This yields `hook-a1b2c3d4-000`, `hook-a1b2c3d4-001`, etc. — lexical sort equals numeric sort, reproducing config declaration order.
+
+## Root Cause
+
+**Struct field removal gap:** The inline dispatcher and NATS supervisor both read from `HookConfig`. Removing fields without auditing all consumers breaks the path that doesn't self-register over NATS.
+
+**Fail-closed gap:** A single-point-of-failure in the crash marker publish can violate the fail-closed invariant. The fallback must guarantee fail-closed even when the bucket is unavailable.
+
+**Name correlation gap:** Without supervisor-assigned names matching the readiness watch key, the supervisor cannot distinguish a stale registration (previous incarnation) from its own child. A per-launch nonce closes this gap.
+
+## Solution
+
+### 1. InlineHookSpec for the inline consumer
+
+Created an explicit struct instead of serde-skipped fields on `HookConfig`:
+
+```rust
+// crates/harnx-hooks/src/dispatch.rs
+pub struct InlineHookSpec {
+    pub event: String,
+    pub matcher: Option<String>,
+    pub command: HookCommand,
+    pub async_hook: Option<bool>,
+}
+```
+
+Changed `dispatch_hooks` and variants to take `&[InlineHookSpec]`. Sandbox-run builds `InlineHookSpec` from its `HookDef` CLI convention, not from `HookConfig`. The NATS path never uses this — it dispatches over NATS.
+
+Key insight: don't leak a consumer-specific concern into the shared domain model.
+
+### 2. Fail-closed fallback chain
+
+Crash handler publishes marker or rejector, never leaves an Open policy alive:
+
+```rust
+// crates/harnx-runtime/src/nats_worker/hook_supervisor.rs
+let route = publish_marker_or_rejector(
+    || async {
+        let expectations = ensure_bucket(&client, HOOK_EXPECTATIONS_BUCKET).await?;
+        publish_registration(&expectations, &key, &marker).await
+    },
+    || publish_crash_rejector(&client, &instance_id, &rejector_name, &rejector_label),
+).await;
+
+match route {
+    Ok(CrashRoute::Marker) => remove_registration(&client, &instance_id, &server).await,
+    Ok(CrashRoute::Rejector) => {
+        log::warn!("crash marker failed; installed rejector");
+        remove_registration(&client, &instance_id, &server).await;
+    }
+    Err(error) => {
+        // Last resort: live registration retained but logging. Provider cache expires in ≤30s.
+        log::error!("failed to install any fail-closed route: {error:#}");
+    }
+}
+```
+
+`publish_crash_rejector` tries `HOOK_EXPECTATIONS_BUCKET`, then falls back to `HOOK_REGISTRY_BUCKET`:
+
+```rust
+pub async fn publish_crash_rejector(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+    server: &str,
+    display_label: &str,
+) -> Result<()> {
+    let registration = fail_closed_rejector(server, display_label);
+    let key = hook_registration_key(instance_id, server);
+
+    let expectation_result = async {
+        let expectations = ensure_bucket(client, HOOK_EXPECTATIONS_BUCKET).await?;
+        publish_registration(&expectations, &key, &registration).await
+    }.await;
+    if expectation_result.is_ok() {
+        return Ok(());
+    }
+
+    // Fallback: registry bucket as second publication path
+    let registry = ensure_bucket(client, HOOK_REGISTRY_BUCKET).await?;
+    publish_registration(&registry, &key, &registration).await
+}
+```
+
+The rejector has two closed specs (priority 0, no timeout):
+- `UserPromptSubmit` (no matcher)
+- `PreToolUse` (matcher `.*`)
+
+### 3. Nonce-as-name dual-purpose pattern
+
+Supervisor generates one `run_id` per `start_local_with_timeout`, derives all hook names from it:
+
+```rust
+let run_id = Uuid::new_v4().simple().to_string()[..8].to_string();
+let launch_plan: Vec<_> = enabled
+    .into_iter()
+    .enumerate()
+    .map(|(order_index, hook)| HookLaunch {
+        order_index,
+        name: hook_server_name(&run_id, order_index),  // hook-{run_id}-{NNN}
+        hook,
+    })
+    .collect();
+```
+
+Name functions:
+1. **Readiness correlation:** The per-name registry watch verifies `registration.server == assigned_name` before declaring success
+2. **Dispatch-order tiebreak:** Zero-padded `NNN` means lexical sort (`000 < 001 < ...`) equals declaration order
+
+Passed to every server via `--name`, including `harnx-proxy-auth` (which no longer hardcodes its name).
+
+### 4. Startup-failure rejector
+
+When a hook never registers (crash before healthy, spawn failure, readiness timeout):
+
+```rust
+// crates/harnx-runtime/src/nats_worker/hook_supervisor.rs — rejector construction
+let rejector = fail_closed_rejector(&rejector_name, &failure_label);
+let key = hook_registration_key(&instance_id, &rejector_name);
+let expectations = ensure_bucket(&client, HOOK_EXPECTATIONS_BUCKET).await?;
+publish_registration(&expectations, &key, &rejector).await?;
+```
+
+Display label: `"hook server failed to start: {status_message ?? command}"` (bounded to 120 chars).
+
+## Why This Works
+
+**InlineHookSpec:** The inline sandbox-run path has its own metadata carrier, isolating it from the NATS supervisor's `HookConfig`. Neither path accidentally depends on fields the other doesn't use.
+
+**Fail-closed chain:** Even if `HOOK_EXPECTATIONS_BUCKET` is unavailable, the rejector lands in `HOOK_REGISTRY_BUCKET`. Discovery always sees at least one closed route. The only gap is an existing provider's cached entry (≤30s refresh), which is the accepted design caveat.
+
+**Nonce-as-name:** One token serves two purposes without divergence. Expectation prep and spawn share the same `name` derivation, so readiness watch and registration are always aligned.
+
+## Prevention Strategies
+
+**Field removal checklist:**
+- [ ] Grep ALL field accesses (`rg '\.field_name'`) across the whole crate tree
+- [ ] Check test fixtures and example configs
+- [ ] Verify secondary paths (inline dispatch, CLI tools) don't read the shared struct
+- [ ] Build the full workspace (`cargo build --workspace`) before running tests
+
+**Fail-closed review:**
+- [ ] Every crash path must publish a blocking route before deleting the live registration
+- [ ] Publish fallback chain must have at least two buckets when one may be unavailable
+- [ ] Integration test must cover bucket-unavailable fallback branches
+
+**Integration test hygiene (repo-specific):**
+- [ ] Run `cargo build --workspace` before `cargo nextest run --workspace` — piecemeal `-p` builds omit e2e prerequisites like `harnx-mcp-time`, `harnx-mock-mcp`
+- [ ] Avoid `pkill -9` during a build — it can delete freshly-linked test binaries
+
+**Non-deterministic name check:**
+- [ ] Server names used for ordering must be zero-padded to match declaration order
+- [ ] Per-launch unique prefix prevents stale replay false positives
+
+## Related Issues
+
+- GitHub: [#1224](https://github.com/dobesv/harnx/issues/1224) — umbrella hooks config migration issue
+- `integration-issues/hooks-nats-launch-dispatch-complete-2026-08-01.md` — Phase 4: launch, lifecycle, and context aggregation
+- `workflow-issues/removing-dead-config-fields-rust-2026-05-05.md` — general field removal checklist

--- a/docs/solutions/hooks-over-nats-core-2026-07-31.md
+++ b/docs/solutions/hooks-over-nats-core-2026-07-31.md
@@ -190,7 +190,7 @@ let mut accumulated = guard.take().unwrap_or_default();
 *guard = Some(accumulated);
 ```
 
-**Discovery fail-open is safe:** If the hook registry bucket doesn't exist, discovery returns an empty list and the worker runs inline-only. This mirrors the tool registry posture.
+**Discovery with no provider:** When no `HARNX_INSTANCE_ID` is set (frontends without NATS), `dispatch_hook_event` returns `Continue` without hook enforcement by design. A normal empty registry (no hooks configured) means no hooks run. If discovery/registry read fails while a provider is set, the fail-closed guard blocks `UserPromptSubmit` and `PreToolUse` — see `hooks-nats-launch-dispatch-complete-2026-08-01.md` for the expectations-manifest pattern.
 
 ## Accepted Behavior Changes / Known Gaps
 

--- a/docs/tool-confirmation-guide.md
+++ b/docs/tool-confirmation-guide.md
@@ -9,9 +9,10 @@ The fastest way to enable manual confirmation for all tools is to add a hook ent
 ```yaml
 hooks:
   entries:
-    - event: PreToolUse
-      type: claude-command
-      command: >-
+    - command: >-
+        harnx-claude-compatible-hook-server
+        --event PreToolUse
+        --
         printf '%s\n' '{"hookSpecificOutput":{"permissionDecision":"ask","permissionDecisionReason":"Manual approval required"}}'
 ```
 
@@ -34,14 +35,13 @@ Harnx uses the **hooks system** to implement tool confirmation. When a `PreToolU
 You can configure confirmation hooks globally in `config.yaml` or per-agent in front-matter.
 
 ### Method A: External Script
+
 For more complex logic, move the hook to a script file:
 
 ```yaml
 hooks:
   entries:
-    - event: PreToolUse
-      type: claude-command
-      command: "/path/to/ask-confirm.sh"
+    - command: harnx-claude-compatible-hook-server --event PreToolUse -- /path/to/ask-confirm.sh
 ```
 
 **ask-confirm.sh** (see `demos/config/ask-confirm-hook.sh` for a working example):
@@ -54,17 +54,14 @@ printf '%s\n' '{"hookSpecificOutput":{"permissionDecision":"ask","permissionDeci
 ```
 
 ### Method B: Selective Confirmation (Matcher)
-Use the `matcher` field to only require confirmation for specific tools:
+Use the `--matcher` flag to only require confirmation for specific tools:
 
 ```yaml
 hooks:
   entries:
-    - event: PreToolUse
-      type: claude-command
-      matcher: "bash_exec|bash_spawn"
-      command: "/path/to/ask-confirm.sh"
+    - command: harnx-claude-compatible-hook-server --event PreToolUse --matcher "bash_exec|bash_spawn" -- /path/to/ask-confirm.sh
 ```
-*The `matcher` uses a regex against the tool name.*
+*The matcher uses a regex against the tool name.*
 
 ### Method C: Per-Agent Hooks
 Enable confirmation only for specific agents by adding the hook to their Markdown front-matter:
@@ -74,9 +71,7 @@ Enable confirmation only for specific agents by adding the hook to their Markdow
 model: openai:gpt-4o
 hooks:
   entries:
-    - event: PreToolUse
-      type: claude-command
-      command: "/path/to/ask-confirm.sh"
+    - command: harnx-claude-compatible-hook-server --event PreToolUse -- /path/to/ask-confirm.sh
 ---
 
 You are a helpful assistant with manual tool oversight.

--- a/example_config/agents/example-agent.md
+++ b/example_config/agents/example-agent.md
@@ -37,9 +37,7 @@ documents:                       # RAG document paths (relative to config dir)
 # hooks:                         # Per-agent hooks (merged with global)
 #   max_resume: 3
 #   entries:
-#   - event: Stop
-#     type: claude-command
-#     command: "/path/to/agent-hook.sh"
+#   - command: harnx-claude-compatible-hook-server --event Stop -- /path/to/agent-hook.sh
 ---
 
 You are a helpful AI assistant. Your task is to help the user with their questions and tasks.

--- a/example_config/config.yaml
+++ b/example_config/config.yaml
@@ -42,20 +42,14 @@ toolsets:
 # ---- hooks ----
 # hooks:
 #   entries:
-#   - event: PreToolUse
-#     type: claude-command
-#     matcher: "Bash"
-#     command: "dcg"
+#   - command: harnx-claude-compatible-hook-server --event PreToolUse --matcher "bash_exec|bash_spawn" -- dcg
 #
 # Example: Mutate tool input via hookSpecificOutput.toolInput
 # This shows how a PreToolUse hook can inject environment variables into Bash calls.
 #
 # hooks:
 #   entries:
-#   - event: PreToolUse
-#     type: claude-command
-#     matcher: "Bash"
-#     command: "/path/to/inject-env-hook.sh"
+#   - command: harnx-claude-compatible-hook-server --event PreToolUse --matcher "bash_exec|bash_spawn" -- /path/to/inject-env-hook.sh
 #
 # The inject-env-hook.sh script would look like:
 #   #!/usr/bin/env python3
@@ -94,10 +88,7 @@ toolsets:
 #
 # hooks:
 #   entries:
-#   - event: PreToolUse
-#     type: claude-command-persistent
-#     matcher: "bash_exec|bash_spawn"
-#     command: >-
+#   - command: >-
 #       harnx-proxy-auth
 #       --env 'if env.GITHUB_TOKEN then .GITHUB_TOKEN = "ghp_\($fake_base64_key)" end'
 #       --hook 'if .host == "github.com"
@@ -126,10 +117,7 @@ toolsets:
 #
 # hooks:
 #   entries:
-#   - event: PreToolUse
-#     type: claude-command-persistent
-#     matcher: "bash_exec|bash_spawn"
-#     command: >-
+#   - command: >-
 #       harnx-proxy-auth
 #       --hook ./example_config/github-app-auth-hook.py
 #       # Inline shebang script content also works.
@@ -142,10 +130,7 @@ toolsets:
 #
 # hooks:
 #   entries:
-#   - event: PreToolUse
-#     type: claude-command-persistent
-#     matcher: "bash_exec|bash_spawn"
-#     command: >-
+#   - command: >-
 #       harnx-proxy-auth
 #       --fs '{"harnx-fs-acli/acli/.keep": ""}'
 #       --env '{"ACLI_CONFIG_DIR": "\($temp_file_root)/harnx-fs-acli"}'
@@ -175,10 +160,7 @@ toolsets:
 #
 # hooks:
 #   entries:
-#   - event: PreToolUse
-#     type: claude-command-persistent
-#     matcher: "bash_exec|bash_spawn"
-#     command: >-
+#   - command: >-
 #       harnx-proxy-auth
 #       --env '{"GCE_METADATA_HOST":"127.0.0.1:\($proxy_port)","METADATA_SERVER_DETECTION":"assume-present"}'
 #       # Optional: add GOOGLE_CLOUD_PROJECT in same --env object.

--- a/packages/coding/tool_servers/bash.yaml
+++ b/packages/coding/tool_servers/bash.yaml
@@ -16,10 +16,7 @@ description: Shell execution — lets agents run commands and scripts
 
 hooks:
   entries:
-    - event: PreToolUse
-      matcher: exec|spawn
-      type: claude-command-persistent
-      command: >-
+    - command: >-
         harnx-proxy-auth
         --hook 'if .host == "github.com" and (env.GITHUB_TOKEN // env.GH_TOKEN) != null then .headers.authorization = "Basic \(["x-access-token", (env.GITHUB_TOKEN // env.GH_TOKEN)] | join(":") | @base64)" end'
         --hook 'if (.host == "api.github.com" or .host == "uploads.github.com" or .host == "objects.githubusercontent.com") and (env.GITHUB_TOKEN // env.GH_TOKEN) != null then .headers.authorization = "Bearer \(env.GITHUB_TOKEN // env.GH_TOKEN)" end'

--- a/packages/pantheon/tool_servers/bash.yaml
+++ b/packages/pantheon/tool_servers/bash.yaml
@@ -16,10 +16,7 @@ description: Shell execution — lets agents run commands and scripts
 
 hooks:
   entries:
-    - event: PreToolUse
-      matcher: exec|spawn
-      type: claude-command-persistent
-      command: >-
+    - command: >-
         harnx-proxy-auth
         --hook 'if .host == "github.com" and (env.GITHUB_TOKEN // env.GH_TOKEN) != null then .headers.authorization = "Basic \(["x-access-token", (env.GITHUB_TOKEN // env.GH_TOKEN)] | join(":") | @base64)" end'
         --hook 'if (.host == "api.github.com" or .host == "uploads.github.com" or .host == "objects.githubusercontent.com") and (env.GITHUB_TOKEN // env.GH_TOKEN) != null then .headers.authorization = "Bearer \(env.GITHUB_TOKEN // env.GH_TOKEN)" end'


### PR DESCRIPTION
Refactor hook configuration to specify only `command` (plus optional `status_message` and `async`), removing `type`, `event`, `matcher`, and `timeout` from `HookConfig`. Hook servers now self-declare metadata over NATS.

Key changes:
- Remove `type`, `event`, `matcher`, and `timeout` fields from `HookConfig`.
- Remove supervisor string special-casing for proxy-auth and spawn hook commands generically.
- Assign ordered nonce names (`hook-<runid>-NNN`) per supervisor run for readiness correlation and dispatch ordering.
- Republish captured self-registrations with closed fail policies on process crash and install synthetic rejectors on startup failure for `UserPromptSubmit` and `PreToolUse`.
- Add `display_label` to `HookRegistration` to improve block reason reporting.
- Decouple `InlineHookSpec` in `harnx-sandbox-run` from `HookConfig.type`.
- Delete the deprecated `harnx-mcp-hooks-proxy` crate and inline dispatch code paths.
- Update agent frontmatter, example configs, package configurations, changesets, and docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hook configurations now use concise command-based entries, with event and matcher options passed directly to hook servers.
  * Added persistent execution and configurable hook names.
  * Hook failures fail closed with clear rejection notices and labels.
  * Blocking notifications include the reason supplied by the hook.

* **Bug Fixes**
  * Improved hook startup, crash, readiness, and discovery handling.

* **Documentation**
  * Updated guides, examples, diagnostics, and credential integrations for the new configuration format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->