### PR TITLE
feat(cli): make one-shot prompts explicit

### DIFF
--- a/.changeset/explicit-cli-prompts.md
+++ b/.changeset/explicit-cli-prompts.md
@@ -1,0 +1,4 @@
+---
+harnx: minor
+---
+Add an explicit `prompt` CLI subcommand and require `--` before root-level prompt text, provide sober one-shot output with a `--final-only` mode, and always show the generated session resume command after standard one-shot runs.

--- a/README.md
+++ b/README.md
@@ -113,16 +113,16 @@ Explore powerful command-line functionalities with Harnx's CMD mode.
 
 Accept diverse input forms such as stdin, local files and directories, and remote URLs, allowing flexibility in data handling.
 
-| Input             | CMD                                  | TUI                              |
-| ----------------- | ------------------------------------ | -------------------------------- |
-| CMD               | `harnx hello`                       |                                  |
-| STDIN             | `cat data.txt \| harnx`             |                                  |
-| Last Reply        |                                      | `.file %%`                       |
-| Local files       | `harnx -f image.png -f data.txt`    | `.file image.png data.txt`       |
-| Local directories | `harnx -f dir/`                     | `.file dir/`                     |
-| Remote URLs       | `harnx -f https://example.com`      | `.file https://example.com`      |
-| External commands | ```harnx -f '`git diff`'```         | ```.file `git diff` ```          |
-| Combine Inputs    | `harnx -f dir/ -f data.txt explain` | `.file dir/ data.txt -- explain` |
+| Input             | CMD                                          | TUI                              |
+| ----------------- | -------------------------------------------- | -------------------------------- |
+| CMD               | `harnx prompt hello`                         |                                  |
+| STDIN             | `cat data.txt \| harnx prompt`              |                                  |
+| Last Reply        |                                              | `.file %%`                       |
+| Local files       | `harnx prompt -f image.png -f data.txt`     | `.file image.png data.txt`       |
+| Local directories | `harnx prompt -f dir/`                      | `.file dir/`                     |
+| Remote URLs       | `harnx prompt -f https://example.com`       | `.file https://example.com`      |
+| External commands | ```harnx prompt -f '`git diff`'```          | ```.file `git diff` ```          |
+| Combine Inputs    | `harnx prompt -f dir/ -f data.txt explain` | `.file dir/ data.txt -- explain` |
 
 ### Agents
 
@@ -301,4 +301,3 @@ See the LICENSE-APACHE and LICENSE-MIT files for license details.
 ## Lineage
 
 Harnx began as an independently continued derivative of [aichat](https://github.com/sigoden/aichat).
-

--- a/crates/harnx/src/agent_event_sink.rs
+++ b/crates/harnx/src/agent_event_sink.rs
@@ -34,12 +34,14 @@ pub fn install_cli_agent_event_sink(
     highlight: bool,
     render_options: RenderOptions,
     abort_signal: AbortSignal,
+    final_only: bool,
 ) {
-    install_agent_event_sink(Arc::new(CliAgentEventSink::new(
-        highlight,
-        render_options,
-        abort_signal,
-    )));
+    let sink = if final_only {
+        CliAgentEventSink::new_with_final_only(highlight, render_options, abort_signal)
+    } else {
+        CliAgentEventSink::new(highlight, render_options, abort_signal)
+    };
+    install_agent_event_sink(Arc::new(sink));
     debug_assert!(
         has_agent_event_sink(),
         "CLI AgentEventSink must be installed after startup call"

--- a/crates/harnx/src/cli.rs
+++ b/crates/harnx/src/cli.rs
@@ -8,92 +8,109 @@ use std::io::{stdin, Read};
     author,
     version,
     about,
-    long_about = None,
-    args_conflicts_with_subcommands = true
+    long_about = None
 )]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Commands>,
     /// Select a LLM model
-    #[clap(short, long, hide = true)]
+    #[clap(short, long, global = true, hide = true)]
     pub model: Option<String>,
     /// Use the system prompt
-    #[clap(long, hide = true)]
+    #[clap(long, global = true, hide = true)]
     pub prompt: Option<String>,
     /// Start or join a session
-    #[clap(short = 's', long, hide = true)]
+    #[clap(short = 's', long, global = true, hide = true)]
     pub session: Option<Option<String>>,
     /// Ensure the session is empty
-    #[clap(long, hide = true)]
+    #[clap(long, global = true, hide = true)]
     pub empty_session: bool,
     /// Start a agent
-    #[clap(short = 'a', long, hide = true)]
+    #[clap(short = 'a', long, global = true, hide = true)]
     pub agent: Option<String>,
     /// Set agent variable pairs (format: --agent-variable key value or -x key value); can be repeated
-    #[clap(short = 'x', long, value_names = ["KEY", "VALUE"], num_args = 2, action = clap::ArgAction::Append, hide = true)]
+    #[clap(short = 'x', long, value_names = ["KEY", "VALUE"], num_args = 2, action = clap::ArgAction::Append, global = true, hide = true)]
     pub agent_variable: Vec<String>,
     /// Use the RAG
-    #[clap(short = 'r', long, hide = true)]
+    #[clap(short = 'r', long, global = true, hide = true)]
     pub rag: Option<String>,
     /// Rebuild the RAG to sync document changes
-    #[clap(long, hide = true)]
+    #[clap(long, global = true, hide = true)]
     pub rebuild_rag: bool,
     /// File to include with the message
-    #[clap(short, long, value_name = "FILE", hide = true)]
+    #[clap(short, long, value_name = "FILE", global = true, hide = true)]
     pub file: Vec<String>,
     /// Highlight code with provided theme
-    #[clap(long, hide = true)]
+    #[clap(long, global = true, hide = true)]
     pub code_theme: Option<String>,
     /// Light theme for markdown rendering
-    #[clap(long, hide = true)]
+    #[clap(long, global = true, hide = true)]
     pub light_theme: bool,
     /// Execute macro command(s) from config by name
-    #[clap(long = "macro", value_name = "NAME", hide = true)]
+    #[clap(long = "macro", value_name = "NAME", global = true, hide = true)]
     pub macro_name: Option<String>,
     /// Disable streaming output
-    #[clap(long, hide = true)]
+    #[clap(long, global = true, hide = true)]
     pub no_stream: bool,
+    /// Print only the final response in non-interactive mode
+    #[clap(long, global = true, hide = true)]
+    pub final_only: bool,
     /// Display the message without sending it
-    #[clap(long, hide = true)]
+    #[clap(long, global = true, hide = true)]
     pub dry_run: bool,
     /// Display internal info
-    #[clap(long, hide = true)]
+    #[clap(long, global = true, hide = true)]
     pub info: bool,
     /// Sync models updates
-    #[clap(long, hide = true)]
+    #[clap(long, global = true, hide = true)]
     pub sync_models: bool,
     /// List all available chat models
-    #[clap(long, hide = true)]
+    #[clap(long, global = true, hide = true)]
     pub list_models: bool,
     /// List all sessions
-    #[clap(long, hide = true)]
+    #[clap(long, global = true, hide = true)]
     pub list_sessions: bool,
     /// List all agents
-    #[clap(long, hide = true)]
+    #[clap(long, global = true, hide = true)]
     pub list_agents: bool,
     /// List agents available for direct interaction (excludes subagent and compaction roles)
-    #[clap(long, hide = true)]
+    #[clap(long, global = true, hide = true)]
     pub list_assistant_agents: bool,
     /// List all RAGs
-    #[clap(long, hide = true)]
+    #[clap(long, global = true, hide = true)]
     pub list_rags: bool,
     /// List all macros
-    #[clap(long, hide = true)]
+    #[clap(long, global = true, hide = true)]
     pub list_macros: bool,
     /// Enable tools or toolsets for this session (can be repeated, also accepts toolset names)
-    #[clap(short = 't', long = "tool", value_name = "TOOL", hide = true)]
+    #[clap(
+        short = 't',
+        long = "tool",
+        value_name = "TOOL",
+        global = true,
+        hide = true
+    )]
     pub tool: Vec<String>,
