### PR TITLE
fix(nats): harden sub-agent tool registration

### DIFF
--- a/crates/harnx-runtime/src/nats_worker/daemon_background.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon_background.rs
@@ -19,6 +19,7 @@ use crate::config::{
 };
 use anyhow::{Context, Result};
 use async_nats::jetstream;
+use futures_util::future::join_all;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
@@ -406,18 +407,20 @@ fn spawn_background_services(ctx: BackgroundServicesCtx) {
         // Tool servers aren't started here anymore — each session's own
         // servers start on demand through `WorkerRuntime::server_reconciler`.
         let (_worker_tool_servers, global_hooks) = configured_worker_services(&config);
-        let mut subagent_tool_servers = Vec::new();
-        for agent in list_agents() {
-            match start_subagent_toolset(SubagentToolsetStart {
+        let registrations = list_agents().into_iter().map(|agent| {
+            let start = SubagentToolsetStart {
                 agent: agent.clone(),
                 cluster: daemon.cluster.clone(),
                 instance_id: instance_id.clone(),
                 client: client.clone(),
                 jetstream: jetstream.clone(),
                 replicas,
-            })
-            .await
-            {
+            };
+            async move { (agent, start_subagent_toolset(start).await) }
+        });
+        let mut subagent_tool_servers = Vec::new();
+        for (agent, result) in join_all(registrations).await {
+            match result {
                 Ok(handle) => subagent_tool_servers.push(handle),
                 // One unusable sub-agent must not cost the others their toolset.
                 Err(error) => {

--- a/crates/harnx-runtime/src/nats_worker/subagent_toolset.rs
+++ b/crates/harnx-runtime/src/nats_worker/subagent_toolset.rs
@@ -8,7 +8,10 @@ use async_trait::async_trait;
 use harnx_core::event::{AgentEvent, AgentEventSink, AgentSource, TurnEvent};
 use harnx_core::package_namespace::sanitize_for_tool_name;
 use harnx_core::session::SessionLogEntry;
-use harnx_toolset::{ToolInvokeError, ToolSpec, Toolset};
+use harnx_toolset::{
+    ToolInvokeError, ToolSpec, Toolset, SUBAGENT_SESSION_CANCEL_TOOL, SUBAGENT_SESSION_LOAD_TOOL,
+    SUBAGENT_SESSION_NEW_TOOL, SUBAGENT_SESSION_PROMPT_TOOL,
+};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::sync::Arc;
@@ -265,7 +268,7 @@ impl SubagentToolset {
         args: Value,
         cancel: CancellationToken,
     ) -> Result<Value, ToolInvokeError> {
-        let args: NewSessionArgs = parse_args("session_new", args)?;
+        let args: NewSessionArgs = parse_args(SUBAGENT_SESSION_NEW_TOOL, args)?;
         let result = self
             .run_prompt(
                 SESSION_NEW_INITIAL_PROMPT,
@@ -282,7 +285,7 @@ impl SubagentToolset {
         args: Value,
         cancel: CancellationToken,
     ) -> Result<Value, ToolInvokeError> {
-        let args: PromptArgs = parse_args("session_prompt", args)?;
+        let args: PromptArgs = parse_args(SUBAGENT_SESSION_PROMPT_TOOL, args)?;
         if args.message.trim().is_empty() {
             return Err(ToolInvokeError::Recoverable(
                 "message must not be empty".to_string(),
@@ -314,7 +317,7 @@ impl SubagentToolset {
     }
 
     async fn session_load(&self, args: Value) -> Result<Value, ToolInvokeError> {
-        let args: SessionArgs = parse_args("session_load", args)?;
+        let args: SessionArgs = parse_args(SUBAGENT_SESSION_LOAD_TOOL, args)?;
         let session_id = required_session_id(args.session_id)?;
         let events = NatsSessionLog::new(self.jetstream.clone(), session_id.clone())
             .load_events_async()
@@ -328,7 +331,7 @@ impl SubagentToolset {
     }
 
     async fn session_cancel(&self, args: Value) -> Result<Value, ToolInvokeError> {
-        let args: SessionArgs = parse_args("session_cancel", args)?;
+        let args: SessionArgs = parse_args(SUBAGENT_SESSION_CANCEL_TOOL, args)?;
         let session_id = required_session_id(args.session_id)?;
         publish_control_command(&self.client, &session_id, &ControlCommand::Cancel)
             .await
@@ -417,13 +420,13 @@ impl Toolset for SubagentToolset {
         args: Value,
         cancel: CancellationToken,
     ) -> Result<Value, ToolInvokeError> {
-        if tool == "session_new" {
+        if tool == SUBAGENT_SESSION_NEW_TOOL {
             self.session_new(args, cancel).await
-        } else if tool == "session_prompt" {
+        } else if tool == SUBAGENT_SESSION_PROMPT_TOOL {
             self.session_prompt(args, cancel).await
-        } else if tool == "session_load" {
+        } else if tool == SUBAGENT_SESSION_LOAD_TOOL {
             self.session_load(args).await
-        } else if tool == "session_cancel" {
+        } else if tool == SUBAGENT_SESSION_CANCEL_TOOL {
             self.session_cancel(args).await
         } else {
             Err(ToolInvokeError::Recoverable(format!(
@@ -449,7 +452,7 @@ const SHORT_SESSION_ID: &str = "{{ args.session_id | truncate(8, end='') }}";
 
 fn session_new_spec(agent: &str, display_name: &str, request_timeout: u64) -> ToolSpec {
     ToolSpec {
-        name: "session_new".to_string(),
+        name: SUBAGENT_SESSION_NEW_TOOL.to_string(),
         description: format!("Create a new session on the '{agent}' agent"),
         input_schema: json!({ "type": "object", "properties": {} }),
         idempotent_hint: false,
@@ -462,7 +465,7 @@ fn session_new_spec(agent: &str, display_name: &str, request_timeout: u64) -> To
 
 fn session_prompt_spec(agent: &str, display_name: &str, request_timeout: u64) -> ToolSpec {
     ToolSpec {
-        name: "session_prompt".to_string(),
+        name: SUBAGENT_SESSION_PROMPT_TOOL.to_string(),
         description: format!(
             "Send a prompt to the '{agent}' agent. To continue a conversation, pass only the exact session_id returned by session_prompt or session_new. To start a new conversation, omit session_id; empty or whitespace-only values also start a new session. Do not invent a session ID."
         ),
@@ -497,6 +500,13 @@ enum SessionIdTool {
 }
 
 impl SessionIdTool {
+    fn tool_name(&self) -> &'static str {
+        match self {
+            Self::Load => SUBAGENT_SESSION_LOAD_TOOL,
+            Self::Cancel => SUBAGENT_SESSION_CANCEL_TOOL,
+        }
+    }
+
     fn verb(&self) -> &'static str {
         match self {
             Self::Load => "load",
@@ -523,7 +533,7 @@ impl SessionIdTool {
 fn session_id_tool_spec(agent: &str, display_name: &str, tool: SessionIdTool) -> ToolSpec {
     let verb = tool.verb();
     ToolSpec {
-        name: format!("session_{verb}"),
+        name: tool.tool_name().to_string(),
         description: tool.describe(agent),
         input_schema: json!({
             "type": "object",

--- a/crates/harnx-runtime/src/nats_worker/tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests.rs
@@ -35,8 +35,6 @@ use tokio_util::sync::CancellationToken;
 mod subagent_discovery_tests;
 mod transcript_render_tests;
 
-use subagent_discovery_tests::{call_registered_agent, registered_agent_provider};
-
 /// Spawn a local JetStream-enabled nats-server on a free port with an isolated
 /// temp store dir, returning the connect URL, the child process, and the temp
 /// dir guard. Using a free port + per-run store dir avoids cross-run state
@@ -1533,6 +1531,135 @@ async fn remote_cancel_published_after_in_flight_marks_session_cancelled() {
     let _ = daemon.await;
     let _ = child.kill();
     let _ = child.wait();
+}
+
+async fn registered_agent_provider(
+    jetstream: &async_nats::jetstream::Context,
+    config: &Config,
+    agents: &[&str],
+    active_package: Option<&str>,
+) -> (
+    String,
+    Arc<crate::nats_tool_provider::NatsToolProvider>,
+    Vec<(String, harnx_toolset::Registration)>,
+) {
+    let (instance_id, registrations) = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if let Ok(registry) = jetstream
+                .get_key_value(harnx_toolset_server::TOOL_REGISTRY_BUCKET)
+                .await
+            {
+                let mut keys = registry.keys().await.expect("list registry keys");
+                let mut registrations = Vec::new();
+                while let Some(key) = keys.next().await {
+                    let key = key.expect("read registry key");
+                    let Some(value) = registry.get(&key).await.expect("read registration") else {
+                        continue;
+                    };
+                    let registration: harnx_toolset::Registration =
+                        serde_json::from_slice(&value).expect("decode registration");
+                    registrations.push((key, registration));
+                }
+                let registration_agent = |registration: &harnx_toolset::Registration| {
+                    registration.package.as_ref().map_or_else(
+                        || registration.server.clone(),
+                        |package| format!("{package}/{}", registration.server),
+                    )
+                };
+                if agents.iter().all(|agent| {
+                    registrations
+                        .iter()
+                        .any(|(_, registration)| registration_agent(registration) == *agent)
+                }) {
+                    let agent = agents.first().expect("at least one requested agent");
+                    let (key, registration) = registrations
+                        .iter()
+                        .find(|(_, registration)| registration_agent(registration) == *agent)
+                        .expect("requested agent registration exists");
+                    let identity =
+                        crate::server_identity::ServerIdentity::identity_token(registration);
+                    let instance_id = key
+                        .strip_suffix(&format!(".{identity}"))
+                        .expect("registry key uses {instance}.{identity_token}")
+                        .to_string();
+                    break (instance_id, registrations);
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("worker did not register configured agents");
+    let provider = crate::nats_tool_provider::NatsToolProvider::discover(
+        config,
+        harnx_core::instance::ServerScope::from_string(instance_id.clone()),
+        crate::nats_tool_provider::NatsInFlightCalls::default(),
+        active_package,
+    )
+    .await
+    .expect("parent discovers configured sub-agent toolsets");
+    (instance_id, Arc::new(provider), registrations)
+}
+
+async fn call_registered_agent(
+    provider: Arc<crate::nats_tool_provider::NatsToolProvider>,
+    tool: String,
+    message: String,
+    early_event: Option<(&mut async_nats::Subscriber, &str)>,
+) -> (serde_json::Value, Option<String>) {
+    let prompt_call = tokio::spawn(async move {
+        provider
+            .call_tool(
+                &tool,
+                json!({ "message": message }),
+                &harnx_core::abort::create_abort_signal(),
+            )
+            .await
+    });
+    let child_session_id = if let Some((parent_events, expected_agent)) = early_event {
+        let (agent, session_id) = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let message = parent_events
+                    .next()
+                    .await
+                    .expect("parent event stream closed");
+                let envelope =
+                    crate::nats_event_sink::AdvisoryEnvelope::from_bytes(&message.payload)
+                        .expect("decode parent advisory");
+                if let AgentEvent::SubAgent { source, event } = envelope.event {
+                    if let AgentEvent::Turn(harnx_core::event::TurnEvent::SubAgentStarted {
+                        agent,
+                        session_id,
+                    }) = *event
+                    {
+                        assert_eq!(source.agent, agent);
+                        assert_eq!(source.session_id.as_deref(), Some(session_id.as_str()));
+                        break (agent, session_id);
+                    }
+                }
+            }
+        })
+        .await
+        .expect("parent did not receive early SubAgentStarted");
+        assert_eq!(agent, expected_agent);
+        assert!(
+            !prompt_call.is_finished(),
+            "SubAgentStarted must arrive before final tool result"
+        );
+        Some(session_id)
+    } else {
+        None
+    };
+    let result = prompt_call
+        .await
+        .expect("join prompt tool call")
+        .unwrap_or_else(|error| match error {
+            harnx_core::tool::ToolError::Recoverable(error)
+            | harnx_core::tool::ToolError::Fatal(error) => {
+                panic!("registered agent prompt failed: {error:#}")
+            }
+        });
+    (result, child_session_id)
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/harnx-runtime/src/nats_worker/tests/subagent_discovery_tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests/subagent_discovery_tests.rs
@@ -1,134 +1,5 @@
 use super::*;
 
-fn registration_agent(registration: &harnx_toolset::Registration) -> String {
-    registration.package.as_ref().map_or_else(
-        || registration.server.clone(),
-        |package| format!("{package}/{}", registration.server),
-    )
-}
-
-pub(super) async fn registered_agent_provider(
-    jetstream: &async_nats::jetstream::Context,
-    config: &Config,
-    agents: &[&str],
-    active_package: Option<&str>,
-) -> (
-    String,
-    Arc<crate::nats_tool_provider::NatsToolProvider>,
-    Vec<(String, harnx_toolset::Registration)>,
-) {
-    let (instance_id, registrations) = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            if let Ok(registry) = jetstream
-                .get_key_value(harnx_toolset_server::TOOL_REGISTRY_BUCKET)
-                .await
-            {
-                let mut keys = registry.keys().await.expect("list registry keys");
-                let mut registrations = Vec::new();
-                while let Some(key) = keys.next().await {
-                    let key = key.expect("read registry key");
-                    let Some(value) = registry.get(&key).await.expect("read registration") else {
-                        continue;
-                    };
-                    let registration = serde_json::from_slice(&value).expect("decode registration");
-                    registrations.push((key, registration));
-                }
-                if agents.iter().all(|agent| {
-                    registrations
-                        .iter()
-                        .any(|(_, registration)| registration_agent(registration) == *agent)
-                }) {
-                    let agent = agents.first().expect("at least one requested agent");
-                    let (key, registration) = registrations
-                        .iter()
-                        .find(|(_, registration)| registration_agent(registration) == *agent)
-                        .expect("requested agent registration exists");
-                    let identity =
-                        crate::server_identity::ServerIdentity::identity_token(registration);
-                    let instance_id = key
-                        .strip_suffix(&format!(".{identity}"))
-                        .expect("registry key uses {instance}.{identity_token}")
-                        .to_string();
-                    break (instance_id, registrations);
-                }
-            }
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
-    })
-    .await
-    .expect("worker did not register configured agents");
-    let provider = crate::nats_tool_provider::NatsToolProvider::discover(
-        config,
-        harnx_core::instance::ServerScope::from_string(instance_id.clone()),
-        crate::nats_tool_provider::NatsInFlightCalls::default(),
-        active_package,
-    )
-    .await
-    .expect("parent discovers configured sub-agent toolsets");
-    (instance_id, Arc::new(provider), registrations)
-}
-
-pub(super) async fn call_registered_agent(
-    provider: Arc<crate::nats_tool_provider::NatsToolProvider>,
-    tool: String,
-    message: String,
-    early_event: Option<(&mut async_nats::Subscriber, &str)>,
-) -> (serde_json::Value, Option<String>) {
-    let prompt_call = tokio::spawn(async move {
-        provider
-            .call_tool(
-                &tool,
-                json!({ "message": message }),
-                &harnx_core::abort::create_abort_signal(),
-            )
-            .await
-    });
-    let child_session_id = if let Some((parent_events, expected_agent)) = early_event {
-        let (agent, session_id) = tokio::time::timeout(Duration::from_secs(5), async {
-            loop {
-                let message = parent_events
-                    .next()
-                    .await
-                    .expect("parent event stream closed");
-                let envelope =
-                    crate::nats_event_sink::AdvisoryEnvelope::from_bytes(&message.payload)
-                        .expect("decode parent advisory");
-                if let AgentEvent::SubAgent { source, event } = envelope.event {
-                    if let AgentEvent::Turn(harnx_core::event::TurnEvent::SubAgentStarted {
-                        agent,
-                        session_id,
-                    }) = *event
-                    {
-                        assert_eq!(source.agent, agent);
-                        assert_eq!(source.session_id.as_deref(), Some(session_id.as_str()));
-                        break (agent, session_id);
-                    }
-                }
-            }
-        })
-        .await
-        .expect("parent did not receive early SubAgentStarted");
-        assert_eq!(agent, expected_agent);
-        assert!(
-            !prompt_call.is_finished(),
-            "SubAgentStarted must arrive before final tool result"
-        );
-        Some(session_id)
-    } else {
-        None
-    };
-    let result = prompt_call
-        .await
-        .expect("join prompt tool call")
-        .unwrap_or_else(|error| match error {
-            harnx_core::tool::ToolError::Recoverable(error)
-            | harnx_core::tool::ToolError::Fatal(error) => {
-                panic!("registered agent prompt failed: {error:#}")
-            }
-        });
-    (result, child_session_id)
-}
-
 fn write_package_agent(seeded: &SeededRemoteParentConfig, agent: &str, contents: &str) {
     let agents_dir = seeded
         .config_dir()
@@ -188,6 +59,7 @@ fn write_registration_race_agents(seeded: &SeededRemoteParentConfig) {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn package_agent_sees_bare_same_package_delegation_tool() {
+    harnx_core::require_nextest();
     let _env_guard = env_lock().await;
     let Some((url, mut nats, _store_dir)) = spawn_test_nats().await else {
         return;
@@ -256,6 +128,7 @@ async fn package_agent_sees_bare_same_package_delegation_tool() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn first_package_agent_turn_waits_for_delegation_registrations() {
+    harnx_core::require_nextest();
     let _env_guard = env_lock().await;
     let Some((url, mut nats, _store_dir)) = spawn_test_nats().await else {
         return;

--- a/crates/harnx-toolset-server/src/lib.rs
+++ b/crates/harnx-toolset-server/src/lib.rs
@@ -16,6 +16,7 @@ use harnx_nats_common::connect::NatsConnection;
 use harnx_toolset::{
     server_identity_token, ControlKind, ControlMessage, Registration, ToolErrorPayload,
     ToolInvokeError, ToolReply, ToolRequest, Toolset, HDR_CALL_ID, HDR_IDEMPOTENCY_KEY,
+    SUBAGENT_SESSION_NEW_TOOL, SUBAGENT_SESSION_PROMPT_TOOL,
 };
 use rmcp::model::{
     CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
@@ -420,7 +421,10 @@ async fn process_tool_request(
 
 fn accepts_parent_session_id(tool: &str) -> bool {
     // Sub-agent toolsets reserve these raw names for calls that start a child turn.
-    matches!(tool, "session_prompt" | "session_new")
+    matches!(
+        tool,
+        SUBAGENT_SESSION_PROMPT_TOOL | SUBAGENT_SESSION_NEW_TOOL
+    )
 }
 
 async fn validate_tool_request(

--- a/crates/harnx-toolset-server/src/registration_identity.rs
+++ b/crates/harnx-toolset-server/src/registration_identity.rs
@@ -83,6 +83,7 @@ mod tests {
 
     #[test]
     fn environment_identity_handles_set_empty_and_unset_package() {
+        harnx_core::require_nextest();
         let _lock = ENV_LOCK.lock().expect("lock registration environment");
         let _restore = EnvRestore::capture();
 

--- a/crates/harnx-toolset/src/lib.rs
+++ b/crates/harnx-toolset/src/lib.rs
@@ -129,6 +129,15 @@ pub struct ToolRequest {
     pub parent_session_id: Option<String>,
 }
 
+/// Raw tool name for creating a sub-agent session.
+pub const SUBAGENT_SESSION_NEW_TOOL: &str = "session_new";
+/// Raw tool name for prompting a sub-agent session.
+pub const SUBAGENT_SESSION_PROMPT_TOOL: &str = "session_prompt";
+/// Raw tool name for loading a sub-agent session.
+pub const SUBAGENT_SESSION_LOAD_TOOL: &str = "session_load";
+/// Raw tool name for cancelling a sub-agent session.
+pub const SUBAGENT_SESSION_CANCEL_TOOL: &str = "session_cancel";
+
 /// Serializable error returned in a [`ToolReply`].
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "message", rename_all = "snake_case")]
@@ -383,5 +392,13 @@ mod tests {
         assert_eq!(HDR_CALL_ID, "X-Harnx-Call-Id");
         assert_eq!(HDR_INSTANCE_ID, "X-Harnx-Instance-Id");
         assert_eq!(HDR_CONTENT_TYPE, "Content-Type");
+    }
+
+    #[test]
+    fn subagent_session_tool_names_are_stable() {
+        assert_eq!(SUBAGENT_SESSION_NEW_TOOL, "session_new");
+        assert_eq!(SUBAGENT_SESSION_PROMPT_TOOL, "session_prompt");
+        assert_eq!(SUBAGENT_SESSION_LOAD_TOOL, "session_load");
+        assert_eq!(SUBAGENT_SESSION_CANCEL_TOOL, "session_cancel");
     }
 }


### PR DESCRIPTION
Start configured sub-agent toolsets concurrently so the registration barrier is bounded by the slowest server instead of cumulative startup latency.

Centralize reserved sub-agent session tool names, require nextest for environment-sensitive coverage, and preserve NATS worker test cohesion. This addresses the CodeRabbit and CodeScene findings from #1492.