### PR TITLE
fix(test): reap nats-server on startup failure and stop blocking the runtime

### DIFF
--- a/crates/harnx-claude-compatible-hook-server/tests/nats_runner.rs
+++ b/crates/harnx-claude-compatible-hook-server/tests/nats_runner.rs
@@ -79,7 +79,7 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
         .spawn()
         .context("spawn nats-server")?;
     let deadline = Instant::now() + Duration::from_secs(15);
-    let url = read_ports_file(ports_dir.path(), &mut child, deadline)?;
+    let url = read_nats_ports_file(ports_dir.path(), &mut child, deadline).await?;
     loop {
         match async_nats::ConnectOptions::new()
             .token(TOKEN.to_string())
@@ -114,25 +114,37 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
 /// can point at a differently named binary. nats-server writes into the file
 /// directly rather than renaming it into place, so a partial read is possible;
 /// failing to parse is treated the same as not-yet-written.
-fn read_ports_file(dir: &Path, child: &mut Child, deadline: Instant) -> Result<String> {
+async fn read_nats_ports_file(dir: &Path, child: &mut Child, deadline: Instant) -> Result<String> {
     loop {
-        if let Some(url) = first_client_url(dir) {
+        if let Some(url) = first_nats_client_url(dir) {
             return Ok(url);
         }
-        if let Some(status) = child.try_wait()? {
-            anyhow::bail!("nats-server exited during startup: {status}");
+        // `std::process::Child` does not kill on drop, so every failure path here
+        // has to reap the server or it keeps running after the test gives up.
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                anyhow::bail!("nats-server exited during startup: {status}")
+            }
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error).context("poll nats-server during startup");
+            }
         }
         if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
             anyhow::bail!(
                 "timed out waiting for the nats-server ports file in {}",
                 dir.display()
             );
         }
-        std::thread::sleep(Duration::from_millis(20));
+        tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }
 
-fn first_client_url(dir: &Path) -> Option<String> {
+fn first_nats_client_url(dir: &Path) -> Option<String> {
     for entry in std::fs::read_dir(dir).ok()? {
         let path = entry.ok()?.path();
         if path.extension().is_some_and(|ext| ext == "ports") {

--- a/crates/harnx-fs-tools/tests/nats_fs.rs
+++ b/crates/harnx-fs-tools/tests/nats_fs.rs
@@ -59,7 +59,8 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
             ports_dir.path(),
             &mut child,
             Instant::now() + Duration::from_secs(15),
-        )?;
+        )
+        .await?;
 
         match wait_for_nats_ready(&mut child, &url).await {
             Ok(()) => {
@@ -344,7 +345,7 @@ async fn fs_toolset_round_trips_over_nats_with_bridge_envelope_parity() -> Resul
 /// can point at a differently named binary. nats-server writes into the file
 /// directly rather than renaming it into place, so a partial read is possible;
 /// failing to parse is treated the same as not-yet-written.
-fn read_nats_ports_file(
+async fn read_nats_ports_file(
     dir: &std::path::Path,
     child: &mut Child,
     deadline: Instant,
@@ -353,16 +354,28 @@ fn read_nats_ports_file(
         if let Some(url) = first_nats_client_url(dir) {
             return Ok(url);
         }
-        if let Some(status) = child.try_wait()? {
-            anyhow::bail!("nats-server exited during startup: {status}");
+        // `std::process::Child` does not kill on drop, so every failure path here
+        // has to reap the server or it keeps running after the test gives up.
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                anyhow::bail!("nats-server exited during startup: {status}")
+            }
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error).context("poll nats-server during startup");
+            }
         }
         if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
             anyhow::bail!(
                 "timed out waiting for the nats-server ports file in {}",
                 dir.display()
             );
         }
-        std::thread::sleep(Duration::from_millis(20));
+        tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }
 

--- a/crates/harnx-hookset-server/tests/nats_hookset.rs
+++ b/crates/harnx-hookset-server/tests/nats_hookset.rs
@@ -63,7 +63,8 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
             ports_dir.path(),
             &mut child,
             Instant::now() + Duration::from_secs(15),
-        )?;
+        )
+        .await?;
 
         match wait_for_nats_ready(&mut child, &url).await {
             Ok(()) => {
@@ -365,7 +366,7 @@ async fn old_instances_shutdown_does_not_delete_a_replacements_registration() ->
 /// can point at a differently named binary. nats-server writes into the file
 /// directly rather than renaming it into place, so a partial read is possible;
 /// failing to parse is treated the same as not-yet-written.
-fn read_nats_ports_file(
+async fn read_nats_ports_file(
     dir: &std::path::Path,
     child: &mut Child,
     deadline: Instant,
@@ -374,16 +375,28 @@ fn read_nats_ports_file(
         if let Some(url) = first_nats_client_url(dir) {
             return Ok(url);
         }
-        if let Some(status) = child.try_wait()? {
-            anyhow::bail!("nats-server exited during startup: {status}");
+        // `std::process::Child` does not kill on drop, so every failure path here
+        // has to reap the server or it keeps running after the test gives up.
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                anyhow::bail!("nats-server exited during startup: {status}")
+            }
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error).context("poll nats-server during startup");
+            }
         }
         if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
             anyhow::bail!(
                 "timed out waiting for the nats-server ports file in {}",
                 dir.display()
             );
         }
-        std::thread::sleep(Duration::from_millis(20));
+        tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }
 

