### PR TITLE
fix(web): move to the useAui hooks in assistant-ui 0.15

### DIFF
--- a/.changeset/assistant-ui-aui-hooks.md
+++ b/.changeset/assistant-ui-aui-hooks.md
@@ -1,0 +1,6 @@
+---
+harnx: patch
+---
+Fix the web build against `@assistant-ui/react` 0.15, which removed the `useThread`, `useMessage`, `useComposerRuntime` and `useThreadRuntime` hooks.
+
+State reads move to `useAuiState`, which takes a selector over one combined state object, so `useThread(s => s.isRunning)` becomes `useAuiState(s => s.thread.isRunning)` and `useMessage(s => s.role)` becomes `useAuiState(s => s.message.role)`. The two runtime handles come off `useAui()` instead, as `aui.composer` and `aui.thread`, and keep the same methods.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -61,7 +61,18 @@ const MessageContent = () => (
 
 const MyMessage = () => {
   const role = useAuiState((s) => s.message.role);
+  // An assistant message with no parts still gets .aui-message padding, so it
+  // shows up as a blank gap in the transcript. The promptless subscribe that
+  // hydrates a session leaves one behind: assistant-ui creates the message
+  // when the run starts, and a run carrying only a transcript snapshot never
+  // puts content in it. Streaming replies are unaffected -- they render as
+  // soon as the first part arrives.
+  const isEmpty = useAuiState(
+    (s) => s.message.role === 'assistant' && s.message.content.length === 0,
+  );
   const [systemExpanded, setSystemExpanded] = useState(false);
+
+  if (isEmpty) return null;
 
   if (role === 'system') {
     return (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,9 +4,8 @@ import {
   MessagePrimitive,
   ComposerPrimitive,
   AttachmentPrimitive,
-  useThread,
-  useComposerRuntime,
-  useMessage,
+  useAui,
+  useAuiState,
 } from '@assistant-ui/react';
 import { MarkdownTextPrimitive } from '@assistant-ui/react-markdown';
 import { makeLightAsyncSyntaxHighlighter } from '@assistant-ui/react-syntax-highlighter';
@@ -61,7 +60,7 @@ const MessageContent = () => (
 );
 
 const MyMessage = () => {
-  const role = useMessage((state) => state.role);
+  const role = useAuiState((s) => s.message.role);
   const [systemExpanded, setSystemExpanded] = useState(false);
 
   if (role === 'system') {
@@ -89,7 +88,7 @@ const MyMessage = () => {
 };
 
 const CancelButton = ({ agentName, sessionId }: { agentName: string, sessionId: string }) => {
-  const isRunning = useThread((s) => s.isRunning);
+  const isRunning = useAuiState((s) => s.thread.isRunning);
   if (!isRunning) return null;
   return (
     <button
@@ -119,8 +118,8 @@ const MyComposer = ({
   sessionId: string;
 }) => {
   const { setErrorText } = useContext(PendingContext);
-  const isRunning = useThread(s => s.isRunning);
-  const composerRuntime = useComposerRuntime();
+  const isRunning = useAuiState(s => s.thread.isRunning);
+  const composerRuntime = useAui().composer;
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const [queuedMessage, setQueuedMessage] = useState<QueuedMessage | null>(null);
 
@@ -229,7 +228,7 @@ const MyComposer = ({
 };
 
 const RunStateMonitor = ({ onRunFinish }: { onRunFinish: () => void }) => {
-  const isRunning = useThread(s => s.isRunning);
+  const isRunning = useAuiState(s => s.thread.isRunning);
   const wasRunning = useRef(isRunning);
   useEffect(() => {
     if (wasRunning.current && !isRunning) {
@@ -280,7 +279,7 @@ const UsageIndicator = ({ usage }: { usage: UsageData }) => {
 const StatusBar = () => {
   const { statusText } = useContext(PendingContext);
   const { usage } = useContext(UsageContext);
-  const isRunning = useThread(s => s.isRunning);
+  const isRunning = useAuiState(s => s.thread.isRunning);
 
   if (!isRunning && !usage && !statusText) return null;
 
@@ -346,7 +345,7 @@ const BatchInterruptUI = () => {
 };
 
 const MyThread = ({ agentName, sessionId, onRunFinish }: { agentName: string, sessionId: string, onRunFinish: () => void }) => {
-  const isEmpty = useThread(s => s.messages.length === 0);
+  const isEmpty = useAuiState(s => s.thread.messages.length === 0);
 
   return (
     <ThreadPrimitive.Root className={`aui-thread ${isEmpty ? 'aui-thread-empty' : ''}`}>

--- a/web/src/ChatProvider.tsx
+++ b/web/src/ChatProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { AssistantRuntimeProvider, useThreadRuntime } from '@assistant-ui/react';
+import { AssistantRuntimeProvider, useAui } from '@assistant-ui/react';
 import type { AttachmentAdapter } from '@assistant-ui/react';
 import { useAgUiRuntime } from '@assistant-ui/react-ag-ui';
 import { HttpAgent } from '@ag-ui/client';
@@ -20,7 +20,7 @@ export interface ChatProviderProps {
 const EMPTY_STATE = {};
 
 const RuntimeSessionSubscriber = ({ enabled }: { enabled: boolean }) => {
-  const threadRuntime = useThreadRuntime();
+  const aui = useAui();
   // The initial promptless subscribe/hydrate must fire exactly once per mount.
   // React StrictMode double-invokes mount effects in dev (and the e2e suite runs
   // against the dev server), so an unguarded startRun opens two concurrent runs
@@ -32,10 +32,10 @@ const RuntimeSessionSubscriber = ({ enabled }: { enabled: boolean }) => {
   useEffect(() => {
     if (!enabled || startedRef.current) return;
     startedRef.current = true;
-    threadRuntime.startRun({
-      parentId: threadRuntime.getState().messages.at(-1)?.id ?? null,
+    aui.thread.startRun({
+      parentId: aui.thread.getState().messages.at(-1)?.id ?? null,
     });
-  }, [enabled, threadRuntime]);
+  }, [enabled, aui]);
 
   return null;
 };


### PR DESCRIPTION
The web build and the whole e2e suite have been broken on main since `@assistant-ui/react` reached 0.15. That release removed `useThread`, `useMessage`, `useComposerRuntime` and `useThreadRuntime`, and nothing replaced them, so `tsc -b` fails and the app throws at import time:

```
src/App.tsx(7,3): error TS2305: Module '"@assistant-ui/react"' has no exported member 'useThread'.
[vite] SyntaxError: The requested module '@assistant-ui/react' does not provide an export named 'useThreadRuntime'
```

#1380 was merged with `Web Build: FAILURE`, and #1383, #1384 and #1387 have failed the same way since. Other PRs look green only because the paths filter skips the web jobs when they don't touch `web/`. E2E on main is 30/30 failing.

Two commits:

**1. Move to the `useAui` hooks.** State reads go through `useAuiState`, which selects from one combined state object instead of a per-scope one:

- `useThread(s => s.isRunning)` → `useAuiState(s => s.thread.isRunning)`
- `useMessage(s => s.role)` → `useAuiState(s => s.message.role)`

The runtime handles come off `useAui()` as `aui.composer` and `aui.thread`, with the methods used here (`setText`, `send`, `clearAttachments`, `getState`, `startRun`) unchanged. The six `implicit any` errors were fallout from the removed hooks' selector parameters losing their types.

**2. Stop rendering the empty assistant message left by hydration.** With the build fixed, four gallery tests still failed, counting one more `.aui-message` than expected. 0.15 creates the assistant message when a run starts, and the promptless subscribe that loads a transcript carries only a `MESSAGES_SNAPSHOT`, so nothing is ever added to it. `.aui-message` has its own padding, so it renders as a blank gap above the composer — a real visual bug, not just a test artifact. `startRun` was verified to fire exactly once, ruling out a double-subscribe.

Verified locally: `pnpm build`, `pnpm lint`, `pnpm test` (42 passing), and `pnpm test:e2e` — **30/30 passing**, against 30/30 failing on main.

Unblocks #1287 and #1158.