### PR TITLE
ci: make the nats-server download retryable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,14 @@ jobs:
         DOWNLOAD_URL="https://github.com/nats-io/nats-server/releases/download/${VERSION}/${ASSET}"
         BINDIR="${HOME}/.local/bin"
         mkdir -p "${BINDIR}"
-        curl -sL "${DOWNLOAD_URL}" | tar -xzf - -C "${BINDIR}" --strip-components=1 "nats-server-${VERSION}-linux-amd64/nats-server"
+        TMPDIR_DL="$(mktemp -d)"
+        # Download to a file rather than piping into tar. A retry can't resume a
+        # stream tar has already started reading, and an HTTP error body piped to
+        # tar surfaces as "tar: Error is not recoverable" instead of naming the
+        # failed download.
+        curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused --retry-delay 2 \
+          --location --silent --show-error --fail --output "${TMPDIR_DL}/${ASSET}" "${DOWNLOAD_URL}"
+        tar -xzf "${TMPDIR_DL}/${ASSET}" -C "${BINDIR}" --strip-components=1 "nats-server-${VERSION}-linux-amd64/nats-server"
         chmod +x "${BINDIR}/nats-server"
         echo "${BINDIR}" >> "${GITHUB_PATH}"
       shell: bash
@@ -88,7 +95,11 @@ jobs:
         DOWNLOAD_URL="https://github.com/nats-io/nats-server/releases/download/${VERSION}/${ASSET}"
         BINDIR="${HOME}/.local/bin"
         mkdir -p "${BINDIR}"
-        curl -sL "${DOWNLOAD_URL}" | tar -xzf - -C "${BINDIR}" --strip-components=1 "nats-server-${VERSION}-darwin-${NATS_ARCH}/nats-server"
+        TMPDIR_DL="$(mktemp -d)"
+        # See the Linux step for why this downloads to a file first.
+        curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused --retry-delay 2 \
+          --location --silent --show-error --fail --output "${TMPDIR_DL}/${ASSET}" "${DOWNLOAD_URL}"
+        tar -xzf "${TMPDIR_DL}/${ASSET}" -C "${BINDIR}" --strip-components=1 "nats-server-${VERSION}-darwin-${NATS_ARCH}/nats-server"
         chmod +x "${BINDIR}/nats-server"
         echo "${BINDIR}" >> "${GITHUB_PATH}"
       shell: bash


### PR DESCRIPTION
A transient failure fetching the nats-server tarball took down the whole Linux
leg of #1427 and cancelled macOS and Windows with it. The pinned URL was never
wrong — it still returns 200 — so a retry would have covered it. The step three
above it (rustup) already retries; this one didn't.

Adding `--retry` alone wouldn't have been enough. `curl | tar` can't be retried:
once curl has written bytes into the pipe tar is already consuming them, so a
restarted transfer hands tar a corrupt stream. Download to a file, then extract.

That also fixes the diagnostics. Without `--fail`, curl passed the HTTP error
body straight to tar, and the only thing CI printed was:

```
tar: Error is not recoverable: exiting now
##[error]Process completed with exit code 2.
```

which says nothing about a download. Verified the new command against a bad URL:

```
curl: (22) The requested URL returned error: 404
```

Retry flags match the rustup step's (`--proto '=https' --tlsv1.2 --retry N
--retry-connrefused --location --silent --show-error --fail`). Uses `mktemp -d`
rather than `RUNNER_TEMP`, which isn't referenced anywhere else in these
workflows and would abort under the step's `set -u` if ever unset.

Both the Linux and macOS steps get the same treatment. Windows deliberately
installs no nats-server (see the comment below those steps).

## Testing

Ran both the download and the extract locally with the exact flags from the
workflow: the happy path produces a working binary (`nats-server: v2.11.6`), and
a nonexistent release tag now fails with the curl 404 above instead of the tar
error. `ci.yaml` parses. No Rust or Python touched, so CI on this PR is the real
gate for the rest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and security when setting up NATS servers on Linux and macOS.
  * Added download retries and safer archive handling to reduce setup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->