### PR TITLE
Fix spurious 503s from session actor reap race

### DIFF
--- a/.changeset/session-actor-reaped-handle.md
+++ b/.changeset/session-actor-reaped-handle.md
@@ -1,0 +1,7 @@
+---
+harnx: patch
+---
+
+Fix spurious 503s from `harnx serve` when a request lands on a session whose actor is reaping itself.
+
+An idle session actor stops after 5 seconds and removes itself from the registry. It used to do that without regard for callers, so a request that had already picked up its handle sent commands into a closed channel and got `session actor unavailable` or `session actor dropped ... reply` back as a JSON-RPC 503 — for a session that was perfectly resumable. The reap now happens atomically with the liveness check: an actor only removes itself while the registry holds the last handle to it, so no in-flight request can be talking to it, and otherwise it waits another interval. Handing out a handle also treats an entry whose channel is closed as no actor at all and spawns a replacement, so a session survives an actor task dying on its own (a panic) instead of failing every later request for that key.

--- a/crates/harnx-serve/README.md
+++ b/crates/harnx-serve/README.md
@@ -121,7 +121,9 @@ Same canonical session URL, negotiated into programmatic control.
   **Result:** `{ "cancelled": true }`
 
 **Error Codes:**
-- `-32001`: Unknown session
+- `-32001`: Unknown session (HTTP 404)
+- `-32002`: Session is not running — `session/cancel` on an idle session (HTTP 400)
+- `-32003`: Session actor unreachable (HTTP 503). Transient: the session's in-process actor could not be reached, so retry the call.
 - `-32601`: Method not found
 - Standard JSON-RPC 2.0 codes (-32700, -32600, -32602)
 

--- a/crates/harnx-serve/src/session_actor.rs
+++ b/crates/harnx-serve/src/session_actor.rs
@@ -5,8 +5,13 @@ mod test_executor;
 #[path = "session_actor_test_log.rs"]
 mod test_log;
 
+mod registry;
+
 pub use crate::session_actor_types::*;
+pub use registry::SessionRegistry;
 pub use test_log::load_test_session_messages;
+
+use registry::get_or_spawn_in;
 
 use crate::ag_ui::AgUiSink;
 use ag_ui_core::{
@@ -17,7 +22,7 @@ use ag_ui_core::{
     },
 };
 use chrono::Utc;
