### PR TITLE
fix(serve): abort orphaned turn task on session actor drop

### DIFF
--- a/.changeset/session-actor-abort-orphan-turn.md
+++ b/.changeset/session-actor-abort-orphan-turn.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Abort a session actor's in-flight turn task when the actor stops, including on panic. Dropping the actor requests cancellation through `JoinHandle::abort()`, so a pending write may be dropped and a replacement actor may overlap until the old task terminates. This bounds the double-writer window instead of eliminating it; a strict single-writer guarantee would require a registry-side join or actor-mediated writes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4202,6 +4202,7 @@ dependencies = [
  "tokio",
  "tokio-graceful",
  "tokio-stream",
+ "tokio-util",
  "uuid",
 ]
 

--- a/crates/harnx-serve/Cargo.toml
+++ b/crates/harnx-serve/Cargo.toml
@@ -43,6 +43,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-graceful = { workspace = true }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 uuid = { workspace = true, features = ["v5"] }
 
 [dev-dependencies]

--- a/crates/harnx-serve/src/session_actor.rs
+++ b/crates/harnx-serve/src/session_actor.rs
@@ -46,9 +46,9 @@ use std::{
 };
 use tokio::{
     sync::{broadcast, mpsc, oneshot, Mutex},
-    task::JoinHandle,
     time::{sleep_until, Instant, Sleep},
 };
+use tokio_util::task::AbortOnDropHandle;
 
 const COMMAND_BUFFER: usize = 32;
 const BROADCAST_BUFFER: usize = 64;
@@ -101,7 +101,13 @@ struct SessionActor {
     active_run: Option<ActiveRun>,
     run_done_tx: mpsc::Sender<RunFinished>,
     run_done_rx: mpsc::Receiver<RunFinished>,
-    run_done_task: Option<JoinHandle<()>>,
+    /// In-flight turn task, aborted on drop so a panicking or stopping actor doesn't leak it.
+    /// Dropping the actor requests cancellation via `JoinHandle::abort`: the task is dropped at
+    /// its next await, so a pending write may be dropped rather than completed, and a replacement
+    /// actor can overlap until this task actually terminates. That bounds the double-writer window
+    /// (issue #1468) but isn't a strict single-writer guarantee. That would need a registry-side
+    /// join or actor-mediated writes.
+    run_done_task: Option<AbortOnDropHandle<()>>,
     reap_ttl: Duration,
     reap_deadline: Option<Instant>,
     history_snapshot: Vec<AgUiMessage>,
@@ -328,6 +334,8 @@ impl SessionActor {
             SessionCommand::EmitTestEvent { event } => {
                 let _ = self.broadcast_tx.send(event);
             }
+            #[cfg(test)]
+            SessionCommand::Panic => panic!("test-triggered session actor panic"),
         }
     }
 
@@ -577,7 +585,7 @@ impl SessionActor {
             agent: self.key.agent.clone(),
             session_id: self.key.session.clone(),
         };
