### PR TITLE
fix(scripts): stop update_models regenerating the broken effort patches

### DIFF
--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -60,6 +60,18 @@ jobs:
         env:
           RUSTFLAGS: --deny warnings
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      # This PR is auto-merge labelled, so the patch guard has to run here and
+      # not only in the PR's own CI.
+      - name: Validate shipped request patches
+        run: cargo nextest run -p harnx-client --test models_yaml_patches
+        env:
+          RUSTFLAGS: --deny warnings
+
       - name: Check for changes
         id: changes
         run: |

--- a/scripts/test_update_models.py
+++ b/scripts/test_update_models.py
@@ -210,7 +210,11 @@ class TestAdaptiveEffortVariants(unittest.TestCase):
                 if provider == "bedrock"
                 else "claude-opus-4-8"
             )
-            patches += [v["patches"][0] for v in um.thinking_variants(base, provider)]
+            patches += [
+                patch
+                for variant in um.thinking_variants(base, provider)
+                for patch in variant["patches"]
+            ]
         for patch in patches:
             for assignment in patch.split("|"):
                 lhs = assignment.split("=")[0].strip()
@@ -566,6 +570,32 @@ class TestBuildDiffSummary(unittest.TestCase):
         summary = self._summary([".body.a = 1"], [".body.a = 1"])
         self.assertIn("No model additions", summary)
         self.assertNotIn("- request patch changes:", summary)
+
+    def test_provider_missing_from_new_catalog_is_reported_as_removed(self) -> None:
+        # Dropping a whole provider block must not read as "no changes".
+        old = {"someprovider": {"m": {"name": "m"}}}
+        summary = um.build_diff_summary(old, OrderedDict())
+        self.assertIn("someprovider:", summary)
+        self.assertIn("removed", summary)
+        self.assertNotIn("No model additions", summary)
+
+
+class TestOrderedProviders(unittest.TestCase):
+    """A provider already in models.yaml but in neither PROVIDER_ORDER nor the
+    LiteLLM response used to be skipped entirely, silently deleting its models."""
+
+    def test_provider_only_in_existing_yaml_is_included(self) -> None:
+        order = um.ordered_providers({}, {"handrolled": {"m": {"name": "m"}}})
+        self.assertIn("handrolled", order)
+
+    def test_provider_only_from_litellm_is_included(self) -> None:
+        order = um.ordered_providers({"fresh": {"m": {"name": "m"}}}, {})
+        self.assertIn("fresh", order)
+
+    def test_known_providers_keep_their_order_and_appear_once(self) -> None:
+        order = um.ordered_providers({"claude": {}}, {"openai": {}})
+        self.assertEqual(order[: len(um.PROVIDER_ORDER)], um.PROVIDER_ORDER)
+        self.assertEqual(len(order), len(set(order)))
 
 
 if __name__ == "__main__":

--- a/scripts/test_update_models.py
+++ b/scripts/test_update_models.py
@@ -194,9 +194,33 @@ class TestAdaptiveEffortVariants(unittest.TestCase):
         xhigh = next(v for v in variants if v["name"].endswith(":xhigh"))
         patch = xhigh["patches"][0]
         self.assertIn('"type":"adaptive"', patch)
-        self.assertIn('.body.output_config.effort = "xhigh"', patch)
+        # Whole-object assignment: jaq won't create the intermediate object.
+        self.assertIn('.body.output_config = {"effort":"xhigh"}', patch)
         self.assertIn("del(.body.temperature)", patch)
         self.assertNotIn("budget_tokens", patch)
+
+    def test_no_generated_patch_assigns_into_a_nested_path(self) -> None:
+        # jaq does not create missing intermediate objects, so an assignment
+        # into `.body.<obj>.<field>` errors at request time and aborts the rest
+        # of the pipeline. Every generated patch must assign whole containers.
+        patches = [um.claude_adaptive_patch(um.BASE_EFFORT), um.BEDROCK_THINKING_PATCH]
+        for provider in ("claude", "vertexai", "bedrock"):
+            base = self._base(
+                "us.anthropic.claude-opus-4-6"
+                if provider == "bedrock"
+                else "claude-opus-4-8"
+            )
+            patches += [v["patches"][0] for v in um.thinking_variants(base, provider)]
+        for patch in patches:
+            for assignment in patch.split("|"):
+                lhs = assignment.split("=")[0].strip()
+                if not lhs.startswith("."):
+                    continue
+                self.assertLessEqual(
+                    lhs.count("."),
+                    2,
+                    f"patch assigns into a nested path: {assignment.strip()!r}",
+                )
 
     def test_effort_variant_requires_max_tokens(self) -> None:
         # Adaptive-only Opus rejects requests without an explicit max_tokens.
