### PR TITLE
fix(runtime): prevent terminal probes from stopping workers

### DIFF
--- a/.changeset/report-waiting-worker-pid.md
+++ b/.changeset/report-waiting-worker-pid.md
@@ -1,0 +1,4 @@
+---
+harnx: patch
+---
+Prevent local workers from being stopped by inherited terminal theme queries, and include the worker PID in slow-start notices for easier diagnostics.

--- a/crates/harnx-runtime/src/config/env_split.rs
+++ b/crates/harnx-runtime/src/config/env_split.rs
@@ -2,8 +2,20 @@
 use super::*;
 use std::env;
 
+fn theme_from_terminal(enabled: bool) -> Option<String> {
+    if !enabled || !*IS_STDOUT_TERMINAL {
+        return None;
+    }
+    theme_mode(QueryOptions::default())
+        .ok()
+        .map(|mode| match mode {
+            ThemeMode::Dark => "dark".into(),
+            ThemeMode::Light => "light".into(),
+        })
+}
+
 impl Config {
-    pub(super) fn load_envs(&mut self) {
+    pub(super) fn load_envs(&mut self, detect_terminal_theme: bool) {
         if let Ok(v) = env::var(get_env_name("model")) {
             self.model_id = v;
         }
@@ -102,14 +114,8 @@ impl Config {
         if self.highlight && self.theme.is_none() {
             if let Some(v) = read_env_value::<String>(&get_env_name("theme")) {
                 self.theme = v;
-            } else if *IS_STDOUT_TERMINAL {
-                if let Ok(mode) = theme_mode(QueryOptions::default()) {
-                    let theme = match mode {
-                        ThemeMode::Dark => "dark",
-                        ThemeMode::Light => "light",
-                    };
-                    self.theme = Some(theme.into());
-                }
+            } else if let Some(theme) = theme_from_terminal(detect_terminal_theme) {
+                self.theme = Some(theme);
             }
         }
         if let Some(v) = read_env_value::<String>(&get_env_name("serve_addr")) {
@@ -179,7 +185,7 @@ mod tests {
         let _cleanup_days = EnvGuard::new("HARNX_CLEANUP_REMOTE_SESSIONS_DAYS", "7");
 
         let mut config = Config::default();
-        config.load_envs();
+        config.load_envs(true);
 
         assert_eq!(config.cleanup_remote_sessions_days, Some(7));
     }
@@ -190,7 +196,7 @@ mod tests {
         let _cleanup_days = EnvGuard::remove("HARNX_CLEANUP_REMOTE_SESSIONS_DAYS");
 
         let mut config = Config::default();
-        config.load_envs();
+        config.load_envs(true);
 
         assert_eq!(config.cleanup_remote_sessions_days, None);
     }

--- a/crates/harnx-runtime/src/config/loader_split.rs
+++ b/crates/harnx-runtime/src/config/loader_split.rs
@@ -12,6 +12,24 @@ fn normalize_description(description: Option<String>) -> Option<String> {
 
 impl Config {
     pub async fn init(working_mode: WorkingMode, info_flag: bool) -> Result<Self> {
+        Self::init_inner(working_mode, info_flag, true).await
+    }
+
+    /// Initialize configuration without querying or changing a controlling
+    /// terminal.
+    ///
+    /// Server and worker processes can inherit terminal streams while running
+    /// in a background process group. A terminal theme query enables raw mode,
+    /// which stops such a process group with `SIGTTOU` on Unix.
+    pub async fn init_headless(working_mode: WorkingMode, info_flag: bool) -> Result<Self> {
+        Self::init_inner(working_mode, info_flag, false).await
+    }
+
+    async fn init_inner(
+        working_mode: WorkingMode,
+        info_flag: bool,
+        allow_terminal_interaction: bool,
+    ) -> Result<Self> {
         // Install any user-supplied models-override list before the
         // harnx-client `ALL_PROVIDER_MODELS` lazy-lock is first accessed.
         crate::client::install_models_override();
@@ -24,7 +42,7 @@ impl Config {
             {
                 Some(v) => Self::load_dynamic(&v)?,
                 None => {
-                    if *IS_STDOUT_TERMINAL {
+                    if allow_terminal_interaction && *IS_STDOUT_TERMINAL {
                         create_config_file(&config_path).await?;
                     }
                     Self::load_from_file(&config_path)?
@@ -38,7 +56,7 @@ impl Config {
         config.info_flag = info_flag;
 
         let setup = |config: &mut Self| -> Result<()> {
-            config.load_envs();
+            config.load_envs(allow_terminal_interaction);
 
             if let Some(wrap) = config.wrap.clone() {
                 config.set_wrap(&wrap)?;

--- a/crates/harnx-runtime/src/local_orchestrator.rs
+++ b/crates/harnx-runtime/src/local_orchestrator.rs
@@ -213,7 +213,7 @@ impl LocalWorkerSupervisor {
 
             let waited = started.elapsed();
             if waited >= next_notice {
-                emit_worker_wait_notice(waited);
+                emit_worker_wait_notice(waited, expected_pid);
                 next_notice = waited + WORKER_SLOW_NOTICE_INTERVAL;
             }
             poll = (poll * 2).min(READINESS_POLL_MAX);
@@ -407,24 +407,28 @@ fn signal_worker_tree(child: &mut Child) {
     let _ = child.start_kill();
 }
 
-fn emit_worker_wait_notice(waited: Duration) {
-    let message = format!(
-        "Still waiting for the local worker to start ({}s). Ctrl-C to cancel; worker output goes to {}.",
-        waited.as_secs(),
-        harnx_core::logging::child_output_destination(),
-    );
+fn emit_worker_wait_notice(waited: Duration, worker_pid: u32) {
+    let message = worker_wait_notice(waited, worker_pid);
     emit_agent_event(AgentEvent::Notice(NoticeEvent::Warning(message.clone())));
     log::info!("{message}");
+}
+
+fn worker_wait_notice(waited: Duration, worker_pid: u32) -> String {
+    format!(
+        "Still waiting for local worker pid {worker_pid} to start ({}s). Ctrl-C to cancel; worker output goes to {}.",
+        waited.as_secs(),
+        harnx_core::logging::child_output_destination(),
+    )
 }
 
 /// Last [`WORKER_OUTPUT_TAIL_BYTES`] of the log the worker writes into, for
 /// error messages.
 ///
-/// The worker is a detached subprocess with no terminal, so anything it writes
-/// outside the `log` facade — a panic, a `main` returning `Err`, a child
-/// process's own stderr — is otherwise lost, and the front-end only sees a
-/// readiness timeout. Empty when the worker inherits our streams instead of a
-/// log file: the output is already wherever the operator is looking.
+/// When the frontend logs to a file, anything the worker writes outside the
+/// `log` facade — a panic, a `main` returning `Err`, a child process's own
+/// stderr — is otherwise easy to miss while the frontend waits for readiness.
+/// Empty when the worker inherits our streams instead: the output is already
+/// wherever the operator is looking.
 fn worker_output_tail() -> String {
     let Some(path) = harnx_core::logging::log_file_path() else {
         return String::new();
@@ -508,6 +512,16 @@ mod tests {
         validate_worker_id(first.worker_id()).expect("first worker id");
         validate_worker_id(second.worker_id()).expect("second worker id");
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn slow_start_notice_identifies_worker_pid() {
+        let notice = worker_wait_notice(Duration::from_secs(15), 42);
+        assert!(
+            notice.contains("worker pid 42"),
+            "unexpected notice: {notice}"
+        );
+        assert!(notice.contains("(15s)"), "unexpected notice: {notice}");
     }
 
     #[tokio::test]

--- a/crates/harnx-serve/src/bin/harnx-serve.rs
+++ b/crates/harnx-serve/src/bin/harnx-serve.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
     setup_logger(LogSink::Stderr)?;
 
     let config = Arc::new(RwLock::new(
-        Config::init(WorkingMode::Serve, false)
+        Config::init_headless(WorkingMode::Serve, false)
             .await
             .context("Failed to init Config")?,
     ));

--- a/crates/harnx-worker/src/main.rs
+++ b/crates/harnx-worker/src/main.rs
@@ -130,7 +130,9 @@ async fn main() -> Result<()> {
     setup_logger(LogSink::Stderr)?;
     harnx_core::alloc_guard::init_from_env();
 
-    let config = Arc::new(RwLock::new(Config::init(WorkingMode::Cmd, true).await?));
+    let config = Arc::new(RwLock::new(
+        Config::init_headless(WorkingMode::Cmd, true).await?,
+    ));
     config.write().agent_variables = collect_agent_variables(&cli.agent_variable)?;
     if cli.diagnose {
         print!(


### PR DESCRIPTION
Initialize harnx-serve and harnx-worker without interactive terminal probing. Frontend-managed workers run in background process groups, so terminal theme detection can trigger SIGTTOU and leave harnx-serve waiting indefinitely.

Include the worker PID in slow-start notices so future subprocess stalls can be inspected directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented local background workers and servers from stopping because of inherited terminal theme queries.
  * Headless processes no longer create configuration files or interact with the terminal during startup.
  * Improved worker readiness timeout notices by including the expected worker process ID and elapsed time.

* **Documentation**
  * Updated guidance on the additional subprocess output sources included when displaying worker output tails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->