### PR TITLE
fix(nats): expose sub-agent session tools

### DIFF
--- a/.changeset/fix-subagent-tool-discovery.md
+++ b/.changeset/fix-subagent-tool-discovery.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Expose package-relative sub-agent session tools to agents and wait for their initial NATS registrations before starting the first turn.

--- a/crates/harnx-runtime/src/nats_worker/daemon_background.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon_background.rs
@@ -193,6 +193,7 @@ async fn start_subagent_toolset(start: SubagentToolsetStart) -> Result<JoinHandl
         jetstream,
         replicas,
     } = start;
+    let package = harnx_core::package_namespace::pkg_from_qualified(&agent).map(str::to_string);
     let registration_context = jetstream.clone();
     let toolset = Arc::new(SubagentToolset::new(
         agent,
@@ -201,13 +202,14 @@ async fn start_subagent_toolset(start: SubagentToolsetStart) -> Result<JoinHandl
         jetstream,
     ));
     let server_name = harnx_toolset::Toolset::name(toolset.as_ref()).to_string();
-    let identity_token = harnx_toolset::server_identity_token(None, "", &server_name);
+    let identity_token = harnx_toolset::server_identity_token(package.as_deref(), "", &server_name);
     let registration_key = harnx_toolset_server::registration_key(&instance_id, &identity_token);
     let connection = harnx_nats_common::connect::NatsConnection { client, replicas };
