### PR TITLE
Avoid logging to stdout from hooks in jsonl mode

### DIFF
--- a/.changeset/silence-persistent-hook-startup.md
+++ b/.changeset/silence-persistent-hook-startup.md
@@ -1,0 +1,5 @@
+---
+harnx: patch
+---
+
+Keep successful persistent-hook startup output out of warning logs, make proxy-auth stdout strictly JSONL when launched as a persistent hook, and stop printing AWS credential bearer tokens.

--- a/crates/harnx-aws-creds/src/main.rs
+++ b/crates/harnx-aws-creds/src/main.rs
@@ -224,12 +224,6 @@ async fn main() -> Result<()> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let port = start_server(Arc::clone(&state), listener).await?;
 
-    eprintln!("harnx-aws-creds: listening on http://127.0.0.1:{port}/creds");
-    eprintln!(
-        "harnx-aws-creds: authorization token: {}",
-        state.bearer_token
-    );
-
     run_hook_loop(&state, port).await
 }
 

--- a/crates/harnx-core/src/hooks.rs
+++ b/crates/harnx-core/src/hooks.rs
@@ -2,6 +2,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::PathBuf;
 
+/// Environment variable describing the stdio protocol expected from a hook.
+pub const HARNX_HOOK_PROTOCOL_ENV: &str = "HARNX_HOOK_PROTOCOL";
+
+/// Value of [`HARNX_HOOK_PROTOCOL_ENV`] for persistent JSON Lines hooks.
+pub const HARNX_HOOK_PROTOCOL_JSONL: &str = "jsonl";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HookPayload {
     pub session_id: String,

--- a/crates/harnx-hooks/src/executor.rs
+++ b/crates/harnx-hooks/src/executor.rs
@@ -51,6 +51,16 @@ pub(crate) fn base_hook_command(argv: &[String], package_dir: Option<&Path>) -> 
     cmd
 }
 
