### PR TITLE
fix(nats): unblock local worker startup and run hook commands as argv

### DIFF
--- a/.changeset/local-worker-startup-and-hook-argv.md
+++ b/.changeset/local-worker-startup-and-hook-argv.md
@@ -1,0 +1,6 @@
+---
+harnx: patch
+---
+Local runs no longer fail with "local worker did not publish readiness within 15s" when a tool server is slow or misconfigured. The worker announces readiness before it starts tool servers, hooks and sub-agent toolsets, and the front-end now waits with backoff and a progress notice instead of a fixed deadline. Worker, tool-server and hook-server output is captured to `harnx_worker.log` in the state dir so a server that dies during startup explains itself.
+
+Hook servers take their command as trailing arguments after `--` and run it directly instead of through a shell, matching what the hooks guide already documented. A hook that needs pipes, redirection or variable expansion asks for a shell explicitly: `-- sh -c '...'`.

--- a/.changeset/local-worker-startup-and-hook-argv.md
+++ b/.changeset/local-worker-startup-and-hook-argv.md
@@ -1,5 +1,5 @@
 ---
-harnx: patch
+harnx: major
 ---
 Local runs no longer fail with "local worker did not publish readiness within 15s" when a tool server is slow or misconfigured. The worker announces readiness before it starts tool servers, hooks and sub-agent toolsets, and the front-end now waits with backoff and a progress notice instead of a fixed deadline. Worker, tool-server and hook-server output is captured to `harnx_worker.log` in the state dir so a server that dies during startup explains itself.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3712,6 +3712,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "shell-words",
  "tokio",
 ]
 

--- a/crates/harnx-bash-tools/src/server/lifecycle.rs
+++ b/crates/harnx-bash-tools/src/server/lifecycle.rs
@@ -62,7 +62,7 @@ impl BashServer {
                 // Writable allowlist entries include broad shared paths such as /tmp.
                 // History discovers repositories lazily from actual snapshot paths, so
                 // scanning every writable path here is both unnecessary and unbounded.
-                history: Arc::new(HistoryManager::new(&[])),
+                history: Arc::new(HistoryManager::new()),
                 sandbox_config,
             }),
         }

--- a/crates/harnx-claude-compatible-hook-server/src/lib.rs
+++ b/crates/harnx-claude-compatible-hook-server/src/lib.rs
@@ -41,13 +41,15 @@ pub struct Args {
     #[arg(long)]
     pub persistent: bool,
 
-    /// Shell command run for hook requests.
-    #[arg(long)]
-    pub command: String,
-
     /// Package directory exposed to the command as HARNX_PACKAGE_DIR.
     #[arg(long)]
     pub package_dir: Option<PathBuf>,
+
+    /// Command run for hook requests, given after `--` as a program and its
+    /// arguments. Executed directly, so a hook wanting pipes, redirection or
+    /// variable expansion asks for a shell explicitly: `-- sh -c '...'`.
+    #[arg(trailing_var_arg = true, required = true, value_name = "COMMAND")]
+    pub command: Vec<String>,
 }
 
 /// Hook dispatch behavior when the server fails.
