### PR TITLE
test(nats): let nats-server pick its own port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3922,6 +3922,7 @@ dependencies = [
  "log",
  "rcgen",
  "rustls-pemfile",
+ "serde_json",
  "tempfile",
  "tokio",
  "tokio-util",

--- a/crates/harnx-claude-compatible-hook-server/tests/nats_runner.rs
+++ b/crates/harnx-claude-compatible-hook-server/tests/nats_runner.rs
@@ -7,8 +7,7 @@ use harnx_core::instance::{ServerScope, HARNX_SERVER_SCOPE};
 use harnx_hookset::{HookRegistration, HARNX_HOOK_NAME};
 use harnx_hookset_server::{hook_registration_key, serve_over_nats, HOOK_REGISTRY_BUCKET};
 use serde_json::json;
-use std::net::TcpListener;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
@@ -19,6 +18,7 @@ const SERVER_NAME: &str = "command-runner";
 struct NatsServerHandle {
     url: String,
     _store_dir: TempDir,
+    _ports_dir: TempDir,
     child: Child,
 }
 
@@ -54,24 +54,32 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
         return Ok(None);
     };
 
-    let listener = TcpListener::bind("127.0.0.1:0").context("allocate NATS test port")?;
-    let port = listener.local_addr()?.port();
-    drop(listener);
     let store_dir = tempfile::tempdir().context("create NATS test store")?;
+    let ports_dir = tempfile::tempdir().context("create NATS ports dir")?;
+    // `-p -1` has nats-server ask the kernel for a free port and keep it, then
+    // report it via `--ports_file_dir`. Binding a port here and dropping the
+    // listener before nats-server rebinds it left a window where a concurrently
+    // starting test could take the same port, and nats-server would exit at once.
+    // `-a 127.0.0.1` keeps the test broker off every other interface — it
+    // otherwise listened on the LAN with a hardcoded token.
     let mut child = Command::new(binary)
         .arg("-js")
         .arg("-sd")
         .arg(store_dir.path())
+        .arg("-a")
+        .arg("127.0.0.1")
         .arg("-p")
-        .arg(port.to_string())
+        .arg("-1")
         .arg("--auth")
         .arg(TOKEN)
+        .arg("--ports_file_dir")
+        .arg(ports_dir.path())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
         .context("spawn nats-server")?;
-    let url = format!("nats://127.0.0.1:{port}");
     let deadline = Instant::now() + Duration::from_secs(15);
+    let url = read_ports_file(ports_dir.path(), &mut child, deadline)?;
     loop {
         match async_nats::ConnectOptions::new()
             .token(TOKEN.to_string())
@@ -83,6 +91,7 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
                 return Ok(Some(NatsServerHandle {
                     url,
                     _store_dir: store_dir,
+                    _ports_dir: ports_dir,
                     child,
                 }));
             }
@@ -95,6 +104,45 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
             Err(error) => return Err(error).context("wait for nats-server readiness"),
         }
     }
