### PR TITLE
fix(nats): publish advisories in emission order

### DIFF
--- a/crates/harnx-runtime/src/nats_event_sink.rs
+++ b/crates/harnx-runtime/src/nats_event_sink.rs
@@ -86,6 +86,13 @@ pub struct NatsEventSink {
     /// Stale-low values are safe (a caught-up client just drops that advisory;
     /// advisory delivery is lossy by contract).
     after_seq: Arc<AtomicU64>,
+    /// Ordered hand-off to the single publisher task. `emit` stamps and enqueues
+    /// synchronously; one task drains this FIFO so advisories reach NATS in
+    /// emission order. Previously `emit` spawned a task per event, which let
+    /// concurrent publishes finish in any order — a warning and the notice that
+    /// followed it could arrive swapped, and no consumer could recover the
+    /// intended sequence.
+    publisher: tokio::sync::mpsc::UnboundedSender<AdvisoryEnvelope>,
 }
 
 impl NatsEventSink {
@@ -111,10 +118,21 @@ impl NatsEventSink {
                 .unwrap_or(0),
             Err(_) => 0,
         };
+        let subject = events_subject(&session_id);
+        let (publisher, mut rx) = tokio::sync::mpsc::unbounded_channel::<AdvisoryEnvelope>();
+        let publisher_client = client.clone();
+        let publisher_subject = subject.clone();
+        // Ends when every clone of this sink is dropped and the channel closes.
+        tokio::spawn(async move {
+            while let Some(envelope) = rx.recv().await {
+                publish_envelope(&publisher_client, &publisher_subject, envelope).await;
+            }
+        });
         Self {
             client,
-            subject: events_subject(&session_id),
+            subject,
             after_seq: Arc::new(AtomicU64::new(seed)),
+            publisher,
         }
     }
 
@@ -136,33 +154,41 @@ impl NatsEventSink {
     /// round-trip — `after_seq` comes from the cached atomic.
     pub async fn publish_event(&self, event: AgentEvent) {
         let after_seq = self.after_seq.load(Ordering::Relaxed);
-        let envelope = AdvisoryEnvelope::new(after_seq, event);
-        match envelope.to_bytes() {
-            Ok(payload) => {
-                if let Err(e) = self
-                    .client
-                    .publish(self.subject.clone(), payload.into())
-                    .await
-                {
-                    log::debug!("advisory event publish failed (lossy-OK): {e}");
-                }
+        publish_envelope(
+            &self.client,
+            &self.subject,
+            AdvisoryEnvelope::new(after_seq, event),
+        )
+        .await;
+    }
+}
+
+/// Publish one advisory. Best-effort core NATS (non-durable); failures are
+/// logged, never propagated.
+async fn publish_envelope(client: &async_nats::Client, subject: &str, envelope: AdvisoryEnvelope) {
+    match envelope.to_bytes() {
+        Ok(payload) => {
+            if let Err(e) = client.publish(subject.to_string(), payload.into()).await {
+                log::debug!("advisory event publish failed (lossy-OK): {e}");
             }
-            Err(e) => log::debug!("failed to serialize advisory event: {e}"),
         }
+        Err(e) => log::debug!("failed to serialize advisory event: {e}"),
     }
 }
 
 impl AgentEventSink for NatsEventSink {
     fn emit(&self, event: AgentEvent) {
-        // The trait method is sync but publish is async. Fire-and-forget onto
-        // the current runtime so the agent loop is never blocked, and so this
-        // works on any runtime flavor (block_in_place would panic on a
-        // current-thread runtime). Advisory delivery is lossy by contract, so
-        // dropping on a missing runtime handle is acceptable.
-        let sink = self.clone();
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            handle.spawn(async move { sink.publish_event(event).await });
-        }
+        // Stamp `after_seq` and enqueue synchronously, so both the ordering hint
+        // and the queue position reflect the order events were emitted in. The
+        // publisher task then sends them one at a time.
+        //
+        // This used to spawn a task per event, which never blocked the agent loop
+        // but also gave up ordering: N detached publishes race, so a notice could
+        // overtake the one emitted before it. Enqueuing is just as non-blocking
+        // and needs no runtime handle. Delivery stays lossy by contract — a send
+        // failure means the publisher task is gone, and is dropped as before.
+        let after_seq = self.after_seq.load(Ordering::Relaxed);
+        let _ = self.publisher.send(AdvisoryEnvelope::new(after_seq, event));
     }
 }
 


### PR DESCRIPTION
This is the root cause of the `tmux_e2e retry_all_fail_shows_warnings_in_tui`
flake, and of the same reordering in what users actually see.

`NatsEventSink::emit` spawned a task per event:

```rust
let sink = self.clone();
if let Ok(handle) = tokio::runtime::Handle::try_current() {
    handle.spawn(async move { sink.publish_event(event).await });
}
```

N events meant N detached tasks racing to publish. Advisories reached NATS in
whatever order the scheduler finished them, so a notice could overtake the one
emitted before it — and no consumer could recover the intended sequence, because
the order was already lost at the publisher.

Retry warnings and per-model failure notices are all advisories, which is why the
captured failure showed `attempt 2/3` jumping over the `error:` block that
preceded it:

```
   30    30 │ ⚠ Retryable error ... attempt 1/3. Retrying in 10ms...
         31 │+⚠ Retryable error ... attempt 2/3. Retrying in 20ms...
   31    32 │ error: Failed to call chat-completions api ...
   36       │-⚠ Retryable error ... attempt 2/3. Retrying in 20ms...
```

## The fix

`emit` stamps `after_seq` and enqueues synchronously; one task drains the channel
and publishes FIFO. Stamping stays on the caller's side so the ordering hint
reflects emission time rather than publish time.

Enqueuing is as non-blocking as spawning was — that was the property the old
comment cared about — and it needs no runtime handle, so the "no current runtime"
fallback is gone. Delivery is still lossy by contract: a send failure means the
publisher task is gone, and is dropped exactly as before. The publisher task ends
when the last clone of the sink drops and the channel closes.

`publish_event` is unchanged for its direct callers (the fan-out tests); it and
the queue now share one `publish_envelope` helper.

## Testing

- **The flake:** 200/200 iterations pass. The base rate was ~2% (2 failures in
  105 runs on `main`), which makes 200 consecutive passes about a 2% coincidence.
- All three `retry_*` tmux tests: 100/100.
- `cargo fmt --check`, `clippy -D warnings` clean;
  `cargo nextest run --workspace --stress-count=5` green (5/5, 2462 tests).
  `cs delta` reports no issues.

## Follow-ups this makes possible

- The `tokio::task::yield_now()` in `retry.rs:277` exists to nudge this ordering
  and should now be unnecessary. I left it alone rather than widen this PR.
- #1443 flushes advisories already queued at turn end. Still worth having — it
  fixes advisories being *dropped* at the turn boundary, which is a different
  failure from being reordered — but it is not what fixed the flake.