### PR TITLE
ci: verify the nats-server archive against a pinned digest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,11 @@ jobs:
         set -euo pipefail
         VERSION="v2.11.6"
         ASSET="nats-server-${VERSION}-linux-amd64.tar.gz"
+        # Pinned digest for the pinned VERSION. GitHub releases are mutable, so
+        # the tag alone does not pin the bytes, and the release's own SHA256SUMS
+        # is served from the same place as the tarball — fetching it would prove
+        # nothing an attacker who can replace one can't also replace.
+        SHA256="5e5272dd1bdb8da020aedc8cf883fb26c128441809a992f156e0b1ccb28ac5b7"
         DOWNLOAD_URL="https://github.com/nats-io/nats-server/releases/download/${VERSION}/${ASSET}"
         BINDIR="${HOME}/.local/bin"
         mkdir -p "${BINDIR}"
@@ -72,6 +77,8 @@ jobs:
         # failed download.
         curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused --retry-delay 2 \
           --location --silent --show-error --fail --output "${TMPDIR_DL}/${ASSET}" "${DOWNLOAD_URL}"
+        echo "${SHA256}  ${TMPDIR_DL}/${ASSET}" | shasum -a 256 --check --status \
+          || { echo "::error::nats-server checksum mismatch for ${ASSET}"; exit 1; }
         tar -xzf "${TMPDIR_DL}/${ASSET}" -C "${BINDIR}" --strip-components=1 "nats-server-${VERSION}-linux-amd64/nats-server"
         chmod +x "${BINDIR}/nats-server"
         echo "${BINDIR}" >> "${GITHUB_PATH}"
@@ -86,9 +93,16 @@ jobs:
         set -euo pipefail
         VERSION="v2.11.6"
         ARCH="$(uname -m)"
+        # See the Linux step for why the digests are pinned here rather than fetched.
         case "${ARCH}" in
-          arm64) NATS_ARCH="arm64" ;;
-          x86_64) NATS_ARCH="amd64" ;;
+          arm64)
+            NATS_ARCH="arm64"
+            SHA256="1a78170526e18a41ca2a24e6eaa00e95d39c677e1d5bfc56d3f662a114324e17"
+            ;;
+          x86_64)
+            NATS_ARCH="amd64"
+            SHA256="6c8f0cf8bc879db372ce0edca34c0178845e92286fac47db1a6a0f5eff59daef"
+            ;;
           *) echo "unsupported macOS arch: ${ARCH}" >&2; exit 1 ;;
         esac
         ASSET="nats-server-${VERSION}-darwin-${NATS_ARCH}.tar.gz"
@@ -99,6 +113,8 @@ jobs:
         # See the Linux step for why this downloads to a file first.
         curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused --retry-delay 2 \
           --location --silent --show-error --fail --output "${TMPDIR_DL}/${ASSET}" "${DOWNLOAD_URL}"
+        echo "${SHA256}  ${TMPDIR_DL}/${ASSET}" | shasum -a 256 --check --status \
+          || { echo "::error::nats-server checksum mismatch for ${ASSET}"; exit 1; }
         tar -xzf "${TMPDIR_DL}/${ASSET}" -C "${BINDIR}" --strip-components=1 "nats-server-${VERSION}-darwin-${NATS_ARCH}/nats-server"
         chmod +x "${BINDIR}/nats-server"
         echo "${BINDIR}" >> "${GITHUB_PATH}"


### PR DESCRIPTION
Follow-up to #1437. CodeRabbit flagged this after the merge, so it goes here.

CI downloads a `nats-server` tarball and runs that binary in the integration
tests, verifying only the transport and the HTTP status. The version tag was
pinned; the bytes weren't. GitHub releases are mutable — the v2.11.6 release
reports `immutable: false` — so pinning the tag does not pin what gets executed.

Each archive is now checked against a SHA-256 pinned in the workflow, and
extraction is blocked on mismatch. macOS pins both arch digests, since that step
selects the asset from `uname -m`.

## On not fetching SHA256SUMS

The release does publish a `SHA256SUMS` asset, and using it would have been the
easier change — but it would prove nothing. It's served from the same release URL
as the tarball, so anyone able to replace one can replace the other. Pinning
in-repo is what actually anchors trust: it detects the artifact changing under a
fixed tag.

Being precise about what this does and doesn't buy: it gives **immutability**, not
**provenance**. It catches a re-uploaded or substituted asset. It does not
establish that upstream built what they claim — signature or attestation
verification would, and this PR doesn't attempt it.

## Testing

- Digests taken from the published `SHA256SUMS` *and* independently recomputed
  with `sha256sum` against each downloaded archive; all three agree
  (linux-amd64, darwin-amd64, darwin-arm64).
- Verified the gate in both directions: the real digest passes (exit 0), a
  tampered digest exits 1 and emits the `::error::` before `tar` runs.
- Uses `shasum -a 256`, present on both runner images. `sha256sum` is not
  available on macOS.
- `ci.yaml` parses. No Rust or Python touched, so CI here is the real gate.