@@ -85,7 +87,7 @@ impl TryFrom<Args> for ClaudeCompatibleHook {
         if args.event.trim().is_empty() {
             bail!("hook event must not be empty");
         }
-        if args.command.trim().is_empty() {
+        if args.command.iter().all(|word| word.trim().is_empty()) {
             bail!("hook command must not be empty");
         }
 
@@ -100,7 +102,7 @@ impl TryFrom<Args> for ClaudeCompatibleHook {
             },
             persistent: args.persistent,
             command: HookCommand {
-                command: args.command,
+                argv: args.command,
                 timeout: args.timeout,
                 package_dir: args.package_dir,
             },
@@ -156,7 +158,7 @@ mod tests {
         }
     }
 
-    fn hook(command: &str, persistent: bool) -> ClaudeCompatibleHook {
+    fn hook(command: &[&str], persistent: bool) -> ClaudeCompatibleHook {
         Args {
             name: "test-hook".to_string(),
             event: "PreToolUse".to_string(),
@@ -165,11 +167,17 @@ mod tests {
             timeout: Some(5),
             fail_policy: CliFailPolicy::Closed,
             persistent,
-            command: command.to_string(),
+            command: command.iter().map(|word| word.to_string()).collect(),
             package_dir: None,
         }
         .try_into()
         .expect("valid test hook")
+    }
+
+    /// Hooks needing shell syntax now ask for a shell explicitly.
+    #[cfg(unix)]
+    fn shell_hook(script: &str, persistent: bool) -> ClaudeCompatibleHook {
+        hook(&["sh", "-c", script], persistent)
     }
 
     #[test]
@@ -181,11 +189,12 @@ mod tests {
             "--event",
             "PreToolUse",
             "--persistent",
-            "--command",
+            "--",
             "true",
         ])
         .expect("parse persistent hook");
         assert!(args.persistent);
+        assert_eq!(args.command, vec!["true".to_string()]);
 
         assert!(Args::try_parse_from([
             "hook-server",
@@ -195,7 +204,7 @@ mod tests {
             "PreToolUse",
             "--type",
             "persistent",
-            "--command",
+            "--",
             "true",
         ])
         .is_err());
@@ -205,7 +214,10 @@ mod tests {
     #[tokio::test]
     async fn one_shot_exit_zero_parses_hook_result() {
         let cwd = tempfile::tempdir().expect("temp dir");
-        let runner = hook(r#"printf '%s' '{"additionalContext":"from-hook"}'"#, false);
+        let runner = hook(
+            &["printf", "%s", r#"{"additionalContext":"from-hook"}"#],
+            false,
+        );
 
         let outcome = runner.handle_hook(payload(cwd.path(), 1)).await;
 
@@ -220,7 +232,7 @@ mod tests {
     #[tokio::test]
     async fn one_shot_exit_two_blocks_with_stderr() {
         let cwd = tempfile::tempdir().expect("temp dir");
-        let runner = hook("printf '%s' 'denied by test' >&2; exit 2", false);
+        let runner = shell_hook("printf '%s' 'denied by test' >&2; exit 2", false);
 
         let outcome = runner.handle_hook(payload(cwd.path(), 1)).await;
 
@@ -237,7 +249,7 @@ mod tests {
     async fn one_shot_returns_mutated_tool_input() {
         let cwd = tempfile::tempdir().expect("temp dir");
         let runner = hook(
-            r#"printf '%s' '{"mutatedToolInput":{"command":"safe"}}'"#,
+            &["printf", "%s", r#"{"mutatedToolInput":{"command":"safe"}}"#],
             false,
         );
 
@@ -253,7 +265,7 @@ mod tests {
     #[tokio::test]
     async fn persistent_process_routes_two_id_framed_round_trips() {
         let cwd = tempfile::tempdir().expect("temp dir");
-        let runner = hook(
+        let runner = shell_hook(
             r#"count=0; while IFS= read -r line; do count=$((count + 1)); id=$(printf '%s' "$line" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p'); printf '{"id":"%s","mutatedToolInput":{"sequence":%s}}\n' "$id" "$count"; done"#,
             true,
         );
@@ -273,7 +285,7 @@ mod tests {
 
     #[test]
     fn hook_metadata_comes_from_configuration() {
-        let runner = hook("true", false);
+        let runner = hook(&["true"], false);
         assert_eq!(runner.name(), "test-hook");
         assert_eq!(
             runner.hooks(),

--- a/crates/harnx-claude-compatible-hook-server/src/lib.rs
+++ b/crates/harnx-claude-compatible-hook-server/src/lib.rs
@@ -87,7 +87,14 @@ impl TryFrom<Args> for ClaudeCompatibleHook {
         if args.event.trim().is_empty() {
             bail!("hook event must not be empty");
         }
-        if args.command.iter().all(|word| word.trim().is_empty()) {
+        // Only the program word must be present: later arguments may legitimately
+        // be empty strings, but an empty argv[0] reaches process creation and fails
+        // with a bare ENOENT.
+        if args
+            .command
+            .first()
+            .is_none_or(|program| program.trim().is_empty())
+        {
             bail!("hook command must not be empty");
         }
 

--- a/crates/harnx-claude-compatible-hook-server/tests/nats_runner.rs
+++ b/crates/harnx-claude-compatible-hook-server/tests/nats_runner.rs
@@ -132,7 +132,10 @@ async fn command_hook_registers_and_answers_over_nats() -> Result<()> {
         timeout: Some(5),
         fail_policy: CliFailPolicy::Closed,
         persistent: false,
-        command: r#"printf '%s' '{"mutatedToolInput":{"overNats":true}}'"#.to_string(),
+        command: ["printf", "%s", r#"{"mutatedToolInput":{"overNats":true}}"#]
+            .iter()
+            .map(|word| word.to_string())
+            .collect(),
         package_dir: None,
     })?;
     let instance_id = InstanceId::new();
@@ -191,9 +194,9 @@ async fn command_hook_uses_env_name_with_end_of_options_separator() -> Result<()
             "PreToolUse",
             "--matcher",
             "exec",
-            "--command",
-            "printf '{}'",
             "--",
+            "printf",
+            "{}",
         ])
         .env(HARNX_HOOK_NAME, assigned_name)
         .env(HARNX_INSTANCE_ID, instance_id.as_str())

--- a/crates/harnx-core/src/hooks.rs
+++ b/crates/harnx-core/src/hooks.rs
@@ -193,7 +193,7 @@ mod tests {
         let yaml = r#"
 max_resume: 3
 entries:
-  - command: "/path/to/hook-server --event Stop --command /path/to/hook.sh"
+  - command: "/path/to/hook-server --event Stop -- /path/to/hook.sh"
     async: true
 "#;
 
@@ -204,7 +204,7 @@ entries:
         let entry = &config.entries[0];
         assert_eq!(
             entry.command,
-            "/path/to/hook-server --event Stop --command /path/to/hook.sh"
+            "/path/to/hook-server --event Stop -- /path/to/hook.sh"
         );
         assert!(entry.status_message.is_none());
         assert_eq!(entry.async_hook, Some(true));

--- a/crates/harnx-fs-tools/src/server/handlers.rs
+++ b/crates/harnx-fs-tools/src/server/handlers.rs
@@ -8,10 +8,9 @@ type ReadLinesPage<'a> = (Vec<(usize, &'a str)>, usize, usize);
 
 impl FsServer {
     pub fn new(allowlist: ResolvedAllowlist) -> Self {
-        let history_paths = allowlist.read_paths().iter().cloned().collect::<Vec<_>>();
         Self {
             allowlist: Arc::new(allowlist),
-            history: Arc::new(HistoryManager::new(&history_paths)),
+            history: Arc::new(HistoryManager::new()),
             repo_locks: Arc::new(Mutex::new(HashMap::new())),
             file_locks: Arc::new(Mutex::new(HashMap::new())),
         }

--- a/crates/harnx-hooks/Cargo.toml
+++ b/crates/harnx-hooks/Cargo.toml
@@ -15,4 +15,5 @@ inquire = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+shell-words = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }

--- a/crates/harnx-hooks/src/async_manager.rs
+++ b/crates/harnx-hooks/src/async_manager.rs
@@ -158,7 +158,7 @@ mod tests {
         manager.spawn_hook(
             payload,
             HookCommand {
-                command: echo_command().to_string(),
+                argv: crate::shell_argv(echo_command()),
                 timeout: Some(5),
                 package_dir: None,
             },

--- a/crates/harnx-hooks/src/dispatch.rs
+++ b/crates/harnx-hooks/src/dispatch.rs
@@ -154,7 +154,8 @@ fn hook_matches_event(hook: &InlineHookSpec, event: &HookEvent) -> bool {
         Err(error) => {
             warn!(
                 "Skipping hook `{}` for event `{}` because matcher compilation failed: {error}",
-                hook.command.command, hook.event
+                hook.command.display(),
+                hook.event
             );
             false
         }
@@ -300,7 +301,7 @@ mod tests {
             event: event.to_string(),
             matcher: None,
             command: HookCommand {
-                command,
+                argv: crate::shell_argv(&command),
                 timeout: Some(5),
                 package_dir: None,
             },

--- a/crates/harnx-hooks/src/executor.rs
+++ b/crates/harnx-hooks/src/executor.rs
@@ -16,29 +16,43 @@ pub const HARNX_PACKAGE_DIR_ENV: &str = "HARNX_PACKAGE_DIR";
 /// A hook command plus the parameters needed to spawn it. Bundling these keeps
 /// the spawn/dispatch signatures within the argument budget and centralizes how
 /// `HARNX_PACKAGE_DIR` is derived.
+///
+/// `argv` is executed directly, not through a shell. A hook that genuinely needs
+/// shell features asks for them explicitly with `sh -c '...'`, which keeps
+/// quoting the caller's problem instead of a lossy string round-trip.
 #[derive(Debug, Clone)]
 pub struct HookCommand {
-    pub command: String,
+    pub argv: Vec<String>,
     pub timeout: Option<u64>,
     pub package_dir: Option<PathBuf>,
 }
 
-/// Build the base shell `Command` for a hook, with `HARNX_PACKAGE_DIR` injected
-/// (the owning package dir, or the config dir when not owned by a package).
-/// Callers add stdio and working directory as needed.
-pub(crate) fn base_hook_command(command: &str, package_dir: Option<&Path>) -> Command {
+impl HookCommand {
+    /// Human-readable form for logs and error messages.
+    pub fn display(&self) -> String {
+        shell_words::join(&self.argv)
+    }
+}
+
+/// Build the base `Command` for a hook, with `HARNX_PACKAGE_DIR` injected (the
+/// owning package dir, or the config dir when not owned by a package). Callers
+/// add stdio and working directory as needed.
+///
+/// An empty argv yields an unnamed program, which fails to spawn and is
+/// reported by the caller's existing spawn-failure path. Callers already reject
+/// empty commands up front, so this needs no separate branch.
+pub(crate) fn base_hook_command(argv: &[String], package_dir: Option<&Path>) -> Command {
     let package_dir = package_dir
         .map(Path::to_path_buf)
         .unwrap_or_else(harnx_core::config_paths::config_dir);
-    let mut cmd = Command::new(default_shell());
-    cmd.arg(default_shell_arg())
-        .arg(command)
+    let mut cmd = Command::new(argv.first().map(String::as_str).unwrap_or_default());
+    cmd.args(argv.get(1..).unwrap_or_default())
         .env(HARNX_PACKAGE_DIR_ENV, package_dir);
     cmd
 }
 
 pub async fn execute_command_hook(payload: &HookPayload, hook: &HookCommand) -> HookOutcome {
-    let command = hook.command.as_str();
+    let command = hook.display();
     let timeout_secs = hook.timeout;
     let event_name = payload.hook_event.event_name();
     debug!(
@@ -47,7 +61,7 @@ pub async fn execute_command_hook(payload: &HookPayload, hook: &HookCommand) -> 
     );
     let started_at = std::time::Instant::now();
 
-    let mut child = match base_hook_command(command, hook.package_dir.as_deref())
+    let mut child = match base_hook_command(&hook.argv, hook.package_dir.as_deref())
         .current_dir(&payload.cwd)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -187,26 +201,6 @@ fn continue_with_default() -> HookOutcome {
     }
 }
 
-#[cfg(unix)]
-pub(crate) fn default_shell() -> String {
-    std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string())
-}
-
-#[cfg(windows)]
-pub(crate) fn default_shell() -> String {
-    "cmd".to_string()
-}
-
-#[cfg(unix)]
-pub(crate) fn default_shell_arg() -> &'static str {
-    "-c"
-}
-
-#[cfg(windows)]
-pub(crate) fn default_shell_arg() -> &'static str {
-    "/C"
-}
-
 #[cfg(test)]
 mod tests {
     use super::{execute_command_hook, parse_success_output, HookCommand};
@@ -218,7 +212,7 @@ mod tests {
 
     fn hc(command: &str, timeout: Option<u64>, package_dir: Option<&Path>) -> HookCommand {
         HookCommand {
-            command: command.to_string(),
+            argv: crate::shell_argv(command),
             timeout,
             package_dir: package_dir.map(Path::to_path_buf),
         }

--- a/crates/harnx-hooks/src/lib.rs
+++ b/crates/harnx-hooks/src/lib.rs
@@ -63,6 +63,17 @@ pub use async_manager::{
 pub use dispatch::{dispatch_hooks, dispatch_hooks_with_options, DispatchOptions, InlineHookSpec};
 #[allow(unused_imports)]
 pub use executor::{execute_command_hook, HookCommand};
+
+/// Wrap a shell script as an argv for tests that exercise shell syntax
+/// (pipes, redirection, loops). Production hooks spell this out themselves.
+#[cfg(test)]
+pub(crate) fn shell_argv(script: &str) -> Vec<String> {
+    #[cfg(unix)]
+    let argv = ["sh", "-c", script];
+    #[cfg(windows)]
+    let argv = ["cmd", "/C", script];
+    argv.iter().map(|word| word.to_string()).collect()
+}
 pub use harnx_core::hooks::*;
 pub use matcher::CompiledMatcher;
 #[allow(unused_imports)]

--- a/crates/harnx-hooks/src/persistent.rs
+++ b/crates/harnx-hooks/src/persistent.rs
@@ -76,7 +76,8 @@ impl PersistentHookManager {
     }
 
     pub async fn send_event(&mut self, payload: &HookPayload, hook: &HookCommand) -> HookOutcome {
-        let command = hook.command.as_str();
+        let command_owned = hook.display();
+        let command = command_owned.as_str();
         if !self.processes.contains_key(command) {
             match PersistentHookProcess::spawn(hook) {
                 Ok(process) => {
@@ -170,13 +171,12 @@ impl Default for PersistentHookManager {
 
 impl PersistentHookProcess {
     fn spawn(hook: &HookCommand) -> Result<Self> {
-        let mut child =
-            super::executor::base_hook_command(&hook.command, hook.package_dir.as_deref())
-                .stdin(std::process::Stdio::piped())
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .kill_on_drop(true)
-                .spawn()?;
+        let mut child = super::executor::base_hook_command(&hook.argv, hook.package_dir.as_deref())
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()?;
 
         let pid = child.id();
 
@@ -371,7 +371,7 @@ mod tests {
 
     fn hook_cmd(command: String, timeout: Option<u64>) -> HookCommand {
         HookCommand {
-            command,
+            argv: crate::shell_argv(&command),
             timeout,
             package_dir: None,
         }

--- a/crates/harnx-mcp-history/src/history.rs
+++ b/crates/harnx-mcp-history/src/history.rs
@@ -355,10 +355,20 @@ impl HistoryManager {
         repo_workdir: &Path,
         commit_id: gix::ObjectId,
     ) -> Result<gix::ObjectId> {
+        // Same lazy discovery as the snapshot paths: nothing pre-populates the
+        // repo map, so a rollback that is not preceded by a snapshot in this
+        // process would otherwise fail with "repo not tracked".
+        self.ensure_repo_for_path(repo_workdir).await;
+        // Tracked repos are keyed by canonical workdir; accept a non-canonical
+        // caller path the same way `diff_commits` does.
+        let canonical = repo_workdir
+            .canonicalize()
+            .unwrap_or_else(|_| repo_workdir.to_path_buf());
         let (ts_repo, workdir, parent) = {
             let repos = self.inner.repos.lock().await;
             let session = repos
-                .get(repo_workdir)
+                .get(&canonical)
+                .or_else(|| repos.get(repo_workdir))
                 .context("repo not tracked for rollback")?;
             (
                 session.repo.clone(),

--- a/crates/harnx-mcp-history/src/history.rs
+++ b/crates/harnx-mcp-history/src/history.rs
@@ -7,7 +7,6 @@ use anyhow::{Context, Result};
 use gix::bstr::ByteSlice;
 
 use crate::diff::diff_commits_blocking;
-use crate::discover::find_repos_under_roots;
 use crate::rollback::rollback_to_commit_blocking;
 
 /// Maximum number of files per snapshot. Override with HARNX_HISTORY_MAX_FILES.
@@ -60,24 +59,23 @@ fn maybe_trigger_gc(
 }
 
 impl HistoryManager {
-    pub fn new(roots: &[PathBuf]) -> Self {
-        let mut repos = HashMap::new();
-
-        for repo_root in find_repos_under_roots(roots) {
-            if let Ok(repo) = gix::open(&repo_root) {
-                repos.insert(
-                    repo_root,
-                    RepoSession {
-                        repo: repo.into_sync(),
-                        last_commit_id: None,
-                    },
-                );
-            }
-        }
-
+    /// Start with no tracked repos.
+    ///
+    /// This used to eagerly walk every allowed root looking for git workdirs.
+    /// That walk descends until it hits a `.git`, so a root that is not itself a
+    /// repo is traversed in full: on a 170k-directory tree it burned over 100
+    /// seconds of syscalls before the caller could do anything. Because it ran
+    /// inside the constructor, a tool server built this way never reached its
+    /// NATS registration and the worker simply reported it as failed to start.
+    ///
+    /// Every entry point that needs a repo already discovers one on demand —
+    /// [`Self::ensure_repo_for_path`] walks up from the file, and
+    /// [`Self::ensure_repos_under`] scans a specific working directory at
+    /// snapshot time — so nothing is lost by starting empty.
+    pub fn new() -> Self {
         Self {
             inner: Arc::new(HistoryManagerInner {
-                repos: tokio::sync::Mutex::new(repos),
+                repos: tokio::sync::Mutex::new(HashMap::new()),
                 last_gc: std::sync::Mutex::new(HashMap::new()),
             }),
         }
@@ -181,7 +179,7 @@ impl HistoryManager {
         // Lazily discover and track a repo covering this file path. This is
         // load-bearing in production: harnx-fs-tools / harnx-bash-tools launch
         // with empty `--root` args and only learn their roots later via the
-        // MCP `roots/list` protocol, so `HistoryManager::new(&[])` finds no
+        // MCP `roots/list` protocol, so `HistoryManager::new()` finds no
         // repos at construction. Without this fallback every snapshot would
         // silently fail with "no tracked repo" and edit_file would omit its
         // diff content block.
@@ -384,6 +382,12 @@ impl HistoryManager {
             }
         }
         Ok(after_id)
+    }
+}
+
+impl Default for HistoryManager {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -865,7 +869,7 @@ mod tests {
         add_file_to_git(&repo_dir, "tracked.txt", b"old\n");
         commit_git(&repo_dir);
 
-        let history = HistoryManager::new(&[]);
+        let history = HistoryManager::new();
         let file_path = repo_dir.join("tracked.txt");
         let before = history
             .snapshot_file(&file_path, "before edit")

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -892,7 +892,7 @@ async fn ask(
 
     if cluster == crate::config::LOCAL_CLUSTER_KEY {
         let mut supervisor = local_worker.lock().await;
-        crate::local_orchestrator::ensure_local_worker(&mut supervisor)
+        crate::local_orchestrator::ensure_local_worker(&mut supervisor, abort_signal.clone())
             .await
             .context("failed to ensure local NATS worker")?;
     }

--- a/crates/harnx-runtime/src/config/tool_servers_split.rs
+++ b/crates/harnx-runtime/src/config/tool_servers_split.rs
@@ -119,7 +119,7 @@ command: harnx-time-server
 hooks:
   max_resume: 3
   entries:
-    - command: "harnx-claude-compatible-hook-server --event PreToolUse --matcher time --timeout 30 --command /path/to/hook.sh"
+    - command: "harnx-claude-compatible-hook-server --event PreToolUse --matcher time --timeout 30 -- /path/to/hook.sh"
       status_message: "Checking time tool"
 "#;
         let config: ToolServerConfig = serde_yaml::from_str(yaml).unwrap();
@@ -130,7 +130,7 @@ hooks:
         let entry = &hooks.entries[0];
         assert_eq!(
             entry.command,
-            "harnx-claude-compatible-hook-server --event PreToolUse --matcher time --timeout 30 --command /path/to/hook.sh"
+            "harnx-claude-compatible-hook-server --event PreToolUse --matcher time --timeout 30 -- /path/to/hook.sh"
         );
         assert_eq!(entry.status_message.as_deref(), Some("Checking time tool"));
         assert!(entry.async_hook.is_none());

--- a/crates/harnx-runtime/src/local_orchestrator.rs
+++ b/crates/harnx-runtime/src/local_orchestrator.rs
@@ -9,18 +9,29 @@ use crate::nats_worker::worker_ready_subject;
 use anyhow::{bail, Context, Result};
 use fs4::fs_std::FileExt;
 use futures_util::StreamExt;
-use harnx_core::config_paths::nats_runtime_dir;
+use harnx_core::abort::AbortSignal;
+use harnx_core::config_paths::{nats_runtime_dir, state_path};
+use harnx_core::event::{AgentEvent, NoticeEvent};
+use harnx_core::sink::emit_agent_event;
 use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 use tokio::process::{Child, Command};
 
-const WORKER_STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
 const READINESS_POLL_INITIAL: Duration = Duration::from_millis(50);
 const READINESS_POLL_MAX: Duration = Duration::from_millis(500);
 const JOINER_READY_TTL: Duration = Duration::from_secs(3);
 const LOCAL_WORKER_ID: &str = "local";
+/// How long the worker may take before the user is told it is still starting.
+const WORKER_SLOW_NOTICE_AFTER: Duration = Duration::from_secs(5);
+/// Spacing of the reminders that follow the first one.
+const WORKER_SLOW_NOTICE_INTERVAL: Duration = Duration::from_secs(10);
+/// Consecutive worker exits tolerated before the wait is declared hopeless.
+const MAX_WORKER_CRASHES: u32 = 3;
+/// Bytes of worker output shown when startup gives up.
+const WORKER_OUTPUT_TAIL_BYTES: u64 = 4096;
 
 /// Path used to elect one local worker owner per user/broker.
 pub fn local_worker_lock_file() -> PathBuf {
@@ -36,17 +47,22 @@ pub struct LocalWorkerSupervisor {
     owns_lock: bool,
     child: Option<Child>,
     last_confirmed_ready: Option<Instant>,
+    /// Owned workers that exited during the current readiness wait.
+    crashes: u32,
 }
 
 /// Lazily starts or re-checks a front-end's process-lifetime local worker.
 ///
 /// Front-ends keep the `Option` alive for their own lifetime. Repeated calls are
 /// cheap and respawn an owned worker when it has exited.
-pub async fn ensure_local_worker(supervisor: &mut Option<LocalWorkerSupervisor>) -> Result<()> {
+pub async fn ensure_local_worker(
+    supervisor: &mut Option<LocalWorkerSupervisor>,
+    abort_signal: AbortSignal,
+) -> Result<()> {
     match supervisor {
-        Some(supervisor) => supervisor.ensure().await,
+        Some(supervisor) => supervisor.ensure(abort_signal).await,
         slot @ None => {
-            *slot = Some(LocalWorkerSupervisor::start().await?);
+            *slot = Some(LocalWorkerSupervisor::start(abort_signal).await?);
             Ok(())
         }
     }
@@ -57,7 +73,7 @@ impl LocalWorkerSupervisor {
     /// Unified CLI callers use their current executable; standalone frontends
     /// such as `harnx-serve` resolve `HARNX_BIN` or a sibling
     /// `harnx` binary because they do not expose the `worker` subcommand.
-    pub async fn start() -> Result<Self> {
+    pub async fn start(abort_signal: AbortSignal) -> Result<Self> {
         let current = std::env::current_exe().context("resolve current frontend executable")?;
         let is_harnx = current
             .file_stem()
@@ -77,13 +93,16 @@ impl LocalWorkerSupervisor {
             }
             sibling
         };
-        Self::start_with_worker_binary(binary).await
+        Self::start_with_worker_binary(binary, abort_signal).await
     }
 
     /// Ensure the shared broker and local worker using an explicit `harnx`
     /// binary. Integration tests and front-end-specific binaries may use this
     /// when their current executable does not expose the `worker` subcommand.
-    pub async fn start_with_worker_binary(binary: impl AsRef<Path>) -> Result<Self> {
+    pub async fn start_with_worker_binary(
+        binary: impl AsRef<Path>,
+        abort_signal: AbortSignal,
+    ) -> Result<Self> {
         let server = ensure_shared_server().await?;
         let worker_binary = binary
             .as_ref()
@@ -100,15 +119,16 @@ impl LocalWorkerSupervisor {
             owns_lock,
             child: None,
             last_confirmed_ready: None,
+            crashes: 0,
         };
-        supervisor.ensure().await?;
+        supervisor.ensure(abort_signal).await?;
         Ok(supervisor)
     }
 
     /// Check worker health, respawn an exited owned worker, or take ownership
     /// after another front-end releases `worker.lock`. Returns only after a
     /// post-consumer readiness marker is observed.
-    pub async fn ensure(&mut self) -> Result<()> {
+    pub async fn ensure(&mut self, abort_signal: AbortSignal) -> Result<()> {
         if self.owned_child_is_running()? {
             return Ok(());
         }
@@ -121,8 +141,9 @@ impl LocalWorkerSupervisor {
         }
 
         let readiness = self.subscribe_to_readiness().await?;
+        self.crashes = 0;
         self.ensure_worker_ownership()?;
-        self.wait_for_readiness(readiness).await
+        self.wait_for_readiness(readiness, abort_signal).await
     }
 
     async fn subscribe_to_readiness(&self) -> Result<async_nats::Subscriber> {
@@ -162,10 +183,26 @@ impl LocalWorkerSupervisor {
         Ok(())
     }
 
-    async fn wait_for_readiness(&mut self, mut readiness: async_nats::Subscriber) -> Result<()> {
-        let deadline = Instant::now() + WORKER_STARTUP_TIMEOUT;
+    /// Wait for the worker's readiness heartbeat, retrying until it arrives or
+    /// the user aborts.
+    ///
+    /// A worker that is merely slow gets unlimited time — startup cost scales
+    /// with the user's agent and tool-server count, so any fixed deadline is
+    /// wrong for someone. A worker that keeps *exiting* is a different failure:
+    /// retrying cannot help, so give up after [`MAX_WORKER_CRASHES`] and show
+    /// what it printed.
+    async fn wait_for_readiness(
+        &mut self,
+        mut readiness: async_nats::Subscriber,
+        abort_signal: AbortSignal,
+    ) -> Result<()> {
+        let started = Instant::now();
         let mut poll = READINESS_POLL_INITIAL;
+        let mut next_notice = WORKER_SLOW_NOTICE_AFTER;
         loop {
+            if abort_signal.aborted() {
+                bail!("cancelled while waiting for the local worker to start");
+            }
             match tokio::time::timeout(poll, readiness.next()).await {
                 Ok(Some(_)) => {
                     self.last_confirmed_ready = Some(Instant::now());
@@ -174,14 +211,21 @@ impl LocalWorkerSupervisor {
                 Ok(None) => bail!("local worker readiness subscription closed"),
                 Err(_) => self.ensure_worker_ownership()?,
             }
-            poll = (poll * 2).min(READINESS_POLL_MAX);
-            if Instant::now() >= deadline {
+
+            if self.crashes >= MAX_WORKER_CRASHES {
                 bail!(
-                    "local worker did not publish readiness on {} within {}s",
-                    worker_ready_subject(LOCAL_CLUSTER_KEY),
-                    WORKER_STARTUP_TIMEOUT.as_secs()
+                    "local worker exited {} times without becoming ready:\n{}",
+                    self.crashes,
+                    worker_output_tail()
                 );
             }
+
+            let waited = started.elapsed();
+            if waited >= next_notice {
+                emit_worker_wait_notice(waited);
+                next_notice = waited + WORKER_SLOW_NOTICE_INTERVAL;
+            }
+            poll = (poll * 2).min(READINESS_POLL_MAX);
         }
     }
 
@@ -209,6 +253,7 @@ impl LocalWorkerSupervisor {
             Some(status) => {
                 log::warn!("local worker exited with {status}; respawning");
                 self.child = None;
+                self.crashes = self.crashes.saturating_add(1);
                 Ok(false)
             }
         }
@@ -228,8 +273,8 @@ impl LocalWorkerSupervisor {
             .env(HARNX_NATS_URL_ENV, &self.server.url)
             .env(HARNX_NATS_TOKEN_ENV, &self.server.token)
             .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stdout(worker_output_sink())
+            .stderr(worker_output_sink())
             .kill_on_drop(true);
         configure_worker_process(&mut command);
         self.child = Some(command.spawn().with_context(|| {
@@ -270,6 +315,79 @@ impl Drop for LocalWorkerSupervisor {
                     std::thread::sleep(Duration::from_millis(10));
                 }
             });
+    }
+}
+
+/// File the local worker's stdout/stderr is appended to.
+///
+/// The worker is a detached subprocess with no terminal, so anything it writes
+/// outside the `log` facade — a panic, a `main` returning `Err`, a child
+/// process's own stderr — is otherwise lost. That made startup failures
+/// undiagnosable: the front-end only saw a readiness timeout.
+pub fn local_worker_output_file() -> PathBuf {
+    state_path("harnx_worker.log")
+}
+
+/// Tell the user the worker is still coming up, on the same channel as other
+/// agent notices so the TUI and the CLI both surface it.
+fn emit_worker_wait_notice(waited: Duration) {
+    let message = format!(
+        "Still waiting for the local worker to start ({}s). Ctrl-C to cancel; worker output goes to {}.",
+        waited.as_secs(),
+        local_worker_output_file().display()
+    );
+    // Warning, not Info: the CLI sink routes Info to stdout, where progress
+    // chatter would corrupt piped output from a one-shot invocation.
+    emit_agent_event(AgentEvent::Notice(NoticeEvent::Warning(message.clone())));
+    log::info!("{message}");
+}
+
+/// Last [`WORKER_OUTPUT_TAIL_BYTES`] of the worker log, for error messages.
+fn worker_output_tail() -> String {
+    let path = local_worker_output_file();
+    let render = |body: String| {
+        if body.trim().is_empty() {
+            format!("(no output in {})", path.display())
+        } else {
+            format!("--- tail of {} ---\n{}", path.display(), body.trim_end())
+        }
+    };
+    let Ok(mut file) = File::open(&path) else {
+        return render(String::new());
+    };
+    let Ok(length) = file.metadata().map(|meta| meta.len()) else {
+        return render(String::new());
+    };
+    let start = length.saturating_sub(WORKER_OUTPUT_TAIL_BYTES);
+    if file.seek(SeekFrom::Start(start)).is_err() {
+        return render(String::new());
+    }
+    let mut body = String::new();
+    let _ = file.read_to_string(&mut body);
+    render(body)
+}
+
+/// Append-mode handle to [`local_worker_output_file`], falling back to a null
+/// sink so a non-writable state dir never blocks worker startup.
+///
+/// Also used for the worker's own children (tool and hook servers) so the whole
+/// worker subtree explains itself in one file. They redirect to this path rather
+/// than inheriting the worker's descriptors: an inherited pipe outlives the
+/// child that holds it, which strands test harness output.
+pub(crate) fn worker_output_sink() -> Stdio {
+    let path = local_worker_output_file();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match OpenOptions::new().create(true).append(true).open(&path) {
+        Ok(file) => Stdio::from(file),
+        Err(error) => {
+            log::warn!(
+                "local worker output not captured to {}: {error}",
+                path.display()
+            );
+            Stdio::null()
+        }
     }
 }
 

--- a/crates/harnx-runtime/src/local_orchestrator.rs
+++ b/crates/harnx-runtime/src/local_orchestrator.rs
@@ -362,9 +362,12 @@ fn worker_output_tail() -> String {
     if file.seek(SeekFrom::Start(start)).is_err() {
         return render(String::new());
     }
-    let mut body = String::new();
-    let _ = file.read_to_string(&mut body);
-    render(body)
+    // Decode leniently: an arbitrary byte offset can land mid-sequence, and
+    // `read_to_string` would reject the whole read for one split character —
+    // discarding exactly the output this message exists to show.
+    let mut body = Vec::new();
+    let _ = file.read_to_end(&mut body);
+    render(String::from_utf8_lossy(&body).into_owned())
 }
 
 /// Append-mode handle to [`local_worker_output_file`], falling back to a null

--- a/crates/harnx-runtime/src/nats_worker/agent_loop.rs
+++ b/crates/harnx-runtime/src/nats_worker/agent_loop.rs
@@ -1428,7 +1428,7 @@ mod tests {
                 hooks: Some(harnx_core::hooks::HooksConfig {
                     max_resume: None,
                     entries: vec![harnx_core::hooks::HookConfig {
-                        command: "harnx-claude-compatible-hook-server --event SessionStart --timeout 30 --command 'echo global'".to_string(),
+                        command: "harnx-claude-compatible-hook-server --event SessionStart --timeout 30 -- echo global".to_string(),
                         status_message: None,
                         async_hook: None,
                         package_dir: None,
@@ -1446,14 +1446,14 @@ mod tests {
     #[test]
     fn session_hook_resolution_keeps_agent_override_of_global_hook() {
         let global_hook = harnx_core::hooks::HookConfig {
-            command: "harnx-claude-compatible-hook-server --event SessionStart --timeout 30 --command 'echo global'".to_string(),
+            command: "harnx-claude-compatible-hook-server --event SessionStart --timeout 30 -- echo global".to_string(),
             status_message: None,
             async_hook: None,
             package_dir: None,
         };
         let agent_config = harnx_core::agent_config::AgentConfig::from_markdown(
             "override-agent",
-            "---\nhooks:\n  entries:\n    - command: harnx-claude-compatible-hook-server --event SessionStart --timeout 30 --command 'echo agent'\n---\nprompt",
+            "---\nhooks:\n  entries:\n    - command: harnx-claude-compatible-hook-server --event SessionStart --timeout 30 -- echo agent\n---\nprompt",
         )
         .expect("agent config");
         let config = Config {
@@ -1473,7 +1473,7 @@ mod tests {
         assert_eq!(hooks.entries.len(), 1);
         assert_eq!(
             hooks.entries[0].command,
-            "harnx-claude-compatible-hook-server --event SessionStart --timeout 30 --command 'echo agent'"
+            "harnx-claude-compatible-hook-server --event SessionStart --timeout 30 -- echo agent"
         );
     }
 

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -25,6 +25,8 @@ use async_nats::jetstream::{
 };
 use chrono::Utc;
 use futures_util::StreamExt;
+use harnx_core::retry_config::RetryConfig;
+use harnx_engine::retry::compute_backoff_delay;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -41,6 +43,13 @@ const WORK_NOTIFY_STREAM_PREFIX: &str = "WORK_NOTIFY_";
 const WORK_NOTIFY_CONSUMER_PREFIX: &str = "worker-";
 const WORK_NOTIFY_ACK_WAIT: Duration = Duration::from_secs(30);
 const WORK_NOTIFY_INACTIVE_THRESHOLD: Duration = Duration::from_secs(60 * 60);
+/// Per-attempt registration wait for a background tool-server retry. Shorter
+/// than the first attempt because the backoff between rounds, not this timeout,
+/// is what gives a slow server time to come up.
+const TOOL_RETRY_TIMEOUT: Duration = Duration::from_secs(5);
+/// Longest a session start will wait for the first tool-server registration
+/// round. Above the round's own budget, so it only fires if that round wedges.
+const INITIAL_TOOL_REGISTRATION_WAIT: Duration = Duration::from_secs(30);
 
 /// Configuration for a worker daemon instance.
 #[derive(Debug, Clone)]
@@ -420,10 +429,18 @@ async fn start_subagent_toolset(
 }
 
 struct WorkerServices {
-    tool_supervisor: Option<ToolServerSupervisor>,
-    global_hook_supervisor: Option<HookServerSupervisor>,
-    subagent_tool_servers: Vec<JoinHandle<Result<()>>>,
+    background: Arc<Mutex<Option<BackgroundServices>>>,
     session_index: Option<async_nats::jetstream::kv::Store>,
+    tools_attempted: tokio::sync::watch::Receiver<bool>,
+}
+
+/// Tool servers, hooks and sub-agent toolsets, started after the worker has
+/// already announced readiness. Held only to keep the children alive for the
+/// worker's lifetime.
+struct BackgroundServices {
+    _tool_supervisor: Option<ToolServerSupervisor>,
+    _global_hook_supervisor: Option<HookServerSupervisor>,
+    _subagent_tool_servers: Vec<JoinHandle<Result<()>>>,
 }
 
 fn configured_worker_services(
@@ -466,33 +483,175 @@ async fn launch_worker_services(
     startup: &WorkerStartup,
     instance_id: &harnx_core::instance::InstanceId,
 ) -> Result<WorkerServices> {
-    let (tool_servers, global_hooks) = configured_worker_services(config);
-    let tool_supervisor =
-        start_local_tool_servers(daemon, startup.client.clone(), instance_id, &tool_servers).await;
-    let global_hook_supervisor =
-        start_global_hooks(daemon, startup.client.clone(), instance_id, &global_hooks).await;
-    let mut subagent_tool_servers = Vec::new();
-    for agent in list_agents() {
-        subagent_tool_servers.push(
-            start_subagent_toolset(
-                agent,
-                daemon.cluster.clone(),
-                instance_id.clone(),
-                startup.client.clone(),
-                startup.jetstream.clone(),
-            )
-            .await
-            .context("start sub-agent toolset")?,
-        );
-    }
+    // Announce readiness before starting tool servers, hooks and sub-agent
+    // toolsets. Those can take tens of seconds — or never finish, when a server
+    // is misconfigured — and none of them are required for the worker to accept
+    // and run a session. Gating readiness on them made a single broken tool
+    // server stall the front-end past its startup deadline, which turned an
+    // intentionally non-fatal degradation into an unusable CLI.
     spawn_readiness_publisher(startup.client.clone(), daemon);
+
+    let background = Arc::new(Mutex::new(None));
+    // Sessions snapshot the tool registry when they start, so a session that
+    // began before the first registration round finished would see no tools at
+    // all. Activation waits on this instead — the cost lands on the first turn,
+    // where it is visible and cancellable, rather than on worker readiness.
+    let (tools_attempted_tx, tools_attempted) = tokio::sync::watch::channel(false);
+    spawn_background_services(BackgroundServicesCtx {
+        config: config.clone(),
+        daemon: daemon.clone(),
+        client: startup.client.clone(),
+        jetstream: startup.jetstream.clone(),
+        instance_id: instance_id.clone(),
+        slot: Arc::clone(&background),
+        tools_attempted: tools_attempted_tx,
+    });
+
     let session_index = optional_session_index(&startup.jetstream).await;
     Ok(WorkerServices {
-        tool_supervisor,
-        global_hook_supervisor,
-        subagent_tool_servers,
+        background,
         session_index,
+        tools_attempted,
     })
+}
+
+/// Block until the first tool-server registration round has finished, so the
+/// session's registry snapshot includes whatever managed to come up.
+///
+/// Returns without waiting once the round is done, making this free for every
+/// turn after the first. A server that never registers costs this wait once.
+async fn await_initial_tool_registration(tools_attempted: &tokio::sync::watch::Receiver<bool>) {
+    if *tools_attempted.borrow() {
+        return;
+    }
+    let mut attempted = tools_attempted.clone();
+    log::debug!("waiting for the first tool-server registration round");
+    // The only sender lives in the background task; if it is gone the round can
+    // never complete and there is nothing left to wait for. Cap the wait so a
+    // wedged round costs the session its tools rather than the whole turn — the
+    // round is bounded by the per-server startup timeout, so reaching this cap
+    // means something below it is stuck.
+    if tokio::time::timeout(
+        INITIAL_TOOL_REGISTRATION_WAIT,
+        attempted.wait_for(|done| *done),
+    )
+    .await
+    .is_err()
+    {
+        log::warn!(
+            "tool servers did not finish their first registration round within {}s; \
+             starting this session with the tools registered so far",
+            INITIAL_TOOL_REGISTRATION_WAIT.as_secs()
+        );
+    }
+}
+
+/// Owned inputs for the post-readiness startup task.
+struct BackgroundServicesCtx {
+    config: GlobalConfig,
+    daemon: WorkerDaemonConfig,
+    client: async_nats::Client,
+    jetstream: jetstream::Context,
+    instance_id: harnx_core::instance::InstanceId,
+    slot: Arc<Mutex<Option<BackgroundServices>>>,
+    tools_attempted: tokio::sync::watch::Sender<bool>,
+}
+
+fn spawn_background_services(ctx: BackgroundServicesCtx) {
+    tokio::spawn(async move {
+        let BackgroundServicesCtx {
+            config,
+            daemon,
+            client,
+            jetstream,
+            instance_id,
+            slot,
+            tools_attempted,
+        } = ctx;
+        let (tool_servers, global_hooks) = configured_worker_services(&config);
+        let tool_supervisor =
+            start_local_tool_servers(&daemon, client.clone(), &instance_id, &tool_servers).await;
+        // Release waiting activations as soon as the first round settles, even
+        // if some servers failed — they are retried below without blocking.
+        let _ = tools_attempted.send(true);
+        let global_hook_supervisor =
+            start_global_hooks(&daemon, client.clone(), &instance_id, &global_hooks).await;
+
+        let mut subagent_tool_servers = Vec::new();
+        for agent in list_agents() {
+            match start_subagent_toolset(
+                agent.clone(),
+                daemon.cluster.clone(),
+                instance_id.clone(),
+                client.clone(),
+                jetstream.clone(),
+            )
+            .await
+            {
+                Ok(handle) => subagent_tool_servers.push(handle),
+                // One unusable sub-agent must not cost the others their toolset.
+                Err(error) => {
+                    log::warn!("sub-agent toolset for '{agent}' unavailable: {error:#}")
+                }
+            }
+        }
+
+        let tool_supervisor =
+            retry_unregistered_tool_servers(tool_supervisor, client, &instance_id, &tool_servers)
+                .await;
+
+        *slot.lock().await = Some(BackgroundServices {
+            _tool_supervisor: tool_supervisor,
+            _global_hook_supervisor: global_hook_supervisor,
+            _subagent_tool_servers: subagent_tool_servers,
+        });
+    });
+}
+
+/// Keep respawning tool servers that never registered, backing off between
+/// rounds. Runs after readiness, so a server that stays broken degrades the
+/// available tools instead of blocking the worker.
+async fn retry_unregistered_tool_servers(
+    supervisor: Option<ToolServerSupervisor>,
+    client: async_nats::Client,
+    instance_id: &harnx_core::instance::InstanceId,
+    servers: &[ToolServerConfig],
+) -> Option<ToolServerSupervisor> {
+    let mut supervisor = supervisor?;
+    if supervisor.unregistered_servers().is_empty() {
+        return Some(supervisor);
+    }
+    let Ok(local) = resolve_local_nats_server_config().await else {
+        return Some(supervisor);
+    };
+    let Some(token) = local.token.as_deref() else {
+        return Some(supervisor);
+    };
+    let start = ToolServerStartConfig::new(client, instance_id.clone(), &local.url, token);
+    let retry = RetryConfig::default();
+
+    // Retries never stop: a server the user fixes mid-session should come up
+    // without restarting harnx. The attempt counter only feeds the backoff
+    // curve, so saturate it rather than letting it wrap.
+    let mut attempt: u32 = 0;
+    loop {
+        let delay = compute_backoff_delay(&retry, attempt);
+        attempt = attempt.saturating_add(1);
+        let pending = supervisor.unregistered_servers().join(", ");
+        log::warn!(
+            "tool servers not registered ({pending}); retrying in {}s",
+            delay.as_secs_f64()
+        );
+        tokio::time::sleep(delay).await;
+        let still_missing = supervisor
+            .retry_unregistered(&start, servers, TOOL_RETRY_TIMEOUT)
+            .await;
+        if !still_missing {
+            log::info!("all tool servers registered");
+            break;
+        }
+    }
+    Some(supervisor)
 }
 
 /// Run a worker daemon: pull `SessionActivate` notifications, claim each via a
@@ -508,9 +667,8 @@ pub async fn run_worker_daemon(
     let runtime = Arc::new(WorkerRuntime {
         config,
         instance_id,
-        _tool_supervisor: services.tool_supervisor,
-        _global_hook_supervisor: services.global_hook_supervisor,
-        _subagent_tool_servers: services.subagent_tool_servers,
+        _background_services: services.background,
+        tools_attempted: services.tools_attempted,
         cluster: daemon.cluster.clone(),
         worker_id: daemon.worker_id.clone(),
         lease: daemon.lease,
@@ -548,9 +706,8 @@ struct ControlListenerCtx<'a> {
 struct WorkerRuntime {
     config: GlobalConfig,
     instance_id: harnx_core::instance::InstanceId,
-    _tool_supervisor: Option<ToolServerSupervisor>,
-    _global_hook_supervisor: Option<HookServerSupervisor>,
-    _subagent_tool_servers: Vec<JoinHandle<Result<()>>>,
+    _background_services: Arc<Mutex<Option<BackgroundServices>>>,
+    tools_attempted: tokio::sync::watch::Receiver<bool>,
     #[allow(dead_code)]
     cluster: String,
     worker_id: String,
@@ -630,6 +787,10 @@ impl WorkerRuntime {
         let Some(lease) = self.acquire_activation_lease(&activation).await? else {
             return Ok(());
         };
+
+        // The session snapshots the tool registry below, so give the first
+        // registration round a chance to finish before that snapshot is taken.
+        await_initial_tool_registration(&self.tools_attempted).await;
         log::info!(
             "session activate claimed: session_id={} worker_id={} revision={} epoch={}",
             activation.session_id,

--- a/crates/harnx-runtime/src/nats_worker/hook_supervisor.rs
+++ b/crates/harnx-runtime/src/nats_worker/hook_supervisor.rs
@@ -147,6 +147,8 @@ struct PreparedHook {
 struct HookStartup {
     name: String,
     key: String,
+    /// Untruncated command, for diagnosing a server that dies before it registers.
+    hook_command: String,
     rejector_name: String,
     display_label: String,
     failure_label: String,
@@ -275,6 +277,7 @@ async fn spawn_enabled_hooks(
         startups.push(HookStartup {
             name: prepared.name,
             key: prepared.key,
+            hook_command: prepared.hook.command.clone(),
             rejector_name: prepared.rejector_name,
             display_label: prepared.display_label,
             failure_label: prepared.failure_label,
@@ -315,6 +318,7 @@ async fn start_hook_server(
     let HookStartup {
         name,
         key,
+        hook_command,
         rejector_name,
         display_label,
         failure_label,
@@ -364,7 +368,12 @@ async fn start_hook_server(
                 &failure_label,
             )
             .await?;
-            log::warn!("hook server '{name}' failed during startup: {error:#}");
+            // `display_label` is capped at 120 chars for the UI, which cuts the
+            // command mid-flag and hides the argument that actually failed.
+            log::warn!(
+                "hook server '{name}' failed during startup: {error:#}; command: {}",
+                hook_command
+            );
             Ok(None)
         }
     }
@@ -404,8 +413,10 @@ fn spawn_hook_server(
         .env(HARNX_NATS_URL_ENV, &config.nats_url)
         .env(HARNX_NATS_TOKEN_ENV, &config.token)
         .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        // Send output to the worker log so a hook server that exits before
+        // registering explains itself instead of failing silently.
+        .stdout(crate::local_orchestrator::worker_output_sink())
+        .stderr(crate::local_orchestrator::worker_output_sink())
         .kill_on_drop(true);
     configure_hook_process(&mut command);
     command

--- a/crates/harnx-runtime/src/nats_worker/mod.rs
+++ b/crates/harnx-runtime/src/nats_worker/mod.rs
@@ -27,6 +27,7 @@ mod control;
 mod daemon;
 mod hook_supervisor;
 mod subagent_toolset;
+mod tool_registry;
 mod tool_supervisor;
 
 #[cfg(test)]

--- a/crates/harnx-runtime/src/nats_worker/session_start_hook_tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/session_start_hook_tests.rs
@@ -55,8 +55,9 @@ fn session_start_marker_hook(marker: &Path) -> HooksConfig {
         max_resume: None,
         entries: vec![HookConfig {
             command: format!(
-                "{} --event SessionStart --timeout 30 -- sh -c 'echo fired >> \"{}\"'",
+                "{} --event SessionStart --timeout 30 -- {} 'echo fired >> \"{}\"'",
                 hook_server_binary().display(),
+                if cfg!(windows) { "cmd /C" } else { "sh -c" },
                 marker.display()
             ),
             status_message: None,

--- a/crates/harnx-runtime/src/nats_worker/session_start_hook_tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/session_start_hook_tests.rs
@@ -55,7 +55,7 @@ fn session_start_marker_hook(marker: &Path) -> HooksConfig {
         max_resume: None,
         entries: vec![HookConfig {
             command: format!(
-                "{} --event SessionStart --timeout 30 --command 'echo fired >> \"{}\"'",
+                "{} --event SessionStart --timeout 30 -- sh -c 'echo fired >> \"{}\"'",
                 hook_server_binary().display(),
                 marker.display()
             ),

--- a/crates/harnx-runtime/src/nats_worker/tool_registry.rs
+++ b/crates/harnx-runtime/src/nats_worker/tool_registry.rs
@@ -1,0 +1,268 @@
+//! Tool-server identity and the JetStream KV registry they announce through.
+//!
+//! Split out of `tool_supervisor` so process supervision (spawning, monitoring,
+//! restarting children) stays separate from registry bookkeeping (watching keys,
+//! validating identities, cleaning up entries).
+
+use crate::nats_tool_provider::NatsInFlightCalls;
+use anyhow::{bail, Context, Result};
+use async_nats::jetstream::{self, kv, stream};
+use futures_util::{StreamExt, TryStreamExt};
+use harnx_core::instance::InstanceId;
+use harnx_toolset::{server_identity_token, Registration};
+use harnx_toolset_server::{registration_key, TOOL_REGISTRY_BUCKET};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+/// Identifies a supervised child by the pair that makes it unique. The bare
+/// config name is ambiguous: two packages may each define a server called `fs`,
+/// and treating them as one makes a live child mask its dead namesake.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(super) struct SupervisedServer {
+    pub(super) package: Option<String>,
+    pub(super) config: String,
+}
+
+impl SupervisedServer {
+    pub(super) fn new(package: Option<&str>, config: &str) -> Self {
+        Self {
+            package: package.map(str::to_string),
+            config: config.to_string(),
+        }
+    }
+
+    pub(super) fn label(&self) -> String {
+        match &self.package {
+            Some(package) => format!("{package}/{}", self.config),
+            None => self.config.clone(),
+        }
+    }
+}
+
+pub(super) type SupervisedProcesses = Arc<Mutex<HashMap<u32, SupervisedServer>>>;
+
+/// Everything [`wait_for_registration`] needs about the server it is awaiting.
+pub(super) struct RegistrationWait<'a> {
+    pub(super) processes: &'a SupervisedProcesses,
+    pub(super) identity: SupervisedServer,
+    pub(super) instance_id: &'a InstanceId,
+    pub(super) key: &'a str,
+    pub(super) deadline: Instant,
+    pub(super) timeout: Duration,
+}
+
+pub(super) async fn ensure_registry_bucket(client: &async_nats::Client) -> Result<kv::Store> {
+    let jetstream = jetstream::new(client.clone());
+    match jetstream
+        .create_key_value(kv::Config {
+            bucket: TOOL_REGISTRY_BUCKET.to_string(),
+            history: 1,
+            num_replicas: 1,
+            storage: stream::StorageType::File,
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(store) => Ok(store),
+        Err(_) => jetstream
+            .get_key_value(TOOL_REGISTRY_BUCKET)
+            .await
+            .map_err(anyhow::Error::from)
+            .context("open tool registry bucket"),
+    }
+}
+
+/// Dump every key in the tool registry when servers fail to register.
+///
+/// Distinguishes the two failure shapes that look identical from the outside: a
+/// server that never published anything, versus one that published under a key
+/// the watcher does not match.
+pub(super) async fn log_registry_contents(registry: &kv::Store, instance_id: &InstanceId) {
+    let keys = match registry.keys().await {
+        Ok(keys) => keys.try_collect::<Vec<_>>().await,
+        Err(error) => {
+            log::warn!("could not list tool registry keys: {error:#}");
+            return;
+        }
+    };
+    match keys {
+        Ok(keys) => {
+            let prefix = format!("{instance_id}.");
+            let (mine, others): (Vec<_>, Vec<_>) =
+                keys.iter().partition(|key| key.starts_with(&prefix));
+            log::warn!(
+                "tool registry for instance {instance_id}: {} key(s) {:?}; {} key(s) from other instances",
+                mine.len(),
+                mine,
+                others.len()
+            );
+        }
+        Err(error) => log::warn!("could not read tool registry keys: {error:#}"),
+    }
+}
+
+/// Wait until the server behind `wait` publishes a registration matching its
+/// identity, its process dies, or the deadline passes.
+pub(super) async fn wait_for_registration(
+    watch: &mut kv::Watch,
+    wait: RegistrationWait<'_>,
+) -> Result<()> {
+    loop {
+        let poll = next_poll_interval(&wait).await?;
+        if watched_entry_completes(watch, poll, &wait).await {
+            return Ok(());
+        }
+    }
+}
+
+/// How long to block on the watch before re-checking liveness, or an error when
+/// the server has died or the deadline has passed.
+async fn next_poll_interval(wait: &RegistrationWait<'_>) -> Result<Duration> {
+    if !is_still_running(wait.processes, &wait.identity).await {
+        bail!(
+            "tool server '{}' exited before registering at '{}'",
+            wait.identity.label(),
+            wait.key
+        );
+    }
+    let now = Instant::now();
+    if now >= wait.deadline {
+        bail!(
+            "tool server '{}' did not register at '{}' within {}s",
+            wait.identity.label(),
+            wait.key,
+            wait.timeout.as_secs_f64()
+        );
+    }
+    Ok(wait
+        .deadline
+        .saturating_duration_since(now)
+        .min(Duration::from_millis(100)))
+}
+
+/// Take one step on the watch, reporting whether it delivered the registration
+/// this wait is looking for. Anything else — a poll timeout, an unrelated key,
+/// a watch error — is a reason to loop again, not to fail.
+async fn watched_entry_completes(
+    watch: &mut kv::Watch,
+    poll: Duration,
+    wait: &RegistrationWait<'_>,
+) -> bool {
+    match tokio::time::timeout(poll, watch.next()).await {
+        Ok(Some(Ok(entry))) => {
+            entry.operation == kv::Operation::Put && entry_completes_registration(&entry, wait)
+        }
+        Ok(Some(Err(error))) => {
+            log::warn!(
+                "ignoring tool registration watch error for '{}': {error}",
+                wait.key
+            );
+            false
+        }
+        Ok(None) => {
+            log::warn!(
+                "tool registration watch closed for '{}'; waiting for timeout",
+                wait.key
+            );
+            tokio::time::sleep(poll).await;
+            false
+        }
+        Err(_) => false,
+    }
+}
+
+async fn is_still_running(processes: &SupervisedProcesses, identity: &SupervisedServer) -> bool {
+    processes.lock().await.values().any(|live| live == identity)
+}
+
+/// Whether a KV entry is the registration this wait is looking for. Mismatches
+/// are logged and rejected rather than silently accepted, so a server announcing
+/// the wrong identity is visible instead of quietly serving another's tools.
+fn entry_completes_registration(entry: &kv::Entry, wait: &RegistrationWait<'_>) -> bool {
+    if !entry.key.starts_with(wait.key.trim_end_matches("<server>")) {
+        return false;
+    }
+    let registration: Registration = match serde_json::from_slice(&entry.value) {
+        Ok(registration) => registration,
+        Err(error) => {
+            log::warn!(
+                "ignoring invalid tool registration '{}': {error}",
+                entry.key
+            );
+            return false;
+        }
+    };
+    if registration.package != wait.identity.package || registration.config != wait.identity.config
+    {
+        log::warn!(
+            "ignoring tool registration '{}' identity mismatch: expected package {:?}, config '{}'; got package {:?}, config '{}'",
+            entry.key,
+            wait.identity.package,
+            wait.identity.config,
+            registration.package,
+            registration.config
+        );
+        return false;
+    }
+    let identity_token = server_identity_token(
+        registration.package.as_deref(),
+        &registration.config,
+        &registration.server,
+    );
+    let expected_key = registration_key(wait.instance_id, &identity_token);
+    if entry.key != expected_key {
+        log::warn!(
+            "ignoring tool registration '{}' because its identity expects key '{expected_key}'",
+            entry.key
+        );
+        return false;
+    }
+    true
+}
+
+pub(super) async fn remove_registrations_for_config(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+    package: Option<&str>,
+    config: &str,
+    failure: Option<(&NatsInFlightCalls, &str)>,
+) {
+    let jetstream = jetstream::new(client.clone());
+    let Ok(store) = jetstream.get_key_value(TOOL_REGISTRY_BUCKET).await else {
+        return;
+    };
+    let Ok(mut keys) = store.keys().await else {
+        return;
+    };
+    let prefix = format!("{instance_id}.");
+    while let Ok(Some(key)) = keys.try_next().await {
+        if !key.starts_with(&prefix) {
+            continue;
+        }
+        let Ok(Some(value)) = store.get(&key).await else {
+            continue;
+        };
+        let Ok(registration) = serde_json::from_slice::<Registration>(&value) else {
+            continue;
+        };
+        if registration.package.as_deref() != package || registration.config != config {
+            continue;
+        }
+        let identity_token = server_identity_token(
+            registration.package.as_deref(),
+            &registration.config,
+            &registration.server,
+        );
+        if key != registration_key(instance_id, &identity_token) {
+            continue;
+        }
+        if let Some((in_flight, message)) = failure {
+            in_flight
+                .fail_server_unavailable(&identity_token, message.to_string())
+                .await;
+        }
+        let _ = store.delete(key).await;
+    }
+}

--- a/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
+++ b/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
@@ -1,18 +1,19 @@
 use super::hook_supervisor::{HookServerStartConfig, HookServerSupervisor};
+use super::tool_registry::{
+    ensure_registry_bucket, log_registry_contents, remove_registrations_for_config,
+    wait_for_registration, RegistrationWait, SupervisedProcesses, SupervisedServer,
+};
 use crate::config::{ToolServerConfig, HARNX_NATS_TOKEN_ENV, HARNX_NATS_URL_ENV};
 use crate::nats_tool_provider::NatsInFlightCalls;
-use anyhow::{bail, Context, Result};
-use async_nats::jetstream::{self, kv, stream};
-use futures_util::{StreamExt, TryStreamExt};
+use anyhow::{Context, Result};
+use async_nats::jetstream::kv;
 use harnx_core::event::{AgentEvent, NoticeEvent};
 use harnx_core::instance::{InstanceId, HARNX_INSTANCE_ID};
 use harnx_core::sink::emit_agent_event;
 use harnx_hooks::executor::HARNX_PACKAGE_DIR_ENV;
-use harnx_toolset::{
-    server_identity_token, Registration, HARNX_SERVER_CONFIG, HARNX_SERVER_PACKAGE,
-};
-use harnx_toolset_server::{registration_key, TOOL_REGISTRY_BUCKET};
-use std::collections::HashMap;
+use harnx_toolset::{server_identity_token, HARNX_SERVER_CONFIG, HARNX_SERVER_PACKAGE};
+use harnx_toolset_server::registration_key;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
@@ -24,6 +25,7 @@ use tokio::task::JoinHandle;
 const TOOL_STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Connection and identity shared by all tool servers spawned for one worker.
+#[derive(Clone)]
 pub struct ToolServerStartConfig {
     client: async_nats::Client,
     instance_id: InstanceId,
@@ -58,9 +60,12 @@ impl ToolServerStartConfig {
 
 /// Owns local tool-server children for one worker process.
 pub struct ToolServerSupervisor {
-    processes: Arc<Mutex<HashMap<u32, String>>>,
+    processes: SupervisedProcesses,
     tasks: Vec<JoinHandle<()>>,
     hook_supervisors: Vec<HookServerSupervisor>,
+    /// Enabled servers that have not registered yet. Retried in the background
+    /// by the worker, so this shrinks as late registrations land.
+    unregistered: Vec<SupervisedServer>,
 }
 
 impl ToolServerSupervisor {
@@ -83,76 +88,160 @@ impl ToolServerSupervisor {
             processes: Arc::clone(&processes),
             tasks: Vec::new(),
             hook_supervisors: Vec::new(),
+            unregistered: Vec::new(),
         };
         let enabled: Vec<_> = servers.iter().filter(|server| server.enabled).collect();
         if enabled.is_empty() {
             return Ok(supervisor);
         }
+        supervisor
+            .start_servers(&config, &enabled, readiness_timeout)
+            .await;
+        start_co_located_hooks(&mut supervisor, &config, enabled).await;
+        Ok(supervisor)
+    }
 
+    /// Spawn `servers` and wait for each to register, recording the ones that
+    /// did not into `self.unregistered`. Per-server failures are warnings: the
+    /// worker stays usable with whatever registered.
+    async fn start_servers(
+        &mut self,
+        config: &ToolServerStartConfig,
+        servers: &[&ToolServerConfig],
+        readiness_timeout: Duration,
+    ) {
         let registry = match ensure_registry_bucket(&config.client).await {
             Ok(registry) => registry,
             Err(error) => {
-                for server in enabled {
+                for server in servers {
                     warn_server_failure(&server.name, format!("prepare tool registry: {error:#}"));
+                    self.unregistered.push(SupervisedServer::new(
+                        server.package.as_deref(),
+                        &server.name,
+                    ));
                 }
-                return Ok(supervisor);
+                return;
             }
         };
 
-        let watches = prepare_registration_watches(&registry, &config, &enabled).await;
-
-        spawn_enabled_tool_servers(&mut supervisor, &config, &enabled, &processes).await;
+        let processes = Arc::clone(&self.processes);
+        let running = running_server_names(&processes).await;
+        let watches = prepare_registration_watches(&registry, config, servers, &running).await;
+        spawn_enabled_tool_servers(self, config, servers, &running).await;
 
         let deadline = Instant::now() + readiness_timeout;
         let instance_id = config.instance_id.clone();
         let readiness = watches.into_iter().map(|(server, key, mut watch)| {
             let processes = Arc::clone(&processes);
             let instance_id = instance_id.clone();
+            let identity = SupervisedServer::new(server.package.as_deref(), &server.name);
             async move {
-                if let Err(error) = wait_for_registration(
-                    &mut watch,
-                    &processes,
-                    server,
-                    &instance_id,
-                    &key,
+                let wait = RegistrationWait {
+                    processes: &processes,
+                    identity: identity.clone(),
+                    instance_id: &instance_id,
+                    key: &key,
                     deadline,
-                    readiness_timeout,
-                )
-                .await
-                {
-                    warn_server_failure(&server.name, format!("{error:#}"));
+                    timeout: readiness_timeout,
+                };
+                match wait_for_registration(&mut watch, wait).await {
+                    Ok(()) => None,
+                    Err(error) => {
+                        warn_server_failure(&server.name, format!("{error:#}"));
+                        Some(identity)
+                    }
                 }
             }
         });
-        futures_util::future::join_all(readiness).await;
+        self.unregistered.extend(
+            futures_util::future::join_all(readiness)
+                .await
+                .into_iter()
+                .flatten(),
+        );
+        if !self.unregistered.is_empty() {
+            log_registry_contents(&registry, &config.instance_id).await;
+        }
+    }
 
-        start_co_located_hooks(&mut supervisor, &config, enabled).await;
-        Ok(supervisor)
+    /// Labels of enabled servers still missing a registration.
+    pub fn unregistered_servers(&self) -> Vec<String> {
+        self.unregistered
+            .iter()
+            .map(SupervisedServer::label)
+            .collect()
+    }
+
+    /// Respawn only the servers that have not registered yet and wait again.
+    /// Returns whether any are still missing afterwards.
+    pub async fn retry_unregistered(
+        &mut self,
+        config: &ToolServerStartConfig,
+        servers: &[ToolServerConfig],
+        readiness_timeout: Duration,
+    ) -> bool {
+        let pending = std::mem::take(&mut self.unregistered);
+        let retry: Vec<_> = servers
+            .iter()
+            .filter(|server| {
+                server.enabled
+                    && pending.contains(&SupervisedServer::new(
+                        server.package.as_deref(),
+                        &server.name,
+                    ))
+            })
+            .collect();
+        if retry.is_empty() {
+            return false;
+        }
+        self.start_servers(config, &retry, readiness_timeout).await;
+        !self.unregistered.is_empty()
     }
 
     pub async fn server_pids(&self) -> HashMap<u32, String> {
-        self.processes.lock().await.clone()
+        self.processes
+            .lock()
+            .await
+            .iter()
+            .map(|(pid, server)| (*pid, server.config.clone()))
+            .collect()
     }
+}
+
+/// Names of servers with a live child process, so retries neither double-spawn
+/// a server that is merely slow to register nor clear a registration it is
+/// about to publish.
+async fn running_server_names(processes: &SupervisedProcesses) -> HashSet<SupervisedServer> {
+    processes.lock().await.values().cloned().collect()
 }
 
 async fn prepare_registration_watches<'a>(
     registry: &kv::Store,
     config: &ToolServerStartConfig,
     servers: &[&'a ToolServerConfig],
+    running: &HashSet<SupervisedServer>,
 ) -> Vec<(&'a ToolServerConfig, String, kv::Watch)> {
     let mut watches = Vec::new();
     for server in servers {
         let expected_token =
             server_identity_token(server.package.as_deref(), &server.name, "<server>");
         let key = registration_key(&config.instance_id, &expected_token);
-        remove_registrations_for_config(
-            &config.client,
-            &config.instance_id,
+        // Only clear stale registrations for servers we are about to respawn.
+        // A still-running server may publish its registration at any moment;
+        // deleting it here would lose a result the watch below cannot replay.
+        if !running.contains(&SupervisedServer::new(
             server.package.as_deref(),
             &server.name,
-            None,
-        )
-        .await;
+        )) {
+            remove_registrations_for_config(
+                &config.client,
+                &config.instance_id,
+                server.package.as_deref(),
+                &server.name,
+                None,
+            )
+            .await;
+        }
         match registry.watch_with_history(">").await {
             Ok(watch) => watches.push((*server, key, watch)),
             Err(error) => warn_server_failure(
@@ -168,17 +257,29 @@ async fn spawn_enabled_tool_servers(
     supervisor: &mut ToolServerSupervisor,
     config: &ToolServerStartConfig,
     servers: &[&ToolServerConfig],
-    processes: &Arc<Mutex<HashMap<u32, String>>>,
+    running: &HashSet<SupervisedServer>,
 ) {
+    let processes = Arc::clone(&supervisor.processes);
     let in_flight = NatsInFlightCalls::for_instance(&config.instance_id);
     for server in servers {
+        // A server whose child is still alive is slow, not dead — give the
+        // existing process more time rather than stacking a second copy.
+        if running.contains(&SupervisedServer::new(
+            server.package.as_deref(),
+            &server.name,
+        )) {
+            continue;
+        }
         match spawn_tool_server(config, server) {
             Ok(child) => {
                 let Some(pid) = child.id() else {
                     warn_server_failure(&server.name, "spawned child has no process ID");
                     continue;
                 };
-                processes.lock().await.insert(pid, server.name.clone());
+                processes.lock().await.insert(
+                    pid,
+                    SupervisedServer::new(server.package.as_deref(), &server.name),
+                );
                 supervisor.tasks.push(spawn_child_monitor(ToolMonitor {
                     child,
                     pid,
@@ -187,7 +288,7 @@ async fn spawn_enabled_tool_servers(
                     config: server.name.clone(),
                     instance_id: config.instance_id.clone(),
                     client: config.client.clone(),
-                    processes: Arc::clone(processes),
+                    processes: Arc::clone(&processes),
                     in_flight: in_flight.clone(),
                 }));
             }
@@ -287,8 +388,11 @@ fn spawn_tool_server(config: &ToolServerStartConfig, server: &ToolServerConfig) 
         .env(HARNX_NATS_URL_ENV, &config.nats_url)
         .env(HARNX_NATS_TOKEN_ENV, &config.token)
         .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        // Send output to the worker log instead of discarding it, so a tool
+        // server that dies or complains on startup leaves a trace there rather
+        // than silently timing out at registration.
+        .stdout(crate::local_orchestrator::worker_output_sink())
+        .stderr(crate::local_orchestrator::worker_output_sink())
         .kill_on_drop(true);
     configure_tool_process(&mut command);
     command.spawn().with_context(|| {
@@ -305,9 +409,15 @@ fn warn_server_failure(server: &str, detail: impl std::fmt::Display) {
 }
 
 fn emit_warning(message: String) {
-    if !emit_agent_event(AgentEvent::Notice(NoticeEvent::Warning(message.clone()))) {
-        eprintln!("Warning: {message}");
-    }
+    // `emit_agent_event` reports success even with no sink installed: it buffers
+    // into a capped queue for replay once one appears. That works for the
+    // front-end, but the worker has no sink while it starts up, so these
+    // warnings would sit in the queue until some later session replayed them —
+    // or be dropped entirely if the worker never gets one. Always write to
+    // stderr too; the supervisor redirects it to the worker log, which is the
+    // only channel that survives worker startup.
+    emit_agent_event(AgentEvent::Notice(NoticeEvent::Warning(message.clone())));
+    eprintln!("Warning: {message}");
     log::warn!("{message}");
 }
 
@@ -319,7 +429,7 @@ struct ToolMonitor {
     config: String,
     instance_id: InstanceId,
     client: async_nats::Client,
-    processes: Arc<Mutex<HashMap<u32, String>>>,
+    processes: SupervisedProcesses,
     in_flight: NatsInFlightCalls,
 }
 fn spawn_child_monitor(monitor: ToolMonitor) -> JoinHandle<()> {
@@ -370,158 +480,6 @@ async fn wait_for_child(child: &mut Child) -> std::io::Result<std::process::Exit
             return Ok(status);
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
-    }
-}
-
-async fn wait_for_registration(
-    watch: &mut kv::Watch,
-    processes: &Arc<Mutex<HashMap<u32, String>>>,
-    server: &ToolServerConfig,
-    instance_id: &InstanceId,
-    key: &str,
-    deadline: Instant,
-    timeout: Duration,
-) -> Result<()> {
-    loop {
-        if !processes
-            .lock()
-            .await
-            .values()
-            .any(|name| name == &server.name)
-        {
-            bail!(
-                "tool server '{}' exited before registering at '{key}'",
-                server.name
-            );
-        }
-        let now = Instant::now();
-        if now >= deadline {
-            bail!(
-                "tool server '{}' did not register at '{key}' within {}s",
-                server.name,
-                timeout.as_secs_f64()
-            );
-        }
-        let remaining = deadline.saturating_duration_since(now);
-        let poll = remaining.min(Duration::from_millis(100));
-        match tokio::time::timeout(poll, watch.next()).await {
-            Ok(Some(Ok(entry))) if entry.operation == kv::Operation::Put => {
-                if !entry.key.starts_with(key.trim_end_matches("<server>")) {
-                    continue;
-                }
-                let registration: Registration = match serde_json::from_slice(&entry.value) {
-                    Ok(registration) => registration,
-                    Err(error) => {
-                        log::warn!(
-                            "ignoring invalid tool registration '{}': {error}",
-                            entry.key
-                        );
-                        continue;
-                    }
-                };
-                if registration.package != server.package || registration.config != server.name {
-                    log::warn!(
-                        "ignoring tool registration '{}' identity mismatch: expected package {:?}, config '{}'; got package {:?}, config '{}'",
-                        entry.key,
-                        server.package,
-                        server.name,
-                        registration.package,
-                        registration.config
-                    );
-                    continue;
-                }
-                let identity_token = server_identity_token(
-                    registration.package.as_deref(),
-                    &registration.config,
-                    &registration.server,
-                );
-                let expected_key = registration_key(instance_id, &identity_token);
-                if entry.key != expected_key {
-                    log::warn!(
-                        "ignoring tool registration '{}' because its identity expects key '{}'",
-                        entry.key,
-                        expected_key
-                    );
-                    continue;
-                }
-                return Ok(());
-            }
-            Ok(Some(Ok(_))) => {}
-            Ok(Some(Err(error))) => {
-                log::warn!("ignoring tool registration watch error for '{key}': {error}");
-            }
-            Ok(None) => {
-                log::warn!("tool registration watch closed for '{key}'; waiting for timeout");
-                tokio::time::sleep(poll).await;
-            }
-            Err(_) => continue,
-        }
-    }
-}
-
-async fn ensure_registry_bucket(client: &async_nats::Client) -> Result<kv::Store> {
-    let jetstream = jetstream::new(client.clone());
-    match jetstream
-        .create_key_value(kv::Config {
-            bucket: TOOL_REGISTRY_BUCKET.to_string(),
-            history: 1,
-            num_replicas: 1,
-            storage: stream::StorageType::File,
-            ..Default::default()
-        })
-        .await
-    {
-        Ok(store) => Ok(store),
-        Err(_) => jetstream
-            .get_key_value(TOOL_REGISTRY_BUCKET)
-            .await
-            .map_err(anyhow::Error::from)
-            .context("open tool registry bucket"),
-    }
-}
-
-async fn remove_registrations_for_config(
-    client: &async_nats::Client,
-    instance_id: &InstanceId,
-    package: Option<&str>,
-    config: &str,
-    failure: Option<(&NatsInFlightCalls, &str)>,
-) {
-    let jetstream = jetstream::new(client.clone());
-    let Ok(store) = jetstream.get_key_value(TOOL_REGISTRY_BUCKET).await else {
-        return;
-    };
-    let Ok(mut keys) = store.keys().await else {
-        return;
-    };
-    let prefix = format!("{instance_id}.");
-    while let Ok(Some(key)) = keys.try_next().await {
-        if !key.starts_with(&prefix) {
-            continue;
-        }
-        let Ok(Some(value)) = store.get(&key).await else {
-            continue;
-        };
-        let Ok(registration) = serde_json::from_slice::<Registration>(&value) else {
-            continue;
-        };
-        if registration.package.as_deref() != package || registration.config != config {
-            continue;
-        }
-        let identity_token = server_identity_token(
-            registration.package.as_deref(),
-            &registration.config,
-            &registration.server,
-        );
-        if key != registration_key(instance_id, &identity_token) {
-            continue;
-        }
-        if let Some((in_flight, message)) = failure {
-            in_flight
-                .fail_server_unavailable(&identity_token, message.to_string())
-                .await;
-        }
-        let _ = store.delete(key).await;
     }
 }
 

--- a/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
+++ b/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
@@ -126,7 +126,9 @@ impl ToolServerSupervisor {
 
         let processes = Arc::clone(&self.processes);
         let running = running_server_names(&processes).await;
-        let watches = prepare_registration_watches(&registry, config, servers, &running).await;
+        let plan = prepare_registration_watches(&registry, config, servers, &running).await;
+        let watches = plan.watches;
+        self.unregistered.extend(plan.unwatchable);
         spawn_enabled_tool_servers(self, config, servers, &running).await;
 
         let deadline = Instant::now() + readiness_timeout;
@@ -220,8 +222,8 @@ async fn prepare_registration_watches<'a>(
     config: &ToolServerStartConfig,
     servers: &[&'a ToolServerConfig],
     running: &HashSet<SupervisedServer>,
-) -> Vec<(&'a ToolServerConfig, String, kv::Watch)> {
-    let mut watches = Vec::new();
+) -> WatchPlan<'a> {
+    let mut plan = WatchPlan::default();
     for server in servers {
         let expected_token =
             server_identity_token(server.package.as_deref(), &server.name, "<server>");
@@ -243,14 +245,31 @@ async fn prepare_registration_watches<'a>(
             .await;
         }
         match registry.watch_with_history(">").await {
-            Ok(watch) => watches.push((*server, key, watch)),
-            Err(error) => warn_server_failure(
-                &server.name,
-                format!("watch tool registration '{key}': {error:#}"),
-            ),
+            Ok(watch) => plan.watches.push((*server, key, watch)),
+            Err(error) => {
+                warn_server_failure(
+                    &server.name,
+                    format!("watch tool registration '{key}': {error:#}"),
+                );
+                // Still record it as unregistered. The child is spawned either
+                // way, and only servers in `unregistered` are ever retried, so
+                // dropping it here would strand a server that merely lost its
+                // watch.
+                plan.unwatchable.push(SupervisedServer::new(
+                    server.package.as_deref(),
+                    &server.name,
+                ));
+            }
         }
     }
-    watches
+    plan
+}
+
+/// Watches to await, plus the servers that could not get one.
+#[derive(Default)]
+struct WatchPlan<'a> {
+    watches: Vec<(&'a ToolServerConfig, String, kv::Watch)>,
+    unwatchable: Vec<SupervisedServer>,
 }
 
 async fn spawn_enabled_tool_servers(

--- a/crates/harnx-runtime/src/tool_context.rs
+++ b/crates/harnx-runtime/src/tool_context.rs
@@ -1,10 +1,11 @@
 use crate::agent_loop::AgentLoopContext;
+use crate::config::HARNX_NATS_URL_ENV;
 use crate::config::{Config, GlobalConfig, Input};
 use crate::nats_hook_provider::NatsHookProvider;
 use crate::nats_tool_provider::{NatsInFlightCalls, NatsToolProvider};
 use crate::tool::CompletionText;
 use crate::utils::AbortSignal;
-use harnx_core::instance::{InstanceId, HARNX_INSTANCE_ID};
+use harnx_core::instance::InstanceId;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
@@ -172,8 +173,17 @@ pub async fn discover_nats_tool_provider_cached(
 
 /// Refresh declarations before completion request construction.
 pub async fn refresh_nats_tool_declarations(config: &GlobalConfig, instance_id: &InstanceId) {
-    // Match hook discovery: only worker process trees have NATS identity and connectivity.
-    if std::env::var_os(HARNX_INSTANCE_ID).is_none() {
+    // Gate on the broker address, not on `HARNX_INSTANCE_ID`. The worker creates
+    // its instance id in-process and only ever exports it to the children it
+    // spawns, so an instance-id check is false in the one process that runs this
+    // — every turn discovered zero tools and the model saw built-ins only.
+    //
+    // A guard is still needed: with no broker address `resolve_local_nats_server_config`
+    // falls back to starting a shared NATS server, which a plain front-end must
+    // never do just to build a tool list. `HARNX_NATS_URL` is set on the worker
+    // by its supervisor and inherited by its children, so it marks exactly the
+    // processes that already have a broker to talk to.
+    if std::env::var_os(HARNX_NATS_URL_ENV).is_none() {
         return;
     }
 
@@ -224,10 +234,12 @@ mod tests {
 
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    /// Without a broker address the refresh must return without touching NATS —
+    /// otherwise a plain front-end would start a shared server to build a tool list.
     #[test]
-    fn refresh_without_worker_instance_is_a_no_op() {
+    fn refresh_without_broker_address_is_a_no_op() {
         let _lock = ENV_LOCK.lock().expect("env lock");
-        let _env = EnvGuard::unset(HARNX_INSTANCE_ID);
+        let _env = EnvGuard::unset(HARNX_NATS_URL_ENV);
         let config = GlobalConfig::default();
 
         tokio_test::block_on(async {

--- a/crates/harnx-runtime/tests/hook_supervisor.rs
+++ b/crates/harnx-runtime/tests/hook_supervisor.rs
@@ -26,17 +26,17 @@ impl<'a> From<&'a str> for RequestId<'a> {
 const TOKEN: &str = "hook-supervisor-test-token";
 
 fn hook_config(event: &str) -> HooksConfig {
-    hook_config_with_command(event, "cat")
+    hook_config_with_command(event, &["cat"])
 }
 
-fn hook_config_with_command(event: &str, child_command: &str) -> HooksConfig {
+fn hook_config_with_command(event: &str, child_argv: &[&str]) -> HooksConfig {
     HooksConfig {
         max_resume: None,
         entries: vec![HookConfig {
             command: format!(
-                "harnx-claude-compatible-hook-server --event {} --matcher exec --timeout 5 --command {}",
+                "harnx-claude-compatible-hook-server --event {} --matcher exec --timeout 5 -- {}",
                 shell_words::quote(event),
-                shell_words::quote(child_command)
+                shell_words::join(child_argv.iter().copied())
             ),
             status_message: None,
             async_hook: None,
@@ -524,7 +524,10 @@ async fn crashed_closed_hook_blocks_through_retained_expectation() -> Result<()>
         _server,
     } = context;
     let mut hooks = hook_config("PreToolUse");
-    hooks.entries[0].command.push_str(" --fail-policy open");
+    // Server flags must precede `--`; anything after it belongs to the child argv.
+    hooks.entries[0].command = hooks.entries[0]
+        .command
+        .replace(" -- ", " --fail-policy open -- ");
     let supervisor = HookServerSupervisor::start_local_with_timeout(
         start,
         &hooks,
@@ -587,7 +590,7 @@ async fn healthy_closed_hook_with_expectation_dispatches_normally() -> Result<()
         start,
         _server,
     } = context;
-    let hooks = hook_config_with_command("PreToolUse", "printf '{}'");
+    let hooks = hook_config_with_command("PreToolUse", &["printf", "{}"]);
     let supervisor = HookServerSupervisor::start_local_with_timeout(
         start,
         &hooks,

--- a/crates/harnx-runtime/tests/local_worker_supervisor.rs
+++ b/crates/harnx-runtime/tests/local_worker_supervisor.rs
@@ -12,6 +12,7 @@ use harnx_runtime::config::LOCAL_CLUSTER_KEY;
 use harnx_runtime::local_orchestrator::{local_worker_lock_file, LocalWorkerSupervisor};
 use harnx_runtime::nats_session_log::NatsSessionLog;
 use harnx_runtime::nats_worker::worker_ready_subject;
+use harnx_runtime::utils::create_abort_signal;
 use harnx_runtime::{ThinClientConfig, ThinClientSession};
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
@@ -242,7 +243,7 @@ async fn local_worker_supervisor_deduplicates_respawns_and_tears_down() {
     let (api_base, mock_task) = start_mock_openai().await;
     write_trivial_agent_config(root.path(), &api_base);
 
-    let mut owner = LocalWorkerSupervisor::start_with_worker_binary(&binary)
+    let mut owner = LocalWorkerSupervisor::start_with_worker_binary(&binary, create_abort_signal())
         .await
         .expect("start local worker owner");
     assert!(owner.is_worker_owner());
@@ -256,7 +257,7 @@ async fn local_worker_supervisor_deduplicates_respawns_and_tears_down() {
     );
     let first_pid = owner.worker_pid().expect("owned worker PID");
 
-    let joiner = LocalWorkerSupervisor::start_with_worker_binary(&binary)
+    let joiner = LocalWorkerSupervisor::start_with_worker_binary(&binary, create_abort_signal())
         .await
         .expect("join existing local worker");
     assert!(
@@ -270,7 +271,10 @@ async fn local_worker_supervisor_deduplicates_respawns_and_tears_down() {
     kill_process(first_pid);
     let deadline = Instant::now() + Duration::from_secs(5);
     let replacement_pid = loop {
-        owner.ensure().await.expect("respawn killed local worker");
+        owner
+            .ensure(create_abort_signal())
+            .await
+            .expect("respawn killed local worker");
         let pid = owner.worker_pid().expect("replacement worker PID");
         if pid != first_pid {
             break pid;

--- a/crates/harnx-sandbox-run/src/hooks.rs
+++ b/crates/harnx-sandbox-run/src/hooks.rs
@@ -94,7 +94,7 @@ fn build_inline_hook(def: &HookDef) -> Option<(InlineHookSpec, bool)> {
         event: "PreToolUse".to_string(),
         matcher: None,
         command: HookCommand {
-            command: build_hook_command(&def.command, &def.args),
+            argv: hook_argv(&def.command, &def.args),
             timeout: Some(30),
             package_dir: None,
         },
@@ -137,17 +137,14 @@ async fn reject_blocked_hook(
     )
 }
 
-fn shell_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\\''"))
-}
-
-fn build_hook_command(command: &str, args: &[String]) -> String {
-    let mut parts = Vec::with_capacity(args.len() + 1);
-    parts.push(shell_quote(command));
-    for arg in args {
-        parts.push(shell_quote(arg));
-    }
-    parts.join(" ")
+/// Hooks run their argv directly, so the program and its arguments pass through
+/// unchanged. This used to shell-quote them into one string only for the
+/// executor to hand back to `sh -c`.
+fn hook_argv(command: &str, args: &[String]) -> Vec<String> {
+    let mut argv = Vec::with_capacity(args.len() + 1);
+    argv.push(command.to_string());
+    argv.extend(args.iter().cloned());
+    argv
 }
 
 fn extract_env_from_value(env: &mut HashMap<String, String>, value: &serde_json::Value) {
@@ -183,13 +180,17 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn shell_quotes_hook_command_and_args() {
+    fn hook_argv_passes_command_and_args_through_unquoted() {
         assert_eq!(
-            build_hook_command(
+            hook_argv(
                 "/tmp/hook script",
                 &["arg with spaces".to_string(), "it's fine".to_string()]
             ),
-            "'/tmp/hook script' 'arg with spaces' 'it'\\''s fine'"
+            vec![
+                "/tmp/hook script".to_string(),
+                "arg with spaces".to_string(),
+                "it's fine".to_string(),
+            ]
         );
     }
 

--- a/crates/harnx-serve/src/ag_ui_rpc.rs
+++ b/crates/harnx-serve/src/ag_ui_rpc.rs
@@ -877,7 +877,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval required\"}}'\"'\"''",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' -- printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval required\"}}'\"'\"''",
             "You are plain.",
         );
 
@@ -935,7 +935,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval required\"}}'\"'\"''",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' -- printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval required\"}}'\"'\"''",
             "You are plain.",
         );
 

--- a/crates/harnx-serve/src/session_actor.rs
+++ b/crates/harnx-serve/src/session_actor.rs
@@ -423,7 +423,7 @@ async fn run_actor_turn(params: ActorTurnParams) -> anyhow::Result<harnx_runtime
 
     {
         let mut supervisor = params.local_worker.lock().await;
-        ensure_local_worker(&mut supervisor).await?;
+        ensure_local_worker(&mut supervisor, params.abort_signal.clone()).await?;
     }
     let session = ThinClientSession::from_global_config(
         ThinClientConfig {
@@ -2056,7 +2056,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' -- printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
             "You are plain.",
         );
 
@@ -2139,7 +2139,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' -- printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
             "You are plain.",
         );
 
@@ -2277,7 +2277,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"batch approval needed\"}}'\"'\"''",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' -- printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"batch approval needed\"}}'\"'\"''",
             "You are plain.",
         );
 
@@ -2448,7 +2448,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read, harnx_agent_session_history_search\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_search$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read, harnx_agent_session_history_search\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_search$' -- printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
             "You are plain.",
         );
 
@@ -2657,7 +2657,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' -- printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
             "You are plain.",
         );
 
@@ -2738,7 +2738,7 @@ mod tests {
         let sandbox = TestConfigSandbox::new();
         sandbox.write_agent_with_front_matter(
             "plain",
-            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' --command 'printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
+            "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' -- printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
             "You are plain.",
         );
 

--- a/crates/harnx-serve/src/session_actor/tests/session_actor_nats_tests.rs
+++ b/crates/harnx-serve/src/session_actor/tests/session_actor_nats_tests.rs
@@ -117,7 +117,7 @@ async fn serve_thin_client_replays_prompt_queued_during_active_run() {
         "Complete the turn.",
     );
     let config = sandbox.config();
-    let supervisor = LocalWorkerSupervisor::start_with_worker_binary(binary)
+    let supervisor = LocalWorkerSupervisor::start_with_worker_binary(binary, create_abort_signal())
         .await
         .expect("start local worker");
     let registry = SessionRegistry::new_with_local_worker_for_tests(config, supervisor);
@@ -223,7 +223,7 @@ async fn serve_local_nats_smoke_streams_sse_events_and_cancel_publishes_control(
         "Complete the turn.",
     );
     let config = sandbox.config();
-    let supervisor = LocalWorkerSupervisor::start_with_worker_binary(binary)
+    let supervisor = LocalWorkerSupervisor::start_with_worker_binary(binary, create_abort_signal())
         .await
         .expect("start local worker");
     let registry = SessionRegistry::new_with_local_worker_for_tests(config.clone(), supervisor);

--- a/crates/harnx-tui/src/prompt.rs
+++ b/crates/harnx-tui/src/prompt.rs
@@ -184,9 +184,12 @@ impl Tui {
 
         if cluster == harnx_runtime::config::LOCAL_CLUSTER_KEY {
             let mut supervisor = ctx.local_worker.lock().await;
-            harnx_runtime::local_orchestrator::ensure_local_worker(&mut supervisor)
-                .await
-                .context("failed to ensure local NATS worker")?;
+            harnx_runtime::local_orchestrator::ensure_local_worker(
+                &mut supervisor,
+                ctx.abort_signal.clone(),
+            )
+            .await
+            .context("failed to ensure local NATS worker")?;
         }
 
         let sink = Arc::new(TuiAgentEventSink::new(ctx.event_tx.clone()));

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -631,9 +631,12 @@ async fn start_directive_inner(
 
     let mut local_worker = None;
     if cluster == harnx_runtime::config::LOCAL_CLUSTER_KEY {
-        harnx_runtime::local_orchestrator::ensure_local_worker(&mut local_worker)
-            .await
-            .context("failed to ensure local NATS worker")?;
+        harnx_runtime::local_orchestrator::ensure_local_worker(
+            &mut local_worker,
+            abort_signal.clone(),
+        )
+        .await
+        .context("failed to ensure local NATS worker")?;
     }
 
     let session = harnx_runtime::ThinClientSession::from_global_config(

--- a/crates/harnx/src/test_utils/interrupt.rs
+++ b/crates/harnx/src/test_utils/interrupt.rs
@@ -234,7 +234,7 @@ pub fn write_with_blocking_hook(
         paths.harnx_config_dir.join("config.yaml"),
         format!(
             "save: false\nclient: mock-llm\nmodel: mock-llm:test\ntool_use: true\nuse_tools: '*'\n\
-             hooks:\n  entries:\n    - command: harnx-claude-compatible-hook-server --event PreToolUse --timeout 300 --command {}\n",
+             hooks:\n  entries:\n    - command: harnx-claude-compatible-hook-server --event PreToolUse --timeout 300 -- {}\n",
             shell_words::quote(&block_sh.display().to_string())
         ),
     )

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -46,6 +46,9 @@ There are two types of hook servers:
      --fail-policy <closed|open>  # Failure behavior (default: closed)
      -- <CHILD_COMMAND>           # The actual hook script/binary to run
    ```
+   Everything after `--` is an argv, executed directly rather than through a
+   shell. For pipes, redirection or variable expansion, ask for a shell:
+   `-- sh -c 'cmd >> log 2>&1'`.
 
 2. **Native hooks** (e.g., `harnx-proxy-auth`): Specialized binaries that implement the NATS hook protocol directly and self-declare their event/matcher via `Hook::hooks()`. They need no `--event`/`--matcher` flags:
    ```sh
@@ -331,7 +334,7 @@ Prevents the use of `bash_exec` for security reasons.
 ```yaml
 hooks:
   entries:
-    - command: harnx-claude-compatible-hook-server --event PreToolUse --matcher bash_exec -- exit 2
+    - command: harnx-claude-compatible-hook-server --event PreToolUse --matcher bash_exec -- sh -c 'exit 2'
       status_message: "Blocking bash_exec for safety"
 ```
 


### PR DESCRIPTION
`harnx -a coding/coder '...'` on a local cluster failed every time with:

```
Error: failed to ensure local NATS worker
Caused by:
    local worker did not publish readiness on cluster.__local__.worker.ready within 15s
```

That one message was hiding several independent defects. This makes local startup work, and makes the next failure diagnosable instead of silent.

## Why it failed

Readiness was published *after* tool servers, hooks and the per-agent toolset loop, and `TOOL_STARTUP_TIMEOUT` (15s) equalled `WORKER_STARTUP_TIMEOUT` (15s). Measured on a real config: the worker published at +15.9s against a 15.0s deadline. Any tool server that failed to register deterministically starved the front-end — even though that failure path is deliberately non-fatal.

Nothing about it was diagnosable, because worker, tool-server and hook-server processes were all spawned with stdout/stderr on `/dev/null`. The tool supervisor's stderr fallback was also dead code: `emit_agent_event` never returns `false` (it buffers into a capped queue for replay), so startup warnings went nowhere in debug builds and nowhere at all in release, where the log level defaults to `Off`.

## Changes

**Startup ordering.** The worker announces readiness first, then starts services in the background, retrying unregistered tool servers with exponential backoff. Session activation waits for the first registration round instead — the cost lands on the first turn, where it is visible and cancellable. Without that wait a session would snapshot an empty tool registry, which is worse than the original bug.

**Front-end wait.** No fixed deadline. Retries with backoff and a progress notice until the user aborts, reusing the shape of `try_model_with_retries_custom`. A worker that keeps *exiting* is treated differently from one that is slow: three crashes stop the wait and print the worker's output.

**Output capture.** Worker, tool-server and hook-server output appends to `harnx_worker.log` in the state dir. (`nats_client_session.rs` already told users to "check the worker log"; that log did not exist.)

**Three real causes this surfaced:**

- `HistoryManager::new` eagerly walked every allowed read path for git workdirs. The walk descends until it hits a `.git`, so a root that isn't itself a repo is traversed in full — **over 100 seconds of syscalls on a 170k-directory tree**, inside the constructor, before the tool server ever reached its NATS registration. Discovery is already lazy at every entry point, so it now starts empty. `harnx-fs-tools` startup went from >100s to 4ms.

- Hook servers exited with clap's usage error. The command was passed as trailing args after `--`, which the binary didn't accept — though `docs/hooks-guide.md` has always documented that form. The CLI takes trailing args again and runs them directly rather than through a shell; a hook needing pipes or redirection asks for one with `-- sh -c '...'`. This also deletes a shell-quoting round-trip in `harnx-sandbox-run`, which already had an argv and was flattening it to a string only to satisfy the old signature.

- `refresh_nats_tool_declarations` bailed unless `HARNX_INSTANCE_ID` was in the environment, but the worker creates its instance id in-process and only exports it to children — so the check was false in the one process that calls it. Every turn discovered zero tools and the model saw built-ins only. It gates on `HARNX_NATS_URL` instead; a guard is still needed, since without a broker address `resolve_local_nats_server_config` starts a NATS server just to build a tool list.

**Supervised server identity.** Tool servers are keyed by `(package, config)` rather than the bare config name. Two packages may each define a server called `fs`, and collapsing them let a live child mask its dead namesake — reporting a registration timeout instead of an exit, and suppressing respawns.

**Module split.** Registry bookkeeping moves to `nats_worker::tool_registry`, keeping process supervision separate from watching keys and validating identities.

## Breaking change

`harnx-claude-compatible-hook-server` no longer accepts `--command <STRING>`. Use trailing args, and be explicit when you want a shell:

```yaml
# before
- command: harnx-claude-compatible-hook-server --event PreToolUse --command 'echo hi >> log'
# after
- command: harnx-claude-compatible-hook-server --event PreToolUse -- sh -c 'echo hi >> log'
```

Configs already using the documented `--` form keep working.

## Testing

`cargo build --workspace`, `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` (2384 passed), and `--stress-count=5` (5/5). `cs delta origin/main` reports only an improvement: `harnx-mcp-history/src/history.rs` 8.28 → 8.81.

Verified against the reporter's real config: the worker now starts, hooks no longer fail, `fs` registers, and a turn completes end to end.

## Not fixed here

`context7`, `exa` and `fetch` still fail to register and emit no output, so they retry on backoff in the background rather than blocking anything. They need their own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local worker startup now reports readiness earlier while tools, hooks, and sub-agents initialize in the background.
  * Startup progress, retries, cancellations, and repeated failures are handled more clearly.
  * Worker and hook output is captured in `harnx_worker.log` for easier troubleshooting.
* **Bug Fixes**
  * Slow or failing tool servers no longer block worker startup and can retry automatically.
  * Cancellation requests are respected during worker initialization.
* **Documentation**
  * Hook commands now accept executable arguments after `--`; explicitly use `sh -c` for shell features such as pipes or variable expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->