### PR TITLE
refactor(runtime): lock files with std instead of fs4

### DIFF
--- a/.changeset/drop-fs4-std-file-locks.md
+++ b/.changeset/drop-fs4-std-file-locks.md
@@ -1,0 +1,6 @@
+---
+harnx: patch
+---
+Drop the `fs4` dependency and lock files through `std::fs::File` instead.
+
+`File::try_lock` and `File::unlock` were stabilised in Rust 1.89, and the inherent methods shadow `fs4`'s extension trait, so the crate was already being bypassed at every call site. Contention and I/O errors now arrive as one `TryLockError`, and a small helper keeps them apart: another process holding the lock makes this one a follower, while an I/O error has to surface rather than be read as a lost election.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,16 +2181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs4"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
-dependencies = [
- "rustix 1.1.4",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4038,7 +4028,6 @@ dependencies = [
  "duct",
  "fancy-regex 0.19.0",
  "filetime",
- "fs4",
  "futures-util",
  "fuzzy-matcher",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ axum = "0.8"
 clap = { version = "4.4.8", features = ["derive"] }
 dirs = "6.0.0"
 futures-util = "0.3.29"
-fs4 = "0.13.1"
 inquire = "0.9.0"
 is-terminal = "0.4.9"
 ratatui = { version = "0.30.1", features = ["crossterm_0_29", "unstable-rendered-line-info"] }

--- a/crates/harnx-runtime/Cargo.toml
+++ b/crates/harnx-runtime/Cargo.toml
@@ -26,7 +26,6 @@ duct = { workspace = true }
 fancy-regex = { workspace = true }
 fuzzy-matcher = { workspace = true }
 futures-util = { workspace = true }
-fs4 = { workspace = true }
 globset = { workspace = true }
 harnx-client = { path = "../harnx-client" }
 harnx-core = { path = "../harnx-core" }

--- a/crates/harnx-runtime/src/file_lock.rs
+++ b/crates/harnx-runtime/src/file_lock.rs
@@ -1,0 +1,40 @@
+//! Advisory file locking for the local worker and shared NATS server elections.
+
+use std::fs::File;
+use std::fs::TryLockError;
+use std::io;
+
+/// Take the exclusive lock if it is free, reporting contention as `Ok(false)`.
+///
+/// `try_lock` returns one `Err` for two outcomes that mean opposite things to
+/// an election. Another process already holding the lock is the ordinary path:
+/// this process loses and becomes a follower. An I/O error means the attempt
+/// never resolved, and treating it as a loss would leave the caller waiting on
+/// an owner that does not exist.
+pub(crate) fn try_lock_exclusive(file: &File) -> io::Result<bool> {
+    match file.try_lock() {
+        Ok(()) => Ok(true),
+        Err(TryLockError::WouldBlock) => Ok(false),
+        Err(TryLockError::Error(err)) => Err(err),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_free_lock_is_acquired_and_a_held_one_reports_contention() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("election.lock");
+        let held = File::create(&path).expect("create lock file");
+        assert!(try_lock_exclusive(&held).expect("first attempt"));
+
+        // A second handle to the same file stands in for the second process.
+        let contender = File::open(&path).expect("reopen lock file");
+        assert!(!try_lock_exclusive(&contender).expect("contended attempt"));
+
+        held.unlock().expect("release lock");
+        assert!(try_lock_exclusive(&contender).expect("attempt after release"));
+    }
+}

--- a/crates/harnx-runtime/src/lib.rs
+++ b/crates/harnx-runtime/src/lib.rs
@@ -16,6 +16,7 @@ pub mod bootstrap;
 pub mod client;
 pub mod commands;
 pub mod config;
+mod file_lock;
 pub mod local_orchestrator;
 pub mod nats_admin;
 pub mod nats_client_session;

--- a/crates/harnx-runtime/src/local_orchestrator.rs
+++ b/crates/harnx-runtime/src/local_orchestrator.rs
@@ -7,7 +7,6 @@ use crate::config::{HARNX_NATS_TOKEN_ENV, HARNX_NATS_URL_ENV, LOCAL_CLUSTER_KEY}
 use crate::nats_local_server::{ensure_shared_server, SharedNatsServer};
 use crate::nats_worker::worker_ready_subject;
 use anyhow::{bail, Context, Result};
-use fs4::fs_std::FileExt;
 use futures_util::StreamExt;
 use harnx_core::abort::AbortSignal;
 use harnx_core::config_paths::{nats_runtime_dir, state_path};
@@ -109,8 +108,7 @@ impl LocalWorkerSupervisor {
             .canonicalize()
             .with_context(|| format!("resolve worker binary {}", binary.as_ref().display()))?;
         let lock_file = open_worker_lock()?;
-        let owns_lock = lock_file
-            .try_lock_exclusive()
+        let owns_lock = crate::file_lock::try_lock_exclusive(&lock_file)
             .context("acquire local worker lock")?;
         let mut supervisor = Self {
             server,
@@ -170,12 +168,12 @@ impl LocalWorkerSupervisor {
             }
             return Ok(());
         }
-        let acquired = self
-            .lock_file
-            .as_ref()
-            .expect("worker lock file must exist while supervisor is alive")
-            .try_lock_exclusive()
-            .context("retry local worker lock")?;
+        let acquired = crate::file_lock::try_lock_exclusive(
+            self.lock_file
+                .as_ref()
+                .expect("worker lock file must exist while supervisor is alive"),
+        )
+        .context("retry local worker lock")?;
         if acquired {
             self.owns_lock = true;
             self.spawn_worker()?;

--- a/crates/harnx-runtime/src/nats_local_server.rs
+++ b/crates/harnx-runtime/src/nats_local_server.rs
@@ -5,7 +5,6 @@
 //! details through an atomically replaced metadata file.
 
 use anyhow::{bail, Context, Result};
-use fs4::fs_std::FileExt;
 use harnx_core::config_paths::{
     nats_runtime_dir, nats_runtime_lock_file, nats_runtime_ports_file, nats_runtime_store_dir,
 };
@@ -104,8 +103,7 @@ pub async fn ensure_shared_server() -> Result<SharedNatsServer> {
     let deadline = Instant::now() + STARTUP_TIMEOUT;
 
     loop {
-        if lock_file
-            .try_lock_exclusive()
+        if crate::file_lock::try_lock_exclusive(&lock_file)
             .context("failed to acquire shared local NATS lock")?
         {
             return start_owned_server(lock_file).await;


### PR DESCRIPTION
Closes #1262 — that PR bumps `fs4` to v1, which can't be applied as written.

fs4 1.0 renames `try_lock_exclusive` to `try_lock`, which collides with `std::fs::File::try_lock`, stabilised in Rust 1.89. The inherent method wins overload resolution, so `file.try_lock()` calls std no matter which fs4 version is in the tree, and the bump fails to compile against `fs4::fs_std::FileExt`, a module 1.0 removed. Both call sites were already reaching std; the dependency wasn't doing anything.

So this removes `fs4` rather than bumping it.

The one thing worth looking at is the error handling. Both callers need three outcomes — lock taken, lock held elsewhere, attempt failed — and `try_lock` folds the last two into a single `Err`. Those mean opposite things in an election: a held lock makes this process a follower and is the normal path, while an I/O error means no election happened and the caller would otherwise sit waiting on an owner that doesn't exist. `file_lock::try_lock_exclusive` splits them back out and returns the same `bool` the call sites used before, so the local worker and shared NATS server elections keep their existing behaviour.

Verified with the full pipeline from AGENTS.md: `cargo build --workspace`, `fmt --check`, `clippy --all-targets -D warnings`, and `nextest run --workspace` (2402 passing, one new test covering acquire / contend / release).