-use dashmap::{mapref::entry::Entry, DashMap};
+use dashmap::DashMap;
 use harnx_core::{
     abort::{create_abort_signal, AbortSignal},
     message::MessageContent,
@@ -31,24 +36,27 @@ use harnx_runtime::{
     AgentCallFn, AgentLoopContext, OnToolRoundFn, ThinClientConfig, ThinClientSession,
     ToolApprovalDecision, ToolApprovalInterrupt, ToolUseConfirmation,
 };
-use std::{collections::VecDeque, sync::Arc, time::Duration};
+use std::{
+    collections::VecDeque,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 use tokio::{
     sync::{broadcast, mpsc, oneshot, Mutex},
     task::JoinHandle,
     time::{sleep_until, Instant, Sleep},
 };
 
-const DEFAULT_REAP_TTL: Duration = Duration::from_secs(5);
 const COMMAND_BUFFER: usize = 32;
 const BROADCAST_BUFFER: usize = 64;
 const FAR_FUTURE_SECS: u64 = 365 * 24 * 60 * 60;
 
-#[derive(Clone)]
-pub struct SessionRegistry {
-    map: Arc<DashMap<SessionKey, SessionHandle>>,
-    reap_ttl: Duration,
-    actor_config: SessionActorConfig,
-}
+type SessionMap = Arc<DashMap<SessionKey, SessionHandle>>;
+
+static NEXT_ACTOR_ID: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Clone)]
 struct SessionActorConfig {
@@ -81,96 +89,10 @@ struct ActorTurnParams {
     session_id: String,
 }
 
-impl SessionRegistry {
-    pub fn new(base_config: Config) -> Self {
-        Self::with_reap_ttl(base_config, DEFAULT_REAP_TTL)
-    }
-
-    pub fn with_reap_ttl(base_config: Config, reap_ttl: Duration) -> Self {
-        Self {
-            map: Arc::new(DashMap::new()),
-            reap_ttl,
-            actor_config: SessionActorConfig {
-                base_config,
-                call_fn: None,
-                local_worker: Arc::new(Mutex::new(None)),
-            },
-        }
-    }
-
-    fn with_options(reap_ttl: Duration, actor_config: SessionActorConfig) -> Self {
-        Self {
-            map: Arc::new(DashMap::new()),
-            reap_ttl,
-            actor_config,
-        }
-    }
-
-    pub fn new_for_tests(
-        base_config: Config,
-        reap_ttl: Duration,
-        call_fn: Option<AgentCallFn>,
-    ) -> Self {
-        Self::with_options(
-            reap_ttl,
-            SessionActorConfig {
-                base_config,
-                call_fn,
-                local_worker: Arc::new(Mutex::new(None)),
-            },
-        )
-    }
-
-    // Only used by the Unix-only NATS serve tests (`nats_tests`).
-    #[cfg(all(test, unix))]
-    fn new_with_local_worker_for_tests(
-        base_config: Config,
-        supervisor: LocalWorkerSupervisor,
-    ) -> Self {
-        Self::with_options(
-            DEFAULT_REAP_TTL,
-            SessionActorConfig {
-                base_config,
-                call_fn: None,
-                local_worker: Arc::new(Mutex::new(Some(supervisor))),
-            },
-        )
-    }
-
-    pub fn has_session(&self, key: &SessionKey) -> bool {
-        self.map.contains_key(key)
-    }
-
-    pub fn get_or_spawn(&self, key: SessionKey) -> SessionHandle {
-        match self.map.entry(key.clone()) {
-            Entry::Occupied(entry) => entry.get().clone(),
-            Entry::Vacant(entry) => {
-                let handle = spawn_session_actor(
-                    key,
-                    Arc::clone(&self.map),
-                    self.reap_ttl,
-                    self.actor_config.clone(),
-                );
-                entry.insert(handle.clone());
-                handle
-            }
-        }
-    }
-
-    pub fn contains(&self, key: &SessionKey) -> bool {
-        self.map.contains_key(key)
-    }
-}
-
-impl Default for SessionRegistry {
-    fn default() -> Self {
-        Self::new(Config::default())
-    }
-}
-
 struct SessionActor {
     key: SessionKey,
-    registry: Arc<DashMap<SessionKey, SessionHandle>>,
+    actor_id: u64,
+    registry: SessionMap,
     rx: mpsc::Receiver<SessionCommand>,
     broadcast_tx: broadcast::Sender<Event>,
     subscribers: usize,
@@ -188,16 +110,21 @@ struct SessionActor {
 
 fn spawn_session_actor(
     key: SessionKey,
-    registry: Arc<DashMap<SessionKey, SessionHandle>>,
+    registry: SessionMap,
     reap_ttl: Duration,
     actor_config: SessionActorConfig,
 ) -> SessionHandle {
     let (tx, rx) = mpsc::channel(COMMAND_BUFFER);
     let (broadcast_tx, _) = broadcast::channel(BROADCAST_BUFFER);
     let (run_done_tx, run_done_rx) = mpsc::channel(COMMAND_BUFFER);
-    let handle = SessionHandle { tx: tx.clone() };
+    let actor_id = NEXT_ACTOR_ID.fetch_add(1, Ordering::Relaxed);
+    let handle = SessionHandle {
+        tx: tx.clone(),
+        actor_id,
+    };
     let actor = SessionActor {
         key,
+        actor_id,
         registry,
         rx,
         broadcast_tx,
@@ -331,22 +258,21 @@ impl SessionActor {
                         if let Some(active_run) = &self.active_run {
                             active_run.abort_signal.set_ctrlc();
                         }
-                        self.registry.remove(&self.key);
+                        self.deregister();
                         break;
                     };
                     self.handle_command(cmd, &mut reap_sleep).await;
                 }
                 maybe_done = self.run_done_rx.recv() => {
                     let Some(done) = maybe_done else {
-                        self.registry.remove(&self.key);
+                        self.deregister();
                         break;
                     };
                     self.handle_run_done(done, &mut reap_sleep).await;
                 }
                 _ = &mut reap_sleep, if self.reap_deadline.is_some() => {
                     if self.subscribers == 0 && !self.is_running() {
-                        if self.should_reap() {
-                            self.registry.remove(&self.key);
+                        if self.reap_now() {
                             break;
                         }
                         self.arm_reap(&mut reap_sleep);
@@ -592,19 +518,12 @@ impl SessionActor {
     }
 
     fn get_or_spawn_target_session_actor(&mut self, target_key: SessionKey) -> SessionHandle {
-        match self.registry.entry(target_key.clone()) {
-            Entry::Occupied(entry) => entry.get().clone(),
-            Entry::Vacant(entry) => {
-                let handle = spawn_session_actor(
-                    target_key,
-                    Arc::clone(&self.registry),
-                    self.reap_ttl,
-                    self.actor_config.clone(),
-                );
-                entry.insert(handle.clone());
-                handle
-            }
-        }
+        get_or_spawn_in(
+            &self.registry,
+            target_key,
+            self.reap_ttl,
+            &self.actor_config,
+        )
     }
 
     async fn start_run(
@@ -765,6 +684,33 @@ impl SessionActor {
             interrupts,
             metadata,
         })
+    }
+
+    /// Drop this actor's registry entry, leaving any replacement under the same key in place.
+    fn deregister(&self) {
+        self.registry
+            .remove_if(&self.key, |_, handle| handle.actor_id == self.actor_id);
+    }
+
+    /// Whether this actor is done: its idle deadline has passed and it managed to deregister,
+    /// which is the point of no return for a reap.
+    fn reap_now(&self) -> bool {
+        self.should_reap() && self.deregister_for_reap()
+    }
+
+    /// Deregister for reaping, but only if nobody outside the registry holds a handle.
+    ///
+    /// `strong_count == 1` means the registry's own sender is the last one, so no caller is
+    /// mid-request. Any other count means a caller already cloned the handle and would hit a
+    /// closed channel the moment this actor stops, which is exactly the spurious 503 the reap
+    /// used to cause. DashMap holds the shard lock across both the check and the removal, and
+    /// handing out a handle needs that same lock, so no caller can slip in between the two.
+    fn deregister_for_reap(&self) -> bool {
+        self.registry
+            .remove_if(&self.key, |_, handle| {
+                handle.actor_id == self.actor_id && handle.tx.strong_count() == 1
+            })
+            .is_some()
     }
 
     fn arm_reap(&mut self, reap_sleep: &mut std::pin::Pin<&mut Sleep>) {
@@ -2821,6 +2767,9 @@ mod tests {
             "target session should be registered in registry after handoff dispatch"
         );
     }
+
+    #[path = "session_actor_registry_tests.rs"]
+    mod registry_tests;
 
     // NATS-backed serve tests spawn a local worker subprocess via
     // `LocalWorkerSupervisor` (Unix process-group management), so they are

--- a/crates/harnx-serve/src/session_actor/registry.rs
+++ b/crates/harnx-serve/src/session_actor/registry.rs
@@ -1,0 +1,119 @@
+//! The session registry: one actor per agent/session key, spawned on demand and reaped when idle.
+
+use super::{spawn_session_actor, SessionActorConfig, SessionHandle, SessionKey, SessionMap};
+use dashmap::{mapref::entry::Entry, DashMap};
+use harnx_runtime::{config::Config, AgentCallFn};
+use std::{sync::Arc, time::Duration};
+use tokio::sync::Mutex;
+
+/// How long an actor stays alive with no subscribers and nothing running.
+const DEFAULT_REAP_TTL: Duration = Duration::from_secs(5);
+
+#[derive(Clone)]
+pub struct SessionRegistry {
+    pub(super) map: SessionMap,
+    reap_ttl: Duration,
+    actor_config: SessionActorConfig,
+}
+
+impl SessionRegistry {
+    pub fn new(base_config: Config) -> Self {
+        Self::with_reap_ttl(base_config, DEFAULT_REAP_TTL)
+    }
+
+    pub fn with_reap_ttl(base_config: Config, reap_ttl: Duration) -> Self {
+        Self::with_options(
+            reap_ttl,
+            SessionActorConfig {
+                base_config,
+                call_fn: None,
+                local_worker: Arc::new(Mutex::new(None)),
+            },
+        )
+    }
+
+    fn with_options(reap_ttl: Duration, actor_config: SessionActorConfig) -> Self {
+        Self {
+            map: Arc::new(DashMap::new()),
+            reap_ttl,
+            actor_config,
+        }
+    }
+
+    pub fn new_for_tests(
+        base_config: Config,
+        reap_ttl: Duration,
+        call_fn: Option<AgentCallFn>,
+    ) -> Self {
+        Self::with_options(
+            reap_ttl,
+            SessionActorConfig {
+                base_config,
+                call_fn,
+                local_worker: Arc::new(Mutex::new(None)),
+            },
+        )
+    }
+
+    // Only used by the Unix-only NATS serve tests (`nats_tests`).
+    #[cfg(all(test, unix))]
+    pub(super) fn new_with_local_worker_for_tests(
+        base_config: Config,
+        supervisor: harnx_runtime::local_orchestrator::LocalWorkerSupervisor,
+    ) -> Self {
+        Self::with_options(
+            DEFAULT_REAP_TTL,
+            SessionActorConfig {
+                base_config,
+                call_fn: None,
+                local_worker: Arc::new(Mutex::new(Some(supervisor))),
+            },
+        )
+    }
+
+    pub fn has_session(&self, key: &SessionKey) -> bool {
+        self.map.contains_key(key)
+    }
+
+    pub fn get_or_spawn(&self, key: SessionKey) -> SessionHandle {
+        get_or_spawn_in(&self.map, key, self.reap_ttl, &self.actor_config)
+    }
+}
+
+impl Default for SessionRegistry {
+    fn default() -> Self {
+        Self::new(Config::default())
+    }
+}
+
+/// Hand out a live handle for `key`, spawning an actor when the key has none.
+///
+/// An entry whose channel is already closed counts as no actor at all: the actor behind it has
+/// stopped, so every command sent through that handle would fail. Replacing it keeps a session
+/// usable even if its actor task died without deregistering (a panic, say) instead of failing
+/// every later request for that key.
+pub(super) fn get_or_spawn_in(
+    map: &SessionMap,
+    key: SessionKey,
+    reap_ttl: Duration,
+    actor_config: &SessionActorConfig,
+) -> SessionHandle {
+    match map.entry(key.clone()) {
+        Entry::Occupied(mut entry) if entry.get().tx.is_closed() => {
+            log::warn!(
+                "session actor for {}/{} stopped without deregistering; spawning a replacement",
+                key.agent,
+                key.session
+            );
+            let handle = spawn_session_actor(key, Arc::clone(map), reap_ttl, actor_config.clone());
+            entry.insert(handle.clone());
+            handle
+        }
+        Entry::Occupied(entry) => entry.get().clone(),
+        Entry::Vacant(entry) => {
+            let handle = spawn_session_actor(key, Arc::clone(map), reap_ttl, actor_config.clone());
+            entry.insert(handle.clone());
+            handle
+        }
+    }
+}

--- a/crates/harnx-serve/src/session_actor/tests/session_actor_registry_tests.rs
+++ b/crates/harnx-serve/src/session_actor/tests/session_actor_registry_tests.rs
@@ -1,0 +1,132 @@
+//! Registry bookkeeping: handing out live handles, and reaping only when it is safe.
+
+use super::*;
+
+fn noop_call_fn() -> AgentCallFn {
+    Arc::new(|_input, _config, _abort| {
+        Box::pin(async {
+            Ok((
+                "done".to_string(),
+                None,
+                vec![],
+                harnx_runtime::client::CompletionTokenUsage::default(),
+            ))
+        })
+    })
+}
+
+/// Registry with a 50ms reap TTL and an agent to resolve, ready to spawn actors.
+async fn registry_sandbox() -> (
+    harnx_runtime::client::TestStateGuard<'static>,
+    TestConfigSandbox,
+    SessionRegistry,
+) {
+    let guard = harnx_runtime::client::TestStateGuard::new(None).await;
+    let sandbox = TestConfigSandbox::new();
+    sandbox.write_agent("plain", "You are plain.");
+    let registry = registry_with_call_fn(noop_call_fn());
+    (guard, sandbox, registry)
+}
+
+/// Arm the reap deadline the way a departing subscriber does, and wait until the actor has
+/// processed it: `Unsubscribe` carries no reply, so a following `Get` round-trip is the
+/// confirmation that the deadline is set.
+async fn arm_reap_deadline(handle: &SessionHandle) {
+    handle
+        .tx
+        .send(SessionCommand::Unsubscribe)
+        .await
+        .expect("send unsubscribe");
+    get_info(handle).await;
+}
+
+async fn wait_until_unregistered(registry: &SessionRegistry, key: &SessionKey) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while registry.has_session(key) {
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("idle session actor should be reaped once no caller holds its handle");
+}
+
+fn registered_actor_id(registry: &SessionRegistry, key: &SessionKey) -> Option<u64> {
+    registry.map.get(key).map(|entry| entry.actor_id)
+}
+
+#[tokio::test]
+async fn reap_spares_an_actor_whose_handle_a_caller_still_holds() {
+    let (_guard, _sandbox, registry) = registry_sandbox().await;
+    let key = key("plain", "reap-with-held-handle");
+    let handle = registry.get_or_spawn(key.clone());
+    let actor_id = handle.actor_id;
+
+    arm_reap_deadline(&handle).await;
+    // Well past the 50ms TTL: the reap must keep deferring while this handle is alive.
+    sleep(Duration::from_millis(300)).await;
+
+    let info = get_info(&handle).await;
+    assert_eq!(info.state, SessionState::Idle);
+    assert_eq!(
+        registered_actor_id(&registry, &key),
+        Some(actor_id),
+        "the same actor should still be registered"
+    );
+}
+
+#[tokio::test]
+async fn reap_removes_an_idle_actor_once_its_handle_is_dropped() {
+    let (_guard, _sandbox, registry) = registry_sandbox().await;
+    let key = key("plain", "reap-after-handle-dropped");
+    let handle = registry.get_or_spawn(key.clone());
+
+    arm_reap_deadline(&handle).await;
+    drop(handle);
+
+    wait_until_unregistered(&registry, &key).await;
+}
+
+#[tokio::test]
+async fn get_or_spawn_replaces_an_entry_whose_actor_has_stopped() {
+    let (_guard, _sandbox, registry) = registry_sandbox().await;
+    let key = key("plain", "stopped-actor-entry");
+
+    // An actor that died without deregistering, e.g. a panicking task.
+    let (dead_tx, dead_rx) = mpsc::channel(1);
+    drop(dead_rx);
+    registry.map.insert(
+        key.clone(),
+        SessionHandle {
+            tx: dead_tx,
+            actor_id: u64::MAX,
+        },
+    );
+
+    let handle = registry.get_or_spawn(key.clone());
+    assert_ne!(handle.actor_id, u64::MAX, "expected a fresh actor");
+    assert_eq!(get_info(&handle).await.state, SessionState::Idle);
+    assert_eq!(registered_actor_id(&registry, &key), Some(handle.actor_id));
+}
+
+#[tokio::test]
+async fn a_stopping_actor_leaves_its_replacement_registered() {
+    let (_guard, _sandbox, registry) = registry_sandbox().await;
+    let key = key("plain", "replacement-survives");
+
+    let outgoing = registry.get_or_spawn(key.clone());
+    // Unregister the first actor so the key is free, then register a second one for it. The
+    // first actor now only stops once `outgoing` goes away.
+    registry.map.remove(&key);
+    let replacement = registry.get_or_spawn(key.clone());
+    assert_ne!(outgoing.actor_id, replacement.actor_id);
+
+    drop(outgoing);
+    sleep(Duration::from_millis(200)).await;
+
+    assert_eq!(
+        registered_actor_id(&registry, &key),
+        Some(replacement.actor_id),
+        "the outgoing actor must not remove its replacement's entry"
+    );
+    assert_eq!(get_info(&replacement).await.state, SessionState::Idle);
+}

--- a/crates/harnx-serve/src/session_actor_types.rs
+++ b/crates/harnx-serve/src/session_actor_types.rs
@@ -13,6 +13,13 @@ pub struct SessionKey {
 #[derive(Clone)]
 pub struct SessionHandle {
     pub tx: mpsc::Sender<SessionCommand>,
+    /// Identifies which actor incarnation this handle talks to. A registry entry can be
+    /// replaced by a fresh actor for the same key, and the outgoing actor must only remove
+    /// its own entry — never its replacement's.
+    ///
+    /// Holding a clone of a handle also keeps its actor alive: the idle reap only fires while
+    /// the registry's own sender is the last one, so a long-lived clone pins the actor.
+    pub(crate) actor_id: u64,
 }
 
 pub(crate) struct ActiveRun {

--- a/docs/solutions/async-patterns/session-actor-concurrency-invariants-2026-07-04.md
+++ b/docs/solutions/async-patterns/session-actor-concurrency-invariants-2026-07-04.md
@@ -18,21 +18,24 @@ tags:
   - session-actor
   - mid-loop-injection
   - reap-race
+  - dashmap
 plan_ref: ag-ui-serve-control-plane
+last_updated: 2026-08-17
 ---
 
 ## Problem
 
 Per-session actor in `harnx-serve` exhibited subtle race conditions:
 1. **Prompt loss at completion boundary**: Prompts enqueued while a run was completing could be silently dropped.
-2. **Reap race**: Actors could be reaped immediately after a new subscriber joined.
+2. **Reap races**: Actors could be reaped right after a new subscriber joined, or while a caller was holding their handle.
 3. **Mid-loop injection data loss**: Multi-prompt injection drained all queued prompts but kept only one, silently discarding the rest.
 4. **Test hangs**: SSE subscription streams drained to completion in tests blocked forever; `Notify::notify_waiters()` lost signals on multi-threaded runtimes.
 
 ## Symptoms
 
 - **Prompt loss**: `session/prompt` during run completion never triggered a subsequent run.
-- **Reap race**: After `Unsubscribe` + quick `Subscribe`, the actor sometimes disappeared from registry.
+- **Reap race (subscribe)**: After `Unsubscribe` + quick `Subscribe`, the actor sometimes disappeared from registry.
+- **Reap race (caller)**: `session/get`, `session/prompt`, and `session/cancel` intermittently returned HTTP 503 with `-32003` and the message `session actor unavailable` (or `session actor dropped … reply`) for a session that existed — ~1 flake in 10 runs of `rpc_session_prompt_returns_ack_and_persists_effect`.
 - **Data loss**: Enqueuing 2+ prompts during a run injected only the first; others silently dropped.
 - **Test hangs**: E2E tests with `body.collect().await` on SSE streams hung indefinitely; tests using `Notify::notify_waiters()` deadlocked on multi-threaded runtimes.
 - **Config panic**: Test helper `load_base_config_for_tests()` (which calls `std::env::set_current_dir` and expects `HARNX_CONFIG_DIR`) used in production paths caused thread-safety violations and panics.
@@ -43,9 +46,13 @@ Per-session actor in `harnx-serve` exhibited subtle race conditions:
 
 The actor had no explicit "completing" state to buffer prompts arriving during run finish. The `inject_tx.try_send` could return `Err(Full|Closed)` during the run-done transition, and without a `pending` queue, prompts were lost.
 
-### 2. Reap Timer Race
+### 2. Reap Races
 
-On `Unsubscribe` when `subscribers == 0 && !running`, the actor armed a reap timer. A concurrent `Subscribe` canceled it, but the timer arm didn't re-check the subscriber count before removing from `DashMap`. A just-revived actor could be incorrectly reaped.
+Two distinct races, both ending in a registry entry removed too early.
+
+**Subscribe vs. timer (2026-07):** on `Unsubscribe` when `subscribers == 0 && !running`, the actor armed a reap timer. A concurrent `Subscribe` canceled it, but the timer arm didn't re-check the subscriber count before removing from `DashMap`. A just-revived actor could be incorrectly reaped.
+
+**Caller vs. reap (2026-08, issue #1465):** re-checking the actor's own state fixed the first race but not this one, because `subscribers`/`is_running` say nothing about callers holding a handle. `get_or_spawn` could clone a still-registered handle *after* the actor decided to reap and *before* its `registry.remove` landed; the caller's `send` then hit a closed channel and the RPC returned 503 (`-32003`, message `session actor unavailable` or `session actor dropped … reply`). A `tx.is_closed()` check in `get_or_spawn` narrows this window but cannot close it: the map stores a live `Sender`, so `is_closed()` only flips once the actor has already dropped `rx`. Separately, an unconditional `registry.remove(&self.key)` on exit could evict a *replacement* actor's entry if the outgoing actor exited late.
 
 ### 3. Drain-All-Keep-First Anti-Pattern
 
@@ -88,17 +95,30 @@ fn handle_run_done(&mut self, result: RunResult) {
 
 **On Prompt while Running**: If `inject_tx.try_send()` returns `Err(Full|Closed)`, push to `pending` queue. No lost prompts across finish boundary.
 
-### 2. Reap Race Guard
+### 2. Reap Guard: State Re-check *Plus* an Identity/Refcount Gate
 
-On last unsubscribe (`subs == 0 && !running`), arm a reap `Sleep`. On `Subscribe`, cancel it. In the timer arm, **RE-CHECK** `subs == 0 && !running` before removing from `DashMap`:
+Layer one (unchanged since 2026-07): on last unsubscribe (`subs == 0 && !running`) arm a reap `Sleep` for `DEFAULT_REAP_TTL` (5s); on `Subscribe` cancel it; in the timer arm re-check `self.subscribers == 0 && !self.is_running()` before doing anything destructive (`SessionActor::run` reap branch and `should_reap()`).
+
+Layer two (2026-08): make the removal itself the decision point, so no caller can observe the actor mid-reap. Both conditions are evaluated inside the same `DashMap` operation that removes the entry — `SessionActor::deregister_for_reap` in `crates/harnx-serve/src/session_actor.rs`:
 
 ```rust
-// In reap timer arm
-if self.subscribers == 0 && self.running.is_none() {
-    // Safe to reap NOW — no race with subscribe
-    self.should_exit = true;
-}
+self.registry.remove_if(&self.key, |_, handle| {
+    handle.actor_id == self.actor_id && handle.tx.strong_count() == 1
+})
 ```
+
+- `SessionHandle::actor_id` (monotonic `AtomicU64`, assigned in `spawn_session_actor`) gives each map entry an identity. Every self-removal path is gated on it (`deregister()` for the two channel-closed exits, `deregister_for_reap()` for the idle reap), so an exiting actor can never evict its replacement. There is no bare `registry.remove()` in the actor anymore.
+- `tx.strong_count() == 1` means the registry's stored handle holds the only `Sender`, i.e. no caller is mid-request. `spawn_session_actor` drops its local `tx` and the actor keeps only `rx`, so 1 really is the idle count. If the predicate rejects, the actor re-arms its deadline and tries again later.
+
+**Invariant this creates: holding a `SessionHandle` clone pins its actor against reaping.** A clone stored anywhere long-lived leaks an actor for as long as it lives, with no log line or metric. The only long-lived holder today is the SSE path, which releases via `UnsubscribeOnDrop` in `crates/harnx-serve/src/ag_ui.rs`.
+
+The atomicity rests on a dashmap implementation detail, not a documented API guarantee: in dashmap 6.2.1 both `_remove_if` and `_entry` take the write lock of the key's shard (`_yield_write_shard`), and `_remove_if` runs the predicate *and* the removal while holding it, so `get_or_spawn`'s `entry()` can't hand out a clone in between. Re-verify on a dashmap upgrade — no test covers it.
+
+Read side, defense in depth: `get_or_spawn_in` in `crates/harnx-serve/src/session_actor/registry.rs` treats an entry whose `tx` is closed as vacant and spawns a replacement (logging a warning), so an actor task that died without deregistering (a panic, say) no longer 503s that key forever.
+
+Asymmetry to know about before "fixing" it: `SessionRegistry::has_session` reports a closed entry as present while `get_or_spawn` treats the same entry as vacant. That's what keeps the 404 gate in `ag_ui_rpc.rs` (`!session_exists(..) && !registry.has_session(..)`) open long enough for the replacement to spawn. Making `has_session` liveness-aware would turn a crashed in-memory-only session into a 404 instead of a self-heal.
+
+Tests: `crates/harnx-serve/src/session_actor/tests/session_actor_registry_tests.rs`.
 
 ### 3. One-Per-Round Injection
 
@@ -161,34 +181,15 @@ Or ensure waiter is registered before trigger, or gate via channels/`AtomicBool`
 
 ### 7. Config Threading
 
-Thread the server's real `Config` through `SessionRegistry::new(config)`:
+Thread the server's real `Config` through `SessionRegistry::new(config)` (now in `crates/harnx-serve/src/session_actor/registry.rs`, which stores it inside `SessionActorConfig`). Each actor forks a per-run copy and scopes it to its own agent/session via `prompt_config_for_agent_session_from_global` (`crates/harnx-serve/src/session_actor.rs`) instead of reloading from env.
 
-```rust
-pub struct SessionRegistry {
-    base_config: Config,
-    map: Arc<DashMap<SessionKey, SessionHandle>>,
-}
-
-impl SessionRegistry {
-    pub fn new(base_config: Config) -> Self { ... }
-}
-
-// Actor clones and scopes per-run
-fn prompt_config_for_agent_session(base_config: &Config, key: &SessionKey) -> GlobalConfig {
-    let prompt_config = Arc::new(RwLock::new(base_config.clone()));
-    let mut cfg = prompt_config.write();
-    cfg.use_agent_by_name(&key.agent).expect("set actor agent");
-    cfg.use_session(Some(&key.session)).expect("set actor session");
-    prompt_config
-}
-```
-
-**Test isolation**: `harnx-serve` tests mutate process env/cwd via `TestConfigSandbox` → MUST run `--test-threads=1` (serial). Parallel causes interference.
+**Test isolation**: `TestConfigSandbox` (`crates/harnx-serve/src/test_support.rs`) mutates process env and briefly `set_current_dir`s while loading config, so it holds a process-global mutex for its whole lifetime. That plus nextest's per-test process isolation is what keeps these tests honest — run them with `cargo nextest`, never `cargo test`, per the root `AGENTS.md`.
 
 ## Why This Works
 
 - **Atomic drain**: No `.await` between run-done and pending check ensures no race window for prompt injection at completion boundary.
-- **Re-check before reap**: Eliminates race between subscribe and timer arm; a just-revived actor survives.
+- **Re-check before reap**: Eliminates the race between subscribe and timer arm; a just-revived actor survives. It says nothing about callers, which is why the removal predicate carries the rest.
+- **Identity + refcount gate on removal**: The reap decision and the removal happen under one shard lock, so a caller either gets a handle to a live actor or spawns a fresh one — never a handle to an actor on its way out.
 - **One-per-round**: Preserves all queued prompts across rounds; no silent drops.
 - **AbortSignal cancellation**: Preserves persistence semantics; partial state committed before unwind.
 - **Bounded test reads**: Tests terminate; streams don't hang forever.
@@ -201,6 +202,9 @@ fn prompt_config_for_agent_session(base_config: &Config, key: &SessionKey) -> Gl
 
 - **Prompt at finish boundary**: Enqueue prompt while run completing; assert subsequent run spawns with correct prompt.
 - **Reap race**: Unsubscribe, sleep briefly, re-subscribe before TTL; assert actor survives and broadcast works.
+- **Reap with a handle held**: Arm the deadline, sleep well past the TTL while keeping the handle, then send a command; assert it still answers and the same `actor_id` is registered. Drop the handle and assert the actor *is* reaped — otherwise a fix that just stops reaping passes.
+- **Replacement not evicted**: Register two incarnations under one key; assert the outgoing actor's exit leaves the replacement's entry in place.
+- **Dead entry self-heals**: Insert a handle whose receiver is dropped; assert `get_or_spawn` returns a working actor with a different `actor_id`.
 - **Multi-prompt injection**: Enqueue 2+ prompts during run; assert BOTH land across successive tool rounds.
 - **Cancel persistence**: Cancel mid-run; assert partial state persisted (persistence is NOT skipped).
 - **SSE bounded read**: Test helper `read_sse_events_until(terminal_pred, timeout)` that returns partial, never hangs.
@@ -210,6 +214,8 @@ fn prompt_config_for_agent_session(base_config: &Config, key: &SessionKey) -> Gl
 
 - [ ] Does actor `select!` avoid `.await` between state transitions?
 - [ ] Are timers/callbacks re-checking invariants before destructive actions?
+- [ ] Does every actor self-removal go through an `actor_id`-gated `remove_if`, never a bare `registry.remove(&self.key)`?
+- [ ] Is each new `SessionHandle` clone short-lived or paired with an explicit drop path? A stored clone pins its actor against reaping for as long as it lives.
 - [ ] Is injection one-per-round (not drain-all-keep-first)?
 - [ ] Does cancellation use `AbortSignal::set_ctrlc()`, not future drop?
 - [ ] Do test SSE streams read bounded with timeouts, not `collect().await`?
@@ -219,10 +225,12 @@ fn prompt_config_for_agent_session(base_config: &Config, key: &SessionKey) -> Gl
 
 ### Testing Mechanics
 
-- Run `harnx-serve` tests with `--test-threads=1` due to `TestConfigSandbox` env/cwd mutation.
+- `TestConfigSandbox` serializes itself with a process-global mutex, so no `--test-threads=1` is needed; run under `cargo nextest` (per-test process isolation), never `cargo test`.
 - Use `#[tokio::test(flavor = "multi_thread")]` for actor tests to catch runtime-specific races.
+- Reap tests need a short TTL (`SessionRegistry::new_for_tests`, e.g. 50ms) and a round-trip command after `Unsubscribe`: `Unsubscribe` carries no reply, so a following `Get` is the only confirmation that the deadline is armed.
 - Seed sessions via `registry.get_or_spawn + prompt`, not SSE stream collection.
 
 ## Related Issues
 
 - **GitHub:** [issue #959](https://github.com/dobesv/harnx/issues/959) — AG-UI Phase 2: per-session actor control plane
+- **GitHub:** [issue #1465](https://github.com/dobesv/harnx/issues/1465) — `get_or_spawn` handed out reaped actors' handles; the source of the ~1-in-10 503 flake in `rpc_session_prompt_returns_ack_and_persists_effect`

--- a/docs/solutions/feature-implementation/agent-handoff-architecture-2026-07-19.md
+++ b/docs/solutions/feature-implementation/agent-handoff-architecture-2026-07-19.md
@@ -16,6 +16,7 @@ tags:
   - session-id-mapping
   - web-ui-navigation
 plan_ref: "harnx-issue-1091-agent-handoff"
+last_updated: 2026-08-17
 ---
 
 ## Problem
@@ -165,16 +166,12 @@ Ok(LoopResult::HandoffRequested { agent, session_id, prompt }) => {
         prompt_config.write().new_session_id().expect("session ID allocation failed")
     });
     
-    // Get or spawn target actor
+    // Get or spawn target actor. Since 2026-08 this goes through the same
+    // `get_or_spawn_in` helper as `SessionRegistry::get_or_spawn` (see
+    // docs/solutions/async-patterns/session-actor-concurrency-invariants-2026-07-04.md §2) —
+    // do not hand-roll the `registry.entry()` match here, it misses the closed-entry case.
     let target_key = SessionKey { agent: agent.clone(), session: target_session_id.clone() };
-    let target_handle = match self.registry.entry(target_key.clone()) {
-        Entry::Occupied(e) => e.get().clone(),
-        Entry::Vacant(e) => {
-            let handle = spawn_session_actor(target_key, Arc::clone(&self.registry), self.reap_ttl, self.actor_config.clone());
-            e.insert(handle.clone());
-            handle
-        }
-    };
+    let target_handle = self.get_or_spawn_target_session_actor(target_key.clone());
     
     // Re-dispatch prompt to target actor (original run finishes with RUN_FINISHED)
     let (reply_tx, _) = oneshot::channel();


### PR DESCRIPTION
An idle session actor reaps itself after 5 seconds without checking whether in-flight callers hold a handle. SessionRegistry::get_or_spawn cached the dead actor's handle, so requests received closed channels and surfaced spurious "session actor unavailable" 503 errors.

The fix gates the reap on atomic strong_count() == 1 so the entry is only removed when the registry alone holds the sender. This atomic check and removal happen under DashMap's shard lock, the same lock get_or_spawn's entry() needs, preventing any handle from being handed out between the check and removal.

Also treat a closed tx in get_or_spawn as vacant and spawn a fresh actor. This handles panicking actors that exit without deregistering, preventing permanent 503s from stale dead channels.

Add deterministic tests for all four race scenarios: handle held across reap TTL, reap firing once a handle is dropped, replacement of dead entries, and identity-gated removal not evicting live replacements.

Add a changeset documenting the fix.

Closes #1465

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented spurious JSON-RPC 503 errors when session actors stop, replace one another, or are idle during requests.
  * Improved session resumability by safely preserving active sessions and recovering from closed session channels.
  * Ensured idle sessions are only removed after all active handles are released.
* **Documentation**
  * Documented new error responses and HTTP status mappings for cancelled, unreachable, and unknown sessions.
  * Updated concurrency and session handoff guidance with recovery and lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->