-    /// Input text
-    #[clap(trailing_var_arg = true, hide = true)]
+    /// Input text after an explicit `--` separator
+    #[clap(last = true, hide = true)]
     text: Vec<String>,
 }
 
 #[derive(Subcommand, Debug, PartialEq, Eq)]
 pub enum Commands {
+    /// Run a non-interactive prompt
+    Prompt(PromptArgs),
     /// Inspect harnx state
     Info(InfoArgs),
     /// Session management commands
     Session(SessionArgs),
+}
+
+#[derive(Args, Debug, PartialEq, Eq)]
+pub struct PromptArgs {
+    /// Input text
+    #[arg(trailing_var_arg = true)]
+    text: Vec<String>,
 }
 
 #[derive(Args, Debug, PartialEq, Eq)]
@@ -141,35 +158,33 @@ impl Cli {
                 .read_to_string(&mut stdin_text)
                 .context("Invalid stdin pipe")?;
         };
-        match self.text.is_empty() {
-            true => {
-                if stdin_text.is_empty() {
-                    Ok(None)
-                } else {
-                    Ok(Some(stdin_text))
-                }
+        let text_args = match &self.command {
+            Some(Commands::Prompt(args)) => &args.text,
+            _ => &self.text,
+        };
+        if text_args.is_empty() {
+            if stdin_text.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(stdin_text))
             }
-            false => {
-                if self.macro_name.is_some() {
-                    let text = self
-                        .text
-                        .iter()
-                        .map(|v| shell_words::quote(v))
-                        .collect::<Vec<_>>()
-                        .join(" ");
-                    if stdin_text.is_empty() {
-                        Ok(Some(text))
-                    } else {
-                        Ok(Some(format!("{text} -- {stdin_text}")))
-                    }
-                } else {
-                    let text = self.text.join(" ");
-                    if stdin_text.is_empty() {
-                        Ok(Some(text))
-                    } else {
-                        Ok(Some(format!("{text}\n{stdin_text}")))
-                    }
-                }
+        } else if self.macro_name.is_some() {
+            let text = text_args
+                .iter()
+                .map(|v| shell_words::quote(v))
+                .collect::<Vec<_>>()
+                .join(" ");
+            if stdin_text.is_empty() {
+                Ok(Some(text))
+            } else {
+                Ok(Some(format!("{text} -- {stdin_text}")))
+            }
+        } else {
+            let text = text_args.join(" ");
+            if stdin_text.is_empty() {
+                Ok(Some(text))
+            } else {
+                Ok(Some(format!("{text}\n{stdin_text}")))
             }
         }
     }
@@ -216,14 +231,47 @@ mod tests {
         }
     }
 
-    /// The worker moved to the `harnx-worker` binary. `harnx worker` is no
-    /// longer a subcommand, so it falls through to the trailing prompt text
-    /// like any other unrecognized words.
     #[test]
