### PR TITLE
fix: harden model resolution and local worker reuse

### DIFF
--- a/.changeset/harden-model-worker-config.md
+++ b/.changeset/harden-model-worker-config.md
@@ -1,0 +1,5 @@
+---
+harnx: patch
+coding: patch
+---
+Prevent test environment races from overwriting user configuration, preserve embedded model metadata alongside custom client models, validate shipped agent model references, and restart or reject stale local workers after configuration or executable changes. Model-list APIs now evaluate the current client configuration on every call and return owned values. Because the local-worker readiness protocol changed, restart long-running frontends when upgrading or rolling back. Add the missing Gemini client used by the coding package's compaction agent.

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,6 +15,10 @@
 [test-groups]
 # Terminal-driving e2e tests contend for the same CPU/process-spawn resources.
 heavy-e2e = { max-threads = 1 }
+# Broker-backed tests each launch a NATS process and several async runtimes.
+# Bound their aggregate process/thread load so one test's broker is not starved
+# or killed when the workspace suite fans out on high-core-count runners.
+broker-e2e = { max-threads = 8 }
 
 [profile.default]
 retries = 0
@@ -22,6 +26,10 @@ retries = 0
 [[profile.default.overrides]]
 filter = 'binary(tmux_e2e) | binary(interrupt_e2e)'
 test-group = 'heavy-e2e'
+
+[[profile.default.overrides]]
+filter = 'binary(/nats/) | binary(local_worker_supervisor) | test(/nats/)'
+test-group = 'broker-e2e'
 
 [profile.ci]
 # Retry transient (timing/load-induced) flakes. A real failure fails all attempts.
@@ -37,3 +45,7 @@ final-status-level = "flaky"
 [[profile.ci.overrides]]
 filter = 'binary(tmux_e2e) | binary(interrupt_e2e)'
 test-group = 'heavy-e2e'
+
+[[profile.ci.overrides]]
+filter = 'binary(/nats/) | binary(local_worker_supervisor) | test(/nats/)'
+test-group = 'broker-e2e'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4121,6 +4121,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.11.0",
  "shell-words",
  "shellexpand",
  "syntect",

