### PR TITLE
fix(nats): name the unsupplied variable instead of failing to render

### DIFF
--- a/.changeset/worker-required-agent-variables.md
+++ b/.changeset/worker-required-agent-variables.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+The NATS worker fails with the variable's name and description when an agent declares a variable nobody supplied, instead of an opaque template error.

--- a/crates/harnx-runtime/src/config/agent.rs
+++ b/crates/harnx-runtime/src/config/agent.rs
@@ -462,6 +462,33 @@ fn prompt_agent_variable(agent_variable: &AgentVariable, printed: &mut bool) -> 
     .map_err(Into::into)
 }
 
+/// Resolve an agent's variables without ever prompting, failing when a declared
+/// variable has no value.
+///
+/// [`init_agent_variables`] tolerates an unset variable when it is told not to
+/// interact, so you can inspect or list an agent without supplying its inputs.
+/// A worker cannot afford that: it is about to render the prompt, and a missing
+/// value surfaces as an opaque "undefined value" from the template engine
+/// instead of naming what the operator has to supply.
+pub fn require_agent_variables(
+    agent_variables: &[AgentVariable],
+    variables: &AgentVariables,
+) -> Result<AgentVariables> {
+    let mut output = IndexMap::new();
+    let mut unset_variables = vec![];
+    let mut printed = false;
+    for agent_variable in agent_variables {
+        match resolve_agent_variable(agent_variable, variables, true, &mut printed)? {
+            Some(value) => {
+                output.insert(agent_variable.name.clone(), value);
+            }
+            None => unset_variables.push(agent_variable),
+        }
+    }
+    ensure_no_unset_variables(&unset_variables)?;
+    Ok(output)
+}
+
 /// Bail with a descriptive error listing all required variables that were left
 /// unset in a non-interactive context.
 fn ensure_no_unset_variables(unset_variables: &[&AgentVariable]) -> Result<()> {

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -1192,6 +1192,24 @@ impl Config {
         Ok(())
     }
 
+    /// Like [`Self::init_agent_shared_variables`], but never prompts and fails
+    /// when a declared variable has no value. Used by the NATS worker, which is
+    /// never attached to a terminal and is about to render the prompt.
+    pub(crate) fn require_agent_shared_variables(&mut self) -> Result<()> {
+        let overrides = self.agent_variables.clone().unwrap_or_default();
+        let agent = match self.agent.as_mut() {
+            Some(v) => v,
+            None => return Ok(()),
+        };
+        if agent.defined_variables().is_empty() || !agent.shared_variables().is_empty() {
+            return Ok(());
+        }
+        let new_variables =
+            self::agent::require_agent_variables(agent.defined_variables(), &overrides)?;
+        agent.set_shared_variables(new_variables);
+        Ok(())
+    }
+
     fn init_agent_session_variables(&mut self, new_session: bool) -> Result<()> {
         let (agent, session) = match (self.agent.as_mut(), self.session.as_mut()) {
             (Some(agent), Some(session)) => (agent, session),

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -867,7 +867,7 @@ impl WorkerRuntime {
         let mut cfg = per_session.write();
         cfg.use_agent_obj(agent)
             .with_context(|| format!("activate agent '{agent_name}'"))?;
-        cfg.init_agent_shared_variables()
+        cfg.require_agent_shared_variables()
             .with_context(|| format!("initialize variables for agent '{agent_name}'"))
     }
 

--- a/crates/harnx-runtime/tests/nats_agent_variables_e2e.rs
+++ b/crates/harnx-runtime/tests/nats_agent_variables_e2e.rs
@@ -30,6 +30,15 @@ use std::time::Duration;
 const FILE_VARIABLE_AGENT: &str = "varagent";
 const BROKEN_AGENT: &str = "brokenagent";
 const UNLOADABLE_AGENT: &str = "unloadableagent";
+const PACKAGE_NAME: &str = "testpkg";
+const PACKAGE_AGENT_STEM: &str = "assembled";
+/// Shared prompt fragments the package agent stitches together, mirroring
+/// `packages/pantheon/agents/shared/*.md`.
+const PACKAGE_SHARED_FILES: [(&str, &str); 3] = [
+    ("core.md", "CORE: you are the assembled agent."),
+    ("review.md", "REVIEW: always run the quality gate."),
+    ("delegation.md", "DELEGATION: hand off research tasks."),
+];
 const VARIABLE_FILE_TEXT: &str = "core instructions loaded from a file";
 /// Generous enough that a slow CI box does not trip it, short enough that a
 /// genuinely stalled turn fails the test rather than hanging the suite.
@@ -148,19 +157,112 @@ impl TestEnv {
         )
     }
 
+    /// A package agent assembled from several shared files, plus an inline
+    /// default and a variable left for the caller to supply — the shape every
+    /// pantheon agent has.
+    ///
+    /// Package agents resolve through `<config>/packages/<pkg>/agents/<stem>.md`
+    /// rather than `<config>/agents/<name>.md`, so their `path:` variables
+    /// resolve against a different directory than a plain agent's.
+    fn write_package_agent(&self) -> Result<()> {
+        let package_dir = self.config_dir.join("packages").join(PACKAGE_NAME);
+        let agents_dir = package_dir.join("agents");
+        std::fs::create_dir_all(agents_dir.join("shared"))?;
+        std::fs::create_dir_all(package_dir.join("clients"))?;
+        for (file, body) in PACKAGE_SHARED_FILES {
+            std::fs::write(agents_dir.join("shared").join(file), body)?;
+        }
+        std::fs::write(
+            package_dir.join("package.yaml"),
+            format!("name: {PACKAGE_NAME}\nversion: 0.0.0\n"),
+        )?;
+        // Package agents resolve their model's client name relative to the
+        // package, so the client must live in the package too — the same way
+        // pantheon ships `clients/claude.yaml` for `model: claude:...`.
+        std::fs::write(
+            package_dir.join("clients").join("openai.yaml"),
+            "type: openai\napi_key: sk-test\nmodels:\n  - name: test-model\n    type: chat\n    max_input_tokens: 4096\n",
+        )?;
+        std::fs::write(
+            agents_dir.join(format!("{PACKAGE_AGENT_STEM}.md")),
+            "---\n\
+             model: openai:test-model\n\
+             variables:\n\
+             - name: core\n\
+             \x20 description: Core identity\n\
+             \x20 path: shared/core.md\n\
+             - name: review\n\
+             \x20 description: Review protocol\n\
+             \x20 path: shared/review.md\n\
+             - name: delegation\n\
+             \x20 description: Delegation protocol\n\
+             \x20 path: shared/delegation.md\n\
+             - name: tone\n\
+             \x20 description: Response tone\n\
+             \x20 default: terse and direct\n\
+             - name: repo\n\
+             \x20 description: Repository under work\n\
+             ---\n\
+             {{core}}\n\n{{review}}\n\n{{delegation}}\n\nTone: {{tone}}\nRepo: {{repo}}\n",
+        )?;
+        Ok(())
+    }
+
     async fn spawn_worker(&self, worker_id: &'static str) -> Result<tokio::task::JoinHandle<()>> {
-        let config = Config::load_from_file(&self.config_dir.join("config.yaml"))?;
+        self.spawn_worker_with(worker_id, fixed_reply_call_fn("stub reply"), &[])
+            .await
+    }
+
+    /// Spawn a worker with `--agent-variable`-style overrides, as
+    /// `run_worker_command` sets them from the CLI.
+    async fn spawn_worker_with(
+        &self,
+        worker_id: &'static str,
+        call_fn: harnx_runtime::agent_loop::AgentCallFn,
+        agent_variables: &[(&str, &str)],
+    ) -> Result<tokio::task::JoinHandle<()>> {
+        let mut config = Config::load_from_file(&self.config_dir.join("config.yaml"))?;
+        // `run_worker_command` builds its config with `Config::init(.., true)`.
+        config.info_flag = true;
+        if !agent_variables.is_empty() {
+            let mut vars = harnx_core::agent_config::AgentVariables::new();
+            for (name, value) in agent_variables {
+                vars.insert((*name).to_string(), (*value).to_string());
+            }
+            config.agent_variables = Some(vars);
+        }
         let config = Arc::new(RwLock::new(config));
         let handle = tokio::spawn(async move {
             let _ = run_worker_daemon(
                 config,
                 WorkerDaemonConfig::new("local", worker_id),
-                Some(fixed_reply_call_fn("stub reply")),
+                Some(call_fn),
             )
             .await;
         });
         tokio::time::sleep(Duration::from_millis(500)).await;
         Ok(handle)
+    }
+
+    /// Link a package straight out of the workspace so the worker loads the
+    /// agents we actually ship, not a stand-in. Returns `None` when the package
+    /// assets are absent (published crates do not carry them).
+    fn link_workspace_package(&self, package: &str) -> Result<Option<()>> {
+        let Some(workspace_root) = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .find(|ancestor| ancestor.join("packages").join(package).is_dir())
+        else {
+            return Ok(None);
+        };
+        let packages_dir = self.config_dir.join("packages");
+        std::fs::create_dir_all(&packages_dir)?;
+        let source = workspace_root.join("packages").join(package);
+        let link = packages_dir.join(package);
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&source, &link)?;
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(&source, &link)?;
+        Ok(Some(()))
     }
 
     async fn jetstream(&self) -> Result<async_nats::jetstream::Context> {
@@ -190,6 +292,34 @@ impl TestEnv {
         .await
         .context("turn stalled: the client never stopped waiting for the worker")?
     }
+}
+
+/// Records the system message the worker would send to the model, by running
+/// the same `build_messages` the real call path uses. Asserting on this rather
+/// than on the variable map proves the prompt the model sees is fully
+/// interpolated.
+fn prompt_capturing_call_fn(
+    captured: Arc<std::sync::Mutex<Option<String>>>,
+) -> harnx_runtime::agent_loop::AgentCallFn {
+    Arc::new(move |input, config, _abort| {
+        let system = harnx_runtime::config::input::build_messages(input, config)
+            .ok()
+            .and_then(|messages| {
+                messages
+                    .into_iter()
+                    .find(|message| message.role == harnx_core::message::MessageRole::System)
+                    .map(|message| message.content.to_text())
+            });
+        *captured.lock().unwrap() = system;
+        Box::pin(async move {
+            Ok((
+                "stub reply".to_string(),
+                None,
+                vec![],
+                harnx_runtime::client::CompletionTokenUsage::default(),
+            ))
+        })
+    })
 }
 
 fn fixed_reply_call_fn(reply: &'static str) -> harnx_runtime::agent_loop::AgentCallFn {
@@ -276,6 +406,169 @@ async fn worker_renders_agent_prompt_with_file_backed_variables() -> Result<()> 
             .iter()
             .any(|(name, value)| name == "agent_core" && value == VARIABLE_FILE_TEXT),
         "header must carry the file-loaded variable value, got {variables:?}"
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    Ok(())
+}
+
+/// A pantheon-shaped package agent: several `path:` fragments, an inline
+/// `default:`, and one variable supplied by the worker's `--agent-variable`.
+/// All of them must be interpolated into the prompt the model receives.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn worker_assembles_package_agent_prompt_from_multiple_files() -> Result<()> {
+    require_nextest();
+
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let env = TestEnv::new(server)?;
+    env.write_package_agent()?;
+
+    let captured = Arc::new(std::sync::Mutex::new(None));
+    let worker = env
+        .spawn_worker_with(
+            "worker-package-agent",
+            prompt_capturing_call_fn(Arc::clone(&captured)),
+            &[("repo", "harnx")],
+        )
+        .await?;
+
+    let agent = format!("{PACKAGE_NAME}/{PACKAGE_AGENT_STEM}");
+    let turn = env.run_turn(&agent, "agent-package-assembled").await?;
+
+    assert_eq!(turn.error, None, "turn must not report a worker failure");
+    assert_eq!(turn.response.as_deref(), Some("stub reply"));
+
+    let prompt = captured
+        .lock()
+        .unwrap()
+        .clone()
+        .context("worker must have built a system message for the turn")?;
+    for (file, body) in PACKAGE_SHARED_FILES {
+        assert!(
+            prompt.contains(body),
+            "prompt is missing the contents of shared/{file}; got:\n{prompt}"
+        );
+    }
+    assert!(
+        prompt.contains("Tone: terse and direct"),
+        "inline default must be interpolated; got:\n{prompt}"
+    );
+    assert!(
+        prompt.contains("Repo: harnx"),
+        "worker --agent-variable must be interpolated; got:\n{prompt}"
+    );
+    assert!(
+        !prompt.contains("{{"),
+        "prompt must be fully interpolated; got:\n{prompt}"
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    Ok(())
+}
+
+/// The real thing: activate a shipped pantheon agent, whose prompt is stitched
+/// together from a dozen `shared/*.md` fragments. This is the case from #1365,
+/// driven through the worker rather than a stand-in package.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn worker_activates_shipped_pantheon_agent() -> Result<()> {
+    require_nextest();
+
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let env = TestEnv::new(server)?;
+    if env.link_workspace_package("pantheon")?.is_none() {
+        eprintln!("skipping: packages/pantheon not available");
+        return Ok(());
+    }
+
+    let captured = Arc::new(std::sync::Mutex::new(None));
+    let worker = env
+        .spawn_worker_with(
+            "worker-pantheon",
+            prompt_capturing_call_fn(Arc::clone(&captured)),
+            &[],
+        )
+        .await?;
+
+    let turn = env.run_turn("pantheon/sisyphus", "agent-pantheon").await?;
+    assert_eq!(
+        turn.error, None,
+        "a shipped pantheon agent must activate cleanly"
+    );
+
+    let prompt = captured
+        .lock()
+        .unwrap()
+        .clone()
+        .context("worker must have built a system message for the turn")?;
+    // The variable that broke in the original report.
+    let core = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .find(|a| a.join("packages/pantheon").is_dir())
+            .expect("workspace root")
+            .join("packages/pantheon/agents/shared/sisyphus.md"),
+    )?;
+    let core_head = core
+        .lines()
+        .find(|line| line.len() > 20)
+        .unwrap_or_default();
+    assert!(
+        prompt.contains(core_head),
+        "prompt must contain shared/sisyphus.md; looked for {core_head:?}"
+    );
+    assert!(
+        !prompt.contains("{{"),
+        "prompt must be fully interpolated; got:\n{prompt}"
+    );
+
+    worker.abort();
+    let _ = worker.await;
+    Ok(())
+}
+
+/// A variable the agent declares but nobody supplies must produce an error
+/// that names the variable, not a bare template failure. The worker is never a
+/// TTY, so there is nothing to prompt.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn worker_reports_required_agent_variable_that_was_never_supplied() -> Result<()> {
+    require_nextest();
+
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("skipping: nats-server not available");
+        return Ok(());
+    };
+
+    let env = TestEnv::new(server)?;
+    env.write_package_agent()?;
+    // Same agent as the happy path, but started without `repo`.
+    let worker = env
+        .spawn_worker_with("worker-missing-variable", fixed_reply_call_fn("stub"), &[])
+        .await?;
+
+    let agent = format!("{PACKAGE_NAME}/{PACKAGE_AGENT_STEM}");
+    let turn = env.run_turn(&agent, "agent-missing-variable").await?;
+
+    let error = turn
+        .error
+        .context("turn must report the unsupplied variable")?;
+    assert!(
+        error.contains("repo"),
+        "error must name the missing variable, got: {error}"
+    );
+    assert!(
+        error.contains("Repository under work"),
+        "error should carry the variable's description so the operator knows \
+         what to supply, got: {error}"
     );
 
     worker.abort();