+/// Build a hook command whose child must speak the persistent JSONL protocol.
+pub(crate) fn persistent_hook_command(argv: &[String], package_dir: Option<&Path>) -> Command {
+    let mut cmd = base_hook_command(argv, package_dir);
+    cmd.env(
+        harnx_core::hooks::HARNX_HOOK_PROTOCOL_ENV,
+        harnx_core::hooks::HARNX_HOOK_PROTOCOL_JSONL,
+    );
+    cmd
+}
+
 pub async fn execute_command_hook(payload: &HookPayload, hook: &HookCommand) -> HookOutcome {
     let command = hook.display();
     let timeout_secs = hook.timeout;

--- a/crates/harnx-hooks/src/persistent.rs
+++ b/crates/harnx-hooks/src/persistent.rs
@@ -1,6 +1,6 @@
 use crate::{
-    executor::control_from_result, HookCommand, HookOutcome, HookPayload, HookResult,
-    HookResultControl,
+    executor::{control_from_result, persistent_hook_command},
+    HookCommand, HookOutcome, HookPayload, HookResult, HookResultControl,
 };
 
 use anyhow::{bail, Result};
@@ -171,7 +171,7 @@ impl Default for PersistentHookManager {
 
 impl PersistentHookProcess {
     fn spawn(hook: &HookCommand) -> Result<Self> {
-        let mut child = super::executor::base_hook_command(&hook.argv, hook.package_dir.as_deref())
+        let mut child = persistent_hook_command(&hook.argv, hook.package_dir.as_deref())
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
@@ -250,7 +250,7 @@ impl PersistentHookProcess {
                     Ok(Some(line)) => {
                         let line = line.trim();
                         if !line.is_empty() {
-                            warn!("Persistent hook stderr: {line}");
+                            debug!("Persistent hook stderr: {line}");
                             if let Ok(mut buf) = stderr_lines_task.lock() {
                                 if buf.len() == HOOK_STDERR_TAIL_LINES {
                                     buf.pop_front();

--- a/crates/harnx-hooks/tests/persistent_protocol.rs
+++ b/crates/harnx-hooks/tests/persistent_protocol.rs
@@ -1,0 +1,143 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use harnx_core::hooks::{HookEvent, HookPayload, HARNX_HOOK_PROTOCOL_JSONL};
+use harnx_hooks::{HookCommand, PersistentHookManager};
+use log::{Level, LevelFilter, Log, Metadata, Record};
+
+fn temp_test_dir(name: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("unix epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("harnx-persistent-protocol-{name}-{suffix}"));
+    fs::create_dir_all(&dir).expect("create temp test dir");
+    dir
+}
+
+fn write_script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(format!("{name}.sh"));
+    fs::write(&path, format!("#!/bin/sh\nset -eu\n{body}\n")).expect("write hook script");
+    let mut permissions = fs::metadata(&path).expect("script metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).expect("set script permissions");
+    path
+}
+
+fn hook_command(path: &Path) -> HookCommand {
+    HookCommand {
+        argv: vec![path.display().to_string()],
+        timeout: Some(5),
+        package_dir: None,
+    }
+}
+
+fn test_payload(cwd: &Path) -> HookPayload {
+    HookPayload {
+        session_id: "session-123".to_string(),
+        cwd: cwd.to_path_buf(),
+        resume_count: 0,
+        hook_event: HookEvent::Stop {
+            stop_hook_active: false,
+            last_assistant_message: Some("done".to_string()),
+        },
+    }
+}
+
+#[tokio::test]
+async fn persistent_process_declares_jsonl_protocol() {
+    let dir = temp_test_dir("jsonl");
+    let script = write_script(
+        &dir,
+        "protocol",
+        r#"while IFS= read -r line; do
+  id=${line#*\"id\":\"}; id=${id%%\"*}
+  printf '{"id":"%s","additionalContext":"%s"}\n' "$id" "$HARNX_HOOK_PROTOCOL"
+done"#,
+    );
+    let mut manager = PersistentHookManager::new();
+
+    let outcome = manager
+        .send_event(&test_payload(&dir), &hook_command(&script))
+        .await;
+
+    assert_eq!(
+        outcome.result.additional_context.as_deref(),
+        Some(HARNX_HOOK_PROTOCOL_JSONL)
+    );
+    manager.shutdown();
+    fs::remove_dir_all(dir).expect("remove temp test dir");
+}
+
+struct RecordingLogger {
+    records: Arc<Mutex<Vec<(Level, String)>>>,
+}
+
+impl Log for RecordingLogger {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        self.records
+            .lock()
+            .expect("lock log records")
+            .push((record.level(), record.args().to_string()));
+    }
+
+    fn flush(&self) {}
+}
+
+#[tokio::test]
+async fn healthy_persistent_hook_stderr_is_debug_only() {
+    harnx_core::require_nextest();
+
+    let records = Arc::new(Mutex::new(Vec::new()));
+    log::set_boxed_logger(Box::new(RecordingLogger {
+        records: Arc::clone(&records),
+    }))
+    .expect("install test logger");
+    log::set_max_level(LevelFilter::Trace);
+
+    let marker = "benign-persistent-hook-startup";
+    let dir = temp_test_dir("stderr");
+    let script = write_script(
+        &dir,
+        "stderr",
+        &format!(
+            r#"printf '%s\n' '{marker}' >&2
+while IFS= read -r line; do
+  id=${{line#*\"id\":\"}}; id=${{id%%\"*}}
+  printf '{{"id":"%s"}}\n' "$id"
+done"#
+        ),
+    );
+    let mut manager = PersistentHookManager::new();
+
+    manager
+        .send_event(&test_payload(&dir), &hook_command(&script))
+        .await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let records = records.lock().expect("lock log records");
+    assert!(
+        records
+            .iter()
+            .any(|(level, message)| *level == Level::Debug && message.contains(marker)),
+        "stderr diagnostic was not logged at debug: {records:?}"
+    );
+    assert!(
+        !records.iter().any(|(level, message)| {
+            matches!(*level, Level::Error | Level::Warn) && message.contains(marker)
+        }),
+        "healthy hook stderr was promoted to a warning: {records:?}"
+    );
+    drop(records);
+    manager.shutdown();
+    fs::remove_dir_all(dir).expect("remove temp test dir");
+}

--- a/crates/harnx-proxy-auth/src/main.rs
+++ b/crates/harnx-proxy-auth/src/main.rs
@@ -78,16 +78,20 @@ async fn main() -> Result<()> {
         extra_env.insert(key, value);
     }
 
-    write_readiness(port, &ca_cert_path, &ca_cert_pem)?;
+    let nats_mode = nats_mode_enabled();
+    write_readiness_for_mode(nats_mode, port, &ca_cert_path, &ca_cert_pem)?;
 
-    run_dispatch_mode(DispatchRuntime {
-        name: hook_name,
-        port,
-        ca_cert_path,
-        extra_env,
-        notice_rx,
-        fs_temp_dir,
-    })
+    run_dispatch_mode(
+        DispatchRuntime {
+            name: hook_name,
+            port,
+            ca_cert_path,
+            extra_env,
+            notice_rx,
+            fs_temp_dir,
+        },
+        nats_mode,
+    )
     .await
 }
 
@@ -124,6 +128,19 @@ fn write_readiness(port: u16, ca_cert_path: &std::path::Path, ca_cert_pem: &str)
     Ok(())
 }
 
+fn write_readiness_for_mode(
+    nats_mode: bool,
+    port: u16,
+    ca_cert_path: &std::path::Path,
+    ca_cert_pem: &str,
+) -> Result<()> {
+    let hook_protocol = std::env::var(harnx_core::hooks::HARNX_HOOK_PROTOCOL_ENV).ok();
+    if should_write_readiness(nats_mode, hook_protocol.as_deref()) {
+        write_readiness(port, ca_cert_path, ca_cert_pem)?;
+    }
+    Ok(())
+}
+
 struct DispatchRuntime {
     name: String,
     port: u16,
@@ -133,7 +150,7 @@ struct DispatchRuntime {
     fs_temp_dir: Option<tempfile::TempDir>,
 }
 
-async fn run_dispatch_mode(runtime: DispatchRuntime) -> Result<()> {
+async fn run_dispatch_mode(runtime: DispatchRuntime, nats_mode: bool) -> Result<()> {
     let DispatchRuntime {
         name,
         port,
@@ -142,7 +159,7 @@ async fn run_dispatch_mode(runtime: DispatchRuntime) -> Result<()> {
         notice_rx,
         fs_temp_dir,
     } = runtime;
-    if nats_mode_enabled() {
+    if nats_mode {
         // Keep generated credentials and notice channel alive for hook-server lifetime.
         let _temp_dir_guard = fs_temp_dir;
         let _notice_rx_guard = notice_rx;
@@ -164,6 +181,10 @@ async fn run_dispatch_mode(runtime: DispatchRuntime) -> Result<()> {
         };
     }
     hook::run_jsonl_loop(port, ca_cert_path, extra_env, notice_rx).await
+}
+
+fn should_write_readiness(nats_mode: bool, hook_protocol: Option<&str>) -> bool {
+    !nats_mode && hook_protocol != Some(harnx_core::hooks::HARNX_HOOK_PROTOCOL_JSONL)
 }
 
 fn nats_mode_enabled() -> bool {

--- a/crates/harnx-proxy-auth/tests/integration.rs
+++ b/crates/harnx-proxy-auth/tests/integration.rs
@@ -17,7 +17,7 @@ use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
 use serde_json::Value;
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
 use tokio::process::{Child, Command};
 use tokio::sync::oneshot;
@@ -75,6 +75,53 @@ async fn test_header_injection_through_proxy() {
 
         shutdown_proxy(&mut proxy).await;
         test_result.expect("integration flow")
+    })
+    .await
+    .expect("test timed out");
+}
+
+#[tokio::test]
+async fn persistent_jsonl_mode_has_no_readiness_preamble() {
+    timeout(Duration::from_secs(15), async {
+        let mut proxy = Command::new(proxy_binary_path())
+            .env(
+                harnx_core::hooks::HARNX_HOOK_PROTOCOL_ENV,
+                harnx_core::hooks::HARNX_HOOK_PROTOCOL_JSONL,
+            )
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn proxy");
+
+        let request = br#"{"id":"probe","tool_input":{"env":{}}}
+"#;
+        proxy
+            .stdin
+            .as_mut()
+            .expect("proxy stdin")
+            .write_all(request)
+            .await
+            .expect("write hook request");
+
+        let stdout = proxy.stdout.take().expect("proxy stdout");
+        let line = BufReader::new(stdout)
+            .lines()
+            .next_line()
+            .await
+            .expect("read first stdout line")
+            .expect("proxy response line");
+        let response: Value = serde_json::from_str(&line)
+            .unwrap_or_else(|error| panic!("first stdout line was not JSON: {line:?}: {error}"));
+
+        assert_eq!(response["id"], "probe");
+        assert!(
+            response["hookSpecificOutput"]["toolInput"]["env"]["HTTP_PROXY"]
+                .as_str()
+                .is_some()
+        );
+
+        shutdown_proxy(&mut proxy).await;
     })
     .await
     .expect("test timed out");

--- a/docs/aws-creds.md
+++ b/docs/aws-creds.md
@@ -89,7 +89,6 @@ If omitted, the AWS SDK default credential chain applies:
 
 - The HTTP server binds to **loopback only** (`127.0.0.1`), never to `0.0.0.0`
 - The bearer token is a **random UUID generated per session** — it changes every time `harnx-aws-creds` starts
-- The token is printed to stderr so operators can see it: `harnx-aws-creds: authorization token: <uuid>`
 - Credentials are fetched on-demand from the provider, so short-lived credentials (STS, SSO) are refreshed automatically
 - `~/.aws` is never mounted into the sandbox — the credential files remain inaccessible to the sandboxed process
 

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -234,6 +234,10 @@ Persistent hooks use a JSONL-based protocol to avoid the overhead of spawning a 
 
 The hook process must read one line from `stdin`, process it, and write exactly one line to `stdout`. The `id` must match the request.
 
+Harnx sets `HARNX_HOOK_PROTOCOL=jsonl` on persistent hook processes. Hooks that
+also support a direct startup/readiness protocol can use this value to keep
+their persistent-hook stdout strictly JSONL.
+
 
 ### Startup Message for Proxy-style Persistent Hooks
 


### PR DESCRIPTION
Fixes #1474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Persistent hooks now explicitly use the JSONL protocol, preserving machine-readable output.
  * JSONL proxy responses are emitted immediately without a readiness preamble.
* **Bug Fixes**
  * Removed credential endpoint and authorization token startup messages.
  * Suppressed readiness metadata where it could interfere with JSONL or NATS communication.
  * Reduced healthy persistent-hook stderr messages to debug-level logging.
* **Documentation**
  * Updated hook guidance for JSONL protocol support.
  * Removed outdated credential token output documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->