### PR TITLE
fix(sandbox): grant allowlist paths as written, resolve only when checking

### DIFF
--- a/.changeset/allowlist-tilde-expansion.md
+++ b/.changeset/allowlist-tilde-expansion.md
@@ -1,7 +1,7 @@
 ---
 harnx: patch
 ---
-Sandbox allowlist entries are now granted exactly as written, and symlinks are resolved only when checking a path against them.
+Sandbox allowlist entries now keep the symlinks they were written with. A relative entry is still made absolute against the working directory, but nothing beyond that is resolved; symlinks are followed only when checking a path against a grant.
 
 Grants were previously canonicalised at insertion, which had two consequences. It widened a grant to wherever a symlink pointed, so allowing a link could hand over its target. And it lost the path callers actually use: on merged-`/usr` systems `/lib64` collapsed into the `/usr/lib64` entry already present, so the sandbox never mounted `/lib64` and every dynamically linked binary failed to start, because loaders are named absolutely as `/lib64/ld-linux-x86-64.so.2`. That surfaced as `bash_exec` failing every command with `sandboxing failure: No such file or directory`.
 

--- a/.changeset/allowlist-tilde-expansion.md
+++ b/.changeset/allowlist-tilde-expansion.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Sandbox allowlist entries written with a leading `~` now resolve against the home directory. Config files and tool-server arguments are read without a shell, so `--allow-read ~/.config/foo` arrived literally and was treated as a relative path, producing `<cwd>/~/.config/foo`. That directory does not exist, so the sandbox failed during setup and every `bash_exec` call returned `sandboxing failure: No such file or directory` with no indication of which path was at fault. `~user` is still left alone, since resolving another account's home would need a passwd lookup.

--- a/.changeset/allowlist-tilde-expansion.md
+++ b/.changeset/allowlist-tilde-expansion.md
@@ -1,4 +1,8 @@
 ---
 harnx: patch
 ---
-Sandbox allowlist entries written with a leading `~` now resolve against the home directory. Config files and tool-server arguments are read without a shell, so `--allow-read ~/.config/foo` arrived literally and was treated as a relative path, producing `<cwd>/~/.config/foo`. That directory does not exist, so the sandbox failed during setup and every `bash_exec` call returned `sandboxing failure: No such file or directory` with no indication of which path was at fault. `~user` is still left alone, since resolving another account's home would need a passwd lookup.
+Sandbox allowlist entries are now granted exactly as written, and symlinks are resolved only when checking a path against them.
+
+Grants were previously canonicalised at insertion, which had two consequences. It widened a grant to wherever a symlink pointed, so allowing a link could hand over its target. And it lost the path callers actually use: on merged-`/usr` systems `/lib64` collapsed into the `/usr/lib64` entry already present, so the sandbox never mounted `/lib64` and every dynamically linked binary failed to start, because loaders are named absolutely as `/lib64/ld-linux-x86-64.so.2`. That surfaced as `bash_exec` failing every command with `sandboxing failure: No such file or directory`.
+
+A leading `~` in an allowlist entry now resolves against the home directory too. Config files and tool-server arguments are read without a shell, so `--allow-read ~/.config/foo` arrived literally and was treated as relative to the working directory. `~user` is left alone, since resolving another account's home would need a passwd lookup.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3518,6 +3518,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shell-words",
  "tempfile",
  "tokio",
  "tokio-util",

--- a/crates/harnx-bash-tools/Cargo.toml
+++ b/crates/harnx-bash-tools/Cargo.toml
@@ -24,6 +24,7 @@ process-wrap = { workspace = true }
 rmcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+shell-words = { workspace = true }
 serde_yaml = { workspace = true }
 tempfile = "3"
 tokio = { workspace = true, features = ["fs"] }