@@ -222,7 +246,7 @@ class TestAdaptiveEffortVariants(unittest.TestCase):
             um.apply_base_thinking(model, provider)
             self.assertEqual(len(model["patches"]), 1)
             self.assertIn('"type":"adaptive"', model["patches"][0])
-            self.assertIn('.body.output_config.effort = "high"', model["patches"][0])
+            self.assertIn('.body.output_config = {"effort":"high"}', model["patches"][0])
             self.assertTrue(model.get("require_max_tokens"))
 
     def test_apply_base_thinking_skips_manual_models(self) -> None:
@@ -521,6 +545,27 @@ class TestOrderedModel(unittest.TestCase):
         # name must come before input_price which must come before patches
         self.assertLess(keys.index("name"), keys.index("input_price"))
         self.assertLess(keys.index("input_price"), keys.index("patches"))
+
+
+class TestBuildDiffSummary(unittest.TestCase):
+    """A regenerated patch differing from the shipped one has to show up in the
+    summary — that summary is the PR body for an auto-merge-labelled PR."""
+
+    def _summary(self, old_patches: list[str], new_patches: list[str]) -> str:
+        old = {"claude": {"m": {"name": "m", "patches": old_patches}}}
+        new = OrderedDict(claude=[{"name": "m", "patches": new_patches}])
+        return um.build_diff_summary(old, new)
+
+    def test_patch_change_reported(self) -> None:
+        summary = self._summary([".body.a = 1"], [".body.a = 2"])
+        self.assertIn("request patch changes", summary)
+        self.assertIn(".body.a = 1", summary)
+        self.assertIn(".body.a = 2", summary)
+
+    def test_identical_patches_report_no_changes(self) -> None:
+        summary = self._summary([".body.a = 1"], [".body.a = 1"])
+        self.assertIn("No model additions", summary)
+        self.assertNotIn("- request patch changes:", summary)
 
 
 if __name__ == "__main__":

