### PR TITLE
refactor: drop "thin client" terminology

### DIFF
--- a/crates/harnx-core/src/session.rs
+++ b/crates/harnx-core/src/session.rs
@@ -152,7 +152,7 @@ pub enum SessionLogEntry {
     },
     /// Durable boundary written only after the worker has finished the full
     /// model/tool/stop-hook loop. Live `Turn::Ended` events are advisory and
-    /// may be lost, so thin clients use this entry as the authoritative
+    /// may be lost, so clients use this entry as the authoritative
     /// successful completion signal.
     #[serde(rename = "turn_end")]
     TurnEnd {

--- a/crates/harnx-runtime/src/commands.rs
+++ b/crates/harnx-runtime/src/commands.rs
@@ -919,8 +919,8 @@ async fn ask(
             .context("failed to ensure local NATS worker")?;
     }
 
-    let session = crate::ThinClientSession::from_global_config(
-        crate::ThinClientConfig {
+    let session = crate::NatsSession::from_global_config(
+        crate::NatsSessionConfig {
             cluster,
             agent,
             session_id,
@@ -929,19 +929,19 @@ async fn ask(
         abort_signal,
     )
     .await
-    .context("failed to create thin-client session for command")?;
+    .context("failed to create NATS session for command")?;
     let sink = harnx_core::sink::current_agent_event_sink()
         .unwrap_or_else(|| Arc::new(harnx_core::event::NullSink));
     let result = session.run_turn(&input.text(), sink, None).await?;
-    update_last_message_after_thin_client_turn(config, input, &result);
+    update_last_message_after_nats_turn(config, input, &result);
     Ok(())
 }
 
-/// Update front-end continuation state after a completed thin-client turn.
-pub fn update_last_message_after_thin_client_turn(
+/// Update front-end continuation state after a completed NATS session turn.
+pub fn update_last_message_after_nats_turn(
     config: &GlobalConfig,
     input: Input,
-    result: &crate::ThinClientTurnResult,
+    result: &crate::NatsTurnResult,
 ) {
     if result.was_cancelled {
         return;
@@ -1199,10 +1199,10 @@ mod tests {
     }
 
     #[test]
-    fn thin_client_result_updates_last_message_only_after_completed_turn() {
+    fn nats_turn_result_updates_last_message_only_after_completed_turn() {
         let config = Arc::new(RwLock::new(Config::default()));
         let input = crate::config::input::from_str(&config, "hello", None);
-        let completed = crate::ThinClientTurnResult {
+        let completed = crate::NatsTurnResult {
             response: Some("world".to_string()),
             session_id: "session".to_string(),
             was_cancelled: false,
@@ -1211,7 +1211,7 @@ mod tests {
             user_msg_id: "message".to_string(),
         };
 
-        update_last_message_after_thin_client_turn(&config, input.clone(), &completed);
+        update_last_message_after_nats_turn(&config, input.clone(), &completed);
         let last = config
             .read()
             .last_message
@@ -1221,12 +1221,12 @@ mod tests {
         assert_eq!(last.output, "world");
         assert!(last.continuous);
 
-        let cancelled = crate::ThinClientTurnResult {
+        let cancelled = crate::NatsTurnResult {
             response: Some("partial".to_string()),
             was_cancelled: true,
             ..completed
         };
-        update_last_message_after_thin_client_turn(&config, input, &cancelled);
+        update_last_message_after_nats_turn(&config, input, &cancelled);
         assert_eq!(
             config
                 .read()

--- a/crates/harnx-runtime/src/config/agent_ops_split.rs
+++ b/crates/harnx-runtime/src/config/agent_ops_split.rs
@@ -222,7 +222,7 @@ impl Config {
         }
     }
 
-    /// Activate a remote agent for the frontend's next NATS thin-client turn.
+    /// Activate an agent for the frontend's next turn.
     async fn use_remote_agent(params: UseRemoteAgentParams<'_>) -> Result<()> {
         let UseRemoteAgentParams {
             config,
@@ -241,7 +241,7 @@ impl Config {
         }
 
         // Store remote agent metadata in config for use during prompt processing
-        // The actual ThinClientSession is created when the user sends a prompt
+        // The actual NatsSession is created when the user sends a prompt
         config
             .write()
             .set_remote_agent(agent.to_string(), cluster.to_string());

--- a/crates/harnx-runtime/src/config/mod.rs
+++ b/crates/harnx-runtime/src/config/mod.rs
@@ -325,9 +325,8 @@ pub struct Config {
     pub session: Option<Session>,
     pub rag: Option<Arc<Rag>>,
     pub agent: Option<Agent>,
-    /// Remote agent metadata for NATS thin-client mode.
-    /// When set, the agent runs on a remote worker and this client
-    /// drives the turn via `ThinClientSession`.
+    /// Agent and cluster when the active agent ref names one
+    /// (`agent@cluster`). When unset, turns run against the local cluster.
     pub remote_agent: Option<(String, String)>, // (agent_name, cluster)
     pub tui_before_editor: Option<Box<dyn FnMut() + Send + Sync>>,
     pub tui_after_editor: Option<Box<dyn FnMut() + Send + Sync>>,
@@ -491,12 +490,12 @@ impl Default for Config {
 pub type GlobalConfig = Arc<RwLock<Config>>;
 
 impl Config {
-    /// Set remote agent metadata for NATS thin-client mode.
+    /// Set the agent and cluster for the active session.
     pub fn set_remote_agent(&mut self, agent: String, cluster: String) {
         self.remote_agent = Some((agent, cluster));
     }
 
-    /// Check if this config is running in remote-agent mode.
+    /// Check whether the active agent ref names a cluster.
     pub fn is_remote_agent(&self) -> bool {
         self.remote_agent.is_some()
     }

--- a/crates/harnx-runtime/src/config/remote_session_ops.rs
+++ b/crates/harnx-runtime/src/config/remote_session_ops.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::nats_client_session::{new_client_message_id, ThinClientConfig, ThinClientSession};
+use crate::nats_session::{new_client_message_id, NatsSession, NatsSessionConfig};
 use crate::nats_session_log::NatsSessionLog;
 use crate::utils::{edit_file, temp_file, AbortSignal};
 use anyhow::{anyhow, bail, Context, Result};
@@ -9,8 +9,11 @@ pub(crate) async fn clear_remote_session(
     config: &GlobalConfig,
     abort_signal: &AbortSignal,
 ) -> Result<()> {
-    let thin = remote_thin_session(config, abort_signal).await?;
-    let log = NatsSessionLog::new(thin.jetstream().clone(), thin.session_id().to_string());
+    let session = remote_nats_session(config, abort_signal).await?;
+    let log = NatsSessionLog::new(
+        session.jetstream().clone(),
+        session.session_id().to_string(),
+    );
     log.append_event_async(&SessionLogEntry::Clear)
         .await
         .context("Failed to persist session clear in NATS")?;
@@ -51,9 +54,9 @@ pub(crate) async fn edit_remote_message_range(
     to: usize,
     abort_signal: &AbortSignal,
 ) -> Result<()> {
-    let thin = remote_thin_session(config, abort_signal).await?;
+    let session = remote_nats_session(config, abort_signal).await?;
 
-    let selected_messages = remote_user_messages_for_range(from, to, &thin).await?;
+    let selected_messages = remote_user_messages_for_range(from, to, &session).await?;
     if selected_messages.len() > 1 {
         bail!("Remote edit supports a single user message at a time");
     }
@@ -67,7 +70,7 @@ pub(crate) async fn edit_remote_message_range(
         cfg.edit_message_text_with_tui_hooks(&target.text)?
     };
 
-    append_session_mutation_batch_cas(&thin, |state| {
+    append_session_mutation_batch_cas(&session, |state| {
         let target_logical_index = find_target_logical_index(state, target.js_seq)?;
         let group = load_seq_group(state, target.js_seq)?;
         let replacements = build_edit_replacements(group, target_logical_index, &new_text)?;
@@ -163,8 +166,8 @@ pub(crate) async fn delete_remote_message_range(
     to: usize,
     abort_signal: &AbortSignal,
 ) -> Result<()> {
-    let thin = remote_thin_session(config, abort_signal).await?;
-    append_session_mutation_batch_cas(&thin, |state| {
+    let session = remote_nats_session(config, abort_signal).await?;
+    append_session_mutation_batch_cas(&session, |state| {
         let (from, to) = self::session_ops_core::compute_delete_range(
             from,
             to,
@@ -287,8 +290,8 @@ pub(crate) async fn rewind_remote_session(
     after_seq: usize,
     abort_signal: &AbortSignal,
 ) -> Result<()> {
-    let thin = remote_thin_session(config, abort_signal).await?;
-    append_session_mutation_batch_cas(&thin, |state| {
+    let session = remote_nats_session(config, abort_signal).await?;
+    append_session_mutation_batch_cas(&session, |state| {
         let len = state.logical_entries.len();
         let after_seq =
             self::session_ops_core::compute_rewind_point(after_seq, len, &state.logical_entries)?;
@@ -303,10 +306,10 @@ pub(crate) async fn rewind_remote_session(
     Ok(())
 }
 
-async fn remote_thin_session(
+async fn remote_nats_session(
     config: &GlobalConfig,
     abort_signal: &AbortSignal,
-) -> Result<ThinClientSession> {
+) -> Result<NatsSession> {
     let (agent, cluster, session_id) = {
         let cfg = config.read();
         let (agent, cluster) = cfg.remote_agent.clone().unwrap_or_else(|| {
@@ -326,8 +329,8 @@ async fn remote_thin_session(
         (agent, cluster, session_id)
     };
 
-    ThinClientSession::from_global_config(
-        ThinClientConfig {
+    NatsSession::from_global_config(
+        NatsSessionConfig {
             cluster,
             agent,
             session_id: Some(session_id),
@@ -429,11 +432,14 @@ fn consume_window_member(
 }
 
 pub async fn load_remote_transcript_for_render(
-    thin: &ThinClientSession,
+    session: &NatsSession,
 ) -> Result<RemoteTranscriptState> {
-    let log = NatsSessionLog::new(thin.jetstream().clone(), thin.session_id().to_string());
+    let log = NatsSessionLog::new(
+        session.jetstream().clone(),
+        session.session_id().to_string(),
+    );
     let entries = log.load_events_async().await?;
-    transcript_state_from_entries(&entries, thin.session_id())
+    transcript_state_from_entries(&entries, session.session_id())
 }
 
 fn transcript_state_from_entries(
@@ -477,9 +483,9 @@ struct RemoteUserMessageSelection {
 async fn remote_user_messages_for_range(
     from: usize,
     to: usize,
-    thin: &ThinClientSession,
+    session: &NatsSession,
 ) -> Result<Vec<RemoteUserMessageSelection>> {
-    let state = load_remote_session_for_render(thin).await?;
+    let state = load_remote_session_for_render(session).await?;
     let mut user_messages = Vec::new();
     for logical_index in from..=to {
         let target = state.logical_target(logical_index)?;
@@ -504,17 +510,17 @@ async fn remote_user_messages_for_range(
     Ok(user_messages)
 }
 
-async fn append_session_mutation_batch_cas<F>(
-    thin: &ThinClientSession,
-    build_entries: F,
-) -> Result<()>
+async fn append_session_mutation_batch_cas<F>(session: &NatsSession, build_entries: F) -> Result<()>
 where
     F: Fn(&RemoteRenderState) -> Result<Vec<SessionLogEntry>>,
 {
     const MAX_CAS_ATTEMPTS: usize = 10;
-    let log = NatsSessionLog::new(thin.jetstream().clone(), thin.session_id().to_string());
+    let log = NatsSessionLog::new(
+        session.jetstream().clone(),
+        session.session_id().to_string(),
+    );
     for attempt in 1..=MAX_CAS_ATTEMPTS {
-        let state = load_remote_session_for_render(thin).await?;
+        let state = load_remote_session_for_render(session).await?;
         let entries = build_entries(&state)?;
         if entries.is_empty() {
             return Ok(());
@@ -596,9 +602,12 @@ struct RemoteLogicalTarget {
 }
 
 pub(crate) async fn load_remote_session_for_render(
-    thin: &ThinClientSession,
+    session: &NatsSession,
 ) -> Result<RemoteRenderState> {
-    let log = NatsSessionLog::new(thin.jetstream().clone(), thin.session_id().to_string());
+    let log = NatsSessionLog::new(
+        session.jetstream().clone(),
+        session.session_id().to_string(),
+    );
     let entries = log.load_events_async().await?;
     let rendered = harnx_core::session_reconstruct::apply_log_mutations_nats(&entries)
         .context("failed to reconstruct remote session log before edit/delete")?;

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -2,7 +2,7 @@ use super::session_externalize::{
     externalize_content, externalize_tool_result_content, record_externalized,
 };
 use super::*;
-use crate::nats_client_session::new_client_message_id;
+use crate::nats_session::new_client_message_id;
 
 pub use harnx_core::session::{Session, SessionLogEntry};
 

--- a/crates/harnx-runtime/src/config/tests.rs
+++ b/crates/harnx-runtime/src/config/tests.rs
@@ -607,9 +607,9 @@ async fn use_agent_routes_remote_refs_to_nats_cluster_validation() {
         .await
         .expect_err("remote ref with an unknown cluster must fail cluster validation");
 
-    // Remote refs are no longer stubbed out — they route into NATS thin-client
-    // mode, which first validates the cluster. With no nats_servers/prod.yaml
-    // the activation fails on cluster lookup, proving the remote path is wired.
+    // Remote refs are no longer stubbed out — activation validates the cluster
+    // first. With no nats_servers/prod.yaml the activation fails on cluster
+    // lookup, proving the path is wired.
     let msg = err.to_string();
     assert!(
         msg.contains("prod") && msg.contains("nats_servers/prod.yaml"),

--- a/crates/harnx-runtime/src/lib.rs
+++ b/crates/harnx-runtime/src/lib.rs
@@ -19,12 +19,12 @@ pub mod config;
 mod file_lock;
 pub mod local_orchestrator;
 pub mod nats_admin;
-pub mod nats_client_session;
 pub mod nats_event_sink;
 pub mod nats_hook_provider;
 pub mod nats_lease;
 pub mod nats_local_server;
 pub mod nats_metrics;
+pub mod nats_session;
 pub mod nats_session_index;
 pub mod nats_session_log;
 pub mod nats_tool_provider;
@@ -40,10 +40,8 @@ pub mod tool_context;
 pub mod utils;
 mod worker_identity;
 
-// Re-export thin-client types for frontends
-pub use nats_client_session::{
-    send_control_command, ThinClientConfig, ThinClientSession, ThinClientTurnResult,
-};
+// Re-export session types for frontends
+pub use nats_session::{send_control_command, NatsSession, NatsSessionConfig, NatsTurnResult};
 pub use nats_worker::ControlCommand;
 
 pub use agent_loop::{

--- a/crates/harnx-runtime/src/nats_session.rs
+++ b/crates/harnx-runtime/src/nats_session.rs
@@ -1,10 +1,8 @@
-//! Thin-client driver for remote NATS agents (agent@cluster).
+//! Session driver for NATS agents (agent@cluster).
 //!
-//! P4.2 implementation: when an agent ref contains `@` (parsed as
-//! `AgentRef::Remote { agent, cluster }`), the client runs in THIN mode:
-//! it posts the user message + control commands to NATS and renders events
-//! from the fan-out — it does NOT run `run_agent_loop` locally. A separate
-//! `harnx-worker --cluster <key>` daemon executes the turn.
+//! The client posts the user message + control commands to NATS and renders
+//! events from the fan-out — it does not run `run_agent_loop` itself. A
+//! separate `harnx-worker --cluster <key>` daemon executes the turn.
 //!
 //! ## Architecture
 //!
@@ -126,7 +124,7 @@ impl OrphanWatchdog {
             Ok(holder) => holder,
             Err(error) => {
                 // An unreadable lease says nothing about the worker.
-                log::debug!("thin client: lease liveness check failed: {error:#}");
+                log::debug!("nats session: lease liveness check failed: {error:#}");
                 self.missing_checks = 0;
                 return None;
             }
@@ -147,19 +145,16 @@ impl OrphanWatchdog {
             );
         };
 
-        log::trace!(
-            "thin client: session {session_id} held by {}",
-            holder.worker_id
-        );
+        log::trace!("nats session: {session_id} held by {}", holder.worker_id);
         self.saw_lease = true;
         self.missing_checks = 0;
         None
     }
 }
 
-/// Configuration for a thin-client session.
+/// Configuration for a NATS session.
 #[derive(Clone)]
-pub struct ThinClientConfig {
+pub struct NatsSessionConfig {
     /// Cluster key (from AgentRef::Remote { cluster, ... }).
     pub cluster: String,
     /// Agent name (from AgentRef::Remote { agent, ... }).
@@ -168,27 +163,27 @@ pub struct ThinClientConfig {
     pub session_id: Option<String>,
 }
 
-/// Thin-client session driver.
+/// Session driver.
 ///
-/// Orchestrates the remote-agent workflow: append user message, activate,
-/// stream events, detect completion.
-pub struct ThinClientSession {
-    config: ThinClientConfig,
+/// Orchestrates the workflow: append user message, activate, stream events,
+/// detect completion.
+pub struct NatsSession {
+    config: NatsSessionConfig,
     session_id: String,
     jetstream: jetstream::Context,
     client: async_nats::Client,
     abort_signal: AbortSignal,
 }
 
-impl ThinClientSession {
-    /// Create a new thin-client session.
+impl NatsSession {
+    /// Create a new NATS session.
     ///
     /// Connects to the NATS cluster and generates/reuses a session ID.
     ///
     /// This function takes the NATS connection components directly to avoid
     /// Send issues with GlobalConfig's parking_lot lock guard across await points.
     pub async fn new(
-        config: ThinClientConfig,
+        config: NatsSessionConfig,
         client: async_nats::Client,
         jetstream: jetstream::Context,
         abort_signal: AbortSignal,
@@ -210,7 +205,7 @@ impl ThinClientSession {
 
     /// Convenience constructor that builds NATS connections from GlobalConfig.
     pub async fn from_global_config(
-        config: ThinClientConfig,
+        config: NatsSessionConfig,
         global_config: &crate::config::GlobalConfig,
         abort_signal: AbortSignal,
     ) -> Result<Self> {
@@ -219,7 +214,7 @@ impl ThinClientSession {
         let client = config_snapshot
             .nats_client(&cluster)
             .await
-            .context("failed to connect to NATS cluster for thin client")?;
+            .context("failed to connect to NATS cluster")?;
         let jetstream = async_nats::jetstream::new(client.clone());
 
         Self::new(config, client, jetstream, abort_signal).await
@@ -251,7 +246,7 @@ impl ThinClientSession {
         user_message: &str,
         event_sink: Arc<dyn AgentEventSink>,
         pending_cancel: Option<tokio::sync::mpsc::Receiver<()>>,
-    ) -> Result<ThinClientTurnResult> {
+    ) -> Result<NatsTurnResult> {
         // Step 1: Append user message to durable log BEFORE activating.
         // The worker derives input from the last user message.
         // Generate a client-side ID for retract/edit reference.
@@ -270,7 +265,7 @@ impl ThinClientSession {
             .context("failed to append user message to session log")?;
 
         log::info!(
-            "thin client: appended user message session_id={} len={}",
+            "nats session: appended user message session_id={} len={}",
             self.session_id,
             user_message.len()
         );
@@ -292,13 +287,13 @@ impl ThinClientSession {
                 Ok(history) => history,
                 Err(err) => {
                     log::warn!(
-                    "failed to apply NATS log mutations while rendering thin-client history: {err}"
-                );
+                        "failed to apply NATS log mutations while rendering session history: {err}"
+                    );
                     history.to_vec()
                 }
             };
         // Front-ends render resumed history through their explicit transcript
-        // loading path. Replaying it on every newly-created per-turn thin client
+        // loading path. Replaying it on every newly-created per-turn session
         // duplicates all prior messages in interactive and continued sessions.
 
         // Step 3: Publish activation to wake a worker.
@@ -308,7 +303,7 @@ impl ThinClientSession {
             .context("failed to publish session activation")?;
 
         log::info!(
-            "thin client: published activation session_id={} agent={} cluster={}",
+            "nats session: published activation session_id={} agent={} cluster={}",
             self.session_id,
             self.config.agent,
             self.config.cluster
@@ -349,7 +344,7 @@ impl ThinClientSession {
                 // Check for cancellation via wait_abort_signal
                 _ = wait_abort_signal(&abort_signal_clone) => {
                     was_cancelled = true;
-                    log::info!("thin client: abort signal received, publishing cancel");
+                    log::info!("nats session: abort signal received, publishing cancel");
                     if let Err(error) = publish_control_command(
                         &self.client,
                         &self.session_id,
@@ -357,7 +352,7 @@ impl ThinClientSession {
                     )
                     .await
                     {
-                        log::warn!("thin client: failed to publish abort control command: {error:#}");
+                        log::warn!("nats session: failed to publish abort control command: {error:#}");
                     }
                     break;
                 }
@@ -371,7 +366,7 @@ impl ThinClientSession {
                     }
                 } => {
                     was_cancelled = true;
-                    log::info!("thin client: pending cancel received, publishing cancel");
+                    log::info!("nats session: pending cancel received, publishing cancel");
                     if let Err(error) = publish_control_command(
                         &self.client,
                         &self.session_id,
@@ -379,7 +374,7 @@ impl ThinClientSession {
                     )
                     .await
                     {
-                        log::warn!("thin client: failed to publish pending cancel control command: {error:#}");
+                        log::warn!("nats session: failed to publish pending cancel control command: {error:#}");
                     }
                     break;
                 }
@@ -442,7 +437,7 @@ impl ThinClientSession {
                             // Check if this advisory should be rendered (dedup rule)
                             if event_stream.should_render(&envelope) {
                                 // Only parent-scope terminal events complete this
-                                // thin-client turn. Sub-agent events remain wrapped
+                                // turn. Sub-agent events remain wrapped
                                 // in AgentEvent::SubAgent and therefore do not set
                                 // either compatibility flag.
                                 saw_terminal_model_error |= matches!(
@@ -501,7 +496,7 @@ impl ThinClientSession {
                         }
                         None => {
                             // Subscription closed, check final state
-                            log::info!("thin client: event stream closed");
+                            log::info!("nats session: event stream closed");
                             break;
                         }
                     }
@@ -577,7 +572,7 @@ impl ThinClientSession {
             }
         }
 
-        Ok(ThinClientTurnResult {
+        Ok(NatsTurnResult {
             response: final_response,
             session_id: self.session_id.clone(),
             was_cancelled: was_cancelled || self.abort_signal.aborted(),
@@ -755,9 +750,9 @@ impl ThinClientSession {
     }
 }
 
-/// Result of a thin-client turn.
+/// Result of a NATS session turn.
 #[derive(Debug, Clone)]
-pub struct ThinClientTurnResult {
+pub struct NatsTurnResult {
     /// Final assistant response text (if any).
     pub response: Option<String>,
     /// Session ID (for resume/attach).
@@ -1059,7 +1054,7 @@ fn render_error_entry(message: &str, sink: &Arc<dyn AgentEventSink>) {
 
 /// Send a control command to a remote session.
 ///
-/// Helper for frontends to send cancel/set-pending without full ThinClientSession.
+/// Helper for frontends to send cancel/set-pending without full NatsSession.
 pub async fn send_control_command(
     client: &async_nats::Client,
     session_id: &str,
@@ -1155,11 +1150,11 @@ mod tests {
         ]);
 
         assert!(
-            !ThinClientSession::is_turn_completion_visible(&entries, 1, false),
+            !NatsSession::is_turn_completion_visible(&entries, 1, false),
             "an assistant row may still be followed by stop-hook or pending-context work"
         );
         assert!(
-            ThinClientSession::is_turn_completion_visible(&entries, 1, true),
+            NatsSession::is_turn_completion_visible(&entries, 1, true),
             "older workers use the parent turn advisory as a compatibility fallback"
         );
 
@@ -1172,7 +1167,7 @@ mod tests {
                 timestamp: None,
             },
         ));
-        assert!(ThinClientSession::is_turn_completion_visible(
+        assert!(NatsSession::is_turn_completion_visible(
             &durably_ended,
             1,
             false
@@ -1211,9 +1206,7 @@ mod tests {
                 },
             ),
         ];
-        assert!(!ThinClientSession::is_turn_completion_visible(
-            &entries, 2, false
-        ));
+        assert!(!NatsSession::is_turn_completion_visible(&entries, 2, false));
     }
 
     #[test]
@@ -1227,13 +1220,11 @@ mod tests {
                 timestamp: None,
             },
         ));
-        assert!(ThinClientSession::has_durable_terminal_failure(&failed, 1));
+        assert!(NatsSession::has_durable_terminal_failure(&failed, 1));
 
         let mut cancelled = test_entries(&[(1, MessageRole::User, "question")]);
         cancelled.push((2, SessionLogEntry::Cancel { fence_token: 7 }));
-        assert!(ThinClientSession::has_durable_terminal_failure(
-            &cancelled, 1
-        ));
+        assert!(NatsSession::has_durable_terminal_failure(&cancelled, 1));
     }
 
     #[test]
@@ -1571,7 +1562,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            ThinClientSession::extract_final_response(&entries, 3),
+            NatsSession::extract_final_response(&entries, 3),
             Some("new".to_string())
         );
     }
@@ -1584,6 +1575,6 @@ mod tests {
             (3, MessageRole::User, "new prompt"),
         ]);
 
-        assert_eq!(ThinClientSession::extract_final_response(&entries, 3), None);
+        assert_eq!(NatsSession::extract_final_response(&entries, 3), None);
     }
 }

--- a/crates/harnx-runtime/src/nats_worker/agent_loop.rs
+++ b/crates/harnx-runtime/src/nats_worker/agent_loop.rs
@@ -752,8 +752,8 @@ async fn load_or_repair_session(
     let mut entries_vec = entries;
     let mut effective_entries =
         harnx_core::session_reconstruct::apply_log_mutations_nats(&entries_vec)?;
-    // The thin client appends its user message before it activates a session, so
-    // a brand-new session reaches this path with a headerless log rather than an
+    // The client appends its user message before it activates a session, so a
+    // brand-new session reaches this path with a headerless log rather than an
     // empty one. Writing the header here is what creates the session.
     let header_written = maybe_insert_remote_header(MaybeInsertRemoteHeaderArgs {
         backend,

--- a/crates/harnx-runtime/src/nats_worker/subagent_toolset.rs
+++ b/crates/harnx-runtime/src/nats_worker/subagent_toolset.rs
@@ -1,7 +1,7 @@
 //! NATS toolset for nested sub-agent sessions.
 
 use super::{publish_control_command, ControlCommand};
-use crate::nats_client_session::{ThinClientConfig, ThinClientSession, ThinClientTurnResult};
+use crate::nats_session::{NatsSession, NatsSessionConfig, NatsTurnResult};
 use crate::nats_session_log::NatsSessionLog;
 use async_nats::jetstream;
 use async_trait::async_trait;
@@ -113,9 +113,9 @@ impl SubagentToolset {
     async fn create_session(
         &self,
         session_id: Option<String>,
-    ) -> Result<ThinClientSession, ToolInvokeError> {
-        ThinClientSession::new(
-            ThinClientConfig {
+    ) -> Result<NatsSession, ToolInvokeError> {
+        NatsSession::new(
+            NatsSessionConfig {
                 cluster: self.cluster.clone(),
                 agent: self.agent.clone(),
                 session_id,
@@ -136,7 +136,7 @@ impl SubagentToolset {
         session_id: Option<String>,
         parent_session_id: Option<String>,
         cancel: CancellationToken,
-    ) -> Result<ThinClientTurnResult, ToolInvokeError> {
+    ) -> Result<NatsTurnResult, ToolInvokeError> {
         let session = self.create_session(session_id).await?;
         let child_session_id = session.session_id().to_string();
         if let Some(parent_session_id) = parent_session_id {
@@ -244,7 +244,7 @@ impl SubagentToolset {
         })
     }
 
-    async fn turn_has_cancel(&self, result: &ThinClientTurnResult) -> bool {
+    async fn turn_has_cancel(&self, result: &NatsTurnResult) -> bool {
         NatsSessionLog::new(self.jetstream.clone(), result.session_id.clone())
             .load_events_async()
             .await
@@ -302,7 +302,7 @@ impl SubagentToolset {
         self.turn_result_value(&result)
     }
 
-    fn turn_result_value(&self, result: &ThinClientTurnResult) -> Result<Value, ToolInvokeError> {
+    fn turn_result_value(&self, result: &NatsTurnResult) -> Result<Value, ToolInvokeError> {
         let response = require_response(result)?;
         let source = AgentSource {
             agent: self.agent.clone(),
@@ -344,7 +344,7 @@ impl SubagentToolset {
     }
 }
 
-fn require_response(result: &ThinClientTurnResult) -> Result<&str, ToolInvokeError> {
+fn require_response(result: &NatsTurnResult) -> Result<&str, ToolInvokeError> {
     if let Some(error) = &result.error {
         return Err(ToolInvokeError::Recoverable(format!(
             "sub-agent turn failed: {error}"

--- a/crates/harnx-runtime/src/nats_worker/tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests.rs
@@ -11,7 +11,7 @@ use crate::nats_session_index::{
 use crate::nats_session_log::NatsSessionLog;
 use crate::nats_worker::agent_loop::{tool_can_rerun, write_header_and_load_session};
 use crate::nats_worker::run_worker_daemon;
-use crate::ThinClientSession;
+use crate::NatsSession;
 use anyhow::{bail, Context};
 use futures_util::StreamExt;
 use harnx_core::agent_config::AgentConfig;
@@ -384,30 +384,30 @@ pub(super) async fn run_remote_round_trip_with_session_id_and_sink(
     parent_config.session = Some(parent_session);
     let parent_global_config = Arc::new(parking_lot::RwLock::new(parent_config));
     let abort_signal = harnx_core::abort::create_abort_signal();
-    let thin_cfg = crate::ThinClientConfig {
+    let session_cfg = crate::NatsSessionConfig {
         cluster: cluster.to_string(),
         agent: "metis".to_string(),
         session_id: Some(session_id),
     };
-    let thin =
-        crate::ThinClientSession::from_global_config(thin_cfg, &parent_global_config, abort_signal)
+    let session =
+        crate::NatsSession::from_global_config(session_cfg, &parent_global_config, abort_signal)
             .await?;
 
     const REMOTE_ROUND_TRIP_TIMEOUT: Duration = Duration::from_secs(60);
     let turn_result = tokio::time::timeout(
         REMOTE_ROUND_TRIP_TIMEOUT,
-        thin.run_turn("delegate over nats", sink, None),
+        session.run_turn("delegate over nats", sink, None),
     )
     .await
     .with_context(|| {
         format!(
-            "thin client run_turn timed out after {}s in remote NATS round-trip test",
+            "run_turn timed out after {}s in remote NATS round-trip test",
             REMOTE_ROUND_TRIP_TIMEOUT.as_secs()
         )
     })??;
     let reply = turn_result.response.with_context(|| {
         format!(
-            "thin client turn must return final assistant response (error={:?}, cancelled={}, user_seq={})",
+            "NATS session turn must return final assistant response (error={:?}, cancelled={}, user_seq={})",
             turn_result.error, turn_result.was_cancelled, turn_result.user_msg_seq
         )
     })?;
@@ -865,24 +865,24 @@ async fn run_remote_turn_returning_reply(
     parent_config.session = Some(parent_session);
     let parent_global_config = Arc::new(parking_lot::RwLock::new(parent_config));
     let abort_signal = harnx_core::abort::create_abort_signal();
-    let thin_cfg = crate::ThinClientConfig {
+    let session_cfg = crate::NatsSessionConfig {
         cluster: "local".to_string(),
         agent: "metis".to_string(),
         session_id: Some(session_id),
     };
-    let thin =
-        crate::ThinClientSession::from_global_config(thin_cfg, &parent_global_config, abort_signal)
+    let session =
+        crate::NatsSession::from_global_config(session_cfg, &parent_global_config, abort_signal)
             .await?;
 
     let turn_result = tokio::time::timeout(
         Duration::from_secs(10),
-        thin.run_turn(prompt, Arc::new(NoopEventSink), None),
+        session.run_turn(prompt, Arc::new(NoopEventSink), None),
     )
     .await
-    .context("thin client run_turn timed out after 10s in remote NATS round-trip test")??;
+    .context("run_turn timed out after 10s in remote NATS round-trip test")??;
     turn_result
         .response
-        .context("thin client turn must return final assistant response")
+        .context("NATS session turn must return final assistant response")
 }
 
 fn leading_user_texts(entries: &[(u64, SessionLogEntry)]) -> Vec<String> {
@@ -998,7 +998,7 @@ async fn remote_headerless_session_inserts_header_on_first_activation() {
     let session_id = crate::nats_worker::new_remote_session_id();
     run_remote_round_trip_with_session_id(seeded.parent_config, session_id.clone())
         .await
-        .expect("run realistic headerless thin-client session");
+        .expect("run realistic headerless NATS session");
 
     let log_client = async_nats::connect(&url)
         .await
@@ -1036,7 +1036,7 @@ async fn remote_multi_turn_after_header_insert_preserves_input_derivation() {
             prompt,
         )
         .await
-        .expect("run remote thin-client turn");
+        .expect("run remote NATS session turn");
         assert_eq!(
             reply,
             format!("stub remote reply over nats: {prompt}"),
@@ -1340,13 +1340,13 @@ async fn remote_replay_and_live_rows_emit_logical_seq_assignments() {
     // emits no LogSeqAssigned (exactly like a LOCAL session, whose header is
     // document 0 and whose first USER message is log_seq 1). The numberable
     // rows therefore carry logical seqs [1, 2, 3]: replayed migrated legacy
-    // user, live thin-client user, then live worker assistant. This is the
+    // user, live client user, then live worker assistant. This is the
     // local==remote numbering parity that makes resumed/live remote rows
     // targetable for edit/delete/rewind.
     assert_eq!(
         replayed_seqs,
         vec![1, 2, 3],
-        "sink should number the migrated legacy user, live thin-client user, and live worker assistant rows (Header at logical 0 renders no row, matching local numbering)"
+        "sink should number the migrated legacy user, live client user, and live worker assistant rows (Header at logical 0 renders no row, matching local numbering)"
     );
     assert_eq!(
         replayed_seqs
@@ -1411,18 +1411,19 @@ async fn remote_cancel_published_after_in_flight_marks_session_cancelled() {
     parent_config.session = Some(parent_session);
     let parent_global_config = Arc::new(parking_lot::RwLock::new(parent_config));
     let abort_signal = harnx_core::abort::create_abort_signal();
-    let thin_cfg = crate::ThinClientConfig {
+    let session_cfg = crate::NatsSessionConfig {
         cluster: "local".to_string(),
         agent: "metis".to_string(),
         session_id: Some(session_id.clone()),
     };
-    let thin =
-        crate::ThinClientSession::from_global_config(thin_cfg, &parent_global_config, abort_signal)
+    let session =
+        crate::NatsSession::from_global_config(session_cfg, &parent_global_config, abort_signal)
             .await
-            .expect("build thin client session");
+            .expect("build NATS session");
 
     let run_turn = tokio::spawn(async move {
-        thin.run_turn("delegate over nats", Arc::new(NoopEventSink), None)
+        session
+            .run_turn("delegate over nats", Arc::new(NoopEventSink), None)
             .await
     });
 
@@ -2207,8 +2208,8 @@ async fn nested_subagent_prompt_returns_final_message_over_nats() {
         .await
         .expect("subscribe to session events");
     client.flush().await.expect("flush event subscription");
-    let thin = ThinClientSession::new(
-        crate::ThinClientConfig {
+    let session = NatsSession::new(
+        crate::NatsSessionConfig {
             cluster: "local".to_string(),
             agent: "metis".to_string(),
             session_id: Some(parent_session_id.clone()),
@@ -2218,10 +2219,10 @@ async fn nested_subagent_prompt_returns_final_message_over_nats() {
         harnx_core::abort::create_abort_signal(),
     )
     .await
-    .expect("create parent thin-client session");
+    .expect("create parent NATS session");
     let parent_result = tokio::time::timeout(
         Duration::from_secs(15),
-        thin.run_turn(
+        session.run_turn(
             "delegate this request through the nested tool",
             Arc::new(NoopEventSink),
             None,
@@ -2321,7 +2322,7 @@ async fn remote_agent_tool_family_and_nats_call_and_return_round_trip() {
 async fn remote_session_activation_writes_session_index_record() {
     let _env_guard = env_lock().await;
     // Use an ISOLATED, self-provisioned NATS server (not the shared
-    // HARNX_NATS_TEST_URL) so the thin-client `run_turn` isn't slowed by
+    // HARNX_NATS_TEST_URL) so `run_turn` isn't slowed by
     // accumulated JetStream state on a shared server — that staleness made this
     // test hit its 10s turn timeout intermittently.
     let Some((server_url, mut child, _store_dir)) = spawn_test_nats().await else {
@@ -2345,7 +2346,7 @@ async fn remote_session_activation_writes_session_index_record() {
         .expect("ensure session index bucket");
 
     let daemon = spawn_metis_worker(&server_url);
-    // Use the expected_session_id in the thin client config
+    // Use the expected_session_id in the NATS session config
     let round_trip =
         run_remote_round_trip_with_session_id(seeded.parent_config, expected_session_id.clone())
             .await;
@@ -2904,8 +2905,8 @@ async fn remote_delete_refreshes_after_concurrent_mutation() {
     let abort = harnx_core::abort::create_abort_signal();
 
     let stale_state = load_remote_session_for_render(
-        &ThinClientSession::from_global_config(
-            crate::ThinClientConfig {
+        &NatsSession::from_global_config(
+            crate::NatsSessionConfig {
                 cluster: "local".to_string(),
                 agent: "metis".to_string(),
                 session_id: Some(session_id.clone()),
@@ -2914,7 +2915,7 @@ async fn remote_delete_refreshes_after_concurrent_mutation() {
             abort.clone(),
         )
         .await
-        .expect("load thin session"),
+        .expect("load session"),
     )
     .await
     .expect("capture stale state");
@@ -3003,8 +3004,8 @@ async fn remote_edit_preserves_header_in_migrated_session() {
         .await
         .expect("edit older user message");
 
-    let thin = ThinClientSession::from_global_config(
-        crate::ThinClientConfig {
+    let session = NatsSession::from_global_config(
+        crate::NatsSessionConfig {
             cluster: "local".to_string(),
             agent: "metis".to_string(),
             session_id: Some(session_id.clone()),
@@ -3013,8 +3014,8 @@ async fn remote_edit_preserves_header_in_migrated_session() {
         abort,
     )
     .await
-    .expect("load thin session");
-    let state = load_remote_session_for_render(&thin)
+    .expect("load session");
+    let state = load_remote_session_for_render(&session)
         .await
         .expect("load remote render state");
 
@@ -3090,8 +3091,8 @@ async fn remote_delete_after_older_edit_deletes_exact_late_range() {
         .await
         .expect("delete later logical range");
 
-    let thin = ThinClientSession::from_global_config(
-        crate::ThinClientConfig {
+    let session = NatsSession::from_global_config(
+        crate::NatsSessionConfig {
             cluster: "local".to_string(),
             agent: "metis".to_string(),
             session_id: Some(session_id.clone()),
@@ -3100,8 +3101,8 @@ async fn remote_delete_after_older_edit_deletes_exact_late_range() {
         abort,
     )
     .await
-    .expect("load thin session");
-    let state = load_remote_session_for_render(&thin)
+    .expect("load session");
+    let state = load_remote_session_for_render(&session)
         .await
         .expect("load remote render state");
     // Assert header survives the edit (key coverage for shared-seq bug fix)
@@ -3176,8 +3177,8 @@ async fn remote_rewind_after_older_edit_preserves_correct_logical_prefix() {
         .await
         .expect("rewind logical suffix");
 
-    let thin = ThinClientSession::from_global_config(
-        crate::ThinClientConfig {
+    let session = NatsSession::from_global_config(
+        crate::NatsSessionConfig {
             cluster: "local".to_string(),
             agent: "metis".to_string(),
             session_id: Some(session_id.clone()),
@@ -3186,8 +3187,8 @@ async fn remote_rewind_after_older_edit_preserves_correct_logical_prefix() {
         abort,
     )
     .await
-    .expect("load thin session");
-    let state = load_remote_session_for_render(&thin)
+    .expect("load session");
+    let state = load_remote_session_for_render(&session)
         .await
         .expect("load remote render state");
     // Assert header survives the edit (key coverage for shared-seq bug fix)
@@ -3262,8 +3263,8 @@ async fn remote_delete_command_routes_to_exact_set_mutations() {
         .await
         .expect("remote delete command succeeds");
 
-    let thin = ThinClientSession::from_global_config(
-        crate::ThinClientConfig {
+    let session = NatsSession::from_global_config(
+        crate::NatsSessionConfig {
             cluster: "local".to_string(),
             agent: "metis".to_string(),
             session_id: Some(session_id.clone()),
@@ -3272,8 +3273,8 @@ async fn remote_delete_command_routes_to_exact_set_mutations() {
         abort.clone(),
     )
     .await
-    .expect("load thin session");
-    let state = load_remote_session_for_render(&thin)
+    .expect("load session");
+    let state = load_remote_session_for_render(&session)
         .await
         .expect("load remote render state");
     // Assert header survives the edit (key coverage for shared-seq bug fix)
@@ -3388,8 +3389,8 @@ async fn remote_rewind_command_routes_to_exact_suffix_deletions() {
         .await
         .expect("remote rewind command succeeds");
 
-    let thin = ThinClientSession::from_global_config(
-        crate::ThinClientConfig {
+    let session = NatsSession::from_global_config(
+        crate::NatsSessionConfig {
             cluster: "local".to_string(),
             agent: "metis".to_string(),
             session_id: Some(session_id.clone()),
@@ -3398,8 +3399,8 @@ async fn remote_rewind_command_routes_to_exact_suffix_deletions() {
         abort.clone(),
     )
     .await
-    .expect("load thin session");
-    let state = load_remote_session_for_render(&thin)
+    .expect("load session");
+    let state = load_remote_session_for_render(&session)
         .await
         .expect("load remote render state");
     // Assert header survives the edit (key coverage for shared-seq bug fix)
@@ -3500,7 +3501,7 @@ async fn load_remote_transcript_multi_leading_user_rows_are_distinct() {
     let session_id = crate::nats_worker::new_remote_session_id();
 
     // Seed two leading user messages directly to the durable log BEFORE the
-    // worker activates, mirroring a thin client that appended several prompts
+    // worker activates, mirroring a client that appended several prompts
     // before the first worker turn.
     let jetstream = seeded
         .parent_config
@@ -3536,8 +3537,8 @@ async fn load_remote_transcript_multi_leading_user_rows_are_distinct() {
         .expect("activate remote session id");
     let global_config = Arc::new(parking_lot::RwLock::new(seeded.parent_config));
     let abort = harnx_core::abort::create_abort_signal();
-    let thin = ThinClientSession::from_global_config(
-        crate::ThinClientConfig {
+    let session = NatsSession::from_global_config(
+        crate::NatsSessionConfig {
             cluster: "local".to_string(),
             agent: "metis".to_string(),
             session_id: Some(session_id.clone()),
@@ -3546,9 +3547,9 @@ async fn load_remote_transcript_multi_leading_user_rows_are_distinct() {
         abort,
     )
     .await
-    .expect("load thin session");
+    .expect("load session");
 
-    let transcript = load_remote_transcript_for_render(&thin)
+    let transcript = load_remote_transcript_for_render(&session)
         .await
         .expect("load transcript state");
 

--- a/crates/harnx-runtime/src/nats_worker/tests/subagent_discovery_tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests/subagent_discovery_tests.rs
@@ -153,8 +153,8 @@ async fn first_package_agent_turn_waits_for_delegation_registrations() {
         .expect("worker readiness timed out")
         .expect("worker readiness subscription closed");
 
-    let thin = ThinClientSession::new(
-        crate::ThinClientConfig {
+    let session = NatsSession::new(
+        crate::NatsSessionConfig {
             cluster: "local".to_string(),
             agent: "pantheon/aristarchus".to_string(),
             session_id: None,
@@ -169,7 +169,7 @@ async fn first_package_agent_turn_waits_for_delegation_registrations() {
     // a regression fails promptly instead of consuming the full 30 seconds.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        thin.run_turn("review this change", Arc::new(NoopEventSink), None),
+        session.run_turn("review this change", Arc::new(NoopEventSink), None),
     )
     .await
     .expect("first package turn timed out")

--- a/crates/harnx-runtime/src/nats_worker/tests/transcript_render_tests.rs
+++ b/crates/harnx-runtime/src/nats_worker/tests/transcript_render_tests.rs
@@ -117,10 +117,10 @@ fn assert_compressed_tool_transcript(
     );
 }
 
-async fn activate_thin_session(
+async fn activate_nats_session(
     seeded: &mut SeededRemoteParentConfig,
     session_id: String,
-) -> ThinClientSession {
+) -> NatsSession {
     seeded
         .parent_config
         .set_remote_agent("metis".to_string(), "local".to_string());
@@ -131,8 +131,8 @@ async fn activate_thin_session(
     let global_config = Arc::new(parking_lot::RwLock::new(std::mem::take(
         &mut seeded.parent_config,
     )));
-    ThinClientSession::from_global_config(
-        crate::ThinClientConfig {
+    NatsSession::from_global_config(
+        crate::NatsSessionConfig {
             cluster: "local".to_string(),
             agent: "metis".to_string(),
             session_id: Some(session_id),
@@ -141,7 +141,7 @@ async fn activate_thin_session(
         harnx_core::abort::create_abort_signal(),
     )
     .await
-    .expect("load thin session")
+    .expect("load session")
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -155,9 +155,9 @@ async fn load_remote_transcript_for_render_prerenders_logical_rows() {
     let session_id = crate::nats_worker::new_remote_session_id();
     append_completed_transcript_fixture(&seeded.parent_config, &session_id).await;
 
-    let thin = activate_thin_session(&mut seeded, session_id).await;
+    let session = activate_nats_session(&mut seeded, session_id).await;
 
-    let transcript = load_remote_transcript_for_render(&thin)
+    let transcript = load_remote_transcript_for_render(&session)
         .await
         .expect("load transcript state");
     assert!(transcript.compressed_messages.is_empty());
@@ -209,9 +209,9 @@ async fn load_remote_transcript_for_render_keeps_tool_rows_and_compressed_prefix
     let log = NatsSessionLog::new(jetstream, session_id.clone());
     append_compressed_tool_fixture(&log).await;
 
-    let thin = activate_thin_session(&mut seeded, session_id).await;
+    let session = activate_nats_session(&mut seeded, session_id).await;
 
-    let transcript = load_remote_transcript_for_render(&thin)
+    let transcript = load_remote_transcript_for_render(&session)
         .await
         .expect("load transcript state");
     assert_compressed_tool_transcript(&transcript);

--- a/crates/harnx-runtime/tests/local_worker_supervisor.rs
+++ b/crates/harnx-runtime/tests/local_worker_supervisor.rs
@@ -13,7 +13,7 @@ use harnx_runtime::local_orchestrator::{local_worker_lock_file, LocalWorkerSuper
 use harnx_runtime::nats_session_log::NatsSessionLog;
 use harnx_runtime::nats_worker::worker_ready_subject;
 use harnx_runtime::utils::create_abort_signal;
-use harnx_runtime::{ThinClientConfig, ThinClientSession};
+use harnx_runtime::{NatsSession, NatsSessionConfig};
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -153,7 +153,7 @@ async fn assert_worker_completes_turn(
         .token(supervisor.server().token.clone())
         .connect(&supervisor.server().url)
         .await
-        .expect("connect thin client");
+        .expect("connect to NATS");
     let jetstream = async_nats::jetstream::new(client.clone());
     let session_id = format!("local-supervisor-{}", uuid::Uuid::new_v4());
     let log = NatsSessionLog::new(jetstream.clone(), session_id.clone());
@@ -177,8 +177,8 @@ async fn assert_worker_completes_turn(
     .await
     .expect("seed local session header");
 
-    let session = ThinClientSession::new(
-        ThinClientConfig {
+    let session = NatsSession::new(
+        NatsSessionConfig {
             cluster: LOCAL_CLUSTER_KEY.to_string(),
             agent: "trivial".to_string(),
             session_id: Some(session_id),
@@ -188,7 +188,7 @@ async fn assert_worker_completes_turn(
         harnx_runtime::utils::create_abort_signal(),
     )
     .await
-    .expect("create local thin client");
+    .expect("create local NATS session");
     let result = tokio::time::timeout(
         Duration::from_secs(15),
         session.run_turn("hello", Arc::new(NullSink), None),

--- a/crates/harnx-runtime/tests/nats_agent_variables_e2e.rs
+++ b/crates/harnx-runtime/tests/nats_agent_variables_e2e.rs
@@ -20,7 +20,7 @@ use harnx_runtime::{
     nats_lease::{NatsLeaseAcquireParams, NatsLeaseConfig, NatsSessionLease},
     nats_session_log::NatsSessionLog,
     nats_worker::{run_worker_daemon, WorkerDaemonConfig},
-    ThinClientConfig, ThinClientSession, ThinClientTurnResult,
+    NatsSession, NatsSessionConfig, NatsTurnResult,
 };
 use parking_lot::RwLock;
 use std::path::Path;
@@ -288,11 +288,11 @@ impl TestEnv {
         Ok(async_nats::jetstream::new(client))
     }
 
-    async fn run_turn(&self, agent: &str, session_id: &str) -> Result<ThinClientTurnResult> {
+    async fn run_turn(&self, agent: &str, session_id: &str) -> Result<NatsTurnResult> {
         let client = async_nats::connect(self.server.url()).await?;
         let jetstream = async_nats::jetstream::new(client.clone());
-        let thin = ThinClientSession::new(
-            ThinClientConfig {
+        let session = NatsSession::new(
+            NatsSessionConfig {
                 cluster: "local".to_string(),
                 agent: agent.to_string(),
                 session_id: Some(session_id.to_string()),
@@ -305,7 +305,7 @@ impl TestEnv {
 
         match tokio::time::timeout(
             TURN_TIMEOUT,
-            thin.run_turn("hello", Arc::new(NullSink), None),
+            session.run_turn("hello", Arc::new(NullSink), None),
         )
         .await
         {
@@ -725,8 +725,8 @@ async fn client_ends_turn_when_worker_vanishes_without_writing() -> Result<()> {
         async move {
             let client = async_nats::connect(&server_url).await?;
             let jetstream = async_nats::jetstream::new(client.clone());
-            let thin = ThinClientSession::new(
-                ThinClientConfig {
+            let session = NatsSession::new(
+                NatsSessionConfig {
                     cluster: "local".to_string(),
                     agent: FILE_VARIABLE_AGENT.to_string(),
                     session_id: Some(session_id),
@@ -736,7 +736,7 @@ async fn client_ends_turn_when_worker_vanishes_without_writing() -> Result<()> {
                 create_abort_signal(),
             )
             .await?;
-            thin.run_turn("hello", Arc::new(NullSink), None).await
+            session.run_turn("hello", Arc::new(NullSink), None).await
         }
     });
 

--- a/crates/harnx-runtime/tests/nats_session.rs
+++ b/crates/harnx-runtime/tests/nats_session.rs
@@ -13,7 +13,7 @@ use harnx_runtime::{
     nats_event_sink::{events_subject, AdvisoryEnvelope},
     nats_session_log::NatsSessionLog,
     nats_worker::ControlCommand,
-    send_control_command, ThinClientConfig, ThinClientSession,
+    send_control_command, NatsSession, NatsSessionConfig,
 };
 use std::{sync::Arc, time::Duration};
 use uuid::Uuid;
@@ -45,8 +45,8 @@ async fn seed_prior_completed_turn(log: &NatsSessionLog) -> Result<u64> {
     Ok(prior_assistant_seq)
 }
 
-fn resumed_session_config(session_id: String) -> ThinClientConfig {
-    ThinClientConfig {
+fn resumed_session_config(session_id: String) -> NatsSessionConfig {
+    NatsSessionConfig {
         cluster: "test".to_string(),
         agent: "test-agent".to_string(),
         session_id: Some(session_id),
@@ -121,7 +121,7 @@ impl AgentEventSink for NoopEventSink {
 
 /// Test that control commands are sent correctly
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn thin_client_sends_control_commands() -> Result<()> {
+async fn nats_session_sends_control_commands() -> Result<()> {
     require_nextest();
     let Some(server) = spawn_nats_server().await? else {
         eprintln!("skipping: nats-server not available");
@@ -153,7 +153,7 @@ async fn thin_client_sends_control_commands() -> Result<()> {
 
 /// Test that user messages are stamped with a client-generated ID.
 ///
-/// This test directly appends a user message (mimicking ThinClientSession's append path)
+/// This test directly appends a user message (mimicking NatsSession's append path)
 /// and verifies the ID field is set to a valid UUID. Does NOT call run_turn because
 /// there's no worker to pick up the activation.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -190,17 +190,17 @@ async fn user_message_has_client_id() -> Result<()> {
     };
     log.append_event_async(&header).await?;
 
-    // Create a thin client session (mirrors retract test pattern)
-    let config = ThinClientConfig {
+    // Create a NATS session (mirrors retract test pattern)
+    let config = NatsSessionConfig {
         cluster: "test".to_string(),
         agent: "test-agent".to_string(),
         session_id: Some(session_id.clone()),
     };
     let abort_signal = harnx_runtime::utils::create_abort_signal();
 
-    let _session = ThinClientSession::new(config, client, jetstream, abort_signal).await?;
+    let _session = NatsSession::new(config, client, jetstream, abort_signal).await?;
 
-    // Append a user message directly (same pattern as in ThinClientSession::run_turn)
+    // Append a user message directly (same pattern as in NatsSession::run_turn)
     let user_msg_id = uuid::Uuid::new_v4().to_string();
     let user_entry = SessionLogEntry::Message {
         id: Some(user_msg_id.clone()),
@@ -274,7 +274,7 @@ async fn retract_queued_user_message() -> Result<()> {
     };
     let _header_seq = log.append_event_async(&header).await?;
 
-    // Append a user message directly (simulating what ThinClientSession does)
+    // Append a user message directly (simulating what NatsSession does)
     let user_msg_id = uuid::Uuid::new_v4().to_string();
     let user_entry = SessionLogEntry::Message {
         id: Some(user_msg_id.clone()),
@@ -293,15 +293,15 @@ async fn retract_queued_user_message() -> Result<()> {
         "User message should exist before retract"
     );
 
-    // Create ThinClientSession and retract the message
-    let config = ThinClientConfig {
+    // Create NatsSession and retract the message
+    let config = NatsSessionConfig {
         cluster: "test".to_string(),
         agent: "test-agent".to_string(),
         session_id: Some(session_id.clone()),
     };
     let abort_signal = harnx_runtime::utils::create_abort_signal();
 
-    let session = ThinClientSession::new(config, client, jetstream.clone(), abort_signal).await?;
+    let session = NatsSession::new(config, client, jetstream.clone(), abort_signal).await?;
 
     // Retract the message
     let edit_seq = session.retract_user_message(user_msg_seq).await?;
@@ -413,13 +413,13 @@ async fn edit_queued_user_message_replaces_text_in_reconstructed_state() -> Resu
     };
     let user_msg_seq = log.append_event_async(&original_entry).await?;
 
-    let config = ThinClientConfig {
+    let config = NatsSessionConfig {
         cluster: "test".to_string(),
         agent: "test-agent".to_string(),
         session_id: Some(session_id.clone()),
     };
     let abort_signal = harnx_runtime::utils::create_abort_signal();
-    let session = ThinClientSession::new(config, client, jetstream.clone(), abort_signal).await?;
+    let session = NatsSession::new(config, client, jetstream.clone(), abort_signal).await?;
 
     let edit_seq = session
         .edit_user_message(user_msg_seq, "edited text".to_string())
@@ -504,7 +504,7 @@ async fn resumed_session_run_turn_ignores_stale_prior_reply_and_returns_new_repl
     let prior_assistant_seq = seed_prior_completed_turn(&log).await?;
 
     let abort_signal = harnx_runtime::utils::create_abort_signal();
-    let session = ThinClientSession::new(
+    let session = NatsSession::new(
         resumed_session_config(session_id.clone()),
         client.clone(),
         jetstream.clone(),

--- a/crates/harnx-runtime/tests/nats_worker.rs
+++ b/crates/harnx-runtime/tests/nats_worker.rs
@@ -24,7 +24,7 @@ use harnx_runtime::{
         NatsSessionLogBackend, RunAgentLoopArgs, SessionActivate, WorkerDaemonConfig,
     },
     utils::create_abort_signal,
-    ControlCommand, ThinClientConfig, ThinClientSession,
+    ControlCommand, NatsSession, NatsSessionConfig,
 };
 use std::sync::LazyLock;
 
@@ -1875,7 +1875,7 @@ async fn load_events_latest_async_empty_stream_returns_empty() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn thin_client_abort_signal_cancels_blocked_worker_and_persists_tombstone() -> Result<()> {
+async fn abort_signal_cancels_blocked_worker_and_persists_tombstone() -> Result<()> {
     let Some(server) = require_nats_server().await? else {
         return Ok(());
     };
@@ -1885,17 +1885,17 @@ async fn thin_client_abort_signal_cancels_blocked_worker_and_persists_tombstone(
     let config = local_nats_runtime_config(server.url());
     let daemon = spawn_worker_daemon_with_call_fn(
         config,
-        "worker-thin-client-cancel",
+        "worker-abort-cancel",
         abort_blocked_call_fn(Arc::clone(&entered), Arc::clone(&saw_abort)),
     )
     .await;
 
     let client = async_nats::connect(server.url()).await?;
     let jetstream = async_nats::jetstream::new(client.clone());
-    let session_id = "thin-client-abort-cancel";
+    let session_id = "abort-cancel";
     let abort = create_abort_signal();
-    let thin = ThinClientSession::new(
-        ThinClientConfig {
+    let session = NatsSession::new(
+        NatsSessionConfig {
             cluster: "local".to_string(),
             agent: "ignored-agent".to_string(),
             session_id: Some(session_id.to_string()),
@@ -1907,7 +1907,8 @@ async fn thin_client_abort_signal_cancels_blocked_worker_and_persists_tombstone(
     .await?;
 
     let run_turn = tokio::spawn(async move {
-        thin.run_turn("block until cancelled", Arc::new(NullSink), None)
+        session
+            .run_turn("block until cancelled", Arc::new(NullSink), None)
             .await
     });
     tokio::time::timeout(CI_SAFE_TIMEOUT, entered.notified()).await?;
@@ -1916,7 +1917,7 @@ async fn thin_client_abort_signal_cancels_blocked_worker_and_persists_tombstone(
     let result = tokio::time::timeout(CI_SAFE_TIMEOUT, run_turn).await???;
     assert!(
         result.was_cancelled,
-        "thin-client turn should report cancellation"
+        "NATS session turn should report cancellation"
     );
 
     let log = NatsSessionLog::new(jetstream, session_id);

--- a/crates/harnx-serve/src/session_actor.rs
+++ b/crates/harnx-serve/src/session_actor.rs
@@ -33,7 +33,7 @@ use harnx_runtime::{
     config::{self, Config, GlobalConfig, LOCAL_CLUSTER_KEY},
     continue_agent_loop_from_tool_round,
     local_orchestrator::{ensure_local_worker, LocalWorkerSupervisor},
-    AgentCallFn, AgentLoopContext, OnToolRoundFn, ThinClientConfig, ThinClientSession,
+    AgentCallFn, AgentLoopContext, NatsSession, NatsSessionConfig, OnToolRoundFn,
     ToolApprovalDecision, ToolApprovalInterrupt, ToolUseConfirmation,
 };
 use std::{
@@ -166,8 +166,8 @@ async fn run_actor_turn(params: ActorTurnParams) -> anyhow::Result<harnx_runtime
         let mut supervisor = params.local_worker.lock().await;
         ensure_local_worker(&mut supervisor, params.abort_signal.clone()).await?;
     }
-    let session = ThinClientSession::from_global_config(
-        ThinClientConfig {
+    let session = NatsSession::from_global_config(
+        NatsSessionConfig {
             cluster: LOCAL_CLUSTER_KEY.to_string(),
             agent: params.agent,
             session_id: Some(params.session_id),
@@ -349,8 +349,8 @@ impl SessionActor {
             };
         };
 
-        // Test executors support same-turn injection. Production thin-client
-        // turns queue the complete prompt for a fresh turn after completion.
+        // Test executors support same-turn injection. Real turns queue the
+        // complete prompt for a fresh turn after completion.
         let run_id = active_run.run_id.clone();
         let injected = active_run
             .inject_tx

--- a/crates/harnx-serve/src/session_actor/tests/session_actor_nats_tests.rs
+++ b/crates/harnx-serve/src/session_actor/tests/session_actor_nats_tests.rs
@@ -106,7 +106,7 @@ async fn start_serve_smoke_openai() -> ServeSmokeOpenAi {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn serve_thin_client_replays_prompt_queued_during_active_run() {
+async fn serve_replays_prompt_queued_during_active_run() {
     harnx_core::require_nextest();
     let Some(binary) = live_worker_binary() else {
         return;
@@ -150,7 +150,7 @@ async fn serve_thin_client_replays_prompt_queued_during_active_run() {
     let _ = mock.release_first.send(());
     let second_request = tokio::time::timeout(Duration::from_secs(15), mock.second_request)
         .await
-        .expect("queued thin-client turn did not reach worker")
+        .expect("queued NATS session turn did not reach worker")
         .expect("second mock request notifier dropped");
     assert!(
         String::from_utf8_lossy(&second_request).contains("queued follow-up"),

--- a/crates/harnx-serve/src/session_actor_test_executor.rs
+++ b/crates/harnx-serve/src/session_actor_test_executor.rs
@@ -20,7 +20,8 @@ pub(super) struct LocalTestTurnParams {
 }
 
 /// Legacy in-process executor used only when tests inject a model call function.
-/// Production serve routing is thin-client-only because it never supplies one.
+/// Production serve routing always goes through NATS because it never
+/// supplies one.
 pub(super) async fn run_local_test_turn(
     params: LocalTestTurnParams,
 ) -> anyhow::Result<harnx_runtime::LoopResult> {

--- a/crates/harnx-tui/src/input.rs
+++ b/crates/harnx-tui/src/input.rs
@@ -1516,11 +1516,10 @@ impl Tui {
             let result: Result<()> = if cluster == harnx_runtime::config::LOCAL_CLUSTER_KEY {
                 Self::run_test_prompt_task(msg, ctx).await
             } else {
-                Self::run_thin_client_prompt_task(msg, ctx, agent, cluster).await
+                Self::run_nats_prompt_task(msg, ctx, agent, cluster).await
             };
             #[cfg(not(test))]
-            let result: Result<()> =
-                Self::run_thin_client_prompt_task(msg, ctx, agent, cluster).await;
+            let result: Result<()> = Self::run_nats_prompt_task(msg, ctx, agent, cluster).await;
 
             let error = match result {
                 Err(_) if new_abort.aborted() => None,

--- a/crates/harnx-tui/src/lifecycle.rs
+++ b/crates/harnx-tui/src/lifecycle.rs
@@ -860,7 +860,7 @@ pub(crate) fn session_history_transcript_items(config: &GlobalConfig) -> Vec<Tra
         Some(session) => session.id().to_string(),
         None => return vec![],
     };
-    let thin_agent = cfg.remote_agent.clone().or_else(|| {
+    let session_agent = cfg.remote_agent.clone().or_else(|| {
         cfg.agent.as_ref().map(|agent| {
             (
                 agent.name().to_string(),
@@ -889,7 +889,7 @@ pub(crate) fn session_history_transcript_items(config: &GlobalConfig) -> Vec<Tra
         );
     }
 
-    if let Some((agent, cluster)) = thin_agent {
+    if let Some((agent, cluster)) = session_agent {
         drop(cfg);
         let Some(state) = crate::session_history_loader::load_remote_session_history(
             config, agent, cluster, session_id,

--- a/crates/harnx-tui/src/prompt.rs
+++ b/crates/harnx-tui/src/prompt.rs
@@ -12,7 +12,7 @@ use harnx_runtime::config::GlobalConfig;
 #[cfg(test)]
 use harnx_runtime::config::Input;
 use harnx_runtime::utils::AbortSignal;
-use harnx_runtime::{ThinClientConfig, ThinClientSession};
+use harnx_runtime::{NatsSession, NatsSessionConfig};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 
@@ -200,7 +200,7 @@ impl Tui {
     }
 
     /// Drive either a local or configured remote agent through NATS.
-    pub(super) async fn run_thin_client_prompt_task(
+    pub(super) async fn run_nats_prompt_task(
         msg: PendingMessage,
         ctx: PromptTaskContext,
         agent: String,
@@ -213,9 +213,7 @@ impl Tui {
             .await;
         }
         if !msg.attachments.is_empty() {
-            return Err(anyhow::anyhow!(
-                "Attachments are not yet supported in thin-client mode"
-            ));
+            return Err(anyhow::anyhow!("Attachments are not yet supported"));
         }
 
         if cluster == harnx_runtime::config::LOCAL_CLUSTER_KEY {
@@ -235,8 +233,8 @@ impl Tui {
             .session
             .as_ref()
             .map(|session| session.id().to_string());
-        let session = ThinClientSession::from_global_config(
-            ThinClientConfig {
+        let session = NatsSession::from_global_config(
+            NatsSessionConfig {
                 cluster: cluster.clone(),
                 agent,
                 session_id,
@@ -245,17 +243,13 @@ impl Tui {
             ctx.abort_signal.clone(),
         )
         .await
-        .context("failed to create thin-client session")?;
+        .context("failed to create NATS session")?;
 
         let input = harnx_runtime::config::input::from_str(&ctx.config, &msg.text, None);
         let result = session.run_turn(&msg.text, sink, None).await?;
-        harnx_runtime::commands::update_last_message_after_thin_client_turn(
-            &ctx.config,
-            input,
-            &result,
-        );
+        harnx_runtime::commands::update_last_message_after_nats_turn(&ctx.config, input, &result);
         log::info!(
-            "thin-client prompt completed: cluster={} session_id={} cancelled={}",
+            "prompt completed: cluster={} session_id={} cancelled={}",
             cluster,
             result.session_id,
             result.was_cancelled

--- a/crates/harnx-tui/src/session_history_loader.rs
+++ b/crates/harnx-tui/src/session_history_loader.rs
@@ -2,7 +2,7 @@ use harnx_runtime::config::{
     remote_session_ops::{load_remote_transcript_for_render, RemoteTranscriptState},
     GlobalConfig,
 };
-use harnx_runtime::{ThinClientConfig, ThinClientSession};
+use harnx_runtime::{NatsSession, NatsSessionConfig};
 use log::warn;
 
 pub(crate) fn load_remote_session_history(
@@ -12,8 +12,8 @@ pub(crate) fn load_remote_session_history(
     session_id: String,
 ) -> Option<RemoteTranscriptState> {
     let remote_load = || async {
-        let thin = ThinClientSession::from_global_config(
-            ThinClientConfig {
+        let session = NatsSession::from_global_config(
+            NatsSessionConfig {
                 cluster,
                 agent,
                 session_id: Some(session_id),
@@ -22,7 +22,7 @@ pub(crate) fn load_remote_session_history(
             harnx_runtime::utils::create_abort_signal(),
         )
         .await?;
-        load_remote_transcript_for_render(&thin).await
+        load_remote_transcript_for_render(&session).await
     };
     let result = match tokio::runtime::Handle::try_current() {
         Ok(handle) => tokio::task::block_in_place(|| handle.block_on(remote_load())),

--- a/crates/harnx/src/main.rs
+++ b/crates/harnx/src/main.rs
@@ -603,8 +603,8 @@ async fn start_directive(
         .context("failed to ensure local NATS worker")?;
     }
 
-    let session = harnx_runtime::ThinClientSession::from_global_config(
-        harnx_runtime::ThinClientConfig {
+    let session = harnx_runtime::NatsSession::from_global_config(
+        harnx_runtime::NatsSessionConfig {
             cluster,
             agent,
             session_id,
@@ -613,7 +613,7 @@ async fn start_directive(
         abort_signal,
     )
     .await
-    .context("failed to create thin-client session")?;
+    .context("failed to create NATS session")?;
     let sink = harnx_core::sink::current_agent_event_sink()
         .context("CLI agent event sink is not installed")?;
     let tracking_sink = Arc::new(oneshot_nats::AssistantTextTrackingSink::new(sink));
@@ -634,7 +634,7 @@ async fn start_directive(
 fn finish_one_shot_output(
     final_only: bool,
     tracking_sink: &oneshot_nats::AssistantTextTrackingSink,
-    result: harnx_runtime::ThinClientTurnResult,
+    result: harnx_runtime::NatsTurnResult,
 ) {
     if final_only {
         print_final_response(&result);
@@ -643,7 +643,7 @@ fn finish_one_shot_output(
     }
 }
 
-fn print_final_response(result: &harnx_runtime::ThinClientTurnResult) {
+fn print_final_response(result: &harnx_runtime::NatsTurnResult) {
     if result.was_cancelled || result.error.is_some() {
         return;
     }

--- a/crates/harnx/src/oneshot_nats.rs
+++ b/crates/harnx/src/oneshot_nats.rs
@@ -1,5 +1,5 @@
 use harnx_core::event::{AgentEvent, AgentEventSink, ContentBlock, ModelEvent};
-use harnx_runtime::ThinClientTurnResult;
+use harnx_runtime::NatsTurnResult;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -18,7 +18,7 @@ impl AssistantTextTrackingSink {
         }
     }
 
-    pub(crate) fn emit_durable_response_if_needed(&self, result: ThinClientTurnResult) {
+    pub(crate) fn emit_durable_response_if_needed(&self, result: NatsTurnResult) {
         if result.was_cancelled || self.rendered_assistant_text.load(Ordering::Acquire) {
             return;
         }

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -313,7 +313,7 @@ Harnx supports agent delegation, allowing a parent agent to run nested sub-agent
 
 ### NATS-Based Session Model
 
-Sub-agents in Harnx execute as standard NATS agent sessions (`ThinClientSession`). ACP (Agent Client Protocol) and its stdio child process architecture have been removed.
+Sub-agents in Harnx execute as standard NATS agent sessions (`NatsSession`). ACP (Agent Client Protocol) and its stdio child process architecture have been removed.
 
 - **Markdown-only agent definitions**: Agents are defined solely by Markdown files with YAML front-matter in `<config-dir>/agents/*.md` (or package agents). ACP server configuration (`acp_servers/*.yaml`) and ACP stdio child processes no longer exist.
 - **Auto-registered toolsets**: For every configured agent, the worker daemon registers a NATS-backed 4-tool toolset. Each registration advertises the raw names `session_new`, `session_prompt`, `session_load`, and `session_cancel`; the provider exposes them to agents with an agent-relative prefix:

--- a/docs/nats-ha.md
+++ b/docs/nats-ha.md
@@ -1,12 +1,12 @@
 # High-Availability Deployment (NATS Mode)
 
-Harnx supports a distributed, high-availability (HA) mode backed by [NATS JetStream](https://nats.io/). In this mode, the agent tool loop runs in a dedicated **worker** process, while thin **clients** (TUI or CLI) connect to the worker via a NATS cluster.
+Harnx supports a distributed, high-availability (HA) mode backed by [NATS JetStream](https://nats.io/). In this mode, the agent tool loop runs in a dedicated **worker** process, while **clients** (TUI or CLI) connect to the worker via a NATS cluster.
 
 ## Architecture Overview
 
 Harnx NATS mode decouples the execution of an agent from the user interface:
 
-- **Clients**: Thin processes (TUI and CLI) that post user messages and render events. They do not execute tools.
+- **Clients**: The TUI and CLI processes that post user messages and render events. They do not execute tools.
 - **NATS Cluster**: The central nervous system. Uses JetStream for a durable session log and Key-Value (KV) for leader election (leases).
 - **Workers**: One or more daemon processes that execute the agent loop. Multiple workers provide redundancy; only one worker holds the active lease for a given session at a time.
 


### PR DESCRIPTION
Closes #1450.

The NATS client is the only client now, so calling it a "thin client" and calling out a separate operating mode just adds noise.

- `ThinClientSession` / `ThinClientConfig` / `ThinClientTurnResult` → `NatsSession` / `NatsSessionConfig` / `NatsTurnResult`
- `harnx-runtime/src/nats_client_session.rs` → `nats_session.rs`; `tests/nats_thin_client.rs` → `tests/nats_session.rs`
- `update_last_message_after_thin_client_turn` → `..._after_nats_turn`, `run_thin_client_prompt_task` → `run_nats_prompt_task`, plus the `thin_client_*` test fn names
- `thin` / `thin_cfg` / `thin_agent` locals and params → `session` / `session_cfg` / `session_agent`
- Log prefix `"thin client: …"` → `"nats session: …"`
- Comments and docs no longer describe a separate mode: `nats_session.rs`'s module header drops the "runs in THIN mode" / "P4.2 implementation" framing, `Config::remote_agent`'s doc now says what the field actually holds, and the TUI error is just "Attachments are not yet supported"
- `docs/agent-guide.md` and `docs/nats-ha.md` updated

Left alone: `docs/solutions/*` and CHANGELOGs (historical records), and unrelated English uses of "thin" (`retry.rs` "thin, low-complexity loop", `bootstrap.rs` "thin-wrapper bins"). The `remote_*` identifiers (`remote_agent`, `remote_session_ops`, `AgentRef::Remote`) keep their names — `remote_agent: None` still means "local cluster", so that distinction is live; only the prose around it got flattened.

No changeset: nothing user-visible ships here.

## Testing

`cargo build --workspace`, `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` clean. `cargo nextest run --workspace`: 2427 passed.

`cs delta origin/HEAD` reports health unchanged (4.11→4.11, 3.18→3.18, 7.29→7.29). The three degraded-issue flags are a ±1 LoC delta from rustfmt rewrapping two long test call sites once the type names got three characters longer.

`--stress-count=5` failed on two separate attempts, but with a different test each time and always at a 30–60s timeout (`specialist_handoff_tool_appears_in_transcript` and `remote_delete_command_routes_to_exact_set_mutations`, then `cancel_immediately_after_activation_ack_is_not_lost`). Those tests pass 6/6 in isolation in 0.13s and 2.2s, so it's contention under the parallel stress run rather than anything here. To confirm the diff can't change behavior, I normalized every touched file on both sides — comments and string literals stripped, all renamed tokens collapsed to one symbol — and diffed: the only remaining differences are rustfmt rewrapping, import reordering, and the intended string edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated session handling across the CLI, TUI, runtime, and server to use the unified NATS session model.
  * Preserved existing cancellation, response handling, transcript rendering, and durable-completion behavior.
  * Standardized session-related terminology in user-facing errors, logs, comments, and documentation.

* **Documentation**
  * Clarified durable completion signals and NATS-based session architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->