### PR TITLE
fix(nats): surface worker turn failures instead of hanging the client

### DIFF
--- a/.changeset/worker-error-visibility.md
+++ b/.changeset/worker-error-visibility.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Surface worker session failures in the UI instead of hanging, and load file-backed agent variables in the NATS worker.

--- a/crates/harnx-core/src/session.rs
+++ b/crates/harnx-core/src/session.rs
@@ -143,6 +143,17 @@ pub enum SessionLogEntry {
         #[serde(default, skip_serializing_if = "is_zero_usize")]
         tokens: usize,
     },
+    /// A turn that ended in a worker-side failure instead of an assistant
+    /// reply. Written by the worker so attached clients stop waiting and the
+    /// transcript records why the turn produced nothing. Unlike `Message`, an
+    /// `Error` is never replayed into the model's context.
+    #[serde(rename = "error")]
+    Error {
+        message: String,
+        fence_token: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timestamp: Option<DateTime<Utc>>,
+    },
     #[serde(other)]
     Unknown,
 }
@@ -163,13 +174,14 @@ impl SessionLogEntry {
     }
 
     /// Fence token carried by this entry, if any. `Message`/`ToolCalls` carry an
-    /// optional fence; `Cancel` always carries one. All other variants are
-    /// unfenced and return `None`.
+    /// optional fence; `Cancel` and `Error` always carry one. All other variants
+    /// are unfenced and return `None`.
     pub fn fence_token(&self) -> Option<u64> {
         match self {
             SessionLogEntry::Message { fence_token, .. }
             | SessionLogEntry::ToolCalls { fence_token, .. } => *fence_token,
-            SessionLogEntry::Cancel { fence_token } => Some(*fence_token),
+            SessionLogEntry::Cancel { fence_token }
+            | SessionLogEntry::Error { fence_token, .. } => Some(*fence_token),
             _ => None,
         }
     }
@@ -869,6 +881,26 @@ content: replacement two
                 assert_eq!(fence_token, 42);
             }
             other => panic!("expected cancel, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_log_entry_error_serde_round_trip() {
+        let entry = SessionLogEntry::Error {
+            message: "Template error in agent 'sisyphus': undefined value".to_string(),
+            fence_token: 7,
+            timestamp: None,
+        };
+
+        let yaml = serde_yaml::to_string(&entry).unwrap();
+        let round_tripped: SessionLogEntry = serde_yaml::from_str(&yaml).unwrap();
+
+        assert_eq!(round_tripped.fence_token(), Some(7));
+        match round_tripped {
+            SessionLogEntry::Error { message, .. } => {
+                assert!(message.contains("undefined value"));
+            }
+            other => panic!("expected error, got {other:?}"),
         }
     }
 

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -1178,6 +1178,7 @@ mod tests {
             response: Some("world".to_string()),
             session_id: "session".to_string(),
             was_cancelled: false,
+            error: None,
             user_msg_seq: 1,
             user_msg_id: "message".to_string(),
         };

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -1172,7 +1172,7 @@ impl Config {
         crate::config::session::add_tool_results(session, tool_results)
     }
 
