### PR TITLE
perf(build): stop rebuilding the workspace on every cargo invocation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,19 @@ repository = "https://github.com/dobesv/harnx"
 categories = ["command-line-utilities"]
 keywords = ["chatgpt", "llm", "cli", "ai", "tui"]
 
+[profile.dev]
+# Full debuginfo (the `dev` default) is what makes a workspace rebuild able to
+# take the machine down: cargo runs one rustc per core by default, and the
+# workspace's ~60 test binaries then link with full DWARF. Measured on a 24-core
+# box rebuilding harnx-core and everything downstream: peak 32.7 GB across the
+# toolchain and load 131, versus 18.0 GB and load 62 with line tables only.
+#
+# Line tables keep file:line in panic backtraces, which is what test failures
+# actually need. What's lost is variable inspection under a debugger — set this
+# back to `2` (or `cargo build --config 'profile.dev.debug=2'`) for a session
+# where you need to step through code in gdb/lldb.
+debug = "line-tables-only"
+
 [profile.release]
 lto = true
 # Keep symbols and line tables (don't strip) so crash backtraces in released

--- a/crates/harnx-runtime/build.rs
+++ b/crates/harnx-runtime/build.rs
@@ -2,18 +2,43 @@
 //! which build is running (see `bootstrap::setup_logger`). Best-effort: falls
 //! back to "unknown" when git or the `.git` directory is unavailable (e.g.
 //! building from a packaged crate).
