### PR TITLE
fix(nats): flush queued advisories before reporting a turn's outcome

### DIFF
--- a/crates/harnx-runtime/src/nats_client_session.rs
+++ b/crates/harnx-runtime/src/nats_client_session.rs
@@ -480,6 +480,16 @@ impl ThinClientSession {
                 harnx_core::session_reconstruct::apply_log_mutations_nats(&entries)
             {
                 cached_effective = Some(effective);
+                // Paired with the cache refresh everywhere else. If the loop
+                // exited before any reload succeeded — a closed subscription, or
+                // a cancel before the first completion tick — this is the first
+                // reconstruction, and without it live Message and ToolCalls rows
+                // never get their LogSeqAssigned.
+                emit_all_logical_seqs_for_window(
+                    cached_effective.as_deref(),
+                    &event_sink,
+                    &mut emitted_logical_seqs,
+                );
             }
         }
 

--- a/crates/harnx-runtime/src/nats_client_session.rs
+++ b/crates/harnx-runtime/src/nats_client_session.rs
@@ -473,7 +473,36 @@ impl ThinClientSession {
         if !turn_complete {
             let entries = self.load_durable_entries().await?;
             (final_response, turn_error) = Self::extract_turn_outcome(&entries, user_msg_seq);
+            if let Ok(effective) =
+                harnx_core::session_reconstruct::apply_log_mutations_nats(&entries)
+            {
+                cached_effective = Some(effective);
+            }
         }
+
+        // Render what the worker already published before reporting the turn's
+        // terminal state.
+        //
+        // Notices — retry warnings, "exhausted retries", fallback transitions —
+        // are ephemeral advisories, published from a detached task. The terminal
+        // error is a durable log entry, found by polling. The two have no ordering
+        // relationship, so breaking out of the loop the moment the log reads
+        // complete abandoned advisories that were already in flight: they arrived
+        // after the error, or were dropped with `pending_advisories` and never
+        // shown at all. Losing the last "exhausted retries" line is the visible
+        // case — it's the only explanation a user gets for a fallback.
+        //
+        // No waiting on the subscription: an earlier version of this spent up to
+        // 250ms hoping in-flight advisories would land, which delayed turn
+        // completion enough to trip the sub-agent idle-timeout watchdog
+        // (`subagent_idle_timeout_resets_on_child_activity` failed 5/5). Flushing
+        // what has already been received costs nothing and never delays a turn.
+        flush_pending_advisories(
+            &mut pending_advisories,
+            cached_effective.as_deref(),
+            &event_sink,
+            &mut emitted_logical_seqs,
+        );
 
         if let Some(error) = &turn_error {
             render_error_entry(error, &event_sink);

--- a/crates/harnx-runtime/src/nats_client_session.rs
+++ b/crates/harnx-runtime/src/nats_client_session.rs
@@ -396,6 +396,7 @@ impl ThinClientSession {
                                 cached_effective.as_deref(),
                                 &event_sink,
                                 &mut emitted_logical_seqs,
+                                AdvisoryFlush::Live,
                             );
                         }
                         if self.is_turn_complete(&entries, user_msg_seq) {
@@ -426,6 +427,7 @@ impl ThinClientSession {
                                     cached_effective.as_deref(),
                                     &event_sink,
                                     &mut emitted_logical_seqs,
+                                    AdvisoryFlush::Live,
                                 );
                             }
                             // Poll durable log for turn completion, but at most
@@ -447,6 +449,7 @@ impl ThinClientSession {
                                             cached_effective.as_deref(),
                                             &event_sink,
                                             &mut emitted_logical_seqs,
+                                            AdvisoryFlush::Live,
                                         );
                                     }
                                     if self.is_turn_complete(&entries, user_msg_seq) {
@@ -502,6 +505,7 @@ impl ThinClientSession {
             cached_effective.as_deref(),
             &event_sink,
             &mut emitted_logical_seqs,
+            AdvisoryFlush::Final,
         );
 
         if let Some(error) = &turn_error {
@@ -770,28 +774,44 @@ fn emit_live_logical_seq_for_physical(
     Some(logical_index)
 }
 
+/// Whether another flush can still happen for this turn.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AdvisoryFlush {
+    /// Mid-turn. With no reconstructed log to decorate against, advisories stay
+    /// queued so a later flush can stamp them.
+    Live,
+    /// Last flush of the turn. Nothing runs after this, so holding an advisory
+    /// means losing it — emit it undecorated instead.
+    Final,
+}
+
 fn flush_pending_advisories(
     pending_advisories: &mut VecDeque<crate::nats_event_sink::AdvisoryEnvelope>,
     effective_entries: Option<&[(u64, SessionLogEntry)]>,
     sink: &Arc<dyn AgentEventSink>,
     emitted_logical_seqs: &mut HashSet<usize>,
+    mode: AdvisoryFlush,
 ) {
-    let Some(effective_entries) = effective_entries else {
-        return;
+    let window = match effective_entries {
+        Some(entries) => Some(active_context_window(entries)),
+        // Reconstruction failed, or no durable load has succeeded yet.
+        None if mode == AdvisoryFlush::Live => return,
+        None => None,
     };
-    let window = active_context_window(effective_entries);
     while let Some(envelope) = pending_advisories.pop_front() {
         // `after_seq` may point at a physical mutation entry (for example the
         // worker's header EditEntries append) that reconstruction intentionally
         // removes. Sequence decoration is therefore best-effort; never hold a
         // live streaming advisory forever merely because that physical seq has
         // no effective logical entry.
-        let _ = emit_live_logical_seq_for_physical(
-            envelope.after_seq,
-            &window,
-            sink,
-            emitted_logical_seqs,
-        );
+        if let Some(window) = &window {
+            let _ = emit_live_logical_seq_for_physical(
+                envelope.after_seq,
+                window,
+                sink,
+                emitted_logical_seqs,
+            );
+        }
         if !matches!(
             envelope.event,
             AgentEvent::Session(SessionEvent::LogSeqAssigned { .. })
@@ -972,6 +992,50 @@ mod tests {
             self.count.fetch_add(1, Ordering::SeqCst);
             self.events.lock().unwrap().push(event);
         }
+    }
+
+    /// A turn's last flush must not swallow notices just because the durable log
+    /// could not be reconstructed. Holding them there loses them, and losing the
+    /// "exhausted retries" warning is the whole reason this queue gets flushed.
+    #[test]
+    fn final_flush_emits_advisories_when_the_log_cannot_be_reconstructed() {
+        use harnx_core::event::NoticeEvent;
+
+        let count = Arc::new(AtomicUsize::new(0));
+        let sink: Arc<dyn AgentEventSink> = Arc::new(TestSink {
+            count: Arc::clone(&count),
+            events: Mutex::new(Vec::new()),
+        });
+        let mut pending = VecDeque::from(vec![crate::nats_event_sink::AdvisoryEnvelope::new(
+            7,
+            AgentEvent::Notice(NoticeEvent::Warning("exhausted retries".to_string())),
+        )]);
+        let mut emitted = HashSet::new();
+
+        // Live: nothing to decorate against, so wait for a later flush.
+        flush_pending_advisories(&mut pending, None, &sink, &mut emitted, AdvisoryFlush::Live);
+        assert_eq!(pending.len(), 1, "live flush must retain, not drop");
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            0,
+            "live flush must not emit yet"
+        );
+
+        // Final: no later flush exists, so emit undecorated rather than lose it.
+        flush_pending_advisories(
+            &mut pending,
+            None,
+            &sink,
+            &mut emitted,
+            AdvisoryFlush::Final,
+        );
+        assert!(pending.is_empty(), "final flush must drain the queue");
+        // The point of the test: drained AND delivered, not drained by dropping.
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "final flush must emit the notice, not discard it"
+        );
     }
 
     fn test_entries(entries: &[(u64, MessageRole, &str)]) -> Vec<(u64, SessionLogEntry)> {

--- a/crates/harnx-runtime/src/nats_client_session.rs
+++ b/crates/harnx-runtime/src/nats_client_session.rs
@@ -472,24 +472,36 @@ impl ThinClientSession {
             }
         }
 
-        // Re-load durable log to get final state if we haven't already
+        // Re-load durable log to get final state if we haven't already.
+        //
+        // The error is held rather than propagated with `?`: returning here would
+        // skip the final flush below and lose advisories that had already been
+        // received, which is the whole point of that flush. They get emitted
+        // undecorated (no reload means no window), then the error is returned.
+        let mut final_reload_error = None;
         if !turn_complete {
-            let entries = self.load_durable_entries().await?;
-            (final_response, turn_error) = Self::extract_turn_outcome(&entries, user_msg_seq);
-            if let Ok(effective) =
-                harnx_core::session_reconstruct::apply_log_mutations_nats(&entries)
-            {
-                cached_effective = Some(effective);
-                // Paired with the cache refresh everywhere else. If the loop
-                // exited before any reload succeeded — a closed subscription, or
-                // a cancel before the first completion tick — this is the first
-                // reconstruction, and without it live Message and ToolCalls rows
-                // never get their LogSeqAssigned.
-                emit_all_logical_seqs_for_window(
-                    cached_effective.as_deref(),
-                    &event_sink,
-                    &mut emitted_logical_seqs,
-                );
+            match self.load_durable_entries().await {
+                Ok(entries) => {
+                    (final_response, turn_error) =
+                        Self::extract_turn_outcome(&entries, user_msg_seq);
+                    if let Ok(effective) =
+                        harnx_core::session_reconstruct::apply_log_mutations_nats(&entries)
+                    {
+                        cached_effective = Some(effective);
+                        // Paired with the cache refresh everywhere else. If the
+                        // loop exited before any reload succeeded — a closed
+                        // subscription, or a cancel before the first completion
+                        // tick — this is the first reconstruction, and without it
+                        // live Message and ToolCalls rows never get their
+                        // LogSeqAssigned.
+                        emit_all_logical_seqs_for_window(
+                            cached_effective.as_deref(),
+                            &event_sink,
+                            &mut emitted_logical_seqs,
+                        );
+                    }
+                }
+                Err(error) => final_reload_error = Some(error),
             }
         }
 
@@ -517,6 +529,10 @@ impl ThinClientSession {
             &mut emitted_logical_seqs,
             AdvisoryFlush::Final,
         );
+
+        if let Some(error) = final_reload_error {
+            return Err(error);
+        }
 
         if let Some(error) = &turn_error {
             render_error_entry(error, &event_sink);


### PR DESCRIPTION
The thin client's turn loop breaks the moment the durable log reads complete, and
`pending_advisories` — advisories received but not yet flushed — was dropped on
the floor with it. Notices live only in that ephemeral stream, so a warning the
worker had already published could be rendered after the terminal error, or never
rendered at all.

The visible case is losing:

```
⚠ Model 'mock-llm:fallback' exhausted retries (...), cooldown 60s. Trying next fallback.
```

That line is the only explanation a user gets for why their model changed
mid-turn, and it goes missing precisely on the turn that failed.

Flushing the queue before rendering the outcome costs nothing and cannot delay a
turn. It also refreshes `cached_effective` on the `!turn_complete` path, because
`flush_pending_advisories` drops everything when it has no effective log to
decorate against — without that, the flush on the fallback path would be a no-op.

## What this deliberately does not do

It does **not** wait on the subscription for advisories still in flight. I tried
that first: a 250ms budget with a 50ms idle poll. It delayed turn completion
enough to trip the sub-agent idle-timeout watchdog —
`subagent_idle_timeout_resets_on_child_activity` failed **5/5, deterministically**:

```
activity must keep idle timeout from false-firing: Recoverable("sub-agent 'metis'
timed out during session prompt (idle timeout)")
```

Advisory delivery is lossy by contract, so waiting was only ever a heuristic. Not
worth regressing turn latency for. The version in this PR has no timing effect at
all.

## Not the flake fix

I originally wrote this for `tmux_e2e retry_all_fail_shows_warnings_in_tui`, and
it does not fix it. Being explicit so nobody assumes otherwise.

That reordering happens mid-turn, not at the boundary. `NatsEventSink::emit`
spawns a detached task **per event**, so notices race each other on the way out
and emission order is lost at the publisher before anything downstream sees them.
The captured failure shows `attempt 2/3` jumping over an intervening `error:`
block — both notices, mid-retry-sequence.

Measured with the timed drain in place: still 1 failure in 199 runs and 1 in 200,
against 2 in 105 on `main`. Within noise. Fixing the flake means serializing that
publish in `nats_event_sink.rs`, which is a separate change I'm working on next.

## Testing

- `cargo fmt --check`, `clippy -D warnings` clean;
  `cargo nextest run --workspace --stress-count=5` green (5/5, 2462 tests).
  `cs delta` reports no issues.
- Confirmed the regression I introduced and then removed is gone:
  `subagent_idle_timeout_resets_on_child_activity` passes 5/5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Terminal errors now display all relevant advisories already received during the session.
  - Turn completion no longer waits unnecessarily for additional subscription events.
  - Durable session history is restored more reliably when reloading the final state.
  - Final advisories are delivered even when session history cannot be reconstructed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->