### PR TITLE
Use a dedicated thread to run server subprocesses

### DIFF
--- a/.changeset/fix-managed-child-parent-thread.md
+++ b/.changeset/fix-managed-child-parent-thread.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Keep managed tool and hook servers alive when Tokio retires the runtime thread that requested their launch.

--- a/crates/harnx-runtime/src/nats_worker/hook_process.rs
+++ b/crates/harnx-runtime/src/nats_worker/hook_process.rs
@@ -54,7 +54,7 @@ pub(super) fn apply_tls_env(command: &mut Command, config: &HookServerStartConfi
     }
 }
 
-pub(super) fn spawn_hook_server(
+pub(super) async fn spawn_hook_server(
     config: &HookServerStartConfig,
     hook: &HookConfig,
     name: &str,
@@ -95,9 +95,10 @@ pub(super) fn spawn_hook_server(
         .stdout(harnx_core::logging::child_output_sink())
         .stderr(harnx_core::logging::child_output_sink())
         .kill_on_drop(true);
-    configure_hook_process(&mut command);
-    command
-        .spawn()
+    config
+        .process_manager
+        .spawn(command)
+        .await
         .with_context(|| format!("spawn hook server '{name}'"))
 }
 
@@ -159,30 +160,3 @@ fn log_child_exit(server: &str, status: std::io::Result<std::process::ExitStatus
         Err(error) => log::warn!("hook server '{server}' wait failed: {error}"),
     }
 }
-
-#[cfg(unix)]
-fn configure_hook_process(command: &mut Command) {
-    #[cfg(target_os = "linux")]
-    let parent_pid = std::process::id() as libc::pid_t;
-    // SAFETY: pre_exec invokes only async-signal-safe libc calls.
-    unsafe {
-        command.pre_exec(move || {
-            if libc::setpgid(0, 0) == -1 {
-                return Err(std::io::Error::last_os_error());
-            }
-            #[cfg(target_os = "linux")]
-            {
-                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) == -1 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                if libc::getppid() != parent_pid {
-                    libc::raise(libc::SIGTERM);
-                }
-            }
-            Ok(())
-        });
-    }
-}
-
-#[cfg(not(unix))]
-fn configure_hook_process(_command: &mut Command) {}

--- a/crates/harnx-runtime/src/nats_worker/hook_supervisor.rs
+++ b/crates/harnx-runtime/src/nats_worker/hook_supervisor.rs
@@ -4,6 +4,7 @@ use super::hook_registration::{
     ensure_bucket_for, prepare_hook_registrations, remove_registration_and_expectation,
     wait_for_registration, PreparedHook,
 };
+use super::process_manager::ChildProcessManager;
 use anyhow::{bail, Context, Result};
 use async_nats::jetstream::kv;
 use harnx_core::hooks::{HookConfig, HooksConfig};
@@ -37,6 +38,7 @@ pub struct HookServerStartConfig {
     pub(super) tls_cert: Option<String>,
     pub(super) tls_key: Option<String>,
     pub(super) tls_ca: Option<String>,
+    pub(super) process_manager: ChildProcessManager,
 }
 
 impl HookServerStartConfig {
@@ -56,12 +58,18 @@ impl HookServerStartConfig {
             tls_cert: None,
             tls_key: None,
             tls_ca: None,
+            process_manager: ChildProcessManager::new(),
         }
     }
 
     /// Set the JetStream replica count from the cluster this config connects to.
     pub fn with_replicas(mut self, replicas: Option<usize>) -> Self {
         self.replicas = replicas;
+        self
+    }
+
+    pub(super) fn with_process_manager(mut self, manager: ChildProcessManager) -> Self {
+        self.process_manager = manager;
         self
     }
 
