### PR TITLE
fix(mcp): stop passing the worker's NATS identity to wrapped servers

### DIFF
--- a/.changeset/mcp-bridge-list-tools.md
+++ b/.changeset/mcp-bridge-list-tools.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+`harnx-mcp-bridge --list-tools -- <command>` starts a wrapped MCP server, prints the tools it advertises, and exits without touching NATS. Reaching the listing proves the child spawns, completes the MCP handshake and answers `tools/list`; when it does not, the error distinguishes a child that failed to spawn, one that died during startup, and one that never finished the handshake — three cases a registration timeout in the worker cannot tell apart. `--name` is now only required when actually serving over NATS.

--- a/.changeset/mcp-bridge-scrub-worker-nats-env.md
+++ b/.changeset/mcp-bridge-scrub-worker-nats-env.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+The MCP bridge no longer passes the worker's NATS identity (`HARNX_INSTANCE_ID`, `HARNX_NATS_URL`, `HARNX_NATS_TOKEN`) to the server it wraps. The bridge is the process that registers over NATS; everything below it speaks MCP on stdio. Leaking those let a descendant conclude it had been launched by a worker and switch protocols — a sandbox shim running `harnx-proxy-auth` as a stdio hook did exactly that, then served NATS instead of answering the stdio handshake, so the wrapped server was never launched and the bridge timed out after 30s. Servers wrapped in a sandbox shim now start under a worker as they already did from a shell.

--- a/.changeset/worker-diagnose-tool-servers.md
+++ b/.changeset/worker-diagnose-tool-servers.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+`harnx worker --cluster __local__ --diagnose` starts this configuration's tool servers, reports which ones registered and how many tools each advertises, and exits without serving sessions. It applies the same selection and startup the worker uses, so it shows what a real run would do — including servers pulled in from packages the active agent cannot use — without racing a front-end that exits after its turn.

--- a/crates/harnx-mcp-bridge/Cargo.toml
+++ b/crates/harnx-mcp-bridge/Cargo.toml
@@ -20,6 +20,7 @@ process-wrap = { workspace = true }
 rmcp = { workspace = true }
 serde_json = { workspace = true }
 shell-words = { workspace = true }
+which = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 

--- a/crates/harnx-mcp-bridge/src/lib.rs
+++ b/crates/harnx-mcp-bridge/src/lib.rs
@@ -124,6 +124,45 @@ pub fn report_tools(bridge: &BridgeToolset) -> String {
     out
 }
 
+/// Summarise the inherited settings that decide whether a wrapped server can
+/// reach the network and find its runtime.
+///
+/// A server that starts in a shell but stalls under the worker differs only by
+/// the environment it inherits, and a proxy pointing at a port that is gone
+/// makes package managers block silently. Names only for anything that could
+/// carry a credential.
+fn child_runtime_env() -> String {
+    const SHOWN: [&str; 6] = [
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "NODE_EXTRA_CA_CERTS",
+        "npm_config_registry",
+        "npm_config_proxy",
+    ];
+    let mut parts: Vec<String> = SHOWN
+        .iter()
+        .filter_map(|name| {
+            std::env::var(name)
+                .ok()
+                .filter(|value| !value.is_empty())
+                .map(|value| format!("{name}={value}"))
+        })
+        .collect();
+    let secretish = ["NPM_TOKEN", "npm_config__auth", "EXA_API_KEY"]
+        .iter()
+        .filter(|name| std::env::var_os(name).is_some_and(|value| !value.is_empty()))
+        .copied()
+        .collect::<Vec<_>>();
+    if !secretish.is_empty() {
+        parts.push(format!("set(no values shown): {}", secretish.join(", ")));
+    }
+    if parts.is_empty() {
+        return "no proxy or registry overrides inherited".to_string();
+    }
+    format!("inherited {}", parts.join(" "))
+}
+
 fn spawn_child(server_name: &str, program: &str, args: &[String]) -> anyhow::Result<SpawnedChild> {
     let mut command = Command::new(program);
     command
@@ -250,6 +289,7 @@ impl BridgeToolset {
             "MCP server '{server_name}': starting {}",
             shell_words::join(&child_argv)
         );
+        log::info!("MCP server '{server_name}': {}", child_runtime_env());
         let (child, stdin, stdout, stderr) = spawn_child(&server_name, program, args)?;
         let stderr_tail = spawn_stderr_reader(&server_name, stderr);
         let (service, cached_tools) =

--- a/crates/harnx-mcp-bridge/src/lib.rs
+++ b/crates/harnx-mcp-bridge/src/lib.rs
@@ -311,6 +311,16 @@ impl BridgeToolset {
             shell_words::join(&child_argv)
         );
         log::info!("MCP server '{server_name}': {}", child_runtime_env());
+        // Resolve argv[0] the way the OS will. A wrapper shim earlier on PATH
+        // than the real binary is invisible in the command line but changes what
+        // actually runs, and a shim that prints anything of its own corrupts a
+        // stdio protocol before the server it wraps ever speaks.
+        log::info!(
+            "MCP server '{server_name}': '{program}' resolves to {}",
+            which::which(program)
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|error| format!("<unresolved: {error}>"))
+        );
         let (child, stdin, stdout, stderr) = spawn_child(&server_name, program, args)?;
         // The pid makes a stalled handshake inspectable from outside: the child
         // is a launcher like `npx`, so knowing which process to look at is the

