### PR TITLE
ci: run clippy and fmt only on Linux

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,10 +161,15 @@ jobs:
           exit 1
         fi
 
+    # Lints are platform-agnostic, so one runner is enough. The per-OS `Build
+    # workspace` step still compiles with `--deny warnings`, which catches rustc
+    # warnings in platform-gated code that Linux clippy never sees.
     - name: Clippy
+      if: runner.os == 'Linux'
       run: cargo clippy --all --all-targets -- -D warnings
 
     - name: Format
+      if: runner.os == 'Linux'
       run: cargo fmt --all --check
 
   docker-lint:


### PR DESCRIPTION
Clippy and rustfmt produce the same result on every runner, so running them across the full ubuntu/macos/windows matrix is wasted CI time. Gate both steps behind `runner.os == 'Linux'`.

The macOS and Windows legs still build and test as before, and they still compile with `RUSTFLAGS: --deny warnings` — so rustc warnings in `cfg(windows)` / `cfg(target_os = ...)` code keep failing on the OS that actually compiles them. The gap is narrow: clippy-only lints inside platform-gated blocks that Linux never compiles.

Closes #1498

## Testing

`cargo fmt --all --check` and `cs delta origin/HEAD` pass. No Rust changed, so the build/nextest legs of the local pipeline have nothing to verify here — the workflow change itself gets exercised by this PR's own CI run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration checks so Clippy and formatting validation run on Linux.
  * Workspace builds continue to run across all supported operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->