--- a/scripts/update_models.py
+++ b/scripts/update_models.py
@@ -368,11 +368,16 @@ def apply_openai_endpoint_default(
 def claude_adaptive_patch(effort: str) -> str:
     """Request-body patch enabling adaptive thinking at a given effort level for
     the Claude/Vertex AI body shape. Sampling params are stripped because they
-    also 400 on adaptive-only Opus models."""
+    also 400 on adaptive-only Opus models.
+
+    `output_config` is assigned as a whole object rather than via
+    `.body.output_config.effort`: jaq, unlike jq, does not create the missing
+    intermediate object, so the nested form errors at request time and takes
+    the rest of the pipeline down with it."""
     return (
         "del(.body.temperature) | del(.body.top_p) | "
         '.body.thinking = {"type":"adaptive"} | '
-        f'.body.output_config.effort = "{effort}"'
+        f'.body.output_config = {{"effort":"{effort}"}}'
     )
 
 
@@ -716,6 +721,55 @@ def compare_price_fields(old_model: dict[str, Any], new_model: dict[str, Any]) -
     return changes
 
 
+def price_change_lines(
+    old_models: dict[str, dict[str, Any]],
+    new_models: dict[str, dict[str, Any]],
+    shared: list[str],
+) -> list[str]:
+    lines = []
+    for name in shared:
+        changes = compare_price_fields(old_models[name], new_models[name])
+        if changes:
+            lines.append(f"- {name}: {', '.join(changes)}")
+    return lines
+
+
+def patch_change_lines(
+    old_models: dict[str, dict[str, Any]],
+    new_models: dict[str, dict[str, Any]],
+    shared: list[str],
+) -> list[str]:
+    lines = []
+    for name in shared:
+        old_patches = old_models[name].get("patches")
+        new_patches = new_models[name].get("patches")
+        if old_patches != new_patches:
+            lines.append(f"- {name}:")
+            lines.append(f"    old: {old_patches}")
+            lines.append(f"    new: {new_patches}")
+    return lines
+
+
+def provider_diff_sections(
+    old_models: dict[str, dict[str, Any]],
+    new_models: dict[str, dict[str, Any]],
+) -> list[tuple[str, list[str]]]:
+    """`(heading, lines)` per kind of change in one provider, empty sections
+    dropped — so an empty result means the provider is unchanged."""
+    shared = sorted(set(new_models) & set(old_models), key=provider_sort_key)
+    added = sorted(set(new_models) - set(old_models), key=provider_sort_key)
+    removed = sorted(set(old_models) - set(new_models), key=provider_sort_key)
+    candidates = [
+        ("added", [f"- {name}" for name in added]),
+        ("removed", [f"- {name}" for name in removed]),
+        ("pricing changes", price_change_lines(old_models, new_models, shared)),
+        # A regenerated patch differing from the shipped one is how a hand-fixed
+        # expression silently gets reverted, so it has to show up here too.
+        ("request patch changes", patch_change_lines(old_models, new_models, shared)),
+    ]
+    return [(heading, lines) for heading, lines in candidates if lines]
+
+
 def build_diff_summary(
     old_by_provider: dict[str, dict[str, dict[str, Any]]],
     new_by_provider: OrderedDict[str, list[dict[str, Any]]],
@@ -723,31 +777,20 @@ def build_diff_summary(
     lines = ["Model catalog diff summary", ""]
     any_changes = False
     for provider, new_models_list in new_by_provider.items():
-        old_models = old_by_provider.get(provider, {})
-        new_models = {model["name"]: model for model in new_models_list}
-        added = sorted(set(new_models) - set(old_models), key=provider_sort_key)
-        removed = sorted(set(old_models) - set(new_models), key=provider_sort_key)
-        price_changes = []
-        for name in sorted(set(new_models) & set(old_models), key=provider_sort_key):
-            changes = compare_price_fields(old_models[name], new_models[name])
-            if changes:
-                price_changes.append(f"- {name}: {', '.join(changes)}")
-
-        if added or removed or price_changes:
-            any_changes = True
-            lines.append(f"{provider}:")
-            if added:
-                lines.append("- added:")
-                lines.extend([f"  - {name}" for name in added])
-            if removed:
-                lines.append("- removed:")
-                lines.extend([f"  - {name}" for name in removed])
-            if price_changes:
-                lines.append("- pricing changes:")
-                lines.extend([f"  {item}" for item in price_changes])
-            lines.append("")
+        sections = provider_diff_sections(
+            old_by_provider.get(provider, {}),
+            {model["name"]: model for model in new_models_list},
+        )
+        if not sections:
+            continue
+        any_changes = True
+        lines.append(f"{provider}:")
+        for heading, section_lines in sections:
+            lines.append(f"- {heading}:")
+            lines.extend([f"  {line}" for line in section_lines])
+        lines.append("")
     if not any_changes:
-        lines.append("No model additions, removals, or pricing changes.")
+        lines.append("No model additions, removals, pricing, or request patch changes.")
     return "\n".join(lines).rstrip()
 
 

--- a/scripts/update_models.py
+++ b/scripts/update_models.py
@@ -770,16 +770,38 @@ def provider_diff_sections(
     return [(heading, lines) for heading, lines in candidates if lines]
 
 
+def ordered_providers(
+    new_provider_models: dict[str, dict[str, dict[str, Any]]],
+    old_by_provider: dict[str, dict[str, dict[str, Any]]],
+) -> list[str]:
+    """Providers to emit, in `PROVIDER_ORDER` first then alphabetical.
+
+    Includes providers already in the YAML, not just `PROVIDER_ORDER` and
+    whatever LiteLLM returned: a hand-added provider block in neither list was
+    never visited, so every one of its models was dropped on the floor.
+    """
+    return PROVIDER_ORDER + sorted(
+        provider
+        for provider in {*new_provider_models, *old_by_provider}
+        if provider not in PROVIDER_ORDER
+    )
+
+
 def build_diff_summary(
     old_by_provider: dict[str, dict[str, dict[str, Any]]],
     new_by_provider: OrderedDict[str, list[dict[str, Any]]],
 ) -> str:
     lines = ["Model catalog diff summary", ""]
     any_changes = False
-    for provider, new_models_list in new_by_provider.items():
+    # Old-only providers last: a provider the generated catalog drops entirely
+    # still has to be reported, or losing a whole block reads as "no changes".
+    providers = list(new_by_provider) + [
+        provider for provider in old_by_provider if provider not in new_by_provider
+    ]
+    for provider in providers:
         sections = provider_diff_sections(
             old_by_provider.get(provider, {}),
-            {model["name"]: model for model in new_models_list},
+            {model["name"]: model for model in new_by_provider.get(provider, [])},
         )
         if not sections:
             continue
@@ -828,9 +850,7 @@ def main() -> int:
         new_provider_models[provider][model_name] = model
 
     final_provider_models: OrderedDict[str, list[dict[str, Any]]] = OrderedDict()
-    provider_order = PROVIDER_ORDER + sorted(
-        provider for provider in new_provider_models.keys() if provider not in PROVIDER_ORDER
-    )
+    provider_order = ordered_providers(new_provider_models, old_by_provider)
 
     for provider in provider_order:
         old_models = old_by_provider.get(provider, {})


### PR DESCRIPTION
The weekly models.yaml update PR (#1414 was the latest) reverted the Claude
effort-alias request patches every single run, and would have hard-broken them
on merge.

#1378 changed those patches in `models.yaml` from
`.body.output_config.effort = "high"` to `.body.output_config = {"effort":"high"}`,
because jaq — unlike jq — does not create the missing intermediate object, so the
nested form errors at request time and takes the rest of the `|` pipeline down
with it. That commit fixed `models.yaml` and the client but never touched the
generator, so `scripts/update_models.py` kept emitting the nested form and each
weekly run put all 21 patches back. #1378 also made a failing patch fail the
request instead of warning, so merging one of those PRs would have broken every
`claude-opus-4-7*`/`claude-opus-4-8*` `:high`/`:max`/`:xhigh` alias outright.

Three things had to change, because all three of the guards that should have
caught this were themselves pointing the wrong way:

- **The generator.** `claude_adaptive_patch` emits the whole-object assignment.
- **The unit tests.** Two assertions pinned the *broken* form, which is why the
  workflow's own `python scripts/test_update_models.py` step passed happily.
  They now pin the correct form, and a new test rejects any generated patch
  (Claude, Vertex AI, Bedrock) that assigns deeper than `.body.<field>`.
- **The diff summary.** It compared additions, removals, and pricing but not
  `patches`, so #1414's body read "No model additions, removals, or pricing
  changes" while reverting 21 patches — on a PR labelled `automerge`. It now
  reports changed patches with old and new values. `build_diff_summary` is split
  into `price_change_lines` / `patch_change_lines` / `provider_diff_sections` to
  stay under the complexity threshold; the rendered format is unchanged.
- **The workflow.** `update-models.yml` now runs
  `cargo nextest run -p harnx-client --test models_yaml_patches`. That guard was
  added in #1378 for exactly this failure and would have caught it, but it only
  ran in the PR's own CI — too late for an auto-merge PR.

No changeset: this is CI tooling, nothing user-visible ships differently.

## Testing

- `python scripts/test_update_models.py` — 80 passed. Verified the new nested-path
  test actually fails when the old expression is monkeypatched back in.
- Ran `scripts/update_models.py` against the live LiteLLM registry: the
  regenerated `models.yaml` is 60 insertions / 0 deletions, with zero
  `output_config` lines touched. Reverted that file so this PR is just the fix.
- `cargo build --workspace`, `cargo fmt --all`,
  `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo nextest run --workspace --stress-count=5` — 2462 tests, 5/5 iterations.
- `cs delta origin/HEAD` — `scripts/update_models.py` health 7.23 -> 7.66.

Unrelated but worth knowing: that live run showed real pending catalog additions
(`claude-mythos-5`, `claude-mythos-preview`, `gpt-4-0613`, `mistral-small-2603`,
and others) that the next scheduled run will pick up legitimately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adaptive model updates to apply configuration changes reliably.
  * Prevented errors when updating nested output configuration settings.

* **Improvements**
  * Model update summaries now clearly report pricing and request-patch changes.
  * No-change updates now provide more accurate feedback.

* **Testing**
  * Expanded validation for model update patches and change-summary reporting.
  * Added automated integration checks for generated model updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->