### PR TITLE
fix(nats): stop the worker re-feeding a turn its own user messages

### DIFF
--- a/.changeset/fix-worker-prompt-reinjection.md
+++ b/.changeset/fix-worker-prompt-reinjection.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Stop the NATS worker from re-feeding a turn's own user messages back into itself. The header-insert migration re-maps a headerless session's leading user block onto the migration's log seq, which sits above the turn's seed cursor, so the mid-round injection callback read the prompt the turn was already answering as a new message. Injected text was also persisted as a fresh user log entry, so every injection guaranteed another one on the next tool round and left a leftover message the end-of-turn drain ran as another turn — the TUI kept spinning and queued replies never started a loop. Worker turns no longer send their prompt to the model twice either.

--- a/crates/harnx-runtime/src/config/session.rs
+++ b/crates/harnx-runtime/src/config/session.rs
@@ -938,6 +938,21 @@ fn append_injected_user_text(session: &mut Session, input: &Input) -> bool {
         return true;
     };
 
+    // `skip_user_log_append` marks an input whose user text was folded out of
+    // the durable log, so the log already holds this message and re-appending
+    // it is not just a duplicate row: the worker's mid-round fold would read
+    // the fresh copy as another unanswered message and inject it again, once
+    // more per remaining tool round. The in-memory push still has to happen —
+    // `session.messages` is loaded once per turn and is what carries the
+    // injected message into the following rounds' wire requests.
+    if input.skip_user_log_append {
+        session.messages.push(Message::new(
+            MessageRole::User,
+            MessageContent::Text(injected.to_string()),
+        ));
+        return true;
+    }
+
     let seq = session.next_seq();
     let injected_msg = Message::new(
         MessageRole::User,
@@ -1042,61 +1057,84 @@ pub(crate) fn expand_message_attachments(session: &Session, messages: &mut [Mess
     }
 }
 
+/// Drop the trailing assistant/tool messages so a regenerate re-answers from
+/// the last user message.
+fn trim_trailing_non_user(messages: &mut Vec<Message>) {
+    while messages.last().is_some_and(|last| !last.role.is_user()) {
+        messages.pop();
+    }
+}
+
+/// Whether the trailing `input.message_content()` user message must be
+/// suppressed because the history already carries that text.
+fn history_already_has_input_text(input: &Input, messages: &[Message]) -> bool {
+    // Mid-tool-round: the pending call/result pair is already in the history.
+    is_tool_continuation(input, messages)
+        // The NATS worker folds its user text out of the durable log, so the
+        // session loaded for this turn already ends with those messages.
+        // Pushing them again would send the prompt to the model twice — once
+        // per turn, since every worker turn derives its input the same way.
+        || input.skip_user_log_append
+}
+
+/// Replace any persisted leading system message with a freshly rendered one, so
+/// each turn sees current agent variables, resolved tools, and the active model
+/// selection (including fallbacks). Agent swaps after construction (e.g.
+/// compaction) also flow through here.
+fn inject_fresh_system_prompt(messages: &mut Vec<Message>, input: &Input) -> Result<()> {
+    if !input.inject_system_prompt() {
+        return Ok(());
+    }
+    let system_text = input
+        .agent()
+        .system_text_with_tools(input.resolved_tools.as_deref().unwrap_or_default())?;
+    // Drop leading system message(s) so only the freshly rendered prompt
+    // survives — including when a legacy transcript stored one but the current
+    // render is empty.
+    while matches!(messages.first().map(|m| m.role), Some(MessageRole::System)) {
+        messages.remove(0);
+    }
+    if !system_text.is_empty() {
+        messages.insert(
+            0,
+            Message::new(MessageRole::System, MessageContent::Text(system_text)),
+        );
+    }
+    Ok(())
+}
+
+/// Extend a single-message history with the tail of the compressed transcript
+/// from its last user message on, so a compacted session keeps recent context.
+fn extend_with_compressed_tail(session: &Session, messages: &mut Vec<Message>) {
+    if messages.len() != 1 || session.compressed_messages.len() < 2 {
+        return;
+    }
+    if let Some(index) = session
+        .compressed_messages
+        .iter()
+        .rposition(|v| v.role == MessageRole::User)
+    {
+        messages.extend(session.compressed_messages[index..].to_vec());
+    }
+}
+
 fn build_messages_inner(session: &Session, input: &Input) -> Result<Vec<Message>> {
     let mut messages = session.messages.clone();
     if input.continue_output().is_some() {
         return Ok(messages);
-    } else if input.regenerate() {
-        while let Some(last) = messages.last() {
-            if !last.role.is_user() {
-                messages.pop();
-            } else {
-                break;
-            }
-        }
+    }
+    if input.regenerate() {
+        trim_trailing_non_user(&mut messages);
         return Ok(messages);
     }
-    let mut need_add_msg = true;
-    let len = messages.len();
-    if len == 0 {
+    let need_add_msg = if messages.is_empty() {
         messages = input.agent().build_messages(input)?;
-        need_add_msg = false;
-    } else if len == 1 && session.compressed_messages.len() >= 2 {
-        if let Some(index) = session
-            .compressed_messages
-            .iter()
-            .rposition(|v| v.role == MessageRole::User)
-        {
-            messages.extend(session.compressed_messages[index..].to_vec());
-        }
-    }
-    // Continuation: suppress the duplicate user message only when the
-    // input is genuinely mid-tool-round — see `is_tool_continuation`.
-    if need_add_msg && is_tool_continuation(input, &messages) {
-        need_add_msg = false;
-    }
-    // System prompt is no longer persisted in session transcript.
-    // Inject it fresh here so each turn sees current agent variables,
-    // resolved tools, and active model selection (including fallbacks).
-    // Agent swaps after construction (e.g. compaction) also flow through
-    // this path via inject_system_prompt.
-    if input.inject_system_prompt() {
-        let system_text = input
-            .agent()
-            .system_text_with_tools(input.resolved_tools.as_deref().unwrap_or_default())?;
-        // Drop any leading system message(s) so only the freshly rendered
-        // prompt survives — including the case where a legacy transcript
-        // stored one but the current render is empty.
-        while matches!(messages.first().map(|m| m.role), Some(MessageRole::System)) {
-            messages.remove(0);
-        }
-        if !system_text.is_empty() {
-            messages.insert(
-                0,
-                Message::new(MessageRole::System, MessageContent::Text(system_text)),
-            );
-        }
-    }
+        false
+    } else {
+        extend_with_compressed_tail(session, &mut messages);
+        !history_already_has_input_text(input, &messages)
+    };
+    inject_fresh_system_prompt(&mut messages, input)?;
     if need_add_msg {
         messages.push(Message::new(MessageRole::User, input.message_content()));
     }

--- a/crates/harnx-runtime/src/nats_worker/agent_loop.rs
+++ b/crates/harnx-runtime/src/nats_worker/agent_loop.rs
@@ -39,9 +39,11 @@ pub struct RunAgentLoopArgs<'a> {
     /// Optional observer of the JetStream seq of the header-insert migration
     /// EditEntries (S2), when the worker migrates a headerless remote session on
     /// this activation. The migration re-maps the leading-user block onto this
-    /// seq, so the daemon must advance its activation high-water cursor to cover
-    /// it — otherwise the end-of-turn drain re-folds the now-remapped (and
-    /// already-answered) leading user messages and re-runs the turn (S3).
+    /// seq, so every cursor tracking "user messages already fed into this turn"
+    /// must advance to cover it. Otherwise the re-mapped (already-answered)
+    /// leading users read as unanswered: the mid-round injection callback
+    /// re-injects the prompt the turn is answering, and the end-of-turn drain
+    /// re-runs the turn (S3).
     pub header_insert_observer: Option<Arc<AtomicU64>>,
     /// Optional NATS KV store for the session index. When set, the worker
     /// upserts a `SessionIndexRecord` after the effective log has a `Header`
@@ -1347,13 +1349,14 @@ async fn maybe_insert_remote_header(args: MaybeInsertRemoteHeaderArgs<'_>) -> Re
             .append_event_with_message_id_async(&edit_entry, message_id)
             .await?;
     debug!("inserted header via EditEntries js{insert_seq}");
-    // Publish the migration seq so the daemon advances its activation high-water
-    // cursor past the re-mapped leading-user block. The migration re-maps those
-    // users onto `insert_seq`; the turn that runs this activation answers them,
-    // so without this the drain would re-fold them (seq > pre-migration cursor)
-    // and re-run the turn (S3).
+    // Publish the migration seq so the worker's turn cursor advances past the
+    // re-mapped leading-user block. The migration re-maps those users onto
+    // `insert_seq`; the turn that runs this activation answers them, so without
+    // this they read as unanswered (seq > pre-migration cursor) and get folded
+    // back in — mid-round as a spurious injection, and again by the drain as a
+    // spurious continuation turn (S3).
     if let Some(observer) = header_insert_observer {
-        observer.fetch_max(insert_seq, std::sync::atomic::Ordering::Relaxed);
+        observer.fetch_max(insert_seq, std::sync::atomic::Ordering::SeqCst);
     }
     *entries_vec = backend.load_events_blocking()?;
     *effective_entries = harnx_core::session_reconstruct::apply_log_mutations_nats(entries_vec)?;

--- a/crates/harnx-runtime/src/nats_worker/daemon_session_exec.rs
+++ b/crates/harnx-runtime/src/nats_worker/daemon_session_exec.rs
@@ -96,14 +96,6 @@ impl WorkerRuntime {
                 let on_tool_round =
                     build_mid_turn_injection_callback(backend.clone(), Arc::clone(&turn_cursor));
 
-                // Per-turn observer for the S2 header-insert migration seq. Only
-                // the first activation of a headerless session migrates; the
-                // migration re-maps the leading-user block onto this seq, which
-                // the turn answers. We must advance the activation high-water
-                // past it so the end-of-turn drain does not re-fold the remapped
-                // (already-answered) users and spuriously re-run the turn (S3).
-                let header_insert_seq = Arc::new(AtomicU64::new(0));
-
                 run_agent_loop_with_nats_inner(
                     RunAgentLoopArgs {
                         cluster_key: &self.cluster,
@@ -124,26 +116,24 @@ impl WorkerRuntime {
                     }
                     .with_lease(Arc::clone(&lease))
                     .with_after_seq_observer(Arc::clone(&after_seq_observer))
-                    .with_header_insert_observer(Arc::clone(&header_insert_seq)),
+                    // The S2 header-insert migration re-maps this turn's
+                    // leading-user block onto the migration seq, which is ABOVE
+                    // the seed cursor. Point the observer at `turn_cursor` so
+                    // BOTH consumers skip the re-mapped block: the mid-round
+                    // injection callback (or round 2 re-injects the prompt this
+                    // turn is already answering) and, via `turn_cursor` below,
+                    // the end-of-turn drain (or it re-runs the answered turn).
+                    .with_header_insert_observer(Arc::clone(&turn_cursor)),
                 )
                 .await?;
 
                 // After turn completes, update activation high-water from turn_cursor.
-                // turn_cursor was updated by mid-round injection callback for any messages
-                // injected during multi-round tool execution.
+                // turn_cursor covers everything this turn consumed: the seed
+                // messages, the header-insert re-map, and any mid-round
+                // injection during multi-round tool execution.
                 let turn_cursor_val = turn_cursor.load(Ordering::SeqCst);
                 if turn_cursor_val > 0 {
                     activation_high_water = Some(activation_high_water.map_or(turn_cursor_val, |h| h.max(turn_cursor_val)));
-                }
-
-                // Advance past the header-insert migration seq (if any). The
-                // migration remaps this turn's leading-user block onto this seq,
-                // so treat it as consumed by this turn's answer.
-                let header_insert_val = header_insert_seq.load(Ordering::SeqCst);
-                if header_insert_val > 0 {
-                    activation_high_water = Some(
-                        activation_high_water.map_or(header_insert_val, |h| h.max(header_insert_val)),
-                    );
                 }
 
                 Self::record_session_turn_end(&backend, &lease, turn_cursor_val).await?;

--- a/crates/harnx-runtime/tests/nats_worker.rs
+++ b/crates/harnx-runtime/tests/nats_worker.rs
@@ -32,6 +32,14 @@ static MID_ROUND_APPEND_READY: LazyLock<Notify> = LazyLock::new(Notify::new);
 static MID_ROUND_APPEND_DONE: LazyLock<Notify> = LazyLock::new(Notify::new);
 static MID_ROUND_FINAL_CALLS: AtomicUsize = AtomicUsize::new(0);
 static MID_ROUND_RELOAD_SEEN: AtomicUsize = AtomicUsize::new(0);
+static SOLO_TURN_ROUNDS: AtomicUsize = AtomicUsize::new(0);
+static SOLO_TURN_INJECTIONS: AtomicUsize = AtomicUsize::new(0);
+static LATE_MSG_READY: LazyLock<Notify> = LazyLock::new(Notify::new);
+static LATE_MSG_DONE: LazyLock<Notify> = LazyLock::new(Notify::new);
+static LATE_MSG_ROUNDS: AtomicUsize = AtomicUsize::new(0);
+static LATE_MSG_INJECTIONS: AtomicUsize = AtomicUsize::new(0);
+static WIRE_CALLS: AtomicUsize = AtomicUsize::new(0);
+static WIRE_PROMPT_COPIES: AtomicUsize = AtomicUsize::new(0);
 static END_TURN_APPEND_READY: LazyLock<Notify> = LazyLock::new(Notify::new);
 static END_TURN_APPEND_DONE: LazyLock<Notify> = LazyLock::new(Notify::new);
 static END_TURN_CALLS: AtomicUsize = AtomicUsize::new(0);
@@ -451,6 +459,114 @@ async fn activate_session(
     Ok(())
 }
 
+/// Stub LLM that emits a tool call for the first `TOOL_ROUNDS` calls and a
+/// final text afterwards, recording how many calls arrived carrying an
+/// `injected_user_text`. Nothing appends a mid-turn message in this scenario,
+/// so a correct worker never injects.
+fn solo_turn_call_fn() -> harnx_runtime::agent_loop::AgentCallFn {
+    const TOOL_ROUNDS: usize = 3;
+    Arc::new(move |input, _config, _abort| {
+        if input.injected_user_text().is_some() {
+            SOLO_TURN_INJECTIONS.fetch_add(1, Ordering::SeqCst);
+        }
+        let round = SOLO_TURN_ROUNDS.fetch_add(1, Ordering::SeqCst) + 1;
+        Box::pin(async move {
+            if round <= TOOL_ROUNDS {
+                Ok((
+                    format!("round-{round}"),
+                    None,
+                    vec![ToolCall::new(
+                        "echo".to_string(),
+                        json!({}),
+                        Some(format!("call-{round}")),
+                        None,
+                    )],
+                    CompletionTokenUsage::default(),
+                ))
+            } else {
+                Ok((
+                    "done".to_string(),
+                    None,
+                    vec![],
+                    CompletionTokenUsage::default(),
+                ))
+            }
+        })
+    })
+}
+
+/// Stub LLM for the "one queued message, many tool rounds" scenario: blocks on
+/// the first call so the test can append a message mid-turn, then keeps the
+/// tool loop running for several more rounds while counting how many of them
+/// arrive carrying the queued text.
+fn repeated_round_injection_call_fn() -> harnx_runtime::agent_loop::AgentCallFn {
+    const TOOL_ROUNDS: usize = 5;
+    Arc::new(move |input, _config, _abort| {
+        if input
+            .injected_user_text()
+            .is_some_and(|text| text.contains("late message"))
+        {
+            LATE_MSG_INJECTIONS.fetch_add(1, Ordering::SeqCst);
+        }
+        let round = LATE_MSG_ROUNDS.fetch_add(1, Ordering::SeqCst) + 1;
+        Box::pin(async move {
+            if round == 1 {
+                LATE_MSG_READY.notify_one();
+                LATE_MSG_DONE.notified().await;
+            }
+            if round <= TOOL_ROUNDS {
+                Ok((
+                    format!("round-{round}"),
+                    None,
+                    vec![ToolCall::new(
+                        "echo".to_string(),
+                        json!({}),
+                        Some(format!("late-call-{round}")),
+                        None,
+                    )],
+                    CompletionTokenUsage::default(),
+                ))
+            } else {
+                Ok((
+                    "done".to_string(),
+                    None,
+                    vec![],
+                    CompletionTokenUsage::default(),
+                ))
+            }
+        })
+    })
+}
+
+/// Stub LLM that records how many copies of the prompt the FIRST wire request
+/// of the turn carries. `build_messages` is the same function the real client
+/// calls, so this sees exactly what the model would.
+fn wire_message_call_fn() -> harnx_runtime::agent_loop::AgentCallFn {
+    Arc::new(move |input, config, _abort| {
+        if WIRE_CALLS.fetch_add(1, Ordering::SeqCst) == 0 {
+            let copies = harnx_runtime::config::input::build_messages(input, config)
+                .map(|messages| {
+                    messages
+                        .iter()
+                        .filter(|message| {
+                            message.role.is_user() && message.content.to_text() == "seed message"
+                        })
+                        .count()
+                })
+                .unwrap_or(0);
+            WIRE_PROMPT_COPIES.store(copies, Ordering::SeqCst);
+        }
+        Box::pin(async move {
+            Ok((
+                "done".to_string(),
+                None,
+                vec![],
+                CompletionTokenUsage::default(),
+            ))
+        })
+    })
+}
+
 fn mid_round_call_fn() -> harnx_runtime::agent_loop::AgentCallFn {
     Arc::new(move |input, _config, _abort| {
         // The mid-turn injection is delivered via `input.injected_user_text`
@@ -576,6 +692,184 @@ fn reset_test_state() {
     // Just reset the counters - tests may flake if run in same process
     MID_ROUND_FINAL_CALLS.store(0, Ordering::SeqCst);
     END_TURN_CALLS.store(0, Ordering::SeqCst);
+}
+
+/// A lone user prompt driving a multi-round tool loop must never be re-injected
+/// into its own turn.
+///
+/// A headerless session gets a `Header` synthesized by an `EditEntries`
+/// migration that re-maps the leading user block onto the migration's seq —
+/// which is ABOVE the seed cursor the turn started from. The mid-round
+/// injection cursor has to account for that, or round 2 folds the very prompt
+/// the turn is already answering back in as a "new" user message. And because
+/// each injection is itself persisted as a user log entry, one bad injection
+/// makes every later round inject again, growing the prompt duplicate per
+/// round and leaving a leftover message the end-of-turn drain runs as yet
+/// another turn.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lone_prompt_is_not_reinjected_across_tool_rounds() -> Result<()> {
+    reset_test_state();
+    SOLO_TURN_ROUNDS.store(0, Ordering::SeqCst);
+    SOLO_TURN_INJECTIONS.store(0, Ordering::SeqCst);
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("Skipping test: nats-server not available");
+        return Ok(());
+    };
+
+    let config = local_nats_runtime_config(server.url());
+    let daemon =
+        spawn_worker_daemon_with_call_fn(config, "worker-solo-turn", solo_turn_call_fn()).await;
+
+    let js = local_test_nats(server.url()).await?;
+    let session_id = "solo-turn-no-reinjection";
+    let log = NatsSessionLog::new(js.clone(), session_id);
+
+    log.append_event_async(&append_user_message_entry("user-1", "seed message"))
+        .await?;
+    activate_session(&js, session_id).await?;
+
+    // Four calls = three tool rounds plus the final text that ends the turn.
+    wait_until(CI_SAFE_TIMEOUT, || {
+        SOLO_TURN_ROUNDS.load(Ordering::SeqCst) >= 4
+    })
+    .await?;
+    // Let the end-of-turn drain decide whether to run a continuation turn.
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    assert_eq!(
+        SOLO_TURN_INJECTIONS.load(Ordering::SeqCst),
+        0,
+        "no client appended a mid-turn message, so the worker must not inject one"
+    );
+    assert_eq!(
+        SOLO_TURN_ROUNDS.load(Ordering::SeqCst),
+        4,
+        "the drain must not run a continuation turn for a prompt already answered"
+    );
+
+    let entries = log.load_events_async().await?;
+    let effective = harnx_core::session_reconstruct::apply_log_mutations_nats(&entries)?;
+    assert_eq!(
+        user_message_texts(&effective),
+        vec!["seed message".to_string()],
+        "the prompt must appear exactly once in the effective log"
+    );
+
+    daemon.abort();
+    let _ = daemon.await;
+    Ok(())
+}
+
+/// One message queued mid-turn must reach the model exactly once, no matter how
+/// many tool rounds follow.
+///
+/// The injected text is folded from the log, where the client already appended
+/// it. If the worker persists it a second time as its own user entry, the next
+/// round's fold sees that copy as another unanswered message and injects it
+/// again — one self-sustaining duplicate per round for the rest of the turn.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn queued_message_is_injected_once_across_many_tool_rounds() -> Result<()> {
+    reset_test_state();
+    LATE_MSG_ROUNDS.store(0, Ordering::SeqCst);
+    LATE_MSG_INJECTIONS.store(0, Ordering::SeqCst);
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("Skipping test: nats-server not available");
+        return Ok(());
+    };
+
+    let config = local_nats_runtime_config(server.url());
+    let daemon = spawn_worker_daemon_with_call_fn(
+        config,
+        "worker-repeated-injection",
+        repeated_round_injection_call_fn(),
+    )
+    .await;
+
+    let js = local_test_nats(server.url()).await?;
+    let session_id = "repeated-round-injection";
+    let log = NatsSessionLog::new(js.clone(), session_id);
+
+    // Register the wakeup before activating so notify_one() cannot be lost.
+    let ready_fut = LATE_MSG_READY.notified();
+    log.append_event_async(&append_user_message_entry("user-1", "seed message"))
+        .await?;
+    activate_session(&js, session_id).await?;
+    ready_fut.await;
+
+    log.append_event_async(&append_user_message_entry("user-2", "late message"))
+        .await?;
+    LATE_MSG_DONE.notify_one();
+
+    // Six calls = five tool rounds plus the final text that ends the turn.
+    wait_until(CI_SAFE_TIMEOUT, || {
+        LATE_MSG_ROUNDS.load(Ordering::SeqCst) >= 6
+    })
+    .await?;
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    assert_eq!(
+        LATE_MSG_INJECTIONS.load(Ordering::SeqCst),
+        1,
+        "the queued message must be injected into exactly one round"
+    );
+
+    let entries = log.load_events_async().await?;
+    let effective = harnx_core::session_reconstruct::apply_log_mutations_nats(&entries)?;
+    assert_eq!(
+        user_message_texts(&effective),
+        vec!["seed message".to_string(), "late message".to_string()],
+        "each user message must appear exactly once in the effective log"
+    );
+
+    daemon.abort();
+    let _ = daemon.await;
+    Ok(())
+}
+
+/// The worker must send the prompt to the model once, not twice.
+///
+/// `derive_turn_input` folds the user messages out of the durable log, so the
+/// session loaded for the turn already ends with them. Appending
+/// `input.message_content()` on top of that history — which is what
+/// `build_messages` does for an ordinary prompt — sends the whole thing again.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn worker_turn_sends_the_prompt_to_the_model_once() -> Result<()> {
+    reset_test_state();
+    WIRE_CALLS.store(0, Ordering::SeqCst);
+    WIRE_PROMPT_COPIES.store(0, Ordering::SeqCst);
+    require_nextest();
+    let Some(server) = spawn_nats_server().await? else {
+        eprintln!("Skipping test: nats-server not available");
+        return Ok(());
+    };
+
+    let config = local_nats_runtime_config(server.url());
+    let daemon =
+        spawn_worker_daemon_with_call_fn(config, "worker-wire-messages", wire_message_call_fn())
+            .await;
+
+    let js = local_test_nats(server.url()).await?;
+    let session_id = "wire-prompt-once";
+    let log = NatsSessionLog::new(js.clone(), session_id);
+
+    log.append_event_async(&append_user_message_entry("user-1", "seed message"))
+        .await?;
+    activate_session(&js, session_id).await?;
+
+    wait_until(CI_SAFE_TIMEOUT, || WIRE_CALLS.load(Ordering::SeqCst) >= 1).await?;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    assert_eq!(
+        WIRE_PROMPT_COPIES.load(Ordering::SeqCst),
+        1,
+        "the model must see the prompt exactly once"
+    );
+
+    daemon.abort();
+    let _ = daemon.await;
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
A turn kept re-answering its own prompt. Symptoms from a real session: the TUI busy spinner never stopped after the agent asked a question, the reply typed in response stayed marked pending instead of starting a loop, and on resume the transcript showed the original message repeated over and over with the agent apparently still working.

Three defects stacked up. All three are visible in one session log, where every request grows by another copy of the prompt — `nmsg=2 roles=uu`, `nmsg=4 roles=uauu`, `nmsg=7 roles=uauuauu`, up to 13 copies — and the turn-complete line (`turn_cursor=35`) is immediately followed by `drain check: latest_new_seq=Some(38)`.

## 1. The header-insert migration moves the prompt above the turn cursor

A headerless session gets a `Header` synthesized by an `EditEntries` migration, and replacements inherit the *EditEntries* seq, so the leading user block moves above the turn's `seed_cursor`. That seq was published only into `activation_high_water`, which is applied after the turn — the in-flight `turn_cursor` never learned about it, so the first mid-round fold read the prompt the turn was already answering as a new message.

The observer now points at `turn_cursor` itself. The drain still sees it, because the high-water takes the max of that cursor after the turn.

## 2. Injected text re-appended itself, once per round

`append_injected_user_text` persisted injected text as a fresh user log entry, and `fold_new_user_messages_since` cannot tell a worker-injected copy from a client message. Each round folded the previous round's copy back in, and the last copy landed above the high-water mark where the end-of-turn drain ran it as another turn. This is the more serious one: it fires for **any** message queued mid-turn, migration or not, which is very likely what is behind #1504.

`skip_user_log_append` already means "this user text is already durable in the log". Honor it here too and only push into the in-memory `session.messages` that carries the message into the following rounds' requests.

## 3. Worker turns sent the prompt to the model twice

`build_messages_inner` appended `input.message_content()` on top of a history that already ended with the folded messages. Invisible in the transcript, but the model saw the prompt twice on the first round of every worker turn, subagents included. Suppressed on the same flag; the function is split up so the added condition does not push it further past the complexity threshold.

## Tests

Three integration tests in `crates/harnx-runtime/tests/nats_worker.rs`, each confirmed failing before the fix:

- `lone_prompt_is_not_reinjected_across_tool_rounds` — 3 spurious injections
- `queued_message_is_injected_once_across_many_tool_rounds` — one queued message injected 5 times
- `worker_turn_sends_the_prompt_to_the_model_once` — 2 wire copies

`cargo build --workspace` / `fmt` / `clippy --all-targets -D warnings` clean. `cargo nextest run --workspace --stress-count=5` passed 5/5 (2432 tests per iteration) on the rebased branch. `cs delta`: `config/session.rs` 7.13 → 7.52; the test file holds at 7.29.

Across 20 stress iterations two unrelated tests each timed out once — `nats_worker::cancel_immediately_after_activation_ack_is_not_lost` and `harnx-tui delegation_tests::specialist_handoff_tool_appears_in_transcript`. Both pass 10-15/15 in isolation in well under a second, neither touches the changed code paths, and clean `main` behaves the same. Pre-existing timing flakes, worth their own issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented workers from reprocessing their own prompts during multi-step turns.
  * Fixed repeated message injections, duplicate model prompts, queued-reply loops, and lingering end-of-turn messages.
  * Improved handling of messages added while a turn is in progress, ensuring they are delivered once.
  * Prevented related spinning behavior in the terminal interface.

* **Tests**
  * Added coverage for prompt delivery, queued messages, and multi-round worker interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->