### PR TITLE
fix(hooks): dispatch SessionStart from the worker and drop SessionEnd

### DIFF
--- a/.changeset/worker-dispatches-session-start.md
+++ b/.changeset/worker-dispatches-session-start.md
@@ -1,0 +1,16 @@
+---
+harnx: minor
+---
+
+Fire `SessionStart` hooks from the worker and drop `SessionEnd` support.
+
+`SessionStart` was dispatched by the CLI/TUI frontend, which never has a NATS
+hook provider, so the event went nowhere and only logged "NATS hook provider
+unavailable". The worker now fires it once per session, on the activation that
+creates the session, where the hook servers it launched are reachable. Any
+`additionalContext` a `SessionStart` hook returns is injected into the first
+turn.
+
+`SessionEnd` is removed. Only the frontend knows a session ended, and worker
+activations happen per turn, so there was no place to fire it correctly. Hooks
+registered for `SessionEnd` no longer match any event.

--- a/crates/harnx-core/src/hooks.rs
+++ b/crates/harnx-core/src/hooks.rs
@@ -19,9 +19,6 @@ pub enum HookEvent {
         source: String,
         model: String,
     },
-    SessionEnd {
-        reason: String,
-    },
     UserPromptSubmit {
         prompt: String,
     },
@@ -65,7 +62,6 @@ impl HookEvent {
     pub fn event_name(&self) -> &'static str {
         match self {
             Self::SessionStart { .. } => "SessionStart",
-            Self::SessionEnd { .. } => "SessionEnd",
             Self::UserPromptSubmit { .. } => "UserPromptSubmit",
             Self::Stop { .. } => "Stop",
             Self::StopFailure { .. } => "StopFailure",
@@ -392,12 +388,6 @@ entries:
                     model: "claude".to_string(),
                 },
                 "SessionStart",
-            ),
-            (
-                HookEvent::SessionEnd {
-                    reason: "complete".to_string(),
-                },
-                "SessionEnd",
             ),
             (
                 HookEvent::UserPromptSubmit {

--- a/crates/harnx-hooks/src/lib.rs
+++ b/crates/harnx-hooks/src/lib.rs
@@ -12,7 +12,7 @@
 //!   or request a follow-up turn; they never block or deny the active operation
 //!
 //! ## Supported Events
-//! SessionStart, SessionEnd, UserPromptSubmit, Stop, StopFailure,
+//! SessionStart, UserPromptSubmit, Stop, StopFailure,
 //! PreToolUse, PostToolUse, PostToolUseFailure, InstructionsLoaded, CwdChanged
 //!
 //! ## Resume

--- a/crates/harnx-runtime/src/nats_hook_provider.rs
+++ b/crates/harnx-runtime/src/nats_hook_provider.rs
@@ -227,7 +227,6 @@ impl NatsHookProvider {
                 outcome
             }
             HookEvent::SessionStart { .. }
-            | HookEvent::SessionEnd { .. }
             | HookEvent::UserPromptSubmit { .. }
             | HookEvent::Stop { .. }
             | HookEvent::StopFailure { .. } => {
@@ -860,9 +859,6 @@ mod tests {
                 source: "cli".to_string(),
                 model: "model".to_string(),
             },
-            HookEvent::SessionEnd {
-                reason: "exit".to_string(),
-            },
             HookEvent::UserPromptSubmit {
                 prompt: "hello".to_string(),
             },
@@ -1226,8 +1222,9 @@ mod tests {
     #[tokio::test]
     async fn unified_entrypoint_without_provider_is_noop() {
         let actual = dispatch_hook_event(HookEventDispatch {
-            event: HookEvent::SessionEnd {
-                reason: "test".to_string(),
+            event: HookEvent::Stop {
+                stop_hook_active: false,
+                last_assistant_message: None,
             },
             provider: None,
             meta: HookDispatchMeta {
@@ -1311,7 +1308,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn session_end_is_delivered_before_dispatch_returns() {
+    async fn session_start_is_delivered_before_dispatch_returns() {
         let dispatcher = Arc::new(StubDispatcher {
             outcomes: Mutex::new(vec![continue_outcome(None)].into()),
             seen_inputs: Mutex::new(Vec::new()),
@@ -1323,15 +1320,16 @@ mod tests {
         });
         let provider = NatsHookProvider::from_dispatcher(
             InstanceId::from_string("test"),
-            vec![hook("lifecycle", "SessionEnd", None, 0)],
+            vec![hook("lifecycle", "SessionStart", None, 0)],
             dispatcher.clone(),
         );
 
         let started = tokio::time::Instant::now();
         let outcome = provider
             .dispatch_event(
-                HookEvent::SessionEnd {
-                    reason: "exit".to_string(),
+                HookEvent::SessionStart {
+                    source: "startup".to_string(),
+                    model: "model".to_string(),
                 },
                 None,
                 HookDispatchMeta {
@@ -1347,7 +1345,7 @@ mod tests {
         assert_eq!(dispatcher.calls.load(Ordering::SeqCst), 1);
         assert_eq!(
             dispatcher.seen_subjects.lock().await.as_slice(),
-            ["harnx.v1.test.hook.lifecycle.SessionEnd"]
+            ["harnx.v1.test.hook.lifecycle.SessionStart"]
         );
         assert_eq!(dispatcher.seen_resume_counts.lock().await.as_slice(), [4]);
     }

--- a/crates/harnx-runtime/src/nats_worker/agent_loop.rs
+++ b/crates/harnx-runtime/src/nats_worker/agent_loop.rs
@@ -5,6 +5,9 @@ use super::hook_supervisor::{HookServerStartConfig, HookServerSupervisor};
 use crate::agent_loop::OnToolRoundFn;
 use crate::config::{resolve_local_nats_server_config, GlobalConfig, Input, LOCAL_CLUSTER_KEY};
 use crate::nats_event_sink::NatsEventSink;
+use crate::nats_hook_provider::{
+    dispatch_hook_event, HookDispatchMeta, HookEventDispatch, NatsHookProvider,
+};
 use crate::nats_lease::{NatsLeaseAcquireParams, NatsLeaseConfig, NatsSessionLease};
 use crate::nats_metrics;
 use crate::nats_session_index::{put_record, SessionIndexRecord};
@@ -199,7 +202,7 @@ pub async fn run_agent_loop_with_nats_inner(args: RunAgentLoopArgs<'_>) -> Resul
         on_tool_round,
         working_dir,
     } = args;
-    let jetstream_ctx = prepare_agent_session(PrepareAgentSessionParams {
+    let (jetstream_ctx, session_origin) = prepare_agent_session(PrepareAgentSessionParams {
         cluster_key,
         session_id,
         config: &config,
@@ -235,6 +238,10 @@ pub async fn run_agent_loop_with_nats_inner(args: RunAgentLoopArgs<'_>) -> Resul
     })
     .await;
 
+    // After hook reconciliation and provider discovery so the dispatch reaches
+    // both global and agent hook servers.
+    dispatch_context_session_start(&ctx, session_origin, session_id).await;
+
     // Run unified agent loop
     // Persistence goes through shared Config.save_message entry construction; append_event routes sink
     run_agent_loop_segment(AgentLoopSegmentArgs {
@@ -268,7 +275,7 @@ struct PrepareAgentSessionParams<'a> {
 
 async fn prepare_agent_session(
     params: PrepareAgentSessionParams<'_>,
-) -> Result<jetstream::Context> {
+) -> Result<(jetstream::Context, SessionOrigin)> {
     let cfg_snapshot = params.config.read().clone();
     let jetstream = cfg_snapshot.nats_jetstream(params.cluster_key).await?;
     let mut backend = NatsSessionLogBackend::new(jetstream.clone(), params.session_id);
@@ -276,7 +283,7 @@ async fn prepare_agent_session(
         backend = backend.with_after_seq_observer(observer);
     }
     abort_resume_if_fenced(&backend, params.lease.map(Arc::as_ref))?;
-    let session = load_or_repair_session(LoadOrRepairSessionParams {
+    let (session, origin) = load_or_repair_session(LoadOrRepairSessionParams {
         backend: &backend,
         config: params.config,
         instance_id: params.instance_id,
@@ -290,7 +297,7 @@ async fn prepare_agent_session(
     })
     .await?;
     attach_session_to_config(params.config, session, &backend, params.lease);
-    Ok(jetstream)
+    Ok((jetstream, origin))
 }
 
 struct AgentContextParams {
@@ -323,6 +330,79 @@ async fn build_agent_loop_context(
         working_dir: params.working_dir,
         session_lock: None,
     }
+}
+
+/// Whether this activation created the session or picked up an existing one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SessionOrigin {
+    Created,
+    Resumed,
+}
+
+struct SessionStartDispatch<'a> {
+    origin: SessionOrigin,
+    provider: Option<&'a NatsHookProvider>,
+    session_id: &'a str,
+    cwd: std::path::PathBuf,
+    model: String,
+    pending_async_context: Option<Arc<tokio::sync::Mutex<Option<String>>>>,
+}
+
+/// Dispatch SessionStart using the loop context's provider, model, and cwd.
+///
+/// Any additional context the hooks return rides the loop's pending queue into
+/// the first turn.
+async fn dispatch_context_session_start(
+    ctx: &crate::agent_loop::AgentLoopContext,
+    origin: SessionOrigin,
+    session_id: &str,
+) {
+    // Same cwd rule as the shared agent loop: the session's working directory
+    // when it has one, else the worker's.
+    let cwd = ctx
+        .working_dir
+        .clone()
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+    let model = ctx.config.read().current_model().id().to_string();
+    dispatch_session_start(SessionStartDispatch {
+        origin,
+        provider: ctx.nats_hook_provider.as_deref(),
+        session_id,
+        cwd,
+        model,
+        pending_async_context: ctx.pending_async_context.clone(),
+    })
+    .await;
+}
+
+/// Fire SessionStart for a session this worker just created.
+///
+/// The worker owns this event because only it can reach the hook servers it
+/// launched. Every activation of an existing session skips it: activations
+/// happen once per turn, and the activation that created the session already
+/// fired it.
+///
+/// The outcome is dropped on purpose. SessionStart hooks observe and contribute
+/// context; the session already exists by the time they run, so there is nothing
+/// for a `Block` to prevent.
+async fn dispatch_session_start(params: SessionStartDispatch<'_>) {
+    if params.origin == SessionOrigin::Resumed {
+        return;
+    }
+    let _ = dispatch_hook_event(HookEventDispatch {
+        event: harnx_core::hooks::HookEvent::SessionStart {
+            source: "startup".to_string(),
+            model: params.model,
+        },
+        provider: params.provider,
+        meta: HookDispatchMeta {
+            session_id: params.session_id.to_string(),
+            cwd: params.cwd,
+            resume_count: 0,
+        },
+        pending_async_context: params.pending_async_context,
+    })
+    .await;
 }
 
 struct AgentLoopSegmentArgs {
@@ -581,7 +661,7 @@ struct LoadOrRepairSessionParams<'a> {
 /// existing session.
 async fn load_or_repair_session(
     params: LoadOrRepairSessionParams<'_>,
-) -> Result<harnx_core::session::Session> {
+) -> Result<(harnx_core::session::Session, SessionOrigin)> {
     let LoadOrRepairSessionParams {
         backend,
         config,
@@ -597,7 +677,7 @@ async fn load_or_repair_session(
     let entries = backend.load_events_blocking()?;
     if entries.is_empty() {
         // New session: write header and load
-        return write_header_and_load_session(
+        let session = write_header_and_load_session(
             backend,
             config,
             input,
@@ -605,14 +685,17 @@ async fn load_or_repair_session(
             session_id,
             working_dir,
         )
-        .await;
+        .await?;
+        return Ok((session, SessionOrigin::Created));
     }
 
-    // Existing session: check effective session log for orphan tool calls and repair with hints
     let mut entries_vec = entries;
     let mut effective_entries =
         harnx_core::session_reconstruct::apply_log_mutations_nats(&entries_vec)?;
-    maybe_insert_remote_header(MaybeInsertRemoteHeaderArgs {
+    // The thin client appends its user message before it activates a session, so
+    // a brand-new session reaches this path with a headerless log rather than an
+    // empty one. Writing the header here is what creates the session.
+    let header_written = maybe_insert_remote_header(MaybeInsertRemoteHeaderArgs {
         backend,
         config,
         input,
@@ -624,35 +707,79 @@ async fn load_or_repair_session(
     })
     .await?;
     refresh_session_index_on_activation(session_index, &effective_entries, session_id).await;
-    let orphan_calls = find_orphan_tool_calls(&effective_entries);
-    if !orphan_calls.is_empty() {
-        nats_metrics::resume_detected();
-        info!(
-            "resume detected: session_id={} worker_id={} revision={} orphan_batches={}",
-            session_id,
-            lease.map(|l| l.worker_id()).unwrap_or("none"),
-            lease.map(|l| l.fence_token()).unwrap_or(0),
-            orphan_calls.len()
-        );
-        repair_orphan_tool_calls_with_hints(
-            backend,
-            &orphan_calls,
-            RepairOrphanToolCallsArgs {
-                config: config.clone(),
-                instance_id,
-                fence_token: lease.map(|l| l.fence_token()),
-                worker_id: lease.map(|l| l.worker_id().to_string()),
-                session_id,
-                abort_signal,
-            },
-        )
-        .await?;
-        // Repair appended ToolResults to the backend; reload so the
-        // in-memory session reflects the repaired log rather than the
-        // stale snapshot that still contains the orphan ToolCalls.
-        entries_vec = backend.load_events_blocking()?;
+    repair_orphan_tool_calls_if_any(RepairOrphanCallsParams {
+        backend,
+        config,
+        instance_id,
+        lease,
+        session_id,
+        abort_signal,
+        effective_entries: &effective_entries,
+        entries_vec: &mut entries_vec,
+    })
+    .await?;
+    let session = crate::nats_session_log::load_session_from_entries(&entries_vec, session_id)?;
+    let origin = if header_written {
+        SessionOrigin::Created
+    } else {
+        SessionOrigin::Resumed
+    };
+    Ok((session, origin))
+}
+
+struct RepairOrphanCallsParams<'a> {
+    backend: &'a NatsSessionLogBackend,
+    config: &'a GlobalConfig,
+    instance_id: &'a harnx_core::instance::InstanceId,
+    lease: Option<&'a NatsSessionLease>,
+    session_id: &'a str,
+    abort_signal: &'a AbortSignal,
+    effective_entries: &'a [(u64, SessionLogEntry)],
+    entries_vec: &'a mut Vec<(u64, SessionLogEntry)>,
+}
+
+/// Repair tool calls left without results by a previous worker, reloading
+/// `entries_vec` so the caller builds the session from the repaired log rather
+/// than the stale snapshot that still holds the orphan calls. No-op when the
+/// effective log has no orphans.
+async fn repair_orphan_tool_calls_if_any(params: RepairOrphanCallsParams<'_>) -> Result<()> {
+    let RepairOrphanCallsParams {
+        backend,
+        config,
+        instance_id,
+        lease,
+        session_id,
+        abort_signal,
+        effective_entries,
+        entries_vec,
+    } = params;
+    let orphan_calls = find_orphan_tool_calls(effective_entries);
+    if orphan_calls.is_empty() {
+        return Ok(());
     }
-    crate::nats_session_log::load_session_from_entries(&entries_vec, session_id)
+    nats_metrics::resume_detected();
+    info!(
+        "resume detected: session_id={} worker_id={} revision={} orphan_batches={}",
+        session_id,
+        lease.map(|l| l.worker_id()).unwrap_or("none"),
+        lease.map(|l| l.fence_token()).unwrap_or(0),
+        orphan_calls.len()
+    );
+    repair_orphan_tool_calls_with_hints(
+        backend,
+        &orphan_calls,
+        RepairOrphanToolCallsArgs {
+            config: config.clone(),
+            instance_id,
+            fence_token: lease.map(|l| l.fence_token()),
+            worker_id: lease.map(|l| l.worker_id().to_string()),
+            session_id,
+            abort_signal,
+        },
+    )
+    .await?;
+    *entries_vec = backend.load_events_blocking()?;
+    Ok(())
 }
 
 fn should_insert_remote_header(effective_entries: &[(u64, SessionLogEntry)]) -> bool {
@@ -1118,7 +1245,10 @@ struct MaybeInsertRemoteHeaderArgs<'a> {
 /// publishes the resulting seq to the daemon's high-water observer, and reloads
 /// `entries_vec` / `effective_entries` so the caller sees the repaired log.
 /// No-op when the effective log already has a header.
-async fn maybe_insert_remote_header(args: MaybeInsertRemoteHeaderArgs<'_>) -> Result<()> {
+///
+/// Returns whether a header was written, which is how the worker recognizes the
+/// activation that brought this session into existence.
+async fn maybe_insert_remote_header(args: MaybeInsertRemoteHeaderArgs<'_>) -> Result<bool> {
     let MaybeInsertRemoteHeaderArgs {
         backend,
         config,
@@ -1131,7 +1261,7 @@ async fn maybe_insert_remote_header(args: MaybeInsertRemoteHeaderArgs<'_>) -> Re
     } = args;
 
     if !should_insert_remote_header(effective_entries) {
-        return Ok(());
+        return Ok(false);
     }
     let Some((first_user_seq, last_user_seq, replacements)) =
         build_remote_header_insert_replacements(
@@ -1143,7 +1273,7 @@ async fn maybe_insert_remote_header(args: MaybeInsertRemoteHeaderArgs<'_>) -> Re
             working_dir,
         )?
     else {
-        return Ok(());
+        return Ok(false);
     };
 
     let edit_entry = SessionLogEntry::EditEntries {
@@ -1167,7 +1297,7 @@ async fn maybe_insert_remote_header(args: MaybeInsertRemoteHeaderArgs<'_>) -> Re
     }
     *entries_vec = backend.load_events_blocking()?;
     *effective_entries = harnx_core::session_reconstruct::apply_log_mutations_nats(entries_vec)?;
-    Ok(())
+    Ok(true)
 }
 
 /// Write a new session header and load the session.
@@ -1195,11 +1325,91 @@ pub(crate) async fn write_header_and_load_session(
 
 #[cfg(test)]
 mod tests {
-    use super::{agent_resolved_hooks, fold_new_user_messages_since};
+    use super::{
+        agent_resolved_hooks, dispatch_session_start, fold_new_user_messages_since, SessionOrigin,
+        SessionStartDispatch,
+    };
     use crate::config::Config;
+    use crate::nats_hook_provider::{DiscoveredHook, NatsHookProvider};
     use chrono::{TimeZone, Utc};
+    use harnx_core::hooks::{HookEvent, HookOutcome, HookPayload, HookResult, HookResultControl};
+    use harnx_core::instance::InstanceId;
     use harnx_core::message::{MessageContent, MessageRole};
     use harnx_core::session::SessionLogEntry;
+    use harnx_hookset::{FailPolicy, HookSpec};
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+
+    /// A provider whose only route is a SessionStart hook recording every
+    /// payload it receives.
+    fn recording_session_start_provider() -> (NatsHookProvider, Arc<Mutex<Vec<HookPayload>>>) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let recorder = Arc::clone(&seen);
+        let provider = NatsHookProvider::from_request_handler(
+            InstanceId::from_string("session-start-test"),
+            vec![DiscoveredHook {
+                server: "lifecycle".to_string(),
+                display_label: None,
+                spec: HookSpec {
+                    event: "SessionStart".to_string(),
+                    matcher: None,
+                    priority: 0,
+                    timeout_secs: Some(1),
+                    fail_policy: FailPolicy::Closed,
+                },
+            }],
+            Arc::new(move |_subject, payload: HookPayload| {
+                recorder.lock().expect("recorder lock").push(payload);
+                HookOutcome {
+                    control: HookResultControl::Continue,
+                    result: HookResult::default(),
+                }
+            }),
+        );
+        (provider, seen)
+    }
+
+    #[tokio::test]
+    async fn created_session_dispatches_session_start_to_worker_hooks() {
+        let (provider, seen) = recording_session_start_provider();
+
+        dispatch_session_start(SessionStartDispatch {
+            origin: SessionOrigin::Created,
+            provider: Some(&provider),
+            session_id: "fresh-session",
+            cwd: PathBuf::from("/tmp/project"),
+            model: "test:test-model".to_string(),
+            pending_async_context: None,
+        })
+        .await;
+
+        let seen = seen.lock().expect("recorder lock");
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].session_id, "fresh-session");
+        assert_eq!(seen[0].cwd, PathBuf::from("/tmp/project"));
+        let HookEvent::SessionStart { source, model } = &seen[0].hook_event else {
+            panic!("expected SessionStart, got {:?}", seen[0].hook_event);
+        };
+        assert_eq!(source, "startup");
+        assert_eq!(model, "test:test-model");
+    }
+
+    #[tokio::test]
+    async fn resumed_session_does_not_redispatch_session_start() {
+        let (provider, seen) = recording_session_start_provider();
+
+        dispatch_session_start(SessionStartDispatch {
+            origin: SessionOrigin::Resumed,
+            provider: Some(&provider),
+            session_id: "existing-session",
+            cwd: PathBuf::from("/tmp/project"),
+            model: "test:test-model".to_string(),
+            pending_async_context: None,
+        })
+        .await;
+
+        assert!(seen.lock().expect("recorder lock").is_empty());
+    }
 
     fn user_entry(id: &str, text: &str, timestamp: chrono::DateTime<Utc>) -> SessionLogEntry {
         SessionLogEntry::Message {

--- a/crates/harnx-runtime/src/nats_worker/mod.rs
+++ b/crates/harnx-runtime/src/nats_worker/mod.rs
@@ -30,6 +30,8 @@ mod subagent_toolset;
 mod tool_supervisor;
 
 #[cfg(test)]
+mod session_start_hook_tests;
+#[cfg(test)]
 mod tests;
 
 // Re-export public items to preserve the `crate::nats_worker::X` path

--- a/crates/harnx-runtime/src/nats_worker/session_start_hook_tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/session_start_hook_tests.rs
@@ -1,0 +1,135 @@
+//! End-to-end coverage for worker-dispatched SessionStart hooks.
+
+use super::tests::{
+    env_lock, fixed_prompt_call_fn, run_remote_round_trip_with_session_id_and_sink,
+    seed_remote_config, spawn_metis_worker_with_hooks, spawn_test_nats, wait_for_condition,
+    NoopEventSink, TestEnvGuard,
+};
+use crate::config::{HARNX_NATS_TOKEN_ENV, HARNX_NATS_URL_ENV, LOCAL_CLUSTER_KEY};
+use crate::nats_worker::{new_remote_session_id, WorkerDaemonConfig};
+use harnx_core::hooks::{HookConfig, HooksConfig};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Resolve the hook-server binary next to the test executable, building it if a
+/// package-scoped test run has not produced it yet.
+fn hook_server_binary() -> PathBuf {
+    let mut path = std::env::current_exe().expect("resolve test executable");
+    path.pop();
+    if path.file_name().is_some_and(|name| name == "deps") {
+        path.pop();
+    }
+    path.push(if cfg!(windows) {
+        "harnx-claude-compatible-hook-server.exe"
+    } else {
+        "harnx-claude-compatible-hook-server"
+    });
+    if path.is_file() {
+        return path;
+    }
+
+    let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("resolve workspace root")
+        .to_path_buf();
+    let status = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
+        .args(["build", "-p", "harnx-claude-compatible-hook-server"])
+        .current_dir(workspace)
+        .status()
+        .expect("build harnx-claude-compatible-hook-server for hook dispatch test");
+    assert!(status.success(), "building the hook server failed");
+    assert!(
+        path.is_file(),
+        "hook server not found at {}",
+        path.display()
+    );
+    path
+}
+
+/// A worker-launched SessionStart hook that appends one line per invocation.
+fn session_start_marker_hook(marker: &Path) -> HooksConfig {
+    HooksConfig {
+        max_resume: None,
+        entries: vec![HookConfig {
+            command: format!(
+                "{} --event SessionStart --timeout 30 --command 'echo fired >> \"{}\"'",
+                hook_server_binary().display(),
+                marker.display()
+            ),
+            status_message: None,
+            async_hook: None,
+            package_dir: None,
+        }],
+    }
+}
+
+fn marker_line_count(marker: &Path) -> usize {
+    std::fs::read_to_string(marker)
+        .map(|contents| contents.lines().count())
+        .unwrap_or(0)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn new_remote_session_fires_session_start_hook_exactly_once() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let marker_dir = tempfile::tempdir().expect("marker temp dir");
+    let marker = marker_dir.path().join("session-start.log");
+    let seeded = seed_remote_config(&url);
+    let _config_dir = TestEnvGuard::new("HARNX_CONFIG_DIR", seeded.config_dir());
+    // The worker resolves the local NATS server from the environment when it
+    // launches hook servers.
+    let _nats_url = TestEnvGuard::new(HARNX_NATS_URL_ENV, &url);
+    let _nats_token = TestEnvGuard::new(HARNX_NATS_TOKEN_ENV, "session-start-token");
+
+    // Hook servers only launch for the reserved local cluster, which resolves
+    // its connection from the environment handoff set above.
+    let worker = spawn_metis_worker_with_hooks(
+        &url,
+        fixed_prompt_call_fn("stub remote reply over nats"),
+        WorkerDaemonConfig::new(LOCAL_CLUSTER_KEY, "worker-metis"),
+        Some(session_start_marker_hook(&marker)),
+    );
+
+    let session_id = new_remote_session_id();
+    run_remote_round_trip_with_session_id_and_sink(
+        seeded.parent_config.clone(),
+        session_id.clone(),
+        Arc::new(NoopEventSink),
+        LOCAL_CLUSTER_KEY,
+    )
+    .await
+    .expect("first turn of a brand-new remote session");
+
+    assert!(
+        wait_for_condition(Duration::from_secs(10), || marker_line_count(&marker) > 0).await,
+        "SessionStart hook must run when the worker creates a session"
+    );
+
+    // A second turn re-activates the same session. SessionStart belongs to the
+    // session, not the turn, so it must not fire again.
+    run_remote_round_trip_with_session_id_and_sink(
+        seeded.parent_config,
+        session_id,
+        Arc::new(NoopEventSink),
+        LOCAL_CLUSTER_KEY,
+    )
+    .await
+    .expect("second turn of the same remote session");
+    assert_eq!(
+        marker_line_count(&marker),
+        1,
+        "SessionStart must fire once per session, not once per activation"
+    );
+
+    worker.abort();
+    let _ = tokio::time::timeout(Duration::from_secs(5), worker).await;
+    let _ = child.kill();
+    let _ = child.wait();
+}

--- a/crates/harnx-runtime/src/nats_worker/tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests.rs
@@ -37,7 +37,7 @@ use tokio_util::sync::CancellationToken;
 /// dir guard. Using a free port + per-run store dir avoids cross-run state
 /// bleed (JetStream KV/lease buckets) and port collisions that make tests flaky
 /// when run repeatedly or in parallel. Returns `None` if nats-server is absent.
-async fn spawn_test_nats() -> Option<(String, std::process::Child, tempfile::TempDir)> {
+pub(super) async fn spawn_test_nats() -> Option<(String, std::process::Child, tempfile::TempDir)> {
     if which::which("nats-server").is_err() {
         eprintln!("skipping: nats-server not available");
         return None;
@@ -97,17 +97,17 @@ impl Drop for CurrentDirGuard {
     }
 }
 
-async fn env_lock() -> tokio::sync::MutexGuard<'static, ()> {
+pub(super) async fn env_lock() -> tokio::sync::MutexGuard<'static, ()> {
     ENV_MUTEX.lock().await
 }
 
-struct TestEnvGuard {
+pub(super) struct TestEnvGuard {
     key: String,
     prev: Option<std::ffi::OsString>,
 }
 
 impl TestEnvGuard {
-    fn new(key: &str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+    pub(super) fn new(key: &str, value: impl AsRef<std::ffi::OsStr>) -> Self {
         let prev = std::env::var_os(key);
         unsafe { std::env::set_var(key, value) };
         Self {
@@ -141,13 +141,13 @@ fn load_config_via_internal_pipeline(config_path: &Path) -> Config {
     config
 }
 
-struct SeededRemoteParentConfig {
+pub(super) struct SeededRemoteParentConfig {
     temp: tempfile::TempDir,
-    parent_config: Config,
+    pub(super) parent_config: Config,
 }
 
 impl SeededRemoteParentConfig {
-    fn config_dir(&self) -> &Path {
+    pub(super) fn config_dir(&self) -> &Path {
         self.temp.path()
     }
 }
@@ -156,7 +156,7 @@ fn expected_metis_remote_tool_names() -> Vec<String> {
     vec!["metis__at__local_session_handoff".to_string()]
 }
 
-fn seed_remote_config(url: &str) -> SeededRemoteParentConfig {
+pub(super) fn seed_remote_config(url: &str) -> SeededRemoteParentConfig {
     use std::fs;
 
     let temp = tempfile::TempDir::new().unwrap();
@@ -337,12 +337,22 @@ fn spawn_metis_worker_with_call_fn_and_daemon(
     call_fn: crate::agent_loop::AgentCallFn,
     daemon: crate::nats_worker::WorkerDaemonConfig,
 ) -> tokio::task::JoinHandle<anyhow::Result<()>> {
+    spawn_metis_worker_with_hooks(url, call_fn, daemon, None)
+}
+
+pub(super) fn spawn_metis_worker_with_hooks(
+    url: &str,
+    call_fn: crate::agent_loop::AgentCallFn,
+    daemon: crate::nats_worker::WorkerDaemonConfig,
+    hooks: Option<harnx_core::hooks::HooksConfig>,
+) -> tokio::task::JoinHandle<anyhow::Result<()>> {
     let worker_agent =
         AgentConfig::from_markdown("metis", "---\nuse_tools: \"*\"\n---\nstub worker prompt")
             .unwrap();
     let worker_config = Config {
         data: harnx_core::config_data::ConfigData {
             model_id: "test:test-model".to_string(),
+            hooks,
             ..Default::default()
         },
         agent: Some(crate::config::Agent::new(worker_agent)),
@@ -381,14 +391,16 @@ async fn run_remote_round_trip_with_session_id(
         parent_config,
         session_id,
         Arc::new(NoopEventSink),
+        "local",
     )
     .await
 }
 
-async fn run_remote_round_trip_with_session_id_and_sink(
+pub(super) async fn run_remote_round_trip_with_session_id_and_sink(
     parent_config: Config,
     session_id: String,
     sink: Arc<dyn AgentEventSink>,
+    cluster: &str,
 ) -> anyhow::Result<()> {
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
@@ -399,7 +411,7 @@ async fn run_remote_round_trip_with_session_id_and_sink(
     let parent_global_config = Arc::new(parking_lot::RwLock::new(parent_config));
     let abort_signal = harnx_core::abort::create_abort_signal();
     let thin_cfg = crate::ThinClientConfig {
-        cluster: "local".to_string(),
+        cluster: cluster.to_string(),
         agent: "metis".to_string(),
         session_id: Some(session_id),
     };
@@ -780,7 +792,7 @@ async fn control_log_append_requires_live_lease() {
     let _ = child.wait();
 }
 
-struct NoopEventSink;
+pub(super) struct NoopEventSink;
 
 impl AgentEventSink for NoopEventSink {
     fn emit(&self, _event: AgentEvent) {}
@@ -803,7 +815,7 @@ impl AgentEventSink for RecordingEventSink {
     }
 }
 
-fn fixed_prompt_call_fn(reply: &'static str) -> crate::agent_loop::AgentCallFn {
+pub(super) fn fixed_prompt_call_fn(reply: &'static str) -> crate::agent_loop::AgentCallFn {
     Arc::new(move |_input, _config, _abort| {
         Box::pin(async move {
             Ok((
@@ -972,7 +984,7 @@ async fn assert_remote_header_inserted_once(log: &NatsSessionLog, expected_first
     }
 }
 
-async fn wait_for_condition<F>(timeout: Duration, mut predicate: F) -> bool
+pub(super) async fn wait_for_condition<F>(timeout: Duration, mut predicate: F) -> bool
 where
     F: FnMut() -> bool,
 {
@@ -1271,6 +1283,7 @@ async fn remote_replay_and_live_rows_emit_logical_seq_assignments() {
         seeded.parent_config,
         session_id.clone(),
         sink.clone(),
+        "local",
     )
     .await
     .expect("worker should migrate legacy session, replay history, then answer turn");

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -28,18 +28,14 @@ use crate::config::{
 use crate::tui::{TranscriptItem, Tui};
 use harnx_core::agent_config::collect_agent_variables;
 use harnx_core::event::{AgentEvent, AgentSource, NoticeEvent};
-use harnx_core::hooks::HookEvent;
 use harnx_render::{render_error, MarkdownRender};
 use harnx_runtime::config::SessionMeta;
-use harnx_runtime::nats_hook_provider::{
-    discover_process_nats_hook_provider, dispatch_hook_event, HookDispatchMeta, HookEventDispatch,
-};
 use harnx_runtime::utils::*;
 
 use anyhow::{bail, Context, Result};
 use clap::Parser;
 use parking_lot::RwLock;
-use std::{env, path::PathBuf, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use harnx_core::sink::emit_agent_event;
 use harnx_runtime::remote_session_cleanup::{run_remote_cleanup, RemoteCleanupStats};
@@ -453,10 +449,9 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
                 }
             }
             let input = create_input(&config, text, &cli.file, abort_signal.clone()).await?;
-            dispatch_session_start(&config, "cmd").await;
             let aborted_check = abort_signal.clone();
             let result = start_directive(&config, input, abort_signal).await;
-            exit_session_with_hook(&config).await?;
+            exit_session(&config)?;
             if aborted_check.aborted() {
                 bail!("interrupted by user");
             }
@@ -469,41 +464,6 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
             start_interactive(&config).await
         }
     }
-}
-
-fn hook_dispatch_context(config: &GlobalConfig) -> (String, PathBuf) {
-    let config = config.read();
-    (
-        config
-            .session
-            .as_ref()
-            .map(|session| session.id())
-            .unwrap_or("default")
-            .to_string(),
-        env::current_dir().unwrap_or_default(),
-    )
-}
-
-async fn dispatch_session_start(config: &GlobalConfig, source: &str) {
-    let (session_id, cwd) = hook_dispatch_context(config);
-    let config_snapshot = config.read().clone();
-    let nats_hook_provider = discover_process_nats_hook_provider(&config_snapshot).await;
-    let model_id = config.read().current_model().id().to_string();
-    let event = HookEvent::SessionStart {
-        source: source.to_string(),
-        model: model_id,
-    };
-    let _ = dispatch_hook_event(HookEventDispatch {
-        event,
-        provider: nats_hook_provider.as_deref(),
-        meta: HookDispatchMeta {
-            session_id: session_id.clone(),
-            cwd: cwd.clone(),
-            resume_count: 0,
-        },
-        pending_async_context: None,
-    })
-    .await;
 }
 
 fn session_resume_command(config: &GlobalConfig) -> Option<String> {
@@ -618,29 +578,9 @@ fn print_session_breakdown(
     }
 }
 
-async fn exit_session_with_hook(config: &GlobalConfig) -> Result<()> {
+fn exit_session(config: &GlobalConfig) -> Result<()> {
     let resume_cmd = session_resume_command(config);
-    let (session_id, cwd) = hook_dispatch_context(config);
-    let config_snapshot = config.read().clone();
-    let nats_hook_provider = discover_process_nats_hook_provider(&config_snapshot).await;
     config.write().exit_session()?;
-    let event = HookEvent::SessionEnd {
-        reason: "session_exit".to_string(),
-    };
-    let _ = tokio::time::timeout(
-        Duration::from_secs(5),
-        dispatch_hook_event(HookEventDispatch {
-            event,
-            provider: nats_hook_provider.as_deref(),
-            meta: HookDispatchMeta {
-                session_id: session_id.clone(),
-                cwd: cwd.clone(),
-                resume_count: 0,
-            },
-            pending_async_context: None,
-        }),
-    )
-    .await;
 
     if let Some(cmd) = resume_cmd {
         eprintln!(
@@ -719,7 +659,6 @@ async fn start_directive_inner(
 }
 
 async fn start_interactive(config: &GlobalConfig) -> Result<()> {
-    dispatch_session_start(config, "tui").await;
     let mut tui: Tui = Tui::init(config).await?;
     let result = tui.run().await;
     let source = {
@@ -731,7 +670,7 @@ async fn start_interactive(config: &GlobalConfig) -> Result<()> {
         }
     };
     print_session_breakdown(tui.transcript(), &source, config);
-    exit_session_with_hook(config).await?;
+    exit_session(config)?;
     result
 }
 

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -67,8 +67,7 @@ Harnx supports the following events. Each event sends a JSON payload to the hook
 
 | Event | When it fires | Payload Fields | Capabilities |
 | :--- | :--- | :--- | :--- |
-| `SessionStart` | At the beginning of a session. | `session_id`, `cwd`, `source`, `model` | Observe |
-| `SessionEnd` | When a session terminates. | `session_id`, `cwd`, `reason` | Observe |
+| `SessionStart` | Once, when a session is created. Resuming a session does not fire it again. `source` is `startup`. | `session_id`, `cwd`, `source`, `model` | Observe, Context |
 | `UserPromptSubmit` | When the user sends a prompt. | `session_id`, `cwd`, `prompt` | Observe |
 | `Stop` | When the agent finishes its turn. | `session_id`, `cwd`, `stop_hook_active`, `last_assistant_message` | Resume |
 | `StopFailure` | When an agent turn fails. | `session_id`, `cwd`, `error`, `error_type` | Observe |
@@ -645,7 +644,7 @@ NATS hook servers register their capabilities in a JetStream Key-Value bucket an
 
 ### Event Processing and Capabilities
 
-`NatsHookProvider` handles all `HookEvent` variants (`SessionStart`, `SessionEnd`, `UserPromptSubmit`, `Stop`, `StopFailure`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `InstructionsLoaded`, `CwdChanged`):
+`NatsHookProvider` handles all `HookEvent` variants (`SessionStart`, `UserPromptSubmit`, `Stop`, `StopFailure`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `InstructionsLoaded`, `CwdChanged`):
 
 * **`PreToolUse` Hooks**: Executed sequentially in priority order.
   * *Input Mutation*: `mutated_tool_input` chains from hook to hook (e.g., sequentially augmenting environment variables).
@@ -653,8 +652,8 @@ NATS hook servers register their capabilities in a JetStream Key-Value bucket an
   * *Context Injection*: `additional_context` and `system_message` strings are aggregated across matching hooks and enqueued into `pending_async_context` for injection into the next agent turn.
 * **`Ask` Outcome & Headless Limitation**: A `PreToolUse` hook returning `Ask` surfaces as a tool confirmation request (`ToolApprovalRequiredError`). In headless worker environments where interactive prompts are unavailable, the caller's confirmation callback or approval handler determines whether the request proceeds or fails.
 * **`PostToolUse` Hooks**: Executed asynchronously (`tokio::spawn` fire-and-forget). Errors emit an `AgentEvent::Notice(Error)`. Returned `additional_context` or `system_message` values route to `pending_async_context`. Note: `mutated_tool_response` is logged and dropped in the NATS dispatch path.
-* **Non-Tool Blocking Events** (`UserPromptSubmit`, `Stop`, `StopFailure`): Executed sequentially; short-circuits on `Block` or `Ask`; appends returned context to `pending_async_context`.
-* **Best-Effort Events** (`SessionStart`, `SessionEnd`, `InstructionsLoaded`, `CwdChanged`, `PostToolUseFailure`): Dispatched as asynchronous background tasks.
+* **Non-Tool Blocking Events** (`SessionStart`, `UserPromptSubmit`, `Stop`, `StopFailure`): Executed sequentially; short-circuits on `Block` or `Ask`; appends returned context to `pending_async_context`.
+* **Best-Effort Events** (`InstructionsLoaded`, `CwdChanged`, `PostToolUseFailure`): Dispatched as asynchronous background tasks.
 
 ### Fail-Closed Behavior & Expectation Tracking
 


### PR DESCRIPTION
`SessionStart` hooks never ran. The CLI/TUI frontend dispatched the event, but
`discover_process_nats_hook_provider` needs `HARNX_INSTANCE_ID`, which is only
set on processes a worker supervisor spawns — so the frontend always got `None`,
the dispatch became a no-op, and all it produced was `NATS hook provider
unavailable; continuing without hook enforcement for SessionStart` in the log
(#1366). The frontend also fired the event before `ensure_local_worker`, so on a
cold start there was no worker and no registered hook set to dispatch to.

This is a regression from bd5f457a8 (#1325). Before that commit the frontend
also ran the hooks inline as subprocesses; removing inline dispatch left the
NATS path as the only one, and in the frontend it does nothing.

The worker owns the event now. It fires on the activation that creates the
session, after hook reconciliation and provider discovery, so both global and
agent hook servers are reachable — and `additionalContext` returned by a hook
now reaches the first turn through the loop's pending queue, which the frontend
path could not do.

## Detecting a brand-new session

Not `entries.is_empty()`. The thin client appends its user message *before*
publishing `SessionActivate` (`nats_client_session.rs:168`), so a fresh session
reaches `load_or_repair_session` with a headerless but non-empty log and the
empty-log branch is nearly dead in practice. Writing the header is what creates
the session, so `maybe_insert_remote_header` reports whether it wrote one.
Activations happen once per turn, so resumed sessions skip the event.

One consequence worth knowing: a legacy headerless session migrated in under S2
gets its header written on first activation, so it fires `SessionStart` once at
that point.

## SessionEnd removed

Only the frontend knows a session ended, and worker activations are per-turn, so
there was nowhere correct to fire it — firing it per activation would run the
hook many times per real session. Hooks registered for `SessionEnd` no longer
match any event.

## Testing

Two unit tests cover the dispatch decision (created fires with source
`startup`; resumed does not). A new e2e in
`nats_worker/session_start_hook_tests.rs` runs a real worker that launches a
real `harnx-claude-compatible-hook-server` against a real broker, and asserts a
marker file gains exactly one line across two turns of the same session.

That e2e earned its keep twice: it failed until the header-based detection
replaced the empty-log assumption, and it exposed that `start_global_hooks`
gates on `LOCAL_CLUSTER_KEY` (`__local__`) while the worker test harness uses
cluster `local`, so hook servers never launch in those tests. The new test uses
the reserved local cluster; a temporary `UserPromptSubmit` probe confirmed the
launch path works before the `SessionStart` result was trusted.

`build`, `fmt`, `clippy -D warnings` clean. `nextest --workspace
--stress-count=5`: 4/5 iterations fully clean; one iteration hit
`harnx-serve ag_ui_rpc::{rpc_session_prompt_returns_ack_and_persists_effect,
rpc_session_get_known_session_...}`, which reproduce 4/8 on a clean tree without
this change. `cs delta origin/HEAD` reports no code-health decrease.

## Follow-up, not in this PR

`commands.rs:814` still dispatches `UserPromptSubmit` from the frontend with a
provider that is always `None`. It is dead rather than harmful — the worker's
agent loop dispatches that event for real — but it is the same pattern and worth
deleting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workers now trigger a `SessionStart` hook once when creating a session.
  - Hook-provided additional context is included in the session’s first turn.
  - Resumed sessions no longer trigger startup hooks.

- **Changes**
  - Removed support for `SessionEnd` hooks.
  - Updated session lifecycle behavior and event processing accordingly.

- **Documentation**
  - Updated the hooks guide with the revised session event behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->