--- a/crates/harnx-mcp-bridge/src/lib.rs
+++ b/crates/harnx-mcp-bridge/src/lib.rs
@@ -540,7 +540,11 @@ impl ClientHandler for BridgeClientHandler {
 mod tests {
     #[cfg(unix)]
     use super::BridgeToolset;
-    use super::{map_tool, report_tools, Args};
+    // Only the unix tests exercise a real child process, so the reporter is
+    // unused elsewhere and `-D warnings` rejects the import.
+    #[cfg(unix)]
+    use super::report_tools;
+    use super::{map_tool, Args};
 
     #[test]
     fn list_tools_parses_without_a_name_but_serving_still_needs_one() {

--- a/crates/harnx-mcp-bridge/src/lib.rs
+++ b/crates/harnx-mcp-bridge/src/lib.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use anyhow::{anyhow, bail, Context};
 use async_trait::async_trait;
 use clap::Parser;
+use harnx_core::instance::HARNX_INSTANCE_ID;
 use harnx_toolset::{ToolInvokeError, ToolSpec, Toolset};
 #[cfg(unix)]
 use process_wrap::tokio::ProcessGroup;
@@ -184,8 +185,20 @@ fn spawn_handshake_progress(server_name: &str) -> tokio::task::JoinHandle<()> {
     })
 }
 
+/// The worker identity a bridge must not pass on.
+///
+/// The bridge is the process that registers over NATS; everything below it
+/// speaks MCP on stdio. Leaking these lets a descendant conclude it was
+/// launched by a worker and switch to a NATS protocol — `harnx-proxy-auth`,
+/// run as a stdio hook by a sandbox shim, does exactly that and then never
+/// answers the stdio handshake, so the wrapped server is never launched at all.
+const WORKER_NATS_ENV: [&str; 3] = [HARNX_INSTANCE_ID, "HARNX_NATS_URL", "HARNX_NATS_TOKEN"];
+
 fn spawn_child(server_name: &str, program: &str, args: &[String]) -> anyhow::Result<SpawnedChild> {
     let mut command = Command::new(program);
+    for name in WORKER_NATS_ENV {
+        command.env_remove(name);
+    }
     command
         .args(args)
         .stdin(Stdio::piped())
@@ -560,6 +573,40 @@ mod tests {
         assert!(report.contains("list_plans"), "{report}");
         // Hints come from the child's advertised metadata, not from defaults.
         assert!(report.contains("[read-only]"), "{report}");
+    }
+
+    /// A sandbox shim in the child chain runs `harnx-proxy-auth` as a stdio
+    /// hook, and that binary switches to a NATS protocol when it finds a
+    /// worker's identity in the environment — leaving the shim waiting on a
+    /// stdio reply that never comes, so the wrapped server never starts.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn wrapped_child_does_not_inherit_the_workers_nats_identity() {
+        harnx_core::require_nextest();
+        let Some(binary) = plans_tools_binary() else {
+            eprintln!("skipping: harnx-plans-tools not built");
+            return;
+        };
+        // SAFETY: nextest gives this test its own process.
+        unsafe {
+            std::env::set_var("HARNX_NATS_URL", "nats://127.0.0.1:1");
+            std::env::set_var("HARNX_NATS_TOKEN", "unused");
+            std::env::set_var(super::HARNX_INSTANCE_ID, "worker-instance");
+        }
+
+        // Stands in for the shim: refuse to exec the real server if any of the
+        // worker's identity survived into the child.
+        let guard = format!(
+            r#"if [ -n "${{HARNX_NATS_URL:-}}" ] || [ -n "${{HARNX_NATS_TOKEN:-}}" ]                  || [ -n "${{HARNX_INSTANCE_ID:-}}" ]; then exit 3; fi
+               exec {} --mcp-stdio"#,
+            binary.display()
+        );
+        let bridge =
+            BridgeToolset::new("scrubbed", vec!["sh".to_string(), "-c".to_string(), guard])
+                .await
+                .expect("child starts only when the worker identity is scrubbed");
+
+        assert!(!bridge.cached_tools().is_empty());
     }
 
     #[cfg(unix)]

--- a/crates/harnx-mcp-bridge/src/lib.rs
+++ b/crates/harnx-mcp-bridge/src/lib.rs
@@ -22,6 +22,8 @@ use tokio_util::sync::CancellationToken;
 
 const STDERR_TAIL_LINES: usize = 50;
 const INITIALIZE_TIMEOUT: Duration = Duration::from_secs(30);
+/// Spacing of the "still waiting" notices during a slow handshake.
+const HANDSHAKE_PROGRESS_INTERVAL: Duration = Duration::from_secs(5);
 const LIST_TOOLS_TIMEOUT: Duration = Duration::from_secs(10);
 
 type StderrTail = Arc<Mutex<VecDeque<String>>>;
@@ -163,6 +165,25 @@ fn child_runtime_env() -> String {
     format!("inherited {}", parts.join(" "))
 }
 
+/// Report that a handshake is still outstanding, every few seconds.
+///
+/// Without this a slow start and a wedged one look identical until the 30s
+/// timeout, by which point a short-lived front-end has often already exited and
+/// taken the evidence with it.
+fn spawn_handshake_progress(server_name: &str) -> tokio::task::JoinHandle<()> {
+    let server_name = server_name.to_owned();
+    tokio::spawn(async move {
+        let started = std::time::Instant::now();
+        loop {
+            tokio::time::sleep(HANDSHAKE_PROGRESS_INTERVAL).await;
+            log::warn!(
+                "MCP server '{server_name}': still waiting for the MCP handshake after {:.0}s",
+                started.elapsed().as_secs_f64()
+            );
+        }
+    })
+}
+
 fn spawn_child(server_name: &str, program: &str, args: &[String]) -> anyhow::Result<SpawnedChild> {
     let mut command = Command::new(program);
     command
@@ -291,9 +312,26 @@ impl BridgeToolset {
         );
         log::info!("MCP server '{server_name}': {}", child_runtime_env());
         let (child, stdin, stdout, stderr) = spawn_child(&server_name, program, args)?;
+        // The pid makes a stalled handshake inspectable from outside: the child
+        // is a launcher like `npx`, so knowing which process to look at is the
+        // difference between "it is slow" and a `/proc` answer for why.
+        log::info!(
+            "MCP server '{server_name}': child pid {}",
+            child
+                .id()
+                .map(|pid| pid.to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        );
         let stderr_tail = spawn_stderr_reader(&server_name, stderr);
+        let handshake = std::time::Instant::now();
+        let progress = spawn_handshake_progress(&server_name);
         let (service, cached_tools) =
             connect_and_list_tools(&server_name, stdin, stdout, &stderr_tail).await?;
+        progress.abort();
+        log::info!(
+            "MCP server '{server_name}': handshake completed in {:.1}s",
+            handshake.elapsed().as_secs_f64()
+        );
 
         log::info!(
             "MCP server '{server_name}': ready with {} tool(s)",

--- a/crates/harnx-mcp-bridge/src/lib.rs
+++ b/crates/harnx-mcp-bridge/src/lib.rs
@@ -36,9 +36,20 @@ type SpawnedChild = (
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
 #[command(trailing_var_arg = true)]
 pub struct Args {
-    /// Server name used for registration.
+    /// Server name used for registration. Required when serving over NATS;
+    /// optional for `--list-tools`, which does not register.
     #[arg(long)]
-    pub name: String,
+    pub name: Option<String>,
+
+    /// Start the wrapped server, print the tools it advertises, and exit
+    /// without connecting to NATS.
+    ///
+    /// Diagnostic for a server that never registers: it separates "the child
+    /// does not start", "it starts but never completes the MCP handshake", and
+    /// "it works and the problem is elsewhere", which are indistinguishable
+    /// from the supervisor's registration timeout alone.
+    #[arg(long)]
+    pub list_tools: bool,
 
     /// Wrapped MCP command followed by its arguments.
     #[arg(required = true, allow_hyphen_values = true)]
@@ -70,6 +81,47 @@ pub struct BridgeToolset {
     _service_watch: tokio::task::JoinHandle<()>,
     _child: Box<dyn ChildWrapper>,
     stderr_tail: StderrTail,
+}
+
+/// Render what a wrapped server advertises, for `--list-tools`.
+///
+/// Reaching this at all establishes that the child starts, completes the MCP
+/// handshake, and answers `tools/list` — the three steps a registration
+/// timeout cannot distinguish between.
+pub fn report_tools(bridge: &BridgeToolset) -> String {
+    let tools = bridge.cached_tools();
+    let mut out = format!(
+        "MCP server '{}': {} tool(s)\n",
+        bridge.server_name(),
+        tools.len()
+    );
+    for tool in tools {
+        out.push_str(&format!("\n  {}\n", tool.name));
+        let description = tool.description.trim();
+        if !description.is_empty() {
+            out.push_str(&format!(
+                "    {}\n",
+                description.lines().next().unwrap_or("")
+            ));
+        }
+        let hints = [
+            tool.read_only_hint.then_some("read-only"),
+            tool.idempotent_hint.then_some("idempotent"),
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+        if !hints.is_empty() {
+            out.push_str(&format!("    [{}]\n", hints.join(", ")));
+        }
+        if let Some(seconds) = tool.timeout_secs {
+            out.push_str(&format!("    timeout: {seconds}s\n"));
+        }
+    }
+    if tools.is_empty() {
+        out.push_str("\n  (the server completed its handshake but advertises no tools)\n");
+    }
+    out
 }
 
 fn spawn_child(server_name: &str, program: &str, args: &[String]) -> anyhow::Result<SpawnedChild> {
@@ -387,7 +439,50 @@ impl ClientHandler for BridgeClientHandler {
 mod tests {
     #[cfg(unix)]
     use super::BridgeToolset;
-    use super::{map_tool, Args};
+    use super::{map_tool, report_tools, Args};
+
+    #[test]
+    fn list_tools_parses_without_a_name_but_serving_still_needs_one() {
+        let listing = Args::parse_from(["bridge", "--list-tools", "--", "npx", "-y", "srv"]);
+        assert!(listing.list_tools);
+        assert_eq!(listing.name, None);
+        assert_eq!(listing.child, vec!["npx", "-y", "srv"]);
+
+        let serving = Args::parse_from(["bridge", "--name", "exa", "--", "npx", "-y", "srv"]);
+        assert!(!serving.list_tools);
+        assert_eq!(serving.name.as_deref(), Some("exa"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn list_tools_reports_the_wrapped_server_inventory() {
+        let Some(binary) = plans_tools_binary() else {
+            eprintln!("skipping: harnx-plans-tools not built");
+            return;
+        };
+        let bridge = BridgeToolset::new(
+            "diag",
+            vec![binary.display().to_string(), "--mcp-stdio".to_string()],
+        )
+        .await
+        .expect("wrap plans tools");
+
+        let report = report_tools(&bridge);
+        assert!(report.starts_with("MCP server 'diag':"), "{report}");
+        assert!(report.contains("list_plans"), "{report}");
+        // Hints come from the child's advertised metadata, not from defaults.
+        assert!(report.contains("[read-only]"), "{report}");
+    }
+
+    #[cfg(unix)]
+    fn plans_tools_binary() -> Option<std::path::PathBuf> {
+        let mut dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
+        if dir.file_name().is_some_and(|name| name == "deps") {
+            dir.pop();
+        }
+        let binary = dir.join("harnx-plans-tools");
+        binary.is_file().then_some(binary)
+    }
 
     #[test]
     fn arg_parses_child_command_and_flags_after_separator() {
@@ -402,7 +497,7 @@ mod tests {
             ".agent/plans",
         ]);
 
-        assert_eq!(args.name, "plans");
+        assert_eq!(args.name.as_deref(), Some("plans"));
         assert_eq!(
             args.child,
             ["harnx-plans-tools", "--mcp-stdio", "--dir", ".agent/plans"]
@@ -419,7 +514,7 @@ mod tests {
             "harnx-plans-tools",
         ]);
 
-        assert_eq!(args.name, "plans");
+        assert_eq!(args.name.as_deref(), Some("plans"));
         assert_eq!(args.child, ["harnx-plans-tools"]);
     }
 

--- a/crates/harnx-mcp-bridge/src/main.rs
+++ b/crates/harnx-mcp-bridge/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use harnx_core::instance::{InstanceId, HARNX_INSTANCE_ID};
-use harnx_mcp_bridge::{Args, BridgeToolset};
+use harnx_mcp_bridge::{report_tools, Args, BridgeToolset};
 use harnx_toolset_server::serve_over_nats;
 
 #[tokio::main]
@@ -9,7 +9,18 @@ async fn main() -> anyhow::Result<()> {
     // goes nowhere until a logger exists.
     harnx_core::server_logging::init_server_logger();
     let args = Args::parse();
-    let bridge = BridgeToolset::new(args.name, args.child).await?;
+
+    if args.list_tools {
+        let name = args.name.unwrap_or_else(|| "mcp-diagnostic".to_string());
+        let bridge = BridgeToolset::new(name, args.child).await?;
+        print!("{}", report_tools(&bridge));
+        return Ok(());
+    }
+
+    let name = args
+        .name
+        .context("--name is required when serving over NATS")?;
+    let bridge = BridgeToolset::new(name, args.child).await?;
     let child_died = bridge.child_died_token();
     let instance_id = std::env::var(HARNX_INSTANCE_ID)
         .with_context(|| format!("{HARNX_INSTANCE_ID} is required"))?;

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -443,7 +443,7 @@ struct BackgroundServices {
     _subagent_tool_servers: Vec<JoinHandle<Result<()>>>,
 }
 
-fn configured_worker_services(
+pub(super) fn configured_worker_services(
     config: &GlobalConfig,
 ) -> (Vec<ToolServerConfig>, harnx_core::hooks::HooksConfig) {
     let config = config.read();

--- a/crates/harnx-runtime/src/nats_worker/diagnostics.rs
+++ b/crates/harnx-runtime/src/nats_worker/diagnostics.rs
@@ -1,0 +1,204 @@
+//! Worker startup diagnostics.
+//!
+//! Reproduces exactly what the worker does to its tool servers — the same
+//! selection, the same spawn, the same registry wait — and reports the outcome
+//! per server instead of running a session.
+//!
+//! Without this the only view of tool startup is a log written during a
+//! front-end run that exits after its turn, which routinely ends before slow
+//! servers finish and leaves the interesting part unobserved.
+
+use super::daemon::configured_worker_services;
+use super::tool_registry::ensure_registry_bucket;
+use super::tool_supervisor::{ToolServerStartConfig, ToolServerSupervisor};
+use crate::config::{
+    resolve_local_nats_server_config, GlobalConfig, ToolServerConfig, HARNX_NATS_TOKEN_ENV,
+    HARNX_NATS_URL_ENV,
+};
+use anyhow::{Context, Result};
+use futures_util::TryStreamExt;
+use harnx_core::instance::InstanceId;
+use harnx_toolset::{server_identity_token, Registration};
+use harnx_toolset_server::registration_key;
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::time::{Duration, Instant};
+
+/// How long a diagnostic run waits for registrations.
+///
+/// Deliberately longer than the worker's own startup budget: a server that is
+/// merely slow should show up as slow-but-working rather than as a failure,
+/// and an MCP bridge waiting on a cold package download can take tens of
+/// seconds by itself.
+const DIAGNOSE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// One configured tool server and what became of it.
+struct ServerOutcome {
+    label: String,
+    command: String,
+    tools: Option<usize>,
+}
+
+/// Start this worker's tool servers and report which ones registered.
+pub async fn diagnose_tool_servers(config: &GlobalConfig) -> Result<String> {
+    let (servers, _hooks) = configured_worker_services(config);
+    if servers.is_empty() {
+        return Ok("No tool servers are enabled for this configuration.\n".to_string());
+    }
+
+    // Hold the broker handle for the whole run. `resolve_local_nats_server_config`
+    // starts a shared server on its fallback path and drops the owner before
+    // returning, which kills it again; the worker never notices because its
+    // supervisor always hands it a broker through the environment.
+    let owned_broker = match (
+        std::env::var(HARNX_NATS_URL_ENV).ok(),
+        std::env::var(HARNX_NATS_TOKEN_ENV).ok(),
+    ) {
+        (Some(_), Some(_)) => None,
+        _ => Some(
+            crate::nats_local_server::ensure_shared_server()
+                .await
+                .context("start the shared local NATS broker")?,
+        ),
+    };
+    let (url, token) = match &owned_broker {
+        Some(server) => (server.url.clone(), server.token.clone()),
+        None => {
+            let local = resolve_local_nats_server_config()
+                .await
+                .context("resolve the local NATS broker")?;
+            let token = local.token.clone().context("local NATS requires a token")?;
+            (local.url, token)
+        }
+    };
+    let client = async_nats::ConnectOptions::new()
+        .token(token.clone())
+        .connect(&url)
+        .await
+        .with_context(|| format!("connect to the local NATS broker at {url}"))?;
+    let instance_id = InstanceId::new();
+
+    let mut report = format!(
+        "Starting {} tool server(s) as instance {instance_id}\n\
+         Waiting up to {}s for each to register.\n\n",
+        servers.len(),
+        DIAGNOSE_TIMEOUT.as_secs()
+    );
+
+    let start = ToolServerStartConfig::new(client.clone(), instance_id.clone(), &url, &token);
+    let began = Instant::now();
+    let supervisor =
+        ToolServerSupervisor::start_local_with_timeout(start, &servers, DIAGNOSE_TIMEOUT).await?;
+    let elapsed = began.elapsed();
+
+    let registered = registered_tool_counts(&client, &instance_id).await;
+    let outcomes = collect_outcomes(&servers, &registered);
+    render_outcomes(&mut report, &outcomes, elapsed);
+    drop(supervisor);
+    drop(owned_broker);
+    Ok(report)
+}
+
+/// Tool count per identity token currently registered for this instance.
+async fn registered_tool_counts(
+    client: &async_nats::Client,
+    instance_id: &InstanceId,
+) -> HashMap<String, usize> {
+    let mut counts = HashMap::new();
+    let Ok(registry) = ensure_registry_bucket(client).await else {
+        return counts;
+    };
+    let Ok(keys) = registry.keys().await else {
+        return counts;
+    };
+    let Ok(keys) = keys.try_collect::<Vec<_>>().await else {
+        return counts;
+    };
+    let prefix = format!("{instance_id}.");
+    for key in keys.into_iter().filter(|key| key.starts_with(&prefix)) {
+        let Ok(Some(value)) = registry.get(&key).await else {
+            continue;
+        };
+        let Ok(registration) = serde_json::from_slice::<Registration>(&value) else {
+            continue;
+        };
+        let identity = server_identity_token(
+            registration.package.as_deref(),
+            &registration.config,
+            &registration.server,
+        );
+        counts.insert(
+            registration_key(instance_id, &identity),
+            registration.tools.len(),
+        );
+    }
+    counts
+}
+
+fn collect_outcomes(
+    servers: &[ToolServerConfig],
+    registered: &HashMap<String, usize>,
+) -> Vec<ServerOutcome> {
+    servers
+        .iter()
+        .map(|server| {
+            // A server registers under its own advertised name, which need not
+            // match the config name, so match on the package/config prefix.
+            let prefix = server_identity_token(server.package.as_deref(), &server.name, "");
+            let tools = registered
+                .iter()
+                .find(|(key, _)| key.contains(&prefix))
+                .map(|(_, count)| *count);
+            ServerOutcome {
+                label: match &server.package {
+                    Some(package) => format!("{package}/{}", server.name),
+                    None => server.name.clone(),
+                },
+                command: shell_words::join(
+                    std::iter::once(server.command.as_str())
+                        .chain(server.args.iter().map(String::as_str)),
+                ),
+                tools,
+            }
+        })
+        .collect()
+}
+
+fn render_outcomes(report: &mut String, outcomes: &[ServerOutcome], elapsed: Duration) {
+    let width = outcomes
+        .iter()
+        .map(|outcome| outcome.label.len())
+        .max()
+        .unwrap_or(0);
+    for outcome in outcomes {
+        let status = match outcome.tools {
+            Some(count) => format!("registered, {count} tool(s)"),
+            None => "DID NOT REGISTER".to_string(),
+        };
+        let _ = writeln!(report, "  {:width$}  {status}", outcome.label);
+        if outcome.tools.is_none() {
+            let _ = writeln!(report, "  {:width$}    command: {}", "", outcome.command);
+        }
+    }
+
+    let failed = outcomes
+        .iter()
+        .filter(|outcome| outcome.tools.is_none())
+        .count();
+    let _ = writeln!(
+        report,
+        "\n{} of {} registered in {:.1}s.",
+        outcomes.len() - failed,
+        outcomes.len(),
+        elapsed.as_secs_f64()
+    );
+    if failed > 0 {
+        let _ = writeln!(
+            report,
+            "\nFor a server that did not register, run its command directly:\n  \
+             harnx-mcp-bridge --list-tools -- <command>\n\
+             which reports whether the child spawns, completes the MCP handshake, \
+             and answers tools/list."
+        );
+    }
+}

--- a/crates/harnx-runtime/src/nats_worker/diagnostics.rs
+++ b/crates/harnx-runtime/src/nats_worker/diagnostics.rs
@@ -85,7 +85,8 @@ pub async fn diagnose_tool_servers(config: &GlobalConfig) -> Result<String> {
         DIAGNOSE_TIMEOUT.as_secs()
     );
 
-    let start = ToolServerStartConfig::new(client.clone(), instance_id.clone(), &url, &token);
+    let start = ToolServerStartConfig::new(client.clone(), instance_id.clone(), &url, &token)
+        .inheriting_child_output();
     let began = Instant::now();
     let supervisor =
         ToolServerSupervisor::start_local_with_timeout(start, &servers, DIAGNOSE_TIMEOUT).await?;

--- a/crates/harnx-runtime/src/nats_worker/mod.rs
+++ b/crates/harnx-runtime/src/nats_worker/mod.rs
@@ -25,6 +25,7 @@ mod agent_loop;
 mod backend;
 mod control;
 mod daemon;
+mod diagnostics;
 mod hook_supervisor;
 mod subagent_toolset;
 mod tool_registry;
@@ -46,6 +47,7 @@ pub use daemon::{
     new_remote_session_id, notify_subject, publish_session_activate, run_worker_daemon,
     worker_ready_subject, SessionActivate, WorkerDaemonConfig,
 };
+pub use diagnostics::diagnose_tool_servers;
 #[doc(hidden)]
 pub use hook_supervisor::publish_crash_rejector;
 pub use hook_supervisor::{HookServerStartConfig, HookServerSupervisor};

--- a/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
+++ b/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
@@ -31,6 +31,10 @@ pub struct ToolServerStartConfig {
     instance_id: InstanceId,
     nats_url: String,
     token: String,
+    /// Send tool-server output to this process's own stdout/stderr instead of
+    /// the worker log. Set by foreground diagnostics, where routing a server's
+    /// explanation of its own failure into a file is the opposite of useful.
+    inherit_child_output: bool,
 }
 
 impl ToolServerStartConfig {
@@ -45,7 +49,14 @@ impl ToolServerStartConfig {
             instance_id,
             nats_url: nats_url.into(),
             token: token.into(),
+            inherit_child_output: false,
         }
+    }
+
+    /// Show tool-server output on this process's stdio rather than the worker log.
+    pub fn inheriting_child_output(mut self) -> Self {
+        self.inherit_child_output = true;
+        self
     }
 
     fn hook_start_config(&self) -> HookServerStartConfig {
@@ -391,6 +402,14 @@ fn tool_server_package_dir(server: &ToolServerConfig) -> PathBuf {
         .unwrap_or_else(harnx_core::config_paths::config_dir)
 }
 
+fn child_output_sink(config: &ToolServerStartConfig) -> Stdio {
+    if config.inherit_child_output {
+        Stdio::inherit()
+    } else {
+        crate::local_orchestrator::worker_output_sink()
+    }
+}
+
 fn spawn_tool_server(config: &ToolServerStartConfig, server: &ToolServerConfig) -> Result<Child> {
     let binary = resolve_tool_binary(server)?;
     let mut command = Command::new(&binary);
@@ -410,8 +429,8 @@ fn spawn_tool_server(config: &ToolServerStartConfig, server: &ToolServerConfig) 
         // Send output to the worker log instead of discarding it, so a tool
         // server that dies or complains on startup leaves a trace there rather
         // than silently timing out at registration.
-        .stdout(crate::local_orchestrator::worker_output_sink())
-        .stderr(crate::local_orchestrator::worker_output_sink())
+        .stdout(child_output_sink(config))
+        .stderr(child_output_sink(config))
         .kill_on_drop(true);
     configure_tool_process(&mut command);
     command.spawn().with_context(|| {

--- a/crates/harnx/src/cli.rs
+++ b/crates/harnx/src/cli.rs
@@ -114,6 +114,10 @@ pub struct WorkerArgs {
     /// Set agent variable pairs (format: --agent-variable key value or -x key value); can be repeated
     #[arg(short = 'x', long, value_names = ["KEY", "VALUE"], num_args = 2, action = clap::ArgAction::Append)]
     pub agent_variable: Vec<String>,
+    /// Start this worker's tool servers, report which ones registered, and
+    /// exit without serving sessions.
+    #[arg(long)]
+    pub diagnose: bool,
 }
 
 #[derive(Args, Debug, PartialEq, Eq)]
@@ -256,10 +260,12 @@ mod tests {
                 cluster,
                 worker_id,
                 agent_variable,
+                diagnose,
             })) => {
                 assert_eq!(cluster, "prod");
                 assert_eq!(worker_id, None);
                 assert_eq!(agent_variable, vec!["cloud_env", "true", "debug", "false"]);
+                assert!(!diagnose);
             }
             other => panic!("unexpected command: {other:?}"),
         }

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -180,6 +180,13 @@ async fn run_session_delete_command(delete_args: &DeleteSessionArgs) -> Result<(
 async fn run_worker_command(worker_args: &WorkerArgs) -> Result<()> {
     let config = Arc::new(RwLock::new(Config::init(WorkingMode::Cmd, true).await?));
     config.write().agent_variables = collect_agent_variables(&worker_args.agent_variable)?;
+    if worker_args.diagnose {
+        print!(
+            "{}",
+            harnx_runtime::nats_worker::diagnose_tool_servers(&config).await?
+        );
+        return Ok(());
+    }
     let worker_id = worker_args
         .worker_id
         .clone()


### PR DESCRIPTION
Every MCP server wrapped in a sandbox shim failed to register under the worker — `context7`, `exa`, `fetch`, in both the `coding` and `pantheon` packages. Zero successes in 30 attempts, always a 30s handshake timeout, always with an empty child stderr. The identical command from a shell started in about a second.

## Root cause

`harnx-proxy-auth` selects its wire protocol by sniffing ambient environment (`main.rs:171`):

```rust
fn nats_mode_enabled() -> bool {
    [HARNX_INSTANCE_ID, "HARNX_NATS_URL", "HARNX_NATS_TOKEN"]
        .iter().all(|name| std::env::var_os(name).is_some())
}
```

`spawn_tool_server` sets all three on every tool server, and they inherit straight down:

```
worker → harnx-mcp-bridge → npx shim → harnx-sandbox-run → harnx-proxy-auth
                                                            ↑ sees all three
```

`harnx-sandbox-run` launches `harnx-proxy-auth` as a **persistent stdio hook** and waits for a JSONL reply. Finding the worker's identity in its environment, proxy-auth instead registered as a **NATS hook server** — so the reply never came, the sandbox never spawned the wrapped command, and the bridge timed out against a child that had produced no output. `pstree` on a stalled server showed exactly that: `harnx-sandbox-run` with `harnx-proxy-auth` beneath it and no `npx`.

From a shell none of those variables exist, so the same binary took the stdio branch and worked.

## Fix

The bridge is the boundary where NATS ends and stdio begins, so it now drops all three before spawning. That protects any descendant from mistaking itself for a worker-managed server, not just proxy-auth.

**Result: 16 of 16 tool servers register in 1.6s, down from 0 of 16 and a 30s timeout each.**

The regression test drives a child that refuses to exec unless all three are absent; it fails without the scrub.

## Diagnostics that found it

Each of these earned its place — five plausible causes were killed by them before the real one surfaced.

- **`harnx-mcp-bridge --list-tools -- <command>`** starts a wrapped server, prints its tools, exits. Distinguishes "child won't spawn", "died during startup", "never handshook" and "works" — four cases a registration timeout collapses into one.
- **`harnx worker --cluster __local__ --diagnose`** runs the worker's own selection and startup and reports per server whether it registered and with how many tools, waiting longer than the worker's budget so slow reads as slow. Output goes to the terminal, not the worker log.
- Bridge breadcrumbs: the child pid, the absolute path `argv[0]` resolves to (this caught a config using a literal `~`, which `execve` does not expand), inherited proxy/CA/registry settings with credential-ish names shown but never values, a "still waiting" notice every 5s, and the handshake duration.

## Testing

`cargo build --workspace --all-targets`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` — 2393 passed. `cs delta origin/main` reports no score change.

Verified against the real configuration that reproduced the bug: 16/16 in 1.6s.

## Follow-ups, not in this PR

- `harnx-proxy-auth` choosing its protocol from ambient environment is the underlying hazard; an explicit `--stdio`/`--nats` flag would stop the next caller hitting it.
- `bash_exec` fails through the same sandbox with a similar signature, but spawns it directly rather than through the bridge, so it likely needs the equivalent scrub on its own path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tool inventory mode to inspect an MCP server’s advertised tools without connecting to NATS.
  * Added worker diagnostics to start configured tool servers, show registration status and tool counts, and exit without serving sessions.
  * Added clearer startup progress and failure reporting for wrapped tool servers.

* **Bug Fixes**
  * Prevented worker connection settings from being passed to wrapped MCP servers, preserving standard MCP behavior.
  * Improved child-process output handling for diagnostic workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->