### PR TITLE
fix(client): report failing request patches and fix the effort aliases

### DIFF
--- a/.changeset/jaq-patch-errors-surfaced.md
+++ b/.changeset/jaq-patch-errors-surfaced.md
@@ -1,0 +1,6 @@
+---
+harnx: patch
+---
+Fix request patches for the Opus 4.7/4.8 effort aliases and the `gpt-5.6-*:high` aliases, which silently did nothing. jaq (unlike jq) won't create a missing parent object for a nested path assignment, so `.body.output_config.effort = "high"` failed at runtime and took the rest of the patch with it — those models were sent `temperature`/`top_p` and no thinking or effort config.
+
+A failing request patch is now reported as an error naming the patch source, the expression, and the jaq message, instead of only a `warn!` that needed debug logging to see.

--- a/crates/harnx-client/src/client.rs
+++ b/crates/harnx-client/src/client.rs
@@ -317,7 +317,8 @@ pub trait Client: Sync + Send {
         let mut json_value = request_data.to_json_value();
 
         if let Some(patches) = self.model().patches() {
-            json_value = harnx_core::jaq::eval_filters(patches, json_value);
+            let source = format!("model `{}`", self.model().id());
+            json_value = apply_request_patches(&source, patches, json_value)?;
         }
 
         if let Some(patches_config) = self.patches_config() {
@@ -326,7 +327,8 @@ pub trait Client: Sync + Send {
                 .model_type()
                 .extract_patches_for(patches_config, self.model().endpoint())
             {
-                json_value = harnx_core::jaq::eval_filters(patches, json_value);
+                let source = format!("client `{}`", self.name());
+                json_value = apply_request_patches(&source, patches, json_value)?;
             }
         }
 
@@ -340,12 +342,21 @@ pub trait Client: Sync + Send {
         if let Ok(raw_patches) = std::env::var(&env_name) {
             let patches: Vec<String> = serde_json::from_str(&raw_patches)
                 .with_context(|| format!("Invalid JSON patch array in {env_name}"))?;
-            json_value = harnx_core::jaq::eval_filters(&patches, json_value);
+            json_value = apply_request_patches(&env_name, &patches, json_value)?;
         }
 
         *request_data = RequestData::from_json_value(json_value)?;
         Ok(())
     }
+}
+
+/// Applies one group of request patches, failing the request if any of them
+/// errors. Skipping a broken patch would send a body the patch was meant to
+/// correct (an unsupported `temperature`, a missing thinking config) and the
+/// only trace used to be a `warn!` in the debug log.
+fn apply_request_patches(source: &str, patches: &[String], json_value: Value) -> Result<Value> {
+    harnx_core::jaq::eval_filters_strict(patches, json_value)
+        .with_context(|| format!("Failed to apply request patches from {source}"))
 }
 
 impl Default for crate::ClientConfig {
@@ -634,7 +645,8 @@ mod request_data_tests {
             r#".headers.authorization = "Bearer patched-token""#.to_string(),
             r#".body.model = "patched-model""#.to_string(),
         ];
-        json_value = harnx_core::jaq::eval_filters(&patches, json_value);
+        json_value = super::apply_request_patches("model `openai:test`", &patches, json_value)
+            .expect("valid patches should apply");
 
         let patched_data =
             RequestData::from_json_value(json_value).expect("should parse patched JSON");
@@ -668,10 +680,37 @@ mod request_data_tests {
             .expect("env var should parse as JSON array of strings");
 
         let input = serde_json::json!({"url": "...", "headers": {}, "body": {"model": "gpt-4o"}});
-        let output = harnx_core::jaq::eval_filters(&patches, input);
+        let output =
+            super::apply_request_patches("HARNX_PATCH_OPENAI_CHAT_COMPLETIONS", &patches, input)
+                .expect("valid patches should apply");
 
         assert_eq!(output["body"]["max_tokens"].as_i64(), Some(100));
         assert_eq!(output["body"]["temperature"].as_f64(), Some(0.5));
+    }
+
+    #[test]
+    fn apply_request_patches_reports_the_failing_patch_and_reason() {
+        // `.body.reasoning.effort` needs a `.body.reasoning` object; jaq won't
+        // create one. The request must fail loudly rather than go out unpatched.
+        let patches = vec![r#".body.reasoning.effort = "high""#.to_string()];
+        let input = serde_json::json!({"url": "...", "headers": {}, "body": {"model": "gpt-5.6"}});
+
+        let err = super::apply_request_patches("model `openai:gpt-5.6`", &patches, input)
+            .expect_err("assigning through a missing object must fail");
+        let message = format!("{err:#}");
+
+        assert!(
+            message.contains("model `openai:gpt-5.6`"),
+            "error should name the patch source: {message}"
+        );
+        assert!(
+            message.contains(".body.reasoning.effort"),
+            "error should name the failing expression: {message}"
+        );
+        assert!(
+            message.contains("cannot use null as iterable"),
+            "error should carry the jaq reason: {message}"
+        );
     }
 
     #[test]

--- a/crates/harnx-client/src/openai_responses.rs
+++ b/crates/harnx-client/src/openai_responses.rs
@@ -60,7 +60,9 @@ use serde_json::{json, Value};
 /// - `store`: hard default `false` (server default is `true`).
 /// - `include`: always `["reasoning.encrypted_content"]`.
 /// - `max_output_tokens`: from `model.max_tokens_param()`, clamped to min 16.
-/// - `reasoning`: NOT emitted by this builder; alias patches set `.body.reasoning.effort`.
+/// - `reasoning`: NOT emitted by this builder; alias patches assign the whole
+///   object, e.g. `.body.reasoning = {"effort":"high"}`. jaq won't create the
+///   missing parent for `.body.reasoning.effort = ...`.
 /// - `temperature`/`top_p`: included only if provided; alias patches may `del(.body.temperature)`
 ///   for reasoning models that reject these params.
 /// - `seed`: NOT supported by Responses API; never emitted.
@@ -1950,11 +1952,10 @@ mod tests {
         // Verify store:false default
         assert_eq!(body["store"], false, "store should default to false");
 
-        // Apply the patch that model aliases use via jaq::eval_filters
-        // (which returns Value directly, not Result)
+        // Apply the patch that model aliases use
         let patches = vec![".body.store = true".to_string()];
         let body_json = json!({ "body": body });
-        let patched = jaq::eval_filters(&patches, body_json);
+        let patched = jaq::eval_filters_strict(&patches, body_json).expect("patch should apply");
 
         // Verify store:true after patch
         assert_eq!(
@@ -1995,7 +1996,8 @@ mod tests {
         // Apply patch
         let body = json!({ "store": false });
         let body_json = json!({ "body": body });
-        let patched = harnx_core::jaq::eval_filters(patches, body_json);
+        let patched = harnx_core::jaq::eval_filters_strict(patches, body_json)
+            .expect("responses patch should apply");
 
         assert_eq!(
             patched.get("body").and_then(|b| b.get("responses")),

--- a/crates/harnx-client/tests/models_yaml_patches.rs
+++ b/crates/harnx-client/tests/models_yaml_patches.rs
@@ -1,0 +1,95 @@
+//! Guards the request patches shipped in `models.yaml`.
+//!
+//! Patches run through jaq at request time and a failing one used to be
+//! skipped with only a `warn!` in the debug log, so a broken expression could
+//! ship unnoticed while every request for that model went out unpatched.
+
+use harnx_client::client::ALL_PROVIDER_MODELS;
+use harnx_core::model::{Model, ModelType};
+use serde_json::{json, Value};
+
+/// A request envelope shaped like `RequestData::to_json_value`, holding the
+/// fields the shipped patches read or delete.
+fn request_envelope(model: &Model) -> Value {
+    json!({
+        "url": "https://example.invalid/v1/messages",
+        "headers": {"authorization": "Bearer test"},
+        "body": {
+            "model": model.real_name(),
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 4096,
+            "temperature": 0.5,
+            "top_p": 0.9,
+            "stream": true
+        }
+    })
+}
+
+#[test]
+fn every_shipped_patch_evaluates_without_error() {
+    let mut checked = 0;
+    for provider in ALL_PROVIDER_MODELS.iter() {
+        for model in Model::from_config(&provider.provider, &provider.models) {
+            let Some(patches) = model.patches() else {
+                continue;
+            };
+            let input = request_envelope(&model);
+            harnx_core::jaq::eval_filters_strict(patches, input).unwrap_or_else(|err| {
+                panic!(
+                    "patches for model {} failed to evaluate: {err:#}",
+                    model.id()
+                )
+            });
+            checked += 1;
+        }
+    }
+    assert!(
+        checked > 0,
+        "no models.yaml patches were checked — the test is not exercising anything"
+    );
+}
+
+/// The effort aliases exist to send an effort level; assert the patched body
+/// actually carries it, so a patch that evaluates but writes nothing is caught.
+#[test]
+fn effort_aliases_set_effort_in_the_request_body() {
+    let mut checked = 0;
+    for provider in ALL_PROVIDER_MODELS.iter() {
+        for model in Model::from_config(&provider.provider, &provider.models) {
+            let Some(patches) = model.patches() else {
+                continue;
+            };
+            let effort_key = match patches.iter().find_map(|p| effort_path(p)) {
+                Some(key) => key,
+                None => continue,
+            };
+            let patched = harnx_core::jaq::eval_filters_strict(patches, request_envelope(&model))
+                .unwrap_or_else(|err| panic!("patches for {} failed: {err:#}", model.id()));
+
+            let effort = patched["body"][effort_key]["effort"].as_str();
+            assert!(
+                effort.is_some(),
+                "model {} patch left .body.{effort_key}.effort unset: {patched}",
+                model.id()
+            );
+            assert_eq!(
+                model.model_type(),
+                ModelType::Chat,
+                "effort patches only make sense on chat models"
+            );
+            checked += 1;
+        }
+    }
+    assert!(
+        checked > 0,
+        "no effort-setting aliases found in models.yaml"
+    );
+}
+
+/// Returns the container key (`output_config` or `reasoning`) when the patch
+/// sets an effort level under it.
+fn effort_path(patch: &str) -> Option<&'static str> {
+    ["output_config", "reasoning"]
+        .into_iter()
+        .find(|key| patch.contains(&format!(".body.{key}")) && patch.contains("effort"))
+}

--- a/crates/harnx-core/src/jaq.rs
+++ b/crates/harnx-core/src/jaq.rs
@@ -3,7 +3,6 @@ use std::fmt::Display;
 use jaq_core::load::{Arena, File, Loader};
 use jaq_core::{data, unwrap_valr, Compiler, Ctx, Vars};
 use jaq_json::Val;
-use log::warn;
 use serde_json::Value;
 
 type JsonFilter = jaq_core::Filter<data::JustLut<Val>>;
@@ -64,95 +63,61 @@ fn runtime_failure_message(expr: &str, err: &impl Display, input: &Value) -> Str
     )
 }
 
-fn run_filter(filter: &JsonFilter, expr: &str, input: Value) -> Option<Value> {
+fn run_filter(filter: &JsonFilter, expr: &str, input: Value) -> Result<Value, String> {
     let input_val = json_to_val(&input);
     let ctx = Ctx::<data::JustLut<Val>>::new(&filter.lut, Vars::new([]));
     let mut outputs = filter.id.run((ctx, input_val)).map(unwrap_valr);
 
     match outputs.next() {
-        Some(Ok(value)) => val_to_json(&value).or(Some(input)),
-        Some(Err(err)) => {
-            warn!("{}", runtime_failure_message(expr, &err, &input));
-            None
-        }
-        None => Some(input),
+        Some(Ok(value)) => Ok(val_to_json(&value).unwrap_or(input)),
+        Some(Err(err)) => Err(runtime_failure_message(expr, &err, &input)),
+        // A filter such as `empty` legitimately yields nothing; pass the input
+        // through rather than treating it as a failure.
+        None => Ok(input),
     }
 }
 
 /// Compiles and runs a single jaq expression against `input`.
-/// Returns `None` and logs a warning on parse/compile/runtime error.
-pub fn eval_filter(expr: &str, input: Value) -> Option<Value> {
-    let filter = match compile_filter(expr) {
-        Ok(filter) => filter,
-        Err(error) => {
-            warn!("jaq parse/compile failed for {expr:?}: {error}");
-            return None;
-        }
-    };
+/// Returns the failure message on parse/compile/runtime error.
+pub fn eval_filter_checked(expr: &str, input: Value) -> Result<Value, String> {
+    let filter = compile_filter(expr)
+        .map_err(|error| format!("jaq parse/compile failed for {expr:?}: {error}"))?;
 
     run_filter(&filter, expr, input)
 }
 
 /// Runs expressions in sequence — result of N is input to N+1.
-/// On error in expression N: logs warning, skips that expression, continues with unmodified value.
-pub fn eval_filters(exprs: &[String], input: Value) -> Value {
-    exprs.iter().fold(input, |current, expr| {
-        eval_filter(expr, current.clone()).unwrap_or(current)
-    })
-}
-
-/// Like eval_filters, but returns Err on any expression parse/compile/runtime error.
+/// Returns Err on any expression parse/compile/runtime error; skipping a failed
+/// expression would hand back a value the caller believes was transformed.
 pub fn eval_filters_strict(exprs: &[String], input: Value) -> anyhow::Result<Value> {
-    exprs
-        .iter()
-        .try_fold(input, |current, expr| eval_filter_strict(expr, current))
-}
-
-/// Like eval_filter, but returns Err instead of None on failure.
-fn eval_filter_strict(expr: &str, input: Value) -> anyhow::Result<Value> {
-    let filter = compile_filter(expr)
-        .map_err(|e| anyhow::anyhow!("jaq compile failed for {:?}: {}", expr, e))?;
-    // `run_filter` only returns `None` after a jaq runtime error, which it has
-    // already logged (via `warn!`) with the failing expression and input kind.
-    // A legitimate empty filter yields `Some(input)`, so `None` here always
-    // means a runtime failure — point the caller at the logs for the reason.
-    run_filter(&filter, expr, input).ok_or_else(|| {
-        anyhow::anyhow!("jaq runtime failed for {expr:?}; see logs for the runtime error details")
+    exprs.iter().try_fold(input, |current, expr| {
+        eval_filter_checked(expr, current).map_err(|message| anyhow::anyhow!(message))
     })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{eval_filter, eval_filters, eval_filters_strict, runtime_failure_message};
+    use super::{eval_filter_checked, eval_filters_strict, runtime_failure_message};
     use serde_json::{json, Value};
 
     #[test]
     fn identity_filter_returns_input() {
         let input = json!({"a": 1, "b": [true, false]});
-        let output = eval_filter(".", input.clone());
-        assert_eq!(output, Some(input));
+        let output = eval_filter_checked(".", input.clone());
+        assert_eq!(output, Ok(input));
     }
 
     #[test]
     fn body_mutation_updates_object() {
         let input = json!({"a": 1});
-        let output = eval_filter(".a = 2", input);
-        assert_eq!(output, Some(json!({"a": 2})));
+        let output = eval_filter_checked(".a = 2", input);
+        assert_eq!(output, Ok(json!({"a": 2})));
     }
 
     #[test]
-    fn invalid_expression_returns_none() {
+    fn invalid_expression_returns_err() {
         let input = json!({"a": 1});
-        let output = eval_filter(".a = ", input.clone());
-        assert_eq!(output, None);
-    }
-
-    #[test]
-    fn eval_filters_skips_invalid_expression() {
-        let input = json!({"a": 1});
-        // invalid expression should be skipped; output = input unchanged
-        let chained = eval_filters(&[".a = ".to_string()], input.clone());
-        assert_eq!(chained, input);
+        assert!(eval_filter_checked(".a = ", input).is_err());
     }
 
     #[test]
@@ -173,15 +138,15 @@ mod tests {
     fn multiline_expression_is_treated_as_whitespace() {
         let input = json!({"a": 1});
         let expr = ".a = 2\n| .b = 3";
-        let output = eval_filter(expr, input);
-        assert_eq!(output, Some(json!({"a": 2, "b": 3})));
+        let output = eval_filter_checked(expr, input);
+        assert_eq!(output, Ok(json!({"a": 2, "b": 3})));
     }
 
     #[test]
     fn multi_expression_chain_feeds_next_filter() {
         let input = json!({"a": 1});
         let exprs = vec![".a = 2".to_string(), ".b = .a + 1".to_string()];
-        let output = eval_filters(&exprs, input);
+        let output = eval_filters_strict(&exprs, input).expect("both expressions are valid");
         assert_eq!(output, json!({"a": 2, "b": 3}));
     }
 
@@ -198,10 +163,10 @@ mod tests {
     }
 
     #[test]
-    fn eval_filters_strict_runtime_error_points_to_logs() {
+    fn eval_filters_strict_runtime_error_includes_the_reason() {
         // `.[]` on a number is a genuine runtime error (not an empty result).
-        // The strict error should name the expression and direct the user to
-        // the logs for the underlying reason, rather than claiming "no output".
+        // The strict error must carry the underlying jaq message, since the
+        // caller reports it to the user and the debug log may not be enabled.
         let input = json!(1);
         let err = eval_filters_strict(&[".[]".to_string()], input)
             .expect_err("iterating a number must be a runtime error");
@@ -212,12 +177,35 @@ mod tests {
             "message should name the expr: {message}"
         );
         assert!(
-            message.contains("see logs"),
-            "message should point to the logs: {message}"
+            message.contains("cannot use 1 as iterable"),
+            "message should carry the jaq reason: {message}"
         );
         assert!(
-            !message.contains("no output"),
-            "message must not claim 'no output' for a runtime error: {message}"
+            !message.contains("see logs"),
+            "message should state the reason instead of deferring to the logs: {message}"
+        );
+    }
+
+    #[test]
+    fn eval_filter_checked_reports_compile_errors() {
+        let err = eval_filter_checked(".a = ", json!({"a": 1}))
+            .expect_err("a truncated expression must not compile");
+
+        assert!(
+            err.contains("jaq parse/compile failed for"),
+            "message should say what failed: {err}"
+        );
+        assert!(err.contains(".a = "), "message should name the expr: {err}");
+    }
+
+    #[test]
+    fn nested_assignment_needs_an_existing_parent_object() {
+        // jaq, unlike jq, does not create missing intermediate objects for a
+        // multi-level path assignment. Patches must assign the whole container.
+        assert!(eval_filter_checked(".a.b = 1", json!({})).is_err());
+        assert_eq!(
+            eval_filter_checked(r#".a = {"b": 1}"#, json!({})),
+            Ok(json!({"a": {"b": 1}}))
         );
     }
 

--- a/crates/harnx-runtime/src/session_history.rs
+++ b/crates/harnx-runtime/src/session_history.rs
@@ -154,12 +154,10 @@ pub fn query_entries_with_jaq(
     let Some(expr) = &query.jaq else {
         return Ok(rows);
     };
-    // `eval_filter` returns `None` on a parse/compile/runtime error; surface
-    // that so the agent can fix or drop the expression. A filter that simply
-    // matches nothing does not return `None`, so this won't misfire on
-    // legitimately-empty results.
-    harnx_core::jaq::eval_filter(expr, rows)
-        .ok_or_else(|| anyhow::anyhow!("invalid jaq expression: {expr}"))
+    // Report the jaq message itself so the agent can fix the expression instead
+    // of guessing. A filter that simply matches nothing is not an error, so this
+    // won't misfire on legitimately-empty results.
+    harnx_core::jaq::eval_filter_checked(expr, rows).map_err(|message| anyhow::anyhow!(message))
 }
 
 /// Parse a session log document string and run the full query against it.

--- a/crates/harnx/models.yaml
+++ b/crates/harnx/models.yaml
@@ -537,7 +537,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.reasoning.effort = "high"
+      - del(.body.temperature) | del(.body.top_p) | .body.reasoning = {"effort":"high"}
       endpoint: responses
     - name: gpt-5.6-terra
       max_input_tokens: 1050000
@@ -556,7 +556,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.reasoning.effort = "high"
+      - del(.body.temperature) | del(.body.top_p) | .body.reasoning = {"effort":"high"}
       endpoint: responses
     - name: gpt-audio
       max_input_tokens: 128000
@@ -1063,7 +1063,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "high"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"high"}
     - name: claude-opus-4-7:max
       real_name: claude-opus-4-7
       max_input_tokens: 1000000
@@ -1074,7 +1074,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "max"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"max"}
     - name: claude-opus-4-7:xhigh
       real_name: claude-opus-4-7
       max_input_tokens: 1000000
@@ -1085,7 +1085,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "xhigh"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"xhigh"}
     - name: claude-opus-4-7-20260416
       max_input_tokens: 1000000
       max_output_tokens: 128000
@@ -1095,7 +1095,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "high"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"high"}
     - name: claude-opus-4-7-20260416:max
       real_name: claude-opus-4-7-20260416
       max_input_tokens: 1000000
@@ -1106,7 +1106,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "max"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"max"}
     - name: claude-opus-4-7-20260416:xhigh
       real_name: claude-opus-4-7-20260416
       max_input_tokens: 1000000
@@ -1117,7 +1117,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "xhigh"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"xhigh"}
     - name: claude-opus-4-8
       max_input_tokens: 1000000
       max_output_tokens: 128000
@@ -1127,7 +1127,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "high"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"high"}
     - name: claude-opus-4-8:max
       real_name: claude-opus-4-8
       max_input_tokens: 1000000
@@ -1138,7 +1138,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "max"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"max"}
     - name: claude-opus-4-8:xhigh
       real_name: claude-opus-4-8
       max_input_tokens: 1000000
@@ -1149,7 +1149,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "xhigh"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"xhigh"}
     - name: claude-opus-5
       max_input_tokens: 1000000
       max_output_tokens: 128000
@@ -2343,7 +2343,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "high"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"high"}
     - name: claude-opus-4-7:max
       real_name: claude-opus-4-7
       max_input_tokens: 1000000
@@ -2354,7 +2354,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "max"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"max"}
     - name: claude-opus-4-7:xhigh
       real_name: claude-opus-4-7
       max_input_tokens: 1000000
@@ -2365,7 +2365,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "xhigh"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"xhigh"}
     - name: claude-opus-4-7@default
       max_input_tokens: 1000000
       max_output_tokens: 128000
@@ -2375,7 +2375,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "high"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"high"}
     - name: claude-opus-4-7@default:max
       real_name: claude-opus-4-7@default
       max_input_tokens: 1000000