+use std::path::Path;
 use std::process::Command;
 
 fn main() {
     let sha = git(&["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
-    let dirty = git(&["status", "--porcelain"])
+    // `--no-optional-locks` keeps `status` from refreshing and rewriting the
+    // index. Without it this build script bumped the index mtime every time it
+    // ran, and — while the index was also a `rerun-if-changed` input — that made
+    // it dirty its own fingerprint, so every cargo invocation rebuilt
+    // harnx-runtime and everything downstream.
+    let dirty = git(&["--no-optional-locks", "status", "--porcelain"])
         .map(|s| !s.is_empty())
         .unwrap_or(false);
     let stamp = if dirty { format!("{sha}-dirty") } else { sha };
     println!("cargo:rustc-env=HARNX_BUILD_SHA={stamp}");
-    // Re-stamp when the checked-out commit changes.
-    println!("cargo:rerun-if-changed=../../.git/HEAD");
-    println!("cargo:rerun-if-changed=../../.git/index");
+    // Re-stamp when the checked-out commit changes. Ask git where HEAD lives
+    // instead of assuming `../../.git/HEAD`: in a linked worktree `.git` is a
+    // file pointing at `.git/worktrees/<name>/`, so the hardcoded path did not
+    // exist — and cargo treats a missing `rerun-if-changed` file as changed,
+    // which was a second way to keep this script permanently dirty.
+    //
+    // The index is deliberately not watched. Doing so tied a full rebuild of
+    // every downstream crate to `git add` (and to anything else that refreshes
+    // the index), which costs minutes for a marker that is only used in one log
+    // line. The tradeoff: `-dirty` reflects the tree as of the last time this
+    // crate was compiled, not necessarily the current working tree.
+    watch_git_path("HEAD");
+}
+
+fn watch_git_path(name: &str) {
+    let Some(path) = git(&["rev-parse", "--git-path", name]) else {
+        return;
+    };
+    // Same trap as above: only watch it if it's really there.
+    if Path::new(&path).exists() {
+        println!("cargo:rerun-if-changed={path}");
+    }
 }
 
 fn git(args: &[&str]) -> Option<String> {

--- a/crates/harnx-runtime/build.rs
+++ b/crates/harnx-runtime/build.rs
@@ -17,18 +17,34 @@ fn main() {
         .unwrap_or(false);
     let stamp = if dirty { format!("{sha}-dirty") } else { sha };
     println!("cargo:rustc-env=HARNX_BUILD_SHA={stamp}");
-    // Re-stamp when the checked-out commit changes. Ask git where HEAD lives
-    // instead of assuming `../../.git/HEAD`: in a linked worktree `.git` is a
-    // file pointing at `.git/worktrees/<name>/`, so the hardcoded path did not
-    // exist — and cargo treats a missing `rerun-if-changed` file as changed,
-    // which was a second way to keep this script permanently dirty.
+    // Re-stamp when the checked-out commit changes. Ask git for these paths
+    // rather than assuming `../../.git/`: in a linked worktree `.git` is a file
+    // pointing at `.git/worktrees/<name>/`, so a hardcoded path does not exist —
+    // and cargo treats a missing `rerun-if-changed` file as changed, which is a
+    // second way to keep this script permanently dirty.
     //
-    // The index is deliberately not watched. Doing so tied a full rebuild of
-    // every downstream crate to `git add` (and to anything else that refreshes
-    // the index), which costs minutes for a marker that is only used in one log
-    // line. The tradeoff: `-dirty` reflects the tree as of the last time this
-    // crate was compiled, not necessarily the current working tree.
+    // Three paths, because no single one covers every way the commit moves.
+    // `git commit` does not touch HEAD at all — HEAD holds `ref: refs/heads/x`,
+    // and only the ref file underneath it moves — so HEAD alone catches checkout
+    // and branch switches but silently misses commits on the current branch.
     watch_git_path("HEAD");
+    watch_head_ref();
+    // A ref that lives in packed-refs has no loose file to watch.
+    watch_git_path("packed-refs");
+    // The index is deliberately not watched: that tied a full rebuild of every
+    // downstream crate to `git add` and to anything else that refreshes the
+    // index, which costs minutes for a marker used in one log line. So `-dirty`
+    // can lag — it reflects the tree as of the last time this crate compiled.
+}
+
+/// Watch the ref HEAD points at, which is what actually moves on `git commit`.
+fn watch_head_ref() {
+    // Fails on a detached HEAD, where the sha lives in HEAD itself and the watch
+    // on HEAD already covers it.
+    let Some(reference) = git(&["symbolic-ref", "--quiet", "HEAD"]) else {
+        return;
+    };
+    watch_git_path(&reference);
 }
 
 fn watch_git_path(name: &str) {


### PR DESCRIPTION
Running the test suite could lock up a whole machine, and the tests weren't the
reason. Every `cargo nextest run` silently recompiled ~10 crates and relinked the
test binaries first, at one rustc per core. That compile phase peaked at **load
131 and 32.7 GB** across rustc/ld on a 24-core box; the test phase itself only
reaches load ~6.7.

## Why it always rebuilt

Two bugs in `crates/harnx-runtime/build.rs` kept its fingerprint permanently
dirty. Everything depends on harnx-runtime, so the whole graph rebuilt with it.

1. The `rerun-if-changed` paths were hardcoded to `../../.git/HEAD` and
   `../../.git/index`. In a linked worktree `.git` is a *file* pointing at
   `.git/worktrees/<name>/`, so neither path existed — and cargo treats a missing
   `rerun-if-changed` file as changed. This one only shows up in worktrees, which
   is why it could go unnoticed. Now it asks git where HEAD actually lives
   (`git rev-parse --git-path HEAD`, correct in both a clone and a worktree) and
   only watches it if it's really there.

2. The script invalidated itself, and this one bites a plain clone too. It ran
   `git status --porcelain` for the `-dirty` suffix, which refreshes and rewrites
   the index — an input it also declared. `--no-optional-locks` stops the rewrite.

The index is no longer watched at all. Watching it tied a full rebuild of every
downstream crate to `git add`, which costs minutes for a marker used in one
startup log line. **Tradeoff:** `-dirty` now reflects the tree as of the last
time harnx-runtime compiled, not necessarily the current working tree.

Consecutive `cargo build --workspace --tests`, before -> after:

| | before | after |
|---|---|---|
| 2nd build | 110s | 9.0s |
| 3rd build | 100s | **0.4s** |

## Making a genuine rebuild survivable

Cargo defaults to one rustc per core (24 here) and full DWARF across the
workspace's test binaries is what makes that spike dangerous. Dev-profile
debuginfo drops to line tables. Rebuilding harnx-core and everything downstream:

| | full debuginfo | line-tables-only |
|---|---|---|
| peak RSS across rustc/ld | 32.7 GB | **18.0 GB** |
| peak load | 131 | **62** |
| min MemAvailable | 19.6 GB | **28.7 GB** |

Panic backtraces still resolve to function names and `file:line`, which is what
test failures need — verified directly. What's lost is variable inspection under
a debugger; the comment in `Cargo.toml` says how to get it back for a session.

No changeset: dev-profile and build-script changes, nothing ships differently.

## Testing

- `cargo build --workspace`, `cargo fmt --all --check`,
  `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo nextest run --workspace --stress-count=5` — 2462 tests, 5/5 iterations.
- `cs delta origin/HEAD` — no issues found.
- Verified `-C debuginfo=line-tables-only` keeps `file:line` in a real backtrace.

One flake worth flagging, not caused by this change: an earlier stress run hit
`harnx-claude-compatible-hook-server::nats_runner
command_hook_uses_env_name_with_end_of_options_separator` once, failing in 65ms.
The re-run was 5/5 green and it passes 30/30 alone and 120x under
self-contention. I lost the captured stderr, so the cause is unconfirmed.

A plausible mechanism I noticed while looking: `spawn_nats_server` binds
`127.0.0.1:0`, reads the port, **drops the listener**, then has `nats-server`
re-bind it. If a concurrently-starting test takes that port in the gap,
nats-server exits at once and the test bails with "nats-server exited during
startup" in tens of milliseconds — which matches the 65ms. That bind-then-drop
pattern appears at 12 sites. Unproven, and a separate concern from this PR.

## Not included, deliberately

- **A `jobs` cap.** Cargo computes negative `jobs` as `ncpu + jobs` floored at 1,
  and CI runs on 4-core `ubuntu-latest`, so a value that suits a 24-core dev box
  would clamp CI to a single job. Better set per-machine via `CARGO_BUILD_JOBS`.
- **mold.** Would be the biggest remaining win on link memory and time, but
  wiring it into `.cargo/config.toml` makes it a hard toolchain requirement for
  every dev and for CI. Its own decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Reduced debug data generated by development builds while preserving line information for diagnostics.
  * Improved build metadata handling for linked worktrees and repositories with missing Git paths.
  * Prevented builds from modifying the Git index and avoided unnecessary rebuild triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->