-    fn worker_is_no_longer_a_subcommand() {
-        let cli = Cli::try_parse_from(["harnx", "worker", "--cluster", "prod"]).unwrap();
+    fn unrecognized_words_are_not_implicit_prompt_text() {
+        assert!(Cli::try_parse_from(["harnx", "worker", "--cluster", "prod"]).is_err());
+        assert!(Cli::try_parse_from(["harnx", "hello"]).is_err());
+    }
+
+    #[test]
+    fn parses_prompt_subcommand_with_options_before_or_after_it() {
+        let before = Cli::try_parse_from(["harnx", "--agent", "foo", "prompt", "hello"]).unwrap();
+        let after = Cli::try_parse_from(["harnx", "prompt", "--agent", "foo", "hello"]).unwrap();
+
+        for cli in [before, after] {
+            assert_eq!(cli.agent.as_deref(), Some("foo"));
+            assert_eq!(
+                cli.command,
+                Some(Commands::Prompt(super::PromptArgs {
+                    text: vec!["hello".to_string()],
+                }))
+            );
+        }
+    }
+
+    #[test]
+    fn parses_explicit_separator_prompt() {
+        let cli = Cli::try_parse_from(["harnx", "--agent", "foo", "--", "info"]).unwrap();
+
         assert!(cli.command.is_none());
-        assert_eq!(cli.text, vec!["worker", "--cluster", "prod"]);
+        assert_eq!(cli.agent.as_deref(), Some("foo"));
+        assert_eq!(cli.text, vec!["info"]);
+    }
+
+    #[test]
+    fn prompt_subcommand_accepts_option_like_text_after_separator() {
+        let cli = Cli::try_parse_from(["harnx", "prompt", "--", "review", "--staged"]).unwrap();
+
+        assert_eq!(
+            cli.command,
+            Some(Commands::Prompt(super::PromptArgs {
+                text: vec!["review".to_string(), "--staged".to_string()],
+            }))
+        );
     }
 }
 

--- a/crates/harnx/src/cli_event_sink.rs
+++ b/crates/harnx/src/cli_event_sink.rs
@@ -15,11 +15,11 @@ use harnx_core::event::{
 };
 
 use harnx_render::{MarkdownRender, RenderOptions};
-use harnx_runtime::utils::{dimmed_text, spawn_spinner, warning_text, Spinner, IS_STDOUT_TERMINAL};
+use harnx_runtime::utils::{dimmed_text, warning_text, IS_STDOUT_TERMINAL};
 
 /// Stderr-bound sink for the non-interactive CLI. Thread-safe — interior
 /// state is held behind an `Arc<Mutex<CliSinkState>>` so multiple clones
