### PR TITLE
chore(deps): migrate to rmcp 3

### DIFF
--- a/.changeset/rmcp-v3.md
+++ b/.changeset/rmcp-v3.md
@@ -1,0 +1,6 @@
+---
+harnx: patch
+---
+Update `rmcp` to 3.x.
+
+The MCP server trait now returns `CallToolResponse`, an enum whose other variants cover elicitation and long-running tasks. Every server here answers in one step, so tool dispatch moved to its own method returning a plain `CallToolResult` and `call_tool` converts. `ListToolsResult` gained the SEP-2549 caching fields and is built with `ListToolsResult::with_all_items`, which fills them in and marks the result complete. `Meta` is now `MetaObject`, and `StreamableHttpServerConfig::with_stateful_mode` is `with_legacy_session_mode`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7073,12 +7073,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "futures",
@@ -7106,9 +7106,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ which = "8.0.0"
 fuzzy-matcher = "0.3.7"
 terminal-colorsaurus = "1.0.3"
 duct = "1.0.0"
-rmcp = { version = "2.0", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server", "transport-streamable-http-client-reqwest"] }
+rmcp = { version = "3.0", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-server", "transport-streamable-http-client-reqwest"] }
 process-wrap = { version = "9", features = ["tokio1"] }
 libc = "0.2"
 async-nats = { version = "0.50", default-features = false, features = ["server_2_10", "server_2_11", "ring", "jetstream", "kv"] }

--- a/crates/harnx-bash-tools/src/server/handler.rs
+++ b/crates/harnx-bash-tools/src/server/handler.rs
@@ -18,16 +18,14 @@ impl ServerHandler for BashServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
-        Ok(ListToolsResult {
-            meta: None,
-            tools: vec![
+        Ok(ListToolsResult::with_all_items(vec![
                 Tool::new(
                     "exec",
                     "Execute a command and return truncated combined stdout/stderr. When output is cropped, stdout/stderr temp log files are included for later retrieval. Prefer head_lines/tail_lines/max_output_bytes params over piping to head/tail in the command string. Supports shebang lines: if the command starts with #!, the script is written to a temp file and executed with the named interpreter (python3, node, ruby, etc.) — prefer this over python3 -c or node -e for multi-line scripts.",
                     Map::new(),
                 )
                 .with_input_schema::<ExecCommandParams>()
-                .with_meta(Meta(json!({
+                .with_meta(MetaObject(json!({
                     "call_template": "```{{ args.command | shebang_lang }}\n$ {{ args.command | strip_shebang }}\n```{% if args.working_dir or args.timeout_secs or args.head_lines or args.tail_lines or args.max_output_bytes %}\n{% if args.working_dir %}({{ args.working_dir }}) {% endif %}{% if args.timeout_secs %}[{{ args.timeout_secs }}s] {% endif %}{% if args.head_lines is not none %}[head:{{ args.head_lines }}] {% endif %}{% if args.tail_lines is not none %}[tail_lines:{{ args.tail_lines }}] {% endif %}{% if args.max_output_bytes is not none %}[:{{ args.max_output_bytes }}b] {% endif %}{% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
@@ -36,7 +34,7 @@ impl ServerHandler for BashServer {
                     Map::new(),
                 )
                 .with_input_schema::<ReadExecLogParams>()
-                .with_meta(Meta(json!({
+                .with_meta(MetaObject(json!({
                     "call_template": "📋 log {{ args.execution_id }}/{{ args.stream }}{% if args.grep %} /{{ args.grep }}/{% endif %}{% if args.offset %} +{{ args.offset }}{% endif %}{% if args.limit %} [:{{ args.limit }}]{% endif %}{% if args.tail %} [tail:{{ args.tail }}]{% endif %}{% if args.head_lines is not none %} [head:{{ args.head_lines }}]{% endif %}{% if args.tail_lines is not none %} [tail_lines:{{ args.tail_lines }}]{% endif %}{% if args.max_output_bytes is not none %} [:{{ args.max_output_bytes }}b]{% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
@@ -45,7 +43,7 @@ impl ServerHandler for BashServer {
                     Map::new(),
                 )
                 .with_input_schema::<SpawnCommandParams>()
-                .with_meta(Meta(json!({
+                .with_meta(MetaObject(json!({
                     "call_template": "```{{ args.command | shebang_lang }}\n$ {{ args.command | strip_shebang }} &\n```{% if args.working_dir %}\n({{ args.working_dir }}) {% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
@@ -54,7 +52,7 @@ impl ServerHandler for BashServer {
                     Map::new(),
                 )
                 .with_input_schema::<WaitParams>()
-                .with_meta(Meta(json!({
+                .with_meta(MetaObject(json!({
                     "call_template": "⏳ wait {{ args.execution_id }}{% if args.timeout_secs %} [{{ args.timeout_secs }}s]{% endif %}{% if args.grep %} /{{ args.grep }}/{% endif %}{% if args.head_lines %} [head:{{ args.head_lines }}]{% endif %}{% if args.tail_lines %} [tail:{{ args.tail_lines }}]{% endif %}{% if args.max_output_bytes %} [:{{ args.max_output_bytes }}b]{% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
@@ -63,7 +61,7 @@ impl ServerHandler for BashServer {
                     Map::new(),
                 )
                 .with_input_schema::<TerminateParams>()
-                .with_meta(Meta(json!({
+                .with_meta(MetaObject(json!({
                     "call_template": "🛑 kill {{ args.execution_id }}{% if args.signal %} ({{ args.signal }}){% endif %}",
                 }).as_object().unwrap().clone())),
                 Tool::new(
@@ -72,15 +70,33 @@ impl ServerHandler for BashServer {
                     Map::new(),
                 )
                 .with_input_schema::<RollbackParams>()
-                .with_meta(Meta(json!({
+                .with_meta(MetaObject(json!({
                     "call_template": "⏪ rollback {{ args.commit_id | truncate(8, end='') }}{% if args.repo_path %} @ {{ args.repo_path }}{% endif %}",
                 }).as_object().unwrap().clone())),
-            ],
-            next_cursor: None,
-        })
+            ]))
     }
 
     async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        self.dispatch_call_tool(request, _context)
+            .await
+            .map(Into::into)
+    }
+
+    async fn on_roots_list_changed(&self, _context: NotificationContext<RoleServer>) {}
+}
+
+impl BashServer {
+    /// The tool dispatch, which always finishes in a single step.
+    ///
+    /// `call_tool` must return `CallToolResponse`, whose other variants cover
+    /// elicitation and long-running tasks that this server does not use.
+    /// Dispatching separately keeps every arm returning a plain
+    /// `CallToolResult`.
+    async fn dispatch_call_tool(
         &self,
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,
@@ -116,6 +132,4 @@ impl ServerHandler for BashServer {
             )),
         }
     }
-
-    async fn on_roots_list_changed(&self, _context: NotificationContext<RoleServer>) {}
 }

--- a/crates/harnx-bash-tools/src/server/mod.rs
+++ b/crates/harnx-bash-tools/src/server/mod.rs
@@ -15,8 +15,9 @@ use process_wrap::tokio::JobObject;
 use process_wrap::tokio::ProcessGroup;
 use process_wrap::tokio::{ChildWrapper, CommandWrap, KillOnDrop};
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ContentBlock, ErrorData, Implementation,
-    ListToolsResult, Meta, PaginatedRequestParams, Role, ServerCapabilities, ServerInfo, Tool,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
+    Implementation, ListToolsResult, MetaObject, PaginatedRequestParams, Role, ServerCapabilities,
+    ServerInfo, Tool,
 };
 use rmcp::schemars::{generate::SchemaGenerator, JsonSchema, Schema};
 use rmcp::service::{NotificationContext, RequestContext, RoleServer};

--- a/crates/harnx-fs-tools/src/server/handler.rs
+++ b/crates/harnx-fs-tools/src/server/handler.rs
@@ -61,14 +61,28 @@ impl ServerHandler for FsServer {
                     .with_meta(make_tool_meta("⏪ rollback {{ args.commit_id | truncate(8, end='') }}{% if args.repo_path %} @ {{ args.repo_path }}{% endif %}")),
             ];
 
-        Ok(ListToolsResult {
-            meta: None,
-            tools,
-            next_cursor: None,
-        })
+        Ok(ListToolsResult::with_all_items(tools))
     }
 
     async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        self.dispatch_call_tool(request, _context)
+            .await
+            .map(Into::into)
+    }
+}
+
+impl FsServer {
+    /// The tool dispatch, which always finishes in a single step.
+    ///
+    /// `call_tool` must return `CallToolResponse`, whose other variants cover
+    /// elicitation and long-running tasks that this server does not use.
+    /// Dispatching separately keeps every arm returning a plain
+    /// `CallToolResult`.
+    async fn dispatch_call_tool(
         &self,
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,

--- a/crates/harnx-fs-tools/src/server/mod.rs
+++ b/crates/harnx-fs-tools/src/server/mod.rs
@@ -14,9 +14,9 @@ use harnx_toolset_server::schema::object_schema_with_desc;
 
 use fancy_regex::Regex;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ContentBlock, ErrorData, Implementation,
-    ListToolsResult, Meta, PaginatedRequestParams, Role, ServerCapabilities, ServerInfo, Tool,
-    ToolAnnotations,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
+    Implementation, ListToolsResult, MetaObject, PaginatedRequestParams, Role, ServerCapabilities,
+    ServerInfo, Tool, ToolAnnotations,
 };
 use rmcp::schemars::{generate::SchemaGenerator, JsonSchema, Schema};
 use rmcp::service::{RequestContext, RoleServer};
@@ -56,8 +56,8 @@ pub struct FsServer {
 /// audience-aware renderer (`extract_user_display_text`), which surfaces
 /// every user-audience and unaudienced content block. That includes the
 /// history diff that mutating tools append after the summary.
-fn make_tool_meta(call_template: &str) -> Meta {
-    Meta(
+fn make_tool_meta(call_template: &str) -> MetaObject {
+    MetaObject(
         json!({ "call_template": call_template })
             .as_object()
             .unwrap()

--- a/crates/harnx-grep-tools/src/server/handler.rs
+++ b/crates/harnx-grep-tools/src/server/handler.rs
@@ -1,7 +1,7 @@
 use rmcp::model::{
-    CallToolRequestMethod, CallToolRequestParams, CallToolResult, ContentBlock, ErrorData,
-    Implementation, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
-    ToolAnnotations,
+    CallToolRequestMethod, CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock,
+    ErrorData, Implementation, ListToolsResult, PaginatedRequestParams, ServerCapabilities,
+    ServerInfo, Tool, ToolAnnotations,
 };
 use rmcp::service::{RequestContext, RoleServer};
 use rmcp::ServerHandler;
@@ -79,14 +79,28 @@ impl ServerHandler for GrepServer {
                 .open_world(true),
         );
 
-        Ok(ListToolsResult {
-            meta: None,
-            tools: vec![grep_query],
-            next_cursor: None,
-        })
+        Ok(ListToolsResult::with_all_items(vec![grep_query]))
     }
 
     async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        self.dispatch_call_tool(request, _context)
+            .await
+            .map(Into::into)
+    }
+}
+
+impl GrepServer {
+    /// The tool dispatch, which always finishes in a single step.
+    ///
+    /// `call_tool` must return `CallToolResponse`, whose other variants cover
+    /// elicitation and long-running tasks that this server does not use.
+    /// Dispatching separately keeps every arm returning a plain
+    /// `CallToolResult`.
+    async fn dispatch_call_tool(
         &self,
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,

--- a/crates/harnx-mcp-bridge/src/lib.rs
+++ b/crates/harnx-mcp-bridge/src/lib.rs
@@ -659,7 +659,7 @@ mod tests {
 
     #[test]
     fn maps_child_tool_meta_into_tool_spec() {
-        let meta = rmcp::model::Meta(
+        let meta = rmcp::model::MetaObject(
             serde_json::json!({ "call_template": "Running {{name}}" })
                 .as_object()
                 .expect("meta object")

--- a/crates/harnx-mcp-plans-core/src/server/handler.rs
+++ b/crates/harnx-mcp-plans-core/src/server/handler.rs
@@ -29,61 +29,75 @@ impl<S: PlanStore + 'static> ServerHandler for PlansServer<S> {
         let mut tools = vec![
                 Tool::new("list_plans", "List all plans with metadata and task/note counts.", Map::new())
                     .with_input_schema::<ListPlansParams>()
-                    .with_meta(Meta(json!({"call_template": "list plans", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "list plans", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("add_plan", "Create a new plan with optional metadata. Set body with content (or body for compatibility). Keep body content under 1000 words per call; use update_plan with replace_in_content for targeted edits.", Map::new())
                     .with_input_schema::<AddPlanParams>()
-                    .with_meta(Meta(json!({"call_template": "create plan {{ args.name }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.git_branch %} [{{ args.git_branch }}]{% endif %}{% if args.github_owner_repo %} ({{ args.github_owner_repo }}){% endif %}{% if args.content %}\n{{ args.content | truncate(80) }}{% elif args.body %}\n{{ args.body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "create plan {{ args.name }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.git_branch %} [{{ args.git_branch }}]{% endif %}{% if args.github_owner_repo %} ({{ args.github_owner_repo }}){% endif %}{% if args.content %}\n{{ args.content | truncate(80) }}{% elif args.body %}\n{{ args.body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("get_plan", "Read plan metadata, body, and list task/note IDs.", Map::new())
                     .with_input_schema::<GetPlanParams>()
-                    .with_meta(Meta(json!({"call_template": "read plan {{ args.name }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "read plan {{ args.name }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("update_plan", "Update plan body and metadata. Creates plan if it doesn't exist. Use content or replace_content to rewrite body, append_content to extend it, or replace_in_content for surgical edits. Provide at most one body-edit parameter. Optionally batch-create tasks. Keep each write under 1000 words.", Map::new())
                     .with_input_schema::<UpdatePlanParams>()
-                    .with_meta(Meta(json!({"call_template": "update plan {{ args.name }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.git_branch %} [{{ args.git_branch }}]{% endif %}{% if args.github_owner_repo %} ({{ args.github_owner_repo }}){% endif %}{% if args.tasks %} [{{ args.tasks | length }} tasks]{% endif %}{% if args.content %}\n{{ args.content | truncate(80) }}{% elif args.replace_content %}\n{{ args.replace_content | truncate(80) }}{% endif %}{% if args.append_content %}\n+{{ args.append_content | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "update plan {{ args.name }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.git_branch %} [{{ args.git_branch }}]{% endif %}{% if args.github_owner_repo %} ({{ args.github_owner_repo }}){% endif %}{% if args.tasks %} [{{ args.tasks | length }} tasks]{% endif %}{% if args.content %}\n{{ args.content | truncate(80) }}{% elif args.replace_content %}\n{{ args.replace_content | truncate(80) }}{% endif %}{% if args.append_content %}\n+{{ args.append_content | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("delete_plan", "Delete an entire plan and all its tasks and notes.", Map::new())
                     .with_input_schema::<DeletePlanParams>()
-                    .with_meta(Meta(json!({"call_template": "delete plan {{ args.name }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "delete plan {{ args.name }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("list_tasks", "List tasks in a plan with optional filters.", Map::new())
                     .with_input_schema::<ListTasksParams>()
-                    .with_meta(Meta(json!({"call_template": "list tasks {{ args.plan }}{% if args.filter and args.filter != 'open' %} [{{ args.filter }}]{% endif %}{% if args.tag %} #{{ args.tag }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "list tasks {{ args.plan }}{% if args.filter and args.filter != 'open' %} [{{ args.filter }}]{% endif %}{% if args.tag %} #{{ args.tag }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("add_task", "Create a task in a plan. Keep body under 1000 words; use update_task with replace_in_body for targeted edits.", Map::new())
                     .with_input_schema::<AddTaskParams>()
-                    .with_meta(Meta(json!({"call_template": "create task {{ args.plan }}/{{ args.title }}{% if args.status %} [{{ args.status }}]{% endif %}{% if args.assignee %} @{{ args.assignee }}{% endif %}{% if args.executor %} ▶{{ args.executor }}{% endif %}{% if args.tags %} #{{ args.tags | join(' #') }}{% endif %}{% if args.body %}\n{{ args.body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "create task {{ args.plan }}/{{ args.title }}{% if args.status %} [{{ args.status }}]{% endif %}{% if args.assignee %} @{{ args.assignee }}{% endif %}{% if args.executor %} ▶{{ args.executor }}{% endif %}{% if args.tags %} #{{ args.tags | join(' #') }}{% endif %}{% if args.body %}\n{{ args.body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("get_task", "Read a task by ID within a plan.", Map::new())
                     .with_input_schema::<GetTaskParams>()
-                    .with_meta(Meta(json!({"call_template": "read task {{ args.plan }}/{{ args.id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "read task {{ args.plan }}/{{ args.id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("update_task", "Update a task within its plan. Use replace_body to rewrite body, append_body to extend it, or replace_in_body for surgical edits. Keep each write under 1000 words.", Map::new())
                     .with_input_schema::<UpdateTaskParams>()
-                    .with_meta(Meta(json!({"call_template": "update task {{ args.plan }}/{{ args.id }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.status %} [{{ args.status }}]{% endif %}{% if args.assignee %} @{{ args.assignee }}{% endif %}{% if args.executor %} ▶{{ args.executor }}{% endif %}{% if args.tags %} #{{ args.tags | join(' #') }}{% endif %}{% if args.replace_body %}\n{{ args.replace_body | truncate(80) }}{% endif %}{% if args.append_body %}\n+{{ args.append_body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "update task {{ args.plan }}/{{ args.id }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.status %} [{{ args.status }}]{% endif %}{% if args.assignee %} @{{ args.assignee }}{% endif %}{% if args.executor %} ▶{{ args.executor }}{% endif %}{% if args.tags %} #{{ args.tags | join(' #') }}{% endif %}{% if args.replace_body %}\n{{ args.replace_body | truncate(80) }}{% endif %}{% if args.append_body %}\n+{{ args.append_body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("delete_task", "Delete a task by ID.", Map::new())
                     .with_input_schema::<DeleteTaskParams>()
-                    .with_meta(Meta(json!({"call_template": "delete task {{ args.plan }}/{{ args.id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "delete task {{ args.plan }}/{{ args.id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("list_notes", "List notes for a plan.", Map::new())
                     .with_input_schema::<ListNotesParams>()
-                    .with_meta(Meta(json!({"call_template": "list notes {{ args.plan }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "list notes {{ args.plan }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("add_note", "Add a note to a plan. Keep body under 1000 words; use update_note with replace_in_body for targeted edits.", Map::new())
                     .with_input_schema::<AddNoteParams>()
-                    .with_meta(Meta(json!({"call_template": "add note {{ args.plan }}{% if args.summary %} — {{ args.summary | truncate(60) }}{% endif %}{% if args.author %} by {{ args.author }}{% endif %}{% if args.body %}\n{{ args.body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "add note {{ args.plan }}{% if args.summary %} — {{ args.summary | truncate(60) }}{% endif %}{% if args.author %} by {{ args.author }}{% endif %}{% if args.body %}\n{{ args.body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("get_note", "Read a note from a plan.", Map::new())
                     .with_input_schema::<GetNoteParams>()
-                    .with_meta(Meta(json!({"call_template": "read note {{ args.plan }}/{{ args.note_id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "read note {{ args.plan }}/{{ args.note_id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("update_note", "Update a note within a plan. Use replace_body, append_body, or replace_in_body for body edits. Keep each write under 1000 words.", Map::new())
                     .with_input_schema::<UpdateNoteParams>()
-                    .with_meta(Meta(json!({"call_template": "update note {{ args.plan }}/{{ args.note_id }}{% if args.summary %} — {{ args.summary | truncate(60) }}{% endif %}{% if args.replace_body %}\n{{ args.replace_body | truncate(80) }}{% endif %}{% if args.append_body %}\n+{{ args.append_body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "update note {{ args.plan }}/{{ args.note_id }}{% if args.summary %} — {{ args.summary | truncate(60) }}{% endif %}{% if args.replace_body %}\n{{ args.replace_body | truncate(80) }}{% endif %}{% if args.append_body %}\n+{{ args.append_body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("delete_note", "Delete a note from a plan.", Map::new())
                     .with_input_schema::<DeleteNoteParams>()
-                    .with_meta(Meta(json!({"call_template": "delete note {{ args.plan }}/{{ args.note_id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "delete note {{ args.plan }}/{{ args.note_id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
             ];
         for tool in &mut tools {
             self.meta.target_policy.apply_to_tool_schema(tool);
         }
-        Ok(ListToolsResult {
-            meta: None,
-            tools,
-            next_cursor: None,
-        })
+        Ok(ListToolsResult::with_all_items(tools))
     }
 
     async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        self.dispatch_call_tool(request, _context)
+            .await
+            .map(Into::into)
+    }
+}
+
+impl<S: PlanStore + 'static> PlansServer<S> {
+    /// The tool dispatch, which always finishes in a single step.
+    ///
+    /// `call_tool` must return `CallToolResponse`, whose other variants cover
+    /// elicitation and long-running tasks that this server does not use.
+    /// Dispatching separately keeps every arm returning a plain
+    /// `CallToolResult`.
+    async fn dispatch_call_tool(
         &self,
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,

--- a/crates/harnx-mcp-plans-core/src/server/mod.rs
+++ b/crates/harnx-mcp-plans-core/src/server/mod.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 
 use jiff::Timestamp;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ContentBlock, ErrorData, Implementation,
-    ListToolsResult, Meta, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
+    Implementation, ListToolsResult, MetaObject, PaginatedRequestParams, ServerCapabilities,
+    ServerInfo, Tool,
 };
 use rmcp::schemars::{generate::SchemaGenerator, JsonSchema, Schema};
 use rmcp::service::{RequestContext, RoleServer};

--- a/crates/harnx-mcp-plans-github/src/runtime.rs
+++ b/crates/harnx-mcp-plans-github/src/runtime.rs
@@ -182,7 +182,7 @@ async fn run_http(store: Arc<GitHubPlanStore>, config: AppConfig) -> Result<()> 
     let ct = CancellationToken::new();
     let factory_store = store.clone();
     let server_config = StreamableHttpServerConfig::default()
-        .with_stateful_mode(false)
+        .with_legacy_session_mode(false)
         .with_json_response(true)
         .with_cancellation_token(ct.child_token());
     let service_default_repo = default_repo.clone();

--- a/crates/harnx-mcp-remote/src/server.rs
+++ b/crates/harnx-mcp-remote/src/server.rs
@@ -1,8 +1,9 @@
 use parking_lot::RwLock;
 use rmcp::handler::server::ServerHandler;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ErrorData, InitializeRequestParams, ListPromptsResult,
-    ListResourcesResult, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ErrorData, InitializeRequestParams,
+    ListPromptsResult, ListResourcesResult, ListToolsResult, PaginatedRequestParams,
+    ServerCapabilities, ServerInfo,
 };
 use rmcp::service::{RequestContext, RoleClient, RoleServer, RunningService};
 use rmcp::Peer;
@@ -75,10 +76,17 @@ impl ServerHandler for RemoteProxyServer {
             .await
             .map_err(|err| ErrorData::internal_error(err.to_string(), None))?;
         let peer = service.peer().clone();
-        let mut info = peer
-            .peer_info()
-            .map(|info| (*info).clone())
-            .unwrap_or_else(|| self.get_info());
+        // Forward what the remote negotiated, but answer under this proxy's own
+        // identity. `peer_info` reports the identity as optional because a
+        // discovery response need not carry one; it is dropped either way, so
+        // only the negotiated fields are copied across.
+        let mut info = self.get_info();
+        if let Some(peer_info) = peer.peer_info() {
+            info.protocol_version = peer_info.protocol_version.clone();
+            info.capabilities = peer_info.capabilities.clone();
+            info.instructions = peer_info.instructions.clone();
+            info.meta = peer_info.meta.clone();
+        }
         info.server_info =
             rmcp::model::Implementation::new("harnx-mcp-remote", env!("CARGO_PKG_VERSION"));
         *self.peer.write() = Some(peer);
@@ -99,9 +107,10 @@ impl ServerHandler for RemoteProxyServer {
         &self,
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, ErrorData> {
-        let peer = self.peer()?;
-        peer.call_tool(request).await.map_err(proxy_error)
+    ) -> Result<CallToolResponse, ErrorData> {
+        self.dispatch_call_tool(request, _context)
+            .await
+            .map(Into::into)
     }
 
     async fn list_prompts(
@@ -120,5 +129,22 @@ impl ServerHandler for RemoteProxyServer {
     ) -> Result<ListResourcesResult, ErrorData> {
         let peer = self.peer()?;
         peer.list_resources(request).await.map_err(proxy_error)
+    }
+}
+
+impl RemoteProxyServer {
+    /// The tool dispatch, which always finishes in a single step.
+    ///
+    /// `call_tool` must return `CallToolResponse`, whose other variants cover
+    /// elicitation and long-running tasks that this server does not use.
+    /// Dispatching separately keeps every arm returning a plain
+    /// `CallToolResult`.
+    async fn dispatch_call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let peer = self.peer()?;
+        peer.call_tool(request).await.map_err(proxy_error)
     }
 }

--- a/crates/harnx-mcp-remote/tests/common.rs
+++ b/crates/harnx-mcp-remote/tests/common.rs
@@ -117,7 +117,7 @@ pub async fn spawn_http_test_server(
 ) -> Result<HttpTestServerHandle> {
     let shutdown = CancellationToken::new();
     let config = StreamableHttpServerConfig::default()
-        .with_stateful_mode(false)
+        .with_legacy_session_mode(false)
         .with_json_response(true)
         .with_cancellation_token(shutdown.child_token())
         .disable_allowed_hosts();
@@ -156,7 +156,7 @@ pub async fn spawn_http_test_server(
 pub async fn spawn_auth_guard_server(expected_auth: &'static str) -> Result<HttpTestServerHandle> {
     let shutdown = CancellationToken::new();
     let config = StreamableHttpServerConfig::default()
-        .with_stateful_mode(false)
+        .with_legacy_session_mode(false)
         .with_json_response(true)
         .with_cancellation_token(shutdown.child_token())
         .disable_allowed_hosts();

--- a/crates/harnx-mcp-time/src/main.rs
+++ b/crates/harnx-mcp-time/src/main.rs
@@ -100,7 +100,7 @@ async fn run_http(args: Args) -> anyhow::Result<()> {
     let Args { host, port, .. } = args;
     let ct = CancellationToken::new();
     let config = StreamableHttpServerConfig::default()
-        .with_stateful_mode(false)
+        .with_legacy_session_mode(false)
         .with_json_response(true)
         .with_cancellation_token(ct.child_token())
         // Empty allowlist = accept any Host header. Required so external

--- a/crates/harnx-mcp-time/src/server.rs
+++ b/crates/harnx-mcp-time/src/server.rs
@@ -2,9 +2,9 @@ use chrono::{Datelike, Offset, TimeZone, Utc};
 use chrono_tz::Tz;
 use jiff::{civil, Span, Timestamp};
 use rmcp::model::{
-    Annotations, CallToolRequestParams, CallToolResult, ContentBlock, ErrorData, Implementation,
-    ListToolsResult, Meta, PaginatedRequestParams, Role, ServerCapabilities, ServerInfo, Tool,
-    ToolAnnotations,
+    Annotations, CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
+    Implementation, ListToolsResult, MetaObject, PaginatedRequestParams, Role, ServerCapabilities,
+    ServerInfo, Tool, ToolAnnotations,
 };
 use rmcp::service::{RequestContext, RoleServer};
 
@@ -291,7 +291,7 @@ impl ServerHandler for TimeServer {
                 ),
             )
             .annotate(read_only.clone())
-            .with_meta(Meta(json!({
+            .with_meta(MetaObject(json!({
                 "call_template": "🕐 time{% if args.timezone %} ({{ args.timezone }}){% endif %}",
                 "result_template": "{{ result.content[0].text | default('') }}"
             }).as_object().unwrap().clone())),
@@ -354,7 +354,7 @@ impl ServerHandler for TimeServer {
                 ),
             )
             .annotate(read_only.clone())
-            .with_meta(Meta(json!({
+            .with_meta(MetaObject(json!({
                 "call_template": "🕐 convert{% if args.isoTimestamp %} {{ args.isoTimestamp }}{% endif %}{% if args.unixTimestamp %} unix={{ args.unixTimestamp }}{% endif %}{% if args.epochMillis %} ms={{ args.epochMillis }}{% endif %}{% if args.sourceTimezone %} from={{ args.sourceTimezone }}{% endif %}{% if args.offsetDays %} +{{ args.offsetDays }}d{% endif %}{% if args.offsetHours %} +{{ args.offsetHours }}h{% endif %}{% if args.offsetMinutes %} +{{ args.offsetMinutes }}m{% endif %}{% if args.offsetSeconds %} +{{ args.offsetSeconds }}s{% endif %}{% if args.timezone %} → {{ args.timezone }}{% endif %}",
                 "result_template": "{{ result.content[0].text | default('') }}"
             }).as_object().unwrap().clone())),
@@ -377,7 +377,7 @@ impl ServerHandler for TimeServer {
                     .idempotent(false)
                     .open_world(false),
             )
-            .with_meta(Meta(json!({
+            .with_meta(MetaObject(json!({
                 "call_template": "⏳ wait {{ args.seconds }}s",
                 "result_template": "{{ result.content[0].text | default('') }}"
             }).as_object().unwrap().clone())),
@@ -409,20 +409,34 @@ impl ServerHandler for TimeServer {
                     .idempotent(false)
                     .open_world(false),
             )
-            .with_meta(Meta(json!({
+            .with_meta(MetaObject(json!({
                 "call_template": "⏳ wait until {{ args.time }}{% if args.timezone %} ({{ args.timezone }}){% endif %}",
                 "result_template": "{{ result.content[0].text | default('') }}"
             }).as_object().unwrap().clone())),
         ];
 
-        Ok(ListToolsResult {
-            meta: None,
-            tools,
-            next_cursor: None,
-        })
+        Ok(ListToolsResult::with_all_items(tools))
     }
 
     async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        self.dispatch_call_tool(request, _context)
+            .await
+            .map(Into::into)
+    }
+}
+
+impl TimeServer {
+    /// The tool dispatch, which always finishes in a single step.
+    ///
+    /// `call_tool` must return `CallToolResponse`, whose other variants cover
+    /// elicitation and long-running tasks that this server does not use.
+    /// Dispatching separately keeps every arm returning a plain
+    /// `CallToolResult`.
+    async fn dispatch_call_tool(
         &self,
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,

--- a/crates/harnx-plans-tools/src/main.rs
+++ b/crates/harnx-plans-tools/src/main.rs
@@ -236,7 +236,7 @@ async fn run_http(
     let ct = CancellationToken::new();
     let factory_dir = plans_dir.clone();
     let config = StreamableHttpServerConfig::default()
-        .with_stateful_mode(false)
+        .with_legacy_session_mode(false)
         .with_json_response(true)
         .with_cancellation_token(ct.child_token())
         // Empty allowlist = accept any Host header. Required so external

--- a/crates/harnx-plans-tools/src/server/handler.rs
+++ b/crates/harnx-plans-tools/src/server/handler.rs
@@ -18,71 +18,85 @@ impl ServerHandler for PlansServer {
         _pagination: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
-        Ok(ListToolsResult {
-            meta: None,
-            tools: vec![
+        Ok(ListToolsResult::with_all_items(vec![
                 Tool::new("list_plans", "List all plans with metadata and task/note counts.", Map::new())
                     .with_input_schema::<ListPlansParams>()
-                    .with_meta(Meta(json!({"call_template": "list plans", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "list plans", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("add_plan", "Create a new plan with optional metadata. Set body with content (or body for compatibility). Keep body content under 1000 words per call; use update_plan with replace_in_content for targeted edits.", Map::new())
                     .with_input_schema::<AddPlanParams>()
-                    .with_meta(Meta(json!({"call_template": "create plan {{ args.name }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.git_branch %} [{{ args.git_branch }}]{% endif %}{% if args.github_owner_repo %} ({{ args.github_owner_repo }}){% endif %}{% if args.content %}
+                    .with_meta(MetaObject(json!({"call_template": "create plan {{ args.name }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.git_branch %} [{{ args.git_branch }}]{% endif %}{% if args.github_owner_repo %} ({{ args.github_owner_repo }}){% endif %}{% if args.content %}
 {{ args.content | truncate(80) }}{% elif args.body %}
 {{ args.body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("get_plan", "Read plan metadata, body, and list task/note IDs.", Map::new())
                     .with_input_schema::<GetPlanParams>()
-                    .with_meta(Meta(json!({"call_template": "read plan {{ args.name }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "read plan {{ args.name }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("update_plan", "Update plan body and metadata. Creates plan if it doesn't exist. Use content or replace_content to rewrite body, append_content to extend it, or replace_in_content for surgical edits. Provide at most one body-edit parameter. Optionally batch-create tasks. Keep each write under 1000 words.", Map::new())
                     .with_input_schema::<UpdatePlanParams>()
-                    .with_meta(Meta(json!({"call_template": "update plan {{ args.name }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.git_branch %} [{{ args.git_branch }}]{% endif %}{% if args.github_owner_repo %} ({{ args.github_owner_repo }}){% endif %}{% if args.tasks %} [{{ args.tasks | length }} tasks]{% endif %}{% if args.content %}
+                    .with_meta(MetaObject(json!({"call_template": "update plan {{ args.name }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.git_branch %} [{{ args.git_branch }}]{% endif %}{% if args.github_owner_repo %} ({{ args.github_owner_repo }}){% endif %}{% if args.tasks %} [{{ args.tasks | length }} tasks]{% endif %}{% if args.content %}
 {{ args.content | truncate(80) }}{% elif args.replace_content %}
 {{ args.replace_content | truncate(80) }}{% endif %}{% if args.append_content %}
 +{{ args.append_content | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("delete_plan", "Delete an entire plan and all its tasks and notes.", Map::new())
                     .with_input_schema::<DeletePlanParams>()
-                    .with_meta(Meta(json!({"call_template": "delete plan {{ args.name }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "delete plan {{ args.name }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("list_tasks", "List tasks in a plan with optional filters.", Map::new())
                     .with_input_schema::<ListTasksParams>()
-                    .with_meta(Meta(json!({"call_template": "list tasks {{ args.plan }}{% if args.filter and args.filter != 'open' %} [{{ args.filter }}]{% endif %}{% if args.tag %} #{{ args.tag }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "list tasks {{ args.plan }}{% if args.filter and args.filter != 'open' %} [{{ args.filter }}]{% endif %}{% if args.tag %} #{{ args.tag }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("add_task", "Create a task in a plan. Keep body under 1000 words; use update_task with replace_in_body for targeted edits.", Map::new())
                     .with_input_schema::<AddTaskParams>()
-                    .with_meta(Meta(json!({"call_template": "create task {{ args.plan }}/{{ args.title }}{% if args.status %} [{{ args.status }}]{% endif %}{% if args.assignee %} @{{ args.assignee }}{% endif %}{% if args.executor %} ▶{{ args.executor }}{% endif %}{% if args.tags %} #{{ args.tags | join(' #') }}{% endif %}{% if args.body %}
+                    .with_meta(MetaObject(json!({"call_template": "create task {{ args.plan }}/{{ args.title }}{% if args.status %} [{{ args.status }}]{% endif %}{% if args.assignee %} @{{ args.assignee }}{% endif %}{% if args.executor %} ▶{{ args.executor }}{% endif %}{% if args.tags %} #{{ args.tags | join(' #') }}{% endif %}{% if args.body %}
 {{ args.body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("get_task", "Read a task by ID within a plan.", Map::new())
                     .with_input_schema::<GetTaskParams>()
-                    .with_meta(Meta(json!({"call_template": "read task {{ args.plan }}/{{ args.id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "read task {{ args.plan }}/{{ args.id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("update_task", "Update a task within its plan. Use replace_body to rewrite body, append_body to extend it, or replace_in_body for surgical edits. Keep each write under 1000 words.", Map::new())
                     .with_input_schema::<UpdateTaskParams>()
-                    .with_meta(Meta(json!({"call_template": "update task {{ args.plan }}/{{ args.id }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.status %} [{{ args.status }}]{% endif %}{% if args.assignee %} @{{ args.assignee }}{% endif %}{% if args.executor %} ▶{{ args.executor }}{% endif %}{% if args.tags %} #{{ args.tags | join(' #') }}{% endif %}{% if args.replace_body %}
+                    .with_meta(MetaObject(json!({"call_template": "update task {{ args.plan }}/{{ args.id }}{% if args.title %} — {{ args.title | truncate(40) }}{% endif %}{% if args.status %} [{{ args.status }}]{% endif %}{% if args.assignee %} @{{ args.assignee }}{% endif %}{% if args.executor %} ▶{{ args.executor }}{% endif %}{% if args.tags %} #{{ args.tags | join(' #') }}{% endif %}{% if args.replace_body %}
 {{ args.replace_body | truncate(80) }}{% endif %}{% if args.append_body %}
 +{{ args.append_body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("delete_task", "Delete a task by ID.", Map::new())
                     .with_input_schema::<DeleteTaskParams>()
-                    .with_meta(Meta(json!({"call_template": "delete task {{ args.plan }}/{{ args.id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "delete task {{ args.plan }}/{{ args.id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("list_notes", "List notes for a plan.", Map::new())
                     .with_input_schema::<ListNotesParams>()
-                    .with_meta(Meta(json!({"call_template": "list notes {{ args.plan }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "list notes {{ args.plan }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("add_note", "Add a note to a plan. Keep body under 1000 words; use update_note with replace_in_body for targeted edits.", Map::new())
                     .with_input_schema::<AddNoteParams>()
-                    .with_meta(Meta(json!({"call_template": "add note {{ args.plan }}{% if args.summary %} — {{ args.summary | truncate(60) }}{% endif %}{% if args.author %} by {{ args.author }}{% endif %}{% if args.body %}
+                    .with_meta(MetaObject(json!({"call_template": "add note {{ args.plan }}{% if args.summary %} — {{ args.summary | truncate(60) }}{% endif %}{% if args.author %} by {{ args.author }}{% endif %}{% if args.body %}
 {{ args.body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("get_note", "Read a note from a plan.", Map::new())
                     .with_input_schema::<GetNoteParams>()
-                    .with_meta(Meta(json!({"call_template": "read note {{ args.plan }}/{{ args.note_id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+                    .with_meta(MetaObject(json!({"call_template": "read note {{ args.plan }}/{{ args.note_id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("update_note", "Update a note within a plan. Use replace_body, append_body, or replace_in_body for body edits. Keep each write under 1000 words.", Map::new())
                     .with_input_schema::<UpdateNoteParams>()
-                    .with_meta(Meta(json!({"call_template": "update note {{ args.plan }}/{{ args.note_id }}{% if args.summary %} — {{ args.summary | truncate(60) }}{% endif %}{% if args.replace_body %}
+                    .with_meta(MetaObject(json!({"call_template": "update note {{ args.plan }}/{{ args.note_id }}{% if args.summary %} — {{ args.summary | truncate(60) }}{% endif %}{% if args.replace_body %}
 {{ args.replace_body | truncate(80) }}{% endif %}{% if args.append_body %}
 +{{ args.append_body | truncate(80) }}{% endif %}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
                 Tool::new("delete_note", "Delete a note from a plan.", Map::new())
                     .with_input_schema::<DeleteNoteParams>()
-                    .with_meta(Meta(json!({"call_template": "delete note {{ args.plan }}/{{ args.note_id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
-            ],
-            next_cursor: None,
-        })
+                    .with_meta(MetaObject(json!({"call_template": "delete note {{ args.plan }}/{{ args.note_id }}", "result_template": "{{ result.content[0].text | default('') }}"}).as_object().unwrap().clone())),
+            ]))
     }
 
     async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        self.dispatch_call_tool(request, _context)
+            .await
+            .map(Into::into)
+    }
+}
+
+impl PlansServer {
+    /// The tool dispatch itself, which always completes in one step.
+    ///
+    /// `call_tool` has to return `CallToolResponse`, whose other variants
+    /// cover elicitation and long-running tasks that this server does not
+    /// use. Keeping the dispatch on its own means every arm still returns a
+    /// plain `CallToolResult`.
+    async fn dispatch_call_tool(
         &self,
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,

--- a/crates/harnx-plans-tools/src/server/mod.rs
+++ b/crates/harnx-plans-tools/src/server/mod.rs
@@ -5,8 +5,9 @@
 //! `<data-dir>/<plan>/notes/<id>.md`.
 
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ContentBlock, ErrorData, Implementation,
-    ListToolsResult, Meta, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
+    Implementation, ListToolsResult, MetaObject, PaginatedRequestParams, ServerCapabilities,
+    ServerInfo, Tool,
 };
 use rmcp::schemars::{generate::SchemaGenerator, JsonSchema, Schema};
 use rmcp::service::{RequestContext, RoleServer};

--- a/crates/harnx-test-bins/src/bin/harnx-mcp-repro249/server.rs
+++ b/crates/harnx-test-bins/src/bin/harnx-mcp-repro249/server.rs
@@ -1,6 +1,6 @@
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ContentBlock, ErrorData, Implementation,
-    ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
+    Implementation, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::service::{RequestContext, RoleServer};
 use rmcp::ServerHandler;
@@ -41,18 +41,32 @@ impl ServerHandler for Repro249Server {
             ("additionalProperties".to_string(), Value::Bool(false)),
         ]);
 
-        Ok(ListToolsResult {
-            meta: None,
-            tools: vec![Tool::new(
-                TOOL_NAME,
-                "Deterministic fake MCP tool for the repro_249 tmux test.",
-                input_schema,
-            )],
-            next_cursor: None,
-        })
+        Ok(ListToolsResult::with_all_items(vec![Tool::new(
+            TOOL_NAME,
+            "Deterministic fake MCP tool for the repro_249 tmux test.",
+            input_schema,
+        )]))
     }
 
     async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        self.dispatch_call_tool(request, _context)
+            .await
+            .map(Into::into)
+    }
+}
+
+impl Repro249Server {
+    /// The tool dispatch, which always finishes in a single step.
+    ///
+    /// `call_tool` must return `CallToolResponse`, whose other variants cover
+    /// elicitation and long-running tasks that this server does not use.
+    /// Dispatching separately keeps every arm returning a plain
+    /// `CallToolResult`.
+    async fn dispatch_call_tool(
         &self,
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,

--- a/crates/harnx-test-bins/src/bin/harnx-mock-mcp/server.rs
+++ b/crates/harnx-test-bins/src/bin/harnx-mock-mcp/server.rs
@@ -26,8 +26,9 @@
 //! MCP server uses).
 
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ContentBlock, ErrorData, Implementation,
-    ListToolsResult, Meta, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
+    Implementation, ListToolsResult, MetaObject, PaginatedRequestParams, ServerCapabilities,
+    ServerInfo, Tool,
 };
 use rmcp::service::{RequestContext, RoleServer};
 use rmcp::ServerHandler;
@@ -132,7 +133,7 @@ impl MockMcpServer {
                         .as_object()
                         .expect("object literal")
                         .clone();
-                    tool = tool.with_meta(Meta(meta));
+                    tool = tool.with_meta(MetaObject(meta));
                 }
                 tool
             })
@@ -155,14 +156,28 @@ impl ServerHandler for MockMcpServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
-        Ok(ListToolsResult {
-            meta: None,
-            tools: self.build_tools(),
-            next_cursor: None,
-        })
+        Ok(ListToolsResult::with_all_items(self.build_tools()))
     }
 
     async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        self.dispatch_call_tool(request, _context)
+            .await
+            .map(Into::into)
+    }
+}
+
+impl MockMcpServer {
+    /// The tool dispatch, which always finishes in a single step.
+    ///
+    /// `call_tool` must return `CallToolResponse`, whose other variants cover
+    /// elicitation and long-running tasks that this server does not use.
+    /// Dispatching separately keeps every arm returning a plain
+    /// `CallToolResult`.
+    async fn dispatch_call_tool(
         &self,
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,

--- a/crates/harnx-toolset-server/src/lib.rs
+++ b/crates/harnx-toolset-server/src/lib.rs
@@ -13,9 +13,9 @@ use harnx_toolset::{
     HDR_CALL_ID, HDR_IDEMPOTENCY_KEY,
 };
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ContentBlock, ErrorData, Implementation,
-    ListToolsResult, Meta, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
-    ToolAnnotations,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
+    Implementation, ListToolsResult, MetaObject, PaginatedRequestParams, ServerCapabilities,
+    ServerInfo, Tool, ToolAnnotations,
 };
 use rmcp::service::{RequestContext, RoleServer};
 use rmcp::{ServerHandler, ServiceExt};
@@ -524,18 +524,32 @@ impl ServerHandler for McpToolsetAdapter {
                         .read_only(spec.read_only_hint)
                         .idempotent(spec.idempotent_hint),
                 );
-                tool.meta = spec.meta.map(Meta);
+                tool.meta = spec.meta.map(MetaObject);
                 tool
             })
             .collect();
-        Ok(ListToolsResult {
-            tools,
-            next_cursor: None,
-            meta: None,
-        })
+        Ok(ListToolsResult::with_all_items(tools))
     }
 
     async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        self.dispatch_call_tool(request, _context)
+            .await
+            .map(Into::into)
+    }
+}
+
+impl McpToolsetAdapter {
+    /// The tool dispatch, which always finishes in a single step.
+    ///
+    /// `call_tool` must return `CallToolResponse`, whose other variants cover
+    /// elicitation and long-running tasks that this server does not use.
+    /// Dispatching separately keeps every arm returning a plain
+    /// `CallToolResult`.
+    async fn dispatch_call_tool(
         &self,
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,


### PR DESCRIPTION
Supersedes #1309, which is the version bump on its own and doesn't compile.

rmcp 3 has four breaking changes that touch the nine MCP servers here.

**`ServerHandler::call_tool` returns `CallToolResponse`** — an enum adding elicitation and long-running task variants next to the plain result. None of these servers use either, so the dispatch moved into `dispatch_call_tool`, which still returns `CallToolResult`, and the trait method converts with `.map(Into::into)`. Splitting them meant none of the match arms had to change.

**`ListToolsResult` gained SEP-2549 caching fields** (`result_type`, `ttl_ms`, `cache_scope`). The struct literals became `ListToolsResult::with_all_items`, which leaves the caching fields absent and marks the result complete. rmcp clears `resultType` again for peers that negotiated an older protocol version, so the wire format is unchanged for them.

**`Meta` → `MetaObject`**, and **`StreamableHttpServerConfig::with_stateful_mode` → `with_legacy_session_mode`**. Sessions are removed in protocol version 2026-07-28, so that flag now only governs older peers; passing `false` preserves the stateless behaviour these servers already had.

**`Peer::peer_info` returns `ServerPeerInfo`**, whose server identity is optional because a discovery response needn't carry one. `harnx-mcp-remote` overwrote that identity with its own regardless, so it now copies the negotiated fields (protocol version, capabilities, instructions, meta) across explicitly rather than cloning the whole struct and patching one field.

Verified with the pipeline from AGENTS.md: `cargo build --workspace`, `fmt --check`, `clippy --all-targets -D warnings`, `nextest run --workspace` — 2402 passing.

One note on flakiness: `nats_worker::subagent_idle_timeout_resets_on_child_activity` and `tool_supervisor::readiness_waits_for_servers_concurrently` each failed once under full-suite load and pass consistently in isolation and on clean runs. They're timing-sensitive and unrelated to this change.