### PR TITLE
feat: split the NATS worker into its own harnx-worker binary

### DIFF
--- a/.changeset/worker-diagnose-tool-servers.md
+++ b/.changeset/worker-diagnose-tool-servers.md
@@ -1,4 +1,4 @@
 ---
 harnx: minor
 ---
-`harnx worker --cluster __local__ --diagnose` starts this configuration's tool servers, reports which ones registered and how many tools each advertises, and exits without serving sessions. It applies the same selection and startup the worker uses, so it shows what a real run would do — including servers pulled in from packages the active agent cannot use — without racing a front-end that exits after its turn.
+`harnx-worker --cluster __local__ --diagnose` starts this configuration's tool servers, reports which ones registered and how many tools each advertises, and exits without serving sessions. It applies the same selection and startup the worker uses, so it shows what a real run would do — including servers pulled in from packages the active agent cannot use — without racing a front-end that exits after its turn.

--- a/.changeset/worker-separate-binary.md
+++ b/.changeset/worker-separate-binary.md
@@ -1,0 +1,12 @@
+---
+harnx: minor
+---
+The NATS worker is now a separate `harnx-worker` binary, and the `harnx worker`
+subcommand is gone. Run `harnx-worker --cluster <key>` where you used to run
+`harnx worker --cluster <key>`.
+
+Front-ends spawn the worker for the local cluster, so `harnx-worker` must be
+installed alongside `harnx` / `harnx-serve` — releases publish it as its own
+archive, and it ships in the Docker image. Discovery checks
+`HARNX_WORKER_BIN`, then a sibling of the running front-end, then `PATH`.
+`HARNX_BIN` no longer plays a part in it.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,7 +125,7 @@ jobs:
       shell: bash
       run: |
         $BUILD_CMD build --locked --release --target=${{ matrix.target }} ${{ matrix.cargo-flags }} \
-          -p harnx -p harnx-serve \
+          -p harnx -p harnx-serve -p harnx-worker \
           -p harnx-bash-tools -p harnx-fs-tools -p harnx-grep-tools -p harnx-plans-tools -p harnx-mcp-plans-github -p harnx-mcp-time \
           -p harnx-aws-creds -p harnx-k8s-creds -p harnx-pkg -p harnx-proxy-auth \
           -p harnx-sandbox-run \