--- a/crates/harnx-bash-tools/src/server/command.rs
+++ b/crates/harnx-bash-tools/src/server/command.rs
@@ -74,13 +74,8 @@ impl BashServer {
         // binary was missing. Logging the invocation makes the failure
         // reproducible outside harnx by pasting it into a shell.
         log::debug!(
-            "sandbox exec: {} {}",
-            sandbox_run_path.display(),
-            sb_args
-                .iter()
-                .map(|arg| shell_words::quote(&arg.to_string_lossy()).into_owned())
-                .collect::<Vec<_>>()
-                .join(" ")
+            "sandbox exec: {}",
+            redacted_invocation(&sandbox_run_path, &sb_args)
         );
         Ok(CommandWrap::with_new(sandbox_run_path, |command_wrap| {
             command_wrap
@@ -248,5 +243,92 @@ impl BashServer {
             stdout_str: String::from_utf8_lossy(&stdout_bytes).into_owned(),
             stderr_str: String::from_utf8_lossy(&stderr_bytes).into_owned(),
         })
+    }
+}
+
+/// Renders the invocation as a line that can be pasted into a shell, with
+/// `--env` values replaced by a placeholder.
+///
+/// Those values carry API keys and tokens. Quoting is not redaction: it only
+/// escapes syntax, so a token would land in the log verbatim. The command
+/// itself is kept, since reproducing it is the whole point of the line and it
+/// is the caller's own, already visible to anyone who can read this log.
+#[cfg(unix)]
+fn redacted_invocation(program: &Path, args: &[OsString]) -> String {
+    fn quote(value: &str) -> String {
+        shell_words::quote(value).into_owned()
+    }
+
+    let mut out = vec![quote(&program.to_string_lossy())];
+    let mut past_separator = false;
+    let mut env_value_next = false;
+    for arg in args {
+        if std::mem::take(&mut env_value_next) {
+            out.push(quote(&redact_env_value(arg)));
+            continue;
+        }
+        // A `--env` appearing after `--` belongs to the sandboxed command.
+        if !past_separator {
+            past_separator = arg == "--";
+            env_value_next = arg == "--env";
+        }
+        out.push(quote(&arg.to_string_lossy()));
+    }
+    out.join(" ")
+}
+
+/// `--env` also accepts a bare name, which names a variable to pass through
+/// from the ambient environment and so carries no value to hide.
+#[cfg(unix)]
+fn redact_env_value(arg: &std::ffi::OsStr) -> String {
+    let raw = arg.to_string_lossy();
+    match raw.split_once('=') {
+        Some((name, _)) => format!("{name}=<redacted>"),
+        None => raw.into_owned(),
+    }
+}
+
+#[cfg(all(test, unix))]
+mod redaction_tests {
+    use super::*;
+
+    fn args(values: &[&str]) -> Vec<OsString> {
+        values.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn env_values_are_replaced_but_their_names_survive() {
+        let line = redacted_invocation(
+            Path::new("/usr/bin/harnx-sandbox-run"),
+            &args(&["--env", "EXA_API_KEY=secret-token", "--read", "/usr"]),
+        );
+
+        assert_eq!(
+            line,
+            // The placeholder is quoted like any other value, so the line stays
+            // safe to paste.
+            "/usr/bin/harnx-sandbox-run --env 'EXA_API_KEY=<redacted>' --read /usr"
+        );
+        assert!(!line.contains("secret-token"));
+    }
+
+    #[test]
+    fn a_bare_env_name_and_the_command_are_left_alone() {
+        let line = redacted_invocation(
+            Path::new("/usr/bin/harnx-sandbox-run"),
+            &args(&["--env", "PATH", "--", "bash", "-c", "echo --env hi"]),
+        );
+
+        assert_eq!(
+            line,
+            "/usr/bin/harnx-sandbox-run --env PATH -- bash -c 'echo --env hi'"
+        );
+    }
+
+    #[test]
+    fn a_path_needing_quoting_is_quoted() {
+        let line = redacted_invocation(Path::new("/opt/my tools/run"), &args(&["--read", "/usr"]));
+
+        assert_eq!(line, "'/opt/my tools/run' --read /usr");
     }
 }

--- a/crates/harnx-bash-tools/src/server/command.rs
+++ b/crates/harnx-bash-tools/src/server/command.rs
@@ -69,6 +69,19 @@ impl BashServer {
             sb_args.push(OsString::from(command));
         }
         let sandbox_run_path = self.inner.sandbox_config.sandbox_run_path.clone();
+        // The sandbox reports its own setup failures from inside a PID
+        // namespace, where the message carries no indication of which path or
+        // binary was missing. Logging the invocation makes the failure
+        // reproducible outside harnx by pasting it into a shell.
+        log::debug!(
+            "sandbox exec: {} {}",
+            sandbox_run_path.display(),
+            sb_args
+                .iter()
+                .map(|arg| shell_words::quote(&arg.to_string_lossy()).into_owned())
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
         Ok(CommandWrap::with_new(sandbox_run_path, |command_wrap| {
             command_wrap
                 .args(&sb_args)

--- a/crates/harnx-bash-tools/src/server/tests.rs
+++ b/crates/harnx-bash-tools/src/server/tests.rs
@@ -1559,8 +1559,10 @@ mod home_filtering {
         let _home = EnvVar::set("HOME", home.path());
         let server = server_with_sandbox(vec![home.path().to_path_buf()], enabled_sandbox_config());
         let pairs = collect_arg_pairs(&server.build_sandbox_args(home.path()));
-        let home = home.path().canonicalize().expect("canonical home");
-        let home = home.to_string_lossy().into_owned();
+        // Grants are emitted as written, not resolved. On macOS a temp dir sits
+        // under /var, a symlink to /private/var, so canonicalising here would
+        // expect a path the allowlist deliberately no longer produces.
+        let home = home.path().to_string_lossy().into_owned();
 
         assert!(pairs.contains(&("--read".into(), home.clone())));
         assert!(!pairs.contains(&("--write".into(), home.clone())));
@@ -1576,7 +1578,7 @@ mod home_filtering {
         let _home = EnvVar::set("HOME", home.path());
         let server = server_with_sandbox(vec![project.clone()], enabled_sandbox_config());
         let pairs = collect_arg_pairs(&server.build_sandbox_args(&project));
-        let project = project.canonicalize().expect("canonical project");
+        // Emitted as written; see the note in home_rwx_is_downgraded_to_read_only.
         let project = project.to_string_lossy().into_owned();
 
         assert!(pairs.contains(&("--write".into(), project.clone())));

--- a/crates/harnx-tool-allow/src/allowlist.rs
+++ b/crates/harnx-tool-allow/src/allowlist.rs
@@ -141,8 +141,12 @@ mod symlink_alias_tests {
             allowlist.exec_paths()
         );
         // Checking still resolves symlinks, so a path under the grant matches
-        // even when the caller names it canonically.
-        assert!(allowlist.contains_exec(real.join("libc.so")));
+        // even when the caller names it canonically. The file has to exist:
+        // a path that does not cannot be resolved, and matching then falls back
+        // to comparing it literally.
+        let under_grant = real.join("libc.so");
+        std::fs::write(&under_grant, b"").expect("create file under the grant");
+        assert!(allowlist.contains_exec(&under_grant));
     }
 
     #[test]

--- a/crates/harnx-tool-allow/src/allowlist.rs
+++ b/crates/harnx-tool-allow/src/allowlist.rs
@@ -43,8 +43,7 @@ impl ResolvedAllowlist {
     }
 
     pub fn insert_read(&mut self, path: impl AsRef<Path>) {
-        self.read
-            .insert(canonicalize_for_containment(path.as_ref()));
+        self.read.insert(granted_path(path.as_ref()));
     }
 
     /// Inserts a write grant unless it would expose `$HOME` or an ancestor.
@@ -94,7 +93,7 @@ impl ResolvedAllowlist {
         home: Option<&Path>,
         permission: PrivilegedPermission,
     ) -> bool {
-        let path = canonicalize_for_containment(path);
+        let path = granted_path(path);
         self.read.insert(path.clone());
         if home.is_some_and(|home| home_or_ancestor(&path, home)) {
             return false;
@@ -106,6 +105,62 @@ impl ResolvedAllowlist {
             self.exec.insert(path);
         }
         true
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod symlink_alias_tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+
+    /// A sandbox mounts what the allowlist lists, and executables name their
+    /// loader by absolute path, so a symlinked grant must survive as itself.
+    /// Its target must NOT be granted: resolving here would widen the grant to
+    /// wherever the link happens to point.
+    #[test]
+    fn symlinked_directory_is_granted_as_written_and_target_is_not() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let real = temp.path().join("usr-lib64");
+        std::fs::create_dir(&real).expect("create target");
+        let link = temp.path().join("lib64");
+        symlink(&real, &link).expect("create symlink");
+
+        let mut allowlist = ResolvedAllowlist::new();
+        allowlist.insert_exec_with_home(&link, None);
+
+        let canonical = std::fs::canonicalize(&real).expect("canonical target");
+        assert!(
+            allowlist.exec_paths().contains(&link),
+            "the granted path itself is missing: {:?}",
+            allowlist.exec_paths()
+        );
+        assert!(
+            !allowlist.exec_paths().contains(&canonical),
+            "granting a symlink must not grant its target: {:?}",
+            allowlist.exec_paths()
+        );
+        // Checking still resolves symlinks, so a path under the grant matches
+        // even when the caller names it canonically.
+        assert!(allowlist.contains_exec(real.join("libc.so")));
+    }
+
+    #[test]
+    fn a_plain_directory_is_not_duplicated() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let dir = temp.path().join("plain");
+        std::fs::create_dir(&dir).expect("create dir");
+
+        let mut allowlist = ResolvedAllowlist::new();
+        allowlist.insert_read(&dir);
+
+        let canonical = std::fs::canonicalize(&dir).expect("canonical");
+        let matching = allowlist
+            .read_paths()
+            .iter()
+            .filter(|path| path.ends_with("plain"))
+            .count();
+        assert_eq!(matching, 1, "expected only {canonical:?}");
     }
 }
 
@@ -128,13 +183,42 @@ impl PrivilegedPermission {
 
 fn contains(paths: &BTreeSet<PathBuf>, path: &Path) -> bool {
     let candidate = canonicalize_for_containment(path);
-    paths.iter().any(|root| candidate.starts_with(root))
+    paths.iter().any(|root| {
+        // Literal first: grants are stored as written, and most are already
+        // canonical, so this answers without touching the filesystem.
+        candidate.starts_with(root)
+            // Then resolved, so a grant written through a symlink still matches
+            // the canonical form of a path underneath it. Resolving here rather
+            // than at insertion keeps the grant itself exactly as narrow as it
+            // was written.
+            || candidate.starts_with(canonicalize_for_containment(root))
+    })
 }
 
 pub(crate) fn home_or_ancestor(path: &Path, home: &Path) -> bool {
     let path = canonicalize_for_containment(path);
     let home = canonicalize_for_containment(home);
     home.starts_with(path)
+}
+
+/// A grant is stored exactly as asked for, only made absolute.
+///
+/// Resolving symlinks here would silently widen the grant to the target, so
+/// allowing a link inside your own directory could hand over whatever it points
+/// at. It also loses the path callers actually use: on merged-`/usr` systems
+/// `/lib64` canonicalises to `/usr/lib64`, so the sandbox never mounted
+/// `/lib64`, and every dynamically linked binary failed to exec because its
+/// loader is named absolutely as `/lib64/ld-linux-x86-64.so.2`.
+///
+/// Symlinks are still resolved when *checking* a path against these grants —
+/// see [`contains`] — which is what stops a link escaping an allowed directory.
+fn granted_path(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    std::env::current_dir()
+        .map(|cwd| cwd.join(path))
+        .unwrap_or_else(|_| path.to_path_buf())
 }
 
 pub(crate) fn canonicalize_for_containment(path: &Path) -> PathBuf {

--- a/crates/harnx-tool-allow/src/resolver.rs
+++ b/crates/harnx-tool-allow/src/resolver.rs
@@ -114,11 +114,15 @@ fn expand_home(path: &Path, home: Option<&Path>) -> PathBuf {
     let Some(home) = home else {
         return path.to_path_buf();
     };
-    let raw = path.to_string_lossy();
-    match raw.strip_prefix('~') {
-        Some("") => home.to_path_buf(),
-        Some(rest) if rest.starts_with('/') => home.join(rest.trim_start_matches('/')),
-        _ => path.to_path_buf(),
+    // Matching on components rather than on a lossy string: a path whose bytes
+    // are not valid UTF-8 would come back with replacement characters, and
+    // joining that onto the home directory names a different file. Comparing
+    // components also leaves `~user` alone for free, since `~user` is one
+    // component and does not have `~` as a prefix.
+    match path.strip_prefix("~") {
+        Ok(rest) if rest.as_os_str().is_empty() => home.to_path_buf(),
+        Ok(rest) => home.join(rest),
+        Err(_) => path.to_path_buf(),
     }
 }
 
@@ -146,6 +150,29 @@ mod tests {
         assert_eq!(
             absolute(Path::new("sub/dir"), &cwd, Some(&home)),
             cwd.join("sub/dir")
+        );
+    }
+
+    /// A filename does not have to be valid UTF-8. Converting one to a string
+    /// substitutes replacement characters, which would grant a path that is not
+    /// the one asked for.
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_bytes_under_the_home_directory_survive_expansion() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let home = PathBuf::from("/home/example");
+        let cwd = PathBuf::from("/mnt/projects/repo");
+        let written = PathBuf::from(OsStr::from_bytes(b"~/\xff\xfe-cache"));
+
+        let resolved = absolute(&written, &cwd, Some(&home));
+
+        // Byte-exact: expanding through a lossy string yields the U+FFFD
+        // encoding here instead of the original 0xff 0xfe.
+        assert_eq!(
+            resolved,
+            PathBuf::from(OsStr::from_bytes(b"/home/example/\xff\xfe-cache"))
         );
     }
 

--- a/crates/harnx-tool-allow/src/resolver.rs
+++ b/crates/harnx-tool-allow/src/resolver.rs
@@ -32,16 +32,25 @@ fn apply_explicit_inputs(
     env: &AllowEnv,
 ) {
     for path in &inputs.read {
-        resolved.insert_read(absolute(path, cwd));
+        resolved.insert_read(absolute(path, cwd, env.home.as_deref()));
     }
     for path in &inputs.write {
-        resolved.insert_write_with_home(&absolute(path, cwd), env.home.as_deref());
+        resolved.insert_write_with_home(
+            &absolute(path, cwd, env.home.as_deref()),
+            env.home.as_deref(),
+        );
     }
     for path in &inputs.exec {
-        resolved.insert_exec_with_home(&absolute(path, cwd), env.home.as_deref());
+        resolved.insert_exec_with_home(
+            &absolute(path, cwd, env.home.as_deref()),
+            env.home.as_deref(),
+        );
     }
     for path in &inputs.rwx {
-        resolved.insert_rwx_with_home(&absolute(path, cwd), env.home.as_deref());
+        resolved.insert_rwx_with_home(
+            &absolute(path, cwd, env.home.as_deref()),
+            env.home.as_deref(),
+        );
     }
 }
 
@@ -82,11 +91,34 @@ fn apply_rules(resolved: &mut ResolvedAllowlist, rules: Vec<AllowRule>, env: &Al
     }
 }
 
-fn absolute(path: &Path, cwd: &Path) -> PathBuf {
+fn absolute(path: &Path, cwd: &Path, home: Option<&Path>) -> PathBuf {
+    let path = expand_home(path, home);
     if path.is_absolute() {
-        path.to_path_buf()
+        path
     } else {
         cwd.join(path)
+    }
+}
+
+/// Expand a leading `~`, which is not a relative path.
+///
+/// Allowlist entries come from config files and command lines that no shell
+/// has touched, so a written `~/.cache` arrives literally. Treating it as
+/// relative silently produced `<cwd>/~/.cache`; the sandbox then failed to set
+/// up that nonexistent directory and reported a bare "No such file or
+/// directory" naming neither the path nor the flag it came from.
+///
+/// `~user` is left alone: resolving another account's home needs a passwd
+/// lookup, and guessing would grant access to the wrong directory.
+fn expand_home(path: &Path, home: Option<&Path>) -> PathBuf {
+    let Some(home) = home else {
+        return path.to_path_buf();
+    };
+    let raw = path.to_string_lossy();
+    match raw.strip_prefix('~') {
+        Some("") => home.to_path_buf(),
+        Some(rest) if rest.starts_with('/') => home.join(rest.trim_start_matches('/')),
+        _ => path.to_path_buf(),
     }
 }
 
@@ -94,6 +126,48 @@ fn absolute(path: &Path, cwd: &Path) -> PathBuf {
 #[cfg(unix)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn leading_tilde_resolves_against_home_not_the_working_directory() {
+        let home = PathBuf::from("/home/example");
+        let cwd = PathBuf::from("/mnt/projects/repo");
+
+        assert_eq!(
+            absolute(Path::new("~/.cache"), &cwd, Some(&home)),
+            PathBuf::from("/home/example/.cache")
+        );
+        assert_eq!(absolute(Path::new("~"), &cwd, Some(&home)), home);
+        // Absolute and genuinely relative paths keep their existing behaviour.
+        assert_eq!(
+            absolute(Path::new("/etc"), &cwd, Some(&home)),
+            PathBuf::from("/etc")
+        );
+        assert_eq!(
+            absolute(Path::new("sub/dir"), &cwd, Some(&home)),
+            cwd.join("sub/dir")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn other_users_home_and_unknown_home_are_left_alone() {
+        let cwd = PathBuf::from("/mnt/projects/repo");
+        // Resolving ~someone needs a passwd lookup; guessing could grant access
+        // to the wrong directory, so it stays relative as before.
+        assert_eq!(
+            absolute(
+                Path::new("~other/data"),
+                &cwd,
+                Some(Path::new("/home/example"))
+            ),
+            cwd.join("~other/data")
+        );
+        assert_eq!(
+            absolute(Path::new("~/.cache"), &cwd, None),
+            cwd.join("~/.cache")
+        );
+    }
 
     #[cfg(unix)]
     #[test]


### PR DESCRIPTION
Every `bash_exec` call failed with:

```
sandboxing failure: No such file or directory (os error 2)
exit_code: 1
```

No stdout, no indication of which path or which operation. Follow-up to #1379.

## Root cause

`ResolvedAllowlist` canonicalised each grant at insertion. On a merged-`/usr` system `/lib64` is a symlink to `/usr/lib64`, so the grant collapsed into an entry already present and **the sandbox never mounted `/lib64`**. Executables name their loader by absolute path:

```
$ readelf -l /usr/bin/bash
[Requesting program interpreter: /lib64/ld-linux-x86-64.so.2]
```

Inside birdcage's fresh tmpfs root that path doesn't exist, so `execve` returned ENOENT for every dynamically linked binary — reported only as the message above, since one string covers mount setup, `/proc` mounting and spawn alike.

Confirmed by bisection on the affected machine: the real 133-entry allowlist fails, and the same allowlist plus `/bin`, `/lib`, `/lib64` succeeds.

## Fix

Grants are stored exactly as written, made absolute and nothing more. Symlinks are resolved when **checking** a path against the grants, which is what stops a link escaping an allowed directory — doing it there rather than at insertion keeps each grant as narrow as it was written.

That also closes a widening bug: resolving at insertion meant allowing a symlink silently allowed whatever it pointed at, so a link inside a permitted directory could hand over its target. Anyone wanting both `/lib64` and `/usr/lib64` now lists both.

`contains` tries the literal root first, so the common case where a grant is already canonical costs no filesystem access.

## Also here

**A leading `~` in an allowlist entry** now resolves against the home directory. Config files and tool-server arguments are read without a shell, so `--allow-read ~/.config/foo` arrived literally and was treated as relative to the working directory, producing `<cwd>/~/.config/foo`. Those entries were silently granting nothing — `~/.cache` and `~/.ruff_cache` were never actually writable. `~user` is left alone, since resolving another account's home needs a passwd lookup.

**`harnx-bash-tools` logs its sandbox invocation** at debug before spawning. The sandbox reports setup failures from PID 1 inside its own namespace with no path and no operation, so the full command line is the only way to reproduce outside harnx and bisect an allowlist spanning dozens of entries. It is what found this bug.

## Regression window

Both faults arrived with `f1435b37c8` (2026-08-03), "harmonize fs and bash allowlists and deprecate roots" (#1224). `git log` on `harnx-tool-allow` shows only that commit before this branch. The previous code canonicalised its `--root` paths too, but the system defaults (`/bin`, `/lib`, `/lib64`) came from elsewhere and never passed through a canonicalising set — moving them in is what collapsed them.

## Testing

`cargo build --workspace`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` — 2397 passed. `cs delta origin/main` reports no change.

New tests cover: a symlinked grant surviving as itself, its target *not* being granted, a path underneath it still matching through resolution, plain directories not being duplicated, and tilde handling for `~/x`, bare `~`, `~user`, absolute, relative and no-home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox allowlists now support `~` and `~/...` paths using the current home directory.
  * Symlinked allowlist entries are preserved as entered while still matching resolved paths during access checks.
  * `~user` paths remain unchanged when targeting another user’s home directory.

* **Documentation**
  * Added documentation describing path expansion and symlink behavior.

* **Diagnostics**
  * Improved visibility into generated sandbox commands for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->