### PR TITLE
Tweak clio instructions

### DIFF
--- a/.changeset/clio-existing-pr-status.md
+++ b/.changeset/clio-existing-pr-status.md
@@ -1,0 +1,4 @@
+---
+pantheon: minor
+---
+Teach Clio to report an existing pull request's link and status after pushing, falling back to a compare link only when the branch has no open pull request.

--- a/crates/harnx-runtime/tests/agent_prompt_rendering.rs
+++ b/crates/harnx-runtime/tests/agent_prompt_rendering.rs
@@ -192,3 +192,31 @@ fn agent_prompt_rendering_renders_all_shipped_agents() {
         "no shipped agent exercised a file-backed variable"
     );
 }
+
+#[test]
+fn clio_prompt_checks_for_an_existing_pull_request_after_push() {
+    harnx_core::require_nextest();
+    let Some(workspace_root) = workspace_root() else {
+        return;
+    };
+    let (_temp, _config_guard) = install_packages(&workspace_root);
+
+    let qualified_name = "pantheon/clio";
+    let agent_path = Config::agent_file(qualified_name);
+    let mut agent = load_with_qualified_name(&agent_path, qualified_name).expect("load Clio");
+    resolve_variables(&mut agent).expect("resolve Clio variables");
+    let prompt = agent.system_text().expect("render Clio prompt");
+
+    assert!(
+        prompt.contains("gh pr list --head \"$branch\" --state open --limit 1"),
+        "Clio must query for an open pull request on the pushed branch"
+    );
+    assert!(
+        prompt.contains("url,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup"),
+        "Clio must retrieve the existing pull request's link and status"
+    );
+    assert!(
+        prompt.contains("Only when no open pull request exists for the branch"),
+        "Clio must reserve the compare-link fallback for branches without an open pull request"
+    );
+}

--- a/packages/pantheon/agents/shared/atlas.md
+++ b/packages/pantheon/agents/shared/atlas.md
@@ -247,8 +247,9 @@ describing the entire branch's purpose. Any knowledge-maintenance content from
 Mnemosyne is already committed as a regular incremental commit and will be
 folded into the same squashed final commit.
 
-Clio will return a PR link. Pass the PR link to the user so they can open the
-pull request themselves. Clio does NOT create the pull request.
+Clio will return an existing pull request's link and status when one is already open,
+or a compare link when the user still needs to open one. Pass that result to the user.
+Clio does NOT create pull requests.
 
 ## Issue Tracking
 

--- a/packages/pantheon/agents/shared/clio.md
+++ b/packages/pantheon/agents/shared/clio.md
@@ -118,6 +118,23 @@ HEAD state, STOP and ask the caller how to proceed.
 **If already on a feature branch** — keep using it. Do NOT rename it
 or create a new branch. Branch continuity keeps PR history clean.
 
+## Pull Request Reporting
+
+After a successful push, check whether the pushed branch already has an open pull request:
+
+```sh
+branch=$(git branch --show-current)
+gh pr list --head "$branch" --state open --limit 1 \
+  --json url,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup
+```
+
+If the query returns a pull request, report its URL and summarize its status, including
+whether it is a draft, its merge and review states, and whether checks are passing,
+pending, or failing. Return this existing pull request URL instead of a compare link.
+
+Only when no open pull request exists for the branch, return a GitHub compare or
+new-pull-request link so the caller can open one. Never create the pull request yourself.
+
 ## Issue Tracker Reference Detection
 
 Look for issue references in these places (in priority order):

--- a/packages/pantheon/agents/shared/sisyphus-clio-delegation.md
+++ b/packages/pantheon/agents/shared/sisyphus-clio-delegation.md
@@ -23,10 +23,15 @@ a gate.
 ## Delegate Squash + Push to Clio
 
 Delegate **final squash, rebase, and force push** to `clio` when all work
-is complete (including any Mnemosyne docs commit). When delegating to `clio`,
-send the plan name and instruct `clio` to read the plan using `plans_get_plan`
-and use the plan content and notes to create the commit. If an issue tracker
-reference is known (JIRA or GitHub), pass it explicitly (e.g. `Issue: FDEV-1234`
-or `Issue: #123`) so Clio includes it in the commit body. Clio will return a
-PR link — pass it back to the user so they can open the pull request
-themselves. Clio does NOT create the pull request.
+is complete (including any Mnemosyne docs commit).
+
+When delegating to `clio`, send the plan name and instruct `clio` to read the 
+plan using `plans_get_plan` and use the plan content and notes to create the
+commit.  **Do NOT provide a pre-composed commit message.** 
+
+If an issue tracker reference is known (JIRA or GitHub), pass it explicitly (e.g. 
+`Issue: FDEV-1234` or `Issue: #123`) so Clio includes it in the commit body.
+
+Clio will return a link — either an existing pull request's link and status or, 
+when none is open, a compare link for opening one. Pass Clio's result back to 
+the user. Clio does NOT create pull requests.


### PR DESCRIPTION
- Have Clio check for an open PR and return PR status if one is open
- Tell Sisyphus not to write the commit message