-    let server = tokio::spawn(harnx_toolset_server::serve_with_client(
+    let server = tokio::spawn(harnx_toolset_server::serve_with_client_and_identity(
         toolset,
         instance_id,
         connection,
+        harnx_toolset_server::RegistrationIdentity::new(package, ""),
     ));
 
     let registration = tokio::time::timeout(Duration::from_secs(5), async {
@@ -310,12 +312,11 @@ pub(super) async fn launch_worker_services(
     super::daemon::spawn_readiness_publisher(startup.client.clone(), daemon);
 
     let background = Arc::new(Mutex::new(None));
-    // There is no longer a global tool-server registration round for a
-    // session to wait on: `handle_activation` waits on the servers it just
-    // asked the reconciler to start instead. Start this already-settled so
-    // `await_initial_tool_registration` is a no-op, kept for the hooks/
-    // sub-agent-toolset background task shape rather than removed outright.
-    let (_tools_attempted_tx, tools_attempted) = tokio::sync::watch::channel(true);
+    // Session-specific tool servers are awaited during activation, but the
+    // worker-wide sub-agent toolsets still start in the background. Keep the
+    // first activation behind this barrier so its registry snapshot cannot
+    // race those registrations and cache an incomplete tool list.
+    let (tools_attempted_tx, tools_attempted) = tokio::sync::watch::channel(false);
 
     let all_tool_servers = all_enabled_tool_servers(config);
     let server_reconciler = build_server_reconciler(
@@ -334,6 +335,7 @@ pub(super) async fn launch_worker_services(
         instance_id: instance_id.clone(),
         slot: Arc::clone(&background),
         replicas: startup.replicas,
+        tools_attempted: tools_attempted_tx,
     });
 
     let session_index =
@@ -346,13 +348,9 @@ pub(super) async fn launch_worker_services(
     })
 }
 
-/// Historically blocked until the first tool-server registration round had
-/// finished, so a session's registry snapshot included whatever managed to
-/// come up. Tool servers now start per session (`handle_activation` awaits
-/// `ServerReconciler::session_started` directly), so `tools_attempted` is
-/// already settled by the time this runs and it returns immediately. Kept
-/// rather than removed so a future global round has somewhere to plug back
-/// in without re-threading `handle_activation`.
+/// Block until the worker's first sub-agent registration round has finished,
+/// so the session's registry snapshot includes every available delegation
+/// toolset. Session-specific tool servers have their own activation barrier.
 pub(super) async fn await_initial_tool_registration(
     tools_attempted: &tokio::sync::watch::Receiver<bool>,
 ) {
@@ -360,7 +358,7 @@ pub(super) async fn await_initial_tool_registration(
         return;
     }
     let mut attempted = tools_attempted.clone();
-    log::debug!("waiting for the first tool-server registration round");
+    log::debug!("waiting for the first sub-agent tool registration round");
     // The only sender lives in the background task; if it is gone the round can
     // never complete and there is nothing left to wait for. Cap the wait so a
     // wedged round costs the session its tools rather than the whole turn — the
@@ -374,7 +372,7 @@ pub(super) async fn await_initial_tool_registration(
     .is_err()
     {
         log::warn!(
-            "tool servers did not finish their first registration round within {}s; \
+            "sub-agent tools did not finish their first registration round within {}s; \
              starting this session with the tools registered so far",
             INITIAL_TOOL_REGISTRATION_WAIT.as_secs()
         );
@@ -390,6 +388,7 @@ struct BackgroundServicesCtx {
     instance_id: harnx_core::instance::ServerScope,
     slot: Arc<Mutex<Option<BackgroundServices>>>,
     replicas: usize,
+    tools_attempted: tokio::sync::watch::Sender<bool>,
 }
 
 fn spawn_background_services(ctx: BackgroundServicesCtx) {
@@ -402,13 +401,11 @@ fn spawn_background_services(ctx: BackgroundServicesCtx) {
             instance_id,
             slot,
             replicas,
+            tools_attempted,
         } = ctx;
         // Tool servers aren't started here anymore — each session's own
         // servers start on demand through `WorkerRuntime::server_reconciler`.
         let (_worker_tool_servers, global_hooks) = configured_worker_services(&config);
-        let global_hook_supervisor =
-            start_global_hooks(&daemon, client.clone(), &instance_id, &global_hooks).await;
-
         let mut subagent_tool_servers = Vec::new();
         for agent in list_agents() {
             match start_subagent_toolset(SubagentToolsetStart {
@@ -428,6 +425,13 @@ fn spawn_background_services(ctx: BackgroundServicesCtx) {
                 }
             }
         }
+        // Release waiting activations once every sub-agent registration has
+        // either succeeded or failed. Global hooks are independent and must
+        // not delay delegation-tool discovery.
+        let _ = tools_attempted.send(true);
+
+        let global_hook_supervisor =
+            start_global_hooks(&daemon, client.clone(), &instance_id, &global_hooks).await;
 
         *slot.lock().await = Some(BackgroundServices {
             _global_hook_supervisor: global_hook_supervisor,

--- a/crates/harnx-runtime/src/nats_worker/subagent_toolset.rs
+++ b/crates/harnx-runtime/src/nats_worker/subagent_toolset.rs
@@ -94,18 +94,17 @@ impl SubagentToolset {
         timeouts: SubagentTimeouts,
     ) -> Self {
         let agent = agent.into();
+        let server_name = agent
+            .rsplit_once('/')
+            .map_or(agent.as_str(), |(_, stem)| stem);
         Self {
-            server_name: sanitize_for_tool_name(&agent),
+            server_name: sanitize_for_tool_name(server_name),
             agent,
             cluster: cluster.into(),
             client,
             jetstream,
             timeouts,
         }
-    }
-
-    fn tool_name(&self, method: &str) -> String {
-        format!("{}_session_{method}", self.server_name)
     }
 
     async fn create_session(
@@ -266,7 +265,7 @@ impl SubagentToolset {
         args: Value,
         cancel: CancellationToken,
     ) -> Result<Value, ToolInvokeError> {
-        let args: NewSessionArgs = parse_args(&self.tool_name("new"), args)?;
+        let args: NewSessionArgs = parse_args("session_new", args)?;
         let result = self
             .run_prompt(
                 SESSION_NEW_INITIAL_PROMPT,
@@ -283,7 +282,7 @@ impl SubagentToolset {
         args: Value,
         cancel: CancellationToken,
     ) -> Result<Value, ToolInvokeError> {
-        let args: PromptArgs = parse_args(&self.tool_name("prompt"), args)?;
+        let args: PromptArgs = parse_args("session_prompt", args)?;
         if args.message.trim().is_empty() {
             return Err(ToolInvokeError::Recoverable(
                 "message must not be empty".to_string(),
@@ -315,7 +314,7 @@ impl SubagentToolset {
     }
 
     async fn session_load(&self, args: Value) -> Result<Value, ToolInvokeError> {
-        let args: SessionArgs = parse_args(&self.tool_name("load"), args)?;
+        let args: SessionArgs = parse_args("session_load", args)?;
         let session_id = required_session_id(args.session_id)?;
         let events = NatsSessionLog::new(self.jetstream.clone(), session_id.clone())
             .load_events_async()
@@ -329,7 +328,7 @@ impl SubagentToolset {
     }
 
     async fn session_cancel(&self, args: Value) -> Result<Value, ToolInvokeError> {
-        let args: SessionArgs = parse_args(&self.tool_name("cancel"), args)?;
+        let args: SessionArgs = parse_args("session_cancel", args)?;
         let session_id = required_session_id(args.session_id)?;
         publish_control_command(&self.client, &session_id, &ControlCommand::Cancel)
             .await
@@ -409,7 +408,7 @@ impl Toolset for SubagentToolset {
     }
 
     fn tools(&self) -> Vec<ToolSpec> {
-        tool_specs(&self.agent, &self.server_name, self.timeouts)
+        tool_specs(&self.agent, self.timeouts)
     }
 
     async fn invoke(
@@ -418,13 +417,13 @@ impl Toolset for SubagentToolset {
         args: Value,
         cancel: CancellationToken,
     ) -> Result<Value, ToolInvokeError> {
-        if tool == self.tool_name("new") {
+        if tool == "session_new" {
             self.session_new(args, cancel).await
-        } else if tool == self.tool_name("prompt") {
+        } else if tool == "session_prompt" {
             self.session_prompt(args, cancel).await
-        } else if tool == self.tool_name("load") {
+        } else if tool == "session_load" {
             self.session_load(args).await
-        } else if tool == self.tool_name("cancel") {
+        } else if tool == "session_cancel" {
             self.session_cancel(args).await
         } else {
             Err(ToolInvokeError::Recoverable(format!(
@@ -434,22 +433,23 @@ impl Toolset for SubagentToolset {
     }
 }
 
-fn tool_specs(agent: &str, server_name: &str, timeouts: SubagentTimeouts) -> Vec<ToolSpec> {
+fn tool_specs(agent: &str, timeouts: SubagentTimeouts) -> Vec<ToolSpec> {
     let request_timeout = timeouts.operation.as_secs().saturating_add(5);
+    let display_name = sanitize_for_tool_name(agent);
     vec![
-        session_new_spec(agent, server_name, request_timeout),
-        session_prompt_spec(agent, server_name, request_timeout),
-        session_id_tool_spec(agent, server_name, SessionIdTool::Load),
-        session_id_tool_spec(agent, server_name, SessionIdTool::Cancel),
+        session_new_spec(agent, &display_name, request_timeout),
+        session_prompt_spec(agent, &display_name, request_timeout),
+        session_id_tool_spec(agent, &display_name, SessionIdTool::Load),
+        session_id_tool_spec(agent, &display_name, SessionIdTool::Cancel),
     ]
 }
 
 /// A truncated session ID, so the call header stays one short line.
 const SHORT_SESSION_ID: &str = "{{ args.session_id | truncate(8, end='') }}";
 
-fn session_new_spec(agent: &str, server_name: &str, request_timeout: u64) -> ToolSpec {
+fn session_new_spec(agent: &str, display_name: &str, request_timeout: u64) -> ToolSpec {
     ToolSpec {
-        name: format!("{server_name}_session_new"),
+        name: "session_new".to_string(),
         description: format!("Create a new session on the '{agent}' agent"),
         input_schema: json!({ "type": "object", "properties": {} }),
         idempotent_hint: false,
@@ -457,12 +457,12 @@ fn session_new_spec(agent: &str, server_name: &str, request_timeout: u64) -> Too
         timeout_secs: Some(request_timeout),
         meta: None,
     }
-    .with_call_template(&format!("@ {server_name} new session"))
+    .with_call_template(&format!("@ {display_name} new session"))
 }
 
-fn session_prompt_spec(agent: &str, server_name: &str, request_timeout: u64) -> ToolSpec {
+fn session_prompt_spec(agent: &str, display_name: &str, request_timeout: u64) -> ToolSpec {
     ToolSpec {
-        name: format!("{server_name}_session_prompt"),
+        name: "session_prompt".to_string(),
         description: format!(
             "Send a prompt to the '{agent}' agent. To continue a conversation, pass only the exact session_id returned by session_prompt or session_new. To start a new conversation, omit session_id; empty or whitespace-only values also start a new session. Do not invent a session ID."
         ),
@@ -486,7 +486,7 @@ fn session_prompt_spec(agent: &str, server_name: &str, request_timeout: u64) -> 
         meta: None,
     }
     .with_call_template(&format!(
-        "@ {server_name}{{% if args.session_id %}} [{SHORT_SESSION_ID}]{{% endif %}}\n{{{{ args.message }}}}"
+        "@ {display_name}{{% if args.session_id %}} [{SHORT_SESSION_ID}]{{% endif %}}\n{{{{ args.message }}}}"
     ))
 }
 
@@ -520,10 +520,10 @@ impl SessionIdTool {
     }
 }
 
-fn session_id_tool_spec(agent: &str, server_name: &str, tool: SessionIdTool) -> ToolSpec {
+fn session_id_tool_spec(agent: &str, display_name: &str, tool: SessionIdTool) -> ToolSpec {
     let verb = tool.verb();
     ToolSpec {
-        name: format!("{server_name}_session_{verb}"),
+        name: format!("session_{verb}"),
         description: tool.describe(agent),
         input_schema: json!({
             "type": "object",
@@ -540,7 +540,7 @@ fn session_id_tool_spec(agent: &str, server_name: &str, tool: SessionIdTool) -> 
         timeout_secs: Some(60),
         meta: None,
     }
-    .with_call_template(&format!("@ {server_name} {verb} {SHORT_SESSION_ID}"))
+    .with_call_template(&format!("@ {display_name} {verb} {SHORT_SESSION_ID}"))
 }
 
 #[cfg(test)]
@@ -551,7 +551,6 @@ mod tests {
     fn generates_four_agent_session_tools_with_stable_schemas() {
         let tools = tool_specs(
             "pkg/helper",
-            "pkg__helper",
             SubagentTimeouts::new(Duration::from_secs(3), Duration::from_secs(7)),
         );
         assert_eq!(
@@ -560,10 +559,10 @@ mod tests {
                 .map(|tool| tool.name.as_str())
                 .collect::<Vec<_>>(),
             vec![
-                "pkg__helper_session_new",
-                "pkg__helper_session_prompt",
-                "pkg__helper_session_load",
-                "pkg__helper_session_cancel",
+                "session_new",
+                "session_prompt",
+                "session_load",
+                "session_cancel",
             ]
         );
         assert_eq!(
@@ -583,7 +582,6 @@ mod tests {
     fn every_session_tool_advertises_a_call_template() {
         let tools = tool_specs(
             "pkg/helper",
-            "pkg__helper",
             SubagentTimeouts::new(Duration::from_secs(3), Duration::from_secs(7)),
         );
 

--- a/crates/harnx-runtime/src/nats_worker/tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests.rs
@@ -32,7 +32,10 @@ use std::time::Duration;
 use tokio::sync::{Mutex as AsyncMutex, Notify};
 use tokio_util::sync::CancellationToken;
 
+mod subagent_discovery_tests;
 mod transcript_render_tests;
+
+use subagent_discovery_tests::{call_registered_agent, registered_agent_provider};
 
 /// Spawn a local JetStream-enabled nats-server on a free port with an isolated
 /// temp store dir, returning the connect URL, the child process, and the temp
@@ -1532,127 +1535,6 @@ async fn remote_cancel_published_after_in_flight_marks_session_cancelled() {
     let _ = child.wait();
 }
 
-async fn registered_agent_provider(
-    jetstream: &async_nats::jetstream::Context,
-    config: &Config,
-    agents: &[&str],
-) -> (
-    String,
-    Arc<crate::nats_tool_provider::NatsToolProvider>,
-    Vec<(String, harnx_toolset::Registration)>,
-) {
-    let (instance_id, registrations) = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            if let Ok(registry) = jetstream
-                .get_key_value(harnx_toolset_server::TOOL_REGISTRY_BUCKET)
-                .await
-            {
-                let mut keys = registry.keys().await.expect("list registry keys");
-                let mut registrations = Vec::new();
-                while let Some(key) = keys.next().await {
-                    let key = key.expect("read registry key");
-                    let Some(value) = registry.get(&key).await.expect("read registration") else {
-                        continue;
-                    };
-                    let registration: harnx_toolset::Registration =
-                        serde_json::from_slice(&value).expect("decode registration");
-                    registrations.push((key, registration));
-                }
-                if agents.iter().all(|agent| {
-                    registrations
-                        .iter()
-                        .any(|(_, registration)| registration.server == *agent)
-                }) {
-                    let agent = agents.first().expect("at least one requested agent");
-                    let key = registrations
-                        .iter()
-                        .find(|(_, registration)| registration.server == *agent)
-                        .map(|(key, _)| key)
-                        .expect("requested agent registration exists");
-                    let instance_id = key
-                        .strip_suffix(&format!(".____{agent}"))
-                        .expect("registry key uses {instance}.{identity_token}")
-                        .to_string();
-                    break (instance_id, registrations);
-                }
-            }
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
-    })
-    .await
-    .expect("worker did not register configured agents");
-    let provider = crate::nats_tool_provider::NatsToolProvider::discover(
-        config,
-        harnx_core::instance::ServerScope::from_string(instance_id.clone()),
-        crate::nats_tool_provider::NatsInFlightCalls::default(),
-        None,
-    )
-    .await
-    .expect("parent discovers configured sub-agent toolsets");
-    (instance_id, Arc::new(provider), registrations)
-}
-
-async fn call_registered_agent(
-    provider: Arc<crate::nats_tool_provider::NatsToolProvider>,
-    tool: String,
-    message: String,
-    early_event: Option<(&mut async_nats::Subscriber, &str)>,
-) -> (serde_json::Value, Option<String>) {
-    let prompt_call = tokio::spawn(async move {
-        provider
-            .call_tool(
-                &tool,
-                json!({ "message": message }),
-                &harnx_core::abort::create_abort_signal(),
-            )
-            .await
-    });
-    let child_session_id = if let Some((parent_events, expected_agent)) = early_event {
-        let (agent, session_id) = tokio::time::timeout(Duration::from_secs(5), async {
-            loop {
-                let message = parent_events
-                    .next()
-                    .await
-                    .expect("parent event stream closed");
-                let envelope =
-                    crate::nats_event_sink::AdvisoryEnvelope::from_bytes(&message.payload)
-                        .expect("decode parent advisory");
-                if let AgentEvent::SubAgent { source, event } = envelope.event {
-                    if let AgentEvent::Turn(harnx_core::event::TurnEvent::SubAgentStarted {
-                        agent,
-                        session_id,
-                    }) = *event
-                    {
-                        assert_eq!(source.agent, agent);
-                        assert_eq!(source.session_id.as_deref(), Some(session_id.as_str()));
-                        break (agent, session_id);
-                    }
-                }
-            }
-        })
-        .await
-        .expect("parent did not receive early SubAgentStarted");
-        assert_eq!(agent, expected_agent);
-        assert!(
-            !prompt_call.is_finished(),
-            "SubAgentStarted must arrive before final tool result"
-        );
-        Some(session_id)
-    } else {
-        None
-    };
-    let result = prompt_call
-        .await
-        .expect("join prompt tool call")
-        .unwrap_or_else(|error| match error {
-            harnx_core::tool::ToolError::Recoverable(error)
-            | harnx_core::tool::ToolError::Fatal(error) => {
-                panic!("registered agent prompt failed: {error:#}")
-            }
-        });
-    (result, child_session_id)
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn worker_registers_and_delegates_to_every_configured_agent() {
     let _env_guard = env_lock().await;
@@ -1681,6 +1563,7 @@ async fn worker_registers_and_delegates_to_every_configured_agent() {
         &jetstream,
         &seeded.parent_config,
         &["alpha", "beta", "metis"],
+        None,
     )
     .await;
 
@@ -1695,17 +1578,17 @@ async fn worker_registers_and_delegates_to_every_configured_agent() {
         assert!(registration
             .tools
             .iter()
-            .all(|tool| tool.name.starts_with(&format!("{agent}_session_"))));
+            .all(|tool| tool.name.starts_with("session_")));
     }
 
     let declarations = provider.declarations_for_use_tools(Some("*"));
     for agent in ["alpha", "beta"] {
         assert!(declarations
             .iter()
-            .any(|tool| tool.name == format!("{agent}_{agent}_session_prompt")));
+            .any(|tool| tool.name == format!("{agent}_session_prompt")));
         let (result, _) = call_registered_agent(
             Arc::clone(&provider),
-            format!("{agent}_{agent}_session_prompt"),
+            format!("{agent}_session_prompt"),
             format!("delegate to {agent}"),
             None,
         )
@@ -1741,7 +1624,7 @@ async fn subagent_new_and_prompt_results_include_agent_source_marker() {
     .await;
 
     let created = toolset
-        .invoke("metis_session_new", json!({}), CancellationToken::new())
+        .invoke("session_new", json!({}), CancellationToken::new())
         .await
         .expect("create marked child session");
     let session_id = created["session_id"]
@@ -1754,7 +1637,7 @@ async fn subagent_new_and_prompt_results_include_agent_source_marker() {
 
     let prompted = toolset
         .invoke(
-            "metis_session_prompt",
+            "session_prompt",
             json!({ "message": "continue marked session", "session_id": session_id }),
             CancellationToken::new(),
         )
@@ -1808,7 +1691,7 @@ async fn subagent_started_reaches_parent_stream_before_prompt_result() {
         .expect("flush parent event subscription");
     let jetstream = async_nats::jetstream::new(client);
     let (_, provider, _) =
-        registered_agent_provider(&jetstream, &seeded.parent_config, &["metis"]).await;
+        registered_agent_provider(&jetstream, &seeded.parent_config, &["metis"], None).await;
     let (result, child_session_id) = call_registered_agent(
         provider,
         "metis_session_prompt".to_string(),
@@ -1847,7 +1730,7 @@ async fn subagent_new_prompt_reuse_and_load_share_one_session_log() {
     .await;
 
     let created = toolset
-        .invoke("metis_session_new", json!({}), CancellationToken::new())
+        .invoke("session_new", json!({}), CancellationToken::new())
         .await
         .expect("create and initialize child session");
     let session_id = created["session_id"]
@@ -1880,7 +1763,7 @@ async fn subagent_new_prompt_reuse_and_load_share_one_session_log() {
     ] {
         let result = toolset
             .invoke(
-                "metis_session_prompt",
+                "session_prompt",
                 json!({ "message": message, "session_id": session_id }),
                 CancellationToken::new(),
             )
@@ -1892,7 +1775,7 @@ async fn subagent_new_prompt_reuse_and_load_share_one_session_log() {
 
     let loaded = toolset
         .invoke(
-            "metis_session_load",
+            "session_load",
             json!({ "session_id": session_id }),
             CancellationToken::new(),
         )
@@ -1967,7 +1850,7 @@ async fn run_subagent_cancel_case(parent_abort: bool) {
         async move {
             toolset
                 .invoke(
-                    "metis_session_prompt",
+                    "session_prompt",
                     json!({ "message": "block until cancelled", "session_id": session_id }),
                     parent_cancel,
                 )
@@ -1983,7 +1866,7 @@ async fn run_subagent_cancel_case(parent_abort: bool) {
     } else {
         toolset
             .invoke(
-                "metis_session_cancel",
+                "session_cancel",
                 json!({ "session_id": session_id }),
                 CancellationToken::new(),
             )
@@ -2049,7 +1932,7 @@ async fn subagent_operation_timeout_returns_error_and_cancels_child() {
     let session_id = crate::nats_worker::new_remote_session_id();
     let error = toolset
         .invoke(
-            "metis_session_prompt",
+            "session_prompt",
             json!({ "message": "time out", "session_id": session_id }),
             CancellationToken::new(),
         )
@@ -2141,7 +2024,7 @@ async fn subagent_idle_timeout_resets_on_child_activity() {
     });
     let result = toolset
         .invoke(
-            "metis_session_prompt",
+            "session_prompt",
             json!({ "message": "stay active", "session_id": session_id }),
             CancellationToken::new(),
         )

--- a/crates/harnx-runtime/src/nats_worker/tests/subagent_discovery_tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests/subagent_discovery_tests.rs
@@ -1,0 +1,314 @@
+use super::*;
+
+fn registration_agent(registration: &harnx_toolset::Registration) -> String {
+    registration.package.as_ref().map_or_else(
+        || registration.server.clone(),
+        |package| format!("{package}/{}", registration.server),
+    )
+}
+
+pub(super) async fn registered_agent_provider(
+    jetstream: &async_nats::jetstream::Context,
+    config: &Config,
+    agents: &[&str],
+    active_package: Option<&str>,
+) -> (
+    String,
+    Arc<crate::nats_tool_provider::NatsToolProvider>,
+    Vec<(String, harnx_toolset::Registration)>,
+) {
+    let (instance_id, registrations) = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if let Ok(registry) = jetstream
+                .get_key_value(harnx_toolset_server::TOOL_REGISTRY_BUCKET)
+                .await
+            {
+                let mut keys = registry.keys().await.expect("list registry keys");
+                let mut registrations = Vec::new();
+                while let Some(key) = keys.next().await {
+                    let key = key.expect("read registry key");
+                    let Some(value) = registry.get(&key).await.expect("read registration") else {
+                        continue;
+                    };
+                    let registration = serde_json::from_slice(&value).expect("decode registration");
+                    registrations.push((key, registration));
+                }
+                if agents.iter().all(|agent| {
+                    registrations
+                        .iter()
+                        .any(|(_, registration)| registration_agent(registration) == *agent)
+                }) {
+                    let agent = agents.first().expect("at least one requested agent");
+                    let (key, registration) = registrations
+                        .iter()
+                        .find(|(_, registration)| registration_agent(registration) == *agent)
+                        .expect("requested agent registration exists");
+                    let identity =
+                        crate::server_identity::ServerIdentity::identity_token(registration);
+                    let instance_id = key
+                        .strip_suffix(&format!(".{identity}"))
+                        .expect("registry key uses {instance}.{identity_token}")
+                        .to_string();
+                    break (instance_id, registrations);
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("worker did not register configured agents");
+    let provider = crate::nats_tool_provider::NatsToolProvider::discover(
+        config,
+        harnx_core::instance::ServerScope::from_string(instance_id.clone()),
+        crate::nats_tool_provider::NatsInFlightCalls::default(),
+        active_package,
+    )
+    .await
+    .expect("parent discovers configured sub-agent toolsets");
+    (instance_id, Arc::new(provider), registrations)
+}
+
+pub(super) async fn call_registered_agent(
+    provider: Arc<crate::nats_tool_provider::NatsToolProvider>,
+    tool: String,
+    message: String,
+    early_event: Option<(&mut async_nats::Subscriber, &str)>,
+) -> (serde_json::Value, Option<String>) {
+    let prompt_call = tokio::spawn(async move {
+        provider
+            .call_tool(
+                &tool,
+                json!({ "message": message }),
+                &harnx_core::abort::create_abort_signal(),
+            )
+            .await
+    });
+    let child_session_id = if let Some((parent_events, expected_agent)) = early_event {
+        let (agent, session_id) = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let message = parent_events
+                    .next()
+                    .await
+                    .expect("parent event stream closed");
+                let envelope =
+                    crate::nats_event_sink::AdvisoryEnvelope::from_bytes(&message.payload)
+                        .expect("decode parent advisory");
+                if let AgentEvent::SubAgent { source, event } = envelope.event {
+                    if let AgentEvent::Turn(harnx_core::event::TurnEvent::SubAgentStarted {
+                        agent,
+                        session_id,
+                    }) = *event
+                    {
+                        assert_eq!(source.agent, agent);
+                        assert_eq!(source.session_id.as_deref(), Some(session_id.as_str()));
+                        break (agent, session_id);
+                    }
+                }
+            }
+        })
+        .await
+        .expect("parent did not receive early SubAgentStarted");
+        assert_eq!(agent, expected_agent);
+        assert!(
+            !prompt_call.is_finished(),
+            "SubAgentStarted must arrive before final tool result"
+        );
+        Some(session_id)
+    } else {
+        None
+    };
+    let result = prompt_call
+        .await
+        .expect("join prompt tool call")
+        .unwrap_or_else(|error| match error {
+            harnx_core::tool::ToolError::Recoverable(error)
+            | harnx_core::tool::ToolError::Fatal(error) => {
+                panic!("registered agent prompt failed: {error:#}")
+            }
+        });
+    (result, child_session_id)
+}
+
+fn write_package_agent(seeded: &SeededRemoteParentConfig, agent: &str, contents: &str) {
+    let agents_dir = seeded
+        .config_dir()
+        .join("packages")
+        .join("pantheon")
+        .join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("create package agents directory");
+    std::fs::write(agents_dir.join(format!("{agent}.md")), contents).expect("write package agent");
+}
+
+fn capture_selected_tools(
+    captured_tools: Arc<AsyncMutex<Vec<String>>>,
+) -> crate::agent_loop::AgentCallFn {
+    Arc::new(move |_input, config, _abort| {
+        let selected = {
+            let config = config.read();
+            let agent = config.agent.as_ref().expect("active package agent");
+            config
+                .select_tools(agent)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|tool| tool.name)
+                .collect::<Vec<_>>()
+        };
+        let captured_tools = Arc::clone(&captured_tools);
+        Box::pin(async move {
+            *captured_tools.lock().await = selected;
+            Ok((
+                "review complete".to_string(),
+                None,
+                vec![],
+                crate::client::CompletionTokenUsage::default(),
+            ))
+        })
+    })
+}
+
+fn write_registration_race_agents(seeded: &SeededRemoteParentConfig) {
+    write_package_agent(
+        seeded,
+        "aristarchus",
+        "---\nuse_tools:\n  - zzz-reviewer_session_prompt\n---\nReview coordinator\n",
+    );
+    for index in 0..16 {
+        write_package_agent(
+            seeded,
+            &format!("specialist-{index:02}"),
+            "---\n---\nConfigured package specialist\n",
+        );
+    }
+    write_package_agent(
+        seeded,
+        "zzz-reviewer",
+        "---\n---\nConfigured final package specialist\n",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn package_agent_sees_bare_same_package_delegation_tool() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut nats, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+    let seeded = seed_remote_config(&url);
+    let _env = subagent_test_env(&url, &seeded);
+    for agent in ["aristarchus", "pytheas"] {
+        write_package_agent(&seeded, agent, "---\n---\nConfigured package agent\n");
+    }
+
+    let captured = Arc::new(AsyncMutex::new(Vec::new()));
+    let daemon = spawn_metis_worker_with_call_fn(&url, echoing_call_fn(captured));
+    let client = async_nats::connect(&url)
+        .await
+        .expect("connect registry observer");
+    let jetstream = async_nats::jetstream::new(client);
+    let (instance_id, provider, registrations) = registered_agent_provider(
+        &jetstream,
+        &seeded.parent_config,
+        &["pantheon/pytheas"],
+        Some("pantheon"),
+    )
+    .await;
+
+    let (key, registration) = registrations
+        .iter()
+        .find(|(_, registration)| {
+            registration.package.as_deref() == Some("pantheon") && registration.server == "pytheas"
+        })
+        .expect("package agent registration exists");
+    assert_eq!(key, &format!("{instance_id}.pantheon____pytheas"));
+    let raw_tools: Vec<_> = registration
+        .tools
+        .iter()
+        .map(|tool| tool.name.as_str())
+        .collect();
+    assert_eq!(
+        raw_tools,
+        [
+            "session_new",
+            "session_prompt",
+            "session_load",
+            "session_cancel"
+        ]
+    );
+
+    let declarations = provider.declarations_for_use_tools(Some("pytheas_session_prompt"));
+    assert_eq!(declarations[0].name, "pytheas_session_prompt");
+    let (result, _) = call_registered_agent(
+        provider,
+        "pytheas_session_prompt".to_string(),
+        "assemble review context".to_string(),
+        None,
+    )
+    .await;
+    assert_eq!(
+        result["response"],
+        "stub remote reply over nats: assemble review context"
+    );
+
+    daemon.abort();
+    let _ = daemon.await;
+    let _ = nats.kill();
+    let _ = nats.wait();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn first_package_agent_turn_waits_for_delegation_registrations() {
+    let _env_guard = env_lock().await;
+    let Some((url, mut nats, _store_dir)) = spawn_test_nats().await else {
+        return;
+    };
+    let seeded = seed_remote_config(&url);
+    let _env = subagent_test_env(&url, &seeded);
+    write_registration_race_agents(&seeded);
+
+    let selected_tools = Arc::new(AsyncMutex::new(Vec::new()));
+    let call_fn = capture_selected_tools(Arc::clone(&selected_tools));
+    let client = async_nats::connect(&url)
+        .await
+        .expect("connect readiness observer");
+    let mut readiness = client
+        .subscribe(super::super::worker_ready_subject("local"))
+        .await
+        .expect("subscribe worker readiness");
+    client.flush().await.expect("flush readiness subscription");
+    let daemon = spawn_metis_worker_with_call_fn(&url, call_fn);
+    tokio::time::timeout(Duration::from_secs(5), readiness.next())
+        .await
+        .expect("worker readiness timed out")
+        .expect("worker readiness subscription closed");
+
+    let thin = ThinClientSession::new(
+        crate::ThinClientConfig {
+            cluster: "local".to_string(),
+            agent: "pantheon/aristarchus".to_string(),
+            session_id: None,
+        },
+        client.clone(),
+        async_nats::jetstream::new(client),
+        harnx_core::abort::create_abort_signal(),
+    )
+    .await
+    .expect("create package parent session");
+    // Keep a shorter test backstop than the production registration barrier so
+    // a regression fails promptly instead of consuming the full 30 seconds.
+    let result = tokio::time::timeout(
+        Duration::from_secs(15),
+        thin.run_turn("review this change", Arc::new(NoopEventSink), None),
+    )
+    .await
+    .expect("first package turn timed out")
+    .expect("first package turn failed");
+    assert_eq!(result.response.as_deref(), Some("review complete"));
+    assert_eq!(
+        selected_tools.lock().await.as_slice(),
+        ["zzz-reviewer_session_prompt"]
+    );
+
+    daemon.abort();
+    let _ = daemon.await;
+    let _ = nats.kill();
+    let _ = nats.wait();
+}

--- a/crates/harnx-toolset-server/src/lib.rs
+++ b/crates/harnx-toolset-server/src/lib.rs
@@ -2,7 +2,10 @@
 
 pub mod content;
 mod drain;
+mod registration_identity;
 pub mod schema;
+
+pub use registration_identity::RegistrationIdentity;
 
 use anyhow::{Context, Result};
 use async_nats::jetstream::{self, kv};
@@ -12,8 +15,7 @@ use harnx_core::instance::ServerScope;
 use harnx_nats_common::connect::NatsConnection;
 use harnx_toolset::{
     server_identity_token, ControlKind, ControlMessage, Registration, ToolErrorPayload,
-    ToolInvokeError, ToolReply, ToolRequest, Toolset, HARNX_SERVER_CONFIG, HARNX_SERVER_PACKAGE,
-    HDR_CALL_ID, HDR_IDEMPOTENCY_KEY,
+    ToolInvokeError, ToolReply, ToolRequest, Toolset, HDR_CALL_ID, HDR_IDEMPOTENCY_KEY,
 };
 use rmcp::model::{
     CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
@@ -72,6 +74,13 @@ struct ValidatedToolRequest {
     reply_subject: async_nats::Subject,
     request: ToolRequest,
     idempotency_key: String,
+}
+
+struct ServeSettings {
+    instance_id: ServerScope,
+    connection: NatsConnection,
+    shutdown: CancellationToken,
+    identity: RegistrationIdentity,
 }
 
 /// Everything `serve_requests` needs to keep the KV registration alive, bundled
@@ -145,9 +154,34 @@ pub async fn serve_with_client(
     instance_id: ServerScope,
     connection: NatsConnection,
 ) -> Result<()> {
+    serve_with_client_and_identity(
+        toolset,
+        instance_id,
+        connection,
+        RegistrationIdentity::from_env(),
+    )
+    .await
+}
+
+/// Serve an in-process toolset with an explicit package/config identity.
+pub async fn serve_with_client_and_identity(
+    toolset: Arc<dyn Toolset>,
+    instance_id: ServerScope,
+    connection: NatsConnection,
+    identity: RegistrationIdentity,
+) -> Result<()> {
     // Never cancelled: this entry point has no shutdown signal of its own, so
     // it only ever exits through `serve_requests`' bail! conditions.
-    serve_with_shutdown(toolset, instance_id, connection, CancellationToken::new()).await
+    serve_configured(
+        toolset,
+        ServeSettings {
+            instance_id,
+            connection,
+            shutdown: CancellationToken::new(),
+            identity,
+        },
+    )
+    .await
 }
 
 /// Serve a toolset using an existing NATS connection, exiting cleanly (and
@@ -159,12 +193,28 @@ pub async fn serve_with_shutdown(
     connection: NatsConnection,
     shutdown: CancellationToken,
 ) -> Result<()> {
+    serve_configured(
+        toolset,
+        ServeSettings {
+            instance_id,
+            connection,
+            shutdown,
+            identity: RegistrationIdentity::from_env(),
+        },
+    )
+    .await
+}
+
+async fn serve_configured(toolset: Arc<dyn Toolset>, settings: ServeSettings) -> Result<()> {
+    let ServeSettings {
+        instance_id,
+        connection,
+        shutdown,
+        identity,
+    } = settings;
     let NatsConnection { client, replicas } = connection;
     let server_name = toolset.name().to_owned();
-    let package = std::env::var(HARNX_SERVER_PACKAGE)
-        .ok()
-        .filter(|package| !package.is_empty());
-    let config = std::env::var(HARNX_SERVER_CONFIG).unwrap_or_default();
+    let RegistrationIdentity { package, config } = identity;
     let identity_token = server_identity_token(package.as_deref(), &config, &server_name);
     let tool_subject = instance_id.tool_subject(&identity_token, ">");
     let control_subject = instance_id.control_subject();
@@ -341,7 +391,7 @@ async fn process_tool_request(
         .await
         .insert(request.call_id.clone(), cancel.clone());
     let mut args = request.args;
-    if request.tool.ends_with("_session_prompt") || request.tool.ends_with("_session_new") {
+    if accepts_parent_session_id(&request.tool) {
         if let (Some(parent_session_id), Some(args)) =
             (request.parent_session_id, args.as_object_mut())
         {
@@ -366,6 +416,11 @@ async fn process_tool_request(
     )
     .await;
     publish_reply(&context.client, reply_subject, &reply).await
+}
+
+fn accepts_parent_session_id(tool: &str) -> bool {
+    // Sub-agent toolsets reserve these raw names for calls that start a child turn.
+    matches!(tool, "session_prompt" | "session_new")
 }
 
 async fn validate_tool_request(
@@ -715,5 +770,18 @@ mod tests {
             CacheReservation::Full
         ));
         assert_eq!(cache.lock().await.len(), IDEMPOTENCY_CACHE_MAX_ENTRIES);
+    }
+
+    #[test]
+    fn parent_session_id_supports_raw_session_start_tools() {
+        for tool in ["session_prompt", "session_new"] {
+            assert!(
+                accepts_parent_session_id(tool),
+                "expected support for {tool}"
+            );
+        }
+        assert!(!accepts_parent_session_id("session_load"));
+        assert!(!accepts_parent_session_id("prompt"));
+        assert!(!accepts_parent_session_id("agent_session_prompt"));
     }
 }

--- a/crates/harnx-toolset-server/src/registration_identity.rs
+++ b/crates/harnx-toolset-server/src/registration_identity.rs
@@ -1,0 +1,110 @@
+use harnx_toolset::{HARNX_SERVER_CONFIG, HARNX_SERVER_PACKAGE};
+
+/// Package/config identity attached to a NATS toolset registration.
+///
+/// Standalone tool servers normally obtain this from the environment. In-process
+/// servers can supply it explicitly so several differently-namespaced toolsets
+/// can share one process without mutating process-wide environment variables.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RegistrationIdentity {
+    /// Package namespace containing the tool server, if any.
+    pub package: Option<String>,
+    /// Tool-server configuration name, or an empty string when not configured.
+    pub config: String,
+}
+
+impl RegistrationIdentity {
+    /// Build a registration identity, treating an empty package as unscoped.
+    pub fn new(package: Option<String>, config: impl Into<String>) -> Self {
+        Self {
+            package: package.filter(|package| !package.is_empty()),
+            config: config.into(),
+        }
+    }
+
+    pub(crate) fn from_env() -> Self {
+        Self {
+            package: std::env::var(HARNX_SERVER_PACKAGE)
+                .ok()
+                .filter(|package| !package.is_empty()),
+            config: std::env::var(HARNX_SERVER_CONFIG).unwrap_or_default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvRestore {
+        package: Option<OsString>,
+        config: Option<OsString>,
+    }
+
+    impl EnvRestore {
+        fn capture() -> Self {
+            Self {
+                package: std::env::var_os(HARNX_SERVER_PACKAGE),
+                config: std::env::var_os(HARNX_SERVER_CONFIG),
+            }
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            set_env_var(HARNX_SERVER_PACKAGE, self.package.as_deref());
+            set_env_var(HARNX_SERVER_CONFIG, self.config.as_deref());
+        }
+    }
+
+    fn set_env_var(key: &str, value: Option<&std::ffi::OsStr>) {
+        // SAFETY: these tests serialize access and restore both variables before
+        // releasing the lock; production code only reads them.
+        unsafe {
+            if let Some(value) = value {
+                std::env::set_var(key, value);
+            } else {
+                std::env::remove_var(key);
+            }
+        }
+    }
+
+    #[test]
+    fn explicit_identity_normalizes_empty_package() {
+        assert_eq!(
+            RegistrationIdentity::new(Some(String::new()), "agent"),
+            RegistrationIdentity::new(None, "agent")
+        );
+    }
+
+    #[test]
+    fn environment_identity_handles_set_empty_and_unset_package() {
+        let _lock = ENV_LOCK.lock().expect("lock registration environment");
+        let _restore = EnvRestore::capture();
+
+        set_env_var(HARNX_SERVER_PACKAGE, Some(std::ffi::OsStr::new("pantheon")));
+        set_env_var(HARNX_SERVER_CONFIG, Some(std::ffi::OsStr::new("agent")));
+        assert_eq!(
+            RegistrationIdentity::from_env(),
+            RegistrationIdentity::new(Some("pantheon".to_string()), "agent")
+        );
+
+        set_env_var(HARNX_SERVER_PACKAGE, Some(std::ffi::OsStr::new("")));
+        set_env_var(HARNX_SERVER_CONFIG, None);
+        assert_eq!(
+            RegistrationIdentity::from_env(),
+            RegistrationIdentity::default()
+        );
+
+        set_env_var(HARNX_SERVER_PACKAGE, None);
+        set_env_var(HARNX_SERVER_CONFIG, Some(std::ffi::OsStr::new("agent")));
+        assert_eq!(
+            RegistrationIdentity::from_env(),
+            RegistrationIdentity::new(None, "agent")
+        );
+    }
+}

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -316,9 +316,9 @@ Harnx supports agent delegation, allowing a parent agent to run nested sub-agent
 Sub-agents in Harnx execute as standard NATS agent sessions (`ThinClientSession`). ACP (Agent Client Protocol) and its stdio child process architecture have been removed.
 
 - **Markdown-only agent definitions**: Agents are defined solely by Markdown files with YAML front-matter in `<config-dir>/agents/*.md` (or package agents). ACP server configuration (`acp_servers/*.yaml`) and ACP stdio child processes no longer exist.
-- **Auto-registered toolsets**: For every configured agent, the worker daemon registers a NATS-backed 4-tool toolset:
+- **Auto-registered toolsets**: For every configured agent, the worker daemon registers a NATS-backed 4-tool toolset. Each registration advertises the raw names `session_new`, `session_prompt`, `session_load`, and `session_cancel`; the provider exposes them to agents with an agent-relative prefix:
   - `{agent}_session_new`: Creates a new sub-agent session and returns its initial response along with session metadata.
-  - `{agent}_session_prompt`: Sends a prompt message (`message`, optional `session_id`, optional `parent_session_id`) to a sub-agent session, returning the sub-agent's final text response.
+  - `{agent}_session_prompt`: Sends a prompt message (`message`, optional `session_id`) to a sub-agent session, returning the sub-agent's final text response. The parent session ID is propagated internally.
   - `{agent}_session_load`: Reads prior event history for an existing sub-agent session log.
   - `{agent}_session_cancel`: Cancels an in-flight prompt on a sub-agent session.
 - **Worker-agnostic execution**: Sub-agent turns route via standard NATS JetStream WorkQueue subjects (`WORK_NOTIFY_<cluster>`) and acquire distributed KV locks (`harnx_leases`). Execution can run on any available worker in a cluster.
@@ -448,4 +448,3 @@ Agent prompts are rendered using [MiniJinja](https://github.com/mitsuhiko/miniji
 - `{{ agent.model }}`: The active model ID (e.g., `openai:gpt-4o`). This updates automatically if the agent falls back to a different model.
 - `{{ tools }}`: A list of available tools. You can iterate over them: `{% for t in tools %}- {{ t.name }}: {{ t.description }}{% endfor %}`.
 - `{{ __os__ }}`, `{{ __arch__ }}`, `{{ __shell__ }}`, `{{ __cwd__ }}`, `{{ __now__ }}`, `{{ __locale__ }}`: Environment and system information.
-


### PR DESCRIPTION
Register sub-agent toolsets with package-aware identities and raw session tool names so agents discover the correct package-relative delegation tools.

Wait for the initial sub-agent registration attempts before the first activation snapshots the registry, while preserving readiness and graceful startup degradation.

Normalize explicit registration identities, document the naming model, and add regression coverage for package discovery and the first-turn startup race.

Fixes #1489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sub-agent session tools are now automatically discovered and available to agents.
  * Initial agent turns wait for sub-agent tools to finish registering.
  * Session tools now use consistent names across packages.

* **Bug Fixes**
  * Improved delegation-tool discovery and registration timing.
  * Prevented unrelated tools from receiving parent-session parameters.

* **Documentation**
  * Updated guidance for sub-agent tools and session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->