### PR TITLE
fix(nats): wire tool discovery and restore package tool-naming

### DIFF
--- a/.changeset/restore-package-tool-naming.md
+++ b/.changeset/restore-package-tool-naming.md
@@ -1,0 +1,5 @@
+---
+harnx: patch
+---
+
+NATS tool discovery now reaches the LLM schema, package-aware `<server>_<tool>` naming is restored through one worker `ServerIdentity` module, and package/config identities prevent the #1350 server collision.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3773,6 +3773,7 @@ dependencies = [
  "async-trait",
  "clap",
  "harnx-core",
+ "harnx-runtime",
  "harnx-toolset",
  "harnx-toolset-server",
  "libc",

--- a/crates/harnx-core/src/instance.rs
+++ b/crates/harnx-core/src/instance.rs
@@ -24,8 +24,8 @@ impl InstanceId {
     }
 
     /// Build the Core NATS subject for a tool invocation.
-    pub fn tool_subject(&self, server: &str, tool: &str) -> String {
-        format!("harnx.v1.{self}.tools.{server}.{tool}")
+    pub fn tool_subject(&self, identity_token: &str, tool: &str) -> String {
+        format!("harnx.v1.{self}.tools.{identity_token}.{tool}")
     }
 
     /// Build the per-instance control subject used for cancel and progress.

--- a/crates/harnx-fs-tools/tests/nats_fs.rs
+++ b/crates/harnx-fs-tools/tests/nats_fs.rs
@@ -129,7 +129,7 @@ async fn wait_for_registration(
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         if let Ok(store) = jetstream.get_key_value(TOOL_REGISTRY_BUCKET).await {
-            let key = registration_key(instance_id, "fs");
+            let key = registration_key(instance_id, "____fs");
             if let Some(value) = store.get(&key).await? {
                 return serde_json::from_slice(&value).context("decode registration");
             }
@@ -157,7 +157,7 @@ async fn invoke(
     };
     let message = client
         .request_with_headers(
-            instance_id.tool_subject("fs", tool),
+            instance_id.tool_subject("____fs", tool),
             request_headers(&call_id, &format!("fs-{tool}-{request_id}-idempotency")),
             serde_json::to_vec(&request)?.into(),
         )

--- a/crates/harnx-mcp-bridge/Cargo.toml
+++ b/crates/harnx-mcp-bridge/Cargo.toml
@@ -24,6 +24,7 @@ tokio-util = { workspace = true }
 
 [dev-dependencies]
 async-nats = { workspace = true }
+harnx-runtime = { path = "../harnx-runtime" }
 tempfile = { workspace = true }
 which = { workspace = true }
 

--- a/crates/harnx-mcp-bridge/src/lib.rs
+++ b/crates/harnx-mcp-bridge/src/lib.rs
@@ -36,7 +36,7 @@ type SpawnedChild = (
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
 #[command(trailing_var_arg = true)]
 pub struct Args {
-    /// Server name used for registration and tool-name prefixes.
+    /// Server name used for registration.
     #[arg(long)]
     pub name: String,
 
@@ -179,11 +179,7 @@ async fn connect_and_list_tools(
         }
         Ok(Ok(result)) => result,
     };
-    let cached_tools = listed
-        .tools
-        .into_iter()
-        .map(|tool| map_tool(server_name, tool))
-        .collect();
+    let cached_tools = listed.tools.into_iter().map(map_tool).collect();
 
     Ok((service, cached_tools))
 }
@@ -230,7 +226,7 @@ impl BridgeToolset {
         })
     }
 
-    /// Server name used to prefix cached tool names.
+    /// Server name used for toolset registration.
     pub fn server_name(&self) -> &str {
         &self.server_name
     }
@@ -282,10 +278,6 @@ impl Toolset for BridgeToolset {
         args: Value,
         cancel: CancellationToken,
     ) -> Result<Value, ToolInvokeError> {
-        let prefix = format!("{}_", self.server_name);
-        let mcp_tool = tool
-            .strip_prefix(&prefix)
-            .ok_or_else(|| ToolInvokeError::Recoverable(format!("bad tool name {tool}")))?;
         let arguments = match args {
             Value::Object(arguments) => Some(arguments),
             Value::Null => None,
@@ -295,7 +287,7 @@ impl Toolset for BridgeToolset {
                 ));
             }
         };
-        let mut params = CallToolRequestParams::new(mcp_tool.to_owned());
+        let mut params = CallToolRequestParams::new(tool.to_owned());
         if let Some(arguments) = arguments {
             params = params.with_arguments(arguments);
         }