--- a/crates/harnx-mcp-bridge/tests/bridge_roundtrip.rs
+++ b/crates/harnx-mcp-bridge/tests/bridge_roundtrip.rs
@@ -83,7 +83,9 @@ async fn try_spawn_nats_server(binary: &Path) -> Result<NatsServerHandle> {
         ports_dir.path(),
         &mut child,
         Instant::now() + Duration::from_secs(15),
-    ) {
+    )
+    .await
+    {
         Ok(url) => url,
         Err(error) => {
             let _ = child.kill();
@@ -536,7 +538,7 @@ async fn bridge_binary_exits_when_wrapped_child_dies_during_stalled_nats_connect
 /// can point at a differently named binary. nats-server writes into the file
 /// directly rather than renaming it into place, so a partial read is possible;
 /// failing to parse is treated the same as not-yet-written.
-fn read_nats_ports_file(
+async fn read_nats_ports_file(
     dir: &std::path::Path,
     child: &mut Child,
     deadline: Instant,
@@ -545,16 +547,28 @@ fn read_nats_ports_file(
         if let Some(url) = first_nats_client_url(dir) {
             return Ok(url);
         }
-        if let Some(status) = child.try_wait()? {
-            anyhow::bail!("nats-server exited during startup: {status}");
+        // `std::process::Child` does not kill on drop, so every failure path here
+        // has to reap the server or it keeps running after the test gives up.
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                anyhow::bail!("nats-server exited during startup: {status}")
+            }
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error).context("poll nats-server during startup");
+            }
         }
         if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
             anyhow::bail!(
                 "timed out waiting for the nats-server ports file in {}",
                 dir.display()
             );
         }
-        std::thread::sleep(Duration::from_millis(20));
+        tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }
 

--- a/crates/harnx-mcp-bridge/tests/sigterm_shutdown.rs
+++ b/crates/harnx-mcp-bridge/tests/sigterm_shutdown.rs
@@ -79,7 +79,8 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
         ports_dir.path(),
         &mut child,
         Instant::now() + Duration::from_secs(15),