-    fn init_agent_shared_variables(&mut self) -> Result<()> {
+    pub(crate) fn init_agent_shared_variables(&mut self) -> Result<()> {
         let agent = match self.agent.as_mut() {
             Some(v) => v,
             None => return Ok(()),

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -334,6 +334,9 @@ pub(crate) fn replay_log_entries_for_external(
                 session.compressed_messages.clear();
                 session.data_urls.clear();
             }
+            // A failed turn is a transcript annotation, not conversation
+            // history — replaying it would feed the error back to the model.
+            SessionLogEntry::Error { .. } => {}
             SessionLogEntry::Cancel { .. } => {}
             SessionLogEntry::EditEntries { .. }
             | SessionLogEntry::Rewind { .. }

--- a/crates/harnx-runtime/src/nats_client_session.rs
+++ b/crates/harnx-runtime/src/nats_client_session.rs
@@ -58,6 +58,101 @@ pub(crate) fn new_client_message_id() -> String {
     uuid::Uuid::new_v4().to_string()
 }
 
+/// How often the client re-reads the session lease. Slower than the durable
+/// completion check because a worker's death is not latency-sensitive and each
+/// read is a NATS round trip on every in-flight turn.
+const ORPHAN_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Consecutive lease reads with no holder before a turn is declared orphaned.
+/// Two reads at the interval above leave ~4s of slack for a worker's lease
+/// release to race the barrier it just wrote.
+const ORPHAN_MISSING_CHECKS: u32 = 2;
+
+/// Detects a turn whose worker vanished without writing a barrier.
+///
+/// The worker writes its assistant message (or its `Error` entry) before
+/// releasing the session lease, so "lease gone, nothing in the log" means the
+/// worker died — a panic, a kill, a lost connection. Only trips once a lease
+/// has actually been observed, so a worker that is slow to claim the activation
+/// is never mistaken for a dead one. A turn no worker ever picks up still waits
+/// indefinitely, which is the correct behaviour for a queued session.
+struct OrphanWatchdog {
+    lease_config: crate::nats_lease::NatsLeaseConfig,
+    /// Opened once and reused: `get_key_value` costs a `stream_info` round trip
+    /// that the per-poll `get` does not.
+    bucket: Option<async_nats::jetstream::kv::Store>,
+    next_check: tokio::time::Instant,
+    saw_lease: bool,
+    missing_checks: u32,
+}
+
+impl OrphanWatchdog {
+    fn new() -> Self {
+        Self {
+            lease_config: crate::nats_lease::NatsLeaseConfig::default(),
+            bucket: None,
+            next_check: tokio::time::Instant::now() + ORPHAN_CHECK_INTERVAL,
+            saw_lease: false,
+            missing_checks: 0,
+        }
+    }
+
+    /// The failure message to end the turn with, or `None` to keep waiting.
+    async fn check(&mut self, jetstream: &jetstream::Context, session_id: &str) -> Option<String> {
+        let now = tokio::time::Instant::now();
+        if now < self.next_check {
+            return None;
+        }
+        self.next_check = now + ORPHAN_CHECK_INTERVAL;
+
+        if self.bucket.is_none() {
+            self.bucket = crate::nats_lease::open_lease_bucket(jetstream, &self.lease_config).await;
+        }
+        // No bucket means no worker has ever leased on this cluster; that is
+        // indistinguishable from "not started yet", so keep waiting.
+        let bucket = self.bucket.as_ref()?;
+
+        let holder = match crate::nats_lease::lease_holder_in(
+            bucket,
+            &self.lease_config,
+            session_id,
+        )
+        .await
+        {
+            Ok(holder) => holder,
+            Err(error) => {
+                // An unreadable lease says nothing about the worker.
+                log::debug!("thin client: lease liveness check failed: {error:#}");
+                self.missing_checks = 0;
+                return None;
+            }
+        };
+
+        let Some(holder) = holder else {
+            if !self.saw_lease {
+                return None;
+            }
+            self.missing_checks += 1;
+            if self.missing_checks < ORPHAN_MISSING_CHECKS {
+                return None;
+            }
+            return Some(
+                "The worker handling this session stopped without answering. \
+                 Check the worker log for the underlying failure."
+                    .to_string(),
+            );
+        };
+
+        log::trace!(
+            "thin client: session {session_id} held by {}",
+            holder.worker_id
+        );
+        self.saw_lease = true;
+        self.missing_checks = 0;
+        None
+    }
+}
+
 /// Configuration for a thin-client session.
 #[derive(Clone)]
 pub struct ThinClientConfig {
@@ -218,6 +313,7 @@ impl ThinClientSession {
         // Step 4: Stream events and handle control until turn completion.
         let mut event_stream = event_stream;
         let mut final_response: Option<String> = None;
+        let mut turn_error: Option<String> = None;
         let mut turn_complete = false;
         // Cached effective log for emitting LogSeqAssigned on live advisory
         // events. Refreshed on throttled durable reloads so we avoid O(N^2)
@@ -238,6 +334,7 @@ impl ThinClientSession {
         // Wrap channel in Option for select! handling.
         let mut pending_cancel_rx = pending_cancel;
         let mut was_cancelled = false;
+        let mut orphan_watchdog = OrphanWatchdog::new();
 
         // Main event loop with abort signal handling
         let abort_signal_clone = self.abort_signal.clone();
@@ -302,7 +399,15 @@ impl ThinClientSession {
                             );
                         }
                         if self.is_turn_complete(&entries, user_msg_seq) {
-                            final_response = Self::extract_final_response(&entries, user_msg_seq);
+                            (final_response, turn_error) =
+                                Self::extract_turn_outcome(&entries, user_msg_seq);
+                            turn_complete = true;
+                            break;
+                        }
+                        if let Some(reason) =
+                            orphan_watchdog.check(&self.jetstream, &self.session_id).await
+                        {
+                            turn_error = Some(reason);
                             turn_complete = true;
                             break;
                         }
@@ -346,7 +451,8 @@ impl ThinClientSession {
                                     }
                                     if self.is_turn_complete(&entries, user_msg_seq) {
                                         // Extract final response before we finish
-                                        final_response = Self::extract_final_response(&entries, user_msg_seq);
+                                        (final_response, turn_error) =
+                                            Self::extract_turn_outcome(&entries, user_msg_seq);
                                         turn_complete = true;
                                         break;
                                     }
@@ -366,13 +472,18 @@ impl ThinClientSession {
         // Re-load durable log to get final state if we haven't already
         if !turn_complete {
             let entries = self.load_durable_entries().await?;
-            final_response = Self::extract_final_response(&entries, user_msg_seq);
+            (final_response, turn_error) = Self::extract_turn_outcome(&entries, user_msg_seq);
+        }
+
+        if let Some(error) = &turn_error {
+            render_error_entry(error, &event_sink);
         }
 
         Ok(ThinClientTurnResult {
             response: final_response,
             session_id: self.session_id.clone(),
             was_cancelled: was_cancelled || self.abort_signal.aborted(),
+            error: turn_error,
             user_msg_seq,
             user_msg_id,
         })
@@ -448,16 +559,43 @@ impl ThinClientSession {
 
     /// Check if the turn is complete based on durable entries.
     fn is_turn_complete(&self, entries: &[(u64, SessionLogEntry)], user_msg_seq: u64) -> bool {
-        let has_assistant_after_user = entries.iter().any(|(seq, entry)| {
+        let has_barrier_after_user = entries.iter().any(|(seq, entry)| {
             *seq > user_msg_seq
-                && matches!(entry, SessionLogEntry::Message { role, .. } if role.is_assistant())
+                && match entry {
+                    SessionLogEntry::Message { role, .. } => role.is_assistant(),
+                    SessionLogEntry::Error { .. } => true,
+                    _ => false,
+                }
         });
 
-        has_assistant_after_user
+        has_barrier_after_user
             || matches!(
                 reconstruct_state_from_nats(entries).turn_status,
                 TurnStatus::InFlightCancelled
             )
+    }
+
+    /// Final assistant text and worker-reported failure for the current turn.
+    fn extract_turn_outcome(
+        entries: &[(u64, SessionLogEntry)],
+        user_msg_seq: u64,
+    ) -> (Option<String>, Option<String>) {
+        (
+            Self::extract_final_response(entries, user_msg_seq),
+            Self::extract_turn_error(entries, user_msg_seq),
+        )
+    }
+
+    /// Worker-reported failure for the current turn, if the turn ended in one.
+    fn extract_turn_error(entries: &[(u64, SessionLogEntry)], user_msg_seq: u64) -> Option<String> {
+        entries
+            .iter()
+            .rev()
+            .filter(|(seq, _)| *seq > user_msg_seq)
+            .find_map(|(_, entry)| match entry {
+                SessionLogEntry::Error { message, .. } => Some(message.clone()),
+                _ => None,
+            })
     }
 
     /// Extract final assistant response text for current turn from durable entries.
@@ -503,6 +641,8 @@ pub struct ThinClientTurnResult {
     pub session_id: String,
     /// Whether the turn was cancelled.
     pub was_cancelled: bool,
+    /// Worker-side failure that ended the turn without an assistant reply.
+    pub error: Option<String>,
     /// Sequence number of the appended user message (for retract/edit).
     pub user_msg_seq: u64,
     /// Client-generated message ID of the appended user message.
@@ -554,6 +694,10 @@ fn render_log_entry_to_sink(
         }
         SessionLogEntry::Cancel { .. } => {
             render_cancel_entry(&sink);
+            false
+        }
+        SessionLogEntry::Error { message, .. } => {
+            render_error_entry(message, &sink);
             false
         }
         SessionLogEntry::Header { .. }
@@ -765,6 +909,12 @@ fn render_cancel_entry(sink: &Arc<dyn AgentEventSink>) {
     sink.emit(AgentEvent::Notice(NoticeEvent::Warning(
         "Session cancelled".to_string(),
     )));
+}
+
+fn render_error_entry(message: &str, sink: &Arc<dyn AgentEventSink>) {
+    use harnx_core::event::NoticeEvent;
+
+    sink.emit(AgentEvent::Notice(NoticeEvent::Error(message.to_string())));
 }
 
 /// Send a control command to a remote session.

--- a/crates/harnx-runtime/src/nats_lease.rs
+++ b/crates/harnx-runtime/src/nats_lease.rs
@@ -297,9 +297,10 @@ impl LeaseState {
 
 /// Open the lease bucket read-only, without creating it.
 ///
-/// `Ok(None)` means no worker has ever taken a lease on this cluster. Callers
-/// that poll should hold on to the returned store: opening it costs a
-/// `stream_info` round trip that a plain `get` does not.
+/// `None` means the lookup did not succeed — either no worker has ever taken a
+/// lease on this cluster, or the lookup failed transiently. Callers that poll
+/// should hold on to the returned store: opening it costs a `stream_info` round
+/// trip that a plain `get` does not.
 pub async fn open_lease_bucket(
     jetstream: &jetstream::Context,
     config: &NatsLeaseConfig,

--- a/crates/harnx-runtime/src/nats_lease.rs
+++ b/crates/harnx-runtime/src/nats_lease.rs
@@ -295,6 +295,42 @@ impl LeaseState {
     }
 }
 
+/// Open the lease bucket read-only, without creating it.
+///
+/// `Ok(None)` means no worker has ever taken a lease on this cluster. Callers
+/// that poll should hold on to the returned store: opening it costs a
+/// `stream_info` round trip that a plain `get` does not.
+pub async fn open_lease_bucket(
+    jetstream: &jetstream::Context,
+    config: &NatsLeaseConfig,
+) -> Option<kv::Store> {
+    jetstream.get_key_value(&config.bucket).await.ok()
+}
+
+/// Read the worker currently holding a session's lease, without acquiring it.
+///
+/// `Ok(None)` means nobody holds the session: the key expired because its
+/// holder stopped renewing, or it was released. Clients use this to tell "a
+/// worker is still working" from "the worker is gone".
+pub async fn lease_holder_in(
+    bucket: &kv::Store,
+    config: &NatsLeaseConfig,
+    session_id: &str,
+) -> Result<Option<LeaseRecord>> {
+    let key = config.key_for_session(session_id);
+    let Some(entry) = bucket
+        .get(&key)
+        .await
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("Failed to read NATS lease for session '{session_id}'"))?
+    else {
+        return Ok(None);
+    };
+    serde_json::from_slice(&entry)
+        .map(Some)
+        .with_context(|| format!("Failed to decode NATS lease record for session '{session_id}'"))
+}
+
 async fn ensure_lease_bucket(
     jetstream: &jetstream::Context,
     config: &NatsLeaseConfig,

--- a/crates/harnx-runtime/src/nats_worker/backend.rs
+++ b/crates/harnx-runtime/src/nats_worker/backend.rs
@@ -91,6 +91,20 @@ impl NatsSessionLogBackend {
         &self.session_id
     }
 
+    /// Append an entry.
+    ///
+    /// Prefer this over [`Self::append_event_blocking`] wherever the caller is
+    /// already async.
+    pub async fn append_event(&self, entry: &harnx_core::session::SessionLogEntry) -> Result<u64> {
+        let log = crate::nats_session_log::NatsSessionLog::new(
+            self.jetstream.clone(),
+            self.session_id.clone(),
+        );
+        let seq = log.append_event_async(entry).await?;
+        self.observe_append(seq);
+        Ok(seq)
+    }
+
     /// Append an entry, blocking on the async NATS call.
     ///
     /// Must be called from within a Tokio multi-threaded runtime.
@@ -106,12 +120,16 @@ impl NatsSessionLogBackend {
         let seq = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(log.append_event_async(entry))
         })?;
-        // Advance the P4.1 fan-out `after_seq` so subsequent advisories in this
-        // (possibly multi-step) turn carry an up-to-date durable sequence.
+        self.observe_append(seq);
+        Ok(seq)
+    }
+
+    /// Advance the P4.1 fan-out `after_seq` so subsequent advisories in this
+    /// (possibly multi-step) turn carry an up-to-date durable sequence.
+    fn observe_append(&self, seq: u64) {
         if let Some(observer) = &self.after_seq_observer {
             observer.fetch_max(seq, std::sync::atomic::Ordering::Relaxed);
         }
-        Ok(seq)
     }
 
     /// Load all events, blocking on async NATS reads.

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -836,6 +836,38 @@ impl WorkerRuntime {
         )
     }
 
+    /// Install the activation's agent into the per-session config.
+    ///
+    /// Mirrors the local `use_agent_by_name` flow: file-backed variable
+    /// defaults (`variables: [{name, path}]`) must be read off disk and folded
+    /// into the agent's shared variables before anything renders the prompt
+    /// template, or an agent like `pantheon/sisyphus` fails with an undefined
+    /// value on its first render.
+    ///
+    /// An agent the worker cannot find is not fatal — the session falls back to
+    /// the worker's own configuration, as it has always done. Failing to set up
+    /// an agent that *does* exist is fatal: running it half-initialized only
+    /// fails later, deeper, and less legibly.
+    fn install_activation_agent(per_session: &GlobalConfig, agent_name: &str) -> Result<()> {
+        let retrieved = per_session.read().retrieve_agent(agent_name);
+        let mut agent = match retrieved {
+            Ok(agent) => agent,
+            Err(error) => {
+                log::warn!(
+                    "activation agent '{agent_name}' not available, using worker config: {error:#}"
+                );
+                return Ok(());
+            }
+        };
+        crate::config::agent::resolve_file_defaults(&mut agent)
+            .with_context(|| format!("resolve file-backed variables for agent '{agent_name}'"))?;
+        let mut cfg = per_session.write();
+        cfg.use_agent_obj(agent)
+            .with_context(|| format!("activate agent '{agent_name}'"))?;
+        cfg.init_agent_shared_variables()
+            .with_context(|| format!("initialize variables for agent '{agent_name}'"))
+    }
+
     async fn execute_session(
         &self,
         activation: SessionActivate,
@@ -849,10 +881,7 @@ impl WorkerRuntime {
             let base = self.config.read().clone();
             Arc::new(parking_lot::RwLock::new(base))
         };
-        if let Ok(agent) = self.config.read().retrieve_agent(&activation.agent) {
-            let mut cfg = per_session.write();
-            let _ = cfg.use_agent_obj(agent);
-        }
+        let agent_setup = Self::install_activation_agent(&per_session, &activation.agent);
 
         // Create event sink for live fan-out. `new` seeds `after_seq` from stream once.
         let event_sink = crate::nats_event_sink::NatsEventSink::new(
@@ -875,6 +904,10 @@ impl WorkerRuntime {
             Self::spawn_lease_loss_watch(&lease, &abort_signal, &activation.session_id);
 
         let result = harnx_core::sink::with_agent_event_sink(event_sink, async {
+            // A half-installed agent cannot render its prompt, so stop here and
+            // let the caller record the failure rather than failing deeper in.
+            agent_setup?;
+
             // Activation high-water cursor: max log seq of ANY user message we've fed into this
             // activation. Includes messages folded into turn inputs AND mid-round injections.
             // A continuation turn only runs if there's a user message with seq > this cursor.
@@ -1015,6 +1048,13 @@ impl WorkerRuntime {
         })
         .await;
 
+        // Record the failure durably BEFORE releasing the lease: attached
+        // clients treat an `Error` entry as the turn barrier, and a client that
+        // reconnects later still sees why the turn produced nothing.
+        if let Err(error) = &result {
+            Self::record_session_error(&backend, &lease, error).await;
+        }
+
         if !lease.is_held() {
             log::warn!(
                 "session execution ended after failover: session_id={} worker_id={} revision={}",
@@ -1031,6 +1071,32 @@ impl WorkerRuntime {
 
         let _ = lease.release().await;
         result
+    }
+
+    /// Append an `Error` entry for a turn that failed.
+    ///
+    /// Skipped when the lease is gone: a newer worker owns the session and
+    /// writing behind it would corrupt the log. That case is covered by the
+    /// client's orphan watchdog instead.
+    async fn record_session_error(
+        backend: &NatsSessionLogBackend,
+        lease: &NatsSessionLease,
+        error: &anyhow::Error,
+    ) {
+        if !should_append_control_log_entry(lease) {
+            return;
+        }
+        let entry = harnx_core::session::SessionLogEntry::Error {
+            message: format!("{error:#}"),
+            fence_token: lease.fence_token(),
+            timestamp: Some(chrono::Utc::now()),
+        };
+        if let Err(append_error) = backend.append_event_blocking(&entry) {
+            log::warn!(
+                "failed to append Error entry: session_id={} err={append_error:#}",
+                backend.session_id(),
+            );
+        }
     }
 
     /// Spawn a task that watches for lease loss and aborts on loss.

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -10,8 +10,8 @@ use super::hook_supervisor::{HookServerStartConfig, HookServerSupervisor};
 use super::subagent_toolset::SubagentToolset;
 use super::tool_supervisor::{ToolServerStartConfig, ToolServerSupervisor};
 use crate::config::{
-    list_agents, resolve_local_nats_server_config, server_display_name, GlobalConfig, Input,
-    ToolServerConfig, LOCAL_CLUSTER_KEY,
+    list_agents, resolve_local_nats_server_config, server_display_name, Config, GlobalConfig,
+    Input, ToolServerConfig, LOCAL_CLUSTER_KEY,
 };
 use crate::nats_lease::{NatsLeaseAcquireParams, NatsLeaseConfig, NatsSessionLease};
 use crate::nats_metrics;
@@ -844,20 +844,23 @@ impl WorkerRuntime {
     /// template, or an agent like `pantheon/sisyphus` fails with an undefined
     /// value on its first render.
     ///
-    /// An agent the worker cannot find is not fatal — the session falls back to
-    /// the worker's own configuration, as it has always done. Failing to set up
-    /// an agent that *does* exist is fatal: running it half-initialized only
-    /// fails later, deeper, and less legibly.
+    /// An agent the worker simply does not have is not fatal — the session
+    /// falls back to the worker's own configuration, as it has always done.
+    /// Anything else is: an agent whose file is present but unreadable,
+    /// unparseable, or names a model the worker cannot resolve must not
+    /// silently answer as some other agent.
     fn install_activation_agent(per_session: &GlobalConfig, agent_name: &str) -> Result<()> {
         let retrieved = per_session.read().retrieve_agent(agent_name);
         let mut agent = match retrieved {
             Ok(agent) => agent,
-            Err(error) => {
+            // No file and no built-in by this name: nothing to load.
+            Err(error) if !Config::agent_file(agent_name).exists() => {
                 log::warn!(
                     "activation agent '{agent_name}' not available, using worker config: {error:#}"
                 );
                 return Ok(());
             }
+            Err(error) => return Err(error).context(format!("load agent '{agent_name}'")),
         };
         crate::config::agent::resolve_file_defaults(&mut agent)
             .with_context(|| format!("resolve file-backed variables for agent '{agent_name}'"))?;
@@ -1091,7 +1094,7 @@ impl WorkerRuntime {
             fence_token: lease.fence_token(),
             timestamp: Some(chrono::Utc::now()),
         };
-        if let Err(append_error) = backend.append_event_blocking(&entry) {
+        if let Err(append_error) = backend.append_event(&entry).await {
             log::warn!(
                 "failed to append Error entry: session_id={} err={append_error:#}",
                 backend.session_id(),

--- a/crates/harnx-runtime/src/nats_worker/subagent_toolset.rs
+++ b/crates/harnx-runtime/src/nats_worker/subagent_toolset.rs
@@ -343,6 +343,11 @@ impl SubagentToolset {
 }
 
 fn require_response(result: &ThinClientTurnResult) -> Result<&str, ToolInvokeError> {
+    if let Some(error) = &result.error {
+        return Err(ToolInvokeError::Recoverable(format!(
+            "sub-agent turn failed: {error}"
+        )));
+    }
     result.response.as_deref().ok_or_else(|| {
         ToolInvokeError::Recoverable("sub-agent turn returned no final response".to_string())
     })

--- a/crates/harnx-runtime/src/nats_worker/tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests.rs
@@ -346,9 +346,13 @@ pub(super) fn spawn_metis_worker_with_hooks(
     daemon: crate::nats_worker::WorkerDaemonConfig,
     hooks: Option<harnx_core::hooks::HooksConfig>,
 ) -> tokio::task::JoinHandle<anyhow::Result<()>> {
-    let worker_agent =
+    let mut worker_agent =
         AgentConfig::from_markdown("metis", "---\nuse_tools: \"*\"\n---\nstub worker prompt")
             .unwrap();
+    // A real worker starts with its model already resolved. Without this the
+    // fixture has no client for `test:`, so loading an agent file that declares
+    // `model: test:test-model` fails outright.
+    worker_agent.set_resolved_model(harnx_core::model::Model::new("test", "test-model"));
     let worker_config = Config {
         data: harnx_core::config_data::ConfigData {
             model_id: "test:test-model".to_string(),

--- a/crates/harnx-runtime/src/session_history.rs
+++ b/crates/harnx-runtime/src/session_history.rs
@@ -39,6 +39,7 @@ pub fn entry_type(entry: &SessionLogEntry) -> &'static str {
         SessionLogEntry::Compress { .. } => "compress",
         SessionLogEntry::Clear => "clear",
         SessionLogEntry::Cancel { .. } => "cancel",
+        SessionLogEntry::Error { .. } => "error",
         SessionLogEntry::EditEntries { .. } => "edit_entries",
         SessionLogEntry::Rewind { .. } => "rewind",
         SessionLogEntry::Title { .. } => "title",
@@ -66,6 +67,7 @@ fn entry_searchable_text(entry: &SessionLogEntry) -> String {
         SessionLogEntry::Compress { prompt } => prompt.clone(),
         SessionLogEntry::Title { title, .. } => title.clone(),
         SessionLogEntry::Header { model_id, .. } => format!("model: {model_id}"),
+        SessionLogEntry::Error { message, .. } => message.clone(),
         _ => String::new(),
     }
 }

--- a/crates/harnx-runtime/tests/agent_prompt_rendering.rs
+++ b/crates/harnx-runtime/tests/agent_prompt_rendering.rs
@@ -159,6 +159,9 @@ fn check_agent(qualified_name: &str, failures: &mut Vec<String>) -> AgentOutcome
 
 #[test]
 fn agent_prompt_rendering_renders_all_shipped_agents() {
+    // `install_packages` sets HARNX_CONFIG_DIR process-wide; the guards are
+    // only sound because nextest runs each test in its own process.
+    harnx_core::require_nextest();
     let Some(workspace_root) = workspace_root() else {
         // Published crates do not include workspace package assets.
         return;
@@ -166,14 +169,14 @@ fn agent_prompt_rendering_renders_all_shipped_agents() {
     let (_temp, _config_guard) = install_packages(&workspace_root);
 
     let mut failures = Vec::new();
-    let mut totals = AgentOutcome::default();
+    let mut file_backed_variables = 0usize;
     let mut rendered = 0usize;
 
     for package in PACKAGES {
         let agents_dir = workspace_root.join("packages").join(package).join("agents");
         for stem in agent_stems(&agents_dir, &mut failures) {
             let outcome = check_agent(&format!("{package}/{stem}"), &mut failures);
-            totals.file_backed_variables += outcome.file_backed_variables;
+            file_backed_variables += outcome.file_backed_variables;
             rendered += usize::from(outcome.rendered);
         }
     }
@@ -185,7 +188,7 @@ fn agent_prompt_rendering_renders_all_shipped_agents() {
     );
     assert!(rendered > 0, "no shipped agents were rendered");
     assert!(
-        totals.file_backed_variables > 0,
+        file_backed_variables > 0,
         "no shipped agent exercised a file-backed variable"
     );
 }

--- a/crates/harnx-runtime/tests/agent_prompt_rendering.rs
+++ b/crates/harnx-runtime/tests/agent_prompt_rendering.rs
@@ -1,96 +1,180 @@
-use std::{ffi::OsStr, fs, path::Path};
+//! Every shipped agent must load and render its prompt through the same code
+//! the runtime uses at activation time.
+//!
+//! Resolving `variables: [{name, path}]` by hand in the test would only prove
+//! the markdown files line up; it would not catch a caller that installs an
+//! agent without running the resolver. So this test installs the packages into
+//! a temp config dir and drives `resolve_variables` — the production path — for
+//! each agent.
 
-use harnx_core::agent_config::{AgentConfig, AgentVariables};
+use std::{ffi::OsStr, fs, path::Path, path::PathBuf};
+
+use harnx_runtime::config::agent::{load_with_qualified_name, resolve_variables};
+use harnx_runtime::config::Config;
+
+const PACKAGES: [&str; 2] = ["pantheon", "coding"];
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn set_path(key: &'static str, value: &Path) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: nextest gives each test its own process, so nothing else
+        // mutates the environment concurrently.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: see EnvVarGuard::set_path.
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+fn workspace_root() -> Option<PathBuf> {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .find(|ancestor| ancestor.join("packages").is_dir())
+        .map(Path::to_path_buf)
+}
+
+/// Point `HARNX_CONFIG_DIR` at a temp dir whose `packages/` mirrors the
+/// workspace's, so `Config::agent_file("pantheon/sisyphus")` resolves to the
+/// real shipped agent.
+fn install_packages(workspace_root: &Path) -> (tempfile::TempDir, EnvVarGuard) {
+    let temp = tempfile::tempdir().expect("temp config dir");
+    let packages_dir = temp.path().join("packages");
+    fs::create_dir_all(&packages_dir).expect("create packages dir");
+    for package in PACKAGES {
+        let source = workspace_root.join("packages").join(package);
+        let link = packages_dir.join(package);
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&source, &link).expect("link package into config dir");
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(&source, &link).expect("link package into config dir");
+    }
+    let guard = EnvVarGuard::set_path("HARNX_CONFIG_DIR", temp.path());
+    (temp, guard)
+}
+
+fn agent_stems(agents_dir: &Path, failures: &mut Vec<String>) -> Vec<String> {
+    let entries = match fs::read_dir(agents_dir) {
+        Ok(entries) => entries,
+        Err(error) => {
+            failures.push(format!("{}: {error}", agents_dir.display()));
+            return Vec::new();
+        }
+    };
+    let mut stems: Vec<String> = entries
+        .filter_map(|entry| match entry {
+            Ok(entry) => {
+                let path = entry.path();
+                if path.is_file() && path.extension() == Some(OsStr::new("md")) {
+                    path.file_stem()
+                        .and_then(OsStr::to_str)
+                        .map(ToOwned::to_owned)
+                } else {
+                    None
+                }
+            }
+            Err(error) => {
+                failures.push(format!("{}: {error}", agents_dir.display()));
+                None
+            }
+        })
+        .collect();
+    stems.sort();
+    stems
+}
+
+/// What one agent contributed to the run: how many `path:` variables it
+/// resolved, and whether its prompt rendered.
+#[derive(Default)]
+struct AgentOutcome {
+    file_backed_variables: usize,
+    rendered: bool,
+}
+
+/// Every `path:` variable must come back with content. An empty value means
+/// the resolver ran but did not actually read the file.
+fn check_file_backed_variables(
+    agent: &harnx_runtime::config::Agent,
+    qualified_name: &str,
+    failures: &mut Vec<String>,
+) -> usize {
+    let declared: Vec<&str> = agent
+        .defined_variables()
+        .iter()
+        .filter(|variable| variable.path.is_some())
+        .map(|variable| variable.name.as_str())
+        .collect();
+    for name in &declared {
+        let resolved = agent.variables().get(*name).is_some_and(|v| !v.is_empty());
+        if !resolved {
+            failures.push(format!(
+                "{qualified_name}: variable '{name}' declares a path but resolved to nothing"
+            ));
+        }
+    }
+    declared.len()
+}
+
+fn check_agent(qualified_name: &str, failures: &mut Vec<String>) -> AgentOutcome {
+    let agent_path = Config::agent_file(qualified_name);
+    let mut agent = match load_with_qualified_name(&agent_path, qualified_name) {
+        Ok(agent) => agent,
+        Err(error) => {
+            failures.push(format!("{qualified_name}: {error:#}"));
+            return AgentOutcome::default();
+        }
+    };
+    if let Err(error) = resolve_variables(&mut agent) {
+        failures.push(format!("{qualified_name}: {error:#}"));
+        return AgentOutcome::default();
+    }
+
+    let file_backed_variables = check_file_backed_variables(&agent, qualified_name, failures);
+    let rendered = match agent.system_text() {
+        Ok(_) => true,
+        Err(error) => {
+            failures.push(format!("{qualified_name}: {error:#}"));
+            false
+        }
+    };
+    AgentOutcome {
+        file_backed_variables,
+        rendered,
+    }
+}
 
 #[test]
 fn agent_prompt_rendering_renders_all_shipped_agents() {
-    let Some(workspace_root) = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .find(|ancestor| ancestor.join("packages").is_dir())
-    else {
+    let Some(workspace_root) = workspace_root() else {
         // Published crates do not include workspace package assets.
         return;
     };
+    let (_temp, _config_guard) = install_packages(&workspace_root);
 
-    let agent_dirs = [
-        workspace_root.join("packages/pantheon/agents"),
-        workspace_root.join("packages/coding/agents"),
-    ];
     let mut failures = Vec::new();
+    let mut totals = AgentOutcome::default();
+    let mut rendered = 0usize;
 
-    for agent_dir in agent_dirs {
-        let entries = match fs::read_dir(&agent_dir) {
-            Ok(entries) => entries,
-            Err(error) => {
-                failures.push(format!("{}: {error}", agent_dir.display()));
-                continue;
-            }
-        };
-        let mut agent_paths = entries
-            .filter_map(|entry| match entry {
-                Ok(entry) => {
-                    let path = entry.path();
-                    (path.is_file() && path.extension() == Some(OsStr::new("md"))).then_some(path)
-                }
-                Err(error) => {
-                    failures.push(format!("{}: {error}", agent_dir.display()));
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-        agent_paths.sort();
-
-        for agent_path in agent_paths {
-            let content = match fs::read_to_string(&agent_path) {
-                Ok(content) => content,
-                Err(error) => {
-                    failures.push(format!("{}: {error}", agent_path.display()));
-                    continue;
-                }
-            };
-            let Some(stem) = agent_path.file_stem().and_then(OsStr::to_str) else {
-                failures.push(format!("{}: invalid UTF-8 file stem", agent_path.display()));
-                continue;
-            };
-            let mut agent = match AgentConfig::from_markdown(stem, &content) {
-                Ok(agent) => agent,
-                Err(error) => {
-                    failures.push(format!("{}: {error:#}", agent_path.display()));
-                    continue;
-                }
-            };
-
-            let mut variables = AgentVariables::new();
-            let mut variable_loading_failed = false;
-            for variable in agent.defined_variables() {
-                if let Some(relative_path) = &variable.path {
-                    let variable_path = agent_dir.join(relative_path);
-                    match fs::read_to_string(&variable_path) {
-                        Ok(value) => {
-                            variables.insert(variable.name.clone(), value);
-                        }
-                        Err(error) => {
-                            failures.push(format!(
-                                "{}: failed to load variable '{}' from {}: {error}",
-                                agent_path.display(),
-                                variable.name,
-                                variable_path.display()
-                            ));
-                            variable_loading_failed = true;
-                        }
-                    }
-                } else if let Some(default) = &variable.default {
-                    variables.insert(variable.name.clone(), default.clone());
-                }
-            }
-            if variable_loading_failed {
-                continue;
-            }
-
-            agent.set_shared_variables(variables);
-            if let Err(error) = agent.system_text() {
-                failures.push(format!("{}: {error:#}", agent_path.display()));
-            }
+    for package in PACKAGES {
+        let agents_dir = workspace_root.join("packages").join(package).join("agents");
+        for stem in agent_stems(&agents_dir, &mut failures) {
+            let outcome = check_agent(&format!("{package}/{stem}"), &mut failures);
+            totals.file_backed_variables += outcome.file_backed_variables;
+            rendered += usize::from(outcome.rendered);
         }
     }
 
@@ -98,5 +182,10 @@ fn agent_prompt_rendering_renders_all_shipped_agents() {
         failures.is_empty(),
         "failed to load or render shipped agent prompts:\n{}",
         failures.join("\n")
+    );
+    assert!(rendered > 0, "no shipped agents were rendered");
+    assert!(
+        totals.file_backed_variables > 0,
+        "no shipped agent exercised a file-backed variable"
     );
 }

--- a/crates/harnx-runtime/tests/nats_agent_variables_e2e.rs
+++ b/crates/harnx-runtime/tests/nats_agent_variables_e2e.rs
@@ -1,0 +1,390 @@
+//! End-to-end coverage for agents whose prompts interpolate variables loaded
+//! from files (the `variables: [{name, path}]` frontmatter used throughout the
+//! pantheon package), and for what a client sees when the worker can't render
+//! the prompt at all.
+//!
+//! The worker resolves the agent from its own config dir on activation. If it
+//! skips the file-backed variables, the first template render fails with an
+//! undefined value and — unless the failure is recorded durably — the client
+//! waits for a reply that never arrives.
+
+mod common;
+
+use anyhow::{Context, Result};
+use common::{spawn_nats_server, NatsServerHandle};
+use harnx_core::{
+    abort::create_abort_signal, event::NullSink, require_nextest, session::SessionLogEntry,
+};
+use harnx_runtime::{
+    config::Config,
+    nats_lease::{NatsLeaseAcquireParams, NatsLeaseConfig, NatsSessionLease},
+    nats_session_log::NatsSessionLog,
+    nats_worker::{run_worker_daemon, WorkerDaemonConfig},
+    ThinClientConfig, ThinClientSession, ThinClientTurnResult,
+};
+use parking_lot::RwLock;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+const FILE_VARIABLE_AGENT: &str = "varagent";
+const BROKEN_AGENT: &str = "brokenagent";
+const VARIABLE_FILE_TEXT: &str = "core instructions loaded from a file";
+/// Generous enough that a slow CI box does not trip it, short enough that a
+/// genuinely stalled turn fails the test rather than hanging the suite.
+const TURN_TIMEOUT: Duration = Duration::from_secs(20);
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn set_path(key: &'static str, value: &Path) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: nextest gives each test its own process, so nothing else
+        // mutates the environment concurrently.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: see EnvVarGuard::set_path.
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+/// A temp config dir wired to a NATS server, plus the env guards that point
+/// harnx at it. Guards must outlive every worker and client in the test.
+struct TestEnv {
+    server: NatsServerHandle,
+    config_dir: std::path::PathBuf,
+    _root: tempfile::TempDir,
+    _guards: Vec<EnvVarGuard>,
+}
+
+impl TestEnv {
+    fn new(server: NatsServerHandle) -> Result<Self> {
+        let root = tempfile::tempdir()?;
+        let config_dir = root.path().join("config");
+        let data_dir = root.path().join("data");
+        let state_dir = root.path().join("state");
+        std::fs::create_dir_all(config_dir.join("clients"))?;
+        std::fs::create_dir_all(config_dir.join("nats_servers"))?;
+        std::fs::create_dir_all(&data_dir)?;
+        std::fs::create_dir_all(&state_dir)?;
+
+        std::fs::write(config_dir.join("config.yaml"), "model: openai:test-model\n")?;
+        std::fs::write(
+            config_dir.join("nats_servers").join("local.yaml"),
+            format!("url: {}\n", server.url()),
+        )?;
+        std::fs::write(
+            config_dir.join("clients").join("openai.yaml"),
+            "type: openai\napi_key: sk-test\nmodels:\n  - name: test-model\n    type: chat\n    max_input_tokens: 4096\n",
+        )?;
+
+        let guards = vec![
+            EnvVarGuard::set_path("HARNX_CONFIG_DIR", &config_dir),
+            EnvVarGuard::set_path("HARNX_DATA_DIR", &data_dir),
+            EnvVarGuard::set_path("HARNX_STATE_DIR", &state_dir),
+        ];
+
+        Ok(Self {
+            server,
+            config_dir,
+            _root: root,
+            _guards: guards,
+        })
+    }
+
+    fn write_agent(&self, name: &str, body: &str) -> Result<()> {
+        let agents_dir = self.config_dir.join("agents");
+        std::fs::create_dir_all(&agents_dir)?;
+        std::fs::write(agents_dir.join(format!("{name}.md")), body)?;
+        Ok(())
+    }
+
+    /// The pantheon layout: a variable whose value is a sibling markdown file.
+    fn write_file_backed_variable_agent(&self) -> Result<()> {
+        let shared_dir = self.config_dir.join("agents").join("shared");
+        std::fs::create_dir_all(&shared_dir)?;
+        std::fs::write(shared_dir.join("core.md"), VARIABLE_FILE_TEXT)?;
+        self.write_agent(
+            FILE_VARIABLE_AGENT,
+            "---\n\
+             model: openai:test-model\n\
+             variables:\n\
+             - name: agent_core\n\
+             \x20 description: Core instructions\n\
+             \x20 path: shared/core.md\n\
+             ---\n\
+             Preamble.\n\n{{agent_core}}\n",
+        )
+    }
+
+    /// An agent whose prompt references a variable that is never defined.
+    fn write_undefined_variable_agent(&self) -> Result<()> {
+        self.write_agent(
+            BROKEN_AGENT,
+            "---\nmodel: openai:test-model\n---\nPreamble.\n\n{{never_defined}}\n",
+        )
+    }
+
+    async fn spawn_worker(&self, worker_id: &'static str) -> Result<tokio::task::JoinHandle<()>> {
+        let config = Config::load_from_file(&self.config_dir.join("config.yaml"))?;
+        let config = Arc::new(RwLock::new(config));
+        let handle = tokio::spawn(async move {
+            let _ = run_worker_daemon(
+                config,
+                WorkerDaemonConfig::new("local", worker_id),
+                Some(fixed_reply_call_fn("stub reply")),
+            )
+            .await;
+        });
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        Ok(handle)
+    }
+
+    async fn jetstream(&self) -> Result<async_nats::jetstream::Context> {
+        let client = async_nats::connect(self.server.url()).await?;
+        Ok(async_nats::jetstream::new(client))
+    }
+
+    async fn run_turn(&self, agent: &str, session_id: &str) -> Result<ThinClientTurnResult> {
+        let client = async_nats::connect(self.server.url()).await?;
+        let jetstream = async_nats::jetstream::new(client.clone());
+        let thin = ThinClientSession::new(
+            ThinClientConfig {
+                cluster: "local".to_string(),
+                agent: agent.to_string(),
+                session_id: Some(session_id.to_string()),
+            },
+            client,
+            jetstream,
+            create_abort_signal(),
+        )
+        .await?;
+
+        tokio::time::timeout(
+            TURN_TIMEOUT,
+            thin.run_turn("hello", Arc::new(NullSink), None),
+        )
+        .await
+        .context("turn stalled: the client never stopped waiting for the worker")?
+    }
+}
+
+fn fixed_reply_call_fn(reply: &'static str) -> harnx_runtime::agent_loop::AgentCallFn {
+    Arc::new(move |_input, _config, _abort| {
+        Box::pin(async move {
+            Ok((
+                reply.to_string(),
+                None,
+                vec![],
+                harnx_runtime::client::CompletionTokenUsage::default(),
+            ))
+        })
+    })
+}
+
+async fn load_entries(
+    jetstream: &async_nats::jetstream::Context,
+    session_id: &str,
+) -> Result<Vec<(u64, SessionLogEntry)>> {
+    NatsSessionLog::new(jetstream.clone(), session_id)
+        .load_events_async()
+        .await
+}
+
+/// The header's recorded agent variables. The worker inserts the header for a
+/// headerless session through an `EditEntries` replacement, so the mutations
+/// have to be applied before the header is visible.
+fn header_agent_variables(entries: &[(u64, SessionLogEntry)]) -> Result<Vec<(String, String)>> {
+    harnx_core::session_reconstruct::apply_log_mutations_nats(entries)?
+        .iter()
+        .find_map(|(_, entry)| match entry {
+            SessionLogEntry::Header {
+                agent_variables, ..
+            } => Some(
+                agent_variables
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect(),
+            ),
+            _ => None,
+        })
+        .context("session header must record agent variables")
+}
+
+fn error_entry_messages(entries: &[(u64, SessionLogEntry)]) -> Vec<String> {
+    entries
+        .iter()
+        .filter_map(|(_, entry)| match entry {
+            SessionLogEntry::Error { message, .. } => Some(message.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// A worker activation for an agent with a file-backed variable must render its
+/// prompt and answer the turn.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn worker_renders_agent_prompt_with_file_backed_variables() -> Result<()> {
+    require_nextest();
+
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let env = TestEnv::new(server)?;
+    env.write_file_backed_variable_agent()?;
+    let worker = env.spawn_worker("worker-agent-variables").await?;
+
+    let session_id = "agent-file-backed-variables";
+    let turn = env.run_turn(FILE_VARIABLE_AGENT, session_id).await?;
+
+    assert_eq!(turn.error, None, "turn must not report a worker failure");
+    assert_eq!(
+        turn.response.as_deref(),
+        Some("stub reply"),
+        "worker must answer a turn for an agent with file-backed variables"
+    );
+
+    let entries = load_entries(&env.jetstream().await?, session_id).await?;
+    let variables = header_agent_variables(&entries)?;
+    assert!(
+        variables
+            .iter()
+            .any(|(name, value)| name == "agent_core" && value == VARIABLE_FILE_TEXT),
+        "header must carry the file-loaded variable value, got {variables:?}"
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    Ok(())
+}
+
+/// A prompt the worker cannot render must end the turn with a visible error
+/// instead of leaving the client waiting.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn worker_reports_template_error_to_client() -> Result<()> {
+    require_nextest();
+
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let env = TestEnv::new(server)?;
+    env.write_undefined_variable_agent()?;
+    let worker = env.spawn_worker("worker-template-error").await?;
+
+    let session_id = "agent-template-error";
+    let turn = env.run_turn(BROKEN_AGENT, session_id).await?;
+
+    let error = turn
+        .error
+        .context("turn must report the template failure")?;
+    assert!(
+        error.contains("never_defined"),
+        "error must name the undefined variable, got: {error}"
+    );
+    assert_eq!(
+        turn.response, None,
+        "a failed turn must not report an assistant response"
+    );
+
+    let entries = load_entries(&env.jetstream().await?, session_id).await?;
+    let messages = error_entry_messages(&entries);
+    assert_eq!(
+        messages.len(),
+        1,
+        "worker must record exactly one durable Error entry, got {messages:?}"
+    );
+    assert!(
+        messages[0].contains("never_defined"),
+        "durable Error entry must carry the failure text, got: {}",
+        messages[0]
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    Ok(())
+}
+
+/// A worker that dies mid-turn writes nothing at all. The client's lease
+/// watchdog must notice the holder is gone and end the turn.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn client_ends_turn_when_worker_vanishes_without_writing() -> Result<()> {
+    require_nextest();
+
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let env = TestEnv::new(server)?;
+    env.write_file_backed_variable_agent()?;
+
+    // Stand in for a worker that claims the session and then dies: hold the
+    // lease, never answer, then let it go without writing a barrier.
+    let session_id = "agent-orphaned-turn";
+    let lease = NatsSessionLease::acquire(NatsLeaseAcquireParams {
+        jetstream: env.jetstream().await?,
+        session_id,
+        worker_id: "worker-that-dies".to_string(),
+        generation: 1,
+        config: NatsLeaseConfig::default(),
+        session_index: None,
+    })
+    .await?
+    .context("test must be able to hold the session lease")?;
+
+    let turn = tokio::spawn({
+        let server_url = env.server.url().to_string();
+        let session_id = session_id.to_string();
+        async move {
+            let client = async_nats::connect(&server_url).await?;
+            let jetstream = async_nats::jetstream::new(client.clone());
+            let thin = ThinClientSession::new(
+                ThinClientConfig {
+                    cluster: "local".to_string(),
+                    agent: FILE_VARIABLE_AGENT.to_string(),
+                    session_id: Some(session_id),
+                },
+                client,
+                jetstream,
+                create_abort_signal(),
+            )
+            .await?;
+            thin.run_turn("hello", Arc::new(NullSink), None).await
+        }
+    });
+
+    // Let the client observe the lease before it disappears; the watchdog only
+    // trips on a holder it has actually seen, and it polls every two seconds.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    lease.release().await?;
+
+    let result = tokio::time::timeout(TURN_TIMEOUT, turn)
+        .await
+        .context("turn stalled after its worker vanished")???;
+
+    let error = result
+        .error
+        .context("turn must report that the worker stopped")?;
+    assert!(
+        error.contains("stopped without answering"),
+        "error must explain the worker vanished, got: {error}"
+    );
+    Ok(())
+}

--- a/crates/harnx-runtime/tests/nats_agent_variables_e2e.rs
+++ b/crates/harnx-runtime/tests/nats_agent_variables_e2e.rs
@@ -29,6 +29,7 @@ use std::time::Duration;
 
 const FILE_VARIABLE_AGENT: &str = "varagent";
 const BROKEN_AGENT: &str = "brokenagent";
+const UNLOADABLE_AGENT: &str = "unloadableagent";
 const VARIABLE_FILE_TEXT: &str = "core instructions loaded from a file";
 /// Generous enough that a slow CI box does not trip it, short enough that a
 /// genuinely stalled turn fails the test rather than hanging the suite.
@@ -135,6 +136,15 @@ impl TestEnv {
         self.write_agent(
             BROKEN_AGENT,
             "---\nmodel: openai:test-model\n---\nPreamble.\n\n{{never_defined}}\n",
+        )
+    }
+
+    /// An agent the worker can find but cannot load: its model names a client
+    /// that is not configured.
+    fn write_unloadable_agent(&self) -> Result<()> {
+        self.write_agent(
+            UNLOADABLE_AGENT,
+            "---\nmodel: nosuchclient:nosuchmodel\n---\nPreamble.\n",
         )
     }
 
@@ -314,6 +324,42 @@ async fn worker_reports_template_error_to_client() -> Result<()> {
         messages[0].contains("never_defined"),
         "durable Error entry must carry the failure text, got: {}",
         messages[0]
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    Ok(())
+}
+
+/// An agent whose file is present but unloadable must fail the turn. Falling
+/// back to the worker's own config would answer as a different agent than the
+/// one the client asked for, without saying so.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn worker_reports_unloadable_agent_instead_of_falling_back() -> Result<()> {
+    require_nextest();
+
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let env = TestEnv::new(server)?;
+    env.write_unloadable_agent()?;
+    let worker = env.spawn_worker("worker-unloadable-agent").await?;
+
+    let session_id = "agent-unloadable";
+    let turn = env.run_turn(UNLOADABLE_AGENT, session_id).await?;
+
+    let error = turn
+        .error
+        .context("turn must report that the agent could not be loaded")?;
+    assert!(
+        error.contains(UNLOADABLE_AGENT),
+        "error must name the agent, got: {error}"
+    );
+    assert_eq!(
+        turn.response, None,
+        "the worker must not answer as its own fallback agent"
     );
 
     worker.abort();

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -654,8 +654,14 @@ async fn start_directive_inner(
         .run_turn(&input.text(), tracking_sink.clone(), None)
         .await?;
 
+    let worker_error = result.error.clone();
     tracking_sink.emit_durable_response_if_needed(result);
-    Ok(())
+    // A worker-side failure must not exit 0 — scripts driving one-shot mode
+    // rely on the exit code to tell an answer from a dead turn.
+    match worker_error {
+        Some(error) => Err(anyhow::anyhow!(error)),
+        None => Ok(()),
+    }
 }
 
 async fn start_interactive(config: &GlobalConfig) -> Result<()> {

--- a/crates/harnx/tests/snapshots/tmux_e2e__retry_all_fail_shows_warnings_in_tui.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__retry_all_fail_shows_warnings_in_tui.snap
@@ -45,8 +45,8 @@ Caused by:
 
 ⚠ Model 'mock-llm:fallback' exhausted retries (error: Failed to call chat-completions api (client: mock-llm, model:
 mock-llm:fallback)), cooldown 60s. Trying next fallback.
-
-
+error: Failed to call chat-completions api (client: mock-llm, model: mock-llm:fallback): Internal Server Error (type:
+server_error) (status: 500)
 
 
 * 🤖 retry-agent ▸ mock-llm:primary ▸ [SID]


### PR DESCRIPTION
Fixes #1365.

Sending a message with `pantheon/sisyphus` spun forever with nothing in the UI. `harnx.log` had the only trace:

```
worker session execution failed: Template error in agent 'pantheon/sisyphus' at line 1: undefined value `sisyphus_core`
```

Two bugs behind one symptom.

**Why the template failed.** `WorkerRuntime::execute_session` installed the activation's agent with `retrieve_agent` + `use_agent_obj`. That parses the markdown and resolves the model, but never reads the files behind `variables: [{name, path}]`. Every other path that installs an agent runs `resolve_file_defaults` and `init_agent_shared_variables` first, which is why a pantheon agent renders fine locally and dies under the worker. Both calls also discarded their errors, so a broken agent silently fell through to whatever the worker had configured.

**Why nothing reached the UI.** `handle_activation` only logged the error. Nothing was written to the session log, and the thin client's loop exits on an assistant message, a cancel tombstone, or abort — none of which happened. There was no timeout, so it polled until the user gave up.

## Changes

- The worker resolves file-backed variables and shared variables before the agent goes active, and no longer swallows setup failures. An agent it cannot find at all still falls back to the worker's own config, as before, but now says so in the log.
- New `SessionLogEntry::Error { message, fence_token, timestamp }`, appended before the lease is released. Clients treat it as a turn barrier and render it as an error notice. It is never replayed into the model's context. Sub-agent tools return the real error instead of "no final response", and one-shot mode exits non-zero.
- The client watches the session lease. If a holder it has been watching disappears with no barrier in the log, the worker died without recording anything, so the turn ends with an error. It only trips on a lease it actually observed, so a worker that is slow to claim an activation is never mistaken for a dead one.

## Tests

New `crates/harnx-runtime/tests/nats_agent_variables_e2e.rs` drives a real nats-server and worker daemon through three cases: an agent with a file-backed variable renders and answers; a prompt the worker cannot render surfaces the error and writes exactly one durable `Error` entry; a worker that vanishes mid-turn ends the turn. The first case reproduced the bug before the fix — `undefined value 'agent_core'` followed by a 20s stall.

`agent_prompt_rendering` now installs the packages into a temp config dir and drives every shipped pantheon and coding agent through `resolve_variables`. It used to read the `path:` files itself, which is exactly why it passed while the real worker path was broken.

One snapshot changed and is worth a look. `retry_all_fail_shows_warnings_in_tui` previously ended in two blank lines after the retry warnings; it now shows the actual error. Same bug class, same fix.

## Verification

`cargo build --workspace`, `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace --stress-count=5` (5/5 iterations, 2380 passing), `cs delta origin/HEAD` (no health decrease; `agent_prompt_rendering.rs` 9.35 → 10.00).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker failures are now surfaced clearly in session output and command results.
  * Added detection for workers that disappear during an active turn.
  * File-backed agent variables are loaded and resolved during worker startup.
  * Error details are preserved in session history and searchable session data.

* **Bug Fixes**
  * Failed turns no longer appear as conversation responses during session replay.
  * Worker setup failures are recorded reliably before lease handoff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->