+}
+
+/// Read the client URL out of the ports file nats-server writes once it has
+/// bound its listeners.
+///
+/// The file is named `<executable_name>_<pid>.ports`, so it's found by scanning
+/// the (private) directory rather than by rebuilding the name — `NATS_SERVER_BIN`
+/// can point at a differently named binary. nats-server writes into the file
+/// directly rather than renaming it into place, so a partial read is possible;
+/// failing to parse is treated the same as not-yet-written.
+fn read_ports_file(dir: &Path, child: &mut Child, deadline: Instant) -> Result<String> {
+    loop {
+        if let Some(url) = first_client_url(dir) {
+            return Ok(url);
+        }
+        if let Some(status) = child.try_wait()? {
+            anyhow::bail!("nats-server exited during startup: {status}");
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for the nats-server ports file in {}",
+                dir.display()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn first_client_url(dir: &Path) -> Option<String> {
+    for entry in std::fs::read_dir(dir).ok()? {
+        let path = entry.ok()?.path();
+        if path.extension().is_some_and(|ext| ext == "ports") {
+            let contents = std::fs::read_to_string(&path).ok()?;
+            let parsed: serde_json::Value = serde_json::from_str(&contents).ok()?;
+            let url = parsed.get("nats")?.get(0)?.as_str()?;
+            return Some(url.to_string());
+        }
+    }
+    None
 }
 
 async fn wait_for_registration(

--- a/crates/harnx-fs-tools/tests/nats_fs.rs
+++ b/crates/harnx-fs-tools/tests/nats_fs.rs
@@ -8,7 +8,6 @@ use harnx_toolset::{
 use harnx_toolset_server::{registration_key, serve_over_nats, TOOL_REGISTRY_BUCKET};
 use serde_json::{json, Value};
 use std::collections::HashMap;
-use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -19,6 +18,7 @@ const TOKEN: &str = "fs-toolset-test-token";
 struct NatsServerHandle {
     url: String,
     _store_dir: TempDir,
+    _ports_dir: TempDir,
     child: Child,
 }
 
@@ -37,29 +37,36 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
 
     const MAX_START_ATTEMPTS: usize = 5;
     for attempt in 1..=MAX_START_ATTEMPTS {
-        let listener = TcpListener::bind("127.0.0.1:0").context("allocate NATS test port")?;
-        let port = listener.local_addr()?.port();
-        drop(listener);
         let store_dir = tempfile::tempdir().context("create NATS test store")?;
+        let ports_dir = tempfile::tempdir().context("create NATS ports dir")?;
         let mut child = Command::new(&binary)
             .arg("-js")
             .arg("-sd")
             .arg(store_dir.path())
+            .arg("-a")
+            .arg("127.0.0.1")
             .arg("-p")
-            .arg(port.to_string())
+            .arg("-1")
             .arg("--auth")
             .arg(TOKEN)
+            .arg("--ports_file_dir")
+            .arg(ports_dir.path())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
             .context("spawn nats-server")?;
-        let url = format!("nats://127.0.0.1:{port}");
+        let url = read_nats_ports_file(
+            ports_dir.path(),
+            &mut child,
+            Instant::now() + Duration::from_secs(15),
+        )?;
 
         match wait_for_nats_ready(&mut child, &url).await {
             Ok(()) => {
                 return Ok(Some(NatsServerHandle {
                     url,
                     _store_dir: store_dir,
+                    _ports_dir: ports_dir,
                     child,
                 }));
             }
@@ -327,4 +334,47 @@ async fn fs_toolset_round_trips_over_nats_with_bridge_envelope_parity() -> Resul
     server_task.abort();
     drop(server);
     Ok(())
+}
+
+/// Read the client URL out of the ports file nats-server writes once it has
+/// bound its listeners.
+///
+/// The file is named `<executable_name>_<pid>.ports`, so it's found by scanning
+/// the (private) directory rather than by rebuilding the name — `NATS_SERVER_BIN`
+/// can point at a differently named binary. nats-server writes into the file
+/// directly rather than renaming it into place, so a partial read is possible;
+/// failing to parse is treated the same as not-yet-written.
+fn read_nats_ports_file(
+    dir: &std::path::Path,
+    child: &mut Child,
+    deadline: Instant,
+) -> Result<String> {
+    loop {
+        if let Some(url) = first_nats_client_url(dir) {
+            return Ok(url);
+        }
+        if let Some(status) = child.try_wait()? {
+            anyhow::bail!("nats-server exited during startup: {status}");
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for the nats-server ports file in {}",
+                dir.display()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn first_nats_client_url(dir: &std::path::Path) -> Option<String> {
+    for entry in std::fs::read_dir(dir).ok()? {
+        let path = entry.ok()?.path();
+        if path.extension().is_some_and(|ext| ext == "ports") {
+            let contents = std::fs::read_to_string(&path).ok()?;
+            let parsed: serde_json::Value = serde_json::from_str(&contents).ok()?;
+            let url = parsed.get("nats")?.get(0)?.as_str()?;
+            return Some(url.to_string());
+        }
+    }
+    None
 }

--- a/crates/harnx-hookset-server/tests/nats_hookset.rs
+++ b/crates/harnx-hookset-server/tests/nats_hookset.rs
@@ -10,7 +10,6 @@ use harnx_hookset_server::{
 };
 use harnx_nats_common::connect::NatsConnection;
 use serde_json::json;
-use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
@@ -23,6 +22,7 @@ const TOKEN: &str = "hookset-server-test-token";
 struct NatsServerHandle {
     url: String,
     _store_dir: TempDir,
+    _ports_dir: TempDir,
     child: Child,
 }
 
@@ -41,29 +41,36 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
 
     const MAX_START_ATTEMPTS: usize = 5;
     for attempt in 1..=MAX_START_ATTEMPTS {
-        let listener = TcpListener::bind("127.0.0.1:0").context("allocate NATS test port")?;
-        let port = listener.local_addr()?.port();
-        drop(listener);
         let store_dir = tempfile::tempdir().context("create NATS test store")?;
+        let ports_dir = tempfile::tempdir().context("create NATS ports dir")?;
         let mut child = Command::new(&binary)
             .arg("-js")
             .arg("-sd")
             .arg(store_dir.path())
+            .arg("-a")
+            .arg("127.0.0.1")
             .arg("-p")
-            .arg(port.to_string())
+            .arg("-1")
             .arg("--auth")
             .arg(TOKEN)
+            .arg("--ports_file_dir")
+            .arg(ports_dir.path())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
             .context("spawn nats-server")?;
-        let url = format!("nats://127.0.0.1:{port}");
+        let url = read_nats_ports_file(
+            ports_dir.path(),
+            &mut child,
+            Instant::now() + Duration::from_secs(15),
+        )?;
 
         match wait_for_nats_ready(&mut child, &url).await {
             Ok(()) => {
                 return Ok(Some(NatsServerHandle {
                     url,
                     _store_dir: store_dir,
+                    _ports_dir: ports_dir,
                     child,
                 }));
             }
@@ -348,4 +355,47 @@ async fn old_instances_shutdown_does_not_delete_a_replacements_registration() ->
 
     drop(server);
     Ok(())
+}
+
+/// Read the client URL out of the ports file nats-server writes once it has
+/// bound its listeners.
+///
+/// The file is named `<executable_name>_<pid>.ports`, so it's found by scanning
+/// the (private) directory rather than by rebuilding the name — `NATS_SERVER_BIN`
+/// can point at a differently named binary. nats-server writes into the file
+/// directly rather than renaming it into place, so a partial read is possible;
+/// failing to parse is treated the same as not-yet-written.
+fn read_nats_ports_file(
+    dir: &std::path::Path,
+    child: &mut Child,
+    deadline: Instant,
+) -> Result<String> {
+    loop {
+        if let Some(url) = first_nats_client_url(dir) {
+            return Ok(url);
+        }
+        if let Some(status) = child.try_wait()? {
+            anyhow::bail!("nats-server exited during startup: {status}");
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for the nats-server ports file in {}",
+                dir.display()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn first_nats_client_url(dir: &std::path::Path) -> Option<String> {
+    for entry in std::fs::read_dir(dir).ok()? {
+        let path = entry.ok()?.path();
+        if path.extension().is_some_and(|ext| ext == "ports") {
+            let contents = std::fs::read_to_string(&path).ok()?;
+            let parsed: serde_json::Value = serde_json::from_str(&contents).ok()?;
+            let url = parsed.get("nats")?.get(0)?.as_str()?;
+            return Some(url.to_string());
+        }
+    }
+    None
 }

--- a/crates/harnx-mcp-bridge/tests/bridge_roundtrip.rs
+++ b/crates/harnx-mcp-bridge/tests/bridge_roundtrip.rs
@@ -23,6 +23,7 @@ const TOKEN: &str = "mcp-bridge-roundtrip-token";
 struct NatsServerHandle {
     url: String,
     _store_dir: TempDir,
+    _ports_dir: TempDir,
     child: Child,
 }
 
@@ -60,24 +61,36 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
 }
 
 async fn try_spawn_nats_server(binary: &Path) -> Result<NatsServerHandle> {
-    let listener = TcpListener::bind("127.0.0.1:0").context("allocate NATS test port")?;
-    let port = listener.local_addr()?.port();
-    drop(listener);
-
     let store_dir = tempfile::tempdir().context("create NATS test store")?;
+    let ports_dir = tempfile::tempdir().context("create NATS ports dir")?;
     let mut child = Command::new(binary)
         .arg("-js")
         .arg("-sd")
         .arg(store_dir.path())
+        .arg("-a")
+        .arg("127.0.0.1")
         .arg("-p")
-        .arg(port.to_string())
+        .arg("-1")
         .arg("--auth")
         .arg(TOKEN)
+        .arg("--ports_file_dir")
+        .arg(ports_dir.path())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
         .with_context(|| format!("spawn {}", binary.display()))?;
-    let url = format!("nats://127.0.0.1:{port}");
+    let url = match read_nats_ports_file(
+        ports_dir.path(),
+        &mut child,
+        Instant::now() + Duration::from_secs(15),
+    ) {
+        Ok(url) => url,
+        Err(error) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(error);
+        }
+    };
 
     if let Err(error) = wait_for_nats_ready(&url).await {
         let _ = child.kill();
@@ -87,6 +100,7 @@ async fn try_spawn_nats_server(binary: &Path) -> Result<NatsServerHandle> {
     Ok(NatsServerHandle {
         url,
         _store_dir: store_dir,
+        _ports_dir: ports_dir,
         child,
     })
 }
@@ -512,4 +526,47 @@ async fn bridge_binary_exits_when_wrapped_child_dies_during_stalled_nats_connect
         "bridge binary exited successfully after wrapped MCP child died during a stalled NATS connect"
     );
     Ok(())
+}
+
+/// Read the client URL out of the ports file nats-server writes once it has
+/// bound its listeners.
+///
+/// The file is named `<executable_name>_<pid>.ports`, so it's found by scanning
+/// the (private) directory rather than by rebuilding the name — `NATS_SERVER_BIN`
+/// can point at a differently named binary. nats-server writes into the file
+/// directly rather than renaming it into place, so a partial read is possible;
+/// failing to parse is treated the same as not-yet-written.
+fn read_nats_ports_file(
+    dir: &std::path::Path,
+    child: &mut Child,
+    deadline: Instant,
+) -> Result<String> {
+    loop {
+        if let Some(url) = first_nats_client_url(dir) {
+            return Ok(url);
+        }
+        if let Some(status) = child.try_wait()? {
+            anyhow::bail!("nats-server exited during startup: {status}");
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for the nats-server ports file in {}",
+                dir.display()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn first_nats_client_url(dir: &std::path::Path) -> Option<String> {
+    for entry in std::fs::read_dir(dir).ok()? {
+        let path = entry.ok()?.path();
+        if path.extension().is_some_and(|ext| ext == "ports") {
+            let contents = std::fs::read_to_string(&path).ok()?;
+            let parsed: serde_json::Value = serde_json::from_str(&contents).ok()?;
+            let url = parsed.get("nats")?.get(0)?.as_str()?;
+            return Some(url.to_string());
+        }
+    }
+    None
 }

--- a/crates/harnx-mcp-bridge/tests/sigterm_shutdown.rs
+++ b/crates/harnx-mcp-bridge/tests/sigterm_shutdown.rs
@@ -11,7 +11,6 @@ use anyhow::{Context, Result};
 use harnx_core::instance::{ServerScope, HARNX_SERVER_SCOPE};
 use harnx_toolset::server_identity_token;
 use harnx_toolset_server::registration_key;
-use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -22,6 +21,7 @@ const TOKEN: &str = "mcp-bridge-sigterm-test-token";
 struct NatsServerHandle {
     url: String,
     _store_dir: TempDir,
+    _ports_dir: TempDir,
     child: Child,
 }
 
@@ -57,28 +57,35 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
         return Ok(None);
     };
 
-    let listener = TcpListener::bind("127.0.0.1:0").context("allocate NATS test port")?;
-    let port = listener.local_addr()?.port();
-    drop(listener);
     let store_dir = tempfile::tempdir().context("create NATS test store")?;
+    let ports_dir = tempfile::tempdir().context("create NATS ports dir")?;
     let mut child = Command::new(binary)
         .arg("-js")
         .arg("-sd")
         .arg(store_dir.path())
+        .arg("-a")
+        .arg("127.0.0.1")
         .arg("-p")
-        .arg(port.to_string())
+        .arg("-1")
         .arg("--auth")
         .arg(TOKEN)
+        .arg("--ports_file_dir")
+        .arg(ports_dir.path())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
         .context("spawn nats-server")?;
-    let url = format!("nats://127.0.0.1:{port}");
+    let url = read_nats_ports_file(
+        ports_dir.path(),
+        &mut child,
+        Instant::now() + Duration::from_secs(15),
+    )?;
 
     match wait_for_nats_ready(&mut child, &url).await {
         Ok(()) => Ok(Some(NatsServerHandle {
             url,
             _store_dir: store_dir,
+            _ports_dir: ports_dir,
             child,
         })),
         Err(error) => {
@@ -228,4 +235,47 @@ async fn sigterm_removes_the_bridge_registration() -> Result<()> {
 
     let _ = bridge.0.wait();
     Ok(())
+}
+
+/// Read the client URL out of the ports file nats-server writes once it has
+/// bound its listeners.
+///
+/// The file is named `<executable_name>_<pid>.ports`, so it's found by scanning
+/// the (private) directory rather than by rebuilding the name — `NATS_SERVER_BIN`
+/// can point at a differently named binary. nats-server writes into the file
+/// directly rather than renaming it into place, so a partial read is possible;
+/// failing to parse is treated the same as not-yet-written.
+fn read_nats_ports_file(
+    dir: &std::path::Path,
+    child: &mut Child,
+    deadline: Instant,
+) -> Result<String> {
+    loop {
+        if let Some(url) = first_nats_client_url(dir) {
+            return Ok(url);
+        }
+        if let Some(status) = child.try_wait()? {
+            anyhow::bail!("nats-server exited during startup: {status}");
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for the nats-server ports file in {}",
+                dir.display()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn first_nats_client_url(dir: &std::path::Path) -> Option<String> {
+    for entry in std::fs::read_dir(dir).ok()? {
+        let path = entry.ok()?.path();
+        if path.extension().is_some_and(|ext| ext == "ports") {
+            let contents = std::fs::read_to_string(&path).ok()?;
+            let parsed: serde_json::Value = serde_json::from_str(&contents).ok()?;
+            let url = parsed.get("nats")?.get(0)?.as_str()?;
+            return Some(url.to_string());
+        }
+    }
+    None
 }

--- a/crates/harnx-nats-common/Cargo.toml
+++ b/crates/harnx-nats-common/Cargo.toml
@@ -15,6 +15,7 @@ tokio-util = { workspace = true }
 [dev-dependencies]
 harnx-core = { path = "../harnx-core" }
 rcgen = { workspace = true }
+serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 which = { workspace = true }

--- a/crates/harnx-nats-common/tests/registry_ttl.rs
+++ b/crates/harnx-nats-common/tests/registry_ttl.rs
@@ -3,7 +3,6 @@ use async_nats::jetstream;
 use harnx_nats_common::registry::{
     ensure_bucket_with_ttl, reconcile_bucket_replicas, REGISTRATION_TTL,
 };
-use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -14,6 +13,7 @@ const TOKEN: &str = "nats-common-test-token";
 struct NatsServerHandle {
     url: String,
     _store_dir: TempDir,
+    _ports_dir: TempDir,
     child: Child,
 }
 
@@ -32,29 +32,36 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
 
     const MAX_START_ATTEMPTS: usize = 5;
     for attempt in 1..=MAX_START_ATTEMPTS {
-        let listener = TcpListener::bind("127.0.0.1:0").context("allocate NATS test port")?;
-        let port = listener.local_addr()?.port();
-        drop(listener);
         let store_dir = tempfile::tempdir().context("create NATS test store")?;
+        let ports_dir = tempfile::tempdir().context("create NATS ports dir")?;
         let mut child = Command::new(&binary)
             .arg("-js")
             .arg("-sd")
             .arg(store_dir.path())
+            .arg("-a")
+            .arg("127.0.0.1")
             .arg("-p")
-            .arg(port.to_string())
+            .arg("-1")
             .arg("--auth")
             .arg(TOKEN)
+            .arg("--ports_file_dir")
+            .arg(ports_dir.path())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
             .context("spawn nats-server")?;
-        let url = format!("nats://127.0.0.1:{port}");
+        let url = read_nats_ports_file(
+            ports_dir.path(),
+            &mut child,
+            Instant::now() + Duration::from_secs(15),
+        )?;
 
         match wait_for_nats_ready(&mut child, &url).await {
             Ok(()) => {
                 return Ok(Some(NatsServerHandle {
                     url,
                     _store_dir: store_dir,
+                    _ports_dir: ports_dir,
                     child,
                 }));
             }
@@ -287,4 +294,47 @@ async fn reconcile_bucket_replicas_never_lowers_an_existing_higher_count() -> Re
         "reconcile must never lower an existing bucket's replicas"
     );
     Ok(())
+}
+
+/// Read the client URL out of the ports file nats-server writes once it has
+/// bound its listeners.
+///
+/// The file is named `<executable_name>_<pid>.ports`, so it's found by scanning
+/// the (private) directory rather than by rebuilding the name — `NATS_SERVER_BIN`
+/// can point at a differently named binary. nats-server writes into the file
+/// directly rather than renaming it into place, so a partial read is possible;
+/// failing to parse is treated the same as not-yet-written.
+fn read_nats_ports_file(
+    dir: &std::path::Path,
+    child: &mut Child,
+    deadline: Instant,
+) -> Result<String> {
+    loop {
+        if let Some(url) = first_nats_client_url(dir) {
+            return Ok(url);
+        }
+        if let Some(status) = child.try_wait()? {
+            anyhow::bail!("nats-server exited during startup: {status}");
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for the nats-server ports file in {}",
+                dir.display()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn first_nats_client_url(dir: &std::path::Path) -> Option<String> {
+    for entry in std::fs::read_dir(dir).ok()? {
+        let path = entry.ok()?.path();
+        if path.extension().is_some_and(|ext| ext == "ports") {
+            let contents = std::fs::read_to_string(&path).ok()?;
+            let parsed: serde_json::Value = serde_json::from_str(&contents).ok()?;
+            let url = parsed.get("nats")?.get(0)?.as_str()?;
+            return Some(url.to_string());
+        }
+    }
+    None
 }

--- a/crates/harnx-proxy-auth/tests/nats_hook.rs
+++ b/crates/harnx-proxy-auth/tests/nats_hook.rs
@@ -7,7 +7,6 @@ use harnx_hookset::{FailPolicy, HookRegistration};
 use harnx_hookset_server::{hook_registration_key, serve_over_nats, HOOK_REGISTRY_BUCKET};
 use harnx_proxy_auth::hook::ProxyAuthHook;
 use serde_json::{json, Map};
-use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -19,6 +18,7 @@ const ASSIGNED_NAME: &str = "hook-a1b2c3d4-000";
 struct NatsServerHandle {
     url: String,
     _store_dir: TempDir,
+    _ports_dir: TempDir,
     child: Child,
 }
 
@@ -45,23 +45,29 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
         return Ok(None);
     };
 
-    let listener = TcpListener::bind("127.0.0.1:0").context("allocate NATS test port")?;
-    let port = listener.local_addr()?.port();
-    drop(listener);
     let store_dir = tempfile::tempdir().context("create NATS test store")?;
+    let ports_dir = tempfile::tempdir().context("create NATS ports dir")?;
     let mut child = Command::new(binary)
         .arg("-js")
         .arg("-sd")
         .arg(store_dir.path())
+        .arg("-a")
+        .arg("127.0.0.1")
         .arg("-p")
-        .arg(port.to_string())
+        .arg("-1")
         .arg("--auth")
         .arg(TOKEN)
+        .arg("--ports_file_dir")
+        .arg(ports_dir.path())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
         .context("spawn nats-server")?;
-    let url = format!("nats://127.0.0.1:{port}");
+    let url = read_nats_ports_file(
+        ports_dir.path(),
+        &mut child,
+        Instant::now() + Duration::from_secs(15),
+    )?;
     let deadline = Instant::now() + Duration::from_secs(15);
     loop {
         match async_nats::ConnectOptions::new()
@@ -74,6 +80,7 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
                 return Ok(Some(NatsServerHandle {
                     url,
                     _store_dir: store_dir,
+                    _ports_dir: ports_dir,
                     child,
                 }));
             }
@@ -181,4 +188,47 @@ async fn proxy_auth_registers_and_mutates_tool_env_over_nats() -> Result<()> {
 
     server_task.abort();
     Ok(())
+}
+
+/// Read the client URL out of the ports file nats-server writes once it has
+/// bound its listeners.
+///
+/// The file is named `<executable_name>_<pid>.ports`, so it's found by scanning
+/// the (private) directory rather than by rebuilding the name — `NATS_SERVER_BIN`
+/// can point at a differently named binary. nats-server writes into the file
+/// directly rather than renaming it into place, so a partial read is possible;
+/// failing to parse is treated the same as not-yet-written.
+fn read_nats_ports_file(
+    dir: &std::path::Path,
+    child: &mut Child,
+    deadline: Instant,
+) -> Result<String> {
+    loop {
+        if let Some(url) = first_nats_client_url(dir) {
+            return Ok(url);
+        }
+        if let Some(status) = child.try_wait()? {
+            anyhow::bail!("nats-server exited during startup: {status}");
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for the nats-server ports file in {}",
+                dir.display()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn first_nats_client_url(dir: &std::path::Path) -> Option<String> {
+    for entry in std::fs::read_dir(dir).ok()? {
+        let path = entry.ok()?.path();
+        if path.extension().is_some_and(|ext| ext == "ports") {
+            let contents = std::fs::read_to_string(&path).ok()?;
+            let parsed: serde_json::Value = serde_json::from_str(&contents).ok()?;
+            let url = parsed.get("nats")?.get(0)?.as_str()?;
+            return Some(url.to_string());
+        }
+    }
+    None
 }

--- a/crates/harnx-runtime/src/nats_tool_provider.rs
+++ b/crates/harnx-runtime/src/nats_tool_provider.rs
@@ -757,28 +757,47 @@ mod tests {
             .map(std::path::PathBuf::from)
             .filter(|path| path.exists())
             .or_else(|| which::which("nats-server").ok())?;
-        let listener =
-            std::net::TcpListener::bind("127.0.0.1:0").expect("allocate a free TCP port");
-        let port = listener.local_addr().expect("read bound port").port();
-        drop(listener);
+        // `-p -1` lets nats-server take a free port from the kernel and keep it.
+        // Allocating one here and dropping the listener first left a window for a
+        // concurrently starting server to claim the same port.
+        let ports_dir = tempfile::tempdir().expect("create NATS ports dir");
         let child = std::process::Command::new(&binary)
+            .arg("-a")
+            .arg("127.0.0.1")
             .arg("-p")
-            .arg(port.to_string())
+            .arg("-1")
+            .arg("--ports_file_dir")
+            .arg(ports_dir.path())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn()
             .expect("spawn nats-server");
-        let url = format!("nats://127.0.0.1:{port}");
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-        loop {
-            if std::net::TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
-                break;
+        let url = loop {
+            if let Some(url) = read_first_nats_url(ports_dir.path()) {
+                break url;
             }
             if std::time::Instant::now() >= deadline {
-                panic!("nats-server did not open its port before the deadline");
+                panic!("nats-server did not report its port before the deadline");
             }
             std::thread::sleep(std::time::Duration::from_millis(20));
-        }
+        };
         Some(JetstreamDisabledNatsServer { url, child })
+    }
+
+    /// nats-server names its ports file `<executable_name>_<pid>.ports`, so scan
+    /// the (private) directory instead of rebuilding the name — `NATS_SERVER_BIN`
+    /// may point at a differently named binary. A parse failure means the file is
+    /// still being written; the caller retries.
+    fn read_first_nats_url(dir: &std::path::Path) -> Option<String> {
+        for entry in std::fs::read_dir(dir).ok()? {
+            let path = entry.ok()?.path();
+            if path.extension().is_some_and(|ext| ext == "ports") {
+                let contents = std::fs::read_to_string(&path).ok()?;
+                let parsed: serde_json::Value = serde_json::from_str(&contents).ok()?;
+                return Some(parsed.get("nats")?.get(0)?.as_str()?.to_string());
+            }
+        }
+        None
     }
 }

--- a/crates/harnx-runtime/tests/common/mod.rs
+++ b/crates/harnx-runtime/tests/common/mod.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -9,6 +8,7 @@ use tokio::time::sleep;
 pub struct NatsServerHandle {
     pub url: String,
     _store_dir: TempDir,
+    _ports_dir: TempDir,
     child: Child,
 }
 
@@ -64,15 +64,19 @@ async fn try_spawn_nats_once(
     binary: &std::path::Path,
     options: &SpawnNatsServerOptions,
 ) -> Result<NatsServerHandle> {
-    let port = free_tcp_port()?;
     let store_dir = tempfile::tempdir().context("Failed to create temp NATS store dir")?;
+    let ports_dir = tempfile::tempdir().context("Failed to create temp NATS ports dir")?;
     let mut command = Command::new(binary);
     command
         .arg("-js")
         .arg("-sd")
         .arg(store_dir.path())
+        .arg("-a")
+        .arg("127.0.0.1")
         .arg("-p")
-        .arg(port.to_string());
+        .arg("-1")
+        .arg("--ports_file_dir")
+        .arg(ports_dir.path());
     if let Some(token) = &options.auth_token {
         command.arg("--auth").arg(token);
     }
@@ -82,10 +86,19 @@ async fn try_spawn_nats_once(
         .spawn()
         .with_context(|| format!("Failed to spawn {}", binary.display()))?;
 
-    let url = format!("nats://127.0.0.1:{port}");
+    let url = match read_nats_ports_file(
+        ports_dir.path(),
+        &mut child,
+        Instant::now() + Duration::from_secs(15),
+    ) {
+        Ok(url) => url,
+        Err(e) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(e);
+        }
+    };
     if let Err(e) = wait_for_nats_ready(&url, options.auth_token.as_deref()).await {
-        // Readiness failed (likely the port was stolen by a parallel server);
-        // reap this child so the retry starts clean.
         let _ = child.kill();
         let _ = child.wait();
         return Err(e);
@@ -94,6 +107,7 @@ async fn try_spawn_nats_once(
     Ok(NatsServerHandle {
         url,
         _store_dir: store_dir,
+        _ports_dir: ports_dir,
         child,
     })
 }
@@ -129,13 +143,6 @@ fn nats_server_binary() -> Option<PathBuf> {
     }
 
     which::which("nats-server").ok()
-}
-
-fn free_tcp_port() -> Result<u16> {
-    let listener = TcpListener::bind("127.0.0.1:0").context("Failed to allocate free TCP port")?;
-    let port = listener.local_addr()?.port();
-    drop(listener);
-    Ok(port)
 }
 
 async fn wait_for_nats_ready(url: &str, auth_token: Option<&str>) -> Result<()> {
@@ -187,4 +194,47 @@ async fn wait_for_nats_ready(url: &str, auth_token: Option<&str>) -> Result<()> 
             }
         }
     }
+}
+
+/// Read the client URL out of the ports file nats-server writes once it has
+/// bound its listeners.
+///
+/// The file is named `<executable_name>_<pid>.ports`, so it's found by scanning
+/// the (private) directory rather than by rebuilding the name — `NATS_SERVER_BIN`
+/// can point at a differently named binary. nats-server writes into the file
+/// directly rather than renaming it into place, so a partial read is possible;
+/// failing to parse is treated the same as not-yet-written.
+fn read_nats_ports_file(
+    dir: &std::path::Path,
+    child: &mut Child,
+    deadline: Instant,
+) -> Result<String> {
+    loop {
+        if let Some(url) = first_nats_client_url(dir) {
+            return Ok(url);
+        }
+        if let Some(status) = child.try_wait()? {
+            anyhow::bail!("nats-server exited during startup: {status}");
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for the nats-server ports file in {}",
+                dir.display()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn first_nats_client_url(dir: &std::path::Path) -> Option<String> {
+    for entry in std::fs::read_dir(dir).ok()? {
+        let path = entry.ok()?.path();
+        if path.extension().is_some_and(|ext| ext == "ports") {
+            let contents = std::fs::read_to_string(&path).ok()?;
+            let parsed: serde_json::Value = serde_json::from_str(&contents).ok()?;
+            let url = parsed.get("nats")?.get(0)?.as_str()?;
+            return Some(url.to_string());
+        }
+    }
+    None
 }

--- a/crates/harnx-runtime/tests/nats_hooks_e2e.rs
+++ b/crates/harnx-runtime/tests/nats_hooks_e2e.rs
@@ -8,7 +8,6 @@ use harnx_hookset_server::{hook_registration_key, serve_over_nats, HOOK_REGISTRY
 use harnx_runtime::config::Config;
 use harnx_runtime::nats_hook_provider::{HookDispatchMeta, NatsHookProvider};
 use serde_json::{json, Value};
-use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex as StdMutex};
@@ -22,6 +21,7 @@ const TEST_TOOL: &str = "test_tool";
 struct NatsServerHandle {
     url: String,
     _store_dir: TempDir,
+    _ports_dir: TempDir,
     child: Child,
 }
 
@@ -289,29 +289,36 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
 
     const MAX_START_ATTEMPTS: usize = 5;
     for attempt in 1..=MAX_START_ATTEMPTS {
-        let listener = TcpListener::bind("127.0.0.1:0").context("allocate NATS test port")?;
-        let port = listener.local_addr()?.port();
-        drop(listener);
         let store_dir = tempfile::tempdir().context("create NATS test store")?;
+        let ports_dir = tempfile::tempdir().context("create NATS ports dir")?;
         let mut child = Command::new(&binary)
             .arg("-js")
             .arg("-sd")
             .arg(store_dir.path())
+            .arg("-a")
+            .arg("127.0.0.1")
             .arg("-p")
-            .arg(port.to_string())
+            .arg("-1")
             .arg("--auth")
             .arg(TOKEN)
+            .arg("--ports_file_dir")
+            .arg(ports_dir.path())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
             .context("spawn nats-server")?;
-        let url = format!("nats://127.0.0.1:{port}");
+        let url = read_nats_ports_file(
+            ports_dir.path(),
+            &mut child,
+            Instant::now() + Duration::from_secs(15),
+        )?;
 
         match wait_for_nats_ready(&mut child, &url).await {
             Ok(()) => {
                 return Ok(Some(NatsServerHandle {
                     url,
                     _store_dir: store_dir,
+                    _ports_dir: ports_dir,
                     child,
                 }));
             }
@@ -363,4 +370,47 @@ fn nats_server_binary() -> Option<PathBuf> {
         }
     }
     which::which("nats-server").ok()
+}
+
+/// Read the client URL out of the ports file nats-server writes once it has
+/// bound its listeners.
+///
+/// The file is named `<executable_name>_<pid>.ports`, so it's found by scanning
+/// the (private) directory rather than by rebuilding the name — `NATS_SERVER_BIN`
+/// can point at a differently named binary. nats-server writes into the file
+/// directly rather than renaming it into place, so a partial read is possible;
+/// failing to parse is treated the same as not-yet-written.
+fn read_nats_ports_file(
+    dir: &std::path::Path,
+    child: &mut Child,
+    deadline: Instant,
+) -> Result<String> {
+    loop {
+        if let Some(url) = first_nats_client_url(dir) {
+            return Ok(url);
+        }
+        if let Some(status) = child.try_wait()? {
+            anyhow::bail!("nats-server exited during startup: {status}");
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for the nats-server ports file in {}",
+                dir.display()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn first_nats_client_url(dir: &std::path::Path) -> Option<String> {
+    for entry in std::fs::read_dir(dir).ok()? {
+        let path = entry.ok()?.path();
+        if path.extension().is_some_and(|ext| ext == "ports") {
+            let contents = std::fs::read_to_string(&path).ok()?;
+            let parsed: serde_json::Value = serde_json::from_str(&contents).ok()?;
+            let url = parsed.get("nats")?.get(0)?.as_str()?;
+            return Some(url.to_string());
+        }
+    }
+    None
 }

--- a/crates/harnx-time-server/tests/sigterm_shutdown.rs
+++ b/crates/harnx-time-server/tests/sigterm_shutdown.rs
@@ -10,7 +10,6 @@ use anyhow::{Context, Result};
 use harnx_core::instance::{ServerScope, HARNX_SERVER_SCOPE};
 use harnx_toolset::{HARNX_SERVER_CONFIG, HARNX_SERVER_PACKAGE};
 use harnx_toolset_server::registration_key;
-use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -25,6 +24,7 @@ const IDENTITY_TOKEN: &str = "____time";
 struct NatsServerHandle {
     url: String,
     _store_dir: TempDir,
+    _ports_dir: TempDir,
     child: Child,
 }
 
@@ -60,28 +60,35 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
         return Ok(None);
     };
 
-    let listener = TcpListener::bind("127.0.0.1:0").context("allocate NATS test port")?;
-    let port = listener.local_addr()?.port();
-    drop(listener);
     let store_dir = tempfile::tempdir().context("create NATS test store")?;
+    let ports_dir = tempfile::tempdir().context("create NATS ports dir")?;
     let mut child = Command::new(binary)
         .arg("-js")
         .arg("-sd")
         .arg(store_dir.path())
+        .arg("-a")
+        .arg("127.0.0.1")
         .arg("-p")
-        .arg(port.to_string())
+        .arg("-1")
         .arg("--auth")
         .arg(TOKEN)
+        .arg("--ports_file_dir")
+        .arg(ports_dir.path())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
         .context("spawn nats-server")?;
-    let url = format!("nats://127.0.0.1:{port}");
+    let url = read_nats_ports_file(
+        ports_dir.path(),
+        &mut child,
+        Instant::now() + Duration::from_secs(15),
+    )?;
 
     match wait_for_nats_ready(&mut child, &url).await {
         Ok(()) => Ok(Some(NatsServerHandle {
             url,
             _store_dir: store_dir,
+            _ports_dir: ports_dir,
             child,
         })),
         Err(error) => {
@@ -203,4 +210,47 @@ async fn sigterm_removes_the_registration() -> Result<()> {
 
     let _ = time_server.0.wait();
     Ok(())
+}
+
+/// Read the client URL out of the ports file nats-server writes once it has
+/// bound its listeners.
+///
+/// The file is named `<executable_name>_<pid>.ports`, so it's found by scanning
+/// the (private) directory rather than by rebuilding the name — `NATS_SERVER_BIN`
+/// can point at a differently named binary. nats-server writes into the file
+/// directly rather than renaming it into place, so a partial read is possible;
+/// failing to parse is treated the same as not-yet-written.
+fn read_nats_ports_file(
+    dir: &std::path::Path,
+    child: &mut Child,
+    deadline: Instant,
+) -> Result<String> {
+    loop {
+        if let Some(url) = first_nats_client_url(dir) {
+            return Ok(url);
+        }
+        if let Some(status) = child.try_wait()? {
+            anyhow::bail!("nats-server exited during startup: {status}");
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for the nats-server ports file in {}",
+                dir.display()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn first_nats_client_url(dir: &std::path::Path) -> Option<String> {
+    for entry in std::fs::read_dir(dir).ok()? {
+        let path = entry.ok()?.path();
+        if path.extension().is_some_and(|ext| ext == "ports") {
+            let contents = std::fs::read_to_string(&path).ok()?;
+            let parsed: serde_json::Value = serde_json::from_str(&contents).ok()?;
+            let url = parsed.get("nats")?.get(0)?.as_str()?;
+            return Some(url.to_string());
+        }
+    }
+    None
 }

--- a/crates/harnx-toolset-server/tests/common/mod.rs
+++ b/crates/harnx-toolset-server/tests/common/mod.rs
@@ -12,7 +12,6 @@ use harnx_nats_common::connect::NatsConnection;
 use harnx_toolset::{ToolInvokeError, ToolSpec, Toolset, HDR_CALL_ID, HDR_IDEMPOTENCY_KEY};
 use harnx_toolset_server::serve_with_shutdown;
 use serde_json::{json, Value};
-use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -27,6 +26,7 @@ pub(crate) const TOKEN: &str = "toolset-test-token";
 pub(crate) struct NatsServerHandle {
     pub(crate) url: String,
     _store_dir: TempDir,
+    _ports_dir: TempDir,
     child: Child,
 }
 
@@ -45,29 +45,36 @@ pub(crate) async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
 
     const MAX_START_ATTEMPTS: usize = 5;
     for attempt in 1..=MAX_START_ATTEMPTS {
-        let listener = TcpListener::bind("127.0.0.1:0").context("allocate NATS test port")?;
-        let port = listener.local_addr()?.port();
-        drop(listener);
         let store_dir = tempfile::tempdir().context("create NATS test store")?;
+        let ports_dir = tempfile::tempdir().context("create NATS ports dir")?;
         let mut child = Command::new(&binary)
             .arg("-js")
             .arg("-sd")
             .arg(store_dir.path())
+            .arg("-a")
+            .arg("127.0.0.1")
             .arg("-p")
-            .arg(port.to_string())
+            .arg("-1")
             .arg("--auth")
             .arg(TOKEN)
+            .arg("--ports_file_dir")
+            .arg(ports_dir.path())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
             .context("spawn nats-server")?;
-        let url = format!("nats://127.0.0.1:{port}");
+        let url = read_nats_ports_file(
+            ports_dir.path(),
+            &mut child,
+            Instant::now() + Duration::from_secs(15),
+        )?;
 
         match wait_for_nats_ready(&mut child, &url).await {
             Ok(()) => {
                 return Ok(Some(NatsServerHandle {
                     url,
                     _store_dir: store_dir,
+                    _ports_dir: ports_dir,
                     child,
                 }));
             }
@@ -278,4 +285,47 @@ impl Drop for TestHarness {
             server_task.abort();
         }
     }
+}
+
+/// Read the client URL out of the ports file nats-server writes once it has
+/// bound its listeners.
+///
+/// The file is named `<executable_name>_<pid>.ports`, so it's found by scanning
+/// the (private) directory rather than by rebuilding the name — `NATS_SERVER_BIN`
+/// can point at a differently named binary. nats-server writes into the file
+/// directly rather than renaming it into place, so a partial read is possible;
+/// failing to parse is treated the same as not-yet-written.
+fn read_nats_ports_file(
+    dir: &std::path::Path,
+    child: &mut Child,
+    deadline: Instant,
+) -> Result<String> {
+    loop {
+        if let Some(url) = first_nats_client_url(dir) {
+            return Ok(url);
+        }
+        if let Some(status) = child.try_wait()? {
+            anyhow::bail!("nats-server exited during startup: {status}");
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for the nats-server ports file in {}",
+                dir.display()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn first_nats_client_url(dir: &std::path::Path) -> Option<String> {
+    for entry in std::fs::read_dir(dir).ok()? {
+        let path = entry.ok()?.path();
+        if path.extension().is_some_and(|ext| ext == "ports") {
+            let contents = std::fs::read_to_string(&path).ok()?;
+            let parsed: serde_json::Value = serde_json::from_str(&contents).ok()?;
+            let url = parsed.get("nats")?.get(0)?.as_str()?;
+            return Some(url.to_string());
+        }
+    }
+    None
 }


### PR DESCRIPTION
Every test that spawns `nats-server` bound `127.0.0.1:0`, read the port, dropped
the listener, then asked nats-server to bind that same port. In the window
between the drop and nats-server's bind the port belongs to nobody, so with many
test binaries starting at once another one can take it — nats-server then exits
immediately and the test fails in tens of milliseconds.

This wasn't theoretical, and it wasn't unknown. Five of these helpers had already
grown a 5-attempt retry loop for it, and the one in harnx-runtime's test common
says so in a comment:

```rust
// Readiness failed (likely the port was stolen by a parallel server);
// reap this child so the retry starts clean.
```

The copies that never got that treatment still fail outright. That's how a stress
run hit `command_hook_uses_env_name_with_end_of_options_separator` failing in
65ms — too fast for any of its 10s deadlines, because nats-server had already
exited.

## The fix

`-p -1` closes the window rather than retrying it: nats-server asks the kernel
for a free port and keeps it, so nothing ever releases and re-acquires.
`--ports_file_dir` then reports what it actually bound:

```json
{"nats":["nats://127.0.0.1:38089"]}
```

Reading that file has two traps, both handled and both verified:

- It's named `<executable_name>_<pid>.ports` — the *invoked* executable's name.
  `NATS_SERVER_BIN` can point at a differently named binary, and I confirmed a
  renamed copy produces `my-renamed-broker_1749144.ports`, so building the name
  from the pid would silently never find it. The code scans a private directory
  instead.
- nats-server writes into the file rather than renaming it into place, so a
  partial read is possible. A parse failure is treated as not-yet-written and
  retried until the deadline. The existing child-exited check is kept so a server
  that dies during startup still fails fast.

Also passes `-a 127.0.0.1`. These brokers were listening on *every* interface
with a hardcoded token — the ports file from an unrestricted run listed LAN and
public IPv6 addresses. With `-a` the list collapses to one entry.

## Scope

Retry loops are kept as-is. They still guard startup failures other than a stolen
port, and removing them would have made this diff structural rather than
mechanical. Worth a follow-up.

`nats_local_server.rs` — the production shared broker — is **not** included. It
writes the port into a config file *before* the server starts so other harnx
processes can find it, so `-p -1` there means restructuring how the port is
published, not a local substitution. Its `free_tcp_port()` is untouched.

The mock-OpenAI listeners in `local_worker_supervisor.rs` and
`session_actor_nats_tests.rs`, and `bridge_roundtrip.rs`'s deliberately stalled
listener, also bind `127.0.0.1:0` but correctly keep their sockets. Not bugs, not
touched.

## Testing

- Full pipeline green: `cargo build`, `fmt --check`, `clippy -D warnings`,
  `cargo nextest run --workspace --stress-count=5` (2462 tests, 5/5). `cs delta`
  reports no issues.
- The previously-flaky `nats_runner` binary: 12 concurrent copies x 10 iterations
  = 120 runs under the contention that produced the original failure, zero
  failures.
- Verified `-p -1` + `--ports_file_dir` end to end against nats-server v2.11.6
  before writing any of this, including that the reported port accepts
  connections.

One unrelated flake surfaced during verification and is **not** caused by this
change: `harnx::tmux_e2e retry_all_fail_shows_warnings_in_tui` is a
nondeterministic snapshot — the same lines in a different order, racing the
stderr `error:` block against the TUI's "exhausted retries" warning. Reproduced
on unmodified `origin/main` at 2 failures in 80 runs. The `ci` nextest profile's
retries are presumably why it has survived. Worth its own issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration test reliability by using automatically assigned local network ports.
  * Added stronger startup handling, including timeout detection, early-failure reporting, and support for partially written server status files.
  * Improved cleanup of temporary test resources and failed test processes.

* **Chores**
  * Updated test tooling to better isolate concurrent test runs and avoid port conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->