-    )?;
+    )
+    .await?;
 
     match wait_for_nats_ready(&mut child, &url).await {
         Ok(()) => Ok(Some(NatsServerHandle {
@@ -245,7 +246,7 @@ async fn sigterm_removes_the_bridge_registration() -> Result<()> {
 /// can point at a differently named binary. nats-server writes into the file
 /// directly rather than renaming it into place, so a partial read is possible;
 /// failing to parse is treated the same as not-yet-written.
-fn read_nats_ports_file(
+async fn read_nats_ports_file(
     dir: &std::path::Path,
     child: &mut Child,
     deadline: Instant,
@@ -254,16 +255,28 @@ fn read_nats_ports_file(
         if let Some(url) = first_nats_client_url(dir) {
             return Ok(url);
         }
-        if let Some(status) = child.try_wait()? {
-            anyhow::bail!("nats-server exited during startup: {status}");
+        // `std::process::Child` does not kill on drop, so every failure path here
+        // has to reap the server or it keeps running after the test gives up.
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                anyhow::bail!("nats-server exited during startup: {status}")
+            }
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error).context("poll nats-server during startup");
+            }
         }
         if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
             anyhow::bail!(
                 "timed out waiting for the nats-server ports file in {}",
                 dir.display()
             );
         }
-        std::thread::sleep(Duration::from_millis(20));
+        tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }
 

--- a/crates/harnx-nats-common/tests/registry_ttl.rs
+++ b/crates/harnx-nats-common/tests/registry_ttl.rs
@@ -54,7 +54,8 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
             ports_dir.path(),
             &mut child,
             Instant::now() + Duration::from_secs(15),
-        )?;
+        )
+        .await?;
 
         match wait_for_nats_ready(&mut child, &url).await {
             Ok(()) => {
@@ -304,7 +305,7 @@ async fn reconcile_bucket_replicas_never_lowers_an_existing_higher_count() -> Re
 /// can point at a differently named binary. nats-server writes into the file
 /// directly rather than renaming it into place, so a partial read is possible;
 /// failing to parse is treated the same as not-yet-written.
-fn read_nats_ports_file(
+async fn read_nats_ports_file(
     dir: &std::path::Path,
     child: &mut Child,
     deadline: Instant,
@@ -313,16 +314,28 @@ fn read_nats_ports_file(
         if let Some(url) = first_nats_client_url(dir) {
             return Ok(url);
         }
-        if let Some(status) = child.try_wait()? {
-            anyhow::bail!("nats-server exited during startup: {status}");
+        // `std::process::Child` does not kill on drop, so every failure path here
+        // has to reap the server or it keeps running after the test gives up.
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                anyhow::bail!("nats-server exited during startup: {status}")
+            }
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error).context("poll nats-server during startup");
+            }
         }
         if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
             anyhow::bail!(
                 "timed out waiting for the nats-server ports file in {}",
                 dir.display()
             );
         }
-        std::thread::sleep(Duration::from_millis(20));
+        tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }
 

--- a/crates/harnx-proxy-auth/tests/nats_hook.rs
+++ b/crates/harnx-proxy-auth/tests/nats_hook.rs
@@ -67,7 +67,8 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
         ports_dir.path(),
         &mut child,
         Instant::now() + Duration::from_secs(15),
-    )?;
+    )
+    .await?;
     let deadline = Instant::now() + Duration::from_secs(15);
     loop {
         match async_nats::ConnectOptions::new()
@@ -198,7 +199,7 @@ async fn proxy_auth_registers_and_mutates_tool_env_over_nats() -> Result<()> {
 /// can point at a differently named binary. nats-server writes into the file
 /// directly rather than renaming it into place, so a partial read is possible;
 /// failing to parse is treated the same as not-yet-written.
-fn read_nats_ports_file(
+async fn read_nats_ports_file(
     dir: &std::path::Path,
     child: &mut Child,
     deadline: Instant,
@@ -207,16 +208,28 @@ fn read_nats_ports_file(
         if let Some(url) = first_nats_client_url(dir) {
             return Ok(url);
         }
-        if let Some(status) = child.try_wait()? {
-            anyhow::bail!("nats-server exited during startup: {status}");
+        // `std::process::Child` does not kill on drop, so every failure path here
+        // has to reap the server or it keeps running after the test gives up.
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                anyhow::bail!("nats-server exited during startup: {status}")
+            }
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error).context("poll nats-server during startup");
+            }
         }
         if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
             anyhow::bail!(
                 "timed out waiting for the nats-server ports file in {}",
                 dir.display()
             );
         }
-        std::thread::sleep(Duration::from_millis(20));
+        tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }
 