### PR DESCRIPTION
Follow-up to #1371, which made the worker resolve file-backed agent variables. This adds the e2e coverage for multi-file pantheon-style agents, and fixes the one gap that coverage exposed.

## The gap

Hand the worker an agent that declares a variable with no `path:`, no `default:`, and no `--agent-variable` override, and it rendered the prompt anyway, failing with the template engine's view of the problem:

```
Template error in agent 'pantheon/sisyphus' at line 8: undefined value `repo`
```

Same shape as the error in #1365, and it still tells the operator nothing about what to supply.

The cause is that `init_agent_variables` only collects unset variables when it is allowed to interact:

```rust
} else if !no_interaction && !*IS_STDOUT_TERMINAL {
    unset_variables.push(agent_variable);
}
```

A worker's config sets `info_flag`, which becomes `no_interaction`, so the unresolved variable was dropped silently and blew up downstream at render time.

Loosening `init_agent_variables` itself would break the paths that legitimately tolerate an unset variable — you can inspect or list an agent without supplying its inputs. So this adds `require_agent_variables`, a never-prompt, always-strict variant, and points the worker at it through `Config::require_agent_shared_variables`. The worker now reports:

```
The following agent variables are required:
  - repo: Repository under work
```

## Tests

The worker fixture now sets `info_flag` the way `run_worker_command` does, so these paths run as the real worker runs them — without that, the tests exercised a configuration no worker ever has.

