### PR TITLE
fix(nats): finalize events after complete agent turns

### DIFF
--- a/.changeset/fix-tui-nats-busy-spinner.md
+++ b/.changeset/fix-tui-nats-busy-spinner.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Emit one final model/turn boundary after the complete agent loop and keep attached TUI and web clients in sync with shared session activity.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4305,6 +4305,7 @@ name = "harnx-tui"
 version = "0.33.4"
 dependencies = [
  "anyhow",
+ "async-nats",
  "async-trait",
  "bincode 2.0.1",
  "chrono",

--- a/crates/harnx-core/src/session.rs
+++ b/crates/harnx-core/src/session.rs
@@ -150,15 +150,29 @@ pub enum SessionLogEntry {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         timestamp: Option<DateTime<Utc>>,
     },
+    /// Durable boundary written only after the worker has finished the full
+    /// model/tool/stop-hook loop. Live `Turn::Ended` events are advisory and
+    /// may be lost, so thin clients use this entry as the authoritative
+    /// successful completion signal.
+    #[serde(rename = "turn_end")]
+    TurnEnd {
+        /// Highest physical user-message sequence consumed by this turn. A
+        /// later queued user row may precede this marker physically without
+        /// having been incorporated into the completed turn.
+        through_seq: u64,
+        fence_token: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timestamp: Option<DateTime<Utc>>,
+    },
     #[serde(other)]
     Unknown,
 }
 
 impl SessionLogEntry {
     /// Stamp the fence token on worker-originated entries that carry one
-    /// (`Message`, `ToolCalls`). Other variants are left unchanged: `Cancel`
-    /// carries its fence at construction (control plane), and client-originated
-    /// entries (`UserMessage`) are intentionally unfenced.
+    /// (`Message`, `ToolCalls`). Other variants are left unchanged: `Cancel`,
+    /// `Error`, and `TurnEnd` carry their fence at construction, while
+    /// client-originated entries (`UserMessage`) are intentionally unfenced.
     pub fn set_fence_token(&mut self, fence: u64) {
         match self {
             SessionLogEntry::Message { fence_token, .. }
@@ -170,14 +184,15 @@ impl SessionLogEntry {
     }
 
     /// Fence token carried by this entry, if any. `Message`/`ToolCalls` carry an
-    /// optional fence; `Cancel` and `Error` always carry one. All other variants
-    /// are unfenced and return `None`.
+    /// optional fence; `Cancel`, `Error`, and `TurnEnd` always carry one. All
+    /// other variants are unfenced and return `None`.
     pub fn fence_token(&self) -> Option<u64> {
         match self {
             SessionLogEntry::Message { fence_token, .. }
             | SessionLogEntry::ToolCalls { fence_token, .. } => *fence_token,
             SessionLogEntry::Cancel { fence_token }
-            | SessionLogEntry::Error { fence_token, .. } => Some(*fence_token),
+            | SessionLogEntry::Error { fence_token, .. }
+            | SessionLogEntry::TurnEnd { fence_token, .. } => Some(*fence_token),
             _ => None,
         }
     }

--- a/crates/harnx-core/src/session_reconstruct.rs
+++ b/crates/harnx-core/src/session_reconstruct.rs
@@ -134,7 +134,10 @@ pub fn apply_log_mutations_with_name(
 
                 effective_entries.splice(start_idx..=end_idx, parsed_replacements);
             }
-            SessionLogEntry::Unknown => {}
+            // TurnEnd is durable control metadata, not a logical transcript
+            // row. Drop it from effective history so it cannot shift the
+            // user-visible logical sequence numbers.
+            SessionLogEntry::TurnEnd { .. } | SessionLogEntry::Unknown => {}
             _ => effective_entries.push((*seq, entry.clone())),
         }
     }

--- a/crates/harnx-engine/src/chat_completions.rs
+++ b/crates/harnx-engine/src/chat_completions.rs
@@ -10,7 +10,7 @@ use harnx_client::{
     SseHandler,
 };
 use harnx_core::abort::wait_abort_signal;
-use harnx_core::event::{AgentEvent, ModelEvent};
+use harnx_core::event::{AgentEvent, ModelEvent, NoticeEvent};
 use harnx_core::sink::emit_agent_event;
 use harnx_core::text::{extract_code_block, strip_think_tag};
 use harnx_core::tool::ToolCall;
@@ -57,17 +57,15 @@ pub async fn chat_completions_streaming_with_data(
 /// tool_calls, usage). Tool-call evaluation stays on the caller side so the
 /// caller can control whether a spinner covers that work.
 ///
-/// `suppress_final_output`: when true, `ModelEvent::Final` fires with an
-/// empty `output` string (signalling that the caller will display the text
-/// via another path, e.g. `print_markdown`). When false, `Final` carries the
-/// full text so any `AgentEventSink` consumer that renders Final sees the
-/// output.
+/// Terminal model events are deliberately not emitted here. One transport
+/// invocation can be followed by tool execution, stop-hook continuation, or
+/// another pending message; the agent loop owns the actual `ModelEvent::Final`
+/// / `ModelEvent::Error` boundary.
 pub async fn run_chat_completion(
     client: &dyn Client,
     data: ChatCompletionsData,
     ctx: &ClientCallContext<'_>,
     extract_code: bool,
-    suppress_final_output: bool,
     _abort_signal: harnx_core::abort::AbortSignal,
 ) -> Result<(String, Option<String>, Vec<ToolCall>, CompletionTokenUsage)> {
     let ret = chat_completions_with_data(client, data, ctx).await;
@@ -89,15 +87,6 @@ pub async fn run_chat_completion(
                 text = extract_code_block(&strip_think_tag(&text)).to_string();
             }
 
-            let final_output = if suppress_final_output {
-                String::new()
-            } else {
-                text.clone()
-            };
-            emit_agent_event(AgentEvent::Model(ModelEvent::Final {
-                output: final_output,
-                usage: usage.clone(),
-            }));
             if !usage.is_empty() {
                 emit_agent_event(AgentEvent::Model(ModelEvent::Usage {
                     input: usage.input_tokens,
@@ -109,19 +98,15 @@ pub async fn run_chat_completion(
 
             Ok((text, thought, tool_calls, usage))
         }
-        Err(err) => {
-            emit_agent_event(AgentEvent::Model(ModelEvent::Error(pretty_error_string(
-                &err,
-            ))));
-            Err(err)
-        }
+        Err(err) => Err(err),
     }
 }
 
 /// Orchestrate one streaming LLM call. Runs `chat_completions_streaming_with_data`
 /// (which consumes the caller-supplied `SseHandler`), then after completion
-/// extracts the response tuple from the handler and emits `AgentEvent::Model`
-/// events via `harnx_core::sink`.
+/// extracts the response tuple from the handler and emits usage events via
+/// `harnx_core::sink`. Terminal model events belong to the agent loop rather
+/// than an individual transport invocation.
 ///
 /// Returns `(text, thought, tool_calls, usage, aborted)`. Caller is responsible
 /// for: tool_call evaluation, stdout newline cleanup, and final Ok/Err shaping.
@@ -148,16 +133,11 @@ pub async fn run_chat_completion_streaming(
     let (text, thought, tool_calls, usage) = handler.take();
 
     if aborted {
-        emit_agent_event(AgentEvent::Model(ModelEvent::Error("aborted".to_string())));
         return Ok((text, thought, vec![], usage, true));
     }
 
     match send_ret {
         Ok(_) => {
-            emit_agent_event(AgentEvent::Model(ModelEvent::Final {
-                output: String::new(),
-                usage: usage.clone(),
-            }));
             if !usage.is_empty() {
                 emit_agent_event(AgentEvent::Model(ModelEvent::Usage {
                     input: usage.input_tokens,
@@ -169,12 +149,12 @@ pub async fn run_chat_completion_streaming(
             Ok((text, thought, tool_calls, usage, false))
         }
         Err(err) => {
-            emit_agent_event(AgentEvent::Model(ModelEvent::Error(pretty_error_string(
-                &err,
-            ))));
             if text.trim().is_empty() {
                 Err(err)
             } else {
+                emit_agent_event(AgentEvent::Notice(NoticeEvent::Warning(
+                    pretty_error_string(&err),
+                )));
                 Ok((text, thought, vec![], usage, false))
             }
         }
@@ -209,7 +189,7 @@ mod tests {
     use super::run_chat_completion_streaming;
     use harnx_client::{ChatCompletionsData, ClientCallContext, CompletionTokenUsage, SseHandler};
     use harnx_core::abort::create_abort_signal;
-    use harnx_core::event::{AgentEvent, AgentEventSink, ModelEvent};
+    use harnx_core::event::{AgentEvent, AgentEventSink, ModelEvent, NoticeEvent};
     use harnx_core::sink::{clear_agent_event_sink, install_agent_event_sink};
     use harnx_runtime::test_utils::{MockClient, MockTurnBuilder};
     use parking_lot::Mutex;
@@ -245,7 +225,8 @@ mod tests {
                 .lock()
                 .iter()
                 .filter_map(|event| match event {
-                    AgentEvent::Model(ModelEvent::Error(message)) => Some(message.clone()),
+                    AgentEvent::Model(ModelEvent::Error(message))
+                    | AgentEvent::Notice(NoticeEvent::Warning(message)) => Some(message.clone()),
                     _ => None,
                 })
                 .collect()
@@ -295,8 +276,8 @@ mod tests {
 
     /// Run `run_chat_completion_streaming` against a mock turn that streams
     /// `text_chunk` (when `Some`) followed by a mid-stream error. Returns the
-    /// call result plus the error messages emitted to the agent-event sink so
-    /// each test can assert its own expectations.
+    /// call result plus terminal/warning messages emitted to the agent-event
+    /// sink so each test can assert its own expectations.
     async fn run_streaming_error_case(text_chunk: Option<&str>) -> (StreamingResult, Vec<String>) {
         let sink = install_collecting_sink();
         let mut turn = MockTurnBuilder::new();
@@ -341,18 +322,18 @@ mod tests {
     fn streaming_error_with_empty_text_returns_err() {
         let (result, messages) = run_streaming_error_case_serial(None);
         assert!(result.is_err());
-        assert_eq!(messages.len(), 1);
+        assert!(messages.is_empty());
     }
 
     #[test]
     fn streaming_error_with_whitespace_only_text_returns_err() {
         let (result, messages) = run_streaming_error_case_serial(Some("\n"));
         assert!(result.is_err());
-        assert_eq!(messages.len(), 1);
+        assert!(messages.is_empty());
     }
 
     #[test]
-    fn streaming_error_with_partial_text_returns_ok_and_emits_error() {
+    fn streaming_error_with_partial_text_returns_ok_and_emits_warning() {
         let (result, messages) = run_streaming_error_case_serial(Some("partial"));
         let output = result.expect("partial text should be returned");
         assert_eq!(output.0, "partial");

--- a/crates/harnx-runtime/src/agent_loop.rs
+++ b/crates/harnx-runtime/src/agent_loop.rs
@@ -241,7 +241,42 @@ pub enum LoopResult {
 /// Recoverable tool errors are already converted to `{"is_error":true}`
 /// results by `execute_tool_round` and fed back to the LLM.
 pub async fn run_agent_loop(ctx: &AgentLoopContext, initial_input: Input) -> Result<LoopResult> {
-    run_agent_loop_inner(ctx, initial_input).await
+    if initial_input.is_empty() {
+        return run_agent_loop_inner(ctx, initial_input).await;
+    }
+
+    with_turn_lifecycle(ctx, run_agent_loop_inner(ctx, initial_input)).await
+}
+
+async fn with_turn_lifecycle<T>(
+    ctx: &AgentLoopContext,
+    future: impl Future<Output = Result<T>>,
+) -> Result<T> {
+    emit_turn_started();
+    let result = future.await;
+    emit_turn_ended(ctx, &result);
+    result
+}
+
+fn emit_turn_started() {
+    use harnx_core::event::{AgentEvent, TurnEvent};
+
+    harnx_core::sink::emit_agent_event(AgentEvent::Turn(TurnEvent::Started));
+}
+
+fn emit_turn_ended<T>(ctx: &AgentLoopContext, result: &Result<T>) {
+    use harnx_core::event::{AgentEvent, ModelEvent, TurnEvent, TurnOutcome};
+
+    if let Err(error) = result {
+        if !ctx.abort_signal.aborted() {
+            harnx_core::sink::emit_agent_event(AgentEvent::Model(ModelEvent::Error(
+                harnx_render::pretty_error_string(error),
+            )));
+        }
+    }
+    harnx_core::sink::emit_agent_event(AgentEvent::Turn(TurnEvent::Ended {
+        outcome: TurnOutcome::default(),
+    }));
 }
 
 /// Runs agent loop, applying file-backed local handoffs until completion.
@@ -253,19 +288,26 @@ pub async fn run_agent_loop_with_local_handoff(
     ctx: &AgentLoopContext,
     mut input: Input,
 ) -> Result<()> {
-    loop {
-        match run_agent_loop(ctx, input).await? {
-            LoopResult::Completed => return Ok(()),
-            LoopResult::HandoffRequested {
-                agent,
-                session_id,
-                prompt,
-            } => {
-                apply_local_handoff(ctx, &agent, session_id.as_deref(), &prompt).await?;
-                input = crate::config::input::from_str(&ctx.config, &prompt, None);
+    if input.is_empty() {
+        return run_agent_loop_inner(ctx, input).await.map(|_| ());
+    }
+
+    with_turn_lifecycle(ctx, async move {
+        loop {
+            match run_agent_loop_inner(ctx, input).await? {
+                LoopResult::Completed => return Ok(()),
+                LoopResult::HandoffRequested {
+                    agent,
+                    session_id,
+                    prompt,
+                } => {
+                    apply_local_handoff(ctx, &agent, session_id.as_deref(), &prompt).await?;
+                    input = crate::config::input::from_str(&ctx.config, &prompt, None);
+                }
             }
         }
-    }
+    })
+    .await
 }
 
 async fn apply_local_handoff(
@@ -487,6 +529,20 @@ async fn complete_model_turn(
         completion.tool_calls,
     )
     .await
+}
+
+async fn emit_final_text_response(
+    ctx: &AgentLoopContext,
+    output: String,
+    usage: CompletionTokenUsage,
+) {
+    if let Some(callback) = &ctx.on_text_response {
+        callback(output, usage).await;
+    } else {
+        harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Model(
+            harnx_core::event::ModelEvent::Final { output, usage },
+        ));
+    }
 }
 
 fn emit_text_turn_status(
@@ -786,10 +842,6 @@ async fn run_agent_loop_inner(ctx: &AgentLoopContext, initial_input: Input) -> R
             continue;
         }
 
-        // Text-only turn — invoke on_text_response callback (TUI emits Final).
-        if let Some(ref cb) = ctx.on_text_response {
-            cb(output.clone(), usage.clone()).await;
-        }
         emitted_text_turns += 1;
 
         match stop_resume_action(ctx, &turn, resume_count, stop_outcome) {
@@ -813,6 +865,8 @@ async fn run_agent_loop_inner(ctx: &AgentLoopContext, initial_input: Input) -> R
             ResumeAction::Abort => break,
             ResumeAction::None => {}
         }
+
+        emit_final_text_response(ctx, output, usage).await;
 
         // Done.
         break;
@@ -852,6 +906,32 @@ mod tests {
         }
     }
 
+    fn assert_single_completed_turn(sink: &CollectingSink) {
+        let events = sink.events.lock().unwrap();
+        assert!(matches!(
+            events.first(),
+            Some((AgentEvent::Turn(TurnEvent::Started), None))
+        ));
+        assert!(matches!(
+            events.last(),
+            Some((AgentEvent::Turn(TurnEvent::Ended { .. }), None))
+        ));
+        let final_outputs: Vec<&str> = events
+            .iter()
+            .filter_map(|(event, source)| match (event, source) {
+                (AgentEvent::Model(harnx_core::event::ModelEvent::Final { output, .. }), None) => {
+                    Some(output.as_str())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            final_outputs,
+            ["all done"],
+            "only the text that ends the full tool loop is final"
+        );
+    }
+
     #[tokio::test]
     async fn user_prompt_block_reason_is_emitted_as_error_notice() {
         let _guard = SINK_LOCK.lock().await;
@@ -888,6 +968,7 @@ mod tests {
     /// duplicate copies. The fix clears the field after each round.
     #[tokio::test(flavor = "multi_thread")]
     async fn injected_user_text_is_not_replayed_across_rounds() {
+        let _sink_guard = SINK_LOCK.lock().await;
         let _guard = crate::client::TestStateGuard::new(None).await;
         let tmp = TempDir::new().unwrap();
         let global_config = replay_test_config(&tmp);
@@ -941,7 +1022,13 @@ mod tests {
         let ctx = make_test_context(global_config.clone(), call_fn, on_tool_round);
 
         let input = crate::config::input::from_str(&global_config, "do work", None);
-        run_agent_loop(&ctx, input).await.unwrap();
+        let sink = Arc::new(CollectingSink::default());
+        harnx_core::sink::with_agent_event_sink(sink.clone(), async {
+            run_agent_loop(&ctx, input).await
+        })
+        .await
+        .unwrap();
+        assert_single_completed_turn(&sink);
 
         // The injection happened once; the bug would have made it appear in
         // round 2 and round 3). With the fix it appears exactly once.
@@ -993,6 +1080,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelled_turn_ends_without_emitting_model_error() {
+        let _guard = SINK_LOCK.lock().await;
+        let config = Arc::new(RwLock::new(crate::config::Config::default()));
+        let call_fn: AgentCallFn = Arc::new(|_, _, _| unreachable!("model is not called"));
+        let ctx = make_test_context(config, call_fn, handoff_on_tool_round());
+        ctx.abort_signal.set_ctrlc();
+        let sink = Arc::new(CollectingSink::default());
+
+        let result: Result<()> = harnx_core::sink::with_agent_event_sink(sink.clone(), async {
+            with_turn_lifecycle(&ctx, async { Err(anyhow::anyhow!("interrupted by user")) }).await
+        })
+        .await;
+        assert!(result.is_err());
+
+        let events = sink.events.lock().unwrap();
+        assert!(matches!(
+            events.as_slice(),
+            [
+                (AgentEvent::Turn(TurnEvent::Started), None),
+                (AgentEvent::Turn(TurnEvent::Ended { .. }), None)
+            ]
+        ));
+    }
+
+    #[tokio::test]
     async fn shared_pending_context_is_taken_and_injected_into_next_input() {
         let config = Arc::new(RwLock::new(crate::config::Config::default()));
         let mut input = crate::config::input::from_str(&config, "user prompt", None);
@@ -1024,9 +1136,7 @@ user prompt"
     }
 
     /// Test that the dispatch path for _session_handoff tools returns a
-    /// ToolResult.switch_agent that the loop detects. We inject a mock
-    /// ToolProvider that returns the switch_agent JSON; the engine's
-    /// detect_switch_agent picks it up.
+    /// ToolResult.switch_agent that the loop detects.
     #[tokio::test(flavor = "multi_thread")]
     async fn handoff_returns_handoff_requested_and_emits_event() {
         let _guard = SINK_LOCK.lock().await;

--- a/crates/harnx-runtime/src/client/common.rs
+++ b/crates/harnx-runtime/src/client/common.rs
@@ -153,7 +153,6 @@ pub async fn call_chat_completions(
             data,
             &ctx,
             extract_code,
-            print, // suppress_final_output = print (we'll display via print_markdown)
             abort_signal.clone(),
         ),
         &spinner_message,
@@ -219,11 +218,6 @@ pub async fn call_chat_completions_streaming(
         }));
     }
 
-    // Turn::Started belongs to the direct agent handling this request.
-    harnx_core::sink::emit_agent_event(harnx_core::event::AgentEvent::Turn(
-        harnx_core::event::TurnEvent::Started,
-    ));
-
     // Drain the SseHandler's channel — chunk display is now driven by
     // AgentEvent::Model::MessageChunk/ThoughtChunk emitted by SseHandler,
     // which the installed sink renders. The channel itself just needs
@@ -243,15 +237,6 @@ pub async fn call_chat_completions_streaming(
     .await;
 
     let _ = drainer.await;
-
-    // Emit Turn::Ended so the sink stops the spinner, exits raw mode,
-    // and emits a trailing newline if needed.
-    {
-        use harnx_core::event::{AgentEvent, TurnEvent, TurnOutcome};
-        harnx_core::sink::emit_agent_event(AgentEvent::Turn(TurnEvent::Ended {
-            outcome: TurnOutcome::default(),
-        }));
-    }
 
     let (text, thought, tool_calls, usage, _aborted) = engine_ret?;
     let _ = abort_signal;

--- a/crates/harnx-runtime/src/config/nats_split.rs
+++ b/crates/harnx-runtime/src/config/nats_split.rs
@@ -92,21 +92,23 @@ pub async fn resolve_local_nats_server_config() -> Result<NatsServerConfig> {
         (None, None) => {
             let manager = LOCAL_NATS_SERVER.get_or_init(|| tokio::sync::Mutex::new(None));
             let mut managed_server = manager.lock().await;
-            if managed_server.is_none() {
+            let needs_refresh = match managed_server.as_mut() {
+                Some(server) => !server.is_current().await,
+                None => true,
+            };
+            if needs_refresh {
+                // A joiner does not control the broker lifetime. Refresh a
+                // cached discovery result after its owner exits, but retain a
+                // live joiner so frequent config lookups do not each perform a
+                // separate NATS connection and flush.
+                managed_server.take();
                 *managed_server = Some(crate::nats_local_server::ensure_shared_server().await?);
             }
             let server = managed_server
                 .as_ref()
                 .expect("local NATS server initialized above");
-            (
-                server.url.clone(),
-                server.token.clone(),
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
+            let (url, token) = (server.url.clone(), server.token.clone());
+            (url, token, None, None, None, None, None)
         }
         _ => bail!("{HARNX_NATS_URL_ENV} and {HARNX_NATS_TOKEN_ENV} must be set together"),
     };

--- a/crates/harnx-runtime/src/config/paths_split.rs
+++ b/crates/harnx-runtime/src/config/paths_split.rs
@@ -57,15 +57,49 @@ impl Config {
     }
 
     async fn reserve_new_session_id_inner(&self) -> Result<String> {
-        use std::time::{SystemTime, UNIX_EPOCH};
+        const LOCAL_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(50);
 
         let cluster = self
             .remote_agent
             .as_ref()
             .map(|(_, cluster)| cluster.as_str())
             .unwrap_or(LOCAL_CLUSTER_KEY);
+        if cluster != LOCAL_CLUSTER_KEY {
+            return self.reserve_new_session_id_once(cluster).await;
+        }
+
+        // The embedded broker is owned by one of the connected processes. It
+        // can legitimately disappear between discovery and the KV operation
+        // when that process exits, so rediscover and retry during that narrow
+        // handoff rather than surfacing a transient no-responders error.
+        loop {
+            match self.reserve_new_session_id_once(cluster).await {
+                Ok(session_id) => return Ok(session_id),
+                Err(_) => tokio::time::sleep(LOCAL_RETRY_DELAY).await,
+            }
+        }
+    }
+
+    async fn reserve_new_session_id_once(&self, cluster: &str) -> Result<String> {
+        const LOCAL_OPERATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
         let server = self.resolve_nats_server(cluster).await?;
-        let client = Self::connect_nats_server(&server).await?;
+        if cluster == LOCAL_CLUSTER_KEY {
+            tokio::time::timeout(
+                LOCAL_OPERATION_TIMEOUT,
+                self.reserve_new_session_id_on_server(&server),
+            )
+            .await
+            .context("Timed out reserving an ID on the shared local NATS server")?
+        } else {
+            self.reserve_new_session_id_on_server(&server).await
+        }
+    }
+
+    async fn reserve_new_session_id_on_server(&self, server: &NatsServerConfig) -> Result<String> {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let client = Self::connect_nats_server(server).await?;
         let store = crate::nats_session_index::ensure_index_bucket(
             &async_nats::jetstream::new(client),
             server.replicas.unwrap_or(1),

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -12,6 +12,14 @@ use std::sync::Arc;
 pub trait SessionAppendSink: Send + Sync + Any {
     /// Append an entry and return its one-based durable sequence number.
     fn append(&self, entry: &SessionLogEntry) -> Result<u64>;
+
+    /// Whether an append failure makes the active turn invalid. File-backed
+    /// sessions can mark themselves dirty and rewrite later; a NATS worker log
+    /// is authoritative and must never publish a successful turn boundary
+    /// after losing an assistant/tool entry.
+    fn failure_is_fatal(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]
@@ -268,6 +276,7 @@ pub fn replay_log_entries_for_external(
             // A failed turn is a transcript annotation, not conversation
             // history — replaying it would feed the error back to the model.
             SessionLogEntry::Error { .. } => {}
+            SessionLogEntry::TurnEnd { .. } => {}
             SessionLogEntry::Cancel { .. } => {}
             SessionLogEntry::EditEntries { .. }
             | SessionLogEntry::Rewind { .. }
@@ -414,6 +423,25 @@ pub fn append_event(session: &mut Session, entry: &SessionLogEntry) -> bool {
         crate::session_history::entry_type(entry)
     );
     false
+}
+
+fn require_authoritative_appends(
+    session: &Session,
+    all_appended: bool,
+    operation: &str,
+) -> Result<()> {
+    if all_appended {
+        return Ok(());
+    }
+    let fatal = session
+        .runtime
+        .as_ref()
+        .and_then(|runtime| runtime.downcast_ref::<Arc<dyn SessionAppendSink>>())
+        .is_some_and(|sink| sink.failure_is_fatal());
+    if fatal {
+        anyhow::bail!("failed to durably persist {operation}");
+    }
+    Ok(())
 }
 
 /// Append a `Title` log entry and update the in-memory session title state.
@@ -662,6 +690,7 @@ pub fn add_assistant_text(
         session.messages.push(assistant_msg);
         emit_agent_event(AgentEvent::Session(SessionEvent::LogSeqAssigned { seq }));
         session.dirty = !all_appended;
+        require_authoritative_appends(session, all_appended, "assistant response")?;
     }
     session.update_tokens();
     Ok(())
@@ -730,6 +759,7 @@ pub fn add_tool_calls(
             .with_log_seq(tool_calls_seq),
     );
     session.dirty = !all_appended;
+    require_authoritative_appends(session, all_appended, "tool calls")?;
     session.update_tokens();
     Ok(())
 }
@@ -808,12 +838,9 @@ pub fn add_tool_results(session: &mut Session, results: &[crate::tool::ToolResul
             timestamp: Some(Utc::now()),
         },
     );
-    if !appended {
-        session.dirty = true;
-    }
-    if !record_externalized(session, cid_urls) {
-        session.dirty = true;
-    }
+    let all_appended = appended & record_externalized(session, cid_urls);
+    session.dirty |= !all_appended;
+    require_authoritative_appends(session, all_appended, "tool results")?;
     session.update_tokens();
     Ok(())
 }
@@ -1080,6 +1107,18 @@ fn build_messages_inner(session: &Session, input: &Input) -> Result<Vec<Message>
 mod tests {
     use super::*;
 
+    struct FailingAuthoritativeSink;
+
+    impl SessionAppendSink for FailingAuthoritativeSink {
+        fn append(&self, _entry: &SessionLogEntry) -> Result<u64> {
+            anyhow::bail!("simulated durable append failure")
+        }
+
+        fn failure_is_fatal(&self) -> bool {
+            true
+        }
+    }
+
     fn test_session() -> Session {
         let mut session = new(&Config::default(), "test", None).unwrap();
         attach_memory_log(&mut session);
@@ -1091,6 +1130,29 @@ mod tests {
             .iter()
             .map(|m| (m.role, m.content.to_text()))
             .collect()
+    }
+
+    #[test]
+    fn authoritative_assistant_append_failure_fails_the_turn() {
+        let config = Config::default();
+        let global_config = Arc::new(parking_lot::RwLock::new(config.clone()));
+        let input = crate::config::input::from_str(
+            &global_config,
+            "question",
+            Some(config.extract_agent()),
+        );
+        let mut session = new(&config, "authoritative-failure", None).unwrap();
+        session.runtime = Some(Arc::new(
+            Arc::new(FailingAuthoritativeSink) as Arc<dyn SessionAppendSink>
+        ));
+
+        let error = add_assistant_text(&mut session, &input, "answer", None)
+            .expect_err("authoritative persistence failure must fail the turn");
+
+        assert!(error
+            .to_string()
+            .contains("failed to durably persist assistant response"));
+        assert!(session.dirty);
     }
 
     #[test]

--- a/crates/harnx-runtime/src/config/session_ops_split.rs
+++ b/crates/harnx-runtime/src/config/session_ops_split.rs
@@ -4,6 +4,8 @@ use crate::nats_admin::kv_bucket_missing;
 use crate::nats_session_index::{self, SessionIndexRecord};
 use std::time::{Duration, UNIX_EPOCH};
 
+const REMOTE_SESSION_LIST_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Convert a `SessionIndexRecord` to `SessionMeta`.
 ///
 /// This mapping is used by `list_remote_sessions_with_meta` to translate
@@ -156,6 +158,23 @@ impl Config {
     /// This distinction allows callers to differentiate "no remote sessions" from
     /// "could not reach the cluster" — important for CLI error reporting and TUI visibility.
     pub async fn list_remote_sessions_with_meta(&self, cluster: &str) -> Result<Vec<SessionMeta>> {
+        tokio::time::timeout(
+            REMOTE_SESSION_LIST_TIMEOUT,
+            self.list_remote_sessions_with_meta_inner(cluster),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "Timed out listing sessions from NATS cluster '{cluster}' after {}s",
+                REMOTE_SESSION_LIST_TIMEOUT.as_secs()
+            )
+        })?
+    }
+
+    async fn list_remote_sessions_with_meta_inner(
+        &self,
+        cluster: &str,
+    ) -> Result<Vec<SessionMeta>> {
         let jetstream = match self.nats_jetstream(cluster).await {
             Ok(js) => js,
             Err(e) => {

--- a/crates/harnx-runtime/src/nats_client_session.rs
+++ b/crates/harnx-runtime/src/nats_client_session.rs
@@ -21,22 +21,26 @@
 //!    |                                            |-- run_agent_loop
 //!    |<----------- advisory events ---------------|
 //!    |                                            |-- append final state
-//!    |--4. Detect turn complete from durable -----|
+//!    |--4. Observe durable TurnEnd ---------------|
 //!    |                                            |
 //!    |--5. Return final response                  |
 //! ```
 //!
 //! ## Turn completion detection
 //!
-//! A turn is complete when the durable log contains a final AssistantMessage
-//! with no pending ToolCalls, or when `reconstruct_state` yields `TurnStatus::Idle`
-//! or `TurnStatus::InFlightCancelled`. The client polls the durable log after
-//! each advisory batch to check for completion.
+//! New workers append a durable `TurnEnd` after the complete model/tool/hook
+//! loop, including the highest user-message sequence it consumed. That marker
+//! is the authoritative success boundary. For compatibility with older
+//! workers, an assistant row plus either a parent `Turn::Ended` advisory or a
+//! confirmed worker-lease release is accepted as a fallback. Durable errors
+//! and cancellation remain terminal barriers.
 
 use anyhow::{Context, Result};
 use async_nats::jetstream;
 use harnx_core::abort::wait_abort_signal;
-use harnx_core::event::{AgentEvent, AgentEventSink, SessionEvent, UserEvent};
+use harnx_core::event::{
+    AgentEvent, AgentEventSink, ModelEvent, SessionEvent, TurnEvent, UserEvent,
+};
 use harnx_core::message::{MessageContent, MessageRole};
 use harnx_core::session::SessionLogEntry;
 use harnx_core::session_reconstruct::{
@@ -335,6 +339,8 @@ impl ThinClientSession {
         let mut pending_cancel_rx = pending_cancel;
         let mut was_cancelled = false;
         let mut orphan_watchdog = OrphanWatchdog::new();
+        let mut saw_terminal_model_error = false;
+        let mut saw_turn_ended = false;
 
         // Main event loop with abort signal handling
         let abort_signal_clone = self.abort_signal.clone();
@@ -378,9 +384,9 @@ impl ThinClientSession {
                     break;
                 }
 
-                // Poll durable completion independently so non-streaming workers
-                // that persist a final assistant message without an advisory still
-                // complete the turn promptly.
+                // Poll durable completion independently so a client that misses
+                // the live Turn::Ended advisory still observes the authoritative
+                // TurnEnd marker promptly.
                 _ = completion_interval.tick() => {
                     if let Ok(entries) = self.load_durable_entries().await {
                         // Refresh cached effective log for live LogSeqAssigned.
@@ -399,16 +405,30 @@ impl ThinClientSession {
                                 AdvisoryFlush::Live,
                             );
                         }
-                        if self.is_turn_complete(&entries, user_msg_seq) {
+                        if Self::is_turn_completion_visible(
+                            &entries,
+                            user_msg_seq,
+                            saw_turn_ended,
+                        ) {
                             (final_response, turn_error) =
                                 Self::extract_turn_outcome(&entries, user_msg_seq);
                             turn_complete = true;
                             break;
                         }
-                        if let Some(reason) =
-                            orphan_watchdog.check(&self.jetstream, &self.session_id).await
+                        if let Some(reason) = orphan_watchdog
+                            .check(&self.jetstream, &self.session_id)
+                            .await
                         {
-                            turn_error = Some(reason);
+                            // Workers predating durable TurnEnd release their
+                            // lease after persisting the assistant row. Treat
+                            // that confirmed release as their durable-compatible
+                            // boundary; a missing worker with no answer remains
+                            // an orphaned-turn failure.
+                            (final_response, turn_error) =
+                                Self::extract_turn_outcome(&entries, user_msg_seq);
+                            if final_response.is_none() {
+                                turn_error = Some(reason);
+                            }
                             turn_complete = true;
                             break;
                         }
@@ -421,6 +441,19 @@ impl ThinClientSession {
                         Some(envelope) => {
                             // Check if this advisory should be rendered (dedup rule)
                             if event_stream.should_render(&envelope) {
+                                // Only parent-scope terminal events complete this
+                                // thin-client turn. Sub-agent events remain wrapped
+                                // in AgentEvent::SubAgent and therefore do not set
+                                // either compatibility flag.
+                                saw_terminal_model_error |= matches!(
+                                    envelope.event,
+                                    AgentEvent::Model(ModelEvent::Error(_))
+                                );
+                                let turn_ended = matches!(
+                                    envelope.event,
+                                    AgentEvent::Turn(TurnEvent::Ended { .. })
+                                );
+                                saw_turn_ended |= turn_ended;
                                 pending_advisories.push_back(envelope.clone());
                                 flush_pending_advisories(
                                     &mut pending_advisories,
@@ -452,7 +485,11 @@ impl ThinClientSession {
                                             AdvisoryFlush::Live,
                                         );
                                     }
-                                    if self.is_turn_complete(&entries, user_msg_seq) {
+                                    if Self::is_turn_completion_visible(
+                                        &entries,
+                                        user_msg_seq,
+                                        saw_turn_ended,
+                                    ) {
                                         // Extract final response before we finish
                                         (final_response, turn_error) =
                                             Self::extract_turn_outcome(&entries, user_msg_seq);
@@ -534,8 +571,10 @@ impl ThinClientSession {
             return Err(error);
         }
 
-        if let Some(error) = &turn_error {
-            render_error_entry(error, &event_sink);
+        if !saw_terminal_model_error {
+            if let Some(error) = &turn_error {
+                render_error_entry(error, &event_sink);
+            }
         }
 
         Ok(ThinClientTurnResult {
@@ -616,22 +655,47 @@ impl ThinClientSession {
             .context("failed to load durable session log")
     }
 
-    /// Check if the turn is complete based on durable entries.
-    fn is_turn_complete(&self, entries: &[(u64, SessionLogEntry)], user_msg_seq: u64) -> bool {
-        let has_barrier_after_user = entries.iter().any(|(seq, entry)| {
-            *seq > user_msg_seq
-                && match entry {
-                    SessionLogEntry::Message { role, .. } => role.is_assistant(),
-                    SessionLogEntry::Error { .. } => true,
-                    _ => false,
-                }
+    /// Check for durable failure/cancellation barriers.
+    ///
+    /// An assistant row is deliberately not terminal here. It is persisted
+    /// before stop hooks and pending-context checks, either of which may resume
+    /// the same model/tool loop.
+    fn has_durable_terminal_failure(entries: &[(u64, SessionLogEntry)], user_msg_seq: u64) -> bool {
+        let has_error_after_user = entries.iter().any(|(seq, entry)| {
+            *seq > user_msg_seq && matches!(entry, SessionLogEntry::Error { .. })
         });
 
-        has_barrier_after_user
+        has_error_after_user
             || matches!(
                 reconstruct_state_from_nats(entries).turn_status,
                 TurnStatus::InFlightCancelled
             )
+    }
+
+    fn has_durable_assistant_response(
+        entries: &[(u64, SessionLogEntry)],
+        user_msg_seq: u64,
+    ) -> bool {
+        Self::extract_final_response(entries, user_msg_seq).is_some()
+    }
+
+    fn has_durable_turn_end(entries: &[(u64, SessionLogEntry)], user_msg_seq: u64) -> bool {
+        entries.iter().any(|(_, entry)| {
+            matches!(
+                entry,
+                SessionLogEntry::TurnEnd { through_seq, .. } if *through_seq >= user_msg_seq
+            )
+        })
+    }
+
+    fn is_turn_completion_visible(
+        entries: &[(u64, SessionLogEntry)],
+        user_msg_seq: u64,
+        saw_turn_ended: bool,
+    ) -> bool {
+        Self::has_durable_terminal_failure(entries, user_msg_seq)
+            || Self::has_durable_turn_end(entries, user_msg_seq)
+            || (saw_turn_ended && Self::has_durable_assistant_response(entries, user_msg_seq))
     }
 
     /// Final assistant text and worker-reported failure for the current turn.
@@ -763,6 +827,7 @@ fn render_log_entry_to_sink(
         | SessionLogEntry::DataUrls { .. }
         | SessionLogEntry::Compress { .. }
         | SessionLogEntry::Title { .. }
+        | SessionLogEntry::TurnEnd { .. }
         | SessionLogEntry::Clear
         | SessionLogEntry::EditEntries { .. }
         | SessionLogEntry::Rewind { .. }
@@ -1080,6 +1145,95 @@ mod tests {
                 )
             })
             .collect()
+    }
+
+    #[test]
+    fn assistant_message_is_not_a_durable_turn_end() {
+        let entries = test_entries(&[
+            (1, MessageRole::User, "question"),
+            (2, MessageRole::Assistant, "intermediate stop-hook response"),
+        ]);
+
+        assert!(
+            !ThinClientSession::is_turn_completion_visible(&entries, 1, false),
+            "an assistant row may still be followed by stop-hook or pending-context work"
+        );
+        assert!(
+            ThinClientSession::is_turn_completion_visible(&entries, 1, true),
+            "older workers use the parent turn advisory as a compatibility fallback"
+        );
+
+        let mut durably_ended = entries;
+        durably_ended.push((
+            3,
+            SessionLogEntry::TurnEnd {
+                through_seq: 1,
+                fence_token: 7,
+                timestamp: None,
+            },
+        ));
+        assert!(ThinClientSession::is_turn_completion_visible(
+            &durably_ended,
+            1,
+            false
+        ));
+    }
+
+    #[test]
+    fn turn_end_does_not_complete_a_later_queued_user() {
+        let entries = vec![
+            (
+                1,
+                SessionLogEntry::Message {
+                    id: None,
+                    role: MessageRole::User,
+                    content: MessageContent::Text("first".to_string()),
+                    timestamp: None,
+                    fence_token: None,
+                },
+            ),
+            (
+                2,
+                SessionLogEntry::Message {
+                    id: None,
+                    role: MessageRole::User,
+                    content: MessageContent::Text("queued".to_string()),
+                    timestamp: None,
+                    fence_token: None,
+                },
+            ),
+            (
+                3,
+                SessionLogEntry::TurnEnd {
+                    through_seq: 1,
+                    fence_token: 7,
+                    timestamp: None,
+                },
+            ),
+        ];
+        assert!(!ThinClientSession::is_turn_completion_visible(
+            &entries, 2, false
+        ));
+    }
+
+    #[test]
+    fn durable_error_and_cancel_are_terminal_without_an_advisory() {
+        let mut failed = test_entries(&[(1, MessageRole::User, "question")]);
+        failed.push((
+            2,
+            SessionLogEntry::Error {
+                message: "worker failed".to_string(),
+                fence_token: 7,
+                timestamp: None,
+            },
+        ));
+        assert!(ThinClientSession::has_durable_terminal_failure(&failed, 1));
+
+        let mut cancelled = test_entries(&[(1, MessageRole::User, "question")]);
+        cancelled.push((2, SessionLogEntry::Cancel { fence_token: 7 }));
+        assert!(ThinClientSession::has_durable_terminal_failure(
+            &cancelled, 1
+        ));
     }
 
     #[test]

--- a/crates/harnx-runtime/src/nats_event_sink.rs
+++ b/crates/harnx-runtime/src/nats_event_sink.rs
@@ -7,9 +7,9 @@
 //!
 //! ## Durable vs advisory contract
 //!
-//! - DURABLE (JetStream session log, authoritative): UserMessage, AssistantMessage(final),
-//!   ToolCalls, ToolResults, Cancel. Reconstructable via NatsSessionLog
-//!   + reconstruct_state.
+//! - DURABLE (JetStream session log, authoritative): UserMessage, AssistantMessage,
+//!   ToolCalls, ToolResults, TurnEnd, Error, Cancel. Reconstructable via
+//!   NatsSessionLog + reconstruct_state.
 //! - ADVISORY (fan-out `sessions.{id}.events` only, non-durable, lossy-OK): streaming token
 //!   deltas (ModelEvent::MessageChunk/ThoughtChunk), thinking/status indicators,
 //!   tool-progress chunks. NEVER authoritative; safe to miss.

--- a/crates/harnx-runtime/src/nats_hook_provider.rs
+++ b/crates/harnx-runtime/src/nats_hook_provider.rs
@@ -17,6 +17,8 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 
 const DEFAULT_HOOK_TIMEOUT: Duration = Duration::from_secs(30);
+const DISCOVERY_ATTEMPTS: usize = 4;
+const DISCOVERY_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 /// Session data needed to serialize a hook event for a remote hook server.
 #[derive(Clone, Debug)]
@@ -141,7 +143,9 @@ pub struct NatsHookProvider {
 impl NatsHookProvider {
     pub async fn discover(config: &Config, instance_id: ServerScope) -> Result<Self> {
         let client = config.nats_client(LOCAL_CLUSTER_KEY).await?;
-        let hooks = hooks_or_fail_closed_guard(registration_snapshot(&client, &instance_id).await);
+        let hooks = hooks_or_fail_closed_guard(
+            registration_snapshot_with_retry(&client, &instance_id).await,
+        );
         Ok(Self::from_hooks(client, instance_id, hooks))
     }
 
@@ -151,7 +155,9 @@ impl NatsHookProvider {
         client: async_nats::Client,
         instance_id: ServerScope,
     ) -> Result<Self> {
-        let hooks = hooks_or_fail_closed_guard(registration_snapshot(&client, &instance_id).await);
+        let hooks = hooks_or_fail_closed_guard(
+            registration_snapshot_with_retry(&client, &instance_id).await,
+        );
         Ok(Self::from_hooks(client, instance_id, hooks))
     }
 
@@ -706,6 +712,31 @@ async fn registration_snapshot(
             .filter(|hook| !active_servers.contains(&hook.server)),
     );
     Ok(hooks)
+}
+
+async fn registration_snapshot_with_retry(
+    client: &async_nats::Client,
+    instance_id: &ServerScope,
+) -> Result<Vec<DiscoveredHook>> {
+    let mut last_error = None;
+    for attempt in 1..=DISCOVERY_ATTEMPTS {
+        match registration_snapshot(client, instance_id).await {
+            Ok(hooks) => return Ok(hooks),
+            Err(error) => {
+                if attempt < DISCOVERY_ATTEMPTS {
+                    log::warn!(
+                        "retrying NATS hook discovery: scope={} attempt={}/{} error={error:#}",
+                        instance_id.as_str(),
+                        attempt,
+                        DISCOVERY_ATTEMPTS,
+                    );
+                    tokio::time::sleep(DISCOVERY_RETRY_DELAY).await;
+                }
+                last_error = Some(error);
+            }
+        }
+    }
+    Err(last_error.expect("at least one hook discovery attempt must record an error"))
 }
 
 async fn optional_bucket_snapshot(

--- a/crates/harnx-runtime/src/nats_local_server.rs
+++ b/crates/harnx-runtime/src/nats_local_server.rs
@@ -51,6 +51,46 @@ impl SharedNatsServer {
     pub fn server_process_id(&self) -> Option<u32> {
         self.owner.as_ref().map(|owner| owner.child.id())
     }
+
+    /// Whether this handle still identifies the active shared broker.
+    ///
+    /// Joiners cannot keep the owner process alive, so their cached discovery
+    /// result is valid only while the same nonce is published and another
+    /// process still holds the lifetime lock. Checking those local files avoids
+    /// a new NATS connection for every config lookup while still detecting an
+    /// owner that exited and left stale metadata behind.
+    pub async fn is_current(&mut self) -> bool {
+        if let Some(owner) = self.owner.as_mut() {
+            return matches!(owner.child.try_wait(), Ok(None));
+        }
+
+        let cached_identity = (self.url.clone(), self.token.clone(), self.nonce.clone());
+        tokio::task::spawn_blocking(move || joiner_is_current(cached_identity))
+            .await
+            .unwrap_or(false)
+    }
+}
+
+fn joiner_is_current(cached_identity: (String, String, String)) -> bool {
+    let Ok(metadata) = read_metadata() else {
+        return false;
+    };
+    let discovered_identity = (metadata.url(), metadata.token, metadata.nonce);
+    if discovered_identity != cached_identity {
+        return false;
+    }
+
+    let Ok(lock_file) = open_lock_file() else {
+        return false;
+    };
+    match crate::file_lock::try_lock_exclusive(&lock_file) {
+        Ok(true) => {
+            let _ = lock_file.unlock();
+            false
+        }
+        Ok(false) => true,
+        Err(_) => false,
+    }
 }
 
 impl std::fmt::Debug for SharedNatsServer {
@@ -355,7 +395,13 @@ async fn try_join_server() -> Option<SharedNatsServer> {
     .await
     .ok()?
     .ok()?;
-    if client.flush().await.is_err() {
+    // The owner can exit after the TCP/auth handshake but before this flush.
+    // async-nats then waits for a reconnect to the now-dead ephemeral port, so
+    // bound the validation just like the connect itself.
+    if !matches!(
+        tokio::time::timeout(CONNECT_TIMEOUT, client.flush()).await,
+        Ok(Ok(()))
+    ) {
         return None;
     }
 
@@ -395,10 +441,9 @@ async fn wait_for_nats_ready(url: &str, token: &str, child: &mut Child) -> Resul
         .await;
         match result {
             Ok(Ok(client)) => {
-                client
-                    .flush()
+                tokio::time::timeout(CONNECT_TIMEOUT, client.flush())
                     .await
-                    .context("failed to flush shared local NATS readiness connection")?;
+                    .context("timed out flushing shared local NATS readiness connection")??;
                 return Ok(());
             }
             Ok(Err(error)) if Instant::now() >= deadline => {

--- a/crates/harnx-runtime/src/nats_worker/backend.rs
+++ b/crates/harnx-runtime/src/nats_worker/backend.rs
@@ -6,6 +6,9 @@ use anyhow::Result;
 use async_nats::jetstream;
 use std::sync::Arc;
 
+const APPEND_ATTEMPTS: usize = 3;
+const APPEND_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(50);
+
 /// NATS session log backend for the async worker.
 ///
 /// Wraps `NatsSessionLog` and provides blocking entrypoints for the sync
@@ -24,6 +27,10 @@ pub struct NatsSessionLogBackend {
 impl crate::config::session::SessionAppendSink for NatsSessionLogBackend {
     fn append(&self, entry: &harnx_core::session::SessionLogEntry) -> Result<u64> {
         self.append_event_blocking(entry)
+    }
+
+    fn failure_is_fatal(&self) -> bool {
+        true
     }
 }
 
@@ -49,20 +56,14 @@ impl FencedSessionLogSink {
 
 impl crate::config::session::SessionAppendSink for FencedSessionLogSink {
     fn append(&self, entry: &harnx_core::session::SessionLogEntry) -> Result<u64> {
-        if !self.lease.is_held() {
-            nats_metrics::fenced_write_rejected();
-            warn!(
-                "fenced write rejected: session_id={} worker_id={} revision={} entry_type={}",
-                self.backend.session_id(),
-                self.lease.worker_id(),
-                self.lease.fence_token(),
-                crate::session_history::entry_type(entry)
-            );
-            anyhow::bail!("refusing worker-originated append: session lease not held (fenced out)");
-        }
         let mut fenced = entry.clone();
         fenced.set_fence_token(self.lease.fence_token());
-        self.backend.append_event_blocking(&fenced)
+        self.backend
+            .append_event_blocking_with_lease(&fenced, Some(&self.lease))
+    }
+
+    fn failure_is_fatal(&self) -> bool {
+        true
     }
 }
 
@@ -96,11 +97,64 @@ impl NatsSessionLogBackend {
     /// Prefer this over [`Self::append_event_blocking`] wherever the caller is
     /// already async.
     pub async fn append_event(&self, entry: &harnx_core::session::SessionLogEntry) -> Result<u64> {
+        self.append_event_with_lease(entry, None).await
+    }
+
+    async fn append_event_with_lease(
+        &self,
+        entry: &harnx_core::session::SessionLogEntry,
+        lease: Option<&NatsSessionLease>,
+    ) -> Result<u64> {
         let log = crate::nats_session_log::NatsSessionLog::new(
             self.jetstream.clone(),
             self.session_id.clone(),
         );
-        let seq = log.append_event_async(entry).await?;
+        let message_id = uuid::Uuid::new_v4().to_string();
+        let mut last_error = None;
+        let mut appended_seq = None;
+        for attempt in 1..=APPEND_ATTEMPTS {
+            if let Some(lease) = lease.filter(|lease| !lease.is_held()) {
+                nats_metrics::fenced_write_rejected();
+                warn!(
+                    "fenced write rejected: session_id={} worker_id={} revision={} entry_type={}",
+                    self.session_id(),
+                    lease.worker_id(),
+                    lease.fence_token(),
+                    crate::session_history::entry_type(entry)
+                );
+                anyhow::bail!(
+                    "refusing worker-originated append: session lease not held (fenced out)"
+                );
+            }
+
+            match log
+                .append_event_with_message_id_async(entry, message_id.clone())
+                .await
+            {
+                Ok(seq) => {
+                    appended_seq = Some(seq);
+                    break;
+                }
+                Err(error) => {
+                    if attempt < APPEND_ATTEMPTS {
+                        warn!(
+                            "retrying session append: session_id={} entry_type={} attempt={}/{} error={error:#}",
+                            self.session_id(),
+                            crate::session_history::entry_type(entry),
+                            attempt,
+                            APPEND_ATTEMPTS,
+                        );
+                    }
+                    last_error = Some(error);
+                    if attempt < APPEND_ATTEMPTS {
+                        tokio::time::sleep(APPEND_RETRY_DELAY).await;
+                    }
+                }
+            }
+        }
+        let seq = appended_seq.ok_or_else(|| {
+            last_error.expect("at least one NATS append attempt must record an error")
+        })?;
         self.observe_append(seq);
         Ok(seq)
     }
@@ -113,14 +167,17 @@ impl NatsSessionLogBackend {
         &self,
         entry: &harnx_core::session::SessionLogEntry,
     ) -> Result<u64> {
-        let log = crate::nats_session_log::NatsSessionLog::new(
-            self.jetstream.clone(),
-            self.session_id.clone(),
-        );
+        self.append_event_blocking_with_lease(entry, None)
+    }
+
+    fn append_event_blocking_with_lease(
+        &self,
+        entry: &harnx_core::session::SessionLogEntry,
+        lease: Option<&NatsSessionLease>,
+    ) -> Result<u64> {
         let seq = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(log.append_event_async(entry))
+            tokio::runtime::Handle::current().block_on(self.append_event_with_lease(entry, lease))
         })?;
-        self.observe_append(seq);
         Ok(seq)
     }
 
@@ -147,8 +204,8 @@ impl NatsSessionLogBackend {
     /// the stream reflects at least the worker's latest durable append before
     /// reading. Uses the shared `after_seq_observer` high-water mark when set;
     /// falls back to a plain load otherwise. Used by the end-of-turn drain
-    /// re-read so the worker sees its own just-written turn barrier and does not
-    /// re-fold already-answered messages.
+    /// re-read so the worker sees its own just-written completion boundary and
+    /// does not re-fold already-answered messages.
     pub async fn load_events_consistent_async(
         &self,
     ) -> Result<Vec<(u64, harnx_core::session::SessionLogEntry)>> {

--- a/crates/harnx-runtime/src/nats_worker/daemon_session_exec.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon_session_exec.rs
@@ -146,6 +146,8 @@ impl WorkerRuntime {
                     );
                 }
 
+                Self::record_session_turn_end(&backend, &lease, turn_cursor_val).await?;
+
                 log::info!(
                     "execute_session turn complete: session_id={} turn_cursor={} activation_high_water={:?}",
                     activation.session_id,
@@ -161,7 +163,7 @@ impl WorkerRuntime {
                 // Re-run another turn ONLY if there's a user message with seq > activation_high_water.
                 // This prevents re-running when we've already consumed everything.
                 // Use the fresh leader-authoritative load so this re-read reflects
-                // both the worker's own just-persisted turn barrier and any client
+                // both the worker's own just-persisted completion boundary and any client
                 // edit/retract committed just before the read (otherwise it would
                 // re-fold already-answered or retracted messages).
                 let tail = backend.load_events_latest_async().await?;
@@ -200,7 +202,7 @@ impl WorkerRuntime {
         .await;
 
         // Record the failure durably BEFORE releasing the lease: attached
-        // clients treat an `Error` entry as the turn barrier, and a client that
+        // clients treat an `Error` entry as a terminal boundary, and a client that
         // reconnects later still sees why the turn produced nothing.
         if let Err(error) = &result {
             Self::record_session_error(&backend, &lease, error).await;
@@ -248,6 +250,27 @@ impl WorkerRuntime {
                 backend.session_id(),
             );
         }
+    }
+
+    /// Persist the successful full-loop boundary before checking for another
+    /// queued turn. Unlike the live Turn::Ended advisory, this cannot be lost
+    /// when the client is briefly disconnected or under load.
+    async fn record_session_turn_end(
+        backend: &NatsSessionLogBackend,
+        lease: &NatsSessionLease,
+        through_seq: u64,
+    ) -> Result<()> {
+        if !should_append_control_log_entry(lease) {
+            return Ok(());
+        }
+        backend
+            .append_event(&harnx_core::session::SessionLogEntry::TurnEnd {
+                through_seq,
+                fence_token: lease.fence_token(),
+                timestamp: Some(chrono::Utc::now()),
+            })
+            .await?;
+        Ok(())
     }
 
     /// Spawn a task that watches for lease loss and aborts on loss.

--- a/crates/harnx-runtime/src/nats_worker/tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests.rs
@@ -32,6 +32,8 @@ use std::time::Duration;
 use tokio::sync::{Mutex as AsyncMutex, Notify};
 use tokio_util::sync::CancellationToken;
 
+mod transcript_render_tests;
+
 /// Spawn a local JetStream-enabled nats-server on a free port with an isolated
 /// temp store dir, returning the connect URL, the child process, and the temp
 /// dir guard. Using a free port + per-run store dir avoids cross-run state
@@ -424,7 +426,7 @@ pub(super) async fn run_remote_round_trip_with_session_id_and_sink(
         crate::ThinClientSession::from_global_config(thin_cfg, &parent_global_config, abort_signal)
             .await?;
 
-    const REMOTE_ROUND_TRIP_TIMEOUT: Duration = Duration::from_secs(30);
+    const REMOTE_ROUND_TRIP_TIMEOUT: Duration = Duration::from_secs(60);
     let turn_result = tokio::time::timeout(
         REMOTE_ROUND_TRIP_TIMEOUT,
         thin.run_turn("delegate over nats", sink, None),
@@ -436,9 +438,12 @@ pub(super) async fn run_remote_round_trip_with_session_id_and_sink(
             REMOTE_ROUND_TRIP_TIMEOUT.as_secs()
         )
     })??;
-    let reply = turn_result
-        .response
-        .context("thin client turn must return final assistant response")?;
+    let reply = turn_result.response.with_context(|| {
+        format!(
+            "thin client turn must return final assistant response (error={:?}, cancelled={}, user_seq={})",
+            turn_result.error, turn_result.was_cancelled, turn_result.user_msg_seq
+        )
+    })?;
     anyhow::ensure!(
         reply.contains("stub remote reply over nats"),
         "expected reply to contain stub remote reply, got: {reply}"
@@ -1240,6 +1245,13 @@ async fn legacy_headerless_session_migrates_on_first_activation() {
             .iter()
             .all(|(_, entry)| !matches!(entry, SessionLogEntry::Header { .. })),
         "migration must not physically reorder or prepend raw header entries"
+    );
+    assert!(
+        raw_entries.iter().any(|(_, entry)| matches!(
+            entry,
+            SessionLogEntry::TurnEnd { through_seq, .. } if *through_seq >= user_seq
+        )),
+        "the worker must persist the successful full-loop boundary"
     );
     assert_eq!(
         leading_user_texts(&effective_after),
@@ -2959,215 +2971,6 @@ async fn remote_delete_refreshes_after_concurrent_mutation() {
     assert!(
         late_user_still_present,
         "retry delete must not target concurrent late row"
-    );
-
-    worker.abort();
-    let _ = worker.await;
-    let _ = child.kill();
-    let _ = child.wait();
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn load_remote_transcript_for_render_prerenders_logical_rows() {
-    let _env_guard = env_lock().await;
-    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
-        return;
-    };
-
-    let mut seeded = seed_remote_config(&url);
-    let session_id = crate::nats_worker::new_remote_session_id();
-    let worker =
-        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
-
-    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
-        .await
-        .expect("worker should build realistic migrated session");
-
-    seeded
-        .parent_config
-        .set_remote_agent("metis".to_string(), "local".to_string());
-    seeded
-        .parent_config
-        .use_session(Some(&session_id))
-        .expect("activate remote session id");
-    let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
-    let abort = harnx_core::abort::create_abort_signal();
-    let thin = ThinClientSession::from_global_config(
-        crate::ThinClientConfig {
-            cluster: "local".to_string(),
-            agent: "metis".to_string(),
-            session_id: Some(session_id.clone()),
-        },
-        &global_config,
-        abort,
-    )
-    .await
-    .expect("load thin session");
-
-    let transcript = load_remote_transcript_for_render(&thin)
-        .await
-        .expect("load transcript state");
-    assert!(
-        transcript.compressed_messages.is_empty(),
-        "worker-migrated headerless fixture should have empty compacted prefix"
-    );
-    let row_seqs: Vec<usize> = transcript
-        .messages
-        .iter()
-        .filter_map(|message| message.log_seq)
-        .collect();
-    assert_eq!(row_seqs, vec![1, 2]);
-    let row_texts: Vec<(harnx_core::message::MessageRole, String)> = transcript
-        .messages
-        .iter()
-        .map(|message| (message.role, message.content.to_text()))
-        .collect();
-    assert_eq!(
-        row_texts,
-        vec![
-            (
-                harnx_core::message::MessageRole::User,
-                "delegate over nats".to_string(),
-            ),
-            (
-                harnx_core::message::MessageRole::Assistant,
-                "stub remote reply over nats".to_string(),
-            ),
-        ]
-    );
-
-    worker.abort();
-    let _ = worker.await;
-    let _ = child.kill();
-    let _ = child.wait();
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn load_remote_transcript_for_render_keeps_tool_rows_and_compressed_prefix() {
-    let _env_guard = env_lock().await;
-    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
-        return;
-    };
-
-    let mut seeded = seed_remote_config(&url);
-    let session_id = crate::nats_worker::new_remote_session_id();
-    let worker =
-        spawn_metis_worker_with_call_fn(&url, fixed_prompt_call_fn("stub remote reply over nats"));
-
-    run_remote_round_trip_with_session_id(seeded.parent_config.clone(), session_id.clone())
-        .await
-        .expect("worker should build realistic migrated session");
-
-    let jetstream = seeded
-        .parent_config
-        .nats_jetstream("local")
-        .await
-        .expect("load local jetstream");
-    let log = NatsSessionLog::new(jetstream, session_id.clone());
-
-    let tool_call = ToolCall::new(
-        "fs_read".to_string(),
-        json!({"path": "README.md"}),
-        Some("tool-1".to_string()),
-        None,
-    );
-    log.append_event_async(&SessionLogEntry::ToolCalls {
-        text: "calling tool".to_string(),
-        thought: Some("tool thought".to_string()),
-        calls: vec![tool_call.clone()],
-        timestamp: None,
-        fence_token: None,
-    })
-    .await
-    .expect("append tool calls");
-    log.append_event_async(&SessionLogEntry::ToolResults {
-        results: vec![ToolOutput {
-            id: tool_call.id.clone(),
-            name: tool_call.name.clone(),
-            output: json!({"ok": true}),
-            markdown: None,
-            content: vec![],
-            switch_agent: None,
-        }],
-        timestamp: None,
-    })
-    .await
-    .expect("append tool results");
-    log.append_event_async(&SessionLogEntry::Compress {
-        prompt: "summary prompt".to_string(),
-    })
-    .await
-    .expect("append compress");
-    log.append_event_async(&SessionLogEntry::Message {
-        id: Some(uuid::Uuid::new_v4().to_string()),
-        role: harnx_core::message::MessageRole::User,
-        content: harnx_core::message::MessageContent::Text("after compress user".to_string()),
-        timestamp: None,
-        fence_token: None,
-    })
-    .await
-    .expect("append post-compress user");
-
-    seeded
-        .parent_config
-        .set_remote_agent("metis".to_string(), "local".to_string());
-    seeded
-        .parent_config
-        .use_session(Some(&session_id))
-        .expect("activate remote session id");
-    let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
-    let thin = ThinClientSession::from_global_config(
-        crate::ThinClientConfig {
-            cluster: "local".to_string(),
-            agent: "metis".to_string(),
-            session_id: Some(session_id.clone()),
-        },
-        &global_config,
-        harnx_core::abort::create_abort_signal(),
-    )
-    .await
-    .expect("load thin session");
-
-    let transcript = load_remote_transcript_for_render(&thin)
-        .await
-        .expect("load transcript state");
-
-    assert!(
-        !transcript.compressed_messages.is_empty(),
-        "compressed_messages must be populated after remote Compress"
-    );
-    assert!(
-        transcript
-            .compressed_messages
-            .iter()
-            .any(|message| message.role == harnx_core::message::MessageRole::Tool),
-        "compressed prefix must retain assembled tool message rows"
-    );
-    assert!(
-        transcript
-            .messages
-            .iter()
-            .all(|message| message.role != harnx_core::message::MessageRole::System),
-        "active transcript must not include a synthetic System message after Compress"
-    );
-    assert_eq!(
-        transcript.compaction_summary.as_deref(),
-        Some("summary prompt"),
-        "compaction summary must carry the summary text after Compress"
-    );
-
-    let active_rows: Vec<(harnx_core::message::MessageRole, String, Option<usize>)> = transcript
-        .messages
-        .iter()
-        .map(|message| (message.role, message.content.to_text(), message.log_seq))
-        .collect();
-    assert_eq!(
-        active_rows,
-        vec![(
-            harnx_core::message::MessageRole::User,
-            "after compress user".to_string(),
-            Some(0),
-        ),]
     );
 
     worker.abort();

--- a/crates/harnx-runtime/src/nats_worker/tests/transcript_render_tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests/transcript_render_tests.rs
@@ -1,0 +1,221 @@
+use super::*;
+
+async fn append_completed_transcript_fixture(config: &Config, session_id: &str) {
+    let jetstream = config
+        .nats_jetstream("local")
+        .await
+        .expect("load local jetstream");
+    let log = NatsSessionLog::new(jetstream, session_id.to_string());
+    let header = crate::config::session::new(config, session_id, None)
+        .expect("build fixture session")
+        .build_header_entry();
+    log.append_event_async(&header)
+        .await
+        .expect("append fixture header");
+    log.append_event_async(&SessionLogEntry::Message {
+        id: Some(uuid::Uuid::new_v4().to_string()),
+        role: harnx_core::message::MessageRole::User,
+        content: harnx_core::message::MessageContent::Text("delegate over nats".to_string()),
+        timestamp: None,
+        fence_token: None,
+    })
+    .await
+    .expect("append fixture user message");
+    log.append_event_async(&SessionLogEntry::Message {
+        id: Some(uuid::Uuid::new_v4().to_string()),
+        role: harnx_core::message::MessageRole::Assistant,
+        content: harnx_core::message::MessageContent::Text(
+            "stub remote reply over nats".to_string(),
+        ),
+        timestamp: None,
+        fence_token: None,
+    })
+    .await
+    .expect("append fixture assistant message");
+    log.append_event_async(&SessionLogEntry::TurnEnd {
+        through_seq: 2,
+        fence_token: 1,
+        timestamp: None,
+    })
+    .await
+    .expect("append fixture turn end");
+}
+
+async fn append_compressed_tool_fixture(log: &NatsSessionLog) {
+    let tool_call = ToolCall::new(
+        "fs_read".to_string(),
+        json!({"path": "README.md"}),
+        Some("tool-1".to_string()),
+        None,
+    );
+    log.append_event_async(&SessionLogEntry::ToolCalls {
+        text: "calling tool".to_string(),
+        thought: Some("tool thought".to_string()),
+        calls: vec![tool_call.clone()],
+        timestamp: None,
+        fence_token: None,
+    })
+    .await
+    .expect("append tool calls");
+    log.append_event_async(&SessionLogEntry::ToolResults {
+        results: vec![ToolOutput {
+            id: tool_call.id.clone(),
+            name: tool_call.name.clone(),
+            output: json!({"ok": true}),
+            markdown: None,
+            content: vec![],
+            switch_agent: None,
+        }],
+        timestamp: None,
+    })
+    .await
+    .expect("append tool results");
+    log.append_event_async(&SessionLogEntry::Compress {
+        prompt: "summary prompt".to_string(),
+    })
+    .await
+    .expect("append compress");
+    log.append_event_async(&SessionLogEntry::Message {
+        id: Some(uuid::Uuid::new_v4().to_string()),
+        role: harnx_core::message::MessageRole::User,
+        content: harnx_core::message::MessageContent::Text("after compress user".to_string()),
+        timestamp: None,
+        fence_token: None,
+    })
+    .await
+    .expect("append post-compress user");
+}
+
+fn assert_compressed_tool_transcript(
+    transcript: &crate::config::remote_session_ops::RemoteTranscriptState,
+) {
+    assert!(!transcript.compressed_messages.is_empty());
+    assert!(transcript
+        .compressed_messages
+        .iter()
+        .any(|message| message.role == harnx_core::message::MessageRole::Tool));
+    assert!(transcript
+        .messages
+        .iter()
+        .all(|message| message.role != harnx_core::message::MessageRole::System));
+    assert_eq!(
+        transcript.compaction_summary.as_deref(),
+        Some("summary prompt")
+    );
+    let active_rows: Vec<_> = transcript
+        .messages
+        .iter()
+        .map(|message| (message.role, message.content.to_text(), message.log_seq))
+        .collect();
+    assert_eq!(
+        active_rows,
+        vec![(
+            harnx_core::message::MessageRole::User,
+            "after compress user".to_string(),
+            Some(0),
+        )]
+    );
+}
+
+async fn activate_thin_session(
+    seeded: &mut SeededRemoteParentConfig,
+    session_id: String,
+) -> ThinClientSession {
+    seeded
+        .parent_config
+        .set_remote_agent("metis".to_string(), "local".to_string());
+    seeded
+        .parent_config
+        .use_session(Some(&session_id))
+        .expect("activate remote session id");
+    let global_config = Arc::new(parking_lot::RwLock::new(std::mem::take(
+        &mut seeded.parent_config,
+    )));
+    ThinClientSession::from_global_config(
+        crate::ThinClientConfig {
+            cluster: "local".to_string(),
+            agent: "metis".to_string(),
+            session_id: Some(session_id),
+        },
+        &global_config,
+        harnx_core::abort::create_abort_signal(),
+    )
+    .await
+    .expect("load thin session")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn load_remote_transcript_for_render_prerenders_logical_rows() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let session_id = crate::nats_worker::new_remote_session_id();
+    append_completed_transcript_fixture(&seeded.parent_config, &session_id).await;
+
+    let thin = activate_thin_session(&mut seeded, session_id).await;
+
+    let transcript = load_remote_transcript_for_render(&thin)
+        .await
+        .expect("load transcript state");
+    assert!(transcript.compressed_messages.is_empty());
+    let row_seqs: Vec<usize> = transcript
+        .messages
+        .iter()
+        .filter_map(|message| message.log_seq)
+        .collect();
+    assert_eq!(row_seqs, vec![1, 2]);
+    let row_texts: Vec<_> = transcript
+        .messages
+        .iter()
+        .map(|message| (message.role, message.content.to_text()))
+        .collect();
+    assert_eq!(
+        row_texts,
+        vec![
+            (
+                harnx_core::message::MessageRole::User,
+                "delegate over nats".to_string(),
+            ),
+            (
+                harnx_core::message::MessageRole::Assistant,
+                "stub remote reply over nats".to_string(),
+            ),
+        ]
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn load_remote_transcript_for_render_keeps_tool_rows_and_compressed_prefix() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut child, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+
+    let mut seeded = seed_remote_config(&url);
+    let session_id = crate::nats_worker::new_remote_session_id();
+    append_completed_transcript_fixture(&seeded.parent_config, &session_id).await;
+
+    let jetstream = seeded
+        .parent_config
+        .nats_jetstream("local")
+        .await
+        .expect("load local jetstream");
+    let log = NatsSessionLog::new(jetstream, session_id.clone());
+    append_compressed_tool_fixture(&log).await;
+
+    let thin = activate_thin_session(&mut seeded, session_id).await;
+
+    let transcript = load_remote_transcript_for_render(&thin)
+        .await
+        .expect("load transcript state");
+    assert_compressed_tool_transcript(&transcript);
+
+    let _ = child.kill();
+    let _ = child.wait();
+}

--- a/crates/harnx-runtime/src/session_history.rs
+++ b/crates/harnx-runtime/src/session_history.rs
@@ -40,6 +40,7 @@ pub fn entry_type(entry: &SessionLogEntry) -> &'static str {
         SessionLogEntry::Clear => "clear",
         SessionLogEntry::Cancel { .. } => "cancel",
         SessionLogEntry::Error { .. } => "error",
+        SessionLogEntry::TurnEnd { .. } => "turn_end",
         SessionLogEntry::EditEntries { .. } => "edit_entries",
         SessionLogEntry::Rewind { .. } => "rewind",
         SessionLogEntry::Title { .. } => "title",

--- a/crates/harnx-runtime/tests/nats_thin_client.rs
+++ b/crates/harnx-runtime/tests/nats_thin_client.rs
@@ -3,15 +3,17 @@ mod common;
 use anyhow::Result;
 use common::spawn_nats_server;
 use harnx_core::{
-    event::{AgentEvent, AgentEventSink},
+    event::{AgentEvent, AgentEventSink, TurnEvent, TurnOutcome},
     message::{MessageContent, MessageRole},
     require_nextest,
     session::SessionLogEntry,
     session_reconstruct::{reconstruct_state_from_nats, TurnStatus},
 };
 use harnx_runtime::{
-    nats_session_log::NatsSessionLog, nats_worker::ControlCommand, send_control_command,
-    ThinClientConfig, ThinClientSession,
+    nats_event_sink::{events_subject, AdvisoryEnvelope},
+    nats_session_log::NatsSessionLog,
+    nats_worker::ControlCommand,
+    send_control_command, ThinClientConfig, ThinClientSession,
 };
 use std::{sync::Arc, time::Duration};
 use uuid::Uuid;
@@ -53,6 +55,8 @@ fn resumed_session_config(session_id: String) -> ThinClientConfig {
 
 async fn append_new_reply_after_current_turn_user(
     log: NatsSessionLog,
+    client: async_nats::Client,
+    session_id: String,
     prior_assistant_seq: u64,
 ) -> Result<u64> {
     tokio::time::timeout(Duration::from_secs(5), async {
@@ -79,14 +83,34 @@ async fn append_new_reply_after_current_turn_user(
     .map_err(|_| {
         anyhow::anyhow!("timed out waiting for current-turn user entry before appending new reply")
     })??;
-    log.append_event_async(&SessionLogEntry::Message {
-        id: Some("new-assistant".to_string()),
-        role: MessageRole::Assistant,
-        content: MessageContent::Text("new reply".to_string()),
-        timestamp: None,
-        fence_token: None,
-    })
-    .await
+    let seq = log
+        .append_event_async(&SessionLogEntry::Message {
+            id: Some("new-assistant".to_string()),
+            role: MessageRole::Assistant,
+            content: MessageContent::Text("new reply".to_string()),
+            timestamp: None,
+            fence_token: None,
+        })
+        .await?;
+    let ended = AdvisoryEnvelope::new(
+        seq,
+        AgentEvent::Turn(TurnEvent::Ended {
+            outcome: TurnOutcome::default(),
+        }),
+    );
+    let subject = events_subject(&session_id);
+    let payload = ended.to_bytes()?;
+    // Legacy workers had no durable TurnEnd marker. Repeat their lossy
+    // advisory in this compatibility test so it cannot race the client's
+    // subscribe-after-append setup.
+    for _ in 0..4 {
+        client
+            .publish(subject.clone(), payload.clone().into())
+            .await?;
+        client.flush().await?;
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    Ok(seq)
 }
 
 struct NoopEventSink;
@@ -489,8 +513,16 @@ async fn resumed_session_run_turn_ignores_stale_prior_reply_and_returns_new_repl
     .await?;
 
     let log_for_reply = log.clone();
+    let client_for_reply = client.clone();
+    let session_id_for_reply = session_id.clone();
     let reply_task = tokio::spawn(async move {
-        append_new_reply_after_current_turn_user(log_for_reply, prior_assistant_seq).await
+        append_new_reply_after_current_turn_user(
+            log_for_reply,
+            client_for_reply,
+            session_id_for_reply,
+            prior_assistant_seq,
+        )
+        .await
     });
 
     let result = tokio::time::timeout(

--- a/crates/harnx-serve/src/ag_ui.rs
+++ b/crates/harnx-serve/src/ag_ui.rs
@@ -15,11 +15,11 @@ use crate::session_actor::{
 use ag_ui_core::event::RunStartedEvent;
 use ag_ui_core::{
     event::{
-        BaseEvent, CustomEvent, Event, MessagesSnapshotEvent, RunErrorEvent, StepFinishedEvent,
-        StepStartedEvent, TextMessageContentEvent, TextMessageEndEvent, TextMessageStartEvent,
-        ThinkingEndEvent, ThinkingStartEvent, ThinkingTextMessageContentEvent,
-        ThinkingTextMessageEndEvent, ThinkingTextMessageStartEvent, ToolCallArgsEvent,
-        ToolCallEndEvent, ToolCallResultEvent, ToolCallStartEvent,
+        BaseEvent, CustomEvent, Event, MessagesSnapshotEvent, StepFinishedEvent, StepStartedEvent,
+        TextMessageContentEvent, TextMessageEndEvent, TextMessageStartEvent, ThinkingEndEvent,
+        ThinkingStartEvent, ThinkingTextMessageContentEvent, ThinkingTextMessageEndEvent,
+        ThinkingTextMessageStartEvent, ToolCallArgsEvent, ToolCallEndEvent, ToolCallResultEvent,
+        ToolCallStartEvent,
     },
     types::{
         context::Context,
@@ -35,6 +35,7 @@ use harnx_core::{
     agent_config::AgentConfig,
     event::{
         AgentEvent, ContentBlock, ModelEvent, NoticeEvent, SessionEvent, ToolEvent, TurnEvent,
+        TurnOutcome,
     },
     message::{Message as HistoryMsg, MessageContent, MessageRole},
 };
@@ -170,8 +171,9 @@ impl std::error::Error for AgUiError {}
 
 /// Sink that maps harnx `AgentEvent`s to ag-ui-core `Event`s.
 ///
-/// Phase-1 mapping: text message content and errors only.
-/// Lifecycle events (RUN_STARTED, TEXT_MESSAGE_START, etc.) are handled by caller.
+/// Run lifecycle events are owned by the session actor. This adapter maps
+/// streamed content and nested-agent steps, and records terminal errors for the
+/// actor to publish after it closes any open content segments.
 enum AgUiEventTx {
     Unbounded(UnboundedSender<Event>),
     Broadcast(broadcast::Sender<Event>),
@@ -205,6 +207,7 @@ impl From<broadcast::Sender<Event>> for AgUiEventTx {
 #[derive(Debug, Clone)]
 struct TextSegmentState {
     open_message_id: Option<MessageId>,
+    content_emitted: bool,
 }
 
 pub struct AgUiSink {
@@ -213,6 +216,7 @@ pub struct AgUiSink {
     text_segment_state: Mutex<TextSegmentState>,
     history_snapshot: Option<Arc<dyn Fn() -> Vec<AgUiMessage> + Send + Sync>>,
     session_context: Option<Arc<dyn Fn() -> Option<UsageContextSnapshot> + Send + Sync>>,
+    pending_run_error: Mutex<Option<String>>,
     in_thinking_segment: std::sync::atomic::AtomicBool,
     turn_counter: std::sync::atomic::AtomicUsize,
 }
@@ -282,9 +286,13 @@ impl AgUiSink {
         Self {
             tx: tx.into(),
             message_id,
-            text_segment_state: Mutex::new(TextSegmentState { open_message_id }),
+            text_segment_state: Mutex::new(TextSegmentState {
+                open_message_id,
+                content_emitted: false,
+            }),
             history_snapshot,
             session_context,
+            pending_run_error: Mutex::new(None),
             in_thinking_segment: std::sync::atomic::AtomicBool::new(false),
             turn_counter: std::sync::atomic::AtomicUsize::new(0),
         }
@@ -325,6 +333,7 @@ impl AgUiSink {
     pub(crate) fn close_text_segment(&self) -> Option<MessageId> {
         let message_id = {
             let mut state = self.text_segment_state.lock().expect("text segment state");
+            state.content_emitted = false;
             state.open_message_id.take()
         }?;
 
@@ -363,6 +372,10 @@ impl AgUiSink {
         }
         self.close_thinking_segment();
         let message_id = self.ensure_text_message_started();
+        self.text_segment_state
+            .lock()
+            .expect("text segment state")
+            .content_emitted = true;
         self.send(Event::TextMessageContent(TextMessageContentEvent {
             base: Self::base_event(),
             message_id,
@@ -398,6 +411,24 @@ impl AgUiSink {
 
     fn finish_turn(&self) {
         self.close_thinking_segment();
+    }
+
+    fn text_content_emitted(&self) -> bool {
+        self.text_segment_state
+            .lock()
+            .expect("text segment state")
+            .content_emitted
+    }
+
+    fn record_run_error(&self, message: String) {
+        *self.pending_run_error.lock().expect("pending run error") = Some(message);
+    }
+
+    pub(crate) fn take_run_error(&self) -> Option<String> {
+        self.pending_run_error
+            .lock()
+            .expect("pending run error")
+            .take()
     }
 
     fn emit_custom(&self, name: impl Into<String>, value: serde_json::Value) {
@@ -527,64 +558,63 @@ impl AgUiSink {
             ToolEvent::Progress { .. } | ToolEvent::Update { .. } => {}
         }
     }
-}
 
-impl harnx_core::event::AgentEventSink for AgUiSink {
-    fn emit(&self, event: AgentEvent) {
-        let event = match event {
-            AgentEvent::SubAgent { event, .. } => *event,
-            event => event,
-        };
+    fn content_text(blocks: &[ContentBlock]) -> String {
+        blocks
+            .iter()
+            .filter_map(|block| match block {
+                ContentBlock::Text(text) => Some(text.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn emit_model_event(&self, event: ModelEvent, is_sub_agent: bool) {
         match event {
-            AgentEvent::Model(ModelEvent::MessageChunk { blocks }) => {
-                let delta: String = blocks
-                    .iter()
-                    .filter_map(|b| match b {
-                        ContentBlock::Text(t) => Some(t.as_str()),
-                        _ => None,
-                    })
-                    .collect();
-                if !delta.is_empty() {
-                    self.close_thinking_segment();
-                }
-                self.emit_text_delta(delta);
+            ModelEvent::MessageChunk { blocks } => {
+                self.emit_text_delta(Self::content_text(&blocks));
             }
-            AgentEvent::Model(ModelEvent::Final { output, .. }) => {
-                self.emit_text_delta(output);
+            ModelEvent::ThoughtChunk { blocks } => {
+                self.emit_thinking_delta(Self::content_text(&blocks));
+            }
+            ModelEvent::Final { output, .. } => {
+                if !self.text_content_emitted() {
+                    self.emit_text_delta(output);
+                }
                 self.finish_turn();
             }
-            AgentEvent::Model(ModelEvent::Usage {
+            ModelEvent::Usage {
                 input,
                 output,
                 cached,
                 session_label,
-            }) => {
-                self.emit_custom(
-                    "usage",
-                    self.build_usage_payload(input, output, cached, session_label),
-                );
-            }
-            AgentEvent::Model(ModelEvent::Error(message))
-            | AgentEvent::Notice(NoticeEvent::Error(message)) => {
-                self.finish_turn();
-                self.send(Event::RunError(RunErrorEvent {
-                    base: Self::base_event(),
-                    message,
-                    code: None,
-                }));
-            }
-            AgentEvent::Tool(tool_event) => self.emit_tool_event(tool_event),
-            AgentEvent::Model(ModelEvent::ThoughtChunk { blocks }) => {
-                let delta: String = blocks
-                    .iter()
-                    .filter_map(|b| match b {
-                        ContentBlock::Text(t) => Some(t.as_str()),
-                        _ => None,
-                    })
-                    .collect();
-                self.emit_thinking_delta(delta);
-            }
-            AgentEvent::Turn(TurnEvent::Started) => {
+            } => self.emit_custom(
+                "usage",
+                self.build_usage_payload(input, output, cached, session_label),
+            ),
+            ModelEvent::Error(message) => self.record_model_error(message, is_sub_agent),
+        }
+    }
+
+    fn record_model_error(&self, message: String, is_sub_agent: bool) {
+        self.finish_turn();
+        if !is_sub_agent {
+            self.record_run_error(message);
+        }
+    }
+
+    fn emit_notice(&self, notice: NoticeEvent) {
+        let (level, message) = match notice {
+            NoticeEvent::Info(_) => return,
+            NoticeEvent::Warning(message) => ("warning", message),
+            NoticeEvent::Error(message) => ("error", message),
+        };
+        self.emit_custom("notice", json!({ "level": level, "message": message }));
+    }
+
+    fn emit_turn_event(&self, event: TurnEvent, is_sub_agent: bool) {
+        match event {
+            TurnEvent::Started if is_sub_agent => {
                 let turn = self
                     .turn_counter
                     .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
@@ -594,71 +624,106 @@ impl harnx_core::event::AgentEventSink for AgUiSink {
                     step_name: format!("turn-{turn}"),
                 }));
             }
-            AgentEvent::Turn(TurnEvent::Ended { outcome }) => {
+            TurnEvent::Ended { outcome } => {
                 self.finish_turn();
-                self.send(Event::StepFinished(StepFinishedEvent {
-                    base: Self::base_event(),
-                    step_name: self.step_name_for_turn(),
-                }));
-                if !outcome.output.is_empty()
-                    || outcome.thought.is_some()
-                    || outcome.handoff.is_some()
-                    || outcome.usage.input_tokens > 0
-                    || outcome.usage.output_tokens > 0
-                    || outcome.usage.cached_tokens > 0
-                {
-                    self.emit_custom(
-                        "turn_outcome",
-                        serde_json::to_value(outcome).expect("turn outcome should serialize"),
-                    );
+                if is_sub_agent {
+                    self.send(Event::StepFinished(StepFinishedEvent {
+                        base: Self::base_event(),
+                        step_name: self.step_name_for_turn(),
+                    }));
                 }
+                self.emit_turn_outcome(outcome);
             }
-            AgentEvent::Turn(TurnEvent::RetryAttempt { attempt, reason }) => {
-                self.emit_custom(
-                    "turn_retry_attempt",
-                    json!({ "attempt": attempt, "reason": reason }),
-                );
-            }
-            AgentEvent::Turn(TurnEvent::ModelFallback { from, to }) => {
+            TurnEvent::RetryAttempt { attempt, reason } => self.emit_custom(
+                "turn_retry_attempt",
+                json!({ "attempt": attempt, "reason": reason }),
+            ),
+            TurnEvent::ModelFallback { from, to } => {
                 self.emit_custom("turn_model_fallback", json!({ "from": from, "to": to }));
             }
-            AgentEvent::Turn(TurnEvent::HandoffRequested { agent, session_id }) => {
+            TurnEvent::HandoffRequested { agent, session_id } => {
                 self.emit_handoff(agent, session_id);
             }
-            AgentEvent::Turn(TurnEvent::SubAgentStarted { agent, session_id }) => {
-                self.emit_custom(
-                    "sub_agent_started",
-                    json!({ "agent": agent, "session_id": session_id }),
-                );
-            }
-            AgentEvent::Session(SessionEvent::CompactingStarted) => {
+            TurnEvent::SubAgentStarted { agent, session_id } => self.emit_custom(
+                "sub_agent_started",
+                json!({ "agent": agent, "session_id": session_id }),
+            ),
+            TurnEvent::Started => {}
+        }
+    }
+
+    fn emit_turn_outcome(&self, outcome: TurnOutcome) {
+        let outcome_is_empty = [
+            outcome.output.is_empty(),
+            outcome.thought.is_none(),
+            outcome.handoff.is_none(),
+            outcome.usage.input_tokens == 0,
+            outcome.usage.output_tokens == 0,
+            outcome.usage.cached_tokens == 0,
+        ]
+        .into_iter()
+        .all(std::convert::identity);
+        if outcome_is_empty {
+            return;
+        }
+        self.emit_custom(
+            "turn_outcome",
+            serde_json::to_value(outcome).expect("turn outcome should serialize"),
+        );
+    }
+
+    fn emit_session_event(&self, event: SessionEvent) {
+        match event {
+            SessionEvent::CompactingStarted => {
                 self.emit_custom("session_compacting_started", json!({}));
             }
-            AgentEvent::Session(SessionEvent::CompactingCompleted) => {
+            SessionEvent::CompactingCompleted => {
                 self.emit_custom("session_compacting_completed", json!({}));
                 self.emit_history_snapshot();
             }
-            AgentEvent::Session(SessionEvent::CompactingFailed(error)) => {
+            SessionEvent::CompactingFailed(error) => {
                 self.emit_custom("session_compacting_failed", json!({ "error": error }));
             }
-            AgentEvent::Session(SessionEvent::TitleGenerationFailed(error)) => {
+            SessionEvent::TitleGenerationFailed(error) => {
                 self.emit_custom("session_title_generation_failed", json!({ "error": error }));
             }
-            AgentEvent::Session(SessionEvent::Saved { path }) => {
+            SessionEvent::Saved { path } => {
                 self.emit_custom("session_saved", json!({ "path": path }));
             }
-            AgentEvent::Session(SessionEvent::AgentInitializing { agent }) => {
+            SessionEvent::AgentInitializing { agent } => {
                 self.emit_custom("session_agent_initializing", json!({ "agent": agent }));
             }
-            AgentEvent::Session(SessionEvent::ModelChanged { from, to }) => {
+            SessionEvent::ModelChanged { from, to } => {
                 self.emit_custom("session_model_changed", json!({ "from": from, "to": to }));
             }
-            AgentEvent::Session(SessionEvent::RagIndexing { url, index, total }) => {
-                self.emit_custom(
-                    "session_rag_indexing",
-                    json!({ "url": url, "index": index, "total": total }),
-                );
+            SessionEvent::RagIndexing { url, index, total } => self.emit_custom(
+                "session_rag_indexing",
+                json!({ "url": url, "index": index, "total": total }),
+            ),
+            SessionEvent::TitleUpdated(title) => {
+                self.emit_custom("session_title_updated", json!({ "title": title }));
             }
+            SessionEvent::Generic { text } => {
+                self.finish_turn();
+                self.emit_custom("session_generic", json!({ "text": text }));
+            }
+            SessionEvent::LogSeqAssigned { .. } => self.finish_turn(),
+        }
+    }
+}
+
+impl harnx_core::event::AgentEventSink for AgUiSink {
+    fn emit(&self, event: AgentEvent) {
+        let (event, is_sub_agent) = match event {
+            AgentEvent::SubAgent { event, .. } => (*event, true),
+            event => (event, false),
+        };
+        match event {
+            AgentEvent::Model(event) => self.emit_model_event(event, is_sub_agent),
+            AgentEvent::Tool(tool_event) => self.emit_tool_event(tool_event),
+            AgentEvent::Turn(event) => self.emit_turn_event(event, is_sub_agent),
+            AgentEvent::Session(event) => self.emit_session_event(event),
+            AgentEvent::Notice(notice) => self.emit_notice(notice),
             AgentEvent::Plan { entries } => {
                 self.emit_custom(
                     "plan",
@@ -667,16 +732,6 @@ impl harnx_core::event::AgentEventSink for AgUiSink {
             }
             AgentEvent::Status(status) => {
                 self.emit_custom("status", json!({ "text": status.text }));
-            }
-            AgentEvent::Session(SessionEvent::TitleUpdated(title)) => {
-                self.emit_custom("session_title_updated", json!({ "title": title }))
-            }
-            AgentEvent::Session(SessionEvent::Generic { text }) => {
-                self.finish_turn();
-                self.emit_custom("session_generic", json!({ "text": text }));
-            }
-            AgentEvent::Session(SessionEvent::LogSeqAssigned { .. }) => {
-                self.finish_turn();
             }
             _ => {}
         }

--- a/crates/harnx-serve/src/ag_ui_tests.rs
+++ b/crates/harnx-serve/src/ag_ui_tests.rs
@@ -129,16 +129,14 @@ fn ag_ui_sink_unwraps_sub_agent_message_chunk() {
 }
 
 #[test]
-fn ag_ui_sink_unwraps_sub_agent_error() {
-    // SubAgent wrapper around Model::Error should produce the same RunError
-    // event as the bare error path after unwrapping at the top of emit.
+fn ag_ui_sink_does_not_promote_sub_agent_error_to_run_error() {
+    // A nested agent failure belongs to that sub-agent step. It must not end
+    // the parent AG-UI run.
     use harnx_core::event::AgentSource;
 
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
     let message_id =
         MessageId::from(uuid::Uuid::parse_str("33333333-3333-3333-3333-333333333333").unwrap());
-    // Use `new` (not with_snapshot) for error path — finish_turn is not called
-    // unless a message was already started, so we expect RunError directly.
     let sink = super::AgUiSink::new(tx, message_id.clone());
 
     let source = AgentSource {
@@ -151,22 +149,8 @@ fn ag_ui_sink_unwraps_sub_agent_error() {
         AgentEvent::Model(ModelEvent::Error("boom".into())),
     ));
 
-    // RunError with the wrapped message
-    match rx.try_recv().expect("run error") {
-        Event::RunError(RunErrorEvent {
-            base,
-            message,
-            code,
-        }) => {
-            assert_eq!(base.timestamp, None);
-            assert_eq!(base.raw_event, None);
-            assert_eq!(message, "boom");
-            assert!(code.is_none());
-        }
-        other => panic!("expected RunError event, got: {other:?}"),
-    }
-
-    assert!(rx.try_recv().is_err(), "no additional events expected");
+    assert!(rx.try_recv().is_err(), "no AG-UI run error expected");
+    assert!(sink.take_run_error().is_none());
 }
 
 #[test]
@@ -190,27 +174,16 @@ fn ag_ui_sink_skips_empty_chunk() {
 }
 
 #[test]
-fn ag_ui_sink_emits_run_error_for_model_error() {
+fn ag_ui_sink_defers_model_error_to_run_owner() {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
     let message_id = MessageId::from(uuid::Uuid::new_v4());
     let sink = super::AgUiSink::new(tx, message_id);
 
     sink.emit(AgentEvent::Model(ModelEvent::Error("boom".to_string())));
 
-    let event = rx.try_recv().expect("should receive event");
-    match event {
-        Event::RunError(RunErrorEvent {
-            base,
-            message,
-            code,
-        }) => {
-            assert_eq!(base.timestamp, None);
-            assert_eq!(base.raw_event, None);
-            assert_eq!(message, "boom");
-            assert!(code.is_none());
-        }
-        _ => panic!("expected RunError event, got: {:?}", event),
-    }
+    assert!(rx.try_recv().is_err());
+    assert_eq!(sink.take_run_error().as_deref(), Some("boom"));
+    assert!(sink.take_run_error().is_none());
 }
 
 #[test]
@@ -234,22 +207,24 @@ fn ag_ui_sink_emits_custom_for_title_generation_failed() {
 }
 
 #[test]
-fn ag_ui_sink_emits_run_error_for_notice_error() {
+fn ag_ui_sink_emits_advisory_notices_without_failing_run() {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
     let message_id = MessageId::from(uuid::Uuid::new_v4());
     let sink = super::AgUiSink::new(tx, message_id);
 
-    sink.emit(AgentEvent::Notice(NoticeEvent::Error(
-        "fatal error".to_string(),
+    sink.emit(AgentEvent::Notice(NoticeEvent::Warning(
+        "partial stream failed".to_string(),
     )));
 
-    let event = rx.try_recv().expect("should receive event");
-    match event {
-        Event::RunError(RunErrorEvent { message, .. }) => {
-            assert_eq!(message, "fatal error");
-        }
-        _ => panic!("expected RunError event, got: {:?}", event),
-    }
+    let Event::Custom(CustomEvent { name, value, .. }) =
+        rx.try_recv().expect("notice should be forwarded")
+    else {
+        panic!("expected custom notice event");
+    };
+    assert_eq!(name, "notice");
+    assert_eq!(value["level"], json!("warning"));
+    assert_eq!(value["message"], json!("partial stream failed"));
+    assert!(sink.take_run_error().is_none());
 }
 
 #[test]
@@ -321,6 +296,33 @@ fn ag_ui_sink_skips_final_when_empty() {
     }));
 
     assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn ag_ui_sink_does_not_repeat_streamed_text_on_final() {
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
+    let message_id = MessageId::from(uuid::Uuid::new_v4());
+    let sink = super::AgUiSink::with_snapshot(tx, message_id.clone(), true, None);
+
+    sink.emit(AgentEvent::Model(ModelEvent::MessageChunk {
+        blocks: vec![ContentBlock::Text("answer".to_string())],
+    }));
+    sink.emit(AgentEvent::Model(ModelEvent::Final {
+        output: "answer".to_string(),
+        usage: CompletionTokenUsage::default(),
+    }));
+
+    match rx.try_recv().expect("streamed text") {
+        Event::TextMessageContent(event) => {
+            assert_eq!(event.message_id, message_id);
+            assert_eq!(event.delta, "answer");
+        }
+        other => panic!("expected TextMessageContent, got: {other:?}"),
+    }
+    assert!(
+        rx.try_recv().is_err(),
+        "Final must not repeat streamed text"
+    );
 }
 
 #[test]
@@ -478,10 +480,6 @@ fn ag_ui_sink_keeps_thinking_open_across_background_session_event() {
     assert!(matches!(
         rx.try_recv().expect("thinking end"),
         Event::ThinkingEnd(_)
-    ));
-    assert!(matches!(
-        rx.try_recv().expect("step finished"),
-        Event::StepFinished(_)
     ));
     assert!(rx.try_recv().is_err());
 }
@@ -864,7 +862,7 @@ fn parse_run_input_accepts_valid_body() {
 }
 
 #[test]
-fn ag_ui_sink_maps_turn_started_and_ended_to_step_events() {
+fn ag_ui_sink_maps_only_sub_agent_turns_to_step_events() {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
     let sink = super::AgUiSink::with_snapshot(tx, MessageId::random(), true, None);
 
@@ -872,6 +870,27 @@ fn ag_ui_sink_maps_turn_started_and_ended_to_step_events() {
     sink.emit(AgentEvent::Turn(TurnEvent::Ended {
         outcome: harnx_core::event::TurnOutcome::default(),
     }));
+
+    assert!(
+        rx.try_recv().is_err(),
+        "the parent turn is already represented by the AG-UI run"
+    );
+
+    let source = harnx_core::event::AgentSource {
+        agent: "sub".into(),
+        session_id: None,
+        model: None,
+    };
+    sink.emit(AgentEvent::sub_agent(
+        source.clone(),
+        AgentEvent::Turn(TurnEvent::Started),
+    ));
+    sink.emit(AgentEvent::sub_agent(
+        source,
+        AgentEvent::Turn(TurnEvent::Ended {
+            outcome: harnx_core::event::TurnOutcome::default(),
+        }),
+    ));
 
     match rx.try_recv().expect("step started") {
         Event::StepStarted(event) => assert_eq!(event.step_name, "turn-1"),
@@ -949,7 +968,8 @@ fn ag_ui_sink_emits_session_handoff_custom_event_on_handoff_requested() {
         session_id: Some("target-session-123".to_string()),
     }));
 
-    // Emit a step finished event (simulating turn end after handoff)
+    // The parent turn ending is represented by RUN_FINISHED in the session
+    // actor, not by a redundant step boundary in this adapter.
     sink.emit(AgentEvent::Turn(TurnEvent::Ended {
         outcome: harnx_core::event::TurnOutcome::default(),
     }));
@@ -960,13 +980,11 @@ fn ag_ui_sink_emits_session_handoff_custom_event_on_handoff_requested() {
         events.push(event);
     }
 
-    // Extract event types for ordering assertions
+    // Extract custom event types for ordering assertions.
     let event_types: Vec<&str> = events
         .iter()
         .map(|e| match e {
             Event::Custom(ce) => ce.name.as_str(),
-            Event::StepFinished(_) => "STEP_FINISHED",
-            Event::StepStarted(_) => "STEP_STARTED",
             _ => "OTHER",
         })
         .collect();
@@ -976,7 +994,6 @@ fn ag_ui_sink_emits_session_handoff_custom_event_on_handoff_requested() {
     let turn_handoff_idx = event_types
         .iter()
         .position(|&t| t == "turn_handoff_requested");
-    let step_finished_idx = event_types.iter().position(|&t| t == "STEP_FINISHED");
 
     // Both custom events must be present
     assert!(
@@ -987,16 +1004,10 @@ fn ag_ui_sink_emits_session_handoff_custom_event_on_handoff_requested() {
         turn_handoff_idx.is_some(),
         "turn_handoff_requested event should be emitted"
     );
-    assert!(
-        step_finished_idx.is_some(),
-        "STEP_FINISHED event should be emitted"
-    );
-
-    // session_handoff must come BEFORE STEP_FINISHED (the terminal event for this test)
-    assert!(
-        session_handoff_idx.unwrap() < step_finished_idx.unwrap(),
-        "session_handoff must appear before STEP_FINISHED; got order: {:?}",
-        event_types
+    assert_eq!(
+        event_types,
+        ["turn_handoff_requested", "session_handoff"],
+        "parent turn end must not add a redundant AG-UI step"
     );
 
     assert_handoff_payload(find_custom_event(&events, "session_handoff"));
@@ -1832,10 +1843,12 @@ async fn ag_ui_run_uses_only_last_message_user_prompt() {
         vec![
             "RUN_STARTED",
             "TEXT_MESSAGE_START",
+            "TEXT_MESSAGE_CONTENT",
             "TEXT_MESSAGE_END",
             "RUN_FINISHED",
         ]
     );
+    assert_eq!(events[2]["delta"].as_str(), Some("assistant2"));
 }
 
 #[tokio::test]

--- a/crates/harnx-serve/src/session_actor.rs
+++ b/crates/harnx-serve/src/session_actor.rs
@@ -433,14 +433,26 @@ impl SessionActor {
     }
 
     fn finish_completed_run(&mut self, done: &RunFinished) {
-        done.sink.sink.close_text_segment();
-        let _ = self.broadcast_tx.send(Event::RunFinished(RunFinishedEvent {
-            base: base_event(),
-            thread_id: done.thread_id.clone(),
-            run_id: done.run_id.clone(),
-            result: None,
-        }));
+        self.finish_run(done, None);
         self.state = SessionState::Idle;
+    }
+
+    fn finish_run(&self, done: &RunFinished, result: Option<serde_json::Value>) {
+        done.sink.sink.close_text_segment();
+        if let Some(message) = done.sink.sink.take_run_error() {
+            let _ = self.broadcast_tx.send(Event::RunError(RunErrorEvent {
+                base: base_event(),
+                message,
+                code: None,
+            }));
+        } else {
+            let _ = self.broadcast_tx.send(Event::RunFinished(RunFinishedEvent {
+                base: base_event(),
+                thread_id: done.thread_id.clone(),
+                run_id: done.run_id.clone(),
+                result,
+            }));
+        }
     }
 
     async fn replay_pending_or_arm_reap(&mut self, reap_sleep: &mut std::pin::Pin<&mut Sleep>) {
@@ -482,13 +494,7 @@ impl SessionActor {
             .await
             .ok();
 
-        done.sink.sink.close_text_segment();
-        let _ = self.broadcast_tx.send(Event::RunFinished(RunFinishedEvent {
-            base: base_event(),
-            thread_id: done.thread_id.clone(),
-            run_id: done.run_id.clone(),
-            result: None,
-        }));
+        self.finish_run(done, None);
         self.state = SessionState::Idle;
     }
 

--- a/crates/harnx-tui/Cargo.toml
+++ b/crates/harnx-tui/Cargo.toml
@@ -12,6 +12,7 @@ keywords.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-nats = { workspace = true }
 async-trait = { workspace = true }
 bincode = { workspace = true }
 chrono = { workspace = true }

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -805,6 +805,17 @@ impl Tui {
             TuiEvent::Agent(event) => {
                 self.render_agent_event(event).await;
             }
+            TuiEvent::PromptTaskFinished { task, error } => {
+                self.finish_prompt_task(task, error).await;
+            }
+            TuiEvent::SessionActivity {
+                session_id,
+                cluster,
+                active,
+            } => {
+                self.handle_session_activity(session_id, cluster, active)
+                    .await;
+            }
             TuiEvent::ToolRoundComplete => {
                 // Intermediate tool round — prompt loop continues, don't clear llm_busy.
                 // Flush any pending thought so follow-up thought after tool results
@@ -871,14 +882,14 @@ impl Tui {
     }
 
     #[cfg(not(test))]
-    async fn submit_pending_message(
+    pub(super) async fn submit_pending_message(
         &mut self,
         pending: crate::types::PendingMessage,
     ) -> Result<()> {
         self.submit_pending_message_inner(pending).await
     }
 
-    async fn submit_pending_message_inner(
+    pub(super) async fn submit_pending_message_inner(
         &mut self,
         pending: crate::types::PendingMessage,
     ) -> Result<()> {
@@ -936,7 +947,7 @@ impl Tui {
         }
     }
 
-    fn flush_pending_thought(&mut self) {
+    pub(super) fn flush_pending_thought(&mut self) {
         if self.app.pending_thought_text.is_empty() {
             return;
         }
@@ -972,14 +983,15 @@ impl Tui {
     }
 
     async fn render_agent_event(&mut self, event: AgentEvent) {
-        use harnx_core::event::{
-            ModelEvent, NoticeEvent, SessionEvent, ToolEvent, TurnEvent, UserEvent,
-        };
+        use harnx_core::event::{ModelEvent, NoticeEvent, SessionEvent, ToolEvent, UserEvent};
 
         let (source, event, is_sub_agent) = match event {
             AgentEvent::SubAgent { source, event } => (Some(source), *event, true),
             event => (None, event, false),
         };
+        if self.handle_turn_activity(&event, is_sub_agent).await {
+            return;
+        }
         let is_thought = matches!(&event, AgentEvent::Model(ModelEvent::ThoughtChunk { .. }));
         let is_usage = matches!(&event, AgentEvent::Model(ModelEvent::Usage { .. }));
         // No streaming-run bookkeeping is needed here: any event that renders a
@@ -1038,20 +1050,7 @@ impl Tui {
             return;
         }
 
-        if let AgentEvent::Turn(TurnEvent::ModelFallback { ref to, .. }) = event {
-            let new_source = self.app.last_ui_output_source.clone().map(|mut s| {
-                s.model = Some(to.clone());
-                s
-            });
-            self.render_ui_output_heading(new_source.as_ref(), false);
-            return;
-        }
-        if let AgentEvent::Session(SessionEvent::ModelChanged { ref to, .. }) = event {
-            let new_source = self.app.last_ui_output_source.clone().map(|mut s| {
-                s.model = Some(to.clone());
-                s
-            });
-            self.render_ui_output_heading(new_source.as_ref(), false);
+        if self.render_model_source_change(&event) {
             return;
         }
         if !is_thought {
@@ -1103,15 +1102,8 @@ impl Tui {
                 output, markdown, ..
             }) => tool_completed_to_transcript_items(&output, markdown.as_deref()),
             AgentEvent::Model(ModelEvent::MessageChunk { blocks }) => {
-                let text = concat_text_blocks(&blocks);
-                if text.is_empty() {
-                    vec![]
-                } else {
-                    self.app.streamed_text_this_turn = true;
-                    self.append_streaming_assistant_chunk(&text);
-                    self.pin_transcript_to_bottom();
-                    vec![]
-                }
+                self.append_streaming_assistant_chunk(&concat_text_blocks(&blocks), is_sub_agent);
+                vec![]
             }
             AgentEvent::SubAgent { .. } => unreachable!("sub-agent event flattened above"),
             AgentEvent::Model(ModelEvent::Final { output, usage }) => {
@@ -1236,10 +1228,9 @@ impl Tui {
                 self.app.streaming_open = false;
                 // A compaction can land mid-turn after some assistant text has
                 // already streamed. The rebuild drops that streamed row, so the
-                // per-turn flag must also reset — otherwise the next
-                // ModelEvent::Final sees streamed_text_this_turn == true and
-                // skips rendering the final assistant row.
-                self.app.streamed_text_this_turn = false;
+                // The rebuild drops the parent streamed row, so its replacement
+                // index must also be cleared before the eventual Final event.
+                self.app.main_streamed_text_idx = None;
                 // The rebuild drops all SourceHeading entries, so the next
                 // output must re-emit its heading even if it shares the prior
                 // source. Without this, the first post-compaction message would
@@ -1292,39 +1283,23 @@ impl Tui {
         usage: &harnx_core::api_types::CompletionTokenUsage,
     ) {
         self.flush_pending_thought();
-        self.app.llm_busy = false;
-        self.active_remote_session = None;
-        // Final means this task is exiting. Keep its completed JoinHandle for
-        // the next start_prompt drain, but drop the obsolete abort signal.
-        self.current_prompt_abort = None;
-        // Prevent a text-only response from leaking a queued message into the
-        // next prompt task as a duplicate user message.
-        *self.shared_pending_message.lock().await = None;
-        self.app.last_ui_output_source = None;
         let usage_str = format_usage(usage);
         if !output.is_empty() {
-            if self.app.streamed_text_this_turn {
-                // Replace the trailing streamed run with canonical final output.
-                let tail_start = self
-                    .app
-                    .transcript
-                    .iter()
-                    .rposition(|item| !matches!(item, TranscriptItem::AssistantText { .. }))
-                    .map_or(0, |idx| idx + 1);
-
-                if tail_start < self.app.transcript.len() {
-                    let mut tail = self.app.transcript.split_off(tail_start);
-                    if let Some(TranscriptItem::AssistantText {
-                        text,
-                        rendered_cache,
-                        ..
-                    }) = tail.first_mut()
-                    {
-                        *text = output;
-                        *rendered_cache = None;
-                    }
-                    tail.truncate(1);
-                    self.app.transcript.extend(tail);
+            if let Some(streamed_idx) = self.app.main_streamed_text_idx {
+                // Replace the latest parent-agent streamed run with canonical
+                // final output. A sub-agent may have emitted a newer assistant
+                // row while the parent tool call was in flight.
+                // Status/usage events may be emitted after the last text chunk
+                // but before the full-loop Final, so the assistant row is not
+                // necessarily the transcript tail.
+                if let Some(TranscriptItem::AssistantText {
+                    text,
+                    rendered_cache,
+                    ..
+                }) = self.app.transcript.get_mut(streamed_idx)
+                {
+                    *text = output;
+                    *rendered_cache = None;
                 } else {
                     self.app.transcript.push(TranscriptItem::AssistantText {
                         text: output,
@@ -1344,7 +1319,7 @@ impl Tui {
             self.pin_transcript_to_bottom();
         }
         self.app.streaming_open = false;
-        self.app.streamed_text_this_turn = false;
+        self.app.main_streamed_text_idx = None;
         if !usage_str.is_empty() {
             self.app
                 .transcript
@@ -1352,27 +1327,27 @@ impl Tui {
             self.pin_transcript_to_bottom();
         }
         self.refresh_input_chrome();
-
-        if let Some(pending) = self.app.pending_message.take() {
-            if let Err(err) = self.submit_pending_message(pending).await {
-                self.app
-                    .transcript
-                    .push(TranscriptItem::ErrorText(pretty_error_string(&err)));
-                self.pin_transcript_to_bottom();
-            }
-        }
     }
 
-    async fn finish_main_prompt_error(&mut self, err: String) {
+    pub(super) async fn finish_main_prompt_error(&mut self, err: String) {
         self.flush_pending_thought();
-        self.app.llm_busy = false;
-        self.active_remote_session = None;
-        self.current_prompt_abort = None;
-        *self.shared_pending_message.lock().await = None;
         self.app.streaming_open = false;
-        self.app.streamed_text_this_turn = false;
+        self.app.main_streamed_text_idx = None;
         self.app.last_ui_output_source = None;
         self.app.transcript.push(TranscriptItem::ErrorText(err));
+        if self
+            .current_prompt_abort
+            .as_ref()
+            .is_some_and(|abort| abort.aborted())
+        {
+            // The user may type a new message while the cancelled task winds
+            // down. Keep that newer message queued; Turn::Ended (or the task
+            // fallback) will submit it after the old task actually exits.
+            self.pin_transcript_to_bottom();
+            self.refresh_input_chrome();
+            return;
+        }
+        *self.shared_pending_message.lock().await = None;
 
         // Do not replay input that failed. Restore it as editable draft so user
         // can change it before resubmitting, avoiding persistent retry loops.
@@ -1427,7 +1402,11 @@ impl Tui {
         self.pin_transcript_to_bottom();
     }
 
-    fn render_ui_output_heading(&mut self, source: Option<&AgentSource>, is_usage: bool) {
+    pub(super) fn render_ui_output_heading(
+        &mut self,
+        source: Option<&AgentSource>,
+        is_usage: bool,
+    ) {
         let source = source.cloned();
         if source != self.app.last_ui_output_source {
             if let Some(source) = &source {
@@ -1499,8 +1478,7 @@ impl Tui {
 
         self.app.llm_busy = true;
         self.app.streaming_open = false;
-
-        self.app.streamed_text_this_turn = false;
+        self.app.main_streamed_text_idx = None;
 
         let (agent, cluster, session_id) = {
             let guard = self.config.read();
@@ -1526,7 +1504,7 @@ impl Tui {
 
         let ctx = crate::prompt::PromptTaskContext {
             config: self.config.clone(),
-            abort_signal: new_abort,
+            abort_signal: new_abort.clone(),
             #[cfg(test)]
             shared_pending_message: self.shared_pending_message.clone(),
             local_worker: self.local_worker.clone(),
@@ -1544,12 +1522,15 @@ impl Tui {
             let result: Result<()> =
                 Self::run_thin_client_prompt_task(msg, ctx, agent, cluster).await;
 
-            if let Err(err) = result {
-                use harnx_core::event::{AgentEvent, ModelEvent};
-                let _ = event_tx.send(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Error(
-                    pretty_error_string(&err),
-                ))));
-            }
+            let error = match result {
+                Err(_) if new_abort.aborted() => None,
+                Err(err) => Some(pretty_error_string(&err)),
+                Ok(()) => None,
+            };
+            let _ = event_tx.send(TuiEvent::PromptTaskFinished {
+                task: new_abort,
+                error,
+            });
         });
         self.current_prompt_handle = Some(handle);
 
@@ -2128,7 +2109,7 @@ impl Tui {
 
         self.app.transcript.clear();
         self.app.streaming_open = false;
-        self.app.streamed_text_this_turn = false;
+        self.app.main_streamed_text_idx = None;
         // Reset scroll state so the widget doesn't subtract-overflow when
         // the rebuilt transcript is shorter than the previous one.
         self.app.scroll_state = ratatui_widget_scrolling::ScrollState::new();

--- a/crates/harnx-tui/src/lib.rs
+++ b/crates/harnx-tui/src/lib.rs
@@ -11,6 +11,7 @@ pub mod markdown_render;
 pub mod prompt;
 pub mod render;
 pub mod render_helpers;
+mod session_activity;
 mod session_history_loader;
 pub mod terminal;
 pub mod test_utils;

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -110,7 +110,7 @@ fn build_initial_app(
         llm_busy: false,
         scroll_state: ratatui_widget_scrolling::ScrollState::new(),
         streaming_open: false,
-        streamed_text_this_turn: false,
+        main_streamed_text_idx: None,
         cache_valid_width: None,
         last_ui_output_source: None,
         last_usage_source: None,
@@ -230,6 +230,8 @@ impl Tui {
             current_prompt_abort: None,
             current_prompt_handle: None,
             active_remote_session: None,
+            session_activity_target: None,
+            session_activity_handle: None,
             needs_full_redraw: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             app,
             event_tx,
@@ -439,7 +441,7 @@ impl Tui {
             {
                 let _ = terminal.clear();
             }
-            terminal.draw(|frame| self.draw(frame))?;
+            self.draw_with_session_activity(terminal)?;
 
             if self.app.should_quit || self.abort_signal.aborted_ctrld() {
                 break;

--- a/crates/harnx-tui/src/prompt.rs
+++ b/crates/harnx-tui/src/prompt.rs
@@ -1,11 +1,10 @@
 use crate::types::Tui;
-use crate::types::{PendingMessage, TuiEvent};
+use crate::types::{PendingMessage, TranscriptItem, TuiEvent};
 use anyhow::{Context, Result};
 #[cfg(test)]
 use harnx_core::event::{AgentEvent, ModelEvent};
 #[cfg(test)]
 use harnx_core::sink::emit_agent_event;
-#[cfg(test)]
 use harnx_render::pretty_error_string;
 #[cfg(test)]
 use harnx_runtime::client::CompletionTokenUsage;
@@ -30,6 +29,44 @@ pub(super) struct PromptTaskContext {
 }
 
 impl Tui {
+    pub(super) async fn finish_prompt_task(&mut self, task: AbortSignal, error: Option<String>) {
+        let is_current = self
+            .current_prompt_abort
+            .as_ref()
+            .is_some_and(|current| Arc::ptr_eq(current, &task));
+        if !is_current {
+            return;
+        }
+
+        self.current_prompt_abort = None;
+        if let Some(error) = error {
+            self.finish_main_prompt_error(error).await;
+        }
+        // Turn lifecycle advisories are lossy by design. Normally Turn::Ended
+        // already completed the UI state; task exit is the local owner's
+        // authoritative fallback when that advisory was missed or setup failed
+        // before a worker could start the turn.
+        self.complete_main_prompt().await;
+    }
+
+    pub(super) async fn complete_main_prompt(&mut self) {
+        self.current_prompt_abort = None;
+        self.app.llm_busy = false;
+        self.active_remote_session = None;
+        *self.shared_pending_message.lock().await = None;
+        self.app.last_ui_output_source = None;
+        self.refresh_input_chrome();
+
+        if let Some(pending) = self.app.pending_message.take() {
+            if let Err(err) = self.submit_pending_message(pending).await {
+                self.app
+                    .transcript
+                    .push(TranscriptItem::ErrorText(pretty_error_string(&err)));
+                self.pin_transcript_to_bottom();
+            }
+        }
+    }
+
     #[cfg(test)]
     pub(super) async fn run_test_prompt_task(
         msg: PendingMessage,
@@ -217,16 +254,6 @@ impl Tui {
             input,
             &result,
         );
-        if result.was_cancelled || result.response.is_none() {
-            let _ = ctx
-                .event_tx
-                .send(TuiEvent::Agent(harnx_core::event::AgentEvent::Model(
-                    harnx_core::event::ModelEvent::Final {
-                        output: String::new(),
-                        usage: Default::default(),
-                    },
-                )));
-        }
         log::info!(
             "thin-client prompt completed: cluster={} session_id={} cancelled={}",
             cluster,

--- a/crates/harnx-tui/src/render.rs
+++ b/crates/harnx-tui/src/render.rs
@@ -4,6 +4,7 @@ use crate::types::{
     App, ModalState, ToolCallBody, TranscriptItem, MAX_INPUT_HEIGHT, MIN_INPUT_HEIGHT,
     SPINNER_FRAMES,
 };
+use harnx_core::event::{AgentEvent, SessionEvent, TurnEvent};
 use harnx_runtime::config::GlobalConfig;
 use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Color, Modifier, Style};
@@ -23,6 +24,20 @@ struct ListModalOpts<'a> {
 }
 
 impl Tui {
+    pub(super) fn render_model_source_change(&mut self, event: &AgentEvent) -> bool {
+        let model = match event {
+            AgentEvent::Turn(TurnEvent::ModelFallback { to, .. })
+            | AgentEvent::Session(SessionEvent::ModelChanged { to, .. }) => to,
+            _ => return false,
+        };
+        let source = self.app.last_ui_output_source.clone().map(|mut source| {
+            source.model = Some(model.clone());
+            source
+        });
+        self.render_ui_output_heading(source.as_ref(), false);
+        true
+    }
+
     fn render_text_entry(
         prefix: &str,
         text: &str,
@@ -649,7 +664,10 @@ impl Tui {
     /// item — a fresh `AssistantText` is started. An interleaving item thus
     /// breaks the surrounding text into separate blocks for free, with no
     /// per-event bookkeeping.
-    pub(super) fn append_streaming_assistant_chunk(&mut self, chunk: &str) {
+    pub(super) fn append_streaming_assistant_chunk(&mut self, chunk: &str, is_sub_agent: bool) {
+        if chunk.is_empty() {
+            return;
+        }
         let open = self.app.streaming_open
             && matches!(
                 self.app.transcript.last(),
@@ -674,6 +692,10 @@ impl Tui {
             // Invalidate the cached render so the appended text repaints.
             *rendered_cache = None;
         }
+        if !is_sub_agent {
+            self.app.main_streamed_text_idx = Some(self.app.transcript.len() - 1);
+        }
+        self.pin_transcript_to_bottom();
     }
 
     pub(super) fn pin_transcript_to_bottom(&mut self) {
@@ -685,7 +707,7 @@ impl Tui {
         self.app.transcript.clear();
         self.app.scroll_state = ratatui_widget_scrolling::ScrollState::new();
         self.app.streaming_open = false;
-        self.app.streamed_text_this_turn = false;
+        self.app.main_streamed_text_idx = None;
     }
 
     pub(super) fn build_input_title(&self) -> Line<'static> {

--- a/crates/harnx-tui/src/session_activity.rs
+++ b/crates/harnx-tui/src/session_activity.rs
@@ -1,0 +1,335 @@
+use crate::types::{Tui, TuiEvent};
+use harnx_core::event::{AgentEvent, SessionEvent, TurnEvent};
+use harnx_core::session::SessionLogEntry;
+use harnx_runtime::config::{GlobalConfig, LOCAL_CLUSTER_KEY};
+use harnx_runtime::nats_event_sink::SessionEventStream;
+use std::time::Duration;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::task::JoinHandle;
+
+const RECONNECT_DELAY: Duration = Duration::from_secs(1);
+type SessionTarget = (String, String);
+
+impl Tui {
+    pub(super) fn draw_with_session_activity<B>(
+        &mut self,
+        terminal: &mut ratatui::Terminal<B>,
+    ) -> anyhow::Result<()>
+    where
+        B: ratatui::backend::Backend,
+        B::Error: std::error::Error + Send + Sync + 'static,
+    {
+        self.sync_session_activity_monitor();
+        terminal.draw(|frame| self.draw(frame))?;
+        Ok(())
+    }
+
+    pub(super) async fn handle_session_activity(
+        &mut self,
+        session_id: String,
+        cluster: String,
+        active: bool,
+    ) {
+        let target = (session_id, cluster);
+        if self.session_activity_target.as_ref() != Some(&target) {
+            return;
+        }
+        if self.current_prompt_abort.is_some() {
+            return;
+        }
+        if self.app.llm_busy == active {
+            return;
+        }
+        if active {
+            self.app.llm_busy = true;
+            self.active_remote_session = Some(target);
+            self.refresh_input_chrome();
+        } else {
+            self.complete_main_prompt().await;
+        }
+    }
+
+    pub(super) async fn handle_turn_activity(
+        &mut self,
+        event: &AgentEvent,
+        is_sub_agent: bool,
+    ) -> bool {
+        if is_sub_agent {
+            return false;
+        }
+        match event {
+            AgentEvent::Turn(TurnEvent::Started) => {
+                self.app.llm_busy = true;
+                self.app.streaming_open = false;
+                self.app.main_streamed_text_idx = None;
+                self.refresh_input_chrome();
+                true
+            }
+            AgentEvent::Turn(TurnEvent::Ended { .. }) => {
+                self.flush_pending_thought();
+                self.app.streaming_open = false;
+                self.complete_main_prompt().await;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub(super) fn sync_session_activity_monitor(&mut self) {
+        let desired = self.session_activity_destination();
+        if desired == self.session_activity_target {
+            return;
+        }
+
+        self.stop_session_activity_monitor();
+        self.session_activity_target = desired.clone();
+        self.session_activity_handle = desired.map(|target| {
+            spawn_session_activity_monitor(self.config.clone(), self.event_tx.clone(), target)
+        });
+    }
+
+    fn stop_session_activity_monitor(&mut self) {
+        if let Some(handle) = self.session_activity_handle.take() {
+            handle.abort();
+        }
+    }
+
+    fn session_activity_destination(&self) -> Option<(String, String)> {
+        let config = self.config.read();
+        let session_id = config.session.as_ref()?.id().to_string();
+        let cluster = config
+            .remote_agent
+            .as_ref()
+            .map(|(_, cluster)| cluster.clone())
+            .unwrap_or_else(|| LOCAL_CLUSTER_KEY.to_string());
+        Some((session_id, cluster))
+    }
+}
+
+impl Drop for Tui {
+    fn drop(&mut self) {
+        self.stop_session_activity_monitor();
+    }
+}
+
+fn spawn_session_activity_monitor(
+    config: GlobalConfig,
+    event_tx: UnboundedSender<TuiEvent>,
+    target: SessionTarget,
+) -> JoinHandle<()> {
+    tokio::spawn(monitor_session_activity(config, event_tx, target))
+}
+
+async fn monitor_session_activity(
+    config: GlobalConfig,
+    event_tx: UnboundedSender<TuiEvent>,
+    target: SessionTarget,
+) {
+    loop {
+        if !monitor_session_connection(&config, &event_tx, &target).await {
+            return;
+        }
+        tokio::time::sleep(RECONNECT_DELAY).await;
+    }
+}
+
+async fn monitor_session_connection(
+    config: &GlobalConfig,
+    event_tx: &UnboundedSender<TuiEvent>,
+    target: &SessionTarget,
+) -> bool {
+    let mut stream = match attach_session_event_stream(config, target).await {
+        Ok(stream) => stream,
+        Err(error) => {
+            log::debug!(
+                "failed to attach session activity monitor: session_id={} cluster={} error={error:#}",
+                target.0,
+                target.1,
+            );
+            return true;
+        }
+    };
+    if !send_activity(event_tx, target, history_has_pending_turn(stream.history())) {
+        return false;
+    }
+    forward_session_activity(&mut stream, event_tx, target).await
+}
+
+async fn attach_session_event_stream(
+    config: &GlobalConfig,
+    target: &SessionTarget,
+) -> anyhow::Result<SessionEventStream> {
+    let config_snapshot = config.read().clone();
+    let client = config_snapshot.nats_client(&target.1).await?;
+    let jetstream = async_nats::jetstream::new(client.clone());
+    SessionEventStream::attach(jetstream, client, &target.0).await
+}
+
+async fn forward_session_activity(
+    stream: &mut SessionEventStream,
+    event_tx: &UnboundedSender<TuiEvent>,
+    target: &SessionTarget,
+) -> bool {
+    while let Some(envelope) = stream.next().await {
+        let active = stream
+            .should_render(&envelope)
+            .then(|| event_activity(&envelope.event))
+            .flatten();
+        let Some(active) = active else {
+            continue;
+        };
+        if !send_activity(event_tx, target, active) {
+            return false;
+        }
+    }
+    true
+}
+
+fn send_activity(
+    event_tx: &UnboundedSender<TuiEvent>,
+    target: &SessionTarget,
+    active: bool,
+) -> bool {
+    event_tx
+        .send(TuiEvent::SessionActivity {
+            session_id: target.0.clone(),
+            cluster: target.1.clone(),
+            active,
+        })
+        .is_ok()
+}
+
+fn event_activity(event: &AgentEvent) -> Option<bool> {
+    match event {
+        AgentEvent::Turn(TurnEvent::Started) => Some(true),
+        AgentEvent::Turn(TurnEvent::Ended { .. }) => Some(false),
+        AgentEvent::Turn(_)
+        | AgentEvent::Model(_)
+        | AgentEvent::Tool(_)
+        | AgentEvent::Status(_) => Some(true),
+        AgentEvent::Session(SessionEvent::CompactingStarted) => Some(true),
+        AgentEvent::Session(
+            SessionEvent::CompactingCompleted | SessionEvent::CompactingFailed(_),
+        ) => Some(false),
+        // Nested activity keeps the parent turn busy. A nested Ended event is
+        // not the parent session's terminal boundary.
+        AgentEvent::SubAgent { .. } => Some(true),
+        AgentEvent::Notice(_)
+        | AgentEvent::User(_)
+        | AgentEvent::Session(_)
+        | AgentEvent::Plan { .. } => None,
+    }
+}
+
+fn history_has_pending_turn(history: &[(u64, SessionLogEntry)]) -> bool {
+    let effective = harnx_core::session_reconstruct::apply_log_mutations_nats(history)
+        .unwrap_or_else(|_| history.to_vec());
+    let Some(latest_user_seq) = effective.iter().rev().find_map(|(seq, entry)| {
+        matches!(entry, SessionLogEntry::Message { role, .. } if role.is_user()).then_some(*seq)
+    }) else {
+        return false;
+    };
+
+    let has_terminal_failure = effective.iter().any(|(seq, entry)| {
+        *seq > latest_user_seq
+            && matches!(
+                entry,
+                SessionLogEntry::Error { .. } | SessionLogEntry::Cancel { .. }
+            )
+    });
+    let has_completed_turn = history.iter().any(|(_, entry)| {
+        matches!(
+            entry,
+            SessionLogEntry::TurnEnd { through_seq, .. } if *through_seq >= latest_user_seq
+        )
+    });
+
+    !has_terminal_failure && !has_completed_turn
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harnx_core::event::ModelEvent;
+    use harnx_core::message::{MessageContent, MessageRole};
+
+    fn message(role: MessageRole, text: &str) -> SessionLogEntry {
+        SessionLogEntry::Message {
+            id: None,
+            role,
+            content: MessageContent::Text(text.to_string()),
+            timestamp: None,
+            fence_token: None,
+        }
+    }
+
+    #[test]
+    fn pending_history_is_busy_until_the_durable_turn_boundary() {
+        let user = vec![(1, message(MessageRole::User, "question"))];
+        assert!(history_has_pending_turn(&user));
+
+        let intermediate_answer = vec![
+            (1, message(MessageRole::User, "question")),
+            (2, message(MessageRole::Assistant, "answer")),
+        ];
+        assert!(
+            history_has_pending_turn(&intermediate_answer),
+            "an assistant row can still be followed by stop-hook work"
+        );
+
+        let mut completed = intermediate_answer;
+        completed.push((
+            3,
+            SessionLogEntry::TurnEnd {
+                through_seq: 1,
+                fence_token: 7,
+                timestamp: None,
+            },
+        ));
+        assert!(!history_has_pending_turn(&completed));
+    }
+
+    #[test]
+    fn turn_boundary_does_not_hide_a_queued_user() {
+        let history = vec![
+            (1, message(MessageRole::User, "first")),
+            (2, message(MessageRole::User, "queued")),
+            (
+                3,
+                SessionLogEntry::TurnEnd {
+                    through_seq: 1,
+                    fence_token: 7,
+                    timestamp: None,
+                },
+            ),
+        ];
+
+        assert!(history_has_pending_turn(&history));
+    }
+
+    #[test]
+    fn only_the_parent_turn_end_marks_shared_activity_idle() {
+        assert_eq!(
+            event_activity(&AgentEvent::Model(ModelEvent::Final {
+                output: "done".to_string(),
+                usage: Default::default(),
+            })),
+            Some(true)
+        );
+        assert_eq!(
+            event_activity(&AgentEvent::Turn(TurnEvent::Ended {
+                outcome: Default::default(),
+            })),
+            Some(false)
+        );
+        assert_eq!(
+            event_activity(&AgentEvent::sub_agent(
+                Default::default(),
+                AgentEvent::Turn(TurnEvent::Ended {
+                    outcome: Default::default(),
+                }),
+            )),
+            Some(true)
+        );
+    }
+}

--- a/crates/harnx-tui/src/tests.rs
+++ b/crates/harnx-tui/src/tests.rs
@@ -18,6 +18,8 @@ use std::time::Duration;
 use tokio::sync::Notify;
 
 mod command_completion;
+mod delegation_tests;
+mod turn_activity_tests;
 
 fn yaml_to_json(yaml: &str) -> serde_json::Value {
     serde_yaml::from_str::<serde_json::Value>(yaml)
@@ -242,6 +244,13 @@ async fn pending_message_is_auto_sent_after_finish() {
     })))
     .await
     .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Turn(
+        harnx_core::event::TurnEvent::Ended {
+            outcome: Default::default(),
+        },
+    )))
+    .await
+    .unwrap();
 
     assert!(tui.app.llm_busy);
     assert!(tui.app.pending_message.is_none());
@@ -250,98 +259,6 @@ async fn pending_message_is_auto_sent_after_finish() {
             |entry| matches!(entry, TranscriptItem::UserText { text, .. } if text == "follow up"),
         );
     assert!(has_user_entry);
-}
-
-fn sub_agent_source() -> AgentSource {
-    AgentSource {
-        agent: "aristarchus".to_string(),
-        session_id: Some("sub-session-1".to_string()),
-        model: None,
-    }
-}
-
-/// A nested sub-agent's error (e.g. a transient LLM failure inside a
-/// delegated agent session) arrives as a `SubAgent`-wrapped `ModelEvent::Error`.
-/// It must NOT be mistaken for the end of the main prompt task: the
-/// delegating tool call is still in flight, so busy state and the queued
-/// pending message must survive. Otherwise the TUI shows idle (no spinner)
-/// while the agent loop is still running and output keeps streaming.
-#[tokio::test]
-async fn sub_agent_error_does_not_clear_llm_busy() {
-    let config = test_config();
-    let mut tui = Tui::init(&config).await.unwrap();
-    tui.app.llm_busy = true;
-    tui.queue_pending_message("follow up".to_string()).await;
-
-    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
-        sub_agent_source(),
-        AgentEvent::Model(ModelEvent::Error("sub-agent exploded".to_string())),
-    )))
-    .await
-    .unwrap();
-
-    assert!(
-        tui.app.llm_busy,
-        "sub-agent error must not clear the main busy flag"
-    );
-    // The queued message still belongs to the (still running) main task.
-    assert!(tui.app.pending_message.is_some());
-    assert!(tui.shared_pending_message.lock().await.is_some());
-    // The error itself is still surfaced in the transcript.
-    assert!(tui.app.transcript.iter().any(
-        |entry| matches!(entry, TranscriptItem::ErrorText(text) if text == "sub-agent exploded")
-    ));
-}
-
-/// Same as above for `ModelEvent::Final`: only a bare main-task Final may
-/// flip the TUI back to idle.
-#[tokio::test]
-async fn sub_agent_final_does_not_clear_llm_busy() {
-    let config = test_config();
-    let mut tui = Tui::init(&config).await.unwrap();
-    tui.app.llm_busy = true;
-    tui.queue_pending_message("follow up".to_string()).await;
-
-    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
-        sub_agent_source(),
-        AgentEvent::Model(ModelEvent::Final {
-            output: "sub-agent final text".to_string(),
-            usage: Default::default(),
-        }),
-    )))
-    .await
-    .unwrap();
-
-    assert!(
-        tui.app.llm_busy,
-        "sub-agent Final must not clear the main busy flag"
-    );
-    // The pending message must not be auto-submitted by a sub-agent Final.
-    assert!(tui.app.pending_message.is_some());
-    assert!(tui.shared_pending_message.lock().await.is_some());
-    // The sub-agent's final text is still rendered.
-    assert!(tui.app.transcript.iter().any(
-        |entry| matches!(entry, TranscriptItem::AssistantText { text, .. } if text == "sub-agent final text")
-    ));
-}
-
-#[tokio::test]
-async fn bare_final_clears_llm_busy() {
-    let config = test_config();
-    let mut tui = Tui::init(&config).await.unwrap();
-    tui.app.llm_busy = true;
-
-    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Final {
-        output: "main final text".to_string(),
-        usage: Default::default(),
-    })))
-    .await
-    .unwrap();
-
-    assert!(
-        !tui.app.llm_busy,
-        "bare Final must clear the main busy flag"
-    );
 }
 
 #[tokio::test]
@@ -373,6 +290,13 @@ async fn pending_dot_command_restores_attachments_before_running() {
         output: "done".to_string(),
         usage: Default::default(),
     })))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Turn(
+        harnx_core::event::TurnEvent::Ended {
+            outcome: Default::default(),
+        },
+    )))
     .await
     .unwrap();
 
@@ -570,7 +494,6 @@ async fn final_coalesces_streamed_multiline_assistant_text() {
     let mut tui = Tui::init(&config).await.unwrap();
 
     tui.app.llm_busy = true;
-    tui.app.streamed_text_this_turn = false;
 
     for chunk in ["Hello\n", "world\n", "Again"] {
         tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
@@ -599,7 +522,52 @@ async fn final_coalesces_streamed_multiline_assistant_text() {
         })
         .collect();
     assert_eq!(assistant_entries, vec!["Hello\nworld\nAgain"]);
-    assert!(!tui.app.streamed_text_this_turn);
+    assert!(tui.app.main_streamed_text_idx.is_none());
+}
+
+#[tokio::test]
+async fn parent_final_does_not_replace_newer_sub_agent_text() {
+    let config = test_config();
+    let mut tui = Tui::init(&config).await.unwrap();
+    tui.clear_transcript();
+
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+        ModelEvent::MessageChunk {
+            blocks: vec![ContentBlock::Text("parent streaming".to_string())],
+        },
+    )))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        AgentSource {
+            agent: "delegate".to_string(),
+            session_id: Some("delegate-session".to_string()),
+            model: None,
+        },
+        AgentEvent::Model(ModelEvent::Final {
+            output: "sub-agent result".to_string(),
+            usage: Default::default(),
+        }),
+    )))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Final {
+        output: "parent final".to_string(),
+        usage: Default::default(),
+    })))
+    .await
+    .unwrap();
+
+    let assistant_entries: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|entry| match entry {
+            TranscriptItem::AssistantText { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(assistant_entries, vec!["parent final", "sub-agent result"]);
 }
 
 #[tokio::test]
@@ -704,6 +672,48 @@ async fn final_only_coalesces_trailing_streamed_run_after_interruption() {
     assert!(transcript
         .iter()
         .any(|entry| matches!(entry, TranscriptItem::SystemText(text) if text == "tool output")));
+}
+
+#[tokio::test]
+async fn final_coalesces_streamed_text_before_trailing_status() {
+    let config = test_config();
+    let mut tui = Tui::init(&config).await.unwrap();
+
+    tui.app.llm_busy = true;
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(
+        ModelEvent::MessageChunk {
+            blocks: vec![ContentBlock::Text("fallback response".to_string())],
+        },
+    )))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Notice(NoticeEvent::Info(
+        "turn status".to_string(),
+    ))))
+    .await
+    .unwrap();
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Final {
+        output: "fallback response".to_string(),
+        usage: Default::default(),
+    })))
+    .await
+    .unwrap();
+
+    let assistant_entries: Vec<_> = tui
+        .app
+        .transcript
+        .iter()
+        .filter_map(|entry| match entry {
+            TranscriptItem::AssistantText { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(assistant_entries, vec!["fallback response"]);
+    assert!(tui
+        .app
+        .transcript
+        .iter()
+        .any(|entry| matches!(entry, TranscriptItem::SystemText(text) if text == "turn status")));
 }
 
 #[tokio::test]
@@ -2238,98 +2248,6 @@ async fn test_streaming_with_tool_calls() {
     harness.drain_and_settle().await.unwrap();
 }
 
-/// Test the specialist_session_handoff tool flow for sub-agent delegation.
-/// This test verifies that when the LLM returns a specialist_session_handoff tool call,
-/// the tool result includes the switch_agent data for the prompt loop to process.
-/// The actual agent switching is complex (requires agent files), so this test
-/// focuses on verifying the tool call appears in the TUI transcript.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_sub_agent_delegation_tool_appears() {
-    let config = test_config_with_mock_client_and_agent("coordinator", Some("delegation-test"));
-
-    // The mock returns specialist_session_handoff tool call, which gets processed
-    // The tool result will have switch_agent data, but we're just verifying
-    // the tool call appears in the transcript
-    let mock_client = Arc::new(
-        MockClient::builder()
-            .global_config(config.clone())
-            .add_turn(
-                MockTurnBuilder::new()
-                    .add_text_chunk("I'll delegate this task.")
-                    .add_tool_call(
-                        "specialist_session_handoff",
-                        serde_json::json!({
-                            "session_id": "handoff-session-1",
-                            "prompt": "Please help with this task"
-                        }),
-                    )
-                    .build(),
-            )
-            .build(),
-    );
-
-    let _guard = TestStateGuard::new(Some(mock_client.clone())).await;
-
-    let mut harness = TuiTestHarness::with_config(config.clone()).await;
-    harness.tui().clear_transcript();
-    harness.tui().app.transcript.push(TranscriptItem::UserText {
-        timestamp: None,
-        text: "Help me".to_string(),
-        seq: None,
-    });
-    harness
-        .tui()
-        .start_prompt(crate::types::PendingMessage {
-            text: "Help me".to_string(),
-            attachments: vec![],
-            attachment_dir: None,
-            paste_count: 0,
-        })
-        .await
-        .unwrap();
-
-    harness
-        .sync()
-        .wait_until_mock_exhausted(mock_client.as_ref(), Duration::from_secs(5))
-        .await
-        .unwrap();
-
-    // Process all pending events
-    loop {
-        match harness.tui().event_rx.try_recv() {
-            Ok(event) => {
-                harness.tui().handle_tui_event(event).await.unwrap();
-            }
-            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
-            Err(e) => panic!("Unexpected error receiving event: {e}"),
-        }
-    }
-    harness.render();
-
-    // Wait for the specialist_session_handoff tool call to appear on screen
-    harness
-        .wait_until_screen_contains("specialist_session_handoff", Duration::from_secs(3))
-        .await
-        .unwrap();
-
-    let screen = harness.screen_contents();
-
-    // Verify tool call appears with its arguments
-    assert!(
-        screen.contains("specialist_session_handoff"),
-        "Screen should show specialist_session_handoff tool call, got: {screen}"
-    );
-    assert!(
-        screen.contains("handoff-session-1"),
-        "Screen should show the target session id in tool call, got: {screen}"
-    );
-
-    // Don't use snapshot testing - the order of tool call display and tool result
-    // is non-deterministic due to async event processing. The assertions above
-    // verify the key content is present.
-
-    harness.drain_and_settle().await.unwrap();
-}
 #[tokio::test(flavor = "multi_thread")]
 async fn test_screen_overflow_and_word_wrap() {
     let config =
@@ -2934,6 +2852,15 @@ async fn test_pending_message_not_replayed_on_error() {
         .send(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Error(
             "boom".to_string(),
         ))))
+        .unwrap();
+    harness
+        .tui()
+        .event_tx
+        .send(TuiEvent::Agent(AgentEvent::Turn(
+            harnx_core::event::TurnEvent::Ended {
+                outcome: Default::default(),
+            },
+        )))
         .unwrap();
     harness.drain_and_settle().await.unwrap();
 
@@ -7363,7 +7290,7 @@ async fn session_picker_enter_loads_selected_session() {
 // --- Reconciliation: origin_* baseline is used, not post-activation state ---
 
 #[tokio::test]
-async fn session_picker_enter_reconciles_from_origin_not_current_agent() {
+async fn transcript_reconciliation_uses_origin_not_current_agent() {
     // This test verifies the transcript reconciliation fix: when the user goes
     // through AgentPicker → SessionPicker, the reconciliation must compare
     // against the state *before* agent activation (origin_*), not against the
@@ -7405,34 +7332,11 @@ async fn session_picker_enter_reconciles_from_origin_not_current_agent() {
         "sentinel should be present before picker action"
     );
 
-    let meta = harnx_runtime::config::SessionMeta {
-        id: format!("reconcile-{}", uuid::Uuid::new_v4()),
-        agent_name: Some("hermes".into()),
-        working_dir: Some("/tmp".into()),
-        git_branch: Some("main".into()),
-        git_remote: None,
-        session_id: None,
-        terminal_session_id: None,
-        title: None,
-        modified: None,
-    };
-
     // origin_agent = Some("apollo") simulates "user was on apollo before entering picker".
     // Current config has "hermes" active (post-activation).
     // Reconciliation should detect origin("apollo") != current("hermes") → clear transcript.
-    tui.app.modal = Some(crate::types::ModalState::SessionPicker {
-        sessions: vec![meta],
-        selected: 0,
-        origin_agent: Some("apollo".to_string()),
-        origin_session: None,
-        error: None,
-    });
+    tui.reconcile_transcript_after_command(None, Some("apollo".to_string()), ".session");
 
-    tui.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
-        .await
-        .unwrap();
-
-    assert!(tui.app.modal.is_none(), "modal should be dismissed");
     // Transcript should have been cleared by reconciliation (sentinel gone).
     assert!(
         !tui.app

--- a/crates/harnx-tui/src/tests/delegation_tests.rs
+++ b/crates/harnx-tui/src/tests/delegation_tests.rs
@@ -1,0 +1,102 @@
+use super::test_config_with_mock_client_and_agent;
+use crate::test_utils::TuiTestHarness;
+use crate::types::{PendingMessage, ToolCallBody, TranscriptItem};
+use harnx_runtime::client::TestStateGuard;
+use harnx_runtime::config::GlobalConfig;
+use harnx_runtime::test_utils::{MockClient, MockTurnBuilder};
+use std::sync::Arc;
+use std::time::Duration;
+
+fn handoff_mock_client(config: &GlobalConfig) -> Arc<MockClient> {
+    Arc::new(
+        MockClient::builder()
+            .global_config(config.clone())
+            .add_turn(
+                MockTurnBuilder::new()
+                    .add_text_chunk("I'll delegate this task.")
+                    .add_tool_call(
+                        "specialist_session_handoff",
+                        serde_json::json!({
+                            "session_id": "handoff-session-1",
+                            "prompt": "Please help with this task"
+                        }),
+                    )
+                    .build(),
+            )
+            .build(),
+    )
+}
+
+async fn drain_ready_events(harness: &mut TuiTestHarness) {
+    while let Ok(event) = harness.tui().event_rx.try_recv() {
+        harness.tui().handle_tui_event(event).await.unwrap();
+    }
+}
+
+fn handoff_body(harness: &mut TuiTestHarness) -> Option<ToolCallBody> {
+    harness
+        .tui()
+        .app
+        .transcript
+        .iter()
+        .find_map(|item| match item {
+            TranscriptItem::ToolCall {
+                tool_name, body, ..
+            } if tool_name == "specialist_session_handoff" => body.clone(),
+            _ => None,
+        })
+}
+
+async fn wait_for_handoff_body(harness: &mut TuiTestHarness) -> ToolCallBody {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        drain_ready_events(harness).await;
+        if let Some(body) = handoff_body(harness) {
+            return body;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "transcript never received specialist_session_handoff: {:?}",
+            harness.tui().app.transcript
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn specialist_handoff_tool_appears_in_transcript() {
+    let config = test_config_with_mock_client_and_agent("coordinator", Some("delegation-test"));
+    let mock_client = handoff_mock_client(&config);
+    let _guard = TestStateGuard::new(Some(mock_client.clone())).await;
+
+    let mut harness = TuiTestHarness::with_config(config).await;
+    harness.tui().clear_transcript();
+    harness.tui().app.transcript.push(TranscriptItem::UserText {
+        timestamp: None,
+        text: "Help me".to_string(),
+        seq: None,
+    });
+    harness
+        .tui()
+        .start_prompt(PendingMessage {
+            text: "Help me".to_string(),
+            attachments: vec![],
+            attachment_dir: None,
+            paste_count: 0,
+        })
+        .await
+        .unwrap();
+
+    harness
+        .sync()
+        .wait_until_mock_exhausted(mock_client.as_ref(), Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    let body = wait_for_handoff_body(&mut harness).await;
+    let body = match body {
+        ToolCallBody::Yaml(body) | ToolCallBody::Markdown(body) => body,
+    };
+    assert!(body.contains("handoff-session-1"));
+    harness.drain_and_settle().await.unwrap();
+}

--- a/crates/harnx-tui/src/tests/turn_activity_tests.rs
+++ b/crates/harnx-tui/src/tests/turn_activity_tests.rs
@@ -1,0 +1,131 @@
+use super::{line_to_plain, test_config};
+use crate::types::{TranscriptItem, Tui, TuiEvent, SPINNER_FRAMES};
+use harnx_core::event::{AgentEvent, AgentSource, ModelEvent, TurnEvent};
+
+fn sub_agent_source() -> AgentSource {
+    AgentSource {
+        agent: "aristarchus".to_string(),
+        session_id: Some("sub-session-1".to_string()),
+        model: None,
+    }
+}
+
+/// A nested sub-agent error must not end the parent prompt while its
+/// delegating tool call is still in flight.
+#[tokio::test]
+async fn sub_agent_error_does_not_clear_llm_busy() {
+    let config = test_config();
+    let mut tui = Tui::init(&config).await.unwrap();
+    tui.app.llm_busy = true;
+    tui.queue_pending_message("follow up".to_string()).await;
+
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        sub_agent_source(),
+        AgentEvent::Model(ModelEvent::Error("sub-agent exploded".to_string())),
+    )))
+    .await
+    .unwrap();
+
+    assert!(tui.app.llm_busy);
+    assert!(tui.app.pending_message.is_some());
+    assert!(tui.shared_pending_message.lock().await.is_some());
+    assert!(tui.app.transcript.iter().any(
+        |entry| matches!(entry, TranscriptItem::ErrorText(text) if text == "sub-agent exploded")
+    ));
+}
+
+#[tokio::test]
+async fn sub_agent_final_does_not_clear_llm_busy() {
+    let config = test_config();
+    let mut tui = Tui::init(&config).await.unwrap();
+    tui.app.llm_busy = true;
+    tui.queue_pending_message("follow up".to_string()).await;
+
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::sub_agent(
+        sub_agent_source(),
+        AgentEvent::Model(ModelEvent::Final {
+            output: "sub-agent final text".to_string(),
+            usage: Default::default(),
+        }),
+    )))
+    .await
+    .unwrap();
+
+    assert!(tui.app.llm_busy);
+    assert!(tui.app.pending_message.is_some());
+    assert!(tui.shared_pending_message.lock().await.is_some());
+    assert!(tui.app.transcript.iter().any(
+        |entry| matches!(entry, TranscriptItem::AssistantText { text, .. } if text == "sub-agent final text")
+    ));
+}
+
+#[tokio::test]
+async fn final_waits_for_turn_end_before_clearing_busy() {
+    let config = test_config();
+    let mut tui = Tui::init(&config).await.unwrap();
+
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Turn(TurnEvent::Started)))
+        .await
+        .unwrap();
+
+    assert!(tui.app.llm_busy);
+    assert!(SPINNER_FRAMES
+        .iter()
+        .any(|frame| line_to_plain(&tui.build_input_title()).starts_with(frame)));
+
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Model(ModelEvent::Final {
+        output: "main final text".to_string(),
+        usage: Default::default(),
+    })))
+    .await
+    .unwrap();
+
+    assert!(
+        tui.app.llm_busy,
+        "Final renders output but does not end a turn"
+    );
+
+    tui.handle_tui_event(TuiEvent::Agent(AgentEvent::Turn(TurnEvent::Ended {
+        outcome: Default::default(),
+    })))
+    .await
+    .unwrap();
+
+    assert!(!tui.app.llm_busy);
+}
+
+#[tokio::test]
+async fn shared_session_activity_starts_and_stops_spinner() {
+    let config = test_config();
+    let mut tui = Tui::init(&config).await.unwrap();
+    tui.session_activity_target = Some(("session-1".to_string(), "cluster-1".to_string()));
+
+    tui.handle_tui_event(TuiEvent::SessionActivity {
+        session_id: "session-1".to_string(),
+        cluster: "cluster-1".to_string(),
+        active: true,
+    })
+    .await
+    .unwrap();
+
+    assert!(tui.app.llm_busy);
+    assert_eq!(
+        tui.active_remote_session,
+        Some(("session-1".to_string(), "cluster-1".to_string()))
+    );
+    assert!(SPINNER_FRAMES
+        .iter()
+        .any(|frame| line_to_plain(&tui.build_input_title()).starts_with(frame)));
+
+    tui.handle_tui_event(TuiEvent::SessionActivity {
+        session_id: "session-1".to_string(),
+        cluster: "cluster-1".to_string(),
+        active: false,
+    })
+    .await
+    .unwrap();
+
+    assert!(!tui.app.llm_busy);
+    assert_eq!(tui.active_remote_session, None);
+    assert!(line_to_plain(&tui.build_input_title()).starts_with('•'));
+}

--- a/crates/harnx-tui/src/types.rs
+++ b/crates/harnx-tui/src/types.rs
@@ -48,6 +48,11 @@ pub struct Tui {
     /// The (session_id, cluster) of the remote agent currently running, if any.
     /// Set in `start_prompt` and cleared when the turn completes.
     pub(super) active_remote_session: Option<(String, String)>,
+    /// Session whose shared NATS turn activity is currently being observed.
+    pub(super) session_activity_target: Option<(String, String)>,
+    /// Background subscription that lets this TUI react to turns submitted by
+    /// another client attached to the same session.
+    pub(super) session_activity_handle: Option<JoinHandle<()>>,
     #[allow(private_interfaces)]
     pub(crate) app: App,
     pub(crate) event_tx: mpsc::UnboundedSender<TuiEvent>,
@@ -82,7 +87,10 @@ pub(super) struct App {
     /// Interleaving items (tool calls, notices, headings, …) end a run
     /// implicitly by becoming the trailing item themselves.
     pub(super) streaming_open: bool,
-    pub(super) streamed_text_this_turn: bool,
+    /// Transcript row containing the latest streamed parent-agent text for
+    /// this turn. Sub-agent rows must never become the replacement target for
+    /// the parent agent's canonical `ModelEvent::Final` output.
+    pub(super) main_streamed_text_idx: Option<usize>,
     pub(super) cache_valid_width: Option<u16>,
     pub(super) last_ui_output_source: Option<AgentSource>,
     pub(super) last_usage_source: Option<AgentSource>,
@@ -331,6 +339,18 @@ impl App {
 
 pub(crate) enum TuiEvent {
     Agent(harnx_core::event::AgentEvent),
+    /// The locally-owned prompt task has exited. `Turn::Ended` normally closes
+    /// busy state; this is the fallback for a lossy advisory or setup failure.
+    PromptTaskFinished {
+        task: AbortSignal,
+        error: Option<String>,
+    },
+    /// Shared activity observed directly from the session fan-out stream.
+    SessionActivity {
+        session_id: String,
+        cluster: String,
+        active: bool,
+    },
     /// Intermediate tool round completed; retained for queued-message tests.
     #[allow(dead_code)]
     ToolRoundComplete,

--- a/crates/harnx/tests/snapshots/tmux_e2e__retry_all_fail_shows_warnings_in_tui.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__retry_all_fail_shows_warnings_in_tui.snap
@@ -7,46 +7,46 @@ retry-agent
 🤖 retry-agent ▸ mock-llm:primary ▸ [SID]
 > hello
 
-error: Failed to call chat-completions api (client: mock-llm, model: mock-llm:primary)
-
-Caused by:
-    Internal Server Error (type: server_error) (status: 500)
-
 ⚠ Retryable error (status 500, Internal Server Error (type: server_error)), attempt 1/3. Retrying in 10ms...
-error: Failed to call chat-completions api (client: mock-llm, model: mock-llm:primary)
-
-Caused by:
-    Internal Server Error (type: server_error) (status: 500)
-
 ⚠ Retryable error (status 500, Internal Server Error (type: server_error)), attempt 2/3. Retrying in 20ms...
-error: Failed to call chat-completions api (client: mock-llm, model: mock-llm:primary)
-
-Caused by:
-    Internal Server Error (type: server_error) (status: 500)
-
 ⚠ Model 'mock-llm:primary' exhausted retries (error: Failed to call chat-completions api (client: mock-llm, model:
 mock-llm:primary)), cooldown 60s. Trying next fallback.
-error: Failed to call chat-completions api (client: mock-llm, model: mock-llm:fallback)
-
-Caused by:
-    Internal Server Error (type: server_error) (status: 500)
-
 ⚠ Retryable error (status 500, Internal Server Error (type: server_error)), attempt 1/3. Retrying in 10ms...
-error: Failed to call chat-completions api (client: mock-llm, model: mock-llm:fallback)
-
-Caused by:
-    Internal Server Error (type: server_error) (status: 500)
-
 ⚠ Retryable error (status 500, Internal Server Error (type: server_error)), attempt 2/3. Retrying in 20ms...
-error: Failed to call chat-completions api (client: mock-llm, model: mock-llm:fallback)
-
-Caused by:
-    Internal Server Error (type: server_error) (status: 500)
-
 ⚠ Model 'mock-llm:fallback' exhausted retries (error: Failed to call chat-completions api (client: mock-llm, model:
 mock-llm:fallback)), cooldown 60s. Trying next fallback.
-error: Failed to call chat-completions api (client: mock-llm, model: mock-llm:fallback): Internal Server Error (type:
-server_error) (status: 500)
+error: Failed to call chat-completions api (client: mock-llm, model: mock-llm:fallback)
+
+Caused by:
+    Internal Server Error (type: server_error) (status: 500)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 * 🤖 retry-agent ▸ mock-llm:primary ▸ [SID]

--- a/crates/harnx/tests/snapshots/tmux_e2e__retry_succeed_after_fallback_shows_transition.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__retry_succeed_after_fallback_shows_transition.snap
@@ -7,22 +7,22 @@ retry-agent
 🤖 retry-agent ▸ mock-llm:primary ▸ [SID]
 > hello
 
-error: Failed to call chat-completions api (client: mock-llm, model: mock-llm:primary)
-
-Caused by:
-    Primary down (type: server_error) (status: 500)
-
 ⚠ Retryable error (status 500, Primary down (type: server_error)), attempt 1/2. Retrying in 10ms...
-error: Failed to call chat-completions api (client: mock-llm, model: mock-llm:primary)
-
-Caused by:
-    Primary still down (type: server_error) (status: 500)
-
 ⚠ Model 'mock-llm:primary' exhausted retries (error: Failed to call chat-completions api (client: mock-llm, model:
 mock-llm:primary)), cooldown 60s. Trying next fallback.
 FALLBACK_SUCCESS: The fallback model handled it!
 
 🤖 retry-agent ▸   💬 [N]
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/crates/harnx/tests/snapshots/tmux_e2e__retry_succeed_after_retry_shows_warning_then_response.snap
+++ b/crates/harnx/tests/snapshots/tmux_e2e__retry_succeed_after_retry_shows_warning_then_response.snap
@@ -7,15 +7,15 @@ retry-agent
 🤖 retry-agent ▸ mock-llm:primary ▸ [SID]
 > hello
 
-error: Failed to call chat-completions api (client: mock-llm, model: mock-llm:primary)
-
-Caused by:
-    Temporary failure (type: server_error) (status: 500)
-
 ⚠ Retryable error (status 500, Temporary failure (type: server_error)), attempt 1/3. Retrying in 10ms...
 RETRY_SUCCESS_RESPONSE: Hello from the retried model!
 
 🤖 retry-agent ▸   💬 [N]
+
+
+
+
+
 
 
 


### PR DESCRIPTION
Model Final and TurnEnded events were emitted per provider invocation, allowing clients to treat a turn as idle between tool calls, stop-hook continuations, or queued context.

Move terminal lifecycle ownership to the full agent loop, persist an authoritative NATS TurnEnd boundary only after successful completion, and fail turns when authoritative session writes are lost. Harden local broker discovery and retries for owner handoffs under load.

Keep attached TUIs synchronized through shared session activity, and align AG-UI output and error sequencing without duplicate final text or redundant parent step events.

Closes #1484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable turn completion tracking so TUI and web clients stay synchronized, including after reconnects.
  - TUI now reflects activity from shared sessions and nested agents with improved busy-state handling.
  - Improved transcript rendering for compressed history, tool activity, and streamed responses.

- **Bug Fixes**
  - Prevented duplicated final text and misleading completion events.
  - Improved handling of partial model failures, cancellations, queued messages, and durable save failures.
  - Added bounded retries and timeouts for session and connection operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->