-/// of the sink share the same spinner/render buffer.
+/// of the sink share the same render buffer.
 #[derive(Clone)]
 pub struct CliAgentEventSink {
     state: Arc<Mutex<CliSinkState>>,
@@ -43,28 +43,45 @@ fn source_heading(source: &AgentSource) -> String {
 }
 
 struct CliSinkState {
-    spinner: Option<Spinner>,
     render: Option<MarkdownRender>,
     buffer: String,
     last_ui_output_source: Option<AgentSource>,
     highlight: bool,
     render_options: RenderOptions,
+    final_only: bool,
 }
 
 impl CliAgentEventSink {
     pub fn new(
         highlight: bool,
         render_options: RenderOptions,
+        abort_signal: harnx_core::abort::AbortSignal,
+    ) -> Self {
+        Self::new_with_options(highlight, render_options, abort_signal, false)
+    }
+
+    pub fn new_with_final_only(
+        highlight: bool,
+        render_options: RenderOptions,
+        abort_signal: harnx_core::abort::AbortSignal,
+    ) -> Self {
+        Self::new_with_options(highlight, render_options, abort_signal, true)
+    }
+
+    fn new_with_options(
+        highlight: bool,
+        render_options: RenderOptions,
         _abort_signal: harnx_core::abort::AbortSignal,
+        final_only: bool,
     ) -> Self {
         Self {
             state: Arc::new(Mutex::new(CliSinkState {
-                spinner: None,
                 render: None,
                 buffer: String::new(),
                 last_ui_output_source: None,
                 highlight,
                 render_options,
+                final_only,
             })),
         }
     }
@@ -94,12 +111,7 @@ impl CliSinkState {
 
     /// Dispatch a chunk of text to either the markdown or raw rendering
     /// path based on the highlight flag snapshot + stdout terminal-ness.
-    /// Stops the spinner on first chunk.
     fn handle_chunk_text(&mut self, text: &str) -> anyhow::Result<()> {
-        if let Some(spinner) = self.spinner.take() {
-            spinner.stop();
-        }
-
         if self.highlight && *IS_STDOUT_TERMINAL {
             self.handle_markdown_chunk(text)
         } else {
@@ -163,12 +175,9 @@ impl CliSinkState {
         Ok(())
     }
 
-    /// End-of-turn cleanup: stop spinner, flush any buffered partial line,
-    /// and reset state so the next turn starts fresh.
+    /// End-of-turn cleanup: flush any buffered partial line and reset state so
+    /// the next turn starts fresh.
     fn cleanup(&mut self) -> anyhow::Result<()> {
-        if let Some(spinner) = self.spinner.take() {
-            spinner.stop();
-        }
         // The partial line in self.buffer has already been printed raw
         // (handle_markdown_chunk prints each chunk immediately).  We just
         // need a trailing newline to close the line on the terminal.
@@ -274,23 +283,14 @@ impl AgentEventSink for CliAgentEventSink {
             Ok(g) => g,
             Err(poisoned) => poisoned.into_inner(),
         };
+        if state.final_only {
+            return;
+        }
         if is_model_output_event(&event) {
             state.maybe_emit_source_heading(source.as_ref());
         }
         match event {
-            AgentEvent::Status(line) => match &state.spinner {
-                Some(spinner) => {
-                    let _ = spinner.set_message(line.text);
-                }
-                None => {
-                    state.spinner = Some(spawn_spinner(&line.text));
-                }
-            },
-            AgentEvent::Turn(TurnEvent::Started) => {
-                if state.spinner.is_none() {
-                    state.spinner = Some(spawn_spinner("Generating"));
-                }
-            }
+            AgentEvent::Status(_) | AgentEvent::Turn(TurnEvent::Started) => {}
             AgentEvent::Turn(TurnEvent::Ended { .. }) => {
                 if let Err(err) = state.cleanup() {
                     eprintln!(
@@ -414,11 +414,9 @@ impl AgentEventSink for CliAgentEventSink {
             // Silent for Progress / Update — they are streamed mid-call
             // updates that would clutter stderr.
             AgentEvent::Tool(_) => {}
-            // Compaction lifecycle: start spinner, stop it, or report failure.
+            // Compaction lifecycle uses stable log lines in one-shot mode.
             AgentEvent::Session(SessionEvent::CompactingStarted) => {
-                if state.spinner.is_none() {
-                    state.spinner = Some(spawn_spinner("Compacting"));
-                }
+                eprintln!("{}", dimmed_text("Compacting the session..."));
             }
             AgentEvent::Session(SessionEvent::CompactingCompleted) => {
                 if let Err(err) = state.cleanup() {
@@ -466,16 +464,16 @@ fn split_line_tail_local(text: &str) -> (&str, &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use harnx_core::event::{ContentBlock, StatusLine};
+    use harnx_core::event::ContentBlock;
 
     fn make_state(highlight: bool) -> CliSinkState {
         CliSinkState {
-            spinner: None,
             render: None,
             buffer: String::new(),
             last_ui_output_source: None,
             highlight,
             render_options: RenderOptions::default(),
+            final_only: false,
         }
     }
 
@@ -536,59 +534,23 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn user_message_cleans_up_spinner_without_panic() {
-        let sink = CliAgentEventSink::new(
+    async fn final_only_ignores_intermediate_events() {
+        let sink = CliAgentEventSink::new_with_final_only(
             false,
             RenderOptions::default(),
             harnx_core::abort::create_abort_signal(),
         );
         sink.emit(AgentEvent::Turn(TurnEvent::Started));
-        {
-            let state = sink.state.lock().unwrap();
-            assert!(state.spinner.is_some(), "spinner should be started");
-        }
         sink.emit(AgentEvent::User(UserEvent::Message {
             content: "hello user".into(),
         }));
-        {
-            let state = sink.state.lock().unwrap();
-            assert!(
-                state.spinner.is_none(),
-                "spinner should be cleared before printing user text"
-            );
-        }
-    }
+        sink.emit(AgentEvent::Model(ModelEvent::MessageChunk {
+            blocks: vec![ContentBlock::Text("hidden".into())],
+        }));
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn status_event_starts_spinner_without_panic() {
-        let sink = CliAgentEventSink::new(
-            false,
-            RenderOptions::default(),
-            harnx_core::abort::create_abort_signal(),
-        );
-        sink.emit(AgentEvent::Status(StatusLine {
-            text: "[test-model] generating".into(),
-        }));
-        sink.emit(AgentEvent::Turn(TurnEvent::Started));
-        sink.emit(AgentEvent::Turn(TurnEvent::Ended {
-            outcome: Default::default(),
-        }));
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn status_event_updates_existing_spinner() {
-        let sink = CliAgentEventSink::new(
-            false,
-            RenderOptions::default(),
-            harnx_core::abort::create_abort_signal(),
-        );
-        sink.emit(AgentEvent::Turn(TurnEvent::Started));
-        sink.emit(AgentEvent::Status(StatusLine {
-            text: "[rich-label] generating".into(),
-        }));
-        sink.emit(AgentEvent::Turn(TurnEvent::Ended {
-            outcome: Default::default(),
-        }));
+        let state = sink.state.lock().unwrap();
+        assert!(state.buffer.is_empty());
+        assert!(state.last_ui_output_source.is_none());
     }
 
     // ----------------------------------------------------------------
@@ -1011,70 +973,16 @@ mod tests {
     // ----------------------------------------------------------------
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn compacting_started_starts_spinner_without_panic() {
+    async fn compaction_events_are_handled_without_panic() {
         let sink = CliAgentEventSink::new(
             false,
             RenderOptions::default(),
             harnx_core::abort::create_abort_signal(),
         );
         sink.emit(AgentEvent::Session(SessionEvent::CompactingStarted));
-        // cleanup to close spinner
         sink.emit(AgentEvent::Session(SessionEvent::CompactingCompleted));
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn compacting_completed_clears_spinner() {
-        let sink = CliAgentEventSink::new(
-            false,
-            RenderOptions::default(),
-            harnx_core::abort::create_abort_signal(),
-        );
-        // Start spinner first
-        sink.emit(AgentEvent::Turn(TurnEvent::Started));
-        {
-            let state = sink.state.lock().unwrap();
-            assert!(state.spinner.is_some(), "spinner should be started");
-        }
-        // CompactingStarted should NOT replace an existing spinner
-        sink.emit(AgentEvent::Session(SessionEvent::CompactingStarted));
-        {
-            let state = sink.state.lock().unwrap();
-            assert!(state.spinner.is_some(), "spinner should still exist");
-        }
-        // CompactingCompleted clears spinner
-        sink.emit(AgentEvent::Session(SessionEvent::CompactingCompleted));
-        {
-            let state = sink.state.lock().unwrap();
-            assert!(
-                state.spinner.is_none(),
-                "spinner should be cleared by Completed"
-            );
-        }
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn compacting_failed_clears_spinner_and_reports_warning() {
-        let sink = CliAgentEventSink::new(
-            false,
-            RenderOptions::default(),
-            harnx_core::abort::create_abort_signal(),
-        );
-        // Start spinner
-        sink.emit(AgentEvent::Session(SessionEvent::CompactingStarted));
-        {
-            let state = sink.state.lock().unwrap();
-            assert!(state.spinner.is_some(), "spinner should be started");
-        }
-        // Failed clears spinner
         sink.emit(AgentEvent::Session(SessionEvent::CompactingFailed(
             "something went wrong".to_string(),
         )));
-        {
-            let state = sink.state.lock().unwrap();
-            assert!(
-                state.spinner.is_none(),
-                "spinner should be cleared by Failed"
-            );
-        }
     }
 }

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -96,21 +96,21 @@ pub fn remote_list_outcome(result: Result<Vec<SessionMeta>, anyhow::Error>) -> L
 async fn main() -> Result<()> {
     load_env_file()?;
     let cli = Cli::parse();
-    if let Some(command) = &cli.command {
-        setup_logger(LogSink::File)?;
-        harnx_core::alloc_guard::init_from_env();
-        return run_command(command).await;
+    setup_logger(LogSink::File)?;
+    harnx_core::alloc_guard::init_from_env();
+    match &cli.command {
+        Some(command @ (Commands::Info(_) | Commands::Session(_))) => {
+            return run_command(command).await;
+        }
+        Some(Commands::Prompt(_)) | None => {}
     }
 
     let text = cli.text()?;
-    let working_mode = if text.is_none() && cli.file.is_empty() {
-        WorkingMode::Tui
-    } else {
-        WorkingMode::Cmd
+    let working_mode = match (&cli.command, &text, cli.file.is_empty()) {
+        (Some(Commands::Prompt(_)), _, _) | (_, Some(_), _) | (_, _, false) => WorkingMode::Cmd,
+        _ => WorkingMode::Tui,
     };
     let info_flag = legacy_info_flag(&cli);
-    setup_logger(LogSink::File)?;
-    harnx_core::alloc_guard::init_from_env();
     let config = Arc::new(RwLock::new(Config::init(working_mode, info_flag).await?));
     if let Err(err) = run(config, cli, text).await {
         render_error(err);
@@ -121,6 +121,7 @@ async fn main() -> Result<()> {
 
 async fn run_command(command: &Commands) -> Result<()> {
     match command {
+        Commands::Prompt(_) => bail!("prompt commands use the one-shot execution path"),
         Commands::Info(info_args) => match &info_args.command {
             InfoSubcommands::Agent { name } => {
                 let config = Config::init(WorkingMode::Cmd, true).await?;
@@ -407,35 +408,7 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
         return Ok(());
     }
     match is_tui {
-        false => {
-            let (highlight, render_options) = {
-                let cfg = config.read();
-                (cfg.highlight, cfg.render_options().unwrap_or_default())
-            };
-            agent_event_sink::install_cli_agent_event_sink(
-                highlight,
-                render_options,
-                abort_signal.clone(),
-            );
-            {
-                let cfg = config.read();
-                if cfg.agent.is_none() {
-                    bail!("No agent selected. Use --agent/-a to specify an agent.");
-                }
-            }
-            if config.read().session.is_none() {
-                let session_id = Config::reserve_new_session_id(&config).await?;
-                config.write().use_session(Some(&session_id))?;
-            }
-            let input = create_input(&config, text, &cli.file, abort_signal.clone()).await?;
-            let aborted_check = abort_signal.clone();
-            let result = start_directive(&config, input, abort_signal).await;
-            exit_session(&config)?;
-            if aborted_check.aborted() {
-                bail!("interrupted by user");
-            }
-            result
-        }
+        false => run_one_shot(&config, &cli, text, abort_signal).await,
         true => {
             if !*IS_STDOUT_TERMINAL {
                 bail!("No TTY for TUI")
@@ -445,13 +418,42 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
     }
 }
 
+async fn run_one_shot(
+    config: &GlobalConfig,
+    cli: &Cli,
+    text: Option<String>,
+    abort_signal: AbortSignal,
+) -> Result<()> {
+    let (highlight, render_options) = {
+        let cfg = config.read();
+        (cfg.highlight, cfg.render_options().unwrap_or_default())
+    };
+    agent_event_sink::install_cli_agent_event_sink(
+        highlight,
+        render_options,
+        abort_signal.clone(),
+        cli.final_only,
+    );
+    if config.read().agent.is_none() {
+        bail!("No agent selected. Use --agent/-a to specify an agent.");
+    }
+    if config.read().session.is_none() {
+        let session_id = Config::reserve_new_session_id(config).await?;
+        config.write().use_session(Some(&session_id))?;
+    }
+    let input = create_input(config, text, &cli.file, abort_signal.clone()).await?;
+    let aborted_check = abort_signal.clone();
+    let result = start_directive(config, input, abort_signal, cli.final_only).await;
+    exit_session(config, !cli.final_only)?;
+    if aborted_check.aborted() {
+        bail!("interrupted by user");
+    }
+    result
+}
+
 fn session_resume_command(config: &GlobalConfig) -> Option<String> {
     let config_read = config.read();
     let session = config_read.session.as_ref()?;
-    if session.is_empty() {
-        return None;
-    }
-
     let session_name = session.id();
 
     let agent_name = config_read.agent.as_ref().map(|a| a.name());
@@ -551,8 +553,10 @@ fn print_session_breakdown(
     }
 }
 
-fn exit_session(config: &GlobalConfig) -> Result<()> {
-    let resume_cmd = session_resume_command(config);
+fn exit_session(config: &GlobalConfig, show_resume_hint: bool) -> Result<()> {
+    let resume_cmd = show_resume_hint
+        .then(|| session_resume_command(config))
+        .flatten();
     config.write().exit_session()?;
 
     if let Some(cmd) = resume_cmd {
@@ -566,26 +570,13 @@ fn exit_session(config: &GlobalConfig) -> Result<()> {
     Ok(())
 }
 
-#[async_recursion::async_recursion]
 async fn start_directive(
-    config: &GlobalConfig,
-    input: Input,
-    abort_signal: AbortSignal,
-) -> Result<()> {
-    start_directive_inner(config, input, abort_signal, 0, true).await
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn start_directive_inner(
     config: &GlobalConfig,
     mut input: Input,
     abort_signal: AbortSignal,
-    _resume_count: u32,
-    with_embeddings: bool,
+    final_only: bool,
 ) -> Result<()> {
-    if with_embeddings {
-        crate::config::input::use_embeddings(&mut input, config, abort_signal.clone()).await?;
-    }
+    crate::config::input::use_embeddings(&mut input, config, abort_signal.clone()).await?;
 
     let (agent, cluster, session_id) = {
         let cfg = config.read();
@@ -631,12 +622,37 @@ async fn start_directive_inner(
         .await?;
 
     let worker_error = result.error.clone();
-    tracking_sink.emit_durable_response_if_needed(result);
+    finish_one_shot_output(final_only, &tracking_sink, result);
     // A worker-side failure must not exit 0 — scripts driving one-shot mode
     // rely on the exit code to tell an answer from a dead turn.
     match worker_error {
         Some(error) => Err(anyhow::anyhow!(error)),
         None => Ok(()),
+    }
+}
+
+fn finish_one_shot_output(
+    final_only: bool,
+    tracking_sink: &oneshot_nats::AssistantTextTrackingSink,
+    result: harnx_runtime::ThinClientTurnResult,
+) {
+    if final_only {
+        print_final_response(&result);
+    } else {
+        tracking_sink.emit_durable_response_if_needed(result);
+    }
+}
+
+fn print_final_response(result: &harnx_runtime::ThinClientTurnResult) {
+    if result.was_cancelled || result.error.is_some() {
+        return;
+    }
+    let Some(response) = result.response.as_deref().filter(|text| !text.is_empty()) else {
+        return;
+    };
+    print!("{response}");
+    if !response.ends_with('\n') {
+        println!();
     }
 }
 
@@ -652,7 +668,7 @@ async fn start_interactive(config: &GlobalConfig) -> Result<()> {
         }
     };
     print_session_breakdown(tui.transcript(), &source, config);
-    exit_session(config)?;
+    exit_session(config, true)?;
     result
 }
 
@@ -814,12 +830,12 @@ mod resume_tests {
     }
 
     #[test]
-    fn returns_none_for_empty_session() {
+    fn returns_command_for_empty_reserved_session() {
         let config = make_config(Some(Session {
             id: "test".to_string(),
             ..Default::default()
         }));
-        assert!(session_resume_command(&config).is_none());
+        assert_eq!(session_resume_command(&config).unwrap(), "harnx -s test");
     }
 
     #[test]

--- a/crates/harnx/src/test_utils/interrupt.rs
+++ b/crates/harnx/src/test_utils/interrupt.rs
@@ -286,7 +286,8 @@ fn shell_escape(s: &str) -> String {
 }
 
 /// Starts tmux + bash, exports `HARNX_CONFIG_DIR`, and launches harnx in
-/// one-shot (Cmd) mode with `prompt` as the argument.  Returns the harness
+/// one-shot (Cmd) mode with `prompt` as the prompt-subcommand input. Returns
+/// the harness
 /// immediately; the harnx process runs inside the pane and the exit code will
 /// appear as `HARNX_EXIT:<code>` when it finishes.
 ///
@@ -312,7 +313,7 @@ pub fn spawn_oneshot_in_tmux(
     // non-zero (interrupted), making exit detection possible from pane capture.
     // --agent default is required since chat activity needs an active agent.
     tmux.send_text(&format!(
-        "{} --agent default {} || echo HARNX_EXIT:$?\n",
+        "{} prompt --agent default {} || echo HARNX_EXIT:$?\n",
         shell_escape(&harnx_bin.to_string_lossy()),
         shell_escape(prompt),
     ))?;
@@ -368,19 +369,41 @@ pub fn wait_for_prompt_return(tmux: &TmuxHarness, budget: Duration) -> Result<()
     }
 }
 
-/// Spawns `harnx "<prompt>"` non-interactively. Returns the `Child` —
+/// Spawns `harnx prompt "<prompt>"` non-interactively. Returns the `Child` —
 /// caller is responsible for `wait_for_exit` or kill.
 pub fn spawn_oneshot(
     paths: &ConfigPaths,
     harnx_bin: &Path,
     prompt: &str,
 ) -> Result<std::process::Child> {
+    spawn_oneshot_with_args(paths, harnx_bin, prompt, &[])
+}
+
+/// Spawns a final-response-only one-shot command.
+pub fn spawn_oneshot_final_only(
+    paths: &ConfigPaths,
+    harnx_bin: &Path,
+    prompt: &str,
+) -> Result<std::process::Child> {
+    spawn_oneshot_with_args(paths, harnx_bin, prompt, &["--final-only"])
+}
+
+fn spawn_oneshot_with_args(
+    paths: &ConfigPaths,
+    harnx_bin: &Path,
+    prompt: &str,
+    extra_args: &[&str],
+) -> Result<std::process::Child> {
     harnx_core::require_nextest();
     use std::process::{Command, Stdio};
     // --agent default is required since chat activity needs an active agent.
     // The "default" agent is written by write_minimal_config.
-    Command::new(harnx_bin)
-        .args(["--agent", "default", prompt])
+    let mut command = Command::new(harnx_bin);
+    command
+        .args(["prompt", "--agent", "default"])
+        .args(extra_args)
+        .arg("--")
+        .arg(prompt)
         .env("HARNX_CONFIG_DIR", &paths.harnx_config_dir)
         .env("HARNX_DATA_DIR", &paths.harnx_data_dir)
         .env("HARNX_STATE_DIR", &paths.harnx_state_dir)

--- a/crates/harnx/tests/interrupt_e2e.rs
+++ b/crates/harnx/tests/interrupt_e2e.rs
@@ -13,10 +13,13 @@ use std::time::Duration;
 
 use harnx::test_utils::interrupt::{
     script_call_trivial_tool, script_call_wait_tool, script_stall_streaming, send_sigint,
-    spawn_oneshot, spawn_oneshot_in_tmux, spawn_tui, wait_for_cmd_exit, wait_for_exit,
-    wait_for_prompt_return, write_minimal_config, write_with_blocking_hook, write_with_wait_tool,
+    spawn_oneshot, spawn_oneshot_final_only, spawn_oneshot_in_tmux, spawn_tui, wait_for_cmd_exit,
+    wait_for_exit, wait_for_prompt_return, write_minimal_config, write_with_blocking_hook,
+    write_with_wait_tool,
 };
-use harnx::test_utils::mock_openai_server::{MockOpenAiScript, MockOpenAiServer, MockOpenAiTurn};
+use harnx::test_utils::mock_openai_server::{
+    MockOpenAiError, MockOpenAiScript, MockOpenAiServer, MockOpenAiTurn,
+};
 use harnx::test_utils::tmux_harness::TmuxHarness;
 
 fn wait_for_mock_request(mock: &MockOpenAiServer) -> Result<()> {
@@ -59,11 +62,118 @@ fn one_shot_local_turn_runs_over_nats() -> Result<()> {
         use std::io::Read;
         pipe.read_to_string(&mut stdout)?;
     }
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stderr.take() {
+        use std::io::Read;
+        pipe.read_to_string(&mut stderr)?;
+    }
     assert!(status.success(), "one-shot exited with {status}");
     assert_eq!(
         stdout.matches("NATS one-shot smoke").count(),
         1,
         "response should be rendered exactly once: {stdout:?}"
+    );
+    assert!(
+        stderr.contains("Resume this session by running:")
+            && stderr.contains("harnx -a default -s "),
+        "one-shot should report its resumable session: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn final_only_prints_only_the_durable_response() -> Result<()> {
+    harnx_core::require_nextest();
+    if std::process::Command::new("nats-server")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("nats-server unavailable; skipping final_only_prints_only_the_durable_response");
+        return Ok(());
+    }
+
+    let mock = MockOpenAiServer::start(MockOpenAiScript {
+        turns: vec![MockOpenAiTurn {
+            text_chunks: vec!["Only the final answer.".to_string()],
+            ..Default::default()
+        }],
+        ..Default::default()
+    })?;
+    let tmp = tempfile::tempdir()?;
+    let paths = write_minimal_config(tmp.path(), &format!("http://127.0.0.1:{}/v1", mock.port()))?;
+    let harnx_bin = PathBuf::from(env!("CARGO_BIN_EXE_harnx"));
+    let mut child = spawn_oneshot_final_only(&paths, &harnx_bin, "answer quietly")?;
+    let status = wait_for_exit(&mut child, Duration::from_secs(30))?;
+
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stdout.take() {
+        use std::io::Read;
+        pipe.read_to_string(&mut stdout)?;
+    }
+    if let Some(mut pipe) = child.stderr.take() {
+        use std::io::Read;
+        pipe.read_to_string(&mut stderr)?;
+    }
+
+    assert!(status.success(), "final-only one-shot exited with {status}");
+    assert_eq!(stdout, "Only the final answer.\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+#[test]
+fn final_only_reports_terminal_failures_on_stderr() -> Result<()> {
+    harnx_core::require_nextest();
+    if std::process::Command::new("nats-server")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!(
+            "nats-server unavailable; skipping final_only_reports_terminal_failures_on_stderr"
+        );
+        return Ok(());
+    }
+
+    let mock = MockOpenAiServer::start(MockOpenAiScript {
+        turns: vec![MockOpenAiTurn {
+            error: Some(MockOpenAiError {
+                status: 400,
+                message: "final-only terminal failure".to_string(),
+                error_type: "invalid_request_error".to_string(),
+                headers: Vec::new(),
+            }),
+            ..Default::default()
+        }],
+        ..Default::default()
+    })?;
+    let tmp = tempfile::tempdir()?;
+    let paths = write_minimal_config(tmp.path(), &format!("http://127.0.0.1:{}/v1", mock.port()))?;
+    let harnx_bin = PathBuf::from(env!("CARGO_BIN_EXE_harnx"));
+    let mut child = spawn_oneshot_final_only(&paths, &harnx_bin, "fail quietly")?;
+    let status = wait_for_exit(&mut child, Duration::from_secs(30))?;
+
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stdout.take() {
+        use std::io::Read;
+        pipe.read_to_string(&mut stdout)?;
+    }
+    if let Some(mut pipe) = child.stderr.take() {
+        use std::io::Read;
+        pipe.read_to_string(&mut stderr)?;
+    }
+
+    assert!(
+        !status.success(),
+        "final-only failure unexpectedly succeeded"
+    );
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("final-only terminal failure"),
+        "terminal failure should remain diagnosable: {stderr:?}"
     );
     Ok(())
 }

--- a/crates/harnx/tests/tmux_e2e.rs
+++ b/crates/harnx/tests/tmux_e2e.rs
@@ -47,7 +47,7 @@ fn proxy_auth_hook_injects_env_vars_into_bash_exec() -> Result<()> {
     prime_proxy_test_shell(&tmux, &paths, &repo_root, &harnx_bin)?;
 
     tmux.send_text(&format!(
-        "{} -a proxy-test -s proxy-auth-e2e {}",
+        "{} prompt -a proxy-test -s proxy-auth-e2e -- {}",
         shell_escape(harnx_bin.to_string_lossy().as_ref()),
         shell_escape("Run a bash command")
     ))?;

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -155,7 +155,7 @@ model: openai:gpt-4o
 You are a helpful assistant that explains things clearly and concisely.
 ```
 
-Running `harnx -a my-agent "What is Rust?"` produces these messages:
+Running `harnx prompt -a my-agent "What is Rust?"` produces these messages:
 
 ```json
 [
@@ -280,14 +280,14 @@ Agent hooks extend global hooks (defined in the main config). The merge rules ar
 
 ```sh
 harnx --agent <name>                    # Start an agent
-harnx --agent <name> "your question"    # Start with input
+harnx prompt --agent <name> "your question" # Run a non-interactive prompt
 harnx --list-agents                     # List available agents
 ```
 
 You can also pass variable values directly:
 
 ```sh
-harnx --agent coder --agent-variable language=rust "write a web server"
+harnx prompt --agent coder --agent-variable language rust "write a web server"
 ```
 
 ### From the TUI
@@ -304,7 +304,7 @@ harnx --agent coder --agent-variable language=rust "write a web server"
 Use `--prompt` to create a temporary agent without a file:
 
 ```sh
-harnx --prompt "You are a helpful translator" "translate hello to French"
+harnx prompt --prompt "You are a helpful translator" "translate hello to French"
 ```
 
 ## Sub-Agents & Agent Delegation

--- a/docs/command-line-guide.md
+++ b/docs/command-line-guide.md
@@ -3,10 +3,12 @@
 ## Usage
 
 ```
-Usage: harnx [OPTIONS] [TEXT]...
+Usage: harnx [OPTIONS] [COMMAND]
 
-Arguments:
-  [TEXT]...  Input text
+Commands:
+  prompt  Run a non-interactive prompt
+  info    Inspect harnx state
+  session Manage sessions
 
 Options:
   -m, --model <MODEL>                  Select a LLM model
@@ -22,6 +24,7 @@ Options:
   -t, --tool <TOOL>                    Use specific tools
   -f, --file <FILE>                    Include files, directories, or URLs
   -S, --no-stream                      Turn off stream mode
+      --final-only                     Print only the final response
       --dry-run                        Display the message without sending it
       --info                           Display information
       --sync-models                    Sync models updates
@@ -38,7 +41,8 @@ Options:
 
 ```
 harnx                                          # Enter the interactive TUI
-harnx Tell a joke                              # Generate response
+harnx prompt Tell a joke                       # Generate response
+harnx -- Tell a joke                           # Same, using an explicit separator
 
 harnx-serve                                    # Run server (standalone binary)
 harnx-serve --addr 0.0.0.0:8080                # Run server with addr
@@ -56,12 +60,19 @@ harnx --info                                   # View system info
 harnx --rag rag1 --info                        # View RAG info
 
 harnx --macro macro1                           # Execute macro 'macro1'
-harnx --macro macro2 arg1 arg2                 # Execute macro 'macro2' with args
+harnx --macro macro2 -- arg1 arg2              # Execute macro 'macro2' with args
 
-output=$(harnx -S $input)                      # Run in the script
+output=$(harnx prompt --final-only -- "$input") # Return only the final response
+cat prompt.txt | harnx prompt                    # Read the prompt from stdin
 
-harnx -f a.png -f b.png diff images            # Use files
+harnx prompt -f a.png -f b.png diff images     # Use files
 ```
+
+Free-form command-line text must be introduced by the `prompt` subcommand or
+an explicit `--` separator. This keeps prompts such as `info` and `session`
+distinct from CLI subcommands. Use `prompt` as the canonical syntax for piped
+stdin and file-only input as well. Bare stdin and file-only forms remain
+supported for compatibility.
 
 ## Shell Integration
 
@@ -81,15 +92,15 @@ The `-f/--file` flag can be used to send files to LLMs.
 
 ```
 # Use local file
-harnx -f data.txt
+harnx prompt -f data.txt
 # Use image file
-harnx -f image.png ocr
+harnx prompt -f image.png ocr
 # Use multiple files
-harnx -f file1 -f file2 explain
+harnx prompt -f file1 -f file2 explain
 # Use local dirs
-harnx -f dir/ summarize
+harnx prompt -f dir/ summarize
 # Use remote URLs
-harnx -f https://example.com/page summarize
+harnx prompt -f https://example.com/page summarize
 ```
 
 ## Run Server


### PR DESCRIPTION
Require either the prompt subcommand or an explicit -- separator for free-form root prompt text so future subcommands cannot be interpreted as prompts.

Add a --final-only mode with clean stdout, remove the non-interactive spinner, and always show the resumable session command after standard one-shot runs. Cover successful and failing final-only output, CLI parsing, and resume hints with automated tests, and update the user documentation and release notes.

Closes #1388

Closes #1429

Closes #1495

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an explicit `prompt` command for one-shot prompts, with support for prompt text after `--`.
  * Added `--final-only` to print only the completed response.
  * One-shot runs now provide commands for resuming sessions when applicable.

* **Documentation**
  * Updated CLI guides and examples to reflect the new command syntax, stdin usage, and variable argument format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->