Three new cases in `nats_agent_variables_e2e`:

- **A package agent assembled from several `shared/*.md` fragments**, plus an inline `default:` and a `--agent-variable` override, asserting on the system message `build_messages` actually produces rather than on the variable map. Package agents resolve through `packages/<pkg>/agents/` and rewrite their model's client name relative to the package, so none of that was covered by the existing single-file local-agent test. (Writing it turned up that a package agent's `model: openai:...` means the package's *own* `openai` client — hence the in-package `clients/openai.yaml` in the fixture, mirroring how pantheon ships `clients/claude.yaml`.)
- **The real shipped `pantheon/sisyphus`**, symlinked out of the workspace and driven through the worker with all fourteen of its variables. This is the agent from the original report; it skips cleanly when the package assets are absent.
- **An agent whose required variable is never supplied**, asserting the error names it.

## Verification

`cargo build --workspace`, `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace --stress-count=5` (5/5 iterations, 2384 passing), `cs delta origin/HEAD` (no health decrease).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - NATS workers now report the name and description of missing agent variables instead of showing an unclear template error.
  - Activation no longer prompts for missing shared variables during installation; required values must already be available.
- **Tests**
  - Added end-to-end coverage for package-based agents, variable defaults, worker-supplied values, prompt interpolation, and missing-variable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->