@@ -340,10 +332,10 @@ fn configure_child_process(command: &mut Command) {
 #[cfg(not(target_os = "linux"))]
 fn configure_child_process(_command: &mut Command) {}
 
-fn map_tool(server_name: &str, tool: Tool) -> ToolSpec {
+fn map_tool(tool: Tool) -> ToolSpec {
     let annotations = tool.annotations.as_ref();
     ToolSpec {
-        name: format!("{server_name}_{}", tool.name),
+        name: tool.name.into(),
         description: tool
             .description
             .map_or_else(String::new, |value| value.into_owned()),
@@ -434,8 +426,9 @@ mod tests {
         let tool =
             rmcp::model::Tool::new("echo", "Echo input", serde_json::Map::new()).with_meta(meta);
 
-        let spec = map_tool("child", tool);
+        let spec = map_tool(tool);
 
+        assert_eq!(spec.name, "echo");
         assert_eq!(
             spec.meta
                 .as_ref()
@@ -447,7 +440,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn caches_prefixed_plans_tool_specs() {
+    async fn caches_raw_plans_tool_specs() {
         let plans_dir = tempfile::tempdir().expect("create temporary plans directory");
         let plans_binary = option_env!("CARGO_BIN_EXE_harnx-plans-tools")
             .map(std::path::PathBuf::from)
@@ -477,8 +470,12 @@ mod tests {
         .expect("connect to plans MCP server");
 
         assert_eq!(bridge.cached_tools().len(), 15);
+        assert!(bridge
+            .cached_tools()
+            .iter()
+            .any(|tool| tool.name == "list_plans"));
         assert!(bridge.cached_tools().iter().all(|tool| {
-            tool.name.starts_with("plans_")
+            !tool.name.starts_with("plans_")
                 && tool
                     .input_schema
                     .as_object()
@@ -557,7 +554,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn invokes_child_tools_and_validates_name_and_cancellation() {
+    async fn invokes_raw_child_tools_and_validates_arguments_and_cancellation() {
         use harnx_toolset::{ToolInvokeError, Toolset};
         use tokio_util::sync::CancellationToken;
 
@@ -568,7 +565,7 @@ mod tests {
 
         let result = bridge
             .invoke(
-                "plans_list_plans",
+                "list_plans",
                 serde_json::json!({}),
                 CancellationToken::new(),
             )
@@ -579,21 +576,9 @@ mod tests {
             .and_then(serde_json::Value::as_array)
             .is_some_and(|content| !content.is_empty()));
 
-        let bad_name = bridge
-            .invoke(
-                "wrongname_foo",
-                serde_json::json!({}),
-                CancellationToken::new(),
-            )
-            .await;
-        assert!(matches!(
-            bad_name,
-            Err(ToolInvokeError::Recoverable(message)) if message == "bad tool name wrongname_foo"
-        ));
-
         let bad_arguments = bridge
             .invoke(
-                "plans_list_plans",
+                "list_plans",
                 serde_json::json!([]),
                 CancellationToken::new(),
             )
@@ -607,7 +592,7 @@ mod tests {
         let cancel = CancellationToken::new();
         cancel.cancel();
         let cancelled = bridge
-            .invoke("plans_list_plans", serde_json::json!({}), cancel)
+            .invoke("list_plans", serde_json::json!({}), cancel)
             .await;
         assert!(matches!(
             cancelled,

--- a/crates/harnx-mcp-bridge/tests/bridge_roundtrip.rs
+++ b/crates/harnx-mcp-bridge/tests/bridge_roundtrip.rs
@@ -3,7 +3,10 @@
 use anyhow::{Context, Result};
 use harnx_core::instance::InstanceId;
 use harnx_mcp_bridge::BridgeToolset;
-use harnx_toolset::{Registration, ToolReply, ToolRequest, HDR_CALL_ID, HDR_IDEMPOTENCY_KEY};
+use harnx_runtime::server_identity::ServerIdentity;
+use harnx_toolset::{
+    server_identity_token, Registration, ToolReply, ToolRequest, HDR_CALL_ID, HDR_IDEMPOTENCY_KEY,
+};
 use harnx_toolset_server::{
     registration_key, serve_over_nats, TOOL_REGISTRY_BUCKET, TOOL_SCHEMA_VERSION,
 };
@@ -108,45 +111,60 @@ async fn wait_for_nats_ready(url: &str) -> Result<()> {
     }
 }
 
-fn plans_binary() -> Result<PathBuf> {
+fn workspace_binary(name: &str, cargo_path: Option<&str>) -> Result<PathBuf> {
     // Cargo's compile-time binary path is preferred. Cross-crate test builds don't always set it,
     // so the fallback resolves the sibling binary next to the test executable's deps directory.
-    let (path, mechanism) = if let Some(path) = option_env!("CARGO_BIN_EXE_harnx-plans-tools") {
-        (PathBuf::from(path), "CARGO_BIN_EXE_harnx-plans-tools")
+    let (path, mechanism) = if let Some(path) = cargo_path {
+        (PathBuf::from(path), "CARGO_BIN_EXE")
     } else {
         let mut path = std::env::current_exe().context("locate current test executable")?;
         path.pop();
         if path.ends_with("deps") {
             path.pop();
         }
-        (path.join("harnx-plans-tools"), "test executable sibling")
+        (path.join(name), "test executable sibling")
     };
     anyhow::ensure!(
         path.is_file(),
-        "harnx-plans-tools binary missing at {} (resolved via {mechanism})",
+        "{name} binary missing at {} (resolved via {mechanism})",
         path.display()
     );
-    eprintln!(
-        "resolved harnx-plans-tools via {mechanism}: {}",
-        path.display()
-    );
+    eprintln!("resolved {name} via {mechanism}: {}", path.display());
     Ok(path)
+}
+
+fn plans_binary() -> Result<PathBuf> {
+    workspace_binary(
+        "harnx-plans-tools",
+        option_env!("CARGO_BIN_EXE_harnx-plans-tools"),
+    )
+}
+
+fn mock_mcp_binary() -> Result<PathBuf> {
+    workspace_binary(
+        "harnx-mock-mcp",
+        option_env!("CARGO_BIN_EXE_harnx-mock-mcp"),
+    )
 }
 
 async fn wait_for_registration(
     client: &async_nats::Client,
     instance_id: &InstanceId,
+    identity_token: &str,
 ) -> Result<Registration> {
     let jetstream = async_nats::jetstream::new(client.clone());
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         if let Ok(store) = jetstream.get_key_value(TOOL_REGISTRY_BUCKET).await {
-            if let Some(value) = store.get(registration_key(instance_id, "plans")).await? {
-                return serde_json::from_slice(&value).context("decode plans registration");
+            if let Some(value) = store
+                .get(registration_key(instance_id, identity_token))
+                .await?
+            {
+                return serde_json::from_slice(&value).context("decode tool registration");
             }
         }
         if Instant::now() >= deadline {
-            anyhow::bail!("timed out waiting for plans tool registration");
+            anyhow::bail!("timed out waiting for tool registration '{identity_token}'");
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
@@ -180,19 +198,24 @@ async fn bridge_registers_plans_and_round_trips_an_invoke() -> Result<()> {
         .token(TOKEN.to_string())
         .connect(&server.url)
         .await?;
-    let registration = wait_for_registration(&client, &instance_id).await?;
+    let identity_token = server_identity_token(None, "", "plans");
+    let registration = wait_for_registration(&client, &instance_id, &identity_token).await?;
     assert_eq!(registration.server, "plans");
     assert_eq!(registration.schema_version, TOOL_SCHEMA_VERSION);
     assert_eq!(registration.tools.len(), 15);
     assert!(registration
         .tools
         .iter()
-        .all(|tool| tool.name.starts_with("plans_")));
+        .any(|tool| tool.name == "list_plans"));
+    assert!(registration
+        .tools
+        .iter()
+        .all(|tool| !tool.name.starts_with("plans_")));
 
     let call_id = "bridge-plans-list";
     let request = ToolRequest {
         call_id: call_id.to_owned(),
-        tool: "plans_list_plans".to_owned(),
+        tool: "list_plans".to_owned(),
         args: json!({}),
         parent_session_id: None,
     };
@@ -201,14 +224,14 @@ async fn bridge_registers_plans_and_round_trips_an_invoke() -> Result<()> {
     headers.insert(HDR_IDEMPOTENCY_KEY, "bridge-plans-list-idempotency");
     let message = client
         .request_with_headers(
-            instance_id.tool_subject("plans", "plans_list_plans"),
+            instance_id.tool_subject(&identity_token, "list_plans"),
             headers,
             serde_json::to_vec(&request)?.into(),
         )
         .await?;
     let reply: ToolReply = serde_json::from_slice(&message.payload)?;
     assert_eq!(reply.call_id, call_id);
-    let value = reply.result.expect("plans_list_plans should succeed");
+    let value = reply.result.expect("list_plans should succeed");
     assert!(value.is_object());
     assert!(value
         .get("content")
@@ -219,6 +242,57 @@ async fn bridge_registers_plans_and_round_trips_an_invoke() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn bridge_registers_raw_search_and_worker_composes_visible_name() -> Result<()> {
+    let Some(server) = spawn_nats_server().await? else {
+        return Ok(());
+    };
+    let script_dir = tempfile::tempdir().context("create mock MCP script directory")?;
+    let script_path = script_dir.path().join("exa.yaml");
+    std::fs::write(
+        &script_path,
+        "tools:\n  - name: search\n    description: Search documents.\nresponses:\n  - found\n",
+    )
+    .context("write mock MCP script")?;
+    let bridge = BridgeToolset::new(
+        "exa",
+        vec![
+            mock_mcp_binary()?.display().to_string(),
+            "--script".to_owned(),
+            script_path.display().to_string(),
+        ],
+    )
+    .await?;
+    let instance_id = InstanceId::new();
+    let server_instance_id = instance_id.clone();
+    let nats_url = server.url.clone();
+    let server_task =
+        tokio::spawn(
+            async move { serve_over_nats(bridge, server_instance_id, &nats_url, TOKEN).await },
+        );
+
+    let client = async_nats::ConnectOptions::new()
+        .token(TOKEN.to_string())
+        .connect(&server.url)
+        .await?;
+    let identity_token = server_identity_token(None, "", "exa");
+    let registration = wait_for_registration(&client, &instance_id, &identity_token).await?;
+
+    assert_eq!(registration.package, None);
+    assert_eq!(registration.config, "");
+    assert_eq!(registration.server, "exa");
+    assert_eq!(registration.tools.len(), 1);
+    assert_eq!(registration.tools[0].name, "search");
+    assert_ne!(registration.tools[0].name, "exa_search");
+    assert_eq!(
+        ServerIdentity::agent_visible_name(Some("agent-package"), &registration, "search"),
+        "exa_search"
+    );
+
+    server_task.abort();
+    let _ = server_task.await;
+    Ok(())
+}
 #[cfg(target_os = "linux")]
 fn direct_child_pid(parent_pid: u32) -> Result<u32> {
     // /proc avoids depending on pgrep in minimal Linux test environments.
@@ -302,7 +376,8 @@ async fn bridge_binary_exits_when_wrapped_child_dies() -> Result<()> {
         .token(TOKEN.to_string())
         .connect(&server.url)
         .await?;
-    wait_for_registration(&client, &instance_id).await?;
+    let identity_token = server_identity_token(None, "", "plans");
+    wait_for_registration(&client, &instance_id, &identity_token).await?;
 
     let wrapped_child_pid = direct_child_pid(bridge_pid)?;
     // SAFETY: wrapped_child_pid was read from the bridge process's direct children.

--- a/crates/harnx-runtime/src/agent_loop.rs
+++ b/crates/harnx-runtime/src/agent_loop.rs
@@ -468,6 +468,7 @@ async fn user_prompt_gate_passes(
 type AgentModelResult = Result<(String, Option<String>, Vec<ToolCall>, CompletionTokenUsage)>;
 
 async fn call_agent_model(ctx: &AgentLoopContext, input: &mut Input) -> AgentModelResult {
+    crate::tool_context::refresh_nats_tool_declarations(&ctx.config, &ctx.instance_id).await;
     if let Some(call_fn) = &ctx.call_fn {
         call_fn(input, &ctx.config, ctx.abort_signal.clone()).await
     } else {

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -307,6 +307,8 @@ pub struct Config {
 
     pub model: Model,
     pub tools: Tools,
+    #[doc(hidden)]
+    pub nats_tool_declarations: Arc<parking_lot::RwLock<Vec<ToolDeclaration>>>,
     pub working_mode: WorkingMode,
     pub last_message: Option<LastMessage>,
 
@@ -383,6 +385,7 @@ impl Clone for Config {
             agent_variables: self.agent_variables.clone(),
             model: self.model.clone(),
             tools: self.tools.clone(),
+            nats_tool_declarations: Arc::clone(&self.nats_tool_declarations),
             working_mode: self.working_mode.clone(),
             last_message: self.last_message.clone(),
             session: self.session.clone(),
@@ -427,6 +430,7 @@ impl Config {
             agent_variables: self.agent_variables.clone(),
             model: self.model.clone(),
             tools: self.tools.clone(),
+            nats_tool_declarations: Arc::clone(&self.nats_tool_declarations),
             working_mode: self.working_mode.clone(),
             last_message: self.last_message.clone(),
             session: None,
@@ -463,6 +467,7 @@ impl Default for Config {
 
             model: Default::default(),
             tools: Default::default(),
+            nats_tool_declarations: Arc::new(parking_lot::RwLock::new(Vec::new())),
             working_mode: WorkingMode::Cmd,
             last_message: None,
 
@@ -1300,6 +1305,7 @@ impl Config {
         active_pkg: Option<&str>,
     ) -> (Vec<ToolDeclaration>, HashMap<String, String>) {
         let mut declarations = self.tools.declarations();
+        declarations.extend(self.nats_tool_declarations.read().iter().cloned());
         let mut handoff_targets = HashMap::new();
         if let Some(use_tools) = use_tools {
             let selectors = split_tool_selectors(use_tools)

--- a/crates/harnx-runtime/src/config/nats_split.rs
+++ b/crates/harnx-runtime/src/config/nats_split.rs
@@ -343,6 +343,7 @@ fn expand_env_string(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::test_support::{env_lock, EnvGuard};
 
     /// Assert a resolved server matches the expected dynamic-local identity
     /// (reserved name, url, token) and routes through the authenticated path.
@@ -369,12 +370,15 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn local_cluster_env_handoff_builds_authenticated_dynamic_config() {
         harnx_core::require_nextest();
-        unsafe {
-            std::env::set_var(HARNX_NATS_URL_ENV, "nats://127.0.0.1:4555");
-            std::env::set_var(HARNX_NATS_TOKEN_ENV, "handoff-token");
-        }
+        let _lock = env_lock();
+        let _url = EnvGuard::new(
+            HARNX_NATS_URL_ENV,
+            std::path::Path::new("nats://127.0.0.1:4555"),
+        );
+        let _token = EnvGuard::new(HARNX_NATS_TOKEN_ENV, std::path::Path::new("handoff-token"));
 
         let server = resolve_local_nats_server_config().await.unwrap();
 
@@ -382,12 +386,15 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn local_cluster_dynamic_resolution_wins_over_reserved_yaml_entry() {
         harnx_core::require_nextest();
-        unsafe {
-            std::env::set_var(HARNX_NATS_URL_ENV, "nats://127.0.0.1:4666");
-            std::env::set_var(HARNX_NATS_TOKEN_ENV, "dynamic-token");
-        }
+        let _lock = env_lock();
+        let _url = EnvGuard::new(
+            HARNX_NATS_URL_ENV,
+            std::path::Path::new("nats://127.0.0.1:4666"),
+        );
+        let _token = EnvGuard::new(HARNX_NATS_TOKEN_ENV, std::path::Path::new("dynamic-token"));
         let directory = tempfile::tempdir().unwrap();
         std::fs::write(
             directory.path().join("__local__.yaml"),
@@ -412,12 +419,11 @@ mod tests {
 
     #[test]
     fn expand_nats_server_envs_expands_secret_fields() {
-        unsafe {
-            std::env::set_var("NATS_TOKEN", "secret-token");
-            std::env::set_var("NATS_CERT", "/tmp/client-cert.pem");
-            std::env::set_var("NATS_KEY", "/tmp/client-key.pem");
-            std::env::set_var("NATS_CA", "/tmp/ca.pem");
-        }
+        let _lock = env_lock();
+        let _token = EnvGuard::new("NATS_TOKEN", std::path::Path::new("secret-token"));
+        let _cert = EnvGuard::new("NATS_CERT", std::path::Path::new("/tmp/client-cert.pem"));
+        let _key = EnvGuard::new("NATS_KEY", std::path::Path::new("/tmp/client-key.pem"));
+        let _ca = EnvGuard::new("NATS_CA", std::path::Path::new("/tmp/ca.pem"));
 
         let mut server = NatsServerConfig {
             name: "local".into(),

--- a/crates/harnx-runtime/src/config/tests.rs
+++ b/crates/harnx-runtime/src/config/tests.rs
@@ -495,6 +495,29 @@ fn select_tools_respects_use_tools_whitelist() {
     );
 }
 
+#[test]
+fn select_tools_merges_cached_nats_declarations() {
+    use harnx_core::agent_config::AgentConfig;
+
+    let config = Config::default();
+    config
+        .nats_tool_declarations
+        .write()
+        .push(make_tool_decl("fs_read"));
+    let mut agent = AgentConfig::from_prompt("test");
+    agent.set_use_tools(Some(vec!["fs_read".to_string()]));
+
+    let declarations = config
+        .select_tools(&agent)
+        .expect("cached NATS tool selected");
+    assert_eq!(
+        declarations
+            .iter()
+            .map(|declaration| declaration.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["fs_read"]
+    );
+}
 /// When use_tools is not set, select_tools should return None (no tools).
 #[test]
 fn select_tools_returns_none_without_use_tools() {

--- a/crates/harnx-runtime/src/lib.rs
+++ b/crates/harnx-runtime/src/lib.rs
@@ -29,11 +29,12 @@ pub mod nats_session_log;
 pub mod nats_tool_provider;
 pub mod nats_worker;
 pub mod remote_session_cleanup;
+pub mod server_identity;
 pub mod session_cleanup;
 pub mod session_history;
 pub mod test_utils;
 pub mod tool;
-mod tool_context;
+pub mod tool_context;
 pub mod utils;
 
 // Re-export thin-client types for frontends

--- a/crates/harnx-runtime/src/nats_tool_provider.rs
+++ b/crates/harnx-runtime/src/nats_tool_provider.rs
@@ -1,4 +1,5 @@
 use crate::config::{Config, LOCAL_CLUSTER_KEY};
+use crate::server_identity::ServerIdentity;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use futures_util::TryStreamExt;
@@ -6,7 +7,7 @@ use harnx_core::abort::{wait_abort_signal, AbortSignal};
 use harnx_core::instance::InstanceId;
 use harnx_core::tool::{JsonSchema, ToolDeclaration, ToolError, ToolProvider};
 use harnx_toolset::{
-    ControlKind, ControlMessage, Registration, ToolErrorPayload, ToolReply, ToolRequest,
+    ControlKind, ControlMessage, Registration, ToolErrorPayload, ToolReply, ToolRequest, ToolSpec,
     HDR_CALL_ID, HDR_CONTENT_TYPE, HDR_IDEMPOTENCY_KEY, HDR_INSTANCE_ID,
 };
 use harnx_toolset_server::{registration_key, TOOL_REGISTRY_BUCKET};
@@ -23,6 +24,8 @@ const JSON_CONTENT_TYPE: &str = "application/json";
 #[derive(Clone, Debug)]
 struct RegisteredTool {
     server: String,
+    selector_server: String,
+    raw_name: String,
     request_timeout: Duration,
 }
 
@@ -113,6 +116,8 @@ pub struct NatsToolProvider {
     instance_id: InstanceId,
     parent_session_id: Option<String>,
     tools: HashMap<String, RegisteredTool>,
+    registrations: Vec<Registration>,
+    active_package: Option<String>,
     declarations: Vec<ToolDeclaration>,
     // Owning this subscription establishes the progress/cancel channel before requests start.
     _control_subscription: Mutex<async_nats::Subscriber>,
@@ -125,16 +130,22 @@ impl NatsToolProvider {
         config: &Config,
         instance_id: InstanceId,
         in_flight: NatsInFlightCalls,
+        active_package: Option<&str>,
     ) -> anyhow::Result<Self> {
         let client = config.nats_client(LOCAL_CLUSTER_KEY).await?;
         let control_subject = instance_id.control_subject();
         let control_subscription = client.subscribe(control_subject).await?;
         client.flush().await?;
 
-        let registrations = registration_snapshot(&client, &instance_id)
+        let mut registrations = registration_snapshot(&client, &instance_id)
             .await
             .unwrap_or_default();
-        let (tools, declarations) = build_registered_tools(registrations);
+        registrations.sort_by_key(|registration| match registration.package.as_deref() {
+            Some(package) if Some(package) == active_package => 0,
+            None => usize::from(active_package.is_some()),
+            Some(_) => 2,
+        });
+        let (tools, declarations) = build_registered_tools(active_package, registrations.clone());
         let parent_session_id = config
             .session
             .as_ref()
@@ -145,12 +156,41 @@ impl NatsToolProvider {
             instance_id,
             parent_session_id,
             tools,
+            registrations,
+            active_package: active_package.map(str::to_string),
             declarations,
             _control_subscription: Mutex::new(control_subscription),
             in_flight,
         })
     }
 
+    fn resolve_route(&self, tool_name: &str) -> Option<RegisteredTool> {
+        if let Some((identity_token, raw_name)) = ServerIdentity::parse_agent_tool_name(
+            tool_name,
+            &self.registrations,
+            self.active_package.as_deref(),
+        ) {
+            let registration = self.registrations.iter().find(|registration| {
+                ServerIdentity::identity_token(registration) == identity_token
+            })?;
+            let spec = registration
+                .tools
+                .iter()
+                .find(|spec| spec.name == raw_name)?;
+            return Some(RegisteredTool {
+                server: identity_token,
+                selector_server: registration.server.clone(),
+                raw_name,
+                request_timeout: spec
+                    .timeout_secs
+                    .map(Duration::from_secs)
+                    .unwrap_or(DEFAULT_REQUEST_TIMEOUT),
+            });
+        }
+
+        // Raw aliases keep persisted calls from before server-prefixed naming routable.
+        self.tools.get(tool_name).cloned()
+    }
     pub fn declarations(&self) -> &[ToolDeclaration] {
         &self.declarations
     }
@@ -163,19 +203,21 @@ impl NatsToolProvider {
         self.declarations
             .iter()
             .filter(|declaration| {
-                let server = self
-                    .tools
-                    .get(&declaration.name)
-                    .map(|tool| tool.server.as_str());
+                let route = self.tools.get(&declaration.name);
                 selectors.iter().any(|selector| {
                     let selector = selector.trim();
                     selector == "*"
                         || selector == declaration.name
-                        || server.is_some_and(|server| selector == server)
+                        || route.is_some_and(|route| {
+                            selector == route.selector_server || selector == route.raw_name
+                        })
                         || globset::Glob::new(selector).is_ok_and(|pattern| {
                             let matcher = pattern.compile_matcher();
                             matcher.is_match(&declaration.name)
-                                || server.is_some_and(|server| matcher.is_match(server))
+                                || route.is_some_and(|route| {
+                                    matcher.is_match(&route.selector_server)
+                                        || matcher.is_match(&route.raw_name)
+                                })
                         })
                 })
             })
@@ -208,14 +250,13 @@ impl NatsToolProvider {
 
     fn prepare_request(
         &self,
-        tool_name: &str,
         arguments: Value,
         route: &RegisteredTool,
     ) -> Result<PendingToolRequest, ToolError> {
         let call_id = Uuid::new_v4().to_string();
         let request = ToolRequest {
             call_id: call_id.clone(),
-            tool: tool_name.to_string(),
+            tool: route.raw_name.clone(),
             args: arguments,
             parent_session_id: self.parent_session_id.clone(),
         };
@@ -230,7 +271,9 @@ impl NatsToolProvider {
         Ok(PendingToolRequest {
             call_id,
             server: route.server.clone(),
-            subject: self.instance_id.tool_subject(&route.server, tool_name),
+            subject: self
+                .instance_id
+                .tool_subject(&route.server, &route.raw_name),
             request: async_nats::Request::new()
                 .headers(headers)
                 .payload(payload.into())
@@ -278,54 +321,101 @@ impl NatsToolProvider {
     }
 }
 
+fn parse_json_schema(mut value: Value) -> serde_json::Result<JsonSchema> {
+    // schemars emits nullable fields as `type: [T, "null"]`, while the
+    // completion schema uses `required` to represent optional fields.
+    normalize_schema_types(&mut value);
+    serde_json::from_value(value)
+}
+
+fn normalize_schema_types(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            if let Some(Value::Array(types)) = object.get_mut("type") {
+                let schema_type = types
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .find(|schema_type| *schema_type != "null")
+                    .or_else(|| types.iter().find_map(Value::as_str));
+                if let Some(schema_type) = schema_type {
+                    *object.get_mut("type").expect("type key exists") =
+                        Value::String(schema_type.to_string());
+                }
+            }
+            for child in object.values_mut() {
+                normalize_schema_types(child);
+            }
+        }
+        Value::Array(values) => {
+            for child in values {
+                normalize_schema_types(child);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn registered_tool(
+    active_package: Option<&str>,
+    registration: &Registration,
+    spec: ToolSpec,
+) -> Option<(String, RegisteredTool, ToolDeclaration)> {
+    let template = |key| {
+        spec.meta
+            .as_ref()
+            .and_then(|meta| meta.get(key))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    };
+    let call_template = template("call_template");
+    let result_template = template("result_template");
+    let parameters = match parse_json_schema(spec.input_schema) {
+        Ok(parameters) => parameters,
+        Err(error) => {
+            log::warn!(
+                "ignoring invalid schema for NATS tool '{}.{}': {error}",
+                registration.server,
+                spec.name
+            );
+            return None;
+        }
+    };
+    let raw_name = spec.name.clone();
+    let name = ServerIdentity::agent_visible_name(active_package, registration, &raw_name);
+    let route = RegisteredTool {
+        server: ServerIdentity::identity_token(registration),
+        selector_server: registration.server.clone(),
+        raw_name,
+        request_timeout: spec
+            .timeout_secs
+            .map(Duration::from_secs)
+            .unwrap_or(DEFAULT_REQUEST_TIMEOUT),
+    };
+    let declaration = ToolDeclaration {
+        name: name.clone(),
+        description: spec.description,
+        parameters,
+        mcp_tool_name: None,
+        mcp_server_name: None,
+        call_template,
+        result_template,
+        idempotent_hint: Some(spec.idempotent_hint),
+        read_only_hint: Some(spec.read_only_hint),
+    };
+    Some((name, route, declaration))
+}
 fn build_registered_tools(
+    active_package: Option<&str>,
     mut registrations: Vec<Registration>,
 ) -> (HashMap<String, RegisteredTool>, Vec<ToolDeclaration>) {
     registrations.sort_by(|left, right| left.server.cmp(&right.server));
     let mut registered = HashMap::new();
     for registration in registrations {
-        for spec in registration.tools {
-            let call_template = spec
-                .meta
-                .as_ref()
-                .and_then(|m| m.get("call_template"))
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-            let result_template = spec
-                .meta
-                .as_ref()
-                .and_then(|m| m.get("result_template"))
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-            let parameters = match serde_json::from_value::<JsonSchema>(spec.input_schema) {
-                Ok(parameters) => parameters,
-                Err(error) => {
-                    log::warn!(
-                        "ignoring invalid schema for NATS tool '{}.{}': {error}",
-                        registration.server,
-                        spec.name
-                    );
-                    continue;
-                }
-            };
-            let name = spec.name.clone();
-            let route = RegisteredTool {
-                server: registration.server.clone(),
-                request_timeout: spec
-                    .timeout_secs
-                    .map(Duration::from_secs)
-                    .unwrap_or(DEFAULT_REQUEST_TIMEOUT),
-            };
-            let declaration = ToolDeclaration {
-                name: spec.name,
-                description: spec.description,
-                parameters,
-                mcp_tool_name: None,
-                mcp_server_name: None,
-                call_template,
-                result_template,
-                idempotent_hint: Some(spec.idempotent_hint),
-                read_only_hint: Some(spec.read_only_hint),
+        for spec in registration.tools.clone() {
+            let Some((name, route, declaration)) =
+                registered_tool(active_package, &registration, spec)
+            else {
+                continue;
             };
             if let Some((previous, _)) = registered.insert(name.clone(), (route, declaration)) {
                 log::warn!(
@@ -336,11 +426,17 @@ fn build_registered_tools(
             }
         }
     }
-    let (tools, mut declarations): (HashMap<_, _>, Vec<_>) = registered
-        .into_iter()
-        .map(|(name, (route, declaration))| ((name, route), declaration))
-        .unzip();
-    declarations.sort_by(|left, right| left.name.cmp(&right.name));
+    let mut entries = registered.into_iter().collect::<Vec<_>>();
+    entries.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut tools = HashMap::new();
+    let mut declarations = Vec::with_capacity(entries.len());
+    for (name, (route, declaration)) in entries {
+        // Keep raw aliases during the naming transition so injected and persisted
+        // calls from older turns still route to the same server.
+        tools.insert(route.raw_name.clone(), route.clone());
+        tools.insert(name, route);
+        declarations.push(declaration);
+    }
     (tools, declarations)
 }
 
@@ -351,7 +447,7 @@ impl ToolProvider for NatsToolProvider {
     }
 
     fn has_tool(&self, tool_name: &str) -> bool {
-        self.tools.contains_key(tool_name)
+        self.resolve_route(tool_name).is_some()
     }
 
     async fn call_tool(
@@ -360,12 +456,12 @@ impl ToolProvider for NatsToolProvider {
         arguments: Value,
         abort: &AbortSignal,
     ) -> Result<Value, ToolError> {
-        let Some(route) = self.tools.get(tool_name) else {
+        let Some(route) = self.resolve_route(tool_name) else {
             return Err(ToolError::Recoverable(anyhow!(
                 "NATS tool is not registered: {tool_name}"
             )));
         };
-        let pending = self.prepare_request(tool_name, arguments, route)?;
+        let pending = self.prepare_request(arguments, &route)?;
         let call_id = pending.call_id.clone();
         let message = self.await_response(pending, abort).await?;
         let reply: ToolReply = serde_json::from_slice(&message.payload).map_err(|error| {
@@ -409,7 +505,8 @@ async fn registration_snapshot(
                 continue;
             }
         };
-        if key == registration_key(instance_id, &registration.server) {
+        let identity_token = ServerIdentity::identity_token(&registration);
+        if key == registration_key(instance_id, &identity_token) {
             registrations.push(registration);
         }
     }
@@ -423,6 +520,43 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    fn prefixes_registered_tool_with_server_and_keeps_raw_route_name() {
+        harnx_core::require_nextest();
+        let registration = Registration {
+            package: None,
+            config: String::new(),
+            server: "fs".to_string(),
+            tools: vec![ToolSpec {
+                name: "read".to_string(),
+                description: "Read a file".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "offset": { "type": ["integer", "null"] }
+                    }
+                }),
+                idempotent_hint: true,
+                read_only_hint: true,
+                timeout_secs: None,
+                meta: None,
+            }],
+            schema_version: 1,
+            proto_version: 1,
+        };
+
+        let (tools, declarations) = build_registered_tools(None, vec![registration]);
+
+        assert_eq!(declarations[0].name, "fs_read");
+        assert_eq!(
+            declarations[0].parameters.properties.as_ref().unwrap()["offset"]
+                .type_value
+                .as_deref(),
+            Some("integer")
+        );
+        assert_eq!(tools["fs_read"].raw_name, "read");
+    }
+
+    #[test]
     fn builds_tool_declaration_templates_from_tool_spec_meta() {
         harnx_core::require_nextest();
         let meta = json!({
@@ -433,6 +567,8 @@ mod tests {
         .expect("meta object")
         .clone();
         let registration = Registration {
+            package: None,
+            config: String::new(),
             server: "template-server".to_string(),
             tools: vec![ToolSpec {
                 name: "template_tool".to_string(),
@@ -447,7 +583,7 @@ mod tests {
             proto_version: 1,
         };
 
-        let (_, declarations) = build_registered_tools(vec![registration]);
+        let (_, declarations) = build_registered_tools(None, vec![registration]);
 
         assert_eq!(declarations.len(), 1);
         assert_eq!(

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -287,7 +287,12 @@ pub(crate) fn tool_servers_matching_use_tools(
             let matches = namespaced_use_tools.iter().any(|selector| {
                 super::super::config::selector_could_match_server(selector, &display_name)
             });
-            matches && seen_names.insert(server.name.clone())
+            let identity_token = harnx_toolset::server_identity_token(
+                server.package.as_deref(),
+                &server.name,
+                &server.name,
+            );
+            matches && seen_names.insert(identity_token)
         })
         .cloned()
         .collect()
@@ -376,7 +381,8 @@ async fn start_subagent_toolset(
         jetstream,
     ));
     let server_name = harnx_toolset::Toolset::name(toolset.as_ref()).to_string();
-    let registration_key = harnx_toolset_server::registration_key(&instance_id, &server_name);
+    let identity_token = harnx_toolset::server_identity_token(None, "", &server_name);
+    let registration_key = harnx_toolset_server::registration_key(&instance_id, &identity_token);
     let server = tokio::spawn(harnx_toolset_server::serve_with_client(
         toolset,
         instance_id,
@@ -1200,7 +1206,7 @@ mod tests {
     }
 
     #[test]
-    fn tool_server_filter_deduplicates_names_first_wins() {
+    fn tool_server_filter_deduplicates_full_identities_first_wins() {
         let user_time = tool_server("time");
         let mut package_time = tool_server("time");
         package_time.package = Some("coding".to_string());
@@ -1209,10 +1215,11 @@ mod tests {
 
         let matching = tool_servers_matching_use_tools(&servers, None, &["*".to_string()]);
 
-        assert_eq!(matching.len(), 2);
+        assert_eq!(matching.len(), 3);
         assert_eq!(matching[0].name, "time");
         assert_eq!(matching[0].package, None);
-        assert_eq!(matching[1].name, "weather");
+        assert_eq!(matching[1].package.as_deref(), Some("coding"));
+        assert_eq!(matching[2].name, "weather");
 
         let mut aaa = tool_server("dup");
         aaa.package = Some("aaa".to_string());
@@ -1220,8 +1227,17 @@ mod tests {
         zzz.package = Some("zzz".to_string());
         let package_matching =
             tool_servers_matching_use_tools(&[aaa, zzz], None, &["*".to_string()]);
-        assert_eq!(package_matching.len(), 1);
+        assert_eq!(package_matching.len(), 2);
         assert_eq!(package_matching[0].package.as_deref(), Some("aaa"));
+        assert_eq!(package_matching[1].package.as_deref(), Some("zzz"));
+
+        let duplicate = tool_server("same");
+        let duplicate_matching = tool_servers_matching_use_tools(
+            &[duplicate.clone(), duplicate],
+            None,
+            &["*".to_string()],
+        );
+        assert_eq!(duplicate_matching.len(), 1);
     }
 
     #[test]

--- a/crates/harnx-runtime/src/nats_worker/tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests.rs
@@ -1498,6 +1498,127 @@ async fn remote_cancel_published_after_in_flight_marks_session_cancelled() {
     let _ = child.wait();
 }
 
+async fn registered_agent_provider(
+    jetstream: &async_nats::jetstream::Context,
+    config: &Config,
+    agents: &[&str],
+) -> (
+    String,
+    Arc<crate::nats_tool_provider::NatsToolProvider>,
+    Vec<(String, harnx_toolset::Registration)>,
+) {
+    let (instance_id, registrations) = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if let Ok(registry) = jetstream
+                .get_key_value(harnx_toolset_server::TOOL_REGISTRY_BUCKET)
+                .await
+            {
+                let mut keys = registry.keys().await.expect("list registry keys");
+                let mut registrations = Vec::new();
+                while let Some(key) = keys.next().await {
+                    let key = key.expect("read registry key");
+                    let Some(value) = registry.get(&key).await.expect("read registration") else {
+                        continue;
+                    };
+                    let registration: harnx_toolset::Registration =
+                        serde_json::from_slice(&value).expect("decode registration");
+                    registrations.push((key, registration));
+                }
+                if agents.iter().all(|agent| {
+                    registrations
+                        .iter()
+                        .any(|(_, registration)| registration.server == *agent)
+                }) {
+                    let agent = agents.first().expect("at least one requested agent");
+                    let key = registrations
+                        .iter()
+                        .find(|(_, registration)| registration.server == *agent)
+                        .map(|(key, _)| key)
+                        .expect("requested agent registration exists");
+                    let instance_id = key
+                        .strip_suffix(&format!(".____{agent}"))
+                        .expect("registry key uses {instance}.{identity_token}")
+                        .to_string();
+                    break (instance_id, registrations);
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("worker did not register configured agents");
+    let provider = crate::nats_tool_provider::NatsToolProvider::discover(
+        config,
+        harnx_core::instance::InstanceId::from_string(instance_id.clone()),
+        crate::nats_tool_provider::NatsInFlightCalls::default(),
+        None,
+    )
+    .await
+    .expect("parent discovers configured sub-agent toolsets");
+    (instance_id, Arc::new(provider), registrations)
+}
+
+async fn call_registered_agent(
+    provider: Arc<crate::nats_tool_provider::NatsToolProvider>,
+    tool: String,
+    message: String,
+    early_event: Option<(&mut async_nats::Subscriber, &str)>,
+) -> (serde_json::Value, Option<String>) {
+    let prompt_call = tokio::spawn(async move {
+        provider
+            .call_tool(
+                &tool,
+                json!({ "message": message }),
+                &harnx_core::abort::create_abort_signal(),
+            )
+            .await
+    });
+    let child_session_id = if let Some((parent_events, expected_agent)) = early_event {
+        let (agent, session_id) = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let message = parent_events
+                    .next()
+                    .await
+                    .expect("parent event stream closed");
+                let envelope =
+                    crate::nats_event_sink::AdvisoryEnvelope::from_bytes(&message.payload)
+                        .expect("decode parent advisory");
+                if let AgentEvent::SubAgent { source, event } = envelope.event {
+                    if let AgentEvent::Turn(harnx_core::event::TurnEvent::SubAgentStarted {
+                        agent,
+                        session_id,
+                    }) = *event
+                    {
+                        assert_eq!(source.agent, agent);
+                        assert_eq!(source.session_id.as_deref(), Some(session_id.as_str()));
+                        break (agent, session_id);
+                    }
+                }
+            }
+        })
+        .await
+        .expect("parent did not receive early SubAgentStarted");
+        assert_eq!(agent, expected_agent);
+        assert!(
+            !prompt_call.is_finished(),
+            "SubAgentStarted must arrive before final tool result"
+        );
+        Some(session_id)
+    } else {
+        None
+    };
+    let result = prompt_call
+        .await
+        .expect("join prompt tool call")
+        .unwrap_or_else(|error| match error {
+            harnx_core::tool::ToolError::Recoverable(error)
+            | harnx_core::tool::ToolError::Fatal(error) => {
+                panic!("registered agent prompt failed: {error:#}")
+            }
+        });
+    (result, child_session_id)
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn worker_registers_and_delegates_to_every_configured_agent() {
     let _env_guard = env_lock().await;
@@ -1522,47 +1643,12 @@ async fn worker_registers_and_delegates_to_every_configured_agent() {
         .await
         .expect("connect registry observer");
     let jetstream = async_nats::jetstream::new(client);
-    let (instance_id, registrations) = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let Ok(registry) = jetstream
-                .get_key_value(harnx_toolset_server::TOOL_REGISTRY_BUCKET)
-                .await
-            else {
-                tokio::time::sleep(Duration::from_millis(25)).await;
-                continue;
-            };
-            let mut keys = registry.keys().await.expect("list registry keys");
-            let mut values = Vec::new();
-            while let Some(key) = keys.next().await {
-                let key = key.expect("read registry key");
-                let Some(value) = registry.get(&key).await.expect("read registration") else {
-                    continue;
-                };
-                let registration: harnx_toolset::Registration =
-                    serde_json::from_slice(&value).expect("decode registration");
-                values.push((key, registration));
-            }
-            let alpha_key = values
-                .iter()
-                .find(|(_, registration)| registration.server == "alpha")
-                .map(|(key, _)| key.clone());
-            let has_remaining_agents = ["beta", "metis"].iter().all(|agent| {
-                values
-                    .iter()
-                    .any(|(_, registration)| registration.server == *agent)
-            });
-            if let (Some(alpha_key), true) = (alpha_key, has_remaining_agents) {
-                let instance = alpha_key
-                    .strip_suffix(".alpha")
-                    .expect("registry key uses {instance}.{agent}")
-                    .to_string();
-                break (instance, values);
-            }
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
-    })
-    .await
-    .expect("configured agent toolsets did not register");
+    let (instance_id, provider, registrations) = registered_agent_provider(
+        &jetstream,
+        &seeded.parent_config,
+        &["alpha", "beta", "metis"],
+    )
+    .await;
 
     // Old auto-registration included the active agent; preserve self-delegation parity.
     for agent in ["alpha", "beta", "metis"] {
@@ -1570,7 +1656,7 @@ async fn worker_registers_and_delegates_to_every_configured_agent() {
             .iter()
             .find(|(_, registration)| registration.server == agent)
             .expect("configured agent registration exists");
-        assert_eq!(key, &format!("{instance_id}.{agent}"));
+        assert_eq!(key, &format!("{instance_id}.____{agent}"));
         assert_eq!(registration.tools.len(), 4);
         assert!(registration
             .tools
@@ -1578,31 +1664,18 @@ async fn worker_registers_and_delegates_to_every_configured_agent() {
             .all(|tool| tool.name.starts_with(&format!("{agent}_session_"))));
     }
 
-    let provider = crate::nats_tool_provider::NatsToolProvider::discover(
-        &seeded.parent_config,
-        harnx_core::instance::InstanceId::from_string(instance_id),
-        crate::nats_tool_provider::NatsInFlightCalls::default(),
-    )
-    .await
-    .expect("parent discovers configured sub-agent toolsets");
     let declarations = provider.declarations_for_use_tools(Some("*"));
     for agent in ["alpha", "beta"] {
         assert!(declarations
             .iter()
-            .any(|tool| tool.name == format!("{agent}_session_prompt")));
-        let result = provider
-            .call_tool(
-                &format!("{agent}_session_prompt"),
-                json!({ "message": format!("delegate to {agent}") }),
-                &harnx_core::abort::create_abort_signal(),
-            )
-            .await
-            .unwrap_or_else(|error| match error {
-                harnx_core::tool::ToolError::Recoverable(error)
-                | harnx_core::tool::ToolError::Fatal(error) => {
-                    panic!("parent delegates to configured agent: {error:#}")
-                }
-            });
+            .any(|tool| tool.name == format!("{agent}_{agent}_session_prompt")));
+        let (result, _) = call_registered_agent(
+            Arc::clone(&provider),
+            format!("{agent}_{agent}_session_prompt"),
+            format!("delegate to {agent}"),
+            None,
+        )
+        .await;
         assert_eq!(
             result["response"],
             format!("stub remote reply over nats: delegate to {agent}")
@@ -1700,84 +1773,16 @@ async fn subagent_started_reaches_parent_stream_before_prompt_result() {
         .await
         .expect("flush parent event subscription");
     let jetstream = async_nats::jetstream::new(client);
-    let instance_id = tokio::time::timeout(Duration::from_secs(5), async {
-        'registration: loop {
-            if let Ok(registry) = jetstream
-                .get_key_value(harnx_toolset_server::TOOL_REGISTRY_BUCKET)
-                .await
-            {
-                let mut keys = registry.keys().await.expect("list registry keys");
-                while let Some(key) = keys.next().await {
-                    let key = key.expect("read registry key");
-                    if let Some(instance) = key.strip_suffix(".metis") {
-                        break 'registration instance.to_string();
-                    }
-                }
-            }
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
-    })
-    .await
-    .expect("metis toolset registration missing");
-    let provider = Arc::new(
-        crate::nats_tool_provider::NatsToolProvider::discover(
-            &seeded.parent_config,
-            harnx_core::instance::InstanceId::from_string(instance_id),
-            crate::nats_tool_provider::NatsInFlightCalls::default(),
-        )
-        .await
-        .expect("discover metis toolset for parent"),
-    );
-    let prompt_call = tokio::spawn({
-        let provider = Arc::clone(&provider);
-        async move {
-            provider
-                .call_tool(
-                    "metis_session_prompt",
-                    json!({ "message": "emit start before finishing" }),
-                    &harnx_core::abort::create_abort_signal(),
-                )
-                .await
-        }
-    });
-
-    let (event_agent, child_session_id) = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let message = parent_events
-                .next()
-                .await
-                .expect("parent event stream closed");
-            let envelope = crate::nats_event_sink::AdvisoryEnvelope::from_bytes(&message.payload)
-                .expect("decode parent advisory");
-            if let AgentEvent::SubAgent { source, event } = envelope.event {
-                if let AgentEvent::Turn(harnx_core::event::TurnEvent::SubAgentStarted {
-                    agent,
-                    session_id,
-                }) = *event
-                {
-                    assert_eq!(source.agent, agent);
-                    assert_eq!(source.session_id.as_deref(), Some(session_id.as_str()));
-                    break (agent, session_id);
-                }
-            }
-        }
-    })
-    .await
-    .expect("parent did not receive early SubAgentStarted");
-    assert_eq!(event_agent, "metis");
-    assert!(
-        !prompt_call.is_finished(),
-        "SubAgentStarted must arrive before final tool result"
-    );
-    let result = prompt_call
-        .await
-        .expect("join prompt tool call")
-        .unwrap_or_else(|error| match error {
-            harnx_core::tool::ToolError::Recoverable(error)
-            | harnx_core::tool::ToolError::Fatal(error) => {
-                panic!("prompt tool call failed: {error:#}")
-            }
-        });
+    let (_, provider, _) =
+        registered_agent_provider(&jetstream, &seeded.parent_config, &["metis"]).await;
+    let (result, child_session_id) = call_registered_agent(
+        provider,
+        "metis_session_prompt".to_string(),
+        "emit start before finishing".to_string(),
+        Some((&mut parent_events, "metis")),
+    )
+    .await;
+    let child_session_id = child_session_id.expect("SubAgentStarted includes child session id");
     assert_eq!(result["response"], "early event child response");
     assert_eq!(result["sub_agent"]["agent"], "metis");
     assert_eq!(result["sub_agent"]["session_id"], child_session_id);

--- a/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
+++ b/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
@@ -3,12 +3,14 @@ use crate::config::{ToolServerConfig, HARNX_NATS_TOKEN_ENV, HARNX_NATS_URL_ENV};
 use crate::nats_tool_provider::NatsInFlightCalls;
 use anyhow::{bail, Context, Result};
 use async_nats::jetstream::{self, kv, stream};
-use futures_util::StreamExt;
+use futures_util::{StreamExt, TryStreamExt};
 use harnx_core::event::{AgentEvent, NoticeEvent};
 use harnx_core::instance::{InstanceId, HARNX_INSTANCE_ID};
 use harnx_core::sink::emit_agent_event;
 use harnx_hooks::executor::HARNX_PACKAGE_DIR_ENV;
-use harnx_toolset::Registration;
+use harnx_toolset::{
+    server_identity_token, Registration, HARNX_SERVER_CONFIG, HARNX_SERVER_PACKAGE,
+};
 use harnx_toolset_server::{registration_key, TOOL_REGISTRY_BUCKET};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -97,29 +99,21 @@ impl ToolServerSupervisor {
             }
         };
 
-        let mut watches = Vec::new();
-        for server in &enabled {
-            let key = registration_key(&config.instance_id, &server.name);
-            let _ = registry.delete(&key).await;
-            match registry.watch_with_history(&key).await {
-                Ok(watch) => watches.push((*server, key, watch)),
-                Err(error) => warn_server_failure(
-                    &server.name,
-                    format!("watch tool registration '{key}': {error:#}"),
-                ),
-            }
-        }
+        let watches = prepare_registration_watches(&registry, &config, &enabled).await;
 
         spawn_enabled_tool_servers(&mut supervisor, &config, &enabled, &processes).await;
 
         let deadline = Instant::now() + readiness_timeout;
+        let instance_id = config.instance_id.clone();
         let readiness = watches.into_iter().map(|(server, key, mut watch)| {
             let processes = Arc::clone(&processes);
+            let instance_id = instance_id.clone();
             async move {
                 if let Err(error) = wait_for_registration(
                     &mut watch,
                     &processes,
-                    &server.name,
+                    server,
+                    &instance_id,
                     &key,
                     deadline,
                     readiness_timeout,
@@ -141,6 +135,35 @@ impl ToolServerSupervisor {
     }
 }
 
+async fn prepare_registration_watches<'a>(
+    registry: &kv::Store,
+    config: &ToolServerStartConfig,
+    servers: &[&'a ToolServerConfig],
+) -> Vec<(&'a ToolServerConfig, String, kv::Watch)> {
+    let mut watches = Vec::new();
+    for server in servers {
+        let expected_token =
+            server_identity_token(server.package.as_deref(), &server.name, "<server>");
+        let key = registration_key(&config.instance_id, &expected_token);
+        remove_registrations_for_config(
+            &config.client,
+            &config.instance_id,
+            server.package.as_deref(),
+            &server.name,
+            None,
+        )
+        .await;
+        match registry.watch_with_history(">").await {
+            Ok(watch) => watches.push((*server, key, watch)),
+            Err(error) => warn_server_failure(
+                &server.name,
+                format!("watch tool registration '{key}': {error:#}"),
+            ),
+        }
+    }
+    watches
+}
+
 async fn spawn_enabled_tool_servers(
     supervisor: &mut ToolServerSupervisor,
     config: &ToolServerStartConfig,
@@ -156,15 +179,17 @@ async fn spawn_enabled_tool_servers(
                     continue;
                 };
                 processes.lock().await.insert(pid, server.name.clone());
-                supervisor.tasks.push(spawn_child_monitor(
+                supervisor.tasks.push(spawn_child_monitor(ToolMonitor {
                     child,
                     pid,
-                    server.name.clone(),
-                    config.instance_id.clone(),
-                    config.client.clone(),
-                    Arc::clone(processes),
-                    in_flight.clone(),
-                ));
+                    server: server.name.clone(),
+                    package: server.package.clone(),
+                    config: server.name.clone(),
+                    instance_id: config.instance_id.clone(),
+                    client: config.client.clone(),
+                    processes: Arc::clone(processes),
+                    in_flight: in_flight.clone(),
+                }));
             }
             Err(error) => warn_server_failure(&server.name, format!("{error:#}")),
         }
@@ -253,6 +278,11 @@ fn spawn_tool_server(config: &ToolServerStartConfig, server: &ToolServerConfig) 
         .args(&server.args)
         .env(HARNX_PACKAGE_DIR_ENV, tool_server_package_dir(server))
         .envs(&server.env)
+        .env(
+            HARNX_SERVER_PACKAGE,
+            server.package.as_deref().unwrap_or_default(),
+        )
+        .env(HARNX_SERVER_CONFIG, &server.name)
         .env(HARNX_INSTANCE_ID, config.instance_id.as_str())
         .env(HARNX_NATS_URL_ENV, &config.nats_url)
         .env(HARNX_NATS_TOKEN_ENV, &config.token)
@@ -281,15 +311,29 @@ fn emit_warning(message: String) {
     log::warn!("{message}");
 }
 
-fn spawn_child_monitor(
-    mut child: Child,
+struct ToolMonitor {
+    child: Child,
     pid: u32,
     server: String,
+    package: Option<String>,
+    config: String,
     instance_id: InstanceId,
     client: async_nats::Client,
     processes: Arc<Mutex<HashMap<u32, String>>>,
     in_flight: NatsInFlightCalls,
-) -> JoinHandle<()> {
+}
+fn spawn_child_monitor(monitor: ToolMonitor) -> JoinHandle<()> {
+    let ToolMonitor {
+        mut child,
+        pid,
+        server,
+        package,
+        config,
+        instance_id,
+        client,
+        processes,
+        in_flight,
+    } = monitor;
     tokio::spawn(async move {
         let status = wait_for_child(&mut child).await;
         processes.lock().await.remove(&pid);
@@ -302,8 +346,14 @@ fn spawn_child_monitor(
         };
         let message = format!("tool server '{server}' crashed, exit {exit}");
         emit_warning(message.clone());
-        in_flight.fail_server_unavailable(&server, message).await;
-        remove_registration(&client, &instance_id, &server).await;
+        remove_registrations_for_config(
+            &client,
+            &instance_id,
+            package.as_deref(),
+            &config,
+            Some((&in_flight, &message)),
+        )
+        .await;
     })
 }
 
@@ -326,19 +376,29 @@ async fn wait_for_child(child: &mut Child) -> std::io::Result<std::process::Exit
 async fn wait_for_registration(
     watch: &mut kv::Watch,
     processes: &Arc<Mutex<HashMap<u32, String>>>,
-    server: &str,
+    server: &ToolServerConfig,
+    instance_id: &InstanceId,
     key: &str,
     deadline: Instant,
     timeout: Duration,
 ) -> Result<()> {
     loop {
-        if !processes.lock().await.values().any(|name| name == server) {
-            bail!("tool server '{server}' exited before registering at '{key}'");
+        if !processes
+            .lock()
+            .await
+            .values()
+            .any(|name| name == &server.name)
+        {
+            bail!(
+                "tool server '{}' exited before registering at '{key}'",
+                server.name
+            );
         }
         let now = Instant::now();
         if now >= deadline {
             bail!(
-                "tool server '{server}' did not register at '{key}' within {}s",
+                "tool server '{}' did not register at '{key}' within {}s",
+                server.name,
                 timeout.as_secs_f64()
             );
         }
@@ -346,17 +406,54 @@ async fn wait_for_registration(
         let poll = remaining.min(Duration::from_millis(100));
         match tokio::time::timeout(poll, watch.next()).await {
             Ok(Some(Ok(entry))) if entry.operation == kv::Operation::Put => {
-                let registration: Registration = serde_json::from_slice(&entry.value)
-                    .with_context(|| format!("decode tool registration '{key}'"))?;
-                if registration.server == server {
-                    return Ok(());
+                if !entry.key.starts_with(key.trim_end_matches("<server>")) {
+                    continue;
                 }
+                let registration: Registration = match serde_json::from_slice(&entry.value) {
+                    Ok(registration) => registration,
+                    Err(error) => {
+                        log::warn!(
+                            "ignoring invalid tool registration '{}': {error}",
+                            entry.key
+                        );
+                        continue;
+                    }
+                };
+                if registration.package != server.package || registration.config != server.name {
+                    log::warn!(
+                        "ignoring tool registration '{}' identity mismatch: expected package {:?}, config '{}'; got package {:?}, config '{}'",
+                        entry.key,
+                        server.package,
+                        server.name,
+                        registration.package,
+                        registration.config
+                    );
+                    continue;
+                }
+                let identity_token = server_identity_token(
+                    registration.package.as_deref(),
+                    &registration.config,
+                    &registration.server,
+                );
+                let expected_key = registration_key(instance_id, &identity_token);
+                if entry.key != expected_key {
+                    log::warn!(
+                        "ignoring tool registration '{}' because its identity expects key '{}'",
+                        entry.key,
+                        expected_key
+                    );
+                    continue;
+                }
+                return Ok(());
             }
             Ok(Some(Ok(_))) => {}
             Ok(Some(Err(error))) => {
-                return Err(error).with_context(|| format!("watch tool registration '{key}'"));
+                log::warn!("ignoring tool registration watch error for '{key}': {error}");
             }
-            Ok(None) => bail!("tool registration watch closed for '{key}'"),
+            Ok(None) => {
+                log::warn!("tool registration watch closed for '{key}'; waiting for timeout");
+                tokio::time::sleep(poll).await;
+            }
             Err(_) => continue,
         }
     }
@@ -383,12 +480,49 @@ async fn ensure_registry_bucket(client: &async_nats::Client) -> Result<kv::Store
     }
 }
 
-async fn remove_registration(client: &async_nats::Client, instance_id: &InstanceId, server: &str) {
+async fn remove_registrations_for_config(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+    package: Option<&str>,
+    config: &str,
+    failure: Option<(&NatsInFlightCalls, &str)>,
+) {
     let jetstream = jetstream::new(client.clone());
     let Ok(store) = jetstream.get_key_value(TOOL_REGISTRY_BUCKET).await else {
         return;
     };
-    let _ = store.delete(registration_key(instance_id, server)).await;
+    let Ok(mut keys) = store.keys().await else {
+        return;
+    };
+    let prefix = format!("{instance_id}.");
+    while let Ok(Some(key)) = keys.try_next().await {
+        if !key.starts_with(&prefix) {
+            continue;
+        }
+        let Ok(Some(value)) = store.get(&key).await else {
+            continue;
+        };
+        let Ok(registration) = serde_json::from_slice::<Registration>(&value) else {
+            continue;
+        };
+        if registration.package.as_deref() != package || registration.config != config {
+            continue;
+        }
+        let identity_token = server_identity_token(
+            registration.package.as_deref(),
+            &registration.config,
+            &registration.server,
+        );
+        if key != registration_key(instance_id, &identity_token) {
+            continue;
+        }
+        if let Some((in_flight, message)) = failure {
+            in_flight
+                .fail_server_unavailable(&identity_token, message.to_string())
+                .await;
+        }
+        let _ = store.delete(key).await;
+    }
 }
 
 #[cfg(unix)]

--- a/crates/harnx-runtime/src/server_identity.rs
+++ b/crates/harnx-runtime/src/server_identity.rs
@@ -1,0 +1,226 @@
+use harnx_core::package_namespace::{mcp_tool_prefix, sanitize_for_tool_name};
+use harnx_toolset::{server_identity_token, Registration};
+
+/// Worker-side source of truth for NATS tool names and route identities.
+pub struct ServerIdentity;
+
+impl ServerIdentity {
+    /// Return `<package>__<config>__<server>` for packaged servers.
+    ///
+    /// Top-level servers use `__<config>__<server>`, including both leading
+    /// separators so their identity cannot collide with a packaged server.
+    pub fn identity_token(registration: &Registration) -> String {
+        server_identity_token(
+            registration.package.as_deref(),
+            &registration.config,
+            &registration.server,
+        )
+    }
+
+    /// Return the tool name exposed to an agent in `agent_package`.
+    pub fn agent_visible_name(
+        agent_package: Option<&str>,
+        registration: &Registration,
+        raw_tool: &str,
+    ) -> String {
+        let server = sanitize_for_tool_name(&registration.server);
+        let raw_tool = sanitize_for_tool_name(raw_tool);
+        let prefix = match registration.package.as_deref() {
+            Some(package) if Some(package) != agent_package => mcp_tool_prefix(package, &server),
+            _ => server,
+        };
+        format!("{prefix}_{raw_tool}")
+    }
+
+    /// Resolve an agent-visible name to `(identity token, raw tool name)`.
+    ///
+    /// Qualified cross-package names are checked first. Bare names prefer
+    /// registrations from `active_package` and top-level registrations before
+    /// falling back to another package. Broader collision handling is tracked
+    /// by #1356.
+    pub fn parse_agent_tool_name(
+        name: &str,
+        known: &[Registration],
+        active_package: Option<&str>,
+    ) -> Option<(String, String)> {
+        Self::resolve_qualified_name(name, known)
+            .or_else(|| Self::resolve_local_name(name, known, active_package))
+            .or_else(|| Self::resolve_cross_package_fallback(name, known, active_package))
+    }
+
+    fn resolve_qualified_name(name: &str, known: &[Registration]) -> Option<(String, String)> {
+        Self::resolve_from(
+            name,
+            known
+                .iter()
+                .filter(|registration| registration.package.is_some()),
+            |registration, tool| {
+                let package = registration.package.as_deref()?;
+                let server = sanitize_for_tool_name(&registration.server);
+                let raw_tool = sanitize_for_tool_name(&tool.name);
+                Some(format!("{}_{raw_tool}", mcp_tool_prefix(package, &server)))
+            },
+        )
+    }
+
+    fn resolve_local_name(
+        name: &str,
+        known: &[Registration],
+        active_package: Option<&str>,
+    ) -> Option<(String, String)> {
+        Self::resolve_from(
+            name,
+            known.iter().filter(|registration| {
+                registration.package.is_none() || registration.package.as_deref() == active_package
+            }),
+            |registration, tool| {
+                Some(Self::agent_visible_name(
+                    registration.package.as_deref(),
+                    registration,
+                    &tool.name,
+                ))
+            },
+        )
+    }
+
+    fn resolve_cross_package_fallback(
+        name: &str,
+        known: &[Registration],
+        active_package: Option<&str>,
+    ) -> Option<(String, String)> {
+        Self::resolve_from(
+            name,
+            known.iter().filter(|registration| {
+                registration.package.is_some() && registration.package.as_deref() != active_package
+            }),
+            |registration, tool| {
+                Some(Self::agent_visible_name(
+                    registration.package.as_deref(),
+                    registration,
+                    &tool.name,
+                ))
+            },
+        )
+    }
+
+    fn resolve_from<'a>(
+        name: &str,
+        registrations: impl Iterator<Item = &'a Registration>,
+        candidate_name: impl Fn(&Registration, &harnx_toolset::ToolSpec) -> Option<String>,
+    ) -> Option<(String, String)> {
+        for registration in registrations {
+            for tool in &registration.tools {
+                if candidate_name(registration, tool).as_deref() == Some(name) {
+                    return Some((Self::identity_token(registration), tool.name.clone()));
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ServerIdentity;
+    use harnx_toolset::{Registration, ToolSpec};
+    use serde_json::json;
+
+    fn registration(package: Option<&str>) -> Registration {
+        Registration {
+            package: package.map(str::to_string),
+            config: "tools".to_string(),
+            server: "fs".to_string(),
+            tools: vec![ToolSpec {
+                name: "read".to_string(),
+                description: String::new(),
+                input_schema: json!({ "type": "object" }),
+                idempotent_hint: true,
+                read_only_hint: true,
+                timeout_secs: None,
+                meta: None,
+            }],
+            schema_version: 1,
+            proto_version: 1,
+        }
+    }
+
+    #[test]
+    fn same_package_name_is_bare() {
+        harnx_core::require_nextest();
+        let registration = registration(Some("p"));
+        assert_eq!(
+            ServerIdentity::agent_visible_name(Some("p"), &registration, "read"),
+            "fs_read"
+        );
+    }
+
+    #[test]
+    fn cross_package_name_is_qualified() {
+        harnx_core::require_nextest();
+        let registration = registration(Some("p"));
+        assert_eq!(
+            ServerIdentity::agent_visible_name(Some("other"), &registration, "read"),
+            "p__fs_read"
+        );
+    }
+
+    #[test]
+    fn top_level_name_is_bare() {
+        harnx_core::require_nextest();
+        let registration = registration(None);
+        assert_eq!(
+            ServerIdentity::agent_visible_name(Some("p"), &registration, "read"),
+            "fs_read"
+        );
+    }
+
+    #[test]
+    fn reverse_parse_round_trips_visible_names() {
+        harnx_core::require_nextest();
+        let same_package = registration(Some("active"));
+        let top_level = registration(None);
+        let cross_package = registration(Some("p"));
+        let known = [
+            same_package.clone(),
+            top_level.clone(),
+            cross_package.clone(),
+        ];
+
+        assert_eq!(
+            ServerIdentity::parse_agent_tool_name("fs_read", &known, Some("active")),
+            Some((
+                ServerIdentity::identity_token(&same_package),
+                "read".to_string()
+            ))
+        );
+        assert_eq!(
+            ServerIdentity::parse_agent_tool_name("p__fs_read", &known, Some("active")),
+            Some((
+                ServerIdentity::identity_token(&cross_package),
+                "read".to_string()
+            ))
+        );
+        assert_eq!(
+            ServerIdentity::parse_agent_tool_name(
+                "fs_read",
+                std::slice::from_ref(&top_level),
+                None,
+            ),
+            Some((
+                ServerIdentity::identity_token(&top_level),
+                "read".to_string()
+            ))
+        );
+        assert_eq!(
+            ServerIdentity::parse_agent_tool_name(
+                "fs_read",
+                std::slice::from_ref(&cross_package),
+                Some("active"),
+            ),
+            Some((
+                ServerIdentity::identity_token(&cross_package),
+                "read".to_string()
+            ))
+        );
+    }
+}

--- a/crates/harnx-runtime/src/tool.rs
+++ b/crates/harnx-runtime/src/tool.rs
@@ -32,7 +32,7 @@ pub struct CompletionText<'a> {
 }
 
 use crate::nats_tool_provider::NatsToolProvider;
-use crate::tool_context::{discover_nats_hook_provider_cached, discover_nats_tool_provider};
+use crate::tool_context::{discover_nats_hook_provider_cached, discover_nats_tool_provider_cached};
 pub use crate::tool_context::{BuildToolEvalContextParams, ToolRoundParams};
 
 #[derive(Debug, Clone)]
@@ -217,9 +217,11 @@ fn build_emit_fns(
 async fn resolve_nats_providers(
     config: &Config,
     instance_id: &harnx_core::instance::InstanceId,
+    active_package: Option<&str>,
     injected_hook_provider: Option<Arc<NatsHookProvider>>,
 ) -> (Option<Arc<NatsToolProvider>>, Option<Arc<NatsHookProvider>>) {
-    let tool_provider = discover_nats_tool_provider(config, instance_id).await;
+    let tool_provider =
+        discover_nats_tool_provider_cached(config, instance_id, active_package).await;
     let hook_provider = match injected_hook_provider {
         Some(provider) => Some(provider),
         None => discover_nats_hook_provider_cached(config, instance_id).await,
@@ -257,8 +259,13 @@ pub async fn build_tool_eval_context(params: BuildToolEvalContextParams<'_>) -> 
         )
     };
 
-    let (nats_provider, nats_hook_provider) =
-        resolve_nats_providers(&config_snapshot, instance_id, nats_hook_provider).await;
+    let (nats_provider, nats_hook_provider) = resolve_nats_providers(
+        &config_snapshot,
+        instance_id,
+        current_agent_package.as_deref(),
+        nats_hook_provider,
+    )
+    .await;
     if let Some(provider) = &nats_provider {
         tool_declarations.extend(provider.declarations_for_use_tools(agent_use_tools));
     }

--- a/crates/harnx-runtime/src/tool_context.rs
+++ b/crates/harnx-runtime/src/tool_context.rs
@@ -4,7 +4,7 @@ use crate::nats_hook_provider::NatsHookProvider;
 use crate::nats_tool_provider::{NatsInFlightCalls, NatsToolProvider};
 use crate::tool::CompletionText;
 use crate::utils::AbortSignal;
-use harnx_core::instance::InstanceId;
+use harnx_core::instance::{InstanceId, HARNX_INSTANCE_ID};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
@@ -78,19 +78,23 @@ impl AgentLoopContext {
     }
 }
 
-const NATS_HOOK_DISCOVERY_TTL: Duration = Duration::from_secs(30);
+const REGISTRATION_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
 
 type HookDiscoveryCache = std::sync::Mutex<HashMap<InstanceId, CachedDiscovery<NatsHookProvider>>>;
+type ToolDiscoveryKey = (InstanceId, Option<String>);
+type ToolDiscoveryCache =
+    std::sync::Mutex<HashMap<ToolDiscoveryKey, CachedDiscovery<NatsToolProvider>>>;
 static NATS_HOOK_DISCOVERY_CACHE: OnceLock<HookDiscoveryCache> = OnceLock::new();
+static NATS_TOOL_DISCOVERY_CACHE: OnceLock<ToolDiscoveryCache> = OnceLock::new();
 
 struct CachedDiscovery<T> {
     provider: Option<Arc<T>>,
     discovered_at: Instant,
 }
 
-fn cached_discovery<T>(
-    cache: &std::sync::Mutex<HashMap<InstanceId, CachedDiscovery<T>>>,
-    instance_id: &InstanceId,
+fn cached_discovery<K: Eq + std::hash::Hash, T>(
+    cache: &std::sync::Mutex<HashMap<K, CachedDiscovery<T>>>,
+    key: &K,
     now: Instant,
     ttl: Duration,
 ) -> Option<Option<Arc<T>>> {
@@ -98,12 +102,12 @@ fn cached_discovery<T>(
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     cache.retain(|_, entry| now.saturating_duration_since(entry.discovered_at) < ttl);
-    cache.get(instance_id).map(|entry| entry.provider.clone())
+    cache.get(key).map(|entry| entry.provider.clone())
 }
 
-fn cache_discovery<T>(
-    cache: &std::sync::Mutex<HashMap<InstanceId, CachedDiscovery<T>>>,
-    instance_id: InstanceId,
+fn cache_discovery<K: Eq + std::hash::Hash, T>(
+    cache: &std::sync::Mutex<HashMap<K, CachedDiscovery<T>>>,
+    key: K,
     provider: Option<Arc<T>>,
     discovered_at: Instant,
 ) {
@@ -111,7 +115,7 @@ fn cache_discovery<T>(
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .insert(
-            instance_id,
+            key,
             CachedDiscovery {
                 provider,
                 discovered_at,
@@ -126,7 +130,8 @@ pub async fn discover_nats_hook_provider_cached(
 ) -> Option<Arc<NatsHookProvider>> {
     let cache = NATS_HOOK_DISCOVERY_CACHE.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
     let now = Instant::now();
-    if let Some(provider) = cached_discovery(cache, instance_id, now, NATS_HOOK_DISCOVERY_TTL) {
+    if let Some(provider) = cached_discovery(cache, instance_id, now, REGISTRATION_REFRESH_INTERVAL)
+    {
         return provider;
     }
 
@@ -139,23 +144,106 @@ pub async fn discover_nats_hook_provider_cached(
     provider
 }
 
-pub async fn discover_nats_tool_provider(
+pub async fn discover_nats_tool_provider_cached(
     config: &Config,
     instance_id: &InstanceId,
+    active_package: Option<&str>,
 ) -> Option<Arc<NatsToolProvider>> {
-    NatsToolProvider::discover(
+    let cache = NATS_TOOL_DISCOVERY_CACHE.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
+    let key = (instance_id.clone(), active_package.map(str::to_string));
+    let now = Instant::now();
+    if let Some(provider) = cached_discovery(cache, &key, now, REGISTRATION_REFRESH_INTERVAL) {
+        return provider;
+    }
+
+    // Don't hold the process-wide lock while connecting to NATS or scanning KV.
+    let provider = NatsToolProvider::discover(
         config,
         instance_id.clone(),
         NatsInFlightCalls::for_instance(instance_id),
+        active_package,
     )
     .await
     .ok()
-    .map(Arc::new)
+    .map(Arc::new);
+    cache_discovery(cache, key, provider.clone(), Instant::now());
+    provider
+}
+
+/// Refresh declarations before completion request construction.
+pub async fn refresh_nats_tool_declarations(config: &GlobalConfig, instance_id: &InstanceId) {
+    // Match hook discovery: only worker process trees have NATS identity and connectivity.
+    if std::env::var_os(HARNX_INSTANCE_ID).is_none() {
+        return;
+    }
+
+    let config_snapshot = config.read().clone();
+    let active_package = config_snapshot.active_package();
+    let provider = discover_nats_tool_provider_cached(
+        &config_snapshot,
+        instance_id,
+        active_package.as_deref(),
+    )
+    .await;
+    let declarations = provider
+        .as_ref()
+        .map(|provider| provider.declarations_for_use_tools(Some("*")))
+        .unwrap_or_default();
+    *config.read().nats_tool_declarations.write() = declarations;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn unset(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            // SAFETY: this test holds ENV_LOCK for the guard's lifetime.
+            unsafe { std::env::remove_var(key) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                // SAFETY: this test holds ENV_LOCK for the guard's lifetime.
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                // SAFETY: this test holds ENV_LOCK for the guard's lifetime.
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn refresh_without_worker_instance_is_a_no_op() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = EnvGuard::unset(HARNX_INSTANCE_ID);
+        let config = GlobalConfig::default();
+
+        tokio_test::block_on(async {
+            tokio::time::timeout(
+                Duration::from_secs(1),
+                refresh_nats_tool_declarations(
+                    &config,
+                    &InstanceId::from_string("non-worker-refresh-test"),
+                ),
+            )
+            .await
+            .expect("refresh returns without connecting to NATS");
+        });
+
+        assert!(config.read().nats_tool_declarations.read().is_empty());
+    }
 
     #[test]
     fn hook_discovery_cache_reuses_arc_until_ttl_expires() {
@@ -204,6 +292,37 @@ mod tests {
         .expect("refreshed provider cached");
         assert!(Arc::ptr_eq(&refreshed, &cached));
         assert!(!Arc::ptr_eq(&first, &cached));
+    }
+
+    #[test]
+    fn tool_discovery_cache_populates_and_expires_at_refresh_interval() {
+        let cache = std::sync::Mutex::new(HashMap::new());
+        let instance_id = InstanceId::from_string("tool-cache-test");
+        let discovered_at = Instant::now();
+        let provider = Arc::new(());
+        cache_discovery(
+            &cache,
+            instance_id.clone(),
+            Some(Arc::clone(&provider)),
+            discovered_at,
+        );
+
+        let cached = cached_discovery(
+            &cache,
+            &instance_id,
+            discovered_at + REGISTRATION_REFRESH_INTERVAL - Duration::from_millis(1),
+            REGISTRATION_REFRESH_INTERVAL,
+        )
+        .flatten()
+        .expect("fresh tool provider cached");
+        assert!(Arc::ptr_eq(&provider, &cached));
+        assert!(cached_discovery(
+            &cache,
+            &instance_id,
+            discovered_at + REGISTRATION_REFRESH_INTERVAL,
+            REGISTRATION_REFRESH_INTERVAL,
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/harnx-runtime/tests/nats_tool_provider.rs
+++ b/crates/harnx-runtime/tests/nats_tool_provider.rs
@@ -3,12 +3,12 @@ mod common;
 
 use anyhow::Result;
 use harnx_core::abort::create_abort_signal;
-use harnx_core::instance::InstanceId;
+use harnx_core::instance::{InstanceId, HARNX_INSTANCE_ID};
 use harnx_core::tool::{ToolError, ToolProvider};
 use harnx_runtime::config::{Config, HARNX_NATS_TOKEN_ENV, HARNX_NATS_URL_ENV};
 use harnx_runtime::nats_tool_provider::{NatsInFlightCalls, NatsToolProvider};
 use harnx_time_server::TimeToolset;
-use harnx_toolset::{Registration, ToolSpec};
+use harnx_toolset::{server_identity_token, Registration, ToolSpec};
 use harnx_toolset_server::{
     registration_key, serve_over_nats, TOOL_PROTOCOL_VERSION, TOOL_REGISTRY_BUCKET,
     TOOL_SCHEMA_VERSION,
@@ -24,17 +24,20 @@ const TOKEN: &str = "nats-tool-provider-test-token";
 struct EnvGuard {
     url: Option<OsString>,
     token: Option<OsString>,
+    instance_id: Option<OsString>,
 }
 
 impl EnvGuard {
-    fn install(url: &str, token: &str) -> Self {
+    fn install(url: &str, token: &str, instance_id: &InstanceId) -> Self {
         let guard = Self {
             url: std::env::var_os(HARNX_NATS_URL_ENV),
             token: std::env::var_os(HARNX_NATS_TOKEN_ENV),
+            instance_id: std::env::var_os(HARNX_INSTANCE_ID),
         };
         unsafe {
             std::env::set_var(HARNX_NATS_URL_ENV, url);
             std::env::set_var(HARNX_NATS_TOKEN_ENV, token);
+            std::env::set_var(HARNX_INSTANCE_ID, instance_id.as_str());
         }
         guard
     }
@@ -51,6 +54,10 @@ impl Drop for EnvGuard {
                 Some(value) => std::env::set_var(HARNX_NATS_TOKEN_ENV, value),
                 None => std::env::remove_var(HARNX_NATS_TOKEN_ENV),
             }
+            match self.instance_id.take() {
+                Some(value) => std::env::set_var(HARNX_INSTANCE_ID, value),
+                None => std::env::remove_var(HARNX_INSTANCE_ID),
+            }
         }
     }
 }
@@ -61,7 +68,7 @@ async fn wait_for_registry(client: &async_nats::Client, instance_id: &InstanceId
     loop {
         if let Ok(store) = jetstream.get_key_value(TOOL_REGISTRY_BUCKET).await {
             if store
-                .get(registration_key(instance_id, "time"))
+                .get(registration_key(instance_id, "____time"))
                 .await?
                 .is_some()
             {
@@ -83,7 +90,7 @@ async fn set_wait_timeout(
     let store = async_nats::jetstream::new(client.clone())
         .get_key_value(TOOL_REGISTRY_BUCKET)
         .await?;
-    let key = registration_key(instance_id, "time");
+    let key = registration_key(instance_id, "____time");
     let value = store
         .get(&key)
         .await?
@@ -108,6 +115,8 @@ async fn add_collision_registration(
     let jetstream = async_nats::jetstream::new(client.clone());
     let store = jetstream.get_key_value(TOOL_REGISTRY_BUCKET).await?;
     let registration = Registration {
+        package: None,
+        config: String::new(),
         server: "collision".to_string(),
         tools: vec![ToolSpec {
             name: harnx_runtime::session_history::TOOL_NAME.to_string(),
@@ -123,7 +132,10 @@ async fn add_collision_registration(
     };
     store
         .put(
-            registration_key(instance_id, &registration.server),
+            registration_key(
+                instance_id,
+                &server_identity_token(None, "", &registration.server),
+            ),
             serde_json::to_vec(&registration)?.into(),
         )
         .await?;
@@ -139,6 +151,8 @@ async fn add_duplicate_registrations(
         .await?;
     for server in ["alpha", "beta"] {
         let registration = Registration {
+            package: None,
+            config: String::new(),
             server: server.to_string(),
             tools: vec![ToolSpec {
                 name: "duplicate_tool".to_string(),
@@ -154,7 +168,7 @@ async fn add_duplicate_registrations(
         };
         store
             .put(
-                registration_key(instance_id, server),
+                registration_key(instance_id, &server_identity_token(None, "", server)),
                 serde_json::to_vec(&registration)?.into(),
             )
             .await?;
@@ -173,18 +187,18 @@ fn assert_declarations_and_collisions(provider: &NatsToolProvider) {
         provider
             .declarations()
             .iter()
-            .filter(|tool| tool.name == "duplicate_tool")
+            .filter(|tool| tool.name.ends_with("_duplicate_tool"))
             .count(),
-        1
+        2
     );
     assert!(provider
         .declarations_for_use_tools(Some("beta"))
         .iter()
-        .any(|tool| tool.name == "duplicate_tool"));
-    assert!(!provider
+        .any(|tool| tool.name == "beta_duplicate_tool"));
+    assert!(provider
         .declarations_for_use_tools(Some("alpha"))
         .iter()
-        .any(|tool| tool.name == "duplicate_tool"));
+        .any(|tool| tool.name == "alpha_duplicate_tool"));
 }
 
 async fn assert_invocation_and_per_call_timeout(provider: &NatsToolProvider) -> Result<()> {
@@ -240,12 +254,13 @@ async fn assert_context_declarations_and_precedence(instance_id: &InstanceId) {
     )
     .await;
     let declarations = &context.render.as_ref().expect("render context").decl_map;
-    for tool in ["get_current_time", "convert_time", "wait", "wait_until"] {
+    for raw_tool in ["get_current_time", "convert_time", "wait", "wait_until"] {
+        let visible_tool = format!("time_{raw_tool}");
         assert!(
-            declarations.contains_key(tool),
-            "pilot tool not declared: {tool}"
+            declarations.contains_key(&visible_tool),
+            "pilot tool not declared: {visible_tool}"
         );
-        assert!(context.allowed_tool_names.contains(tool));
+        assert!(context.allowed_tool_names.contains(&visible_tool));
     }
     let collision = harnx_runtime::session_history::TOOL_NAME;
     assert!(context.providers[0].has_tool(collision));
@@ -274,7 +289,7 @@ async fn assert_abort_and_supervisor_failure(provider: &NatsToolProvider) -> Res
     let fail_task = tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(100)).await;
         in_flight
-            .fail_server_unavailable("time", "time tool process exited")
+            .fail_server_unavailable("____time", "time tool process exited")
             .await;
     });
     let failure = provider
@@ -324,8 +339,8 @@ async fn nats_tool_provider_end_to_end_declarations_cancel_and_precedence() -> R
     else {
         return Ok(());
     };
-    let _env = EnvGuard::install(server.url(), TOKEN);
     let instance_id = InstanceId::new();
+    let _env = EnvGuard::install(server.url(), TOKEN, &instance_id);
     let server_url = server.url.clone();
     let server_instance = instance_id.clone();
     let server_task = tokio::spawn(async move {
@@ -343,6 +358,7 @@ async fn nats_tool_provider_end_to_end_declarations_cancel_and_precedence() -> R
         &Config::default(),
         instance_id.clone(),
         NatsInFlightCalls::for_instance(&instance_id),
+        None,
     )
     .await?;
 
@@ -354,6 +370,7 @@ async fn nats_tool_provider_end_to_end_declarations_cancel_and_precedence() -> R
         &Config::default(),
         instance_id.clone(),
         NatsInFlightCalls::for_instance(&instance_id),
+        None,
     )
     .await?;
     assert_per_call_timeout_enforced(&short_timeout_provider).await?;

--- a/crates/harnx-runtime/tests/package_tool_naming_e2e.rs
+++ b/crates/harnx-runtime/tests/package_tool_naming_e2e.rs
@@ -1,0 +1,320 @@
+#[allow(dead_code)]
+mod common;
+
+use anyhow::{Context, Result};
+use harnx_core::abort::create_abort_signal;
+use harnx_core::agent_config::AgentConfig;
+use harnx_core::instance::{InstanceId, HARNX_INSTANCE_ID};
+use harnx_core::tool::ToolCall;
+use harnx_runtime::config::agent::Agent;
+use harnx_runtime::config::{
+    Config, GlobalConfig, ToolServerConfig, HARNX_NATS_TOKEN_ENV, HARNX_NATS_URL_ENV,
+};
+use harnx_runtime::nats_tool_provider::{NatsInFlightCalls, NatsToolProvider};
+use harnx_runtime::nats_worker::{ToolServerStartConfig, ToolServerSupervisor};
+use harnx_toolset::{server_identity_token, Registration};
+use harnx_toolset_server::{registration_key, TOOL_REGISTRY_BUCKET};
+use parking_lot::RwLock;
+use serde_json::json;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+const TOKEN: &str = "package-tool-naming-e2e-token";
+const SERVER_PACKAGE: &str = "tools-pkg";
+const OTHER_PACKAGE: &str = "agent-pkg";
+
+struct EnvGuard(Vec<(&'static str, Option<OsString>)>);
+
+impl EnvGuard {
+    fn install(values: &[(&'static str, &str)]) -> Self {
+        let old = values
+            .iter()
+            .map(|(name, _)| (*name, std::env::var_os(name)))
+            .collect();
+        for (name, value) in values {
+            // SAFETY: nextest runs this integration test in its own process, and
+            // this file has one test, so no other thread mutates these variables.
+            unsafe { std::env::set_var(name, value) };
+        }
+        Self(old)
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (name, value) in self.0.drain(..) {
+            // SAFETY: see EnvGuard::install. Guard lives for the whole test.
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+}
+
+fn fs_server_binary() -> Result<PathBuf> {
+    let mut path = std::env::current_exe().context("resolve test executable")?;
+    path.pop();
+    if path.file_name().is_some_and(|name| name == "deps") {
+        path.pop();
+    }
+    path.push(if cfg!(windows) {
+        "harnx-fs-tools.exe"
+    } else {
+        "harnx-fs-tools"
+    });
+    if path.is_file() {
+        return Ok(path);
+    }
+
+    let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .context("resolve workspace root")?
+        .to_path_buf();
+    let status = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
+        .arg("build")
+        .arg("-p")
+        .arg("harnx-fs-tools")
+        .current_dir(workspace)
+        .status()
+        .context("build harnx-fs-tools for package naming test")?;
+    anyhow::ensure!(status.success(), "building harnx-fs-tools failed");
+    anyhow::ensure!(
+        path.is_file(),
+        "harnx-fs-tools not found at {}",
+        path.display()
+    );
+    Ok(path)
+}
+
+fn fs_server_config(binary: &Path, readable_dir: &Path) -> ToolServerConfig {
+    ToolServerConfig {
+        name: "fs".to_string(),
+        command: binary.to_string_lossy().into_owned(),
+        args: vec![
+            "--allow-read".to_string(),
+            readable_dir.to_string_lossy().into_owned(),
+        ],
+        env: Default::default(),
+        enabled: true,
+        description: None,
+        package: Some(SERVER_PACKAGE.to_string()),
+        hooks: None,
+    }
+}
+
+fn agent(package: &str, tool_name: &str) -> AgentConfig {
+    let mut agent = AgentConfig::from_prompt("");
+    agent.set_name(&format!("{package}/reader"));
+    agent.set_use_tools(Some(vec![tool_name.to_string()]));
+    agent
+}
+
+fn config_for(agent_config: &AgentConfig) -> GlobalConfig {
+    Arc::new(RwLock::new(Config {
+        agent: Some(Agent::new(agent_config.clone())),
+        ..Config::default()
+    }))
+}
+
+async fn wait_for_fs_registration(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+) -> Result<Registration> {
+    let store = async_nats::jetstream::new(client.clone())
+        .get_key_value(TOOL_REGISTRY_BUCKET)
+        .await?;
+    let identity = server_identity_token(Some(SERVER_PACKAGE), "fs", "fs");
+    let key = registration_key(instance_id, &identity);
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(entry) = store.get(&key).await? {
+            return serde_json::from_slice(&entry).context("decode fs registration");
+        }
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "fs registration {key} did not appear"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn assert_schema_contains(
+    config: &GlobalConfig,
+    instance_id: &InstanceId,
+    agent_config: &AgentConfig,
+    expected_name: &str,
+) {
+    harnx_runtime::tool_context::refresh_nats_tool_declarations(config, instance_id).await;
+    let declarations = config.read().select_tools(agent_config).unwrap_or_default();
+    assert!(
+        declarations.iter().any(|tool| tool.name == expected_name),
+        "selected schema did not contain {expected_name}: {:?}",
+        declarations
+            .iter()
+            .map(|tool| tool.name.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+struct ReadAssertion<'a> {
+    config: &'a GlobalConfig,
+    instance_id: &'a InstanceId,
+    package: &'a str,
+    visible_name: &'a str,
+    file: &'a Path,
+    expected_content: &'a str,
+}
+
+async fn assert_read_executes(params: ReadAssertion<'_>) -> Result<()> {
+    let context = harnx_runtime::tool::build_tool_eval_context(
+        harnx_runtime::tool::BuildToolEvalContextParams::new(params.config, params.instance_id)
+            .with_agent_use_tools(Some(params.visible_name))
+            .with_current_agent_package(Some(params.package.to_string())),
+    )
+    .await;
+    let call_id = format!("{}-fs-read", params.package);
+    let results = harnx_runtime::tool::eval_tool_calls(
+        &context,
+        vec![ToolCall::new(
+            params.visible_name.to_string(),
+            json!({ "path": params.file }),
+            Some(call_id.clone()),
+            None,
+        )],
+        &create_abort_signal(),
+    )
+    .await?;
+    let result = results
+        .iter()
+        .find(|result| result.call.id.as_deref() == Some(call_id.as_str()))
+        .context("fs result in worker transcript")?;
+    assert!(
+        result.output.get("error").is_none(),
+        "fs read returned an error: {}",
+        result.output
+    );
+    assert!(
+        result.output.to_string().contains(params.expected_content),
+        "fs read result did not contain file content: {}",
+        result.output
+    );
+    Ok(())
+}
+
+struct E2eServer {
+    _nats: common::NatsServerHandle,
+    _temp: tempfile::TempDir,
+    _env: EnvGuard,
+    _supervisor: ToolServerSupervisor,
+    instance_id: InstanceId,
+    file: PathBuf,
+    expected_content: &'static str,
+}
+
+async fn start_e2e_server() -> Result<Option<E2eServer>> {
+    let Some(nats) = common::spawn_nats_server_with_options(common::SpawnNatsServerOptions {
+        auth_token: Some(TOKEN.to_string()),
+    })
+    .await?
+    else {
+        return Ok(None);
+    };
+    let temp = tempfile::tempdir()?;
+    let file = temp.path().join("proof.txt");
+    let expected_content = "package-aware fs read succeeded";
+    std::fs::write(&file, expected_content)?;
+    let binary = fs_server_binary()?;
+    let client = async_nats::ConnectOptions::new()
+        .token(TOKEN.to_string())
+        .connect(nats.url())
+        .await?;
+    let instance_id = InstanceId::new();
+    let env = EnvGuard::install(&[
+        (HARNX_NATS_URL_ENV, nats.url()),
+        (HARNX_NATS_TOKEN_ENV, TOKEN),
+        (HARNX_INSTANCE_ID, instance_id.as_str()),
+    ]);
+    let start = ToolServerStartConfig::new(client.clone(), instance_id.clone(), nats.url(), TOKEN);
+    let servers = [fs_server_config(&binary, temp.path())];
+    let supervisor =
+        ToolServerSupervisor::start_local_with_timeout(start, &servers, Duration::from_secs(5))
+            .await?;
+    let registration = wait_for_fs_registration(&client, &instance_id).await?;
+    assert_eq!(registration.package.as_deref(), Some(SERVER_PACKAGE));
+    assert_eq!(registration.config, "fs");
+    assert_eq!(registration.server, "fs");
+    assert!(registration.tools.iter().any(|tool| tool.name == "read"));
+
+    Ok(Some(E2eServer {
+        _nats: nats,
+        _temp: temp,
+        _env: env,
+        _supervisor: supervisor,
+        instance_id,
+        file,
+        expected_content,
+    }))
+}
+
+async fn assert_schema_and_execution(
+    server: &E2eServer,
+    agent_package: &str,
+    visible_name: &str,
+) -> Result<()> {
+    let agent = agent(agent_package, visible_name);
+    let config = config_for(&agent);
+    assert_eq!(
+        config.read().active_package().as_deref(),
+        Some(agent_package)
+    );
+    let config_snapshot = config.read().clone();
+    let discovered = NatsToolProvider::discover(
+        &config_snapshot,
+        server.instance_id.clone(),
+        NatsInFlightCalls::for_instance(&server.instance_id),
+        Some(agent_package),
+    )
+    .await?;
+    let discovered_names = discovered
+        .declarations_for_use_tools(Some("*"))
+        .into_iter()
+        .map(|tool| tool.name)
+        .collect::<Vec<_>>();
+    assert!(
+        discovered_names.iter().any(|tool| tool == visible_name),
+        "live provider did not expose {visible_name}: {discovered_names:?}"
+    );
+    assert_schema_contains(&config, &server.instance_id, &agent, visible_name).await;
+    assert_read_executes(ReadAssertion {
+        config: &config,
+        instance_id: &server.instance_id,
+        package: agent_package,
+        visible_name,
+        file: &server.file,
+        expected_content: server.expected_content,
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn model_schema_selection_routing_and_execution_use_package_tool_names() -> Result<()> {
+    harnx_core::require_nextest();
+    let Some(server) = start_e2e_server().await? else {
+        return Ok(());
+    };
+
+    assert_schema_and_execution(&server, SERVER_PACKAGE, "fs_read").await?;
+    let cross_package_name = format!("{SERVER_PACKAGE}__fs_read");
+    assert_schema_and_execution(&server, OTHER_PACKAGE, &cross_package_name).await?;
+
+    // Distinct identities for same-named packaged servers are covered by
+    // tool_supervisor::same_named_packaged_servers_use_distinct_identities_and_cleanup (#1350).
+    Ok(())
+}

--- a/crates/harnx-runtime/tests/tool_supervisor.rs
+++ b/crates/harnx-runtime/tests/tool_supervisor.rs
@@ -11,6 +11,9 @@ use harnx_runtime::config::{Config, ToolServerConfig, HARNX_NATS_TOKEN_ENV, HARN
 use harnx_runtime::nats_tool_provider::{NatsInFlightCalls, NatsToolProvider};
 use harnx_runtime::nats_worker::{ToolServerStartConfig, ToolServerSupervisor};
 use harnx_toolset::{ControlKind, ControlMessage};
+// Only the Linux-gated #1350 identity/cleanup test uses these.
+#[cfg(target_os = "linux")]
+use harnx_toolset::{server_identity_token, Registration};
 use harnx_toolset_server::{registration_key, TOOL_REGISTRY_BUCKET};
 use parking_lot::RwLock;
 use serde_json::json;
@@ -133,7 +136,7 @@ async fn wait_until_registration_removed(
     let store = async_nats::jetstream::new(client.clone())
         .get_key_value(TOOL_REGISTRY_BUCKET)
         .await?;
-    let key = registration_key(instance_id, "time");
+    let key = registration_key(instance_id, "__time__time");
     let deadline = Instant::now() + Duration::from_secs(2);
     loop {
         if store.get(&key).await?.is_none() {
@@ -158,7 +161,7 @@ async fn assert_pilot_registration(
         .get_key_value(TOOL_REGISTRY_BUCKET)
         .await?;
     assert!(store
-        .get(registration_key(instance_id, "time"))
+        .get(registration_key(instance_id, "__time__time"))
         .await?
         .is_some());
     Ok(pid)
@@ -175,7 +178,7 @@ async fn assert_nats_eval_batch(instance_id: &InstanceId) -> Result<()> {
     let results = harnx_runtime::tool::eval_tool_calls(
         &context,
         vec![ToolCall::new(
-            "get_current_time".to_string(),
+            "time_get_current_time".to_string(),
             json!({ "timezone": "UTC" }),
             Some("nats-time".to_string()),
             None,
@@ -209,7 +212,7 @@ async fn assert_cancel_control(
     };
     let started = Instant::now();
     let cancelled = provider
-        .call_tool("wait", json!({ "seconds": 30.0 }), &abort)
+        .call_tool("time_wait", json!({ "seconds": 30.0 }), &abort)
         .await;
     abort_task.await?;
     assert!(started.elapsed() < Duration::from_secs(2));
@@ -245,7 +248,11 @@ async fn assert_crash_failure(
     });
     let started = Instant::now();
     let result = provider
-        .call_tool("wait", json!({ "seconds": 30.0 }), &create_abort_signal())
+        .call_tool(
+            "time_wait",
+            json!({ "seconds": 30.0 }),
+            &create_abort_signal(),
+        )
         .await;
     kill_task.await?;
     assert!(started.elapsed() < Duration::from_secs(2));
@@ -262,9 +269,10 @@ async fn assert_crash_failure(
         &Config::default(),
         instance_id.clone(),
         NatsInFlightCalls::for_instance(instance_id),
+        None,
     )
     .await?;
-    assert!(!snapshot.has_tool("wait"));
+    assert!(!snapshot.has_tool("time_wait"));
     Ok(())
 }
 
@@ -298,6 +306,7 @@ async fn time_over_nats_pilot_e2e_eval_cancel_and_crash() -> Result<()> {
         &Config::default(),
         instance_id.clone(),
         NatsInFlightCalls::for_instance(&instance_id),
+        None,
     )
     .await?;
 
@@ -379,7 +388,7 @@ async fn tool_server_readiness_failure_warns_and_continues() -> Result<()> {
         .await?;
     assert!(
         store
-            .get(registration_key(&fixture.instance_id, "time"))
+            .get(registration_key(&fixture.instance_id, "__time__time"))
             .await?
             .is_none(),
         "non-registering server must not become available"
@@ -416,7 +425,7 @@ async fn readiness_waits_for_servers_concurrently() -> Result<()> {
         .await?;
     assert!(
         store
-            .get(registration_key(&fixture.instance_id, "time"))
+            .get(registration_key(&fixture.instance_id, "__time__time"))
             .await?
             .is_some(),
         "healthy server must register while another server stalls"
@@ -431,6 +440,138 @@ async fn readiness_waits_for_servers_concurrently() -> Result<()> {
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
+fn packaged_time_servers(binary: &str) -> [ToolServerConfig; 2] {
+    let mut alpha = time_server_config(binary.to_string());
+    alpha.package = Some("alpha".to_string());
+    let mut beta = time_server_config(binary.to_string());
+    beta.package = Some("beta".to_string());
+    [alpha, beta]
+}
+
+#[cfg(target_os = "linux")]
+async fn assert_packaged_registrations(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+) -> Result<(async_nats::jetstream::kv::Store, String, String)> {
+    let alpha_key = registration_key(
+        instance_id,
+        &server_identity_token(Some("alpha"), "time", "time"),
+    );
+    let beta_key = registration_key(
+        instance_id,
+        &server_identity_token(Some("beta"), "time", "time"),
+    );
+    let store = async_nats::jetstream::new(client.clone())
+        .get_key_value(TOOL_REGISTRY_BUCKET)
+        .await?;
+    for (key, package) in [(&alpha_key, "alpha"), (&beta_key, "beta")] {
+        let registration: Registration = serde_json::from_slice(
+            &store
+                .get(key)
+                .await?
+                .with_context(|| format!("{package} registration after supervisor readiness"))?,
+        )?;
+        assert_eq!(registration.package.as_deref(), Some(package));
+        assert_eq!(registration.config, "time");
+    }
+    Ok((store, alpha_key, beta_key))
+}
+
+#[cfg(target_os = "linux")]
+async fn assert_distinct_time_routes(instance_id: &InstanceId) -> Result<()> {
+    let provider = NatsToolProvider::discover(
+        &Config::default(),
+        instance_id.clone(),
+        NatsInFlightCalls::for_instance(instance_id),
+        Some("alpha"),
+    )
+    .await?;
+    for tool in ["time_get_current_time", "beta__time_get_current_time"] {
+        assert!(provider.has_tool(tool), "missing distinct route {tool}");
+        let result = provider
+            .call_tool(tool, json!({ "timezone": "UTC" }), &create_abort_signal())
+            .await
+            .map_err(|error| match error {
+                ToolError::Recoverable(error) | ToolError::Fatal(error) => error,
+            })?;
+        assert_eq!(result["timezone"], "UTC");
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+async fn kill_alpha_and_assert_cleanup(
+    supervisor: &ToolServerSupervisor,
+    store: &async_nats::jetstream::kv::Store,
+    alpha_key: &str,
+    beta_key: &str,
+) -> Result<()> {
+    let alpha_pid = supervisor
+        .server_pids()
+        .await
+        .into_keys()
+        .find(|pid| {
+            std::fs::read(format!("/proc/{pid}/environ"))
+                .map(|env| {
+                    env.split(|byte| *byte == 0)
+                        .any(|entry| entry == b"HARNX_SERVER_PACKAGE=alpha")
+                })
+                .unwrap_or(false)
+        })
+        .context("alpha tool server PID")?;
+    // SAFETY: PID belongs to child owned by this test's supervisor.
+    unsafe {
+        libc::kill(alpha_pid as libc::pid_t, libc::SIGKILL);
+    }
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while store.get(alpha_key).await?.is_some() {
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "alpha registration remained after its child exited"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        store.get(beta_key).await?.is_some(),
+        "crash cleanup removed the other package's registration"
+    );
+    Ok(())
+}
+#[cfg(target_os = "linux")]
+#[tokio::test(flavor = "multi_thread")]
+async fn same_named_packaged_servers_use_distinct_identities_and_cleanup() -> Result<()> {
+    let Some(nats) = common::spawn_nats_server_with_options(common::SpawnNatsServerOptions {
+        auth_token: Some(TOKEN.to_string()),
+    })
+    .await?
+    else {
+        return Ok(());
+    };
+    let binary = time_server_binary()?.to_string_lossy().into_owned();
+    let instance_id = InstanceId::new();
+    let _env = EnvGuard::install(&[
+        (HARNX_NATS_URL_ENV, nats.url()),
+        (HARNX_NATS_TOKEN_ENV, TOKEN),
+    ]);
+    let client = async_nats::ConnectOptions::new()
+        .token(TOKEN.to_string())
+        .connect(nats.url())
+        .await?;
+    let supervisor = ToolServerSupervisor::start_local_with_timeout(
+        ToolServerStartConfig::new(client.clone(), instance_id.clone(), nats.url(), TOKEN),
+        &packaged_time_servers(&binary),
+        Duration::from_secs(5),
+    )
+    .await?;
+
+    let (store, alpha_key, beta_key) = assert_packaged_registrations(&client, &instance_id).await?;
+    assert_distinct_time_routes(&instance_id).await?;
+    kill_alpha_and_assert_cleanup(&supervisor, &store, &alpha_key, &beta_key).await?;
+
+    drop(supervisor);
+    Ok(())
+}
 #[tokio::test(flavor = "multi_thread")]
 async fn missing_tool_server_binary_warns_and_continues() -> Result<()> {
     let Some(server) = common::spawn_nats_server_with_options(common::SpawnNatsServerOptions {

--- a/crates/harnx-toolset-server/src/lib.rs
+++ b/crates/harnx-toolset-server/src/lib.rs
@@ -8,8 +8,9 @@ use async_nats::jetstream::{self, kv, stream};
 use futures_util::StreamExt;
 use harnx_core::instance::{InstanceId, HARNX_INSTANCE_ID};
 use harnx_toolset::{
-    ControlKind, ControlMessage, Registration, ToolErrorPayload, ToolInvokeError, ToolReply,
-    ToolRequest, Toolset, HDR_CALL_ID, HDR_IDEMPOTENCY_KEY,
+    server_identity_token, ControlKind, ControlMessage, Registration, ToolErrorPayload,
+    ToolInvokeError, ToolReply, ToolRequest, Toolset, HARNX_SERVER_CONFIG, HARNX_SERVER_PACKAGE,
+    HDR_CALL_ID, HDR_IDEMPOTENCY_KEY,
 };
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, ContentBlock, ErrorData, Implementation,
@@ -70,8 +71,8 @@ struct ValidatedToolRequest {
 }
 
 /// KV key for one worker instance's tool server registration.
-pub fn registration_key(instance_id: &InstanceId, server: &str) -> String {
-    format!("{instance_id}.{server}")
+pub fn registration_key(instance_id: &InstanceId, identity_token: &str) -> String {
+    format!("{instance_id}.{identity_token}")
 }
 
 /// Host a toolset over Core NATS request-reply and publish its KV registration.
@@ -98,11 +99,16 @@ pub async fn serve_with_client(
     client: async_nats::Client,
 ) -> Result<()> {
     let server_name = toolset.name().to_owned();
-    let tool_subject = instance_id.tool_subject(&server_name, ">");
+    let package = std::env::var(HARNX_SERVER_PACKAGE)
+        .ok()
+        .filter(|package| !package.is_empty());
+    let config = std::env::var(HARNX_SERVER_CONFIG).unwrap_or_default();
+    let identity_token = server_identity_token(package.as_deref(), &config, &server_name);
+    let tool_subject = instance_id.tool_subject(&identity_token, ">");
     let control_subject = instance_id.control_subject();
 
     let mut tool_requests = client
-        .subscribe(tool_subject.clone())
+        .queue_subscribe(tool_subject.clone(), identity_token.clone())
         .await
         .with_context(|| format!("subscribe to tool requests on {tool_subject}"))?;
     let mut controls = client
@@ -114,7 +120,9 @@ pub async fn serve_with_client(
     client.flush().await.context("flush tool subscriptions")?;
 
     let registration = Registration {
-        server: server_name.clone(),
+        package,
+        config,
+        server: server_name,
         tools: toolset.tools(),
         schema_version: TOOL_SCHEMA_VERSION,
         proto_version: TOOL_PROTOCOL_VERSION,
@@ -437,7 +445,12 @@ async fn publish_registration(
     instance_id: &InstanceId,
     registration: &Registration,
 ) -> Result<u64> {
-    let key = registration_key(instance_id, &registration.server);
+    let identity_token = server_identity_token(
+        registration.package.as_deref(),
+        &registration.config,
+        &registration.server,
+    );
+    let key = registration_key(instance_id, &identity_token);
     let payload = serde_json::to_vec(registration).context("encode tool registration")?;
     registry
         .put(&key, payload.into())

--- a/crates/harnx-toolset-server/tests/nats_server.rs
+++ b/crates/harnx-toolset-server/tests/nats_server.rs
@@ -182,7 +182,7 @@ async fn wait_for_registration(
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         if let Ok(store) = jetstream.get_key_value(TOOL_REGISTRY_BUCKET).await {
-            let key = registration_key(instance_id, "test");
+            let key = registration_key(instance_id, "____test");
             if let Some(value) = store.get(&key).await? {
                 return serde_json::from_slice(&value).context("decode registration");
             }
@@ -229,7 +229,7 @@ impl TestHarness {
     }
 
     fn echo_subject(&self) -> String {
-        self.instance_id.tool_subject("test", "echo")
+        self.instance_id.tool_subject("____test", "echo")
     }
 }
 
@@ -385,7 +385,7 @@ async fn assert_cancellation(harness: &TestHarness) -> Result<()> {
         parent_session_id: None,
     };
     let slow_request = harness.client.request_with_headers(
-        harness.instance_id.tool_subject("test", "slow"),
+        harness.instance_id.tool_subject("____test", "slow"),
         request_headers(&request.call_id, "logical-slow"),
         serde_json::to_vec(&request)?.into(),
     );

--- a/crates/harnx-toolset/src/lib.rs
+++ b/crates/harnx-toolset/src/lib.rs
@@ -6,6 +6,16 @@ use serde_json::Value;
 use std::fmt;
 use tokio_util::sync::CancellationToken;
 
+/// Environment variable carrying the tool server's package name.
+pub const HARNX_SERVER_PACKAGE: &str = "HARNX_SERVER_PACKAGE";
+/// Environment variable carrying the tool server's config-file stem.
+pub const HARNX_SERVER_CONFIG: &str = "HARNX_SERVER_CONFIG";
+
+/// Build the wire identity for a tool server.
+pub fn server_identity_token(package: Option<&str>, config: &str, server: &str) -> String {
+    format!("{}__{config}__{server}", package.unwrap_or_default())
+}
+
 /// Header carrying the request's idempotency key.
 pub const HDR_IDEMPOTENCY_KEY: &str = "Idempotency-Key";
 /// Header carrying the tool call ID.
@@ -145,6 +155,10 @@ impl From<ProgressMessageWire> for ProgressMessage {
 /// Tool server metadata stored in KV for discovery and schema publication.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Registration {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package: Option<String>,
+    #[serde(default)]
+    pub config: String,
     pub server: String,
     pub tools: Vec<ToolSpec>,
     pub schema_version: u32,
@@ -233,6 +247,8 @@ mod tests {
             chunk: json!({ "completed": 1, "total": 2 }),
         });
         assert_round_trip(Registration {
+            package: None,
+            config: String::new(),
             server: "time".to_string(),
             tools: vec![tool_spec()],
             schema_version: 1,
@@ -241,9 +257,32 @@ mod tests {
     }
 
     #[test]
+    fn registration_without_identity_fields_uses_defaults() {
+        let registration: Registration = serde_json::from_value(json!({
+            "server": "time",
+            "tools": [],
+            "schema_version": 1,
+            "proto_version": 1
+        }))
+        .expect("legacy registration should deserialize");
+
+        assert_eq!(registration.package, None);
+        assert_eq!(registration.config, "");
+    }
+
+    #[test]
     fn error_payload_variants_round_trip_through_serde() {
         assert_round_trip(ToolErrorPayload::Recoverable("retry".to_string()));
         assert_round_trip(ToolErrorPayload::Fatal("stop".to_string()));
+    }
+
+    #[test]
+    fn server_identity_token_preserves_package_boundary() {
+        assert_eq!(
+            server_identity_token(Some("coding"), "time", "time"),
+            "coding__time__time"
+        );
+        assert_eq!(server_identity_token(None, "time", "time"), "__time__time");
     }
 
     #[test]

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -101,12 +101,16 @@ This deletes the package directory. Session transcripts referencing the package'
 
 Package agents and servers are automatically namespaced to avoid collisions with top-level configs and with each other.
 
-| What | On-disk name | Runtime name | Tool name |
-|------|-------------|-------------|-----------|
+| What | On-disk name | Runtime name | Tool name visible to agent |
+|------|-------------|-------------|----------------------------|
 | Agent `coder.md` in `my-pkg` | `packages/my-pkg/agents/coder.md` | `my-pkg/coder` | `my-pkg__coder_session_prompt` |
-| Tool server `fs.yaml` in `my-pkg` | `packages/my-pkg/tool_servers/fs.yaml` | `my-pkg__fs` | `my-pkg__fs_read` |
+| Package tool server `fs.yaml`, used by an agent in `my-pkg` | `packages/my-pkg/tool_servers/fs.yaml` | `my-pkg__fs` | `fs_read` |
+| Package tool server `fs.yaml`, used by an agent outside `my-pkg` | `packages/my-pkg/tool_servers/fs.yaml` | `my-pkg__fs` | `my-pkg__fs_read` |
+| Top-level tool server `fs.yaml` | `tool_servers/fs.yaml` | `fs` | `fs_read` |
 
-The `/` in agent names is replaced with `__` in tool names.
+Package separators become `__` in tool names. Harnx keeps the server/tool separator as `_`.
+
+Add native tool servers through `tool_servers/`. To use an external MCP server, add its bridge configuration there as well; the bridge publishes the MCP tools through the same naming and routing path.
 
 ### Naming Convention
 

--- a/docs/solutions/integration-issues/nats-tool-discovery-schema-gap-2026-08-04.md
+++ b/docs/solutions/integration-issues/nats-tool-discovery-schema-gap-2026-08-04.md
@@ -1,0 +1,222 @@
+---
+title: "NATS Tool Discovery Left Native Tools Unwired From LLM Schema"
+date: 2026-08-04
+category: "integration-issues"
+problem_type: integration_issue
+component: "harnx-runtime, NatsToolProvider, agent_loop, tool_supervisor"
+root_cause: "native-NATS conversion wired registration but not schema discovery; Config.tools cleared at load; NatsToolProvider only consulted post-tool-call"
+resolution_type: code_fix
+severity: critical
+tags:
+  - nats
+  - tool-discovery
+  - schema
+  - e2e-test
+  - test-coverage
+  - schemars
+plan_ref: "restore-package-tool-naming"
+---
+
+## Problem
+
+Native-NATS tool conversion left tool discovery unwired. Native tool declarations (fs, bash, plans, grep, time) never reached the LLM function schema — `NatsToolProvider` was only consulted after the model emitted a tool call, and `Config.tools` was cleared at load. Native tools also registered raw names (`read`), so prefixed `use_tools:[fs_read]` matched nothing. No test covered the full model-schema→routing→execution path, which is how the regression shipped.
+
+## Symptoms
+
+- Agent requests with `use_tools: [fs_read]` produced empty tool schema in completions
+- Native tools registered with raw names but routing expected prefixed names
+- Tool declarations visible in KV registry but not in LLM function-call schema
+- Existing tests passed because they used raw names + bare `*` selectors + injected calls, routing around the gap
+- Production agents could not invoke native tools by their documented package-aware names
+
+## Investigation Steps
+
+1. Traced `NatsToolProvider::discover` — found it builds registrations but `Config::select_tools` never called it
+2. Checked `Config::load_from_file` — `self.tools` cleared by design for NATS mode
+3. Located the schema path: `prepare_completion_data` → `Config::tool_declarations_for_use_tools` → static `self.tools.declarations()` only
+4. Found hook discovery pattern (`discover_process_nats_hook_provider`) gated on `HARNX_INSTANCE_ID` — tool discovery had no equivalent
+5. Reviewed existing tests — all used raw tool names or bare `*` selectors, none exercised schema→selection→routing→execution
+
+## Root Cause
+
+Three coupled gaps:
+
+1. **Discovery unwired**: `NatsToolProvider::discover` existed but was never called before schema construction. The completion path used only static declarations from `Config.tools`.
+
+2. **Config.tools cleared**: At load, `Config::load_from_file` cleared `self.tools` for NATS mode, expecting declarations to come from discovery. But discovery was never invoked.
+
+3. **Naming drift**: Native tools registered raw names (`read`). The worker's `ServerIdentity` module did not exist, so there was no single source of truth for forward/reverse mapping between agent-visible names (`fs_read`) and wire routing (`identity_token`, raw tool).
+
+The coverage gap: existing tests used raw names or `*` selectors with synthetic tool calls, never exercising the full path from LLM schema through selection to tool execution.
+
+## Solution
+
+### L1: Wire Discovery into Schema Construction
+
+Added async NATS tool-declaration discovery with 30s TTL cache in `tool_context.rs`. Refresh happens at the single choke point `call_agent_model` (agent_loop.rs:471) before request build:
+
+```rust
+// crates/harnx-runtime/src/tool_context.rs:174-193
+pub async fn refresh_nats_tool_declarations(config: &GlobalConfig, instance_id: &InstanceId) {
+    // Match hook discovery: only worker process trees have NATS identity.
+    if std::env::var_os(HARNX_INSTANCE_ID).is_none() {
+        return;
+    }
+
+    let config_snapshot = config.read().clone();
+    let active_package = config_snapshot.active_package();
+    let provider = discover_nats_tool_provider_cached(
+        &config_snapshot,
+        instance_id,
+        active_package.as_deref(),
+    )
+    .await;
+    let declarations = provider
+        .as_ref()
+        .map(|provider| provider.declarations_for_use_tools(Some("*")))
+        .unwrap_or_default();
+    *config.read().nats_tool_declarations.write() = declarations;
+}
+```
+
+Declarations merge in `Config::tool_declarations_for_use_tools`, no preload into `Config.tools`.
+
+**Critical gate**: Discovery returns early when `HARNX_INSTANCE_ID` absent, matching hook discovery. Without this gate, non-worker paths hang on `async_nats::connect` (test hang discovered during verification).
+
+### L2: Centralize Naming in ServerIdentity Module
+
+Added `ServerIdentity` module as single source of truth for forward (agent-visible name) and reverse (route) tool naming:
+
+```rust
+// crates/harnx-runtime/src/server_identity.rs:7-33
+pub struct ServerIdentity;
+
+impl ServerIdentity {
+    pub fn identity_token(registration: &Registration) -> String {
+        server_identity_token(
+            registration.package.as_deref(),
+            &registration.config,
+            &registration.server,
+        )
+    }
+
+    pub fn agent_visible_name(
+        agent_package: Option<&str>,
+        registration: &Registration,
+        raw_tool: &str,
+    ) -> String { /* ... */ }
+
+    pub fn parse_agent_tool_name(name: &str, known: &[Registration]) -> Option<(String, String)> { /* ... */ }
+}
+```
+
+`Registration` struct gained `package: Option<String>` and `config: String` fields with `#[serde(default)]` for backward compatibility.
+
+### L3: Authoritative Identity Injection (GitHub #1350)
+
+Worker injects `HARNX_SERVER_PACKAGE` and `HARNX_SERVER_CONFIG` at spawn. Identity token `<pkg>__<config>__<server>` folds into KV key + subject via S1 fold (token occupies existing `<server>` slot — still 5 segments, NO proto bump):
+
+```rust
+// crates/harnx-core/src/instance.rs:tool_subject
+format!("harnx.v1.{self}.tools.{identity_token}.{tool}")
+
+// KV registration key: <instance>.<identity_token>
+```
+
+Tool request subscription uses `queue_subscribe` keyed by identity token; control stays fanout. Supervisor readiness validates echoed package/config; cleanup deletes exact identity token.
+
+**Safe without proto bump**: Instance IDs are per-boot nonces (`InstanceId::new` = pid+uuid), so version cohorts never share a namespace.
+
+### L4: Native/Bridge Emit Raw Names
+
+Bridge and native toolsets emit raw tool names; `ServerIdentity` handles all composition. No `{server}_` prefixing in toolset code.
+
+### L5: Required E2E Test
+
+Added `model_schema_selection_routing_and_execution_use_package_tool_names` test that exercises schema→selection→routing→execution without live LLM:
+
+- Starts real `harnx-fs-tools` server
+- Verifies raw `read` registration
+- Asserts same-package `fs_read` and cross-package `tools-pkg__fs_read` schema visibility
+- Asserts tool execution returns file content
+- **Fails on main** (no declarations), **passes on branch** (discovery wired)
+
+```rust
+// crates/harnx-runtime/tests/package_tool_naming_e2e.rs:264-267
+assert!(
+    discovered_names.iter().any(|tool| tool == "fs_read"),
+    "live provider did not expose fs_read: {discovered_names:?}"
+);
+```
+
+### Bonus Bug Found: schemars Nullable Schema Parse Failure
+
+During e2e development, `fs_read` declaration silently dropped. Root cause: schemars emits nullable as `type: ["T", "null"]`, but `JsonSchema` parse expected scalar type.
+
+Fix: normalize `[T, "null"]` → `T` before parse:
+
+```rust
+// crates/harnx-runtime/src/nats_tool_provider.rs:327-351
+fn normalize_schema_types(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            if let Some(Value::Array(types)) = object.get_mut("type") {
+                let schema_type = types
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .find(|schema_type| *schema_type != "null")
+                    .or_else(|| types.iter().find_map(Value::as_str));
+                if let Some(schema_type) = schema_type {
+                    *object.get_mut("type").expect("type key exists") =
+                        Value::String(schema_type.to_string());
+                }
+            }
+            for child in object.values_mut() {
+                normalize_schema_types(child);
+            }
+        }
+        // ...
+    }
+}
+```
+
+## Why This Works
+
+1. **Discovery choke point**: `call_agent_model` is the single path where all real agent turns request completions. Wiring discovery there ensures declarations are fresh before schema construction.
+
+2. **Env gate prevents hangs**: `HARNX_INSTANCE_ID` check mirrors hook discovery, ensuring non-worker paths (tests, one-shot commands) skip NATS connection attempts.
+
+3. **Single naming module**: `ServerIdentity` owns all forward/reverse mapping; native toolsets and bridge do zero composition. Mapping can't drift between registration and invocation.
+
+4. **S1 fold avoids proto bump**: Reusing an existing wire slot for richer token works because worker owns both ends and namespaces are per-instance nonces. No version negotiation needed.
+
+5. **E2e test closes the gap**: The test exercises the exact path that shipped broken. Fail-on-main/pass-on-branch validates the fix end-to-end.
+
+## Prevention Strategies
+
+**Test Coverage:**
+- Required e2e test for any tool-registration path change
+- Schema→selection→routing→execution coverage without live LLM
+- Fail-on-main validation ensures regression can't re-enter
+
+**Code Patterns:**
+- Async discovery must gate on worker identity (`HARNX_INSTANCE_ID`) to prevent hangs in non-worker contexts
+- Single module for naming (`ServerIdentity`) — zero composition in callers
+- Normalize schemars output before parsing; never assume scalar `type`
+
+**Code Review Checklist:**
+- [ ] Does `use_tools` schema include discovered declarations?
+- [ ] Is discovery gated for non-worker paths?
+- [ ] Is naming consistent between registration and routing?
+- [ ] Does an e2e test cover schema→execution without live LLM?
+
+**Test Isolation:**
+- Env-mutating tests must take shared `env_lock()` and use `EnvGuard` for restoration
+- Parallel test execution (`cargo nextest -j 8`) exposes races that sequential (`-j 4`) hides
+
+## Related Issues
+
+- **GitHub:** [#1350](https://github.com/dobesv/harnx/issues/1350) — Identity collision fixed by L3
+- **Related Solution:** [integration-issues/native-nats-toolset-conversion-pattern-2026-07-31.md](./native-nats-toolset-conversion-pattern-2026-07-31.md) — S1 fs conversion pattern
+- **Related Solution:** [integration-issues/stateful-toolset-conversion-2026-08-02.md](./stateful-toolset-conversion-2026-08-02.md) — Stateful server conversion
+- **Related Solution:** [integration-issues/hooks-nats-launch-dispatch-complete-2026-08-01.md](./hooks-nats-launch-dispatch-complete-2026-08-01.md) — Hook discovery pattern (mirrored for tools)


### PR DESCRIPTION
Fixes unwired NATS tool discovery, restores package-aware tool naming under a central worker module, and resolves tool server identity collisions.

Key changes:
- Wire NATS tool discovery into LLM schema generation with a 30s TTL async cache refreshed prior to completion calls, merging declarations into select_tools and tool_declarations_for_use_tools.
- Introduce worker ServerIdentity module as single source of truth for agent-visible tool names (<server>_<tool>, <pkg>__<server>_<tool>) and reverse routing.
- Bridge and native toolsets emit raw tool names directly; tool composition is handled entirely worker-side.
- Inject HARNX_SERVER_PACKAGE and HARNX_SERVER_CONFIG at spawn and fold the <pkg>__<config>__<server> identity token into KV registration keys and tool request subjects.
- Use queue_subscribe keyed by identity token to prevent double-execution and fix supervisor readiness and cleanup key collisions.
- Add end-to-end integration test validating schema generation, tool selection, routing, and execution without requiring a live LLM.
- Update package documentation and record solution notes.

Fixes #1350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added package-aware tool naming to distinguish servers with identical names across packages.
  * Improved tool discovery, schema availability, and support for nullable schemas.
  * Added reliable routing and cleanup for multiple independently running tool servers.
* **Bug Fixes**
  * Fixed native and MCP tool invocation when server names overlap.
  * Preserved raw MCP tool names while maintaining correct routing.
* **Documentation**
  * Expanded guidance on package-qualified tool names and tool-server configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->