-        let task = tokio::spawn(async move {
+        let task = AbortOnDropHandle::new(tokio::spawn(async move {
             let loop_result = run_actor_turn(turn).await;
             let _ = done_tx
                 .send(RunFinished {
@@ -588,7 +596,7 @@ impl SessionActor {
                     attachment_refs,
                 })
                 .await;
-        });
+        }));
 
         self.run_done_task = Some(task);
         self.active_run = Some(ActiveRun {
@@ -888,7 +896,7 @@ impl SessionActor {
         ));
         let sink_for_task = sink.clone();
         let abort_signal_for_task = abort_signal.clone();
-        let task = tokio::spawn(async move {
+        let task = AbortOnDropHandle::new(tokio::spawn(async move {
             let loop_result = with_agent_event_sink(sink_for_task.clone(), async {
                 let mut input = input;
                 loop {
@@ -947,7 +955,7 @@ impl SessionActor {
                     attachment_refs: options.attachment_refs.clone(),
                 })
                 .await;
-        });
+        }));
 
         self.run_done_task = Some(task);
         self.active_run = Some(ActiveRun {
@@ -2773,6 +2781,9 @@ mod tests {
             "target session should be registered in registry after handoff dispatch"
         );
     }
+
+    #[path = "session_actor_panic_abort_tests.rs"]
+    mod panic_abort_tests;
 
     #[path = "session_actor_registry_tests.rs"]
     mod registry_tests;

--- a/crates/harnx-serve/src/session_actor/tests/session_actor_panic_abort_tests.rs
+++ b/crates/harnx-serve/src/session_actor/tests/session_actor_panic_abort_tests.rs
@@ -1,0 +1,145 @@
+//! Panic cleanup for active initial and resumed turns.
+
+use super::*;
+use harnx_core::tool::ToolCall;
+use serde_json::json;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use tokio::sync::{oneshot, Notify};
+
+struct DropCanary(Option<oneshot::Sender<()>>);
+
+impl Drop for DropCanary {
+    fn drop(&mut self) {
+        if let Some(tx) = self.0.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+fn blocking_drop_canary_call_fn(
+    leading_interrupt_rounds: usize,
+) -> (AgentCallFn, Arc<Notify>, oneshot::Receiver<()>) {
+    let round = Arc::new(AtomicUsize::new(0));
+    let turn_started = Arc::new(Notify::new());
+    let (dropped_tx, dropped_rx) = oneshot::channel();
+    let dropped_tx = Arc::new(std::sync::Mutex::new(Some(dropped_tx)));
+    let call_fn: AgentCallFn = {
+        let round = Arc::clone(&round);
+        let turn_started = Arc::clone(&turn_started);
+        Arc::new(move |_input, _config, _abort| {
+            let round = Arc::clone(&round);
+            let turn_started = Arc::clone(&turn_started);
+            let dropped_tx = Arc::clone(&dropped_tx);
+            Box::pin(async move {
+                if round.fetch_add(1, Ordering::SeqCst) < leading_interrupt_rounds {
+                    return Ok((
+                        "approval required".to_string(),
+                        None,
+                        vec![ToolCall::new(
+                            "harnx_agent_session_history_read".to_string(),
+                            json!({}),
+                            Some("resume-call".to_string()),
+                            None,
+                        )],
+                        harnx_runtime::client::CompletionTokenUsage::default(),
+                    ));
+                }
+
+                let dropped_tx = dropped_tx
+                    .lock()
+                    .expect("lock drop canary sender")
+                    .take()
+                    .expect("blocking turn should start once");
+                let _canary = DropCanary(Some(dropped_tx));
+                turn_started.notify_one();
+                std::future::pending().await
+            })
+        })
+    };
+    (call_fn, turn_started, dropped_rx)
+}
+
+#[tokio::test]
+async fn session_actor_panic_aborts_in_flight_turn() {
+    let _guard = harnx_runtime::client::TestStateGuard::new(None).await;
+    let sandbox = TestConfigSandbox::new();
+    sandbox.write_agent("plain", "You are plain.");
+
+    let (call_fn, turn_started, dropped_rx) = blocking_drop_canary_call_fn(0);
+    let registry = registry_with_call_fn(call_fn);
+    let handle = registry.get_or_spawn(key("plain", "panic-abort"));
+    let _sub = subscribe(&handle).await;
+
+    let result = prompt(&handle, "run until actor stops").await;
+    assert!(matches!(result, PromptResult::Accepted { .. }));
+    tokio::time::timeout(Duration::from_secs(2), turn_started.notified())
+        .await
+        .expect("timed out waiting for turn to start");
+
+    handle
+        .tx
+        .send(SessionCommand::Panic)
+        .await
+        .expect("send panic command");
+    tokio::time::timeout(Duration::from_secs(2), dropped_rx)
+        .await
+        .expect("timed out waiting for in-flight turn to be aborted")
+        .expect("drop canary sender closed without notification");
+}
+
+#[tokio::test]
+async fn session_actor_panic_aborts_in_flight_resume_turn() {
+    let _guard = harnx_runtime::client::TestStateGuard::new(None).await;
+    let sandbox = TestConfigSandbox::new();
+    sandbox.write_agent_with_front_matter(
+        "plain",
+        "model: openai:gpt-4o\nuse_tools: harnx_agent_session_history_read\nhooks:\n  entries:\n    - command: |\n        harnx-claude-compatible-hook-server --event PreToolUse --matcher '^harnx_agent_session_history_read$' -- printf '\"'\"'{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"approval needed\"}}'\"'\"''",
+        "You are plain.",
+    );
+
+    let (call_fn, resume_turn_started, dropped_rx) = blocking_drop_canary_call_fn(1);
+    let registry = registry_with_call_fn(call_fn);
+    let handle = registry.get_or_spawn(key("plain", "panic-abort-resume"));
+    let _sub = subscribe(&handle).await;
+
+    let result = prompt(&handle, "interrupt before resume").await;
+    assert!(matches!(result, PromptResult::Accepted { .. }));
+    wait_for_state(&handle, "interrupted", |state| {
+        matches!(state, SessionState::Interrupted { .. })
+    })
+    .await;
+
+    let resumed = prompt_with_options(
+        &handle,
+        "interrupt before resume",
+        SessionPromptOptions {
+            resume: vec![InterruptResume {
+                interrupt_id: "resume-call".to_string(),
+                status: InterruptResumeStatus::Approved,
+                payload: InterruptResumePayload {
+                    approved: true,
+                    reason: None,
+                },
+            }],
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(matches!(resumed, PromptResult::Accepted { .. }));
+    tokio::time::timeout(Duration::from_secs(2), resume_turn_started.notified())
+        .await
+        .expect("timed out waiting for resumed turn to start");
+
+    handle
+        .tx
+        .send(SessionCommand::Panic)
+        .await
+        .expect("send panic command");
+    tokio::time::timeout(Duration::from_secs(2), dropped_rx)
+        .await
+        .expect("timed out waiting for in-flight resumed turn to be aborted")
+        .expect("drop canary sender closed without notification");
+}

--- a/crates/harnx-serve/src/session_actor_types.rs
+++ b/crates/harnx-serve/src/session_actor_types.rs
@@ -81,6 +81,8 @@ pub enum SessionCommand {
     EmitTestEvent {
         event: Event,
     },
+    #[cfg(test)]
+    Panic,
 }
 
 pub struct SubscribeResult {

--- a/docs/solutions/async-patterns/session-actor-concurrency-invariants-2026-07-04.md
+++ b/docs/solutions/async-patterns/session-actor-concurrency-invariants-2026-07-04.md
@@ -20,7 +20,7 @@ tags:
   - reap-race
   - dashmap
 plan_ref: ag-ui-serve-control-plane
-last_updated: 2026-08-17
+last_updated: 2026-08-20
 ---
 
 ## Problem
@@ -222,6 +222,7 @@ Thread the server's real `Config` through `SessionRegistry::new(config)` (now in
 - [ ] Is `notify_one()` used instead of `notify_waiters()` for single-waiter signaling?
 - [ ] Are test-only helpers excluded from production paths (grep for `load_base_config_for_tests`, `set_current_dir`, env `.expect`)?
 - [ ] Does `SessionRegistry`/actor hold the server's real `Config`, not reload from env?
+- [ ] Are actor-owned child tasks held in `AbortOnDropHandle`, not bare `JoinHandle`? A dropped `JoinHandle` does not abort its task, orphaning it on actor stop (panic or exit). See `run_done_task` in `session_actor.rs` and issue #1468.
 
 ### Testing Mechanics
 
@@ -234,3 +235,4 @@ Thread the server's real `Config` through `SessionRegistry::new(config)` (now in
 
 - **GitHub:** [issue #959](https://github.com/dobesv/harnx/issues/959) — AG-UI Phase 2: per-session actor control plane
 - **GitHub:** [issue #1465](https://github.com/dobesv/harnx/issues/1465) — `get_or_spawn` handed out reaped actors' handles; the source of the ~1-in-10 503 flake in `rpc_session_prompt_returns_ack_and_persists_effect`
+- **GitHub:** [issue #1468](https://github.com/dobesv/harnx/issues/1468) — orphan turn task after actor panic; double-writer window narrowed by `AbortOnDropHandle`


### PR DESCRIPTION
Wrap in-flight turn JoinHandles in AbortOnDropHandle within SessionActor so that dropping or panicking the actor automatically cancels running turn tasks. This prevents orphaned turn execution when a session actor stops and is replaced by a new instance.

Closes #1468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session shutdown now reliably cancels in-progress turns, including when the session encounters a panic.
  * Prevented orphaned tasks and reduced overlapping work when a session is replaced.

* **Documentation**
  * Updated concurrency guidance and documented the related issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->