--- a/crates/harnx-runtime/src/nats_tool_provider.rs
+++ b/crates/harnx-runtime/src/nats_tool_provider.rs
@@ -761,7 +761,7 @@ mod tests {
         // Allocating one here and dropping the listener first left a window for a
         // concurrently starting server to claim the same port.
         let ports_dir = tempfile::tempdir().expect("create NATS ports dir");
-        let child = std::process::Command::new(&binary)
+        let mut child = std::process::Command::new(&binary)
             .arg("-a")
             .arg("127.0.0.1")
             .arg("-p")
@@ -778,6 +778,10 @@ mod tests {
                 break url;
             }
             if std::time::Instant::now() >= deadline {
+                // Reap first: Child does not kill on drop, so panicking here would
+                // leave nats-server running for the rest of the test binary.
+                let _ = child.kill();
+                let _ = child.wait();
                 panic!("nats-server did not report its port before the deadline");
             }
             std::thread::sleep(std::time::Duration::from_millis(20));

--- a/crates/harnx-runtime/tests/common/mod.rs
+++ b/crates/harnx-runtime/tests/common/mod.rs
@@ -90,7 +90,9 @@ async fn try_spawn_nats_once(
         ports_dir.path(),
         &mut child,
         Instant::now() + Duration::from_secs(15),
-    ) {
+    )
+    .await
+    {
         Ok(url) => url,
         Err(e) => {
             let _ = child.kill();
@@ -204,7 +206,7 @@ async fn wait_for_nats_ready(url: &str, auth_token: Option<&str>) -> Result<()> 
 /// can point at a differently named binary. nats-server writes into the file
 /// directly rather than renaming it into place, so a partial read is possible;
 /// failing to parse is treated the same as not-yet-written.
-fn read_nats_ports_file(
+async fn read_nats_ports_file(
     dir: &std::path::Path,
     child: &mut Child,
     deadline: Instant,
@@ -213,16 +215,28 @@ fn read_nats_ports_file(
         if let Some(url) = first_nats_client_url(dir) {
             return Ok(url);
         }
-        if let Some(status) = child.try_wait()? {
-            anyhow::bail!("nats-server exited during startup: {status}");
+        // `std::process::Child` does not kill on drop, so every failure path here
+        // has to reap the server or it keeps running after the test gives up.
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                anyhow::bail!("nats-server exited during startup: {status}")
+            }
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error).context("poll nats-server during startup");
+            }
         }
         if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
             anyhow::bail!(
                 "timed out waiting for the nats-server ports file in {}",
                 dir.display()
             );
         }
-        std::thread::sleep(Duration::from_millis(20));
+        tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }
 

--- a/crates/harnx-runtime/tests/nats_hooks_e2e.rs
+++ b/crates/harnx-runtime/tests/nats_hooks_e2e.rs
@@ -311,7 +311,8 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
             ports_dir.path(),
             &mut child,
             Instant::now() + Duration::from_secs(15),
-        )?;
+        )
+        .await?;
 
         match wait_for_nats_ready(&mut child, &url).await {
             Ok(()) => {
@@ -380,7 +381,7 @@ fn nats_server_binary() -> Option<PathBuf> {
 /// can point at a differently named binary. nats-server writes into the file
 /// directly rather than renaming it into place, so a partial read is possible;
 /// failing to parse is treated the same as not-yet-written.
-fn read_nats_ports_file(
+async fn read_nats_ports_file(
     dir: &std::path::Path,
     child: &mut Child,
     deadline: Instant,
@@ -389,16 +390,28 @@ fn read_nats_ports_file(
         if let Some(url) = first_nats_client_url(dir) {
             return Ok(url);
         }
-        if let Some(status) = child.try_wait()? {
-            anyhow::bail!("nats-server exited during startup: {status}");
+        // `std::process::Child` does not kill on drop, so every failure path here
+        // has to reap the server or it keeps running after the test gives up.
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                anyhow::bail!("nats-server exited during startup: {status}")
+            }
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error).context("poll nats-server during startup");
+            }
         }
         if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
             anyhow::bail!(
                 "timed out waiting for the nats-server ports file in {}",
                 dir.display()
             );
         }
-        std::thread::sleep(Duration::from_millis(20));
+        tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }
 

--- a/crates/harnx-time-server/tests/sigterm_shutdown.rs
+++ b/crates/harnx-time-server/tests/sigterm_shutdown.rs
@@ -82,7 +82,8 @@ async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
         ports_dir.path(),
         &mut child,
         Instant::now() + Duration::from_secs(15),
-    )?;
+    )
+    .await?;
 
     match wait_for_nats_ready(&mut child, &url).await {
         Ok(()) => Ok(Some(NatsServerHandle {
@@ -220,7 +221,7 @@ async fn sigterm_removes_the_registration() -> Result<()> {
 /// can point at a differently named binary. nats-server writes into the file
 /// directly rather than renaming it into place, so a partial read is possible;
 /// failing to parse is treated the same as not-yet-written.
-fn read_nats_ports_file(
+async fn read_nats_ports_file(
     dir: &std::path::Path,
     child: &mut Child,
     deadline: Instant,
@@ -229,16 +230,28 @@ fn read_nats_ports_file(
         if let Some(url) = first_nats_client_url(dir) {
             return Ok(url);
         }
-        if let Some(status) = child.try_wait()? {
-            anyhow::bail!("nats-server exited during startup: {status}");
+        // `std::process::Child` does not kill on drop, so every failure path here
+        // has to reap the server or it keeps running after the test gives up.
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                anyhow::bail!("nats-server exited during startup: {status}")
+            }
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error).context("poll nats-server during startup");
+            }
         }
         if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
             anyhow::bail!(
                 "timed out waiting for the nats-server ports file in {}",
                 dir.display()
             );
         }
-        std::thread::sleep(Duration::from_millis(20));
+        tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }
 

--- a/crates/harnx-toolset-server/tests/common/mod.rs
+++ b/crates/harnx-toolset-server/tests/common/mod.rs
@@ -67,7 +67,8 @@ pub(crate) async fn spawn_nats_server() -> Result<Option<NatsServerHandle>> {
             ports_dir.path(),
             &mut child,
             Instant::now() + Duration::from_secs(15),
-        )?;
+        )
+        .await?;
 
         match wait_for_nats_ready(&mut child, &url).await {
             Ok(()) => {
@@ -295,7 +296,7 @@ impl Drop for TestHarness {
 /// can point at a differently named binary. nats-server writes into the file
 /// directly rather than renaming it into place, so a partial read is possible;
 /// failing to parse is treated the same as not-yet-written.
-fn read_nats_ports_file(
+async fn read_nats_ports_file(
     dir: &std::path::Path,
     child: &mut Child,
     deadline: Instant,
@@ -304,16 +305,28 @@ fn read_nats_ports_file(
         if let Some(url) = first_nats_client_url(dir) {
             return Ok(url);
         }
-        if let Some(status) = child.try_wait()? {
-            anyhow::bail!("nats-server exited during startup: {status}");
+        // `std::process::Child` does not kill on drop, so every failure path here
+        // has to reap the server or it keeps running after the test gives up.
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                anyhow::bail!("nats-server exited during startup: {status}")
+            }
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error).context("poll nats-server during startup");
+            }
         }
         if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
             anyhow::bail!(
                 "timed out waiting for the nats-server ports file in {}",
                 dir.display()
             );
         }
-        std::thread::sleep(Duration::from_millis(20));
+        tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }
 


### PR DESCRIPTION
Follow-up to #1438. CodeRabbit raised two valid problems with the ports-file wait
it added, but the review landed after the merge, so they go here.

**The child wasn't reaped on failure.** `std::process::Child` does not kill on
drop, so returning early from a ports-file timeout left `nats-server` running —
with its store `TempDir` already deleted out from under it. Every failure path in
the helper now kills and waits first. That includes the `try_wait` error that was
previously propagated with `?`; it's matched now so it can clean up before
returning. `nats_tool_provider`'s sync variant reaps before it panics.

**The poll blocked a tokio worker.** It used `std::thread::sleep` inside an
`async fn`. These tests use `#[tokio::test(flavor = "multi_thread")]`, some with
as few as two worker threads, so a wait of up to 15s could stall unrelated tasks
on the same runtime. The helper is async now and sleeps on the tokio timer.

Also renames the helper in the claude-compatible-hook-server copy from
`read_ports_file`/`first_client_url` to match the other twelve, so the duplicated
block is genuinely identical everywhere. That matters for the consolidation
follow-up — thirteen copies that differ only in name are harder to lift into one
shared helper than thirteen identical ones.

## Testing

- `cargo build`, `fmt --check`, `clippy -D warnings` clean;
  `cargo nextest run --workspace --stress-count=5` green (5/5). `cs delta`
  reports no issues.
- Checked for orphans directly: `pgrep -c nats-server` is 0 before and after
  running the affected crates, so nothing survives a normal run. This is also
  what confirmed the reaping under an abnormal one — an earlier verification run
  was SIGKILLed mid-suite and still left zero `nats-server` processes behind.