@@ -2386,7 +2386,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "max"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"max"}
     - name: claude-opus-4-7@default:xhigh
       real_name: claude-opus-4-7@default
       max_input_tokens: 1000000
@@ -2397,7 +2397,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "xhigh"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"xhigh"}
     - name: claude-opus-4-8
       max_input_tokens: 1000000
       max_output_tokens: 128000
@@ -2407,7 +2407,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "high"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"high"}
     - name: claude-opus-4-8:max
       real_name: claude-opus-4-8
       max_input_tokens: 1000000
@@ -2418,7 +2418,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "max"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"max"}
     - name: claude-opus-4-8:xhigh
       real_name: claude-opus-4-8
       max_input_tokens: 1000000
@@ -2429,7 +2429,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "xhigh"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"xhigh"}
     - name: claude-opus-4-8@default
       max_input_tokens: 1000000
       max_output_tokens: 128000
@@ -2439,7 +2439,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "high"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"high"}
     - name: claude-opus-4-8@default:max
       real_name: claude-opus-4-8@default
       max_input_tokens: 1000000
@@ -2450,7 +2450,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "max"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"max"}
     - name: claude-opus-4-8@default:xhigh
       real_name: claude-opus-4-8@default
       max_input_tokens: 1000000
@@ -2461,7 +2461,7 @@
       supports_vision: true
       supports_tool_use: true
       patches:
-      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config.effort = "xhigh"
+      - del(.body.temperature) | del(.body.top_p) | .body.thinking = {"type":"adaptive"} | .body.output_config = {"effort":"xhigh"}
     - name: claude-opus-4@20250514
       max_input_tokens: 200000
       max_output_tokens: 32000

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -88,7 +88,16 @@ patches:                  # Patch API requests using jq expressions
 
 The `patches.chat_completions`, `patches.embeddings`, and `patches.rerank` fields are arrays of **jq filter strings**. Each filter receives the full request object as JSON (`{url, headers, body}`) and must return the modified version.
 
-Filters are applied in sequence. If an expression fails, a warning is logged and that specific patch is skipped.
+Filters are applied in sequence. If an expression fails, the request fails with the jq error and the name of the patch source — a skipped patch would send the very request body the patch exists to correct.
+
+Harnx evaluates filters with [jaq](https://github.com/01mf02/jaq), which does not create missing intermediate objects the way jq does. Assign the whole container rather than a nested path:
+
+```yaml
+patches:
+  chat_completions:
+    - '.body.reasoning = {"effort":"high"}'      # works
+    # - '.body.reasoning.effort = "high"'        # fails: `.body.reasoning` is null
+```
 
 To target specific models, use `if/then` within the expression:
 

--- a/docs/solutions/openai-responses-api.md
+++ b/docs/solutions/openai-responses-api.md
@@ -45,7 +45,7 @@ New `endpoint: Option<String>` field on `ModelData` triggers routing. Model alia
   real_name: gpt-5.6-sol
   endpoint: responses
   patches:
-    - del(.body.temperature) | del(.body.top_p) | .body.reasoning.effort = "high"
+    - del(.body.temperature) | del(.body.top_p) | .body.reasoning = {"effort":"high"}
 ```
 
 Dispatch in `openai.rs` checks `model.endpoint()`:


### PR DESCRIPTION
Fixes #1375.

The reported log line was one symptom of two bugs.

## The patch was broken

jaq, unlike jq, won't create a missing intermediate object for a nested path assignment. `null | .a.b = 1` works in jq; in jaq it's `cannot use null as iterable`. So `.body.output_config.effort = "high"` failed at runtime, and because it sat at the end of a `|` pipeline, the whole patch was discarded — the Opus 4.7/4.8 effort aliases and the `gpt-5.6-*:high` aliases were sending `temperature` and `top_p` with no thinking or effort config. 23 patch lines in `models.yaml` now assign the whole container instead.

## The failure was invisible

`eval_filters` logged a `warn!` and continued with the untransformed value, so you needed debug logging to see it at all, and the one strict caller reported `see logs for the runtime error details` without the reason. Now:

- Request patches fail the request, naming the patch source, the expression, and the jaq message. A skipped patch sends the very body the patch exists to correct, so continuing was never safe.
- `eval_filters` is removed. It had no remaining production callers and its whole contract was to hide this class of error.
- `session_history`'s jq error carries the jaq message instead of a bare `invalid jaq expression: ...`.

## Guard

`crates/harnx-client/tests/models_yaml_patches.rs` evaluates every patch shipped in `models.yaml` against a representative request envelope, and asserts the effort aliases actually land an `effort` value in the body. Both tests fail on `main`.

## Testing

`cargo build`, `cargo fmt --check`, `cargo clippy -D warnings`, `cargo nextest run --workspace --stress-count=5` (2388 tests), and `cs delta origin/HEAD` ("No issues found") all pass.

Two timing tests (`nats_worker::subagent_idle_timeout_resets_on_child_activity`, `tool_supervisor::readiness_waits_for_servers_concurrently`) flake under full-workspace load on the first stress iteration. I reproduced both on an `origin/main` worktree and neither reproduces on this branch across 20 iterations, so they're pre-existing and unrelated.