@@ -86,6 +94,7 @@ impl HookServerStartConfig {
 
 /// Owns one child process per configured hook and removes registrations on exit.
 pub struct HookServerSupervisor {
+    _process_manager: ChildProcessManager,
     processes: Arc<Mutex<HashMap<u32, String>>>,
     tasks: Vec<JoinHandle<()>>,
     client: async_nats::Client,
@@ -111,6 +120,7 @@ impl HookServerSupervisor {
         let run_id = Uuid::new_v4().simple().to_string()[..8].to_string();
         let processes = Arc::new(Mutex::new(HashMap::new()));
         let mut supervisor = Self {
+            _process_manager: config.process_manager.clone(),
             processes: Arc::clone(&processes),
             tasks: Vec::new(),
             client: config.client.clone(),
@@ -190,7 +200,7 @@ async fn spawn_enabled_hooks(
     let expectations = ensure_bucket_for(config, HOOK_EXPECTATIONS_BUCKET).await?;
     let mut startups = Vec::new();
     for prepared in prepared {
-        let mut child = match spawn_hook_server(config, &prepared.hook, &prepared.name) {
+        let mut child = match spawn_hook_server(config, &prepared.hook, &prepared.name).await {
             Ok(child) => child,
             Err(error) => {
                 publish_startup_rejector(

--- a/crates/harnx-runtime/src/nats_worker/mod.rs
+++ b/crates/harnx-runtime/src/nats_worker/mod.rs
@@ -34,6 +34,7 @@ mod hook_crash;
 mod hook_process;
 mod hook_registration;
 mod hook_supervisor;
+mod process_manager;
 pub mod server_reconciler;
 mod subagent_toolset;
 mod tool_registry;

--- a/crates/harnx-runtime/src/nats_worker/process_manager.rs
+++ b/crates/harnx-runtime/src/nats_worker/process_manager.rs
@@ -1,0 +1,227 @@
+//! Stable OS-thread parent for worker-managed child processes.
+//!
+//! Linux ties `PR_SET_PDEATHSIG` to the thread that calls `fork`, not merely
+//! to that thread's process. Spawning directly from a Tokio worker is unsafe:
+//! `block_in_place` can hand that worker to the blocking pool, whose idle
+//! threads retire and make healthy children believe their parent died. This
+//! manager serializes process creation through one ordinary thread that lives
+//! for as long as its owning supervisor.
+
+use std::io;
+use std::sync::{mpsc, Arc, OnceLock};
+use std::thread::JoinHandle;
+use tokio::process::{Child, Command};
+use tokio::sync::oneshot;
+
+#[derive(Clone)]
+pub(super) struct ChildProcessManager {
+    inner: Arc<ManagerInner>,
+}
+
+struct ManagerInner {
+    started: OnceLock<StartedManager>,
+}
+
+struct StartedManager {
+    sender: Option<mpsc::Sender<ManagerRequest>>,
+    thread: Option<JoinHandle<()>>,
+    startup_error: Option<String>,
+}
+
+enum ManagerRequest {
+    Spawn {
+        command: Box<Command>,
+        runtime: tokio::runtime::Handle,
+        response: oneshot::Sender<io::Result<Child>>,
+    },
+    Shutdown,
+}
+
+impl ChildProcessManager {
+    pub(super) fn new() -> Self {
+        Self {
+            inner: Arc::new(ManagerInner {
+                started: OnceLock::new(),
+            }),
+        }
+    }
+
+    /// Spawn `command` from the manager's stable OS thread and return a Tokio
+    /// child handle that callers may monitor from any runtime task.
+    pub(super) async fn spawn(&self, mut command: Command) -> io::Result<Child> {
+        configure_managed_process(&mut command);
+        let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
+            io::Error::other(format!(
+                "spawn managed child outside a Tokio runtime: {error}"
+            ))
+        })?;
+        let manager = self.inner.started.get_or_init(start_manager);
+        let sender = manager.sender.as_ref().ok_or_else(|| {
+            io::Error::other(format!(
+                "child process manager failed to start: {}",
+                manager.startup_error.as_deref().unwrap_or("unknown error")
+            ))
+        })?;
+        let (response, result) = oneshot::channel();
+        sender
+            .send(ManagerRequest::Spawn {
+                command: Box::new(command),
+                runtime,
+                response,
+            })
+            .map_err(|_| io::Error::other("child process manager stopped unexpectedly"))?;
+        result
+            .await
+            .map_err(|_| io::Error::other("child process manager stopped during spawn"))?
+    }
+}
+
+fn start_manager() -> StartedManager {
+    let (sender, receiver) = mpsc::channel();
+    match std::thread::Builder::new()
+        .name("harnx-process-manager".to_string())
+        .spawn(move || run_manager(receiver))
+    {
+        Ok(thread) => StartedManager {
+            sender: Some(sender),
+            thread: Some(thread),
+            startup_error: None,
+        },
+        Err(error) => StartedManager {
+            sender: None,
+            thread: None,
+            startup_error: Some(error.to_string()),
+        },
+    }
+}
+
+impl Drop for StartedManager {
+    fn drop(&mut self) {
+        if let Some(sender) = &self.sender {
+            let _ = sender.send(ManagerRequest::Shutdown);
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn run_manager(receiver: mpsc::Receiver<ManagerRequest>) {
+    while let Ok(request) = receiver.recv() {
+        match request {
+            ManagerRequest::Spawn {
+                mut command,
+                runtime,
+                response,
+            } => {
+                // Tokio builds its async child reaper after std::process::Command
+                // performs the actual spawn. Enter the caller's runtime here so
+                // the returned Child remains compatible with its async monitor,
+                // while the kernel still sees this stable thread as the parent.
+                let _guard = runtime.enter();
+                let _ = response.send(command.spawn());
+            }
+            ManagerRequest::Shutdown => break,
+        }
+    }
+}
+
+#[cfg(unix)]
+fn configure_managed_process(command: &mut Command) {
+    #[cfg(target_os = "linux")]
+    let parent_pid = std::process::id() as libc::pid_t;
+    // SAFETY: pre_exec invokes only async-signal-safe libc calls.
+    unsafe {
+        command.pre_exec(move || {
+            if libc::setpgid(0, 0) == -1 {
+                return Err(io::Error::last_os_error());
+            }
+            #[cfg(target_os = "linux")]
+            {
+                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) == -1 {
+                    return Err(io::Error::last_os_error());
+                }
+                if libc::getppid() != parent_pid {
+                    libc::raise(libc::SIGTERM);
+                }
+            }
+            Ok(())
+        });
+    }
+}
+
+#[cfg(not(unix))]
+fn configure_managed_process(_command: &mut Command) {}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use std::process::Stdio;
+    use std::time::Duration;
+
+    fn long_running_command() -> Command {
+        let mut command = Command::new("sleep");
+        command
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .kill_on_drop(true);
+        command
+    }
+
+    #[test]
+    fn managed_child_survives_tokio_blocking_thread_retirement() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_keep_alive(Duration::from_millis(25))
+            .enable_all()
+            .build()
+            .expect("build test runtime");
+        runtime.block_on(async {
+            let manager = ChildProcessManager::new();
+            let mut child = manager
+                .spawn(long_running_command())
+                .await
+                .expect("spawn managed child");
+
+            tokio::task::block_in_place(|| std::thread::sleep(Duration::from_millis(200)));
+            tokio::time::sleep(Duration::from_millis(200)).await;
+
+            assert_eq!(
+                child.try_wait().expect("poll managed child"),
+                None,
+                "retiring a Tokio blocking thread must not terminate its managed child"
+            );
+            child.start_kill().expect("kill managed child");
+            child.wait().await.expect("reap managed child");
+        });
+    }
+
+    #[test]
+    fn dropping_manager_terminates_its_children() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build test runtime");
+        runtime.block_on(async {
+            let manager = ChildProcessManager::new();
+            assert!(
+                manager.inner.started.get().is_none(),
+                "constructing a manager must not start its thread"
+            );
+            let mut child = manager
+                .spawn(long_running_command())
+                .await
+                .expect("spawn managed child");
+            assert!(manager.inner.started.get().is_some());
+
+            drop(manager);
+
+            tokio::time::timeout(Duration::from_secs(2), child.wait())
+                .await
+                .expect("parent-death signal should terminate child")
+                .expect("reap terminated child");
+        });
+    }
+}

--- a/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
+++ b/crates/harnx-runtime/src/nats_worker/tool_supervisor.rs
@@ -1,4 +1,5 @@
 use super::hook_supervisor::{HookServerStartConfig, HookServerSupervisor};
+use super::process_manager::ChildProcessManager;
 use super::tool_registry::{
     ensure_registry_bucket, log_registry_contents, remove_registrations_for_config,
     wait_for_registration, RegistrationWait, SupervisedProcesses, SupervisedServer,
@@ -52,6 +53,7 @@ pub struct ToolServerStartConfig {
     /// the worker log. Set by foreground diagnostics, where routing a server's
     /// explanation of its own failure into a file is the opposite of useful.
     inherit_child_output: bool,
+    process_manager: ChildProcessManager,
 }
 
 impl ToolServerStartConfig {
@@ -72,6 +74,7 @@ impl ToolServerStartConfig {
             tls_key: None,
             tls_ca: None,
             inherit_child_output: false,
+            process_manager: ChildProcessManager::new(),
         }
     }
 
@@ -118,6 +121,7 @@ impl ToolServerStartConfig {
             self.nats_url.clone(),
             self.token.clone(),
         )
+        .with_process_manager(self.process_manager.clone())
         .with_replicas(self.replicas)
         .with_tls(&self.tls_endpoint())
     }
@@ -125,6 +129,7 @@ impl ToolServerStartConfig {
 
 /// Owns local tool-server children for one worker process.
 pub struct ToolServerSupervisor {
+    _process_manager: ChildProcessManager,
     processes: SupervisedProcesses,
     tasks: Vec<JoinHandle<()>>,
     hook_supervisors: Vec<HookServerSupervisor>,
@@ -161,6 +166,7 @@ impl ToolServerSupervisor {
     ) -> Result<Self> {
         let processes = Arc::new(Mutex::new(HashMap::new()));
         let mut supervisor = Self {
+            _process_manager: config.process_manager.clone(),
             processes: Arc::clone(&processes),
             tasks: Vec::new(),
             hook_supervisors: Vec::new(),
@@ -387,7 +393,7 @@ async fn spawn_enabled_tool_servers(
         )) {
             continue;
         }
-        match spawn_tool_server(config, server) {
+        match spawn_tool_server(config, server).await {
             Ok(child) => {
                 let Some(pid) = child.id() else {
                     warn_server_failure(&server.name, "spawned child has no process ID");
@@ -517,7 +523,10 @@ fn apply_tls_env(command: &mut Command, config: &ToolServerStartConfig) {
     }
 }
 
-fn spawn_tool_server(config: &ToolServerStartConfig, server: &ToolServerConfig) -> Result<Child> {
+async fn spawn_tool_server(
+    config: &ToolServerStartConfig,
+    server: &ToolServerConfig,
+) -> Result<Child> {
     let binary = resolve_tool_binary(server)?;
     let mut command = Command::new(&binary);
     command
@@ -545,14 +554,17 @@ fn spawn_tool_server(config: &ToolServerStartConfig, server: &ToolServerConfig) 
         .stdout(child_output_sink(config))
         .stderr(child_output_sink(config))
         .kill_on_drop(true);
-    configure_tool_process(&mut command);
-    command.spawn().with_context(|| {
-        format!(
-            "spawn tool server '{}' from {}",
-            server.name,
-            binary.display()
-        )
-    })
+    config
+        .process_manager
+        .spawn(command)
+        .await
+        .with_context(|| {
+            format!(
+                "spawn tool server '{}' from {}",
+                server.name,
+                binary.display()
+            )
+        })
 }
 
 /// Report a tool-server problem. Deliberately not phrased as "failed to start":
@@ -675,33 +687,6 @@ async fn wait_for_child(child: &mut Child) -> std::io::Result<std::process::Exit
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 }
-
-#[cfg(unix)]
-fn configure_tool_process(command: &mut Command) {
-    #[cfg(target_os = "linux")]
-    let parent_pid = std::process::id() as libc::pid_t;
-    // SAFETY: pre_exec invokes only async-signal-safe libc calls.
-    unsafe {
-        command.pre_exec(move || {
-            if libc::setpgid(0, 0) == -1 {
-                return Err(std::io::Error::last_os_error());
-            }
-            #[cfg(target_os = "linux")]
-            {
-                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) == -1 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                if libc::getppid() != parent_pid {
-                    libc::raise(libc::SIGTERM);
-                }
-            }
-            Ok(())
-        });
-    }
-}
-
-#[cfg(not(unix))]
-fn configure_tool_process(_command: &mut Command) {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Keep managed tool and hook servers alive when Tokio retires the runtime thread that requested their launch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of managed tool and hook servers when runtime worker threads are retired.
  * Servers now remain active instead of being unintentionally terminated during runtime thread changes.
  * Improved process startup and shutdown handling across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->