--- a/crates/harnx-client/src/macros.rs
+++ b/crates/harnx-client/src/macros.rs
@@ -55,28 +55,12 @@ macro_rules! register_client {
 
                 pub fn list_models(local_config: &$config) -> Vec<Model> {
                     let client_name = Self::name(local_config);
-                    let mut models = if local_config.models.is_empty() {
-                        if let Some(v) = $crate::ALL_PROVIDER_MODELS.iter().find(|v| {
-                            v.provider == $name ||
-                                ($name == OpenAICompatibleClient::NAME
-                                    && local_config.name.starts_with(&v.provider))
-                        }) {
-                            Model::from_config(client_name, &v.models)
-                        } else {
-                            vec![]
-                        }
-                    } else {
-                        Model::from_config(client_name, &local_config.models)
-                    };
-                    // Propagate client-level system_prompt_prefix to models
-                    if let Some(ref prefix) = local_config.system_prompt_prefix {
-                        for model in &mut models {
-                            if model.data().system_prompt_prefix.is_none() {
-                                model.data_mut().system_prompt_prefix = Some(prefix.clone());
-                            }
-                        }
-                    }
-                    models
+                    $crate::models_for_client_config(
+                        $name,
+                        client_name,
+                        &local_config.models,
+                        local_config.system_prompt_prefix.as_deref(),
+                    )
                 }
 
                 pub fn name(local_config: &$config) -> &str {
@@ -103,37 +87,36 @@ macro_rules! register_client {
             client_types
         }
 
-        static ALL_CLIENT_NAMES: std::sync::OnceLock<Vec<String>> = std::sync::OnceLock::new();
-
-        pub fn list_client_names(clients: &[ClientConfig]) -> Vec<&'static String> {
-            let names = ALL_CLIENT_NAMES.get_or_init(|| {
-                clients
-                    .iter()
-                    .flat_map(|v| match v {
-                        $(ClientConfig::$config(c) => vec![$client::name(c).to_string()],)+
-                        ClientConfig::Unknown => vec![],
-                    })
-                    .collect()
-            });
-            names.iter().collect()
+        /// Return the effective names from the current client configuration.
+        ///
+        /// The names are recomputed and returned as owned values so configuration
+        /// reloads are reflected immediately.
+        pub fn list_client_names(clients: &[ClientConfig]) -> Vec<String> {
+            clients
+                .iter()
+                .flat_map(|v| match v {
+                    $(ClientConfig::$config(c) => vec![$client::name(c).to_string()],)+
+                    ClientConfig::Unknown => vec![],
+                })
+                .collect()
         }
 
-        static ALL_MODELS: std::sync::OnceLock<Vec<$crate::Model>> = std::sync::OnceLock::new();
-
-        pub fn list_all_models(clients: &[ClientConfig]) -> Vec<&'static $crate::Model> {
-            let models = ALL_MODELS.get_or_init(|| {
-                clients
-                    .iter()
-                    .flat_map(|v| match v {
-                        $(ClientConfig::$config(c) => $client::list_models(c),)+
-                        ClientConfig::Unknown => vec![],
-                    })
-                    .collect()
-            });
-            models.iter().collect()
+        /// Return every model from the current client configuration.
+        ///
+        /// The models are recomputed and returned as owned values so configuration
+        /// reloads are reflected immediately.
+        pub fn list_all_models(clients: &[ClientConfig]) -> Vec<$crate::Model> {
+            clients
+                .iter()
+                .flat_map(|v| match v {
+                    $(ClientConfig::$config(c) => $client::list_models(c),)+
+                    ClientConfig::Unknown => vec![],
+                })
+                .collect()
         }
 
-        pub fn list_models(clients: &[ClientConfig], model_type: $crate::ModelType) -> Vec<&'static $crate::Model> {
+        /// Return owned models of `model_type` from the current client configuration.
+        pub fn list_models(clients: &[ClientConfig], model_type: $crate::ModelType) -> Vec<$crate::Model> {
             list_all_models(clients).into_iter().filter(|v| v.model_type() == model_type).collect()
         }
 

--- a/crates/harnx-client/src/model.rs
+++ b/crates/harnx-client/src/model.rs
@@ -1,8 +1,58 @@
-use crate::{list_all_models, list_client_names, ClientConfig};
+use crate::{list_all_models, list_client_names, ClientConfig, ALL_PROVIDER_MODELS};
 
 use anyhow::{bail, Result};
 
 pub use harnx_core::model::{Model, ModelType, ProviderModels, RequestPatches};
+
+/// Build one client's effective model list from explicit entries followed by
+/// every non-overridden provider-catalog entry.
+#[doc(hidden)]
+pub fn models_for_client_config(
+    client_type: &str,
+    client_name: &str,
+    local_models: &[harnx_core::model::ModelData],
+    system_prompt_prefix: Option<&[String]>,
+) -> Vec<Model> {
+    let catalog = provider_catalog(client_type, client_name);
+    let model_data = merge_model_data(local_models, catalog);
+    let mut models = Model::from_config(client_name, &model_data);
+    apply_system_prompt_prefix(&mut models, system_prompt_prefix);
+    models
+}
+
+fn provider_catalog(client_type: &str, client_name: &str) -> Option<&'static ProviderModels> {
+    ALL_PROVIDER_MODELS.iter().find(|provider| {
+        provider.provider == client_type
+            || (client_type == "openai-compatible" && client_name.starts_with(&provider.provider))
+    })
+}
+
+fn merge_model_data(
+    local_models: &[harnx_core::model::ModelData],
+    catalog: Option<&ProviderModels>,
+) -> Vec<harnx_core::model::ModelData> {
+    let mut merged = local_models.to_vec();
+    let Some(catalog) = catalog else {
+        return merged;
+    };
+    for catalog_model in &catalog.models {
+        if !merged.iter().any(|local| local.name == catalog_model.name) {
+            merged.push(catalog_model.clone());
+        }
+    }
+    merged
+}
+
+fn apply_system_prompt_prefix(models: &mut [Model], prefix: Option<&[String]>) {
+    let Some(prefix) = prefix else {
+        return;
+    };
+    for model in models {
+        if model.data().system_prompt_prefix.is_none() {
+            model.data_mut().system_prompt_prefix = Some(prefix.to_vec());
+        }
+    }
+}
 
 pub fn retrieve_model(
     clients: &[ClientConfig],
@@ -24,14 +74,14 @@ pub fn retrieve_model(
         Some(model_name) => {
             if let Some(model) = models.iter().find(|v| v.id() == model_id) {
                 if model.model_type() == model_type {
-                    return Ok((*model).clone());
+                    return Ok(model.clone());
                 } else {
                     bail!("Model '{model_id}' is not a {model_type} model")
                 }
             }
             if list_client_names(clients)
                 .into_iter()
-                .any(|v| *v == client_name)
+                .any(|v| v == client_name)
                 && model_type.can_create_from_name()
             {
                 let mut new_model = Model::new(client_name, model_name);
@@ -44,9 +94,58 @@ pub fn retrieve_model(
                 .iter()
                 .find(|v| v.client_name() == client_name && v.model_type() == model_type)
             {
-                return Ok((*found).clone());
+                return Ok(found.clone());
             }
         }
     };
     bail!("Unknown {model_type} model '{model_id}'")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{list_all_models, ClientConfig, OpenAIConfig};
+    use harnx_core::model::ModelData;
+
+    fn openai_with_models(names: &[&str]) -> ClientConfig {
+        ClientConfig::OpenAIConfig(OpenAIConfig {
+            name: "openai".to_string(),
+            models: names.iter().map(|name| ModelData::new(name)).collect(),
+            ..OpenAIConfig::default()
+        })
+    }
+
+    #[test]
+    fn custom_models_do_not_hide_embedded_provider_metadata() {
+        let clients = vec![openai_with_models(&["test-model"])];
+
+        let model = retrieve_model(&clients, "openai:gpt-5.6-sol", ModelType::Chat)
+            .expect("embedded OpenAI model remains resolvable");
+
+        assert_eq!(model.endpoint(), Some("responses"));
+        assert!(model.supports_tool_use());
+        assert!(
+            list_all_models(&clients)
+                .iter()
+                .any(|model| model.id() == "openai:test-model"),
+            "the custom model must remain available"
+        );
+    }
+
+    #[test]
+    fn model_lists_follow_the_current_client_configuration() {
+        let first = vec![openai_with_models(&["first-custom-model"])];
+        let second = vec![openai_with_models(&["second-custom-model"])];
+
+        assert!(list_all_models(&first)
+            .iter()
+            .any(|model| model.name() == "first-custom-model"));
+        let reloaded = list_all_models(&second);
+        assert!(reloaded
+            .iter()
+            .any(|model| model.name() == "second-custom-model"));
+        assert!(!reloaded
+            .iter()
+            .any(|model| model.name() == "first-custom-model"));
+    }
 }

--- a/crates/harnx-client/tests/models_yaml_patches.rs
+++ b/crates/harnx-client/tests/models_yaml_patches.rs
@@ -86,6 +86,31 @@ fn effort_aliases_set_effort_in_the_request_body() {
     );
 }
 
+#[test]
+fn gpt_5_6_sol_variants_use_responses_without_sampling_parameters() {
+    let openai = ALL_PROVIDER_MODELS
+        .iter()
+        .find(|provider| provider.provider == "openai")
+        .expect("OpenAI provider catalog");
+    for name in ["gpt-5.6-sol", "gpt-5.6-sol:high", "gpt-5.6-sol:max"] {
+        let model = Model::from_config("openai", &openai.models)
+            .into_iter()
+            .find(|model| model.name() == name)
+            .unwrap_or_else(|| panic!("missing OpenAI model alias {name}"));
+        assert_eq!(model.endpoint(), Some("responses"), "{name}");
+        let patched = harnx_core::jaq::eval_filters_strict(
+            model.patches().expect("GPT-5.6 Sol patch"),
+            request_envelope(&model),
+        )
+        .unwrap_or_else(|error| panic!("patches for {name} failed: {error:#}"));
+        assert!(patched["body"].get("temperature").is_none(), "{name}");
+        assert!(patched["body"].get("top_p").is_none(), "{name}");
+        if let Some((_, effort)) = name.rsplit_once(':') {
+            assert_eq!(patched["body"]["reasoning"]["effort"], effort, "{name}");
+        }
+    }
+}
+
 /// Returns the container key (`output_config` or `reasoning`) when the patch
 /// sets an effort level under it.
 fn effort_path(patch: &str) -> Option<&'static str> {

--- a/crates/harnx-rag/src/lib.rs
+++ b/crates/harnx-rag/src/lib.rs
@@ -976,7 +976,7 @@ impl DocumentId {
     }
 }
 
-fn select_embedding_model(models: &[&Model]) -> Result<String> {
+fn select_embedding_model(models: &[Model]) -> Result<String> {
     let models: Vec<_> = models
         .iter()
         .map(|v| SelectOption::new(v.id(), v.description()))

--- a/crates/harnx-runtime/Cargo.toml
+++ b/crates/harnx-runtime/Cargo.toml
@@ -54,6 +54,7 @@ reqwest-eventsource = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+sha2 = { workspace = true }
 shell-words = { workspace = true }
 shellexpand = { workspace = true }
 time = { workspace = true }

--- a/crates/harnx-runtime/src/config/agent_dump_tests.rs
+++ b/crates/harnx-runtime/src/config/agent_dump_tests.rs
@@ -2,16 +2,14 @@
 #![cfg(test)]
 
 use super::*;
+use crate::config::test_support::{env_lock, EnvGuard};
 use harnx_core::config_paths::config_dir;
 use std::{
     fs,
     path::Path,
     path::PathBuf,
-    sync::{LazyLock, Mutex},
     time::{SystemTime, UNIX_EPOCH},
 };
-
-static TEST_CONFIG_DIR_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 fn write_agent_dump_test_config() {
     let config_dir = config_dir();
@@ -40,7 +38,7 @@ fn unique_test_config_dir() -> PathBuf {
 }
 
 fn with_test_config_dir<T>(f: impl FnOnce(&Path) -> Result<T>) -> Result<T> {
-    let _guard = TEST_CONFIG_DIR_LOCK.lock().unwrap();
+    let _guard = env_lock();
     let config_dir = unique_test_config_dir();
     let data_dir = config_dir.with_file_name(format!(
         "{}-data",
@@ -55,17 +53,12 @@ fn with_test_config_dir<T>(f: impl FnOnce(&Path) -> Result<T>) -> Result<T> {
     fs::create_dir_all(&data_dir)?;
     fs::create_dir_all(&state_dir)?;
 
-    unsafe {
-        std::env::set_var("HARNX_CONFIG_DIR", &config_dir);
-        std::env::set_var("HARNX_DATA_DIR", &data_dir);
-        std::env::set_var("HARNX_STATE_DIR", &state_dir);
-    }
-    let result = f(&config_dir);
-    unsafe {
-        std::env::remove_var("HARNX_CONFIG_DIR");
-        std::env::remove_var("HARNX_DATA_DIR");
-        std::env::remove_var("HARNX_STATE_DIR");
-    }
+    let result = {
+        let _config = EnvGuard::new("HARNX_CONFIG_DIR", &config_dir);
+        let _data = EnvGuard::new("HARNX_DATA_DIR", &data_dir);
+        let _state = EnvGuard::new("HARNX_STATE_DIR", &state_dir);
+        f(&config_dir)
+    };
 
     let _ = fs::remove_dir_all(&data_dir);
     let _ = fs::remove_dir_all(&state_dir);
@@ -204,49 +197,18 @@ fn render_agent_dump_errors_cleanly_for_unknown_agent() {
 
 #[test]
 fn render_agent_dump_handles_package_qualified_agent() {
-    let _guard = TEST_CONFIG_DIR_LOCK.lock().unwrap();
-    let config_dir = unique_test_config_dir();
-    let data_dir = config_dir.with_file_name(format!(
-        "{}-data",
-        config_dir.file_name().unwrap().to_string_lossy()
-    ));
-    let state_dir = config_dir.with_file_name(format!(
-        "{}-state",
-        config_dir.file_name().unwrap().to_string_lossy()
-    ));
-    let packages_dir = config_dir.join("packages");
-    let pkg_dir = packages_dir.join("mypkg");
-    let agents_dir = pkg_dir.join("agents");
-    fs::create_dir_all(&agents_dir).unwrap();
-    fs::create_dir_all(&data_dir).unwrap();
-    fs::create_dir_all(&state_dir).unwrap();
-
-    unsafe {
-        std::env::set_var("HARNX_CONFIG_DIR", &config_dir);
-        std::env::set_var("HARNX_DATA_DIR", &data_dir);
-        std::env::set_var("HARNX_STATE_DIR", &state_dir);
-    }
-
-    let agent_content = r#"---
+    let rendered = with_test_config_dir(|config_dir| {
+        let agents_dir = config_dir.join("packages/mypkg/agents");
+        fs::create_dir_all(&agents_dir)?;
+        let agent_content = r#"---
 model: openai:gpt-4o
 ---
 You are a package agent.
 "#;
-    fs::write(agents_dir.join("pkg-agent.md"), agent_content).unwrap();
-
-    let config = Config::default();
-    let result = render_agent_dump(&config, "mypkg/pkg-agent");
-
-    unsafe {
-        std::env::remove_var("HARNX_CONFIG_DIR");
-        std::env::remove_var("HARNX_DATA_DIR");
-        std::env::remove_var("HARNX_STATE_DIR");
-    }
-    let _ = fs::remove_dir_all(&config_dir);
-    let _ = fs::remove_dir_all(&data_dir);
-    let _ = fs::remove_dir_all(&state_dir);
-
-    let rendered = result.expect("should succeed for package-qualified agent");
+        fs::write(agents_dir.join("pkg-agent.md"), agent_content)?;
+        render_agent_dump(&Config::default(), "mypkg/pkg-agent")
+    })
+    .expect("should succeed for package-qualified agent");
     assert!(
         rendered.contains("You are a package agent"),
         "should have agent body"

--- a/crates/harnx-runtime/src/config/agent_tests.rs
+++ b/crates/harnx-runtime/src/config/agent_tests.rs
@@ -3,17 +3,15 @@
 
 use super::*;
 use crate::client::MessageRole;
+use crate::config::test_support::{env_lock, EnvGuard};
 use crate::config::GlobalConfig;
 use crate::utils::create_abort_signal;
 use std::{
     fs,
     path::Path,
     path::PathBuf,
-    sync::{LazyLock, Mutex},
     time::{SystemTime, UNIX_EPOCH},
 };
-
-static TEST_CONFIG_DIR_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 fn unique_test_config_dir() -> PathBuf {
     let timestamp = SystemTime::now()
@@ -27,7 +25,7 @@ fn unique_test_config_dir() -> PathBuf {
 }
 
 fn with_test_config_dir<T>(f: impl FnOnce(&Path) -> Result<T>) -> Result<T> {
-    let _guard = TEST_CONFIG_DIR_LOCK.lock().unwrap();
+    let _guard = env_lock();
     let config_dir = unique_test_config_dir();
     let data_dir = config_dir.with_file_name(format!(
         "{}-data",
@@ -42,17 +40,12 @@ fn with_test_config_dir<T>(f: impl FnOnce(&Path) -> Result<T>) -> Result<T> {
     fs::create_dir_all(&data_dir)?;
     fs::create_dir_all(&state_dir)?;
 
-    unsafe {
-        std::env::set_var("HARNX_CONFIG_DIR", &config_dir);
-        std::env::set_var("HARNX_DATA_DIR", &data_dir);
-        std::env::set_var("HARNX_STATE_DIR", &state_dir);
-    }
-    let result = f(&config_dir);
-    unsafe {
-        std::env::remove_var("HARNX_CONFIG_DIR");
-        std::env::remove_var("HARNX_DATA_DIR");
-        std::env::remove_var("HARNX_STATE_DIR");
-    }
+    let result = {
+        let _config = EnvGuard::new("HARNX_CONFIG_DIR", &config_dir);
+        let _data = EnvGuard::new("HARNX_DATA_DIR", &data_dir);
+        let _state = EnvGuard::new("HARNX_STATE_DIR", &state_dir);
+        f(&config_dir)
+    };
 
     let _ = fs::remove_dir_all(&data_dir);
     let _ = fs::remove_dir_all(&state_dir);

--- a/crates/harnx-runtime/src/config/compaction_tests.rs
+++ b/crates/harnx-runtime/src/config/compaction_tests.rs
@@ -1,7 +1,7 @@
 //! compact_session / compaction-agent tests for the config module.
 #![cfg(test)]
 
-use super::test_support::EnvGuard;
+use super::test_support::{env_lock_async, EnvGuard};
 use super::*;
 use crate::client::TestStateGuard;
 use crate::test_utils::{MockClient, MockTurnBuilder};
@@ -142,6 +142,7 @@ async fn test_compact_session_with_compaction_agent_sends_rendered_transcript() 
         )],
     );
     let (mock, _guard) = install_summarizer_mock().await;
+    let _env_lock = env_lock_async().await;
     let _env = EnvGuard::new("HARNX_CONFIG_DIR", temp.path());
 
     Config::compact_session(&config).await.unwrap();
@@ -225,6 +226,7 @@ async fn test_compact_session_package_bare_compaction_agent_resolves_within_pack
         )],
     );
     let (mock, _guard) = install_summarizer_mock().await;
+    let _env_lock = env_lock_async().await;
     let _env = EnvGuard::new("HARNX_CONFIG_DIR", temp.path());
 
     Config::compact_session(&config).await.unwrap();
@@ -272,6 +274,7 @@ async fn test_compact_session_honors_compaction_keep_recent_turns() {
     }
     let config = with_session(config, turns);
     let (mock, _guard) = install_summarizer_mock().await;
+    let _env_lock = env_lock_async().await;
     let _env = EnvGuard::new("HARNX_CONFIG_DIR", temp.path());
 
     Config::compact_session(&config).await.unwrap();

--- a/crates/harnx-runtime/src/config/env_split.rs
+++ b/crates/harnx-runtime/src/config/env_split.rs
@@ -171,62 +171,42 @@ pub fn load_env_file() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::test_support::{env_lock, EnvGuard};
 
-    /// RAII guard that removes an env var on drop.
     #[test]
     fn load_envs_reads_cleanup_remote_sessions_days() {
-        let _lock = crate::config::test_support::env_lock();
-        let prev = std::env::var_os("HARNX_CLEANUP_REMOTE_SESSIONS_DAYS");
-        // SAFETY: test-only; global test lock held.
-        unsafe { std::env::set_var("HARNX_CLEANUP_REMOTE_SESSIONS_DAYS", "7") };
+        let _lock = env_lock();
+        let _cleanup_days = EnvGuard::new("HARNX_CLEANUP_REMOTE_SESSIONS_DAYS", "7");
 
         let mut config = Config::default();
         config.load_envs();
 
         assert_eq!(config.cleanup_remote_sessions_days, Some(7));
-
-        // Restore prior state
-        match prev {
-            Some(v) => unsafe { std::env::set_var("HARNX_CLEANUP_REMOTE_SESSIONS_DAYS", v) },
-            None => unsafe { std::env::remove_var("HARNX_CLEANUP_REMOTE_SESSIONS_DAYS") },
-        }
     }
 
     #[test]
     fn load_envs_unset_cleanup_remote_sessions_days_is_none() {
-        let _lock = crate::config::test_support::env_lock();
-        let prev = std::env::var_os("HARNX_CLEANUP_REMOTE_SESSIONS_DAYS");
-        // SAFETY: test-only; global test lock held.
-        unsafe { std::env::remove_var("HARNX_CLEANUP_REMOTE_SESSIONS_DAYS") };
+        let _lock = env_lock();
+        let _cleanup_days = EnvGuard::remove("HARNX_CLEANUP_REMOTE_SESSIONS_DAYS");
 
         let mut config = Config::default();
         config.load_envs();
 
         assert_eq!(config.cleanup_remote_sessions_days, None);
-
-        // Restore prior state
-        if let Some(v) = prev {
-            unsafe { std::env::set_var("HARNX_CLEANUP_REMOTE_SESSIONS_DAYS", v) }
-        }
     }
 
     #[test]
     fn load_env_file_ambient_env_always_wins() {
         use std::io::Write;
 
-        let _lock = crate::config::test_support::env_lock();
-        let prev_log_level = std::env::var_os("HARNX_LOG_LEVEL");
-        let prev_inherited = std::env::var_os("SOME_INHERITED_VAR");
-        let prev_unset_var = std::env::var_os("ENV_ONLY_VAR");
-        let prev_harnx_env_file = std::env::var_os("HARNX_ENV_FILE");
+        let _lock = env_lock();
 
         // Set inherited vars: one logging var, one arbitrary non-log var. Both
         // are already present in the ambient environment.
-        // SAFETY: test-only; global test lock held.
-        unsafe { std::env::set_var("HARNX_LOG_LEVEL", "debug") };
-        unsafe { std::env::set_var("SOME_INHERITED_VAR", "from-ambient") };
+        let _log_level = EnvGuard::new("HARNX_LOG_LEVEL", "debug");
+        let _inherited = EnvGuard::new("SOME_INHERITED_VAR", "from-ambient");
         // Ensure the .env-only var is NOT set ambiently.
-        unsafe { std::env::remove_var("ENV_ONLY_VAR") };
+        let _env_only = EnvGuard::remove("ENV_ONLY_VAR");
 
         // .env tries to override both inherited vars AND sets a fresh var.
         let tmpdir = tempfile::tempdir().expect("tempdir");
@@ -238,7 +218,7 @@ mod tests {
         .expect("write .env");
         f.sync_all().expect("sync .env");
 
-        unsafe { std::env::set_var("HARNX_ENV_FILE", env_file.display().to_string()) };
+        let _env_file = EnvGuard::new("HARNX_ENV_FILE", &env_file);
 
         load_env_file().expect("load_env_file");
 
@@ -261,23 +241,5 @@ mod tests {
             Some("from-dotenv".to_string()),
             "unset var should be filled in from .env"
         );
-
-        // Restore prior state
-        unsafe { std::env::remove_var("HARNX_ENV_FILE") };
-        unsafe { std::env::remove_var("ENV_ONLY_VAR") };
-        match prev_log_level {
-            Some(v) => unsafe { std::env::set_var("HARNX_LOG_LEVEL", v) },
-            None => unsafe { std::env::remove_var("HARNX_LOG_LEVEL") },
-        }
-        match prev_inherited {
-            Some(v) => unsafe { std::env::set_var("SOME_INHERITED_VAR", v) },
-            None => unsafe { std::env::remove_var("SOME_INHERITED_VAR") },
-        }
-        if let Some(v) = prev_unset_var {
-            unsafe { std::env::set_var("ENV_ONLY_VAR", v) }
-        }
-        if let Some(v) = prev_harnx_env_file {
-            unsafe { std::env::set_var("HARNX_ENV_FILE", v) }
-        }
     }
 }

--- a/crates/harnx-runtime/src/config/nats_split.rs
+++ b/crates/harnx-runtime/src/config/nats_split.rs
@@ -276,7 +276,7 @@ fn expand_env_string(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::test_support::{env_lock, EnvGuard};
+    use crate::config::test_support::{env_lock, env_lock_async, EnvGuard};
 
     /// Assert a resolved server matches the expected dynamic-local identity
     /// (reserved name, url, token) and routes through the authenticated path.
@@ -303,10 +303,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[allow(clippy::await_holding_lock)]
     async fn local_cluster_env_handoff_builds_authenticated_dynamic_config() {
         harnx_core::require_nextest();
-        let _lock = env_lock();
+        let _lock = env_lock_async().await;
         let _url = EnvGuard::new(
             HARNX_NATS_URL_ENV,
             std::path::Path::new("nats://127.0.0.1:4555"),
@@ -321,10 +320,9 @@ mod tests {
     /// An operator's typo in `HARNX_NATS_REPLICAS` (e.g. "3x") must fail
     /// startup loudly, not silently resolve to a single-replica bucket.
     #[tokio::test]
-    #[allow(clippy::await_holding_lock)]
     async fn local_cluster_env_handoff_rejects_an_unparseable_replicas_value() {
         harnx_core::require_nextest();
-        let _lock = env_lock();
+        let _lock = env_lock_async().await;
         let _url = EnvGuard::new(
             HARNX_NATS_URL_ENV,
             std::path::Path::new("nats://127.0.0.1:4555"),
@@ -346,10 +344,9 @@ mod tests {
     /// `HARNX_NATS_TLS*` variables `NatsEndpoint::from_env` does, or that
     /// discovery silently stays plaintext regardless of cluster config.
     #[tokio::test]
-    #[allow(clippy::await_holding_lock)]
     async fn local_cluster_env_handoff_carries_tls_settings() {
         harnx_core::require_nextest();
-        let _lock = env_lock();
+        let _lock = env_lock_async().await;
         let _url = EnvGuard::new(
             HARNX_NATS_URL_ENV,
             std::path::Path::new("tls://127.0.0.1:4555"),
@@ -386,10 +383,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[allow(clippy::await_holding_lock)]
     async fn local_cluster_dynamic_resolution_wins_over_reserved_yaml_entry() {
         harnx_core::require_nextest();
-        let _lock = env_lock();
+        let _lock = env_lock_async().await;
         let _url = EnvGuard::new(
             HARNX_NATS_URL_ENV,
             std::path::Path::new("nats://127.0.0.1:4666"),

--- a/crates/harnx-runtime/src/config/test_support.rs
+++ b/crates/harnx-runtime/src/config/test_support.rs
@@ -1,39 +1,4 @@
 //! Shared test-only helpers for the config module's test submodules.
 #![cfg(test)]
 
-/// RAII guard that sets an env var for a test and restores the prior value on
-/// drop. Test-only; callers must hold the global test lock while it is alive to
-/// prevent concurrent env mutation.
-pub(super) struct EnvGuard {
-    key: &'static str,
-    prev: Option<std::ffi::OsString>,
-}
-impl EnvGuard {
-    pub(super) fn new(key: &'static str, value: &std::path::Path) -> Self {
-        let prev = std::env::var_os(key);
-        // SAFETY: test-only; concurrent env mutation is prevented by the
-        // global test lock held by the caller while the guard is alive.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, prev }
-    }
-}
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        match &self.prev {
-            Some(v) => unsafe { std::env::set_var(self.key, v) },
-            None => unsafe { std::env::remove_var(self.key) },
-        }
-    }
-}
-
-/// Serialize env-mutating tests to prevent HOME/HARNX_CONFIG_DIR from racing.
-/// Cross-platform: used by both the unix-only HOME tests and the
-/// platform-agnostic remote-agent/use_tools tests, so it must compile on all
-/// targets (Windows CI builds these tests too).
-pub(super) fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-    match LOCK.get_or_init(|| std::sync::Mutex::new(())).lock() {
-        Ok(g) => g,
-        Err(e) => e.into_inner(),
-    }
-}
+pub(super) use crate::test_environment::{env_lock, env_lock_async, EnvGuard};

--- a/crates/harnx-runtime/src/config/tests.rs
+++ b/crates/harnx-runtime/src/config/tests.rs
@@ -1,8 +1,8 @@
 //! Tests for the config module (extracted from mod.rs for code health).
 #![cfg(test)]
 
-#[cfg(unix)]
 use super::test_support::env_lock;
+use super::test_support::env_lock_async;
 use super::test_support::EnvGuard;
 use super::*;
 use harnx_core::message::MessageRole;
@@ -271,6 +271,7 @@ async fn test_use_agent_by_name_resolves_file_backed_variable_defaults() {
     // Hold the global test lock so concurrent tests can't race on the
     // shared HARNX_CONFIG_DIR env var.
     let _guard = TestStateGuard::new(None).await;
+    let _env_lock = env_lock_async().await;
     let _env = EnvGuard::new("HARNX_CONFIG_DIR", temp.path());
 
     // Drive use_session in non-interactive mode so the inquire prompt
@@ -574,22 +575,10 @@ fn session_history_tool_declaration_is_gated_by_use_tools() {
 
 #[test]
 fn dynamic_provider_model_init_sets_client_name_from_provider() {
-    struct ProviderGuard(Option<std::ffi::OsString>);
-    impl Drop for ProviderGuard {
-        fn drop(&mut self) {
-            match self.0.take() {
-                Some(value) => unsafe { std::env::set_var("HARNX_PROVIDER", value) },
-                None => unsafe { std::env::remove_var("HARNX_PROVIDER") },
-            }
-        }
-    }
-
-    #[cfg(unix)]
     let _lock = env_lock();
     let tmp = tempfile::tempdir().unwrap();
     let _config_dir = EnvGuard::new("HARNX_CONFIG_DIR", tmp.path());
-    let _provider_guard = ProviderGuard(std::env::var_os("HARNX_PROVIDER"));
-    unsafe { std::env::set_var("HARNX_PROVIDER", "claude:some-model") };
+    let _provider = EnvGuard::new("HARNX_PROVIDER", "claude:some-model");
 
     let config = tokio_test::block_on(Config::init(WorkingMode::Cmd, false))
         .expect("dynamic config should load");
@@ -603,12 +592,11 @@ async fn use_agent_routes_remote_refs_to_nats_cluster_validation() {
     use harnx_core::{abort::create_abort_signal, working_mode::WorkingMode};
 
     let _guard = TestStateGuard::new(None).await;
+    let _env_lock = env_lock_async().await;
 
     let temp = tempfile::TempDir::new().unwrap();
     let _env = EnvGuard::new("HARNX_CONFIG_DIR", temp.path());
-    let provider_prev = std::env::var_os("HARNX_PROVIDER");
-    // SAFETY: test-only; shared test lock held for duration.
-    unsafe { std::env::set_var("HARNX_PROVIDER", "claude:some-model") };
+    let _provider = EnvGuard::new("HARNX_PROVIDER", "claude:some-model");
 
     let config = Config::init(WorkingMode::Cmd, false)
         .await
@@ -618,14 +606,6 @@ async fn use_agent_routes_remote_refs_to_nats_cluster_validation() {
     let err = Config::use_agent(&config, "atlas@prod", None, create_abort_signal())
         .await
         .expect_err("remote ref with an unknown cluster must fail cluster validation");
-
-    // SAFETY: test-only; restore provider env.
-    unsafe {
-        match &provider_prev {
-            Some(v) => std::env::set_var("HARNX_PROVIDER", v),
-            None => std::env::remove_var("HARNX_PROVIDER"),
-        }
-    }
 
     // Remote refs are no longer stubbed out — they route into NATS thin-client
     // mode, which first validates the cluster. With no nats_servers/prod.yaml

--- a/crates/harnx-runtime/src/lib.rs
+++ b/crates/harnx-runtime/src/lib.rs
@@ -32,10 +32,13 @@ pub mod nats_worker;
 pub mod remote_session_cleanup;
 pub mod server_identity;
 pub mod session_history;
+#[cfg(test)]
+mod test_environment;
 pub mod test_utils;
 pub mod tool;
 pub mod tool_context;
 pub mod utils;
+mod worker_identity;
 
 // Re-export thin-client types for frontends
 pub use nats_client_session::{

--- a/crates/harnx-runtime/src/local_orchestrator.rs
+++ b/crates/harnx-runtime/src/local_orchestrator.rs
@@ -98,8 +98,22 @@ pub struct LocalWorkerSupervisor {
     owns_lock: bool,
     child: Option<Child>,
     last_confirmed_ready: Option<Instant>,
+    confirmed_config_fingerprint: Option<String>,
+    confirmed_executable_fingerprint: Option<String>,
+    spawned_config_fingerprint: Option<String>,
+    spawned_executable_fingerprint: Option<String>,
     /// Owned workers that exited during the current readiness wait.
     crashes: u32,
+}
+
+struct ExpectedWorkerIdentity {
+    config_fingerprint: String,
+    executable_fingerprint: String,
+}
+
+enum ReadinessStatus {
+    Ready,
+    Pending,
 }
 
 /// Lazily starts or re-checks a front-end's process-lifetime local worker.
@@ -148,6 +162,10 @@ impl LocalWorkerSupervisor {
             owns_lock,
             child: None,
             last_confirmed_ready: None,
+            confirmed_config_fingerprint: None,
+            confirmed_executable_fingerprint: None,
+            spawned_config_fingerprint: None,
+            spawned_executable_fingerprint: None,
             crashes: 0,
         };
         supervisor.ensure(abort_signal).await?;
@@ -158,21 +176,38 @@ impl LocalWorkerSupervisor {
     /// after another front-end releases `worker.lock`. Returns only after a
     /// post-consumer readiness marker is observed.
     pub async fn ensure(&mut self, abort_signal: AbortSignal) -> Result<()> {
+        let expected = self.current_expected_identity().await?;
         if self.owned_child_is_running()? {
-            return Ok(());
+            if self.spawned_config_fingerprint.as_deref() == Some(&expected.config_fingerprint)
+                && self.spawned_executable_fingerprint.as_deref()
+                    == Some(&expected.executable_fingerprint)
+            {
+                return Ok(());
+            }
+            log::info!(
+                "local worker inputs changed: config={} -> {} executable={} -> {}; restarting owned worker",
+                self.spawned_config_fingerprint
+                    .as_deref()
+                    .map(crate::worker_identity::short_fingerprint)
+                    .unwrap_or("unknown"),
+                crate::worker_identity::short_fingerprint(&expected.config_fingerprint),
+                self.spawned_executable_fingerprint
+                    .as_deref()
+                    .map(crate::worker_identity::short_fingerprint)
+                    .unwrap_or("unknown"),
+                crate::worker_identity::short_fingerprint(&expected.executable_fingerprint),
+            );
+            self.stop_owned_worker().await?;
         }
-        if !self.owns_lock
-            && self
-                .last_confirmed_ready
-                .is_some_and(|ready| ready.elapsed() < JOINER_READY_TTL)
-        {
+        if self.recently_confirmed(&expected) {
             return Ok(());
         }
 
         let readiness = self.subscribe_to_readiness().await?;
         self.crashes = 0;
-        self.ensure_worker_ownership()?;
-        self.wait_for_readiness(readiness, abort_signal).await
+        self.ensure_worker_ownership(&expected)?;
+        self.wait_for_readiness(readiness, abort_signal, &expected)
+            .await
     }
 
     async fn subscribe_to_readiness(&self) -> Result<async_nats::Subscriber> {
@@ -192,10 +227,10 @@ impl LocalWorkerSupervisor {
         Ok(readiness)
     }
 
-    fn ensure_worker_ownership(&mut self) -> Result<()> {
+    fn ensure_worker_ownership(&mut self, expected: &ExpectedWorkerIdentity) -> Result<()> {
         if self.owns_lock {
             if !self.owned_child_is_running()? {
-                self.spawn_worker()?;
+                self.spawn_worker(expected)?;
             }
             return Ok(());
         }
@@ -207,7 +242,7 @@ impl LocalWorkerSupervisor {
         .context("retry local worker lock")?;
         if acquired {
             self.owns_lock = true;
-            self.spawn_worker()?;
+            self.spawn_worker(expected)?;
         }
         Ok(())
     }
@@ -224,6 +259,7 @@ impl LocalWorkerSupervisor {
         &mut self,
         mut readiness: async_nats::Subscriber,
         abort_signal: AbortSignal,
+        expected: &ExpectedWorkerIdentity,
     ) -> Result<()> {
         let started = Instant::now();
         let mut poll = READINESS_POLL_INITIAL;
@@ -232,13 +268,9 @@ impl LocalWorkerSupervisor {
             if abort_signal.aborted() {
                 bail!("cancelled while waiting for the local worker to start");
             }
-            match tokio::time::timeout(poll, readiness.next()).await {
-                Ok(Some(_)) => {
-                    self.last_confirmed_ready = Some(Instant::now());
-                    return Ok(());
-                }
-                Ok(None) => bail!("local worker readiness subscription closed"),
-                Err(_) => self.ensure_worker_ownership()?,
+            match self.poll_readiness(&mut readiness, poll, expected).await? {
+                ReadinessStatus::Ready => return Ok(()),
+                ReadinessStatus::Pending => {}
             }
 
             if self.crashes >= MAX_WORKER_CRASHES {
@@ -256,6 +288,93 @@ impl LocalWorkerSupervisor {
             }
             poll = (poll * 2).min(READINESS_POLL_MAX);
         }
+    }
+
+    async fn poll_readiness(
+        &mut self,
+        readiness: &mut async_nats::Subscriber,
+        poll: Duration,
+        expected: &ExpectedWorkerIdentity,
+    ) -> Result<ReadinessStatus> {
+        match tokio::time::timeout(poll, readiness.next()).await {
+            Ok(Some(message)) => self.readiness_status(&message.payload, expected),
+            Ok(None) => bail!("local worker readiness subscription closed"),
+            Err(_) => {
+                self.ensure_worker_ownership(expected)?;
+                Ok(ReadinessStatus::Pending)
+            }
+        }
+    }
+
+    fn readiness_status(
+        &mut self,
+        payload: &[u8],
+        expected: &ExpectedWorkerIdentity,
+    ) -> Result<ReadinessStatus> {
+        match self.accept_readiness(payload, expected) {
+            Ok(()) => Ok(ReadinessStatus::Ready),
+            Err(error) if self.owns_lock => {
+                log::warn!(
+                    "ignoring stale local worker readiness while waiting for the owned worker: {error:#}"
+                );
+                self.ensure_worker_ownership(expected)?;
+                Ok(ReadinessStatus::Pending)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    fn recently_confirmed(&self, expected: &ExpectedWorkerIdentity) -> bool {
+        if self.owns_lock {
+            return false;
+        }
+        let fresh = self
+            .last_confirmed_ready
+            .is_some_and(|ready| ready.elapsed() < JOINER_READY_TTL);
+        fresh
+            && self.confirmed_config_fingerprint.as_deref() == Some(&expected.config_fingerprint)
+            && self.confirmed_executable_fingerprint.as_deref()
+                == Some(&expected.executable_fingerprint)
+    }
+
+    fn accept_readiness(
+        &mut self,
+        payload: &[u8],
+        expected: &ExpectedWorkerIdentity,
+    ) -> Result<()> {
+        let identity =
+            crate::worker_identity::WorkerIdentity::from_payload(payload).with_context(|| {
+                "active local worker is too old to verify; restart the frontend that owns it"
+            })?;
+        self.validate_worker_identity(&identity, expected)?;
+        log::info!(
+            "local worker ready: worker_id={} pid={} build={} executable={} config={}",
+            identity.worker_id,
+            identity.pid,
+            identity.build,
+            crate::worker_identity::short_fingerprint(&identity.executable_fingerprint),
+            crate::worker_identity::short_fingerprint(&identity.config_fingerprint),
+        );
+        self.last_confirmed_ready = Some(Instant::now());
+        self.confirmed_config_fingerprint = Some(identity.config_fingerprint);
+        self.confirmed_executable_fingerprint = Some(identity.executable_fingerprint);
+        Ok(())
+    }
+
+    fn validate_worker_identity(
+        &self,
+        identity: &crate::worker_identity::WorkerIdentity,
+        expected: &ExpectedWorkerIdentity,
+    ) -> Result<()> {
+        if identity.build != crate::worker_identity::current_build() {
+            return Err(stale_worker_error(identity, expected));
+        }
+        if identity.config_fingerprint != expected.config_fingerprint
+            || identity.executable_fingerprint != expected.executable_fingerprint
+        {
+            return Err(stale_worker_error(identity, expected));
+        }
+        Ok(())
     }
 
     /// Whether this front-end owns `worker.lock` and therefore the subprocess.
@@ -282,13 +401,15 @@ impl LocalWorkerSupervisor {
             Some(status) => {
                 log::warn!("local worker exited with {status}; respawning");
                 self.child = None;
+                self.spawned_config_fingerprint = None;
+                self.spawned_executable_fingerprint = None;
                 self.crashes = self.crashes.saturating_add(1);
                 Ok(false)
             }
         }
     }
 
-    fn spawn_worker(&mut self) -> Result<()> {
+    fn spawn_worker(&mut self, expected: &ExpectedWorkerIdentity) -> Result<()> {
         if self.child.is_some() {
             return Ok(());
         }
@@ -297,6 +418,36 @@ impl LocalWorkerSupervisor {
         self.child = Some(command.spawn().with_context(|| {
             format!("spawn local worker from {}", self.worker_binary.display())
         })?);
+        self.spawned_config_fingerprint = Some(expected.config_fingerprint.clone());
+        self.spawned_executable_fingerprint = Some(expected.executable_fingerprint.clone());
+        Ok(())
+    }
+
+    async fn current_expected_identity(&self) -> Result<ExpectedWorkerIdentity> {
+        let worker_binary = self.worker_binary.clone();
+        tokio::task::spawn_blocking(move || {
+            Ok(ExpectedWorkerIdentity {
+                config_fingerprint: crate::worker_identity::config_fingerprint()?,
+                executable_fingerprint: crate::worker_identity::executable_fingerprint(
+                    &worker_binary,
+                )?,
+            })
+        })
+        .await
+        .context("join expected local worker identity fingerprint task")?
+    }
+
+    async fn stop_owned_worker(&mut self) -> Result<()> {
+        let Some(mut child) = self.child.take() else {
+            return Ok(());
+        };
+        signal_worker_tree(&mut child);
+        child.wait().await.context("wait for stale local worker")?;
+        self.last_confirmed_ready = None;
+        self.confirmed_config_fingerprint = None;
+        self.confirmed_executable_fingerprint = None;
+        self.spawned_config_fingerprint = None;
+        self.spawned_executable_fingerprint = None;
         Ok(())
     }
 }
@@ -337,15 +488,7 @@ impl Drop for LocalWorkerSupervisor {
         let Some(mut child) = self.child.take() else {
             return;
         };
-        #[cfg(unix)]
-        if let Some(pid) = child.id() {
-            // Negative PID addresses the worker's dedicated process group.
-            // SAFETY: kill is async-signal-safe and the PID came from Child.
-            unsafe {
-                libc::kill(-(pid as libc::pid_t), libc::SIGTERM);
-            }
-        }
-        let _ = child.start_kill();
+        signal_worker_tree(&mut child);
 
         // Keep the lock descriptor alive until the child is reaped. This prevents
         // another front-end from spawning a replacement while shutdown is still
@@ -364,6 +507,34 @@ impl Drop for LocalWorkerSupervisor {
                 }
             });
     }
+}
+
+fn signal_worker_tree(child: &mut Child) {
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        // Negative PID addresses the worker's dedicated process group.
+        // SAFETY: kill is async-signal-safe and the PID came from Child.
+        unsafe {
+            libc::kill(-(pid as libc::pid_t), libc::SIGTERM);
+        }
+    }
+    let _ = child.start_kill();
+}
+
+fn stale_worker_error(
+    identity: &crate::worker_identity::WorkerIdentity,
+    expected: &ExpectedWorkerIdentity,
+) -> anyhow::Error {
+    anyhow::anyhow!(
+        "active local worker is stale: pid={} build={} executable={} config={}; current frontend expects build={} executable={} config={}. Restart the frontend that owns the local worker and retry",
+        identity.pid,
+        identity.build,
+        crate::worker_identity::short_fingerprint(&identity.executable_fingerprint),
+        crate::worker_identity::short_fingerprint(&identity.config_fingerprint),
+        crate::worker_identity::current_build(),
+        crate::worker_identity::short_fingerprint(&expected.executable_fingerprint),
+        crate::worker_identity::short_fingerprint(&expected.config_fingerprint),
+    )
 }
 
 /// Tell the user the worker is still coming up, on the same channel as other

--- a/crates/harnx-runtime/src/nats_worker/daemon.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon.rs
@@ -217,12 +217,14 @@ pub(super) struct WorkerStartup {
     /// every bucket this worker creates (leases, session index, tool/hook
     /// registries) agrees on it instead of drifting to a per-site default.
     pub(super) replicas: usize,
+    pub(super) identity: crate::worker_identity::WorkerIdentity,
 }
 
 async fn prepare_worker_startup(
     config: &GlobalConfig,
     daemon: &WorkerDaemonConfig,
 ) -> Result<WorkerStartup> {
+    let identity = crate::worker_identity::WorkerIdentity::current(&daemon.worker_id).await?;
     let (jetstream, client, replicas) = {
         let cfg = config.read().clone();
         let jetstream = cfg.nats_jetstream(&daemon.cluster).await?;
@@ -253,16 +255,21 @@ async fn prepare_worker_startup(
         client,
         consumer,
         replicas,
+        identity,
     })
 }
 
-pub(super) fn spawn_readiness_publisher(client: async_nats::Client, daemon: &WorkerDaemonConfig) {
+pub(super) fn spawn_readiness_publisher(
+    client: async_nats::Client,
+    daemon: &WorkerDaemonConfig,
+    identity: &crate::worker_identity::WorkerIdentity,
+) -> Result<()> {
     let subject = worker_ready_subject(&daemon.cluster);
-    let worker_id = daemon.worker_id.clone();
+    let payload = identity.payload()?;
     tokio::spawn(async move {
         loop {
             if let Err(error) = client
-                .publish(subject.clone(), worker_id.clone().into())
+                .publish(subject.clone(), payload.clone().into())
                 .await
             {
                 log::warn!("failed to publish worker readiness marker: {error}");
@@ -275,6 +282,7 @@ pub(super) fn spawn_readiness_publisher(client: async_nats::Client, daemon: &Wor
             tokio::time::sleep(Duration::from_millis(250)).await;
         }
     });
+    Ok(())
 }
 
 pub(super) async fn optional_session_index(
@@ -340,8 +348,16 @@ pub async fn run_worker_daemon(
     call_fn: Option<crate::agent_loop::AgentCallFn>,
 ) -> Result<()> {
     let instance_id = resolve_worker_scope(daemon.manage_servers)?;
-    log::info!("serving under scope '{}'", instance_id.as_str());
     let startup = prepare_worker_startup(&config, &daemon).await?;
+    log::info!(
+        "serving under scope '{}' worker_id={} pid={} build={} executable={} config={}",
+        instance_id.as_str(),
+        startup.identity.worker_id,
+        startup.identity.pid,
+        startup.identity.build,
+        crate::worker_identity::short_fingerprint(&startup.identity.executable_fingerprint),
+        crate::worker_identity::short_fingerprint(&startup.identity.config_fingerprint),
+    );
     // `WorkerDaemonConfig::new` has no cluster to resolve against yet, so its
     // lease config carries the bare default; now that `daemon.cluster` is
     // resolved, the lease bucket agrees with everything else this worker
@@ -357,6 +373,7 @@ pub async fn run_worker_daemon(
         cluster: daemon.cluster.clone(),
         manage_servers: daemon.manage_servers,
         worker_id: daemon.worker_id.clone(),
+        identity: startup.identity.clone(),
         lease: daemon.lease,
         jetstream: startup.jetstream,
         session_index: services.session_index,

--- a/crates/harnx-runtime/src/nats_worker/daemon_background.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon_background.rs
@@ -310,7 +310,7 @@ pub(super) async fn launch_worker_services(
     // intentionally non-fatal degradation into an unusable CLI. Tool servers
     // no longer start here at all: each session's own servers start (and are
     // waited on) in `handle_activation` when that session activates.
-    super::daemon::spawn_readiness_publisher(startup.client.clone(), daemon);
+    super::daemon::spawn_readiness_publisher(startup.client.clone(), daemon, &startup.identity)?;
 
     let background = Arc::new(Mutex::new(None));
     // Session-specific tool servers are awaited during activation, but the

--- a/crates/harnx-runtime/src/nats_worker/daemon_runtime.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon_runtime.rs
@@ -61,6 +61,7 @@ pub(super) struct WorkerRuntime {
     pub(super) cluster: String,
     pub(super) manage_servers: bool,
     pub(super) worker_id: String,
+    pub(super) identity: crate::worker_identity::WorkerIdentity,
     pub(super) lease: NatsLeaseConfig,
     pub(super) jetstream: jetstream::Context,
     pub(super) session_index: Option<async_nats::jetstream::kv::Store>,
@@ -238,9 +239,13 @@ impl WorkerRuntime {
         // registration round a chance to finish before that snapshot is taken.
         super::daemon_background::await_initial_tool_registration(&self.tools_attempted).await;
         log::info!(
-            "session activate claimed: session_id={} worker_id={} revision={} epoch={}",
+            "session activate claimed: session_id={} worker_id={} worker_pid={} build={} executable={} config={} revision={} epoch={}",
             activation.session_id,
             lease.worker_id(),
+            self.identity.pid,
+            self.identity.build,
+            crate::worker_identity::short_fingerprint(&self.identity.executable_fingerprint),
+            crate::worker_identity::short_fingerprint(&self.identity.config_fingerprint),
             lease.fence_token(),
             activation.epoch
         );

--- a/crates/harnx-runtime/src/nats_worker/tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests.rs
@@ -74,7 +74,7 @@ pub(super) async fn spawn_test_nats() -> Option<(String, std::process::Child, te
 }
 
 static CWD_MUTEX: LazyLock<std::sync::Mutex<()>> = LazyLock::new(|| std::sync::Mutex::new(()));
-static ENV_MUTEX: LazyLock<AsyncMutex<()>> = LazyLock::new(|| AsyncMutex::new(()));
+const NATS_TEST_CONDITION_TIMEOUT: Duration = Duration::from_secs(15);
 
 struct CurrentDirGuard {
     original_dir: PathBuf,
@@ -100,48 +100,14 @@ impl Drop for CurrentDirGuard {
     }
 }
 
-pub(super) async fn env_lock() -> tokio::sync::MutexGuard<'static, ()> {
-    ENV_MUTEX.lock().await
-}
-
-pub(super) struct TestEnvGuard {
-    key: String,
-    prev: Option<std::ffi::OsString>,
-}
-
-impl TestEnvGuard {
-    pub(super) fn new(key: &str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-        let prev = std::env::var_os(key);
-        unsafe { std::env::set_var(key, value) };
-        Self {
-            key: key.to_string(),
-            prev,
-        }
-    }
-}
-
-impl Drop for TestEnvGuard {
-    fn drop(&mut self) {
-        match &self.prev {
-            Some(value) => unsafe { std::env::set_var(&self.key, value) },
-            None => unsafe { std::env::remove_var(&self.key) },
-        }
-    }
-}
+pub(super) use crate::test_environment::{env_lock_async as env_lock, EnvGuard as TestEnvGuard};
 
 fn load_config_via_internal_pipeline(config_path: &Path) -> Config {
-    let prev = std::env::var_os("HARNX_CONFIG_DIR");
     let config_dir = config_path
         .parent()
         .expect("config path must have parent directory");
     let _config_guard = TestEnvGuard::new("HARNX_CONFIG_DIR", config_dir);
-    let config = Config::load_from_file(config_path).unwrap();
-    drop(_config_guard);
-    match prev {
-        Some(value) => unsafe { std::env::set_var("HARNX_CONFIG_DIR", value) },
-        None => unsafe { std::env::remove_var("HARNX_CONFIG_DIR") },
-    }
-    config
+    Config::load_from_file(config_path).unwrap()
 }
 
 pub(super) struct SeededRemoteParentConfig {
@@ -1460,7 +1426,7 @@ async fn remote_cancel_published_after_in_flight_marks_session_cancelled() {
             .await
     });
 
-    tokio::time::timeout(Duration::from_secs(5), entered.notified())
+    tokio::time::timeout(NATS_TEST_CONDITION_TIMEOUT, entered.notified())
         .await
         .expect("worker never entered in-flight call_fn before cancel publish");
 
@@ -1472,7 +1438,7 @@ async fn remote_cancel_published_after_in_flight_marks_session_cancelled() {
         .expect("publish cancel control command");
 
     assert!(
-        wait_for_condition(Duration::from_secs(5), || worker_saw_abort
+        wait_for_condition(NATS_TEST_CONDITION_TIMEOUT, || worker_saw_abort
             .load(Ordering::SeqCst))
         .await,
         "worker call_fn never observed abort after remote cancel publish"
@@ -1482,7 +1448,7 @@ async fn remote_cancel_published_after_in_flight_marks_session_cancelled() {
         .await
         .expect("connect nats client for session log polling");
     let log = NatsSessionLog::new(async_nats::jetstream::new(log_client), session_id.clone());
-    let _cancel_entries = tokio::time::timeout(Duration::from_secs(5), async {
+    let _cancel_entries = tokio::time::timeout(NATS_TEST_CONDITION_TIMEOUT, async {
         loop {
             let entries = log
                 .load_events_async()
@@ -1500,7 +1466,7 @@ async fn remote_cancel_published_after_in_flight_marks_session_cancelled() {
     .await
     .expect("durable session log never recorded Cancel entry");
 
-    let _turn_result = tokio::time::timeout(Duration::from_secs(5), run_turn)
+    let _turn_result = tokio::time::timeout(NATS_TEST_CONDITION_TIMEOUT, run_turn)
         .await
         .expect("run_turn task did not complete after remote cancel")
         .expect("run_turn join must succeed")
@@ -2095,6 +2061,38 @@ async fn subagent_operation_timeout_returns_error_and_cancels_child() {
     let _ = nats.wait();
 }
 
+async fn spawn_child_activity_heartbeat(
+    url: &str,
+    session_id: &str,
+) -> (CancellationToken, tokio::task::JoinHandle<()>) {
+    let client = async_nats::connect(url)
+        .await
+        .expect("connect activity publisher");
+    let subject = crate::nats_event_sink::events_subject(session_id);
+    let payload = crate::nats_event_sink::AdvisoryEnvelope::new(
+        u64::MAX,
+        AgentEvent::Turn(harnx_core::event::TurnEvent::Started),
+    )
+    .to_bytes()
+    .expect("encode activity");
+    let stop = CancellationToken::new();
+    let task_stop = stop.clone();
+    let task = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                () = task_stop.cancelled() => break,
+                () = tokio::time::sleep(Duration::from_millis(40)) => {}
+            }
+            client
+                .publish(subject.clone(), payload.clone().into())
+                .await
+                .expect("publish child activity");
+            client.flush().await.expect("flush child activity");
+        }
+    });
+    (stop, task)
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn subagent_idle_timeout_resets_on_child_activity() {
     let _env_guard = env_lock().await;
@@ -2119,46 +2117,24 @@ async fn subagent_idle_timeout_resets_on_child_activity() {
         &url,
         super::subagent_toolset::SubagentTimeouts::new(
             Duration::from_millis(75),
-            Duration::from_secs(2),
+            Duration::from_secs(10),
         ),
     )
     .await;
     let session_id = crate::nats_worker::new_remote_session_id();
-    let activity_publisher = tokio::spawn({
-        let url = url.clone();
-        let session_id = session_id.clone();
-        async move {
-            let client = async_nats::connect(url)
-                .await
-                .expect("connect activity publisher");
-            let subject = crate::nats_event_sink::events_subject(&session_id);
-            for _ in 0..15 {
-                tokio::time::sleep(Duration::from_millis(40)).await;
-                let envelope = crate::nats_event_sink::AdvisoryEnvelope::new(
-                    u64::MAX,
-                    AgentEvent::Turn(harnx_core::event::TurnEvent::Started),
-                );
-                client
-                    .publish(
-                        subject.clone(),
-                        envelope.to_bytes().expect("encode activity").into(),
-                    )
-                    .await
-                    .expect("publish child activity");
-                client.flush().await.expect("flush child activity");
-            }
-        }
-    });
+    let (activity_stop, activity_publisher) =
+        spawn_child_activity_heartbeat(&url, &session_id).await;
     let result = toolset
         .invoke(
             "session_prompt",
             json!({ "message": "stay active", "session_id": session_id }),
             CancellationToken::new(),
         )
-        .await
-        .expect("activity must keep idle timeout from false-firing");
-    assert_eq!(result["response"], "active child completed");
+        .await;
+    activity_stop.cancel();
     activity_publisher.await.expect("join activity publisher");
+    let result = result.expect("activity must keep idle timeout from false-firing");
+    assert_eq!(result["response"], "active child completed");
 
     daemon.abort();
     let _ = daemon.await;

--- a/crates/harnx-runtime/src/test_environment.rs
+++ b/crates/harnx-runtime/src/test_environment.rs
@@ -1,0 +1,86 @@
+//! Process-wide environment isolation for runtime unit tests.
+//!
+//! Rust's test harness runs unit tests from every module in one process. Any
+//! test that changes a path such as `HARNX_CONFIG_DIR` must therefore use this
+//! one lock and restore the previous value when it finishes.
+
+use std::ffi::{OsStr, OsString};
+use tokio::sync::{Mutex, MutexGuard};
+
+static LOCK: Mutex<()> = Mutex::const_new(());
+
+pub(crate) fn env_lock() -> MutexGuard<'static, ()> {
+    LOCK.blocking_lock()
+}
+
+pub(crate) async fn env_lock_async() -> MutexGuard<'static, ()> {
+    LOCK.lock().await
+}
+
+/// Sets one environment variable and restores its exact previous value on
+/// drop. Callers must hold [`env_lock`] for the guard's whole lifetime.
+pub(crate) struct EnvGuard {
+    key: String,
+    previous: Option<OsString>,
+}
+
+impl EnvGuard {
+    pub(crate) fn new(key: impl Into<String>, value: impl AsRef<OsStr>) -> Self {
+        let key = key.into();
+        let previous = std::env::var_os(&key);
+        // SAFETY: every runtime unit test that mutates process environment uses
+        // the shared lock above for the full lifetime of this guard.
+        unsafe { std::env::set_var(&key, value) };
+        Self { key, previous }
+    }
+
+    pub(crate) fn remove(key: impl Into<String>) -> Self {
+        let key = key.into();
+        let previous = std::env::var_os(&key);
+        // SAFETY: every runtime unit test that mutates process environment uses
+        // the shared lock for the full lifetime of this guard.
+        unsafe { std::env::remove_var(&key) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: see `EnvGuard::new`; the caller still holds the shared lock.
+        match &self.previous {
+            Some(value) => unsafe { std::env::set_var(&self.key, value) },
+            None => unsafe { std::env::remove_var(&self.key) },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nested_guard_restores_existing_config_root() {
+        let _lock = env_lock();
+        let sentinel = tempfile::tempdir().expect("create sentinel config root");
+        let fixture = tempfile::tempdir().expect("create fixture config root");
+        let _original = EnvGuard::new("HARNX_CONFIG_DIR", sentinel.path());
+
+        {
+            let _fixture = EnvGuard::new("HARNX_CONFIG_DIR", fixture.path());
+            assert_eq!(
+                std::env::var_os("HARNX_CONFIG_DIR"),
+                Some(fixture.path().into())
+            );
+        }
+
+        assert_eq!(
+            std::env::var_os("HARNX_CONFIG_DIR"),
+            Some(sentinel.path().into()),
+            "dropping a fixture guard must restore the caller's config root"
+        );
+        assert!(
+            !sentinel.path().join("config.yaml").exists(),
+            "the sentinel config root must remain untouched"
+        );
+    }
+}

--- a/crates/harnx-runtime/src/worker_identity.rs
+++ b/crates/harnx-runtime/src/worker_identity.rs
@@ -1,0 +1,359 @@
+//! Identity advertised by local workers for stale-process detection.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use std::fmt::Write;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+const IDENTITY_PROTOCOL: u8 = 1;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct WorkerIdentity {
+    protocol: u8,
+    pub(crate) worker_id: String,
+    pub(crate) pid: u32,
+    pub(crate) build: String,
+    pub(crate) executable_fingerprint: String,
+    pub(crate) config_fingerprint: String,
+}
+
+impl WorkerIdentity {
+    pub(crate) async fn current(worker_id: impl Into<String>) -> Result<Self> {
+        let worker_id = worker_id.into();
+        tokio::task::spawn_blocking(move || {
+            Ok(Self {
+                protocol: IDENTITY_PROTOCOL,
+                worker_id,
+                pid: std::process::id(),
+                build: current_build().to_string(),
+                executable_fingerprint: executable_fingerprint(
+                    &std::env::current_exe().context(
+                        "resolve the current worker executable for identity verification",
+                    )?,
+                )?,
+                config_fingerprint: config_fingerprint()?,
+            })
+        })
+        .await
+        .context("join worker identity fingerprint task")?
+    }
+
+    pub(crate) fn from_payload(payload: &[u8]) -> Result<Self> {
+        let identity: Self = serde_json::from_slice(payload)
+            .context("local worker sent a legacy or invalid readiness marker")?;
+        anyhow::ensure!(
+            identity.protocol == IDENTITY_PROTOCOL,
+            "local worker uses unsupported readiness protocol {}",
+            identity.protocol
+        );
+        Ok(identity)
+    }
+
+    pub(crate) fn payload(&self) -> Result<Vec<u8>> {
+        serde_json::to_vec(self).context("serialize local worker identity")
+    }
+}
+
+pub(crate) const fn current_build() -> &'static str {
+    env!("HARNX_BUILD_SHA")
+}
+
+pub(crate) fn short_fingerprint(fingerprint: &str) -> &str {
+    fingerprint.get(..12).unwrap_or(fingerprint)
+}
+
+pub(crate) fn executable_fingerprint(path: &Path) -> Result<String> {
+    let normalized = normalize(path);
+    let metadata = fs::metadata(path)
+        .with_context(|| format!("inspect worker executable '{}'", path.display()))?;
+    let modified = metadata
+        .modified()
+        .with_context(|| format!("read worker executable mtime '{}'", path.display()))?
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let mut hasher = Sha256::new();
+    hasher.update(b"harnx-worker-executable-v1\0");
+    hasher.update(normalized.as_os_str().as_encoded_bytes());
+    hasher.update(metadata.len().to_le_bytes());
+    hasher.update(modified.as_secs().to_le_bytes());
+    hasher.update(modified.subsec_nanos().to_le_bytes());
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        hasher.update(metadata.dev().to_le_bytes());
+        hasher.update(metadata.ino().to_le_bytes());
+    }
+    Ok(hex_digest(hasher.finalize()))
+}
+
+/// Hash every file under the active config roots, plus an explicitly
+/// redirected dotenv file. Absolute roots are part of the hash so two
+/// frontends sharing a broker but using different config directories cannot
+/// accidentally share one worker.
+pub(crate) fn config_fingerprint() -> Result<String> {
+    retry_transient_config_io(config_fingerprint_once)
+}
+
+fn config_fingerprint_once() -> Result<String> {
+    let mut roots = vec![
+        harnx_core::config_paths::config_dir(),
+        harnx_core::config_paths::config_dir_path(),
+    ];
+    roots.sort();
+    roots.dedup();
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"harnx-local-worker-config-v1\0");
+    for root in roots {
+        hash_tree(&mut hasher, &root)?;
+    }
+    hash_external_file(
+        &mut hasher,
+        "env-file",
+        &harnx_core::config_paths::env_file(),
+    )?;
+    Ok(hex_digest(hasher.finalize()))
+}
+
+fn retry_transient_config_io<T>(mut operation: impl FnMut() -> Result<T>) -> Result<T> {
+    const MAX_ATTEMPTS: usize = 3;
+
+    for attempt in 1..MAX_ATTEMPTS {
+        match operation() {
+            Ok(value) => return Ok(value),
+            Err(error) if is_transient_config_io_error(&error) => {
+                log::debug!(
+                    "config changed while fingerprinting; retrying ({attempt}/{MAX_ATTEMPTS})"
+                );
+                std::thread::yield_now();
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    operation()
+}
+
+fn is_transient_config_io_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause.downcast_ref::<std::io::Error>().is_some_and(|error| {
+            matches!(
+                error.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::Interrupted
+            )
+        })
+    })
+}
+
+fn hex_digest(digest: impl AsRef<[u8]>) -> String {
+    let digest = digest.as_ref();
+    let mut fingerprint = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(fingerprint, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    fingerprint
+}
+
+fn hash_tree(hasher: &mut Sha256, root: &Path) -> Result<()> {
+    let normalized = normalize(root);
+    hasher.update(b"root\0");
+    hasher.update(normalized.as_os_str().as_encoded_bytes());
+    hasher.update(b"\0");
+    if !root.exists() {
+        hasher.update(b"missing\0");
+        return Ok(());
+    }
+    let mut visited = HashSet::new();
+    hash_path(hasher, root, root, &mut visited)
+}
+
+fn hash_path(
+    hasher: &mut Sha256,
+    root: &Path,
+    path: &Path,
+    visited: &mut HashSet<PathBuf>,
+) -> Result<()> {
+    hash_path_name(hasher, root, path);
+    let symlink_metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("inspect config path '{}'", path.display()))?;
+    let is_symlink = symlink_metadata.file_type().is_symlink();
+    if is_symlink {
+        hash_symlink_target(hasher, path)?;
+    }
+    let Some(metadata) = followed_metadata(path, is_symlink)? else {
+        return Ok(());
+    };
+    if metadata.is_dir() {
+        return hash_directory(hasher, root, path, visited);
+    }
+    if metadata.is_file() {
+        hash_regular_file(hasher, path)?;
+    }
+    Ok(())
+}
+
+fn hash_path_name(hasher: &mut Sha256, root: &Path, path: &Path) {
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    hasher.update(b"path\0");
+    hasher.update(relative.as_os_str().as_encoded_bytes());
+    hasher.update(b"\0");
+}
+
+fn hash_symlink_target(hasher: &mut Sha256, path: &Path) -> Result<()> {
+    let target =
+        fs::read_link(path).with_context(|| format!("read config symlink '{}'", path.display()))?;
+    hasher.update(b"symlink\0");
+    hasher.update(target.as_os_str().as_encoded_bytes());
+    hasher.update(b"\0");
+    Ok(())
+}
+
+fn followed_metadata(path: &Path, is_symlink: bool) -> Result<Option<fs::Metadata>> {
+    match fs::metadata(path) {
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(_) if is_symlink => Ok(None),
+        Err(error) => {
+            Err(error).with_context(|| format!("inspect config path '{}'", path.display()))
+        }
+    }
+}
+
+fn hash_directory(
+    hasher: &mut Sha256,
+    root: &Path,
+    path: &Path,
+    visited: &mut HashSet<PathBuf>,
+) -> Result<()> {
+    if !visited.insert(normalize(path)) {
+        hasher.update(b"directory-cycle\0");
+        return Ok(());
+    }
+    let mut entries = fs::read_dir(path)
+        .with_context(|| format!("read config directory '{}'", path.display()))?
+        .collect::<std::io::Result<Vec<_>>>()?;
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
+        hash_path(hasher, root, &entry.path(), visited)?;
+    }
+    Ok(())
+}
+
+fn hash_regular_file(hasher: &mut Sha256, path: &Path) -> Result<()> {
+    hasher.update(b"file\0");
+    hasher
+        .update(fs::read(path).with_context(|| format!("read config file '{}'", path.display()))?);
+    hasher.update(b"\0");
+    Ok(())
+}
+
+fn hash_external_file(hasher: &mut Sha256, label: &str, path: &Path) -> Result<()> {
+    hasher.update(label.as_bytes());
+    hasher.update(b"\0");
+    let normalized = normalize(path);
+    hasher.update(normalized.as_os_str().as_encoded_bytes());
+    hasher.update(b"\0");
+    match fs::read(path) {
+        Ok(contents) => hasher.update(contents),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => hasher.update(b"missing"),
+        Err(error) => {
+            return Err(error).with_context(|| format!("read config file '{}'", path.display()))
+        }
+    }
+    hasher.update(b"\0");
+    Ok(())
+}
+
+fn normalize(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_environment::{env_lock, EnvGuard};
+    use std::cell::Cell;
+
+    #[test]
+    fn config_fingerprint_changes_with_client_config() {
+        let _lock = env_lock();
+        let root = tempfile::tempdir().expect("create config root");
+        let data = tempfile::tempdir().expect("create data root");
+        let _config = EnvGuard::new("HARNX_CONFIG_DIR", root.path());
+        let _data = EnvGuard::new("HARNX_DATA_DIR", data.path());
+        fs::create_dir(root.path().join("clients")).expect("create clients directory");
+        let client = root.path().join("clients/openai.yaml");
+        fs::write(&client, "type: openai\napi_key: first\n").expect("write client config");
+        let first = config_fingerprint().expect("fingerprint initial config");
+
+        fs::write(&client, "type: openai\napi_key: second\n").expect("update client config");
+        let second = config_fingerprint().expect("fingerprint updated config");
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn executable_fingerprint_tracks_file_metadata() {
+        let directory = tempfile::tempdir().expect("create executable fixture directory");
+        let executable = directory.path().join("worker");
+        fs::write(&executable, b"first build").expect("write first executable fixture");
+        let first = executable_fingerprint(&executable).expect("fingerprint first fixture");
+
+        fs::write(&executable, b"second build").expect("write second executable fixture");
+        let second = executable_fingerprint(&executable).expect("fingerprint second fixture");
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn config_fingerprint_retries_transient_io_errors() {
+        let attempts = Cell::new(0);
+        let fingerprint = retry_transient_config_io(|| {
+            let attempt = attempts.get() + 1;
+            attempts.set(attempt);
+            if attempt < 3 {
+                return Err(std::io::Error::from(std::io::ErrorKind::NotFound).into());
+            }
+            Ok("fingerprint")
+        })
+        .expect("transient config errors should be retried");
+
+        assert_eq!(fingerprint, "fingerprint");
+        assert_eq!(attempts.get(), 3);
+    }
+
+    #[test]
+    fn worker_identity_rejects_invalid_readiness_payload() {
+        let error = WorkerIdentity::from_payload(b"local")
+            .expect_err("legacy readiness marker must be rejected");
+
+        assert!(
+            format!("{error:#}").contains("legacy or invalid readiness marker"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
+    fn worker_identity_rejects_unsupported_protocol() {
+        let identity = WorkerIdentity {
+            protocol: IDENTITY_PROTOCOL + 1,
+            worker_id: "local".to_string(),
+            pid: 42,
+            build: "test-build".to_string(),
+            executable_fingerprint: "executable".to_string(),
+            config_fingerprint: "config".to_string(),
+        };
+        let payload = serde_json::to_vec(&identity).expect("serialize test identity");
+        let error = WorkerIdentity::from_payload(&payload)
+            .expect_err("unsupported readiness protocol must be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported readiness protocol 2"),
+            "unexpected error: {error:#}"
+        );
+    }
+}

--- a/crates/harnx-runtime/tests/agent_prompt_rendering.rs
+++ b/crates/harnx-runtime/tests/agent_prompt_rendering.rs
@@ -9,6 +9,7 @@
 
 use std::{ffi::OsStr, fs, path::Path, path::PathBuf};
 
+use harnx_runtime::client::{retrieve_model, ModelType};
 use harnx_runtime::config::agent::{load_with_qualified_name, resolve_variables};
 use harnx_runtime::config::Config;
 
@@ -190,6 +191,72 @@ fn agent_prompt_rendering_renders_all_shipped_agents() {
     assert!(
         file_backed_variables > 0,
         "no shipped agent exercised a file-backed variable"
+    );
+}
+
+fn check_agent_models(config: &Config, qualified_name: &str) -> (usize, Vec<String>) {
+    let agent_path = Config::agent_file(qualified_name);
+    let agent = match load_with_qualified_name(&agent_path, qualified_name) {
+        Ok(agent) => agent,
+        Err(error) => return (0, vec![format!("{qualified_name}: {error:#}")]),
+    };
+    let model_ids = agent
+        .model_id()
+        .into_iter()
+        .chain(agent.model_fallbacks().iter().map(String::as_str));
+    let mut checked = 0;
+    let mut failures = Vec::new();
+    for model_id in model_ids {
+        checked += 1;
+        if let Err(error) = check_model_metadata(config, model_id) {
+            failures.push(format!("{qualified_name}: {error}"));
+        }
+    }
+    (checked, failures)
+}
+
+fn check_model_metadata(config: &Config, model_id: &str) -> Result<(), String> {
+    let model = retrieve_model(&config.clients, model_id, ModelType::Chat)
+        .map_err(|error| format!("model {model_id} does not resolve: {error:#}"))?;
+    if model.real_name() != "gpt-5.6-sol" {
+        return Ok(());
+    }
+    if model.endpoint() != Some("responses") {
+        return Err(format!("{model_id} lost its Responses endpoint metadata"));
+    }
+    Ok(())
+}
+
+#[test]
+fn shipped_agent_models_resolve_with_required_endpoint_metadata() {
+    harnx_core::require_nextest();
+    let Some(workspace_root) = workspace_root() else {
+        return;
+    };
+    let (temp, _config_guard) = install_packages(&workspace_root);
+    let config = Config::load_from_file(&temp.path().join("config.yaml"))
+        .expect("load package client configs");
+    let mut failures = Vec::new();
+    let mut checked = 0usize;
+
+    for package in PACKAGES {
+        let agents_dir = workspace_root.join("packages").join(package).join("agents");
+        for stem in agent_stems(&agents_dir, &mut failures) {
+            let qualified_name = format!("{package}/{stem}");
+            let (agent_checked, agent_failures) = check_agent_models(&config, &qualified_name);
+            checked += agent_checked;
+            failures.extend(agent_failures);
+        }
+    }
+
+    assert!(
+        checked > 0,
+        "no shipped agent model references were checked"
+    );
+    assert!(
+        failures.is_empty(),
+        "invalid shipped agent model references:\n{}",
+        failures.join("\n")
     );
 }
 

--- a/crates/harnx-runtime/tests/local_worker_supervisor.rs
+++ b/crates/harnx-runtime/tests/local_worker_supervisor.rs
@@ -19,6 +19,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_util::sync::CancellationToken;
 
 struct EnvGuard {
     key: &'static str,
@@ -230,14 +231,111 @@ async fn wait_for_process_exit(pid: u32) {
     );
 }
 
+async fn assert_stale_joiner_is_rejected(binary: &Path) {
+    let stale_error = match tokio::time::timeout(
+        Duration::from_secs(10),
+        LocalWorkerSupervisor::start_with_worker_binary(binary, create_abort_signal()),
+    )
+    .await
+    .expect("stale joiner readiness timeout")
+    {
+        Ok(_) => panic!("a joiner must reject a worker with stale config"),
+        Err(error) => error,
+    };
+    assert!(
+        stale_error
+            .to_string()
+            .contains("active local worker is stale"),
+        "unexpected stale-worker error: {stale_error:#}"
+    );
+}
+
+async fn update_config_and_restart_owner(
+    root: &Path,
+    binary: &Path,
+    owner: &mut LocalWorkerSupervisor,
+    old_pid: u32,
+) -> u32 {
+    std::fs::write(
+        root.join("config/config.yaml"),
+        "save: false\nstream: false\nclient: mock\nmodel: mock:test\n# changed\n",
+    )
+    .expect("update local config");
+    assert_stale_joiner_is_rejected(binary).await;
+    let (stale_stop, stale_publisher) = spawn_stale_readiness_heartbeat(owner).await;
+    let restart_result =
+        tokio::time::timeout(Duration::from_secs(15), owner.ensure(create_abort_signal())).await;
+    stale_stop.cancel();
+    stale_publisher
+        .await
+        .expect("join stale readiness publisher");
+    restart_result
+        .expect("owner restart timeout while stale readiness is published")
+        .expect("restart worker after config change");
+    let reloaded_pid = owner.worker_pid().expect("reloaded worker PID");
+    assert_ne!(reloaded_pid, old_pid);
+    assert!(process_exists(reloaded_pid));
+    reloaded_pid
+}
+
+async fn spawn_stale_readiness_heartbeat(
+    owner: &LocalWorkerSupervisor,
+) -> (CancellationToken, tokio::task::JoinHandle<()>) {
+    let client = async_nats::ConnectOptions::new()
+        .token(owner.server().token.clone())
+        .connect(&owner.server().url)
+        .await
+        .expect("connect stale readiness publisher");
+    let subject = worker_ready_subject(LOCAL_CLUSTER_KEY);
+    let stop = CancellationToken::new();
+    let task_stop = stop.clone();
+    let task = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_millis(50));
+        loop {
+            tokio::select! {
+                () = task_stop.cancelled() => break,
+                _ = interval.tick() => {
+                    client
+                        .publish(subject.clone(), "stale readiness".into())
+                        .await
+                        .expect("publish stale readiness marker");
+                    client.flush().await.expect("flush stale readiness marker");
+                }
+            }
+        }
+    });
+    (stop, task)
+}
+
+async fn update_executable_and_restart_owner(
+    binary: &Path,
+    owner: &mut LocalWorkerSupervisor,
+    old_pid: u32,
+) -> u32 {
+    let rebuilt = binary.with_extension("rebuilt");
+    std::fs::copy(binary, &rebuilt).expect("copy rebuilt worker fixture");
+    std::fs::rename(rebuilt, binary).expect("atomically replace worker binary fixture");
+    assert_stale_joiner_is_rejected(binary).await;
+    owner
+        .ensure(create_abort_signal())
+        .await
+        .expect("restart worker after executable change");
+    let reloaded_pid = owner.worker_pid().expect("rebuilt worker PID");
+    assert_ne!(reloaded_pid, old_pid);
+    assert!(process_exists(reloaded_pid));
+    reloaded_pid
+}
+
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn local_worker_supervisor_deduplicates_respawns_and_tears_down() {
     require_nextest();
-    let Some(binary) = skip_without_binaries() else {
+    let Some(installed_binary) = skip_without_binaries() else {
         return;
     };
     let root = tempfile::tempdir().expect("create isolated supervisor environment");
+    let binary = root.path().join("harnx-worker");
+    std::fs::copy(installed_binary, &binary).expect("copy worker binary fixture");
     let _environment = isolated_environment(root.path());
     let (api_base, mock_task) = start_mock_openai().await;
     write_trivial_agent_config(root.path(), &api_base);
@@ -267,7 +365,13 @@ async fn local_worker_supervisor_deduplicates_respawns_and_tears_down() {
 
     assert_worker_completes_turn(&owner, mock_task).await;
 
-    kill_process(first_pid);
+    let executable_reloaded_pid =
+        update_executable_and_restart_owner(&binary, &mut owner, first_pid).await;
+    let config_reloaded_pid =
+        update_config_and_restart_owner(root.path(), &binary, &mut owner, executable_reloaded_pid)
+            .await;
+
+    kill_process(config_reloaded_pid);
     let deadline = Instant::now() + Duration::from_secs(5);
     let replacement_pid = loop {
         owner
@@ -275,7 +379,7 @@ async fn local_worker_supervisor_deduplicates_respawns_and_tears_down() {
             .await
             .expect("respawn killed local worker");
         let pid = owner.worker_pid().expect("replacement worker PID");
-        if pid != first_pid {
+        if pid != config_reloaded_pid {
             break pid;
         }
         assert!(Instant::now() < deadline, "worker was not respawned");

--- a/crates/harnx-runtime/tests/nats_worker.rs
+++ b/crates/harnx-runtime/tests/nats_worker.rs
@@ -224,7 +224,7 @@ async fn seed_session_and_attach_runtime(
     backend.append_event_blocking(&session_header(session_id))?;
 
     let log = NatsSessionLog::new(jetstream, session_id);
-    let entries = log.load_events_async().await?;
+    let entries = log.load_events_at_least_async(1).await?;
     let mut session =
         harnx_runtime::nats_session_log::load_session_from_entries(&entries, session_id)?;
     let runtime = std::sync::Arc::new(backend.clone())
@@ -838,8 +838,10 @@ async fn nats_worker_persists_full_turn_end_to_end() -> Result<()> {
     })
     .await?;
 
-    // Verify: load entries from NATS
-    let entries = log.load_events_async().await?;
+    // A publish ack can precede JetStream's stream metadata reflecting the
+    // same sequence under load. Read the leader-authoritative tail before
+    // asserting on the immediately reloaded log.
+    let entries = log.load_events_latest_async().await?;
     let entries_only: Vec<SessionLogEntry> = entries.iter().map(|(_, e)| e.clone()).collect();
 
     // Should have: Header, User message, ToolCalls, ToolResults, final assistant Message
@@ -909,7 +911,7 @@ async fn nats_worker_honors_configured_token_auth() -> Result<()> {
     })
     .await?;
 
-    let entries = log.load_events_async().await?;
+    let entries = log.load_events_latest_async().await?;
     assert!(
         entries.len() >= 4,
         "expected the authenticated worker to persist a full turn, got {} entries",
@@ -964,7 +966,7 @@ async fn wait_until(timeout: std::time::Duration, mut cond: impl FnMut() -> bool
 /// Generous enough to avoid flakes under CI load (contended runners, slow
 /// subprocess startup). The poll loop returns immediately when the condition
 /// is met, so this only matters when the system is slow.
-const CI_SAFE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const CI_SAFE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn dispatch_runs_exactly_one_worker_per_activation_and_reactivation_is_noop() -> Result<()> {

--- a/crates/harnx-serve/src/lib.rs
+++ b/crates/harnx-serve/src/lib.rs
@@ -211,7 +211,7 @@ impl Server {
         let mut models = list_all_models(&config.clients);
         let mut default_model = config.model.clone();
         default_model.data_mut().name = DEFAULT_MODEL_NAME.into();
-        models.insert(0, &default_model);
+        models.insert(0, default_model);
         let models: Vec<Value> = models
             .into_iter()
             .enumerate()

--- a/crates/harnx/models.yaml
+++ b/crates/harnx/models.yaml
@@ -539,6 +539,8 @@
       output_price: 30
       supports_vision: true
       supports_tool_use: true
+      patches:
+      - del(.body.temperature) | del(.body.top_p)
       endpoint: responses
     - name: gpt-5.6-sol:high
       real_name: gpt-5.6-sol
@@ -550,6 +552,17 @@
       supports_tool_use: true
       patches:
       - del(.body.temperature) | del(.body.top_p) | .body.reasoning = {"effort":"high"}
+      endpoint: responses
+    - name: gpt-5.6-sol:max
+      real_name: gpt-5.6-sol
+      max_input_tokens: 1050000
+      max_output_tokens: 128000
+      input_price: 5
+      output_price: 30
+      supports_vision: true
+      supports_tool_use: true
+      patches:
+      - del(.body.temperature) | del(.body.top_p) | .body.reasoning = {"effort":"max"}
       endpoint: responses
     - name: gpt-5.6-terra
       max_input_tokens: 1050000

--- a/packages/coding/clients/gemini.yaml
+++ b/packages/coding/clients/gemini.yaml
@@ -1,0 +1,3 @@
+type: gemini
+# api_key: AIza...   # or set GEMINI_API_KEY env var
+# api_base: https://generativelanguage.googleapis.com/v1beta   # optional override


### PR DESCRIPTION
Merge configured client models with the embedded catalog so custom entries do not discard endpoint metadata, and add validated GPT-5.6 Sol aliases plus the missing Coding Gemini client.

Serialize environment-mutating tests with exact restoration and bound broker-backed test concurrency to eliminate configuration and NATS stress races.

Advertise worker build, executable, and configuration identities so supervisors restart owned stale processes or reject stale shared workers with actionable diagnostics.

Fixes #1493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the OpenAI `gpt-5.6-sol` model and a maximum-reasoning variant.
  - Added Gemini support for coding compaction workflows.
  - Improved model discovery while preserving provider metadata and system prompt settings.

- **Bug Fixes**
  - Prevented stale workers from being reused after configuration or executable changes.
  - Improved worker restart and readiness handling.
  - Added validation for agent model references and model request compatibility.

- **Tests**
  - Expanded coverage for model configuration, worker refresh behavior, and reliable broker-backed tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->