@@ -149,6 +149,7 @@ jobs:
         archive_specs=(
           "harnx:harnx"
           "harnx-serve:harnx-serve"
+          "harnx-worker:harnx-worker"
           "harnx-bash-tools:harnx-bash-tools"
           "harnx-fs-tools:harnx-fs-tools"
           "harnx-grep-tools:harnx-grep-tools"
@@ -321,6 +322,8 @@ jobs:
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-serve-$V-x86_64-unknown-linux-musl.tar.gz" || true
           gh release download "$GITHUB_REF_NAME" \
+            --pattern "harnx-worker-$V-x86_64-unknown-linux-musl.tar.gz" || true
+          gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-bash-tools-$V-x86_64-unknown-linux-musl.tar.gz" || true
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-fs-tools-$V-x86_64-unknown-linux-musl.tar.gz" || true
@@ -347,6 +350,8 @@ jobs:
             --pattern "harnx-$V-aarch64-unknown-linux-musl.tar.gz" || true
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-serve-$V-aarch64-unknown-linux-musl.tar.gz" || true
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern "harnx-worker-$V-aarch64-unknown-linux-musl.tar.gz" || true
           gh release download "$GITHUB_REF_NAME" \
             --pattern "harnx-bash-tools-$V-aarch64-unknown-linux-musl.tar.gz" || true
           gh release download "$GITHUB_REF_NAME" \
@@ -384,7 +389,7 @@ jobs:
         run: |
           missing=0
           for dir in linux-amd64 linux-arm64; do
-            for bin in harnx harnx-serve harnx-bash-tools harnx-fs-tools harnx-grep-tools harnx-plans-tools harnx-mcp-plans-github harnx-mcp-time harnx-aws-creds harnx-k8s-creds harnx-pkg harnx-proxy-auth harnx-sandbox-run harnx-sandbox-exec; do
+            for bin in harnx harnx-serve harnx-worker harnx-bash-tools harnx-fs-tools harnx-grep-tools harnx-plans-tools harnx-mcp-plans-github harnx-mcp-time harnx-aws-creds harnx-k8s-creds harnx-pkg harnx-proxy-auth harnx-sandbox-run harnx-sandbox-exec; do
               if [ ! -f "$dir/$bin" ]; then
                 echo "ERROR: missing $dir/$bin"
                 missing=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4279,6 +4279,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "harnx-worker"
+version = "0.33.4"
+dependencies = [
+ "anyhow",
+ "clap",
+ "harnx-core",
+ "harnx-runtime",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "crates/harnx-toolset",
     "crates/harnx-toolset-server",
     "crates/harnx-tui",
+    "crates/harnx-worker",
     "crates/harnx-proxy-auth",
     "crates/ratatui-widget-scrolling",
     "xtask",

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ what you need:
 |-------------------------|---------------------------------------------------------------------------------|--------------------------------------------------|
 | `harnx`                 | Terminal interface, TUI or non-interactive                                      | [Command-Line Guide](docs/command-line-guide.md) |
 | `harnx-serve`           | HTTP-only server, no TUI deps                                                   | [README](crates/harnx-serve/README.md)           |
+| `harnx-worker`          | NATS worker daemon that executes agent turns                                    | [README](crates/harnx-worker/README.md)          |
 | `harnx-pkg`             | Package manager for harnx agent configurations                                  | [Package System](docs/packages.md)               |
 | `harnx-bash-tools`      | Native toolset server exposing bash/subprocess execution with safety guards     | [Bash Toolset Server](docs/bash-mcp-server.md)   |
 | `harnx-fs-tools`        | Toolset server exposing filesystem operations with safety guards                 | [README](crates/harnx-fs-tools/README.md)       |
@@ -28,9 +29,12 @@ what you need:
 | `harnx-k8s-creds`       | Persistent hook that injects scoped Kubernetes credentials into sandboxed tools | [README](crates/harnx-k8s-creds/README.md)       |
 | `harnx-proxy-auth`      | TLS-intercepting auth proxy that injects credentials and runs hooks             | [README](crates/harnx-proxy-auth/README.md)      |
 
-Install whichever you need. Most users want just `harnx`; headless server
-deployments can skip the TUI deps by picking `harnx-serve` directly. MCP server
-binaries (`harnx-mcp-*`) are needed only when configured as external servers.
+Install whichever you need. Most users want `harnx` plus `harnx-worker`:
+`harnx` runs agent turns by handing them to a worker over NATS, and it spawns
+`harnx-worker` from its own directory (or `PATH`, or `HARNX_WORKER_BIN`) to do
+that. Headless server deployments can skip the TUI deps by picking
+`harnx-serve` — it needs `harnx-worker` too. MCP server binaries
+(`harnx-mcp-*`) are needed only when configured as external servers.
 
 ### Install using asdf
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ what you need:
 
 Install whichever you need. Most users want `harnx` plus `harnx-worker`:
 `harnx` runs agent turns by handing them to a worker over NATS, and it spawns
-`harnx-worker` from its own directory (or `PATH`, or `HARNX_WORKER_BIN`) to do
-that. Headless server deployments can skip the TUI deps by picking
-`harnx-serve` — it needs `harnx-worker` too. MCP server binaries
-(`harnx-mcp-*`) are needed only when configured as external servers.
+`harnx-worker` to do that. It looks for the worker at `HARNX_WORKER_BIN` first,
+then next to itself, then on `PATH`. Headless server deployments can skip the
+TUI deps by picking `harnx-serve` — it needs `harnx-worker` too. MCP server
+binaries (`harnx-mcp-*`) are needed only when configured as external servers.
 
 ### Install using asdf
 

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -41,6 +41,10 @@ pub const LOCAL_CLUSTER_KEY: &str = "__local__";
 pub const HARNX_NATS_URL_ENV: &str = "HARNX_NATS_URL";
 /// Worker handoff variable containing shared local NATS authentication token.
 pub const HARNX_NATS_TOKEN_ENV: &str = "HARNX_NATS_TOKEN";
+/// Overrides discovery of the `harnx-worker` binary a front-end spawns for the
+/// shared local cluster. Useful when the worker is not installed next to the
+/// front-end, and for tests that build both into a scratch directory.
+pub const HARNX_WORKER_BIN_ENV: &str = "HARNX_WORKER_BIN";
 pub(crate) use self::persistence_split::collect_tool_calls;
 pub use self::session_dump::render_session_dump;
 pub(crate) use self::session_log_split::{

--- a/crates/harnx-runtime/src/local_orchestrator.rs
+++ b/crates/harnx-runtime/src/local_orchestrator.rs
@@ -3,7 +3,9 @@
 //! One front-end owns the worker through `worker.lock`; other front-ends join
 //! the same broker and wait for that worker's readiness heartbeat.
 
-use crate::config::{HARNX_NATS_TOKEN_ENV, HARNX_NATS_URL_ENV, LOCAL_CLUSTER_KEY};
+use crate::config::{
+    HARNX_NATS_TOKEN_ENV, HARNX_NATS_URL_ENV, HARNX_WORKER_BIN_ENV, LOCAL_CLUSTER_KEY,
+};
 use crate::nats_local_server::{ensure_shared_server, SharedNatsServer};
 use crate::nats_worker::worker_ready_subject;
 use anyhow::{bail, Context, Result};
@@ -32,9 +34,59 @@ const MAX_WORKER_CRASHES: u32 = 3;
 /// Bytes of worker output shown when startup gives up.
 const WORKER_OUTPUT_TAIL_BYTES: u64 = 4096;
 
+/// Name of the worker executable front-ends spawn.
+const WORKER_BINARY: &str = if cfg!(windows) {
+    "harnx-worker.exe"
+} else {
+    "harnx-worker"
+};
+
 /// Path used to elect one local worker owner per user/broker.
 pub fn local_worker_lock_file() -> PathBuf {
     nats_runtime_dir().join("worker.lock")
+}
+
+/// Locate the `harnx-worker` binary a front-end should spawn.
+///
+/// `HARNX_WORKER_BIN` wins, then a sibling of the running front-end, then
+/// `PATH`. The sibling case is what makes an ordinary install work: front-end
+/// and worker land in the same `bin` directory, so neither has to be on `PATH`.
+pub fn resolve_worker_binary() -> Result<PathBuf> {
+    if let Some(path) = std::env::var_os(HARNX_WORKER_BIN_ENV) {
+        let path = PathBuf::from(path);
+        if !path.is_file() {
+            bail!(
+                "{HARNX_WORKER_BIN_ENV} points at {}, which is not a file",
+                path.display()
+            );
+        }
+        return Ok(path);
+    }
+
+    let current = std::env::current_exe().context("resolve current frontend executable")?;
+    let directory = current
+        .parent()
+        .context("current frontend executable has no parent directory")?;
+    // Integration tests run from `target/debug/deps`; the worker sits one level up.
+    let directory = if directory.file_name().is_some_and(|name| name == "deps") {
+        directory
+            .parent()
+            .context("test executable deps directory has no parent")?
+    } else {
+        directory
+    };
+    let sibling = directory.join(WORKER_BINARY);
+    if sibling.is_file() {
+        return Ok(sibling);
+    }
+
+    which::which(WORKER_BINARY).with_context(|| {
+        format!(
+            "worker binary '{WORKER_BINARY}' not found next to {} or on PATH; \
+             install it or set {HARNX_WORKER_BIN_ENV}",
+            current.display()
+        )
+    })
 }
 
 /// Keeps the shared broker alive and owns a worker subprocess when this
@@ -68,36 +120,15 @@ pub async fn ensure_local_worker(
 }
 
 impl LocalWorkerSupervisor {
-    /// Ensure the shared broker and local worker using the `harnx` executable.
-    /// Unified CLI callers use their current executable; standalone frontends
-    /// such as `harnx-serve` resolve `HARNX_BIN` or a sibling
-    /// `harnx` binary because they do not expose the `worker` subcommand.
+    /// Ensure the shared broker and local worker using the `harnx-worker`
+    /// executable found next to the running front-end.
     pub async fn start(abort_signal: AbortSignal) -> Result<Self> {
-        let current = std::env::current_exe().context("resolve current frontend executable")?;
-        let is_harnx = current
-            .file_stem()
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| name == "harnx");
-        let binary = if is_harnx {
-            current
-        } else if let Some(path) = std::env::var_os("HARNX_BIN") {
-            PathBuf::from(path)
-        } else {
-            let sibling = current.with_file_name(if cfg!(windows) { "harnx.exe" } else { "harnx" });
-            if !sibling.is_file() {
-                bail!(
-                    "frontend {} requires HARNX_BIN or sibling harnx binary to start local worker",
-                    current.display()
-                );
-            }
-            sibling
-        };
-        Self::start_with_worker_binary(binary, abort_signal).await
+        Self::start_with_worker_binary(resolve_worker_binary()?, abort_signal).await
     }
 
-    /// Ensure the shared broker and local worker using an explicit `harnx`
-    /// binary. Integration tests and front-end-specific binaries may use this
-    /// when their current executable does not expose the `worker` subcommand.
+    /// Ensure the shared broker and local worker using an explicit
+    /// `harnx-worker` binary. Integration tests use this when the worker they
+    /// want is not the one discovery would pick.
     pub async fn start_with_worker_binary(
         binary: impl AsRef<Path>,
         abort_signal: AbortSignal,
@@ -263,7 +294,6 @@ impl LocalWorkerSupervisor {
         }
         let mut command = Command::new(&self.worker_binary);
         command
-            .arg("worker")
             .arg("--cluster")
             .arg(LOCAL_CLUSTER_KEY)
             .arg("--worker-id")
@@ -432,3 +462,31 @@ fn configure_worker_process(command: &mut Command) {
 
 #[cfg(not(unix))]
 fn configure_worker_process(_command: &mut Command) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `HARNX_WORKER_BIN` wins over sibling/PATH discovery. Nextest gives each
+    /// test its own process, so setting the variable here is contained.
+    #[test]
+    fn worker_bin_override_wins() {
+        harnx_core::require_nextest();
+        let file = tempfile::NamedTempFile::new().expect("create fake worker binary");
+        unsafe { std::env::set_var(HARNX_WORKER_BIN_ENV, file.path()) };
+        assert_eq!(resolve_worker_binary().unwrap(), file.path());
+    }
+
+    /// A stale override must fail loudly instead of silently falling back to a
+    /// different worker than the operator asked for.
+    #[test]
+    fn worker_bin_override_rejects_missing_file() {
+        harnx_core::require_nextest();
+        unsafe { std::env::set_var(HARNX_WORKER_BIN_ENV, "/nonexistent/harnx-worker") };
+        let error = resolve_worker_binary().expect_err("missing override must fail");
+        assert!(
+            error.to_string().contains("/nonexistent/harnx-worker"),
+            "unexpected error: {error:#}"
+        );
+    }
+}

--- a/crates/harnx-runtime/src/nats_client_session.rs
+++ b/crates/harnx-runtime/src/nats_client_session.rs
@@ -4,7 +4,7 @@
 //! `AgentRef::Remote { agent, cluster }`), the client runs in THIN mode:
 //! it posts the user message + control commands to NATS and renders events
 //! from the fan-out — it does NOT run `run_agent_loop` locally. A separate
-//! `harnx worker --cluster <key>` daemon executes the turn.
+//! `harnx-worker --cluster <key>` daemon executes the turn.
 //!
 //! ## Architecture
 //!

--- a/crates/harnx-runtime/tests/common/mod.rs
+++ b/crates/harnx-runtime/tests/common/mod.rs
@@ -99,8 +99,8 @@ async fn try_spawn_nats_once(
 }
 
 #[allow(dead_code)]
-pub fn harnx_binary() -> Option<PathBuf> {
-    if let Some(path) = std::env::var_os("HARNX_BIN") {
+pub fn harnx_worker_binary() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("HARNX_WORKER_BIN") {
         let path = PathBuf::from(path);
         if path.is_file() {
             return Some(path);
@@ -112,7 +112,11 @@ pub fn harnx_binary() -> Option<PathBuf> {
     if path.file_name().is_some_and(|name| name == "deps") {
         path.pop();
     }
-    path.push(if cfg!(windows) { "harnx.exe" } else { "harnx" });
+    path.push(if cfg!(windows) {
+        "harnx-worker.exe"
+    } else {
+        "harnx-worker"
+    });
     path.is_file().then_some(path)
 }
 

--- a/crates/harnx-runtime/tests/local_worker_supervisor.rs
+++ b/crates/harnx-runtime/tests/local_worker_supervisor.rs
@@ -55,8 +55,8 @@ fn skip_without_binaries() -> Option<PathBuf> {
         eprintln!("skipping local worker supervisor test: nats-server binary not found");
         return None;
     }
-    let Some(binary) = common::harnx_binary() else {
-        eprintln!("skipping local worker supervisor test: harnx binary not found");
+    let Some(binary) = common::harnx_worker_binary() else {
+        eprintln!("skipping local worker supervisor test: harnx-worker binary not found");
         return None;
     };
     Some(binary)

--- a/crates/harnx-serve/src/session_actor/tests/session_actor_nats_tests.rs
+++ b/crates/harnx-serve/src/session_actor/tests/session_actor_nats_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-fn live_harnx_binary() -> Option<std::path::PathBuf> {
+fn live_worker_binary() -> Option<std::path::PathBuf> {
     if std::process::Command::new(
         std::env::var_os("NATS_SERVER_BIN").unwrap_or_else(|| "nats-server".into()),
     )
@@ -11,7 +11,7 @@ fn live_harnx_binary() -> Option<std::path::PathBuf> {
         eprintln!("skipping serve NATS smoke: nats-server not available");
         return None;
     }
-    if let Some(path) = std::env::var_os("HARNX_BIN").map(std::path::PathBuf::from) {
+    if let Some(path) = std::env::var_os("HARNX_WORKER_BIN").map(std::path::PathBuf::from) {
         if path.is_file() {
             return Some(path);
         }
@@ -20,7 +20,11 @@ fn live_harnx_binary() -> Option<std::path::PathBuf> {
     if directory.file_name().is_some_and(|name| name == "deps") {
         directory.pop();
     }
-    let binary = directory.join(if cfg!(windows) { "harnx.exe" } else { "harnx" });
+    let binary = directory.join(if cfg!(windows) {
+        "harnx-worker.exe"
+    } else {
+        "harnx-worker"
+    });
     binary.is_file().then_some(binary)
 }
 
@@ -104,7 +108,7 @@ async fn start_serve_smoke_openai() -> ServeSmokeOpenAi {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn serve_thin_client_replays_prompt_queued_during_active_run() {
     harnx_core::require_nextest();
-    let Some(binary) = live_harnx_binary() else {
+    let Some(binary) = live_worker_binary() else {
         return;
     };
     let _guard = harnx_runtime::client::TestStateGuard::new(None).await;
@@ -210,7 +214,7 @@ async fn assert_cancel_reached_worker(config: &harnx_runtime::config::Config, se
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn serve_local_nats_smoke_streams_sse_events_and_cancel_publishes_control() {
     harnx_core::require_nextest();
-    let Some(binary) = live_harnx_binary() else {
+    let Some(binary) = live_worker_binary() else {
         return;
     };
     let _guard = harnx_runtime::client::TestStateGuard::new(None).await;

--- a/crates/harnx-worker/Cargo.toml
+++ b/crates/harnx-worker/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "harnx-worker"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
+description = "NATS worker daemon that executes harnx agent turns"
+
+[[bin]]
+name = "harnx-worker"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+harnx-core = { path = "../harnx-core" }
+harnx-runtime = { path = "../harnx-runtime" }
+parking_lot = { workspace = true }
+tokio = { workspace = true }

--- a/crates/harnx-worker/README.md
+++ b/crates/harnx-worker/README.md
@@ -1,0 +1,39 @@
+# harnx-worker
+
+The worker daemon that executes harnx agent turns. Front-ends (`harnx`,
+`harnx-serve`) don't run the agent loop themselves — they append the user
+message to a NATS session log, and a worker leases the session and runs the
+loop, including tool calls and hooks.
+
+## Usage
+
+```sh
+harnx-worker --cluster local --worker-id worker-1
+```
+
+- `--cluster` — key from `nats_servers/<name>.yaml`, or `__local__` to use the
+  shared local broker handed off via `HARNX_NATS_URL` / `HARNX_NATS_TOKEN`.
+- `--worker-id` — stable identity for leases and the durable consumer name.
+  Defaults to a generated id. Recommended in production so a restart rejoins
+  its own consumer.
+- `-x KEY VALUE` / `--agent-variable KEY VALUE` — agent variables, repeatable.
+- `--diagnose` — start this configuration's tool servers, report which ones
+  registered and how many tools each advertises, then exit without serving
+  sessions.
+
+Run several workers against one cluster for redundancy. Only one holds the
+active lease for a given session; if it dies, another picks the session up.
+
+## Local use
+
+You normally don't launch this by hand. For the default `__local__` cluster,
+`harnx` and `harnx-serve` start a worker themselves and supervise it for the
+front-end's lifetime, so `harnx-worker` needs to be installed where they can
+find it:
+
+1. `HARNX_WORKER_BIN`, if set, must point at the binary.
+2. Otherwise a `harnx-worker` next to the running front-end.
+3. Otherwise `harnx-worker` on `PATH`.
+
+Worker stdout/stderr goes to `harnx_worker.log` in the harnx state directory —
+check there when a front-end reports that the worker never became ready.

--- a/crates/harnx-worker/src/main.rs
+++ b/crates/harnx-worker/src/main.rs
@@ -1,0 +1,120 @@
+//! `harnx-worker` — NATS worker daemon that executes agent turns.
+//!
+//! Front-ends (`harnx`, `harnx-serve`) publish session activations to a NATS
+//! cluster; a worker leases the session and runs the agent loop. Shipping the
+//! worker as its own binary keeps it out of the front-end's dep graph and lets
+//! deployments run workers without the TUI.
+
+use anyhow::Result;
+use clap::Parser;
+use harnx_core::agent_config::collect_agent_variables;
+use harnx_runtime::bootstrap::setup_logger;
+use harnx_runtime::config::{load_env_file, Config, WorkingMode};
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+/// Heap-usage guard installed as the process allocator: aborts with a backtrace
+/// if live heap exceeds `HARNX_HEAP_LIMIT_MB`. Disarmed (plain passthrough to
+/// the system allocator) when that env var is unset.
+#[global_allocator]
+static GLOBAL_ALLOC: harnx_core::alloc_guard::HeapGuard = harnx_core::alloc_guard::HeapGuard;
+
+#[derive(Parser, Debug, PartialEq, Eq)]
+#[command(
+    author,
+    version,
+    about = "Run a worker daemon for a configured or shared-local NATS cluster",
+    long_about = None
+)]
+struct Cli {
+    /// Cluster key from nats_servers/<name>.yaml, or __local__ with
+    /// HARNX_NATS_URL and HARNX_NATS_TOKEN handoff
+    #[arg(long)]
+    cluster: String,
+    /// Stable worker identity for leases and the durable consumer name.
+    /// Defaults to a generated id if omitted.
+    #[arg(long)]
+    worker_id: Option<String>,
+    /// Set agent variable pairs (format: --agent-variable key value or -x key value); can be repeated
+    #[arg(short = 'x', long, value_names = ["KEY", "VALUE"], num_args = 2, action = clap::ArgAction::Append)]
+    agent_variable: Vec<String>,
+    /// Start this worker's tool servers, report which ones registered, and
+    /// exit without serving sessions.
+    #[arg(long)]
+    diagnose: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    load_env_file()?;
+    let cli = Cli::parse();
+    setup_logger(false)?;
+    harnx_core::alloc_guard::init_from_env();
+
+    let config = Arc::new(RwLock::new(Config::init(WorkingMode::Cmd, true).await?));
+    config.write().agent_variables = collect_agent_variables(&cli.agent_variable)?;
+    if cli.diagnose {
+        print!(
+            "{}",
+            harnx_runtime::nats_worker::diagnose_tool_servers(&config).await?
+        );
+        return Ok(());
+    }
+
+    let worker_id = cli
+        .worker_id
+        .unwrap_or_else(harnx_runtime::nats_worker::new_remote_session_id);
+    let daemon = harnx_runtime::nats_worker::WorkerDaemonConfig::new(cli.cluster, worker_id);
+    // `None` selects the agent loop's default call path
+    // (`call_with_retry_and_fallback`), which is what the worker wants.
+    harnx_runtime::nats_worker::run_worker_daemon(config, daemon, None).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+    use clap::Parser;
+
+    #[test]
+    fn parses_agent_variables() {
+        let cli = Cli::try_parse_from([
+            "harnx-worker",
+            "--cluster",
+            "prod",
+            "--agent-variable",
+            "cloud_env",
+            "true",
+            "--agent-variable",
+            "debug",
+            "false",
+        ])
+        .unwrap();
+        assert_eq!(cli.cluster, "prod");
+        assert_eq!(cli.worker_id, None);
+        assert_eq!(
+            cli.agent_variable,
+            vec!["cloud_env", "true", "debug", "false"]
+        );
+        assert!(!cli.diagnose);
+    }
+
+    #[test]
+    fn requires_cluster() {
+        assert!(Cli::try_parse_from(["harnx-worker"]).is_err());
+    }
+
+    #[test]
+    fn parses_worker_id_and_diagnose() {
+        let cli = Cli::try_parse_from([
+            "harnx-worker",
+            "--cluster",
+            "__local__",
+            "--worker-id",
+            "local",
+            "--diagnose",
+        ])
+        .unwrap();
+        assert_eq!(cli.worker_id.as_deref(), Some("local"));
+        assert!(cli.diagnose);
+    }
+}

--- a/crates/harnx/src/cli.rs
+++ b/crates/harnx/src/cli.rs
@@ -97,27 +97,6 @@ pub enum Commands {
     Info(InfoArgs),
     /// Session management commands
     Session(SessionArgs),
-    /// Run a worker daemon for a configured or shared-local NATS cluster
-    Worker(WorkerArgs),
-}
-
-#[derive(Args, Debug, PartialEq, Eq)]
-pub struct WorkerArgs {
-    /// Cluster key from nats_servers/<name>.yaml, or __local__ with
-    /// HARNX_NATS_URL and HARNX_NATS_TOKEN handoff
-    #[arg(long)]
-    pub cluster: String,
-    /// Stable worker identity for leases and the durable consumer name.
-    /// Defaults to a generated id if omitted.
-    #[arg(long)]
-    pub worker_id: Option<String>,
-    /// Set agent variable pairs (format: --agent-variable key value or -x key value); can be repeated
-    #[arg(short = 'x', long, value_names = ["KEY", "VALUE"], num_args = 2, action = clap::ArgAction::Append)]
-    pub agent_variable: Vec<String>,
-    /// Start this worker's tool servers, report which ones registered, and
-    /// exit without serving sessions.
-    #[arg(long)]
-    pub diagnose: bool,
 }
 
 #[derive(Args, Debug, PartialEq, Eq)]
@@ -201,7 +180,7 @@ impl Cli {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Commands, InfoSubcommands, SessionSubcommands, WorkerArgs};
+    use super::{Cli, Commands, InfoSubcommands, SessionSubcommands};
     use clap::Parser;
 
     #[test]
@@ -240,35 +219,14 @@ mod tests {
         }
     }
 
+    /// The worker moved to the `harnx-worker` binary. `harnx worker` is no
+    /// longer a subcommand, so it falls through to the trailing prompt text
+    /// like any other unrecognized words.
     #[test]
-    fn parses_worker_agent_variables() {
-        let cli = Cli::try_parse_from([
-            "harnx",
-            "worker",
-            "--cluster",
-            "prod",
-            "--agent-variable",
-            "cloud_env",
-            "true",
-            "--agent-variable",
-            "debug",
-            "false",
-        ])
-        .unwrap();
-        match cli.command {
-            Some(Commands::Worker(WorkerArgs {
-                cluster,
-                worker_id,
-                agent_variable,
-                diagnose,
-            })) => {
-                assert_eq!(cluster, "prod");
-                assert_eq!(worker_id, None);
-                assert_eq!(agent_variable, vec!["cloud_env", "true", "debug", "false"]);
-                assert!(!diagnose);
-            }
-            other => panic!("unexpected command: {other:?}"),
-        }
+    fn worker_is_no_longer_a_subcommand() {
+        let cli = Cli::try_parse_from(["harnx", "worker", "--cluster", "prod"]).unwrap();
+        assert!(cli.command.is_none());
+        assert_eq!(cli.text, vec!["worker", "--cluster", "prod"]);
     }
 }
 

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -17,10 +17,8 @@ pub use harnx_core::safety as mcp_safety;
 pub use harnx_runtime::{client, commands, config, tool};
 pub use harnx_tui as tui;
 
-use crate::cli::{
-    Cli, Commands, DeleteSessionArgs, InfoSubcommands, SessionSubcommands, WorkerArgs,
-};
-use crate::client::{list_models, retry::call_with_retry_and_fallback, ModelType};
+use crate::cli::{Cli, Commands, DeleteSessionArgs, InfoSubcommands, SessionSubcommands};
+use crate::client::{list_models, ModelType};
 use crate::config::{
     list_agents, list_assistant_agents, load_env_file, macro_execute, render_agent_dump,
     render_session_dump, Config, GlobalConfig, Input, WorkingMode,
@@ -146,7 +144,6 @@ async fn run_command(command: &Commands) -> Result<()> {
                 run_session_delete_command(delete_args).await
             }
         },
-        Commands::Worker(worker_args) => run_worker_command(worker_args).await,
     }
 }
 
@@ -175,29 +172,6 @@ async fn run_session_delete_command(delete_args: &DeleteSessionArgs) -> Result<(
     }
 
     Ok(())
-}
-
-async fn run_worker_command(worker_args: &WorkerArgs) -> Result<()> {
-    let config = Arc::new(RwLock::new(Config::init(WorkingMode::Cmd, true).await?));
-    config.write().agent_variables = collect_agent_variables(&worker_args.agent_variable)?;
-    if worker_args.diagnose {
-        print!(
-            "{}",
-            harnx_runtime::nats_worker::diagnose_tool_servers(&config).await?
-        );
-        return Ok(());
-    }
-    let worker_id = worker_args
-        .worker_id
-        .clone()
-        .unwrap_or_else(harnx_runtime::nats_worker::new_remote_session_id);
-    let daemon =
-        harnx_runtime::nats_worker::WorkerDaemonConfig::new(worker_args.cluster.clone(), worker_id);
-    let call_fn: harnx_runtime::agent_loop::AgentCallFn =
-        std::sync::Arc::new(|input, config, abort| {
-            Box::pin(call_with_retry_and_fallback(input, config, abort))
-        });
-    harnx_runtime::nats_worker::run_worker_daemon(config, daemon, Some(call_fn)).await
 }
 
 fn legacy_info_flag(cli: &Cli) -> bool {

--- a/docker/harnx.Dockerfile
+++ b/docker/harnx.Dockerfile
@@ -8,6 +8,7 @@ ARG TARGETARCH
 
 COPY linux-${TARGETARCH}/harnx /usr/local/bin/harnx
 COPY linux-${TARGETARCH}/harnx-serve /usr/local/bin/harnx-serve
+COPY linux-${TARGETARCH}/harnx-worker /usr/local/bin/harnx-worker
 COPY linux-${TARGETARCH}/harnx-bash-tools /usr/local/bin/harnx-bash-tools
 COPY linux-${TARGETARCH}/harnx-fs-tools /usr/local/bin/harnx-fs-tools
 COPY linux-${TARGETARCH}/harnx-grep-tools /usr/local/bin/harnx-grep-tools

--- a/docs/nats-ha.md
+++ b/docs/nats-ha.md
@@ -65,9 +65,9 @@ harnx-worker --cluster local --worker-id worker-1
 - `--worker-id`: (Optional but recommended) A stable identity for the worker.
 
 For the default local cluster you don't run this yourself: `harnx` and
-`harnx-serve` spawn `harnx-worker` from their own directory (falling back to
-`PATH`, or to `HARNX_WORKER_BIN` if set), so the worker has to be installed
-alongside the front-end.
+`harnx-serve` spawn `harnx-worker` themselves. They look for it at
+`HARNX_WORKER_BIN` first, then next to the running front-end, then on `PATH` —
+so normally the worker just has to be installed alongside the front-end.
 
 You can run multiple workers for redundancy. If the active worker for a session dies, another worker will acquire the lease and resume execution.
 

--- a/docs/nats-ha.md
+++ b/docs/nats-ha.md
@@ -54,14 +54,20 @@ tls_key: "/etc/harnx/client-key.pem"
 
 ## Running Workers
 
-A worker joins a cluster and waits for session assignments.
+A worker is its own binary, `harnx-worker`. It joins a cluster and waits for
+session assignments.
 
 ```bash
-harnx worker --cluster local --worker-id worker-1
+harnx-worker --cluster local --worker-id worker-1
 ```
 
 - `--cluster`: The key from `nats_servers/`.
 - `--worker-id`: (Optional but recommended) A stable identity for the worker.
+
+For the default local cluster you don't run this yourself: `harnx` and
+`harnx-serve` spawn `harnx-worker` from their own directory (falling back to
+`PATH`, or to `HARNX_WORKER_BIN` if set), so the worker has to be installed
+alongside the front-end.
 
 You can run multiple workers for redundancy. If the active worker for a session dies, another worker will acquire the lease and resume execution.
 


### PR DESCRIPTION
Closes #1389.

The worker daemon moves out of the `harnx` binary into a new `harnx-worker`
crate. It depends only on `harnx-core` and `harnx-runtime`, so a worker no
longer pulls in ratatui/crossterm, and `harnx` no longer carries the agent
loop's daemon entry point.

`harnx worker` is removed outright — no deprecation stub. `harnx worker ...`
now falls through to the trailing prompt text like any other unrecognized
words, which a test pins.

## Worker discovery

`LocalWorkerSupervisor::start` used to re-exec its own binary when that binary
was `harnx`, and fall back to `HARNX_BIN` or a sibling `harnx` for front-ends
like `harnx-serve` that had no `worker` subcommand. That special-casing is
gone. `resolve_worker_binary()` now checks, in order:

1. `HARNX_WORKER_BIN` (errors if it points at a nonexistent path, rather than
   silently running a different worker)
2. a `harnx-worker` next to the running front-end
3. `harnx-worker` on `PATH`

Same shape as the existing tool-server and hook-server resolvers in
`nats_worker/`, including the `target/debug/deps` hop for tests.

## Packaging consequence

Every `harnx` turn goes through a worker — including the default local
cluster, for both TUI and one-shot — so `harnx-worker` is now a required
companion install, not an optional extra. Release builds it, publish it as its
own per-target archive, verify it in the docker asset check, and copy it into
the image. README and `docs/nats-ha.md` say so.

`run_worker_daemon` is now called with `call_fn: None`: the old `Some(...)`
wrapped `call_with_retry_and_fallback`, which is exactly what the agent loop
already defaults to when it's `None`.

## Testing

Full pipeline from AGENTS.md: `cargo build --workspace`, `cargo fmt --all`,
`cargo clippy --workspace --all-targets -- -D warnings` (clean), and
`cargo nextest run --workspace --stress-count=5` — 5/5 iterations, 2408 tests
passing. `cs delta origin/HEAD` keeps `crates/harnx/src/main.rs` code health at
6.10; it flags mean cyclomatic complexity rising 4.95 → 5.11, which is the
average moving because a short function was deleted from a large file.

The end-to-end coverage that matters is
`local_worker_supervisor_deduplicates_respawns_and_tears_down` — it spawns the
real `harnx-worker` against a real `nats-server` and asserts a completed turn,
so it would fail if the new binary or its argv were wrong. New unit tests cover
`resolve_worker_binary`'s override branch, the `harnx-worker` CLI parse, and
`harnx worker` no longer being a subcommand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the standalone `harnx-worker` daemon binary.
  * Added worker discovery through `HARNX_WORKER_BIN`, the application directory, or `PATH`.
  * Included the worker in releases and Docker images.

* **Changes**
  * Removed the `harnx worker` subcommand.
  * Updated `harnx`, `harnx-serve`, and headless deployments to launch the standalone worker.

* **Documentation**
  * Updated installation, usage, diagnostics, and high-availability guidance for `harnx-worker`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->